### PR TITLE
chore: add pre-commit hook for ruff format + check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+# Run on staged files at commit time. Mirrors what CI runs so format/lint
+# failures are caught locally before push. Install once per clone:
+#
+#     uv pip install -e ".[dev]" && pre-commit install
+#
+# Bypass with --no-verify only if you know what you're doing; CI will still
+# gate the same checks. Pinned to ruff 0.15.7 to match pyproject.toml's
+# ruff>=0.7.0 floor and avoid format-rule drift between hook and CI.
+#
+# Scoped to src/ and tests/ to match what CI actually checks
+# (`.github/workflows/*` runs `ruff format --check src tests`). benchmarks/
+# is intentionally excluded — out of CI scope, would silently expand the
+# format gate beyond what's enforced upstream.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.7
+    hooks:
+      - id: ruff-format
+        files: ^(src|tests)/
+      - id: ruff-check
+        files: ^(src|tests)/
+        args: [--fix]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,15 @@ Requires Python >=3.12. Use `uv` for environment and dependency management:
 
 ```bash
 uv venv -p 3.12 .venv && uv pip install -e ".[dev]"
+.venv/bin/pre-commit install                           # one-time per clone — runs ruff on commit
 .venv/bin/python -m pytest tests/                      # unit tests (no Docker needed)
 .venv/bin/python -m pytest -m live tests/test_smoke.py # e2e smoke (real Docker + API)
 ```
+
+Pre-commit hook runs `ruff format` + `ruff check` on staged files in `src/`
+and `tests/`, matching what CI gates. After cloning, run `pre-commit install`
+once. Bypassing with `--no-verify` defeats the local guard but CI still
+enforces the same checks — fix the underlying issue rather than skipping.
 
 Use Haiku 4.5 (`claude-haiku-4-5-20251001`) for smoke tests.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+    "pre-commit>=3.7",
     "pytest>=8.0",
     "pytest-asyncio>=0.24.0",
     "ruff>=0.7.0",


### PR DESCRIPTION
## Summary

Closes Tier 1 #3 in the SWE gaps audit. PR #121 (I001 import order after rename) and PR #122 (ruff format on a new test file) both shipped with the same class of failure: local pre-push protocol passed, CI gate failed, costing an extra commit + force-rebuild each time. The local rule (\"run ruff before push\") relied on memory and proved insufficient — twice in two PRs.

This PR makes the gate mechanical:

- **`.pre-commit-config.yaml`** — runs `ruff format` + `ruff check --fix` on staged files at commit time. Pinned to ruff `v0.15.7` to match what's in the dev env. Scoped to `^(src|tests)/` to match exactly what `.github/workflows/test.yml` checks (`ruff format --check src tests`) — no scope creep into `benchmarks/`.
- **`pre-commit>=3.7`** added to `[project.optional-dependencies].dev`.
- **CLAUDE.md** — Testing section now lists `pre-commit install` as a one-time step after clone, with a note that bypassing with `--no-verify` defeats the local guard.

ty + pytest are intentionally **not** in the hook — too slow per commit. CI still gates them.

### Verified

- `pre-commit run --all-files` on the current tree: both hooks pass
- Smoke test of the block path: introduced `def bad(  ): return    1+2` in a scratch file, staged, attempted commit → ruff format auto-fixed and the commit was blocked (no commit hash in output, file remained staged with bad content)

### Merge note

This PR and #122 both touch the Testing section of CLAUDE.md. Whichever lands first will create a small conflict in the other; resolution is mechanical (both edits add to the same code block).

## Test plan

- [x] `pre-commit run --all-files` — both hooks pass on current tree
- [x] `ruff format --check src tests` — clean
- [x] `ruff check src tests` — clean
- [x] `pytest tests/ -q` — 474 passed
- [x] `ty check` — clean
- [x] End-to-end block test: bad file staged → commit blocked, file auto-fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)