### PR TITLE
fix: drop PYTHONHOME="" from VERIFIER_ENV (breaks Py_Initialize)

### DIFF
--- a/.dev-docs/harden-sandbox.md
+++ b/.dev-docs/harden-sandbox.md
@@ -97,7 +97,7 @@ and is composed of two class constants plus one method:
   | `PATH` | `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin` | locked PATH (Pattern 7) |
   | `PYTEST_ADDOPTS` | `-c /dev/null --confcutdir=/tests --rootdir=/tests -p no:cacheprovider` | L1 (`-c /dev/null`) blocks `pyproject.toml`/`pytest.ini`/`tox.ini`/`setup.cfg` walk-up; L2 (`--confcutdir=/tests`) blocks `conftest.py` walk-up; rootdir pin + cache disable from original Pattern 7 |
   | `PYTHONSAFEPATH` | `1` | L4 — Python 3.11+ drops implicit `''` (cwd) from `sys.path`, blocking module-shadow via `import helpers` finding `/app/helpers.py` |
-  | `PYTHONPATH`, `PYTHONHOME` | `""` | block env-var path injection |
+  | `PYTHONPATH` | `""` | block env-var path injection (empty list = same as unset, safe) |
   | `PYTHONSTARTUP`, `LD_PRELOAD`, `LD_LIBRARY_PATH` | `""` | L5 — clear image-`ENV` carryover (zero-downside insurance against malicious base images) |
   | `PYTHONDONTWRITEBYTECODE` | `1` | no `.pyc` artifacts left behind |
 
@@ -111,6 +111,17 @@ and is composed of two class constants plus one method:
     `sys.path` entry.
   - `PYTHONNOUSERSITE=1` — root verifier means `/root/.local` is the only
     user-site on `sys.path`, and `sandbox_user` cannot write there.
+  - `PYTHONHOME=""` — setting it to empty string is NOT equivalent to
+    leaving it unset. CPython reads the empty prefix, fails to find
+    `lib/python3.X/encodings`, and aborts during `Py_Initialize` with
+    `ModuleNotFoundError: No module named 'encodings'`. This broke any
+    verifier `test.sh` that spawned a fresh Python interpreter (seen
+    deterministically on swebench astropy__7166/7336/7606/7671 which run
+    `python -m pip install -e .[test]` before pytest). The PYTHONHOME
+    attack surface is already covered structurally: `sandbox_user` cannot
+    set env vars that persist across `docker exec` boundaries, and nothing
+    in benchflow base images sets `PYTHONHOME`. Removed in commit against
+    `main` — see `test_pythonhome_not_set` for the negative guard.
 - `SDK._CLEANUP_CMD` — defense-in-depth shell command:
   `find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete`
   plus `python3 -c "import sys..."` to enumerate real `sys.path` and remove

--- a/.dev-docs/harden-sandbox.md
+++ b/.dev-docs/harden-sandbox.md
@@ -111,17 +111,9 @@ and is composed of two class constants plus one method:
     `sys.path` entry.
   - `PYTHONNOUSERSITE=1` — root verifier means `/root/.local` is the only
     user-site on `sys.path`, and `sandbox_user` cannot write there.
-  - `PYTHONHOME=""` — setting it to empty string is NOT equivalent to
-    leaving it unset. CPython reads the empty prefix, fails to find
-    `lib/python3.X/encodings`, and aborts during `Py_Initialize` with
-    `ModuleNotFoundError: No module named 'encodings'`. This broke any
-    verifier `test.sh` that spawned a fresh Python interpreter (seen
-    deterministically on swebench astropy__7166/7336/7606/7671 which run
-    `python -m pip install -e .[test]` before pytest). The PYTHONHOME
-    attack surface is already covered structurally: `sandbox_user` cannot
-    set env vars that persist across `docker exec` boundaries, and nothing
-    in benchflow base images sets `PYTHONHOME`. Removed in commit against
-    `main` — see `test_pythonhome_not_set` for the negative guard.
+  - `PYTHONHOME=""` — not equivalent to unset; empty prefix aborts
+    `Py_Initialize` and breaks any verifier `test.sh` that spawns a fresh
+    Python (e.g. `python -m pip install` before pytest).
 - `SDK._CLEANUP_CMD` — defense-in-depth shell command:
   `find / -maxdepth 5 -name conftest.py -not -path '/tests/*' -delete`
   plus `python3 -c "import sys..."` to enumerate real `sys.path` and remove

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -163,28 +163,8 @@ async def lockdown_paths(env, paths: list[str]) -> None:
 # ── Verifier hardening ────────────────────────────────────────────────────────
 
 # Trusted env vars for verifier execution — override any agent pollution.
