### PR TITLE
Add disallow_web_tools task field for benchmark integrity

### DIFF
--- a/src/benchflow/_agent_setup.py
+++ b/src/benchflow/_agent_setup.py
@@ -69,13 +69,27 @@ async def _link_skill_paths(
     return len(parts)
 
 
-async def install_agent(env, agent: str, trial_dir: Path) -> AgentConfig | None:
-    """Install agent in sandbox and return its config."""
+async def install_agent(
+    env,
+    agent: str,
+    trial_dir: Path,
+    *,
+    disallow_web_tools: bool = False,
+) -> AgentConfig | None:
+    """Install agent in sandbox and return its config.
+
+    When ``disallow_web_tools`` is True, the agent's
+    ``disallow_web_tools_install_suffix`` (if any) is appended to the install
+    command — typically writing a settings file that disables the agent's
+    built-in web tools.
+    """
     agent_base = agent.split()[0]
     agent_cfg = AGENTS.get(agent_base)
     if agent_base not in AGENT_INSTALLERS:
         return agent_cfg
     install_cmd = AGENT_INSTALLERS[agent_base]
+    if disallow_web_tools and agent_cfg and agent_cfg.disallow_web_tools_install_suffix:
+        install_cmd = install_cmd + agent_cfg.disallow_web_tools_install_suffix
     install_timeout = agent_cfg.install_timeout if agent_cfg else 900
     logger.info(f"Installing {agent_base} in sandbox (timeout={install_timeout}s)...")
     install_result = await env.exec(

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -45,6 +45,7 @@ Look at the existing entries below for worked examples:
 """
 
 import base64
+import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -94,6 +95,27 @@ _OPENCLAW_SHIM = (Path(__file__).parent / "openclaw_acp_shim.py").read_text()
 
 # Path to the Pi launch wrapper (bridges BENCHFLOW_PROVIDER_* → Pi config)
 _PI_LAUNCHER = (Path(__file__).parent / "pi_acp_launcher.py").read_text()
+
+
+def _json_settings_merge(path: str, mutator: str) -> str:
+    """Idempotent JSON-settings merge as a one-line bash snippet.
+
+    ``path`` is the target file (under $HOME, supports ~ expansion).
+    ``mutator`` is a Python expression operating on the in-scope ``d`` dict
+    (loaded from the file or {}). Result is written back as JSON.
+
+    Used to enable the web-tool deny-list in claude / gemini / opencode
+    settings without overwriting user state from subscription-auth copy.
+    """
+    py = (
+        "import json,os,pathlib;"
+        f"p=pathlib.Path(os.path.expanduser({path!r}));"
+        "p.parent.mkdir(parents=True, exist_ok=True);"
+        "d=json.loads(p.read_text()) if p.exists() else {};"
+        f"{mutator};"
+        "p.write_text(json.dumps(d))"
+    )
+    return f"python3 -c {shlex.quote(py)}"
 
 
 @dataclass
@@ -170,6 +192,15 @@ class AgentConfig:
     supports_acp_set_model: bool = True
     # Some ACP agents configure the model through env/config at launch time and
     # do not implement session/set_model (e.g. OpenHands CLI ACP).
+    disallow_web_tools_install_suffix: str = ""
+    # Bash snippet appended to ``install_cmd`` when the task's
+    # ``disallow_web_tools`` flag is on. Use for agents whose web-tool toggle
+    # lives in a config file written at install time (claude settings.json,
+    # gemini settings.json, opencode opencode.json, openhands config.toml).
+    disallow_web_tools_launch_suffix: str = ""
+    # String appended to ``launch_cmd`` when ``disallow_web_tools`` is on.
+    # Use for agents whose toggle is a launch flag (codex-acp's
+    # ``-c tools.web_search=false``).
 
 
 # Agent registry — all supported agents
@@ -201,6 +232,17 @@ AGENTS: dict[str, AgentConfig] = {
                     "~/.claude/.credentials.json", "{home}/.claude/.credentials.json"
                 ),
             ],
+        ),
+        # claude-agent-acp loads ~/.claude/settings.json via the Claude Agent
+        # SDK's settingSources=["user","project","local"]; permissions.deny
+        # rules are honored without any wrapper change.
+        # See: https://github.com/zed-industries/claude-code-acp/blob/main/src/acp-agent.ts
+        disallow_web_tools_install_suffix=" && "
+        + _json_settings_merge(
+            "~/.claude/settings.json",
+            'd.setdefault("permissions",{}).setdefault("deny",[]);'
+            '[d["permissions"]["deny"].append(t) for t in ["WebSearch","WebFetch"] '
+            'if t not in d["permissions"]["deny"]]',
         ),
     ),
     "pi-acp": AgentConfig(
@@ -281,6 +323,10 @@ AGENTS: dict[str, AgentConfig] = {
                 HostAuthFile("~/.codex/auth.json", "{home}/.codex/auth.json"),
             ],
         ),
+        # codex-acp parses CliConfigOverrides::parse() and forwards `-c k=v`
+        # to the underlying codex runtime. Disables the built-in web_search
+        # tool. See: https://github.com/zed-industries/codex-acp/blob/main/src/main.rs
+        disallow_web_tools_launch_suffix=" -c tools.web_search=false",
     ),
     "gemini": AgentConfig(
         name="gemini",
@@ -317,6 +363,17 @@ AGENTS: dict[str, AgentConfig] = {
                 ),
             ],
         ),
+        # gemini-cli builds excludeTools from settings.tools.exclude. Merges
+        # with any settings.json copied from the host via subscription_auth.
+        # See: packages/cli/src/config/config.ts (mergeExcludeTools).
+        disallow_web_tools_install_suffix=" && "
+        + _json_settings_merge(
+            "~/.gemini/settings.json",
+            'd.setdefault("tools",{}).setdefault("exclude",[]);'
+            '[d["tools"]["exclude"].append(t) for t in '
+            '["google_web_search","web_fetch"] '
+            'if t not in d["tools"]["exclude"]]',
+        ),
     ),
     "opencode": AgentConfig(
         name="opencode",
@@ -339,6 +396,14 @@ AGENTS: dict[str, AgentConfig] = {
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "OPENAI_BASE_URL",
         },
+        # opencode honors per-tool permission overrides in opencode.json's
+        # ``tools`` map. Built-in is ``webfetch``; no built-in web search.
+        # See: https://github.com/sst/opencode/blob/dev/packages/opencode/src/config/config.ts
+        disallow_web_tools_install_suffix=" && "
+        + _json_settings_merge(
+            "~/.config/opencode/opencode.json",
+            'd.setdefault("tools",{})["webfetch"]=False',
+        ),
     ),
     "openhands": AgentConfig(
         name="openhands",
@@ -392,6 +457,14 @@ AGENTS: dict[str, AgentConfig] = {
             "BENCHFLOW_PROVIDER_API_KEY": "LLM_API_KEY",
         },
         supports_acp_set_model=False,
+        # OpenHands' BrowsingAgent / browser tool is disabled via
+        # ``[agent] enable_browsing = false`` in ~/.openhands/config.toml.
+        # See AgentConfig.enable_browsing in OpenHands core/config/agent_config.py.
+        disallow_web_tools_install_suffix=(
+            " && mkdir -p ~/.openhands && "
+            "printf '[agent]\\nenable_browsing = false\\n' "
+            "> ~/.openhands/config.toml"
+        ),
     ),
 }
 

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -66,11 +66,37 @@ from benchflow._trajectory import (
     _scrape_agent_trajectory,
 )
 from benchflow.acp.client import ACPClient, ACPError
-from benchflow.agents.registry import AGENT_LAUNCH
+from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
 from benchflow.models import RunResult, TrajectorySource
 from benchflow.user import BaseUser, RoundResult
 
 logger = logging.getLogger(__name__)
+
+
+_NO_WEB_TOOLS_PROMPT = (
+    "You have no web access for this task. Do not use any web search or "
+    "web fetch tool; solve using only the local environment."
+)
+
+
+def _read_disallow_web_tools(task_path: Path) -> bool:
+    """Read [environment] disallow_web_tools from task.toml.
+
+    Harbor 0.3.0's ``EnvironmentConfig`` does not declare this field, so
+    pydantic drops it silently. Read raw TOML until the harbor pin bumps
+    to a release that preserves it.
+    """
+    import tomllib
+
+    toml_path = task_path / "task.toml"
+    if not toml_path.exists():
+        return False
+    try:
+        data = tomllib.loads(toml_path.read_text())
+    except Exception as e:
+        logger.warning("Failed to parse %s for disallow_web_tools: %s", toml_path, e)
+        return False
+    return bool(data.get("environment", {}).get("disallow_web_tools", False))
 
 
 @dataclass
@@ -219,6 +245,10 @@ class TrialConfig:
 class Trial:
     """Decomposed trial lifecycle with independently-callable phases."""
 
+    # Class-level default so test stubs that bypass __init__ via
+    # Trial.__new__() still see a sane value when connect_as() reads it.
+    _disallow_web_tools: bool = False
+
     def __init__(self, config: TrialConfig) -> None:
         self._config = config
         self._phase = "created"
@@ -237,6 +267,7 @@ class Trial:
         self._timeout: int = 0
         self._timing: dict[str, float] = {}
         self._effective_locked: list[str] = []
+        self._disallow_web_tools: bool = False
 
         # Populated by install_agent()
         self._agent_cfg: Any = None
@@ -320,12 +351,41 @@ class Trial:
             cfg.primary_agent, cfg.primary_model, cfg.agent_env
         )
         self._resolved_prompts = SDK._resolve_prompts(
-            cfg.task_path, cfg.prompts,
+            cfg.task_path,
+            cfg.prompts,
             skills_dir=cfg.skills_dir,
             skill_nudge=(cfg.agent_env or {}).get("BENCHFLOW_SKILL_NUDGE", ""),
             agent=cfg.primary_agent,
         )
         self._agent_launch = AGENT_LAUNCH.get(cfg.primary_agent, cfg.primary_agent)
+
+        # Read disallow_web_tools directly from task.toml — harbor 0.3.0's
+        # EnvironmentConfig silently drops unknown fields, so this can't be
+        # read off self._task.config.environment yet. Drop this block once
+        # benchflow's harbor pin includes the field.
+        self._disallow_web_tools = _read_disallow_web_tools(cfg.task_path)
+        if self._disallow_web_tools:
+            agent_cfg = AGENTS.get(cfg.primary_agent)
+            if agent_cfg and agent_cfg.disallow_web_tools_launch_suffix:
+                self._agent_launch = (
+                    self._agent_launch + agent_cfg.disallow_web_tools_launch_suffix
+                )
+            has_hard_knob = bool(
+                agent_cfg
+                and (
+                    agent_cfg.disallow_web_tools_install_suffix
+                    or agent_cfg.disallow_web_tools_launch_suffix
+                )
+            )
+            if not has_hard_knob:
+                logger.warning(
+                    "Agent %r has no upstream knob to disable web tools; "
+                    "falling back to a soft prompt prefix only.",
+                    cfg.primary_agent,
+                )
+            self._resolved_prompts = [
+                f"{_NO_WEB_TOOLS_PROMPT}\n\n{p}" for p in self._resolved_prompts
+            ]
 
         # Copy task dir to temp when Dockerfile mutations are needed
         # (_inject_skills writes into environment/_deps/, stage_dockerfile
@@ -418,7 +478,12 @@ class Trial:
             return
 
         agent_name = cfg.primary_agent
-        self._agent_cfg = await install_agent(self._env, agent_name, self._trial_dir)
+        self._agent_cfg = await install_agent(
+            self._env,
+            agent_name,
+            self._trial_dir,
+            disallow_web_tools=self._disallow_web_tools,
+        )
         cred_home = f"/home/{cfg.sandbox_user}" if cfg.sandbox_user else "/root"
         await write_credential_files(
             self._env,
@@ -1004,6 +1069,10 @@ class Trial:
         t0 = datetime.now()
 
         agent_launch = AGENT_LAUNCH.get(role.agent, role.agent)
+        if self._disallow_web_tools:
+            role_cfg = AGENTS.get(role.agent)
+            if role_cfg and role_cfg.disallow_web_tools_launch_suffix:
+                agent_launch = agent_launch + role_cfg.disallow_web_tools_launch_suffix
         # Merge cfg.agent_env (config-level) with role.env (role-specific) so
         # provider creds from YAML reach the agent. role.env wins on overlap.
         agent_env = resolve_agent_env(
@@ -1013,7 +1082,12 @@ class Trial:
         )
 
         if role.agent != cfg.primary_agent:
-            agent_cfg = await install_agent(self._env, role.agent, self._trial_dir)
+            agent_cfg = await install_agent(
+                self._env,
+                role.agent,
+                self._trial_dir,
+                disallow_web_tools=self._disallow_web_tools,
+            )
             cred_home = f"/home/{cfg.sandbox_user}" if cfg.sandbox_user else "/root"
             await write_credential_files(
                 self._env,


### PR DESCRIPTION
## Summary

Add a new `disallow_web_tools` field to `task.toml`'s `[environment]` section that disables an agent's built-in web tools (web search, URL fetch, browser) so a task can require the agent to "solve on its own" without cutting the container's network.

## Motivation

`allow_internet = false` is unusable with installed agents: it sets `network_mode: none` on the task container, but the agent process runs *inside* that container, so its install scripts (`curl`, `npm install`, `uv pip install`) and its LLM API calls (`api.anthropic.com`, etc.) all fail. Users hitting this on skillsbench tasks (PRs #741/#742/#747) wanted a way to constrain the *agent's tools* — keep the LLM reachable, just don't let it search the web. That's what this field does.

This is an agent-side knob, not a network knob. Network isolation via `allow_internet = false` is unchanged and orthogonal.

## What changed

### Field

New field on `EnvironmentConfig` (`src/harbor/models/task/config.py`):

```toml
[environment]
disallow_web_tools = true   # default: false
```

Threaded through `src/harbor/trial/trial.py` into agent kwargs alongside `mcp_servers` / `skills_dir`.

### Base class plumbing

`src/harbor/agents/installed/base.py`:

- `BaseInstalledAgent.__init__` accepts `disallow_web_tools: bool = False`.
- New hook `_apply_disallow_web_tools()` — called after `super().__init__` when the flag is on. Subclasses override to translate the flag into their CLI/config.
- Default implementation logs a warning ("no hard mechanism for this agent") and turns on a **soft fallback**: prepends a "no web access" notice to the rendered instruction via `render_instruction()`. So even unsupported agents get instruction-level discouragement.
- `NO_WEB_TOOLS_PROMPT` is a class constant so subclasses can reuse the wording.

### Per-agent overrides

| Agent | Mechanism |
|---|---|
| **claude-code** | merges `WebSearch,WebFetch` into `--disallowedTools` (composes with any user value) and appends a system-prompt nudge via `--append-system-prompt` |
| **codex** | adds `-c web_search="disabled"` ([config override](https://developers.openai.com/codex/config-basic)) |
| **openhands** | writes `[agent] enable_browsing = false` to `~/.openhands/config.toml` (re-uses existing config-toml builder) |
| **aider** | appends `--disable-playwright` (turns off URL scraping) + keeps the soft instruction prefix as belt-and-suspenders against `Bash` curl |
| all others | base default — warning + soft instruction prefix; ready for follow-up overrides |

## Files changed

- `src/harbor/models/task/config.py` — `disallow_web_tools` field
- `src/harbor/trial/trial.py` — wire into agent kwargs
- `src/harbor/agents/installed/base.py` — kwarg + hook + soft-prepend default
- `src/harbor/agents/installed/claude_code.py`
- `src/harbor/agents/installed/codex.py`
- `src/harbor/agents/installed/openhands.py`
- `src/harbor/agents/installed/aider.py`

## Verification

- `uv run pytest tests/unit/` — **1640 passed, 1 skipped**, no regressions.
- `uvx ruff check` and `uvx ruff format` clean.
- Programmatic smoke check confirms rendered output for each of the four overrides:
  - codex: `-c model_reasoning_effort=high -c web_search="disabled"`
  - aider: `--disable-playwright` + instruction prefixed
  - openhands: `[agent]\nenable_browsing = false\n`
  - claude-code: `--append-system-prompt '...' --disallowedTools WebSearch,WebFetch`
- **End-to-end live run** on `skillsbench/tasks/bike-rebalance` with `disallow_web_tools = true` and claude-code:
  - Agent installs and runs successfully (would have failed under `allow_internet = false`).
  - Session init `tools` list contains no `WebSearch` / `WebFetch`.
  - Final stream record: `"web_search_requests": 0, "web_fetch_requests": 0`.

## How to use

```toml
# task.toml
[environment]
disallow_web_tools = true   # the agent must solve without web search
allow_internet = true       # but keep the container online so the agent can run
```

## Out of scope / follow-ups

- Real overrides for the other installed agents (`gemini-cli`, `qwen-code`, `opencode`, `goose`, `cursor-cli`, `cline`, `copilot-cli`, `kimi-cli`, `rovodev-cli`, `trae-agent`, `hermes`, `pi`, `nemo-agent`, `swe-agent`, `openhands-sdk`, `mini-swe-agent`). They currently fall back to the soft-prepend; each needs its own upstream-flag mapping when discovered.
- Modal `allow_internet = false` bugs noticed during investigation but not touched here:
  - `modal.py:391-396` appends both `docker-compose-no-network.yaml` and `docker-compose-host-network.yaml`, the latter overrides the former.
  - `modal.py:808-811` sets `disable_internet=not self._compose_mode`, giving a misleading "not supported by modal" error in compose mode.
- Network-level egress allowlisting (firewall keeping LLM API reachable while blocking web search egress) — explicitly not done; tool-disable is the right primitive for "solve on its own."

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/216" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
