### PR TITLE
fix: parse top-level scenes in Job.from_yaml (Harbor + native)

### DIFF
--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -169,7 +169,8 @@ class JobConfig:
     context_root: str | None = None
     exclude_tasks: set[str] = field(default_factory=set)
     # None = unspecified (legacy single-turn execution); non-empty list = multi-scene flow.
-    # Empty list `[]` is rejected at parse time (warning, treated as None).
+    # Empty list `[]` from YAML is coerced to None with a warning in _from_*_yaml; the
+    # dataclass itself does not enforce that — direct construction with [] is accepted.
     scenes: list[Scene] | None = None
 
     def __post_init__(self):
@@ -301,7 +302,7 @@ class Job:
         agent_name = raw.get("agent", DEFAULT_AGENT)
         model = effective_model(agent_name, raw.get("model"))
 
-        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        # scenes_raw: None → legacy single-turn, [] → warn-then-legacy, list → multi-scene.
         scenes_raw = raw.get("scenes")
         scenes: list[Scene] | None
         if scenes_raw is None:
@@ -316,10 +317,13 @@ class Job:
             scenes = [parse_scene(s) for s in scenes_raw]
 
         # Derive summary fields from scenes when present so summary.json reflects what runs.
+        # Re-resolve through effective_model so the oracle short-circuit applies to the
+        # scene's agent (not the top-level one) — otherwise a non-oracle top-level + oracle
+        # role would leak DEFAULT_MODEL into JobConfig and disagree with result.json.
         if scenes and scenes[0].roles:
             primary_role = scenes[0].roles[0]
             agent_name = primary_role.agent
