### PR TITLE
feat: add optional skill nudge to prompt resolution

### DIFF
--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -330,13 +330,68 @@ class SDK:
 
     @staticmethod
     def _resolve_prompts(
-        task_path: Path, prompts: list[str | None] | None
+        task_path: Path,
+        prompts: list[str | None] | None,
+        skills_dir: str | Path | None = None,
+        skill_nudge: str = "",
+        agent: str | None = None,
     ) -> list[str]:
-        """Read instruction.md and resolve prompt list."""
+        """Read instruction.md and resolve prompt list.
+
+        skill_nudge: "", "name", "description", or "full".
+        """
         instruction_path = task_path / "instruction.md"
         if not instruction_path.exists():
             raise FileNotFoundError(f"Task missing instruction.md: {task_path}")
         instruction = instruction_path.read_text().strip()
+
+        if skill_nudge:
+            from benchflow.agents.registry import AGENTS
+
+            skill_display_path = "~/.claude/skills"
+            if agent:
+                agent_cfg = AGENTS.get(agent)
+                if agent_cfg and agent_cfg.skill_paths:
+                    skill_display_path = agent_cfg.skill_paths[0].replace("$HOME", "~")
+
+            skills = []
+            for src in [skills_dir, task_path / "environment" / "skills"]:
+                if src and Path(src).is_dir():
+                    for d in sorted(Path(src).iterdir()):
+                        if d.is_dir() and (d / "SKILL.md").exists():
+                            content = d.joinpath("SKILL.md").read_text()
+                            name = d.name
+                            desc = ""
+                            if content.startswith("---"):
+                                parts = content.split("---", 2)
+                                if len(parts) >= 3:
+                                    import yaml
+                                    try:
+                                        fm = yaml.safe_load(parts[1])
+                                        desc = fm.get("description", "") if fm else ""
+                                    except Exception:
+                                        pass
+                            skills.append({"name": name, "desc": desc, "content": content})
+                    if skills:
+                        break
+
+            if skills:
+                if skill_nudge == "name":
+                    names = ", ".join(s["name"] for s in skills)
+                    nudge = f"Skills available at {skill_display_path}: {names}. Read them before starting."
+                    instruction = nudge + "\n\n" + instruction
+                elif skill_nudge == "description":
+                    lines = [f"Skills available at {skill_display_path}:\n"]
+                    for s in skills:
+                        lines.append(f"- **{s['name']}**: {s['desc']}")
+                    lines.append("\nRead the relevant skills before starting.")
+                    instruction = "\n".join(lines) + "\n\n" + instruction
+                elif skill_nudge == "full":
+                    blocks = []
+                    for s in skills:
+                        blocks.append(f"<skill name=\"{s['name']}\">\n{s['content']}\n</skill>")
+                    instruction = "\n\n".join(blocks) + "\n\n" + instruction
+
         if prompts is None:
             return [instruction]
         return [p if p is not None else instruction for p in prompts]

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -319,7 +319,12 @@ class Trial:
         self._agent_env = resolve_agent_env(
             cfg.primary_agent, cfg.primary_model, cfg.agent_env
         )
-        self._resolved_prompts = SDK._resolve_prompts(cfg.task_path, cfg.prompts)
+        self._resolved_prompts = SDK._resolve_prompts(
+            cfg.task_path, cfg.prompts,
+            skills_dir=cfg.skills_dir,
+            skill_nudge=cfg.agent_env.get("BENCHFLOW_SKILL_NUDGE", ""),
+            agent=cfg.primary_agent,
+        )
         self._agent_launch = AGENT_LAUNCH.get(cfg.primary_agent, cfg.primary_agent)
 
         # Copy task dir to temp when Dockerfile mutations are needed

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -322,7 +322,7 @@ class Trial:
         self._resolved_prompts = SDK._resolve_prompts(
             cfg.task_path, cfg.prompts,
             skills_dir=cfg.skills_dir,
-            skill_nudge=cfg.agent_env.get("BENCHFLOW_SKILL_NUDGE", ""),
+            skill_nudge=(cfg.agent_env or {}).get("BENCHFLOW_SKILL_NUDGE", ""),
             agent=cfg.primary_agent,
         )
         self._agent_launch = AGENT_LAUNCH.get(cfg.primary_agent, cfg.primary_agent)


### PR DESCRIPTION
## Summary

- Add optional `BENCHFLOW_SKILL_NUDGE` env var that prepends skill discovery hints to task instructions
- Three modes: `name`, `description`, `full` — default off (no behavior change)
- Skill path auto-resolved per agent from registry (e.g. `~/.claude/skills`, `~/.agents/skills`)

## Problem

BenchFlow uses each agent's native skill mechanism (progressive disclosure for claude-agent-acp), but agents often fail to discover and invoke skills. This creates a parity gap with Harbor, which injects skill content directly into the system prompt. See #204 for full analysis.

## Solution

When `BENCHFLOW_SKILL_NUDGE=name` is set, prepend one line to the instruction:

```
Skills available at ~/.claude/skills: xlsx, pdf-editing. Read them before starting.
```

This is a pure text prepend — no agent-specific mechanism needed, works across all agents.

## Experiment Results (10 tasks, single-run)

| Agent / Model | No nudge | With nudge=name |
|---|---|---|
| Claude Opus 4.7 | 50% | **80%** |
| Codex GPT 5.5 | 70% | **80%** |

Trajectory analysis shows Claude reads SKILL.md files directly after being told the path. Without the nudge, it ignores skills entirely on most tasks.

## Usage

```bash
# CLI
BENCHFLOW_SKILL_NUDGE=name bench eval create -t tasks/my-task -a claude-agent-acp -s tasks/my-task/environment/skills/

# Python SDK
await sdk.run(..., agent_env={"BENCHFLOW_SKILL_NUDGE": "name"})

# YAML config
environment:
  env:
    - BENCHFLOW_SKILL_NUDGE=name
```

## Modes

| Value | Effect |
|---|---|
| `""` (default) | Off — no change |
| `"name"` | `Skills available at <path>: X, Y. Read them before starting.` |
| `"description"` | Names + YAML frontmatter descriptions |
| `"full"` | Entire SKILL.md content prepended |

## Test plan

- [x] Default behavior unchanged (empty string = no nudge)
- [x] `name` mode prepends skill names with correct agent-specific path
- [x] `description` mode includes frontmatter descriptions
- [x] `full` mode injects complete SKILL.md content
- [x] Invalid values silently ignored
- [x] All 5 registered agents resolve correct paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/207" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
