### PR TITLE
fix: improve error message for missing requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Before you start, please get your `BF_TOKEN` on [BenchFlow.ai](https://benchflow
        task_ids=[0],
        agents=your_agents,
        api={"provider": "openai", "model": "gpt-4o-mini", "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY")},
-       requirements_txt="webarena_requirements.txt",
+       requirements_txt="examples/webarena/webarena_requirements.txt",  # Path relative to your working directory
        args={}
    )
 

--- a/docs/tutorial/user.mdx
+++ b/docs/tutorial/user.mdx
@@ -116,11 +116,11 @@ run_ids = bench.run(
         task_ids=[0],
         agents=agent,
         api={
-            "provider": "openai", 
-            "model": "gpt-4o-mini", 
+            "provider": "openai",
+            "model": "gpt-4o-mini",
             "OPENAI_API_KEY": os.getenv("OPENAI_API_KEY")
         },
-        requirements_txt="webarena_requirements.txt",
+        requirements_txt="path/to/your_requirements.txt",  # Path relative to your working directory
         args={}
     )
 ```

--- a/src/benchflow/Bench.py
+++ b/src/benchflow/Bench.py
@@ -63,10 +63,35 @@ class Bench:
 
         try:
             with open(requirements_txt, 'r') as f:
-                requirements_txt = f.read()
-            if install_sh:
+                requirements_content = f.read()
+        except FileNotFoundError:
+            logger.error(
+                f"Requirements file not found: '{requirements_txt}'. "
+                f"Please ensure the file exists and the path is correct. "
+                f"Current working directory: {Path.cwd()}"
+            )
+            return None
+        except Exception as e:
+            logger.error(f"Failed to read requirements file: {str(e)}")
+            return None
+
+        install_sh_content = None
+        if install_sh:
+            try:
                 with open(install_sh, 'r') as f:
-                    install_sh = f.read()
+                    install_sh_content = f.read()
+            except FileNotFoundError:
+                logger.error(
+                    f"Install script not found: '{install_sh}'. "
+                    f"Please ensure the file exists and the path is correct. "
+                    f"Current working directory: {Path.cwd()}"
+                )
+                return None
+            except Exception as e:
+                logger.error(f"Failed to read install script: {str(e)}")
+                return None
+
+        try:
             agent_code = self._get_agent_code(agent)
         except Exception as e:
             logger.error(f"Failed to get agent code: {str(e)}")
@@ -79,8 +104,8 @@ class Bench:
             "benchmark_name": self.benchmark_name,
             "params": args,
             "require_gpu": require_gpu,
-            "requirements": requirements_txt if requirements_txt else "",
-            "install_sh": install_sh if install_sh else "",
+            "requirements": requirements_content if requirements_content else "",
+            "install_sh": install_sh_content if install_sh_content else "",
             "agent_code": agent_code if agent_code else "",
             "api": api
         }


### PR DESCRIPTION
## Summary

Fixes #74

When users follow the README quick start guide and run the webarena example from the repository root, they would get a confusing error:
```
[ERROR] benchflow.Bench: Failed to get agent code: [Errno 2] No such file or directory: 'webarena_requirements.txt'
```

The error message was misleading (mentions "agent code" when the issue is the requirements file) and didn't help users understand what went wrong.

## Changes

- **Improved error handling in `Bench.py`**: Separated error handling for requirements file, install script, and agent code with specific `FileNotFoundError` handling
- **Better error messages**: Now includes the attempted path and current working directory to help users debug path issues
- **Fixed README example**: Changed path from `webarena_requirements.txt` to `examples/webarena/webarena_requirements.txt`
- **Updated docs tutorial**: Clarified that the path should be relative to the working directory

## New error message

Users will now see:
```
[ERROR] benchflow.Bench: Requirements file not found: 'webarena_requirements.txt'. Please ensure the file exists and the path is correct. Current working directory: /path/to/repo
```

## Test plan

- [ ] Verify Python syntax compiles correctly
- [ ] Test that FileNotFoundError is raised with helpful message when requirements file is missing
- [ ] Test that existing functionality works when correct path is provided