### PR TITLE
feat: multi-turn Scene demo — 5 patterns, works backwards from harbor #1316

### DIFF
--- a/docs/notebooks/consultation-demo.py
+++ b/docs/notebooks/consultation-demo.py
@@ -1,0 +1,145 @@
+"""Realistic multi-round demo — client↔advisor contract consultation.
+
+Shows how benchflow's Scene lifecycle handles a real-world multi-agent
+interaction: a client shares details gradually, an advisor analyzes and
+recommends. This is the pattern harbor #1316 was designed for.
+
+No Docker required — runs entirely via LLM API calls to demonstrate
+the Scene/Role/Turn data model without needing Daytona.
+
+Usage:
+    export GEMINI_API_KEY="AIza..."
+    python docs/notebooks/consultation-demo.py
+"""
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# Show the Scene config — this is what matters for the demo
+def show_scene_config():
+    """Print the YAML-equivalent config that drives this interaction."""
+    print("""
+┌─────────────────────────────────────────────────────────┐
+│  Scene Config (what you'd put in a trial YAML)          │
+├─────────────────────────────────────────────────────────┤
+│  scenes:                                                │
+│    - name: contract-review                              │
+│      roles:                                             │
+│        - name: client                                   │
+│          agent: gemini                                  │
+│          model: gemini-3.1-flash-lite-preview            │
+│        - name: advisor                                  │
+│          agent: gemini                                  │
+│          model: gemini-3.1-flash-lite-preview            │
+│      turns:                                             │
+│        - role: client   # shares initial situation      │
+│        - role: advisor  # analyzes contract             │
+│        - role: client   # clarifies priorities          │
+│        - role: advisor  # gives final recommendation    │
+└─────────────────────────────────────────────────────────┘
+
+This is 15 lines of config. Harbor PR #1462 needs 600+ lines of
+runtime code to support the same pattern.
+""")
+
+
+def run_consultation():
+    """Simulate the multi-round consultation using direct LLM calls.
+
+    This demonstrates the INTERACTION PATTERN, not the full benchflow
+    sandbox. For the full pipeline (Docker, verifier, trajectory),
+    use the Trial API with a real task.
+    """
+    try:
+        import google.generativeai as genai
+    except ImportError:
+        print("pip install google-generativeai")
+        return
+
+    api_key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not api_key:
+        print("Set GEMINI_API_KEY or GOOGLE_API_KEY")
+        return
+
+    genai.configure(api_key=api_key)
+    model = genai.GenerativeModel("gemini-2.0-flash")
+
+    contract = Path(__file__).parent / "consultation-task" / "contract.md"
+    contract_text = contract.read_text()
+
+    # ── Round 1: Client shares situation ──────────────────────────────
+    print("=" * 60)
+    print("Round 1: Client → Advisor")
+    print("=" * 60)
+
+    client_msg_1 = model.generate_content(
+        f"You are a startup CTO. You received this vendor contract and "
+        f"need help reviewing it. Share your main concerns in 3-4 sentences. "
+        f"Focus on: you're a small company, cash-conscious, and worried about "
+        f"lock-in.\n\nContract:\n{contract_text}"
+    ).text
+    print(f"\n[Client]: {client_msg_1[:300]}...")
+
+    # ── Round 1: Advisor analyzes ─────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("Round 1: Advisor → Client")
+    print("=" * 60)
+
+    advisor_msg_1 = model.generate_content(
+        f"You are a contract review advisor. A client shared these concerns:\n\n"
+        f"{client_msg_1}\n\n"
+        f"Review this contract and provide a structured risk analysis:\n\n"
+        f"{contract_text}\n\n"
+        f"Format: list each clause with HIGH/MEDIUM/LOW risk and a 1-line explanation."
+    ).text
+    print(f"\n[Advisor]: {advisor_msg_1[:500]}...")
+
+    # ── Round 2: Client clarifies priorities ──────────────────────────
+    print("\n" + "=" * 60)
+    print("Round 2: Client → Advisor")
+    print("=" * 60)
+
+    client_msg_2 = model.generate_content(
+        f"You are the startup CTO. The advisor gave this analysis:\n\n"
+        f"{advisor_msg_1[:500]}\n\n"
+        f"Based on this, tell the advisor your top 2 priorities to negotiate. "
+        f"Be specific about what terms you'd accept. 2-3 sentences."
+    ).text
+    print(f"\n[Client]: {client_msg_2[:300]}...")
+
+    # ── Round 2: Advisor gives final recommendation ───────────────────
+    print("\n" + "=" * 60)
+    print("Round 2: Advisor → Client (final recommendation)")
+    print("=" * 60)
+
+    advisor_msg_2 = model.generate_content(
+        f"You are the contract advisor. The client's priorities:\n\n"
+        f"{client_msg_2}\n\n"
+        f"Original contract:\n{contract_text}\n\n"
+        f"Write a final recommendation with:\n"
+        f"1. Specific redline changes to propose\n"
+        f"2. Fallback positions if vendor pushes back\n"
+        f"3. Deal-breakers (walk away if these aren't fixed)\n"
+        f"Be concrete — reference specific clause numbers."
+    ).text
+    print(f"\n[Advisor]: {advisor_msg_2[:600]}...")
+
+    # ── Summary ───────────────────────────────────────────────────────
+    print("\n" + "=" * 60)
+    print("Summary")
+    print("=" * 60)
+    print(f"  Rounds:    2 (client→advisor→client→advisor)")
+    print(f"  Pattern:   Multi-ROUND (two roles communicating)")
+    print(f"  Messages:  4 total")
+    print(f"  Harbor equivalent: PR #1462 (BaseUser + UserFactory + per-round archiving)")
+    print(f"  BenchFlow:         15 lines of YAML config")
+
+
+if __name__ == "__main__":
+    print("BenchFlow Scene Demo — Realistic Contract Consultation")
+    print("=" * 60)
+    show_scene_config()
+    run_consultation()

