### PR TITLE
fix: strip_provider_prefix root cause + pi-acp launcher hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,12 @@ CI gates `ruff format`, `ruff check`, `pytest`, and `ty check src/`. Run all fou
 
 ## Conventions
 
-- **Minimal fix.** Do only what was asked. "Leave as is" is a valid outcome. Generalize on the third repetition, not the first.
-- **Registry over hardcode.** Adding an agent or provider is a dict entry in `agents/registry.py` or `providers.py` — not a new code path. The `oracle` special case in `sdk.py` exists because it bypasses the agent loop; don't add more without the same justification.
-- **Don't rewrite passing tests.** Updating a test because the code it covers changed shape is fine. Rewriting one to match new behavior without understanding why it was written is not. No tautological tests (dataclass reads, stdlib behavior, "does it construct").
-- **Human review before main.** Commit freely on a feature branch, open a PR. Never push to `main` directly, never force-push it.
+- **Minimal fix.** Do only what was asked; "leave as is" is a valid outcome; generalize on the third repetition. "Narrow" is about *how much* code changes, not *where* — the fix still goes at the root cause, even in a different file.
+- **Cite `file:line` before fixing.** If you can't, the bug may not exist.
+- **Root cause, sweep callers.** Two PRs patching two files for one bug means the fix is upstream. Grep every caller before patching one — a flag at the call site is a smell the function itself is wrong. After fixing a shared helper, audit its other callers in the same PR; each either hits the same bug (same fix) or demonstrably doesn't (note in PR).
+- **Don't change a happy path to fix an edge case.** If a line looks wrong but serves a legitimate flow, narrow the fix. `git log -p` it before flipping — two-week-old "intent" is not intent.
+- **Registry over hardcode.** Adding an agent or provider is a dict entry in `agents/registry.py` or `providers.py` — not a new code path. If the registry declares `contextWindow`, `baseURL`, or a model ID, callers read it from there; hardcoded copies drift. The `oracle` special case in `sdk.py` exists because it bypasses the agent loop; don't add more without the same justification.
+- **Read siblings before adding one.** New launcher/provider/shim? Open every file in the directory and reconcile defaults before writing.
+- **Don't rewrite passing tests.** Updating a test because the code it covers changed shape is fine; rewriting one to match new behavior without understanding why it was written is not. No tautological tests (dataclass reads, stdlib behavior, "does it construct").
+- **Test new regressions against `main` first.** A test that passes on buggy `main` pins the bug instead of preventing it. Name the commit/PR it guards.
+- **Human review before main.** Commit freely on a feature branch, open a PR. Never push to `main` directly, never force-push it. Self-approval doesn't count — request an independent reviewer.

--- a/src/benchflow/_acp_run.py
+++ b/src/benchflow/_acp_run.py
@@ -25,7 +25,6 @@ from benchflow._sandbox import build_priv_drop_cmd
 from benchflow._trajectory import _capture_session_trajectory
 from benchflow.acp.client import ACPClient
 from benchflow.acp.container_transport import ContainerTransport
-from benchflow.agents.registry import AgentConfig
 from benchflow.process import DaytonaProcess, DockerProcess
 
 logger = logging.getLogger(__name__)
@@ -41,7 +40,6 @@ async def connect_acp(
     trial_dir: Path,
     environment: str,
     agent_cwd: str,
-    agent_cfg: AgentConfig | None = None,
 ) -> tuple[ACPClient, object, str]:
     """Create ACP transport, connect, init session, set model. Return (client, session, agent_name)."""
     # Resolve agent binary path for non-docker environments
