### PR TITLE
verifier: mkdir -p /app before pytest

### DIFF
--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -545,9 +545,15 @@ class Trial:
         from benchflow._sandbox import _build_cleanup_cmd, _read_hardening_config
 
         self._trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
-        # Clean verifier output dir — chmod 777 so non-root verifier processes can write
+        # Clean verifier output dir — chmod 777 so non-root verifier processes can write.
+        # Also ensure /app exists: VERIFIER_ENV pins PYTEST_ADDOPTS=--rootdir=/app for
+        # test-node-ID anchoring, and pytest aborts with "Directory '/app' not found"
+        # when the task's Dockerfile WORKDIRs elsewhere (e.g. /root). Tasks that DO
+        # populate /app are unaffected — `mkdir -p` is a no-op when the directory
+        # already exists, and we don't chmod it (any task content stays root-owned).
         await self._env.exec(
-            "rm -rf /logs/verifier && mkdir -p /logs/verifier && chmod 777 /logs/verifier",
+            "rm -rf /logs/verifier && mkdir -p /logs/verifier /app && "
+            "chmod 777 /logs/verifier",
             user="root", timeout_sec=10,
         )
         # Purge agent-injected conftest/sitecustomize/.pth without


### PR DESCRIPTION
## Summary

`VERIFIER_ENV` pins `PYTEST_ADDOPTS="--rootdir=/app …"` (see `_sandbox.py:307`) for test-node-ID anchoring across SkillsBench / TB-style tasks. Tasks whose Dockerfile `WORKDIR`s elsewhere (e.g. `/root`) and don't otherwise create `/app` trip pytest's at-startup directory check:

```
ERROR: Directory '/app' not found. Check your '--rootdir' option.
```

The verifier aborts before reaching `test_outputs.py` and the trial scores `0` even when the agent produced correct output.

Surfaced today by trajectory analysis of the SkillsBench Apr 2026 patch trial:

- `pg-essay-to-audiobook` wrote `/root/audiobook.mp3` (29:45 MP3, valid ffmpeg output) and the verifier's pytest still aborted on the missing `/app` rootdir.
- Same shape on `scheduling-email-assistant` and several other Trial 1 ERROR-classified tasks.

`skill_eval`'s Dockerfile augmentation already does this (`src/benchflow/skill_eval.py:325` runs `mkdir -p /logs/verifier /logs/agent /logs/artifacts /app /tests`). This PR adds the equivalent to the regular eval path so all benchflow runs get `/app`, not just skill_eval ones.

## Idempotence

`mkdir -p` is a no-op when the directory already exists. We deliberately don't `chmod` `/app` so any task content (e.g. swebench-style repo at `/app/<repo>`) stays root-owned and undisturbed.

## Test plan
- [ ] Re-run `pg-essay-to-audiobook` and `scheduling-email-assistant` from the SkillsBench Apr 2026 patch trial — verifier should now reach `test_outputs.py` instead of aborting at pytest's rootdir check.
- [ ] Existing tasks with `WORKDIR /app` (e.g. `azure-bgp-oscillation-route-leak`, `dialogue-parser`) should be unaffected — `mkdir -p` is a no-op there.
- [ ] No change to `skill_eval` flow (it was already doing this).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
