### PR TITLE
fix: Add Python for Modal Dockerfile builds

### DIFF
--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -36,6 +36,96 @@ _IGNORE_DIRS = {
 }
 
 
+def _modal_add_python_version() -> str | None:
+    """Python version Modal should add to Dockerfile images that lack Python."""
+    value = os.environ.get("BENCHFLOW_MODAL_ADD_PYTHON", "3.12").strip()
+    return value or None
+
+
+def _create_benchflow_modal_environment_class():
+    """Create a ModalEnvironment subclass with BenchFlow's image-build defaults."""
+    from harbor.environments.modal import ModalEnvironment
+
+    class BenchFlowModalEnvironment(ModalEnvironment):
+        async def start(self, force_build: bool) -> None:
+            """Starts the Modal sandbox, adding Python for plain Linux images."""
+            from harbor.models.trial.paths import EnvironmentPaths
+            from modal import App, Image, Secret, Volume
+
+            docker_image = self.task_env_config.docker_image
+
+            if docker_image:
+                registry_secret = (
+                    Secret.from_name(self._registry_secret)
+                    if self._registry_secret
+                    else None
+                )
+                if ".dkr.ecr." in docker_image:
+                    self._image = Image.from_aws_ecr(
+                        docker_image,
+                        secret=registry_secret,
+                    )
+                else:
+                    self._image = Image.from_registry(
+                        docker_image,
+                        secret=registry_secret,
+                    )
+            else:
+                self._image = Image.from_dockerfile(
+                    self._environment_definition_path,
+                    force_build=force_build,
+                    context_dir=self.environment_dir,
+                    add_python=_modal_add_python_version(),
+                )
+
+            self._app = await App.lookup.aio(
+                name="__harbor__",
+                create_if_missing=True,
+            )
+
+            gpu_config = None
+            gpu_type = "any"
+
+            if self.task_env_config.gpus > 0:
+                if self.task_env_config.gpu_types:
+                    if len(self.task_env_config.gpu_types) > 1:
+                        self.logger.debug(
+                            "Multiple GPU types specified but Modal only supports one GPU "
+                            "type. Using the first GPU type."
+                        )
+                    gpu_type = self.task_env_config.gpu_types[0]
+
+                gpu_config = f"{gpu_type}:{self.task_env_config.gpus}"
+
+            secrets_config = [Secret.from_name(secret) for secret in self._secrets]
+            volumes_config = {
+                mount_path: Volume.from_name(volume_name)
+                for mount_path, volume_name in self._volumes.items()
+            }
+
+            self._sandbox = await self._create_sandbox(
+                gpu_config=gpu_config,
+                secrets_config=secrets_config,
+                volumes_config=volumes_config,
+            )
+
+            await self._sandbox.mkdir.aio(
+                str(EnvironmentPaths.agent_dir),
+                parents=True,
+            )
+            await self._sandbox.mkdir.aio(
+                str(EnvironmentPaths.verifier_dir),
+                parents=True,
+            )
+
+            # Make log directories world-writable so non-root agents/verifiers can write to them.
+            await self.exec(
+                f"chmod 777 {EnvironmentPaths.agent_dir} {EnvironmentPaths.verifier_dir}"
+            )
+
+    return BenchFlowModalEnvironment
+
+
 def _get_agent_skill_paths() -> list[str]:
     """Derive Dockerfile skill symlink targets from all agents' skill_paths.
 
@@ -309,11 +399,10 @@ def _create_environment(
             auto_delete_interval_mins=1440,
         )
     elif environment_type == "modal":
-        from harbor.environments.modal import ModalEnvironment
+        modal_environment_class = _create_benchflow_modal_environment_class()
+        modal_environment_class.preflight()
 
-        ModalEnvironment.preflight()
-
-        return ModalEnvironment(
+        return modal_environment_class(
             environment_dir=task.paths.environment_dir,
             environment_name=task_path.name,
             session_id=trial_name,

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -2,9 +2,12 @@
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from benchflow._env_setup import (
+    _create_benchflow_modal_environment_class,
     _create_environment,
     _dep_local_name,
     _get_agent_skill_paths,
@@ -202,7 +205,10 @@ class TestCreateEnvironment:
             config=SimpleNamespace(environment=env_config),
         )
 
-        with patch("harbor.environments.modal.ModalEnvironment") as modal_env:
+        with patch(
+            "benchflow._env_setup._create_benchflow_modal_environment_class"
+        ) as modal_env_class:
+            modal_env = modal_env_class.return_value
             result = _create_environment("modal", task, tmp_path, "trial", trial_paths)
 
         modal_env.preflight.assert_called_once_with()
@@ -214,6 +220,69 @@ class TestCreateEnvironment:
             task_env_config=env_config,
         )
         assert result is modal_env.return_value
+
+    @pytest.mark.asyncio
+    async def test_modal_dockerfile_build_adds_python(self, tmp_path, monkeypatch):
+        (tmp_path / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        env_config = SimpleNamespace(
+            docker_image=None,
+            gpus=0,
+            gpu_types=None,
+            allow_internet=True,
+            env={},
+        )
+        modal_env_class = _create_benchflow_modal_environment_class()
+        env = modal_env_class(
+            environment_dir=tmp_path,
+            environment_name=tmp_path.name,
+            session_id="trial",
+            trial_paths=MagicMock(),
+            task_env_config=env_config,
+        )
+
+        calls = {}
+
+        class FakeImage:
+            @staticmethod
+            def from_dockerfile(path, **kwargs):
+                calls["from_dockerfile"] = {"path": path, **kwargs}
+                return "image"
+
+        class FakeLookup:
+            @staticmethod
+            async def aio(**kwargs):
+                calls["app_lookup"] = kwargs
+                return "app"
+
+        class FakeApp:
+            lookup = FakeLookup
+
+        class FakeMkdir:
+            async def aio(self, *args, **kwargs):
+                calls.setdefault("mkdir", []).append((args, kwargs))
+
+        class FakeSandbox:
+            mkdir = FakeMkdir()
+
+        monkeypatch.setattr("modal.Image", FakeImage)
+        monkeypatch.setattr("modal.App", FakeApp)
+        env._create_sandbox = AsyncMock(return_value=FakeSandbox())
+        env.exec = AsyncMock()
+
+        await env.start(force_build=True)
+
+        assert calls["from_dockerfile"] == {
+            "path": tmp_path / "Dockerfile",
+            "force_build": True,
+            "context_dir": tmp_path,
+            "add_python": "3.12",
+        }
+        env._create_sandbox.assert_awaited_once_with(
+            gpu_config=None,
+            secrets_config=[],
+            volumes_config={},
+        )
+        env.exec.assert_awaited_once()
 
 
 class TestStageDockerfileDeps:


### PR DESCRIPTION
## Summary
- wrap Harbor ModalEnvironment with BenchFlow image-build defaults
- pass add_python=3.12 for Modal Image.from_dockerfile builds so plain Linux task images can build
- keep BENCHFLOW_MODAL_ADD_PYTHON as an override; set it empty to disable

## Tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff format --check src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff check src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/test_env_setup.py tests/test_sandbox.py tests/test_yaml_config.py tests/test_job.py
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ty check src/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/219" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
