### PR TITLE
build: restrict sdist to src/tests/metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,15 +58,14 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.sdist]
-exclude = [
-    ".venv*",
-    ".ref",
-    "jobs",
-    "dist",
-    ".claude",
-    ".dev-docs",
-    ".pytest_cache",
-    "__pycache__",
+# Allowlist: only ship what the installed package needs.
+only-include = [
+    "src",
+    "tests",
+    "README.md",
+    "CHANGELOG.md",
+    "LICENSE",
+    "pyproject.toml",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
## Summary
- Switches `[tool.hatch.build.targets.sdist]` from a whack-a-mole `exclude` list to an `only-include` allowlist (`src`, `tests`, `README.md`, `CHANGELOG.md`, `LICENSE`, `pyproject.toml`).
- Prevents `labs/*/.corpora` and other working-dir artifacts from leaking into the release tarball — the previous publish attempt 504'd because the sdist hit 452 MB.
- Verified the resulting sdist is **141K** and contains only the expected top-level entries.

## Test plan
- [x] `rm -rf dist && uv build --sdist` → `dist/benchflow-0.2.2.tar.gz` (141K)
- [x] `tar -tzf dist/benchflow-*.tar.gz | awk -F/ '{print $2}' | sort -u` → `CHANGELOG.md`, `LICENSE`, `PKG-INFO`, `README.md`, `pyproject.toml`, `src`, `tests` (no `labs/`, `.claude/`, `jobs/`, `.corpora/`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)