### PR TITLE
fix: dynamic --rootdir in PYTEST_ADDOPTS based on task workspace

### DIFF
--- a/src/benchflow/_acp_run.py
+++ b/src/benchflow/_acp_run.py
@@ -115,6 +115,8 @@ async def connect_acp(
         logger.info(f"Agent sandboxed as: {sandbox_user}")
 
     acp_client: ACPClient | None = None
+    session: object | None = None
+    agent_name = agent
     for attempt in range(_ACP_CONNECT_MAX_RETRIES + 1):
         if attempt > 0:
             delay = _ACP_CONNECT_BASE_DELAY * (2 ** (attempt - 1))
@@ -174,6 +176,9 @@ async def connect_acp(
                 with contextlib.suppress(Exception):
                     await acp_client.close()
             raise
+
+    if acp_client is None or session is None:
+        raise RuntimeError("ACP connection did not initialize")
 
     agent_cfg = AGENTS.get(agent)
     if model and (agent_cfg is None or agent_cfg.supports_acp_set_model):

--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -235,7 +235,7 @@ def resolve_agent_env(
                 )
             )
         )
-        if has_agent_native_bridge_key:
+        if has_agent_native_bridge_key and mapped_provider_key is not None:
             # Only pre-existing same-provider aliases or explicit generic bridge
             # keys can satisfy provider auth. Values synthesized by env_mapping
             # or inherited from another provider context must not bypass the

--- a/src/benchflow/_daytona_patches.py
+++ b/src/benchflow/_daytona_patches.py
@@ -6,7 +6,7 @@ SDK is only touched when a Daytona environment is actually being built.
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +97,7 @@ def apply() -> None:
         )
         return SessionCommandLogsResponse(output="", stdout="", stderr="")
 
-    AsyncProcess.get_session_command_logs = _patched_get_session_command_logs  # type: ignore[method-assign]
+    async_process_cls = cast(Any, AsyncProcess)
+    async_process_cls.get_session_command_logs = _patched_get_session_command_logs
     _PATCHED = True
     logger.debug("daytona SDK patches applied")

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -351,9 +351,7 @@ _RUNTIME_PATH_PREFIXES = ("/tmp", "/var/tmp", "/logs", "/testbed")
 _DEFAULT_ROOTDIR = "/app"
 
 
-def _build_pytest_addopts(
-    workspace: str | None = None, plugin_flags: str = ""
-) -> str:
+def _build_pytest_addopts(workspace: str | None = None, plugin_flags: str = "") -> str:
     """Build PYTEST_ADDOPTS with a dynamic --rootdir based on the workspace.
 
     Without an explicit --rootdir, -c /dev/null causes pytest to fall back to
@@ -361,13 +359,11 @@ def _build_pytest_addopts(
     The rootdir must point to a directory that actually exists in the container.
     """
     rootdir = workspace or _DEFAULT_ROOTDIR
-    addopts = (
-        f"{VERIFIER_ENV['PYTEST_ADDOPTS']} "
-        f"--rootdir={shlex.quote(rootdir)}"
-    )
+    addopts = f"{VERIFIER_ENV['PYTEST_ADDOPTS']} --rootdir={shlex.quote(rootdir)}"
     if plugin_flags:
         addopts += f" {plugin_flags}"
     return addopts
