### PR TITLE
Fix DinD compose ACP: use Daytona PTY WebSocket for live agent pipes

### DIFF
--- a/src/benchflow/_acp_run.py
+++ b/src/benchflow/_acp_run.py
@@ -26,7 +26,7 @@ from benchflow._trajectory import _capture_session_trajectory
 from benchflow.acp.client import ACPClient
 from benchflow.acp.container_transport import ContainerTransport
 from benchflow.agents.providers import strip_provider_prefix
-from benchflow.process import DaytonaProcess, DockerProcess
+from benchflow.process import DaytonaProcess, DaytonaPtyProcess, DockerProcess
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,12 @@ async def connect_acp(
             if environment == "docker":
                 live_proc = DockerProcess.from_harbor_env(env)
             else:
-                live_proc = await DaytonaProcess.from_harbor_env(env)
+                is_dind = hasattr(env, "_strategy") and hasattr(env._strategy, "_compose_cmd")
+                if is_dind:
+                    live_proc = await DaytonaPtyProcess.from_harbor_env(env)
+                    logger.info("Using PTY transport for DinD compose task")
+                else:
+                    live_proc = await DaytonaProcess.from_harbor_env(env)
 
             agent_log = trial_dir / "agent" / f"{agent.replace('-', '_')}.txt"
             transport = ContainerTransport(

--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -1,5 +1,6 @@
 """ACP client — benchflow acts as the client, agents are ACP servers."""
 
+import json
 import logging
 from typing import Any
 
@@ -88,14 +89,16 @@ class ACPClient:
                 f"has_result={'result' in msg} has_error={'error' in msg}"
             )
 
-            # It's a response to our request
-            if "id" in msg and msg["id"] == request_id:
+            # It's a response to our request (has id, no method — distinguishes
+            # from echoed requests when running through a PTY)
+            if "id" in msg and msg["id"] == request_id and "method" not in msg:
                 if msg.get("error"):
                     raise ACPError(
                         msg["error"].get("code", -1),
                         msg["error"].get("message", "Unknown error"),
                     )
                 return msg.get("result", {})
+
 
             # It's a notification (no id)
             if "method" in msg and "id" not in msg:

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -393,6 +393,13 @@ class Job:
         except Exception as e:
             logger.warning(f"Docker prune failed: {e}")
 
+    def _resolve_skills_dir(self, task_dir: Path, skills_dir: str | None) -> str | None:
+        """Resolve skills_dir — 'auto' means per-task environment/skills/."""
+        if skills_dir == "auto":
+            candidate = task_dir / "environment" / "skills"
+            return str(candidate) if candidate.is_dir() else None
+        return skills_dir
+
     async def _run_single_task(self, task_dir: Path, cfg: JobConfig) -> RunResult:
         """Execute one trial via Trial."""
         from benchflow.trial import Trial, TrialConfig
@@ -406,7 +413,7 @@ class Job:
             job_name=self._job_name,
             jobs_dir=str(self._jobs_dir),
             environment=cfg.environment,
-            skills_dir=cfg.skills_dir,
+            skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,
             context_root=cfg.context_root,
@@ -425,7 +432,7 @@ class Job:
             job_name=self._job_name,
             jobs_dir=str(self._jobs_dir),
             environment=cfg.environment,
-            skills_dir=cfg.skills_dir,
+            skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,
             context_root=cfg.context_root,

--- a/src/benchflow/process.py
+++ b/src/benchflow/process.py
@@ -389,3 +389,135 @@ class DaytonaProcess(LiveProcess):
             limit=_BUFFER_LIMIT,
         )
         logger.info(f"Daytona process started (pid={self._process.pid})")
