### PR TITLE
fix: redirect oracle output to container log

### DIFF
--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -90,6 +90,7 @@ Critical invariants
 import asyncio
 import json
 import logging
+import shlex
 from datetime import datetime
 from pathlib import Path
 
@@ -320,26 +321,33 @@ class SDK:
         logger.info("Oracle mode: running solution/solve.sh")
         if not (task_path / "solution" / "solve.sh").exists():
             raise FileNotFoundError(f"Oracle requires solution/solve.sh: {task_path}")
+        await env.exec("chmod +x /solution/solve.sh", user="root", timeout_sec=10)
         if sandbox_user:
+            oracle_cmd = "DEBIAN_FRONTEND=noninteractive /solution/solve.sh"
             cmd = (
-                f"chmod +x /solution/solve.sh && "
-                f"su -s /bin/bash {sandbox_user} -c /solution/solve.sh"
-                f" 2>&1 | tee /logs/agent/oracle.txt"
+                f"su -s /bin/bash {shlex.quote(sandbox_user)} "
+                f"-c {shlex.quote(oracle_cmd)}"
             )
         else:
-            cmd = (
-                "chmod +x /solution/solve.sh && "
-                "/solution/solve.sh 2>&1 | tee /logs/agent/oracle.txt"
-            )
-        result = await env.exec(cmd, timeout_sec=timeout)
+            cmd = "/solution/solve.sh"
+        result = await env.exec(
+            f"{cmd} > /logs/agent/oracle.txt 2>&1",
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+            timeout_sec=timeout,
+        )
         if result.return_code != 0:
             logger.warning(f"Oracle solve.sh exited with rc={result.return_code}")
+        preview = await env.exec(
+            f"tail -c {shlex.quote(str(_DIAG_TRUNCATE))} /logs/agent/oracle.txt 2>/dev/null || true",
+            user="root",
+            timeout_sec=10,
+        )
         trajectory = [
             {
                 "type": "oracle",
                 "command": "solution/solve.sh",
                 "return_code": result.return_code,
-                "stdout": (result.stdout or "")[:_DIAG_TRUNCATE],
+                "stdout": (preview.stdout or "")[:_DIAG_TRUNCATE],
             }
         ]
         return trajectory, "oracle"

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,0 +1,63 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _oracle_env():
+    env = MagicMock()
+
+    async def exec_side_effect(cmd, **kwargs):
+        if "tail -c" in cmd:
+            return MagicMock(return_code=0, stdout="oracle preview")
+        return MagicMock(return_code=0, stdout="")
+
+    env.exec = AsyncMock(side_effect=exec_side_effect)
+    return env
+
+
+@pytest.mark.asyncio
+async def test_run_oracle_redirects_to_container_log(tmp_path):
+    from benchflow.sdk import SDK
+
+    solve = tmp_path / "solution" / "solve.sh"
+    solve.parent.mkdir()
+    solve.write_text("#!/bin/sh\necho ok\n")
+    env = _oracle_env()
+
+    trajectory, agent_name = await SDK()._run_oracle(env, tmp_path, timeout=123)
+
+    calls = env.exec.call_args_list
+    solve_call = calls[1]
+    assert solve_call.args[0] == "/solution/solve.sh > /logs/agent/oracle.txt 2>&1"
+    assert "tee" not in solve_call.args[0]
+    assert solve_call.kwargs["env"] == {"DEBIAN_FRONTEND": "noninteractive"}
+    assert solve_call.kwargs["timeout_sec"] == 123
+    assert trajectory == [
+        {
+            "type": "oracle",
+            "command": "solution/solve.sh",
+            "return_code": 0,
+            "stdout": "oracle preview",
+        }
+    ]
+    assert agent_name == "oracle"
+
+
+@pytest.mark.asyncio
+async def test_run_oracle_redirects_sandbox_user_output(tmp_path):
+    from benchflow.sdk import SDK
+
+    solve = tmp_path / "solution" / "solve.sh"
+    solve.parent.mkdir()
+    solve.write_text("#!/bin/sh\necho ok\n")
+    env = _oracle_env()
+
+    await SDK()._run_oracle(env, tmp_path, timeout=123, sandbox_user="agent")
+
+    solve_cmd = env.exec.call_args_list[1].args[0]
+    assert solve_cmd == (
+        "su -s /bin/bash agent -c "
+        "'DEBIAN_FRONTEND=noninteractive /solution/solve.sh' "
+        "> /logs/agent/oracle.txt 2>&1"
+    )
+    assert "tee" not in solve_cmd


### PR DESCRIPTION
## Summary
- redirect oracle solve output to /logs/agent/oracle.txt instead of streaming through tee
- set DEBIAN_FRONTEND=noninteractive for oracle runs
- keep a bounded trajectory preview by tailing the local oracle log after execution

## Context
Part of #137: Bug 1, oracle tee-stream slowdown on apt-heavy tasks.

## Tests
- uv run --extra dev pytest -q tests/test_oracle.py