### PR TITLE
feat: add OpenHands agent to registry (#169)

### DIFF
--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -40,6 +40,8 @@ def auto_inherit_env(agent_env: dict[str, str]) -> None:
         "GEMINI_API_KEY",
         "GOOGLE_CLOUD_PROJECT",
         "GOOGLE_CLOUD_LOCATION",
+        "LLM_API_KEY",
+        "LLM_BASE_URL",
     }
     for cfg in PROVIDERS.values():
         if cfg.auth_env:

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -308,6 +308,24 @@ AGENTS: dict[str, AgentConfig] = {
             ],
         ),
     ),
+    "openhands": AgentConfig(
+        name="openhands",
+        description="OpenHands agent via ACP (multi-model, Python-based)",
+        skill_paths=[],
+        install_cmd=(
+            "( command -v openhands >/dev/null 2>&1 || "
+            "pip install openhands >/dev/null 2>&1 ) && "
+            "command -v openhands >/dev/null 2>&1"
+        ),
+        launch_cmd="openhands acp --always-approve --override-with-envs",
+        protocol="acp",
+        requires_env=["LLM_API_KEY"],
+        api_protocol="",
+        env_mapping={
+            "BENCHFLOW_PROVIDER_BASE_URL": "LLM_BASE_URL",
+            "BENCHFLOW_PROVIDER_API_KEY": "LLM_API_KEY",
+        },
+    ),
 }
 
 
@@ -387,6 +405,8 @@ AGENT_ALIASES: dict[str, str] = {
     "gemini": "gemini",
     "pi": "pi-acp",
     "openclaw": "openclaw",
+    "openhands": "openhands",
+    "oh": "openhands",
 }
 
 VALID_PROTOCOLS = {"acp", "harbor"}


### PR DESCRIPTION
Closes #169.

## Summary
Add OpenHands agent to the benchflow registry. OpenHands speaks ACP natively
(built into the `openhands` package, no wrapper needed).

## Changes
- `registry.py`: new `openhands` AgentConfig
- `_agent_env.py`: add `LLM_API_KEY`, `LLM_BASE_URL` to auto_inherit_env
- Aliases: `openhands`, `oh`

## Usage
```bash
bench eval create -t tasks/X -a openhands --ae LLM_API_KEY=sk-... --ae LLM_MODEL=claude-sonnet-4-5
```

## Test plan
- [ ] `bench agent list` shows openhands
- [ ] `bench agent show openhands` displays config
- [ ] Integration: run a task with openhands agent on Daytona
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/170" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