--- a/docs/notebooks/consultation-task/contract.md
+++ b/docs/notebooks/consultation-task/contract.md
@@ -1,0 +1,40 @@
+# Software License Agreement
+
+Between: Acme Corp ("Vendor") and Client ("Licensee")
+Effective Date: January 1, 2026
+
+## 1. License Grant
+Vendor grants Licensee a non-exclusive, non-transferable license to use
+the Software for internal business purposes only.
+
+## 2. Term
+Initial term: 36 months. Auto-renews for successive 12-month periods
+unless either party gives 90 days written notice before expiration.
+
+## 3. Fees
+- Year 1: $120,000
+- Year 2: $138,000 (15% increase)
+- Year 3: $158,700 (15% increase)
+- Renewal years: subject to Vendor's then-current pricing
+
+## 4. Data
+All data processed through the Software remains Licensee's property.
+Vendor may use anonymized, aggregated data for product improvement.
+Upon termination, Vendor will make Licensee's data available for export
+for 30 days, after which it may be deleted.
+
+## 5. SLA
+Vendor targets 99.5% uptime. No credits or remedies for downtime.
+
+## 6. Limitation of Liability
+Vendor's total liability shall not exceed fees paid in the prior 12 months.
+In no event shall Vendor be liable for indirect, consequential, or
+special damages.
+
+## 7. Termination
+Either party may terminate for material breach with 30 days notice
+and opportunity to cure. Vendor may terminate immediately if Licensee
+fails to pay within 15 days of invoice.
+
+## 8. Governing Law
+This agreement shall be governed by the laws of Delaware.

--- a/docs/notebooks/consultation-task/instruction.md
+++ b/docs/notebooks/consultation-task/instruction.md
@@ -1,0 +1,14 @@
+# Client Consultation — Contract Review Task
+
+You are a professional advisor helping a client review a vendor contract.
+The client will share details about their situation in stages. Your job:
+
+1. Read the contract at /app/contract.md
+2. Identify key risks, unfavorable terms, and missing protections
+3. Write a structured analysis to /app/analysis.md with:
+   - Summary of key terms
+   - Risk assessment (HIGH/MEDIUM/LOW for each clause)
+   - Recommended changes
+   - Questions for the client
+
+Be thorough but practical — focus on terms that actually matter.

--- a/docs/notebooks/multi-turn-scene-demo.py
+++ b/docs/notebooks/multi-turn-scene-demo.py
@@ -35,6 +35,7 @@ async def demo_single_agent():
 
     result = await bf.run(
         "gemini",
+        env="daytona",
         task_path=".ref/terminal-bench-2/regex-log",
         model="gemini-3.1-flash-lite-preview",
     )

--- a/docs/notebooks/multi-turn-scene-demo.py
+++ b/docs/notebooks/multi-turn-scene-demo.py
@@ -1,10 +1,17 @@
-"""Multi-turn Scene demo — interactive agent benchmarking with benchflow.
+"""Scene demo — multi-turn, multi-round, and multi-scene benchmarking.
 
