### PR TITLE
chore: add CI workflow with pytest, ruff lint, and format gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,5 +28,8 @@ jobs:
       - name: Lint
         run: .venv/bin/ruff check src tests
 
+      - name: Format check
+        run: .venv/bin/ruff format --check src tests
+
       - name: Test
         run: .venv/bin/python -m pytest tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: |
+          uv venv -p 3.12 .venv
+          uv pip install -e ".[dev]"
+
+      - name: Test
+        run: .venv/bin/python -m pytest tests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,8 @@ jobs:
           uv venv -p 3.12 .venv
           uv pip install -e ".[dev]"
 
+      - name: Lint
+        run: .venv/bin/ruff check src tests
+
       - name: Test
         run: .venv/bin/python -m pytest tests/

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -12,21 +12,39 @@ __version__ = "2.0.0"
 
 # Re-export Harbor's core types for downstream task authors
 from harbor import (  # noqa: F401
-    BaseAgent, BaseEnvironment, ExecResult,
-    Task, TaskConfig, Trial, Verifier, VerifierResult,
+    BaseAgent,
+    BaseEnvironment,
+    ExecResult,
+    Task,
+    TaskConfig,
+    Trial,
+    Verifier,
+    VerifierResult,
 )
 
 # benchflow's additions
 from benchflow.acp.client import ACPClient  # noqa: F401
 from benchflow.acp.session import ACPSession  # noqa: F401
-from benchflow.agents.registry import AGENTS, get_agent, list_agents, register_agent, infer_env_key_for_model, is_vertex_model  # noqa: F401
+from benchflow.agents.registry import (  # noqa: F401
+    AGENTS,
+    get_agent,
+    infer_env_key_for_model,
+    is_vertex_model,
+    list_agents,
+    register_agent,
+)
 from benchflow.job import Job, JobConfig, JobResult, RetryConfig  # noqa: F401
 from benchflow.metrics import BenchmarkMetrics, collect_metrics  # noqa: F401
 from benchflow._env_setup import stage_dockerfile_deps  # noqa: F401
 from benchflow._models import AgentInstallError, AgentTimeoutError, RunResult  # noqa: F401
 from benchflow.sdk import SDK  # noqa: F401
 from benchflow.skills import discover_skills, install_skill, parse_skill, SkillInfo  # noqa: F401
-from benchflow.environments import SERVICES, detect_services_from_dockerfile, build_service_hooks, register_service  # noqa: F401
+from benchflow.environments import (  # noqa: F401
+    SERVICES,
+    build_service_hooks,
+    detect_services_from_dockerfile,
+    register_service,
+)
 from benchflow.trajectories.otel import OTelCollector  # noqa: F401
 from benchflow.trajectories.proxy import TrajectoryProxy  # noqa: F401
 from benchflow.trajectories.types import Trajectory  # noqa: F401

--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -15,7 +15,15 @@ from benchflow.agents.registry import AGENTS
 logger = logging.getLogger(__name__)
 
 # Directories to ignore when copying deps
-_IGNORE_DIRS = {".venv", "__pycache__", ".pytest_cache", "node_modules", ".git", ".mypy_cache", ".ruff_cache"}
+_IGNORE_DIRS = {
+    ".venv",
+    "__pycache__",
+    ".pytest_cache",
+    "node_modules",
+    ".git",
+    ".mypy_cache",
+    ".ruff_cache",
+}
 
 
 def _get_agent_skill_paths() -> list[str]:
@@ -80,9 +88,7 @@ def stage_dockerfile_deps(
     new_lines = []
 
     for line in lines:
-        copy_match = re.match(
-            r"^(\s*COPY\s+(?:--\S+\s+)*)(\S+)\s+(\S+)\s*$", line
-        )
+        copy_match = re.match(r"^(\s*COPY\s+(?:--\S+\s+)*)(\S+)\s+(\S+)\s*$", line)
         if copy_match:
             prefix = copy_match.group(1)
             src_path = copy_match.group(2)
@@ -101,7 +107,11 @@ def stage_dockerfile_deps(
                 if abs_src.is_dir():
                     if local_dest.exists():
                         shutil.rmtree(local_dest)
-                    shutil.copytree(abs_src, local_dest, ignore=shutil.ignore_patterns(*_IGNORE_DIRS))
+                    shutil.copytree(
+                        abs_src,
+                        local_dest,
+                        ignore=shutil.ignore_patterns(*_IGNORE_DIRS),
+                    )
                 else:
                     local_dest.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(abs_src, local_dest)
@@ -143,7 +153,9 @@ def _inject_skills_into_dockerfile(task_path: Path, skills_dir: Path) -> None:
 
     content = dockerfile_path.read_text()
     dockerfile_path.write_text(content + "\n".join(lines) + "\n")
-    logger.info(f"Skills injected into Dockerfile: {len(list(skills_dir.iterdir()))} items")
+    logger.info(
+        f"Skills injected into Dockerfile: {len(list(skills_dir.iterdir()))} items"
+    )
 
 
 def _detect_dind_mount() -> tuple[str, str] | None:
@@ -157,11 +169,14 @@ def _detect_dind_mount() -> tuple[str, str] | None:
     if not Path("/.dockerenv").exists():
         return None
     import subprocess as _sp
+
     try:
         hostname = _sp.check_output(["hostname"], text=True).strip()
         result = _sp.run(
             ["docker", "inspect", hostname],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
         if result.returncode != 0:
             return None
@@ -202,10 +217,14 @@ def _patch_harbor_dind() -> None:
 
     def _patched(self, include_os_env=True):
         env = _original(self, include_os_env=include_os_env)
-        for key in ("HOST_VERIFIER_LOGS_PATH", "HOST_AGENT_LOGS_PATH", "HOST_ARTIFACTS_PATH"):
+        for key in (
+            "HOST_VERIFIER_LOGS_PATH",
+            "HOST_AGENT_LOGS_PATH",
+            "HOST_ARTIFACTS_PATH",
+        ):
             val = env.get(key, "")
             if val.startswith(container_dest):
-                env[key] = host_source + val[len(container_dest):]
+                env[key] = host_source + val[len(container_dest) :]
         return env
 
     DockerEnvironmentEnvVars.to_env_dict = _patched
@@ -221,6 +240,7 @@ def _create_environment(
     """Create a Harbor environment (Docker or Daytona)."""
     if environment_type == "docker":
         from harbor.environments.docker.docker import DockerEnvironment
+
         return DockerEnvironment(
             environment_dir=task.paths.environment_dir,
             environment_name=task_path.name,
@@ -230,6 +250,7 @@ def _create_environment(
         )
     elif environment_type == "daytona":
         from harbor.environments.daytona import DaytonaEnvironment
+
         return DaytonaEnvironment(
             environment_dir=task.paths.environment_dir,
             environment_name=task_path.name,
@@ -240,4 +261,6 @@ def _create_environment(
             auto_delete_interval_mins=1440,
         )
     else:
-        raise ValueError(f"Unknown environment_type: {environment_type!r} (use 'docker' or 'daytona')")
+        raise ValueError(
+            f"Unknown environment_type: {environment_type!r} (use 'docker' or 'daytona')"
+        )

--- a/src/benchflow/_models.py
+++ b/src/benchflow/_models.py
@@ -16,7 +16,14 @@ class AgentInstallError(RuntimeError):
     triage; ``log_path`` points to the full log on disk.
     """
 
-    def __init__(self, agent: str, return_code: int, stdout: str, diagnostics: str, log_path: str = ""):
+    def __init__(
+        self,
+        agent: str,
+        return_code: int,
+        stdout: str,
+        diagnostics: str,
+        log_path: str = "",
+    ):
         self.agent = agent
         self.return_code = return_code
         self.stdout = stdout

--- a/src/benchflow/_trajectory.py
+++ b/src/benchflow/_trajectory.py
@@ -18,28 +18,36 @@ def _capture_session_trajectory(session: ACPSession | None) -> list[dict]:
         return []
     trajectory: list[dict] = []
     for tc in session.tool_calls:
-        trajectory.append({
-            "type": "tool_call",
-            "tool_call_id": tc.tool_call_id,
-            "kind": tc.kind,
-            "title": tc.title,
-            "status": tc.status.value,
-            "content": tc.content,
-        })
+        trajectory.append(
+            {
+                "type": "tool_call",
+                "tool_call_id": tc.tool_call_id,
+                "kind": tc.kind,
+                "title": tc.title,
+                "status": tc.status.value,
+                "content": tc.content,
+            }
+        )
     if session.full_message:
-        trajectory.append({
-            "type": "agent_message",
-            "text": session.full_message,
-        })
+        trajectory.append(
+            {
+                "type": "agent_message",
+                "text": session.full_message,
+            }
+        )
     if session.full_thought:
-        trajectory.append({
-            "type": "agent_thought",
-            "text": session.full_thought,
-        })
+        trajectory.append(
+            {
+                "type": "agent_thought",
+                "text": session.full_thought,
+            }
+        )
     return trajectory
 
 
-async def _scrape_agent_trajectory(env: Any, agent: str, sandbox_user: str | None) -> list[dict]:
+async def _scrape_agent_trajectory(
+    env: Any, agent: str, sandbox_user: str | None
+) -> list[dict]:
     """Fallback: read agent-native trajectory files from the container."""
     home = f"/home/{sandbox_user}" if sandbox_user else "/root"
 
@@ -65,14 +73,18 @@ def _parse_gemini_trajectory(data: dict) -> list[dict]:
         if msg.get("type") == "user":
             continue
         for tc in msg.get("toolCalls", []):
-            events.append({
-                "type": "tool_call",
-                "tool_call_id": tc.get("id", ""),
-                "kind": tc.get("name", ""),
-                "title": tc.get("args", {}).get("command", tc.get("name", "")),
-                "status": "completed" if tc.get("status") == "success" else "failed",
-                "content": tc.get("result", []),
-            })
+            events.append(
+                {
+                    "type": "tool_call",
+                    "tool_call_id": tc.get("id", ""),
+                    "kind": tc.get("name", ""),
+                    "title": tc.get("args", {}).get("command", tc.get("name", "")),
+                    "status": "completed"
+                    if tc.get("status") == "success"
+                    else "failed",
+                    "content": tc.get("result", []),
+                }
+            )
         content = msg.get("content", "")
         if content:
             events.append({"type": "agent_message", "text": content})

--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -102,7 +102,9 @@ class ACPClient:
                 try:
                     await self._handle_notification(msg)
                 except Exception as e:
-                    logger.warning(f"Error handling notification {msg.get('method')}: {e}")
+                    logger.warning(
+                        f"Error handling notification {msg.get('method')}: {e}"
+                    )
                 continue
 
             # It's a request from the agent (has id + method)
@@ -111,7 +113,9 @@ class ACPClient:
                 try:
                     await self._handle_agent_request(msg)
                 except Exception as e:
-                    logger.warning(f"Error handling agent request {msg.get('method')}: {e}")
+                    logger.warning(
+                        f"Error handling agent request {msg.get('method')}: {e}"
+                    )
                 continue
 
             logger.debug(f"ACPClient ignoring unknown message: {msg}")
@@ -198,7 +202,9 @@ class ACPClient:
             )
         return self._session
 
-    async def session_load(self, session_id: str, cwd: str = "/app") -> ACPSession:  # ACP spec; unused until session resume is wired
+    async def session_load(
+        self, session_id: str, cwd: str = "/app"
+    ) -> ACPSession:  # ACP spec; unused until session resume is wired
         """Load an existing session (used by agents like openclaw that need pre-created sessions)."""
         params = {"sessionId": session_id, "cwd": cwd, "mcpServers": []}
         result = await self._send_request("session/load", params)

--- a/src/benchflow/acp/transport.py
+++ b/src/benchflow/acp/transport.py
@@ -63,7 +63,8 @@ class StdioTransport(Transport):
             stderr=asyncio.subprocess.PIPE,
             env=proc_env,
             cwd=self._cwd,
-            limit=1024 * 1024,  # 1MB line buffer (default 64KB too small for large tool results)
+            limit=1024
+            * 1024,  # 1MB line buffer (default 64KB too small for large tool results)
         )
         logger.info(f"Started agent process: {self._command} (pid={self._process.pid})")
 

--- a/src/benchflow/agents/__init__.py
+++ b/src/benchflow/agents/__init__.py
@@ -1,2 +1,1 @@
 """benchflow agents — ACP-native agent implementations."""
-

--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -71,10 +71,10 @@ def setup_workspace(cwd: str):
     if not workspace_skills.exists():
         # Search for skills in known locations
         skill_sources = [
-            Path(cwd) / ".claude" / "skills",      # SkillsBench Claude format
-            Path(home) / ".claude" / "skills",      # Home dir Claude skills
-            Path(cwd) / ".codex" / "skills",        # Codex format
-            Path(cwd) / ".agents" / "skills",       # Generic agent skills
+            Path(cwd) / ".claude" / "skills",  # SkillsBench Claude format
+            Path(home) / ".claude" / "skills",  # Home dir Claude skills
+            Path(cwd) / ".codex" / "skills",  # Codex format
+            Path(cwd) / ".agents" / "skills",  # Generic agent skills
         ]
         for src in skill_sources:
             if src.is_dir() and any(src.iterdir()):
@@ -111,14 +111,17 @@ def setup_gcloud_adc():
     adc_json = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS_JSON")
     if not adc_json:
         return
-    adc_path = Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
+    adc_path = (
+        Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
+    )
     adc_path.parent.mkdir(parents=True, exist_ok=True)
     adc_path.write_text(adc_json)
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(adc_path)
     # Enable the google plugin so openclaw recognizes google-vertex/ models
     subprocess.run(
         ["openclaw", "plugins", "enable", "google"],
-        capture_output=True, timeout=10,
+        capture_output=True,
+        timeout=10,
     )
 
 
@@ -136,7 +139,9 @@ def _get_adc_token() -> str:
     adc_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
     if not adc_path or not Path(adc_path).exists():
         # Fallback to default ADC location
-        adc_path = str(Path.home() / ".config" / "gcloud" / "application_default_credentials.json")
+        adc_path = str(
+            Path.home() / ".config" / "gcloud" / "application_default_credentials.json"
+        )
     with open(adc_path) as f:
         creds = json.load(f)
 
@@ -144,12 +149,14 @@ def _get_adc_token() -> str:
 
     if cred_type == "authorized_user":
         # Refresh token flow
-        data = urllib.parse.urlencode({
-            "client_id": creds["client_id"],
-            "client_secret": creds["client_secret"],
-            "refresh_token": creds["refresh_token"],
-            "grant_type": "refresh_token",
-        }).encode()
+        data = urllib.parse.urlencode(
+            {
+                "client_id": creds["client_id"],
+                "client_secret": creds["client_secret"],
+                "refresh_token": creds["refresh_token"],
+                "grant_type": "refresh_token",
+            }
+        ).encode()
         req = urllib.request.Request(
             "https://oauth2.googleapis.com/token",
             data=data,
@@ -162,20 +169,25 @@ def _get_adc_token() -> str:
         # JWT → access token flow (RS256)
         # Requires PyJWT or manual RSA — use subprocess openssl as fallback
         now = int(time.time())
-        header = base64.urlsafe_b64encode(json.dumps(
-            {"alg": "RS256", "typ": "JWT"}
-        ).encode()).rstrip(b"=")
-        payload = base64.urlsafe_b64encode(json.dumps({
-            "iss": creds["client_email"],
-            "scope": "https://www.googleapis.com/auth/cloud-platform",
-            "aud": "https://oauth2.googleapis.com/token",
-            "iat": now,
-            "exp": now + 3600,
-        }).encode()).rstrip(b"=")
+        header = base64.urlsafe_b64encode(
+            json.dumps({"alg": "RS256", "typ": "JWT"}).encode()
+        ).rstrip(b"=")
+        payload = base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "iss": creds["client_email"],
+                    "scope": "https://www.googleapis.com/auth/cloud-platform",
+                    "aud": "https://oauth2.googleapis.com/token",
+                    "iat": now,
+                    "exp": now + 3600,
+                }
+            ).encode()
+        ).rstrip(b"=")
         signing_input = header + b"." + payload
 
         # Sign with openssl (available in most containers)
         import tempfile
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as kf:
             kf.write(creds["private_key"])
             key_path = kf.name
@@ -183,17 +195,20 @@ def _get_adc_token() -> str:
             result = subprocess.run(
                 ["openssl", "dgst", "-sha256", "-sign", key_path],
                 input=signing_input,
-                capture_output=True, timeout=10,
+                capture_output=True,
+                timeout=10,
             )
             signature = base64.urlsafe_b64encode(result.stdout).rstrip(b"=")
         finally:
             os.unlink(key_path)
 
         jwt_token = (signing_input + b"." + signature).decode()
-        data = urllib.parse.urlencode({
-            "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
-            "assertion": jwt_token,
-        }).encode()
+        data = urllib.parse.urlencode(
+            {
+                "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+                "assertion": jwt_token,
+            }
+        ).encode()
         req = urllib.request.Request(
             "https://oauth2.googleapis.com/token",
             data=data,
@@ -206,9 +221,13 @@ def _get_adc_token() -> str:
         raise ValueError(f"Unsupported ADC credential type: {cred_type!r}")
 
 
-def setup_custom_provider(provider_name: str, base_url: str, api_key: str,
-                          api_protocol: str = "openai-completions",
-                          models: list[dict] | None = None):
+def setup_custom_provider(
+    provider_name: str,
+    base_url: str,
+    api_key: str,
+    api_protocol: str = "openai-completions",
+    models: list[dict] | None = None,
+):
     """Configure an openclaw custom provider in ~/.openclaw/openclaw.json.
 
     This is the generic replacement for per-provider setup functions.
@@ -275,7 +294,11 @@ def _find_and_setup_provider(model: str) -> str | None:
                     try:
                         api_key = _get_adc_token()
                     except Exception:
-                        logger.debug("ADC token acquisition failed for %s", provider_name, exc_info=True)
+                        logger.debug(
+                            "ADC token acquisition failed for %s",
+                            provider_name,
+                            exc_info=True,
+                        )
                         return None
                 elif cfg.auth_type == "none":
                     api_key = ""
@@ -285,7 +308,9 @@ def _find_and_setup_provider(model: str) -> str | None:
                         return None
                 else:
                     return None
-                setup_custom_provider(provider_name, base_url, api_key, cfg.api_protocol, cfg.models)
+                setup_custom_provider(
+                    provider_name, base_url, api_key, cfg.api_protocol, cfg.models
+                )
                 return provider_name
     except ImportError:
         logger.debug("benchflow.agents.providers not available, using env var fallback")
@@ -366,57 +391,68 @@ def parse_session_jsonl(path: Path, session_id: str) -> list[dict]:
                         block_type = block.get("type", "")
 
                         if block_type in ("text",):
-                            updates.append({
-                                "jsonrpc": "2.0",
-                                "method": "session/update",
-                                "params": {
-                                    "sessionId": session_id,
-                                    "update": {
-                                        "sessionUpdate": "text_update",
-                                        "text": block.get("text", ""),
+                            updates.append(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "method": "session/update",
+                                    "params": {
+                                        "sessionId": session_id,
+                                        "update": {
+                                            "sessionUpdate": "text_update",
+                                            "text": block.get("text", ""),
+                                        },
                                     },
-                                },
-                            })
+                                }
+                            )
 
                         elif block_type in ("tool_use", "toolCall"):
                             _input = block.get("input", block.get("arguments", {}))
-                            _title = _input.get("command", _input.get("description", block.get("name", "tool")))
-                            updates.append({
-                                "jsonrpc": "2.0",
-                                "method": "session/update",
-                                "params": {
-                                    "sessionId": session_id,
-                                    "update": {
-                                        "sessionUpdate": "tool_call",
-                                        "toolCallId": block.get("id", ""),
-                                        "kind": block.get("name", "tool"),
-                                        "title": _title,
-                                        "status": "completed",
-                                        "content": [
-                                            {
-                                                "type": "content",
-                                                "content": {
-                                                    "type": "text",
-                                                    "text": json.dumps(_input)[:500],
-                                                },
-                                            }
-                                        ],
+                            _title = _input.get(
+                                "command",
+                                _input.get("description", block.get("name", "tool")),
+                            )
+                            updates.append(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "method": "session/update",
+                                    "params": {
+                                        "sessionId": session_id,
+                                        "update": {
+                                            "sessionUpdate": "tool_call",
+                                            "toolCallId": block.get("id", ""),
+                                            "kind": block.get("name", "tool"),
+                                            "title": _title,
+                                            "status": "completed",
+                                            "content": [
+                                                {
+                                                    "type": "content",
+                                                    "content": {
+                                                        "type": "text",
+                                                        "text": json.dumps(_input)[
+                                                            :500
+                                                        ],
+                                                    },
+                                                }
+                                            ],
+                                        },
                                     },
-                                },
-                            })
+                                }
+                            )
 
                         elif block_type == "thinking":
-                            updates.append({
-                                "jsonrpc": "2.0",
-                                "method": "session/update",
-                                "params": {
-                                    "sessionId": session_id,
-                                    "update": {
-                                        "sessionUpdate": "agent_thought",
-                                        "text": block.get("thinking", ""),
+                            updates.append(
+                                {
+                                    "jsonrpc": "2.0",
+                                    "method": "session/update",
+                                    "params": {
+                                        "sessionId": session_id,
+                                        "update": {
+                                            "sessionUpdate": "agent_thought",
+                                            "text": block.get("thinking", ""),
+                                        },
                                     },
-                                },
-                            })
+                                }
+                            )
 
                 elif role == "toolResult":
                     # Emit as tool_call_update (status=completed) to update
@@ -425,33 +461,38 @@ def parse_session_jsonl(path: Path, session_id: str) -> list[dict]:
                     result_text = ""
                     if isinstance(content, list):
                         result_text = " ".join(
-                            b.get("text", "") for b in content
+                            b.get("text", "")
+                            for b in content
                             if isinstance(b, dict) and b.get("type") == "text"
                         )
                     elif isinstance(content, str):
                         result_text = content
 
-                    updates.append({
-                        "jsonrpc": "2.0",
-                        "method": "session/update",
-                        "params": {
-                            "sessionId": session_id,
-                            "update": {
-                                "sessionUpdate": "tool_call_update",
-                                "toolCallId": tool_id,
-                                "status": "completed",
-                                "content": [
-                                    {
-                                        "type": "content",
-                                        "content": {
-                                            "type": "text",
-                                            "text": result_text[:_TOOL_RESULT_TRUNCATE],
-                                        },
-                                    }
-                                ],
+                    updates.append(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/update",
+                            "params": {
+                                "sessionId": session_id,
+                                "update": {
+                                    "sessionUpdate": "tool_call_update",
+                                    "toolCallId": tool_id,
+                                    "status": "completed",
+                                    "content": [
+                                        {
+                                            "type": "content",
+                                            "content": {
+                                                "type": "text",
+                                                "text": result_text[
+                                                    :_TOOL_RESULT_TRUNCATE
+                                                ],
+                                            },
+                                        }
+                                    ],
+                                },
                             },
-                        },
-                    })
+                        }
+                    )
 
     except Exception:
         logger.debug("Failed to parse session JSONL for trajectory", exc_info=True)
@@ -476,28 +517,32 @@ def main():
         params = msg.get("params", {})
 
         if method == "initialize":
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {
-                    "protocolVersion": 1,
-                    "agentCapabilities": {
-                        "loadSession": False,
-                        "promptCapabilities": {"image": False, "audio": False},
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {
+                            "loadSession": False,
+                            "promptCapabilities": {"image": False, "audio": False},
+                        },
+                        "agentInfo": {"name": "openclaw", "version": "1.0"},
                     },
-                    "agentInfo": {"name": "openclaw", "version": "1.0"},
-                },
-            })
+                }
+            )
 
         elif method == "session/new":
             cwd = params.get("cwd", "/app")
             setup_workspace(cwd)
             session_id = "openclaw-shim"
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {"sessionId": session_id},
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {"sessionId": session_id},
+                }
+            )
 
         elif method == "session/set_model":
             model = params.get("modelId", "")
@@ -526,7 +571,8 @@ def main():
 
                 subprocess.run(
                     ["openclaw", "config", "set", "agents.defaults.model", model],
-                    capture_output=True, timeout=10,
+                    capture_output=True,
+                    timeout=10,
                 )
 
             # Apply model generation parameters from env vars
@@ -540,7 +586,8 @@ def main():
                 if val:
                     subprocess.run(
                         ["openclaw", "config", "set", config_path, val],
-                        capture_output=True, timeout=10,
+                        capture_output=True,
+                        timeout=10,
                     )
 
             send({"jsonrpc": "2.0", "id": req_id, "result": {}})
@@ -555,8 +602,16 @@ def main():
             try:
                 result = subprocess.run(
                     [
-                        "openclaw", "agent", "--local", "--agent", "main",
-                        "--json", "-m", text, "--timeout", "900",
+                        "openclaw",
+                        "agent",
+                        "--local",
+                        "--agent",
+                        "main",
+                        "--json",
+                        "-m",
+                        text,
+                        "--timeout",
+                        "900",
                     ],
                     capture_output=True,
                     text=True,
@@ -566,17 +621,19 @@ def main():
 
                 # Surface stderr as agent thought (for debugging)
                 if result.stderr and result.stderr.strip():
-                    send({
-                        "jsonrpc": "2.0",
-                        "method": "session/update",
-                        "params": {
-                            "sessionId": session_id,
-                            "update": {
-                                "sessionUpdate": "agent_thought",
-                                "text": f"[openclaw stderr]\n{result.stderr[:_DIAG_TRUNCATE]}",
+                    send(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/update",
+                            "params": {
+                                "sessionId": session_id,
+                                "update": {
+                                    "sessionUpdate": "agent_thought",
+                                    "text": f"[openclaw stderr]\n{result.stderr[:_DIAG_TRUNCATE]}",
+                                },
                             },
-                        },
-                    })
+                        }
+                    )
 
                 # Parse openclaw's session JSONL for full trajectory
                 # Extract session ID from JSON output (may be multi-line)
@@ -586,12 +643,15 @@ def main():
                     stdout = result.stdout.strip()
                     if stdout:
                         response_data = json.loads(stdout)
-                        oc_session_id = response_data.get("meta", {}).get(
-                            "agentMeta", {}
-                        ).get("sessionId")
+                        oc_session_id = (
+                            response_data.get("meta", {})
+                            .get("agentMeta", {})
+                            .get("sessionId")
+                        )
                 except (json.JSONDecodeError, KeyError, TypeError):
                     # Try finding sessionId in raw output
                     import re
+
                     m = re.search(r'"sessionId"\s*:\s*"([^"]+)"', result.stdout or "")
                     if m:
                         oc_session_id = m.group(1)
@@ -616,7 +676,9 @@ def main():
                         key=lambda f: f.stat().st_mtime,
                         reverse=True,
                     ):
-                        if jf.name not in ("sessions.json",) and not jf.name.endswith(".lock"):
+                        if jf.name not in ("sessions.json",) and not jf.name.endswith(
+                            ".lock"
+                        ):
                             session_jsonl = jf
                             break
 
@@ -631,39 +693,49 @@ def main():
                         response = json.loads(result.stdout)
                         agent_text = response.get("payloads", [{}])[0].get("text", "")
                     except (json.JSONDecodeError, IndexError, KeyError):
-                        agent_text = result.stdout[:_DIAG_TRUNCATE] if result.stdout else ""
+                        agent_text = (
+                            result.stdout[:_DIAG_TRUNCATE] if result.stdout else ""
+                        )
 
                     if agent_text:
-                        send({
-                            "jsonrpc": "2.0",
-                            "method": "session/update",
-                            "params": {
-                                "sessionId": session_id,
-                                "update": {
-                                    "sessionUpdate": "text_update",
-                                    "text": agent_text,
+                        send(
+                            {
+                                "jsonrpc": "2.0",
+                                "method": "session/update",
+                                "params": {
+                                    "sessionId": session_id,
+                                    "update": {
+                                        "sessionUpdate": "text_update",
+                                        "text": agent_text,
+                                    },
                                 },
-                            },
-                        })
+                            }
+                        )
 
-                send({
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "result": {"stopReason": "end_turn"},
-                })
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {"stopReason": "end_turn"},
+                    }
+                )
 
             except subprocess.TimeoutExpired:
