### PR TITLE
refactor: split sdk.py orchestrator into greppable phase modules

### DIFF
--- a/src/benchflow/_acp_run.py
+++ b/src/benchflow/_acp_run.py
@@ -1,0 +1,115 @@
+"""ACP transport bring-up and the multi-turn prompt loop.
+
+Owns the live agent-side of a run:
+    - connect_acp: spawn the agent process inside the container, wrap it in
+      the ACP stdio transport, run initialize → session_new → set_model
+    - execute_prompts: send each prompt through the session, capture the
+      ACP-native trajectory, and report tool-call counts
+
+The one allowed horizontal phase import in this refactor lives here:
+``from benchflow._sandbox import build_priv_drop_cmd``. connect_acp wraps
+the agent launch command in the sandbox user's privilege-drop prefix
+before handing it to the transport. It is a single pure-function call
+with no shared state — not a coupling of concerns.
+
+Does not own:
+    - Verifier hardening or model-set authentication — see _sandbox /
+      _credentials respectively
+"""
+
+import asyncio
+import logging
+from pathlib import Path
+
+from benchflow._sandbox import build_priv_drop_cmd
+from benchflow._trajectory import _capture_session_trajectory
+from benchflow.acp.client import ACPClient
+from benchflow.acp.container_transport import ContainerTransport
+from benchflow.process import DaytonaProcess, DockerProcess
+
+logger = logging.getLogger(__name__)
+
+
+async def connect_acp(
+    env,
+    agent: str,
+    agent_launch: str,
+    agent_env: dict,
+    sandbox_user: str | None,
+    model: str | None,
+    trial_dir: Path,
+    environment: str,
+    agent_cwd: str,
+) -> tuple[ACPClient, object, str]:
+    """Create ACP transport, connect, init session, set model. Return (client, session, agent_name)."""
+    # Resolve agent binary path for non-docker environments
+    if environment != "docker":
+        which_result = await env.exec(
+            f"which {agent_launch.split()[0]}", timeout_sec=10
+        )
+        if which_result.return_code == 0 and (which_result.stdout or "").strip():
+            full_path = which_result.stdout.strip()
+            parts = agent_launch.split()
+            parts[0] = full_path
+            agent_launch = " ".join(parts)
+            logger.info(f"Resolved agent path: {agent_launch}")
+
+    if sandbox_user:
+        agent_launch = build_priv_drop_cmd(agent_launch, sandbox_user)
+        logger.info(f"Agent sandboxed as: {sandbox_user}")
+
+    if environment == "docker":
+        live_proc = DockerProcess.from_harbor_env(env)
+    else:
+        live_proc = await DaytonaProcess.from_harbor_env(env)
+
+    agent_log = trial_dir / "agent" / f"{agent.replace('-', '_')}.txt"
+    transport = ContainerTransport(
+        container_process=live_proc,
+        command=agent_launch,
+        env=agent_env,
+        cwd=agent_cwd,
+        agent_log_path=agent_log,
+    )
+    acp_client = ACPClient(transport)
+    await acp_client.connect()
+
+    init_result = await asyncio.wait_for(acp_client.initialize(), timeout=60)
+    agent_name = init_result.agent_info.name if init_result.agent_info else agent
+    logger.info(f"ACP agent: {agent_name}")
+
+    session = await asyncio.wait_for(acp_client.session_new(cwd=agent_cwd), timeout=60)
+    logger.info(f"Session: {session.session_id}")
+
+    if model:
+        from benchflow.agents.providers import strip_provider_prefix
+
+        acp_model_id = strip_provider_prefix(model)
+        try:
+            await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
+            logger.info(f"Model set to: {acp_model_id} (from {model})")
+        except Exception as e:
+            logger.warning(f"Failed to set model via ACP: {e}")
+
+    return acp_client, session, agent_name
+
+
+async def execute_prompts(
+    acp_client: ACPClient,
+    session,
+    prompts: list[str],
+    timeout: int,
+) -> tuple[list[dict], int]:
+    """Send prompts via ACP and capture trajectory. Return (trajectory, n_tool_calls)."""
+    for i, prompt in enumerate(prompts):
+        logger.info(f"Prompt {i + 1}/{len(prompts)}: {prompt[:80]}...")
+        prompt_result = await asyncio.wait_for(
+            acp_client.prompt(prompt),
+            timeout=timeout,
+        )
+        logger.info(
+            f"  → {prompt_result.stop_reason.value}, "
+            f"{len(session.tool_calls)} total tool calls"
+        )
+    trajectory = _capture_session_trajectory(session)
+    return trajectory, len(session.tool_calls)

