### PR TITLE
fix: OpenHands agent — sandbox launch, auth, model, and cwd (#169)

### DIFF
--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -88,7 +88,7 @@ def build_priv_drop_cmd(agent_launch: str, sandbox_user: str) -> str:
     No outer sh -c wrapper — DockerProcess wraps in bash -c already.
     """
     inner = (
-        f"export HOME=/home/{sandbox_user} && cd /home/{sandbox_user} && {agent_launch}"
+        f"export HOME=/home/{sandbox_user} && {agent_launch}"
     )
     quoted = shlex.quote(inner)
     return (

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -312,6 +312,7 @@ AGENTS: dict[str, AgentConfig] = {
         name="openhands",
         description="OpenHands agent via ACP (multi-model, Python-based)",
         skill_paths=[],
+        home_dirs=[".openhands"],
         install_cmd=(
             "export DEBIAN_FRONTEND=noninteractive && "
             "export PATH=\"$HOME/.local/bin:$PATH\" && "
@@ -323,15 +324,29 @@ AGENTS: dict[str, AgentConfig] = {
             "  ) ) && "
             "  uv tool install openhands --python 3.12 >/dev/null 2>&1 "
             ") ) && "
+            # Let sandbox user traverse to the uv-managed Python interpreter
+            "chmod o+x /root /root/.local /root/.local/share "
+            "/root/.local/share/uv /root/.local/share/uv/tools 2>/dev/null; "
+            # Seed agent_settings.json so _is_authenticated() passes
+            "mkdir -p ~/.openhands && "
+            "echo '{\"llm\":{\"model\":\"placeholder\",\"api_key\":\"placeholder\"}}' "
+            "> ~/.openhands/agent_settings.json && "
             "command -v openhands >/dev/null 2>&1"
         ),
-        launch_cmd="openhands acp --always-approve --override-with-envs",
+        launch_cmd=(
+            "export PATH=\"$HOME/.local/bin:$PATH\" && "
+            "mkdir -p ~/.openhands && "
+            "printf '{\"llm\":{\"model\":\"%s\",\"api_key\":\"%s\"}}' "
+            "\"$LLM_MODEL\" \"$LLM_API_KEY\" > ~/.openhands/agent_settings.json && "
+            "openhands acp --always-approve --override-with-envs"
+        ),
         protocol="acp",
         requires_env=["LLM_API_KEY"],
         api_protocol="",
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "LLM_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY": "LLM_API_KEY",
+            "BENCHFLOW_PROVIDER_MODEL": "LLM_MODEL",
         },
     ),
 }


### PR DESCRIPTION
## Summary

Fixes #169 — OpenHands agent fails with `command not found` (and then auth / model / cwd issues once that's resolved).

Five root causes found and fixed:

1. **PATH**: `uv tool install` puts binaries in `~/.local/bin/` which isn't on PATH at launch time → add `$HOME/.local/bin` to `launch_cmd`
2. **Interpreter access**: entry point shebang points to `/root/.local/share/uv/tools/.../python`, but `/root/` is mode 700 → `chmod o+x` on path chain (traverse only, not read)
3. **ACP auth**: OpenHands `_is_authenticated()` requires `agent_settings.json` on disk, and `_create_conversation` doesn't pass `env_overrides_enabled` → seed settings at install, overwrite with real `LLM_MODEL`/`LLM_API_KEY` at launch
4. **Model env**: `BENCHFLOW_PROVIDER_MODEL` → `LLM_MODEL` mapping was missing → add to `env_mapping`
5. **CWD**: `build_priv_drop_cmd` hardcoded `cd /home/{user}` which overrode docker's `-w /app` workspace → remove the `cd`

Also adds `home_dirs=[".openhands"]` so `setup_sandbox_user` copies the settings dir.

## Test plan

- [x] `bench eval create -t hello-world-task -a openhands -m gemini/gemini-3.1-flash-lite-preview` → reward 1.0
- [x] `bench run hello-world-task -a openhands` → reward 1.0
- [x] `bench eval create` with `--sandbox-user none` (root) → reward 1.0
- [x] `bench run hello-world-task -a gemini` → reward 1.0 (regression check)
- [x] 45/45 registry + sandbox unit tests pass
- [ ] Devin review
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
