### PR TITLE
fix: preserve trusted verifier path entries

### DIFF
--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -325,6 +325,124 @@ VERIFIER_ENV: dict[str, str] = {
     "CELERY_CONFIG_MODULE": "",
 }
 
+_SAFE_VERIFIER_PATH = VERIFIER_ENV["PATH"]
+_SAFE_VERIFIER_PATH_PARTS = tuple(_SAFE_VERIFIER_PATH.split(":"))
+_RUNTIME_PATH_PREFIXES = ("/tmp", "/var/tmp", "/logs", "/testbed")
+
+
+def _under_path(path: str, prefix: str) -> bool:
+    prefix = prefix.rstrip("/")
+    return path == prefix or path.startswith(f"{prefix}/")
+
+
+def _blocked_verifier_path_prefixes(
+    sandbox_user: str | None, workspace: str | None
+) -> tuple[str, ...]:
+    """Paths that must never be preserved as verifier PATH extras."""
+    prefixes = list(_RUNTIME_PATH_PREFIXES)
+    if workspace:
+        prefixes.append(workspace)
+    if sandbox_user:
+        prefixes.append(f"/home/{sandbox_user}")
+    return tuple(dict.fromkeys(prefixes))
+
+
+def _merge_trusted_verifier_path(extras: list[str]) -> str:
+    """Prepend validated image PATH entries to the verifier allowlist."""
+    kept: list[str] = []
+    seen: set[str] = set(_SAFE_VERIFIER_PATH_PARTS)
+    for entry in extras:
+        if entry and entry not in seen:
+            seen.add(entry)
+            kept.append(entry)
+    return ":".join([*kept, *_SAFE_VERIFIER_PATH_PARTS])
+
+
+_TRUSTED_PATH_EXTRAS_SCRIPT = r"""
+import json
+import os
+import stat
+import sys
+
+raw_path = json.loads(sys.argv[1])
+safe_parts = set(json.loads(sys.argv[2]))
+blocked_prefixes = tuple(json.loads(sys.argv[3]))
+
+
+def under_path(path, prefix):
+    prefix = prefix.rstrip("/")
+    return path == prefix or path.startswith(prefix + "/")
+
+
+trusted = []
+seen = set(safe_parts)
+for entry in raw_path.split(":"):
+    entry = entry.strip()
+    if (
+        not entry
+        or entry in seen
+        or not entry.startswith("/")
+        or "\x00" in entry
+        or "\n" in entry
+    ):
+        continue
+    seen.add(entry)
+    try:
+        real = os.path.realpath(entry)
+        st = os.stat(real)
+    except OSError:
+        continue
+    if not stat.S_ISDIR(st.st_mode):
+        continue
+    if any(under_path(real, prefix) for prefix in blocked_prefixes):
+        continue
+    if st.st_uid != 0:
+        continue
+    if st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        continue
+    trusted.append(entry)
+print(json.dumps(trusted))
+""".strip()
+
+
+def _trusted_path_extras_cmd(raw_path: str, blocked_prefixes: tuple[str, ...]) -> str:
+    """Build the container-side command that validates verifier PATH extras."""
+    return (
+        f"python3 -c {shlex.quote(_TRUSTED_PATH_EXTRAS_SCRIPT)} "
+        f"{shlex.quote(_json.dumps(raw_path))} "
+        f"{shlex.quote(_json.dumps(_SAFE_VERIFIER_PATH_PARTS))} "
+        f"{shlex.quote(_json.dumps(blocked_prefixes))}"
+    )
+
+
+async def _trusted_verifier_path(
+    env, sandbox_user: str | None, workspace: str | None
+) -> str:
+    """Return verifier PATH with trusted image extras preserved.
+
+    Dockerfile PATH additions are accepted only after container-side stat
+    checks prove they are root-owned directories and not group/world writable.
+    Runtime locations and sandbox-user writable locations stay excluded.
+    """
+    path_result = await env.exec("printenv PATH", user="root", timeout_sec=10)
+    raw_path = path_result.stdout or ""
+    if not raw_path.strip():
+        return _SAFE_VERIFIER_PATH
+    cmd = _trusted_path_extras_cmd(
+        raw_path, _blocked_verifier_path_prefixes(sandbox_user, workspace)
+    )
+    result = await env.exec(cmd, user="root", timeout_sec=10)
+    try:
+        extras = _json.loads(result.stdout or "[]")
+    except _json.JSONDecodeError:
+        logger.warning("Could not parse trusted verifier PATH extras; using safe PATH")
+        extras = []
+    if not isinstance(extras, list):
+        logger.warning("Invalid trusted verifier PATH extras; using safe PATH")
+        extras = []
+    return _merge_trusted_verifier_path([e for e in extras if isinstance(e, str)])
+
+
 # Wipe and recreate /logs/verifier/ before the verifier runs.
 # rm -rf severs hardlinks, removes symlink replacements, and eliminates
 # variant filenames/subdirs the agent may have pre-staged.