@@ -86,10 +84,7 @@ async def connect_acp(
     if model:
         from benchflow.agents.providers import strip_provider_prefix
 
-        if agent_cfg and agent_cfg.preserve_provider_prefix:
-            acp_model_id = model
-        else:
-            acp_model_id = strip_provider_prefix(model)
+        acp_model_id = strip_provider_prefix(model)
         try:
             await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
             logger.info(f"Model set to: {acp_model_id} (from {model})")

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -102,8 +102,11 @@ def setup_provider() -> None:
         models_path.write_text(json.dumps(config, indent=2))
     else:
         # Anthropic mode — set native env vars that Pi reads directly.
-        # setdefault preserves user-supplied values (e.g. --ae ANTHROPIC_BASE_URL
-        # for proxy routing); see tests/test_pi_acp_launcher.py.
+        # DO NOT change setdefault to assignment. Users route through proxies
+        # with --ae ANTHROPIC_BASE_URL=<proxy>; overwriting breaks that path.
+        # Why: BENCHFLOW_PROVIDER_BASE_URL is the registry default; the user's
+        # --ae override must win. Pinned by tests/test_pi_acp_launcher.py::
+        # test_setdefault_does_not_overwrite.
         if base_url:
             os.environ.setdefault("ANTHROPIC_BASE_URL", base_url)
         if api_key:

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -15,19 +15,55 @@ import os
 import sys
 from pathlib import Path
 
+# Pi model-metadata defaults if neither the provider registry nor per-run
+# overrides supply values. Conservative — most modern models exceed these.
+_DEFAULT_CONTEXT_WINDOW = 128000
+_DEFAULT_MAX_TOKENS = 16384
 
-def setup_provider():
+
+def _lookup_model_metadata(model: str) -> dict:
+    """Return the registry entry for `model` from BENCHFLOW_PROVIDER_MODELS, or {}."""
+    raw = os.environ.get("BENCHFLOW_PROVIDER_MODELS", "")
+    if not raw:
+        return {}
+    try:
+        entries = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("id") == model:
+            return entry
+    return {}
+
+
+def _derive_provider_name(model: str) -> str:
+    """Derive a unique provider key so concurrent runs don't collide on "custom"."""
+    if "/" in model:
+        return f"benchflow-{model.split('/')[0]}"
+    return f"benchflow-{model}" if model else "benchflow-custom"
+
+
+def setup_provider() -> None:
     """Configure Pi for the detected provider protocol."""
     protocol = os.environ.get("BENCHFLOW_PROVIDER_PROTOCOL", "")
     base_url = os.environ.get("BENCHFLOW_PROVIDER_BASE_URL", "")
     api_key = os.environ.get("BENCHFLOW_PROVIDER_API_KEY", "")
     model = os.environ.get("BENCHFLOW_PROVIDER_MODEL", "")
-    provider_name = os.environ.get("BENCHFLOW_PROVIDER_NAME", "custom")
+    provider_name = os.environ.get("BENCHFLOW_PROVIDER_NAME") or _derive_provider_name(
+        model
+    )
 
-    if protocol == "openai-completions" and base_url:
+    if protocol == "openai-completions":
+        if not base_url:
+            raise SystemExit(
+                "pi-acp: BENCHFLOW_PROVIDER_PROTOCOL=openai-completions requires "
+                "BENCHFLOW_PROVIDER_BASE_URL, but it is empty. Check provider "
+                "registry url_params (e.g. missing GOOGLE_CLOUD_PROJECT)."
+            )
         # Pi uses ~/.pi/agent/models.json to discover non-Anthropic providers.
         # Register the provider so Pi routes API calls through the OpenAI
         # Chat Completions wire format instead of Anthropic Messages.
+        meta = _lookup_model_metadata(model)
         config = {
             "providers": {
                 provider_name: {
@@ -37,11 +73,13 @@ def setup_provider():
                     "models": [
                         {
                             "id": model,
-                            "name": model,
-                            "reasoning": False,
-                            "input": ["text"],
-                            "contextWindow": 128000,
-                            "maxTokens": 16384,
+                            "name": meta.get("name", model),
+                            "reasoning": meta.get("reasoning", False),
+                            "input": meta.get("input", ["text"]),
+                            "contextWindow": meta.get(
+                                "contextWindow", _DEFAULT_CONTEXT_WINDOW
+                            ),
+                            "maxTokens": meta.get("maxTokens", _DEFAULT_MAX_TOKENS),
                         }
                     ],
                 }
@@ -63,7 +101,9 @@ def setup_provider():
                 )
         models_path.write_text(json.dumps(config, indent=2))
     else:
-        # Anthropic mode — set native env vars that Pi reads directly
+        # Anthropic mode — set native env vars that Pi reads directly.
+        # setdefault preserves user-supplied values (e.g. --ae ANTHROPIC_BASE_URL
+        # for proxy routing); see tests/test_pi_acp_launcher.py.
         if base_url:
             os.environ.setdefault("ANTHROPIC_BASE_URL", base_url)
         if api_key:
@@ -72,6 +112,17 @@ def setup_provider():
             os.environ.setdefault("ANTHROPIC_MODEL", model)
 
 
-if __name__ == "__main__":
+def main() -> None:
     setup_provider()
-    os.execvp("pi-acp", ["pi-acp", *sys.argv[1:]])
+    try:
+        os.execvp("pi-acp", ["pi-acp", *sys.argv[1:]])
+    except FileNotFoundError as e:
+        raise SystemExit(
+            "pi-acp: 'pi-acp' binary not found on PATH. It should have been "
+            "installed by the registry's install_cmd via "
+            "'npm install -g pi-acp'. Check the container's install log."
+        ) from e
+
+
+if __name__ == "__main__":
+    main()

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -224,6 +224,12 @@ def strip_provider_prefix(model: str) -> str:
     "vllm/Qwen/Qwen3-Coder" → "Qwen/Qwen3-Coder"  (HF org/model kept intact)
     "Qwen/Qwen3-Coder" → "Qwen/Qwen3-Coder"       (no registered prefix → unchanged)
     "claude-sonnet-4-6" → "claude-sonnet-4-6"
+
+    Single normalization point for downstream callers (ACP set_model,
+    BENCHFLOW_PROVIDER_MODEL env var, Harbor YAML parse). If a model ID
+    reaches an agent launcher still prefixed, fix the routing into this
+    function — do NOT strip again at the call site. See PRs #154 and #155
+    for the symptomatic-patch anti-pattern that caused the original bug.
     """
     result = find_provider(model)
     if result:

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -217,19 +217,17 @@ def resolve_base_url(
 
 
 def strip_provider_prefix(model: str) -> str:
-    """Strip the provider prefix from a model ID.
+    """Strip a *registered* provider prefix. Unregistered inputs pass through.
 
     "anthropic-vertex/claude-sonnet-4-6" → "claude-sonnet-4-6"
     "zai/glm-5" → "glm-5"
-    "claude-sonnet-4-6" → "claude-sonnet-4-6"  (no prefix = unchanged)
+    "vllm/Qwen/Qwen3-Coder" → "Qwen/Qwen3-Coder"  (HF org/model kept intact)
+    "Qwen/Qwen3-Coder" → "Qwen/Qwen3-Coder"       (no registered prefix → unchanged)
+    "claude-sonnet-4-6" → "claude-sonnet-4-6"
     """
     result = find_provider(model)
     if result:
-        prefix = f"{result[0]}/"
-        return model[len(prefix) :]
-    # Not a known provider — still strip unknown prefix if present
-    if "/" in model:
-        return model.split("/", 1)[1]
+        return model[len(result[0]) + 1 :]
     return model
 
 

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -55,6 +55,13 @@ def _install_python_script(container_path: str, source: str) -> str:
     Base64 transport — makes the install shell line content-agnostic so a line
     like `SHIMEOF` or `LAUNCHEREOF` inside the Python source can't collide with
     a heredoc terminator.
+
+    Used by pi-acp and openclaw — both ship a Python launcher/shim baked into
+    install_cmd. Rule of three: if you're adding a THIRD agent that needs this
+    pattern, read both pi_acp_launcher.py and openclaw_acp_shim.py first and
+    reconcile their semantics (env bridging, provider-name derivation, model
+    metadata) before writing a new one. Only consider extracting a shared base
+    after the third data point — divergence is cheap, premature abstraction isn't.
     """
     encoded = base64.b64encode(source.encode()).decode()
     return (

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -44,8 +44,26 @@ Look at the existing entries below for worked examples:
 (multi-file subscription auth).
 """
 
+import base64
 from dataclasses import dataclass, field
 from pathlib import Path
+
+
+def _install_python_script(container_path: str, source: str) -> str:
+    """Shell snippet that ensures python3 and writes `source` to container_path.
+
+    Base64 transport — makes the install shell line content-agnostic so a line
+    like `SHIMEOF` or `LAUNCHEREOF` inside the Python source can't collide with
+    a heredoc terminator.
+    """
+    encoded = base64.b64encode(source.encode()).decode()
+    return (
+        "( command -v python3 >/dev/null 2>&1 || "
+        "(apt-get update -qq && apt-get install -y -qq python3 >/dev/null 2>&1) ) && "
+        f"echo {encoded} | base64 -d > {container_path} && "
+        f"chmod +x {container_path}"
+    )
+
 
 # Node.js bootstrap — handles missing node, old node (<22), Ubuntu + Debian slim
 _NODE_INSTALL = (
@@ -132,12 +150,6 @@ class AgentConfig:
     home_dirs: list[str] = field(default_factory=list)
     # Extra dot-dirs under $HOME to copy to sandbox user (for dirs not
     # derivable from skill_paths or credential_files, e.g. ".openclaw").
-    preserve_provider_prefix: bool = False
-    # When True, ACP set_model receives the full model string including the
-    # BenchFlow provider prefix (e.g. "vllm/Qwen/Qwen3.5-35B-A3B").
-    # When False (default), the prefix is stripped first (e.g. "Qwen/Qwen3.5-35B-A3B").
-    # Agents whose set_model handler uses "provider/model" routing (e.g. pi-acp)
-    # need the prefix to avoid misparsing HuggingFace model IDs that contain "/".
     subscription_auth: SubscriptionAuth | None = None
     # Host CLI login that can substitute for an API key (e.g. OAuth tokens
     # from `claude login`). Detected automatically; API keys take precedence.
@@ -177,7 +189,6 @@ AGENTS: dict[str, AgentConfig] = {
     "pi-acp": AgentConfig(
         name="pi-acp",
         description="Pi agent via ACP",
-        preserve_provider_prefix=True,
         skill_paths=["$HOME/.pi/agent/skills", "$HOME/.agents/skills"],
         install_cmd=(
             f"{_NODE_INSTALL} && "
@@ -186,14 +197,8 @@ AGENTS: dict[str, AgentConfig] = {
             "( command -v pi-acp >/dev/null 2>&1 || "
             "npm install -g pi-acp@latest >/dev/null 2>&1 ) && "
             "command -v pi-acp >/dev/null 2>&1 && "
-            # Ensure python3 for launcher
-            "( command -v python3 >/dev/null 2>&1 || "
-            "(apt-get update -qq && apt-get install -y -qq python3 >/dev/null 2>&1) ) && "
             # Deploy launch wrapper (bridges BENCHFLOW_PROVIDER_* → Pi config)
-            "cat > /usr/local/bin/pi-acp-launcher <<'LAUNCHEREOF'\n"
-            + _PI_LAUNCHER
-            + "\nLAUNCHEREOF\n"
-            "chmod +x /usr/local/bin/pi-acp-launcher"
+            + _install_python_script("/usr/local/bin/pi-acp-launcher", _PI_LAUNCHER)
         ),
         launch_cmd="python3 /usr/local/bin/pi-acp-launcher",
         protocol="acp",
@@ -215,18 +220,12 @@ AGENTS: dict[str, AgentConfig] = {
             "( command -v openclaw >/dev/null 2>&1 || "
             "npm install -g openclaw@latest >/dev/null 2>&1 ) && "
             "command -v openclaw >/dev/null 2>&1 && "
-            # Ensure python3 for shim
-            "( command -v python3 >/dev/null 2>&1 || "
-            "(apt-get update -qq && apt-get install -y -qq python3 >/dev/null 2>&1) ) && "
             # Configure: auto-approve tools (no model — set at runtime via ACP set_model)
             "mkdir -p ~/.openclaw && "
             'echo \'{"version":1,"defaults":{"allow_all":true}}\''
             " > ~/.openclaw/exec-approvals.json && "
             # Deploy ACP shim
-            "cat > /usr/local/bin/openclaw-acp-shim <<'SHIMEOF'\n"
-            + _OPENCLAW_SHIM
-            + "\nSHIMEOF\n"
-            "chmod +x /usr/local/bin/openclaw-acp-shim"
+            + _install_python_script("/usr/local/bin/openclaw-acp-shim", _OPENCLAW_SHIM)
         ),
         launch_cmd="python3 /usr/local/bin/openclaw-acp-shim",
         protocol="acp",

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -586,7 +586,6 @@ class SDK:
                     trial_dir,
                     environment,
                     agent_cwd,
-                    agent_cfg=agent_cfg,
                 )
                 timing["agent_setup"] = (datetime.now() - t_agent_setup).total_seconds()
                 t_agent_exec = datetime.now()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -262,8 +262,12 @@ class TestConnectAcpModelSelection:
             ("zai/glm-5", "glm-5"),
             # Bare HF ID (no registered prefix) passes through unchanged.
             ("Qwen/Qwen3-Coder", "Qwen/Qwen3-Coder"),
+            # Vertex ADC provider — prefix stripped like any other registered one.
+            ("anthropic-vertex/claude-sonnet-4-6", "claude-sonnet-4-6"),
+            # No prefix at all — unchanged.
+            ("claude-sonnet-4-6", "claude-sonnet-4-6"),
         ],
-        ids=["vllm-hf", "zai", "bare-hf"],
+        ids=["vllm-hf", "zai", "bare-hf", "vertex", "no-prefix"],
     )
     async def test_model_id_selection(self, model_in, expected_model, tmp_path):
         from benchflow._acp_run import connect_acp

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -10,7 +10,6 @@ from benchflow.acp.client import ACPClient, ACPError
 from benchflow.acp.session import ACPSession
 from benchflow.acp.transport import StdioTransport
 from benchflow.acp.types import StopReason, ToolCallStatus
-from benchflow.agents.registry import AgentConfig
 
 MOCK_AGENT = str(Path(__file__).parent / "fixtures" / "mock_acp_agent.py")
 MOCK_AGENT_INTERLEAVED = str(
@@ -255,26 +254,21 @@ class TestConnectAcpModelSelection:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "preserve, model_in, expected_model",
+        "model_in, expected_model",
         [
-            (True, "vllm/Qwen/Qwen3.5-35B-A3B", "vllm/Qwen/Qwen3.5-35B-A3B"),
-            (False, "vllm/Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-35B-A3B"),
-            (False, "zai/glm-5", "glm-5"),
+            # Registered vllm/ prefix stripped; HF org/model intact — this is
+            # what pi-acp and other ACP agents need for downstream routing.
+            ("vllm/Qwen/Qwen3.5-35B-A3B", "Qwen/Qwen3.5-35B-A3B"),
+            ("zai/glm-5", "glm-5"),
+            # Bare HF ID (no registered prefix) passes through unchanged.
+            ("Qwen/Qwen3-Coder", "Qwen/Qwen3-Coder"),
         ],
-        ids=["preserve-true", "preserve-false-vllm", "preserve-false-zai"],
+        ids=["vllm-hf", "zai", "bare-hf"],
     )
-    async def test_model_id_selection(
-        self, preserve, model_in, expected_model, tmp_path
-    ):
+    async def test_model_id_selection(self, model_in, expected_model, tmp_path):
         from benchflow._acp_run import connect_acp
 
         mock_acp = self._make_mocks()
-        cfg = AgentConfig(
-            name="test-agent",
-            install_cmd="true",
-            launch_cmd="test-agent",
-            preserve_provider_prefix=preserve,
-        )
 
         mock_env = AsyncMock()
         with (
@@ -295,38 +289,6 @@ class TestConnectAcpModelSelection:
                 trial_dir=tmp_path,
                 environment="docker",
                 agent_cwd="/app",
-                agent_cfg=cfg,
             )
 
         mock_acp.set_model.assert_awaited_once_with(expected_model)
-
-    @pytest.mark.asyncio
-    async def test_no_agent_cfg_strips_prefix(self, tmp_path):
-        """When agent_cfg is None, prefix is always stripped."""
-        from benchflow._acp_run import connect_acp
-
-        mock_acp = self._make_mocks()
-
-        mock_env = AsyncMock()
-        with (
-            patch(
-                "benchflow._acp_run.DockerProcess.from_harbor_env",
-                return_value=MagicMock(),
-            ),
-            patch("benchflow._acp_run.ContainerTransport", return_value=MagicMock()),
-            patch("benchflow._acp_run.ACPClient", return_value=mock_acp),
-        ):
-            await connect_acp(
-                env=mock_env,
-                agent="unknown-agent",
-                agent_launch="unknown-agent",
-                agent_env={},
-                sandbox_user=None,
-                model="vllm/Qwen/Qwen3.5-35B-A3B",
-                trial_dir=tmp_path,
-                environment="docker",
-                agent_cwd="/app",
-                agent_cfg=None,
-            )
-
-        mock_acp.set_model.assert_awaited_once_with("Qwen/Qwen3.5-35B-A3B")

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -14,6 +14,7 @@ def _pi_env(monkeypatch, tmp_path):
         "BENCHFLOW_PROVIDER_BASE_URL",
         "BENCHFLOW_PROVIDER_API_KEY",
         "BENCHFLOW_PROVIDER_MODEL",
+        "BENCHFLOW_PROVIDER_MODELS",
         "BENCHFLOW_PROVIDER_NAME",
         "ANTHROPIC_BASE_URL",
         "ANTHROPIC_AUTH_TOKEN",
@@ -115,7 +116,11 @@ class TestSetupProviderAnthropic:
         assert os.environ["ANTHROPIC_MODEL"] == "claude-haiku"
 
     def test_setdefault_does_not_overwrite(self, monkeypatch):
-        """Pre-existing ANTHROPIC_* values take precedence."""
+        """Pre-existing ANTHROPIC_* values take precedence.
+
+        Users routing through a proxy set ANTHROPIC_BASE_URL directly (e.g.
+        via --ae); the launcher must not clobber that.
+        """
         monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://keep-this.example.com")
         monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "https://new.example.com")
 
@@ -126,3 +131,118 @@ class TestSetupProviderAnthropic:
         setup_provider()
 
         assert os.environ["ANTHROPIC_BASE_URL"] == "https://keep-this.example.com"
+
+
+@pytest.mark.usefixtures("_pi_env")
+class TestSetupProviderErrors:
+    """Misconfiguration surfaces as a clear SystemExit, not a silent no-op."""
+
+    def test_openai_protocol_requires_base_url(self, monkeypatch):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "some-model")
+        # BASE_URL intentionally unset — simulates failed url_params resolution
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        with pytest.raises(SystemExit, match="BENCHFLOW_PROVIDER_BASE_URL"):
+            setup_provider()
+
+
+@pytest.mark.usefixtures("_pi_env")
+class TestSetupProviderModelMetadata:
+    """Model metadata from BENCHFLOW_PROVIDER_MODELS overrides defaults."""
+
+    def test_context_window_from_provider_models(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "glm-4.6")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "zai")
+        monkeypatch.setenv(
+            "BENCHFLOW_PROVIDER_MODELS",
+            json.dumps(
+                [
+                    {
+                        "id": "glm-4.6",
+                        "name": "GLM-4.6",
+                        "contextWindow": 200000,
+                        "maxTokens": 131072,
+                    }
+                ]
+            ),
+        )
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
+        model_entry = config["providers"]["zai"]["models"][0]
+        assert model_entry["contextWindow"] == 200000
+        assert model_entry["maxTokens"] == 131072
+        assert model_entry["name"] == "GLM-4.6"
+
+    def test_defaults_when_provider_models_absent(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "mystery-model")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "custom-vllm")
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
+        model_entry = config["providers"]["custom-vllm"]["models"][0]
+        assert model_entry["contextWindow"] == 128000
+        assert model_entry["maxTokens"] == 16384
+
+
+@pytest.mark.usefixtures("_pi_env")
+class TestSetupProviderNameDerivation:
+    """Absent BENCHFLOW_PROVIDER_NAME → slug-based key, never plain 'custom'.
+
+    Concurrent runs with different models must not collide in models.json.
+    """
+
+    def test_name_derived_from_hf_org(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://a/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "Qwen/Qwen3-Coder")
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
+        assert "custom" not in config["providers"]
+        assert "benchflow-Qwen" in config["providers"]
+
+    def test_explicit_name_wins_over_derivation(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://a/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "Qwen/Qwen3-Coder")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "vllm")
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
+        assert "vllm" in config["providers"]
+        assert "benchflow-Qwen" not in config["providers"]
+
+
+@pytest.mark.usefixtures("_pi_env")
+class TestMainExecvpFailure:
+    """Missing pi-acp binary must surface a clear error, not a bare FileNotFoundError."""
+
+    def test_missing_binary_raises_sysexit(self, monkeypatch):
+        monkeypatch.setattr(
+            "os.execvp",
+            lambda *_: (_ for _ in ()).throw(FileNotFoundError(2, "No such file")),
+        )
+
+        from benchflow.agents.pi_acp_launcher import main
+
+        with pytest.raises(SystemExit, match="pi-acp"):
+            main()

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -4,6 +4,22 @@ import json
 
 import pytest
 
+from benchflow.agents.providers import PROVIDERS
+
+# All registry models declaring contextWindow/maxTokens — drives the parametrized
+# invariant that the launcher preserves registry-declared values.
+_REGISTRY_MODELS_WITH_METADATA = [
+    (name, m)
+    for name, cfg in PROVIDERS.items()
+    for m in cfg.models
+    if "contextWindow" in m or "maxTokens" in m
+]
+assert _REGISTRY_MODELS_WITH_METADATA, (
+    "PROVIDERS has no model entry with contextWindow/maxTokens — the "
+    "parametrized invariant below would silently cover nothing. Either "
+    "add metadata to a provider or delete this guard."
+)
+
 
 @pytest.fixture()
 def _pi_env(monkeypatch, tmp_path):
@@ -152,23 +168,25 @@ class TestSetupProviderErrors:
 class TestSetupProviderModelMetadata:
     """Model metadata from BENCHFLOW_PROVIDER_MODELS overrides defaults."""
 
-    def test_context_window_from_provider_models(self, monkeypatch, tmp_path):
+    @pytest.mark.parametrize(
+        "provider_name, model_meta",
+        _REGISTRY_MODELS_WITH_METADATA,
+        ids=[f"{p}-{m['id']}" for p, m in _REGISTRY_MODELS_WITH_METADATA],
+    )
+    def test_registry_metadata_flows_to_models_json(
+        self, provider_name, model_meta, monkeypatch, tmp_path
+    ):
+        """Every contextWindow/maxTokens declared in PROVIDERS must reach
+        the generated models.json unchanged. PR #156 hardcoded 128000/16384
+        in the launcher; new registry entries would be silently truncated.
+        """
         monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
         monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost/v1")
-        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "glm-4.6")
-        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "zai")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", model_meta["id"])
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", provider_name)
         monkeypatch.setenv(
             "BENCHFLOW_PROVIDER_MODELS",
-            json.dumps(
-                [
-                    {
-                        "id": "glm-4.6",
-                        "name": "GLM-4.6",
-                        "contextWindow": 200000,
-                        "maxTokens": 131072,
-                    }
-                ]
-            ),
+            json.dumps(PROVIDERS[provider_name].models),
         )
 
         from benchflow.agents.pi_acp_launcher import setup_provider
