### PR TITLE
fix: clamp Daytona storage_mb to configurable max

### DIFF
--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 # build) instead of erroring out. Override via env if running on a paid tier.
 _DAYTONA_MAX_CPUS = int(os.environ.get("BENCHFLOW_DAYTONA_MAX_CPUS", "4"))
 _DAYTONA_MAX_MEMORY_MB = int(os.environ.get("BENCHFLOW_DAYTONA_MAX_MEMORY_MB", "8192"))
+_DAYTONA_MAX_STORAGE_MB = int(os.environ.get("BENCHFLOW_DAYTONA_MAX_STORAGE_MB", "10240"))
 
 # Directories to ignore when copying deps
 _IGNORE_DIRS = {
@@ -275,6 +276,13 @@ def _create_environment(
                 _DAYTONA_MAX_MEMORY_MB,
             )
             env_config.memory_mb = _DAYTONA_MAX_MEMORY_MB
+        if env_config.storage_mb > _DAYTONA_MAX_STORAGE_MB:
+            logger.warning(
+                "Clamping storage_mb %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_STORAGE_MB)",
+                env_config.storage_mb,
+                _DAYTONA_MAX_STORAGE_MB,
+            )
+            env_config.storage_mb = _DAYTONA_MAX_STORAGE_MB
 
         return DaytonaEnvironment(
             environment_dir=task.paths.environment_dir,


### PR DESCRIPTION
## Summary

- Add `_DAYTONA_MAX_STORAGE_MB` constant (default 10240 / 10 GB, configurable via `BENCHFLOW_DAYTONA_MAX_STORAGE_MB` env var)
- Clamp `env_config.storage_mb` in `_create_environment()`, matching the existing pattern for CPU and memory clamping
- Tasks requesting more storage than the tier allows now degrade gracefully instead of failing at sandbox creation

## Test plan

- [ ] Verify a task with `storage_mb > 10240` logs a warning and creates the sandbox successfully
- [ ] Verify `BENCHFLOW_DAYTONA_MAX_STORAGE_MB` override is respected
- [ ] Verify tasks with `storage_mb <= 10240` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
