### PR TITLE
fix: propagate OPENAI_API_KEY for vllm provider

### DIFF
--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -130,7 +130,8 @@ PROVIDERS: dict[str, ProviderConfig] = {
         name="vllm",
         base_url="",  # user-supplied via --ae BENCHFLOW_PROVIDER_BASE_URL=...
         api_protocol="openai-completions",
-        auth_type="none",
+        auth_type="api_key",
+        auth_env="OPENAI_API_KEY",  # vLLM uses OpenAI-compatible auth
     ),
     # ── Custom providers (need explicit endpoint config in agent shims) ──
     "zai": ProviderConfig(


### PR DESCRIPTION
Fixes #3.

## Problem

When a vLLM server is started with `--api-key`, the API key never reaches the container because the vllm provider is configured with `auth_type="none"`. `resolve_provider_env()` skips API key injection for `auth_type="none"`, so `BENCHFLOW_PROVIDER_API_KEY` is never set and the agent gets a 401.

## Fix

Change vllm provider config to `auth_type="api_key"` with `auth_env="OPENAI_API_KEY"`. Since vLLM speaks the OpenAI protocol, `OPENAI_API_KEY` is the natural env var.

## Backward compatibility

If `OPENAI_API_KEY` is unset, `_key` is empty and `BENCHFLOW_PROVIDER_API_KEY` is not injected — identical behavior to `auth_type="none"`. The fix only activates when a key is present.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
