### PR TITLE
feat: MCP reviewer server for multi-agent code review

### DIFF
--- a/src/benchflow/mcp/__init__.py
+++ b/src/benchflow/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP (Model Context Protocol) support for benchflow.
+
+Enables multi-agent patterns where agents communicate via MCP tool calls
+rather than filesystem-based message passing.
+"""

--- a/src/benchflow/mcp/hooks.py
+++ b/src/benchflow/mcp/hooks.py
@@ -37,14 +37,17 @@ def mcp_reviewer_hook(
             f"--port {port} --model {model} --host {host} &",
             timeout_sec=10,
         )
-        # Wait for health
-        await env.exec(
+        # Wait for server to respond
+        result = await env.exec(
             f"for i in $(seq 1 15); do "
-            f"curl -sf http://localhost:{port}/health > /dev/null 2>&1 && break; "
-            f"sleep 1; done",
+            f"curl -sf http://localhost:{port}/mcp > /dev/null 2>&1 && echo ok && exit 0; "
+            f"sleep 1; done; echo fail",
             timeout_sec=20,
         )
-        logger.info(f"MCP reviewer server ready on port {port}")
+        if "ok" in (result.stdout or ""):
+            logger.info(f"MCP reviewer server ready on port {port}")
+        else:
+            logger.warning(f"MCP reviewer server may not be ready on port {port}")
 
     return _start_reviewer
 

--- a/src/benchflow/mcp/hooks.py
+++ b/src/benchflow/mcp/hooks.py
@@ -1,0 +1,71 @@
+"""MCP service hooks for Trial lifecycle.
+
+Starts MCP servers (reviewer, tools, etc.) as background processes
+in the sandbox before agent execution begins. Declared in TrialConfig.services.
+
+Usage in trial YAML:
+    services:
+      - "benchflow-reviewer:8100"
+
+Or programmatically:
+    config = TrialConfig(
+        ...,
+        services=["benchflow-reviewer:8100"],
+        pre_agent_hooks=[mcp_reviewer_hook(port=8100, model="gemini-3.1-flash-lite")],
+    )
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def mcp_reviewer_hook(
+    port: int = 8100,
+    model: str = "gemini-3.1-flash-lite",
+    host: str = "0.0.0.0",
+):
+    """Create a pre_agent_hook that starts the MCP reviewer server in the sandbox."""
+
+    async def _start_reviewer(env: Any) -> None:
+        logger.info(f"Starting MCP reviewer server on port {port} (model={model})")
+        await env.exec(
+            f"python -m benchflow.mcp.reviewer_server "
+            f"--port {port} --model {model} --host {host} &",
+            timeout_sec=10,
+        )
+        # Wait for health
+        await env.exec(
+            f"for i in $(seq 1 15); do "
+            f"curl -sf http://localhost:{port}/health > /dev/null 2>&1 && break; "
+            f"sleep 1; done",
+            timeout_sec=20,
+        )
+        logger.info(f"MCP reviewer server ready on port {port}")
+
+    return _start_reviewer
+
+
+def mcp_service_hooks_from_config(services: list[str] | None) -> list:
+    """Parse service declarations into pre_agent_hooks.
+
+    Format: "service-name:port" where service-name maps to a known MCP server.
+    """
+    if not services:
+        return []
+
+    hooks = []
+    for svc in services:
+        parts = svc.split(":")
+        name = parts[0]
+        port = int(parts[1]) if len(parts) > 1 else 8100
+
+        if name == "benchflow-reviewer":
+            hooks.append(mcp_reviewer_hook(port=port))
+        else:
+            logger.warning(f"Unknown MCP service: {name}")
+
+    return hooks