@@ -424,12 +542,16 @@ async def harden_before_verify(
         )
     await env.exec(CLEANUP_CMD, user="root", timeout_sec=10)
 
+    hardened_path = await _trusted_verifier_path(env, sandbox_user, workspace)
+
     verifier_env = dict(VERIFIER_ENV)
     if task.config.verifier.env:
         verifier_env.update(task.config.verifier.env)
     # Hard security invariants — re-pin after task-env merge so a task cannot
-    # strip -c /dev/null / --confcutdir, re-enable entry-point plugin loading,
-    # or inject code via breakpoint()/coverage/Django/Celery startup hooks.
+    # replace PATH, strip -c /dev/null / --confcutdir, re-enable entry-point
+    # plugin loading, or inject code via breakpoint()/coverage/Django/Celery
+    # startup hooks.
+    verifier_env["PATH"] = hardened_path
     verifier_env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     verifier_env["PYTHONBREAKPOINT"] = "0"
     verifier_env["COVERAGE_PROCESS_START"] = ""

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -143,7 +143,9 @@ class TestHardenSequence:
 
     @pytest.mark.asyncio
     async def test_task_env_overrides_win(self, harness):
-        """Task-level verifier env vars override VERIFIER_ENV defaults."""
+        """Task-level verifier env vars override defaults except pinned invariants."""
+        from benchflow._sandbox import VERIFIER_ENV
+
         sdk, env, task, tp = harness
         task.config.verifier.env = {"PATH": "/custom/bin", "MY_VAR": "hello"}
         mock_v = MagicMock()
@@ -151,7 +153,7 @@ class TestHardenSequence:
         with patch("benchflow.sdk.Verifier", return_value=mock_v):
             await sdk._verify(env, task, tp, {})
         injected = task.config.verifier.env
-        assert injected["PATH"] == "/custom/bin"
+        assert injected["PATH"] == VERIFIER_ENV["PATH"]
         assert injected["MY_VAR"] == "hello"
         assert injected["PYTHONPATH"] == ""  # non-overridden defaults kept
 
@@ -619,6 +621,113 @@ class TestVerifierEnv:
         from benchflow._sandbox import VERIFIER_ENV
 
         assert VERIFIER_ENV.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