-                send({
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "result": {"stopReason": "end_turn"},
-                })
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {"stopReason": "end_turn"},
+                    }
+                )
             except Exception as e:
-                send({
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "error": {"code": -32603, "message": str(e)},
-                })
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "error": {"code": -32603, "message": str(e)},
+                    }
+                )
 
         elif method == "session/cancel":
             send({"jsonrpc": "2.0", "id": req_id, "result": {}})
@@ -671,11 +743,15 @@ def main():
         elif method == "session/request_permission":
             options = params.get("options", [])
             option_id = options[0].get("optionId", "default") if options else "default"
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {"outcome": {"outcome": "selected", "optionId": option_id}},
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "outcome": {"outcome": "selected", "optionId": option_id}
+                    },
+                }
+            )
 
         else:
             if req_id:

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -21,8 +21,12 @@ class ProviderConfig:
     """Configuration for a custom LLM provider."""
 
     name: str
-    base_url: str  # primary endpoint; may contain {placeholders} expanded via url_params
-    api_protocol: str  # protocol for base_url: "openai-completions" | "anthropic-messages"
+    base_url: (
+        str  # primary endpoint; may contain {placeholders} expanded via url_params
+    )
+    api_protocol: (
+        str  # protocol for base_url: "openai-completions" | "anthropic-messages"
+    )
     auth_type: str  # "api_key" | "adc" | "none"
     auth_env: str | None = None  # env var holding the API key (None for ADC)
     url_params: dict[str, str] = field(default_factory=dict)  # {placeholder: ENV_VAR}
@@ -51,30 +55,38 @@ PROVIDERS: dict[str, ProviderConfig] = {
         base_url="https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}",
         api_protocol="openai-completions",
         auth_type="adc",
-        url_params={"project_id": "GOOGLE_CLOUD_PROJECT", "location": "GOOGLE_CLOUD_LOCATION"},
-        credential_files=[{
-            "path": "{home}/.config/gcloud/application_default_credentials.json",
-            "env_source": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
-            "post_env": {
-                "GOOGLE_APPLICATION_CREDENTIALS":
-                    "{home}/.config/gcloud/application_default_credentials.json",
-            },
-        }],
+        url_params={
+            "project_id": "GOOGLE_CLOUD_PROJECT",
+            "location": "GOOGLE_CLOUD_LOCATION",
+        },
+        credential_files=[
+            {
+                "path": "{home}/.config/gcloud/application_default_credentials.json",
+                "env_source": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+                "post_env": {
+                    "GOOGLE_APPLICATION_CREDENTIALS": "{home}/.config/gcloud/application_default_credentials.json",
+                },
+            }
+        ],
     ),
     "anthropic-vertex": ProviderConfig(
         name="anthropic-vertex",
         base_url="https://aiplatform.googleapis.com/v1/projects/{project_id}/locations/{location}",
         api_protocol="anthropic-messages",
         auth_type="adc",
-        url_params={"project_id": "GOOGLE_CLOUD_PROJECT", "location": "GOOGLE_CLOUD_LOCATION"},
-        credential_files=[{
-            "path": "{home}/.config/gcloud/application_default_credentials.json",
-            "env_source": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
-            "post_env": {
-                "GOOGLE_APPLICATION_CREDENTIALS":
-                    "{home}/.config/gcloud/application_default_credentials.json",
-            },
-        }],
+        url_params={
+            "project_id": "GOOGLE_CLOUD_PROJECT",
+            "location": "GOOGLE_CLOUD_LOCATION",
+        },
+        credential_files=[
+            {
+                "path": "{home}/.config/gcloud/application_default_credentials.json",
+                "env_source": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+                "post_env": {
+                    "GOOGLE_APPLICATION_CREDENTIALS": "{home}/.config/gcloud/application_default_credentials.json",
+                },
+            }
+        ],
     ),
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(
@@ -177,7 +189,7 @@ def strip_provider_prefix(model: str) -> str:
     result = find_provider(model)
     if result:
         prefix = f"{result[0]}/"
-        return model[len(prefix):]
+        return model[len(prefix) :]
     # Not a known provider — still strip unknown prefix if present
     if "/" in model:
         return model.split("/", 1)[1]

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -18,9 +18,9 @@ _NODE_INSTALL = (
     "NODE_OK=0; "
     "if command -v node >/dev/null 2>&1; then "
     "  NODE_VER=$(node -e 'console.log(process.versions.node.split(\".\")[0])' 2>/dev/null || echo 0); "
-    "  [ \"$NODE_VER\" -ge 22 ] 2>/dev/null && NODE_OK=1; "
+    '  [ "$NODE_VER" -ge 22 ] 2>/dev/null && NODE_OK=1; '
     "fi; "
-    "if [ \"$NODE_OK\" = 0 ]; then "
+    'if [ "$NODE_OK" = 0 ]; then '
     "  apt-get update -qq && "
     "  apt-get install -y -qq curl ca-certificates && "
     "  curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && "
@@ -123,7 +123,9 @@ AGENTS: dict[str, AgentConfig] = {
             replaces_env="ANTHROPIC_API_KEY",
             detect_file="~/.claude/.credentials.json",
             files=[
-                HostAuthFile("~/.claude/.credentials.json", "{home}/.claude/.credentials.json"),
+                HostAuthFile(
+                    "~/.claude/.credentials.json", "{home}/.claude/.credentials.json"
+                ),
             ],
         ),
     ),
@@ -167,8 +169,8 @@ AGENTS: dict[str, AgentConfig] = {
             " > ~/.openclaw/exec-approvals.json && "
             # Deploy ACP shim
             "cat > /usr/local/bin/openclaw-acp-shim <<'SHIMEOF'\n"
-            + _OPENCLAW_SHIM +
-            "\nSHIMEOF\n"
+            + _OPENCLAW_SHIM
+            + "\nSHIMEOF\n"
             "chmod +x /usr/local/bin/openclaw-acp-shim"
         ),
         launch_cmd="python3 /usr/local/bin/openclaw-acp-shim",
@@ -234,9 +236,14 @@ AGENTS: dict[str, AgentConfig] = {
             replaces_env="GEMINI_API_KEY",
             detect_file="~/.gemini/oauth_creds.json",
             files=[
-                HostAuthFile("~/.gemini/oauth_creds.json", "{home}/.gemini/oauth_creds.json"),
+                HostAuthFile(
+                    "~/.gemini/oauth_creds.json", "{home}/.gemini/oauth_creds.json"
+                ),
                 HostAuthFile("~/.gemini/settings.json", "{home}/.gemini/settings.json"),
-                HostAuthFile("~/.gemini/google_accounts.json", "{home}/.gemini/google_accounts.json"),
+                HostAuthFile(
+                    "~/.gemini/google_accounts.json",
+                    "{home}/.gemini/google_accounts.json",
+                ),
             ],
         ),
     ),
@@ -283,6 +290,7 @@ def get_sandbox_home_dirs() -> set[str]:
 def is_vertex_model(model: str) -> bool:
     """True if the model uses Vertex AI (GCP ADC auth, not API keys)."""
     from benchflow.agents.providers import find_provider
+
     result = find_provider(model)
     if result:
         _, cfg = result
@@ -294,6 +302,7 @@ def infer_env_key_for_model(model: str) -> str | None:
     """Infer the required API key environment variable from a model ID."""
     # Check custom providers first
     from benchflow.agents.providers import resolve_auth_env
+
     custom = resolve_auth_env(model)
     if custom is not None:
         return custom

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -54,11 +54,16 @@ def run(
     ] = None,
     skills_dir: Annotated[
         Path | None,
-        typer.Option("--skills-dir", "-s", help="Skills directory to deploy into sandbox"),
+        typer.Option(
+            "--skills-dir", "-s", help="Skills directory to deploy into sandbox"
+        ),
     ] = None,
     sandbox_user: Annotated[
         str | None,
-        typer.Option("--sandbox-user", help="Run agent as non-root user (default: 'agent'). Pass 'none' for root."),
+        typer.Option(
+            "--sandbox-user",
+            help="Run agent as non-root user (default: 'agent'). Pass 'none' for root.",
+        ),
     ] = "agent",
 ) -> None:
     """Run a single task with an ACP agent."""
@@ -105,7 +110,9 @@ def job(
     ] = None,
     config_file: Annotated[
         Path | None,
-        typer.Option("--config", "-f", help="YAML config file (Harbor or benchflow format)"),
+        typer.Option(
+            "--config", "-f", help="YAML config file (Harbor or benchflow format)"
+        ),
     ] = None,
     agent: Annotated[
         str,
@@ -133,7 +140,9 @@ def job(
     ] = "jobs",
     skills_dir: Annotated[
         Path | None,
-        typer.Option("--skills-dir", "-s", help="Skills directory to deploy into sandbox"),
+        typer.Option(
+            "--skills-dir", "-s", help="Skills directory to deploy into sandbox"
+        ),
     ] = None,
 ) -> None:
     """Run all tasks in a directory with concurrency and retries.
@@ -182,10 +191,11 @@ def agents() -> None:
     table.add_column("Requires", style="yellow")
 
     for agent in list_agents():
-        sub_env = agent.subscription_auth.replaces_env if agent.subscription_auth else None
+        sub_env = (
+            agent.subscription_auth.replaces_env if agent.subscription_auth else None
+        )
         requires = [
-            f"{e} (or login)" if e == sub_env else e
-            for e in agent.requires_env
+            f"{e} (or login)" if e == sub_env else e for e in agent.requires_env
         ]
         table.add_row(
             agent.name,
@@ -223,9 +233,7 @@ def metrics(
     """Collect and display metrics from a jobs directory."""
     from benchflow.metrics import collect_metrics
 
-    m = collect_metrics(
-        str(jobs_dir), benchmark=benchmark, agent=agent, model=model
-    )
+    m = collect_metrics(str(jobs_dir), benchmark=benchmark, agent=agent, model=model)
     summary = m.summary()
 
     if output_json:
@@ -250,9 +258,7 @@ def metrics(
     if summary["passed_tasks"]:
         console.print(f"\n[green]Passed:[/green] {', '.join(summary['passed_tasks'])}")
     if summary["errored_tasks"]:
-        console.print(
-            f"[yellow]Errors:[/yellow] {', '.join(summary['errored_tasks'])}"
-        )
+        console.print(f"[yellow]Errors:[/yellow] {', '.join(summary['errored_tasks'])}")
     if summary["error_breakdown"]:
         console.print(f"[yellow]Error breakdown:[/yellow] {summary['error_breakdown']}")
 
@@ -279,7 +285,9 @@ def eval(
     ],
     skill: Annotated[
         Path | None,
-        typer.Option("--skill", help="Path to SKILL.md (parent dir used as skills_dir)"),
+        typer.Option(
+            "--skill", help="Path to SKILL.md (parent dir used as skills_dir)"
+        ),
     ] = None,
     skills_dir: Annotated[
         Path | None,
@@ -318,7 +326,9 @@ def eval(
     from benchflow.job import Job, JobConfig
 
     # Use --skill as skills_dir if --skills-dir not provided
-    effective_skills = str(skills_dir) if skills_dir else (str(skill.parent) if skill else None)
+    effective_skills = (
+        str(skills_dir) if skills_dir else (str(skill.parent) if skill else None)
+    )
 
     j = Job(
         tasks_dir=str(tasks_dir),
@@ -355,7 +365,11 @@ def skills(
     ] = None,
     install: Annotated[
         str | None,
-        typer.Option("--install", "-i", help="Install skill from skills.sh (e.g. anthropics/skills@find-skills)"),
+        typer.Option(
+            "--install",
+            "-i",
+            help="Install skill from skills.sh (e.g. anthropics/skills@find-skills)",
+        ),
     ] = None,
 ) -> None:
     """List or install agent skills."""
@@ -371,10 +385,16 @@ def skills(
             raise typer.Exit(1)
         return
 
-    search_dirs = [directory] if directory else [DEFAULT_SKILLS_DIR, Path(".claude/skills"), Path("skills")]
+    search_dirs = (
+        [directory]
+        if directory
+        else [DEFAULT_SKILLS_DIR, Path(".claude/skills"), Path("skills")]
+    )
     found = discover_skills(*search_dirs)
     if not found:
-        console.print("No skills found. Install with: benchflow skills --install owner/repo@skill-name")
+        console.print(
+            "No skills found. Install with: benchflow skills --install owner/repo@skill-name"
+        )
         return
 
     table = Table(title="Discovered Skills")
@@ -400,15 +420,24 @@ def tasks_init(
         Path,
         typer.Option("--dir", "-p", help="Parent directory (default: tasks/)"),
     ] = Path("tasks"),
-    no_pytest: Annotated[bool, typer.Option("--no-pytest", help="Skip pytest template")] = False,
-    no_solution: Annotated[bool, typer.Option("--no-solution", help="Skip solution template")] = False,
+    no_pytest: Annotated[
+        bool, typer.Option("--no-pytest", help="Skip pytest template")
+    ] = False,
+    no_solution: Annotated[
+        bool, typer.Option("--no-solution", help="Skip solution template")
+    ] = False,
 ) -> None:
     """Scaffold a new benchmark task."""
     from benchflow.tasks import init_task
+
     try:
-        task_dir = init_task(name, parent_dir=parent_dir, no_pytest=no_pytest, no_solution=no_solution)
+        task_dir = init_task(
+            name, parent_dir=parent_dir, no_pytest=no_pytest, no_solution=no_solution
+        )
         console.print(f"[green]Created:[/green] {task_dir}/")
-        console.print("  task.toml, instruction.md, environment/Dockerfile, tests/test.sh")
+        console.print(
+            "  task.toml, instruction.md, environment/Dockerfile, tests/test.sh"
+        )
         if not no_solution:
             console.print("  solution/solve.sh")
     except FileExistsError as e:
@@ -422,6 +451,7 @@ def tasks_check(
 ) -> None:
     """Validate a task directory structure."""
     from benchflow.tasks import check_task
+
     issues = check_task(task_dir)
     if not issues:
         console.print(f"[green]✓[/green] {task_dir.name} — valid")
@@ -473,10 +503,14 @@ def cleanup(
             if age_minutes < max_age_minutes:
                 total_skipped += 1
                 if dry_run:
-                    console.print(f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [green](skip)[/green]")
+                    console.print(
+                        f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [green](skip)[/green]"
+                    )
                 continue
             if dry_run:
-                console.print(f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [red](delete)[/red]")
+                console.print(
+                    f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [red](delete)[/red]"
+                )
             else:
                 try:
                     d.delete(sb)
@@ -488,9 +522,13 @@ def cleanup(
         page += 1
 
     if dry_run:
-        console.print(f"\n[bold]{total_found} sandboxes found, {total_found - total_skipped} older than {max_age_minutes}m[/bold] (use without --dry-run to delete)")
+        console.print(
+            f"\n[bold]{total_found} sandboxes found, {total_found - total_skipped} older than {max_age_minutes}m[/bold] (use without --dry-run to delete)"
+        )
     else:
-        console.print(f"\n[bold green]{total_deleted} sandboxes deleted[/bold green] ({total_skipped} skipped, younger than {max_age_minutes}m)")
+        console.print(
+            f"\n[bold green]{total_deleted} sandboxes deleted[/bold green] ({total_skipped} skipped, younger than {max_age_minutes}m)"
+        )
 
 
 if __name__ == "__main__":

--- a/src/benchflow/environments.py
+++ b/src/benchflow/environments.py
@@ -16,10 +16,11 @@ logger = logging.getLogger(__name__)
 @dataclass
 class ServiceConfig:
     """Configuration for a sandbox service (e.g. claw-gmail)."""
+
     name: str
-    cli_name: str            # Binary name (e.g. "claw-gmail")
-    port: int                # Default port
-    db_path: str             # Default database path
+    cli_name: str  # Binary name (e.g. "claw-gmail")
+    port: int  # Default port
+    db_path: str  # Default database path
     health_path: str = "/health"
     description: str = ""
 
@@ -72,7 +73,9 @@ def register_service(
     **kwargs,
 ) -> ServiceConfig:
     """Register a custom service at runtime."""
-    config = ServiceConfig(name=name, cli_name=cli_name, port=port, db_path=db_path, **kwargs)
+    config = ServiceConfig(
+        name=name, cli_name=cli_name, port=port, db_path=db_path, **kwargs
+    )
     SERVICES[name] = config
     return config
 
@@ -86,7 +89,9 @@ def detect_services_from_dockerfile(task_path: Path | str) -> list[ServiceConfig
     return [svc for svc in SERVICES.values() if svc.cli_name in text]
 
 
-def build_service_hooks(services: list[ServiceConfig]) -> list[Callable[[Any], Coroutine[Any, Any, None]]]:
+def build_service_hooks(
+    services: list[ServiceConfig],
+) -> list[Callable[[Any], Coroutine[Any, Any, None]]]:
     """Build pre_agent_hooks that start the given services.
 
     Returns a list of async callables compatible with SDK.run(pre_agent_hooks=...).

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -83,6 +83,7 @@ class JobConfig:
 
     def __post_init__(self):
         from benchflow.agents.registry import AGENTS
