### PR TITLE
fix: Support Modal backend

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -50,7 +50,7 @@ bench eval create \
 | `--tasks-dir`, `-t` | — | Task dir (single task with task.toml, or parent of many tasks) |
 | `--agent`, `-a` | `gemini` | Agent name |
 | `--model`, `-m` | `gemini-3.1-flash-lite-preview` | Model ID |
-| `--env`, `-e` | `docker` | Environment: docker or daytona |
+| `--env`, `-e` | `docker` | Environment: docker, daytona, or modal |
 | `--concurrency`, `-c` | `4` | Max concurrent tasks (batch mode only) |
 | `--jobs-dir`, `-o` | `jobs` | Output directory |
 | `--sandbox-user` | `agent` | Sandbox user (null for root) |

--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -250,7 +250,7 @@ def _create_environment(
     trial_paths: TrialPaths,
     preserve_agent_network: bool = False,
 ) -> Any:
-    """Create a Harbor environment (Docker or Daytona)."""
+    """Create a Harbor environment (Docker, Daytona, or Modal)."""
     env_config = task.config.environment
     if preserve_agent_network and env_config.allow_internet is False:
         # LLM agents run inside the sandbox and need outbound network for model
@@ -308,7 +308,19 @@ def _create_environment(
             auto_stop_interval_mins=1440,
             auto_delete_interval_mins=1440,
         )
+    elif environment_type == "modal":
+        from harbor.environments.modal import ModalEnvironment
+
+        ModalEnvironment.preflight()
+
+        return ModalEnvironment(
+            environment_dir=task.paths.environment_dir,
+            environment_name=task_path.name,
+            session_id=trial_name,
+            trial_paths=trial_paths,
+            task_env_config=env_config,
+        )
     else:
         raise ValueError(
-            f"Unknown environment_type: {environment_type!r} (use 'docker' or 'daytona')"
+            f"Unknown environment_type: {environment_type!r} (use 'docker', 'daytona', or 'modal')"
         )

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -525,7 +525,7 @@ async def _discover_pytest_plugin_flags(env, task: "Task") -> str:
             if isinstance(name, str):
                 add_plugin(name)
 
-    # The standard task template runs pytest-json-ctrf through `uvx --with`,
+    # The standard task template runs pytest-ctrf through `uvx --with`,
     # so the plugin is not visible during pre-verifier entry-point discovery.
     # Infer only this known reporting plugin from test.sh while keeping
     # PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 for all other entry points.
@@ -549,7 +549,7 @@ def _infer_pytest_plugins_from_test_script(task: "Task") -> list[str]:
     uncommented = "\n".join(line.split("#", 1)[0] for line in text.splitlines())
     plugins: list[str] = []
     if re.search(r"(^|[^\w-])--ctrf([=\s]|$)", uncommented):
-        plugins.append("json_ctrf")
+        plugins.append("ctrf")
     return plugins
 
 

