### PR TITLE
fix: align YAML path resolution

### DIFF
--- a/.claude/skills/launch-prep/SKILL.md
+++ b/.claude/skills/launch-prep/SKILL.md
@@ -21,6 +21,7 @@ Arguments passed: `$ARGUMENTS`
 .venv/bin/ruff format --check src tests && .venv/bin/ruff check src tests
 .venv/bin/ty check
 .venv/bin/python -m pytest tests/ -q
+uv lock --check
 ```
 
 **`patch` / `minor` / `major`** — follow Steps 0–6 below.
@@ -55,6 +56,7 @@ Mirrors `.github/workflows/test.yml` exactly. Stop on any failure.
 .venv/bin/ruff check src tests
 .venv/bin/ty check
 .venv/bin/python -m pytest tests/ -q
+uv lock --check
 ```
 
 If `ruff format` changed files: `git diff --name-only`, then `git add <those files only>` — not `git add .`.
@@ -84,18 +86,18 @@ Map prefixes: `feat:` → Added, `fix:` → Fixed, `chore:`/`refactor:`/`build:`
 
 ---
 
-## Step 5 — Write CHANGELOG and pyproject.toml
+## Step 5 — Write CHANGELOG, pyproject.toml, and uv.lock
 
 **CHANGELOG:** Insert approved entries as `## <NEW_VERSION> — $(date +%Y-%m-%d)` immediately after `## [Unreleased]`, leaving `[Unreleased]` empty. Use Edit, not Write.
 
-**pyproject.toml:** Edit only `version = "..."` under `[project]` (line 3). Do not touch `target-version` (ruff) or `python-version` (ty) — those are Python version pins. Do not edit `__init__.py`; it reads version from `importlib.metadata` automatically.
+**pyproject.toml + uv.lock:** Edit only `version = "..."` under `[project]` (line 3). Do not touch `target-version` (ruff) or `python-version` (ty) — those are Python version pins. Then run `uv lock` so the editable `benchflow` package entry in `uv.lock` matches the new version. Do not edit `__init__.py`; it reads version from `importlib.metadata` automatically.
 
 ---
 
 ## Step 6 — Commit and PR
 
 ```bash
-git add CHANGELOG.md pyproject.toml   # plus any ruff-formatted files from Step 2
+git add CHANGELOG.md pyproject.toml uv.lock   # plus any ruff-formatted files from Step 2
 git commit -m "chore: release v<NEW_VERSION>"
 git push -u origin HEAD
 gh pr create --title "chore: release v<NEW_VERSION>" --body "$(cat <<'EOF'
@@ -108,6 +110,7 @@ See CHANGELOG.md for details.
 - [ ] e2e smoke test passes
 - [ ] CHANGELOG updated
 - [ ] Version bumped in pyproject.toml
+- [ ] uv.lock refreshed
 - [ ] Merge and tag after review
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/benchmarks/run_skillsbench.py
+++ b/benchmarks/run_skillsbench.py
@@ -13,7 +13,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 
 async def main():
     config = sys.argv[1] if len(sys.argv) > 1 else str(
-        Path(__file__).parent / "skillsbench.yaml"
+        Path(__file__).parent / "skillsbench-codex-gpt54.yaml"
     )
     ensure_tasks("skillsbench")
     job = Job.from_yaml(config)

--- a/benchmarks/run_tb2.py
+++ b/benchmarks/run_tb2.py
@@ -1,8 +1,8 @@
 """Run Terminal-Bench 2.0 — downloads tasks if needed, runs via Job.
 
 Usage:
-    python benchmarks/run_tb2.py                          # defaults to tb2_single.yaml
-    python benchmarks/run_tb2.py benchmarks/tb2_multiturn.yaml
+    python benchmarks/run_tb2.py  # defaults to tb2_single-codex-gpt54.yaml
+    python benchmarks/run_tb2.py benchmarks/tb2_multiturn-codex-gpt54.yaml
 """
 
 import asyncio
@@ -18,7 +18,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(mess
 
 async def main():
     config = sys.argv[1] if len(sys.argv) > 1 else str(
-        Path(__file__).parent / "tb2_single.yaml"
+        Path(__file__).parent / "tb2_single-codex-gpt54.yaml"
     )
     ensure_tasks("terminal-bench-2")
     job = Job.from_yaml(config)

--- a/benchmarks/skillsbench-claude-glm5.yaml
+++ b/benchmarks/skillsbench-claude-glm5.yaml
@@ -1,5 +1,5 @@
-tasks_dir: ../.ref/skillsbench/tasks
-jobs_dir: ../jobs/skillsbench-claude-glm51
+tasks_dir: .ref/skillsbench/tasks
+jobs_dir: jobs/skillsbench-claude-glm51
 agent: claude-agent-acp
 model: zai/glm-5.1
 environment: daytona

--- a/benchmarks/skillsbench-codex-gpt54.yaml
+++ b/benchmarks/skillsbench-codex-gpt54.yaml
@@ -1,5 +1,5 @@
-tasks_dir: ../.ref/skillsbench/tasks
-jobs_dir: ../jobs/skillsbench-codex-gpt54
+tasks_dir: .ref/skillsbench/tasks
+jobs_dir: jobs/skillsbench-codex-gpt54
 agent: codex-acp
 model: gpt-5.4
 environment: daytona

--- a/benchmarks/tb2_multiturn-codex-gpt54.yaml
+++ b/benchmarks/tb2_multiturn-codex-gpt54.yaml
@@ -1,5 +1,5 @@
-tasks_dir: ../.ref/terminal-bench-2
-jobs_dir: ../jobs/tb2_multiturn-codex-gpt54
+tasks_dir: .ref/terminal-bench-2
+jobs_dir: jobs/tb2_multiturn-codex-gpt54
 agent: codex-acp
 model: gpt-5.4
 environment: daytona

--- a/benchmarks/tb2_single-codex-gpt54.yaml
+++ b/benchmarks/tb2_single-codex-gpt54.yaml
@@ -1,5 +1,5 @@
-tasks_dir: ../.ref/terminal-bench-2
-jobs_dir: ../jobs/tb2_single-codex-gpt54
+tasks_dir: .ref/terminal-bench-2
+jobs_dir: jobs/tb2_single-codex-gpt54
 agent: codex-acp
 model: gpt-5.4
 environment: daytona

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -107,8 +107,8 @@ The repo ships ready-to-run configs in `benchmarks/` targeting Daytona (`concurr
 **Local Docker config (`my-skillsbench.yaml`)**
 
 ```yaml
-tasks_dir: ../.ref/skillsbench/tasks
-jobs_dir: ../jobs/skillsbench-local
+tasks_dir: .ref/skillsbench/tasks
+jobs_dir: jobs/skillsbench-local
 agent: claude-agent-acp
 model: claude-haiku-4-5-20251001
 environment: docker
@@ -175,8 +175,8 @@ benchflow job --config benchmarks/tb2_multiturn-codex-gpt54.yaml --env docker --
 Or write your own local config. Multi-turn adds a `prompts` list:
 
 ```yaml