--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -1,0 +1,176 @@
+"""Agent environment variable resolution.
+
+Pure helpers that build the env-var dict handed to the agent process. No I/O
+beyond filesystem reads (Vertex ADC discovery, subscription-auth file probe).
+No state. Every function here is callable from a test in isolation.
+
+Owns:
+    - Auto-inheritance of well-known API keys from host os.environ
+    - Vertex AI ADC injection for google-vertex/* models
+    - Provider detection (BENCHFLOW_PROVIDER_*) and env_mapping translation
+    - Subscription auth detection (host login files substituting for API keys)
+    - The full resolve_agent_env pipeline that runs all of the above
+
+Does not own:
+    - Writing credential files into the container — see _credentials.py
+    - Setting model via ACP session/set_model — see _acp_run.py
+"""
+
+import contextlib
+import json
+import logging
+import os
+from pathlib import Path
+
+from benchflow.agents.registry import AGENTS
+
+logger = logging.getLogger(__name__)
+
+
+def auto_inherit_env(agent_env: dict[str, str]) -> None:
+    """Copy well-known API keys from host os.environ into agent_env."""
+    from benchflow.agents.providers import PROVIDERS
+
+    keys = {
+        "ANTHROPIC_API_KEY",
+        "OPENAI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_LOCATION",
+    }
+    for cfg in PROVIDERS.values():
+        if cfg.auth_env:
+            keys.add(cfg.auth_env)
+        for env_var in cfg.url_params.values():
+            keys.add(env_var)
+    for key in keys:
+        if key in os.environ:
+            agent_env.setdefault(key, os.environ[key])
+    # Mirror GEMINI_API_KEY as GOOGLE_API_KEY (some agents expect one or the other)
+    if "GEMINI_API_KEY" in agent_env and "GOOGLE_API_KEY" not in agent_env:
+        agent_env["GOOGLE_API_KEY"] = agent_env["GEMINI_API_KEY"]
+
+
+def inject_vertex_credentials(agent_env: dict[str, str], model: str) -> None:
+    """Inject ADC credentials and defaults for Vertex AI models."""
+    from benchflow.agents.registry import is_vertex_model
+
+    if not is_vertex_model(model):
+        return
+    adc_path = Path.home() / ".config/gcloud/application_default_credentials.json"
+    if not adc_path.exists():
+        raise ValueError(
+            f"Vertex AI model {model!r} requires ADC credentials. "
+            f"Run: gcloud auth application-default login"
+        )
+    agent_env.setdefault("GOOGLE_APPLICATION_CREDENTIALS_JSON", adc_path.read_text())
+    agent_env.setdefault("GOOGLE_CLOUD_LOCATION", "global")
+    if "GOOGLE_CLOUD_PROJECT" not in agent_env:
+        raise ValueError(
+            f"GOOGLE_CLOUD_PROJECT required for Vertex AI model {model!r}. "
+            f"Export it or pass via --ae GOOGLE_CLOUD_PROJECT=<project>"
+        )
+
+
+def resolve_provider_env(
+    agent_env: dict[str, str],
+    model: str,
+    agent: str,
+) -> None:
+    """Detect provider for model, inject BENCHFLOW_PROVIDER_* and env_mapping."""
+    from benchflow.agents.providers import (
+        find_provider,
+        resolve_base_url,
+        strip_provider_prefix,
+    )
+
+    agent_env.setdefault("BENCHFLOW_PROVIDER_MODEL", strip_provider_prefix(model))
+    agent_cfg = AGENTS.get(agent)
+    # Agent-declared protocol takes precedence over provider's primary so
+    # multi-endpoint providers (e.g. zai) route to the right URL.
+    agent_protocol = agent_cfg.api_protocol if agent_cfg else ""
+    _prov = find_provider(model)
+    if _prov:
+        _prov_name, _prov_cfg = _prov
+        agent_env.setdefault("BENCHFLOW_PROVIDER_NAME", _prov_name)
+        # URL params missing — will fail later with clear error
+        with contextlib.suppress(KeyError):
+            agent_env.setdefault(
+                "BENCHFLOW_PROVIDER_BASE_URL",
+                resolve_base_url(_prov_cfg, agent_env, protocol=agent_protocol or None),
+            )
+        agent_env.setdefault(
+            "BENCHFLOW_PROVIDER_PROTOCOL",
+            agent_protocol or _prov_cfg.api_protocol,
+        )
+        if _prov_cfg.models:
+            agent_env.setdefault(
+                "BENCHFLOW_PROVIDER_MODELS", json.dumps(_prov_cfg.models)
+            )
+        if _prov_cfg.auth_type == "api_key" and _prov_cfg.auth_env:
+            _key = agent_env.get(_prov_cfg.auth_env, "")
+            if _key:
+                agent_env.setdefault("BENCHFLOW_PROVIDER_API_KEY", _key)
+    # Apply agent env_mapping: translate BENCHFLOW_PROVIDER_* → agent-native vars
+    if agent_cfg and agent_cfg.env_mapping:
+        for src, dst in agent_cfg.env_mapping.items():
+            if src in agent_env:
+                agent_env.setdefault(dst, agent_env[src])
+
+
+def check_subscription_auth(agent: str, required_key: str) -> bool:
+    """Return True if host subscription auth can substitute for required_key."""
+    agent_cfg = AGENTS.get(agent)
+    if not agent_cfg or not agent_cfg.subscription_auth:
+        return False
+    sa = agent_cfg.subscription_auth
+    if sa.replaces_env != required_key:
+        return False
+    return Path(sa.detect_file).expanduser().is_file()
+
+
+def resolve_agent_env(
+    agent: str,
+    model: str | None,
+    agent_env: dict[str, str] | None,
+) -> dict[str, str]:
+    """Resolve agent environment: auto-inherit keys, provider vars, env_mapping."""
+    agent_env = dict(agent_env or {})
+    auto_inherit_env(agent_env)
+    if model:
+        inject_vertex_credentials(agent_env, model)
+        resolve_provider_env(agent_env, model, agent)
+        # Validate required API key for the chosen model
+        from benchflow.agents.registry import infer_env_key_for_model
+
+        required_key = infer_env_key_for_model(model)
+        if required_key and required_key not in agent_env:
+            if check_subscription_auth(agent, required_key):
+                agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
+                logger.info(
+                    "Using host subscription auth (no %s set)",
+                    required_key,
+                )
+            else:
+                raise ValueError(
+                    f"{required_key} required for model {model!r} but not set. "
+                    f"Export it, pass via agent_env, or log in with the "
+                    f"agent CLI (e.g. claude login, codex --login)."
+                )
+    else:
+        # No model specified — still check subscription auth for required env vars
+        agent_cfg = AGENTS.get(agent)
+        if agent_cfg:
+            for req_key in agent_cfg.requires_env:
+                if req_key not in agent_env and check_subscription_auth(agent, req_key):
+                    agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
+                    logger.info(
+                        "Using host subscription auth (no %s set)",
+                        req_key,
+                    )
+    # Increase output token limit to avoid truncation errors
+    agent_env.setdefault("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "128000")
+    # Disable telemetry/non-essential traffic in container
+    agent_env.setdefault("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+    return agent_env

--- a/src/benchflow/_agent_setup.py
+++ b/src/benchflow/_agent_setup.py
@@ -1,0 +1,121 @@
+"""Agent provisioning inside the sandbox: install + skill deployment.
+
+Owns the "prepare the sandbox for the agent" phase that runs once,
+sequentially, before ACP connection:
+
+    install_agent  → registry-driven install_cmd, captures stdout, raises
+                     AgentInstallError on non-zero return code
+    deploy_skills  → runtime skill upload (Dockerfile-mount fallback) and
+                     distribution into agent-specific discovery paths
+
+Together they form the install → distribute lifecycle that the SDK loop
+runs as: install_agent → deploy_skills → connect_acp → execute_prompts.
+
+Does not own:
+    - Agent / provider env vars — see _agent_env.py
+    - Credential file writing — see _credentials.py
+"""
+
+import logging
+import shlex
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from benchflow._models import AgentInstallError
+from benchflow.agents.registry import AGENT_INSTALLERS, AGENTS, AgentConfig
+
+if TYPE_CHECKING:
+    from harbor.models.task.task import Task
+
+logger = logging.getLogger(__name__)
+
+
+async def install_agent(env, agent: str, trial_dir: Path) -> AgentConfig | None:
+    """Install agent in sandbox and return its config."""
+    agent_base = agent.split()[0]
+    agent_cfg = AGENTS.get(agent_base)
+    if agent_base not in AGENT_INSTALLERS:
+        return agent_cfg
+    install_timeout = agent_cfg.install_timeout if agent_cfg else 900
+    logger.info(f"Installing {agent_base} in sandbox (timeout={install_timeout}s)...")
+    install_result = await env.exec(
+        AGENT_INSTALLERS[agent_base],
+        timeout_sec=install_timeout,
+    )
+    install_log = trial_dir / "agent" / "install-stdout.txt"
+    install_log.parent.mkdir(parents=True, exist_ok=True)
+    install_log.write_text(install_result.stdout or "")
+    if install_result.return_code != 0:
+        diag = await env.exec(
+            "echo 'OS:' && cat /etc/os-release 2>/dev/null | head -2; "
+            "echo 'Node:' && node --version 2>&1; "
+            f"echo 'Agent:' && which {agent_base} 2>&1",
+            timeout_sec=10,
+        )
+        raise AgentInstallError(
+            agent=agent_base,
+            return_code=install_result.return_code,
+            stdout=install_result.stdout or "",
+            diagnostics=diag.stdout or "",
+            log_path=str(install_log),
+        )
+    return agent_cfg
+
+
+async def deploy_skills(
+    env,
+    task_path: Path,
+    skills_dir: str | Path | None,
+    agent_cfg,
+    sandbox_user: str | None,
+    agent_cwd: str,
+    task: "Task",
+) -> None:
+    """Deploy and distribute skills into sandbox."""
+    # Runtime upload (fallback if not baked into Dockerfile)
+    if skills_dir:
+        dockerfile = task_path / "environment" / "Dockerfile"
+        already_injected = (
+            dockerfile.exists()
+            and "COPY _deps/skills /skills/" in dockerfile.read_text()
+        )
+        if not already_injected:
+            skills_path = Path(skills_dir)
+            if skills_path.is_dir():
+                logger.info(f"Deploying skills via runtime upload from {skills_path}")
+                await env.upload_dir(skills_path, "/skills")
+                if agent_cfg and agent_cfg.skill_paths:
+                    parts = []
+                    for sp in agent_cfg.skill_paths:
+                        expanded = sp.replace("$HOME", "/root").replace(
+                            "$WORKSPACE", "/app"
+                        )
+                        parent = str(Path(expanded).parent)
+                        parts.append(
+                            f"mkdir -p '{parent}' && ln -sf /skills '{expanded}'"
+                        )
+                    await env.exec(" && ".join(parts), timeout_sec=10)
+                logger.info("Skills deployed to /skills and symlinked")
+            else:
+                logger.warning(f"Skills dir not found: {skills_path}")
+        else:
+            logger.info("Skills already injected via Dockerfile")
+
+    # Distribute to agent-specific discovery paths
+    task_skills_dir = task.config.environment.skills_dir
+    effective_skills = "/skills" if skills_dir else task_skills_dir
+    if effective_skills and agent_cfg and agent_cfg.skill_paths:
+        home = f"/home/{sandbox_user}" if sandbox_user else "/root"
+        parts = []
+        for sp in agent_cfg.skill_paths:
+            expanded = sp.replace("$HOME", home).replace("$WORKSPACE", agent_cwd)
+            q_expanded = shlex.quote(expanded)
+            q_skills = shlex.quote(effective_skills)
+            parts.append(
+                f"mkdir -p {q_expanded} && cp -r {q_skills}/. {q_expanded}/ 2>/dev/null"
+            )
+        if parts:
+            await env.exec("; ".join(parts), timeout_sec=15)
+            logger.info(
+                f"Skills distributed to {len(parts)} paths for {agent_cfg.name}"
+            )

--- a/src/benchflow/_credentials.py
+++ b/src/benchflow/_credentials.py
@@ -1,0 +1,136 @@
+"""Credential file writing into the agent sandbox.
+
+Single home for "writes a file under the agent's credential dir":
+    - upload_credential       core helper: stage tmpfile, upload to container
+    - write_credential_files  agent + provider credential files (cf. AgentConfig)
+    - write_gemini_vertex_settings  ~/.gemini/settings.json for Vertex backend
+    - upload_subscription_auth  host login files (e.g. ~/.claude/.credentials.json)
+
+The Gemini Vertex settings helper lives here (not in _agent_env.py) so the
+module has a single coherent role and zero horizontal imports between phase
+modules. Putting it elsewhere creates a two-way cycle with upload_credential.
+
+Does not own:
+    - Resolving which env vars become credentials — see _agent_env.py
+    - Detecting whether host subscription auth is available — see
+      _agent_env.check_subscription_auth (read-only filesystem probe)
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+
+from benchflow.agents.registry import AGENTS
+
+logger = logging.getLogger(__name__)
+
+
+async def upload_credential(env, path: str, content: str) -> None:
+    """Write a credential file into the container via upload_file."""
+    parent = path.rsplit("/", 1)[0]
+    await env.exec(f"mkdir -p {parent}", timeout_sec=10)
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        f.write(content)
+        tmp_path = f.name
+    try:
+        await env.upload_file(tmp_path, path)
+    finally:
+        os.unlink(tmp_path)
+
+
+async def write_credential_files(
+    env,
+    agent: str,
+    agent_env: dict,
+    agent_cfg,
+    model: str | None,
+    cred_home: str,
+) -> None:
+    """Write credential files into container from agent + provider configs."""
+    # Provider credential files (e.g. GCP ADC for Vertex)
+    if model:
+        from benchflow.agents.providers import find_provider
+
+        _prov = find_provider(model)
+        if _prov:
+            _, _prov_cfg = _prov
+            for cf in _prov_cfg.credential_files:
+                value = agent_env.get(cf["env_source"])
+                if value:
+                    path = cf["path"].format(home=cred_home)
+                    await upload_credential(env, path, value)
+                    for k, v in cf.get("post_env", {}).items():
+                        agent_env.setdefault(k, v.format(home=cred_home))
+                    logger.info("Provider credential file written: %s", path)
+
+    # Gemini CLI needs settings.json to use Vertex AI backend
+    await write_gemini_vertex_settings(env, agent, model, cred_home)
+
+    # Agent credential files (e.g. codex auth.json)
+    if agent_cfg and agent_cfg.credential_files:
+        for cf in agent_cfg.credential_files:
+            value = agent_env.get(cf.env_source)
+            if value:
+                content = cf.template.format(value=value) if cf.template else value
+                path = cf.path.format(home=cred_home)
+                await upload_credential(env, path, content)
+                logger.info("Agent credential file written: %s", path)
+
+
+async def write_gemini_vertex_settings(
+    env,
+    agent: str,
+    model: str | None,
+    cred_home: str,
+) -> None:
+    """Write ~/.gemini/settings.json to select Vertex AI backend.
+
+    Gemini CLI defaults to API key auth. When a google-vertex/ model is
+    used, we must write settings.json with selectedType=vertex-ai so the
+    CLI uses ADC instead of looking for GEMINI_API_KEY.
+
+    No conflict with upload_subscription_auth: Vertex models have
+    infer_env_key_for_model() return None, so subscription auth is
+    never triggered for Vertex — the two paths are mutually exclusive.
+    """
+    if not model or agent != "gemini":
+        return
+    from benchflow.agents.registry import is_vertex_model
+
+    if not is_vertex_model(model):
+        return
+    settings = json.dumps(
+        {"security": {"auth": {"selectedType": "vertex-ai"}}},
+    )
+    path = f"{cred_home}/.gemini/settings.json"
+    await upload_credential(env, path, settings)
+    logger.info("Gemini Vertex settings written: %s", path)
+
+
+async def upload_subscription_auth(
+    env,
+    agent: str,
+    cred_home: str,
+) -> None:
+    """Upload host subscription auth files into the container.
+
+    Called when _BENCHFLOW_SUBSCRIPTION_AUTH is set, meaning no API key
+    was provided but a host auth file was detected.
+    """
+    agent_cfg = AGENTS.get(agent)
+    if not agent_cfg or not agent_cfg.subscription_auth:
+        return
+    for f in agent_cfg.subscription_auth.files:
+        host_path = Path(f.host_path).expanduser()
+        if not host_path.is_file():
+            continue
+        container_path = f.container_path.format(home=cred_home)
+        content = host_path.read_text()
+        await upload_credential(env, container_path, content)
+        logger.info(
+            "Subscription auth uploaded: %s -> %s",
+            host_path,
+            container_path,
+        )

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -1,0 +1,232 @@
+"""Sandbox user setup, path lockdown, and verifier hardening.
+
+Owns the "agent runs as non-root" lifecycle:
+    - Creating the sandbox user and copying root's tooling into its home
+    - Building the privilege-drop wrapper (setpriv / su) for agent launch
+    - Locking down solution/test paths so the sandbox user cannot read them
+    - Hardening the environment before the verifier runs (kill sandbox
+      processes, scrub injected conftest/.pth files, install trusted env)
+
+Plus the supporting cast that only this module touches:
+    - Path validation against shell-injection (_validate_locked_path)
+    - Effective lockdown path resolution (_resolve_locked_paths)
+    - VERIFIER_ENV / CLEANUP_CMD module constants (consumed only by
+      harden_before_verify; never read directly from sdk.py)
+
+Does not own:
+    - Spawning the agent process — see _acp_run.py (which imports
+      build_priv_drop_cmd from here as the one allowed horizontal hop)
+    - Running the verifier itself — see SDK._verify
+"""
+
+import logging
+import re
+import shlex
+from typing import TYPE_CHECKING
+
+from benchflow.agents.registry import get_sandbox_home_dirs
+
+if TYPE_CHECKING:
+    from harbor.models.task.task import Task
+
+logger = logging.getLogger(__name__)
+
+
+# ── Path lockdown defaults and validation ─────────────────────────────────────
+
+_DEFAULT_LOCKED = ["/solution", "/tests"]
+_SAFE_PATH_RE = re.compile(r"^/[a-zA-Z0-9_./*?\-]+(/[a-zA-Z0-9_./*?\-]+)*$")
+
+
+def _validate_locked_path(p: str) -> None:
+    """Validate a locked path — reject injection and traversal."""
+    import os
+
+    p_norm = os.path.normpath(p)
+    if p_norm != p:
+        raise ValueError(
+            f"Invalid locked path {p!r}: normalizes to {p_norm!r} — "
+            f"use the normalized form directly"
+        )
+    if any(c == ".." for c in p.split("/")):
+        raise ValueError(f"Invalid locked path {p!r}: '..' component not allowed")
+    if not _SAFE_PATH_RE.match(p):
+        raise ValueError(
+            f"Invalid locked path {p!r}: must be absolute, "
+            f"alphanumeric with /-_.*? only"
+        )
+    if p.endswith("/") and p != "/":
+        raise ValueError(
+            f"Invalid locked path {p!r}: trailing slash not allowed "
+            f"(chown on '/dir/' may have unintended scope)"
+        )
+
+
+def _resolve_locked_paths(
+    sandbox_user: str | None,
+    sandbox_locked_paths: list[str] | None,
+) -> list[str]:
+    """Resolve effective locked paths.
+
+    - sandbox_user=None → [] (no lockdown)
+    - sandbox_user set, paths=None → defaults (/solution, /tests)
+    - sandbox_user set, paths=[] → [] (explicit opt-out)
+    - sandbox_user set, paths=[...] → union of defaults + caller paths
+    """
+    if not sandbox_user:
+        if sandbox_locked_paths:
+            raise ValueError("sandbox_locked_paths requires sandbox_user")
+        return []
+    if sandbox_locked_paths is None:
+        return list(_DEFAULT_LOCKED)
+    if not sandbox_locked_paths:
+        return []  # explicit opt-out
+    return list(dict.fromkeys(_DEFAULT_LOCKED + sandbox_locked_paths))
+
+
+# ── Sandbox user + privilege drop ─────────────────────────────────────────────
+
+
+def build_priv_drop_cmd(agent_launch: str, sandbox_user: str) -> str:
+    """Build a shell command that drops to sandbox_user via setpriv or su.
+
+    setpriv (util-linux, Debian/Ubuntu) execs directly with no parent process.
+    su -l is the universal fallback (works on Alpine/BusyBox too).
+    No outer sh -c wrapper — DockerProcess wraps in bash -c already.
+    """
+    inner = (
+        f"export HOME=/home/{sandbox_user} && cd /home/{sandbox_user} && {agent_launch}"
+    )
+    quoted = shlex.quote(inner)
+    return (
+        f"if setpriv --help 2>&1 | grep -q reuid; then"
+        f" exec setpriv --reuid={sandbox_user} --regid={sandbox_user}"
+        f" --init-groups -- bash -c {quoted};"
+        f" else exec su -l {sandbox_user} -c {quoted};"
+        f" fi"
+    )
+
+
+async def setup_sandbox_user(env, sandbox_user: str, workspace: str) -> str:
+    """Create non-root sandbox user, grant workspace access. Return agent_cwd."""
+    if not re.match(r"^[a-z_][a-z0-9_-]*$", sandbox_user):
+        raise ValueError(
+            f"Invalid sandbox_user: {sandbox_user!r} (must be alphanumeric)"
+        )
+    logger.info(f"Setting up sandbox user: {sandbox_user}")
+    await env.exec(
+        f"id -u {sandbox_user} >/dev/null 2>&1 || "
+        f"useradd -m -s /bin/bash {sandbox_user} && "
+        f"mkdir -p /home/{sandbox_user}/.local/bin && "
+        "if [ -d /root/.local/bin ]; then "
+        f"cp -aL /root/.local/bin/. /home/{sandbox_user}/.local/bin/ 2>/dev/null || true; fi && "
+        "if [ -d /root/.nvm ]; then "
+        f"cp -a /root/.nvm/. /home/{sandbox_user}/.nvm/ 2>/dev/null || true; fi && "
+        f"for d in {' '.join(sorted(get_sandbox_home_dirs()))}; do "
+        f"if [ -d /root/$d ]; then mkdir -p /home/{sandbox_user}/$d && "
+        f"cp -a /root/$d/. /home/{sandbox_user}/$d/ 2>/dev/null || true; fi; done && "
+        f"chown -R {sandbox_user}:{sandbox_user} /home/{sandbox_user} && "
+        f"chown -R {sandbox_user}:{sandbox_user} {shlex.quote(workspace)}",
+        timeout_sec=30,
+    )
+    logger.info(f"Sandbox user {sandbox_user} ready (workspace={workspace})")
+    return workspace
+
+
+async def lockdown_paths(env, paths: list[str]) -> None:
+    """Lock directories so the sandbox user cannot access them.
+
+    Runs after all root-level setup but before agent launch.
+    Uses chown-then-chmod ordering to prevent TOCTOU window.
+    Rejects symlinks and validates path patterns against injection.
+    """
+    if not paths:
+        return
+
+    for p in paths:
+        _validate_locked_path(p)
+
+    # Build shell command: reject symlinks, chown before chmod
+    parts = []
+    for p in paths:
+        parts.append(
+            f"for d in {p}; do "
+            f'  [ -L "$d" ] && echo "WARN: skipping symlink $d" >&2 && continue; '
+            f'  [ -e "$d" ] || continue; '
+            f'  chown root:root "$d" && chmod 700 "$d"; '
+            f"done"
+        )
+    cmd = " && ".join(parts)
+    await env.exec(cmd, timeout_sec=30)
+
+
+# ── Verifier hardening ────────────────────────────────────────────────────────
+
+# Trusted env vars for verifier execution — override any agent pollution.
+#
+# PYTEST_DISABLE_PLUGIN_AUTOLOAD intentionally omitted: would break ~94
+# SkillsBench tasks that rely on pytest-json-ctrf's --ctrf flag. Entry-point
+# plugin injection is already blocked by verifier-runs-as-root + system
+# site-packages permissions + the .pth cleanup in CLEANUP_CMD.
+#
+# PYTHONNOUSERSITE intentionally omitted: verifier runs as root, so the
+# only user-site dir on sys.path is /root/.local which sandbox_user cannot
+# touch, and CLEANUP_CMD already wipes .pth files there as belt-and-braces.
+VERIFIER_ENV: dict[str, str] = {
+    "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+    "PYTEST_ADDOPTS": (
+        "-c /dev/null "  # block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
+        "--confcutdir=/tests "  # block conftest.py walk-up beyond /tests
+        "--rootdir=/tests "
+        "-p no:cacheprovider"
+    ),
+    "PYTHONDONTWRITEBYTECODE": "1",
+    "PYTHONPATH": "",
+    "PYTHONHOME": "",
+    "PYTHONSTARTUP": "",
+    "PYTHONSAFEPATH": "1",  # drop implicit '' (cwd) from sys.path
+    "LD_PRELOAD": "",
+    "LD_LIBRARY_PATH": "",
+}
+
+# Cleanup command for pytest hook / Python startup injection.
+# Removes conftest.py outside /tests, sitecustomize.py/usercustomize.py
+# and .pth files from writable sys.path entries (preserves /usr/lib,
+# /usr/local/lib).
+CLEANUP_CMD = (
+    "find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete 2>/dev/null; "
+    'python3 -c "'
+    "import sys,os;"
+    "[os.remove(os.path.join(d,f)) "
+    " for d in sys.path "
+    " for f in ('sitecustomize.py','usercustomize.py') "
+    " if d and not d.startswith('/usr/lib') and not d.startswith('/usr/local/lib') "
+    " and os.path.isfile(os.path.join(d,f))];"
+    "[os.remove(os.path.join(d,f)) "
+    " for d in sys.path if d and os.path.isdir(d) "
+    " for f in os.listdir(d) if f.endswith('.pth') "
+    " and not d.startswith('/usr/lib') and not d.startswith('/usr/local/lib') "
+    " and os.path.isfile(os.path.join(d,f))]"
+    '" 2>/dev/null || true'
+)
+
+
+async def harden_before_verify(env, task: "Task", sandbox_user: str | None) -> None:
+    """Neutralize agent tampering before running the verifier.
+
+    1. Kill sandbox-user processes (prevent concurrent writes).
+    2. Remove injected conftest.py, sitecustomize.py, .pth files.
+    3. Merge trusted env vars into task.config.verifier.env.
+    """
+    if sandbox_user:
+        await env.exec(
+            f"pkill -u {sandbox_user} 2>/dev/null; "
+            f"sleep 1; pkill -9 -u {sandbox_user} 2>/dev/null || true",
+            timeout_sec=10,
+        )
+    await env.exec(CLEANUP_CMD, timeout_sec=10)
+
+    verifier_env = dict(VERIFIER_ENV)
+    if task.config.verifier.env:
+        verifier_env.update(task.config.verifier.env)
+    task.config.verifier.env = verifier_env

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -73,9 +73,7 @@ Critical invariants
 import asyncio
 import json
 import logging
-import os
 import shlex
-import tempfile
 from datetime import datetime
 from pathlib import Path
 
@@ -84,6 +82,10 @@ from harbor.models.trial.paths import TrialPaths
 from harbor.verifier.verifier import Verifier
 
 from benchflow._agent_env import resolve_agent_env
+from benchflow._credentials import (
+    upload_subscription_auth,
+    write_credential_files,
+)
 from benchflow._env_setup import (
     _create_environment,
     _inject_skills_into_dockerfile,
@@ -138,115 +140,6 @@ class SDK:
         print(result.rewards)
         print(result.trajectory)
     """
-
-    @staticmethod
-    async def _upload_credential(env, path: str, content: str) -> None:
-        """Write a credential file into the container via upload_file."""
-        parent = path.rsplit("/", 1)[0]
-        await env.exec(f"mkdir -p {parent}", timeout_sec=10)
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
-            f.write(content)
-            tmp_path = f.name
-        try:
-            await env.upload_file(tmp_path, path)
-        finally:
-            os.unlink(tmp_path)
-
-    async def _write_credential_files(
-        self,
-        env,
-        agent: str,
-        agent_env: dict,
-        agent_cfg,
-        model: str | None,
-        cred_home: str,
-    ) -> None:
-        """Write credential files into container from agent + provider configs."""
-        # Provider credential files (e.g. GCP ADC for Vertex)
-        if model:
-            from benchflow.agents.providers import find_provider
-
-            _prov = find_provider(model)
-            if _prov:
-                _, _prov_cfg = _prov
-                for cf in _prov_cfg.credential_files:
-                    value = agent_env.get(cf["env_source"])
-                    if value:
-                        path = cf["path"].format(home=cred_home)
-                        await self._upload_credential(env, path, value)
-                        for k, v in cf.get("post_env", {}).items():
-                            agent_env.setdefault(k, v.format(home=cred_home))
-                        logger.info("Provider credential file written: %s", path)
-
-        # Gemini CLI needs settings.json to use Vertex AI backend
-        await self._write_gemini_vertex_settings(env, agent, model, cred_home)
-
-        # Agent credential files (e.g. codex auth.json)
-        if agent_cfg and agent_cfg.credential_files:
-            for cf in agent_cfg.credential_files:
-                value = agent_env.get(cf.env_source)
-                if value:
-                    content = cf.template.format(value=value) if cf.template else value
-                    path = cf.path.format(home=cred_home)
-                    await self._upload_credential(env, path, content)
-                    logger.info("Agent credential file written: %s", path)
-
-    async def _write_gemini_vertex_settings(
-        self,
-        env,
-        agent: str,
-        model: str | None,
-        cred_home: str,
-    ) -> None:
-        """Write ~/.gemini/settings.json to select Vertex AI backend.
-
-        Gemini CLI defaults to API key auth. When a google-vertex/ model is
-        used, we must write settings.json with selectedType=vertex-ai so the
-        CLI uses ADC instead of looking for GEMINI_API_KEY.
-
-        No conflict with _upload_subscription_auth: Vertex models have
-        infer_env_key_for_model() return None, so subscription auth is
-        never triggered for Vertex — the two paths are mutually exclusive.
-        """
-        if not model or agent != "gemini":
-            return
-        from benchflow.agents.registry import is_vertex_model
-
-        if not is_vertex_model(model):
-            return
-        settings = json.dumps(
-            {"security": {"auth": {"selectedType": "vertex-ai"}}},
-        )
-        path = f"{cred_home}/.gemini/settings.json"
-        await self._upload_credential(env, path, settings)
-        logger.info("Gemini Vertex settings written: %s", path)
-
-    async def _upload_subscription_auth(
-        self,
-        env,
-        agent: str,
-        cred_home: str,
-    ) -> None:
-        """Upload host subscription auth files into the container.
-
-        Called when _BENCHFLOW_SUBSCRIPTION_AUTH is set, meaning no API key
-        was provided but a host auth file was detected.
-        """
-        agent_cfg = AGENTS.get(agent)
-        if not agent_cfg or not agent_cfg.subscription_auth:
-            return
-        for f in agent_cfg.subscription_auth.files:
-            host_path = Path(f.host_path).expanduser()
-            if not host_path.is_file():
-                continue
-            container_path = f.container_path.format(home=cred_home)
-            content = host_path.read_text()
-            await self._upload_credential(env, container_path, content)
-            logger.info(
-                "Subscription auth uploaded: %s -> %s",
-                host_path,
-                container_path,
-            )
 
     @staticmethod
     def _init_trial(
@@ -773,7 +666,7 @@ class SDK:
             else:
                 agent_cfg = await self._install_agent(env, agent, trial_dir)
                 cred_home = f"/home/{sandbox_user}" if sandbox_user else "/root"
-                await self._write_credential_files(
+                await write_credential_files(
                     env,
                     agent,
                     agent_env,
@@ -782,7 +675,7 @@ class SDK:
                     cred_home,
                 )
                 if agent_env.get("_BENCHFLOW_SUBSCRIPTION_AUTH"):
-                    await self._upload_subscription_auth(env, agent, cred_home)
+                    await upload_subscription_auth(env, agent, cred_home)
 
                 # Detect working directory (preserved when sandbox user is set)
                 cwd_result = await env.exec("pwd", timeout_sec=10)

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -73,7 +73,6 @@ Critical invariants
 import asyncio
 import json
 import logging
-import shlex
 from datetime import datetime
 from pathlib import Path
 
@@ -83,6 +82,7 @@ from harbor.verifier.verifier import Verifier
 
 from benchflow._acp_run import connect_acp, execute_prompts
 from benchflow._agent_env import resolve_agent_env
+from benchflow._agent_setup import deploy_skills, install_agent
 from benchflow._credentials import (
     upload_subscription_auth,
     write_credential_files,
@@ -93,7 +93,7 @@ from benchflow._env_setup import (
     _patch_harbor_dind,
     stage_dockerfile_deps,
 )
-from benchflow._models import AgentInstallError, RunResult
+from benchflow._models import RunResult
 from benchflow._sandbox import (
     _resolve_locked_paths,
     harden_before_verify,
@@ -105,12 +105,7 @@ from benchflow._trajectory import (
     _scrape_agent_trajectory,
 )
 from benchflow.acp.client import ACPClient
-from benchflow.agents.registry import (
-    AGENT_INSTALLERS,
-    AGENT_LAUNCH,
-    AGENTS,
-    AgentConfig,
-)
+from benchflow.agents.registry import AGENT_LAUNCH
 
 logger = logging.getLogger(__name__)
 
@@ -119,9 +114,6 @@ _DIAG_TRUNCATE = 2000  # max chars for diagnostic stdout/stderr in logs
 
 # Apply DinD patch once at import time
 _patch_harbor_dind()
-
-# Re-exported from registry for backwards compat (AGENT_INSTALLERS, AGENT_LAUNCH
-# are imported above alongside AGENTS)
 
 
 class SDK:
@@ -324,102 +316,6 @@ class SDK:
         ]
         return trajectory, "oracle"
 
-    async def _install_agent(
-        self, env, agent: str, trial_dir: Path
-    ) -> AgentConfig | None:
-        """Install agent in sandbox and return its config."""
-        agent_base = agent.split()[0]
-        agent_cfg = AGENTS.get(agent_base)
-        if agent_base not in AGENT_INSTALLERS:
-            return agent_cfg
-        install_timeout = agent_cfg.install_timeout if agent_cfg else 900
-        logger.info(
-            f"Installing {agent_base} in sandbox (timeout={install_timeout}s)..."
-        )
-        install_result = await env.exec(
-            AGENT_INSTALLERS[agent_base],
-            timeout_sec=install_timeout,
-        )
-        install_log = trial_dir / "agent" / "install-stdout.txt"
-        install_log.parent.mkdir(parents=True, exist_ok=True)
-        install_log.write_text(install_result.stdout or "")
-        if install_result.return_code != 0:
-            diag = await env.exec(
-                "echo 'OS:' && cat /etc/os-release 2>/dev/null | head -2; "
-                "echo 'Node:' && node --version 2>&1; "
-                f"echo 'Agent:' && which {agent_base} 2>&1",
-                timeout_sec=10,
-            )
-            raise AgentInstallError(
-                agent=agent_base,
-                return_code=install_result.return_code,
-                stdout=install_result.stdout or "",
-                diagnostics=diag.stdout or "",
-                log_path=str(install_log),
-            )
-        return agent_cfg
-
-    async def _deploy_skills(
-        self,
-        env,
-        task_path: Path,
-        skills_dir: str | Path | None,
-        agent_cfg,
-        sandbox_user: str | None,
-        agent_cwd: str,
-        task: "Task",
-    ) -> None:
-        """Deploy and distribute skills into sandbox."""
-        # Runtime upload (fallback if not baked into Dockerfile)
-        if skills_dir:
-            dockerfile = task_path / "environment" / "Dockerfile"
-            already_injected = (
-                dockerfile.exists()
-                and "COPY _deps/skills /skills/" in dockerfile.read_text()
-            )
-            if not already_injected:
-                skills_path = Path(skills_dir)
-                if skills_path.is_dir():
-                    logger.info(
-                        f"Deploying skills via runtime upload from {skills_path}"
-                    )
-                    await env.upload_dir(skills_path, "/skills")
-                    if agent_cfg and agent_cfg.skill_paths:
-                        parts = []
-                        for sp in agent_cfg.skill_paths:
-                            expanded = sp.replace("$HOME", "/root").replace(
-                                "$WORKSPACE", "/app"
-                            )
-                            parent = str(Path(expanded).parent)
-                            parts.append(
-                                f"mkdir -p '{parent}' && ln -sf /skills '{expanded}'"
-                            )
-                        await env.exec(" && ".join(parts), timeout_sec=10)
-                    logger.info("Skills deployed to /skills and symlinked")
-                else:
-                    logger.warning(f"Skills dir not found: {skills_path}")
-            else:
-                logger.info("Skills already injected via Dockerfile")
-
-        # Distribute to agent-specific discovery paths
-        task_skills_dir = task.config.environment.skills_dir
-        effective_skills = "/skills" if skills_dir else task_skills_dir
-        if effective_skills and agent_cfg and agent_cfg.skill_paths:
-            home = f"/home/{sandbox_user}" if sandbox_user else "/root"
-            parts = []
-            for sp in agent_cfg.skill_paths:
-                expanded = sp.replace("$HOME", home).replace("$WORKSPACE", agent_cwd)
-                q_expanded = shlex.quote(expanded)
-                q_skills = shlex.quote(effective_skills)
-                parts.append(
-                    f"mkdir -p {q_expanded} && cp -r {q_skills}/. {q_expanded}/ 2>/dev/null"
-                )
-            if parts:
-                await env.exec("; ".join(parts), timeout_sec=15)
-                logger.info(
-                    f"Skills distributed to {len(parts)} paths for {agent_cfg.name}"
-                )
-
     async def _verify(
         self,
         env,
@@ -575,7 +471,7 @@ class SDK:
             if agent == "oracle":
                 trajectory, agent_name = await self._run_oracle(env, task_path, timeout)
             else:
-                agent_cfg = await self._install_agent(env, agent, trial_dir)
+                agent_cfg = await install_agent(env, agent, trial_dir)
                 cred_home = f"/home/{sandbox_user}" if sandbox_user else "/root"
                 await write_credential_files(
                     env,
@@ -596,7 +492,7 @@ class SDK:
                         env, sandbox_user, workspace=agent_cwd
                     )
 
-                await self._deploy_skills(
+                await deploy_skills(
                     env,
                     task_path,
                     skills_dir,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -71,7 +71,6 @@ Critical invariants
 """
 
 import asyncio
-import contextlib
 import json
 import logging
 import os
@@ -86,6 +85,7 @@ from harbor.models.task.task import Task
 from harbor.models.trial.paths import TrialPaths
 from harbor.verifier.verifier import Verifier
 
+from benchflow._agent_env import resolve_agent_env
 from benchflow._env_setup import (
     _create_environment,
     _inject_skills_into_dockerfile,
@@ -313,161 +313,6 @@ class SDK:
         for subdir in ("agent", "verifier", "artifacts", "trajectory"):
             (trial_dir / subdir).mkdir(exist_ok=True)
         return task, trial_dir, trial_paths, started_at, job_name, trial_name
-
-    @staticmethod
-    def _auto_inherit_env(agent_env: dict[str, str]) -> None:
-        """Copy well-known API keys from host os.environ into agent_env."""
-        from benchflow.agents.providers import PROVIDERS
-
-        keys = {
-            "ANTHROPIC_API_KEY",
-            "OPENAI_API_KEY",
-            "GOOGLE_API_KEY",
-            "GEMINI_API_KEY",
-            "GOOGLE_CLOUD_PROJECT",
-            "GOOGLE_CLOUD_LOCATION",
-        }
-        for cfg in PROVIDERS.values():
-            if cfg.auth_env:
-                keys.add(cfg.auth_env)
-            for env_var in cfg.url_params.values():
-                keys.add(env_var)
-        for key in keys:
-            if key in os.environ:
-                agent_env.setdefault(key, os.environ[key])
-        # Mirror GEMINI_API_KEY as GOOGLE_API_KEY (some agents expect one or the other)
-        if "GEMINI_API_KEY" in agent_env and "GOOGLE_API_KEY" not in agent_env:
-            agent_env["GOOGLE_API_KEY"] = agent_env["GEMINI_API_KEY"]
-
-    @staticmethod
-    def _inject_vertex_credentials(agent_env: dict[str, str], model: str) -> None:
-        """Inject ADC credentials and defaults for Vertex AI models."""
-        from benchflow.agents.registry import is_vertex_model
-
-        if not is_vertex_model(model):
-            return
-        adc_path = Path.home() / ".config/gcloud/application_default_credentials.json"
-        if not adc_path.exists():
-            raise ValueError(
-                f"Vertex AI model {model!r} requires ADC credentials. "
-                f"Run: gcloud auth application-default login"
-            )
-        agent_env.setdefault(
-            "GOOGLE_APPLICATION_CREDENTIALS_JSON", adc_path.read_text()
-        )
-        agent_env.setdefault("GOOGLE_CLOUD_LOCATION", "global")
-        if "GOOGLE_CLOUD_PROJECT" not in agent_env:
-            raise ValueError(
-                f"GOOGLE_CLOUD_PROJECT required for Vertex AI model {model!r}. "
-                f"Export it or pass via --ae GOOGLE_CLOUD_PROJECT=<project>"
-            )
-
-    @staticmethod
-    def _resolve_provider_env(
-        agent_env: dict[str, str],
-        model: str,
-        agent: str,
-    ) -> None:
-        """Detect provider for model, inject BENCHFLOW_PROVIDER_* and env_mapping."""
-        from benchflow.agents.providers import (
-            find_provider,
-            resolve_base_url,
-            strip_provider_prefix,
-        )
-
-        agent_env.setdefault("BENCHFLOW_PROVIDER_MODEL", strip_provider_prefix(model))
-        agent_cfg = AGENTS.get(agent)
-        # Agent-declared protocol takes precedence over provider's primary so
-        # multi-endpoint providers (e.g. zai) route to the right URL.
-        agent_protocol = agent_cfg.api_protocol if agent_cfg else ""
-        _prov = find_provider(model)
-        if _prov:
-            _prov_name, _prov_cfg = _prov
-            agent_env.setdefault("BENCHFLOW_PROVIDER_NAME", _prov_name)
-            # URL params missing — will fail later with clear error
-            with contextlib.suppress(KeyError):
-                agent_env.setdefault(
-                    "BENCHFLOW_PROVIDER_BASE_URL",
-                    resolve_base_url(
-                        _prov_cfg, agent_env, protocol=agent_protocol or None
-                    ),
-                )
-            agent_env.setdefault(
-                "BENCHFLOW_PROVIDER_PROTOCOL",
-                agent_protocol or _prov_cfg.api_protocol,
-            )
-            if _prov_cfg.models:
-                agent_env.setdefault(
-                    "BENCHFLOW_PROVIDER_MODELS", json.dumps(_prov_cfg.models)
-                )
-            if _prov_cfg.auth_type == "api_key" and _prov_cfg.auth_env:
-                _key = agent_env.get(_prov_cfg.auth_env, "")
-                if _key:
-                    agent_env.setdefault("BENCHFLOW_PROVIDER_API_KEY", _key)
-        # Apply agent env_mapping: translate BENCHFLOW_PROVIDER_* → agent-native vars
-        if agent_cfg and agent_cfg.env_mapping:
-            for src, dst in agent_cfg.env_mapping.items():
-                if src in agent_env:
-                    agent_env.setdefault(dst, agent_env[src])
-
-    @staticmethod
-    def _check_subscription_auth(agent: str, required_key: str) -> bool:
-        """Return True if host subscription auth can substitute for required_key."""
-        agent_cfg = AGENTS.get(agent)
-        if not agent_cfg or not agent_cfg.subscription_auth:
-            return False
-        sa = agent_cfg.subscription_auth
-        if sa.replaces_env != required_key:
-            return False
-        return Path(sa.detect_file).expanduser().is_file()
-
-    @staticmethod
-    def _resolve_agent_env(
-        agent: str,
-        model: str | None,
-        agent_env: dict[str, str] | None,
-    ) -> dict[str, str]:
-        """Resolve agent environment: auto-inherit keys, provider vars, env_mapping."""
-        agent_env = dict(agent_env or {})
-        SDK._auto_inherit_env(agent_env)
-        if model:
-            SDK._inject_vertex_credentials(agent_env, model)
-            SDK._resolve_provider_env(agent_env, model, agent)
-            # Validate required API key for the chosen model
-            from benchflow.agents.registry import infer_env_key_for_model
-
-            required_key = infer_env_key_for_model(model)
-            if required_key and required_key not in agent_env:
-                if SDK._check_subscription_auth(agent, required_key):
-                    agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
-                    logger.info(
-                        "Using host subscription auth (no %s set)",
-                        required_key,
-                    )
-                else:
-                    raise ValueError(
-                        f"{required_key} required for model {model!r} but not set. "
-                        f"Export it, pass via agent_env, or log in with the "
-                        f"agent CLI (e.g. claude login, codex --login)."
-                    )
-        else:
-            # No model specified — still check subscription auth for required env vars
-            agent_cfg = AGENTS.get(agent)
-            if agent_cfg:
-                for req_key in agent_cfg.requires_env:
-                    if req_key not in agent_env and SDK._check_subscription_auth(
-                        agent, req_key
-                    ):
-                        agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
-                        logger.info(
-                            "Using host subscription auth (no %s set)",
-                            req_key,
-                        )
-        # Increase output token limit to avoid truncation errors
-        agent_env.setdefault("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "128000")
-        # Disable telemetry/non-essential traffic in container
-        agent_env.setdefault("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
-        return agent_env
 
     @staticmethod
     def _write_config(
@@ -1057,7 +902,7 @@ class SDK:
                 jobs_dir,
             )
         )
-        agent_env = self._resolve_agent_env(agent, model, agent_env)
+        agent_env = resolve_agent_env(agent, model, agent_env)
         # Use a new local so the type narrows from `list[str | None] | None`
         # (the public API allows None entries to mean "use default") to
         # `list[str]` after _resolve_prompts has substituted them.

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -81,6 +81,7 @@ from harbor.models.task.task import Task
 from harbor.models.trial.paths import TrialPaths
 from harbor.verifier.verifier import Verifier
 
+from benchflow._acp_run import connect_acp, execute_prompts
 from benchflow._agent_env import resolve_agent_env
 from benchflow._credentials import (
     upload_subscription_auth,
@@ -95,7 +96,6 @@ from benchflow._env_setup import (
 from benchflow._models import AgentInstallError, RunResult
 from benchflow._sandbox import (
     _resolve_locked_paths,
-    build_priv_drop_cmd,
     harden_before_verify,
     lockdown_paths,
     setup_sandbox_user,
@@ -105,14 +105,12 @@ from benchflow._trajectory import (
     _scrape_agent_trajectory,
 )
 from benchflow.acp.client import ACPClient
-from benchflow.acp.container_transport import ContainerTransport
 from benchflow.agents.registry import (
     AGENT_INSTALLERS,
     AGENT_LAUNCH,
     AGENTS,
     AgentConfig,
 )
-from benchflow.process import DaytonaProcess, DockerProcess
 
 logger = logging.getLogger(__name__)
 
@@ -422,93 +420,6 @@ class SDK:
                     f"Skills distributed to {len(parts)} paths for {agent_cfg.name}"
                 )
 
-    async def _connect_acp(
-        self,
-        env,
-        agent: str,
-        agent_launch: str,
-        agent_env: dict,
-        sandbox_user: str | None,
-        model: str | None,
-        trial_dir: Path,
-        environment: str,
-        agent_cwd: str,
-    ) -> tuple[ACPClient, object, str]:
-        """Create ACP transport, connect, init session, set model. Return (client, session, agent_name)."""
-        # Resolve agent binary path for non-docker environments
-        if environment != "docker":
-            which_result = await env.exec(
-                f"which {agent_launch.split()[0]}", timeout_sec=10
-            )
-            if which_result.return_code == 0 and (which_result.stdout or "").strip():
-                full_path = which_result.stdout.strip()
-                parts = agent_launch.split()
-                parts[0] = full_path
-                agent_launch = " ".join(parts)
-                logger.info(f"Resolved agent path: {agent_launch}")
-
-        if sandbox_user:
-            agent_launch = build_priv_drop_cmd(agent_launch, sandbox_user)
-            logger.info(f"Agent sandboxed as: {sandbox_user}")
-
-        if environment == "docker":
-            live_proc = DockerProcess.from_harbor_env(env)
-        else:
-            live_proc = await DaytonaProcess.from_harbor_env(env)
-
-        agent_log = trial_dir / "agent" / f"{agent.replace('-', '_')}.txt"
-        transport = ContainerTransport(
-            container_process=live_proc,
-            command=agent_launch,
-            env=agent_env,
-            cwd=agent_cwd,
-            agent_log_path=agent_log,
-        )
-        acp_client = ACPClient(transport)
-        await acp_client.connect()
-
-        init_result = await asyncio.wait_for(acp_client.initialize(), timeout=60)
-        agent_name = init_result.agent_info.name if init_result.agent_info else agent
-        logger.info(f"ACP agent: {agent_name}")
-
-        session = await asyncio.wait_for(
-            acp_client.session_new(cwd=agent_cwd), timeout=60
-        )
-        logger.info(f"Session: {session.session_id}")
-
-        if model:
-            from benchflow.agents.providers import strip_provider_prefix
-
-            acp_model_id = strip_provider_prefix(model)
-            try:
-                await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
-                logger.info(f"Model set to: {acp_model_id} (from {model})")
-            except Exception as e:
-                logger.warning(f"Failed to set model via ACP: {e}")
-
-        return acp_client, session, agent_name
-
-    async def _execute_prompts(
-        self,
-        acp_client: ACPClient,
-        session,
-        prompts: list[str],
-        timeout: int,
-    ) -> tuple[list[dict], int]:
-        """Send prompts via ACP and capture trajectory. Return (trajectory, n_tool_calls)."""
-        for i, prompt in enumerate(prompts):
-            logger.info(f"Prompt {i + 1}/{len(prompts)}: {prompt[:80]}...")
-            prompt_result = await asyncio.wait_for(
-                acp_client.prompt(prompt),
-                timeout=timeout,
-            )
-            logger.info(
-                f"  → {prompt_result.stop_reason.value}, "
-                f"{len(session.tool_calls)} total tool calls"
-            )
-        trajectory = _capture_session_trajectory(session)
-        return trajectory, len(session.tool_calls)
-
     async def _verify(
         self,
         env,
@@ -697,7 +608,7 @@ class SDK:
 
                 await lockdown_paths(env, effective_locked)
 
-                acp_client, session, agent_name = await self._connect_acp(
+                acp_client, session, agent_name = await connect_acp(
                     env,
                     agent,
                     agent_launch,
@@ -711,7 +622,7 @@ class SDK:
                 timing["agent_setup"] = (datetime.now() - t_agent_setup).total_seconds()
                 t_agent_exec = datetime.now()
 
-                trajectory, n_tool_calls = await self._execute_prompts(
+                trajectory, n_tool_calls = await execute_prompts(
                     acp_client,
                     session,
                     resolved_prompts,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -74,12 +74,10 @@ import asyncio
 import json
 import logging
 import os
-import re
 import shlex
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from typing import ClassVar
 
 from harbor.models.task.task import Task
 from harbor.models.trial.paths import TrialPaths
@@ -93,6 +91,13 @@ from benchflow._env_setup import (
     stage_dockerfile_deps,
 )
 from benchflow._models import AgentInstallError, RunResult
+from benchflow._sandbox import (
+    _resolve_locked_paths,
+    build_priv_drop_cmd,
+    harden_before_verify,
+    lockdown_paths,
+    setup_sandbox_user,
+)
 from benchflow._trajectory import (
     _capture_session_trajectory,
     _scrape_agent_trajectory,
@@ -104,61 +109,12 @@ from benchflow.agents.registry import (
     AGENT_LAUNCH,
     AGENTS,
     AgentConfig,
-    get_sandbox_home_dirs,
 )
 from benchflow.process import DaytonaProcess, DockerProcess
 
 logger = logging.getLogger(__name__)
 
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stdout/stderr in logs
-
-# Path lockdown defaults and validation
-_DEFAULT_LOCKED = ["/solution", "/tests"]
-_SAFE_PATH_RE = re.compile(r"^/[a-zA-Z0-9_./*?\-]+(/[a-zA-Z0-9_./*?\-]+)*$")
-
-
-def _validate_locked_path(p: str) -> None:
-    """Validate a locked path — reject injection and traversal."""
-    p_norm = os.path.normpath(p)
-    if p_norm != p:
-        raise ValueError(
-            f"Invalid locked path {p!r}: normalizes to {p_norm!r} — "
-            f"use the normalized form directly"
-        )
-    if any(c == ".." for c in p.split("/")):
-        raise ValueError(f"Invalid locked path {p!r}: '..' component not allowed")
-    if not _SAFE_PATH_RE.match(p):
-        raise ValueError(
-            f"Invalid locked path {p!r}: must be absolute, "
-            f"alphanumeric with /-_.*? only"
-        )
-    if p.endswith("/") and p != "/":
-        raise ValueError(
-            f"Invalid locked path {p!r}: trailing slash not allowed "
-            f"(chown on '/dir/' may have unintended scope)"
-        )
-
-
-def _resolve_locked_paths(
-    sandbox_user: str | None,
-    sandbox_locked_paths: list[str] | None,
-) -> list[str]:
-    """Resolve effective locked paths.
-
-    - sandbox_user=None → [] (no lockdown)
-    - sandbox_user set, paths=None → defaults (/solution, /tests)
-    - sandbox_user set, paths=[] → [] (explicit opt-out)
-    - sandbox_user set, paths=[...] → union of defaults + caller paths
-    """
-    if not sandbox_user:
-        if sandbox_locked_paths:
-            raise ValueError("sandbox_locked_paths requires sandbox_user")
-        return []
-    if sandbox_locked_paths is None:
-        return list(_DEFAULT_LOCKED)
-    if not sandbox_locked_paths:
-        return []  # explicit opt-out
-    return list(dict.fromkeys(_DEFAULT_LOCKED + sandbox_locked_paths))
 
 
 # Apply DinD patch once at import time
@@ -573,76 +529,6 @@ class SDK:
                     f"Skills distributed to {len(parts)} paths for {agent_cfg.name}"
                 )
 
-    @staticmethod
-    def _build_priv_drop_cmd(agent_launch: str, sandbox_user: str) -> str:
-        """Build a shell command that drops to sandbox_user via setpriv or su.
-
-        setpriv (util-linux, Debian/Ubuntu) execs directly with no parent process.
-        su -l is the universal fallback (works on Alpine/BusyBox too).
-        No outer sh -c wrapper — DockerProcess wraps in bash -c already.
-        """
-        inner = f"export HOME=/home/{sandbox_user} && cd /home/{sandbox_user} && {agent_launch}"
-        quoted = shlex.quote(inner)
-        return (
-            f"if setpriv --help 2>&1 | grep -q reuid; then"
-            f" exec setpriv --reuid={sandbox_user} --regid={sandbox_user}"
-            f" --init-groups -- bash -c {quoted};"
-            f" else exec su -l {sandbox_user} -c {quoted};"
-            f" fi"
-        )
-
-    @staticmethod
-    async def _lockdown_paths(env, paths: list[str]) -> None:
-        """Lock directories so the sandbox user cannot access them.
-
-        Runs after all root-level setup but before agent launch.
-        Uses chown-then-chmod ordering to prevent TOCTOU window.
-        Rejects symlinks and validates path patterns against injection.
-        """
-        if not paths:
-            return
-
-        for p in paths:
-            _validate_locked_path(p)
-
-        # Build shell command: reject symlinks, chown before chmod
-        parts = []
-        for p in paths:
-            parts.append(
-                f"for d in {p}; do "
-                f'  [ -L "$d" ] && echo "WARN: skipping symlink $d" >&2 && continue; '
-                f'  [ -e "$d" ] || continue; '
-                f'  chown root:root "$d" && chmod 700 "$d"; '
-                f"done"
-            )
-        cmd = " && ".join(parts)
-        await env.exec(cmd, timeout_sec=30)
-
-    async def _setup_sandbox_user(self, env, sandbox_user: str, workspace: str) -> str:
-        """Create non-root sandbox user, grant workspace access. Return agent_cwd."""
-        if not re.match(r"^[a-z_][a-z0-9_-]*$", sandbox_user):
-            raise ValueError(
-                f"Invalid sandbox_user: {sandbox_user!r} (must be alphanumeric)"
-            )
-        logger.info(f"Setting up sandbox user: {sandbox_user}")
-        await env.exec(
-            f"id -u {sandbox_user} >/dev/null 2>&1 || "
-            f"useradd -m -s /bin/bash {sandbox_user} && "
-            f"mkdir -p /home/{sandbox_user}/.local/bin && "
-            "if [ -d /root/.local/bin ]; then "
-            f"cp -aL /root/.local/bin/. /home/{sandbox_user}/.local/bin/ 2>/dev/null || true; fi && "
-            "if [ -d /root/.nvm ]; then "
-            f"cp -a /root/.nvm/. /home/{sandbox_user}/.nvm/ 2>/dev/null || true; fi && "
-            f"for d in {' '.join(sorted(get_sandbox_home_dirs()))}; do "
-            f"if [ -d /root/$d ]; then mkdir -p /home/{sandbox_user}/$d && "
-            f"cp -a /root/$d/. /home/{sandbox_user}/$d/ 2>/dev/null || true; fi; done && "
-            f"chown -R {sandbox_user}:{sandbox_user} /home/{sandbox_user} && "
-            f"chown -R {sandbox_user}:{sandbox_user} {shlex.quote(workspace)}",
-            timeout_sec=30,
-        )
-        logger.info(f"Sandbox user {sandbox_user} ready (workspace={workspace})")
-        return workspace
-
     async def _connect_acp(
         self,
         env,
@@ -669,7 +555,7 @@ class SDK:
                 logger.info(f"Resolved agent path: {agent_launch}")
 
         if sandbox_user:
-            agent_launch = self._build_priv_drop_cmd(agent_launch, sandbox_user)
+            agent_launch = build_priv_drop_cmd(agent_launch, sandbox_user)
             logger.info(f"Agent sandboxed as: {sandbox_user}")
 
         if environment == "docker":
@@ -730,76 +616,6 @@ class SDK:
         trajectory = _capture_session_trajectory(session)
         return trajectory, len(session.tool_calls)
 
-    # Trusted env vars for verifier execution — override any agent pollution.
-    #
-    # PYTEST_DISABLE_PLUGIN_AUTOLOAD intentionally omitted: would break ~94
-    # SkillsBench tasks that rely on pytest-json-ctrf's --ctrf flag. Entry-point
-    # plugin injection is already blocked by verifier-runs-as-root + system
-    # site-packages permissions + the .pth cleanup in _CLEANUP_CMD.
-    #
-    # PYTHONNOUSERSITE intentionally omitted: verifier runs as root, so the
-    # only user-site dir on sys.path is /root/.local which sandbox_user cannot
-    # touch, and _CLEANUP_CMD already wipes .pth files there as belt-and-braces.
-    _VERIFIER_ENV: ClassVar[dict[str, str]] = {
-        "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
-        "PYTEST_ADDOPTS": (
-            "-c /dev/null "  # block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
-            "--confcutdir=/tests "  # block conftest.py walk-up beyond /tests
-            "--rootdir=/tests "
-            "-p no:cacheprovider"
-        ),
-        "PYTHONDONTWRITEBYTECODE": "1",
-        "PYTHONPATH": "",
-        "PYTHONHOME": "",
-        "PYTHONSTARTUP": "",
-        "PYTHONSAFEPATH": "1",  # drop implicit '' (cwd) from sys.path
-        "LD_PRELOAD": "",
-        "LD_LIBRARY_PATH": "",
-    }
-
-    # Cleanup command for pytest hook / Python startup injection.
-    # Removes conftest.py outside /tests, sitecustomize.py/usercustomize.py
-    # and .pth files from writable sys.path entries (preserves /usr/lib,
-    # /usr/local/lib).
-    _CLEANUP_CMD = (
-        "find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete 2>/dev/null; "
-        'python3 -c "'
-        "import sys,os;"
-        "[os.remove(os.path.join(d,f)) "
-        " for d in sys.path "
-        " for f in ('sitecustomize.py','usercustomize.py') "
-        " if d and not d.startswith('/usr/lib') and not d.startswith('/usr/local/lib') "
-        " and os.path.isfile(os.path.join(d,f))];"
-        "[os.remove(os.path.join(d,f)) "
-        " for d in sys.path if d and os.path.isdir(d) "
-        " for f in os.listdir(d) if f.endswith('.pth') "
-        " and not d.startswith('/usr/lib') and not d.startswith('/usr/local/lib') "
-        " and os.path.isfile(os.path.join(d,f))]"
-        '" 2>/dev/null || true'
-    )
-
-    async def _harden_before_verify(
-        self, env, task: "Task", sandbox_user: str | None
-    ) -> None:
-        """Neutralize agent tampering before running the verifier.
-
-        1. Kill sandbox-user processes (prevent concurrent writes).
-        2. Remove injected conftest.py, sitecustomize.py, .pth files.
-        3. Merge trusted env vars into task.config.verifier.env.
-        """
-        if sandbox_user:
-            await env.exec(
-                f"pkill -u {sandbox_user} 2>/dev/null; "
-                f"sleep 1; pkill -9 -u {sandbox_user} 2>/dev/null || true",
-                timeout_sec=10,
-            )
-        await env.exec(self._CLEANUP_CMD, timeout_sec=10)
-
-        verifier_env = dict(self._VERIFIER_ENV)
-        if task.config.verifier.env:
-            verifier_env.update(task.config.verifier.env)
-        task.config.verifier.env = verifier_env
-
     async def _verify(
         self,
         env,
@@ -810,7 +626,7 @@ class SDK:
     ) -> tuple[dict | None, str | None]:
         """Run verifier with pre-verification hardening."""
         trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
-        await self._harden_before_verify(env, task, sandbox_user)
+        await harden_before_verify(env, task, sandbox_user)
         logger.info("Running verifier...")
         t0 = datetime.now()
         verifier_error = None
@@ -972,7 +788,7 @@ class SDK:
                 cwd_result = await env.exec("pwd", timeout_sec=10)
                 agent_cwd = (cwd_result.stdout or "").strip() or "/app"
                 if sandbox_user:
-                    agent_cwd = await self._setup_sandbox_user(
+                    agent_cwd = await setup_sandbox_user(
                         env, sandbox_user, workspace=agent_cwd
                     )
 
@@ -986,7 +802,7 @@ class SDK:
                     task,
                 )
 
-                await self._lockdown_paths(env, effective_locked)
+                await lockdown_paths(env, effective_locked)
 
                 acp_client, session, agent_name = await self._connect_acp(
                     env,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -1,8 +1,8 @@
 """benchflow SDK — unified run() that uses ACP inside Harbor environments.
 
-The whole framework is one ``SDK.run()`` call that orchestrates ~20 small
-private methods, each owning one phase of the run. This docstring is the
-map: read it before navigating the file.
+``SDK.run()`` is a thin orchestrator that calls into five phase modules.
+Each phase module owns one slice of the run loop and is independently
+greppable. This docstring is the map: read it before navigating the file.
 
 Run loop (SDK.run, top to bottom)
 ---------------------------------
@@ -11,12 +11,12 @@ Run loop (SDK.run, top to bottom)
 
     ┌─ SETUP (host) ──────────────────────────────────────────────┐
     │  _init_trial            task, trial_dir, paths, names        │
-    │  _resolve_agent_env     env vars: inherit, mirror, vertex,   │
+    │  resolve_agent_env      env vars: inherit, mirror, vertex,   │  ← _agent_env
     │                         subscription auth detection          │
     │  _resolve_prompts       prompt list (instruction.md fallback)│
-    │  stage_dockerfile_deps  COPY rewrites for context_root       │
-    │  _inject_skills_…       Dockerfile skill mount               │
-    │  _create_environment    Docker or Daytona, not yet started   │
+    │  stage_dockerfile_deps  COPY rewrites for context_root       │  ← _env_setup
+    │  _inject_skills_…       Dockerfile skill mount               │  ← _env_setup
+    │  _create_environment    Docker or Daytona, not yet started   │  ← _env_setup
     │  _write_config          config.json → trial_dir              │
     └──────────────────────────────────────────────────────────────┘
     ┌─ START (sandbox) ───────────────────────────────────────────┐
@@ -24,28 +24,44 @@ Run loop (SDK.run, top to bottom)
     │  pre_agent_hooks        user callbacks (services, etc.)      │
     └──────────────────────────────────────────────────────────────┘
     ┌─ AGENT (oracle: _run_oracle and skip everything below) ─────┐
-    │  _install_agent             registry-driven install_cmd      │
-    │  _write_credential_files    AgentConfig.credential_files     │
-    │  _upload_subscription_auth  if host login files detected     │
-    │  _setup_sandbox_user        non-root user + path lockdown    │
-    │  _deploy_skills             symlink skills into agent paths  │
-    │  _lockdown_paths            chmod -r on solution / tests     │
-    │  _connect_acp               stdio pipe + ACP initialize/new  │
-    │  _execute_prompts           multi-turn session/prompt loop   │
+    │  install_agent             registry-driven install_cmd      │  ← _agent_setup
+    │  write_credential_files    AgentConfig.credential_files     │  ← _credentials
+    │  upload_subscription_auth  if host login files detected     │  ← _credentials
+    │  setup_sandbox_user        non-root user + path lockdown    │  ← _sandbox
+    │  deploy_skills             symlink skills into agent paths  │  ← _agent_setup
+    │  lockdown_paths            chmod -r on solution / tests     │  ← _sandbox
+    │  connect_acp               stdio pipe + ACP initialize/new  │  ← _acp_run
+    │  execute_prompts           multi-turn session/prompt loop   │  ← _acp_run
     └──────────────────────────────────────────────────────────────┘
     ┌─ VERIFY ────────────────────────────────────────────────────┐
     │  (fallback) _scrape_agent_trajectory  if ACP captured none   │
     │             — labeled trajectory_source="scraped" UNTRUSTED  │
-    │  _harden_before_verify  permissions reset for verifier root  │
+    │  harden_before_verify  permissions reset for verifier root   │  ← _sandbox
     │  _verify                Harbor verifier → rewards            │
     │  _build_result          RunResult + result.json + timing     │
     └──────────────────────────────────────────────────────────────┘
     finally: env.stop()
 
+Phase modules (extracted from sdk.py — see refactor branch for the arc)
+-----------------------------------------------------------------------
+- ``_agent_env``    env var resolution: auto-inherit, vertex ADC, provider
+                    BENCHFLOW_PROVIDER_*, env_mapping, subscription auth
+- ``_credentials``  credential file writing: upload_credential, agent +
+                    provider credential_files, gemini vertex settings,
+                    upload_subscription_auth
+- ``_sandbox``      sandbox user creation, privilege drop (setpriv/su),
+                    path lockdown, verifier hardening + VERIFIER_ENV /
+                    CLEANUP_CMD constants
+- ``_acp_run``      ACP transport bring-up + the multi-turn prompt loop.
+                    Imports ``build_priv_drop_cmd`` from ``_sandbox`` —
+                    the only allowed horizontal phase-to-phase import.
+- ``_agent_setup``  install_agent (registry-driven) + deploy_skills
+                    (runtime upload + per-agent distribution)
+
 Support modules
 ---------------
 - ``_env_setup``    Dockerfile staging, skills injection, DinD patching,
-                    ``_create_environment``, ``_resolve_locked_paths``
+                    ``_create_environment``
 - ``_trajectory``   ACP-native + agent-scraped trajectory capture
 - ``_models``       ``RunResult``, ``AgentInstallError``, ``AgentTimeoutError``
 - ``_scoring``      pure functions: ``extract_reward``,
@@ -57,7 +73,7 @@ Support modules
 
 Critical invariants
 -------------------
-- The phases above run in strict order. Methods named ``_resolve_*`` are pure
+- The phases above run in strict order. Functions in ``_agent_env`` are pure
   and can be called in tests independently; everything from
   ``_start_env_and_upload`` onward assumes a live container and ordered setup.
 - Trajectory source is *labeled*, not deleted. ``trajectory_source`` is one of

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -128,7 +128,9 @@ logger = logging.getLogger(__name__)
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stdout/stderr in logs
 
 
-# Apply DinD patch once at import time
+# Apply at import time so any Harbor DockerEnvironment in this process
+# (SDK.run or otherwise) gets the env-var rewrite, and so we patch exactly
+# once without an idempotency guard. Do not move into SDK.run().
 _patch_harbor_dind()
 
 

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -1,79 +1,85 @@
-"""Tests for extracted _resolve_agent_env helper methods.
+"""Tests for extracted resolve_agent_env helper functions.
 
-Covers SDK._auto_inherit_env, _inject_vertex_credentials,
-_resolve_provider_env, _check_subscription_auth, and the no-model
-subscription auth path in _resolve_agent_env.
+Covers auto_inherit_env, inject_vertex_credentials, resolve_provider_env,
+check_subscription_auth, and the no-model subscription auth path in
+resolve_agent_env.
 """
 
 from pathlib import Path
 
 import pytest
 
-from benchflow.sdk import SDK
+from benchflow._agent_env import (
+    auto_inherit_env,
+    check_subscription_auth,
+    inject_vertex_credentials,
+    resolve_agent_env,
+    resolve_provider_env,
+)
 
-# ── _auto_inherit_env ──
+# ── auto_inherit_env ──
 
 
 class TestAutoInheritEnv:
-    """Tests for SDK._auto_inherit_env — host env key inheritance."""
+    """Tests for auto_inherit_env — host env key inheritance."""
 
     def test_inherits_anthropic_key(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-host")
         env = {}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert env["ANTHROPIC_API_KEY"] == "sk-host"
 
     def test_inherits_openai_key(self, monkeypatch):
         monkeypatch.setenv("OPENAI_API_KEY", "sk-oai")
         env = {}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert env["OPENAI_API_KEY"] == "sk-oai"
 
     def test_does_not_overwrite_explicit(self, monkeypatch):
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-host")
         env = {"ANTHROPIC_API_KEY": "sk-explicit"}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert env["ANTHROPIC_API_KEY"] == "sk-explicit"
 
     def test_inherits_provider_auth_env(self, monkeypatch):
         """Custom provider auth keys (e.g. ZAI_API_KEY) are inherited."""
         monkeypatch.setenv("ZAI_API_KEY", "zk-host")
         env = {}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert env["ZAI_API_KEY"] == "zk-host"
 
     def test_gemini_mirrored_to_google(self):
         env = {"GEMINI_API_KEY": "gk-test"}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert env["GOOGLE_API_KEY"] == "gk-test"
 
     def test_gemini_mirror_no_overwrite(self):
         env = {"GEMINI_API_KEY": "gk-test", "GOOGLE_API_KEY": "gk-explicit"}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert env["GOOGLE_API_KEY"] == "gk-explicit"
 
     def test_missing_host_key_not_added(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         env = {}
-        SDK._auto_inherit_env(env)
+        auto_inherit_env(env)
         assert "ANTHROPIC_API_KEY" not in env
 
 
-# ── _inject_vertex_credentials ──
+# ── inject_vertex_credentials ──
 
 
 class TestInjectVertexCredentials:
-    """Tests for SDK._inject_vertex_credentials — Vertex AI ADC setup."""
+    """Tests for inject_vertex_credentials — Vertex AI ADC setup."""
 
     def test_non_vertex_model_is_noop(self):
         env = {}
-        SDK._inject_vertex_credentials(env, "claude-sonnet-4-6")
+        inject_vertex_credentials(env, "claude-sonnet-4-6")
         assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
 
     def test_missing_adc_raises(self, monkeypatch, tmp_path):
         monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
         with pytest.raises(ValueError, match="requires ADC credentials"):
-            SDK._inject_vertex_credentials(
+            inject_vertex_credentials(
                 {"GOOGLE_CLOUD_PROJECT": "proj"},
                 "google-vertex/gemini-3-flash",
             )
@@ -85,7 +91,7 @@ class TestInjectVertexCredentials:
         monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
         monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
         with pytest.raises(ValueError, match="GOOGLE_CLOUD_PROJECT required"):
-            SDK._inject_vertex_credentials({}, "google-vertex/gemini-3-flash")
+            inject_vertex_credentials({}, "google-vertex/gemini-3-flash")
 
     def test_success_injects_adc(self, monkeypatch, tmp_path):
         adc_dir = tmp_path / ".config" / "gcloud"
@@ -93,33 +99,33 @@ class TestInjectVertexCredentials:
         (adc_dir / "application_default_credentials.json").write_text('{"key": "val"}')
         monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
         env = {"GOOGLE_CLOUD_PROJECT": "my-proj"}
-        SDK._inject_vertex_credentials(env, "google-vertex/gemini-3-flash")
+        inject_vertex_credentials(env, "google-vertex/gemini-3-flash")
         assert env["GOOGLE_APPLICATION_CREDENTIALS_JSON"] == '{"key": "val"}'
         assert env["GOOGLE_CLOUD_LOCATION"] == "global"
 
 
-# ── _resolve_provider_env ──
+# ── resolve_provider_env ──
 
 
 class TestResolveProviderEnv:
-    """Tests for SDK._resolve_provider_env — provider detection and env_mapping."""
+    """Tests for resolve_provider_env — provider detection and env_mapping."""
 
     def test_sets_provider_model(self):
         env = {"ANTHROPIC_API_KEY": "sk-test"}
-        SDK._resolve_provider_env(env, "claude-haiku-4-5-20251001", "claude-agent-acp")
+        resolve_provider_env(env, "claude-haiku-4-5-20251001", "claude-agent-acp")
         assert env["BENCHFLOW_PROVIDER_MODEL"] == "claude-haiku-4-5-20251001"
         # env_mapping translates to agent-native var
         assert env["ANTHROPIC_MODEL"] == "claude-haiku-4-5-20251001"
 
     def test_strips_provider_prefix(self):
         env = {"ZAI_API_KEY": "zk-test"}
-        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
         assert env["BENCHFLOW_PROVIDER_MODEL"] == "glm-5"
         assert env["ANTHROPIC_MODEL"] == "glm-5"
 
     def test_injects_benchflow_provider_vars(self):
         env = {"ZAI_API_KEY": "zk-test"}
-        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
         assert env["BENCHFLOW_PROVIDER_NAME"] == "zai"
         assert "BENCHFLOW_PROVIDER_BASE_URL" in env
         assert "BENCHFLOW_PROVIDER_PROTOCOL" in env
@@ -128,14 +134,14 @@ class TestResolveProviderEnv:
     def test_env_mapping_applied(self):
         """claude-agent-acp maps BENCHFLOW_PROVIDER_* → agent-native vars."""
         env = {"ZAI_API_KEY": "zk-test"}
-        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
         assert "ANTHROPIC_BASE_URL" in env
         assert env["ANTHROPIC_AUTH_TOKEN"] == "zk-test"
 
     def test_zai_picks_anthropic_endpoint_for_claude_agent(self):
         """claude-agent-acp speaks anthropic-messages → routes to zai's anthropic endpoint."""
         env = {"ZAI_API_KEY": "zk-test"}
-        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
         assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/anthropic"
         assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "anthropic-messages"
         # env_mapping translates to ANTHROPIC_BASE_URL
@@ -144,7 +150,7 @@ class TestResolveProviderEnv:
     def test_zai_picks_openai_endpoint_for_codex_agent(self):
         """codex-acp speaks openai-completions → routes to zai's openai endpoint."""
         env = {"ZAI_API_KEY": "zk-test"}
-        SDK._resolve_provider_env(env, "zai/glm-5", "codex-acp")
+        resolve_provider_env(env, "zai/glm-5", "codex-acp")
         assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
         assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-completions"
         assert env["OPENAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
@@ -155,22 +161,22 @@ class TestResolveProviderEnv:
             "ZAI_API_KEY": "zk-test",
             "ANTHROPIC_BASE_URL": "https://custom.example/anthropic",
         }
-        SDK._resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
+        resolve_provider_env(env, "zai/glm-5", "claude-agent-acp")
         assert env["ANTHROPIC_BASE_URL"] == "https://custom.example/anthropic"
 
     def test_no_provider_still_sets_model(self):
         """Model with no registered provider still sets BENCHFLOW_PROVIDER_MODEL."""
         env = {"ANTHROPIC_API_KEY": "sk-test"}
-        SDK._resolve_provider_env(env, "claude-sonnet-4-6", "claude-agent-acp")
+        resolve_provider_env(env, "claude-sonnet-4-6", "claude-agent-acp")
         assert env["BENCHFLOW_PROVIDER_MODEL"] == "claude-sonnet-4-6"
         assert env["ANTHROPIC_MODEL"] == "claude-sonnet-4-6"
 
 
-# ── _check_subscription_auth ──
+# ── check_subscription_auth ──
 
 
 class TestCheckSubscriptionAuth:
-    """Tests for SDK._check_subscription_auth — host auth file detection."""
+    """Tests for check_subscription_auth — host auth file detection."""
 
     def _patch_expanduser(self, monkeypatch, tmp_path):
         orig = Path.expanduser
@@ -188,17 +194,11 @@ class TestCheckSubscriptionAuth:
         creds_dir.mkdir()
         (creds_dir / ".credentials.json").write_text("{}")
         self._patch_expanduser(monkeypatch, tmp_path)
-        assert (
-            SDK._check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY")
-            is True
-        )
+        assert check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY") is True
 
     def test_returns_false_when_file_missing(self, monkeypatch, tmp_path):
         self._patch_expanduser(monkeypatch, tmp_path)
-        assert (
-            SDK._check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY")
-            is False
-        )
+        assert check_subscription_auth("claude-agent-acp", "ANTHROPIC_API_KEY") is False
 
     def test_returns_false_for_wrong_key(self, monkeypatch, tmp_path):
         """subscription_auth.replaces_env must match required_key."""
@@ -207,33 +207,30 @@ class TestCheckSubscriptionAuth:
         (creds_dir / ".credentials.json").write_text("{}")
         self._patch_expanduser(monkeypatch, tmp_path)
         # claude-agent-acp replaces ANTHROPIC_API_KEY, not OPENAI_API_KEY
-        assert (
-            SDK._check_subscription_auth("claude-agent-acp", "OPENAI_API_KEY") is False
-        )
+        assert check_subscription_auth("claude-agent-acp", "OPENAI_API_KEY") is False
 
     def test_returns_false_for_unknown_agent(self):
         assert (
-            SDK._check_subscription_auth("nonexistent-agent", "ANTHROPIC_API_KEY")
-            is False
+            check_subscription_auth("nonexistent-agent", "ANTHROPIC_API_KEY") is False
         )
 
     def test_returns_false_when_no_subscription_auth(self):
         """Agents without subscription_auth (e.g. openclaw) return False."""
-        assert SDK._check_subscription_auth("openclaw", "ANTHROPIC_API_KEY") is False
+        assert check_subscription_auth("openclaw", "ANTHROPIC_API_KEY") is False
 
     def test_codex_auth(self, monkeypatch, tmp_path):
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()
         (codex_dir / "auth.json").write_text("{}")
         self._patch_expanduser(monkeypatch, tmp_path)
-        assert SDK._check_subscription_auth("codex-acp", "OPENAI_API_KEY") is True
+        assert check_subscription_auth("codex-acp", "OPENAI_API_KEY") is True
 
 
-# ── _resolve_agent_env: no-model subscription auth ──
+# ── resolve_agent_env: no-model subscription auth ──
 
 
 class TestResolveAgentEnvNoModel:
-    """Tests for the no-model path in _resolve_agent_env."""
+    """Tests for the no-model path in resolve_agent_env."""
 
     def _patch_expanduser(self, monkeypatch, tmp_path):
         orig = Path.expanduser
@@ -247,7 +244,7 @@ class TestResolveAgentEnvNoModel:
         monkeypatch.setattr(Path, "expanduser", fake)
 
     def _resolve(self, agent="claude-agent-acp", model=None, agent_env=None):
-        return SDK._resolve_agent_env(agent, model, agent_env)
+        return resolve_agent_env(agent, model, agent_env)
 
     def test_no_model_with_api_key_works(self):
         """When API key is present and no model, no subscription auth needed."""

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -17,9 +17,9 @@ class TestResolveAgentEnv:
     """Tests for SDK._resolve_agent_env — env var resolution logic."""
 
     def _resolve(self, agent="claude-agent-acp", model=None, agent_env=None):
-        from benchflow.sdk import SDK
+        from benchflow._agent_env import resolve_agent_env
 
-        return SDK._resolve_agent_env(agent, model, agent_env)
+        return resolve_agent_env(agent, model, agent_env)
 
     def test_returns_dict(self):
         result = self._resolve(agent_env={"ANTHROPIC_API_KEY": "sk-test"})

--- a/tests/test_sdk_lockdown.py
+++ b/tests/test_sdk_lockdown.py
@@ -1,15 +1,17 @@
-"""Tests for path lockdown — _validate_locked_path, _resolve_locked_paths, _lockdown_paths."""
+"""Tests for path lockdown — _validate_locked_path, _resolve_locked_paths, lockdown_paths."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from benchflow.sdk import (
-    SDK,
+from benchflow._sandbox import (
     _resolve_locked_paths,
     _validate_locked_path,
+    build_priv_drop_cmd,
+    lockdown_paths,
 )
+from benchflow.sdk import SDK
 
 # ---------------------------------------------------------------------------
 # _validate_locked_path
@@ -98,12 +100,12 @@ class TestResolveLockedPaths:
 
 
 # ---------------------------------------------------------------------------
-# SDK._lockdown_paths
+# lockdown_paths
 # ---------------------------------------------------------------------------
 
 
 class TestLockdownPaths:
-    """_lockdown_paths sends correct commands to env."""
+    """lockdown_paths sends correct commands to env."""
 
     @pytest.fixture
     def mock_env(self):
@@ -116,29 +118,29 @@ class TestLockdownPaths:
         return mock_env.exec.call_args_list[0][0][0]
 
     def test_noop_empty_paths(self, mock_env):
-        asyncio.run(SDK._lockdown_paths(mock_env, []))
+        asyncio.run(lockdown_paths(mock_env, []))
         mock_env.exec.assert_not_called()
 
     def test_chown_before_chmod_and_symlink_skip(self, mock_env):
-        asyncio.run(SDK._lockdown_paths(mock_env, ["/solution"]))
+        asyncio.run(lockdown_paths(mock_env, ["/solution"]))
         assert mock_env.exec.call_count == 1
         cmd = self._get_lockdown_cmd(mock_env)
         assert cmd.index("chown root:root") < cmd.index("chmod 700")
         assert '[ -L "$d" ]' in cmd
 
     def test_multiple_paths(self, mock_env):
-        asyncio.run(SDK._lockdown_paths(mock_env, ["/solution", "/tests", "/data"]))
+        asyncio.run(lockdown_paths(mock_env, ["/solution", "/tests", "/data"]))
         cmd = self._get_lockdown_cmd(mock_env)
         for p in ["/solution", "/tests", "/data"]:
             assert f"for d in {p}" in cmd
 
     def test_glob_expansion(self, mock_env):
-        asyncio.run(SDK._lockdown_paths(mock_env, ["/app-*"]))
+        asyncio.run(lockdown_paths(mock_env, ["/app-*"]))
         assert "for d in /app-*" in self._get_lockdown_cmd(mock_env)
 
     def test_validation_rejects_bad_path(self, mock_env):
         with pytest.raises(ValueError):
-            asyncio.run(SDK._lockdown_paths(mock_env, ["/solution/../etc"]))
+            asyncio.run(lockdown_paths(mock_env, ["/solution/../etc"]))
         mock_env.exec.assert_not_called()
 
 
@@ -258,35 +260,35 @@ class TestSandboxUserWarnings:
 
 
 class TestPrivDropCommand:
-    """SDK._build_priv_drop_cmd — setpriv/su-l command generation."""
+    """build_priv_drop_cmd — setpriv/su-l command generation."""
 
     def test_contains_setpriv_and_su_fallback(self):
-        cmd = SDK._build_priv_drop_cmd("my-agent --stdio", "agent")
+        cmd = build_priv_drop_cmd("my-agent --stdio", "agent")
         assert "setpriv --reuid=agent --regid=agent --init-groups" in cmd
         assert "su -l agent -c" in cmd
 
     def test_exec_prefix(self):
         """Both branches use exec to replace the shell (no lingering parent)."""
-        cmd = SDK._build_priv_drop_cmd("my-agent", "agent")
+        cmd = build_priv_drop_cmd("my-agent", "agent")
         assert "exec setpriv" in cmd
         assert "exec su" in cmd
 
     def test_inner_command_is_shlex_quoted(self):
         import shlex
 
-        cmd = SDK._build_priv_drop_cmd("agent --flag value", "agent")
+        cmd = build_priv_drop_cmd("agent --flag value", "agent")
         inner = "export HOME=/home/agent && cd /home/agent && agent --flag value"
         assert shlex.quote(inner) in cmd
 
     def test_single_quotes_in_launch(self):
         """Single quotes in agent_launch don't break the command."""
-        cmd = SDK._build_priv_drop_cmd("agent --prompt 'hello world'", "agent")
+        cmd = build_priv_drop_cmd("agent --prompt 'hello world'", "agent")
         assert "hello world" in cmd
         assert cmd.count("if ") == 1
         assert cmd.count(" fi") == 1
 
     def test_custom_sandbox_user(self):
-        cmd = SDK._build_priv_drop_cmd("my-agent", "bench-user")
+        cmd = build_priv_drop_cmd("my-agent", "bench-user")
         assert "--reuid=bench-user" in cmd
         assert "su -l bench-user" in cmd
         assert "/home/bench-user" in cmd

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -112,9 +112,9 @@ def _patch_expanduser(monkeypatch, tmp_path):
 
 class TestResolveAgentEnvSubscription:
     def _resolve(self, agent="claude-agent-acp", model=None, agent_env=None):
-        from benchflow.sdk import SDK
+        from benchflow._agent_env import resolve_agent_env
 
-        return SDK._resolve_agent_env(agent, model, agent_env)
+        return resolve_agent_env(agent, model, agent_env)
 
     def test_api_key_present_no_subscription_marker(self):
         """When API key is provided, no subscription auth marker is set."""

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -551,19 +551,19 @@ class TestVerifierHardening:
         assert injected["PYTHONPATH"] == ""  # non-overridden defaults kept
 
     def test_verifier_env_contract(self):
-        """SDK._VERIFIER_ENV pins every layer of the pytest ini/plugin hardening.
+        """VERIFIER_ENV pins every layer of the pytest ini/plugin hardening.
 
         Static dict inspection — no async harness needed. See
         tmp/lockdown-sandbox_4.md for the threat model. Each assertion guards a
         specific bypass; collapsing them into one test gives a single
         authoritative contract for the env's contents.
         """
-        from benchflow.sdk import SDK
+        from benchflow._sandbox import VERIFIER_ENV
 
-        env = SDK._VERIFIER_ENV
+        env = VERIFIER_ENV
         addopts = env["PYTEST_ADDOPTS"]
 
-        # Closed-set: any new key added to _VERIFIER_ENV must be deliberately
+        # Closed-set: any new key added to VERIFIER_ENV must be deliberately
         # accounted for here. Catches accidental additions that could weaken
         # the contract (e.g. a stray debug var with sensitive content).
         assert set(env.keys()) == {
@@ -604,20 +604,20 @@ class TestVerifierHardening:
         )
 
     def test_plugin_autoload_not_disabled(self):
-        """Negative guard: PYTEST_DISABLE_PLUGIN_AUTOLOAD must NOT be in _VERIFIER_ENV.
+        """Negative guard: PYTEST_DISABLE_PLUGIN_AUTOLOAD must NOT be in VERIFIER_ENV.
 
         Disabling plugin autoload would break ~94 SkillsBench tasks that use
         pytest-json-ctrf's --ctrf flag. Entry-point plugin injection is already
         blocked structurally (root verifier + system site-packages perms +
-        .pth cleanup in _CLEANUP_CMD).
+        .pth cleanup in CLEANUP_CMD).
 
         This guards against accidental re-addition. A developer who *intends*
         to add it will (correctly) update this test and the comment in
-        sdk.py:_VERIFIER_ENV at the same time.
+        _sandbox.py:VERIFIER_ENV at the same time.
         """
-        from benchflow.sdk import SDK
+        from benchflow._sandbox import VERIFIER_ENV
 
-        assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD" not in SDK._VERIFIER_ENV
+        assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD" not in VERIFIER_ENV
 
     def test_dash_c_devnull_blocks_hostile_pyproject(self, tmp_path):
         """End-to-end: real pytest under `-c /dev/null` ignores agent-written

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -804,9 +804,9 @@ class TestScrapedTrajectoryTrust:
         """Apply shared + extra patches for SDK.run() internals."""
         patches = [
             patch("benchflow.sdk._create_environment", return_value=mock_env),
-            patch.object(
-                sdk,
-                "_install_agent",
+            patch(
+                "benchflow.sdk.install_agent",
+                new_callable=AsyncMock,
                 return_value=MagicMock(
                     credential_files={},
                     home_dirs=[],
@@ -815,7 +815,7 @@ class TestScrapedTrajectoryTrust:
                 ),
             ),
             patch("benchflow.sdk.write_credential_files", new_callable=AsyncMock),
-            patch.object(sdk, "_deploy_skills", new_callable=AsyncMock),
+            patch("benchflow.sdk.deploy_skills", new_callable=AsyncMock),
             *extra_patches,
         ]
         with contextlib.ExitStack() as stack:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -842,15 +842,13 @@ class TestScrapedTrajectoryTrust:
                 sdk,
                 mock_env,
                 [
-                    patch.object(
-                        sdk,
-                        "_connect_acp",
+                    patch(
+                        "benchflow.sdk.connect_acp",
                         new_callable=AsyncMock,
                         return_value=(mock_acp, mock_session, "test-agent"),
                     ),
-                    patch.object(
-                        sdk,
-                        "_execute_prompts",
+                    patch(
+                        "benchflow.sdk.execute_prompts",
                         new_callable=AsyncMock,
                         return_value=([], 5),
                     ),
@@ -896,15 +894,13 @@ class TestScrapedTrajectoryTrust:
             sdk,
             mock_env,
             [
-                patch.object(
-                    sdk,
-                    "_connect_acp",
+                patch(
+                    "benchflow.sdk.connect_acp",
                     new_callable=AsyncMock,
                     return_value=(mock_acp, mock_session, "test-agent"),
                 ),
-                patch.object(
-                    sdk,
-                    "_execute_prompts",
+                patch(
+                    "benchflow.sdk.execute_prompts",
                     new_callable=AsyncMock,
                     side_effect=ConnectionError("lost"),
                 ),

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -814,7 +814,7 @@ class TestScrapedTrajectoryTrust:
                     env_mapping={},
                 ),
             ),
-            patch.object(sdk, "_write_credential_files", new_callable=AsyncMock),
+            patch("benchflow.sdk.write_credential_files", new_callable=AsyncMock),
             patch.object(sdk, "_deploy_skills", new_callable=AsyncMock),
             *extra_patches,
         ]


### PR DESCRIPTION
## Summary

- Extracts five phase modules from `sdk.py` so each slice of the run loop is independently greppable: `_agent_env`, `_sandbox`, `_credentials`, `_acp_run`, `_agent_setup`. `sdk.py` shrinks from ~1500 to ~625 lines and becomes a thin orchestrator.
- Adds an architecture map docstring at the top of `sdk.py` that walks the run loop top-to-bottom and labels which phase module owns each step.
- Documents why `_patch_harbor_dind()` is called at import time (process-wide coverage of any Harbor `DockerEnvironment`, idempotency without a guard).

No behavior changes — this is a structural refactor. Tests in the affected areas were updated to import from the new module paths.

## Test plan

- [ ] `.venv/bin/python -m pytest tests/` passes
- [ ] `from benchflow import RunResult, AgentInstallError, AgentTimeoutError, stage_dockerfile_deps` still works (public re-exports unchanged)
- [ ] Smoke run on a real task to confirm the orchestrator path still produces a non-empty trajectory and rewards

🤖 Generated with [Claude Code](https://claude.com/claude-code)