### PR TITLE
fix: resolve YAML config paths against CWD, not config parent (#135)

### DIFF
--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -243,14 +243,19 @@ class Job:
 
         # Detect format: Harbor uses "agents" + "datasets", benchflow uses "agent"
         if "agents" in raw or "datasets" in raw:
-            return cls._from_harbor_yaml(raw, path.parent, **kwargs)
-        return cls._from_native_yaml(raw, path.parent, **kwargs)
+            return cls._from_harbor_yaml(raw, **kwargs)
+        return cls._from_native_yaml(raw, **kwargs)
 
     @classmethod
-    def _from_native_yaml(cls, raw: dict, base_dir: Path, **kwargs) -> "Job":
-        """Parse benchflow-native YAML."""
-        tasks_dir = base_dir / raw["tasks_dir"]
-        jobs_dir = base_dir / raw.get("jobs_dir", "jobs")
+    def _from_native_yaml(cls, raw: dict, **kwargs) -> "Job":
+        """Parse benchflow-native YAML.
+
+        Relative paths (``tasks_dir``, ``jobs_dir``, ``skills_dir``) are
+        resolved against the current working directory, matching CLI flag
+        semantics. Absolute paths are passed through unchanged. See #135.
+        """
+        tasks_dir = raw["tasks_dir"]
+        jobs_dir = raw.get("jobs_dir", "jobs")
 
         # Parse prompts — YAML null becomes Python None
         prompts = raw.get("prompts")
@@ -268,9 +273,7 @@ class Job:
             prompts=prompts,
             agent_env=agent_env_raw,
             retry=RetryConfig(max_retries=raw.get("max_retries", 2)),
-            skills_dir=str(base_dir / raw["skills_dir"])
-            if raw.get("skills_dir")
-            else None,
+            skills_dir=raw.get("skills_dir"),
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             exclude_tasks=exclude,
@@ -278,8 +281,13 @@ class Job:
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
     @classmethod
-    def _from_harbor_yaml(cls, raw: dict, base_dir: Path, **kwargs) -> "Job":
-        """Parse Harbor-compatible YAML."""
+    def _from_harbor_yaml(cls, raw: dict, **kwargs) -> "Job":
+        """Parse Harbor-compatible YAML.
+
+        Relative paths in ``datasets[].path``, ``jobs_dir``, and
+        ``skills_dir`` are resolved against the current working directory,
+        matching CLI flag semantics and Harbor's own convention. See #135.
+        """
         # Agent
         agents = raw.get("agents", [{}])
         agent_cfg = agents[0] if agents else {}
@@ -306,20 +314,19 @@ class Job:
 
         # Datasets
         datasets = raw.get("datasets", [{}])
-        tasks_dir = base_dir / datasets[0].get("path", "tasks")
+        tasks_dir = datasets[0].get("path", "tasks")
 
         # Orchestrator
         orch = raw.get("orchestrator", {})
         concurrency = orch.get("n_concurrent_trials", 4)
 
-        jobs_dir = base_dir / raw.get("jobs_dir", "jobs")
+        jobs_dir = raw.get("jobs_dir", "jobs")
         max_retries = (
             raw.get("n_attempts", 1) - 1
         )  # Harbor n_attempts includes first try
 
         # Skills dir (shared with benchflow-native format)
-        skills_dir_raw = raw.get("skills_dir")
-        skills_dir = str(base_dir / skills_dir_raw) if skills_dir_raw else None
+        skills_dir = raw.get("skills_dir")
         sandbox_user = raw.get("sandbox_user", "agent")
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
 

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,5 +1,7 @@
 """Tests for YAML job config loading."""
 
+from pathlib import Path
+
 import pytest
 
 from benchflow.job import Job
@@ -107,7 +109,11 @@ datasets:
 
 
 def test_native_yaml_with_skills_dir(tmp_path):
-    """Test that skills_dir is parsed from native YAML."""
+    """skills_dir is parsed from native YAML and passed through verbatim.
+
+    Relative paths are stored as-is — they're resolved against CWD when
+    the agent setup actually opens the directory, not at parse time. See #135.
+    """
     tasks = tmp_path / "tasks" / "task-a"
     tasks.mkdir(parents=True)
     (tasks / "task.toml").write_text('version = "1.0"')
@@ -122,7 +128,7 @@ skills_dir: my-skills
 """)
 
     job = Job.from_yaml(config)
-    assert job._config.skills_dir == str(tmp_path / "my-skills")
+    assert job._config.skills_dir == "my-skills"
 
 
 def test_native_yaml_without_skills_dir(native_yaml):
@@ -143,7 +149,7 @@ def _make_tasks(tmp_path, names=("task-a", "task-b", "task-c")):
 
 
 class TestNativeYamlNewFields:
-    def test_exclude_parsed(self, tmp_path):
+    def test_exclude_parsed(self, tmp_path, monkeypatch):
         _make_tasks(tmp_path)
         config = tmp_path / "config.yaml"
         config.write_text("""
@@ -152,6 +158,8 @@ exclude:
   - task-a
   - task-c
 """)
+        # Paths in YAML are CWD-relative (#135), so chdir before iterating.
+        monkeypatch.chdir(tmp_path)
         job = Job.from_yaml(config)
         assert job._config.exclude_tasks == {"task-a", "task-c"}
         dirs = job._get_task_dirs()
@@ -190,3 +198,103 @@ sandbox_user: testuser
         assert job._config.exclude_tasks == set()
         assert job._config.agent_env == {}
         assert job._config.sandbox_user == "agent"
+
+
+class TestPathResolution:
+    """Regression tests for #135: YAML paths must resolve against CWD,
+    not the config file's parent directory. CLI flag semantics and Harbor
+    convention both expect CWD-relative resolution.
+    """
+
+    def test_native_yaml_paths_are_cwd_relative_not_config_relative(
+        self, tmp_path, monkeypatch
+    ):
+        """Loading subdir/config.yaml from tmp_path must NOT prepend subdir/
+        to relative paths inside the YAML."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        config = subdir / "config.yaml"
+        config.write_text("""
+tasks_dir: tasks
+jobs_dir: jobs/my-run
+skills_dir: skills
+""")
+        monkeypatch.chdir(tmp_path)
+
+        job = Job.from_yaml(config)
+
+        # Pre-#135-fix, these would have been "subdir/tasks", "subdir/jobs/my-run",
+        # "subdir/skills" — i.e. config-parent-relative.
+        assert job._tasks_dir == Path("tasks")
+        assert job._jobs_dir == Path("jobs/my-run")
+        assert job._config.skills_dir == "skills"
+
+    def test_harbor_yaml_paths_are_cwd_relative_not_config_relative(
+        self, tmp_path, monkeypatch
+    ):
+        """Harbor format: same expectation."""
+        subdir = tmp_path / "subdir"
+        subdir.mkdir()
+        config = subdir / "harbor.yaml"
+        config.write_text("""
+jobs_dir: jobs/my-run
+skills_dir: skills
+agents:
+  - name: claude-agent-acp
+datasets:
+  - path: tasks
+""")
+        monkeypatch.chdir(tmp_path)
+
+        job = Job.from_yaml(config)
+
+        assert job._tasks_dir == Path("tasks")
+        assert job._jobs_dir == Path("jobs/my-run")
+        assert job._config.skills_dir == "skills"
+
+    def test_absolute_yaml_paths_are_preserved(self, tmp_path, monkeypatch):
+        """Absolute paths in YAML must be preserved regardless of CWD."""
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        abs_tasks = tmp_path / "abs_tasks"
+        abs_jobs = tmp_path / "abs_jobs"
+        abs_skills = tmp_path / "abs_skills"
+
+        config = tmp_path / "config.yaml"
+        config.write_text(f"""
+tasks_dir: {abs_tasks}
+jobs_dir: {abs_jobs}
+skills_dir: {abs_skills}
+""")
+        monkeypatch.chdir(elsewhere)
+
+        job = Job.from_yaml(config)
+
+        assert job._tasks_dir == abs_tasks
+        assert job._jobs_dir == abs_jobs
+        assert job._config.skills_dir == str(abs_skills)
+
+    def test_get_task_dirs_finds_cwd_relative_tasks(self, tmp_path, monkeypatch):
+        """End-to-end: with config in subdir/, _get_task_dirs() should walk
+        the CWD-relative `tasks/` tree, not `subdir/tasks/`."""
+        # CWD-relative tasks (the ones that should be found)
+        cwd_tasks = tmp_path / "tasks"
+        for name in ("alpha", "beta"):
+            d = cwd_tasks / name
+            d.mkdir(parents=True)
+            (d / "task.toml").write_text('version = "1.0"')
+
+        # Config-parent-relative tasks (the trap — these should NOT be found,
+        # because we're testing the new semantics)
+        subdir = tmp_path / "subdir"
+        trap_tasks = subdir / "tasks" / "should-not-be-found"
+        trap_tasks.mkdir(parents=True)
+        (trap_tasks / "task.toml").write_text('version = "1.0"')
+
+        config = subdir / "config.yaml"
+        config.write_text("tasks_dir: tasks\n")
+        monkeypatch.chdir(tmp_path)
+
+        job = Job.from_yaml(config)
+        names = sorted(d.name for d in job._get_task_dirs())
+        assert names == ["alpha", "beta"]


### PR DESCRIPTION
## Summary

- Fixes #135. `Job.from_yaml` previously prepended the YAML file's parent directory to relative `tasks_dir` / `jobs_dir` / `skills_dir` values, while CLI flags resolved them against CWD — same string, different output location.
- Drops the `base_dir` prefix from both `_from_native_yaml` and `_from_harbor_yaml` so YAML paths are passed through verbatim. CLI semantics, the example in `docs/cli-reference.md`, and Harbor convention all expect CWD-relative resolution.
- Absolute paths in YAML still work — `Path` preserves them under `truediv` for free.

## Test plan

- [x] `pytest tests/test_yaml_config.py` — 13 passed (4 new regression tests + 9 existing)
- [x] `pytest tests/` — 479 passed, 1 deselected (live test)
- [x] `ruff format --check src/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `ty check src/` — clean

New regression tests cover both native and Harbor formats:
- `test_native_yaml_paths_are_cwd_relative_not_config_relative`
- `test_harbor_yaml_paths_are_cwd_relative_not_config_relative`
- `test_absolute_yaml_paths_are_preserved`
- `test_get_task_dirs_finds_cwd_relative_tasks` (end-to-end check that would have caught #135)

Two pre-existing tests (`test_native_yaml_with_skills_dir`, `test_exclude_parsed`) were updated — they hard-coded the old config-relative behavior.