-tasks_dir: ../.ref/terminal-bench-2
-jobs_dir: ../jobs/tb2_multiturn-local
+tasks_dir: .ref/terminal-bench-2
+jobs_dir: jobs/tb2_multiturn-local
 agent: claude-agent-acp
 model: claude-haiku-4-5-20251001
 environment: docker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ only-include = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 addopts = "-m 'not live'"
+testpaths = ["tests"]
 markers = [
     "live: requires real Anthropic API and Docker daemon (run with -m live)",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "pre-commit>=3.7",
-    "pytest>=8.0",
+    "pytest>=9.0.3",
     "pytest-asyncio>=0.24.0",
     "ruff>=0.7.0",
     "ty>=0.0.1a1",

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -243,14 +243,14 @@ class Job:
 
         # Detect format: Harbor uses "agents" + "datasets", benchflow uses "agent"
         if "agents" in raw or "datasets" in raw:
-            return cls._from_harbor_yaml(raw, path.parent, **kwargs)
-        return cls._from_native_yaml(raw, path.parent, **kwargs)
+            return cls._from_harbor_yaml(raw, **kwargs)
+        return cls._from_native_yaml(raw, **kwargs)
 
     @classmethod
-    def _from_native_yaml(cls, raw: dict, base_dir: Path, **kwargs) -> "Job":
+    def _from_native_yaml(cls, raw: dict, **kwargs) -> "Job":
         """Parse benchflow-native YAML."""
-        tasks_dir = base_dir / raw["tasks_dir"]
-        jobs_dir = base_dir / raw.get("jobs_dir", "jobs")
+        tasks_dir = Path(raw["tasks_dir"])
+        jobs_dir = Path(raw.get("jobs_dir", "jobs"))
 
         # Parse prompts — YAML null becomes Python None
         prompts = raw.get("prompts")
@@ -268,9 +268,7 @@ class Job:
             prompts=prompts,
             agent_env=agent_env_raw,
             retry=RetryConfig(max_retries=raw.get("max_retries", 2)),
-            skills_dir=str(base_dir / raw["skills_dir"])
-            if raw.get("skills_dir")
-            else None,
+            skills_dir=str(Path(raw["skills_dir"])) if raw.get("skills_dir") else None,
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             exclude_tasks=exclude,
@@ -278,7 +276,7 @@ class Job:
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
     @classmethod
-    def _from_harbor_yaml(cls, raw: dict, base_dir: Path, **kwargs) -> "Job":
+    def _from_harbor_yaml(cls, raw: dict, **kwargs) -> "Job":
         """Parse Harbor-compatible YAML."""
         # Agent
         agents = raw.get("agents", [{}])
@@ -306,20 +304,20 @@ class Job:
 
         # Datasets
         datasets = raw.get("datasets", [{}])
-        tasks_dir = base_dir / datasets[0].get("path", "tasks")
+        tasks_dir = Path(datasets[0].get("path", "tasks"))
 
         # Orchestrator
         orch = raw.get("orchestrator", {})
         concurrency = orch.get("n_concurrent_trials", 4)
 
-        jobs_dir = base_dir / raw.get("jobs_dir", "jobs")
+        jobs_dir = Path(raw.get("jobs_dir", "jobs"))
         max_retries = (
             raw.get("n_attempts", 1) - 1
         )  # Harbor n_attempts includes first try
 
         # Skills dir (shared with benchflow-native format)
         skills_dir_raw = raw.get("skills_dir")
-        skills_dir = str(base_dir / skills_dir_raw) if skills_dir_raw else None
+        skills_dir = str(Path(skills_dir_raw)) if skills_dir_raw else None
         sandbox_user = raw.get("sandbox_user", "agent")
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
 

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,5 +1,7 @@
 """Tests for YAML job config loading."""
 
+from pathlib import Path
+
 import pytest
 
 from benchflow.job import Job
@@ -68,7 +70,8 @@ def test_from_native_yaml(native_yaml):
     assert cfg.concurrency == 32
     assert cfg.retry.max_retries == 1
     assert cfg.prompts == [None, "Review your solution."]
-    assert job._tasks_dir.name == "tasks"
+    assert job._tasks_dir == Path("tasks")
+    assert job._jobs_dir == Path("output")
 
 
 def test_from_harbor_yaml(harbor_yaml):
@@ -82,7 +85,8 @@ def test_from_harbor_yaml(harbor_yaml):
     assert cfg.concurrency == 8
     assert cfg.retry.max_retries == 1  # n_attempts=2 → max_retries=1
     assert cfg.agent_env.get("ANTHROPIC_API_KEY") == "test-key"
-    assert job._tasks_dir.name == "tasks"
+    assert job._tasks_dir == Path("tasks")
+    assert job._jobs_dir == Path("output")
 
 
 def test_from_harbor_yaml_defaults(tmp_path):
@@ -104,6 +108,8 @@ datasets:
     assert cfg.agent == "pi-acp"
     assert cfg.environment == "docker"
     assert cfg.concurrency == 4
+    assert job._tasks_dir == Path("tasks")
+    assert job._jobs_dir == Path("jobs")
 
 
 def test_native_yaml_with_skills_dir(tmp_path):
@@ -122,7 +128,44 @@ skills_dir: my-skills
 """)
 
     job = Job.from_yaml(config)
-    assert job._config.skills_dir == str(tmp_path / "my-skills")
+    assert job._config.skills_dir == "my-skills"
+
+
+def test_native_yaml_paths_are_cwd_relative(tmp_path):
+    """Relative YAML paths are not rebased to the config file directory."""
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    config = config_dir / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+jobs_dir: jobs/my-run
+skills_dir: skills
+""")
+
+    job = Job.from_yaml(config)
+    assert job._tasks_dir == Path("tasks")
+    assert job._jobs_dir == Path("jobs/my-run")
+    assert job._config.skills_dir == "skills"
+
+
+def test_harbor_yaml_paths_are_cwd_relative(tmp_path):
+    """Harbor relative paths match CLI and SDK path behavior."""
+    config_dir = tmp_path / "configs"
+    config_dir.mkdir()
+    config = config_dir / "config.yaml"
+    config.write_text("""
+jobs_dir: jobs/my-run
+skills_dir: skills
+agents:
+  - name: pi-acp
+datasets:
+  - path: tasks
+""")
+
+    job = Job.from_yaml(config)
+    assert job._tasks_dir == Path("tasks")
+    assert job._jobs_dir == Path("jobs/my-run")
+    assert job._config.skills_dir == "skills"
 
 
 def test_native_yaml_without_skills_dir(native_yaml):