+
         if self.agent not in AGENTS:
             available = ", ".join(sorted(AGENTS.keys()))
             logger.warning(
@@ -211,7 +212,9 @@ class Job:
             prompts=prompts,
             agent_env=agent_env_raw,
             retry=RetryConfig(max_retries=raw.get("max_retries", 2)),
-            skills_dir=str(base_dir / raw["skills_dir"]) if raw.get("skills_dir") else None,
+            skills_dir=str(base_dir / raw["skills_dir"])
+            if raw.get("skills_dir")
+            else None,
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             exclude_tasks=exclude,
@@ -254,7 +257,9 @@ class Job:
         concurrency = orch.get("n_concurrent_trials", 4)
 
         jobs_dir = base_dir / raw.get("jobs_dir", "jobs")
-        max_retries = raw.get("n_attempts", 1) - 1  # Harbor n_attempts includes first try
+        max_retries = (
+            raw.get("n_attempts", 1) - 1
+        )  # Harbor n_attempts includes first try
 
         # Skills dir (shared with benchflow-native format)
         skills_dir_raw = raw.get("skills_dir")
@@ -278,8 +283,10 @@ class Job:
     def _get_task_dirs(self) -> list[Path]:
         """Get all valid task directories."""
         return sorted(
-            d for d in self._tasks_dir.iterdir()
-            if d.is_dir() and (d / "task.toml").exists()
+            d
+            for d in self._tasks_dir.iterdir()
+            if d.is_dir()
+            and (d / "task.toml").exists()
             and d.name not in self._config.exclude_tasks
         )
 
@@ -292,7 +299,9 @@ class Job:
                 task = r["task_name"]
                 if r.get("rewards") is not None or r.get("verifier_error"):
                     if r.get("verifier_error"):
-                        logger.info(f"Skipping verifier-errored task on resume: {task} ({r['verifier_error'][:80]})")
+                        logger.info(
+                            f"Skipping verifier-errored task on resume: {task} ({r['verifier_error'][:80]})"
+                        )
                     completed[task] = r
             except Exception as e:
                 logger.debug(f"Skipping corrupt result file {rfile}: {e}")
@@ -303,8 +312,12 @@ class Job:
         if self._config.environment != "docker":
             return
         try:
-            subprocess.run(["docker", "container", "prune", "-f"], capture_output=True, timeout=30)
-            subprocess.run(["docker", "network", "prune", "-f"], capture_output=True, timeout=30)
+            subprocess.run(
+                ["docker", "container", "prune", "-f"], capture_output=True, timeout=30
+            )
+            subprocess.run(
+                ["docker", "network", "prune", "-f"], capture_output=True, timeout=30
+            )
         except Exception as e:
             logger.warning(f"Docker prune failed: {e}")
 
@@ -313,7 +326,9 @@ class Job:
         cfg = self._config
         last_result = None
 
-        for attempt in range(1, cfg.retry.max_retries + 2):  # +2 because range is exclusive and attempt 1 is first try
+        for attempt in range(
+            1, cfg.retry.max_retries + 2
+        ):  # +2 because range is exclusive and attempt 1 is first try
             if attempt > 1:
                 self._prune_docker()
             result = await self._sdk.run(
@@ -333,11 +348,17 @@ class Job:
             last_result = result
 
             # If succeeded, verifier-errored (terminal), or non-retryable, stop
-            if result.rewards is not None or result.verifier_error or not cfg.retry.should_retry(result.error):
+            if (
+                result.rewards is not None
+                or result.verifier_error
+                or not cfg.retry.should_retry(result.error)
+            ):
                 break
 
             if attempt <= cfg.retry.max_retries:
-                logger.info(f"Retrying {task_dir.name} (attempt {attempt + 1}): {result.error[:60]}")
+                logger.info(
+                    f"Retrying {task_dir.name} (attempt {attempt + 1}): {result.error[:60]}"
+                )
 
         return last_result
 
@@ -388,7 +409,9 @@ class Job:
                 self._prune_docker()
                 # Log result
                 reward = result.rewards.get("reward") if result.rewards else None
-                status = "PASS" if reward == 1 else ("FAIL" if reward is not None else "ERR")
+                status = (
+                    "PASS" if reward == 1 else ("FAIL" if reward is not None else "ERR")
+                )
                 err_msg = result.error or result.verifier_error
                 err = f" ({err_msg[:50]})" if err_msg else ""
                 logger.info(f"[{status}] {td.name} (tools={result.n_tool_calls}){err}")
@@ -408,9 +431,15 @@ class Job:
             if isinstance(r, BaseException):
                 task_name = remaining[i].name
                 logger.error(f"[ERR] {task_name}: unexpected exception: {r}")
-                pairs.append((task_name, RunResult(
-                    task_name=task_name, error=f"Unexpected: {r}",
-                )))
+                pairs.append(
+                    (
+                        task_name,
+                        RunResult(
+                            task_name=task_name,
+                            error=f"Unexpected: {r}",
+                        ),
+                    )
+                )
             else:
                 pairs.append(r)
 
@@ -433,16 +462,29 @@ class Job:
             config=cfg,
             total=len(task_dirs),
             passed=sum(1 for r in all_results.values() if extract_reward(r) == 1.0),
-            failed=sum(1 for r in all_results.values()
-                       if extract_reward(r) is not None and extract_reward(r) != 1.0),
-            errored=sum(1 for r in all_results.values()
-                        if r.get("error") and r.get("rewards") is None),
-            verifier_errored=sum(1 for r in all_results.values()
-                                if r.get("verifier_error")),
+            failed=sum(
+                1
+                for r in all_results.values()
+                if extract_reward(r) is not None and extract_reward(r) != 1.0
+            ),
+            errored=sum(
+                1
+                for r in all_results.values()
+                if r.get("error") and r.get("rewards") is None
+            ),
+            verifier_errored=sum(
+                1 for r in all_results.values() if r.get("verifier_error")
+            ),
             elapsed_sec=elapsed,
         )
 
-        assert job_result.passed + job_result.failed + job_result.errored + job_result.verifier_errored == job_result.total, (
+        assert (
+            job_result.passed
+            + job_result.failed
+            + job_result.errored
+            + job_result.verifier_errored
+            == job_result.total
+        ), (
             f"Counting bug: {job_result.passed}+{job_result.failed}+{job_result.errored}+"
             f"{job_result.verifier_errored} != {job_result.total}"
         )
@@ -479,7 +521,7 @@ class Job:
         logger.info(
             f"Job complete: {job_result.passed}/{job_result.total} "
             f"({job_result.score:.1%}), errors={job_result.errored}, "
-            f"time={elapsed/60:.1f}min"
+            f"time={elapsed / 60:.1f}min"
         )
 
         return job_result

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -10,7 +10,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-from benchflow._scoring import classify_error, classify_verifier_error, pass_rate, pass_rate_excl_errors
+from benchflow._scoring import (
+    classify_error,
+    classify_verifier_error,
+    pass_rate,
+    pass_rate_excl_errors,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -90,13 +95,25 @@ class BenchmarkMetrics:
     def avg_tool_calls(self) -> float:
         """Average tool calls per completed task."""
         completed = [t for t in self.tasks if not t.errored and not t.verifier_errored]
-        return sum(t.n_tool_calls for t in completed) / len(completed) if completed else 0.0
+        return (
+            sum(t.n_tool_calls for t in completed) / len(completed)
+            if completed
+            else 0.0
+        )
 
     @property
     def avg_duration(self) -> float:
         """Average duration per completed task (seconds)."""
-        completed = [t for t in self.tasks if not t.errored and not t.verifier_errored and t.duration_sec > 0]
-        return sum(t.duration_sec for t in completed) / len(completed) if completed else 0.0
+        completed = [
+            t
+            for t in self.tasks
+            if not t.errored and not t.verifier_errored and t.duration_sec > 0
+        ]
+        return (
+            sum(t.duration_sec for t in completed) / len(completed)
+            if completed
+            else 0.0
+        )
 
     @property
     def error_breakdown(self) -> dict[str, int]:
@@ -142,7 +159,9 @@ class BenchmarkMetrics:
             "passed_tasks": sorted(t.task_name for t in self.tasks if t.passed),
             "failed_tasks": sorted(t.task_name for t in self.tasks if t.failed),
             "errored_tasks": sorted(t.task_name for t in self.tasks if t.errored),
-            "verifier_errored_tasks": sorted(t.task_name for t in self.tasks if t.verifier_errored),
+            "verifier_errored_tasks": sorted(
+                t.task_name for t in self.tasks if t.verifier_errored
+            ),
         }
 
 
@@ -169,8 +188,10 @@ def collect_metrics(
             elif r.get("rewards") is not None and best[task].get("rewards") is None:
                 best[task] = r
             elif (
-                r.get("rewards") and best[task].get("rewards")
-                and r["rewards"].get("reward", 0) > best[task]["rewards"].get("reward", 0)
+                r.get("rewards")
+                and best[task].get("rewards")
+                and r["rewards"].get("reward", 0)
+                > best[task]["rewards"].get("reward", 0)
             ):
                 best[task] = r
         except Exception as e:
@@ -183,22 +204,25 @@ def collect_metrics(
         duration = 0.0
         try:
             from datetime import datetime
+
             started = datetime.fromisoformat(r["started_at"])
             finished = datetime.fromisoformat(r["finished_at"])
             duration = (finished - started).total_seconds()
         except (KeyError, ValueError):
             logger.debug("Could not compute duration for task %s", task_name)
 
-        tasks.append(TaskMetrics(
-            task_name=task_name,
-            reward=reward,
-            n_tool_calls=r.get("n_tool_calls", 0),
-            n_prompts=r.get("n_prompts", 0),
-            error=r.get("error"),
-            verifier_error=r.get("verifier_error"),
-            duration_sec=duration,
-            agent_name=r.get("agent_name", ""),
-        ))
+        tasks.append(
+            TaskMetrics(
+                task_name=task_name,
+                reward=reward,
+                n_tool_calls=r.get("n_tool_calls", 0),
+                n_prompts=r.get("n_prompts", 0),
+                error=r.get("error"),
+                verifier_error=r.get("verifier_error"),
+                duration_sec=duration,
+                agent_name=r.get("agent_name", ""),
+            )
+        )
 
     return BenchmarkMetrics(
         benchmark=benchmark,

--- a/src/benchflow/process.py
+++ b/src/benchflow/process.py
@@ -138,9 +138,12 @@ class DockerProcess(LiveProcess):
     def _compose_cmd(self) -> list[str]:
         """Base docker compose command with project/file flags."""
         cmd = [
-            "docker", "compose",
-            "-p", self._project_name,
-            "--project-directory", self._project_dir,
+            "docker",
+            "compose",
+            "-p",
+            self._project_name,
+            "--project-directory",
+            self._project_dir,
         ]
         for f in self._compose_files:
             cmd.extend(["-f", f])
@@ -151,11 +154,19 @@ class DockerProcess(LiveProcess):
         proc_env = os.environ.copy()
         if not proc_env.get("DOCKER_HOST"):
             import subprocess
+
             try:
                 r = subprocess.run(
-                    ["docker", "context", "inspect", "--format",
-                     "{{.Endpoints.docker.Host}}"],
-                    capture_output=True, text=True, timeout=5,
+                    [
+                        "docker",
+                        "context",
+                        "inspect",
+                        "--format",
+                        "{{.Endpoints.docker.Host}}",
+                    ],
+                    capture_output=True,
+                    text=True,
+                    timeout=5,
                 )
                 if r.returncode == 0 and r.stdout.strip():
                     proc_env["DOCKER_HOST"] = r.stdout.strip()
@@ -166,16 +177,23 @@ class DockerProcess(LiveProcess):
     _ENV_PATH = "/tmp/.benchflow_env"
 
     async def _write_env_to_container(
-        self, env: dict[str, str], proc_env: dict[str, str],
+        self,
+        env: dict[str, str],
+        proc_env: dict[str, str],
     ) -> None:
         """Write env vars to a file inside the container (not visible in ps aux)."""
         lines = "".join(f"export {k}={shlex.quote(v)}\n" for k, v in env.items())
         write_cmd = self._compose_cmd()
-        write_cmd.extend([
-            "exec", "-T", self._service,
-            "bash", "-c",
-            f"cat > {self._ENV_PATH} && chmod 600 {self._ENV_PATH}",
-        ])
+        write_cmd.extend(
+            [
+                "exec",
+                "-T",
+                self._service,
+                "bash",
+                "-c",
+                f"cat > {self._ENV_PATH} && chmod 600 {self._ENV_PATH}",
+            ]
+        )
         proc = await asyncio.create_subprocess_exec(
             *write_cmd,
             stdin=asyncio.subprocess.PIPE,
@@ -235,7 +253,9 @@ class DaytonaProcess(LiveProcess):
     For direct sandboxes, the command runs directly via SSH.
     """
 
-    def __init__(self, sandbox: Any, is_dind: bool = False, compose_cmd_prefix: str = ""):
+    def __init__(
+        self, sandbox: Any, is_dind: bool = False, compose_cmd_prefix: str = ""
+    ):
         """
         Args:
             sandbox: Daytona AsyncSandbox instance
@@ -254,19 +274,20 @@ class DaytonaProcess(LiveProcess):
             raise RuntimeError("Daytona sandbox not started")
 
         # Detect DinD mode by checking if the environment uses compose
-        is_dind = hasattr(env, '_strategy') and hasattr(env._strategy, '_compose_cmd')
+        is_dind = hasattr(env, "_strategy") and hasattr(env._strategy, "_compose_cmd")
 
         compose_cmd_prefix = ""
         if is_dind:
             # Build compose env vars and command prefix for DinD
             strategy = env._strategy
             compose_env = " ".join(
-                f"{k}={shlex.quote(v)}"
-                for k, v in strategy._compose_env_vars().items()
+                f"{k}={shlex.quote(v)}" for k, v in strategy._compose_env_vars().items()
             )
             compose_cmd_prefix = compose_env
 
-        return cls(sandbox=sandbox, is_dind=is_dind, compose_cmd_prefix=compose_cmd_prefix)
+        return cls(
+            sandbox=sandbox, is_dind=is_dind, compose_cmd_prefix=compose_cmd_prefix
+        )
 
     async def start(
         self,
@@ -304,7 +325,9 @@ class DaytonaProcess(LiveProcess):
                     f"umask 077 && cat > {remote_env_path} <<'__BENCHFLOW_ENV__'\n"
                     f"{env_lines}\n__BENCHFLOW_ENV__"
                 )
-                remote_cmd = f"{write_cmd}\ntrap 'rm -f {remote_env_path}' EXIT\n{remote_cmd}"
+                remote_cmd = (
+                    f"{write_cmd}\ntrap 'rm -f {remote_env_path}' EXIT\n{remote_cmd}"
+                )
         else:
             # Direct sandbox — run command via SSH.
             # Write env vars to a file on the remote host and source it,
@@ -327,13 +350,18 @@ class DaytonaProcess(LiveProcess):
                     f"umask 077 && cat > {remote_env_path} <<'__BENCHFLOW_ENV__'\n"
                     f"{env_lines}\n__BENCHFLOW_ENV__"
                 )
-                remote_cmd = f"{write_cmd}\ntrap 'rm -f {remote_env_path}' EXIT\n{remote_cmd}"
+                remote_cmd = (
+                    f"{write_cmd}\ntrap 'rm -f {remote_env_path}' EXIT\n{remote_cmd}"
+                )
 
         cmd = [
             "ssh",
-            "-o", "StrictHostKeyChecking=no",
-            "-o", "UserKnownHostsFile=/dev/null",
-            "-o", "LogLevel=ERROR",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "LogLevel=ERROR",
             ssh_target,
             remote_cmd,
         ]

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -41,6 +41,7 @@ from benchflow.agents.registry import (
     AGENTS,
     AGENT_INSTALLERS,
     AGENT_LAUNCH,
+    AgentConfig,
     get_sandbox_home_dirs,
 )
 from benchflow.process import DockerProcess, DaytonaProcess
@@ -520,7 +521,7 @@ class SDK:
         }]
         return trajectory, "oracle"
 
-    async def _install_agent(self, env, agent: str, trial_dir: Path) -> "AgentConfig | None":
+    async def _install_agent(self, env, agent: str, trial_dir: Path) -> AgentConfig | None:
         """Install agent in sandbox and return its config."""
         agent_base = agent.split()[0]
         agent_cfg = AGENTS.get(agent_base)

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -135,13 +135,19 @@ class SDK:
             os.unlink(tmp_path)
 
     async def _write_credential_files(
-        self, env, agent: str, agent_env: dict, agent_cfg, model: str | None,
+        self,
+        env,
+        agent: str,
+        agent_env: dict,
+        agent_cfg,
+        model: str | None,
         cred_home: str,
     ) -> None:
         """Write credential files into container from agent + provider configs."""
         # Provider credential files (e.g. GCP ADC for Vertex)
         if model:
             from benchflow.agents.providers import find_provider
+
             _prov = find_provider(model)
             if _prov:
                 _, _prov_cfg = _prov
@@ -168,7 +174,11 @@ class SDK:
                     logger.info("Agent credential file written: %s", path)
 
     async def _write_gemini_vertex_settings(
-        self, env, agent: str, model: str | None, cred_home: str,
+        self,
+        env,
+        agent: str,
+        model: str | None,
+        cred_home: str,
     ) -> None:
         """Write ~/.gemini/settings.json to select Vertex AI backend.
 
@@ -183,6 +193,7 @@ class SDK:
         if not model or agent != "gemini":
             return
         from benchflow.agents.registry import is_vertex_model
+
         if not is_vertex_model(model):
             return
         settings = json.dumps(
@@ -193,7 +204,10 @@ class SDK:
         logger.info("Gemini Vertex settings written: %s", path)
 
     async def _upload_subscription_auth(
-        self, env, agent: str, cred_home: str,
+        self,
+        env,
+        agent: str,
+        cred_home: str,
     ) -> None:
         """Upload host subscription auth files into the container.
 
@@ -211,7 +225,9 @@ class SDK:
             content = host_path.read_text()
             await self._upload_credential(env, container_path, content)
             logger.info(
-                "Subscription auth uploaded: %s -> %s", host_path, container_path,
+                "Subscription auth uploaded: %s -> %s",
+                host_path,
+                container_path,
             )
 
     @staticmethod
@@ -223,6 +239,7 @@ class SDK:
     ) -> tuple["Task", Path, "TrialPaths", datetime, str, str]:
         """Set up trial directory tree and return core trial objects."""
         from uuid import uuid4
+
         task = Task(task_path)
         job_name = job_name or datetime.now().strftime("%Y-%m-%d__%H-%M-%S")
         trial_name = trial_name or f"{task_path.name}__{uuid4().hex[:8]}"
@@ -239,8 +256,15 @@ class SDK:
     def _auto_inherit_env(agent_env: dict[str, str]) -> None:
         """Copy well-known API keys from host os.environ into agent_env."""
         from benchflow.agents.providers import PROVIDERS
-        keys = {"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY",
-                "GEMINI_API_KEY", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"}
+
+        keys = {
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_LOCATION",
+        }
         for cfg in PROVIDERS.values():
             if cfg.auth_env:
                 keys.add(cfg.auth_env)
@@ -257,6 +281,7 @@ class SDK:
     def _inject_vertex_credentials(agent_env: dict[str, str], model: str) -> None:
         """Inject ADC credentials and defaults for Vertex AI models."""
         from benchflow.agents.registry import is_vertex_model
+
         if not is_vertex_model(model):
             return
         adc_path = Path.home() / ".config/gcloud/application_default_credentials.json"
@@ -265,7 +290,9 @@ class SDK:
                 f"Vertex AI model {model!r} requires ADC credentials. "
                 f"Run: gcloud auth application-default login"
             )
-        agent_env.setdefault("GOOGLE_APPLICATION_CREDENTIALS_JSON", adc_path.read_text())
+        agent_env.setdefault(
+            "GOOGLE_APPLICATION_CREDENTIALS_JSON", adc_path.read_text()
+        )
         agent_env.setdefault("GOOGLE_CLOUD_LOCATION", "global")
         if "GOOGLE_CLOUD_PROJECT" not in agent_env:
             raise ValueError(
@@ -275,10 +302,17 @@ class SDK:
 
     @staticmethod
     def _resolve_provider_env(
-        agent_env: dict[str, str], model: str, agent: str,
+        agent_env: dict[str, str],
+        model: str,
+        agent: str,
     ) -> None:
         """Detect provider for model, inject BENCHFLOW_PROVIDER_* and env_mapping."""
-        from benchflow.agents.providers import find_provider, resolve_base_url, strip_provider_prefix
+        from benchflow.agents.providers import (
+            find_provider,
+            resolve_base_url,
+            strip_provider_prefix,
+        )
+
         agent_env.setdefault("BENCHFLOW_PROVIDER_MODEL", strip_provider_prefix(model))
         agent_cfg = AGENTS.get(agent)
         # Agent-declared protocol takes precedence over provider's primary so
@@ -291,7 +325,9 @@ class SDK:
             try:
                 agent_env.setdefault(
                     "BENCHFLOW_PROVIDER_BASE_URL",
-                    resolve_base_url(_prov_cfg, agent_env, protocol=agent_protocol or None),
+                    resolve_base_url(
+                        _prov_cfg, agent_env, protocol=agent_protocol or None
+                    ),
                 )
             except KeyError:
                 pass  # URL params missing — will fail later with clear error
@@ -300,8 +336,9 @@ class SDK:
                 agent_protocol or _prov_cfg.api_protocol,
             )
             if _prov_cfg.models:
-                agent_env.setdefault("BENCHFLOW_PROVIDER_MODELS",
-                                     json.dumps(_prov_cfg.models))
+                agent_env.setdefault(
+                    "BENCHFLOW_PROVIDER_MODELS", json.dumps(_prov_cfg.models)
+                )
             if _prov_cfg.auth_type == "api_key" and _prov_cfg.auth_env:
                 _key = agent_env.get(_prov_cfg.auth_env, "")
                 if _key:
@@ -337,12 +374,14 @@ class SDK:
             SDK._resolve_provider_env(agent_env, model, agent)
             # Validate required API key for the chosen model
             from benchflow.agents.registry import infer_env_key_for_model
+
             required_key = infer_env_key_for_model(model)
             if required_key and required_key not in agent_env:
                 if SDK._check_subscription_auth(agent, required_key):
                     agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
                     logger.info(
-                        "Using host subscription auth (no %s set)", required_key,
+                        "Using host subscription auth (no %s set)",
+                        required_key,
                     )
                 else:
                     raise ValueError(
@@ -359,7 +398,8 @@ class SDK:
                         if SDK._check_subscription_auth(agent, req_key):
                             agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
                             logger.info(
-                                "Using host subscription auth (no %s set)", req_key,
+                                "Using host subscription auth (no %s set)",
+                                req_key,
                             )
         # Increase output token limit to avoid truncation errors
         agent_env.setdefault("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "128000")
@@ -386,7 +426,8 @@ class SDK:
         """Write config.json to trial_dir with secrets filtered out."""
         _secret_substrings = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIALS")
         recorded_env = {
-            k: v for k, v in agent_env.items()
+            k: v
+            for k, v in agent_env.items()
             if not any(s in k.upper() for s in _secret_substrings)
         }
         config_data = {
@@ -480,7 +521,9 @@ class SDK:
         return result
 
     @staticmethod
-    def _resolve_prompts(task_path: Path, prompts: list[str | None] | None) -> list[str]:
+    def _resolve_prompts(
+        task_path: Path, prompts: list[str | None] | None
+    ) -> list[str]:
         """Read instruction.md and resolve prompt list."""
         instruction_path = task_path / "instruction.md"
         if not instruction_path.exists():
@@ -501,7 +544,9 @@ class SDK:
         if (task_path / "solution").is_dir():
             await env.upload_dir(task_path / "solution", "/solution")
 
-    async def _run_oracle(self, env, task_path: Path, timeout: int) -> tuple[list[dict], str]:
+    async def _run_oracle(
+        self, env, task_path: Path, timeout: int
+    ) -> tuple[list[dict], str]:
         """Run oracle mode (solution/solve.sh), return (trajectory, agent_name)."""
         logger.info("Oracle mode: running solution/solve.sh")
         if not (task_path / "solution" / "solve.sh").exists():
@@ -513,24 +558,31 @@ class SDK:
         )
         if result.return_code != 0:
             logger.warning(f"Oracle solve.sh exited with rc={result.return_code}")
-        trajectory = [{
-            "type": "oracle",
-            "command": "solution/solve.sh",
-            "return_code": result.return_code,
-            "stdout": (result.stdout or "")[:_DIAG_TRUNCATE],
-        }]
+        trajectory = [
+            {
+                "type": "oracle",
+                "command": "solution/solve.sh",
+                "return_code": result.return_code,
+                "stdout": (result.stdout or "")[:_DIAG_TRUNCATE],
+            }
+        ]
         return trajectory, "oracle"
 
-    async def _install_agent(self, env, agent: str, trial_dir: Path) -> AgentConfig | None:
+    async def _install_agent(
+        self, env, agent: str, trial_dir: Path
+    ) -> AgentConfig | None:
         """Install agent in sandbox and return its config."""
         agent_base = agent.split()[0]
         agent_cfg = AGENTS.get(agent_base)
         if agent_base not in AGENT_INSTALLERS:
             return agent_cfg
         install_timeout = agent_cfg.install_timeout if agent_cfg else 900
-        logger.info(f"Installing {agent_base} in sandbox (timeout={install_timeout}s)...")
+        logger.info(
+            f"Installing {agent_base} in sandbox (timeout={install_timeout}s)..."
+        )
         install_result = await env.exec(
-            AGENT_INSTALLERS[agent_base], timeout_sec=install_timeout,
+            AGENT_INSTALLERS[agent_base],
+            timeout_sec=install_timeout,
         )
         install_log = trial_dir / "agent" / "install-stdout.txt"
         install_log.parent.mkdir(parents=True, exist_ok=True)
@@ -552,8 +604,14 @@ class SDK:
         return agent_cfg
 
     async def _deploy_skills(
-        self, env, task_path: Path, skills_dir: str | Path | None,
-        agent_cfg, sandbox_user: str | None, agent_cwd: str, task: "Task",
+        self,
+        env,
+        task_path: Path,
+        skills_dir: str | Path | None,
+        agent_cfg,
+        sandbox_user: str | None,
+        agent_cwd: str,
+        task: "Task",
     ) -> None:
         """Deploy and distribute skills into sandbox."""
         # Runtime upload (fallback if not baked into Dockerfile)
@@ -566,14 +624,20 @@ class SDK:
             if not already_injected:
                 skills_path = Path(skills_dir)
                 if skills_path.is_dir():
-                    logger.info(f"Deploying skills via runtime upload from {skills_path}")
+                    logger.info(
+                        f"Deploying skills via runtime upload from {skills_path}"
+                    )
                     await env.upload_dir(skills_path, "/skills")
                     if agent_cfg and agent_cfg.skill_paths:
                         parts = []
                         for sp in agent_cfg.skill_paths:
-                            expanded = sp.replace("$HOME", "/root").replace("$WORKSPACE", "/app")
+                            expanded = sp.replace("$HOME", "/root").replace(
+                                "$WORKSPACE", "/app"
+                            )
                             parent = str(Path(expanded).parent)
-                            parts.append(f"mkdir -p '{parent}' && ln -sf /skills '{expanded}'")
+                            parts.append(
+                                f"mkdir -p '{parent}' && ln -sf /skills '{expanded}'"
+                            )
                         await env.exec(" && ".join(parts), timeout_sec=10)
                     logger.info("Skills deployed to /skills and symlinked")
                 else:
@@ -591,10 +655,14 @@ class SDK:
                 expanded = sp.replace("$HOME", home).replace("$WORKSPACE", agent_cwd)
                 q_expanded = shlex.quote(expanded)
                 q_skills = shlex.quote(effective_skills)
-                parts.append(f"mkdir -p {q_expanded} && cp -r {q_skills}/. {q_expanded}/ 2>/dev/null")
+                parts.append(
+                    f"mkdir -p {q_expanded} && cp -r {q_skills}/. {q_expanded}/ 2>/dev/null"
+                )
             if parts:
                 await env.exec("; ".join(parts), timeout_sec=15)
-                logger.info(f"Skills distributed to {len(parts)} paths for {agent_cfg.name}")
+                logger.info(
+                    f"Skills distributed to {len(parts)} paths for {agent_cfg.name}"
+                )
 
     @staticmethod
     def _build_priv_drop_cmd(agent_launch: str, sandbox_user: str) -> str:
@@ -632,19 +700,21 @@ class SDK:
         parts = []
         for p in paths:
             parts.append(
-                f'for d in {p}; do '
+                f"for d in {p}; do "
                 f'  [ -L "$d" ] && echo "WARN: skipping symlink $d" >&2 && continue; '
                 f'  [ -e "$d" ] || continue; '
                 f'  chown root:root "$d" && chmod 700 "$d"; '
-                f'done'
+                f"done"
             )
         cmd = " && ".join(parts)
         await env.exec(cmd, timeout_sec=30)
 
     async def _setup_sandbox_user(self, env, sandbox_user: str, workspace: str) -> str:
         """Create non-root sandbox user, grant workspace access. Return agent_cwd."""
-        if not re.match(r'^[a-z_][a-z0-9_-]*$', sandbox_user):
-            raise ValueError(f"Invalid sandbox_user: {sandbox_user!r} (must be alphanumeric)")
+        if not re.match(r"^[a-z_][a-z0-9_-]*$", sandbox_user):
+            raise ValueError(
+                f"Invalid sandbox_user: {sandbox_user!r} (must be alphanumeric)"
+            )
         logger.info(f"Setting up sandbox user: {sandbox_user}")
         await env.exec(
             f"id -u {sandbox_user} >/dev/null 2>&1 || "
@@ -665,14 +735,23 @@ class SDK:
         return workspace
 
     async def _connect_acp(
-        self, env, agent: str, agent_launch: str, agent_env: dict,
-        sandbox_user: str | None, model: str | None,
-        trial_dir: Path, environment: str, agent_cwd: str,
+        self,
+        env,
+        agent: str,
+        agent_launch: str,
+        agent_env: dict,
+        sandbox_user: str | None,
+        model: str | None,
+        trial_dir: Path,
+        environment: str,
+        agent_cwd: str,
     ) -> tuple[ACPClient, object, str]:
         """Create ACP transport, connect, init session, set model. Return (client, session, agent_name)."""
         # Resolve agent binary path for non-docker environments
         if environment != "docker":
-            which_result = await env.exec(f"which {agent_launch.split()[0]}", timeout_sec=10)
+            which_result = await env.exec(
+                f"which {agent_launch.split()[0]}", timeout_sec=10
+            )
             if which_result.return_code == 0 and (which_result.stdout or "").strip():
                 full_path = which_result.stdout.strip()
                 parts = agent_launch.split()
@@ -691,8 +770,11 @@ class SDK:
 
         agent_log = trial_dir / "agent" / f"{agent.replace('-', '_')}.txt"
         transport = ContainerTransport(
-            container_process=live_proc, command=agent_launch,
-            env=agent_env, cwd=agent_cwd, agent_log_path=agent_log,
+            container_process=live_proc,
+            command=agent_launch,
+            env=agent_env,
+            cwd=agent_cwd,
+            agent_log_path=agent_log,
         )
         acp_client = ACPClient(transport)
         await acp_client.connect()
@@ -701,11 +783,14 @@ class SDK:
         agent_name = init_result.agent_info.name if init_result.agent_info else agent
         logger.info(f"ACP agent: {agent_name}")
 
-        session = await asyncio.wait_for(acp_client.session_new(cwd=agent_cwd), timeout=60)
+        session = await asyncio.wait_for(
+            acp_client.session_new(cwd=agent_cwd), timeout=60
+        )
         logger.info(f"Session: {session.session_id}")
 
         if model:
             from benchflow.agents.providers import strip_provider_prefix
+
             acp_model_id = strip_provider_prefix(model)
             try:
                 await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
@@ -716,13 +801,18 @@ class SDK:
         return acp_client, session, agent_name
 
     async def _execute_prompts(
-        self, acp_client: ACPClient, session, prompts: list[str], timeout: int,
+        self,
+        acp_client: ACPClient,
+        session,
+        prompts: list[str],
+        timeout: int,
     ) -> tuple[list[dict], int]:
         """Send prompts via ACP and capture trajectory. Return (trajectory, n_tool_calls)."""
         for i, prompt in enumerate(prompts):
             logger.info(f"Prompt {i + 1}/{len(prompts)}: {prompt[:80]}...")
             prompt_result = await asyncio.wait_for(
-                acp_client.prompt(prompt), timeout=timeout,
+                acp_client.prompt(prompt),
+                timeout=timeout,
             )
             logger.info(
                 f"  → {prompt_result.stop_reason.value}, "
@@ -744,8 +834,8 @@ class SDK:
     _VERIFIER_ENV = {
         "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
         "PYTEST_ADDOPTS": (
-            "-c /dev/null "          # block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
-            "--confcutdir=/tests "   # block conftest.py walk-up beyond /tests
+            "-c /dev/null "  # block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
+            "--confcutdir=/tests "  # block conftest.py walk-up beyond /tests
             "--rootdir=/tests "
             "-p no:cacheprovider"
         ),
@@ -753,7 +843,7 @@ class SDK:
         "PYTHONPATH": "",
         "PYTHONHOME": "",
         "PYTHONSTARTUP": "",
-        "PYTHONSAFEPATH": "1",       # drop implicit '' (cwd) from sys.path
+        "PYTHONSAFEPATH": "1",  # drop implicit '' (cwd) from sys.path
         "LD_PRELOAD": "",
         "LD_LIBRARY_PATH": "",
     }
@@ -779,7 +869,9 @@ class SDK:
         '" 2>/dev/null || true'
     )
 
-    async def _harden_before_verify(self, env, task: "Task", sandbox_user: str | None) -> None:
+    async def _harden_before_verify(
+        self, env, task: "Task", sandbox_user: str | None
+    ) -> None:
         """Neutralize agent tampering before running the verifier.
 
         1. Kill sandbox-user processes (prevent concurrent writes).
@@ -799,7 +891,14 @@ class SDK:
             verifier_env.update(task.config.verifier.env)
         task.config.verifier.env = verifier_env
 
-    async def _verify(self, env, task: "Task", trial_paths: "TrialPaths", timing: dict, sandbox_user: str | None = None) -> tuple[dict | None, str | None]:
+    async def _verify(
+        self,
+        env,
+        task: "Task",
+        trial_paths: "TrialPaths",
+        timing: dict,
+        sandbox_user: str | None = None,
+    ) -> tuple[dict | None, str | None]:
         """Run verifier with pre-verification hardening."""
         trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
         await self._harden_before_verify(env, task, sandbox_user)
@@ -818,7 +917,9 @@ class SDK:
         except asyncio.TimeoutError:
             timing["verifier"] = (datetime.now() - t0).total_seconds()
             # NOTE: these prefixes must stay in sync with classify_verifier_error() in _scoring.py
-            verifier_error = f"verifier timed out after {task.config.verifier.timeout_sec}s"
+            verifier_error = (
+                f"verifier timed out after {task.config.verifier.timeout_sec}s"
+            )
             rewards = None
             logger.error(verifier_error)
         except Exception as e:
@@ -884,8 +985,13 @@ class SDK:
         effective_locked = _resolve_locked_paths(sandbox_user, sandbox_locked_paths)
 
         task_path = Path(task_path)
-        task, trial_dir, trial_paths, started_at, job_name, trial_name = self._init_trial(
-            task_path, job_name, trial_name, jobs_dir,
+        task, trial_dir, trial_paths, started_at, job_name, trial_name = (
+            self._init_trial(
+                task_path,
+                job_name,
+                trial_name,
+                jobs_dir,
+            )
         )
         agent_env = self._resolve_agent_env(agent, model, agent_env)
         prompts = self._resolve_prompts(task_path, prompts)
@@ -902,10 +1008,17 @@ class SDK:
 
         self._write_config(
             trial_dir,
-            task_path=task_path, agent=agent, model=model, environment=environment,
-            skills_dir=skills_dir, sandbox_user=sandbox_user, context_root=context_root,
+            task_path=task_path,
+            agent=agent,
+            model=model,
+            environment=environment,
+            skills_dir=skills_dir,
+            sandbox_user=sandbox_user,
+            context_root=context_root,
             sandbox_locked_paths=effective_locked,
-            timeout=timeout, started_at=started_at, agent_env=agent_env,
+            timeout=timeout,
+            started_at=started_at,
+            agent_env=agent_env,
         )
 
         acp_client: ACPClient | None = None
@@ -923,7 +1036,7 @@ class SDK:
             t_agent_setup = datetime.now()
             t_agent_exec = t_agent_setup
 
-            for hook in (pre_agent_hooks or []):
+            for hook in pre_agent_hooks or []:
                 await hook(env)
 
             if agent == "oracle":
@@ -932,7 +1045,12 @@ class SDK:
                 agent_cfg = await self._install_agent(env, agent, trial_dir)
                 cred_home = f"/home/{sandbox_user}" if sandbox_user else "/root"
                 await self._write_credential_files(
-                    env, agent, agent_env, agent_cfg, model, cred_home,
+                    env,
+                    agent,
+                    agent_env,
+                    agent_cfg,
+                    model,
+                    cred_home,
                 )
                 if agent_env.get("_BENCHFLOW_SUBSCRIPTION_AUTH"):
                     await self._upload_subscription_auth(env, agent, cred_home)
@@ -941,32 +1059,54 @@ class SDK:
                 cwd_result = await env.exec("pwd", timeout_sec=10)
                 agent_cwd = (cwd_result.stdout or "").strip() or "/app"
                 if sandbox_user:
-                    agent_cwd = await self._setup_sandbox_user(env, sandbox_user, workspace=agent_cwd)
+                    agent_cwd = await self._setup_sandbox_user(
+                        env, sandbox_user, workspace=agent_cwd
+                    )
 
                 await self._deploy_skills(
-                    env, task_path, skills_dir, agent_cfg, sandbox_user, agent_cwd, task,
+                    env,
+                    task_path,
+                    skills_dir,
+                    agent_cfg,
+                    sandbox_user,
+                    agent_cwd,
+                    task,
                 )
 
                 await self._lockdown_paths(env, effective_locked)
 
                 acp_client, session, agent_name = await self._connect_acp(
-                    env, agent, agent_launch, agent_env, sandbox_user,
-                    model, trial_dir, environment, agent_cwd,
+                    env,
+                    agent,
+                    agent_launch,
+                    agent_env,
+                    sandbox_user,
+                    model,
+                    trial_dir,
+                    environment,
+                    agent_cwd,
                 )
                 timing["agent_setup"] = (datetime.now() - t_agent_setup).total_seconds()
                 t_agent_exec = datetime.now()
 
                 trajectory, n_tool_calls = await self._execute_prompts(
-                    acp_client, session, prompts, timeout,
+                    acp_client,
+                    session,
+                    prompts,
+                    timeout,
                 )
                 trajectory_source = "acp"
 
             if agent != "oracle" and "agent_setup" not in timing:
                 timing["agent_setup"] = (datetime.now() - t_agent_setup).total_seconds()
             if agent == "oracle":
-                timing["agent_execution"] = (datetime.now() - t_agent_setup).total_seconds()
+                timing["agent_execution"] = (
+                    datetime.now() - t_agent_setup
+                ).total_seconds()
             elif "agent_execution" not in timing:
-                timing["agent_execution"] = (datetime.now() - t_agent_exec).total_seconds()
+                timing["agent_execution"] = (
+                    datetime.now() - t_agent_exec
+                ).total_seconds()
 
             # Fallback: scrape agent-native trajectory if ACP captured nothing
             if not trajectory and agent != "oracle":
@@ -981,7 +1121,9 @@ class SDK:
                         f"agent-writable directory — data is UNTRUSTED"
                     )
 
-            rewards, verifier_error = await self._verify(env, task, trial_paths, timing, sandbox_user=sandbox_user)
+            rewards, verifier_error = await self._verify(
+                env, task, trial_paths, timing, sandbox_user=sandbox_user
+            )
 
         except asyncio.TimeoutError:
             error = f"Agent timed out after {timeout}s"
@@ -1001,7 +1143,9 @@ class SDK:
                         partial_trajectory = True
                         trajectory_source = "partial_acp"
                         n_tool_calls = len(acp_client.session.tool_calls)
-                        logger.info(f"Captured {len(trajectory)} partial trajectory events")
+                        logger.info(
+                            f"Captured {len(trajectory)} partial trajectory events"
+                        )
                 except Exception as e:
                     logger.warning(f"Partial trajectory capture failed: {e}")
 

--- a/src/benchflow/skills.py
+++ b/src/benchflow/skills.py
@@ -18,6 +18,7 @@ DEFAULT_SKILLS_DIR = Path.home() / ".claude" / "skills"
 @dataclass
 class SkillInfo:
     """Parsed skill metadata from SKILL.md frontmatter."""
+
     name: str
     description: str = ""
     version: str = ""
@@ -95,7 +96,9 @@ def install_skill(spec: str, target_dir: Path | None = None) -> Path | None:
     try:
         result = subprocess.run(
             ["npx", "skills", "add", spec],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True,
+            text=True,
+            timeout=60,
             cwd=str(target.parent),
         )
         if result.returncode != 0:

--- a/src/benchflow/task_download.py
+++ b/src/benchflow/task_download.py
@@ -35,7 +35,9 @@ def ensure_tasks(benchmark: str) -> Path:
     regardless of the caller's working directory.
     """
     if benchmark not in TASK_REPOS:
-        raise ValueError(f"Unknown benchmark: {benchmark!r}. Available: {sorted(TASK_REPOS)}")
+        raise ValueError(
+            f"Unknown benchmark: {benchmark!r}. Available: {sorted(TASK_REPOS)}"
+        )
 
     info = TASK_REPOS[benchmark]
     root = _repo_root()
@@ -62,5 +64,9 @@ def ensure_tasks(benchmark: str) -> Path:
         if clone_dir.exists():
             shutil.rmtree(clone_dir, ignore_errors=True)
 
-    logger.info("Downloaded %d tasks to %s", sum(1 for d in target.iterdir() if d.is_dir()), target)
+    logger.info(
+        "Downloaded %d tasks to %s",
+        sum(1 for d in target.iterdir() if d.is_dir()),
+        target,
+    )
     return target

--- a/src/benchflow/tasks.py
+++ b/src/benchflow/tasks.py
@@ -55,7 +55,9 @@ def check_task(task_dir: Path) -> list[str]:
         if not any(tests_dir.iterdir()):
             issues.append("tests/ directory is empty")
     else:
-        issues.append("Missing tests/ directory (verifier needs test.sh or evaluate.py)")
+        issues.append(
+            "Missing tests/ directory (verifier needs test.sh or evaluate.py)"
+        )
 
     return issues
 
@@ -74,7 +76,7 @@ def init_task(
     task_dir.mkdir(parents=True)
 
     # task.toml
-    (task_dir / "task.toml").write_text('''version = "1.0"
+    (task_dir / "task.toml").write_text("""version = "1.0"
 
 [metadata]
 author_name = ""
@@ -91,7 +93,7 @@ timeout_sec = 120
 [environment]
 cpus = 1
 memory_mb = 2048
-''')
+""")
 
     # instruction.md
     (task_dir / "instruction.md").write_text(f"""# {name}
@@ -128,7 +130,9 @@ echo "1.0" > /logs/verifier/reward.txt
     (tests_dir / "test.sh").chmod(0o755)
 
     if not no_pytest:
-        (tests_dir / "test_outputs.py").write_text("""\"\"\"Pytest-based verifier. Run by Harbor after agent completes.\"\"\"
+        (
+            tests_dir / "test_outputs.py"
+        ).write_text("""\"\"\"Pytest-based verifier. Run by Harbor after agent completes.\"\"\"
 
 def test_placeholder():
     # Replace with actual verification logic

--- a/src/benchflow/trajectories/__init__.py
+++ b/src/benchflow/trajectories/__init__.py
@@ -21,4 +21,3 @@ __all__ = [
     "Trajectory",
     "TrajectoryProxy",
 ]
-

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -359,7 +359,9 @@ def _reconstruct_response(events: list[dict[str, Any]]) -> dict[str, Any]:
                 try:
                     block["input"] = json.loads(block["input"])
                 except json.JSONDecodeError:
-                    logger.debug("Could not parse tool_use input as JSON, keeping as string")
+                    logger.debug(
+                        "Could not parse tool_use input as JSON, keeping as string"
+                    )
         return {
             "content": content,
             "model": model,

--- a/src/benchflow/viewer.py
+++ b/src/benchflow/viewer.py
@@ -73,9 +73,13 @@ def render_turn(events: list[dict], turn_number: int, prompt: str = "") -> str:
                             content_preview = args["content"][:_CONTENT_PREVIEW]
                             arg_display += f"\n{html.escape(content_preview)}{'...' if len(args['content']) > _CONTENT_PREVIEW else ''}"
                     elif name == "Agent":
-                        arg_display = html.escape(str(args.get("prompt", ""))[:_CONTENT_PREVIEW])
+                        arg_display = html.escape(
+                            str(args.get("prompt", ""))[:_CONTENT_PREVIEW]
+                        )
                     else:
-                        arg_display = html.escape(json.dumps(args, indent=2)[:_ARGS_PREVIEW])
+                        arg_display = html.escape(
+                            json.dumps(args, indent=2)[:_ARGS_PREVIEW]
+                        )
 
                     parts.append(
                         f'<div class="tool">'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,4 +14,3 @@ def hello_world_task_dir() -> Path:
     if not path.exists():
         pytest.skip("Harbor reference tasks not available")
     return path
-

--- a/tests/fixtures/mock_acp_agent.py
+++ b/tests/fixtures/mock_acp_agent.py
@@ -127,4 +127,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tests/fixtures/mock_acp_agent_interleaved.py
+++ b/tests/fixtures/mock_acp_agent_interleaved.py
@@ -75,7 +75,7 @@ def main():
 
             # Agent reads the permission response (we just consume it)
             # The client will send back a response to id=9000
-            resp_line = sys.stdin.readline().strip()
+            sys.stdin.readline()
             # (ignore the response content — we just needed the round trip)
 
             # 3. Send tool_call_update notification

--- a/tests/fixtures/mock_acp_agent_interleaved.py
+++ b/tests/fixtures/mock_acp_agent_interleaved.py
@@ -24,54 +24,62 @@ def main():
         req_id = msg.get("id")
 
         if method == "initialize":
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {
-                    "protocolVersion": 0,
-                    "agentInfo": {"name": "interleaved-agent", "version": "1.0.0"},
-                    "agentCapabilities": {},
-                },
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "protocolVersion": 0,
+                        "agentInfo": {"name": "interleaved-agent", "version": "1.0.0"},
+                        "agentCapabilities": {},
+                    },
+                }
+            )
 
         elif method == "session/new":
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {"sessionId": "mock-session-1"},
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {"sessionId": "mock-session-1"},
+                }
+            )
 
         elif method == "session/prompt":
             session_id = msg.get("params", {}).get("sessionId", "")
 
             # 1. Send a notification (tool_call)
-            send({
-                "jsonrpc": "2.0",
-                "method": "session/update",
-                "params": {
-                    "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "tool_call",
-                        "toolCallId": "tc_1",
-                        "title": "ls /",
-                        "kind": "bash",
-                        "status": "pending",
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "tool_call",
+                            "toolCallId": "tc_1",
+                            "title": "ls /",
+                            "kind": "bash",
+                            "status": "pending",
+                        },
                     },
-                },
-            })
+                }
+            )
 
             # 2. Send an agent request (request_permission) — has id + method
