### PR TITLE
feat: bench run as the user-friendly primary command

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -21,11 +21,11 @@ app = typer.Typer(
 )
 
 
-@app.command(hidden=True, deprecated=True)
+@app.command()
 def run(
     task_dir: Annotated[
         Path,
-        typer.Option("--task-dir", "-t", help="Task directory"),
+        typer.Argument(help="Task directory (must contain task.toml)"),
     ],
     agent: Annotated[
         str,
@@ -37,7 +37,7 @@ def run(
     ] = None,
     environment: Annotated[
         str,
-        typer.Option("--env", "-e", help="Environment: docker or daytona"),
+        typer.Option("--backend", "-b", help="Backend: docker or daytona"),
     ] = "docker",
     prompt: Annotated[
         list[str] | None,
@@ -51,7 +51,7 @@ def run(
     ] = "jobs",
     agent_env: Annotated[
         list[str] | None,
-        typer.Option("--ae", help="Agent env var (KEY=VALUE)"),
+        typer.Option("--agent-env", "--ae", help="Agent env var (KEY=VALUE)"),
     ] = None,
     skills_dir: Annotated[
         Path | None,
@@ -67,7 +67,12 @@ def run(
         ),
     ] = "agent",
 ) -> None:
-    """Run a single task with an ACP agent."""
+    """Run a single task with an ACP agent.
+
+    Examples:
+        bench run tasks/regex-log --agent gemini --model gemini-3.1-flash-lite-preview
+        bench run tasks/X --agent openhands --backend daytona
+    """
     from benchflow.sdk import SDK
 
     parsed_env: dict[str, str] = {}


### PR DESCRIPTION
Addresses CLI ergonomics feedback from Codex + kywch review.

## Changes
- `bench run` unhidden — now the primary user-facing command
- Task path is positional: `bench run tasks/X` (not `--task-dir/-t`)
- `--env` → `--backend/-b` (avoids Docker `-e` = env confusion)
- `--ae` → `--agent-env/--ae` (descriptive name + shortcut)
- Examples in docstring

## Before
```bash
bench eval create -t tasks/X -a openhands --ae LLM_API_KEY=sk-... -e daytona
```

## After
```bash
bench run tasks/X --agent openhands --model claude-sonnet-4-5 --backend daytona
```

`bench eval create` stays as the advanced batch/async surface.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/171" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
