### PR TITLE
fix: preserve provider prefix in Harbor YAML model parsing

### DIFF
--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -283,11 +283,8 @@ class Job:
         agent_cfg = agents[0] if agents else {}
         agent_name = agent_cfg.get("name", DEFAULT_AGENT)
 
-        # Model — Harbor uses "anthropic/model-name" format
-        model = agent_cfg.get("model_name", "")
-        if "/" in model:
-            model = model.split("/", 1)[1]
-        model = model or DEFAULT_MODEL
+        # Model — keep provider prefix intact for downstream resolution
+        model = agent_cfg.get("model_name", "") or DEFAULT_MODEL
 
         # Environment
         env_cfg = raw.get("environment", {})

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -80,13 +80,32 @@ def test_from_harbor_yaml(harbor_yaml):
     cfg = job._config
 
     assert cfg.agent == "claude-agent-acp"
-    assert cfg.model == "claude-haiku-4-5-20251001"
+    assert cfg.model == "anthropic/claude-haiku-4-5-20251001"
     assert cfg.environment == "daytona"
     assert cfg.concurrency == 8
     assert cfg.retry.max_retries == 1  # n_attempts=2 → max_retries=1
     assert cfg.agent_env.get("ANTHROPIC_API_KEY") == "test-key"
     assert job._tasks_dir == Path("tasks")
     assert job._jobs_dir == Path("output")
+
+
+def test_harbor_yaml_preserves_provider_prefix(tmp_path):
+    """Provider prefix must survive _from_harbor_yaml for downstream resolution."""
+    tasks = tmp_path / "tasks" / "task-a"
+    tasks.mkdir(parents=True)
+    (tasks / "task.toml").write_text('version = "1.0"')
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agents:
+  - name: pi-acp
+    model_name: vllm/Qwen/Qwen3.5-35B-A3B
+datasets:
+  - path: tasks
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.model == "vllm/Qwen/Qwen3.5-35B-A3B"
 
 
 def test_from_harbor_yaml_defaults(tmp_path):


### PR DESCRIPTION
## Summary
- Removed naive `split("/", 1)[1]` in `_from_harbor_yaml` that stripped provider prefixes (e.g. `vllm/`) before the provider system could resolve them
- This caused `vllm/Qwen/Qwen3.5-35B-A3B` to lose both the provider prefix and the HuggingFace org, producing the wrong model ID downstream

## Test plan
- [x] Existing `test_from_harbor_yaml` updated to expect full `anthropic/claude-haiku-4-5-20251001` in `config.model`
- [x] New `test_harbor_yaml_preserves_provider_prefix` covers the vllm multi-slash case (`vllm/Qwen/Qwen3.5-35B-A3B`)
- [x] All 12 yaml config tests pass

Fixes #151