-This script demonstrates benchflow's Scene-based Trial lifecycle, showing
-how to run multi-turn, multi-agent evaluations that Harbor #1316 proposed
-and PR #1462 built 600+ lines to implement.
+Terminology:
+  Turn  = one prompt in one ACP session (one role acts)
+  Round = one cycle of multi-agent exchange (A→B = 1 round)
+  Scene = one interaction region with roles + turns
 
-With benchflow, the same patterns are YAML configs — no new runtime code.
+  Multi-turn:  same agent, multiple sequential prompts (Demo 2)
+  Multi-round: different agents take turns communicating (Demo 3, 4)
+  Multi-scene: sequential scenes in shared sandbox (Demo 5)
+
+This demonstrates benchflow's Scene-based Trial lifecycle, showing
+how to run all patterns that Harbor #1316 proposed (and PR #1462 built
+600+ lines to implement) as YAML configs — no new runtime code.
 
 Run:
     pip install benchflow==0.3.0a8
@@ -48,9 +55,9 @@ async def demo_single_agent():
     return reward
 
 
-# ── Demo 2: Multi-turn self-review ─────────────────────────────────────
-# Same agent gets two prompts: solve, then review your own work.
-# Harbor equivalent: prompts list in YAML
+# ── Demo 2: Multi-TURN self-review ────────────────────────────────────
+# Same agent, two sequential prompts (maintains ACP session context).
+# This is multi-TURN — one role, multiple prompts.
 
 async def demo_multi_turn():
     print("\n" + "=" * 60)
@@ -81,10 +88,10 @@ async def demo_multi_turn():
     return reward
 
 
-# ── Demo 3: Coder + Reviewer (two-role Scene) ────────────────────────
-# Two agents in one scene — coder solves, reviewer critiques, coder fixes.
-# Harbor equivalent: PR #1462 (600+ lines of User orchestration)
-# Benchflow: 15 lines of config.
+# ── Demo 3: Coder + Reviewer (multi-ROUND) ───────────────────────────
+# Two roles taking turns — coder→reviewer→coder = 1.5 rounds.
+# This is multi-ROUND — different roles communicate.
+# Harbor equivalent: PR #1462 (600+ lines). Benchflow: 15 lines of config.
 
 async def demo_coder_reviewer():
     print("\n" + "=" * 60)
@@ -126,9 +133,9 @@ async def demo_coder_reviewer():
     return reward
 
 
-# ── Demo 4: Interactive user simulation (harbor #1316) ────────────────
-# A "user" role reveals task info gradually. Agent asks questions.
-# This is exactly what harbor #1316 proposed.
+# ── Demo 4: Interactive user simulation (multi-ROUND, harbor #1316) ───
+# A "user" role reveals task info gradually. Agent responds.
+# This is multi-ROUND with a simulated user — exactly harbor #1316.
 
 async def demo_interactive_user():
     print("\n" + "=" * 60)
@@ -170,8 +177,9 @@ async def demo_interactive_user():
     return reward
 
 
-# ── Demo 5: Two-scene BYOS (skill generation → solve) ────────────────
-# First scene: agent generates a skill. Second scene: agent uses it.
+# ── Demo 5: Multi-SCENE BYOS (skill generation → solve) ──────────────
+# Two scenes in sequence, shared sandbox. First generates, second solves.
+# This is multi-SCENE — sequential scenes with state carryover.
 
 async def demo_byos():
     print("\n" + "=" * 60)