--- a/src/benchflow/mcp/reviewer_server.py
+++ b/src/benchflow/mcp/reviewer_server.py
@@ -85,11 +85,14 @@ def create_reviewer_server(
         genai.configure(api_key=api_key)
         llm = genai.GenerativeModel(model)
 
-        # Read the files
+        # Read files — restrict to /app/ to prevent path traversal
         file_contents = []
         target_files = files or _find_modified_files()
+        app_root = Path("/app").resolve()
         for f in target_files:
-            path = Path("/app") / f if not f.startswith("/") else Path(f)
+            path = (Path("/app") / f).resolve()
+            if not str(path).startswith(str(app_root)):
+                continue
             if path.exists():
                 content = path.read_text()[:50000]
                 file_contents.append(f"=== {f} ===\n{content}")
@@ -103,7 +106,7 @@ def create_reviewer_server(
 
         full_prompt = f"{prompt}\n\nReview the following:\n{review_input}"
 
-        response = llm.generate_content(full_prompt)
+        response = await asyncio.to_thread(llm.generate_content, full_prompt)
         return response.text
 
     @mcp.tool()

--- a/src/benchflow/mcp/reviewer_server.py
+++ b/src/benchflow/mcp/reviewer_server.py
@@ -1,0 +1,140 @@
+"""MCP reviewer server — exposes code review as a tool for other agents.
+
+Runs as a sidecar in the same sandbox. The coder agent calls the
+`review_code` tool via MCP; the reviewer LLM analyzes the code and
+returns structured feedback.
+
+This replaces the filesystem-based outbox pattern from followup-bench
+with a clean tool-call interface that prevents reward hacking (reviewer
+never has write access to /app/).
+
+Usage in task.toml:
+    [[environment.mcp_servers]]
+    name = "reviewer"
+    transport = "streamable-http"
+    url = "http://localhost:8100/mcp"
+
+Or start manually:
+    python -m benchflow.mcp.reviewer_server --port 8100
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Default review prompt — can be overridden via REVIEWER_PROMPT env var
+DEFAULT_REVIEW_PROMPT = """You are an expert code reviewer. Analyze the provided code for:
+1. Correctness — does it produce the right output for all inputs?
+2. Completeness — does it address every requirement?
+3. Bugs — trace through with concrete inputs, flag any wrong paths.
+
+Be specific: reference file names and concrete failing inputs.
+If uncertain, say so. Only report evidence-backed issues."""
+
+
+def create_reviewer_server(
+    model: str = "gemini-3.1-flash-lite",
+    port: int = 8100,
+    review_prompt: str | None = None,
+):
+    """Create a FastMCP reviewer server.
+
+    Returns the server app (for use with uvicorn or similar).
+    Requires: pip install fastmcp
+    """
+    try:
+        from fastmcp import FastMCP
+    except ImportError:
+        raise ImportError(
+            "fastmcp required for MCP reviewer server. "
+            "Install with: pip install fastmcp"
+        )
+
+    mcp = FastMCP("benchflow-reviewer")
+    prompt = review_prompt or os.environ.get("REVIEWER_PROMPT", DEFAULT_REVIEW_PROMPT)
+
+    @mcp.tool()
+    async def review_code(
+        files: list[str] | None = None,
+        task_instruction: str | None = None,
+    ) -> str:
+        """Review code files for correctness, completeness, and bugs.
+
+        Args:
+            files: List of file paths to review (relative to /app/).
+                   If None, reviews all modified files in /app/.
+            task_instruction: Optional task description for context.
+
+        Returns:
+            Structured review feedback as a string.
+        """
+        import google.generativeai as genai
+
+        api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+        if not api_key:
+            return "Error: No GOOGLE_API_KEY or GEMINI_API_KEY set for reviewer."
+
+        genai.configure(api_key=api_key)
+        llm = genai.GenerativeModel(model)
+
+        # Read the files
+        file_contents = []
+        target_files = files or _find_modified_files()
+        for f in target_files:
+            path = Path("/app") / f if not f.startswith("/") else Path(f)
+            if path.exists():
+                content = path.read_text()[:50000]
+                file_contents.append(f"=== {f} ===\n{content}")
+
+        if not file_contents:
+            return "No files found to review."
+
+        review_input = "\n\n".join(file_contents)
+        if task_instruction:
+            review_input = f"TASK:\n{task_instruction}\n\nCODE:\n{review_input}"
+
+        full_prompt = f"{prompt}\n\nReview the following:\n{review_input}"
+
+        response = llm.generate_content(full_prompt)
+        return response.text
+
+    @mcp.tool()
+    async def get_review_status() -> str:
+        """Check if the reviewer is ready."""
+        return json.dumps({"status": "ready", "model": model})
+
+    return mcp
+
+
+def _find_modified_files() -> list[str]:
+    """Find files in /app/ that look like code (not config/data)."""
+    app = Path("/app")
+    if not app.exists():
+        return []
+    code_exts = {".py", ".js", ".ts", ".sh", ".c", ".cpp", ".go", ".rs", ".java", ".rb"}
+    return [
+        str(f.relative_to(app))
+        for f in app.rglob("*")
+        if f.is_file() and f.suffix in code_exts and ".git" not in str(f)
+    ][:20]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="BenchFlow MCP Reviewer Server")
+    parser.add_argument("--port", type=int, default=8100)
+    parser.add_argument("--model", default="gemini-3.1-flash-lite")
+    parser.add_argument("--host", default="0.0.0.0")
+    args = parser.parse_args()
+
+    server = create_reviewer_server(model=args.model, port=args.port)
+    server.run(transport="streamable-http", host=args.host, port=args.port)


### PR DESCRIPTION
## Summary
MCP-based code reviewer that runs as a sidecar in the sandbox.

- `src/benchflow/mcp/reviewer_server.py` — FastMCP server with `review_code` tool
- `src/benchflow/mcp/hooks.py` — pre_agent_hooks to start MCP services

## Why MCP over filesystem outbox
- Reviewer can't write to /app/ — no reward hacking
- Structured tool interface (typed feedback vs raw file reads)
- Matches harbor-cookbook pattern
- Path traversal prevention (resolve under /app/ only)
- Async LLM call (asyncio.to_thread, no event loop blocking)

## Test plan
- [ ] reviewer_server imports and creates app
- [ ] hooks starts server and waits for health
- [ ] Dogfood: run task with MCP reviewer vs baseline
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/165" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
