### PR TITLE
fix: preserve verifier log mount

### DIFF
--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -642,11 +642,16 @@ async def _trusted_verifier_pythonpath(
     return ":".join(e for e in extras if isinstance(e, str))
 
 
-# Wipe and recreate /logs/verifier/ before the verifier runs.
-# rm -rf severs hardlinks, removes symlink replacements, and eliminates
-# variant filenames/subdirs the agent may have pre-staged.
+# Wipe /logs/verifier/ contents before the verifier runs while preserving the
+# directory itself. Docker mounts the host trial verifier directory directly at
+# this path, so deleting/recreating the mountpoint would hide verifier outputs
+# from the host.
 _CLEAR_VERIFIER_DIR_CMD = (
-    "rm -rf /logs/verifier && mkdir -p /logs/verifier /app && chmod 777 /logs/verifier"
+    "if [ -L /logs/verifier ] || [ ! -d /logs/verifier ]; then "
+    "rm -rf /logs/verifier && mkdir -p /logs/verifier; "
+    "else "
+    "find /logs/verifier -mindepth 1 -maxdepth 1 -exec rm -rf -- {} +; "
+    "fi && mkdir -p /app && chmod 777 /logs/verifier"
 )
 
 # Per-task hardening opt-outs. Tasks declare these in task.toml under

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -650,15 +650,18 @@ class Trial:
         """
         from harbor import Verifier
 
-        from benchflow._sandbox import _build_cleanup_cmd, _read_hardening_config
+        from benchflow._sandbox import (
+            _CLEAR_VERIFIER_DIR_CMD,
+            _build_cleanup_cmd,
+            _read_hardening_config,
+        )
 
         self._trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
         # Clean verifier output dir — chmod 777 so non-root verifier processes can write.
         # Keep /app present for task/verifier paths that still use the legacy
         # rootdir fallback; tasks that populate /app are unaffected.
         await self._env.exec(
-            "rm -rf /logs/verifier && mkdir -p /logs/verifier /app && "
-            "chmod 777 /logs/verifier",
+            _CLEAR_VERIFIER_DIR_CMD,
             user="root",
             timeout_sec=10,
         )

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -134,7 +134,7 @@ class TestHardenSequence:
         cmds = [c.args[0] for c in env.exec.call_args_list]
         assert "pkill -u agent" in cmds[0]
         wipe_idx = next(
-            (i for i, c in enumerate(cmds) if "rm -rf /logs/verifier" in c), None
+            (i for i, c in enumerate(cmds) if "find /logs/verifier" in c), None
         )
         chown_idx = next(
             (i for i, c in enumerate(cmds) if "chown -R root:root /testbed" in c),
@@ -148,7 +148,7 @@ class TestHardenSequence:
         assert not any("rm -f /testbed/setup.py" in c for c in cmds)
         assert not any("rsync -a --delete /testbed_verify/" in c for c in cmds)
         assert any("mkdir -p /logs/verifier" in c for c in cmds)
-        assert any("mkdir -p /logs/verifier /app" in c for c in cmds)
+        assert any("mkdir -p /app" in c for c in cmds)
         cleanup_cmd = next(c for c in cmds if "conftest.py" in c)
         assert "sitecustomize.py" in cleanup_cmd and ".pth" in cleanup_cmd
         assert "-not -path '/tests/*'" in cleanup_cmd
@@ -196,11 +196,11 @@ class TestHardenSequence:
 
 
 class TestVerifierDirWipe:
-    """Tier 1: /logs/verifier/ is wiped and recreated before the verifier runs."""
+    """Tier 1: /logs/verifier/ is wiped before the verifier runs."""
 
     @pytest.mark.asyncio
-    async def test_wipe_recreates_verifier_dir(self):
-        """rm -rf, mkdir -p, and chmod 777 are all in one atomic call; it runs as root."""
+    async def test_wipe_preserves_verifier_dir(self):
+        """The cleanup removes contents, preserves the mountpoint, and runs as root."""
         from benchflow._sandbox import harden_before_verify
 
         env = _make_env()
@@ -210,14 +210,15 @@ class TestVerifierDirWipe:
             (
                 c
                 for c in env.exec.call_args_list
-                if "rm -rf /logs/verifier" in c.args[0]
-                and "mkdir -p /logs/verifier /app" in c.args[0]
+                if "find /logs/verifier -mindepth 1 -maxdepth 1" in c.args[0]
+                and "mkdir -p /app" in c.args[0]
                 and "chmod 777 /logs/verifier" in c.args[0]
             ),
             None,
         )
         assert match is not None, (
-            "expected a single call with rm -rf, mkdir -p, and chmod 777 for /logs/verifier"
+            "expected a single call that clears /logs/verifier contents, "
+            "preserves the directory, and chmods it"
         )
         assert match.kwargs.get("user") == "root"
 


### PR DESCRIPTION
## Summary
- Preserve the /logs/verifier directory during verifier hardening so Docker bind mounts stay attached
- Clear only verifier log contents before verification
- Reuse the same cleanup command in soft verification

## Test Plan
- uv run ruff format --check src/benchflow/_sandbox.py src/benchflow/trial.py tests/test_sandbox_hardening.py
- uv run ruff check src/benchflow/_sandbox.py src/benchflow/trial.py tests/test_sandbox_hardening.py
- uv run pytest tests/test_sandbox_hardening.py tests/test_sandbox_verifier_workspace.py tests/test_sdk_lockdown.py