-            send({
-                "jsonrpc": "2.0",
-                "id": 9000,
-                "method": "session/request_permission",
-                "params": {
-                    "sessionId": session_id,
-                    "options": [
-                        {"optionId": "allow_once", "kind": "allow_once"},
-                    ],
-                },
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 9000,
+                    "method": "session/request_permission",
+                    "params": {
+                        "sessionId": session_id,
+                        "options": [
+                            {"optionId": "allow_once", "kind": "allow_once"},
+                        ],
+                    },
+                }
+            )
 
             # Agent reads the permission response (we just consume it)
             # The client will send back a response to id=9000
@@ -79,45 +87,53 @@ def main():
             # (ignore the response content — we just needed the round trip)
 
             # 3. Send tool_call_update notification
-            send({
-                "jsonrpc": "2.0",
-                "method": "session/update",
-                "params": {
-                    "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "tool_call_update",
-                        "toolCallId": "tc_1",
-                        "status": "completed",
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "tc_1",
+                            "status": "completed",
+                        },
                     },
-                },
-            })
+                }
+            )
 
             # 4. Send agent message notification
-            send({
-                "jsonrpc": "2.0",
-                "method": "session/update",
-                "params": {
-                    "sessionId": session_id,
-                    "update": {
-                        "sessionUpdate": "agent_message_chunk",
-                        "content": {"type": "text", "text": "done"},
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "session/update",
+                    "params": {
+                        "sessionId": session_id,
+                        "update": {
+                            "sessionUpdate": "agent_message_chunk",
+                            "content": {"type": "text", "text": "done"},
+                        },
                     },
-                },
-            })
+                }
+            )
 
             # 5. Finally, send the actual response for the prompt
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "result": {"stopReason": "end_turn"},
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {"stopReason": "end_turn"},
+                }
+            )
 
         else:
