### PR TITLE
Sandbox & verifier hardening (Patterns 1, 2, 7)

### DIFF
--- a/benchmarks/skillsbench-claude-glm5.yaml
+++ b/benchmarks/skillsbench-claude-glm5.yaml
@@ -1,0 +1,10 @@
+tasks_dir: ../.ref/skillsbench/tasks
+jobs_dir: ../jobs/skillsbench-claude-glm51
+agent: claude-agent-acp
+model: zai/glm-5.1
+environment: daytona
+concurrency: 8
+max_retries: 2
+exclude:
+  - scheduling-email-assistant
+  - mhc-layer-impl

--- a/docs/harden-sandbox.md
+++ b/docs/harden-sandbox.md
@@ -75,16 +75,42 @@ with `error`. `_verify()` now owns its own try/except with an explicit
 4. **PATH / environment poisoning** — agent could shadow verifier tools, or
    inject `sitecustomize.py` / `usercustomize.py` / `.pth` files into
    `sys.path`.
+5. **Pytest ini-file injection via agent-writable cwd** — extends #3. Real
+   tasks `cd /app` (agent-writable scratch dir) before invoking pytest, and
+   pytest walks up from **cwd** looking for `pyproject.toml`, `pytest.ini`,
+   `tox.ini`, `setup.cfg`. An agent-written `/app/pyproject.toml` with
+   `[tool.pytest.ini_options] addopts = "-p evil"` plus `/app/evil.py`
+   (importable because `''` is on `sys.path` for `python -m pytest`) loads
+   attacker code as root. `--rootdir=/tests` alone does **not** block this:
+   it controls test discovery, not ini-file discovery.
 
 ### Fix
 
 A new `SDK._harden_before_verify()` runs before every verifier invocation
 and is composed of two class constants plus one method:
 
-- `SDK._VERIFIER_ENV` — canonical env merged into the verifier:
-  `PATH`, `PYTEST_ADDOPTS=--rootdir=/tests -p no:cacheprovider`,
-  `PYTHONDONTWRITEBYTECODE=1`, `PYTHONPATH=""`, `PYTHONHOME=""`. Task-level
+- `SDK._VERIFIER_ENV` — canonical env merged into the verifier. Task-level
   env from `task.toml` is merged last so authors can override.
+
+  | Var | Value | Layer / purpose |
+  |---|---|---|
+  | `PATH` | `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` | locked PATH (Pattern 7) |
+  | `PYTEST_ADDOPTS` | `-c /dev/null --confcutdir=/tests --rootdir=/tests -p no:cacheprovider` | L1 (`-c /dev/null`) blocks `pyproject.toml`/`pytest.ini`/`tox.ini`/`setup.cfg` walk-up; L2 (`--confcutdir=/tests`) blocks `conftest.py` walk-up; rootdir pin + cache disable from original Pattern 7 |
+  | `PYTHONSAFEPATH` | `1` | L4 — Python 3.11+ drops implicit `''` (cwd) from `sys.path`, blocking module-shadow via `import helpers` finding `/app/helpers.py` |
+  | `PYTHONPATH`, `PYTHONHOME` | `""` | block env-var path injection |
+  | `PYTHONSTARTUP`, `LD_PRELOAD`, `LD_LIBRARY_PATH` | `""` | L5 — clear image-`ENV` carryover (zero-downside insurance against malicious base images) |
+  | `PYTHONDONTWRITEBYTECODE` | `1` | no `.pyc` artifacts left behind |
+
+  **Intentionally omitted**, with reasons documented inline at the
+  declaration:
+  - `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` — would break ~94 SkillsBench tasks
+    that rely on `pytest-json-ctrf`'s `--ctrf` flag. Entry-point plugin
+    injection is structurally blocked anyway: verifier runs as root, system
+    site-packages is root-owned, agent's user-site is not on root's
+    `sys.path`, and `_CLEANUP_CMD` wipes `.pth` files in any writable
+    `sys.path` entry.
+  - `PYTHONNOUSERSITE=1` — root verifier means `/root/.local` is the only
+    user-site on `sys.path`, and `sandbox_user` cannot write there.
 - `SDK._CLEANUP_CMD` — defense-in-depth shell command:
   `find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete`
   plus `python3 -c "import sys..."` to enumerate real `sys.path` and remove
@@ -197,7 +223,10 @@ block does not crash after `pkill` has already killed the ACP transport.
 | Systemic verifier bug masquerades as agent failure | `>20%` ERROR threshold, separate aggregation |
 | Agent forges `reward.txt` via background process | `pkill -u sandbox_user` before verify |
 | Agent forges scraped tool-call count | `n_tool_calls` only sourced from ACP session |
-| `conftest.py` injection forces tests to pass | `PYTEST_ADDOPTS --rootdir=/tests` + `find -delete` |
+| `conftest.py` injection forces tests to pass | `--confcutdir=/tests` + `find -delete` |
+| `pyproject.toml` / `pytest.ini` injection from agent-writable cwd | `-c /dev/null` in `PYTEST_ADDOPTS` |
+| Module-shadow via `import x` finding `/app/x.py` | `PYTHONSAFEPATH=1` drops implicit `''` from `sys.path` |
+| Image-`ENV` carryover (`LD_PRELOAD`, `PYTHONSTARTUP`) | Cleared in `_VERIFIER_ENV` |
 | `sitecustomize.py` / `.pth` injection | sys.path-aware cleanup |
 | PATH poisoning to shadow verifier tools | Canonical `_VERIFIER_ENV` PATH |
 | Agent reads `/solution` or `/tests` to cheat | `chown root + chmod 700` lockdown |
@@ -211,3 +240,63 @@ block does not crash after `pkill` has already killed the ACP transport.
   SUID binary stripping is future work
 - Service-mediated exfiltration — benchmark author responsibility
 - Harbor private-attribute coupling in `process.py` — upstream-blocked
+- **Custom task layouts that `cd` into deeply nested agent-writable dirs
+  other than `/app`** — `--confcutdir=/tests` blocks `conftest.py` walk-up
+  to any depth, and `-c /dev/null` blocks ini-file walk-up entirely, so
+  the residual surface is small. Tasks that intentionally operate in
+  agent-writable dirs deeper than `find -maxdepth 5 -name conftest.py`
+  reaches still benefit from L1/L2 (which are walk-depth-independent).
+
+## Future directions
+
+Items deferred but on the roadmap. Each entry lists the trigger that
+should prompt revisiting it.
+
+- **Verifier as a dedicated non-root user, distinct from `sandbox_user`.**
+  Today the verifier inherits Harbor's default of running as root, which is
+  the load-bearing assumption behind several layers (e.g. "agent's user-site
+  isn't on the verifier's `sys.path`" only holds because the verifier's user
+  is root, not the agent). Inverting this — verifier as its own UID, neither
+  root nor `sandbox_user` — would make most of the layered defenses
+  *redundant in a good way*: the agent-writable cwd, `/root/.local`, and
+  PATH-shadowing vectors all become structurally unreachable instead of
+  defended in depth. **Trigger:** Harbor exposes a `verifier.user` setting,
+  or benchflow adds its own privilege-drop wrapper around the verifier
+  invocation (mirroring `_setup_sandbox_user`).
+
+- **Per-task pytest plugin allowlist.** Would let us safely enable
+  `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` (Layer 3 from the original plan,
+  currently dropped). Today ~94 SkillsBench tasks rely on
+  `pytest-json-ctrf`'s `--ctrf` flag, so global autoload-disable would
+  break them. A per-task `pytest_plugins = [...]` declaration in
+  `test.sh` (or `task.toml`) would let those tasks opt back in
+  explicitly. **Trigger:** a real entry-point plugin injection attack is
+  found, OR a one-time refactor pass over the SkillsBench tasks becomes
+  worthwhile (e.g. as part of a broader test-infra cleanup).
+
+- **`pytest --import-mode=importlib`.** Eliminates pytest's default
+  `prepend` import mode, which mutates `sys.path` to add each test file's
+  rootdir. `PYTHONSAFEPATH=1` (Layer 4) handles the *Python interpreter*'s
+  cwd-on-`sys.path` behavior, but pytest's own `--import-mode=prepend`
+  injection is independent. The audit confirmed no current task relies on
+  cwd-on-`sys.path` for sibling imports, so a migration is feasible but has
+  non-trivial breakage risk. **Trigger:** a `sys.path`-based bypass is
+  discovered that PYTHONSAFEPATH alone doesn't cover.
+
+- **End-to-end pytest-injection smoke test in CI.** The unit-level
+  subprocess test in `tests/test_verify.py` invokes `pytest -c /dev/null`
+  directly to bind the static `_VERIFIER_ENV` assertions to real pytest
+  behavior. A complementary CI job would build a minimal task fixture with
+  a hostile `pyproject.toml`/`conftest.py`/`*.pth` baked in, run the full
+  benchflow verifier path against it, and assert the verifier rejects all
+  three. Currently this is a manual smoke test step (see commit message of
+  this hardening round). **Trigger:** any new layer added to `_VERIFIER_ENV`,
+  or any change to `_harden_before_verify` / `_CLEANUP_CMD`.
+
+- **SUID binary stripping in agent base images.** Closes the agent →
+  root re-escalation vector that `setpriv` / `su` privilege-drop alone
+  does not fully cover. Already in Out-of-scope as "future work"; would
+  pair naturally with the verifier-user change above. **Trigger:** an
+  audit finds a SUID binary the agent can exploit, OR the verifier-user
+  change lands and we want to close the remaining horizontal-escalation
+  path symmetrically.

