### PR TITLE
fix: grant sandbox user write access to /logs/artifacts

### DIFF
--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -249,6 +249,8 @@ async def _seed_verifier_workspace(
 
     Called once after setup_sandbox_user, before agent launch.
     - Locks /logs/ parent so sandbox_user cannot rename /logs/verifier/ out.
+    - Grants sandbox_user write access to /logs/agent and /logs/artifacts
+      so tasks that write answers there (e.g. infinitebench) work.
     - Seeds /testbed_verify as a root-owned readable copy of the workspace
       so harden_before_verify can rsync it back to restore ALL source files
       to pre-agent canonical state before the verifier runs.

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -242,7 +242,9 @@ async def _restore_build_config(env, workspace: str) -> None:
         await env.exec(cmd, user="root")
 
 
-async def _seed_verifier_workspace(env, workspace: str = "/testbed") -> None:
+async def _seed_verifier_workspace(
+    env, workspace: str = "/testbed", sandbox_user: str | None = None
+) -> None:
     """Seed /testbed_verify as a pre-agent snapshot for the full workspace restore.
 
     Called once after setup_sandbox_user, before agent launch.
@@ -259,6 +261,13 @@ async def _seed_verifier_workspace(env, workspace: str = "/testbed") -> None:
     cmds = [
         # Lock /logs/ parent: sandbox_user cannot rename /logs/verifier/ out.
         "chown root:root /logs && chmod 755 /logs",
+        # Grant sandbox user write access to agent-writable log dirs so tasks
+        # that write answers to /logs/artifacts/ (e.g. infinitebench) work.
+        *(
+            [f"chown {sandbox_user}:{sandbox_user} /logs/agent /logs/artifacts"]
+            if sandbox_user
+            else []
+        ),
         # Seed root-owned readable workspace copy from the actual workspace
         # (may differ from /testbed for tasks with WORKDIR=/app etc.).
         f"rm -rf /testbed_verify && cp -a {shlex.quote(workspace)} /testbed_verify && "

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -522,7 +522,9 @@ class SDK:
                 if sandbox_user:
                     await setup_sandbox_user(env, sandbox_user, workspace=agent_cwd)
                     await _snapshot_build_config(env, workspace=agent_cwd)
-                    await _seed_verifier_workspace(env, workspace=agent_cwd, sandbox_user=sandbox_user)
+                    await _seed_verifier_workspace(
+                        env, workspace=agent_cwd, sandbox_user=sandbox_user
+                    )
                 await lockdown_paths(env, effective_locked)
                 await env.exec(
                     "git config --global --add safe.directory "
@@ -558,7 +560,9 @@ class SDK:
                     # before the agent launches — both have ordering invariants
                     # that require a clean pre-agent workspace state.
                     await _snapshot_build_config(env, workspace=agent_cwd)
-                    await _seed_verifier_workspace(env, workspace=agent_cwd, sandbox_user=sandbox_user)
+                    await _seed_verifier_workspace(
+                        env, workspace=agent_cwd, sandbox_user=sandbox_user
+                    )
 
                 await deploy_skills(
                     env,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -522,7 +522,7 @@ class SDK:
                 if sandbox_user:
                     await setup_sandbox_user(env, sandbox_user, workspace=agent_cwd)
                     await _snapshot_build_config(env, workspace=agent_cwd)
-                    await _seed_verifier_workspace(env, workspace=agent_cwd)
+                    await _seed_verifier_workspace(env, workspace=agent_cwd, sandbox_user=sandbox_user)
                 await lockdown_paths(env, effective_locked)
                 await env.exec(
                     "git config --global --add safe.directory "
@@ -558,7 +558,7 @@ class SDK:
                     # before the agent launches — both have ordering invariants
                     # that require a clean pre-agent workspace state.
                     await _snapshot_build_config(env, workspace=agent_cwd)
-                    await _seed_verifier_workspace(env, workspace=agent_cwd)
+                    await _seed_verifier_workspace(env, workspace=agent_cwd, sandbox_user=sandbox_user)
 
                 await deploy_skills(
                     env,

--- a/tests/test_sandbox_verifier_workspace.py
+++ b/tests/test_sandbox_verifier_workspace.py
@@ -134,6 +134,42 @@ async def test_harden_restore_fallback_uses_shutil():
     )
 
 
+@pytest.mark.asyncio
+async def test_seed_verifier_workspace_chowns_agent_log_dirs():
+    """/logs/agent and /logs/artifacts are chowned to sandbox_user when provided."""
+    from benchflow._sandbox import _seed_verifier_workspace
+
+    env = _make_env()
+    await _seed_verifier_workspace(env, sandbox_user="testuser")
+
+    pairs = _cmds(env)
+    match = next(
+        (
+            call
+            for cmd, call in pairs
+            if "chown testuser:testuser /logs/agent /logs/artifacts" in cmd
+        ),
+        None,
+    )
+    assert match is not None, (
+        "expected chown testuser:testuser /logs/agent /logs/artifacts"
+    )
+
+
+@pytest.mark.asyncio
+async def test_seed_verifier_workspace_no_chown_without_sandbox_user():
+    """No agent-log chown when sandbox_user is not set."""
+    from benchflow._sandbox import _seed_verifier_workspace
+
+    env = _make_env()
+    await _seed_verifier_workspace(env)
+
+    cmds_list = [c.args[0] for c in env.exec.call_args_list]
+    assert not any("chown" in c and "/logs/agent" in c for c in cmds_list), (
+        "should not chown /logs/agent without sandbox_user"
+    )
+
+
 def test_oracle_branch_setup_calls():
     """Regression guard: oracle mode must wire up all pre-verify setup calls.
 


### PR DESCRIPTION
## Summary

- `/logs/artifacts/` was root-owned and unwritable by the sandbox user during agent execution, causing all trials to score 0 for tasks that write answers there (e.g. infinitebench)
- Added `sandbox_user` param to `_seed_verifier_workspace()` and chown `/logs/agent` + `/logs/artifacts` to the sandbox user after locking the `/logs/` parent
- Added tests for both the chown-present and chown-absent cases

Closes #148

## Test plan

- [x] `pytest tests/test_sandbox_verifier_workspace.py -v` — 7/7 pass (2 new)
- [x] `pytest tests/ -x` — 494 pass
- [x] `ty check src/` — clean
- [ ] Live test with sandbox_user + infinitebench adapter to confirm agent can write to `/logs/artifacts/`