-            send({
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "error": {"code": -32601, "message": f"Unknown method: {method}"},
-            })
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32601, "message": f"Unknown method: {method}"},
+                }
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -11,7 +11,9 @@ from benchflow.acp.transport import StdioTransport
 from benchflow.acp.types import StopReason, ToolCallStatus
 
 MOCK_AGENT = str(Path(__file__).parent / "fixtures" / "mock_acp_agent.py")
-MOCK_AGENT_INTERLEAVED = str(Path(__file__).parent / "fixtures" / "mock_acp_agent_interleaved.py")
+MOCK_AGENT_INTERLEAVED = str(
+    Path(__file__).parent / "fixtures" / "mock_acp_agent_interleaved.py"
+)
 
 
 class TestACPClient:
@@ -108,66 +110,82 @@ class TestACPClient:
 class TestACPSession:
     def test_handle_tool_call(self):
         session = ACPSession("test-session")
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_1",
-            "title": "echo hello",
-            "kind": "bash",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "echo hello",
+                "kind": "bash",
+            }
+        )
         assert len(session.tool_calls) == 1
         assert session.tool_calls[0].tool_call_id == "tc_1"
         assert session.tool_calls[0].kind == "bash"
 
     def test_handle_tool_call_update(self):
         session = ACPSession("test-session")
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_1",
-            "title": "echo",
-            "kind": "bash",
-        })
-        session.handle_update({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "tc_1",
-            "status": "completed",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "echo",
+                "kind": "bash",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+            }
+        )
         assert session.tool_calls[0].status == ToolCallStatus.COMPLETED
 
     def test_handle_invalid_tool_call_status(self):
         """Invalid status should fall back to IN_PROGRESS, not crash."""
         session = ACPSession("test-session")
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_1",
-            "title": "echo",
-            "kind": "bash",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "echo",
+                "kind": "bash",
+            }
+        )
         # Should not raise — invalid status handled gracefully
-        session.handle_update({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "tc_1",
-            "status": "totally_invalid_status",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "totally_invalid_status",
+            }
+        )
         assert session.tool_calls[0].status == ToolCallStatus.IN_PROGRESS
 
     def test_handle_message_chunks(self):
         session = ACPSession("test-session")
-        session.handle_update({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "Hello "},
-        })
-        session.handle_update({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "world"},
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "Hello "},
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "world"},
+            }
+        )
         assert session.full_message == "Hello world"
 
     def test_handle_thought_chunks(self):
         session = ACPSession("test-session")
-        session.handle_update({
-            "sessionUpdate": "agent_thought_chunk",
-            "content": {"type": "text", "text": "thinking..."},
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "thinking..."},
+            }
+        )
         assert session.full_thought == "thinking..."
 
     def test_handle_unknown_update_type(self):
@@ -181,11 +199,13 @@ class TestACPSession:
         """Update for non-existent tool call should be silently ignored."""
         session = ACPSession("test-session")
         # Should not raise
-        session.handle_update({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "nonexistent",
-            "status": "completed",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "nonexistent",
+                "status": "completed",
+            }
+        )
 
 
 class TestACPInterleaving:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from benchflow.acp.client import ACPClient, ACPError
-from benchflow.acp.session import ACPSession, ToolCallRecord
+from benchflow.acp.session import ACPSession
 from benchflow.acp.transport import StdioTransport
 from benchflow.acp.types import StopReason, ToolCallStatus
 

--- a/tests/test_agent_model_decouple.py
+++ b/tests/test_agent_model_decouple.py
@@ -52,13 +52,18 @@ class TestInferEnvKey:
         assert infer_env_key_for_model("gemini-3.1-pro") == "GEMINI_API_KEY"
 
     def test_gemini_with_provider_prefix(self):
-        assert infer_env_key_for_model("google/gemini-3.1-flash-lite-preview") == "GEMINI_API_KEY"
+        assert (
+            infer_env_key_for_model("google/gemini-3.1-flash-lite-preview")
+            == "GEMINI_API_KEY"
+        )
 
     def test_claude_model(self):
         assert infer_env_key_for_model("claude-opus-4-6") == "ANTHROPIC_API_KEY"
 
     def test_haiku_model(self):
-        assert infer_env_key_for_model("claude-haiku-4-5-20251001") == "ANTHROPIC_API_KEY"
+        assert (
+            infer_env_key_for_model("claude-haiku-4-5-20251001") == "ANTHROPIC_API_KEY"
+        )
 
     def test_sonnet_model(self):
         assert infer_env_key_for_model("claude-sonnet-4-6") == "ANTHROPIC_API_KEY"
@@ -80,7 +85,6 @@ class TestInferEnvKey:
         """anthropic-vertex/ models use ADC, not API keys."""
         assert infer_env_key_for_model("anthropic-vertex/claude-sonnet-4-6") is None
 
-
     def test_unknown_model_returns_none(self):
         assert infer_env_key_for_model("some-custom-model") is None
 
@@ -95,6 +99,7 @@ class TestResultMetadata:
 
     def test_run_result_has_model(self):
         from benchflow._models import RunResult
+
         r = RunResult(
             task_name="test",
             agent="openclaw",
@@ -107,6 +112,7 @@ class TestResultMetadata:
 
     def test_run_result_defaults(self):
         from benchflow._models import RunResult
+
         r = RunResult(task_name="test")
         assert r.agent == ""
         assert r.model == ""

--- a/tests/test_capture_trajectory.py
+++ b/tests/test_capture_trajectory.py
@@ -15,17 +15,21 @@ class TestCaptureSessionTrajectory:
 
     def test_captures_tool_calls(self) -> None:
         session = ACPSession("s1")
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_1",
-            "title": "echo hello",
-            "kind": "bash",
-        })
-        session.handle_update({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "tc_1",
-            "status": "completed",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "echo hello",
+                "kind": "bash",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+            }
+        )
         result = _capture_session_trajectory(session)
         assert len(result) == 1
         assert result[0]["type"] == "tool_call"
@@ -36,10 +40,12 @@ class TestCaptureSessionTrajectory:
 
     def test_captures_message(self) -> None:
         session = ACPSession("s1")
-        session.handle_update({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "Hello world"},
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "Hello world"},
+            }
+        )
         result = _capture_session_trajectory(session)
         assert len(result) == 1
         assert result[0]["type"] == "agent_message"
@@ -47,10 +53,12 @@ class TestCaptureSessionTrajectory:
 
     def test_captures_thought(self) -> None:
         session = ACPSession("s1")
-        session.handle_update({
-            "sessionUpdate": "agent_thought_chunk",
-            "content": {"type": "text", "text": "thinking..."},
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "thinking..."},
+            }
+        )
         result = _capture_session_trajectory(session)
         assert len(result) == 1
         assert result[0]["type"] == "agent_thought"
@@ -60,29 +68,37 @@ class TestCaptureSessionTrajectory:
         """Simulates timeout mid-execution: tool calls exist but are still in-progress."""
         session = ACPSession("s1")
         # First tool call completed
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_1",
-            "title": "ls /app",
-            "kind": "bash",
-        })
-        session.handle_update({
-            "sessionUpdate": "tool_call_update",
-            "toolCallId": "tc_1",
-            "status": "completed",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "ls /app",
+                "kind": "bash",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+            }
+        )
         # Second tool call still in progress (timeout happened here)
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_2",
-            "title": "cat README.md",
-            "kind": "bash",
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_2",
+                "title": "cat README.md",
+                "kind": "bash",
+            }
+        )
         # Partial message streamed before timeout
-        session.handle_update({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "Let me read"},
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "Let me read"},
+            }
+        )
 
         result = _capture_session_trajectory(session)
         assert len(result) == 3  # 2 tool calls + 1 message
@@ -93,20 +109,26 @@ class TestCaptureSessionTrajectory:
 
     def test_captures_all_types_together(self) -> None:
         session = ACPSession("s1")
-        session.handle_update({
-            "sessionUpdate": "tool_call",
-            "toolCallId": "tc_1",
-            "title": "echo hi",
-            "kind": "bash",
-        })
-        session.handle_update({
-            "sessionUpdate": "agent_thought_chunk",
-            "content": {"type": "text", "text": "hmm"},
-        })
-        session.handle_update({
-            "sessionUpdate": "agent_message_chunk",
-            "content": {"type": "text", "text": "done"},
-        })
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "echo hi",
+                "kind": "bash",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_thought_chunk",
+                "content": {"type": "text", "text": "hmm"},
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "agent_message_chunk",
+                "content": {"type": "text", "text": "done"},
+            }
+        )
         result = _capture_session_trajectory(session)
         assert len(result) == 3
         types = [e["type"] for e in result]

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -52,13 +52,17 @@ class TestAgentCredentialFiles:
 
 class TestProviderCredentialFiles:
     def test_provider_config_has_field(self):
-        cfg = ProviderConfig(name="t", base_url="", api_protocol="", auth_type="api_key")
+        cfg = ProviderConfig(
+            name="t", base_url="", api_protocol="", auth_type="api_key"
+        )
         assert cfg.credential_files == []
 
     def test_vertex_providers_have_adc(self):
         for name in ("google-vertex", "anthropic-vertex"):
             cfg = PROVIDERS[name]
-            assert len(cfg.credential_files) == 1, f"{name} should have 1 credential_file"
+            assert len(cfg.credential_files) == 1, (
+                f"{name} should have 1 credential_file"
+            )
             cf = cfg.credential_files[0]
             assert cf["env_source"] == "GOOGLE_APPLICATION_CREDENTIALS_JSON"
             assert "gcloud" in cf["path"]

--- a/tests/test_dep_staging.py
+++ b/tests/test_dep_staging.py
@@ -1,6 +1,5 @@
 """Tests for Dockerfile dependency staging."""
 
-
 from benchflow._env_setup import stage_dockerfile_deps, _dep_local_name
 
 
@@ -15,7 +14,10 @@ class TestDepLocalName:
         assert _dep_local_name("tasks/email-foo/data") == "email-foo__data"
 
     def test_skills_basename(self):
-        assert _dep_local_name("tasks/email-foo/environment/skills") == "environment__skills"
+        assert (
+            _dep_local_name("tasks/email-foo/environment/skills")
+            == "environment__skills"
+        )
 
 
 class TestStageDockerfileDeps:
@@ -33,9 +35,7 @@ class TestStageDockerfileDeps:
         env_dir.mkdir(parents=True)
         (task_dir / "task.toml").write_text('version = "1.0"')
         (env_dir / "Dockerfile").write_text(
-            "FROM ubuntu:24.04\n"
-            "COPY packages/claw-gmail /app\n"
-            "RUN echo hello\n"
+            "FROM ubuntu:24.04\nCOPY packages/claw-gmail /app\nRUN echo hello\n"
         )
 
         stage_dockerfile_deps(task_dir, repo_root)
@@ -106,8 +106,8 @@ class TestStageDockerfileDeps:
 
         rewritten = (env_dir / "Dockerfile").read_text()
         lines = rewritten.split("\n")
-        assert "_deps/" in lines[1]   # first COPY rewritten
-        assert "_deps/" in lines[3]   # second COPY rewritten
+        assert "_deps/" in lines[1]  # first COPY rewritten
+        assert "_deps/" in lines[3]  # second COPY rewritten
         assert "packages/dep1" not in rewritten
         assert "packages/dep2" not in rewritten
         # Content preserved

--- a/tests/test_dep_staging.py
+++ b/tests/test_dep_staging.py
@@ -1,6 +1,5 @@
 """Tests for Dockerfile dependency staging."""
 
-from pathlib import Path
 
 from benchflow._env_setup import stage_dockerfile_deps, _dep_local_name
 

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -153,12 +153,18 @@ class TestGetAgentSkillPaths:
 
         mock_agents = {
             "agent-a": AgentConfig(
-                name="agent-a", install_cmd="true", launch_cmd="true",
-                requires_env=[], skill_paths=["$HOME/.a/skills"],
+                name="agent-a",
+                install_cmd="true",
+                launch_cmd="true",
+                requires_env=[],
+                skill_paths=["$HOME/.a/skills"],
             ),
             "agent-b": AgentConfig(
-                name="agent-b", install_cmd="true", launch_cmd="true",
-                requires_env=[], skill_paths=["$HOME/.a/skills", "$WORKSPACE/skills"],
+                name="agent-b",
+                install_cmd="true",
+                launch_cmd="true",
+                requires_env=[],
+                skill_paths=["$HOME/.a/skills", "$WORKSPACE/skills"],
             ),
         }
         with patch("benchflow._env_setup.AGENTS", mock_agents):

--- a/tests/test_exclude_tasks.py
+++ b/tests/test_exclude_tasks.py
@@ -1,7 +1,5 @@
 """Tests for exclude_tasks, agent_env, and sandbox_user in Job config."""
 
-
-
 from benchflow.job import Job, JobConfig
 
 
@@ -70,7 +68,10 @@ agent_env:
   OTHER_KEY: other-value
 """)
         job = Job.from_yaml(config)
-        assert job._config.agent_env == {"MY_KEY": "my-value", "OTHER_KEY": "other-value"}
+        assert job._config.agent_env == {
+            "MY_KEY": "my-value",
+            "OTHER_KEY": "other-value",
+        }
 
     def test_sandbox_user_parsed(self, tmp_path):
         _make_tasks(tmp_path)

--- a/tests/test_exclude_tasks.py
+++ b/tests/test_exclude_tasks.py
@@ -1,8 +1,6 @@
 """Tests for exclude_tasks, agent_env, and sandbox_user in Job config."""
 
-from pathlib import Path
 
-import pytest
 
 from benchflow.job import Job, JobConfig
 
@@ -49,7 +47,7 @@ class TestExcludeTasksFilter:
 
 class TestNativeYamlNewFields:
     def test_exclude_parsed(self, tmp_path):
-        tasks_dir = _make_tasks(tmp_path)
+        _make_tasks(tmp_path)
         config = tmp_path / "config.yaml"
         config.write_text("""
 tasks_dir: tasks

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -2,8 +2,7 @@
 
 import json
 import logging
-from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 import pytest
 

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -53,8 +53,12 @@ class TestJobResult:
 
     def test_score_excl_errors(self):
         r = JobResult(
-            job_name="test", config=JobConfig(),
-            total=10, passed=5, failed=3, errored=2,
+            job_name="test",
+            config=JobConfig(),
+            total=10,
+            passed=5,
+            failed=3,
+            errored=2,
         )
         assert r.score_excl_errors == 5 / 8
 
@@ -68,10 +72,16 @@ class TestJobCounting:
 
         return {
             "passed": sum(1 for r in all_results.values() if extract_reward(r) == 1.0),
-            "failed": sum(1 for r in all_results.values()
-                         if extract_reward(r) is not None and extract_reward(r) != 1.0),
-            "errored": sum(1 for r in all_results.values()
-                          if r.get("error") and r.get("rewards") is None),
+            "failed": sum(
+                1
+                for r in all_results.values()
+                if extract_reward(r) is not None and extract_reward(r) != 1.0
+            ),
+            "errored": sum(
+                1
+                for r in all_results.values()
+                if r.get("error") and r.get("rewards") is None
+            ),
         }
 
     def test_basic_counting(self):
@@ -137,7 +147,9 @@ class TestRunTaskLoop:
     async def test_exhausts_retries(self, tmp_path):
         """SDK called 1 + max_retries times when all attempts fail with retryable error."""
         job, task_dir = self._make_job(tmp_path, max_retries=2)
-        fail_result = RunResult(task_name="task-a", error="Agent install failed (rc=1): boom")
+        fail_result = RunResult(
+            task_name="task-a", error="Agent install failed (rc=1): boom"
+        )
         job._sdk = AsyncMock()
         job._sdk.run = AsyncMock(return_value=fail_result)
 
@@ -149,7 +161,9 @@ class TestRunTaskLoop:
     async def test_non_retryable_exits_immediately(self, tmp_path):
         """Non-retryable error (timeout) exits after 1 attempt."""
         job, task_dir = self._make_job(tmp_path, max_retries=3)
-        timeout_result = RunResult(task_name="task-a", error="Agent timed out after 900.0s")
+        timeout_result = RunResult(
+            task_name="task-a", error="Agent timed out after 900.0s"
+        )
         job._sdk = AsyncMock()
         job._sdk.run = AsyncMock(return_value=timeout_result)
 
@@ -161,7 +175,9 @@ class TestRunTaskLoop:
     async def test_succeeds_on_retry(self, tmp_path):
         """SDK fails once then succeeds — returns success result."""
         job, task_dir = self._make_job(tmp_path, max_retries=2)
