### PR TITLE
fix: skip model/API-key validation for oracle agent

### DIFF
--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -144,7 +144,7 @@ def resolve_agent_env(
     """Resolve agent environment: auto-inherit keys, provider vars, env_mapping."""
     agent_env = dict(agent_env or {})
     auto_inherit_env(agent_env)
-    if model and agent != "oracle":
+    if model:
         inject_vertex_credentials(agent_env, model)
         resolve_provider_env(agent_env, model, agent)
         # Validate required API key for the chosen model

--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -144,7 +144,7 @@ def resolve_agent_env(
     """Resolve agent environment: auto-inherit keys, provider vars, env_mapping."""
     agent_env = dict(agent_env or {})
     auto_inherit_env(agent_env)
-    if model:
+    if model and agent != "oracle":
         inject_vertex_credentials(agent_env, model)
         resolve_provider_env(agent_env, model, agent)
         # Validate required API key for the chosen model

--- a/src/benchflow/cli/eval.py
+++ b/src/benchflow/cli/eval.py
@@ -228,11 +228,12 @@ def _run_single(
     from benchflow.sdk import SDK
 
     sdk = SDK()
+    effective_model = None if agent == "oracle" else (model or DEFAULT_MODEL)
     result = asyncio.run(
         sdk.run(
             task_path=task_dir,
             agent=agent,
-            model=model or DEFAULT_MODEL,
+            model=effective_model,
             environment=environment,
             prompts=cast("list[str | None] | None", prompt),
             agent_env=agent_env,
@@ -268,9 +269,10 @@ def _run_batch(
 ) -> None:
     from benchflow.job import Job, JobConfig, RetryConfig
 
+    effective_model = None if agent == "oracle" else (model or DEFAULT_MODEL)
     config = JobConfig(
         agent=agent,
-        model=model or DEFAULT_MODEL,
+        model=effective_model,
         environment=environment,
         concurrency=concurrency,
         retry=RetryConfig(max_retries=max_retries),

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -146,7 +146,7 @@ class JobConfig:
     """Configuration for a benchmark job."""
 
     agent: str = DEFAULT_AGENT
-    model: str = DEFAULT_MODEL
+    model: str | None = DEFAULT_MODEL
     environment: str = "docker"
     concurrency: int = 4
     prompts: list[str | None] | None = None


### PR DESCRIPTION
Closes #172

## Summary

- Oracle agent runs `solution/solve.sh` and never calls an LLM, but `resolve_agent_env()` was validating API keys for the CLI's default model (`claude-haiku-4-5-20251001`)
- `bench eval create -a oracle` now works without `ANTHROPIC_API_KEY` set
- One-line change: skip the model validation block when `agent == "oracle"`

## Test plan

- [x] All 42 tests in `test_resolve_env_helpers.py` and `test_subscription_auth.py` pass
- [ ] Run `bench eval create -t <task> -a oracle` without `ANTHROPIC_API_KEY` — should succeed
- [ ] Run `bench eval create -t <task> -a claude-agent-acp` — API key validation still works as before
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