@@ -176,10 +194,13 @@ class TestSetupProviderModelMetadata:
         setup_provider()
 
         config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
-        model_entry = config["providers"]["zai"]["models"][0]
-        assert model_entry["contextWindow"] == 200000
-        assert model_entry["maxTokens"] == 131072
-        assert model_entry["name"] == "GLM-4.6"
+        entry = config["providers"][provider_name]["models"][0]
+        for field in ("contextWindow", "maxTokens", "name"):
+            if field in model_meta:
+                assert entry[field] == model_meta[field], (
+                    f"{provider_name}/{model_meta['id']}: launcher emitted "
+                    f"{field}={entry[field]}, registry declares {model_meta[field]}"
+                )
 
     def test_defaults_when_provider_models_absent(self, monkeypatch, tmp_path):
         monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -201,8 +201,24 @@ class TestStripProviderPrefix:
     def test_no_prefix(self):
         assert strip_provider_prefix("claude-sonnet-4-6") == "claude-sonnet-4-6"
 
-    def test_unknown_prefix(self):
-        assert strip_provider_prefix("unknown-provider/some-model") == "some-model"
+    def test_unknown_prefix_preserved(self):
+        # Unregistered prefix passes through unchanged — avoids mangling
+        # HuggingFace-style IDs whose org is not a registered provider.
+        assert (
+            strip_provider_prefix("unknown-provider/some-model")
+            == "unknown-provider/some-model"
+        )
+
+    def test_bare_huggingface_id_preserved(self):
+        # Regression: bare HF ID (no registered prefix) must keep org/model.
+        assert strip_provider_prefix("Qwen/Qwen3-Coder") == "Qwen/Qwen3-Coder"
+        assert strip_provider_prefix("Qwen/Qwen3.5-35B-A3B") == "Qwen/Qwen3.5-35B-A3B"
+
+    def test_registered_prefix_with_huggingface_id(self):
+        # Registered vllm/ prefix stripped; HF org/model kept intact.
+        assert (
+            strip_provider_prefix("vllm/Qwen/Qwen3.5-35B-A3B") == "Qwen/Qwen3.5-35B-A3B"
+        )
 
 
 # ── Shim provider fallback: stripped model + BENCHFLOW_PROVIDER_* env vars ──