-        fail_result = RunResult(task_name="task-a", error="Agent install failed (rc=1): boom")
+        fail_result = RunResult(
+            task_name="task-a", error="Agent install failed (rc=1): boom"
+        )
         ok_result = RunResult(task_name="task-a", rewards={"reward": 1.0})
         job._sdk = AsyncMock()
         job._sdk.run = AsyncMock(side_effect=[fail_result, ok_result])
@@ -234,9 +250,12 @@ class TestJobResume:
         job = Job(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=cfg)
         # Patch _run_task so run() doesn't actually run anything real
         job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=RunResult(task_name="task-b", rewards={"reward": 1.0}))
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(task_name="task-b", rewards={"reward": 1.0})
+        )
         with caplog.at_level(logging.WARNING):
             import asyncio
+
             asyncio.get_event_loop().run_until_complete(job.run())
         assert any("old-agent" in msg for msg in caplog.messages)
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,7 +1,6 @@
 """Tests for metrics collection and aggregation."""
 
 import json
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -13,38 +13,50 @@ def results_dir(tmp_path):
     # Task A: passed
     trial_a = tmp_path / "job1" / "task-a__abc123"
     trial_a.mkdir(parents=True)
-    (trial_a / "result.json").write_text(json.dumps({
-        "task_name": "task-a",
-        "rewards": {"reward": 1.0},
-        "error": None,
-        "n_tool_calls": 10,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:01:00.000000",
-    }))
+    (trial_a / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "n_tool_calls": 10,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:01:00.000000",
+            }
+        )
+    )
 
     # Task B: failed
     trial_b = tmp_path / "job1" / "task-b__def456"
     trial_b.mkdir(parents=True)
-    (trial_b / "result.json").write_text(json.dumps({
-        "task_name": "task-b",
-        "rewards": {"reward": 0.0},
-        "error": None,
-        "n_tool_calls": 25,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:02:00.000000",
-    }))
+    (trial_b / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-b",
+                "rewards": {"reward": 0.0},
+                "error": None,
+                "n_tool_calls": 25,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:02:00.000000",
+            }
+        )
+    )
 
     # Task C: errored
     trial_c = tmp_path / "job1" / "task-c__ghi789"
     trial_c.mkdir(parents=True)
-    (trial_c / "result.json").write_text(json.dumps({
-        "task_name": "task-c",
-        "rewards": None,
-        "error": "Agent timed out after 900.0s",
-        "n_tool_calls": 0,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:15:00.000000",
-    }))
+    (trial_c / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-c",
+                "rewards": None,
+                "error": "Agent timed out after 900.0s",
+                "n_tool_calls": 0,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:15:00.000000",
+            }
+        )
+    )
 
     return tmp_path
 
@@ -55,26 +67,34 @@ def results_dir_with_retries(tmp_path):
     # Task A: first attempt failed
     trial_a1 = tmp_path / "attempt1" / "task-a__first"
     trial_a1.mkdir(parents=True)
-    (trial_a1 / "result.json").write_text(json.dumps({
-        "task_name": "task-a",
-        "rewards": {"reward": 0.0},
-        "error": None,
-        "n_tool_calls": 5,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:01:00.000000",
-    }))
+    (trial_a1 / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 0.0},
+                "error": None,
+                "n_tool_calls": 5,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:01:00.000000",
+            }
+        )
+    )
 
     # Task A: retry passed
     trial_a2 = tmp_path / "attempt2" / "task-a__second"
     trial_a2.mkdir(parents=True)
-    (trial_a2 / "result.json").write_text(json.dumps({
-        "task_name": "task-a",
-        "rewards": {"reward": 1.0},
-        "error": None,
-        "n_tool_calls": 15,
-        "started_at": "2026-03-24 10:02:00.000000",
-        "finished_at": "2026-03-24 10:03:00.000000",
-    }))
+    (trial_a2 / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "n_tool_calls": 15,
+                "started_at": "2026-03-24 10:02:00.000000",
+                "finished_at": "2026-03-24 10:03:00.000000",
+            }
+        )
+    )
 
     return tmp_path
 
@@ -117,46 +137,62 @@ def test_collect_metrics_best_result_picking(results_dir_with_retries):
     # --- Both errored (no rewards): first seen is kept, counted once as errored ---
     trial_b1 = base / "attempt1" / "task-b__err1"
     trial_b1.mkdir(parents=True)
-    (trial_b1 / "result.json").write_text(json.dumps({
-        "task_name": "task-b",
-        "rewards": None,
-        "error": "install failed",
-        "n_tool_calls": 0,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:01:00.000000",
-    }))
+    (trial_b1 / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-b",
+                "rewards": None,
+                "error": "install failed",
+                "n_tool_calls": 0,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:01:00.000000",
+            }
+        )
+    )
     trial_b2 = base / "attempt2" / "task-b__err2"
     trial_b2.mkdir(parents=True)
-    (trial_b2 / "result.json").write_text(json.dumps({
-        "task_name": "task-b",
-        "rewards": None,
-        "error": "pipe closed",
-        "n_tool_calls": 0,
-        "started_at": "2026-03-24 10:02:00.000000",
-        "finished_at": "2026-03-24 10:03:00.000000",
-    }))
+    (trial_b2 / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-b",
+                "rewards": None,
+                "error": "pipe closed",
+                "n_tool_calls": 0,
+                "started_at": "2026-03-24 10:02:00.000000",
+                "finished_at": "2026-03-24 10:03:00.000000",
+            }
+        )
+    )
 
     # --- Equal rewards: deterministic pick (counted once) ---
     trial_c1 = base / "attempt1" / "task-c__eq1"
     trial_c1.mkdir(parents=True)
-    (trial_c1 / "result.json").write_text(json.dumps({
-        "task_name": "task-c",
-        "rewards": {"reward": 0.5},
-        "error": None,
-        "n_tool_calls": 3,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:01:00.000000",
-    }))
+    (trial_c1 / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-c",
+                "rewards": {"reward": 0.5},
+                "error": None,
+                "n_tool_calls": 3,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:01:00.000000",
+            }
+        )
+    )
     trial_c2 = base / "attempt2" / "task-c__eq2"
     trial_c2.mkdir(parents=True)
-    (trial_c2 / "result.json").write_text(json.dumps({
-        "task_name": "task-c",
-        "rewards": {"reward": 0.5},
-        "error": None,
-        "n_tool_calls": 4,
-        "started_at": "2026-03-24 10:02:00.000000",
-        "finished_at": "2026-03-24 10:03:00.000000",
-    }))
+    (trial_c2 / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-c",
+                "rewards": {"reward": 0.5},
+                "error": None,
+                "n_tool_calls": 4,
+                "started_at": "2026-03-24 10:02:00.000000",
+                "finished_at": "2026-03-24 10:03:00.000000",
+            }
+        )
+    )
 
     metrics = collect_metrics(str(base))
     s = metrics.summary()
@@ -207,14 +243,18 @@ def test_collect_metrics_partial_reward(tmp_path):
     """Test handling of partial rewards (not 0 or 1)."""
     trial = tmp_path / "job" / "task-a__abc"
     trial.mkdir(parents=True)
-    (trial / "result.json").write_text(json.dumps({
-        "task_name": "task-a",
-        "rewards": {"reward": 0.5},
-        "error": None,
-        "n_tool_calls": 10,
-        "started_at": "2026-03-24 10:00:00.000000",
-        "finished_at": "2026-03-24 10:01:00.000000",
-    }))
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 0.5},
+                "error": None,
+                "n_tool_calls": 10,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:01:00.000000",
+            }
+        )
+    )
 
     metrics = collect_metrics(str(tmp_path))
     s = metrics.summary()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -19,6 +19,7 @@ class TestDockerProcessEnv:
 
     def _mock_exec(self, captured_calls: list):
         """Return a fake create_subprocess_exec that records calls."""
+
         async def fake_exec(*args, **kwargs):
             captured_calls.append(list(args))
             mock_proc = AsyncMock()
@@ -29,13 +30,16 @@ class TestDockerProcessEnv:
             mock_proc.stderr = AsyncMock()
             mock_proc.communicate = AsyncMock(return_value=(b"", b""))
             return mock_proc
+
         return fake_exec
 
     @pytest.mark.asyncio
     async def test_env_not_in_main_cmd(self):
         """Secrets must not appear as args in the main exec command."""
         calls = []
-        with patch("asyncio.create_subprocess_exec", side_effect=self._mock_exec(calls)):
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=self._mock_exec(calls)
+        ):
             proc = self._make_process()
             await proc.start(
                 command="echo hello",
@@ -68,6 +72,7 @@ class TestDockerProcessEnv:
                 if data:
                     communicate_inputs.append(data)
                 return (b"", b"")
+
             mock_proc.communicate = capture_communicate
             return mock_proc
 
@@ -93,7 +98,9 @@ class TestDockerProcessEnv:
     async def test_main_cmd_sources_and_deletes_env(self):
         """Main command sources the env file and then removes it."""
         calls = []
-        with patch("asyncio.create_subprocess_exec", side_effect=self._mock_exec(calls)):
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=self._mock_exec(calls)
+        ):
             proc = self._make_process()
             await proc.start(
                 command="codex-acp",
@@ -109,7 +116,9 @@ class TestDockerProcessEnv:
     async def test_no_env_single_call(self):
         """When no env is passed, only the main exec runs (no env write step)."""
         calls = []
-        with patch("asyncio.create_subprocess_exec", side_effect=self._mock_exec(calls)):
+        with patch(
+            "asyncio.create_subprocess_exec", side_effect=self._mock_exec(calls)
+        ):
             proc = self._make_process()
             await proc.start(command="echo hello")
 
@@ -133,6 +142,7 @@ class TestDockerProcessEnv:
                 if data:
                     communicate_inputs.append(data)
                 return (b"", b"")
+
             mock_proc.communicate = capture_communicate
             return mock_proc
 
@@ -164,6 +174,7 @@ class TestDockerProcessEnv:
                 if data:
                     communicate_inputs.append(data)
                 return (b"", b"")
+
             mock_proc.communicate = capture_communicate
             return mock_proc
 
@@ -184,7 +195,10 @@ class TestDockerProcessEnv:
             assert f"export {key}=" in content
         # shlex.quote wraps values in single quotes
         import shlex
+
         assert f"export CMD_INJECT={shlex.quote('value; rm -rf /')}" in content
         assert f"export NEWLINE_VAL={shlex.quote('line1\nline2')}" in content
         assert f"export BACKTICK={shlex.quote('$(whoami)')}" in content
-        assert f"export SINGLE_QUOTE={shlex.quote('it' + chr(39) + 's a test')}" in content
+        assert (
+            f"export SINGLE_QUOTE={shlex.quote('it' + chr(39) + 's a test')}" in content
+        )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,6 +1,5 @@
 """Tests for process.py env handling (no Docker required)."""
 
-import asyncio
 from unittest.mock import AsyncMock, patch
 
 import pytest

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -114,6 +114,7 @@ class TestFindProvider:
     def test_no_prefix_returns_none(self):
         assert find_provider("glm-5") is None
 
+
 # ── resolve_base_url: template expansion ──
 
 
@@ -157,14 +158,23 @@ class TestResolveBaseUrl:
     def test_protocol_selects_endpoint(self):
         """resolve_base_url with protocol= picks from endpoints dict."""
         p = PROVIDERS["zai"]
-        assert resolve_base_url(p, {}, protocol="anthropic-messages") == "https://api.z.ai/api/anthropic"
-        assert resolve_base_url(p, {}, protocol="openai-completions") == "https://api.z.ai/api/paas/v4"
+        assert (
+            resolve_base_url(p, {}, protocol="anthropic-messages")
+            == "https://api.z.ai/api/anthropic"
+        )
+        assert (
+            resolve_base_url(p, {}, protocol="openai-completions")
+            == "https://api.z.ai/api/paas/v4"
+        )
 
     def test_protocol_fallback_to_base_url(self):
         """Unknown protocol falls back to primary base_url."""
         p = PROVIDERS["zai"]
         assert resolve_base_url(p, {}) == "https://api.z.ai/api/paas/v4"
-        assert resolve_base_url(p, {}, protocol="unknown") == "https://api.z.ai/api/paas/v4"
+        assert (
+            resolve_base_url(p, {}, protocol="unknown")
+            == "https://api.z.ai/api/paas/v4"
+        )
 
 
 # ── resolve_auth_env: which env var does this provider need? ──
@@ -190,16 +200,19 @@ class TestRegistryIntegration:
     def test_infer_env_key_for_zai(self):
         """infer_env_key_for_model should return ZAI_API_KEY for zai/ models."""
         from benchflow.agents.registry import infer_env_key_for_model
+
         assert infer_env_key_for_model("zai/glm-5") == "ZAI_API_KEY"
 
     def test_is_vertex_model_zai_direct(self):
         """zai/ (direct API) is NOT vertex."""
         from benchflow.agents.registry import is_vertex_model
+
         assert is_vertex_model("zai/glm-5") is False
 
     def test_existing_models_unchanged(self):
         """Existing model inference must not regress."""
         from benchflow.agents.registry import infer_env_key_for_model
+
         assert infer_env_key_for_model("gemini-3.1-pro") == "GEMINI_API_KEY"
         assert infer_env_key_for_model("claude-sonnet-4-6") == "ANTHROPIC_API_KEY"
         assert infer_env_key_for_model("gpt-5.4") == "OPENAI_API_KEY"
@@ -239,7 +252,10 @@ class TestStripProviderPrefix:
         assert strip_provider_prefix("zai/glm-5") == "glm-5"
 
     def test_vertex_provider(self):
-        assert strip_provider_prefix("anthropic-vertex/claude-sonnet-4-6") == "claude-sonnet-4-6"
+        assert (
+            strip_provider_prefix("anthropic-vertex/claude-sonnet-4-6")
+            == "claude-sonnet-4-6"
+        )
 
     def test_nested_prefix(self):
         assert strip_provider_prefix("google-vertex/gemini-3-flash") == "gemini-3-flash"
@@ -297,19 +313,23 @@ class TestInferProviderPrefix:
     @pytest.fixture(autouse=True)
     def _import(self):
         from benchflow.agents.openclaw_acp_shim import _infer_provider_prefix
+
         self.infer = _infer_provider_prefix
 
-    @pytest.mark.parametrize("model,expected", [
-        ("gpt-4o", "openai"),
-        ("gpt-4o-mini", "openai"),
-        ("o1-preview", "openai"),
-        ("o3-mini", "openai"),
-        ("gemini-3-flash", "google"),
-        ("gemini-2.5-pro", "google"),
-        ("claude-sonnet-4-6", "anthropic"),
-        ("claude-haiku-4-5-20251001", "anthropic"),
-        ("some-unknown-model", "anthropic"),  # default
-    ])
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("gpt-4o", "openai"),
+            ("gpt-4o-mini", "openai"),
+            ("o1-preview", "openai"),
+            ("o3-mini", "openai"),
+            ("gemini-3-flash", "google"),
+            ("gemini-2.5-pro", "google"),
+            ("claude-sonnet-4-6", "anthropic"),
+            ("claude-haiku-4-5-20251001", "anthropic"),
+            ("some-unknown-model", "anthropic"),  # default
+        ],
+    )
     def test_infer(self, model, expected):
         assert self.infer(model) == expected
 
@@ -323,7 +343,9 @@ class TestSetupOpenaiAuth:
         return tmp_path
 
     def _auth_path(self, home_dir):
-        return home_dir / ".openclaw" / "agents" / "main" / "agent" / "auth-profiles.json"
+        return (
+            home_dir / ".openclaw" / "agents" / "main" / "agent" / "auth-profiles.json"
+        )
 
     def test_writes_key(self, home_dir, monkeypatch):
         import json
@@ -370,7 +392,10 @@ class TestShimModelParams:
         """session/set_model handler should map all three env vars."""
         # Read the shim source and extract the _PARAM_MAP dict
         from pathlib import Path
-        shim_src = (Path(__file__).parent.parent / "src/benchflow/agents/openclaw_acp_shim.py").read_text()
+
+        shim_src = (
+            Path(__file__).parent.parent / "src/benchflow/agents/openclaw_acp_shim.py"
+        ).read_text()
         assert "BENCHFLOW_MODEL_TEMPERATURE" in shim_src
         assert "BENCHFLOW_MODEL_TOP_P" in shim_src
         assert "BENCHFLOW_MODEL_MAX_TOKENS" in shim_src
@@ -382,6 +407,7 @@ class TestShimModelParams:
         """When BENCHFLOW_MODEL_* env vars are set, the shim should call
         openclaw config set for each param during session/set_model."""
         import subprocess
+
         calls = []
         original_run = subprocess.run
 
@@ -397,6 +423,7 @@ class TestShimModelParams:
         # Import and simulate the set_model handler logic inline
         # (the shim's main() is a blocking loop, so we test the logic directly)
         import os