-#
-# PYTEST_DISABLE_PLUGIN_AUTOLOAD intentionally omitted: would break ~94
-# SkillsBench tasks that rely on pytest-json-ctrf's --ctrf flag. Entry-point
-# plugin injection is already blocked by verifier-runs-as-root + system
-# site-packages permissions + the .pth cleanup in CLEANUP_CMD.
-#
-# PYTHONNOUSERSITE intentionally omitted: verifier runs as root, so the
-# only user-site dir on sys.path is /root/.local which sandbox_user cannot
-# touch, and CLEANUP_CMD already wipes .pth files there as belt-and-braces.
-#
-# PYTHONHOME intentionally omitted: setting it to "" (empty string) is NOT
-# equivalent to leaving it unset — CPython reads it as the installation
-# prefix, fails to find lib/python3.X/encodings under the empty prefix,
-# and aborts during Py_Initialize with `ModuleNotFoundError: No module
-# named 'encodings'`. This breaks any verifier test.sh that spawns a
-# fresh Python interpreter (seen deterministically on 4 swebench astropy
-# __7xxx tasks whose test.sh does `python -m pip install -e .[test]`
-# before pytest runs). Defense-in-depth for PYTHONHOME is already covered
-# structurally: `sandbox_user` cannot set env vars that persist across
-# `docker exec` boundaries, so an agent-set PYTHONHOME never reaches the
-# verifier subprocess, and nothing in our base images sets PYTHONHOME.
-# See test_plugin_autoload_not_disabled-style negative guard below.
+# Intentionally omitted (negative guards in test_verify.py explain why):
+# PYTEST_DISABLE_PLUGIN_AUTOLOAD, PYTHONNOUSERSITE, PYTHONHOME.
 VERIFIER_ENV: dict[str, str] = {
     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "PYTEST_ADDOPTS": (

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -172,6 +172,19 @@ async def lockdown_paths(env, paths: list[str]) -> None:
 # PYTHONNOUSERSITE intentionally omitted: verifier runs as root, so the
 # only user-site dir on sys.path is /root/.local which sandbox_user cannot
 # touch, and CLEANUP_CMD already wipes .pth files there as belt-and-braces.
+#
+# PYTHONHOME intentionally omitted: setting it to "" (empty string) is NOT
+# equivalent to leaving it unset — CPython reads it as the installation
+# prefix, fails to find lib/python3.X/encodings under the empty prefix,
+# and aborts during Py_Initialize with `ModuleNotFoundError: No module
+# named 'encodings'`. This breaks any verifier test.sh that spawns a
+# fresh Python interpreter (seen deterministically on 4 swebench astropy
+# __7xxx tasks whose test.sh does `python -m pip install -e .[test]`
+# before pytest runs). Defense-in-depth for PYTHONHOME is already covered
+# structurally: `sandbox_user` cannot set env vars that persist across
+# `docker exec` boundaries, so an agent-set PYTHONHOME never reaches the
+# verifier subprocess, and nothing in our base images sets PYTHONHOME.
+# See test_plugin_autoload_not_disabled-style negative guard below.
 VERIFIER_ENV: dict[str, str] = {
     "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
     "PYTEST_ADDOPTS": (
@@ -182,7 +195,6 @@ VERIFIER_ENV: dict[str, str] = {
     ),
     "PYTHONDONTWRITEBYTECODE": "1",
     "PYTHONPATH": "",
-    "PYTHONHOME": "",
     "PYTHONSTARTUP": "",
     "PYTHONSAFEPATH": "1",  # drop implicit '' (cwd) from sys.path
     "LD_PRELOAD": "",

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -504,7 +504,9 @@ class TestVerifierHardening:
         assert "--rootdir=/tests" in injected["PYTEST_ADDOPTS"]
         assert "-p no:cacheprovider" in injected["PYTEST_ADDOPTS"]
         assert injected["PYTHONPATH"] == ""
-        assert injected["PYTHONHOME"] == ""
+        assert (
+            "PYTHONHOME" not in injected
+        )  # see _sandbox.py comment — breaks Py_Initialize
         assert injected["PYTHONDONTWRITEBYTECODE"] == "1"
 
     @pytest.mark.asyncio
@@ -558,7 +560,6 @@ class TestVerifierHardening:
             "PYTEST_ADDOPTS",
             "PYTHONDONTWRITEBYTECODE",
             "PYTHONPATH",
-            "PYTHONHOME",
             "PYTHONSTARTUP",
             "PYTHONSAFEPATH",
             "LD_PRELOAD",
@@ -583,7 +584,6 @@ class TestVerifierHardening:
 
         # Pattern 7 hardening (pre-existing)
         assert env["PYTHONPATH"] == ""
-        assert env["PYTHONHOME"] == ""
         assert env["PYTHONDONTWRITEBYTECODE"] == "1"
         assert (
             env["PATH"]
@@ -605,6 +605,31 @@ class TestVerifierHardening:
         from benchflow._sandbox import VERIFIER_ENV
 
         assert "PYTEST_DISABLE_PLUGIN_AUTOLOAD" not in VERIFIER_ENV
+
+    def test_pythonhome_not_set(self):
+        """Negative guard: PYTHONHOME must NOT be in VERIFIER_ENV.
+
+        Setting PYTHONHOME="" (empty string) is NOT equivalent to leaving it
+        unset. CPython reads the empty string as the installation prefix,
+        fails to locate lib/python3.X/encodings under the empty prefix, and
+        aborts during Py_Initialize with
+        `ModuleNotFoundError: No module named 'encodings'`. This breaks any
+        verifier test.sh that spawns a fresh Python interpreter — seen
+        deterministically on swebench astropy__7166/7336/7606/7671 whose
+        test.sh does `python -m pip install -e .[test]` before pytest runs.
+
+        Defense-in-depth for PYTHONHOME is already covered structurally:
+        sandbox_user cannot set env vars that persist across `docker exec`
+        boundaries, so an agent-set PYTHONHOME never reaches the verifier
+        subprocess, and nothing in our base images sets PYTHONHOME.
+
+        A developer who wants to reintroduce a PYTHONHOME defense must use
+        a real "unset" mechanism (not empty string), update _sandbox.py's
+        VERIFIER_ENV comment, and update this test at the same time.
+        """
+        from benchflow._sandbox import VERIFIER_ENV
+
+        assert "PYTHONHOME" not in VERIFIER_ENV
 
     def test_dash_c_devnull_blocks_hostile_pyproject(self, tmp_path):
         """End-to-end: real pytest under `-c /dev/null` ignores agent-written

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -609,23 +609,9 @@ class TestVerifierHardening:
     def test_pythonhome_not_set(self):
         """Negative guard: PYTHONHOME must NOT be in VERIFIER_ENV.
 
-        Setting PYTHONHOME="" (empty string) is NOT equivalent to leaving it
-        unset. CPython reads the empty string as the installation prefix,
-        fails to locate lib/python3.X/encodings under the empty prefix, and
-        aborts during Py_Initialize with
-        `ModuleNotFoundError: No module named 'encodings'`. This breaks any
-        verifier test.sh that spawns a fresh Python interpreter — seen
-        deterministically on swebench astropy__7166/7336/7606/7671 whose
-        test.sh does `python -m pip install -e .[test]` before pytest runs.
-
-        Defense-in-depth for PYTHONHOME is already covered structurally:
-        sandbox_user cannot set env vars that persist across `docker exec`
-        boundaries, so an agent-set PYTHONHOME never reaches the verifier
-        subprocess, and nothing in our base images sets PYTHONHOME.
-
-        A developer who wants to reintroduce a PYTHONHOME defense must use
-        a real "unset" mechanism (not empty string), update _sandbox.py's
-        VERIFIER_ENV comment, and update this test at the same time.
+        PYTHONHOME="" is not equivalent to unset — CPython reads the empty
+        prefix and aborts during Py_Initialize, breaking any test.sh that
+        spawns a fresh interpreter (e.g. `python -m pip install` before pytest).
         """
         from benchflow._sandbox import VERIFIER_ENV
 


### PR DESCRIPTION
## Summary

`_VERIFIER_ENV` in `src/benchflow/_sandbox.py` set `PYTHONHOME=""`, which is **not** equivalent to leaving it unset. CPython reads the empty string as the installation prefix, fails to find `lib/python3.X/encodings`, and aborts during `Py_Initialize` with:

```
Fatal Python error: Py_Initialize: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'
```

This breaks any verifier `test.sh` that spawns a fresh Python interpreter. Deterministic under `0.2.1` on 4 swebench-verified astropy tasks — `astropy__astropy-7166`, `7336`, `7606`, `7671` — whose `test.sh` runs `python -m pip install -e .[test]` before pytest. Under `0.2.0` those tasks produce the expected reward; under `0.2.1` they always crash with `verifier_error='verifier crashed: No reward file found'` because the `pip install` aborts during interpreter startup, pytest never runs, `test.sh` exits 1, and nothing writes `reward.txt`.

## Discovery

Surfaced by `labs/reward-hack-matrix`'s 20-task option-B sweep on 2026-04-13. 4 of 20 swebench trials on `0.2.1` hit this exact regression — all on the astropy `__7xxx` subset whose `test.sh` does a fresh pip install. Extrapolated to the full 500-task corpus, this would produce ~100 false-positive `verifier_error` crashes in a full sweep, which would invalidate the 0.2.1 hardening claim for the launch post.

## Root cause read from a failed run's `verifier/test-stdout.txt`

```
+ cd /testbed
+ python -m pip install -e '.[test]' --verbose
Fatal Python error: Py_Initialize: Unable to get the locale encoding
ModuleNotFoundError: No module named 'encodings'

/tests/test.sh: line 17:   935 Aborted (core dumped) python -m pip install -e .[test] --verbose
```

## Why the defense is redundant

The defense `PYTHONHOME=""` was trying to provide — blocking an agent-set `PYTHONHOME` from reaching the verifier — is already covered structurally:

1. `sandbox_user` cannot set env vars that persist across `docker exec` boundaries. Every verifier exec is a fresh invocation, and env vars from the agent phase don't persist.
2. Nothing in benchflow base images sets `PYTHONHOME`.
3. `/etc/environment` and shell rc files are not writable by `sandbox_user`, so an agent can't plant a persistent `PYTHONHOME` there either.

## Changes

- `src/benchflow/_sandbox.py` — remove `PYTHONHOME=""` from `VERIFIER_ENV`, add multi-line comment documenting the `Py_Initialize` failure alongside the existing `PYTEST_DISABLE_PLUGIN_AUTOLOAD` / `PYTHONNOUSERSITE` omission comments.
- `tests/test_verify.py` — update the three existing `PYTHONHOME == ""` assertions to `not in` negative checks, drop `PYTHONHOME` from the `VERIFIER_ENV` closed-set assertion, add `test_pythonhome_not_set` as a new negative guard mirroring `test_plugin_autoload_not_disabled`.
- `.dev-docs/harden-sandbox.md` — update the `_VERIFIER_ENV` table and the "Intentionally omitted" section.

## Test plan

- [x] \`ruff format\` — reformatted
- [x] \`ruff check\` — All checks passed
- [x] \`ty check src/\` — All checks passed
- [x] \`pytest tests/\` — **430 passed, 1 deselected**
- [x] \`pytest tests/test_verify.py -v\` — 44 passed including the new negative guard
- [ ] post-merge: rerun the 4 astropy \`__7xxx\` tasks through \`labs/reward-hack-matrix\` to confirm the regression is gone end-to-end
- [ ] post-merge: full 500-task swebench option-A sweep to confirm the tail of false-positive verifier crashes goes to zero

cc @kywch @xdotli