+
+
+class DaytonaPtyProcess(LiveProcess):
+    """Live stdin/stdout via Daytona PTY WebSocket API.
+
+    Uses the Daytona SDK's PTY session (WebSocket) instead of SSH, which
+    maintains long-lived interactive pipes through DinD compose layers.
+    Falls back to this for DinD sandboxes where SSH pipes break.
+    """
+
+    _process = None  # Not used — override readline/writeline/close
+
+    def __init__(self, sandbox: Any, compose_cmd_prefix: str, compose_cmd_base: str):
+        self._sandbox = sandbox
+        self._compose_cmd_prefix = compose_cmd_prefix
+        self._compose_cmd_base = compose_cmd_base
+        self._pty = None
+        self._line_buffer = asyncio.Queue()
+        self._partial = b""
+        self._closed = False
+
+    @classmethod
+    async def from_harbor_env(cls, env: Any) -> "DaytonaPtyProcess":
+        sandbox = env._sandbox
+        if not sandbox:
+            raise RuntimeError("Daytona sandbox not started")
+        strategy = env._strategy
+        compose_env = " ".join(
+            f"{k}={shlex.quote(v)}" for k, v in strategy._compose_env_vars().items()
+        )
+        compose_cmd_base = strategy._compose_cmd([])
+        return cls(sandbox=sandbox, compose_cmd_prefix=compose_env, compose_cmd_base=compose_cmd_base)
+
+    async def _on_pty_data(self, data: bytes) -> None:
+        self._partial += data
+        while b"\n" in self._partial:
+            line, self._partial = self._partial.split(b"\n", 1)
+            line = line.replace(b"\r", b"")
+            await self._line_buffer.put(line + b"\n")
+
+    async def start(
+        self,
+        command: str,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        import uuid
+        session_id = f"acp-{uuid.uuid4().hex[:8]}"
+        pty_env = {}
+        if self._compose_cmd_prefix:
+            for part in shlex.split(self._compose_cmd_prefix):
+                if "=" in part:
+                    k, v = part.split("=", 1)
+                    pty_env[k] = v
+
+        self._pty = await self._sandbox.process.create_pty_session(
+            id=session_id,
+            on_data=self._on_pty_data,
+            envs=pty_env if pty_env else None,
+        )
+        await self._pty.wait_for_connection()
+        logger.info(f"DaytonaPtyProcess: PTY connected (session={session_id})")
+
+        compose_parts = shlex.split(self._compose_cmd_base) if self._compose_cmd_base else ["docker", "compose"]
+        exec_parts = compose_parts + ["exec", "-i", "-T"]
+        if cwd:
+            exec_parts.extend(["-w", cwd])
+        # Write env vars to a file inside the container (not visible in ps aux),
+        # matching the approach in DaytonaProcess.start().
+        env_file_cmd = ""
+        if env:
+            env_lines = "\n".join(f"export {k}={shlex.quote(v)}" for k, v in env.items())
+            env_file_cmd = (
+                f"cat > /tmp/.benchflow_env <<'__EOF__'\n{env_lines}\n__EOF__\n"
+                f". /tmp/.benchflow_env && rm -f /tmp/.benchflow_env && "
+            )
+        exec_parts.extend(["main", "bash", "-lc", f"{env_file_cmd}{command}"])
+        exec_cmd = shlex.join(exec_parts)
+
+        # Use a marker + stty to cleanly hand over the PTY to the agent.
+        # 1. Disable echo so typed commands don't appear in output
+        # 2. Print marker so we know when to start reading ACP output
+        # 3. exec into compose exec so the agent owns the PTY
+        marker = f"__BENCHFLOW_ACP_{session_id}__"
+        setup = f"stty -echo 2>/dev/null; echo '{marker}'; exec {exec_cmd}\n"
+        await self._pty.send_input(setup)
+        logger.info(f"DaytonaPtyProcess: sent setup, waiting for marker...")
+
+        while True:
+            try:
+                line = await asyncio.wait_for(self._line_buffer.get(), timeout=120)
+                decoded = line.decode(errors="replace").strip()
+                logger.debug(f"DaytonaPtyProcess drain: {decoded[:120]}")
+                if marker in decoded:
+                    break
+            except TimeoutError:
+                raise ConnectionError("DaytonaPtyProcess: timeout waiting for agent start marker")
+
+        logger.info(f"DaytonaPtyProcess: marker seen, agent starting")
+
+    async def readline(self) -> bytes:
+        if self._closed:
+            raise ConnectionError("PTY closed")
+        try:
+            line = await asyncio.wait_for(self._line_buffer.get(), timeout=300)
+            return line
+        except TimeoutError:
+            raise ConnectionError("PTY readline timeout (300s)")
+        except Exception as e:
+            raise ConnectionError(f"PTY readline error: {e}")
+
+    async def writeline(self, data: str) -> None:
+        if not self._pty or self._closed:
+            raise RuntimeError("PTY not started")
+        await self._pty.send_input(data + "\n")
+
+    async def close(self) -> None:
+        self._closed = True
+        if self._pty:
+            try:
+                await self._pty.kill()
+            except Exception:
+                pass
+            try:
+                await self._pty.disconnect()
+            except Exception:
+                pass
+            logger.info("DaytonaPtyProcess terminated")
+
+    @property
+    def is_running(self) -> bool:
+        return self._pty is not None and not self._closed


### PR DESCRIPTION
## Summary

- New `DaytonaPtyProcess` class that uses Daytona SDK's WebSocket PTY API instead of SSH for DinD compose tasks
- SSH pipes break through the DinD→compose exec chain (`Process closed stdout rc=None`). WebSocket PTY maintains the connection.
- Echo-resistant ACP response matching in `client.py` (filter echoed requests by checking for `method` field absence)
- `skills_dir: "auto"` support in Job for per-task skill resolution (needed after skillsbench PR #720 removed COPY skills from Dockerfiles)

## How it works

```
Old (SSH, breaks):
local → SSH → DinD VM → docker compose exec -T → container → agent
                         ↑ stdout pipe dies here

New (PTY WebSocket):
local → WebSocket → DinD VM PTY → docker compose exec -i -T → container → agent
                    ↑ persistent interactive session
```

1. Outer PTY (Daytona WebSocket): keeps connection alive through DinD
2. Inner `-T` (compose exec): disables TTY inside container so agent gets clean stdio
3. Marker-based startup: drains shell output before ACP handshake
4. Auto-detection: `_acp_run.py` detects DinD → uses PTY transport automatically

## Test results

| Task | Before | After |
|------|--------|-------|
| pedestrian-traffic-counting | rc=None, 0 tools | reward=0.014, 7 tools |
| gh-repo-analytics | rc=None, 0 tools | reward=0.0, 11 tools |
| pg-essay-to-audiobook | rc=None, 0 tools | 34 tools (PTY timeout — needs longer readline) |

## Test plan
- [x] pedestrian-traffic-counting: agent runs, produces reward
- [x] gh-repo-analytics: agent runs, 11 tool calls
- [x] pg-essay-to-audiobook: agent runs 34 tool calls (readline timeout needs increase)
- [ ] Non-compose tasks unaffected (PTY only used for DinD)

Ref: #192
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