--- a/docs/notebooks/multi-turn-scene-demo.py
+++ b/docs/notebooks/multi-turn-scene-demo.py
@@ -1,0 +1,238 @@
+"""Multi-turn Scene demo — interactive agent benchmarking with benchflow.
+
+This script demonstrates benchflow's Scene-based Trial lifecycle, showing
+how to run multi-turn, multi-agent evaluations that Harbor #1316 proposed
+and PR #1462 built 600+ lines to implement.
+
+With benchflow, the same patterns are YAML configs — no new runtime code.
+
+Run:
+    pip install benchflow==0.3.0a8
+    export DAYTONA_API_KEY="dtn_..."
+    export GEMINI_API_KEY="AIza..."
+    python docs/notebooks/multi-turn-scene-demo.py
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+# Add src to path for dev installs
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "src"))
+
+import benchflow as bf
+from benchflow.trial import Trial, TrialConfig, Scene, Role, Turn
+
+
+# ── Demo 1: Single-agent baseline ─────────────────────────────────────
+# The simplest case — one agent, one task, one turn.
+# Harbor equivalent: `harbor run`
+
+async def demo_single_agent():
+    print("=" * 60)
+    print("Demo 1: Single-agent baseline")
+    print("=" * 60)
+
+    result = await bf.run(
+        "gemini",
+        task_path=".ref/terminal-bench-2/regex-log",
+        model="gemini-3.1-flash-lite-preview",
+    )
+
+    reward = (result.rewards or {}).get("reward", 0.0)
+    print(f"  Task:       regex-log")
+    print(f"  Reward:     {reward}")
+    print(f"  Tool calls: {result.n_tool_calls}")
+    print(f"  Error:      {result.error or 'none'}")
+    return reward
+
+
+# ── Demo 2: Multi-turn self-review ─────────────────────────────────────
+# Same agent gets two prompts: solve, then review your own work.
+# Harbor equivalent: prompts list in YAML
+
+async def demo_multi_turn():
+    print("\n" + "=" * 60)
+    print("Demo 2: Multi-turn self-review")
+    print("=" * 60)
+
+    config = TrialConfig(
+        task_path=Path(".ref/terminal-bench-2/regex-log"),
+        scenes=[Scene(
+            name="self-review",
+            roles=[Role("agent", "gemini", "gemini-3.1-flash-lite-preview")],
+            turns=[
+                Turn("agent"),  # solve (uses instruction.md)
+                Turn("agent", "Review your solution. Check edge cases, test it mentally with concrete inputs, and fix any issues you find."),
+            ],
+        )],
+        environment="daytona",
+    )
+
+    trial = await Trial.create(config)
+    result = await trial.run()
+
+    reward = (result.rewards or {}).get("reward", 0.0)
+    print(f"  Task:       regex-log")
+    print(f"  Reward:     {reward}")
+    print(f"  Tool calls: {result.n_tool_calls}")
+    print(f"  Error:      {result.error or 'none'}")
+    return reward
+
+
+# ── Demo 3: Coder + Reviewer (two-role Scene) ────────────────────────
+# Two agents in one scene — coder solves, reviewer critiques, coder fixes.
+# Harbor equivalent: PR #1462 (600+ lines of User orchestration)
+# Benchflow: 15 lines of config.
+
+async def demo_coder_reviewer():
+    print("\n" + "=" * 60)
+    print("Demo 3: Coder + Reviewer (independent code review)")
+    print("=" * 60)
+
+    config = TrialConfig(
+        task_path=Path(".ref/terminal-bench-2/regex-log"),
+        scenes=[Scene(
+            name="code-review",
+            roles=[
+                Role("coder", "gemini", "gemini-3.1-flash-lite-preview"),
+                Role("reviewer", "gemini", "gemini-3.1-flash-lite-preview"),
+            ],
+            turns=[
+                Turn("coder"),
+                Turn("reviewer",
+                     "You are a code reviewer. Read the coder's work in /app/. "
+                     "Check for correctness and edge cases. "
+                     "Write specific feedback to /app/.outbox/coder.json: "
+                     '{"to": "coder", "content": "YOUR FEEDBACK"}'),
+                Turn("coder",
+                     "Read the reviewer's feedback at /app/.outbox/coder.json "
+                     "and fix the issues they found. Focus on the specific "
+                     "problems mentioned."),
+            ],
+        )],
+        environment="daytona",
+    )
+
+    trial = await Trial.create(config)
+    result = await trial.run()
+
+    reward = (result.rewards or {}).get("reward", 0.0)
+    print(f"  Task:       regex-log")
+    print(f"  Reward:     {reward}")
+    print(f"  Tool calls: {result.n_tool_calls}")
+    print(f"  Error:      {result.error or 'none'}")
+    return reward
+
+
+# ── Demo 4: Interactive user simulation (harbor #1316) ────────────────
+# A "user" role reveals task info gradually. Agent asks questions.
+# This is exactly what harbor #1316 proposed.
+
+async def demo_interactive_user():
+    print("\n" + "=" * 60)
+    print("Demo 4: Interactive user simulation (harbor #1316)")
+    print("=" * 60)
+
+    config = TrialConfig(
+        task_path=Path(".ref/terminal-bench-2/regex-log"),
+        scenes=[Scene(
+            name="interactive",
+            roles=[
+                Role("user", "gemini", "gemini-3.1-flash-lite-preview"),
+                Role("agent", "gemini", "gemini-3.1-flash-lite-preview"),
+            ],
+            turns=[
+                # User gives vague instruction first
+                Turn("user",
+                     "You are simulating a user who wants help writing a regex. "
+                     "Read /app/instruction.md for the full spec, but only tell "
+                     "the agent: 'I need a regex to find dates in log files that "
+                     "have IP addresses.' Save your message to /app/.outbox/agent.json"),
+                Turn("agent",
+                     "Read the user's request at /app/.outbox/agent.json. "
+                     "Ask clarifying questions or start solving. "
+                     "Save your regex to /app/regex.txt"),
+            ],
+        )],
+        environment="daytona",
+    )
+
+    trial = await Trial.create(config)
+    result = await trial.run()
+
+    reward = (result.rewards or {}).get("reward", 0.0)
+    print(f"  Task:       regex-log (via simulated user)")
+    print(f"  Reward:     {reward}")
+    print(f"  Tool calls: {result.n_tool_calls}")
+    print(f"  Error:      {result.error or 'none'}")
+    return reward
+
+
+# ── Demo 5: Two-scene BYOS (skill generation → solve) ────────────────
+# First scene: agent generates a skill. Second scene: agent uses it.
+
+async def demo_byos():
+    print("\n" + "=" * 60)
+    print("Demo 5: BYOS (skill generation → solve)")
+    print("=" * 60)
+
+    config = TrialConfig(
+        task_path=Path(".ref/terminal-bench-2/regex-log"),
+        scenes=[
+            Scene(
+                name="skill-gen",
+                roles=[Role("gen", "gemini", "gemini-3.1-flash-lite-preview")],
+                turns=[Turn("gen",
+                    "Read /app/instruction.md. Write a concise skill document "
+                    "to /app/generated-skill.md capturing the key domain "
+                    "knowledge and step-by-step procedure needed.")],
+            ),
+            Scene(
+                name="solve",
+                roles=[Role("solver", "gemini", "gemini-3.1-flash-lite-preview")],
+                turns=[Turn("solver")],
+            ),
+        ],
+        environment="daytona",
+    )
+
+    trial = await Trial.create(config)
+    result = await trial.run()
+
+    reward = (result.rewards or {}).get("reward", 0.0)
+    print(f"  Task:       regex-log (with skill generation)")
+    print(f"  Reward:     {reward}")
+    print(f"  Tool calls: {result.n_tool_calls}")
+    print(f"  Error:      {result.error or 'none'}")
+    return reward
+
+
+# ── Run all demos ─────────────────────────────────────────────────────
+
+async def main():
+    print("BenchFlow Multi-Turn Scene Demo")
+    print(f"Version: {bf.__version__}")
+    print()
+
+    results = {}
+    results["single"] = await demo_single_agent()
+    results["multi-turn"] = await demo_multi_turn()
+    results["coder-reviewer"] = await demo_coder_reviewer()
+    results["interactive-user"] = await demo_interactive_user()
+    results["byos"] = await demo_byos()
+
+    print("\n" + "=" * 60)
+    print("Summary")
+    print("=" * 60)
+    for name, reward in results.items():
+        status = "PASS" if reward == 1.0 else "FAIL"
+        print(f"  {name:<20} reward={reward}  [{status}]")
+
+    print(f"\nAll patterns demonstrated with the same task (regex-log).")
+    print(f"Harbor #1316 needs 600+ lines of runtime code.")
+    print(f"BenchFlow needs 15 lines of YAML config per pattern.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
Demo script showing 5 multi-turn patterns on regex-log TB2 task.
Works backwards from harbor #1316 (Tai Vu's multi-turn need).

## Patterns demonstrated
1. Single-agent baseline
2. Multi-turn self-review (same agent, two prompts)
3. Coder + reviewer (two roles, three turns)
4. Interactive user simulation (harbor #1316 equivalent)
5. Two-scene BYOS (skill-gen → solve)

## Why this matters
Harbor PR #1462 adds 600+ lines of runtime code for pattern #4.
BenchFlow does all 5 patterns with ~15 lines of config each.

## Test plan
- [ ] All 5 demos run without errors
- [ ] Results committed after dogfood run completes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/166" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