-            model = primary_role.model or model
+            model = effective_model(agent_name, primary_role.model)
 
         config = JobConfig(
             agent=agent_name,
@@ -345,7 +349,8 @@ class Job:
 
         # Agent — accept both Harbor-canonical agents[].name/model_name and the
         # singular top-level fallback (issue #4: `agent: pi-acp` + top-level
-        # `model_name: vllm/...`). agents[].* wins when both are present.
+        # `model_name: vllm/...`). agents[].* wins when truthy; falsy values
+        # (missing key, empty string) fall through to top-level keys.
         agents = raw.get("agents") or []
         agent_cfg = agents[0] if agents else {}
         agent_name = agent_cfg.get("name") or raw.get("agent", DEFAULT_AGENT)
@@ -390,7 +395,7 @@ class Job:
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
-        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        # scenes_raw: None → legacy single-turn, [] → warn-then-legacy, list → multi-scene.
         scenes_raw = raw.get("scenes")
         scenes: list[Scene] | None
         if scenes_raw is None:
@@ -405,10 +410,11 @@ class Job:
             scenes = [parse_scene(s) for s in scenes_raw]
 
         # Derive summary fields from scenes when present so summary.json reflects what runs.
+        # See _from_native_yaml: must re-resolve through effective_model so oracle stays None.
         if scenes and scenes[0].roles:
             primary_role = scenes[0].roles[0]
             agent_name = primary_role.agent
-            model = primary_role.model or model
+            model = effective_model(agent_name, primary_role.model)
 
         config = JobConfig(
             agent=agent_name,

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -90,6 +90,7 @@ from benchflow._scoring import (
 )
 from benchflow.models import RunResult
 from benchflow.sdk import SDK
+from benchflow.trial import Scene
 
 logger = logging.getLogger(__name__)
 
@@ -167,6 +168,9 @@ class JobConfig:
     sandbox_setup_timeout: int = 120
     context_root: str | None = None
     exclude_tasks: set[str] = field(default_factory=set)
+    # None = unspecified (legacy single-turn execution); non-empty list = multi-scene flow.
+    # Empty list `[]` is rejected at parse time (warning, treated as None).
+    scenes: list[Scene] | None = None
 
     def __post_init__(self):
         from benchflow.agents.registry import AGENTS
@@ -280,6 +284,8 @@ class Job:
     @classmethod
     def _from_native_yaml(cls, raw: dict, **kwargs) -> "Job":
         """Parse benchflow-native YAML."""
+        from benchflow.trial_yaml import parse_scene
+
         tasks_dir = Path(raw["tasks_dir"])
         jobs_dir = Path(raw.get("jobs_dir", "jobs"))
 
@@ -293,9 +299,31 @@ class Job:
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
         agent_name = raw.get("agent", DEFAULT_AGENT)
+        model = effective_model(agent_name, raw.get("model"))
+
+        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        scenes_raw = raw.get("scenes")
+        scenes: list[Scene] | None
+        if scenes_raw is None:
+            scenes = None
+        elif not scenes_raw:
+            logger.warning(
+                "scenes: [] is empty — falling through to legacy single-turn execution. "
+                "Remove the key entirely if that is the intent."
+            )
+            scenes = None
+        else:
+            scenes = [parse_scene(s) for s in scenes_raw]
+
+        # Derive summary fields from scenes when present so summary.json reflects what runs.
+        if scenes and scenes[0].roles:
+            primary_role = scenes[0].roles[0]
+            agent_name = primary_role.agent
+            model = primary_role.model or model
+
         config = JobConfig(
             agent=agent_name,
-            model=effective_model(agent_name, raw.get("model")),
+            model=model,
             environment=raw.get("environment", "docker"),
             concurrency=raw.get("concurrency", 4),
             prompts=prompts,
@@ -306,19 +334,28 @@ class Job:
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
             exclude_tasks=exclude,
+            scenes=scenes,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
     @classmethod
     def _from_harbor_yaml(cls, raw: dict, **kwargs) -> "Job":
         """Parse Harbor-compatible YAML."""
-        # Agent
-        agents = raw.get("agents", [{}])
-        agent_cfg = agents[0] if agents else {}
-        agent_name = agent_cfg.get("name", DEFAULT_AGENT)
+        from benchflow.trial_yaml import parse_scene
 
+        # Agent — accept both Harbor-canonical agents[].name/model_name and the
+        # singular top-level fallback (issue #4: `agent: pi-acp` + top-level
+        # `model_name: vllm/...`). agents[].* wins when both are present.
+        agents = raw.get("agents") or []
+        agent_cfg = agents[0] if agents else {}
+        agent_name = agent_cfg.get("name") or raw.get("agent", DEFAULT_AGENT)
+        model_raw = (
+            agent_cfg.get("model_name")
+            or raw.get("model_name")
+            or raw.get("model")
+        )
         # Model — keep provider prefix intact for downstream resolution
-        model = effective_model(agent_name, agent_cfg.get("model_name") or None)
+        model = effective_model(agent_name, model_raw)
 
         # Environment
         env_cfg = raw.get("environment", {})
@@ -353,6 +390,26 @@ class Job:
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
+        # Parse scenes (decision 1A): None = legacy, [] = warn-then-legacy, list = multi-scene.
+        scenes_raw = raw.get("scenes")
+        scenes: list[Scene] | None
+        if scenes_raw is None:
+            scenes = None
+        elif not scenes_raw:
+            logger.warning(
+                "scenes: [] is empty — falling through to legacy single-turn execution. "
+                "Remove the key entirely if that is the intent."
+            )
+            scenes = None
+        else:
+            scenes = [parse_scene(s) for s in scenes_raw]
+
+        # Derive summary fields from scenes when present so summary.json reflects what runs.
+        if scenes and scenes[0].roles:
+            primary_role = scenes[0].roles[0]
+            agent_name = primary_role.agent
+            model = primary_role.model or model
+
         config = JobConfig(
             agent=agent_name,
             model=model,
@@ -364,6 +421,7 @@ class Job:
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
+            scenes=scenes,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -416,23 +474,39 @@ class Job:
         return skills_dir
 
     async def _run_single_task(self, task_dir: Path, cfg: JobConfig) -> RunResult:
-        """Execute one trial via Trial."""
+        """Execute one trial via Trial.
+
+        Uses cfg.scenes when present (multi-scene flow); otherwise synthesizes
+        a single Scene from the legacy agent/model/prompts so single-turn jobs
+        keep working unchanged.
+        """
         from benchflow.trial import Trial, TrialConfig
 
-        trial_config = TrialConfig.from_legacy(
+        resolved_skills = self._resolve_skills_dir(task_dir, cfg.skills_dir)
+        scenes = cfg.scenes or [
+            Scene.single(
+                agent=cfg.agent,
+                model=cfg.model,
+                prompts=cfg.prompts,
+                skills_dir=resolved_skills,
+            )
+        ]
+        trial_config = TrialConfig(
             task_path=task_dir,
-            agent=cfg.agent,
-            model=cfg.model,
-            prompts=cfg.prompts,
-            agent_env=cfg.agent_env,
+            scenes=scenes,
             job_name=self._job_name,
             jobs_dir=str(self._jobs_dir),
             environment=cfg.environment,
-            skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
             context_root=cfg.context_root,
+            agent_env=cfg.agent_env,
+            skills_dir=resolved_skills,
+            # Legacy mirror fields kept for any consumers reading them off TrialConfig:
+            agent=cfg.agent,
+            model=cfg.model,
+            prompts=cfg.prompts,
         )
         trial = await Trial.create(trial_config)
         return await trial.run()

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -349,11 +349,15 @@ class Trial:
         )
         self._timeout = int(self._task.config.agent.timeout_sec or 0)
 
+        from benchflow.job import effective_model
+
         SDK._write_config(
             self._trial_dir,
             task_path=cfg.task_path,
             agent=cfg.primary_agent,
-            model=cfg.primary_model,
+            # Surface the effective model (oracle → None, others → DEFAULT_MODEL when
+            # role.model is unset) so config.json agrees with summary.json (cfg.model).
+            model=effective_model(cfg.primary_agent, cfg.primary_model),
             environment=cfg.environment,
             skills_dir=cfg.skills_dir,
             sandbox_user=cfg.sandbox_user,
@@ -1061,6 +1065,7 @@ class Trial:
         return str(e)
 
     def _build_result(self) -> RunResult:
+        from benchflow.job import effective_model
         from benchflow.sdk import SDK
 
         return SDK._build_result(
@@ -1069,7 +1074,11 @@ class Trial:
             trial_name=self._trial_name or "",
             agent=self._config.primary_agent,
             agent_name=self._agent_name,
-            model=self._config.primary_model or "",
+            # Surface the effective model so result.json agrees with summary.json — the
+            # raw role.model is None for non-oracle roles with no explicit model:, which
+            # would otherwise leak '' into result.json while summary.json shows DEFAULT_MODEL.
+            model=effective_model(self._config.primary_agent, self._config.primary_model)
+            or "",
             n_tool_calls=self._n_tool_calls,
             prompts=self._resolved_prompts,
             error=self._error,

--- a/src/benchflow/trial_yaml.py
+++ b/src/benchflow/trial_yaml.py
@@ -78,7 +78,7 @@ def trial_config_from_dict(
 
     # Scene-based format
     if "scenes" in raw:
-        scenes = [_parse_scene(s) for s in raw["scenes"]]
+        scenes = [parse_scene(s) for s in raw["scenes"]]
     elif "agent" in raw:
         # Legacy flat format
         prompts_raw = raw.get("prompts")
@@ -117,10 +117,10 @@ def trial_config_from_dict(
     )
 
 
-def _parse_scene(raw: dict) -> Scene:
+def parse_scene(raw: dict) -> Scene:
     """Parse a scene dict from YAML."""
-    roles = [_parse_role(r) for r in raw.get("roles", [])]
-    turns = [_parse_turn(t) for t in raw.get("turns", [])]
+    roles = [parse_role(r) for r in raw.get("roles", [])]
+    turns = [parse_turn(t) for t in raw.get("turns", [])]
 
     # If no turns specified but roles exist, create one turn per role
     if not turns and roles:
@@ -134,17 +134,17 @@ def _parse_scene(raw: dict) -> Scene:
     )
 
 
-def _parse_role(raw: dict) -> Role:
+def parse_role(raw: dict) -> Role:
     """Parse a role dict from YAML."""
     return Role(
         name=raw["name"],
         agent=raw["agent"],
-        model=raw.get("model"),
+        model=raw.get("model") or raw.get("model_name"),
         env=raw.get("env", {}),
     )
 
 
-def _parse_turn(raw: dict) -> Turn:
+def parse_turn(raw: dict) -> Turn:
     """Parse a turn dict from YAML."""
     return Turn(
         role=raw["role"],

--- a/tests/test_trial_yaml.py
+++ b/tests/test_trial_yaml.py
@@ -1,0 +1,21 @@
+"""Tests for trial YAML parsing helpers."""
+
+from benchflow.trial_yaml import parse_role
+
+
+def test_parse_role_model_name_fallback():
+    """Guards parse_role model_name fallback (issue #4 plan, decision 2C)."""
+    role = parse_role({"name": "r", "agent": "a", "model_name": "m"})
+    assert role.model == "m"
+
+
+def test_parse_role_model_takes_precedence():
+    """Guards parse_role precedence: model wins when both keys set (issue #4, decision 2C)."""
+    role = parse_role({"name": "r", "agent": "a", "model": "m1", "model_name": "m2"})
+    assert role.model == "m1"
+
+
+def test_parse_role_no_model_or_model_name():
+    """Guards parse_role None default (issue #4 plan, decision 2C)."""
+    role = parse_role({"name": "r", "agent": "a"})
+    assert role.model is None

--- a/tests/test_trial_yaml.py
+++ b/tests/test_trial_yaml.py
@@ -4,18 +4,18 @@ from benchflow.trial_yaml import parse_role
 
 
 def test_parse_role_model_name_fallback():
-    """Guards parse_role model_name fallback (issue #4 plan, decision 2C)."""
+    """Guards the fix from commit 5431cdd: parse_role accepts model_name as fallback for model (issue #4)."""
     role = parse_role({"name": "r", "agent": "a", "model_name": "m"})
     assert role.model == "m"
 
 
 def test_parse_role_model_takes_precedence():
-    """Guards parse_role precedence: model wins when both keys set (issue #4, decision 2C)."""
+    """Guards the fix from commit 5431cdd: parse_role prefers model over model_name when both are set (issue #4)."""
     role = parse_role({"name": "r", "agent": "a", "model": "m1", "model_name": "m2"})
     assert role.model == "m1"
 
 
 def test_parse_role_no_model_or_model_name():
-    """Guards parse_role None default (issue #4 plan, decision 2C)."""
+    """Guards the fix from commit 5431cdd: parse_role returns Role.model=None when neither key is set (issue #4)."""
     role = parse_role({"name": "r", "agent": "a"})
     assert role.model is None

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -374,7 +374,7 @@ def test_harbor_yaml_without_scenes_unchanged(harbor_yaml):
 
 
 def test_native_yaml_parses_top_level_scenes(tmp_path):
-    """Guards commit 22f52b4: native YAML scenes: parses just like Harbor (decision 1A, issue #4)."""
+    """Guards commit 22f52b4: native YAML scenes: parses just like Harbor (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -402,13 +402,13 @@ scenes:
 
 
 def test_native_yaml_without_scenes_unchanged(native_yaml):
-    """Guards commit 22f52b4: native YAML without scenes: still produces scenes=None (decision 1A, issue #4)."""
+    """Guards commit 22f52b4: native YAML without scenes: still produces scenes=None (issue #4)."""
     job = Job.from_yaml(native_yaml)
     assert job._config.scenes is None
 
 
 def test_harbor_yaml_top_level_singular_agent_and_model_name(tmp_path):
-    """Guards commit 22f52b4: Harbor accepts singular top-level agent: + model_name: when agents[] is absent (TODO 1, issue #4)."""
+    """Guards commit 22f52b4: Harbor accepts singular top-level agent: + model_name: when agents[] is absent (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -425,7 +425,7 @@ datasets:
 
 
 def test_harbor_yaml_empty_scenes_warns(tmp_path, caplog):
-    """Guards commit 22f52b4: scenes: [] logs a warning and falls through to legacy (TODO 2, issue #4)."""
+    """Guards commit 22f52b4: scenes: [] logs a warning and falls through to legacy (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -448,7 +448,7 @@ scenes: []
 
 
 def test_harbor_yaml_summary_fields_match_first_scene_role(tmp_path):
-    """Guards commit 22f52b4: when scenes is non-empty, JobConfig.agent/model derive from scenes[0].roles[0] so summary.json reflects what runs (TODO 3, issue #4)."""
+    """Guards commit 22f52b4: when scenes is non-empty, JobConfig.agent/model derive from scenes[0].roles[0] so summary.json reflects what runs (issue #4)."""
     _make_task_dir(tmp_path)
 
     config = tmp_path / "config.yaml"
@@ -472,3 +472,157 @@ scenes:
     job = Job.from_yaml(config)
     assert job._config.agent == "pi-acp"
     assert job._config.model == "vllm/Qwen/Qwen3.6-27B"
+
+
+def test_harbor_yaml_oracle_role_keeps_model_none(tmp_path):
+    """Guards the fix from PR #5: scene-derived agent must re-resolve through effective_model so an oracle role does not inherit DEFAULT_MODEL from a non-oracle top-level (would otherwise make summary.json disagree with result.json)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agent: pi-acp
+datasets:
+  - path: tasks
+scenes:
+  - name: verify
+    roles:
+      - name: checker
+        agent: oracle
+    turns:
+      - role: checker
+        prompt: "run solve.sh"
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "oracle"
+    assert job._config.model is None
+
+
+def test_native_yaml_oracle_role_keeps_model_none(tmp_path):
+    """Guards the fix from PR #5: same oracle short-circuit as the Harbor parallel — the native loader carries a duplicate of the summary-field derivation block (issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+agent: pi-acp
+scenes:
+  - name: verify
+    roles:
+      - name: checker
+        agent: oracle
+    turns:
+      - role: checker
+        prompt: "run solve.sh"
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "oracle"
+    assert job._config.model is None
+
+
+async def test_native_yaml_branch_passes_scenes_to_trial(tmp_path, monkeypatch):
+    """Guards the fix from PR #5: native loader's scenes-to-Trial wiring is verified end-to-end, mirroring the Harbor parallel — closes the duplicated-block coverage gap (issue #4)."""
+    task_dir = _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+scenes:
+  - name: build
+    roles:
+      - name: builder
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: builder
+        prompt: "build it"
+  - name: verify
+    roles:
+      - name: solver
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: solver
+""")
+
+    job = Job.from_yaml(config)
+
+    seen: dict = {}
+
+    async def capturing_create(trial_config):
+        seen["config"] = trial_config
+        trial = AsyncMock()
+        trial.run = AsyncMock(
+            return_value=RunResult(task_name=task_dir.name, rewards={"reward": 1.0})
+        )
+        return trial
+
+    monkeypatch.setattr("benchflow.trial.Trial.create", capturing_create)
+
+    await job._run_single_task(task_dir, job._config)
+
+    captured = seen["config"]
+    assert captured.scenes == job._config.scenes
+    assert [s.name for s in captured.scenes] == ["build", "verify"]
+
+
+def test_native_yaml_empty_scenes_warns(tmp_path, caplog):
+    """Guards the fix from PR #5: native loader's scenes: [] warning matches Harbor (issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+scenes: []
+""")
+
+    with caplog.at_level(logging.WARNING, logger="benchflow.job"):
+        job = Job.from_yaml(config)
+
+    assert job._config.scenes is None
+    assert any(
+        "scenes" in msg and "empty" in msg for msg in caplog.messages
+    ), f"Expected warning about empty scenes; got: {caplog.messages!r}"
+
+
+async def test_run_single_task_legacy_branch_synthesizes_single_scene(
+    tmp_path, monkeypatch
+):
+    """Guards the fix from PR #5: when cfg.scenes is None, _run_single_task must synthesize a single Scene from agent/model/prompts and pass it to Trial.create. The legacy single-turn path was previously TrialConfig.from_legacy(...); the refactor's correctness rides on this branch and existing job tests bypass it via the _sdk mock (issue #4)."""
+    from benchflow.job import JobConfig
+
+    task_dir = _make_task_dir(tmp_path)
+    job = Job(
+        tasks_dir=task_dir.parent,
+        jobs_dir=tmp_path / "out",
+        config=JobConfig(
+            agent="claude-agent-acp",
+            model="claude-haiku-4-5-20251001",
+            prompts=["do x", "review"],
+        ),
+    )
+
+    seen: dict = {}
+
+    async def capturing_create(trial_config):
+        seen["config"] = trial_config
+        trial = AsyncMock()
+        trial.run = AsyncMock(
+            return_value=RunResult(task_name=task_dir.name, rewards={"reward": 1.0})
+        )
+        return trial
+
+    monkeypatch.setattr("benchflow.trial.Trial.create", capturing_create)
+
+    await job._run_single_task(task_dir, job._config)
+
+    captured = seen["config"]
+    assert len(captured.scenes) == 1
+    assert captured.scenes[0].roles[0].agent == "claude-agent-acp"
+    assert captured.scenes[0].roles[0].model == "claude-haiku-4-5-20251001"
+    assert [t.prompt for t in captured.scenes[0].turns] == ["do x", "review"]
+    # Legacy mirror fields on TrialConfig must round-trip the same values.
+    assert captured.agent == "claude-agent-acp"
+    assert captured.model == "claude-haiku-4-5-20251001"
+    assert captured.prompts == ["do x", "review"]

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -1,10 +1,13 @@
 """Tests for YAML job config loading."""
 
+import logging
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 
 from benchflow.job import Job
+from benchflow.models import RunResult
 
 
 @pytest.fixture
@@ -259,3 +262,213 @@ sandbox_user: testuser
         assert job._config.agent_env == {}
         assert job._config.sandbox_user == "agent"
         assert job._config.sandbox_setup_timeout == 120
+
+
+# ── Scenes parsing (issue #4) ──
+
+
+def _make_task_dir(tmp_path: Path, name: str = "task-a") -> Path:
+    """Create a tasks/<name> directory with task.toml."""
+    task_dir = tmp_path / "tasks" / name
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('version = "1.0"')
+    return task_dir
+
+
+def test_harbor_yaml_parses_issue_4_repro(tmp_path):
+    """Guards the fix from commit 22f52b4 against the silent-scenes-drop regression in issue #4 — mirrors the literal repro YAML."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agent: pi-acp
+model_name: vllm/Qwen/Qwen3.6-27B
+datasets:
+  - path: tasks
+scenes:
+  - name: build-skill
+    roles:
+      - name: builder
+        agent: pi-acp
+        model: vllm/Qwen/Qwen3.6-27B
+    turns:
+      - role: builder
+        prompt: "build the skill ..."
+  - name: answer
+    roles:
+      - name: solver
+        agent: pi-acp
+        model: vllm/Qwen/Qwen3.6-27B
+    turns:
+      - role: solver
+""")
+
+    job = Job.from_yaml(config)
+    scenes = job._config.scenes
+
+    assert scenes is not None
+    assert len(scenes) == 2
+    assert scenes[0].name == "build-skill"
+    assert scenes[0].roles[0].agent == "pi-acp"
+    assert scenes[0].roles[0].model == "vllm/Qwen/Qwen3.6-27B"
+    assert scenes[0].turns[0].prompt == "build the skill ..."
+    assert scenes[1].name == "answer"
+    assert scenes[1].turns[0].prompt is None
+
+
+async def test_harbor_yaml_branch_passes_scenes_to_trial(tmp_path, monkeypatch):
+    """Guards the fix from commit 22f52b4 against the bug where Harbor scenes never reached Trial — exercises the path that would have failed pre-fix (issue #4)."""
+    task_dir = _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+datasets:
+  - path: tasks
+scenes:
+  - name: build-skill
+    roles:
+      - name: builder
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: builder
+        prompt: "build it"
+  - name: answer
+    roles:
+      - name: solver
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: solver
+""")
+
+    job = Job.from_yaml(config)
+
+    seen: dict = {}
+
+    async def capturing_create(trial_config):
+        seen["config"] = trial_config
+        trial = AsyncMock()
+        trial.run = AsyncMock(
+            return_value=RunResult(task_name=task_dir.name, rewards={"reward": 1.0})
+        )
+        return trial
+
+    monkeypatch.setattr("benchflow.trial.Trial.create", capturing_create)
+
+    result = await job._run_single_task(task_dir, job._config)
+
+    assert result.rewards == {"reward": 1.0}
+    captured = seen["config"]
+    assert captured.scenes == job._config.scenes
+    assert [s.name for s in captured.scenes] == ["build-skill", "answer"]
+    assert len(captured.scenes[0].roles) == 1
+    assert len(captured.scenes[0].turns) == 1
+    assert len(captured.scenes[1].turns) == 1
+
+
+def test_harbor_yaml_without_scenes_unchanged(harbor_yaml):
+    """Guards commit 22f52b4: harbor YAML without scenes: still produces scenes=None (legacy single-turn path, issue #4)."""
+    job = Job.from_yaml(harbor_yaml)
+    assert job._config.scenes is None
+
+
+def test_native_yaml_parses_top_level_scenes(tmp_path):
+    """Guards commit 22f52b4: native YAML scenes: parses just like Harbor (decision 1A, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+scenes:
+  - name: solve
+    roles:
+      - name: solver
+        agent: claude-agent-acp
+        model: claude-haiku-4-5-20251001
+    turns:
+      - role: solver
+        prompt: "solve it"
+""")
+
+    job = Job.from_yaml(config)
+    scenes = job._config.scenes
+
+    assert scenes is not None
+    assert len(scenes) == 1
+    assert scenes[0].name == "solve"
+    assert scenes[0].roles[0].agent == "claude-agent-acp"
+    assert scenes[0].turns[0].prompt == "solve it"
+
+
+def test_native_yaml_without_scenes_unchanged(native_yaml):
+    """Guards commit 22f52b4: native YAML without scenes: still produces scenes=None (decision 1A, issue #4)."""
+    job = Job.from_yaml(native_yaml)
+    assert job._config.scenes is None
+
+
+def test_harbor_yaml_top_level_singular_agent_and_model_name(tmp_path):
+    """Guards commit 22f52b4: Harbor accepts singular top-level agent: + model_name: when agents[] is absent (TODO 1, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agent: pi-acp
+model_name: vllm/Qwen/Qwen3.6-27B
+datasets:
+  - path: tasks
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "pi-acp"
+    assert job._config.model == "vllm/Qwen/Qwen3.6-27B"
+
+
+def test_harbor_yaml_empty_scenes_warns(tmp_path, caplog):
+    """Guards commit 22f52b4: scenes: [] logs a warning and falls through to legacy (TODO 2, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agents:
+  - name: claude-agent-acp
+    model_name: claude-haiku-4-5-20251001
+datasets:
+  - path: tasks
+scenes: []
+""")
+
+    with caplog.at_level(logging.WARNING, logger="benchflow.job"):
+        job = Job.from_yaml(config)
+
+    assert job._config.scenes is None
+    assert any(
+        "scenes" in msg and "empty" in msg for msg in caplog.messages
+    ), f"Expected warning about empty scenes; got: {caplog.messages!r}"
+
+
+def test_harbor_yaml_summary_fields_match_first_scene_role(tmp_path):
+    """Guards commit 22f52b4: when scenes is non-empty, JobConfig.agent/model derive from scenes[0].roles[0] so summary.json reflects what runs (TODO 3, issue #4)."""
+    _make_task_dir(tmp_path)
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agents:
+  - name: claude-agent-acp
+    model_name: claude-haiku-4-5-20251001
+datasets:
+  - path: tasks
+scenes:
+  - name: solve
+    roles:
+      - name: solver
+        agent: pi-acp
+        model: vllm/Qwen/Qwen3.6-27B
+    turns:
+      - role: solver
+        prompt: "solve it"
+""")
+
+    job = Job.from_yaml(config)
+    assert job._config.agent == "pi-acp"
+    assert job._config.model == "vllm/Qwen/Qwen3.6-27B"

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -626,3 +626,67 @@ async def test_run_single_task_legacy_branch_synthesizes_single_scene(
     assert captured.agent == "claude-agent-acp"
     assert captured.model == "claude-haiku-4-5-20251001"
     assert captured.prompts == ["do x", "review"]
+
+
+def test_trial_build_result_resolves_non_oracle_no_model_to_default(tmp_path):
+    """Follow-up to PR #5: Trial._build_result must surface the effective model in result.json. On the multi-scene path JobConfig.model is resolved via effective_model() (so summary.json shows DEFAULT_MODEL for a non-oracle role with no explicit model:), but Trial._build_result was reading scenes[0].roles[0].model raw — empty string in result.json, null in config.json. The three files disagreed for the same logical state."""
+    import json
+    from datetime import datetime
+
+    from benchflow.job import DEFAULT_MODEL
+    from benchflow.trial import Role, Scene, Trial, TrialConfig, Turn
+
+    cfg = TrialConfig(
+        task_path=tmp_path / "task-a",
+        scenes=[
+            Scene(
+                name="solve",
+                roles=[Role(name="solver", agent="claude-agent-acp", model=None)],
+                turns=[Turn(role="solver", prompt="do it")],
+            )
+        ],
+    )
+    trial = Trial(cfg)
+    trial._trial_dir = tmp_path
+    trial._trial_name = "t1"
+    trial._agent_name = "Claude"
+    trial._started_at = datetime(2026, 4, 26, 12, 0)
+
+    trial._build_result()
+
+    data = json.loads((tmp_path / "result.json").read_text())
+    assert data["model"] == DEFAULT_MODEL, (
+        f"result.json must report DEFAULT_MODEL for non-oracle role with no explicit "
+        f"model: (so it matches summary.json), got {data['model']!r}"
+    )
+
+
+def test_trial_build_result_keeps_oracle_model_unset(tmp_path):
+    """Follow-up to PR #5: oracle role must not gain a fabricated model in result.json — effective_model('oracle', ...) returns None, so the field must reflect that (currently '') and not leak DEFAULT_MODEL even after non-oracle resolution is added."""
+    import json
+    from datetime import datetime
+
+    from benchflow.trial import Role, Scene, Trial, TrialConfig, Turn
+
+    cfg = TrialConfig(
+        task_path=tmp_path / "task-a",
+        scenes=[
+            Scene(
+                name="verify",
+                roles=[Role(name="checker", agent="oracle", model=None)],
+                turns=[Turn(role="checker", prompt="run solve.sh")],
+            )
+        ],
+    )
+    trial = Trial(cfg)
+    trial._trial_dir = tmp_path
+    trial._trial_name = "t1"
+    trial._agent_name = "oracle"
+    trial._started_at = datetime(2026, 4, 26, 12, 0)
+
+    trial._build_result()
+
+    data = json.loads((tmp_path / "result.json").read_text())
+    assert data["model"] in ("", None), (
+        f"oracle result.json must not surface a synthetic model — got {data['model']!r}"
+    )


### PR DESCRIPTION
## Summary

Top-level `scenes:` declared in a YAML config — both Harbor and benchflow-native — were silently dropped by `Job.from_yaml`, so multi-turn jobs degraded to single-turn `TrialConfig.from_legacy()` without warning. This series fixes the top-level scenes regression and tightens the model-field plumbing exposed by the fix.

- **`5d8763a`** `refactor`: promote `parse_scene` / `parse_role` / `parse_turn` to public helpers in `trial_yaml`; `parse_role` accepts `model_name` as a fallback for `model`.
- **`fdc1e52`** `feat`: `_from_harbor_yaml` and `_from_native_yaml` now parse top-level `scenes:` and thread them through `JobConfig`. Empty `scenes: []` warns and falls through to the legacy single-turn path. `_run_single_task` branches on `cfg.scenes` so the multi-scene flow reaches the scene-aware Trial path.
- **`274c94e`** `test`: regression coverage mirroring the top-level scenes repro YAML — guards both Harbor and native loaders against silent scene drop.
- **`3d18ba8`** `fix`: scene-derived agent in `JobConfig` re-resolves through `effective_model(...)`, so an oracle role under a non-oracle top-level no longer leaks `DEFAULT_MODEL` into `JobConfig.model` (`summary.json` was reporting a fabricated model for oracle).
- **`372a628`** `fix`: `Trial._build_result` and `Trial.setup`'s `_write_config` call also resolve through `effective_model(...)`, so `result.json` / `config.json` agree with `summary.json` for non-oracle roles with no explicit `model:` (was emitting `""` and `null` respectively while `summary.json` had `DEFAULT_MODEL`).

## Test plan

- [x] `pytest tests/` — 711 passed, 1 skipped, 1 deselected (709 baseline + 2 new in `test_yaml_config.py` covering `Trial._build_result` model resolution).
- [x] `pytest tests/test_yaml_config.py tests/test_trial_yaml.py` — 30 passed; covers Harbor + native YAML parsing, scenes wiring, the `model_name` fallback, and the new model-field guards.
- [x] `ruff check .` — clean.
- [x] `ty check src/` — diagnostics on touched files unchanged from `main`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/208" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