+
+    def test_trusted_path_merge_keeps_validated_extras(self):
+        """Validated image PATH entries are prepended once to the safe base."""
+        from benchflow._sandbox import _merge_trusted_verifier_path
+
+        merged = _merge_trusted_verifier_path(
+            [
+                "/root/.local/bin",
+                "/opt/tool/bin",
+                "/usr/local/bin",
+                "/root/.local/bin",
+            ]
+        )
+
+        assert merged == (
+            "/root/.local/bin:/opt/tool/bin:"
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
+
+    def test_blocked_path_prefixes_include_runtime_and_sandbox_paths(self):
+        """Runtime, workspace, and sandbox-user dirs are excluded from PATH extras."""
+        from benchflow._sandbox import _blocked_verifier_path_prefixes
+
+        blocked = _blocked_verifier_path_prefixes("agent", "/workspace")
+
+        assert "/tmp" in blocked
+        assert "/var/tmp" in blocked
+        assert "/logs" in blocked
+        assert "/testbed" in blocked
+        assert "/workspace" in blocked
+        assert "/home/agent" in blocked
+
+    def test_trusted_path_extras_cmd_passes_json_args(self):
+        """Container-side PATH validation receives JSON-encoded policy inputs."""
+        import shlex
+
+        from benchflow._sandbox import _trusted_path_extras_cmd
+
+        cmd = _trusted_path_extras_cmd("/root/.local/bin:/tmp/bin", ("/tmp",))
+        parts = shlex.split(cmd)
+
+        assert parts[:2] == ["python3", "-c"]
+        assert json.loads(parts[3]) == "/root/.local/bin:/tmp/bin"
+        assert "/usr/local/bin" in json.loads(parts[4])
+        assert json.loads(parts[5]) == ["/tmp"]
+
+    @pytest.mark.asyncio
+    async def test_harden_preserves_trusted_container_path_extras(self):
+        """Verifier PATH includes trusted image-level additions from the container."""
+        from benchflow._sandbox import harden_before_verify
+
+        def side_effect(cmd, **kwargs):
+            if cmd == "printenv PATH":
+                return MagicMock(
+                    stdout="/root/.local/bin:/tmp/pwn:/usr/local/bin:/opt/uv/bin\n",
+                    stderr="",
+                    exit_code=0,
+                )
+            if cmd.startswith("python3 -c"):
+                return MagicMock(
+                    stdout='["/root/.local/bin", "/opt/uv/bin"]',
+                    stderr="",
+                    exit_code=0,
+                )
+            return MagicMock(stdout="", stderr="", exit_code=0)
+
+        task = _make_task()
+        await harden_before_verify(
+            _make_env(side_effect=side_effect), task, sandbox_user=None
+        )
+
+        assert task.config.verifier.env["PATH"] == (
+            "/root/.local/bin:/opt/uv/bin:"
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
+
+    @pytest.mark.asyncio
+    async def test_task_env_path_cannot_override_hardened_path(self):
+        """Task env keeps ordinary vars but cannot replace verifier PATH."""
+        from benchflow._sandbox import harden_before_verify
+
+        def side_effect(cmd, **kwargs):
+            if cmd == "printenv PATH":
+                return MagicMock(
+                    stdout="/root/.local/bin:/tmp/pwn:/usr/local/bin\n",
+                    stderr="",
+                    exit_code=0,
+                )
+            if cmd.startswith("python3 -c"):
+                return MagicMock(
+                    stdout='["/root/.local/bin"]',
+                    stderr="",
+                    exit_code=0,
+                )
+            return MagicMock(stdout="", stderr="", exit_code=0)
+
+        task = _make_task()
+        task.config.verifier.env = {"PATH": "/custom/bin", "MY_VAR": "hello"}
+        await harden_before_verify(
+            _make_env(side_effect=side_effect), task, sandbox_user="agent"
+        )
+
+        assert task.config.verifier.env["PATH"] == (
+            "/root/.local/bin:"
+            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+        )
+        assert task.config.verifier.env["MY_VAR"] == "hello"
 
     @pytest.mark.asyncio
     async def test_plugin_autoload_disabled_survives_task_env_override(self):


### PR DESCRIPTION
## Summary
- preserve trusted image/Dockerfile PATH entries for verifier execution
- validate PATH extras inside the container before preserving them
- reject runtime or agent-controlled path prefixes and group/world-writable dirs
- re-pin PATH after task env merge so task config cannot bypass verifier hardening

## Context
Part of #137: Bug 3, verifier PATH scrub dropping Dockerfile compile-time entries such as /root/.local/bin.

## Tests
- uv run --extra dev pytest -q tests/test_sandbox_hardening.py
- uv run --extra dev ruff check src/benchflow/_sandbox.py tests/test_sandbox_hardening.py
- uv run --extra dev pytest -q