### PR TITLE
fix: preserve provider prefix in set_model for pi-acp

### DIFF
--- a/src/benchflow/_acp_run.py
+++ b/src/benchflow/_acp_run.py
@@ -25,6 +25,7 @@ from benchflow._sandbox import build_priv_drop_cmd
 from benchflow._trajectory import _capture_session_trajectory
 from benchflow.acp.client import ACPClient
 from benchflow.acp.container_transport import ContainerTransport
+from benchflow.agents.registry import AgentConfig
 from benchflow.process import DaytonaProcess, DockerProcess
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,7 @@ async def connect_acp(
     trial_dir: Path,
     environment: str,
     agent_cwd: str,
+    agent_cfg: AgentConfig | None = None,
 ) -> tuple[ACPClient, object, str]:
     """Create ACP transport, connect, init session, set model. Return (client, session, agent_name)."""
     # Resolve agent binary path for non-docker environments
@@ -83,9 +85,7 @@ async def connect_acp(
 
     if model:
         from benchflow.agents.providers import strip_provider_prefix
-        from benchflow.agents.registry import AGENTS
 
-        agent_cfg = AGENTS.get(agent)
         if agent_cfg and agent_cfg.preserve_provider_prefix:
             acp_model_id = model
         else:

--- a/src/benchflow/_acp_run.py
+++ b/src/benchflow/_acp_run.py
@@ -83,8 +83,13 @@ async def connect_acp(
 
     if model:
         from benchflow.agents.providers import strip_provider_prefix
+        from benchflow.agents.registry import AGENTS
 
-        acp_model_id = strip_provider_prefix(model)
+        agent_cfg = AGENTS.get(agent)
+        if agent_cfg and agent_cfg.preserve_provider_prefix:
+            acp_model_id = model
+        else:
+            acp_model_id = strip_provider_prefix(model)
         try:
             await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
             logger.info(f"Model set to: {acp_model_id} (from {model})")

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -129,6 +129,12 @@ class AgentConfig:
     home_dirs: list[str] = field(default_factory=list)
     # Extra dot-dirs under $HOME to copy to sandbox user (for dirs not
     # derivable from skill_paths or credential_files, e.g. ".openclaw").
+    preserve_provider_prefix: bool = False
+    # When True, ACP set_model receives the full model string including the
+    # BenchFlow provider prefix (e.g. "vllm/Qwen/Qwen3.5-35B-A3B").
+    # When False (default), the prefix is stripped first (e.g. "Qwen/Qwen3.5-35B-A3B").
+    # Agents whose set_model handler uses "provider/model" routing (e.g. pi-acp)
+    # need the prefix to avoid misparsing HuggingFace model IDs that contain "/".
     subscription_auth: SubscriptionAuth | None = None
     # Host CLI login that can substitute for an API key (e.g. OAuth tokens
     # from `claude login`). Detected automatically; API keys take precedence.
@@ -168,6 +174,7 @@ AGENTS: dict[str, AgentConfig] = {
     "pi-acp": AgentConfig(
         name="pi-acp",
         description="Pi agent via ACP",
+        preserve_provider_prefix=True,
         skill_paths=["$HOME/.pi/agent/skills", "$HOME/.agents/skills"],
         install_cmd=(
             f"{_NODE_INSTALL} && "

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -586,6 +586,7 @@ class SDK:
                     trial_dir,
                     environment,
                     agent_cwd,
+                    agent_cfg=agent_cfg,
                 )
                 timing["agent_setup"] = (datetime.now() - t_agent_setup).total_seconds()
                 t_agent_exec = datetime.now()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2,6 +2,7 @@
 
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -9,6 +10,7 @@ from benchflow.acp.client import ACPClient, ACPError
 from benchflow.acp.session import ACPSession
 from benchflow.acp.transport import StdioTransport
 from benchflow.acp.types import StopReason, ToolCallStatus
+from benchflow.agents.registry import AgentConfig
 
 MOCK_AGENT = str(Path(__file__).parent / "fixtures" / "mock_acp_agent.py")
 MOCK_AGENT_INTERLEAVED = str(
@@ -231,3 +233,100 @@ class TestACPInterleaving:
             assert session.full_message == "done"
         finally:
             await client.close()
+
+
+class TestConnectAcpModelSelection:
+    """Verify connect_acp passes the right model string to set_model."""
+
+    @staticmethod
+    def _make_mocks():
+        mock_session = MagicMock()
+        mock_session.session_id = "s1"
+        mock_init = MagicMock()
+        mock_init.agent_info = None
+
+        mock_acp = AsyncMock(spec=ACPClient)
+        mock_acp.connect = AsyncMock()
+        mock_acp.initialize = AsyncMock(return_value=mock_init)
+        mock_acp.session_new = AsyncMock(return_value=mock_session)
+        mock_acp.set_model = AsyncMock()
+        mock_acp.close = AsyncMock()
+        return mock_acp
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "preserve, model_in, expected_model",
+        [
+            (True, "vllm/Qwen/Qwen3.5-35B-A3B", "vllm/Qwen/Qwen3.5-35B-A3B"),
+            (False, "vllm/Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-35B-A3B"),
+            (False, "zai/glm-5", "glm-5"),
+        ],
+        ids=["preserve-true", "preserve-false-vllm", "preserve-false-zai"],
+    )
+    async def test_model_id_selection(
+        self, preserve, model_in, expected_model, tmp_path
+    ):
+        from benchflow._acp_run import connect_acp
+
+        mock_acp = self._make_mocks()
+        cfg = AgentConfig(
+            name="test-agent",
+            install_cmd="true",
+            launch_cmd="test-agent",
+            preserve_provider_prefix=preserve,
+        )
+
+        mock_env = AsyncMock()
+        with (
+            patch(
+                "benchflow._acp_run.DockerProcess.from_harbor_env",
+                return_value=MagicMock(),
+            ),
+            patch("benchflow._acp_run.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow._acp_run.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="test-agent",
+                agent_launch="test-agent",
+                agent_env={},
+                sandbox_user=None,
+                model=model_in,
+                trial_dir=tmp_path,
+                environment="docker",
+                agent_cwd="/app",
+                agent_cfg=cfg,
+            )
+
+        mock_acp.set_model.assert_awaited_once_with(expected_model)
+
+    @pytest.mark.asyncio
+    async def test_no_agent_cfg_strips_prefix(self, tmp_path):
+        """When agent_cfg is None, prefix is always stripped."""
+        from benchflow._acp_run import connect_acp
+
+        mock_acp = self._make_mocks()
+
+        mock_env = AsyncMock()
+        with (
+            patch(
+                "benchflow._acp_run.DockerProcess.from_harbor_env",
+                return_value=MagicMock(),
+            ),
+            patch("benchflow._acp_run.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow._acp_run.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="unknown-agent",
+                agent_launch="unknown-agent",
+                agent_env={},
+                sandbox_user=None,
+                model="vllm/Qwen/Qwen3.5-35B-A3B",
+                trial_dir=tmp_path,
+                environment="docker",
+                agent_cwd="/app",
+                agent_cfg=None,
+            )
+
+        mock_acp.set_model.assert_awaited_once_with("Qwen/Qwen3.5-35B-A3B")


### PR DESCRIPTION
## Summary

- Add `preserve_provider_prefix` flag to `AgentConfig` (default `False`) to control whether `strip_provider_prefix` is applied before ACP `set_model`
- Set `preserve_provider_prefix=True` for `pi-acp`, whose `set_model` handler splits on the first `/` to extract the provider
- Skip stripping in `_acp_run.py` when the flag is set, so `vllm/Qwen/Qwen3.5-35B-A3B` reaches pi-acp intact instead of being misparsed as `provider=Qwen`

Closes #153

## Test plan

- [x] All 492 unit tests pass (1 pre-existing failure in `test_from_harbor_yaml` unrelated to this change)
- [x] `ty check` passes on modified files
- [ ] Manual verification with pi-acp + vLLM + HuggingFace model ID (e.g. `vllm/Qwen/Qwen3.5-35B-A3B`)