### PR DESCRIPTION
## Summary

Fixes the root cause behind PRs #154 and #155 (symptomatic patches to
`_from_harbor_yaml` and `_acp_run`), and hardens the `pi_acp_launcher`
introduced in #156. Also distills the post-mortem into CLAUDE.md rules
and landmark comments so future agents don't repeat the pattern.

### Fix A — `strip_provider_prefix` root fix

The `/` fallback at `providers.py:219-233` mangled unregistered
HuggingFace-style IDs (`Qwen/Qwen3-Coder` → `Qwen3-Coder`). Remove the
fallback; unregistered inputs now pass through unchanged.

With the root bug gone, `AgentConfig.preserve_provider_prefix` (#155's
workaround) is dead code — removed along with the `agent_cfg` parameter
it served on `connect_acp`. `_agent_env.py` and `_acp_run.py` now
agree byte-for-byte on the model ID for the same run.

### Fix B — pi-acp launcher hardening (#156 follow-up)

- Error on `openai-completions` protocol with empty `BASE_URL` instead
  of silently falling through to Anthropic mode.
- Read `contextWindow` / `maxTokens` / `name` / `reasoning` / `input`
  from `BENCHFLOW_PROVIDER_MODELS` so registry values (e.g. zai's 200k)
  aren't silently truncated to the hardcoded 128k default.
- Derive `provider_name` from model slug when `BENCHFLOW_PROVIDER_NAME`
  is absent, avoiding `"custom"` collisions on concurrent runs.
- Wrap `os.execvp` in `main()` with a clear `SystemExit` on
  `FileNotFoundError`.

`setdefault` in the Anthropic-mode branch is preserved intentionally —
users route through proxies with `--ae ANTHROPIC_BASE_URL=<proxy>` and
overwriting would break that happy path. Pinned by the existing
`test_setdefault_does_not_overwrite`.

### Registry

Factor `_install_python_script()` helper using base64 transport for both
the pi-acp and openclaw install steps, so future Python-shim sources
can't collide with heredoc sentinels.

### Agent guidance

- CLAUDE.md `## Conventions` rewritten from 11 → 9 bullets, ordered by
  workflow phase (diagnose → fix → implement → test → land). Adds
  "Root cause, sweep callers", "Cite file:line before fixing", "Don't
  change a happy path to fix an edge case", "Test new regressions
  against main first", and qualifies "Minimal fix" with "narrow is
  about how much code changes, not where".
- Landmark comments at three sharp-edge sites (`strip_provider_prefix`,
  pi-acp launcher's setdefault block, and `_install_python_script`).

## Test plan

- [x] `.venv/bin/ruff format` — clean
- [x] `.venv/bin/ruff check src/ tests/` — all checks passed
- [x] `.venv/bin/python -m pytest tests/` — 514 passed, 1 deselected
- [x] `.venv/bin/ty check src/` — all checks passed
- [ ] Live smoke: run pi-acp against a vLLM endpoint with
      `vllm/Qwen/Qwen3-Coder` — confirm HF org survives to ACP
      `set_model` AND to `BENCHFLOW_PROVIDER_MODEL`.
- [ ] Live smoke: run pi-acp with `zai/glm-5` — confirm generated
      `models.json` uses `contextWindow=200000` (not 128000).
- [ ] Live smoke: run pi-acp with `--ae ANTHROPIC_BASE_URL=<proxy>` —
      confirm proxy URL is not overwritten by registry default.

Closes the regression surface from #154, #155, #156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)