+
         _PARAM_MAP = {
             "BENCHFLOW_MODEL_TEMPERATURE": "agents.defaults.params.temperature",
             "BENCHFLOW_MODEL_TOP_P": "agents.defaults.params.topP",
@@ -409,7 +436,8 @@ class TestShimModelParams:
             if val:
                 subprocess.run(
                     ["openclaw", "config", "set", config_path, val],
-                    capture_output=True, timeout=10,
+                    capture_output=True,
+                    timeout=10,
                 )
 
         monkeypatch.setattr(subprocess, "run", original_run)
@@ -428,6 +456,7 @@ class TestShimModelParams:
     def test_missing_env_vars_skipped(self, monkeypatch):
         """When no BENCHFLOW_MODEL_* env vars are set, no config calls are made."""
         import subprocess
+
         calls = []
 
         def mock_run(cmd, **kwargs):
@@ -439,6 +468,7 @@ class TestShimModelParams:
         monkeypatch.delenv("BENCHFLOW_MODEL_MAX_TOKENS", raising=False)
 
         import os
+
         _PARAM_MAP = {
             "BENCHFLOW_MODEL_TEMPERATURE": "agents.defaults.params.temperature",
             "BENCHFLOW_MODEL_TOP_P": "agents.defaults.params.topP",
@@ -451,7 +481,8 @@ class TestShimModelParams:
             if val:
                 subprocess.run(
                     ["openclaw", "config", "set", config_path, val],
-                    capture_output=True, timeout=10,
+                    capture_output=True,
+                    timeout=10,
                 )
 
         assert len(calls) == 0

--- a/tests/test_reexport.py
+++ b/tests/test_reexport.py
@@ -53,7 +53,13 @@ def test_extracted_modules_importable():
 
 def test_public_api_reexports():
     """Public API symbols are still importable from benchflow top-level."""
-    from benchflow import SDK, RunResult, AgentInstallError, AgentTimeoutError, stage_dockerfile_deps
+    from benchflow import (
+        SDK,
+        RunResult,
+        AgentInstallError,
+        AgentTimeoutError,
+        stage_dockerfile_deps,
+    )
 
     assert callable(SDK)
     assert callable(RunResult)

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -189,11 +189,17 @@ class TestCheckSubscriptionAuth:
         creds_dir.mkdir()
         (creds_dir / ".credentials.json").write_text("{}")
         self._patch_expanduser(monkeypatch, tmp_path)
-        assert SDK._check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY") is True
+        assert (
+            SDK._check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY")
+            is True
+        )
 
     def test_returns_false_when_file_missing(self, monkeypatch, tmp_path):
         self._patch_expanduser(monkeypatch, tmp_path)
-        assert SDK._check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY") is False
+        assert (
+            SDK._check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY")
+            is False
+        )
 
     def test_returns_false_for_wrong_key(self, monkeypatch, tmp_path):
         """subscription_auth.replaces_env must match required_key."""
@@ -202,10 +208,15 @@ class TestCheckSubscriptionAuth:
         (creds_dir / ".credentials.json").write_text("{}")
         self._patch_expanduser(monkeypatch, tmp_path)
         # claude-agent-acp replaces ANTHROPIC_API_KEY, not OPENAI_API_KEY
-        assert SDK._check_subscription_auth("claude-agent-acp", "OPENAI_API_KEY") is False
+        assert (
+            SDK._check_subscription_auth("claude-agent-acp", "OPENAI_API_KEY") is False
+        )
 
     def test_returns_false_for_unknown_agent(self):
-        assert SDK._check_subscription_auth("nonexistent-agent", "ANTHROPIC_API_KEY") is False
+        assert (
+            SDK._check_subscription_auth("nonexistent-agent", "ANTHROPIC_API_KEY")
+            is False
+        )
 
     def test_returns_false_when_no_subscription_auth(self):
         """Agents without subscription_auth (e.g. openclaw) return False."""
@@ -246,7 +257,12 @@ class TestResolveAgentEnvNoModel:
 
     def test_no_model_subscription_auth_detected(self, monkeypatch, tmp_path):
         """No model + no API key + host credentials → subscription auth."""
-        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         creds_dir = tmp_path / ".claude"
         creds_dir.mkdir()
@@ -258,7 +274,12 @@ class TestResolveAgentEnvNoModel:
 
     def test_no_model_no_auth_no_error(self, monkeypatch, tmp_path):
         """No model + no API key + no host credentials → no error (no model to validate)."""
-        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         self._patch_expanduser(monkeypatch, tmp_path)
         # Should not raise — no model means no required key validation

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,6 +1,11 @@
 """Tests for benchflow._scoring — pure scoring/classification helpers."""
 
-from benchflow._scoring import classify_error, extract_reward, pass_rate, pass_rate_excl_errors
+from benchflow._scoring import (
+    classify_error,
+    extract_reward,
+    pass_rate,
+    pass_rate_excl_errors,
+)
 
 
 class TestExtractReward:
@@ -47,7 +52,10 @@ class TestClassifyError:
         assert classify_error("") is None
 
     def test_install_failed(self):
-        assert classify_error("Agent claude-agent-acp install failed (rc=1)") == "install_failure"
+        assert (
+            classify_error("Agent claude-agent-acp install failed (rc=1)")
+            == "install_failure"
+        )
 
     def test_pipe_closed(self):
         assert classify_error("Agent closed stdout") == "pipe_closed"

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -19,6 +19,7 @@ class TestResolveAgentEnv:
 
     def _resolve(self, agent="claude-agent-acp", model=None, agent_env=None):
         from benchflow.sdk import SDK
+
         return SDK._resolve_agent_env(agent, model, agent_env)
 
     def test_returns_dict(self):
@@ -44,10 +45,12 @@ class TestResolveAgentEnv:
 
     def test_gemini_mirror_no_overwrite(self):
         """Explicit GOOGLE_API_KEY not overwritten by mirror."""
-        result = self._resolve(agent_env={
-            "GEMINI_API_KEY": "gk-test",
-            "GOOGLE_API_KEY": "gk-explicit",
-        })
+        result = self._resolve(
+            agent_env={
+                "GEMINI_API_KEY": "gk-test",
+                "GOOGLE_API_KEY": "gk-explicit",
+            }
+        )
         assert result["GOOGLE_API_KEY"] == "gk-explicit"
 
     def test_none_agent_env_creates_empty(self):
@@ -172,6 +175,7 @@ class TestResolvePrompts:
 
     def _resolve(self, task_path, prompts):
         from benchflow.sdk import SDK
+
         return SDK._resolve_prompts(task_path, prompts)
 
     def test_none_prompts_returns_instruction(self, tmp_path):
@@ -207,6 +211,7 @@ class TestInitTrial:
 
     def _init(self, task_path, job_name=None, trial_name=None, jobs_dir="jobs"):
         from benchflow.sdk import SDK
+
         return SDK._init_trial(task_path, job_name, trial_name, jobs_dir)
 
     @pytest.fixture()
@@ -216,14 +221,16 @@ class TestInitTrial:
         td.mkdir()
         (td / "task.toml").write_text(
             'version = "1.0"\n\n[verifier]\ntimeout_sec = 900.0\n\n'
-            '[agent]\ntimeout_sec = 900.0\n\n[environment]\n'
+            "[agent]\ntimeout_sec = 900.0\n\n[environment]\n"
         )
         (td / "instruction.md").write_text("Do the thing.")
         return td
 
     def test_returns_tuple(self, task_dir, tmp_path):
         result = self._init(task_dir, jobs_dir=tmp_path / "jobs")
-        assert len(result) == 6  # task, trial_dir, trial_paths, started_at, job_name, trial_name
+        assert (
+            len(result) == 6
+        )  # task, trial_dir, trial_paths, started_at, job_name, trial_name
 
     def test_trial_dir_created(self, task_dir, tmp_path):
         _, trial_dir, _, _, _, _ = self._init(task_dir, jobs_dir=tmp_path / "jobs")
@@ -239,7 +246,9 @@ class TestInitTrial:
 
     def test_custom_job_name(self, task_dir, tmp_path):
         _, _, _, _, job_name, _ = self._init(
-            task_dir, job_name="my-job", jobs_dir=tmp_path / "jobs",
+            task_dir,
+            job_name="my-job",
+            jobs_dir=tmp_path / "jobs",
         )
         assert job_name == "my-job"
 
@@ -249,7 +258,9 @@ class TestInitTrial:
 
     def test_custom_trial_name(self, task_dir, tmp_path):
         _, _, _, _, _, trial_name = self._init(
-            task_dir, trial_name="custom-trial", jobs_dir=tmp_path / "jobs",
+            task_dir,
+            trial_name="custom-trial",
+            jobs_dir=tmp_path / "jobs",
         )
         assert trial_name == "custom-trial"
 
@@ -266,6 +277,7 @@ class TestWriteConfig:
 
     def _write(self, trial_dir, **kwargs):
         from benchflow.sdk import SDK
+
         return SDK._write_config(trial_dir, **kwargs)
 
     def test_config_json_written(self, tmp_path):
@@ -326,6 +338,7 @@ class TestBuildResult:
 
     def _build(self, trial_dir, **kwargs):
         from benchflow.sdk import SDK
+
         defaults = dict(
             task_name="my-task",
             trial_name="my-trial",
@@ -347,6 +360,7 @@ class TestBuildResult:
 
     def test_returns_run_result(self, tmp_path):
         from benchflow._models import RunResult
+
         result = self._build(tmp_path)
         assert isinstance(result, RunResult)
 

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -5,7 +5,6 @@ independently testable private methods.
 """
 
 import json
-import os
 from datetime import datetime
 from pathlib import Path
 
@@ -390,7 +389,7 @@ class TestBuildResult:
         assert traj_file.exists()
 
     def test_timing_values_rounded(self, tmp_path):
-        result = self._build(tmp_path, timing={"agent_setup": 1.5678})
+        self._build(tmp_path, timing={"agent_setup": 1.5678})
         data = json.loads((tmp_path / "timing.json").read_text())
         assert data["agent_setup"] == 1.6
 

--- a/tests/test_sdk_lockdown.py
+++ b/tests/test_sdk_lockdown.py
@@ -7,7 +7,6 @@ import pytest
 
 from benchflow.sdk import (
     SDK,
-    _DEFAULT_LOCKED,
     _resolve_locked_paths,
     _validate_locked_path,
 )

--- a/tests/test_sdk_lockdown.py
+++ b/tests/test_sdk_lockdown.py
@@ -16,31 +16,51 @@ from benchflow.sdk import (
 # _validate_locked_path
 # ---------------------------------------------------------------------------
 
+
 class TestValidateLockedPath:
     """Path validation rejects injection and traversal."""
 
-    @pytest.mark.parametrize("p", [
-        "/solution", "/tests", "/logs/verifier", "/app-foo", "/data", "/app-*",
-    ])
+    @pytest.mark.parametrize(
+        "p",
+        [
+            "/solution",
+            "/tests",
+            "/logs/verifier",
+            "/app-foo",
+            "/data",
+            "/app-*",
+        ],
+    )
     def test_valid_paths(self, p):
         _validate_locked_path(p)  # should not raise
 
-    @pytest.mark.parametrize("bad,match", [
-        ("$(rm -rf /)", "must be absolute"),
-        ("/solution; rm -rf /", None),
-        ("/solution/`whoami`", None),
-        ("/solution/../etc", None),
-        ("/solution/./foo", "normalizes to"),
-        ("//solution//foo", None),
-        ("/solution/", None),
-        ("solution", "must be absolute"),
-        ("/solution | cat /etc/passwd", "must be absolute"),
-        ("/", None),
-    ], ids=[
-        "dollar_injection", "semicolon", "backtick",
-        "dotdot_traversal", "dot_normpath", "double_slash",
-        "trailing_slash", "relative", "pipe", "bare_root",
-    ])
+    @pytest.mark.parametrize(
+        "bad,match",
+        [
+            ("$(rm -rf /)", "must be absolute"),
+            ("/solution; rm -rf /", None),
+            ("/solution/`whoami`", None),
+            ("/solution/../etc", None),
+            ("/solution/./foo", "normalizes to"),
+            ("//solution//foo", None),
+            ("/solution/", None),
+            ("solution", "must be absolute"),
+            ("/solution | cat /etc/passwd", "must be absolute"),
+            ("/", None),
+        ],
+        ids=[
+            "dollar_injection",
+            "semicolon",
+            "backtick",
+            "dotdot_traversal",
+            "dot_normpath",
+            "double_slash",
+            "trailing_slash",
+            "relative",
+            "pipe",
+            "bare_root",
+        ],
+    )
     def test_rejects_invalid(self, bad, match):
         with pytest.raises(ValueError, match=match):
             _validate_locked_path(bad)
@@ -49,6 +69,7 @@ class TestValidateLockedPath:
 # ---------------------------------------------------------------------------
 # _resolve_locked_paths
 # ---------------------------------------------------------------------------
+
 
 class TestResolveLockedPaths:
     """Effective path resolution logic."""
@@ -80,6 +101,7 @@ class TestResolveLockedPaths:
 # ---------------------------------------------------------------------------
 # SDK._lockdown_paths
 # ---------------------------------------------------------------------------
+
 
 class TestLockdownPaths:
     """_lockdown_paths sends correct commands to env."""
@@ -125,6 +147,7 @@ class TestLockdownPaths:
 # JobConfig YAML parsing
 # ---------------------------------------------------------------------------
 
+
 class TestJobConfigYAML:
     """sandbox_locked_paths round-trips from YAML."""
 
@@ -140,19 +163,18 @@ class TestJobConfigYAML:
         (tmp_path / "tasks").mkdir()
 
         from benchflow.job import Job
+
         job = Job.from_yaml(tmp_path / "config.yaml")
         assert job._config.sandbox_locked_paths == ["/tasks", "/data"]
         assert job._config.sandbox_user == "agent"
 
     def test_native_yaml_without_locked_paths(self, tmp_path):
-        yaml_content = (
-            "tasks_dir: tasks\n"
-            "sandbox_user: agent\n"
-        )
+        yaml_content = "tasks_dir: tasks\nsandbox_user: agent\n"
         (tmp_path / "config.yaml").write_text(yaml_content)
         (tmp_path / "tasks").mkdir()
 
         from benchflow.job import Job
+
         job = Job.from_yaml(tmp_path / "config.yaml")
         assert job._config.sandbox_locked_paths is None
 
@@ -170,6 +192,7 @@ class TestJobConfigYAML:
         (tmp_path / "tasks").mkdir()
 
         from benchflow.job import Job
+
         job = Job.from_yaml(tmp_path / "config.yaml")
         assert job._config.sandbox_locked_paths == ["/data"]
         assert job._config.sandbox_user == "agent"
@@ -180,6 +203,7 @@ class TestJobConfigYAML:
         (tmp_path / "tasks").mkdir()
 
         from benchflow.job import Job
+
         job = Job.from_yaml(tmp_path / "config.yaml")
         assert job._config.sandbox_user == "agent"
 
@@ -187,6 +211,7 @@ class TestJobConfigYAML:
 # ---------------------------------------------------------------------------
 # _write_config records locked paths
 # ---------------------------------------------------------------------------
+
 
 class TestWriteConfigRecordsPaths:
     """config.json includes effective locked paths."""
@@ -216,12 +241,14 @@ class TestWriteConfigRecordsPaths:
 # Sandbox user defaults and warnings
 # ---------------------------------------------------------------------------
 
+
 class TestSandboxUserWarnings:
     """Default sandbox_user and root warnings."""
 
     def test_default_is_agent(self):
         """Default sandbox_user is 'agent', not None."""
         import inspect
+
         sig = inspect.signature(SDK.run)
         assert sig.parameters["sandbox_user"].default == "agent"
 
@@ -229,6 +256,7 @@ class TestSandboxUserWarnings:
 # ---------------------------------------------------------------------------
 # Privilege dropping command construction
 # ---------------------------------------------------------------------------
+
 
 class TestPrivDropCommand:
     """SDK._build_priv_drop_cmd — setpriv/su-l command generation."""
@@ -246,6 +274,7 @@ class TestPrivDropCommand:
 
     def test_inner_command_is_shlex_quoted(self):
         import shlex
+
         cmd = SDK._build_priv_drop_cmd("agent --flag value", "agent")
         inner = "export HOME=/home/agent && cd /home/agent && agent --flag value"
         assert shlex.quote(inner) in cmd

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -17,7 +17,9 @@ class TestParseSkill:
     """parse_skill(skill_md) -> SkillInfo | None"""
 
     def test_basic_frontmatter(self, tmp_path):
-        md = _write_skill_md(tmp_path / "my-skill", "name: my-skill\ndescription: A test skill\n")
+        md = _write_skill_md(
+            tmp_path / "my-skill", "name: my-skill\ndescription: A test skill\n"
+        )
         info = parse_skill(md)
         assert info is not None
         assert info.name == "my-skill"

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -22,7 +22,9 @@ class TestSubscriptionAuthDataclass:
             replaces_env="ANTHROPIC_API_KEY",
             detect_file="~/.claude/.credentials.json",
             files=[
-                HostAuthFile("~/.claude/.credentials.json", "{home}/.claude/.credentials.json"),
+                HostAuthFile(
+                    "~/.claude/.credentials.json", "{home}/.claude/.credentials.json"
+                ),
             ],
         )
         assert sa.replaces_env == "ANTHROPIC_API_KEY"
@@ -112,6 +114,7 @@ def _patch_expanduser(monkeypatch, tmp_path):
 class TestResolveAgentEnvSubscription:
     def _resolve(self, agent="claude-agent-acp", model=None, agent_env=None):
         from benchflow.sdk import SDK
+
         return SDK._resolve_agent_env(agent, model, agent_env)
 
     def test_api_key_present_no_subscription_marker(self):
@@ -124,7 +127,12 @@ class TestResolveAgentEnvSubscription:
 
     def test_subscription_auth_detected(self, monkeypatch, tmp_path):
         """When host auth file exists and no API key, subscription auth is used."""
-        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         creds_dir = tmp_path / ".claude"
         creds_dir.mkdir()
@@ -139,7 +147,12 @@ class TestResolveAgentEnvSubscription:
 
     def test_no_auth_file_raises(self, monkeypatch, tmp_path):
         """When no API key and no host auth file, raises ValueError."""
-        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GOOGLE_API_KEY", "GEMINI_API_KEY"):
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "OPENAI_API_KEY",
+            "GOOGLE_API_KEY",
+            "GEMINI_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         _patch_expanduser(monkeypatch, tmp_path)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -16,7 +16,7 @@ class TestCheckTask:
         task = tmp_path / "my-task"
         task.mkdir()
         (task / "task.toml").write_text(
-            '[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n'
+            "[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n"
         )
         (task / "instruction.md").write_text("# Do something\n")
         (task / "environment").mkdir()
@@ -69,7 +69,9 @@ class TestCheckTask:
         task = self._make_valid_task(tmp_path)
         shutil.rmtree(task / "tests")
         issues = check_task(task)
-        assert "Missing tests/ directory (verifier needs test.sh or evaluate.py)" in issues
+        assert (
+            "Missing tests/ directory (verifier needs test.sh or evaluate.py)" in issues
+        )
 
     def test_empty_tests_dir(self, tmp_path):
         task = self._make_valid_task(tmp_path)
@@ -86,13 +88,13 @@ class TestCheckTask:
 
     def test_task_toml_missing_agent_section(self, tmp_path):
         task = self._make_valid_task(tmp_path)
-        (task / "task.toml").write_text('[verifier]\ntimeout_sec = 120\n')
+        (task / "task.toml").write_text("[verifier]\ntimeout_sec = 120\n")
         issues = check_task(task)
         assert "task.toml missing [agent] section" in issues
 
     def test_task_toml_missing_timeout_sec(self, tmp_path):
         task = self._make_valid_task(tmp_path)
-        (task / "task.toml").write_text('[agent]\n')
+        (task / "task.toml").write_text("[agent]\n")
         issues = check_task(task)
         assert "task.toml [agent] missing timeout_sec" in issues
 
@@ -143,11 +145,13 @@ class TestInitTask:
     def test_test_sh_is_executable(self, tmp_path):
         task = init_task("exec-test", parent_dir=tmp_path)
         import os
+
         assert os.access(task / "tests" / "test.sh", os.X_OK)
 
     def test_solve_sh_is_executable(self, tmp_path):
         task = init_task("exec-sol", parent_dir=tmp_path)
         import os
+
         assert os.access(task / "solution" / "solve.sh", os.X_OK)
 
     def test_raises_on_existing_dir(self, tmp_path):

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -49,7 +49,9 @@ class TestTrajectoryTypes:
         # Add second exchange (Anthropic format)
         traj.exchanges.append(
             LLMExchange(
-                request=LLMRequest(body={"messages": [{"role": "user", "content": "more"}]}),
+                request=LLMRequest(
+                    body={"messages": [{"role": "user", "content": "more"}]}
+                ),
                 response=LLMResponse(
                     body={
                         "content": [{"type": "text", "text": "ok"}],
@@ -58,8 +60,8 @@ class TestTrajectoryTypes:
                 ),
             )
         )
-        assert traj.total_input_tokens == 210   # 10 + 200
-        assert traj.total_output_tokens == 55   # 5 + 50
+        assert traj.total_input_tokens == 210  # 10 + 200
+        assert traj.total_output_tokens == 55  # 5 + 50
 
         # Add third exchange (OpenAI format fallback)
         traj.exchanges.append(
@@ -67,14 +69,16 @@ class TestTrajectoryTypes:
                 request=LLMRequest(body={"messages": []}),
                 response=LLMResponse(
                     body={
-                        "choices": [{"message": {"role": "assistant", "content": "hi"}}],
+                        "choices": [
+                            {"message": {"role": "assistant", "content": "hi"}}
+                        ],
                         "usage": {"prompt_tokens": 50, "completion_tokens": 10},
                     }
                 ),
             )
         )
-        assert traj.total_input_tokens == 260   # 210 + 50
-        assert traj.total_output_tokens == 65   # 55 + 10
+        assert traj.total_input_tokens == 260  # 210 + 50
+        assert traj.total_output_tokens == 65  # 55 + 10
 
     def test_messages_extraction(self) -> None:
         traj = Trajectory(session_id="s1")

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -21,13 +21,17 @@ from benchflow.metrics import BenchmarkMetrics, TaskMetrics
 # classify_verifier_error
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("input_str,expected", [
-    (None, None),
-    ("", None),
-    ("verifier crashed: ImportError", VERIFIER_FAILED),
-    ("verifier timed out after 900s", VERIFIER_TIMEOUT),
-    ("verifier did something weird", "verifier_other"),
-])
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        (None, None),
+        ("", None),
+        ("verifier crashed: ImportError", VERIFIER_FAILED),
+        ("verifier timed out after 900s", VERIFIER_TIMEOUT),
+        ("verifier did something weird", "verifier_other"),
+    ],
+)
 def test_classify_verifier_error(input_str, expected):
     assert classify_verifier_error(input_str) == expected
 
@@ -36,8 +40,8 @@ def test_classify_verifier_error(input_str, expected):
 # RunResult with verifier_error
 # ---------------------------------------------------------------------------
 
-class TestRunResultVerifierError:
 
+class TestRunResultVerifierError:
     def test_success_requires_no_errors(self):
         assert RunResult(task_name="t", rewards={"reward": 1.0}).success is True
         assert RunResult(task_name="t", error="x").success is False
@@ -57,24 +61,36 @@ class TestRunResultVerifierError:
 # Result JSON round-trip via _build_result
 # ---------------------------------------------------------------------------
 
-class TestResultJson:
 
+class TestResultJson:
     def _build(self, tmp_path, **overrides):
         from benchflow.sdk import SDK
         from datetime import datetime
+
         defaults = dict(
-            task_name="t1", trial_name="trial-1", agent="test",
-            agent_name="", model="", n_tool_calls=0, prompts=["x"],
-            error=None, verifier_error=None, trajectory=[],
-            partial_trajectory=False, rewards={"reward": 1.0},
-            started_at=datetime.now(), timing={},
+            task_name="t1",
+            trial_name="trial-1",
+            agent="test",
+            agent_name="",
+            model="",
+            n_tool_calls=0,
+            prompts=["x"],
+            error=None,
+            verifier_error=None,
+            trajectory=[],
+            partial_trajectory=False,
+            rewards={"reward": 1.0},
+            started_at=datetime.now(),
+            timing={},
         )
         defaults.update(overrides)
         SDK._build_result(tmp_path, **defaults)
         return json.loads((tmp_path / "result.json").read_text())
 
     def test_verifier_error_in_json(self, tmp_path):
-        data = self._build(tmp_path, verifier_error="verifier crashed: KeyError", rewards=None)
+        data = self._build(
+            tmp_path, verifier_error="verifier crashed: KeyError", rewards=None
+        )
         assert data["verifier_error"] == "verifier crashed: KeyError"
         assert data["error"] is None
         assert data["rewards"] is None
@@ -89,11 +105,12 @@ class TestResultJson:
 # SDK._verify() integration
 # ---------------------------------------------------------------------------
 
-class TestSdkVerify:
 
+class TestSdkVerify:
     @pytest.fixture
     def verify_harness(self, tmp_path):
         from benchflow.sdk import SDK
+
         sdk = SDK()
         task = MagicMock()
         task.config.verifier.timeout_sec = 5
@@ -146,6 +163,7 @@ class TestSdkVerify:
 # Job: retry, resume, bounded log, threshold warning
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def job_factory(tmp_path):
     """Create a Job with n task directories and a mocked SDK."""
@@ -159,24 +177,27 @@ def job_factory(tmp_path):
             td.mkdir(exist_ok=True)
             (td / "task.toml").write_text(
                 'version = "1.0"\n[verifier]\ntimeout_sec = 60\n'
-                '[agent]\ntimeout_sec = 60\n[environment]\n'
+                "[agent]\ntimeout_sec = 60\n[environment]\n"
             )
         cfg = JobConfig(retry=RetryConfig(max_retries=max_retries))
         job = Job(tasks_dir=tasks_dir, jobs_dir=tmp_path / "jobs", config=cfg)
         return job, tasks_dir
+
     return _make
 
 
 class TestRetry:
-
     @pytest.mark.asyncio
     async def test_verifier_error_is_terminal(self, job_factory):
         """Verifier errors exit after 1 attempt — no retry."""
         job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
         job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=RunResult(
-            task_name="task-0", verifier_error="verifier crashed: x",
-        ))
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(
+                task_name="task-0",
+                verifier_error="verifier crashed: x",
+            )
+        )
         result = await job._run_task(tasks_dir / "task-0")
         assert job._sdk.run.call_count == 1
         assert result.verifier_error == "verifier crashed: x"
@@ -186,23 +207,32 @@ class TestRetry:
         """Agent install errors are retried."""
         job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
         job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=RunResult(
-            task_name="task-0", error="Agent claude-agent-acp install failed (rc=1)",
-        ))
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(
+                task_name="task-0",
+                error="Agent claude-agent-acp install failed (rc=1)",
+            )
+        )
         await job._run_task(tasks_dir / "task-0")
         assert job._sdk.run.call_count == 3  # 1 + 2 retries
 
 
 class TestResume:
-
     def test_verifier_errored_is_complete(self, tmp_path, caplog):
         task_dir = tmp_path / "task1" / "trial-1"
         task_dir.mkdir(parents=True)
-        (task_dir / "result.json").write_text(json.dumps({
-            "task_name": "task1", "rewards": None,
-            "error": None, "verifier_error": "verifier timed out after 900s",
-        }))
+        (task_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task1",
+                    "rewards": None,
+                    "error": None,
+                    "verifier_error": "verifier timed out after 900s",
+                }
+            )
+        )
         from benchflow.job import Job, JobConfig
+
         job = Job(tasks_dir=tmp_path, jobs_dir=tmp_path, config=JobConfig())
         with caplog.at_level(logging.INFO):
             completed = job._get_completed_tasks()
@@ -212,11 +242,18 @@ class TestResume:
     def test_agent_errored_not_complete(self, tmp_path):
         task_dir = tmp_path / "task2" / "trial-1"
         task_dir.mkdir(parents=True)
-        (task_dir / "result.json").write_text(json.dumps({
-            "task_name": "task2", "rewards": None,
-            "error": "install failed", "verifier_error": None,
-        }))
+        (task_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task2",
+                    "rewards": None,
+                    "error": "install failed",
+                    "verifier_error": None,
+                }
+            )
+        )
         from benchflow.job import Job, JobConfig
+
         job = Job(tasks_dir=tmp_path, jobs_dir=tmp_path, config=JobConfig())
         assert "task2" not in job._get_completed_tasks()
 
@@ -228,9 +265,12 @@ class TestJobRunLogs:
     async def test_bounded_log_shows_verifier_error(self, job_factory, caplog):
         job, _ = job_factory(n_tasks=1)
         job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=RunResult(
-            task_name="task-0", verifier_error="verifier crashed: KeyError",
-        ))
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(
+                task_name="task-0",
+                verifier_error="verifier crashed: KeyError",
+            )
+        )
         with caplog.at_level(logging.INFO):
             await job.run()
         assert any("verifier crashed" in m for m in caplog.messages)
@@ -239,16 +279,22 @@ class TestJobRunLogs:
     async def test_over_20_pct_threshold_error(self, job_factory, caplog):
         job, _ = job_factory(n_tasks=3)
         call_count = 0
+
         async def make_result(**kwargs):
             nonlocal call_count
-            r = RunResult(task_name=f"task-{call_count}", verifier_error="verifier crashed: x")
+            r = RunResult(
+                task_name=f"task-{call_count}", verifier_error="verifier crashed: x"
+            )
             call_count += 1
             return r
+
         job._sdk = AsyncMock()
         job._sdk.run = make_result
         with caplog.at_level(logging.WARNING):
             await job.run()
-        warning_records = [r for r in caplog.records if "had verifier errors" in r.message]
+        warning_records = [
+            r for r in caplog.records if "had verifier errors" in r.message
+        ]
         assert warning_records and warning_records[0].levelno == logging.WARNING
         error_records = [r for r in caplog.records if "Over 20%" in r.message]
         assert error_records and error_records[0].levelno == logging.ERROR
@@ -260,11 +306,13 @@ class TestJobRunLogs:
             RunResult(task_name=f"task-{i}", rewards={"reward": 1.0}) for i in range(4)
         ] + [RunResult(task_name="task-4", verifier_error="verifier crashed: x")]
         idx = 0
+
         async def make_result(**kwargs):
             nonlocal idx
             r = results[idx]
             idx += 1
             return r
+
         job._sdk = AsyncMock()
         job._sdk.run = make_result
         with caplog.at_level(logging.WARNING):
@@ -276,9 +324,12 @@ class TestJobRunLogs:
     async def test_summary_json_includes_verifier_errored(self, job_factory):
         job, _ = job_factory(n_tasks=1)
         job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=RunResult(
-            task_name="task-0", verifier_error="verifier crashed: x",
-        ))
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(
+                task_name="task-0",
+                verifier_error="verifier crashed: x",
+            )
+        )
         await job.run()
         summary = json.loads((job._jobs_dir / "summary.json").read_text())
         assert summary["verifier_errored"] == 1
@@ -288,11 +339,21 @@ class TestJobRunLogs:
 # JobResult invariant
 # ---------------------------------------------------------------------------
 
+
 def test_total_invariant():
     from benchflow.job import JobResult, JobConfig
-    jr = JobResult(job_name="t", config=JobConfig(), total=4,
-                   passed=1, failed=1, errored=1, verifier_errored=1)
+
+    jr = JobResult(
+        job_name="t",
+        config=JobConfig(),
+        total=4,
+        passed=1,
+        failed=1,
+        errored=1,
+        verifier_errored=1,
+    )
     assert jr.passed + jr.failed + jr.errored + jr.verifier_errored == jr.total
+
 
 def test_double_count_violates_invariant():
     """Both error and verifier_error set would double-count — documents mutual exclusivity."""
@@ -306,22 +367,42 @@ def test_double_count_violates_invariant():
 # Metrics
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture
 def sample_metrics():
     return BenchmarkMetrics(
-        benchmark="test", agent="test", model="test",
+        benchmark="test",
+        agent="test",
+        model="test",
         tasks=[
             TaskMetrics(task_name="pass1", reward=1.0, n_tool_calls=3, duration_sec=10),
             TaskMetrics(task_name="fail1", reward=0.0, n_tool_calls=5, duration_sec=20),
-            TaskMetrics(task_name="err1", reward=None, error="timed out", n_tool_calls=1, duration_sec=5),
-            TaskMetrics(task_name="verr1", reward=None, verifier_error="verifier crashed: x", n_tool_calls=100, duration_sec=999),
-            TaskMetrics(task_name="verr2", reward=None, verifier_error="verifier timed out after 900s", n_tool_calls=50, duration_sec=500),
+            TaskMetrics(
+                task_name="err1",
+                reward=None,
+                error="timed out",
+                n_tool_calls=1,
+                duration_sec=5,
+            ),
+            TaskMetrics(
+                task_name="verr1",
+                reward=None,
+                verifier_error="verifier crashed: x",
+                n_tool_calls=100,
+                duration_sec=999,
+            ),
+            TaskMetrics(
+                task_name="verr2",
+                reward=None,
+                verifier_error="verifier timed out after 900s",
+                n_tool_calls=50,
+                duration_sec=500,
+            ),
         ],
     )
 
 
 class TestMetricsVerifierError:
-
     def test_counts(self, sample_metrics):
         assert sample_metrics.verifier_errored == 2
         assert sample_metrics.errored == 1
@@ -349,28 +430,42 @@ class TestMetricsVerifierError:
     def test_collect_metrics_reads_verifier_error(self, tmp_path):
         from benchflow.metrics import collect_metrics
         from datetime import datetime
+
         task_dir = tmp_path / "task1" / "trial-1"
         task_dir.mkdir(parents=True)
         now = datetime.now().isoformat()
-        (task_dir / "result.json").write_text(json.dumps({
-            "task_name": "task1", "rewards": None, "error": None,
-            "verifier_error": "verifier crashed: KeyError",
-            "n_tool_calls": 5, "n_prompts": 1,
-            "started_at": now, "finished_at": now,
-        }))
+        (task_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task1",
+                    "rewards": None,
+                    "error": None,
+                    "verifier_error": "verifier crashed: KeyError",
+                    "n_tool_calls": 5,
+                    "n_prompts": 1,
+                    "started_at": now,
+                    "finished_at": now,
+                }
+            )
+        )
         m = collect_metrics(tmp_path)
         assert m.tasks[0].verifier_error == "verifier crashed: KeyError"
         assert m.tasks[0].verifier_errored is True
 
 
-@pytest.mark.parametrize("reward,error,verifier_error,expected", [
-    (None, None, "verifier crashed: x", True),
-    (1.0, None, None, False),
-    (None, "timed out", None, False),
-    (0.0, None, "verifier crashed: x", False),  # reward set → not verifier_errored
-])
+@pytest.mark.parametrize(
+    "reward,error,verifier_error,expected",
+    [
+        (None, None, "verifier crashed: x", True),
+        (1.0, None, None, False),
+        (None, "timed out", None, False),
+        (0.0, None, "verifier crashed: x", False),  # reward set → not verifier_errored
+    ],
+)
 def test_task_metrics_verifier_errored(reward, error, verifier_error, expected):
-    t = TaskMetrics(task_name="t", reward=reward, error=error, verifier_error=verifier_error)
+    t = TaskMetrics(
+        task_name="t", reward=reward, error=error, verifier_error=verifier_error
+    )
     assert t.verifier_errored is expected
 
 
@@ -378,12 +473,14 @@ def test_task_metrics_verifier_errored(reward, error, verifier_error, expected):
 # Verifier hardening (PR 2)
 # ---------------------------------------------------------------------------
 
+
 class TestVerifierHardening:
     """Pre-verification hardening: pkill, conftest cleanup, env injection."""
 
     @pytest.fixture
     def hardening_harness(self, tmp_path):
         from benchflow.sdk import SDK
+
         sdk = SDK()
         task = MagicMock()
         task.config.verifier.timeout_sec = 5
@@ -412,7 +509,10 @@ class TestVerifierHardening:
         assert "-not -path '/tests/*'" in cleanup[0]
         # Env injection — all _VERIFIER_ENV keys present
         injected = task.config.verifier.env
-        assert injected["PATH"] == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        assert (
+            injected["PATH"]
+            == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
         assert "--rootdir=/tests" in injected["PYTEST_ADDOPTS"]
         assert "-p no:cacheprovider" in injected["PYTEST_ADDOPTS"]
         assert injected["PYTHONPATH"] == ""
@@ -458,6 +558,7 @@ class TestVerifierHardening:
         authoritative contract for the env's contents.
         """
         from benchflow.sdk import SDK
+
         env = SDK._VERIFIER_ENV
         addopts = env["PYTEST_ADDOPTS"]
 
@@ -496,7 +597,10 @@ class TestVerifierHardening:
         assert env["PYTHONPATH"] == ""
         assert env["PYTHONHOME"] == ""
         assert env["PYTHONDONTWRITEBYTECODE"] == "1"
-        assert env["PATH"] == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        assert (
+            env["PATH"]
+            == "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
 
     def test_plugin_autoload_not_disabled(self):
         """Negative guard: PYTEST_DISABLE_PLUGIN_AUTOLOAD must NOT be in _VERIFIER_ENV.
@@ -511,6 +615,7 @@ class TestVerifierHardening:
         sdk.py:_VERIFIER_ENV at the same time.
         """
         from benchflow.sdk import SDK
+
         assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD" not in SDK._VERIFIER_ENV
 
     def test_dash_c_devnull_blocks_hostile_pyproject(self, tmp_path):
@@ -533,8 +638,7 @@ class TestVerifierHardening:
 
         plugin_marker = "benchflow_test_nonexistent_plugin_xyz123"
         (tmp_path / "pyproject.toml").write_text(
-            "[tool.pytest.ini_options]\n"
-            f'addopts = "-p {plugin_marker}"\n'
+            f'[tool.pytest.ini_options]\naddopts = "-p {plugin_marker}"\n'
         )
         (tmp_path / "test_dummy.py").write_text("def test_pass():\n    assert True\n")
 
@@ -550,7 +654,10 @@ class TestVerifierHardening:
 
         unhardened = subprocess.run(
             [sys.executable, "-m", "pytest", "--collect-only", "test_dummy.py"],
-            cwd=tmp_path, env=clean_env, capture_output=True, text=True,
+            cwd=tmp_path,
+            env=clean_env,
+            capture_output=True,
+            text=True,
         )
         # Must fail, AND must fail because of OUR hostile plugin marker —
         # not because of an unrelated collection / setup error.
@@ -565,9 +672,19 @@ class TestVerifierHardening:
         )
 
         hardened = subprocess.run(
-            [sys.executable, "-m", "pytest", "-c", "/dev/null",
-             "--collect-only", "test_dummy.py"],
-            cwd=tmp_path, env=clean_env, capture_output=True, text=True,
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                "-c",
+                "/dev/null",
+                "--collect-only",
+                "test_dummy.py",
+            ],
+            cwd=tmp_path,
+            env=clean_env,
+            capture_output=True,
+            text=True,
         )
         # Must succeed, AND must have actually collected the dummy test —
         # not silently collected zero items (which also returns 0 with
@@ -595,26 +712,43 @@ class TestTrajectorySource:
     def _build(self, tmp_path, **overrides):
         from benchflow.sdk import SDK
         from datetime import datetime
+
         defaults = dict(
-            task_name="t1", trial_name="trial-1", agent="test",
-            agent_name="", model="", n_tool_calls=0, prompts=["x"],
-            error=None, verifier_error=None, trajectory=[],
-            partial_trajectory=False, trajectory_source=None,
+            task_name="t1",
+            trial_name="trial-1",
+            agent="test",
+            agent_name="",
+            model="",
+            n_tool_calls=0,
+            prompts=["x"],
+            error=None,
+            verifier_error=None,
+            trajectory=[],
+            partial_trajectory=False,
+            trajectory_source=None,
             rewards={"reward": 1.0},
-            started_at=datetime.now(), timing={},
+            started_at=datetime.now(),
+            timing={},
         )
         defaults.update(overrides)
         SDK._build_result(tmp_path, **defaults)
         return json.loads((tmp_path / "result.json").read_text())
 
-    @pytest.mark.parametrize("source,partial,expected_source,expected_partial", [
-        ("acp", False, "acp", False),
-        ("scraped", False, "scraped", False),
-        ("partial_acp", True, "partial_acp", True),
-        (None, False, None, False),
-    ])
-    def test_trajectory_source_in_result_json(self, tmp_path, source, partial, expected_source, expected_partial):
-        data = self._build(tmp_path, trajectory_source=source, partial_trajectory=partial)
+    @pytest.mark.parametrize(
+        "source,partial,expected_source,expected_partial",
+        [
+            ("acp", False, "acp", False),
+            ("scraped", False, "scraped", False),
+            ("partial_acp", True, "partial_acp", True),
+            (None, False, None, False),
+        ],
+    )
+    def test_trajectory_source_in_result_json(
+        self, tmp_path, source, partial, expected_source, expected_partial
+    ):
+        data = self._build(
+            tmp_path, trajectory_source=source, partial_trajectory=partial
+        )
         assert data["trajectory_source"] == expected_source
         assert data["partial_trajectory"] == expected_partial
 
@@ -623,7 +757,9 @@ class TestTrajectorySource:
         assert r_default.trajectory_source is None
         assert r_default.partial_trajectory is False
 
-        r_set = RunResult(task_name="t", trajectory_source="acp", partial_trajectory=True)
+        r_set = RunResult(
+            task_name="t", trajectory_source="acp", partial_trajectory=True
+        )
         assert r_set.trajectory_source == "acp"
         assert r_set.partial_trajectory is True
 
@@ -640,17 +776,20 @@ class TestScrapedTrajectoryTrust:
     def sdk_run_mocks(self, tmp_path):
         """Mocks for SDK.run() that reach scraping/finally without real containers."""
         from benchflow.sdk import SDK
+
         sdk = SDK()
 
         mock_env = AsyncMock()
-        mock_env.exec = AsyncMock(return_value=MagicMock(stdout="", stderr="", exit_code=0))
+        mock_env.exec = AsyncMock(
+            return_value=MagicMock(stdout="", stderr="", exit_code=0)
+        )
         mock_env.stop = AsyncMock()
 
         task_dir = tmp_path / "task"
         task_dir.mkdir()
         (task_dir / "task.toml").write_text(
             'version = "1.0"\n[verifier]\ntimeout_sec = 5\n'
-            '[agent]\ntimeout_sec = 5\n[environment]\n'
+            "[agent]\ntimeout_sec = 5\n[environment]\n"
         )
         (task_dir / "environment").mkdir()
         (task_dir / "environment" / "Dockerfile").write_text("FROM ubuntu:22.04\n")
@@ -663,9 +802,16 @@ class TestScrapedTrajectoryTrust:
         """Apply shared + extra patches for SDK.run() internals."""
         patches = [
             patch("benchflow.sdk._create_environment", return_value=mock_env),
-            patch.object(sdk, "_install_agent", return_value=MagicMock(
-                credential_files={}, home_dirs=[], skill_paths=[], env_mapping={},
-            )),
+            patch.object(
+                sdk,
+                "_install_agent",
+                return_value=MagicMock(
+                    credential_files={},
+                    home_dirs=[],
+                    skill_paths=[],
+                    env_mapping={},
+                ),
+            ),
             patch.object(sdk, "_write_credential_files", new_callable=AsyncMock),
             patch.object(sdk, "_deploy_skills", new_callable=AsyncMock),
         ] + extra_patches
@@ -675,7 +821,9 @@ class TestScrapedTrajectoryTrust:
             yield
 
     @pytest.mark.asyncio
-    async def test_scraped_trajectory_preserves_n_tool_calls(self, sdk_run_mocks, caplog):
+    async def test_scraped_trajectory_preserves_n_tool_calls(
+        self, sdk_run_mocks, caplog
+    ):
         """Main path: forged scraped trajectory must NOT overwrite ACP n_tool_calls."""
         sdk, mock_env, task_dir = sdk_run_mocks
 
@@ -686,15 +834,45 @@ class TestScrapedTrajectoryTrust:
         mock_acp.session = mock_session
         mock_acp.close = AsyncMock()
 
-        with self._patch_sdk_run(sdk, mock_env, [
-            patch.object(sdk, "_connect_acp", new_callable=AsyncMock, return_value=(mock_acp, mock_session, "test-agent")),
-            patch.object(sdk, "_execute_prompts", new_callable=AsyncMock, return_value=([], 5)),
-            patch("benchflow.sdk._scrape_agent_trajectory", new_callable=AsyncMock, return_value=forged),
-            patch.object(sdk, "_verify", new_callable=AsyncMock, return_value=({"reward": 1.0}, None)),
-        ]), caplog.at_level(logging.WARNING):
-            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"}, sandbox_user=None)
+        with (
+            self._patch_sdk_run(
+                sdk,
+                mock_env,
+                [
+                    patch.object(
+                        sdk,
+                        "_connect_acp",
+                        new_callable=AsyncMock,
+                        return_value=(mock_acp, mock_session, "test-agent"),
+                    ),
+                    patch.object(
+                        sdk,
+                        "_execute_prompts",
+                        new_callable=AsyncMock,
+                        return_value=([], 5),
+                    ),
+                    patch(
+                        "benchflow.sdk._scrape_agent_trajectory",
+                        new_callable=AsyncMock,
+                        return_value=forged,
+                    ),
+                    patch.object(
+                        sdk,
+                        "_verify",
+                        new_callable=AsyncMock,
+                        return_value=({"reward": 1.0}, None),
+                    ),
+                ],
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            result = await sdk.run(
+                task_dir, agent="test-agent", agent_env={"TEST": "1"}, sandbox_user=None
+            )
 
-        assert result.n_tool_calls == 5, "ACP n_tool_calls must survive scraping fallback"
+        assert result.n_tool_calls == 5, (
+            "ACP n_tool_calls must survive scraping fallback"
+        )
         assert result.trajectory_source == "scraped"
         assert len(result.trajectory) == 100
         assert any("UNTRUSTED" in m for m in caplog.messages)
@@ -711,14 +889,39 @@ class TestScrapedTrajectoryTrust:
         mock_acp.session = mock_session
         mock_acp.close = AsyncMock()
 
-        with self._patch_sdk_run(sdk, mock_env, [
-            patch.object(sdk, "_connect_acp", new_callable=AsyncMock, return_value=(mock_acp, mock_session, "test-agent")),
-            patch.object(sdk, "_execute_prompts", new_callable=AsyncMock, side_effect=ConnectionError("lost")),
-            patch("benchflow.sdk._capture_session_trajectory", return_value=partial_events),
-            patch("benchflow.sdk._scrape_agent_trajectory", new_callable=AsyncMock, return_value=[]),
-        ]):
-            result = await sdk.run(task_dir, agent="test-agent", agent_env={"TEST": "1"}, sandbox_user=None)
+        with self._patch_sdk_run(
+            sdk,
+            mock_env,
+            [
+                patch.object(
+                    sdk,
+                    "_connect_acp",
+                    new_callable=AsyncMock,
+                    return_value=(mock_acp, mock_session, "test-agent"),
+                ),
+                patch.object(
+                    sdk,
+                    "_execute_prompts",
+                    new_callable=AsyncMock,
+                    side_effect=ConnectionError("lost"),
+                ),
+                patch(
+                    "benchflow.sdk._capture_session_trajectory",
+                    return_value=partial_events,
+                ),
+                patch(
+                    "benchflow.sdk._scrape_agent_trajectory",
+                    new_callable=AsyncMock,
+                    return_value=[],
+                ),
+            ],
+        ):
+            result = await sdk.run(
+                task_dir, agent="test-agent", agent_env={"TEST": "1"}, sandbox_user=None
+            )
 
-        assert result.n_tool_calls == 3, "Must use session.tool_calls, not trajectory count"
+        assert result.n_tool_calls == 3, (
+            "Must use session.tool_calls, not trajectory count"
+        )
         assert result.trajectory_source == "partial_acp"
         assert result.partial_trajectory is True

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -13,7 +13,6 @@ from benchflow._scoring import (
     VERIFIER_FAILED,
     VERIFIER_TIMEOUT,
     classify_verifier_error,
-    extract_reward,
 )
 from benchflow.metrics import BenchmarkMetrics, TaskMetrics
 
@@ -263,7 +262,9 @@ class TestJobRunLogs:
         idx = 0
         async def make_result(**kwargs):
             nonlocal idx
-            r = results[idx]; idx += 1; return r
+            r = results[idx]
+            idx += 1
+            return r
         job._sdk = AsyncMock()
         job._sdk.run = make_result
         with caplog.at_level(logging.WARNING):

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,7 +1,6 @@
 """Tests for YAML job config loading."""
 
 import pytest
-from pathlib import Path
 
 from benchflow.job import Job
 


### PR DESCRIPTION
## Summary

- **Add `.github/workflows/test.yml`** — first CI on the repo. Single ubuntu-latest job: `uv` install + `ruff check` + `ruff format --check` + `pytest tests/`. Python 3.12 only.
- **Lint cleanup** — auto-fixed 12 unused imports across test files; 6 remaining issues fixed by hand (forward-ref import for `AgentConfig` in `sdk.py`, dropped unused locals, expanded a triple-semicolon line in `test_verify.py`). No behavior changes.
- **Format pass** — `ruff format` applied across 46 files. Mechanical only — the diff is large but no behavior changes. Per-line `# noqa: F401` added to two multi-line re-export blocks in `__init__.py` since format moved the noqa off the closing paren.

Lint and format use ruff defaults — broader rule selection (`select = ["E","F","I","B","UP","SIM","RUF"]`) is intentionally deferred to a follow-up branch to keep this PR focused.

## Test plan

- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] `pytest tests/` — 440/440 pass
- [ ] CI workflow runs green on this PR (first real run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)