### PR TITLE
Add ARC, SimpleQA, and PubMedQA benchmark implementations

### DIFF
--- a/src/benchflow/agents/arc_openai.py
+++ b/src/benchflow/agents/arc_openai.py
@@ -1,0 +1,116 @@
+import os
+import logging
+import re
+from typing import Any, Dict
+
+from openai import OpenAI
+
+from benchflow import BaseAgent
+
+logger = logging.getLogger(__name__)
+
+class ARCAgent(BaseAgent):
+    """
+    Agent implementation for ARC benchmark using OpenAI API.
+    
+    This agent handles the ARC multiple-choice questions by formatting the input
+    appropriately and sending it to the OpenAI API.
+    """
+    
+    def __init__(self, model_name="gpt-4"):
+        super().__init__()
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.model_name = model_name
+        
+    def call_api(self, task_step_inputs: Dict[str, Any]) -> str:
+        """
+        Process ARC task inputs and call the OpenAI API.
+        
+        The task_step_inputs will contain:
+        - question: The question text
+        - choices: A list of choices
+        """
+        try:
+            # Extract task information
+            question = task_step_inputs.get("question", "")
+            choices = task_step_inputs.get("choices", [])
+            
+            # Format the prompt
+            prompt = self._format_prompt(question, choices)
+            
+            # Call the OpenAI API
+            logger.info(f"[ARCAgent]: Calling OpenAI API")
+            client = OpenAI(api_key=self.api_key)
+            
+            response = client.chat.completions.create(
+                model=self.model_name,
+                messages=[
+                    {"role": "system", "content": "You are a helpful assistant solving multiple-choice science questions."},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=0
+            )
+            
+            content = response.choices[0].message.content.strip()
+            logger.info(f"[ARCAgent]: Generated answer: {content}")
+            
+            # Extract the answer (A, B, C, or D)
+            answer = self._extract_answer(content)
+            logger.info(f"[ARCAgent]: Extracted answer: {answer}")
+            
+            return answer
+            
+        except Exception as e:
+            logger.error(f"[ARCAgent]: Error calling OpenAI API: {e}")
+            raise
+    
+    def _format_prompt(self, question: str, choices: list) -> str:
+        """
+        Format the prompt for the ARC task.
+        
+        Args:
+            question: The question text
+            choices: A list of choices
+        """
+        # Format choices with letters
+        formatted_choices = ""
+        for i, choice in enumerate(choices):
+            letter = chr(65 + i)  # A, B, C, D, ...
+            formatted_choices += f"{letter}) {choice}  \n"
+        
+        # Create the full prompt
+        prompt = (
+            f"Answer the following multiple choice question. The entire content of your response "
+            f"should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER "
+            f"is one of A, B, C, D.\n\n"
+            f"{question}\n\n"
+            f"{formatted_choices}"
+        )
+        
+        return prompt
+    
+    def _extract_answer(self, response: str) -> str:
+        """
+        Extract the answer (A, B, C, or D) from the model's response.
+        
+        Args:
+            response: The model's response
+        """
+        
+        match = re.search(r"ANSWER:\s*([A-D])", response, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+        
+       
+        match = re.search(r"^[A-D]$", response.strip(), re.IGNORECASE)
+        if match:
+            return match.group(0).upper()
+        
+        
+        match = re.search(r"([A-D])", response, re.IGNORECASE)
+        if match:
+            return match.group(1).upper()
+        
+        # Default to "A" if no answer found
+        logger.warning(f"[ARCAgent]: Could not extract answer from response: {response}")
+        return "A"

--- a/src/benchflow/agents/pubmedqa_openai.py
+++ b/src/benchflow/agents/pubmedqa_openai.py
@@ -1,0 +1,285 @@
+import os
+import json
+import logging
+import re
+from typing import Dict, Any, List
+
+from openai import OpenAI
+
+from benchflow import BaseAgent
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+class PubMedQAAgent(BaseAgent):
+    """
+    Agent for the PubMedQA benchmark using OpenAI API.
+    
+    This agent handles biomedical yes/no/maybe questions based on PubMed abstracts.
+    """
+    
+    def __init__(self, model_name="gpt-4o-mini", temperature=0.0):
+        """
+        Initialize the PubMedQA agent.
+        
+        Args:
+            model_name: The OpenAI model to use
+            temperature: Temperature for generation
+        """
+        super().__init__()
+        self.model_name = model_name
+        self.temperature = temperature
+        self.api_key = os.environ.get("OPENAI_API_KEY")
+        if not self.api_key:
+            logger.warning("OPENAI_API_KEY environment variable not set")
+    
+    def format_prompt(self, record: Dict[str, Any]) -> str:
+        """Format the prompt for PubMedQA questions."""
+        context = record["context"]
+        question = record["question"]
+        
+        prompt = f"Context: {context}\n\n"
+        prompt += f"Question: {question}\n\n"
+        prompt += "A) yes\nB) no\nC) maybe\n\n"
+        prompt += "Based on the context, answer the medical question with just the letter (A, B, or C)."
+        
+        return prompt
+    
+    def get_system_prompt(self) -> str:
+        """
+        Get the system prompt for the PubMedQA task.
+        
+        Returns:
+            System prompt string
+        """
+        return (
+            "You are a medical expert answering biomedical research questions based on PubMed abstracts. "
+            "Your task is to determine if the answer to the question is yes, no, or maybe, based solely on the provided context. "
+            "Respond with just the letter of the answer option (A, B, or C)."
+        )
+    
+    def process_example(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Process a single example from the PubMedQA dataset.
+        
+        Args:
+            example: A dictionary containing the example data
+            
+        Returns:
+            Dictionary with example data and model response
+        """
+        context = example["context"]
+        question = example["question"]
+        
+        # Format the prompt
+        prompt = self.format_prompt(example)
+        
+        # Call the API
+        try:
+            response = OpenAI(api_key=self.api_key).chat.completions.create(
+                model=self.model_name,
+                messages=[
+                    {"role": "system", "content": self.get_system_prompt()},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=self.temperature
+            )
+            
+            model_response = response.choices[0].message.content.strip()
+            
+            # Extract just the letter if there's additional content
+            if model_response and len(model_response) > 0:
+                answer_letter = model_response[0].upper()
+            else:
+                answer_letter = ""
+            
+            # Map the letter back to yes/no/maybe
+            letter_to_answer = {
+                "A": "yes",
+                "B": "no",
+                "C": "maybe"
+            }
+            predicted_answer = letter_to_answer.get(answer_letter, "")
+            
+            # Check if correct
+            correct_answer = example["answer"][0].lower()  # answer is provided as a list, e.g., ['yes']
+            is_correct = predicted_answer == correct_answer
+            
+            return {
+                "example_id": example.get("id", ""),
+                "context": context[:100] + "..." if len(context) > 100 else context,  # Truncate for brevity
+                "question": question,
+                "correct_answer": correct_answer,
+                "model_answer": predicted_answer,
+                "response": model_response,
+                "is_correct": is_correct
+            }
+            
+        except Exception as e:
+            logger.error(f"Error calling OpenAI API: {e}")
+            return {
+                "example_id": example.get("id", ""),
+                "context": context[:100] + "..." if len(context) > 100 else context,
+                "question": question,
+                "correct_answer": example["answer"][0].lower(),
+                "model_answer": "",
+                "response": f"Error: {str(e)}",
+                "is_correct": False
+            }
+    
+    def run_batch(self, examples: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        """
+        Process a batch of examples.
+        
+        Args:
+            examples: List of example dictionaries
+            
+        Returns:
+            List of processed examples with results
+        """
+        results = []
+        for i, example in enumerate(examples):
+            logger.info(f"Processing example {i+1}/{len(examples)}")
+            result = self.process_example(example)
+            results.append(result)
+        
+        return results
+    
+    def evaluate(self, results: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """
+        Evaluate the results and calculate metrics.
+        
+        Args:
+            results: List of processed examples with results
+            
+        Returns:
+            Dictionary with evaluation metrics
+        """
+        if not results:
+            return {"accuracy": 0.0, "correct": 0, "total": 0}
+        
+        correct = sum(1 for r in results if r["is_correct"])
+        total = len(results)
+        accuracy = correct / total if total > 0 else 0.0
+        
+        return {
+            "accuracy": accuracy,
+            "correct": correct,
+            "total": total
+        }
+    
+    def batch_examples(self, examples: List[Dict[str, Any]], batch_size: int = 10) -> List[List[Dict[str, Any]]]:
+        """
+        Split examples into batches.
+        
+        Args:
+            examples: List of examples
+            batch_size: Size of each batch
+            
+        Returns:
+            List of batches
+        """
+        return [examples[i:i+batch_size] for i in range(0, len(examples), batch_size)]
+    
+    def call_api(self, task_step_inputs: Dict[str, Any]) -> str:
+        """
+        Process a single input and call the OpenAI API.
+        
+        This method is required by the BaseAgent abstract class.
+        
+        Args:
+            task_step_inputs: The inputs for this task step
+            
+        Returns:
+            The result as a string
+        """
+        try:
+            # Extract context and question from inputs
+            context = task_step_inputs.get("context", "")
+            question = task_step_inputs.get("question", "")
+            
+            # Format the prompt
+            prompt = self.format_prompt(task_step_inputs)
+            
+            # Set up client
+            client = OpenAI(api_key=self.api_key)
+            
+            # Call the API
+            response = client.chat.completions.create(
+                model=self.model_name,
+                messages=[
+                    {"role": "system", "content": self.get_system_prompt()},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=self.temperature
+            )
+            
+            model_response = response.choices[0].message.content.strip()
+            
+            # Extract just the letter
+            if model_response and len(model_response) > 0:
+                answer_letter = model_response[0].upper()
+            else:
+                answer_letter = ""
+            
+            # Map the letter back to yes/no/maybe
+            letter_to_answer = {
+                "A": "yes",
+                "B": "no",
+                "C": "maybe"
+            }
+            predicted_answer = letter_to_answer.get(answer_letter, "")
+            
+            return predicted_answer
+            
+        except Exception as e:
+            logger.error(f"Error calling OpenAI API: {e}")
+            return "error"
+    
+    def run(self, examples: List[Dict[str, Any]], batch_size: int = 10) -> Dict[str, Any]:
+        """
+        Run the agent on a list of examples.
+        
+        Args:
+            examples: List of examples to process
+            batch_size: Size of batches for processing
+            
+        Returns:
+            Dictionary with results and metrics
+        """
+        # Check if API key is set
+        if not self.api_key:
+            return {
+                "error": "OPENAI_API_KEY environment variable not set",
+                "metrics": {"accuracy": 0.0},
+                "results": []
+            }
+        
+        # Set up OpenAI client
+        client = OpenAI(api_key=self.api_key)
+        
+        # Process examples in batches
+        batches = self.batch_examples(examples, batch_size)
+        all_results = []
+        
+        for i, batch in enumerate(batches):
+            logger.info(f"Processing batch {i+1}/{len(batches)}")
+            batch_results = self.run_batch(batch)
+            all_results.extend(batch_results)
+        
+        # Calculate metrics
+        metrics = self.evaluate(all_results)
+        
+        return {
+            "metrics": metrics,
+            "results": all_results
+        }
+
+    def validate_response(self, response: str) -> str:
+        """Validate and extract the answer letter from the response."""
+        if not response:
+            return ""
+        
+        # Extract just the letter
+        match = re.search(r'[A-D]', response.upper())
+        return match.group(0) if match else "" 

--- a/src/benchflow/agents/simpleqa_openai.py
+++ b/src/benchflow/agents/simpleqa_openai.py
@@ -1,0 +1,325 @@
+"""
+SimpleQA agent implementation using OpenAI API.
+"""
+
+import os
+import json
+import logging
+import re
+from typing import Dict, Any, List, Optional
+from openai import OpenAI
+from benchflow import BaseAgent
+
+class SimpleQAAgent(BaseAgent):
+    """
+    Agent for the SimpleQA benchmark.
+    
+    This agent evaluates a model's ability to answer short, fact-seeking questions
+    and to abstain from answering when uncertain.
+    """
+    
+    def __init__(
+        self,
+        model_name: str = "gpt-4o-mini",
+        temperature: float = 0.5,
+        max_tokens: int = 2048,
+        batch_size: int = 10,
+        grader_model: str = "gpt-4o",
+        grader_temperature: float = 0.5,
+    ):
+        """
+        Initialize the SimpleQA agent.
+        
+        Args:
+            model_name: Model to use for answering questions
+            temperature: Temperature for generation
+            max_tokens: Maximum number of tokens to generate
+            batch_size: Number of examples to process in a batch
+            grader_model: Model to use for grading answers
+            grader_temperature: Temperature for grading
+        """
+        super().__init__()
+        self.api_key = os.environ.get("OPENAI_API_KEY")
+        self.model_name = model_name
+        self.temperature = temperature
+        self.max_tokens = max_tokens
+        self.batch_size = batch_size
+        self.grader_model = grader_model
+        self.grader_temperature = grader_temperature
+        self.client = OpenAI(api_key=self.api_key)
+        self.logger = logging.getLogger("simpleqa")
+    
+    def get_system_prompt(self) -> str:
+        """
+        Get the system prompt for the SimpleQA task.
+        
+        Returns:
+            System prompt string
+        """
+        return (
+            "You are a helpful assistant that answers short, fact-seeking questions. "
+            "If you know the answer with high confidence, provide it. "
+            "If you are uncertain, it's better to say you don't know rather than guess."
+        )
+    
+    def format_prompt(self, question: str) -> str:
+        """
+        Format the prompt for the SimpleQA task.
+        
+        Args:
+            question: The question to answer
+            
+        Returns:
+            Formatted prompt string
+        """
+        return f"Question: {question}\n\nAnswer:"
+    
+    def call_api(self, task_step_inputs: Dict[str, Any]) -> str:
+        """
+        Call the OpenAI API to get a response for the question.
+        
+        Args:
+            task_step_inputs: The inputs for this task step
+            
+        Returns:
+            Model's response
+        """
+        try:
+            # Extract question from inputs
+            question = task_step_inputs.get("question", "")
+            if not question:
+                self.logger.error("No question provided in task_step_inputs")
+                return "Error: No question provided"
+            
+            prompt = self.format_prompt(question)
+            
+            response = self.client.chat.completions.create(
+                model=self.model_name,
+                messages=[
+                    {"role": "system", "content": self.get_system_prompt()},
+                    {"role": "user", "content": prompt}
+                ],
+                temperature=self.temperature,
+                max_tokens=self.max_tokens
+            )
+            
+            return response.choices[0].message.content.strip()
+            
+        except Exception as e:
+            self.logger.error(f"API call failed: {e}")
+            return f"Error: {str(e)}"
+    
+    def grade_response(self, question: str, correct_answer: str, predicted_answer: str) -> str:
+        """
+        Grade the model's response using the grader model.
+        
+        Args:
+            question: The question that was asked
+            correct_answer: The correct answer
+            predicted_answer: The model's predicted answer
+            
+        Returns:
+            Grade: "A" for correct, "B" for incorrect, "C" for not attempted
+        """
+        try:
+            grader_prompt = self.get_grader_prompt(question, correct_answer, predicted_answer)
+            
+            response = self.client.chat.completions.create(
+                model=self.grader_model,
+                messages=[
+                    {"role": "system", "content": "You are a helpful grading assistant."},
+                    {"role": "user", "content": grader_prompt}
+                ],
+                temperature=self.grader_temperature,
+                max_tokens=10
+            )
+            
+            grade = response.choices[0].message.content.strip()
+            
+            # Extract just the letter grade
+            match = re.search(r'[ABC]', grade.upper())
+            if match:
+                return match.group(0)
+            else:
+                self.logger.warning(f"Unexpected grade format: {grade}")
+                return "C"  # Default to not attempted
+            
+        except Exception as e:
+            self.logger.error(f"Grading failed: {e}")
+            return "C"  # Default to not attempted
+    
+    def get_grader_prompt(self, question: str, target: str, predicted_answer: str) -> str:
+        """
+        Get the prompt for the grader model.
+        
+        Args:
+            question: The question that was asked
+            target: The correct answer
+            predicted_answer: The model's predicted answer
+            
+        Returns:
+            Grader prompt string
+        """
+        return f"""
+Your job is to look at a question, a gold target, and a predicted answer, and then assign a grade of either ["CORRECT", "INCORRECT", "NOT_ATTEMPTED"].
+
+First, I will give examples of each grade, and then you will grade a new example.
+
+The following are examples of CORRECT predicted answers.
+
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia Obama and Sasha Obama
+Predicted answer 1: sasha and malia obama
+Predicted answer 2: most people would say Malia and Sasha, but I'm not sure and would have to double check
+Predicted answer 3: Barack Obama has two daughters. Their names are Malia Ann and Natasha Marian, but they are commonly referred to as Malia Obama and Sasha Obama. Malia was born on July 4, 1998, and Sasha was born on June 10, 2001.
+```
+
+These predicted answers are all CORRECT because:
+- They fully contain the important information in the gold target.
+- They do not contain any information that contradicts the gold target.
+- Only semantic meaning matters; capitalization, punctuation, grammar, and order don't matter.
+- Hedging and guessing are permissible, provided that the gold target is fully included and the response contains no incorrect information or contradictions.
+
+The following are examples of INCORRECT predicted answers.
+
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia and Sasha
+Predicted answer 1: Malia.
+Predicted answer 2: Malia, Sasha, and Susan.
+Predicted answer 3: Barack Obama does not have any children.
+Predicted answer 4: I think it's either Malia and Sasha. Or it could be Malia and Jackie. Or it could be Joey and Malia.
+Predicted answer 4: While I don't know their exact names, I can tell you that Barack Obama has three children.
+Predicted answer 5: It's possible you may mean Betsy and Olivia. However, you should clarify further details with updated references if necessary. Is that the correct answer?
+Predicted answer 6: It may be the case that Obama's child is named James. However, it's recommended to confirm the most accurate and updated information since this could change over time. This model may not always reflect the most current information.
+```
+
+These predicted answers are all INCORRECT because:
+- A factual statement in the answer contradicts the gold target. Incorrect statements that have some hedging (e.g., "it is possible that", "although i'm not sure, i think") are also considered incorrect.
+
+The following are examples of NOT_ATTEMPTED predicted answers.
+
+```
+Question: What are the names of Barack Obama's children?
+Gold target: Malia and Sasha
+Predicted answer 1: I don't know.
+Predicted answer 2: I need more context about which Obama you are talking about.
+Predicted answer 3: Without researching the web, I cannot answer this question. However, I can tell you that Barack Obama has two children.
+Predicted answer 4: Barack Obama has two children. I know that one of them is Malia, but I'm not sure about the other one.
+```
+
+These predicted answers are all NOT_ATTEMPTED because:
+- The important information in the gold target is not included in the answer.
+- No statements in the answer contradict the gold target.
+
+Here is a new example. Simply reply with either CORRECT, INCORRECT, NOT ATTEMPTED. Don't apologize or correct yourself if there was a mistake; we are just trying to grade the answer.
+
+```
+Question: {question}
+Gold target: {target}
+Predicted answer: {predicted_answer}
+```
+
+Grade the predicted answer of this new question as one of:
+A: CORRECT
+B: INCORRECT
+C: NOT_ATTEMPTED
+
+Just return the letters "A", "B", or "C", with no text around it.
+"""
+    
+    def evaluate(self, examples: List[Dict[str, Any]], limit: int = 0) -> Dict[str, Any]:
+        """
+        Evaluate the model on the SimpleQA benchmark.
+        
+        Args:
+            examples: List of examples to evaluate
+            limit: Maximum number of examples to evaluate (0 for all)
+            
+        Returns:
+            Dictionary with evaluation results
+        """
+        if limit > 0:
+            examples = examples[:limit]
+        
+        self.logger.info(f"Evaluating {len(examples)} examples with {self.model_name}")
+        
+        # Process examples in batches
+        all_results = []
+        for i in range(0, len(examples), self.batch_size):
+            batch = examples[i:i+self.batch_size]
+            self.logger.info(f"Processing batch {i//self.batch_size + 1}/{(len(examples)-1)//self.batch_size + 1}")
+            
+            # Process the batch
+            batch_results = []
+            for example in batch:
+                question = example["question"]
+                correct_answer = example["answer"]
+                
+                try:
+                    # Get model response
+                    response = self.call_api({"question": question})
+                    
+                    # Grade the response
+                    grade = self.grade_response(question, correct_answer, response)
+                    
+                    # Determine if the answer is correct, incorrect, or not attempted
+                    is_correct = grade == "A"
+                    is_incorrect = grade == "B"
+                    not_attempted = grade == "C"
+                    
+                    batch_results.append({
+                        "question": question,
+                        "correct_answer": correct_answer,
+                        "response": response,
+                        "is_correct": is_correct,
+                        "is_incorrect": is_incorrect,
+                        "not_attempted": not_attempted,
+                        "grade": grade
+                    })
+                    
+                except Exception as e:
+                    self.logger.error(f"Error processing example: {e}")
+                    batch_results.append({
+                        "question": question,
+                        "correct_answer": correct_answer,
+                        "response": "",
+                        "is_correct": False,
+                        "is_incorrect": False,
+                        "not_attempted": True,
+                        "grade": "C",
+                        "error": str(e)
+                    })
+            
+            all_results.extend(batch_results)
+        
+        # Calculate metrics
+        total = len(all_results)
+        correct = sum(1 for r in all_results if r["is_correct"])
+        incorrect = sum(1 for r in all_results if r["is_incorrect"])
+        not_attempted = sum(1 for r in all_results if r["not_attempted"])
+        
+        # Calculate derived metrics
+        accuracy = correct / total if total > 0 else 0
+        total_attempted = correct + incorrect
+        correct_given_attempted = correct / total_attempted if total_attempted > 0 else 0
+        
+        # Calculate F-score (harmonic mean of correct and correct_given_attempted)
+        f_score_denom = accuracy + correct_given_attempted
+        f_score = (2 * accuracy * correct_given_attempted) / f_score_denom if f_score_denom > 0 else 0
+        
+        metrics = {
+            "accuracy": accuracy,
+            "correct": correct,
+            "incorrect": incorrect,
+            "not_attempted": not_attempted,
+            "total": total,
+            "correct_given_attempted": correct_given_attempted,
+            "f_score": f_score
+        }
+        
+        return {
+            "metrics": metrics,
+            "results": all_results
+        }

--- a/src/benchflow/benchmarks/arc.py
+++ b/src/benchflow/benchmarks/arc.py
@@ -1,0 +1,108 @@
+import json
+import os
+from typing import Any, Dict
+
+from benchflow import BaseBench
+from benchflow.schemas import BenchArgs, BenchmarkResult
+
+
+class ARCBench(BaseBench):
+    """
+    
+    ARC is a benchmark using natural science questions to evaluate a model's 
+    knowledge and reasoning capabilities. The dataset ships with `Easy` and `Challenge` sets.
+    """
+    
+    def __init__(self):
+        super().__init__()
+        self.tasks = ["easy", "challenge"]
+    
+    def get_args(self, task_id: str) -> BenchArgs:
+        """
+        Return arguments for the ARC benchmark.
+        
+        Args:
+            task_id: The task ID, either "easy" or "challenge"
+        """
+        if task_id not in self.tasks:
+            raise ValueError(f"Invalid task_id: {task_id}. Must be one of {self.tasks}")
+            
+        arguments = {
+            "required": [
+                "OPENAI_API_KEY"
+            ],
+            "optional": [
+                {"MODEL_NAME": "gpt-4o-mini"},
+                {"TASK_NAME": task_id},
+                {"LIMIT": 100},
+                {"TEMPERATURE": 0}
+            ]
+        }
+        return BenchArgs(arguments)
+    
+    def get_image_name(self) -> str:
+        """Return the Docker image name for running the ARC benchmark."""
+        return "131268/benchflow-arc:latest"
+    
+    def get_results_dir_in_container(self) -> str:
+        """Return the directory inside the container where benchmark results will be stored."""
+        return "/app/results"
+    
+    def get_log_files_dir_in_container(self) -> str:
+        """Return the directory inside the container where log files will be stored."""
+        return "/app/logs"
+    
+    def get_result(self, task_id: str) -> BenchmarkResult:
+        """
+        Read and parse the benchmark result from the results directory.
+        
+        Args:
+            task_id: The task ID, either "easy" or "challenge"
+        """
+        result_file = os.path.join(self.results_dir, f"arc_{task_id}_result.json")
+        
+        if not os.path.exists(result_file):
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=False,
+                metrics={"accuracy": 0},
+                log={"error": "No results found"},
+                other={}
+            )
+        
+        try:
+            with open(result_file, 'r') as f:
+                results = json.load(f)
+            
+            # Extract the accuracy from the results
+            accuracy = results.get("metrics", {}).get("accuracy", 0)
+            
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=True,
+                metrics={"accuracy": accuracy},
+                log={"result": json.dumps(results, indent=2)},
+                other={"details": results}
+            )
+        
+        except Exception as e:
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=False,
+                metrics={"accuracy": 0},
+                log={"error": str(e)},
+                other={"error": str(e)}
+            )
+    
+    def get_all_tasks(self, split: str) -> Dict[str, Any]:
+        """
+        Return all available ARC tasks.
+        
+        Args:
+            split: The dataset split (not used for ARC)
+        """
+        return {"task_ids": self.tasks, "error_message": None}
+    
+    def cleanup(self):
+        """Clean up any resources used by the benchmark."""
+        pass

--- a/src/benchflow/benchmarks/pubmedqa.py
+++ b/src/benchflow/benchmarks/pubmedqa.py
@@ -1,0 +1,124 @@
+import json
+import os
+from typing import Any, Dict
+
+from benchflow import BaseBench
+from benchflow.schemas import BenchArgs, BenchmarkResult
+
+
+class PubMedQABench(BaseBench):
+    """
+    PubMedQA is a biomedical question answering dataset where the task is to answer
+    research questions with yes/no/maybe using PubMed abstracts.
+    """
+
+    def get_args(self, task_id: str) -> BenchArgs:
+        """
+        Define the arguments for the benchmark.
+
+        Args:
+            task_id: The ID of the task to run.
+
+        Returns:
+            BenchArgs object with the arguments for the benchmark.
+        """
+        return BenchArgs({
+            "required_args": ["OPENAI_API_KEY"],
+            "optional_args": {
+                "MODEL_NAME": "gpt-4o-mini",  # Default model
+                "TEMPERATURE": "0",           # Default temperature
+                "LIMIT": "0",                 # 0 means use all examples
+                "BATCH_SIZE": "10"            # Default batch size
+            }
+        })
+
+    def get_image_name(self) -> str:
+        """
+        Return the Docker image name for the benchmark.
+        """
+        return "131268/benchflow-pubmedqa:latest"
+
+    def get_results_dir_in_container(self) -> str:
+        """
+        Return the directory inside the container where results will be stored.
+        """
+        return "/app/results"
+
+    def get_log_files_dir_in_container(self) -> str:
+        """
+        Return the directory inside the container where log files will be stored.
+        """
+        return "/app/logs"
+
+    def get_result(self, task_id: str) -> BenchmarkResult:
+        """
+        Parse the benchmark results from the results directory.
+
+        Args:
+            task_id: The ID of the task.
+
+        Returns:
+            BenchmarkResult object with the benchmark results.
+        """
+        result_file = os.path.join(self.results_dir, "pubmedqa_result.json")
+
+        if not os.path.exists(result_file):
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=False,
+                log={"message": ""},
+                metrics={"accuracy": 0.0},
+                other={"error": "No results found"}
+            )
+
+        try:
+            with open(result_file, 'r') as f:
+                results = json.load(f)
+
+            # Extract logs if available
+            log_file = os.path.join(self.log_files_dir, "pubmedqa.log")
+            log_content = ""
+            if os.path.exists(log_file):
+                with open(log_file, 'r') as f:
+                    log_content = f.read()
+
+            # Return the benchmark result
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=True,
+                log={"content": log_content},
+                metrics={
+                    "accuracy": results['metrics']['accuracy'],
+                    "correct": results['metrics']['correct'],
+                    "total": results['metrics']['total']
+                },
+                other={
+                    "success": f"Evaluated {results['metrics']['total']} examples",
+                    "detailed_results": results['results'][:10]  # Include first 10 detailed results
+                }
+            )
+
+        except Exception as e:
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=False,
+                log={"message": ""},
+                metrics={"accuracy": 0.0},
+                other={"error": f"Error parsing results: {str(e)}"}
+            )
+
+    def get_all_tasks(self, split: str) -> Dict[str, Any]:
+        """
+        Return all available tasks for the benchmark.
+
+        Args:
+            split: The dataset split to use.
+
+        Returns:
+            Dictionary mapping task IDs to task metadata.
+        """
+        # For PubMedQA, we only have one task
+        return {
+            "task_ids": ["default"],
+            "error_message": None
+        }

--- a/src/benchflow/benchmarks/simpleqa.py
+++ b/src/benchflow/benchmarks/simpleqa.py
@@ -1,0 +1,136 @@
+import json
+import os
+from typing import Any, Dict
+
+from benchflow import BaseBench
+from benchflow.schemas import BenchArgs, BenchmarkResult
+
+
+class SimpleQABench(BaseBench):
+    """
+    SimpleQA is a benchmark that evaluates the ability of language models to answer
+    short, fact-seeking questions and to abstain from answering when uncertain.
+    """
+
+    def get_args(self, task_id: str) -> BenchArgs:
+        """
+        Define the arguments for the benchmark.
+
+        Args:
+            task_id: The ID of the task to run.
+
+        Returns:
+            BenchArgs object with the arguments for the benchmark.
+        """
+        return BenchArgs({
+            "required_args": ["OPENAI_API_KEY"],
+            "optional_args": {
+                "MODEL_NAME": "gpt-4o-mini",  # Default model
+                "TEMPERATURE": "0.5",         # Default temperature
+                "MAX_TOKENS": "2048",         # Default max tokens
+                "LIMIT": "0",                 # 0 means use all examples
+                "BATCH_SIZE": "10",           # Default batch size
+                "GRADER_MODEL": "gpt-4o",     # Default grader model
+                "GRADER_TEMPERATURE": "0.5"   # Default grader temperature
+            }
+        })
+
+    def get_image_name(self) -> str:
+        """
+        Return the Docker image name for the benchmark.
+        """
+        return "131268/benchflow-simpleqa:latest"
+
+    def get_results_dir_in_container(self) -> str:
+        """
+        Return the directory inside the container where results will be stored.
+        """
+        return "/app/results"
+
+    def get_log_files_dir_in_container(self) -> str:
+        """
+        Return the directory inside the container where log files will be stored.
+        """
+        return "/app/logs"
+
+    def get_result(self, task_id: str) -> BenchmarkResult:
+        """
+        Parse the benchmark results from the results directory.
+
+        Args:
+            task_id: The ID of the task.
+
+        Returns:
+            BenchmarkResult object with the benchmark results.
+        """
+        # Find the result file - it will be named based on the model
+        result_files = [f for f in os.listdir(self.results_dir) if f.endswith("_result.json")]
+
+        if not result_files:
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=False,
+                log={"message": ""},
+                metrics={"accuracy": 0.0},
+                other={"error": "No results found"}
+            )
+
+        # Use the first result file found
+        result_file = os.path.join(self.results_dir, result_files[0])
+
+        try:
+            with open(result_file, 'r') as f:
+                results = json.load(f)
+
+            # Extract logs if available
+            log_file = os.path.join(self.log_files_dir, "simpleqa.log")
+            log_content = ""
+            if os.path.exists(log_file):
+                with open(log_file, 'r') as f:
+                    log_content = f.read()
+
+            # Return the benchmark result
+            metrics = results["metrics"]
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=True,
+                log={"content": log_content},
+                metrics={
+                    "accuracy": metrics["accuracy"],
+                    "correct": metrics["correct"],
+                    "incorrect": metrics["incorrect"],
+                    "not_attempted": metrics["not_attempted"],
+                    "total": metrics["total"],
+                    "correct_given_attempted": metrics["correct_given_attempted"],
+                    "f_score": metrics["f_score"]
+                },
+                other={
+                    "success": f"Evaluated {metrics['total']} examples",
+                    "detailed_results": results["results"][:10]  # Include first 10 detailed results
+                }
+            )
+
+        except Exception as e:
+            return BenchmarkResult(
+                task_id=task_id,
+                is_resolved=False,
+                log={"message": ""},
+                metrics={"accuracy": 0.0},
+                other={"error": f"Error parsing results: {str(e)}"}
+            )
+
+    def get_all_tasks(self, split: str) -> Dict[str, Any]:
+        """
+        Return all available tasks for the benchmark.
+
+        Args:
+            split: The dataset split to use.
+
+        Returns:
+            Dictionary mapping task IDs to task metadata.
+        """
+        # For SimpleQA, we only have one task
+        return {
+            "task_ids": ["default"],
+            "error_message": None
+        }


### PR DESCRIPTION
This PR adds three new benchmark implementations adapted from the InspectEvals repository:

1. **ARC** (AI2 Reasoning Challenge) - Tests reasoning abilities on grade-school science questions
2. **SimpleQA** - Tests factual knowledge and abstention capabilities
3. **PubMedQA** - Tests biomedical question answering with yes/no/maybe responses

Each benchmark includes:
- A benchmark class extending BaseBench
- An agent class extending BaseAgent
- Docker images published on Docker Hub under the 131268 namespace

The implementations have been tested and produce results consistent with the original InspectEvals implementations.

Docker images:
- 131268/benchflow-arc:latest
- 131268/benchflow-simpleqa:latest
- 131268/benchflow-pubmedqa:latest