### PR TITLE
fix: make pi-acp multi-protocol so OpenAI-compatible providers work

### DIFF
--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -57,7 +57,10 @@ def setup_provider():
                 existing.setdefault("providers", {}).update(config["providers"])
                 config = existing
             except (json.JSONDecodeError, OSError):
-                pass
+                print(
+                    f"Warning: could not parse {models_path}, overwriting.",
+                    file=sys.stderr,
+                )
         models_path.write_text(json.dumps(config, indent=2))
     else:
         # Anthropic mode — set native env vars that Pi reads directly

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Launch wrapper for pi-acp — bridges BENCHFLOW_PROVIDER_* to Pi config.
+
+Pi natively reads ANTHROPIC_* env vars for Anthropic providers. For
+OpenAI-compatible providers (vLLM, etc.), Pi requires a ``models.json``
+config file at ``~/.pi/agent/models.json`` that declares the provider's
+wire protocol.  This wrapper generates it from BENCHFLOW_PROVIDER_* env
+vars injected by the SDK, then execs ``pi-acp``.
+
+See https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def setup_provider():
+    """Configure Pi for the detected provider protocol."""
+    protocol = os.environ.get("BENCHFLOW_PROVIDER_PROTOCOL", "")
+    base_url = os.environ.get("BENCHFLOW_PROVIDER_BASE_URL", "")
+    api_key = os.environ.get("BENCHFLOW_PROVIDER_API_KEY", "")
+    model = os.environ.get("BENCHFLOW_PROVIDER_MODEL", "")
+    provider_name = os.environ.get("BENCHFLOW_PROVIDER_NAME", "custom")
+
+    if protocol == "openai-completions" and base_url:
+        # Pi uses ~/.pi/agent/models.json to discover non-Anthropic providers.
+        # Register the provider so Pi routes API calls through the OpenAI
+        # Chat Completions wire format instead of Anthropic Messages.
+        config = {
+            "providers": {
+                provider_name: {
+                    "baseUrl": base_url,
+                    "api": "openai-completions",
+                    "apiKey": api_key or "unused",
+                    "models": [
+                        {
+                            "id": model,
+                            "name": model,
+                            "reasoning": False,
+                            "input": ["text"],
+                            "contextWindow": 128000,
+                            "maxTokens": 16384,
+                        }
+                    ],
+                }
+            }
+        }
+        config_dir = Path.home() / ".pi" / "agent"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        models_path = config_dir / "models.json"
+        # Merge with existing config so manually-added providers survive
+        if models_path.exists():
+            try:
+                existing = json.loads(models_path.read_text())
+                existing.setdefault("providers", {}).update(config["providers"])
+                config = existing
+            except (json.JSONDecodeError, OSError):
+                pass
+        models_path.write_text(json.dumps(config, indent=2))
+    else:
+        # Anthropic mode — set native env vars that Pi reads directly
+        if base_url:
+            os.environ.setdefault("ANTHROPIC_BASE_URL", base_url)
+        if api_key:
+            os.environ.setdefault("ANTHROPIC_AUTH_TOKEN", api_key)
+        if model:
+            os.environ.setdefault("ANTHROPIC_MODEL", model)
+
+
+if __name__ == "__main__":
+    setup_provider()
+    os.execvp("pi-acp", ["pi-acp", *sys.argv[1:]])

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -67,6 +67,9 @@ _NODE_INSTALL = (
 # Path to the openclaw ACP shim script
 _OPENCLAW_SHIM = (Path(__file__).parent / "openclaw_acp_shim.py").read_text()
 
+# Path to the Pi launch wrapper (bridges BENCHFLOW_PROVIDER_* → Pi config)
+_PI_LAUNCHER = (Path(__file__).parent / "pi_acp_launcher.py").read_text()
+
 
 @dataclass
 class CredentialFile:
@@ -175,17 +178,26 @@ AGENTS: dict[str, AgentConfig] = {
             "npm install -g @mariozechner/pi-coding-agent@latest >/dev/null 2>&1 ) && "
             "( command -v pi-acp >/dev/null 2>&1 || "
             "npm install -g pi-acp@latest >/dev/null 2>&1 ) && "
-            "command -v pi-acp >/dev/null 2>&1"
+            "command -v pi-acp >/dev/null 2>&1 && "
+            # Ensure python3 for launcher
+            "( command -v python3 >/dev/null 2>&1 || "
+            "(apt-get update -qq && apt-get install -y -qq python3 >/dev/null 2>&1) ) && "
+            # Deploy launch wrapper (bridges BENCHFLOW_PROVIDER_* → Pi config)
+            "cat > /usr/local/bin/pi-acp-launcher <<'LAUNCHEREOF'\n"
+            + _PI_LAUNCHER
+            + "\nLAUNCHEREOF\n"
+            "chmod +x /usr/local/bin/pi-acp-launcher"
         ),
-        launch_cmd="pi-acp",
+        launch_cmd="python3 /usr/local/bin/pi-acp-launcher",
         protocol="acp",
-        requires_env=["ANTHROPIC_API_KEY"],
-        api_protocol="anthropic-messages",
-        env_mapping={
-            "BENCHFLOW_PROVIDER_BASE_URL": "ANTHROPIC_BASE_URL",
-            "BENCHFLOW_PROVIDER_API_KEY": "ANTHROPIC_AUTH_TOKEN",
-            "BENCHFLOW_PROVIDER_MODEL": "ANTHROPIC_MODEL",
-        },
+        requires_env=[],  # inferred from --model at runtime
+        # Pi is multi-protocol: speaks Anthropic natively and OpenAI via
+        # models.json.  Empty lets the provider determine the protocol so
+        # multi-endpoint providers (e.g. zai) route to the right URL.
+        api_protocol="",
+        # env_mapping intentionally empty — the launch wrapper handles
+        # protocol-dependent translation (env vars for Anthropic,
+        # models.json for OpenAI-compatible providers like vLLM).
     ),
     "openclaw": AgentConfig(
         name="openclaw",

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -18,10 +18,10 @@ class TestEnvMappingField:
         assert cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"] == "ANTHROPIC_BASE_URL"
         assert cfg.env_mapping["BENCHFLOW_PROVIDER_API_KEY"] == "ANTHROPIC_AUTH_TOKEN"
 
-    def test_pi_acp_has_mapping(self):
+    def test_pi_acp_no_static_mapping(self):
+        """pi-acp is multi-protocol — launch wrapper handles env translation."""
         cfg = AGENTS["pi-acp"]
-        assert cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"] == "ANTHROPIC_BASE_URL"
-        assert cfg.env_mapping["BENCHFLOW_PROVIDER_API_KEY"] == "ANTHROPIC_AUTH_TOKEN"
+        assert cfg.env_mapping == {}
 
     def test_codex_acp_has_mapping(self):
         cfg = AGENTS["codex-acp"]

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -1,0 +1,128 @@
+"""Tests for pi_acp_launcher.setup_provider — protocol-dependent Pi config."""
+
+import json
+
+import pytest
+
+
+@pytest.fixture()
+def _pi_env(monkeypatch, tmp_path):
+    """Redirect Path.home() and clear BENCHFLOW_PROVIDER_* vars."""
+    monkeypatch.setattr("pathlib.Path.home", staticmethod(lambda: tmp_path))
+    for key in (
+        "BENCHFLOW_PROVIDER_PROTOCOL",
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "BENCHFLOW_PROVIDER_API_KEY",
+        "BENCHFLOW_PROVIDER_MODEL",
+        "BENCHFLOW_PROVIDER_NAME",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_MODEL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.mark.usefixtures("_pi_env")
+class TestSetupProviderOpenAI:
+    """OpenAI-completions path: generates ~/.pi/agent/models.json."""
+
+    def test_writes_models_json(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost:8080/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "test-key")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "Qwen3.5-35B")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "vllm")
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        models_path = tmp_path / ".pi" / "agent" / "models.json"
+        assert models_path.exists()
+        config = json.loads(models_path.read_text())
+        provider = config["providers"]["vllm"]
+        assert provider["api"] == "openai-completions"
+        assert provider["baseUrl"] == "http://localhost:8080/v1"
+        assert provider["apiKey"] == "test-key"
+        assert provider["models"][0]["id"] == "Qwen3.5-35B"
+
+    def test_merges_with_existing_providers(self, monkeypatch, tmp_path):
+        """Manually-added providers survive when a new one is registered."""
+        config_dir = tmp_path / ".pi" / "agent"
+        config_dir.mkdir(parents=True)
+        existing = {
+            "providers": {
+                "other": {
+                    "baseUrl": "http://other:9000/v1",
+                    "api": "openai-completions",
+                    "apiKey": "k",
+                    "models": [{"id": "m1", "name": "m1"}],
+                }
+            }
+        }
+        (config_dir / "models.json").write_text(json.dumps(existing))
+
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost:8080/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "new-model")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "vllm")
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((config_dir / "models.json").read_text())
+        assert "other" in config["providers"], "pre-existing provider must survive"
+        assert "vllm" in config["providers"], "new provider must be added"
+
+    def test_overwrites_corrupt_models_json(self, monkeypatch, tmp_path, capsys):
+        config_dir = tmp_path / ".pi" / "agent"
+        config_dir.mkdir(parents=True)
+        (config_dir / "models.json").write_text("{corrupt json")
+
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost:8080/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "m")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "vllm")
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((config_dir / "models.json").read_text())
+        assert "vllm" in config["providers"]
+        assert "Warning" in capsys.readouterr().err
+
+
+@pytest.mark.usefixtures("_pi_env")
+class TestSetupProviderAnthropic:
+    """Anthropic path: sets ANTHROPIC_* env vars."""
+
+    def test_sets_anthropic_env_vars(self, monkeypatch):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "https://api.example.com")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "sk-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "claude-haiku")
+        # No BENCHFLOW_PROVIDER_PROTOCOL → defaults to Anthropic path
+
+        import os
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://api.example.com"
+        assert os.environ["ANTHROPIC_AUTH_TOKEN"] == "sk-test"
+        assert os.environ["ANTHROPIC_MODEL"] == "claude-haiku"
+
+    def test_setdefault_does_not_overwrite(self, monkeypatch):
+        """Pre-existing ANTHROPIC_* values take precedence."""
+        monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://keep-this.example.com")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "https://new.example.com")
+
+        import os
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://keep-this.example.com"

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -108,7 +108,7 @@ def test_agent_negative_config_invariants():
     """
     no_credential_files = {"claude-agent-acp", "openclaw"}
     no_subscription_auth = {"openclaw", "pi-acp"}
-    no_env_mapping = {"openclaw"}
+    no_env_mapping = {"openclaw", "pi-acp"}
 
     for name in no_credential_files:
         assert AGENTS[name].credential_files == [], (


### PR DESCRIPTION
## Summary

- Adds a launch wrapper (`pi_acp_launcher.py`) that bridges `BENCHFLOW_PROVIDER_*` env vars to Pi's native config based on the detected protocol:
  - **Anthropic**: sets `ANTHROPIC_*` env vars (unchanged behavior)
  - **OpenAI-compatible** (vLLM, etc.): generates `~/.pi/agent/models.json` with the provider registered as `openai-completions`
- Changes pi-acp registry: `api_protocol=""` (multi-protocol), `requires_env=[]` (inferred at runtime), `env_mapping={}` (launcher handles it)

Closes #152

## Test plan

- [x] All 494 unit tests pass
- [x] ruff check + format clean
- [ ] Manual: run pi-acp with `vllm/` model against a local vLLM server — verify models.json is generated and Pi sends OpenAI Chat Completions requests
- [ ] Manual: run pi-acp with an Anthropic model — verify ANTHROPIC_* env vars are set (regression check)