--- a/src/benchflow/cli/eval.py
+++ b/src/benchflow/cli/eval.py
@@ -116,7 +116,7 @@ def eval_create(
         typer.Option(
             "--environment",
             "-e",
-            help="docker | daytona | ... (uses the agent's default if unset)",
+            help="docker | daytona | modal | ... (uses the agent's default if unset)",
         ),
     ] = "docker",
     prompt: Annotated[

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -37,7 +37,7 @@ def run(
     ] = None,
     environment: Annotated[
         str,
-        typer.Option("--backend", "-b", help="Backend: docker or daytona"),
+        typer.Option("--backend", "-b", help="Backend: docker, daytona, or modal"),
     ] = "docker",
     prompt: Annotated[
         list[str] | None,
@@ -132,7 +132,7 @@ def job(
     ] = None,
     environment: Annotated[
         str,
-        typer.Option("--env", "-e", help="Environment: docker or daytona"),
+        typer.Option("--env", "-e", help="Environment: docker, daytona, or modal"),
     ] = "docker",
     concurrency: Annotated[
         int,
@@ -311,7 +311,7 @@ def eval(
     ] = None,
     environment: Annotated[
         str,
-        typer.Option("--env", "-e", help="Environment: docker or daytona"),
+        typer.Option("--env", "-e", help="Environment: docker, daytona, or modal"),
     ] = "docker",
     concurrency: Annotated[
         int,
@@ -442,7 +442,7 @@ def skills_eval(
     ] = None,
     environment: Annotated[
         str,
-        typer.Option("--env", "-e", help="Environment: docker or daytona"),
+        typer.Option("--env", "-e", help="Environment: docker, daytona, or modal"),
     ] = "docker",
     concurrency: Annotated[
         int,
@@ -726,7 +726,7 @@ def eval_create(
     ] = None,
     environment: Annotated[
         str,
-        typer.Option("--env", "-e", help="Backend: docker or daytona"),
+        typer.Option("--env", "-e", help="Backend: docker, daytona, or modal"),
     ] = "docker",
     concurrency: Annotated[
         int,
@@ -995,7 +995,7 @@ def environment_create(
     ],
     backend: Annotated[
         str,
-        typer.Option("--backend", "-b", help="Backend: docker or daytona"),
+        typer.Option("--backend", "-b", help="Backend: docker, daytona, or modal"),
     ] = "daytona",
 ) -> None:
     """Create an environment from a task directory (does not start it)."""

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -16,7 +16,7 @@ Run loop (SDK.run, top to bottom)
     │  _resolve_prompts       prompt list (instruction.md fallback)│
     │  stage_dockerfile_deps  COPY rewrites for context_root       │  ← _env_setup
     │  _inject_skills_…       Dockerfile skill mount               │  ← _env_setup
-    │  _create_environment    Docker or Daytona, not yet started   │  ← _env_setup
+    │  _create_environment    Docker, Daytona, or Modal sandbox    │  ← _env_setup
     │  _write_config          config.json → trial_dir              │
     └──────────────────────────────────────────────────────────────┘
     ┌─ START (sandbox) ───────────────────────────────────────────┐
@@ -529,7 +529,7 @@ class SDK:
             job_name: Job name. Auto-generated if not provided.
             trial_name: Custom trial name. Auto-generated if not provided.
             jobs_dir: Directory for job output (Harbor convention).
-            environment: Environment type — "docker" or "daytona".
+            environment: Environment type — "docker", "daytona", or "modal".
             skills_dir: Path to skills directory. Copied into sandbox and symlinked
                 to agent-specific discovery paths (e.g. ~/.claude/skills/).
             sandbox_user: Run agent as this non-root user (e.g. "agent"). Uses

--- a/src/benchflow/skill_eval.py
+++ b/src/benchflow/skill_eval.py
@@ -397,7 +397,7 @@ class SkillEvaluator:
         Args:
             agents: List of agent names to test.
             models: List of models (matched 1:1 with agents, or broadcast).
-            environment: docker or daytona.
+            environment: docker, daytona, or modal.
             jobs_dir: Base output directory.
             no_baseline: Skip baseline (no-skill) runs.
             concurrency: Max concurrent tasks per job.

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -1,9 +1,11 @@
 """Tests for benchflow._env_setup — Dockerfile skills injection and dep staging."""
 
 from pathlib import Path
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from benchflow._env_setup import (
+    _create_environment,
     _dep_local_name,
     _get_agent_skill_paths,
     _inject_skills_into_dockerfile,
@@ -189,6 +191,29 @@ class TestDepLocalName:
             _dep_local_name("tasks/email-foo/environment/skills")
             == "environment__skills"
         )
+
+
+class TestCreateEnvironment:
+    def test_modal_preflights_and_constructs_environment(self, tmp_path):
+        env_config = MagicMock()
+        trial_paths = MagicMock()
+        task = SimpleNamespace(
+            paths=SimpleNamespace(environment_dir=tmp_path / "environment"),
+            config=SimpleNamespace(environment=env_config),
+        )
+
+        with patch("harbor.environments.modal.ModalEnvironment") as modal_env:
+            result = _create_environment("modal", task, tmp_path, "trial", trial_paths)
+
+        modal_env.preflight.assert_called_once_with()
+        modal_env.assert_called_once_with(
+            environment_dir=tmp_path / "environment",
+            environment_name=tmp_path.name,
+            session_id="trial",
+            trial_paths=trial_paths,
+            task_env_config=env_config,
+        )
+        assert result is modal_env.return_value
 
 
 class TestStageDockerfileDeps:

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -929,7 +929,7 @@ class TestVerifierEnv:
 
     @pytest.mark.asyncio
     async def test_ctrf_plugin_inferred_from_test_script(self, tmp_path):
-        """test.sh using --ctrf gets json_ctrf loaded even with plugin autoload disabled."""
+        """test.sh using --ctrf gets ctrf loaded even with plugin autoload disabled."""
         from benchflow._sandbox import harden_before_verify
 
         tests_dir = tmp_path / "tests"
@@ -945,7 +945,7 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None, workspace="/app")
 
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
-        assert "-p json_ctrf" in addopts
+        assert "-p ctrf" in addopts
         assert task.config.verifier.env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] == "1"
 
     @pytest.mark.asyncio
@@ -963,7 +963,7 @@ class TestVerifierEnv:
         await harden_before_verify(env, task, sandbox_user=None, workspace="/app")
 
         addopts = task.config.verifier.env["PYTEST_ADDOPTS"]
-        assert "-p json_ctrf" not in addopts
+        assert "-p ctrf" not in addopts
 
     @pytest.mark.asyncio
     async def test_rootdir_follows_workspace(self):


### PR DESCRIPTION
## Summary
- add Modal backend support in _create_environment with ModalEnvironment.preflight()
- update backend help/docs to include modal
- infer pytest --ctrf plugin as ctrf instead of json_ctrf

## Tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff format --check src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff check src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/test_env_setup.py tests/test_sandbox.py tests/test_yaml_config.py tests/test_job.py
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ty check src/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/218" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