@@ -143,8 +186,9 @@ def _make_tasks(tmp_path, names=("task-a", "task-b", "task-c")):
 
 
 class TestNativeYamlNewFields:
-    def test_exclude_parsed(self, tmp_path):
+    def test_exclude_parsed(self, tmp_path, monkeypatch):
         _make_tasks(tmp_path)
+        monkeypatch.chdir(tmp_path)
         config = tmp_path / "config.yaml"
         config.write_text("""
 tasks_dir: tasks

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },
@@ -205,7 +205,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0" },
@@ -2102,17 +2102,18 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "8.3.5"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
     { name = "iniconfig" },
     { name = "packaging" },
     { name = "pluggy" },
+    { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891, upload-time = "2025-03-02T12:54:54.503Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634, upload-time = "2025-03-02T12:54:52.069Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Resolve YAML `tasks_dir`, `jobs_dir`, and `skills_dir` relative to the current working directory for both native and Harbor configs.
- Update benchmark configs/docs and benchmark runner defaults for the new CWD-relative behavior.
- Bump pytest to 9.0.3 for Dependabot alert #119 and document uv.lock release handling.
- Limit default pytest collection to `tests/` so lab fixtures are not collected by bare pytest.

Closes #135.

## Verification
- `uv run pytest tests -q` -> 477 passed, 1 deselected
- `uv run ruff check src tests benchmarks docs` -> passed
- `uv lock --check` -> passed
- `uv run pytest -q` -> 477 passed, 1 deselected