+
 
 # Container-side script to enumerate pre-installed pytest11 entry points.
 # Runs after sandbox_user processes are killed, so the agent cannot install

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -304,8 +304,10 @@ VERIFIER_ENV: dict[str, str] = {
     "PYTEST_ADDOPTS": (
         "-c /dev/null "  # block pyproject.toml/pytest.ini/tox.ini/setup.cfg discovery
         "--confcutdir=/tests "  # block conftest.py walk-up beyond /tests
-        "--rootdir=/app "  # anchor test node IDs to repo root (not /dev from -c)
         "-p no:cacheprovider"
+        # --rootdir is injected dynamically by _build_pytest_addopts() based on
+        # the task's actual workspace, so it works for both /app (Harbor/SWE-bench)
+        # and /root (SkillsBench) conventions.
     ),
     # Block pytest11 entry-point plugins. An agent can modify a pre-installed
     # package's plugin source to forge a reward; -c /dev/null does not block
@@ -345,6 +347,27 @@ VERIFIER_ENV: dict[str, str] = {
 _SAFE_VERIFIER_PATH = VERIFIER_ENV["PATH"]
 _SAFE_VERIFIER_PATH_PARTS = tuple(_SAFE_VERIFIER_PATH.split(":"))
 _RUNTIME_PATH_PREFIXES = ("/tmp", "/var/tmp", "/logs", "/testbed")
+
+_DEFAULT_ROOTDIR = "/app"
+
+
+def _build_pytest_addopts(
+    workspace: str | None = None, plugin_flags: str = ""
+) -> str:
+    """Build PYTEST_ADDOPTS with a dynamic --rootdir based on the workspace.
+
+    Without an explicit --rootdir, -c /dev/null causes pytest to fall back to
+    /dev as rootdir, producing broken test node IDs (../dev/::test_foo).
+    The rootdir must point to a directory that actually exists in the container.
+    """
+    rootdir = workspace or _DEFAULT_ROOTDIR
+    addopts = (
+        f"{VERIFIER_ENV['PYTEST_ADDOPTS']} "
+        f"--rootdir={shlex.quote(rootdir)}"
+    )
+    if plugin_flags:
+        addopts += f" {plugin_flags}"
+    return addopts
 
 # Container-side script to enumerate pre-installed pytest11 entry points.
 # Runs after sandbox_user processes are killed, so the agent cannot install
@@ -800,10 +823,6 @@ async def harden_before_verify(
     verifier_env["CELERY_CONFIG_MODULE"] = ""
     # Auto-discover pytest plugins from root-owned system packages and
     # task.toml declarations. Appends -p flags to the hardened base.
-    base_addopts = VERIFIER_ENV["PYTEST_ADDOPTS"]
     flags = await _discover_pytest_plugin_flags(env, task)
-    if flags:
-        verifier_env["PYTEST_ADDOPTS"] = base_addopts + f" {flags}"
-    else:
-        verifier_env["PYTEST_ADDOPTS"] = base_addopts
+    verifier_env["PYTEST_ADDOPTS"] = _build_pytest_addopts(workspace, flags)
     task.config.verifier.env = verifier_env

--- a/src/benchflow/mcp/reviewer_server.py
+++ b/src/benchflow/mcp/reviewer_server.py
@@ -49,7 +49,7 @@ def create_reviewer_server(
     Requires: pip install fastmcp
     """
     try:
-        from fastmcp import FastMCP
+        from fastmcp import FastMCP  # ty: ignore[unresolved-import]
     except ImportError as e:
         raise ImportError(
             "fastmcp required for MCP reviewer server. "
@@ -74,7 +74,7 @@ def create_reviewer_server(
         Returns:
             Structured review feedback as a string.
         """
-        import google.generativeai as genai
+        import google.generativeai as genai  # ty: ignore[unresolved-import]
 
         api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
         if not api_key:

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -21,9 +21,13 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS, AgentConfig
+
+if TYPE_CHECKING:
+    from benchflow.models import RunResult
+    from benchflow.trial import TrialConfig
 
 logger = logging.getLogger(__name__)
 
@@ -65,12 +69,13 @@ class Environment:
         task_path = Path(task_path)
         task = Task(task_path)
         trial_name = trial_name or task_path.name
+        trial_paths: Any = None
         inner = _create_environment(
             environment_type=backend,
             task=task,
             task_path=task_path,
             trial_name=trial_name,
-            trial_paths=None,
+            trial_paths=trial_paths,  # ty: ignore[invalid-argument-type]
         )
         return cls(inner=inner, task_path=task_path, backend=backend)
 

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -366,12 +366,15 @@ class SDK:
                                 parts = content.split("---", 2)
                                 if len(parts) >= 3:
                                     import yaml
+
                                     try:
                                         fm = yaml.safe_load(parts[1])
                                         desc = fm.get("description", "") if fm else ""
                                     except Exception:
                                         pass
-                            skills.append({"name": name, "desc": desc, "content": content})
+                            skills.append(
+                                {"name": name, "desc": desc, "content": content}
+                            )
                     if skills:
                         break
 
@@ -389,7 +392,9 @@ class SDK:
                 elif skill_nudge == "full":
                     blocks = []
                     for s in skills:
-                        blocks.append(f"<skill name=\"{s['name']}\">\n{s['content']}\n</skill>")
+                        blocks.append(
+                            f'<skill name="{s["name"]}">\n{s["content"]}\n</skill>'
+                        )
                     instruction = "\n\n".join(blocks) + "\n\n" + instruction
 
         if prompts is None:

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -93,6 +93,7 @@ import logging
 import shlex
 from datetime import datetime
 from pathlib import Path
+from typing import Any, cast
 
 from harbor.models.task.task import Task
 from harbor.models.trial.paths import TrialPaths
@@ -131,20 +132,25 @@ def _write_rewards_jsonl(
     """
     if not rewards:
         return
-    events: list[dict] = []
+    events: list[dict[str, Any]] = []
     rubric = rewards.get("rubric")
     if isinstance(rubric, list):
         for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            rubric_item = cast(dict[str, Any], item)
             events.append(
                 {
                     "ts": finished_at.isoformat(),
                     "type": "process",
                     "source": "verifier_rubric",
-                    "value": item.get("score", 0.0),
-                    "tag": item.get("name", f"rubric_{i}"),
+                    "value": rubric_item.get("score", 0.0),
+                    "tag": rubric_item.get("name", f"rubric_{i}"),
                     "step_index": i,
                     "meta": {
-                        k: v for k, v in item.items() if k not in ("score", "name")
+                        k: v
+                        for k, v in rubric_item.items()
+                        if k not in ("score", "name")
                     },
                 }
             )

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -366,15 +366,12 @@ class SDK:
                                 parts = content.split("---", 2)
                                 if len(parts) >= 3:
                                     import yaml
-
                                     try:
                                         fm = yaml.safe_load(parts[1])
                                         desc = fm.get("description", "") if fm else ""
                                     except Exception:
                                         pass
-                            skills.append(
-                                {"name": name, "desc": desc, "content": content}
-                            )
+                            skills.append({"name": name, "desc": desc, "content": content})
                     if skills:
                         break
 
@@ -392,9 +389,7 @@ class SDK:
                 elif skill_nudge == "full":
                     blocks = []
                     for s in skills:
-                        blocks.append(
-                            f'<skill name="{s["name"]}">\n{s["content"]}\n</skill>'
-                        )
+                        blocks.append(f"<skill name=\"{s['name']}\">\n{s['content']}\n</skill>")
                     instruction = "\n\n".join(blocks) + "\n\n" + instruction
 
         if prompts is None:

--- a/src/benchflow/skill_eval.py
+++ b/src/benchflow/skill_eval.py
@@ -11,6 +11,7 @@ import json
 import logging
 import shutil
 import tempfile
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from string import Template
@@ -385,7 +386,7 @@ class SkillEvaluator:
     async def run(
         self,
         agents: list[str],
-        models: list[str] | None = None,
+        models: Sequence[str | None] | None = None,
         environment: str = "docker",
         jobs_dir: str = "jobs",
         no_baseline: bool = False,
@@ -406,13 +407,15 @@ class SkillEvaluator:
         """
         # Resolve models
         if models is None:
-            models = [None] * len(agents)
+            resolved_models: list[str | None] = [None] * len(agents)
         elif len(models) == 1 and len(agents) > 1:
-            models = models * len(agents)
+            resolved_models = list(models) * len(agents)
         elif len(models) != len(agents):
             raise ValueError(
                 f"models length ({len(models)}) must match agents ({len(agents)}) or be 1"
             )
+        else:
+            resolved_models = list(models)
 
         # Create temp directory for ephemeral tasks (local var, not instance)
         tmp_dir = Path(tempfile.mkdtemp(prefix="benchflow-skill-eval-"))
@@ -437,7 +440,7 @@ class SkillEvaluator:
             all_results: list[CaseResult] = []
 
             # Run each agent
-            for agent, model in zip(agents, models, strict=False):
+            for agent, model in zip(agents, resolved_models, strict=False):
                 agent_label = agent.split("/")[-1] if "/" in agent else agent
 
                 # With-skill run
@@ -466,7 +469,9 @@ class SkillEvaluator:
                     all_results.extend(baseline_results)
 
             # Compute lifts
-            agent_lifts = self._compute_lifts(all_results, agents, models, no_baseline)
+            agent_lifts = self._compute_lifts(
+                all_results, agents, resolved_models, no_baseline
+            )
 
             return SkillEvalResult(
                 skill_name=self.dataset.skill_name,

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -320,7 +320,8 @@ class Trial:
             cfg.primary_agent, cfg.primary_model, cfg.agent_env
         )
         self._resolved_prompts = SDK._resolve_prompts(
-            cfg.task_path, cfg.prompts,
+            cfg.task_path,
+            cfg.prompts,
             skills_dir=cfg.skills_dir,
             skill_nudge=(cfg.agent_env or {}).get("BENCHFLOW_SKILL_NUDGE", ""),
             agent=cfg.primary_agent,

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -320,8 +320,7 @@ class Trial:
             cfg.primary_agent, cfg.primary_model, cfg.agent_env
         )
         self._resolved_prompts = SDK._resolve_prompts(
-            cfg.task_path,
-            cfg.prompts,
+            cfg.task_path, cfg.prompts,
             skills_dir=cfg.skills_dir,
             skill_nudge=(cfg.agent_env or {}).get("BENCHFLOW_SKILL_NUDGE", ""),
             agent=cfg.primary_agent,

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -285,6 +285,16 @@ class Trial:
             return None
         return self._build_result()
 
+    def _require_trial_dir(self) -> Path:
+        if self._trial_dir is None:
+            raise RuntimeError("Trial.setup() must run before this phase")
+        return self._trial_dir
+
+    def _require_started_at(self) -> datetime:
+        if self._started_at is None:
+            raise RuntimeError("Trial.setup() must run before building a result")
+        return self._started_at
+
     # ── Phase 1: SETUP (host-side, no container yet) ──
 
     async def setup(self) -> None:
@@ -397,6 +407,7 @@ class Trial:
         This method installs the primary agent to set up the sandbox baseline.
         """
         cfg = self._config
+        trial_dir = self._require_trial_dir()
 
         cwd_result = await self._env.exec("pwd", timeout_sec=10)
         agent_cwd = (cwd_result.stdout or "").strip() or "/app"
@@ -419,7 +430,7 @@ class Trial:
             return
 
         agent_name = cfg.primary_agent
-        self._agent_cfg = await install_agent(self._env, agent_name, self._trial_dir)
+        self._agent_cfg = await install_agent(self._env, agent_name, trial_dir)
         cred_home = f"/home/{cfg.sandbox_user}" if cfg.sandbox_user else "/root"
         await write_credential_files(
             self._env,
@@ -462,6 +473,7 @@ class Trial:
     async def connect(self) -> None:
         """Open an ACP connection to the agent. Can be called multiple times."""
         cfg = self._config
+        trial_dir = self._require_trial_dir()
         t0 = datetime.now()
 
         self._acp_client, self._session, self._agent_name = await connect_acp(
@@ -471,7 +483,7 @@ class Trial:
             agent_env=self._agent_env,
             sandbox_user=cfg.sandbox_user,
             model=cfg.primary_model,
-            trial_dir=self._trial_dir,
+            trial_dir=trial_dir,
             environment=cfg.environment,
             agent_cwd=self._agent_cwd,
         )
@@ -509,6 +521,8 @@ class Trial:
         session is reused across multiple turns.
         """
         effective_prompts = prompts or self._resolved_prompts
+        if self._acp_client is None:
+            raise RuntimeError("Trial.connect() must run before execute()")
         prev_session_tools = getattr(self, "_session_tool_count", 0)
         t0 = datetime.now()
 
@@ -801,6 +815,8 @@ class Trial:
             await self.execute(prompts=prompts)
 
             if multi_role:
+                if current_role is None:
+                    raise RuntimeError("No active role after scene turn execution")
                 for recipient, content in await self._read_scene_outbox(current_role):
                     turn_counter += 1
                     inbox.setdefault(recipient, []).append(
@@ -1002,6 +1018,7 @@ class Trial:
         Updates _agent_launch so disconnect() kills the correct process.
         """
         cfg = self._config
+        trial_dir = self._require_trial_dir()
         t0 = datetime.now()
 
         agent_launch = AGENT_LAUNCH.get(role.agent, role.agent)
@@ -1014,7 +1031,7 @@ class Trial:
         )
 
         if role.agent != cfg.primary_agent:
-            agent_cfg = await install_agent(self._env, role.agent, self._trial_dir)
+            agent_cfg = await install_agent(self._env, role.agent, trial_dir)
             cred_home = f"/home/{cfg.sandbox_user}" if cfg.sandbox_user else "/root"
             await write_credential_files(
                 self._env,
@@ -1036,7 +1053,7 @@ class Trial:
             agent_env=agent_env,
             sandbox_user=cfg.sandbox_user,
             model=role.model,
-            trial_dir=self._trial_dir,
+            trial_dir=trial_dir,
             environment=cfg.environment,
             agent_cwd=self._agent_cwd,
         )
@@ -1069,8 +1086,9 @@ class Trial:
     def _build_result(self) -> RunResult:
         from benchflow.sdk import SDK
 
+        trial_dir = self._require_trial_dir()
         return SDK._build_result(
-            self._trial_dir,
+            trial_dir,
             task_name=self._config.task_path.name,
             trial_name=self._trial_name or "",
             agent=self._config.primary_agent,
@@ -1084,6 +1102,6 @@ class Trial:
             partial_trajectory=self._partial_trajectory,
             trajectory_source=self._trajectory_source,
             rewards=self._rewards,
-            started_at=self._started_at,
+            started_at=self._require_started_at(),
             timing=self._timing,
         )

--- a/src/benchflow/trial_yaml.py
+++ b/src/benchflow/trial_yaml.py
@@ -82,8 +82,13 @@ def trial_config_from_dict(
     elif "agent" in raw:
         # Legacy flat format
         prompts_raw = raw.get("prompts")
+        prompts: list[str | None]
         if isinstance(prompts_raw, list):
-            prompts = prompts_raw
+            prompts = []
+            for prompt in prompts_raw:
+                if prompt is not None and not isinstance(prompt, str):
+                    raise ValueError("YAML prompts entries must be strings or null")
+                prompts.append(prompt)
         elif isinstance(prompts_raw, str):
             prompts = [prompts_raw]
         else:

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -629,7 +629,9 @@ class TestVerifierEnv:
 
         assert "-c /dev/null" in addopts
         assert "--confcutdir=/tests" in addopts
-        assert "--rootdir" not in addopts  # injected dynamically by _build_pytest_addopts
+        assert (
+            "--rootdir" not in addopts
+        )  # injected dynamically by _build_pytest_addopts
         assert "-p no:cacheprovider" in addopts
         assert (
             "PYTHONSAFEPATH" not in VERIFIER_ENV
@@ -696,9 +698,8 @@ class TestVerifierEnv:
         task = _make_task()
         await harden_before_verify(env, task, sandbox_user=None)
 
-        assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"]
-            == _build_pytest_addopts(workspace=None)
+        assert task.config.verifier.env["PYTEST_ADDOPTS"] == _build_pytest_addopts(
+            workspace=None
         )
 
     @pytest.mark.asyncio
@@ -866,9 +867,8 @@ class TestVerifierEnv:
         task.config.verifier.pytest_plugins = plugins
         await harden_before_verify(env, task, sandbox_user=None, workspace=None)
 
-        assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"]
-            == _build_pytest_addopts(workspace=None)
+        assert task.config.verifier.env["PYTEST_ADDOPTS"] == _build_pytest_addopts(
+            workspace=None
         )
         assert task.config.verifier.env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
 
@@ -886,9 +886,8 @@ class TestVerifierEnv:
         task.config.verifier.env = None
         await harden_before_verify(env, task, sandbox_user=None)
 
-        assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"]
-            == _build_pytest_addopts(workspace=None)
+        assert task.config.verifier.env["PYTEST_ADDOPTS"] == _build_pytest_addopts(
+            workspace=None
         )
         assert "-c /dev/null" in task.config.verifier.env["PYTEST_ADDOPTS"]
         assert "--confcutdir=/tests" in task.config.verifier.env["PYTEST_ADDOPTS"]
@@ -907,9 +906,8 @@ class TestVerifierEnv:
         task.config.verifier.env = {"PYTEST_ADDOPTS": "--rootdir=/testbed"}
         await harden_before_verify(env, task, sandbox_user=None)
 
-        assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"]
-            == _build_pytest_addopts(workspace=None)
+        assert task.config.verifier.env["PYTEST_ADDOPTS"] == _build_pytest_addopts(
+            workspace=None
         )
 
     @pytest.mark.asyncio
@@ -935,9 +933,7 @@ class TestVerifierEnv:
 
         env = _make_env()
         task = _make_task()
-        await harden_before_verify(
-            env, task, sandbox_user=None, workspace="/root"
-        )
+        await harden_before_verify(env, task, sandbox_user=None, workspace="/root")
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
         assert "--rootdir=/root" in addopts
         assert "--rootdir=/app" not in addopts
@@ -949,9 +945,7 @@ class TestVerifierEnv:
 
         env = _make_env()
         task = _make_task()
-        await harden_before_verify(
-            env, task, sandbox_user=None, workspace=None
-        )
+        await harden_before_verify(env, task, sandbox_user=None, workspace=None)
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
         assert "--rootdir=/app" in addopts
 
@@ -963,9 +957,7 @@ class TestVerifierEnv:
 
         env = _make_env()
         task = _make_task()
-        await harden_before_verify(
-            env, task, sandbox_user=None, workspace=workspace
-        )
+        await harden_before_verify(env, task, sandbox_user=None, workspace=workspace)
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
         assert f"--rootdir={workspace}" in addopts
 
@@ -984,7 +976,9 @@ class TestVerifierEnv:
         """_build_pytest_addopts appends plugin flags after rootdir."""
         from benchflow._sandbox import _build_pytest_addopts
 
-        addopts = _build_pytest_addopts(workspace="/root", plugin_flags="-p ctrf -p xdist")
+        addopts = _build_pytest_addopts(
+            workspace="/root", plugin_flags="-p ctrf -p xdist"
+        )
         assert "--rootdir=/root" in addopts
         assert "-p ctrf" in addopts
         assert "-p xdist" in addopts
@@ -1030,9 +1024,7 @@ class TestVerifierEnv:
         env = _make_env()
         task = _make_task()
         task.config.verifier.env = {"PYTEST_ADDOPTS": "--rootdir=/evil -p evil"}
-        await harden_before_verify(
-            env, task, sandbox_user=None, workspace="/root"
-        )
+        await harden_before_verify(env, task, sandbox_user=None, workspace="/root")
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
         assert "--rootdir=/root" in addopts
         assert "--rootdir=/evil" not in addopts

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -152,7 +152,7 @@ class TestHardenSequence:
         assert "sitecustomize.py" in cleanup_cmd and ".pth" in cleanup_cmd
         assert "-not -path '/tests/*'" in cleanup_cmd
         injected = task.config.verifier.env
-        assert "--rootdir=/app" in injected["PYTEST_ADDOPTS"]
+        assert "--rootdir=/testbed" in injected["PYTEST_ADDOPTS"]
         assert "-p no:cacheprovider" in injected["PYTEST_ADDOPTS"]
         assert injected["PYTHONPATH"] == ""
         assert "PYTHONHOME" not in injected  # breaks Py_Initialize if set to ""
@@ -629,7 +629,7 @@ class TestVerifierEnv:
 
         assert "-c /dev/null" in addopts
         assert "--confcutdir=/tests" in addopts
-        assert "--rootdir=/app" in addopts
+        assert "--rootdir" not in addopts  # injected dynamically by _build_pytest_addopts
         assert "-p no:cacheprovider" in addopts
         assert (
             "PYTHONSAFEPATH" not in VERIFIER_ENV
@@ -685,7 +685,7 @@ class TestVerifierEnv:
     @pytest.mark.asyncio
     async def test_plugin_discovery_failure_graceful(self):
         """If container-side discovery fails, hardening proceeds without extra plugins."""
-        from benchflow._sandbox import VERIFIER_ENV, harden_before_verify
+        from benchflow._sandbox import _build_pytest_addopts, harden_before_verify
 
         def side_effect(cmd, **kwargs):
             if "importlib.metadata" in str(cmd):
@@ -697,7 +697,8 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None)
 
         assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"] == VERIFIER_ENV["PYTEST_ADDOPTS"]
+            task.config.verifier.env["PYTEST_ADDOPTS"]
+            == _build_pytest_addopts(workspace=None)
         )
 
     @pytest.mark.asyncio
@@ -858,7 +859,7 @@ class TestVerifierEnv:
     @pytest.mark.parametrize("plugins", [None, []])
     async def test_no_extra_addopts_when_no_plugins(self, plugins):
         """PYTEST_ADDOPTS is not modified when pytest_plugins is None or empty list."""
-        from benchflow._sandbox import VERIFIER_ENV, harden_before_verify
+        from benchflow._sandbox import _build_pytest_addopts, harden_before_verify
 
         env = _make_env(side_effect=_manifest_env(_blank_manifest()))
         task = _make_task()
@@ -866,7 +867,8 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None, workspace=None)
 
         assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"] == VERIFIER_ENV["PYTEST_ADDOPTS"]
+            task.config.verifier.env["PYTEST_ADDOPTS"]
+            == _build_pytest_addopts(workspace=None)
         )
         assert task.config.verifier.env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
 
@@ -877,7 +879,7 @@ class TestVerifierEnv:
         The rebuild must happen unconditionally — not only when task env is populated.
         Without this, a None task env would leave PYTEST_ADDOPTS unset or lost.
         """
-        from benchflow._sandbox import VERIFIER_ENV, harden_before_verify
+        from benchflow._sandbox import _build_pytest_addopts, harden_before_verify
 
         env = _make_env()
         task = _make_task()
@@ -885,7 +887,8 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None)
 
         assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"] == VERIFIER_ENV["PYTEST_ADDOPTS"]
+            task.config.verifier.env["PYTEST_ADDOPTS"]
+            == _build_pytest_addopts(workspace=None)
         )
         assert "-c /dev/null" in task.config.verifier.env["PYTEST_ADDOPTS"]
         assert "--confcutdir=/tests" in task.config.verifier.env["PYTEST_ADDOPTS"]
@@ -897,7 +900,7 @@ class TestVerifierEnv:
         Without the re-pin the task could strip -c /dev/null and --confcutdir,
         re-enabling pyproject.toml discovery and conftest walk-up.
         """
-        from benchflow._sandbox import VERIFIER_ENV, harden_before_verify
+        from benchflow._sandbox import _build_pytest_addopts, harden_before_verify
 
         env = _make_env()
         task = _make_task()
@@ -905,7 +908,8 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None)
 
         assert (
-            task.config.verifier.env["PYTEST_ADDOPTS"] == VERIFIER_ENV["PYTEST_ADDOPTS"]
+            task.config.verifier.env["PYTEST_ADDOPTS"]
+            == _build_pytest_addopts(workspace=None)
         )
 
     @pytest.mark.asyncio
@@ -920,9 +924,135 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None)
 
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
-        assert addopts.startswith(VERIFIER_ENV["PYTEST_ADDOPTS"])
+        assert VERIFIER_ENV["PYTEST_ADDOPTS"] in addopts
         assert "-p ctrf" in addopts
         assert "--rootdir=/evil" not in addopts
+
+    @pytest.mark.asyncio
+    async def test_rootdir_follows_workspace(self):
+        """--rootdir is set to the workspace path, not hardcoded /app."""
+        from benchflow._sandbox import harden_before_verify
+
+        env = _make_env()
+        task = _make_task()
+        await harden_before_verify(
+            env, task, sandbox_user=None, workspace="/root"
+        )
+        addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
+        assert "--rootdir=/root" in addopts
+        assert "--rootdir=/app" not in addopts
+
+    @pytest.mark.asyncio
+    async def test_rootdir_defaults_to_app_when_no_workspace(self):
+        """Without a workspace, --rootdir falls back to /app (Harbor convention)."""
+        from benchflow._sandbox import harden_before_verify
+
+        env = _make_env()
+        task = _make_task()
+        await harden_before_verify(
+            env, task, sandbox_user=None, workspace=None
+        )
+        addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
+        assert "--rootdir=/app" in addopts
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("workspace", ["/app", "/testbed", "/root", "/workspace"])
+    async def test_rootdir_matches_various_workspaces(self, workspace):
+        """--rootdir tracks the workspace for any conventional directory."""
+        from benchflow._sandbox import harden_before_verify
+
+        env = _make_env()
+        task = _make_task()
+        await harden_before_verify(
+            env, task, sandbox_user=None, workspace=workspace
+        )
+        addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
+        assert f"--rootdir={workspace}" in addopts
+
+    def test_build_pytest_addopts_security_invariants(self):
+        """_build_pytest_addopts always includes the security-critical flags."""
+        from benchflow._sandbox import _build_pytest_addopts
+
+        for ws in [None, "/app", "/root", "/testbed"]:
+            addopts = _build_pytest_addopts(workspace=ws)
+            assert "-c /dev/null" in addopts
+            assert "--confcutdir=/tests" in addopts
+            assert "-p no:cacheprovider" in addopts
+            assert "--rootdir=" in addopts
+
+    def test_build_pytest_addopts_with_plugins(self):
+        """_build_pytest_addopts appends plugin flags after rootdir."""
+        from benchflow._sandbox import _build_pytest_addopts
+
+        addopts = _build_pytest_addopts(workspace="/root", plugin_flags="-p ctrf -p xdist")
+        assert "--rootdir=/root" in addopts
+        assert "-p ctrf" in addopts
+        assert "-p xdist" in addopts
+
+    def test_build_pytest_addopts_empty_workspace_falls_back(self):
+        """Empty string workspace is falsy — falls back to /app like None."""
+        from benchflow._sandbox import _build_pytest_addopts
+
+        assert "--rootdir=/app" in _build_pytest_addopts(workspace="")
+        assert "--rootdir=/app" in _build_pytest_addopts(workspace=None)
+
+    def test_build_pytest_addopts_no_trailing_space_without_plugins(self):
+        """No trailing whitespace when plugin_flags is empty."""
+        from benchflow._sandbox import _build_pytest_addopts
+
+        addopts = _build_pytest_addopts(workspace="/root", plugin_flags="")
+        assert not addopts.endswith(" ")
+        assert addopts.endswith("--rootdir=/root")
+
+    def test_build_pytest_addopts_quotes_special_chars(self):
+        """Workspace paths with spaces are shell-quoted."""
+        from benchflow._sandbox import _build_pytest_addopts
+
+        addopts = _build_pytest_addopts(workspace="/my workspace")
+        assert "--rootdir='/my workspace'" in addopts
+
+    def test_build_pytest_addopts_single_rootdir(self):
+        """Exactly one --rootdir flag in the output, no duplicates."""
+        from benchflow._sandbox import _build_pytest_addopts
+
+        addopts = _build_pytest_addopts(workspace="/root", plugin_flags="-p ctrf")
+        assert addopts.count("--rootdir") == 1
+
+    @pytest.mark.asyncio
+    async def test_rootdir_not_overridable_by_task_env(self):
+        """A task setting PYTEST_ADDOPTS with --rootdir=/evil cannot win.
+
+        The re-pin in harden_before_verify rebuilds PYTEST_ADDOPTS entirely,
+        so any task-injected rootdir is discarded.
+        """
+        from benchflow._sandbox import harden_before_verify
+
+        env = _make_env()
+        task = _make_task()
+        task.config.verifier.env = {"PYTEST_ADDOPTS": "--rootdir=/evil -p evil"}
+        await harden_before_verify(
+            env, task, sandbox_user=None, workspace="/root"
+        )
+        addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
+        assert "--rootdir=/root" in addopts
+        assert "--rootdir=/evil" not in addopts
+        assert "-p evil" not in addopts
+
+    @pytest.mark.asyncio
+    async def test_successive_harden_calls_use_latest_workspace(self):
+        """Multiple harden_before_verify calls update rootdir to match the workspace."""
+        from benchflow._sandbox import harden_before_verify
+
+        env = _make_env()
+        task = _make_task()
+
+        await harden_before_verify(env, task, sandbox_user=None, workspace="/app")
+        assert "--rootdir=/app" in task.config.verifier.env["PYTEST_ADDOPTS"]
+
+        await harden_before_verify(env, task, sandbox_user=None, workspace="/root")
+        addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
+        assert "--rootdir=/root" in addopts
+        assert "--rootdir=/app" not in addopts
 
     def test_pythonpycacheprefix_set_to_nonexistent(self):
         """PYTHONPYCACHEPREFIX must redirect .pyc lookups away from __pycache__ dirs.


### PR DESCRIPTION
## Summary

- PR #194 hardcoded `--rootdir=/app` in `VERIFIER_ENV["PYTEST_ADDOPTS"]`, which breaks **67 SkillsBench tasks** that use `WORKDIR /root` — pytest fails with `ERROR: Directory '/app' not found`
- Extract `_build_pytest_addopts(workspace, plugin_flags)` that sets `--rootdir` to the task's actual workspace (from Dockerfile `WORKDIR`), falling back to `/app` when workspace is `None`
- All security invariants preserved: `-c /dev/null`, `--confcutdir=/tests`, ADDOPTS re-pin after task env merge, `shlex.quote` on workspace path

## Changes

| File | What |
|------|------|
| `src/benchflow/_sandbox.py` | Remove static `--rootdir=/app` from `VERIFIER_ENV`; add `_build_pytest_addopts()` helper; simplify ADDOPTS assembly in `harden_before_verify()` |
| `tests/test_sandbox_hardening.py` | Update 6 existing assertions; add 13 new tests (workspace tracking, fallback, edge cases, security) |

## Test plan

- [x] 79 sandbox hardening tests pass (13 new)
- [x] 707 full test suite pass, 0 regressions
- [x] Oracle eval on `WORKDIR /root` tasks: weighted-gdp-calc (27/27), offer-letter-generator (18/18), earthquake-plate-calculation (8/8), parallel-tfidf-search (5/5) — all reward 1.0, `rootdir: /root`
- [x] Oracle eval on `WORKDIR /app` task: dialogue-parser — `rootdir: /app` confirmed

Closes #211 (point 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/212" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
