### PR TITLE
chore: add GitHub release step to launch-prep skill

### DIFF
--- a/.claude/skills/launch-prep/SKILL.md
+++ b/.claude/skills/launch-prep/SKILL.md
@@ -124,5 +124,11 @@ Return the PR URL.
 ```bash
 git checkout main && git pull
 git tag v<NEW_VERSION> && git push origin v<NEW_VERSION>
-uv build && uv publish   # requires UV_PUBLISH_TOKEN or ~/.pypirc
+
+# GitHub release — substitute the actual version for <NEW_VERSION> in the awk pattern
+awk '/^## <NEW_VERSION> /{flag=1; next} /^## [0-9]/{flag=0} flag' CHANGELOG.md > /tmp/release_notes.md
+gh release create v<NEW_VERSION> --title "v<NEW_VERSION>" --notes-file /tmp/release_notes.md
+
+# PyPI publish — separate step (requires UV_PUBLISH_TOKEN or ~/.pypirc)
+uv build && uv publish
 ```


### PR DESCRIPTION
## Summary
- Adds a `gh release create` step to the launch-prep skill's Step 7, using awk to extract the current version's CHANGELOG section as the release body.
- Places it between the tag push and `uv build && uv publish` — GitHub release happens before the PyPI publish, which is usually a separate step with the PyPI token.

## Test plan
- [x] Ran the awk pattern against the existing CHANGELOG.md on 0.2.2 — extracts the section cleanly, stops at the next `## 0.2.1` heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)