--- a/docs/harden-sandbox.md
+++ b/docs/harden-sandbox.md
@@ -1,0 +1,213 @@
+# Sandbox Hardening
+
+benchflow's sandbox was audited against the seven vulnerability patterns
+documented in
+[Trustworthy AI Agent Benchmarks](https://moogician.github.io/blog/2026/trustworthy-benchmarks-cont/).
+This doc summarizes the gaps that were closed and how.
+
+## The seven patterns
+
+| # | Pattern | What it means | Status in benchflow |
+|---|---------|---------------|---------------------|
+| 1 | No isolation between agent and evaluator | Agent code runs in the same environment the evaluator inspects, so the agent can tamper with evaluation. | **Addressed** — [Default non-root sandbox + path lockdown](#default-non-root-sandbox--path-lockdown) |
+| 2 | Answers shipped with the test | Reference answers reachable from the agent (task configs, repos, metadata) turn evaluation into lookup. | **Addressed** — [Default non-root sandbox + path lockdown](#default-non-root-sandbox--path-lockdown) |
+| 3 | `eval()` on untrusted input | Evaluator executes agent-controlled strings without sandboxing → arbitrary code execution. | Not present — benchflow's verifier does not `eval` agent output. |
+| 4 | LLM judges without input sanitization | Agent output is interpolated into judge prompts, enabling prompt injection to bias scoring. | Not applicable — benchflow has no LLM judge in-tree (benchmark author responsibility if used). |
+| 5 | Weak string matching | Overly permissive comparison (substring, aggressive normalization) lets wrong answers pass. | Not applicable — scoring is reward-based, not string-match. |
+| 6 | Evaluation logic that doesn't evaluate | Scoring functions skip checks, contain dead code, or fail to compare against ground truth. | **Addressed** — [Verifier failure isolation](#verifier-failure-isolation) |
+| 7 | Trusting the output of untrusted code | Test results and artifacts produced inside the agent's environment are treated as reliable. | **Addressed** — [Verifier hardening](#verifier-hardening) |
+
+---
+
+## Verifier failure isolation
+
+### Problem
+
+`SDK.run()`'s broad `except Exception` caught verifier crashes and stuffed
+them into the agent `error` field. Three distinct outcomes were conflated:
+
+- Verifier crashed (infrastructure bug — should be investigated)
+- Verifier timed out (task too slow — should be retried)
+- Agent failed and verifier returned zero (legitimate zero)
+
+Result JSON could not distinguish them, retry/resume logic mis-handled them,
+and aggregation hid systemic verifier bugs as "agent errors".
+
+### Fix
+
+A new `verifier_error: str | None` field on `RunResult`, mutually exclusive
+with `error`. `_verify()` now owns its own try/except with an explicit
+`asyncio.wait_for` timeout and returns `(rewards, verifier_error)`.
+
+- **Classification** — `_scoring.classify_verifier_error()` maps the prefix
+  to `verifier_failure`, `verifier_timeout`, or `verifier_other`. Prefixes
+  in `_verify()` are kept in sync via comments.
+- **Retry** — verifier errors are terminal in `job._run_task()`; broken
+  verifiers do not self-heal.
+- **Resume** — `_get_completed_tasks()` treats verifier-errored tasks as
+  complete (with INFO log) so resume does not loop forever on a systemic bug.
+- **Aggregation** — `JobResult.verifier_errored` is a separate bucket from
+  `errored`. An assertion enforces
+  `passed + failed + errored + verifier_errored == total`. A WARNING fires on
+  any verifier error and an ERROR fires above 20%.
+- **Metrics** — `TaskMetrics.verifier_error`, `BenchmarkMetrics.verifier_errored`,
+  `verifier_error_breakdown`, plus `avg_tool_calls` / `avg_duration` filters
+  exclude verifier-errored tasks so they cannot skew averages.
+- **Scoring** — `score = passed / total` (conservative, counts verifier
+  errors against the agent). `score_excl_errors = passed / (passed + failed)`
+  (clean, excludes both error types).
+
+---
+
+## Verifier hardening
+
+### Problems
+
+1. **Forged verifier output** — if the agent ran as root or
+   `/logs/verifier` was world-writable, the agent could pre-write
+   `reward.txt` and the verifier might read its own forged prior output.
+2. **Forged scraped trajectory** — `_scrape_agent_trajectory()` reads from
+   the agent's own home directory. Tool-call counts derived from it were
+   trusted.
+3. **conftest.py injection** — pytest's `rootdir` is the common ancestor of
+   collected paths and CWD. An agent that drops `/conftest.py` with a
+   `pytest_runtest_makereport` hook can force every test to pass.
+4. **PATH / environment poisoning** — agent could shadow verifier tools, or
+   inject `sitecustomize.py` / `usercustomize.py` / `.pth` files into
+   `sys.path`.
+
+### Fix
+
+A new `SDK._harden_before_verify()` runs before every verifier invocation
+and is composed of two class constants plus one method:
+
+- `SDK._VERIFIER_ENV` — canonical env merged into the verifier:
+  `PATH`, `PYTEST_ADDOPTS=--rootdir=/tests -p no:cacheprovider`,
+  `PYTHONDONTWRITEBYTECODE=1`, `PYTHONPATH=""`, `PYTHONHOME=""`. Task-level
+  env from `task.toml` is merged last so authors can override.
+- `SDK._CLEANUP_CMD` — defense-in-depth shell command:
+  `find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete`
+  plus `python3 -c "import sys..."` to enumerate real `sys.path` and remove
+  writable `sitecustomize.py`, `usercustomize.py`, and `.pth` files
+  (stdlib copies under `/usr/lib` and `/usr/local/lib` are preserved).
+- `pkill -u {sandbox_user}` (SIGTERM, sleep 1, SIGKILL) — kills any agent
+  background daemons before verification, so they cannot race the verifier.
+  Only runs when `sandbox_user` is set.
+
+**Untrusted trajectory accounting** — `RunResult` gained
+`trajectory_source: str | None` (`acp` / `scraped` / `partial_acp` / `None`)
+and a proper `partial_trajectory: bool` field. When falling back to scraped
+or partial trajectories, `n_tool_calls` is **not** overwritten — only the
+ACP-tracked count (`session.tool_calls`) is trusted. A WARNING with the
+`UNTRUSTED` label is emitted on the scraped path.
+
+`/logs/verifier` filesystem lockdown is **not** done here — it is a host
+bind mount and `chmod 700` would block Harbor's SDK from writing.
+
+---
+
+## Default non-root sandbox + path lockdown
+
+### Problems
+
+- **Agent ran as root by default** — full filesystem access made every
+  other mitigation moot.
+- **Solution / test files were readable** — the agent could simply `cat
+  /solution/answer.py` or `cat /tests/test_*.py` to game the verifier.
+
+### Fix
+
+**Default `sandbox_user="agent"`** in `SDK.run()`, `JobConfig`, and the CLI
+(`--sandbox-user`). Passing `sandbox_user=None` falls back to root and
+emits a WARNING about cheating risk.
+
+**Privilege drop without gosu.** `SDK._build_priv_drop_cmd()` detects
+`setpriv` (util-linux) and uses
+`setpriv --reuid=USER --regid=USER --init-groups -- bash -c CMD`, falling
+back to `su -l USER -c CMD` on Alpine/BusyBox. No Dockerfile mutation, no
+external dependency. `DockerProcess` already wraps in `bash -c`, so there
+is no outer `sh -c` wrapper to mis-quote.
+
+**`_setup_sandbox_user`** creates the user, then `chown`s the container's
+working directory (detected via `pwd`) and the agent home so the agent can
+write where the task expects output. `shlex.quote()` is used on the
+attacker-controlled `pwd` output and on skill paths to prevent command
+injection.
+
+**Path lockdown** — new `sandbox_locked_paths: list[str] | None` parameter:
+
+- Default when `sandbox_user` is set: `["/solution", "/tests"]`
+- Default when `sandbox_user` is `None`: `[]` (no-op + warning)
+- Caller-supplied paths are unioned with defaults (deduped, order-preserving)
+- `[]` opts out explicitly; non-empty paths without `sandbox_user` raises
+  `ValueError`
+- Shell globs (`/app-*`) supported; `**` is not
+
+`_validate_locked_path()` rejects shell metacharacters, `..` traversal,
+paths that change under `os.path.normpath`, and trailing slashes.
+
+`_lockdown_paths()` runs **after** install/setup/skills but **before**
+ACP connect:
+
+```shell
+for d in /solution; do
+  [ -L "$d" ] && echo "WARN: skipping symlink $d" >&2 && continue;
+  [ -e "$d" ] || continue;
+  chown root:root "$d" && chmod 700 "$d";
+done
+```
+
+Security properties:
+1. `chown` before `chmod` — agent loses access at `chown`
+2. Symlink rejection prevents `ln -s /usr/bin /solution` attacks
+3. Non-recursive by design — `chmod 700` removes the traverse bit, so
+   contents are unreachable regardless of individual file modes
+
+**`/logs/verifier` is not locked** — bind mount; verifier integrity is
+covered by `_harden_before_verify` instead.
+
+**Idempotent process close** — `LiveProcess.close()` checks `returncode`
+before `terminate()` and catches `OSError` on stdin close, so the finally
+block does not crash after `pkill` has already killed the ACP transport.
+
+---
+
+## SDK flow after hardening
+
+```
+1.  _start_env_and_upload   — start container, upload task files
+2.  pre_agent_hooks         — caller-provided hooks
+3.  _install_agent          — install agent binary (as root)
+4.  _write_credential_files — write API keys
+5.  _setup_sandbox_user     — create user, chown workspace + home
+6.  _deploy_skills          — copy skills to agent paths
+7.  _lockdown_paths         — chown root + chmod 700 on locked paths
+8.  _connect_acp            — setpriv/su privilege drop, ACP handshake
+9.  _execute_prompts        — multi-turn agent execution
+10. _harden_before_verify   — pkill agent, cleanup, env reset
+11. _verify                 — run verifier as root, isolated errors
+```
+
+## Threat model coverage
+
+| Threat | Mitigation |
+|--------|------------|
+| Verifier crash misclassified as agent error | `verifier_error` field, separate bucket, terminal retry |
+| Verifier hangs and inflates duration | Explicit `asyncio.wait_for(verifier.timeout_sec)` |
+| Systemic verifier bug masquerades as agent failure | `>20%` ERROR threshold, separate aggregation |
+| Agent forges `reward.txt` via background process | `pkill -u sandbox_user` before verify |
+| Agent forges scraped tool-call count | `n_tool_calls` only sourced from ACP session |
+| `conftest.py` injection forces tests to pass | `PYTEST_ADDOPTS --rootdir=/tests` + `find -delete` |
+| `sitecustomize.py` / `.pth` injection | sys.path-aware cleanup |
+| PATH poisoning to shadow verifier tools | Canonical `_VERIFIER_ENV` PATH |
+| Agent reads `/solution` or `/tests` to cheat | `chown root + chmod 700` lockdown |
+| Agent runs as root with full FS access | Default `sandbox_user="agent"` + setpriv/su |
+| Symlink attack on locked paths | Symlink guard in `_lockdown_paths` |
+| Command injection via `pwd` / skill paths | `shlex.quote()` |
+
+**Out of scope** (documented, not addressed):
+- Network-based cheating — handled by `allow_internet=false`
+- Agent re-escalating to root — mitigated by setpriv/su capability drop;
+  SUID binary stripping is future work
+- Service-mediated exfiltration — benchmark author responsibility
+- Harbor private-attribute coupling in `process.py` — upstream-blocked

--- a/docs/sdk-reference.md
+++ b/docs/sdk-reference.md
@@ -161,7 +161,7 @@ await sdk.run(..., sandbox_user="agent")
 - **Requires gosu** in the container (`apt-get install -y gosu`)
 - **Auto-creates user** via `useradd -m -s /bin/bash {sandbox_user}` if not exists
 - **Name must match** `^[a-z_][a-z0-9_-]*$` (lowercase, underscores, hyphens)
-- **Agent cwd** changes to `/home/{sandbox_user}` (not the container's WORKDIR)
+- **Agent cwd** stays at the container's WORKDIR (e.g. `/app`); the sandbox user's home is `/home/{sandbox_user}`
 - Agent config dirs (`.claude`, `.gemini`, `.openclaw`, `.pi`, `.agents`, `.codex`) are copied from root
 - Install runs as root, agent runs as sandbox_user via gosu
 - Custom agents: must support ACP — see [ACP spec](https://agentclientprotocol.com/)

--- a/src/benchflow/_models.py
+++ b/src/benchflow/_models.py
@@ -54,6 +54,8 @@ class RunResult:
         n_tool_calls: Total tool calls observed during the session.
         n_prompts:    Number of user prompts sent to the agent.
         error:        Error description string, or None on success.
+        verifier_error: Verifier error description, or None if verifier succeeded
+                      or was not reached. Separate from ``error`` (agent errors).
         started_at:   Wall-clock start time.
         finished_at:  Wall-clock end time.
     """
@@ -70,6 +72,7 @@ class RunResult:
         n_tool_calls: int = 0,
         n_prompts: int = 0,
         error: str | None = None,
+        verifier_error: str | None = None,
         started_at: datetime | None = None,
         finished_at: datetime | None = None,
     ):
@@ -83,16 +86,21 @@ class RunResult:
         self.n_tool_calls = n_tool_calls
         self.n_prompts = n_prompts
         self.error = error
+        self.verifier_error = verifier_error
         self.started_at = started_at
         self.finished_at = finished_at
 
     @property
     def success(self) -> bool:
-        """True when the trial completed without error (rewards may still be zero)."""
-        return self.error is None
+        """True when the trial completed without agent or verifier error.
+
+        Agent errors (error) and verifier errors (verifier_error) both
+        indicate an incomplete trial. Rewards may still be zero on success.
+        """
+        return self.error is None and self.verifier_error is None
 
     def __repr__(self) -> str:
-        status = "OK" if self.success else f"ERROR: {self.error}"
+        status = "OK" if self.success else f"ERROR: {self.error or self.verifier_error}"
         return (
             f"RunResult(task={self.task_name}, {status}, "
             f"rewards={self.rewards}, "

--- a/src/benchflow/_models.py
+++ b/src/benchflow/_models.py
@@ -73,6 +73,8 @@ class RunResult:
         n_prompts: int = 0,
         error: str | None = None,
         verifier_error: str | None = None,
+        partial_trajectory: bool = False,
+        trajectory_source: str | None = None,
         started_at: datetime | None = None,
         finished_at: datetime | None = None,
     ):
@@ -87,6 +89,8 @@ class RunResult:
         self.n_prompts = n_prompts
         self.error = error
         self.verifier_error = verifier_error
+        self.partial_trajectory = partial_trajectory
+        self.trajectory_source = trajectory_source
         self.started_at = started_at
         self.finished_at = finished_at
 

--- a/src/benchflow/_scoring.py
+++ b/src/benchflow/_scoring.py
@@ -6,6 +6,10 @@ PIPE_CLOSED = "pipe_closed"
 ACP_ERROR = "acp_error"
 TIMED_OUT = "timeout"
 
+# Verifier error category constants
+VERIFIER_FAILED = "verifier_failure"
+VERIFIER_TIMEOUT = "verifier_timeout"
+
 
 def extract_reward(result: dict) -> float | None:
     """Extract the reward value from a result dict, or None if absent."""
@@ -28,6 +32,17 @@ def classify_error(error: str | None) -> str | None:
     if "timed out" in error:
         return TIMED_OUT
     return "other"
+
+
+def classify_verifier_error(verifier_error: str | None) -> str | None:
+    """Classify a verifier error string, or None if no error."""
+    if not verifier_error:
+        return None
+    if "verifier crashed" in verifier_error:
+        return VERIFIER_FAILED
+    if "verifier timed out" in verifier_error:
+        return VERIFIER_TIMEOUT
+    return "verifier_other"
 
 
 def pass_rate(*, passed: int, total: int) -> float:

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -80,6 +80,11 @@ class AgentConfig:
     skill_paths: list[str] = field(default_factory=list)
     install_timeout: int = 900  # seconds
     default_model: str = ""  # default model ID when --model is omitted
+    api_protocol: str = ""
+    # The LLM API protocol the agent natively speaks:
+    # "anthropic-messages" | "openai-completions" | "" (runtime/native).
+    # Used to pick the correct provider endpoint when a provider exposes
+    # multiple (e.g. zai has both anthropic-messages and openai-completions).
     env_mapping: dict[str, str] = field(default_factory=dict)
     # Maps BENCHFLOW_PROVIDER_* → agent-native env var names.
     # Applied by SDK after provider resolution.
@@ -108,6 +113,7 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd="claude-agent-acp",
         protocol="acp",
         requires_env=["ANTHROPIC_API_KEY"],
+        api_protocol="anthropic-messages",
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "ANTHROPIC_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY": "ANTHROPIC_AUTH_TOKEN",
@@ -136,6 +142,7 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd="pi-acp",
         protocol="acp",
         requires_env=["ANTHROPIC_API_KEY"],
+        api_protocol="anthropic-messages",
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "ANTHROPIC_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY": "ANTHROPIC_AUTH_TOKEN",
@@ -182,6 +189,7 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd="codex-acp",
         protocol="acp",
         requires_env=["OPENAI_API_KEY"],
+        api_protocol="openai-completions",
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "OPENAI_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY": "OPENAI_API_KEY",
@@ -214,6 +222,10 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd="gemini --acp",
         protocol="acp",
         requires_env=["GOOGLE_API_KEY"],
+        # api_protocol intentionally empty: Gemini speaks Google's native
+        # GenerateContent format, which no current PROVIDERS entry exposes as
+        # a multi-endpoint option. Set this when a Gemini-compatible provider
+        # with multiple endpoints (e.g. OpenRouter) is added.
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "GEMINI_API_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY": "GOOGLE_API_KEY",

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -56,6 +56,10 @@ def run(
         Path | None,
         typer.Option("--skills-dir", "-s", help="Skills directory to deploy into sandbox"),
     ] = None,
+    sandbox_user: Annotated[
+        str | None,
+        typer.Option("--sandbox-user", help="Run agent as non-root user (default: 'agent'). Pass 'none' for root."),
+    ] = "agent",
 ) -> None:
     """Run a single task with an ACP agent."""
     from benchflow.sdk import SDK
@@ -79,6 +83,7 @@ def run(
             jobs_dir=jobs_dir,
             environment=environment,
             skills_dir=str(skills_dir) if skills_dir else None,
+            sandbox_user=sandbox_user,
         )
     )
 

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -76,7 +76,8 @@ class JobConfig:
     agent_env: dict[str, str] = field(default_factory=dict)
     retry: RetryConfig = field(default_factory=RetryConfig)
     skills_dir: str | None = None
-    sandbox_user: str | None = None
+    sandbox_user: str | None = "agent"
+    sandbox_locked_paths: list[str] | None = None
     context_root: str | None = None
     exclude_tasks: set[str] = field(default_factory=set)
 
@@ -199,7 +200,8 @@ class Job:
 
         agent_env_raw = raw.get("agent_env", {})
         exclude = set(raw.get("exclude", []))
-        sandbox_user = raw.get("sandbox_user")
+        sandbox_user = raw.get("sandbox_user", "agent")
+        sandbox_locked_paths = raw.get("sandbox_locked_paths")
 
         config = JobConfig(
             agent=raw.get("agent", DEFAULT_AGENT),
@@ -211,6 +213,7 @@ class Job:
             retry=RetryConfig(max_retries=raw.get("max_retries", 2)),
             skills_dir=str(base_dir / raw["skills_dir"]) if raw.get("skills_dir") else None,
             sandbox_user=sandbox_user,
+            sandbox_locked_paths=sandbox_locked_paths,
             exclude_tasks=exclude,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
@@ -256,6 +259,8 @@ class Job:
         # Skills dir (shared with benchflow-native format)
         skills_dir_raw = raw.get("skills_dir")
         skills_dir = str(base_dir / skills_dir_raw) if skills_dir_raw else None
+        sandbox_user = raw.get("sandbox_user", "agent")
+        sandbox_locked_paths = raw.get("sandbox_locked_paths")
 
         config = JobConfig(
             agent=agent_name,
@@ -265,6 +270,8 @@ class Job:
             agent_env=agent_env,
             retry=RetryConfig(max_retries=max(0, max_retries)),
             skills_dir=skills_dir,
+            sandbox_user=sandbox_user,
+            sandbox_locked_paths=sandbox_locked_paths,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -320,6 +327,7 @@ class Job:
                 environment=cfg.environment,
                 skills_dir=cfg.skills_dir,
                 sandbox_user=cfg.sandbox_user,
+                sandbox_locked_paths=cfg.sandbox_locked_paths,
                 context_root=cfg.context_root,
             )
             last_result = result

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -100,6 +100,7 @@ class JobResult:
     passed: int = 0
     failed: int = 0
     errored: int = 0
+    verifier_errored: int = 0
     elapsed_sec: float = 0.0
 
     @property
@@ -276,13 +277,15 @@ class Job:
         )
 
     def _get_completed_tasks(self) -> dict[str, dict]:
-        """Load tasks that already have results with rewards."""
+        """Load tasks that already have results with rewards or verifier errors."""
         completed = {}
         for rfile in self._jobs_dir.rglob("result.json"):
             try:
                 r = json.loads(rfile.read_text())
                 task = r["task_name"]
-                if r.get("rewards") is not None:
+                if r.get("rewards") is not None or r.get("verifier_error"):
+                    if r.get("verifier_error"):
+                        logger.info(f"Skipping verifier-errored task on resume: {task} ({r['verifier_error'][:80]})")
                     completed[task] = r
             except Exception as e:
                 logger.debug(f"Skipping corrupt result file {rfile}: {e}")
@@ -321,8 +324,8 @@ class Job:
             )
             last_result = result
 
-            # If succeeded or non-retryable error, return
-            if result.rewards is not None or not cfg.retry.should_retry(result.error):
+            # If succeeded, verifier-errored (terminal), or non-retryable, stop
+            if result.rewards is not None or result.verifier_error or not cfg.retry.should_retry(result.error):
                 break
 
             if attempt <= cfg.retry.max_retries:
@@ -378,7 +381,8 @@ class Job:
                 # Log result
                 reward = result.rewards.get("reward") if result.rewards else None
                 status = "PASS" if reward == 1 else ("FAIL" if reward is not None else "ERR")
-                err = f" ({result.error[:50]})" if result.error else ""
+                err_msg = result.error or result.verifier_error
+                err = f" ({err_msg[:50]})" if err_msg else ""
                 logger.info(f"[{status}] {td.name} (tools={result.n_tool_calls}){err}")
                 if self._on_result:
                     self._on_result(td.name, result)
@@ -411,6 +415,7 @@ class Job:
                 "task_name": result.task_name,
                 "rewards": result.rewards,
                 "error": result.error,
+                "verifier_error": result.verifier_error,
                 "n_tool_calls": result.n_tool_calls,
             }
 
@@ -424,7 +429,14 @@ class Job:
                        if extract_reward(r) is not None and extract_reward(r) != 1.0),
             errored=sum(1 for r in all_results.values()
                         if r.get("error") and r.get("rewards") is None),
+            verifier_errored=sum(1 for r in all_results.values()
+                                if r.get("verifier_error")),
             elapsed_sec=elapsed,
+        )
+
+        assert job_result.passed + job_result.failed + job_result.errored + job_result.verifier_errored == job_result.total, (
+            f"Counting bug: {job_result.passed}+{job_result.failed}+{job_result.errored}+"
+            f"{job_result.verifier_errored} != {job_result.total}"
         )
 
         # Save summary
@@ -437,11 +449,24 @@ class Job:
             "passed": job_result.passed,
             "failed": job_result.failed,
             "errored": job_result.errored,
+            "verifier_errored": job_result.verifier_errored,
             "score": f"{job_result.score:.1%}",
             "score_excl_errors": f"{job_result.score_excl_errors:.1%}",
             "elapsed_sec": elapsed,
         }
         (self._jobs_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+
+        if job_result.verifier_errored > 0:
+            pct = job_result.verifier_errored / job_result.total * 100
+            logger.warning(
+                f"{job_result.verifier_errored} tasks ({pct:.0f}%) had verifier errors — "
+                f"check verifier scripts for bugs"
+            )
+            if pct > 20:
+                logger.error(
+                    "Over 20% of tasks had verifier errors — results may be unreliable. "
+                    "This likely indicates a systemic verifier bug, not agent failure."
+                )
 
         logger.info(
             f"Job complete: {job_result.passed}/{job_result.total} "

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from benchflow._scoring import classify_error, pass_rate, pass_rate_excl_errors
+from benchflow._scoring import classify_error, classify_verifier_error, pass_rate, pass_rate_excl_errors
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +24,7 @@ class TaskMetrics:
     n_tool_calls: int = 0
     n_prompts: int = 0
     error: str | None = None
+    verifier_error: str | None = None
     duration_sec: float = 0.0
     agent_name: str = ""
 
@@ -38,6 +39,11 @@ class TaskMetrics:
     @property
     def errored(self) -> bool:
         return self.reward is None and self.error is not None
+
+    @property
+    def verifier_errored(self) -> bool:
+        """True when task failed due to verifier error (not agent error)."""
+        return self.reward is None and self.verifier_error is not None
 
 
 @dataclass
@@ -66,6 +72,11 @@ class BenchmarkMetrics:
         return sum(1 for t in self.tasks if t.errored)
 
     @property
+    def verifier_errored(self) -> int:
+        """Count of tasks that failed due to verifier error."""
+        return sum(1 for t in self.tasks if t.verifier_errored)
+
+    @property
     def score(self) -> float:
         """Pass rate over all tasks."""
         return pass_rate(passed=self.passed, total=self.total)
@@ -78,13 +89,13 @@ class BenchmarkMetrics:
     @property
     def avg_tool_calls(self) -> float:
         """Average tool calls per completed task."""
-        completed = [t for t in self.tasks if not t.errored]
+        completed = [t for t in self.tasks if not t.errored and not t.verifier_errored]
         return sum(t.n_tool_calls for t in completed) / len(completed) if completed else 0.0
 
     @property
     def avg_duration(self) -> float:
         """Average duration per completed task (seconds)."""
-        completed = [t for t in self.tasks if not t.errored and t.duration_sec > 0]
+        completed = [t for t in self.tasks if not t.errored and not t.verifier_errored and t.duration_sec > 0]
         return sum(t.duration_sec for t in completed) / len(completed) if completed else 0.0
 
     @property
@@ -99,6 +110,18 @@ class BenchmarkMetrics:
                 breakdown[category] = breakdown.get(category, 0) + 1
         return breakdown
 
+    @property
+    def verifier_error_breakdown(self) -> dict[str, int]:
+        """Categorize verifier errors."""
+        breakdown: dict[str, int] = {}
+        for t in self.tasks:
+            if not t.verifier_errored:
+                continue
+            category = classify_verifier_error(t.verifier_error)
+            if category:
+                breakdown[category] = breakdown.get(category, 0) + 1
+        return breakdown
+
     def summary(self) -> dict[str, Any]:
         """Export as summary dict."""
         return {
@@ -109,14 +132,17 @@ class BenchmarkMetrics:
             "passed": self.passed,
             "failed": self.failed,
             "errored": self.errored,
+            "verifier_errored": self.verifier_errored,
             "score": f"{self.score:.1%}",
             "score_excl_errors": f"{self.score_excl_errors:.1%}",
             "avg_tool_calls": round(self.avg_tool_calls, 1),
             "avg_duration_sec": round(self.avg_duration, 1),
             "error_breakdown": self.error_breakdown,
+            "verifier_error_breakdown": self.verifier_error_breakdown,
             "passed_tasks": sorted(t.task_name for t in self.tasks if t.passed),
             "failed_tasks": sorted(t.task_name for t in self.tasks if t.failed),
             "errored_tasks": sorted(t.task_name for t in self.tasks if t.errored),
+            "verifier_errored_tasks": sorted(t.task_name for t in self.tasks if t.verifier_errored),
         }
 
 
@@ -169,6 +195,7 @@ def collect_metrics(
             n_tool_calls=r.get("n_tool_calls", 0),
             n_prompts=r.get("n_prompts", 0),
             error=r.get("error"),
+            verifier_error=r.get("verifier_error"),
             duration_sec=duration,
             agent_name=r.get("agent_name", ""),
         ))

--- a/src/benchflow/process.py
+++ b/src/benchflow/process.py
@@ -87,16 +87,20 @@ class LiveProcess(ABC):
         await self._process.stdin.drain()
 
     async def close(self) -> None:
-        """Terminate the process."""
+        """Terminate the process (idempotent — safe to call after process death)."""
         if self._process:
             if self._process.stdin:
-                self._process.stdin.close()
-            self._process.terminate()
-            try:
-                await asyncio.wait_for(self._process.wait(), timeout=5)
-            except asyncio.TimeoutError:
-                self._process.kill()
-                await self._process.wait()
+                try:
+                    self._process.stdin.close()
+                except OSError:
+                    pass  # already closed
+            if self._process.returncode is None:
+                self._process.terminate()
+                try:
+                    await asyncio.wait_for(self._process.wait(), timeout=5)
+                except asyncio.TimeoutError:
+                    self._process.kill()
+                    await self._process.wait()
             logger.info("Process terminated")
 
     @property

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -359,6 +359,7 @@ class SDK:
         verifier_error: str | None,
         trajectory: list[dict],
         partial_trajectory: bool,
+        trajectory_source: str | None = None,
         rewards: dict | None,
         started_at: datetime,
         timing: dict[str, float],
@@ -376,6 +377,8 @@ class SDK:
             n_prompts=len(prompts),
             error=error,
             verifier_error=verifier_error,
+            partial_trajectory=partial_trajectory,
+            trajectory_source=trajectory_source,
             started_at=started_at,
             finished_at=datetime.now(),
         )
@@ -403,7 +406,8 @@ class SDK:
                     "n_prompts": result.n_prompts,
                     "error": result.error,
                     "verifier_error": result.verifier_error,
-                    "partial_trajectory": partial_trajectory,
+                    "partial_trajectory": result.partial_trajectory,
+                    "trajectory_source": result.trajectory_source,
                     "started_at": str(result.started_at),
                     "finished_at": str(result.finished_at),
                     "timing": timing,
@@ -620,9 +624,60 @@ class SDK:
         trajectory = _capture_session_trajectory(session)
         return trajectory, len(session.tool_calls)
 
+    # Trusted env vars for verifier execution — override any agent pollution
+    _VERIFIER_ENV = {
+        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "PYTEST_ADDOPTS": "--rootdir=/tests -p no:cacheprovider",
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "PYTHONPATH": "",
+        "PYTHONHOME": "",
+    }
+
+    # Cleanup command for pytest hook / Python startup injection.
+    # Removes conftest.py outside /tests, sitecustomize.py/usercustomize.py
+    # and .pth files from writable sys.path entries (preserves /usr/lib,
+    # /usr/local/lib).
+    _CLEANUP_CMD = (
+        "find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete 2>/dev/null; "
+        'python3 -c "'
+        "import sys,os;"
+        "[os.remove(os.path.join(d,f)) "
+        " for d in sys.path "
+        " for f in ('sitecustomize.py','usercustomize.py') "
+        " if d and not d.startswith('/usr/lib') and not d.startswith('/usr/local/lib') "
+        " and os.path.isfile(os.path.join(d,f))];"
+        "[os.remove(os.path.join(d,f)) "
+        " for d in sys.path if d and os.path.isdir(d) "
+        " for f in os.listdir(d) if f.endswith('.pth') "
+        " and not d.startswith('/usr/lib') and not d.startswith('/usr/local/lib') "
+        " and os.path.isfile(os.path.join(d,f))]"
+        '" 2>/dev/null || true'
+    )
+
+    async def _harden_before_verify(self, env, task: "Task", sandbox_user: str | None) -> None:
+        """Neutralize agent tampering before running the verifier.
+
+        1. Kill sandbox-user processes (prevent concurrent writes).
+        2. Remove injected conftest.py, sitecustomize.py, .pth files.
+        3. Merge trusted env vars into task.config.verifier.env.
+        """
+        if sandbox_user:
+            await env.exec(
+                f"pkill -u {sandbox_user} 2>/dev/null; "
+                f"sleep 1; pkill -9 -u {sandbox_user} 2>/dev/null || true",
+                timeout_sec=10,
+            )
+        await env.exec(self._CLEANUP_CMD, timeout_sec=10)
+
+        verifier_env = dict(self._VERIFIER_ENV)
+        if task.config.verifier.env:
+            verifier_env.update(task.config.verifier.env)
+        task.config.verifier.env = verifier_env
+
     async def _verify(self, env, task: "Task", trial_paths: "TrialPaths", timing: dict, sandbox_user: str | None = None) -> tuple[dict | None, str | None]:
-        """Run verifier and return (rewards, verifier_error)."""
+        """Run verifier with pre-verification hardening."""
         trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
+        await self._harden_before_verify(env, task, sandbox_user)
         logger.info("Running verifier...")
         t0 = datetime.now()
         verifier_error = None
@@ -718,6 +773,7 @@ class SDK:
         acp_client: ACPClient | None = None
         trajectory: list[dict] = []
         partial_trajectory = False
+        trajectory_source: str | None = None
         agent_name = ""
         n_tool_calls = 0
         error = None
@@ -763,6 +819,7 @@ class SDK:
                 trajectory, n_tool_calls = await self._execute_prompts(
                     acp_client, session, prompts, timeout,
                 )
+                trajectory_source = "acp"
 
             if agent != "oracle" and "agent_setup" not in timing:
                 timing["agent_setup"] = (datetime.now() - t_agent_setup).total_seconds()
@@ -776,8 +833,13 @@ class SDK:
                 scraped = await _scrape_agent_trajectory(env, agent, sandbox_user)
                 if scraped:
                     trajectory = scraped
-                    n_tool_calls = sum(1 for e in trajectory if e.get("type") == "tool_call")
-                    logger.info(f"Scraped {len(trajectory)} events from agent-native trajectory")
+                    trajectory_source = "scraped"
+                    # Do NOT overwrite n_tool_calls — keep ACP-sourced value (trusted).
+                    # Scraped trajectory is agent-writable and forgeable.
+                    logger.warning(
+                        f"Using scraped trajectory ({len(scraped)} events) from "
+                        f"agent-writable directory — data is UNTRUSTED"
+                    )
 
             rewards, verifier_error = await self._verify(env, task, trial_paths, timing, sandbox_user=sandbox_user)
 
@@ -795,9 +857,10 @@ class SDK:
             if not trajectory and acp_client:
                 try:
                     trajectory = _capture_session_trajectory(acp_client.session)
-                    n_tool_calls = sum(1 for e in trajectory if e.get("type") == "tool_call")
                     if trajectory:
                         partial_trajectory = True
+                        trajectory_source = "partial_acp"
+                        n_tool_calls = len(acp_client.session.tool_calls)
                         logger.info(f"Captured {len(trajectory)} partial trajectory events")
                 except Exception as e:
                     logger.warning(f"Partial trajectory capture failed: {e}")
@@ -825,6 +888,7 @@ class SDK:
             verifier_error=verifier_error,
             trajectory=trajectory,
             partial_trajectory=partial_trajectory,
+            trajectory_source=trajectory_source,
             rewards=rewards,
             started_at=started_at,
             timing=timing,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -279,16 +279,25 @@ class SDK:
         """Detect provider for model, inject BENCHFLOW_PROVIDER_* and env_mapping."""
         from benchflow.agents.providers import find_provider, resolve_base_url, strip_provider_prefix
         agent_env.setdefault("BENCHFLOW_PROVIDER_MODEL", strip_provider_prefix(model))
+        agent_cfg = AGENTS.get(agent)
+        # Agent-declared protocol takes precedence over provider's primary so
+        # multi-endpoint providers (e.g. zai) route to the right URL.
+        agent_protocol = agent_cfg.api_protocol if agent_cfg else ""
         _prov = find_provider(model)
         if _prov:
             _prov_name, _prov_cfg = _prov
             agent_env.setdefault("BENCHFLOW_PROVIDER_NAME", _prov_name)
             try:
-                agent_env.setdefault("BENCHFLOW_PROVIDER_BASE_URL",
-                                     resolve_base_url(_prov_cfg, agent_env))
+                agent_env.setdefault(
+                    "BENCHFLOW_PROVIDER_BASE_URL",
+                    resolve_base_url(_prov_cfg, agent_env, protocol=agent_protocol or None),
+                )
             except KeyError:
                 pass  # URL params missing — will fail later with clear error
-            agent_env.setdefault("BENCHFLOW_PROVIDER_PROTOCOL", _prov_cfg.api_protocol)
+            agent_env.setdefault(
+                "BENCHFLOW_PROVIDER_PROTOCOL",
+                agent_protocol or _prov_cfg.api_protocol,
+            )
             if _prov_cfg.models:
                 agent_env.setdefault("BENCHFLOW_PROVIDER_MODELS",
                                      json.dumps(_prov_cfg.models))
@@ -297,7 +306,6 @@ class SDK:
                 if _key:
                     agent_env.setdefault("BENCHFLOW_PROVIDER_API_KEY", _key)
         # Apply agent env_mapping: translate BENCHFLOW_PROVIDER_* → agent-native vars
-        agent_cfg = AGENTS.get(agent)
         if agent_cfg and agent_cfg.env_mapping:
             for src, dst in agent_cfg.env_mapping.items():
                 if src in agent_env:

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -730,13 +730,31 @@ class SDK:
         trajectory = _capture_session_trajectory(session)
         return trajectory, len(session.tool_calls)
 
-    # Trusted env vars for verifier execution — override any agent pollution
+    # Trusted env vars for verifier execution — override any agent pollution.
+    #
+    # PYTEST_DISABLE_PLUGIN_AUTOLOAD intentionally omitted: would break ~94
+    # SkillsBench tasks that rely on pytest-json-ctrf's --ctrf flag. Entry-point
+    # plugin injection is already blocked by verifier-runs-as-root + system
+    # site-packages permissions + the .pth cleanup in _CLEANUP_CMD.
+    #
+    # PYTHONNOUSERSITE intentionally omitted: verifier runs as root, so the
+    # only user-site dir on sys.path is /root/.local which sandbox_user cannot
+    # touch, and _CLEANUP_CMD already wipes .pth files there as belt-and-braces.
     _VERIFIER_ENV = {
         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "PYTEST_ADDOPTS": "--rootdir=/tests -p no:cacheprovider",
+        "PYTEST_ADDOPTS": (
+            "-c /dev/null "          # block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
+            "--confcutdir=/tests "   # block conftest.py walk-up beyond /tests
+            "--rootdir=/tests "
+            "-p no:cacheprovider"
+        ),
         "PYTHONDONTWRITEBYTECODE": "1",
         "PYTHONPATH": "",
         "PYTHONHOME": "",
+        "PYTHONSTARTUP": "",
+        "PYTHONSAFEPATH": "1",       # drop implicit '' (cwd) from sys.path
+        "LD_PRELOAD": "",
+        "LD_LIBRARY_PATH": "",
     }
 
     # Cleanup command for pytest hook / Python startup injection.

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -49,6 +49,55 @@ logger = logging.getLogger(__name__)
 
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stdout/stderr in logs
 
+# Path lockdown defaults and validation
+_DEFAULT_LOCKED = ["/solution", "/tests"]
+_SAFE_PATH_RE = re.compile(r"^/[a-zA-Z0-9_./*?\-]+(/[a-zA-Z0-9_./*?\-]+)*$")
+
+
+def _validate_locked_path(p: str) -> None:
+    """Validate a locked path — reject injection and traversal."""
+    p_norm = os.path.normpath(p)
+    if p_norm != p:
+        raise ValueError(
+            f"Invalid locked path {p!r}: normalizes to {p_norm!r} — "
+            f"use the normalized form directly"
+        )
+    if any(c == ".." for c in p.split("/")):
+        raise ValueError(f"Invalid locked path {p!r}: '..' component not allowed")
+    if not _SAFE_PATH_RE.match(p):
+        raise ValueError(
+            f"Invalid locked path {p!r}: must be absolute, "
+            f"alphanumeric with /-_.*? only"
+        )
+    if p.endswith("/") and p != "/":
+        raise ValueError(
+            f"Invalid locked path {p!r}: trailing slash not allowed "
+            f"(chown on '/dir/' may have unintended scope)"
+        )
+
+
+def _resolve_locked_paths(
+    sandbox_user: str | None,
+    sandbox_locked_paths: list[str] | None,
+) -> list[str]:
+    """Resolve effective locked paths.
+
+    - sandbox_user=None → [] (no lockdown)
+    - sandbox_user set, paths=None → defaults (/solution, /tests)
+    - sandbox_user set, paths=[] → [] (explicit opt-out)
+    - sandbox_user set, paths=[...] → union of defaults + caller paths
+    """
+    if not sandbox_user:
+        if sandbox_locked_paths:
+            raise ValueError("sandbox_locked_paths requires sandbox_user")
+        return []
+    if sandbox_locked_paths is None:
+        return list(_DEFAULT_LOCKED)
+    if not sandbox_locked_paths:
+        return []  # explicit opt-out
+    return list(dict.fromkeys(_DEFAULT_LOCKED + sandbox_locked_paths))
+
+
 # Apply DinD patch once at import time
 _patch_harbor_dind()
 
@@ -320,6 +369,7 @@ class SDK:
         skills_dir: str | Path | None,
         sandbox_user: str | None,
         context_root: str | Path | None,
+        sandbox_locked_paths: list[str] | None = None,
         timeout: int,
         started_at: datetime,
         agent_env: dict[str, str],
@@ -337,6 +387,7 @@ class SDK:
             "environment": environment,
             "skills_dir": str(skills_dir) if skills_dir else None,
             "sandbox_user": sandbox_user,
+            "sandbox_locked_paths": sandbox_locked_paths,
             "context_root": str(context_root) if context_root else None,
             "timeout_sec": timeout,
             "started_at": str(started_at),
@@ -529,13 +580,60 @@ class SDK:
             parts = []
             for sp in agent_cfg.skill_paths:
                 expanded = sp.replace("$HOME", home).replace("$WORKSPACE", agent_cwd)
-                parts.append(f"mkdir -p '{expanded}' && cp -r '{effective_skills}'/. '{expanded}'/ 2>/dev/null")
+                q_expanded = shlex.quote(expanded)
+                q_skills = shlex.quote(effective_skills)
+                parts.append(f"mkdir -p {q_expanded} && cp -r {q_skills}/. {q_expanded}/ 2>/dev/null")
             if parts:
                 await env.exec("; ".join(parts), timeout_sec=15)
                 logger.info(f"Skills distributed to {len(parts)} paths for {agent_cfg.name}")
 
-    async def _setup_sandbox_user(self, env, sandbox_user: str) -> str:
-        """Create non-root sandbox user and copy agent configs. Return agent_cwd."""
+    @staticmethod
+    def _build_priv_drop_cmd(agent_launch: str, sandbox_user: str) -> str:
+        """Build a shell command that drops to sandbox_user via setpriv or su.
+
+        setpriv (util-linux, Debian/Ubuntu) execs directly with no parent process.
+        su -l is the universal fallback (works on Alpine/BusyBox too).
+        No outer sh -c wrapper — DockerProcess wraps in bash -c already.
+        """
+        inner = f"export HOME=/home/{sandbox_user} && cd /home/{sandbox_user} && {agent_launch}"
+        quoted = shlex.quote(inner)
+        return (
+            f"if setpriv --help 2>&1 | grep -q reuid; then"
+            f" exec setpriv --reuid={sandbox_user} --regid={sandbox_user}"
+            f" --init-groups -- bash -c {quoted};"
+            f" else exec su -l {sandbox_user} -c {quoted};"
+            f" fi"
+        )
+
+    @staticmethod
+    async def _lockdown_paths(env, paths: list[str]) -> None:
+        """Lock directories so the sandbox user cannot access them.
+
+        Runs after all root-level setup but before agent launch.
+        Uses chown-then-chmod ordering to prevent TOCTOU window.
+        Rejects symlinks and validates path patterns against injection.
+        """
+        if not paths:
+            return
+
+        for p in paths:
+            _validate_locked_path(p)
+
+        # Build shell command: reject symlinks, chown before chmod
+        parts = []
+        for p in paths:
+            parts.append(
+                f'for d in {p}; do '
+                f'  [ -L "$d" ] && echo "WARN: skipping symlink $d" >&2 && continue; '
+                f'  [ -e "$d" ] || continue; '
+                f'  chown root:root "$d" && chmod 700 "$d"; '
+                f'done'
+            )
+        cmd = " && ".join(parts)
+        await env.exec(cmd, timeout_sec=30)
+
+    async def _setup_sandbox_user(self, env, sandbox_user: str, workspace: str) -> str:
+        """Create non-root sandbox user, grant workspace access. Return agent_cwd."""
         if not re.match(r'^[a-z_][a-z0-9_-]*$', sandbox_user):
             raise ValueError(f"Invalid sandbox_user: {sandbox_user!r} (must be alphanumeric)")
         logger.info(f"Setting up sandbox user: {sandbox_user}")
@@ -550,11 +648,12 @@ class SDK:
             f"for d in {' '.join(sorted(get_sandbox_home_dirs()))}; do "
             f"if [ -d /root/$d ]; then mkdir -p /home/{sandbox_user}/$d && "
             f"cp -a /root/$d/. /home/{sandbox_user}/$d/ 2>/dev/null || true; fi; done && "
-            f"chown -R {sandbox_user}:{sandbox_user} /home/{sandbox_user}",
+            f"chown -R {sandbox_user}:{sandbox_user} /home/{sandbox_user} && "
+            f"chown -R {sandbox_user}:{sandbox_user} {shlex.quote(workspace)}",
             timeout_sec=30,
         )
-        logger.info(f"Sandbox user {sandbox_user} ready")
-        return f"/home/{sandbox_user}"
+        logger.info(f"Sandbox user {sandbox_user} ready (workspace={workspace})")
+        return workspace
 
     async def _connect_acp(
         self, env, agent: str, agent_launch: str, agent_env: dict,
@@ -573,8 +672,7 @@ class SDK:
                 logger.info(f"Resolved agent path: {agent_launch}")
 
         if sandbox_user:
-            inner = f"export HOME=/home/{sandbox_user} && cd /home/{sandbox_user} && {agent_launch}"
-            agent_launch = f"gosu {sandbox_user} bash -c {shlex.quote(inner)}"
+            agent_launch = self._build_priv_drop_cmd(agent_launch, sandbox_user)
             logger.info(f"Agent sandboxed as: {sandbox_user}")
 
         if environment == "docker":
@@ -717,7 +815,8 @@ class SDK:
         jobs_dir: str | Path = "jobs",
         environment: str = "docker",
         skills_dir: str | Path | None = None,
-        sandbox_user: str | None = None,
+        sandbox_user: str | None = "agent",
+        sandbox_locked_paths: list[str] | None = None,
         pre_agent_hooks: list | None = None,
         context_root: str | Path | None = None,
     ) -> RunResult:
@@ -735,8 +834,9 @@ class SDK:
             environment: Environment type — "docker" or "daytona".
             skills_dir: Path to skills directory. Copied into sandbox and symlinked
                 to agent-specific discovery paths (e.g. ~/.claude/skills/).
-            sandbox_user: Run agent as this non-root user (e.g. "agent"). Requires
-                gosu in the container. Setup (install) and verification run as root.
+            sandbox_user: Run agent as this non-root user (e.g. "agent"). Uses
+                setpriv (Debian/Ubuntu) or su (Alpine/others) — no external
+                dependencies. Setup (install) and verification run as root.
             pre_agent_hooks: List of async callables(env) to run after setup but
                 before agent launch. Use for starting background services, etc.
             context_root: Repo root for resolving Dockerfile COPY paths. When set,
@@ -746,6 +846,16 @@ class SDK:
         Returns:
             RunResult with rewards, trajectory, and metadata.
         """
+        if sandbox_user is None:
+            logger.warning(
+                "sandbox_user=None — agent runs as root with no path lockdown. "
+                "Root can read solution/test files. "
+                "Set sandbox_user='agent' for answer integrity."
+            )
+
+        # Resolve effective locked paths
+        effective_locked = _resolve_locked_paths(sandbox_user, sandbox_locked_paths)
+
         task_path = Path(task_path)
         task, trial_dir, trial_paths, started_at, job_name, trial_name = self._init_trial(
             task_path, job_name, trial_name, jobs_dir,
@@ -767,6 +877,7 @@ class SDK:
             trial_dir,
             task_path=task_path, agent=agent, model=model, environment=environment,
             skills_dir=skills_dir, sandbox_user=sandbox_user, context_root=context_root,
+            sandbox_locked_paths=effective_locked,
             timeout=timeout, started_at=started_at, agent_env=agent_env,
         )
 
@@ -799,15 +910,17 @@ class SDK:
                 if agent_env.get("_BENCHFLOW_SUBSCRIPTION_AUTH"):
                     await self._upload_subscription_auth(env, agent, cred_home)
 
-                # Detect working directory (overridden by sandbox user)
+                # Detect working directory (preserved when sandbox user is set)
                 cwd_result = await env.exec("pwd", timeout_sec=10)
                 agent_cwd = (cwd_result.stdout or "").strip() or "/app"
                 if sandbox_user:
-                    agent_cwd = await self._setup_sandbox_user(env, sandbox_user)
+                    agent_cwd = await self._setup_sandbox_user(env, sandbox_user, workspace=agent_cwd)
 
                 await self._deploy_skills(
                     env, task_path, skills_dir, agent_cfg, sandbox_user, agent_cwd, task,
                 )
+
+                await self._lockdown_paths(env, effective_locked)
 
                 acp_client, session, agent_name = await self._connect_acp(
                     env, agent, agent_launch, agent_env, sandbox_user,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -356,6 +356,7 @@ class SDK:
         n_tool_calls: int,
         prompts: list[str],
         error: str | None,
+        verifier_error: str | None,
         trajectory: list[dict],
         partial_trajectory: bool,
         rewards: dict | None,
@@ -374,6 +375,7 @@ class SDK:
             n_tool_calls=n_tool_calls,
             n_prompts=len(prompts),
             error=error,
+            verifier_error=verifier_error,
             started_at=started_at,
             finished_at=datetime.now(),
         )
@@ -400,6 +402,7 @@ class SDK:
                     "n_tool_calls": result.n_tool_calls,
                     "n_prompts": result.n_prompts,
                     "error": result.error,
+                    "verifier_error": result.verifier_error,
                     "partial_trajectory": partial_trajectory,
                     "started_at": str(result.started_at),
                     "finished_at": str(result.finished_at),
@@ -617,16 +620,34 @@ class SDK:
         trajectory = _capture_session_trajectory(session)
         return trajectory, len(session.tool_calls)
 
-    async def _verify(self, env, task: "Task", trial_paths: "TrialPaths", timing: dict) -> dict | None:
-        """Run verifier and return rewards."""
+    async def _verify(self, env, task: "Task", trial_paths: "TrialPaths", timing: dict, sandbox_user: str | None = None) -> tuple[dict | None, str | None]:
+        """Run verifier and return (rewards, verifier_error)."""
         trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
         logger.info("Running verifier...")
         t0 = datetime.now()
-        verifier = Verifier(task=task, trial_paths=trial_paths, environment=env)
-        verifier_result = await verifier.verify()
-        timing["verifier"] = (datetime.now() - t0).total_seconds()
-        logger.info(f"Rewards: {verifier_result.rewards}")
-        return verifier_result.rewards
+        verifier_error = None
+        try:
+            verifier = Verifier(task=task, trial_paths=trial_paths, environment=env)
+            verifier_result = await asyncio.wait_for(
+                verifier.verify(),
+                timeout=task.config.verifier.timeout_sec,
+            )
+            timing["verifier"] = (datetime.now() - t0).total_seconds()
+            rewards = verifier_result.rewards
+            logger.info(f"Rewards: {rewards}")
+        except asyncio.TimeoutError:
+            timing["verifier"] = (datetime.now() - t0).total_seconds()
+            # NOTE: these prefixes must stay in sync with classify_verifier_error() in _scoring.py
+            verifier_error = f"verifier timed out after {task.config.verifier.timeout_sec}s"
+            rewards = None
+            logger.error(verifier_error)
+        except Exception as e:
+            timing["verifier"] = (datetime.now() - t0).total_seconds()
+            # NOTE: these prefixes must stay in sync with classify_verifier_error() in _scoring.py
+            verifier_error = f"verifier crashed: {e}"
+            rewards = None
+            logger.error(verifier_error)
+        return rewards, verifier_error
 
     async def run(
         self,
@@ -700,6 +721,7 @@ class SDK:
         agent_name = ""
         n_tool_calls = 0
         error = None
+        verifier_error = None
         rewards = None
 
         try:
@@ -757,7 +779,7 @@ class SDK:
                     n_tool_calls = sum(1 for e in trajectory if e.get("type") == "tool_call")
                     logger.info(f"Scraped {len(trajectory)} events from agent-native trajectory")
 
-            rewards = await self._verify(env, task, trial_paths, timing)
+            rewards, verifier_error = await self._verify(env, task, trial_paths, timing, sandbox_user=sandbox_user)
 
         except asyncio.TimeoutError:
             error = f"Agent timed out after {timeout}s"
@@ -800,6 +822,7 @@ class SDK:
             n_tool_calls=n_tool_calls,
             prompts=prompts,
             error=error,
+            verifier_error=verifier_error,
             trajectory=trajectory,
             partial_trajectory=partial_trajectory,
             rewards=rewards,

--- a/tests/examples/hello-world-task/instruction.md
+++ b/tests/examples/hello-world-task/instruction.md
@@ -1,4 +1,4 @@
-Create a file at `/app/hello.txt` containing exactly:
+Create a file called `hello.txt` in the current directory containing exactly:
 
 ```
 Hello, world!

--- a/tests/examples/hello-world-task/tests/test.sh
+++ b/tests/examples/hello-world-task/tests/test.sh
@@ -3,8 +3,8 @@ set -e
 
 REWARD=0
 
-if [ -f /app/hello.txt ]; then
-    content=$(cat /app/hello.txt | tr -d '\n')
+if [ -f hello.txt ]; then
+    content=$(cat hello.txt | tr -d '\n')
     if [ "$content" = "Hello, world!" ]; then
         REWARD=1
     fi

--- a/tests/examples/test_claude.sh
+++ b/tests/examples/test_claude.sh
@@ -64,7 +64,7 @@ declare -A MODELS
 MODELS=(
   [subscription]="claude-sonnet-4-6"
   [sonnet]="anthropic-vertex/claude-sonnet-4-6"
-  [zai-glm5]="zai/glm-5"
+  [zai-glm5]="zai/glm-5.1"
 )
 
 # Extra --ae flags per model
@@ -72,7 +72,7 @@ declare -A EXTRA_ARGS
 EXTRA_ARGS=(
   [subscription]=""
   [sonnet]="--ae CLAUDE_CODE_USE_VERTEX=1 --ae GOOGLE_CLOUD_PROJECT=$PROJECT --ae GOOGLE_CLOUD_LOCATION=global"
-  [zai-glm5]="--ae ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic --ae ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY --ae BENCHFLOW_PROVIDER_MODEL=claude-sonnet-4-6"
+  [zai-glm5]="--ae ANTHROPIC_BASE_URL=https://api.z.ai/api/anthropic --ae ANTHROPIC_AUTH_TOKEN=$ZAI_API_KEY"
 )
 
 # ── Pre-flight checks ──

--- a/tests/examples/test_claude.sh
+++ b/tests/examples/test_claude.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Source .env from repo root if it exists
 if [ -f "$REPO_ROOT/.env" ]; then
@@ -25,7 +25,7 @@ if [ -f "$REPO_ROOT/.env" ]; then
   set +a
 fi
 
-TASK="examples/hello-world-task"
+TASK="$SCRIPT_DIR/hello-world-task"
 ENV="${ENV:-docker}"
 ARGS=()
 for arg in "$@"; do

--- a/tests/examples/test_codex.sh
+++ b/tests/examples/test_codex.sh
@@ -14,7 +14,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Source .env from repo root if it exists
 if [ -f "$REPO_ROOT/.env" ]; then
@@ -23,7 +23,7 @@ if [ -f "$REPO_ROOT/.env" ]; then
   set +a
 fi
 
-TASK="examples/hello-world-task"
+TASK="$SCRIPT_DIR/hello-world-task"
 ENV="${ENV:-docker}"
 ARGS=()
 for arg in "$@"; do

--- a/tests/examples/test_gemini.sh
+++ b/tests/examples/test_gemini.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Source .env from repo root if it exists
 if [ -f "$REPO_ROOT/.env" ]; then
@@ -24,7 +24,7 @@ if [ -f "$REPO_ROOT/.env" ]; then
   set +a
 fi
 
-TASK="examples/hello-world-task"
+TASK="$SCRIPT_DIR/hello-world-task"
 ENV="${ENV:-docker}"
 ARGS=()
 for arg in "$@"; do

--- a/tests/examples/test_openclaw.sh
+++ b/tests/examples/test_openclaw.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # Source .env from repo root if it exists
 if [ -f "$REPO_ROOT/.env" ]; then
@@ -24,7 +24,7 @@ if [ -f "$REPO_ROOT/.env" ]; then
   set +a
 fi
 
-TASK="examples/hello-world-task"
+TASK="$SCRIPT_DIR/hello-world-task"
 ENV="${ENV:-docker}"
 ARGS=()
 for arg in "$@"; do

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -3,7 +3,10 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from benchflow._env_setup import _inject_skills_into_dockerfile, _get_agent_skill_paths
+from benchflow._env_setup import (
+    _inject_skills_into_dockerfile,
+    _get_agent_skill_paths,
+)
 
 
 def _make_task(tmp_path: Path, dockerfile_content: str = "FROM ubuntu:22.04\n") -> Path:

--- a/tests/test_exclude_tasks.py
+++ b/tests/test_exclude_tasks.py
@@ -91,4 +91,4 @@ sandbox_user: testuser
         job = Job.from_yaml(config)
         assert job._config.exclude_tasks == set()
         assert job._config.agent_env == {}
-        assert job._config.sandbox_user is None
+        assert job._config.sandbox_user == "agent"

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -121,7 +121,7 @@ class TestResolveProviderEnv:
     def test_injects_benchflow_provider_vars(self):
         env = {"ZAI_API_KEY": "zk-test"}
         SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
-        assert "BENCHFLOW_PROVIDER_NAME" in env
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "zai"
         assert "BENCHFLOW_PROVIDER_BASE_URL" in env
         assert "BENCHFLOW_PROVIDER_PROTOCOL" in env
         assert env["BENCHFLOW_PROVIDER_API_KEY"] == "zk-test"
@@ -132,6 +132,32 @@ class TestResolveProviderEnv:
         SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
         assert "ANTHROPIC_BASE_URL" in env
         assert env["ANTHROPIC_AUTH_TOKEN"] == "zk-test"
+
+    def test_zai_picks_anthropic_endpoint_for_claude_agent(self):
+        """claude-agent-acp speaks anthropic-messages → routes to zai's anthropic endpoint."""
+        env = {"ZAI_API_KEY": "zk-test"}
+        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/anthropic"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "anthropic-messages"
+        # env_mapping translates to ANTHROPIC_BASE_URL
+        assert env["ANTHROPIC_BASE_URL"] == "https://api.z.ai/api/anthropic"
+
+    def test_zai_picks_openai_endpoint_for_codex_agent(self):
+        """codex-acp speaks openai-completions → routes to zai's openai endpoint."""
+        env = {"ZAI_API_KEY": "zk-test"}
+        SDK._resolve_provider_env(env, "zai/glm-5", "codex-acp")
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-completions"
+        assert env["OPENAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+    def test_explicit_base_url_not_overwritten(self):
+        """User-supplied ANTHROPIC_BASE_URL must win over derived value."""
+        env = {
+            "ZAI_API_KEY": "zk-test",
+            "ANTHROPIC_BASE_URL": "https://custom.example/anthropic",
+        }
+        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        assert env["ANTHROPIC_BASE_URL"] == "https://custom.example/anthropic"
 
     def test_no_provider_still_sets_model(self):
         """Model with no registered provider still sets BENCHFLOW_PROVIDER_MODEL."""

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -336,6 +336,7 @@ class TestBuildResult:
             n_tool_calls=5,
             prompts=["solve it"],
             error=None,
+            verifier_error=None,
             trajectory=[{"type": "message", "text": "hello"}],
             partial_trajectory=False,
             rewards={"score": 1.0},

--- a/tests/test_sdk_lockdown.py
+++ b/tests/test_sdk_lockdown.py
@@ -1,0 +1,265 @@
+"""Tests for path lockdown — _validate_locked_path, _resolve_locked_paths, _lockdown_paths."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from benchflow.sdk import (
+    SDK,
+    _DEFAULT_LOCKED,
+    _resolve_locked_paths,
+    _validate_locked_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# _validate_locked_path
+# ---------------------------------------------------------------------------
+
+class TestValidateLockedPath:
+    """Path validation rejects injection and traversal."""
+
+    @pytest.mark.parametrize("p", [
+        "/solution", "/tests", "/logs/verifier", "/app-foo", "/data", "/app-*",
+    ])
+    def test_valid_paths(self, p):
+        _validate_locked_path(p)  # should not raise
+
+    @pytest.mark.parametrize("bad,match", [
+        ("$(rm -rf /)", "must be absolute"),
+        ("/solution; rm -rf /", None),
+        ("/solution/`whoami`", None),
+        ("/solution/../etc", None),
+        ("/solution/./foo", "normalizes to"),
+        ("//solution//foo", None),
+        ("/solution/", None),
+        ("solution", "must be absolute"),
+        ("/solution | cat /etc/passwd", "must be absolute"),
+        ("/", None),
+    ], ids=[
+        "dollar_injection", "semicolon", "backtick",
+        "dotdot_traversal", "dot_normpath", "double_slash",
+        "trailing_slash", "relative", "pipe", "bare_root",
+    ])
+    def test_rejects_invalid(self, bad, match):
+        with pytest.raises(ValueError, match=match):
+            _validate_locked_path(bad)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_locked_paths
+# ---------------------------------------------------------------------------
+
+class TestResolveLockedPaths:
+    """Effective path resolution logic."""
+
+    def test_defaults_with_sandbox_user(self):
+        result = _resolve_locked_paths("agent", None)
+        assert result == ["/solution", "/tests"]
+
+    def test_union_with_caller_paths(self):
+        result = _resolve_locked_paths("agent", ["/data"])
+        assert result == ["/solution", "/tests", "/data"]
+
+    def test_dedup_preserves_order(self):
+        result = _resolve_locked_paths("agent", ["/solution", "/data"])
+        assert result == ["/solution", "/tests", "/data"]
+
+    def test_explicit_opt_out(self):
+        result = _resolve_locked_paths("agent", [])
+        assert result == []
+
+    def test_no_sandbox_user_returns_empty(self):
+        assert _resolve_locked_paths(None, None) == []
+
+    def test_paths_without_sandbox_user_raises(self):
+        with pytest.raises(ValueError, match="requires sandbox_user"):
+            _resolve_locked_paths(None, ["/solution"])
+
+
+# ---------------------------------------------------------------------------
+# SDK._lockdown_paths
+# ---------------------------------------------------------------------------
+
+class TestLockdownPaths:
+    """_lockdown_paths sends correct commands to env."""
+
+    @pytest.fixture
+    def mock_env(self):
+        env = MagicMock()
+        env.exec = AsyncMock(return_value=MagicMock(stdout="", stderr=""))
+        return env
+
+    def _get_lockdown_cmd(self, mock_env):
+        """Extract the lockdown command (single exec call)."""
+        return mock_env.exec.call_args_list[0][0][0]
+
+    def test_noop_empty_paths(self, mock_env):
+        asyncio.run(SDK._lockdown_paths(mock_env, []))
+        mock_env.exec.assert_not_called()
+
+    def test_chown_before_chmod_and_symlink_skip(self, mock_env):
+        asyncio.run(SDK._lockdown_paths(mock_env, ["/solution"]))
+        assert mock_env.exec.call_count == 1
+        cmd = self._get_lockdown_cmd(mock_env)
+        assert cmd.index("chown root:root") < cmd.index("chmod 700")
+        assert '[ -L "$d" ]' in cmd
+
+    def test_multiple_paths(self, mock_env):
+        asyncio.run(SDK._lockdown_paths(mock_env, ["/solution", "/tests", "/data"]))
+        cmd = self._get_lockdown_cmd(mock_env)
+        for p in ["/solution", "/tests", "/data"]:
+            assert f"for d in {p}" in cmd
+
+    def test_glob_expansion(self, mock_env):
+        asyncio.run(SDK._lockdown_paths(mock_env, ["/app-*"]))
+        assert "for d in /app-*" in self._get_lockdown_cmd(mock_env)
+
+    def test_validation_rejects_bad_path(self, mock_env):
+        with pytest.raises(ValueError):
+            asyncio.run(SDK._lockdown_paths(mock_env, ["/solution/../etc"]))
+        mock_env.exec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# JobConfig YAML parsing
+# ---------------------------------------------------------------------------
+
+class TestJobConfigYAML:
+    """sandbox_locked_paths round-trips from YAML."""
+
+    def test_native_yaml_with_locked_paths(self, tmp_path):
+        yaml_content = (
+            "tasks_dir: tasks\n"
+            "sandbox_user: agent\n"
+            "sandbox_locked_paths:\n"
+            "  - /tasks\n"
+            "  - /data\n"
+        )
+        (tmp_path / "config.yaml").write_text(yaml_content)
+        (tmp_path / "tasks").mkdir()
+
+        from benchflow.job import Job
+        job = Job.from_yaml(tmp_path / "config.yaml")
+        assert job._config.sandbox_locked_paths == ["/tasks", "/data"]
+        assert job._config.sandbox_user == "agent"
+
+    def test_native_yaml_without_locked_paths(self, tmp_path):
+        yaml_content = (
+            "tasks_dir: tasks\n"
+            "sandbox_user: agent\n"
+        )
+        (tmp_path / "config.yaml").write_text(yaml_content)
+        (tmp_path / "tasks").mkdir()
+
+        from benchflow.job import Job
+        job = Job.from_yaml(tmp_path / "config.yaml")
+        assert job._config.sandbox_locked_paths is None
+
+    def test_harbor_yaml_with_locked_paths(self, tmp_path):
+        yaml_content = (
+            "agents:\n"
+            "  - name: claude-agent-acp\n"
+            "datasets:\n"
+            "  - path: tasks\n"
+            "sandbox_user: agent\n"
+            "sandbox_locked_paths:\n"
+            "  - /data\n"
+        )
+        (tmp_path / "config.yaml").write_text(yaml_content)
+        (tmp_path / "tasks").mkdir()
+
+        from benchflow.job import Job
+        job = Job.from_yaml(tmp_path / "config.yaml")
+        assert job._config.sandbox_locked_paths == ["/data"]
+        assert job._config.sandbox_user == "agent"
+
+    def test_native_yaml_sandbox_user_defaults_to_agent(self, tmp_path):
+        yaml_content = "tasks_dir: tasks\n"
+        (tmp_path / "config.yaml").write_text(yaml_content)
+        (tmp_path / "tasks").mkdir()
+
+        from benchflow.job import Job
+        job = Job.from_yaml(tmp_path / "config.yaml")
+        assert job._config.sandbox_user == "agent"
+
+
+# ---------------------------------------------------------------------------
+# _write_config records locked paths
+# ---------------------------------------------------------------------------
+
+class TestWriteConfigRecordsPaths:
+    """config.json includes effective locked paths."""
+
+    def test_config_json_includes_locked_paths(self, tmp_path):
+        import json
+
+        SDK._write_config(
+            tmp_path,
+            task_path=tmp_path / "task",
+            agent="test",
+            model=None,
+            environment="docker",
+            skills_dir=None,
+            sandbox_user="agent",
+            context_root=None,
+            sandbox_locked_paths=["/solution", "/tests"],
+            timeout=300,
+            started_at=__import__("datetime").datetime.now(),
+            agent_env={},
+        )
+        config = json.loads((tmp_path / "config.json").read_text())
+        assert config["sandbox_locked_paths"] == ["/solution", "/tests"]
+
+
+# ---------------------------------------------------------------------------
+# Sandbox user defaults and warnings
+# ---------------------------------------------------------------------------
+
+class TestSandboxUserWarnings:
+    """Default sandbox_user and root warnings."""
+
+    def test_default_is_agent(self):
+        """Default sandbox_user is 'agent', not None."""
+        import inspect
+        sig = inspect.signature(SDK.run)
+        assert sig.parameters["sandbox_user"].default == "agent"
+
+
+# ---------------------------------------------------------------------------
+# Privilege dropping command construction
+# ---------------------------------------------------------------------------
+
+class TestPrivDropCommand:
+    """SDK._build_priv_drop_cmd — setpriv/su-l command generation."""
+
+    def test_contains_setpriv_and_su_fallback(self):
+        cmd = SDK._build_priv_drop_cmd("my-agent --stdio", "agent")
+        assert "setpriv --reuid=agent --regid=agent --init-groups" in cmd
+        assert "su -l agent -c" in cmd
+
+    def test_exec_prefix(self):
+        """Both branches use exec to replace the shell (no lingering parent)."""
+        cmd = SDK._build_priv_drop_cmd("my-agent", "agent")
+        assert "exec setpriv" in cmd
+        assert "exec su" in cmd
+
+    def test_inner_command_is_shlex_quoted(self):
+        import shlex
+        cmd = SDK._build_priv_drop_cmd("agent --flag value", "agent")
+        inner = "export HOME=/home/agent && cd /home/agent && agent --flag value"
+        assert shlex.quote(inner) in cmd
+
+    def test_single_quotes_in_launch(self):
+        """Single quotes in agent_launch don't break the command."""
+        cmd = SDK._build_priv_drop_cmd("agent --prompt 'hello world'", "agent")
+        assert "hello world" in cmd
+        assert cmd.count("if ") == 1
+        assert cmd.count(" fi") == 1
+
+    def test_custom_sandbox_user(self):
+        cmd = SDK._build_priv_drop_cmd("my-agent", "bench-user")
+        assert "--reuid=bench-user" in cmd
+        assert "su -l bench-user" in cmd
+        assert "/home/bench-user" in cmd

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,6 +1,7 @@
 """Tests for verifier failure isolation — verifier_error field, retry, resume, metrics."""
 
 import asyncio
+import contextlib
 import json
 import logging
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -97,9 +98,11 @@ class TestSdkVerify:
         sdk = SDK()
         task = MagicMock()
         task.config.verifier.timeout_sec = 5
+        task.config.verifier.env = None
         tp = MagicMock()
         tp.verifier_dir = tmp_path / "verifier"
         env = MagicMock()
+        env.exec = AsyncMock(return_value=MagicMock(stdout="", stderr="", exit_code=0))
         return sdk, env, task, tp
 
     @pytest.mark.asyncio
@@ -368,3 +371,212 @@ class TestMetricsVerifierError:
 def test_task_metrics_verifier_errored(reward, error, verifier_error, expected):
     t = TaskMetrics(task_name="t", reward=reward, error=error, verifier_error=verifier_error)
     assert t.verifier_errored is expected
+
+
+# ---------------------------------------------------------------------------
+# Verifier hardening (PR 2)
+# ---------------------------------------------------------------------------
+
+class TestVerifierHardening:
+    """Pre-verification hardening: pkill, conftest cleanup, env injection."""
+
+    @pytest.fixture
+    def hardening_harness(self, tmp_path):
+        from benchflow.sdk import SDK
+        sdk = SDK()
+        task = MagicMock()
+        task.config.verifier.timeout_sec = 5
+        task.config.verifier.env = None
+        tp = MagicMock()
+        tp.verifier_dir = tmp_path / "verifier"
+        env = MagicMock()
+        env.exec = AsyncMock(return_value=MagicMock(stdout="", stderr="", exit_code=0))
+        return sdk, env, task, tp
+
+    @pytest.mark.asyncio
+    async def test_hardening_with_sandbox_user(self, hardening_harness):
+        """With sandbox_user: pkill runs first, cleanup runs, env injected."""
+        sdk, env, task, tp = hardening_harness
+        mock_v = MagicMock()
+        mock_v.verify = AsyncMock(return_value=MagicMock(rewards={"reward": 1.0}))
+        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+            await sdk._verify(env, task, tp, {}, sandbox_user="agent")
+
+        exec_cmds = [c[0][0] for c in env.exec.call_args_list]
+        # pkill is first call
+        assert "pkill -u agent" in exec_cmds[0]
+        # Cleanup runs (conftest, sitecustomize, .pth — all in one command)
+        cleanup = [c for c in exec_cmds if "conftest.py" in c]
+        assert cleanup and "sitecustomize.py" in cleanup[0] and ".pth" in cleanup[0]
+        assert "-not -path '/tests/*'" in cleanup[0]
+        # Env injection — all _VERIFIER_ENV keys present
+        injected = task.config.verifier.env
+        assert injected["PATH"] == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        assert "--rootdir=/tests" in injected["PYTEST_ADDOPTS"]
+        assert "-p no:cacheprovider" in injected["PYTEST_ADDOPTS"]
+        assert injected["PYTHONPATH"] == ""
+        assert injected["PYTHONHOME"] == ""
+        assert injected["PYTHONDONTWRITEBYTECODE"] == "1"
+
+    @pytest.mark.asyncio
+    async def test_hardening_without_sandbox_user(self, hardening_harness):
+        """Without sandbox_user: no pkill, cleanup still runs, env still injected."""
+        sdk, env, task, tp = hardening_harness
+        mock_v = MagicMock()
+        mock_v.verify = AsyncMock(return_value=MagicMock(rewards={"reward": 1.0}))
+        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+            await sdk._verify(env, task, tp, {}, sandbox_user=None)
+
+        exec_cmds = [c[0][0] for c in env.exec.call_args_list]
+        assert all("pkill" not in c for c in exec_cmds)
+        assert any("conftest.py" in c for c in exec_cmds)
+        assert task.config.verifier.env["PYTEST_ADDOPTS"] == "--rootdir=/tests -p no:cacheprovider"
+
+    @pytest.mark.asyncio
+    async def test_task_env_overrides_win(self, hardening_harness):
+        """Task-level verifier env vars override _VERIFIER_ENV defaults."""
+        sdk, env, task, tp = hardening_harness
+        task.config.verifier.env = {"PATH": "/custom/bin", "MY_VAR": "hello"}
+        mock_v = MagicMock()
+        mock_v.verify = AsyncMock(return_value=MagicMock(rewards={"reward": 1.0}))
+        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+            await sdk._verify(env, task, tp, {})
+        injected = task.config.verifier.env
+        assert injected["PATH"] == "/custom/bin"
+        assert injected["MY_VAR"] == "hello"
+        assert injected["PYTHONPATH"] == ""  # non-overridden defaults kept
+
+
+class TestTrajectorySource:
+    """trajectory_source and partial_trajectory fields in RunResult and result.json."""
+
+    def _build(self, tmp_path, **overrides):
+        from benchflow.sdk import SDK
+        from datetime import datetime
+        defaults = dict(
+            task_name="t1", trial_name="trial-1", agent="test",
+            agent_name="", model="", n_tool_calls=0, prompts=["x"],
+            error=None, verifier_error=None, trajectory=[],
+            partial_trajectory=False, trajectory_source=None,
+            rewards={"reward": 1.0},
+            started_at=datetime.now(), timing={},
+        )
+        defaults.update(overrides)
+        SDK._build_result(tmp_path, **defaults)
+        return json.loads((tmp_path / "result.json").read_text())
+
+    @pytest.mark.parametrize("source,partial,expected_source,expected_partial", [
+        ("acp", False, "acp", False),
+        ("scraped", False, "scraped", False),
+        ("partial_acp", True, "partial_acp", True),
+        (None, False, None, False),
+    ])
+    def test_trajectory_source_in_result_json(self, tmp_path, source, partial, expected_source, expected_partial):
+        data = self._build(tmp_path, trajectory_source=source, partial_trajectory=partial)
+        assert data["trajectory_source"] == expected_source
+        assert data["partial_trajectory"] == expected_partial
+
+    def test_run_result_fields_and_defaults(self):
+        r_default = RunResult(task_name="t")
+        assert r_default.trajectory_source is None
+        assert r_default.partial_trajectory is False
+
+        r_set = RunResult(task_name="t", trajectory_source="acp", partial_trajectory=True)
+        assert r_set.trajectory_source == "acp"
+        assert r_set.partial_trajectory is True
+
+
+class TestScrapedTrajectoryTrust:
+    """Scraped trajectory must NOT overwrite ACP-sourced n_tool_calls.
+
+    These tests exercise the actual SDK.run() codepath by mocking all
+    external dependencies and verifying n_tool_calls is never derived
+    from agent-writable data.
+    """
+
+    @pytest.fixture
+    def sdk_run_mocks(self, tmp_path):
+        """Mocks for SDK.run() that reach scraping/finally without real containers."""
+        from benchflow.sdk import SDK
+        sdk = SDK()
+
+        mock_env = AsyncMock()
+        mock_env.exec = AsyncMock(return_value=MagicMock(stdout="", stderr="", exit_code=0))
+        mock_env.stop = AsyncMock()
+
+        task_dir = tmp_path / "task"
+        task_dir.mkdir()
+        (task_dir / "task.toml").write_text(
+            'version = "1.0"\n[verifier]\ntimeout_sec = 5\n'
+            '[agent]\ntimeout_sec = 5\n[environment]\n'
+        )
+        (task_dir / "environment").mkdir()
+        (task_dir / "environment" / "Dockerfile").write_text("FROM ubuntu:22.04\n")
+        (task_dir / "instruction.md").write_text("do the thing")
+
+        return sdk, mock_env, task_dir
+
+    @contextlib.contextmanager
+    def _patch_sdk_run(self, sdk, mock_env, extra_patches):
+        """Apply shared + extra patches for SDK.run() internals."""
+        patches = [
+            patch("benchflow.sdk._create_environment", return_value=mock_env),
+            patch.object(sdk, "_install_agent", return_value=MagicMock(
+                credential_files={}, home_dirs=[], skill_paths=[], env_mapping={},
+            )),
+            patch.object(sdk, "_write_credential_files", new_callable=AsyncMock),
+            patch.object(sdk, "_deploy_skills", new_callable=AsyncMock),
+        ] + extra_patches
+        with contextlib.ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            yield
+
+    @pytest.mark.asyncio
+    async def test_scraped_trajectory_preserves_n_tool_calls(self, sdk_run_mocks, caplog):
+        """Main path: forged scraped trajectory must NOT overwrite ACP n_tool_calls."""
+        sdk, mock_env, task_dir = sdk_run_mocks
+
+        forged = [{"type": "tool_call", "name": f"fake_{i}"} for i in range(100)]
+        mock_session = MagicMock()
+        mock_session.tool_calls = [MagicMock() for _ in range(5)]
+        mock_acp = AsyncMock()
+        mock_acp.session = mock_session
+        mock_acp.close = AsyncMock()
+
+        with self._patch_sdk_run(sdk, mock_env, [
+            patch.object(sdk, "_connect_acp", new_callable=AsyncMock, return_value=(mock_acp, mock_session, "test-agent")),
+            patch.object(sdk, "_execute_prompts", new_callable=AsyncMock, return_value=([], 5)),
+            patch("benchflow.sdk._scrape_agent_trajectory", new_callable=AsyncMock, return_value=forged),
+            patch.object(sdk, "_verify", new_callable=AsyncMock, return_value=({"reward": 1.0}, None)),
+        ]), caplog.at_level(logging.WARNING):
+            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"})
+
+        assert result.n_tool_calls == 5, "ACP n_tool_calls must survive scraping fallback"
+        assert result.trajectory_source == "scraped"
+        assert len(result.trajectory) == 100
+        assert any("UNTRUSTED" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_partial_acp_uses_session_tool_calls(self, sdk_run_mocks):
+        """Finally block: partial_acp path gets n_tool_calls from session, not trajectory."""
+        sdk, mock_env, task_dir = sdk_run_mocks
+
+        mock_session = MagicMock()
+        mock_session.tool_calls = [MagicMock() for _ in range(3)]
+        partial_events = [{"type": "tool_call"}] * 7 + [{"type": "message"}] * 3
+        mock_acp = AsyncMock()
+        mock_acp.session = mock_session
+        mock_acp.close = AsyncMock()
+
+        with self._patch_sdk_run(sdk, mock_env, [
+            patch.object(sdk, "_connect_acp", new_callable=AsyncMock, return_value=(mock_acp, mock_session, "test-agent")),
+            patch.object(sdk, "_execute_prompts", new_callable=AsyncMock, side_effect=ConnectionError("lost")),
+            patch("benchflow.sdk._capture_session_trajectory", return_value=partial_events),
+            patch("benchflow.sdk._scrape_agent_trajectory", new_callable=AsyncMock, return_value=[]),
+        ]):
+            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"})
+
+        assert result.n_tool_calls == 3, "Must use session.tool_calls, not trajectory count"
+        assert result.trajectory_source == "partial_acp"
+        assert result.partial_trajectory is True

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -1,0 +1,370 @@
+"""Tests for verifier failure isolation — verifier_error field, retry, resume, metrics."""
+
+import asyncio
+import json
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from benchflow._models import RunResult
+from benchflow._scoring import (
+    VERIFIER_FAILED,
+    VERIFIER_TIMEOUT,
+    classify_verifier_error,
+    extract_reward,
+)
+from benchflow.metrics import BenchmarkMetrics, TaskMetrics
+
+
+# ---------------------------------------------------------------------------
+# classify_verifier_error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("input_str,expected", [
+    (None, None),
+    ("", None),
+    ("verifier crashed: ImportError", VERIFIER_FAILED),
+    ("verifier timed out after 900s", VERIFIER_TIMEOUT),
+    ("verifier did something weird", "verifier_other"),
+])
+def test_classify_verifier_error(input_str, expected):
+    assert classify_verifier_error(input_str) == expected
+
+
+# ---------------------------------------------------------------------------
+# RunResult with verifier_error
+# ---------------------------------------------------------------------------
+
+class TestRunResultVerifierError:
+
+    def test_success_requires_no_errors(self):
+        assert RunResult(task_name="t", rewards={"reward": 1.0}).success is True
+        assert RunResult(task_name="t", error="x").success is False
+        assert RunResult(task_name="t", verifier_error="x").success is False
+
+    def test_repr_shows_verifier_error(self):
+        r = RunResult(task_name="t", verifier_error="verifier timed out after 900s")
+        assert "ERROR: verifier timed out after 900s" in repr(r)
+
+    def test_verifier_error_default_none(self):
+        r = RunResult(task_name="t", error="install failed (rc=1)")
+        assert r.verifier_error is None
+        assert r.success is False
+
+
+# ---------------------------------------------------------------------------
+# Result JSON round-trip via _build_result
+# ---------------------------------------------------------------------------
+
+class TestResultJson:
+
+    def _build(self, tmp_path, **overrides):
+        from benchflow.sdk import SDK
+        from datetime import datetime
+        defaults = dict(
+            task_name="t1", trial_name="trial-1", agent="test",
+            agent_name="", model="", n_tool_calls=0, prompts=["x"],
+            error=None, verifier_error=None, trajectory=[],
+            partial_trajectory=False, rewards={"reward": 1.0},
+            started_at=datetime.now(), timing={},
+        )
+        defaults.update(overrides)
+        SDK._build_result(tmp_path, **defaults)
+        return json.loads((tmp_path / "result.json").read_text())
+
+    def test_verifier_error_in_json(self, tmp_path):
+        data = self._build(tmp_path, verifier_error="verifier crashed: KeyError", rewards=None)
+        assert data["verifier_error"] == "verifier crashed: KeyError"
+        assert data["error"] is None
+        assert data["rewards"] is None
+
+    def test_clean_run_json(self, tmp_path):
+        data = self._build(tmp_path)
+        assert data["verifier_error"] is None
+        assert data["rewards"] == {"reward": 1.0}
+
+
+# ---------------------------------------------------------------------------
+# SDK._verify() integration
+# ---------------------------------------------------------------------------
+
+class TestSdkVerify:
+
+    @pytest.fixture
+    def verify_harness(self, tmp_path):
+        from benchflow.sdk import SDK
+        sdk = SDK()
+        task = MagicMock()
+        task.config.verifier.timeout_sec = 5
+        tp = MagicMock()
+        tp.verifier_dir = tmp_path / "verifier"
+        env = MagicMock()
+        return sdk, env, task, tp
+
+    @pytest.mark.asyncio
+    async def test_verifier_timeout(self, verify_harness):
+        sdk, env, task, tp = verify_harness
+        task.config.verifier.timeout_sec = 0.1
+        mock_v = MagicMock()
+        mock_v.verify = lambda: asyncio.sleep(10)
+        timing = {}
+        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+            rewards, verifier_error = await sdk._verify(env, task, tp, timing)
+        assert rewards is None
+        assert "timed out" in verifier_error
+        assert "verifier" in timing
+
+    @pytest.mark.asyncio
+    async def test_verifier_crash(self, verify_harness):
+        sdk, env, task, tp = verify_harness
+        mock_v = MagicMock()
+        mock_v.verify = AsyncMock(side_effect=RuntimeError("kaboom"))
+        timing = {}
+        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+            rewards, verifier_error = await sdk._verify(env, task, tp, timing)
+        assert rewards is None
+        assert "crashed" in verifier_error and "kaboom" in verifier_error
+
+    @pytest.mark.asyncio
+    async def test_verifier_success(self, verify_harness):
+        sdk, env, task, tp = verify_harness
+        mock_result = MagicMock()
+        mock_result.rewards = {"reward": 1.0}
+        mock_v = MagicMock()
+        mock_v.verify = AsyncMock(return_value=mock_result)
+        timing = {}
+        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+            rewards, verifier_error = await sdk._verify(env, task, tp, timing)
+        assert rewards == {"reward": 1.0}
+        assert verifier_error is None
+
+
+# ---------------------------------------------------------------------------
+# Job: retry, resume, bounded log, threshold warning
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def job_factory(tmp_path):
+    """Create a Job with n task directories and a mocked SDK."""
+    from benchflow.job import Job, JobConfig, RetryConfig
+
+    def _make(n_tasks=1, max_retries=0):
+        tasks_dir = tmp_path / "tasks"
+        tasks_dir.mkdir(exist_ok=True)
+        for i in range(n_tasks):
+            td = tasks_dir / f"task-{i}"
+            td.mkdir(exist_ok=True)
+            (td / "task.toml").write_text(
+                'version = "1.0"\n[verifier]\ntimeout_sec = 60\n'
+                '[agent]\ntimeout_sec = 60\n[environment]\n'
+            )
+        cfg = JobConfig(retry=RetryConfig(max_retries=max_retries))
+        job = Job(tasks_dir=tasks_dir, jobs_dir=tmp_path / "jobs", config=cfg)
+        return job, tasks_dir
+    return _make
+
+
+class TestRetry:
+
+    @pytest.mark.asyncio
+    async def test_verifier_error_is_terminal(self, job_factory):
+        """Verifier errors exit after 1 attempt — no retry."""
+        job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(return_value=RunResult(
+            task_name="task-0", verifier_error="verifier crashed: x",
+        ))
+        result = await job._run_task(tasks_dir / "task-0")
+        assert job._sdk.run.call_count == 1
+        assert result.verifier_error == "verifier crashed: x"
+
+    @pytest.mark.asyncio
+    async def test_agent_error_still_retries(self, job_factory):
+        """Agent install errors are retried."""
+        job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(return_value=RunResult(
+            task_name="task-0", error="Agent claude-agent-acp install failed (rc=1)",
+        ))
+        await job._run_task(tasks_dir / "task-0")
+        assert job._sdk.run.call_count == 3  # 1 + 2 retries
+
+
+class TestResume:
+
+    def test_verifier_errored_is_complete(self, tmp_path, caplog):
+        task_dir = tmp_path / "task1" / "trial-1"
+        task_dir.mkdir(parents=True)
+        (task_dir / "result.json").write_text(json.dumps({
+            "task_name": "task1", "rewards": None,
+            "error": None, "verifier_error": "verifier timed out after 900s",
+        }))
+        from benchflow.job import Job, JobConfig
+        job = Job(tasks_dir=tmp_path, jobs_dir=tmp_path, config=JobConfig())
+        with caplog.at_level(logging.INFO):
+            completed = job._get_completed_tasks()
+        assert "task1" in completed
+        assert any("Skipping verifier-errored task" in m for m in caplog.messages)
+
+    def test_agent_errored_not_complete(self, tmp_path):
+        task_dir = tmp_path / "task2" / "trial-1"
+        task_dir.mkdir(parents=True)
+        (task_dir / "result.json").write_text(json.dumps({
+            "task_name": "task2", "rewards": None,
+            "error": "install failed", "verifier_error": None,
+        }))
+        from benchflow.job import Job, JobConfig
+        job = Job(tasks_dir=tmp_path, jobs_dir=tmp_path, config=JobConfig())
+        assert "task2" not in job._get_completed_tasks()
+
+
+class TestJobRunLogs:
+    """Tests that exercise actual Job.run() and check log output."""
+
+    @pytest.mark.asyncio
+    async def test_bounded_log_shows_verifier_error(self, job_factory, caplog):
+        job, _ = job_factory(n_tasks=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(return_value=RunResult(
+            task_name="task-0", verifier_error="verifier crashed: KeyError",
+        ))
+        with caplog.at_level(logging.INFO):
+            await job.run()
+        assert any("verifier crashed" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_over_20_pct_threshold_error(self, job_factory, caplog):
+        job, _ = job_factory(n_tasks=3)
+        call_count = 0
+        async def make_result(**kwargs):
+            nonlocal call_count
+            r = RunResult(task_name=f"task-{call_count}", verifier_error="verifier crashed: x")
+            call_count += 1
+            return r
+        job._sdk = AsyncMock()
+        job._sdk.run = make_result
+        with caplog.at_level(logging.WARNING):
+            await job.run()
+        warning_records = [r for r in caplog.records if "had verifier errors" in r.message]
+        assert warning_records and warning_records[0].levelno == logging.WARNING
+        error_records = [r for r in caplog.records if "Over 20%" in r.message]
+        assert error_records and error_records[0].levelno == logging.ERROR
+
+    @pytest.mark.asyncio
+    async def test_under_20_pct_no_error(self, job_factory, caplog):
+        job, _ = job_factory(n_tasks=5)
+        results = [
+            RunResult(task_name=f"task-{i}", rewards={"reward": 1.0}) for i in range(4)
+        ] + [RunResult(task_name="task-4", verifier_error="verifier crashed: x")]
+        idx = 0
+        async def make_result(**kwargs):
+            nonlocal idx
+            r = results[idx]; idx += 1; return r
+        job._sdk = AsyncMock()
+        job._sdk.run = make_result
+        with caplog.at_level(logging.WARNING):
+            await job.run()
+        assert any("had verifier errors" in r.message for r in caplog.records)
+        assert not any("Over 20%" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_summary_json_includes_verifier_errored(self, job_factory):
+        job, _ = job_factory(n_tasks=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(return_value=RunResult(
+            task_name="task-0", verifier_error="verifier crashed: x",
+        ))
+        await job.run()
+        summary = json.loads((job._jobs_dir / "summary.json").read_text())
+        assert summary["verifier_errored"] == 1
+
+
+# ---------------------------------------------------------------------------
+# JobResult invariant
+# ---------------------------------------------------------------------------
+
+def test_total_invariant():
+    from benchflow.job import JobResult, JobConfig
+    jr = JobResult(job_name="t", config=JobConfig(), total=4,
+                   passed=1, failed=1, errored=1, verifier_errored=1)
+    assert jr.passed + jr.failed + jr.errored + jr.verifier_errored == jr.total
+
+def test_double_count_violates_invariant():
+    """Both error and verifier_error set would double-count — documents mutual exclusivity."""
+    r = {"rewards": None, "error": "x", "verifier_error": "y"}
+    errored = 1 if r.get("error") and r.get("rewards") is None else 0
+    v_errored = 1 if r.get("verifier_error") else 0
+    assert errored + v_errored > 1  # proves double-counting
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def sample_metrics():
+    return BenchmarkMetrics(
+        benchmark="test", agent="test", model="test",
+        tasks=[
+            TaskMetrics(task_name="pass1", reward=1.0, n_tool_calls=3, duration_sec=10),
+            TaskMetrics(task_name="fail1", reward=0.0, n_tool_calls=5, duration_sec=20),
+            TaskMetrics(task_name="err1", reward=None, error="timed out", n_tool_calls=1, duration_sec=5),
+            TaskMetrics(task_name="verr1", reward=None, verifier_error="verifier crashed: x", n_tool_calls=100, duration_sec=999),
+            TaskMetrics(task_name="verr2", reward=None, verifier_error="verifier timed out after 900s", n_tool_calls=50, duration_sec=500),
+        ],
+    )
+
+
+class TestMetricsVerifierError:
+
+    def test_counts(self, sample_metrics):
+        assert sample_metrics.verifier_errored == 2
+        assert sample_metrics.errored == 1
+
+    def test_error_breakdowns_are_separate(self, sample_metrics):
+        assert VERIFIER_FAILED not in sample_metrics.error_breakdown
+        bd = sample_metrics.verifier_error_breakdown
+        assert bd[VERIFIER_FAILED] == 1
+        assert bd[VERIFIER_TIMEOUT] == 1
+
+    def test_averages_exclude_verifier_errored(self, sample_metrics):
+        # Only pass1 (3/10) and fail1 (5/20)
+        assert sample_metrics.avg_tool_calls == 4.0
+        assert sample_metrics.avg_duration == 15.0
+
+    def test_score_excl_errors(self, sample_metrics):
+        assert sample_metrics.score_excl_errors == 0.5  # 1 passed / (1+1)
+
+    def test_summary_includes_verifier_fields(self, sample_metrics):
+        s = sample_metrics.summary()
+        assert s["verifier_errored"] == 2
+        assert sorted(s["verifier_errored_tasks"]) == ["verr1", "verr2"]
+        assert "verifier_error_breakdown" in s
+
+    def test_collect_metrics_reads_verifier_error(self, tmp_path):
+        from benchflow.metrics import collect_metrics
+        from datetime import datetime
+        task_dir = tmp_path / "task1" / "trial-1"
+        task_dir.mkdir(parents=True)
+        now = datetime.now().isoformat()
+        (task_dir / "result.json").write_text(json.dumps({
+            "task_name": "task1", "rewards": None, "error": None,
+            "verifier_error": "verifier crashed: KeyError",
+            "n_tool_calls": 5, "n_prompts": 1,
+            "started_at": now, "finished_at": now,
+        }))
+        m = collect_metrics(tmp_path)
+        assert m.tasks[0].verifier_error == "verifier crashed: KeyError"
+        assert m.tasks[0].verifier_errored is True
+
+
+@pytest.mark.parametrize("reward,error,verifier_error,expected", [
+    (None, None, "verifier crashed: x", True),
+    (1.0, None, None, False),
+    (None, "timed out", None, False),
+    (0.0, None, "verifier crashed: x", False),  # reward set → not verifier_errored
+])
+def test_task_metrics_verifier_errored(reward, error, verifier_error, expected):
+    t = TaskMetrics(task_name="t", reward=reward, error=error, verifier_error=verifier_error)
+    assert t.verifier_errored is expected

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -430,7 +430,9 @@ class TestVerifierHardening:
         exec_cmds = [c[0][0] for c in env.exec.call_args_list]
         assert all("pkill" not in c for c in exec_cmds)
         assert any("conftest.py" in c for c in exec_cmds)
-        assert task.config.verifier.env["PYTEST_ADDOPTS"] == "--rootdir=/tests -p no:cacheprovider"
+        addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
+        assert "--rootdir=/tests" in addopts
+        assert "-p no:cacheprovider" in addopts
 
     @pytest.mark.asyncio
     async def test_task_env_overrides_win(self, hardening_harness):
@@ -445,6 +447,145 @@ class TestVerifierHardening:
         assert injected["PATH"] == "/custom/bin"
         assert injected["MY_VAR"] == "hello"
         assert injected["PYTHONPATH"] == ""  # non-overridden defaults kept
+
+    def test_verifier_env_contract(self):
+        """SDK._VERIFIER_ENV pins every layer of the pytest ini/plugin hardening.
+
+        Static dict inspection — no async harness needed. See
+        tmp/lockdown-sandbox_4.md for the threat model. Each assertion guards a
+        specific bypass; collapsing them into one test gives a single
+        authoritative contract for the env's contents.
+        """
+        from benchflow.sdk import SDK
+        env = SDK._VERIFIER_ENV
+        addopts = env["PYTEST_ADDOPTS"]
+
+        # Closed-set: any new key added to _VERIFIER_ENV must be deliberately
+        # accounted for here. Catches accidental additions that could weaken
+        # the contract (e.g. a stray debug var with sensitive content).
+        assert set(env.keys()) == {
+            "PATH",
+            "PYTEST_ADDOPTS",
+            "PYTHONDONTWRITEBYTECODE",
+            "PYTHONPATH",
+            "PYTHONHOME",
+            "PYTHONSTARTUP",
+            "PYTHONSAFEPATH",
+            "LD_PRELOAD",
+            "LD_LIBRARY_PATH",
+        }
+
+        # Layer 1 — block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
+        assert "-c /dev/null" in addopts
+        # Layer 2 — block conftest.py walk-up beyond /tests
+        assert "--confcutdir=/tests" in addopts
+        # Pre-existing rootdir pin + cache disable
+        assert "--rootdir=/tests" in addopts
+        assert "-p no:cacheprovider" in addopts
+
+        # Layer 4 — drop implicit '' (cwd) from sys.path (Python 3.11+)
+        assert env["PYTHONSAFEPATH"] == "1"
+
+        # Layer 5 — clear image-ENV carryover (zero-downside insurance)
+        assert env["PYTHONSTARTUP"] == ""
+        assert env["LD_PRELOAD"] == ""
+        assert env["LD_LIBRARY_PATH"] == ""
+
+        # Pattern 7 hardening (pre-existing)
+        assert env["PYTHONPATH"] == ""
+        assert env["PYTHONHOME"] == ""
+        assert env["PYTHONDONTWRITEBYTECODE"] == "1"
+        assert env["PATH"] == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+    def test_plugin_autoload_not_disabled(self):
+        """Negative guard: PYTEST_DISABLE_PLUGIN_AUTOLOAD must NOT be in _VERIFIER_ENV.
+
+        Disabling plugin autoload would break ~94 SkillsBench tasks that use
+        pytest-json-ctrf's --ctrf flag. Entry-point plugin injection is already
+        blocked structurally (root verifier + system site-packages perms +
+        .pth cleanup in _CLEANUP_CMD).
+
+        This guards against accidental re-addition. A developer who *intends*
+        to add it will (correctly) update this test and the comment in
+        sdk.py:_VERIFIER_ENV at the same time.
+        """
+        from benchflow.sdk import SDK
+        assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD" not in SDK._VERIFIER_ENV
+
+    def test_dash_c_devnull_blocks_hostile_pyproject(self, tmp_path):
+        """End-to-end: real pytest under `-c /dev/null` ignores agent-written
+        `pyproject.toml` in cwd.
+
+        Binds the static `_VERIFIER_ENV` assertions above to actual pytest
+        behavior — if pytest ever changes such that `-c /dev/null` stops
+        suppressing ini-file discovery, this catches it. Drops a hostile
+        `pyproject.toml` referencing a nonexistent plugin into a tmpdir,
+        invokes pytest from that cwd, and asserts both directions:
+
+          1. without `-c /dev/null`: hostile config is loaded → pytest errors
+             (sanity check that the test setup is meaningful)
+          2. with `-c /dev/null`: hostile config is ignored → pytest succeeds
+        """
+        import os
+        import subprocess
+        import sys
+
+        plugin_marker = "benchflow_test_nonexistent_plugin_xyz123"
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.pytest.ini_options]\n"
+            f'addopts = "-p {plugin_marker}"\n'
+        )
+        (tmp_path / "test_dummy.py").write_text("def test_pass():\n    assert True\n")
+
+        # Whitelist parent env (not blacklist): only pass through what pytest
+        # genuinely needs. A blacklist of `PYTEST_*` would still leak
+        # PYTHONPATH, VIRTUAL_ENV, CI, TOX_*, etc., any of which can change
+        # pytest's behavior and let either branch pass for the wrong reason.
+        clean_env = {
+            k: os.environ[k]
+            for k in ("PATH", "HOME", "LANG", "LC_ALL")
+            if k in os.environ
+        }
+
+        unhardened = subprocess.run(
+            [sys.executable, "-m", "pytest", "--collect-only", "test_dummy.py"],
+            cwd=tmp_path, env=clean_env, capture_output=True, text=True,
+        )
+        # Must fail, AND must fail because of OUR hostile plugin marker —
+        # not because of an unrelated collection / setup error.
+        assert unhardened.returncode != 0, (
+            "Sanity check failed: hostile pyproject.toml should crash unhardened pytest. "
+            f"stdout: {unhardened.stdout}\nstderr: {unhardened.stderr}"
+        )
+        combined_unhardened = unhardened.stdout + unhardened.stderr
+        assert plugin_marker in combined_unhardened, (
+            "Sanity check passed for the wrong reason: hostile plugin marker not in output. "
+            f"stdout: {unhardened.stdout}\nstderr: {unhardened.stderr}"
+        )
+
+        hardened = subprocess.run(
+            [sys.executable, "-m", "pytest", "-c", "/dev/null",
+             "--collect-only", "test_dummy.py"],
+            cwd=tmp_path, env=clean_env, capture_output=True, text=True,
+        )
+        # Must succeed, AND must have actually collected the dummy test —
+        # not silently collected zero items (which also returns 0 with
+        # --collect-only on some pytest versions).
+        assert hardened.returncode == 0, (
+            "-c /dev/null should block hostile pyproject.toml discovery. "
+            f"stdout: {hardened.stdout}\nstderr: {hardened.stderr}"
+        )
+        assert "test_pass" in hardened.stdout, (
+            "Hardened branch returned 0 but did not collect test_pass — "
+            "the test may have passed for the wrong reason. "
+            f"stdout: {hardened.stdout}\nstderr: {hardened.stderr}"
+        )
+        # And the hostile plugin marker must NOT appear — proves -c /dev/null
+        # actually suppressed pyproject.toml loading.
+        assert plugin_marker not in hardened.stdout + hardened.stderr, (
+            "-c /dev/null did not suppress hostile pyproject.toml — "
+            f"plugin marker {plugin_marker!r} leaked into hardened output."
+        )
 
 
 class TestTrajectorySource:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -550,7 +550,7 @@ class TestScrapedTrajectoryTrust:
             patch("benchflow.sdk._scrape_agent_trajectory", new_callable=AsyncMock, return_value=forged),
             patch.object(sdk, "_verify", new_callable=AsyncMock, return_value=({"reward": 1.0}, None)),
         ]), caplog.at_level(logging.WARNING):
-            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"})
+            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"}, sandbox_user=None)
 
         assert result.n_tool_calls == 5, "ACP n_tool_calls must survive scraping fallback"
         assert result.trajectory_source == "scraped"
@@ -575,7 +575,7 @@ class TestScrapedTrajectoryTrust:
             patch("benchflow.sdk._capture_session_trajectory", return_value=partial_events),
             patch("benchflow.sdk._scrape_agent_trajectory", new_callable=AsyncMock, return_value=[]),
         ]):
-            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"})
+            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"}, sandbox_user=None)
 
         assert result.n_tool_calls == 3, "Must use session.tool_calls, not trajectory count"
         assert result.trajectory_source == "partial_acp"


### PR DESCRIPTION
## Summary
- Isolates verifier failures from agent errors with a new `verifier_error` field tracked end-to-end (SDK → Job → metrics → retry/resume).
- Defaults the sandbox to non-root (`sandbox_user="agent"`) with `/solution` and `/tests` locked down before agent launch, using `setpriv`/`su` for privilege drop.
- Hardens the verifier against agent tampering: pre-verify cleanup of `conftest.py` / `sitecustomize.py` / `.pth` injection, trusted env injection, and a follow-up fix that closes a pytest ini-discovery / `conftest.py` walk-up bypass via `-c /dev/null`, `--confcutdir=/tests`, `PYTHONSAFEPATH=1`, and clearing `PYTHONSTARTUP` / `LD_PRELOAD` / `LD_LIBRARY_PATH`.
- Routes multi-endpoint providers (e.g. zai exposing both openai-completions and anthropic-messages) by the agent's native API protocol via a new `api_protocol` field on `AgentConfig`, fixing the `ANTHROPIC_BASE_URL` mismatch that broke `claude-agent-acp` + glm-5 in Job YAML runs.
- Adds `docs/harden-sandbox.md` mapping the three hardening changes to the seven-pattern Trustworthy AI Agent Benchmarks audit, plus a `skillsbench-claude-glm5.yaml` benchmark config and corrected paths in `tests/examples/test_*.sh`.

## Test plan
- [ ] `.venv/bin/python -m pytest tests/` (incl. new `tests/test_sdk_lockdown.py` and `tests/test_verify.py`)
- [ ] Smoke `tests/examples/test_claude.sh` against hello-world-task (verify non-root sandbox, verifier still passes)
- [ ] Smoke a SkillsBench task with `pytest --ctrf` to confirm verifier hardening doesn't regress plugin loading
- [ ] Run `benchmarks/skillsbench-claude-glm5.yaml` end-to-end to confirm anthropic-messages routing works
- [ ] Confirm a deliberately-crashed verifier reports `verifier_errored` (not `errored`) in Job metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)