### PR TITLE
fix: API key shadowing warning + DinD bind mount loud failure

### DIFF
--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -158,16 +158,19 @@ def resolve_agent_env(
                     f"Export it, pass via agent_env, or log in with the "
                     f"agent CLI (e.g. claude login, codex --login)."
                 )
-        elif required_key and required_key in agent_env:
-            if check_subscription_auth(agent, required_key):
-                logger.warning(
-                    "%s is set (possibly inherited from host env) AND "
-                    "subscription auth credentials exist — the env var takes "
-                    "precedence. If the key is stale, unset it: "
-                    "env -u %s <command>",
-                    required_key,
-                    required_key,
-                )
+        elif (
+            required_key
+            and required_key in agent_env
+            and check_subscription_auth(agent, required_key)
+        ):
+            logger.warning(
+                "%s is set (possibly inherited from host env) AND "
+                "subscription auth credentials exist — the env var takes "
+                "precedence. If the key is stale, unset it: "
+                "env -u %s <command>",
+                required_key,
+                required_key,
+            )
     else:
         # No model specified — still check subscription auth for required env vars
         agent_cfg = AGENTS.get(agent)

--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -158,6 +158,16 @@ def resolve_agent_env(
                     f"Export it, pass via agent_env, or log in with the "
                     f"agent CLI (e.g. claude login, codex --login)."
                 )
+        elif required_key and required_key in agent_env:
+            if check_subscription_auth(agent, required_key):
+                logger.warning(
+                    "%s is set (possibly inherited from host env) AND "
+                    "subscription auth credentials exist — the env var takes "
+                    "precedence. If the key is stale, unset it: "
+                    "env -u %s <command>",
+                    required_key,
+                    required_key,
+                )
     else:
         # No model specified — still check subscription auth for required env vars
         agent_cfg = AGENTS.get(agent)

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -120,7 +120,7 @@ from benchflow._trajectory import (
     _capture_session_trajectory,
     _scrape_agent_trajectory,
 )
-from benchflow.acp.client import ACPClient
+from benchflow.acp.client import ACPClient, ACPError
 from benchflow.agents.registry import AGENT_LAUNCH
 from benchflow.models import RunResult, TrajectorySource
 
@@ -579,6 +579,23 @@ class SDK:
         except ConnectionError as e:
             error = str(e)
             logger.error(f"Agent connection lost: {error}")
+        except ACPError as e:
+            if "Invalid API key" in e.message:
+                from benchflow._agent_env import check_subscription_auth
+                from benchflow.agents.registry import infer_env_key_for_model
+
+                key = infer_env_key_for_model(model) if model else None
+                if key and check_subscription_auth(agent, key):
+                    error = (
+                        f"{key} was rejected as invalid. "
+                        f"Subscription auth credentials exist — unset the env var "
+                        f"to use them: env -u {key} <command>"
+                    )
+                else:
+                    error = str(e)
+            else:
+                error = str(e)
+            logger.error(error)
         except Exception as e:
             error = str(e)
             logger.error("Run failed", exc_info=True)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -105,6 +105,12 @@ def smoke_jobs_dir(tmp_path: Path) -> Iterator[Path]:
     may not be removable by our (non-root) test user.
     """
     if _detect_dind_mount() is None:
+        if Path("/.dockerenv").exists():
+            pytest.fail(
+                "Running inside DinD (/.dockerenv present) but cwd is not under any "
+                "container bind mount. Move your checkout under a bind-mounted path "
+                "(e.g. /workspace) so host docker can see it."
+            )
         yield tmp_path
         return
 


### PR DESCRIPTION
## Summary

- **Stale API key warning** (`_agent_env.py`, `sdk.py`): when `ANTHROPIC_API_KEY` is set in the host env and `~/.claude/.credentials.json` also exists, `resolve_agent_env` now warns that the env var takes precedence. When ACP rejects the key as invalid and subscription auth is available, `SDK.run()` surfaces an actionable error pointing at the env var. Closes #125
- **DinD bind mount loud failure** (`test_smoke.py`): `_detect_dind_mount()` returning `None` was indistinguishable between "not in DinD" and "in DinD but cwd outside any bind mount", causing `smoke_jobs_dir` to silently fall back to `tmp_path` and the verifier to write `reward.txt` into the void. Now probes `/.dockerenv` directly and calls `pytest.fail()` immediately with an actionable message. Closes #126

## Test plan

- [x] `test_hello_world_smoke` passes on normal host — verified locally (114s)
- [ ] Stale API key warning: set `ANTHROPIC_API_KEY` to an old key with credentials.json present, verify warning appears
- [ ] DinD false-negative: in a devcontainer with checkout outside `/workspace`, verify test fails fast with clear message instead of 4-minute mystery failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)