### PR TITLE
fix: Use effective task environment dir

### DIFF
--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -457,6 +457,9 @@ def _create_environment(
 ) -> Any:
     """Create a Harbor environment (Docker, Daytona, or Modal)."""
     env_config = task.config.environment
+    environment_dir = task_path / "environment"
+    if not environment_dir.exists():
+        environment_dir = task.paths.environment_dir
     if preserve_agent_network and env_config.allow_internet is False:
         # LLM agents run inside the sandbox and need outbound network for model
         # APIs and first-run agent installation. BenchFlow enforces the task's
@@ -469,7 +472,7 @@ def _create_environment(
         from harbor.environments.docker.docker import DockerEnvironment
 
         return DockerEnvironment(
-            environment_dir=task.paths.environment_dir,
+            environment_dir=environment_dir,
             environment_name=task_path.name,
             session_id=trial_name,
             trial_paths=trial_paths,
@@ -505,7 +508,7 @@ def _create_environment(
             env_config.storage_mb = _DAYTONA_MAX_STORAGE_MB
 
         return DaytonaEnvironment(
-            environment_dir=task.paths.environment_dir,
+            environment_dir=environment_dir,
             environment_name=task_path.name,
             session_id=trial_name,
             trial_paths=trial_paths,
@@ -518,7 +521,7 @@ def _create_environment(
         modal_environment_class.preflight()
 
         return modal_environment_class(
-            environment_dir=task.paths.environment_dir,
+            environment_dir=environment_dir,
             environment_name=task_path.name,
             session_id=trial_name,
             trial_paths=trial_paths,

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -199,6 +199,22 @@ class TestDepLocalName:
 
 
 class TestCreateEnvironment:
+    def test_prefers_effective_task_path_environment_dir(self, tmp_path):
+        original_env_dir = tmp_path / "original" / "environment"
+        effective_task = tmp_path / "effective-task"
+        effective_env_dir = effective_task / "environment"
+        effective_env_dir.mkdir(parents=True)
+        env_config = MagicMock()
+        task = SimpleNamespace(
+            paths=SimpleNamespace(environment_dir=original_env_dir),
+            config=SimpleNamespace(environment=env_config),
+        )
+
+        with patch("harbor.environments.docker.docker.DockerEnvironment") as docker_env:
+            _create_environment("docker", task, effective_task, "trial", MagicMock())
+
+        assert docker_env.call_args.kwargs["environment_dir"] == effective_env_dir
+
     def test_modal_preflights_and_constructs_environment(self, tmp_path):
         env_config = MagicMock()
         trial_paths = MagicMock()


### PR DESCRIPTION
## Summary
- prefer the effective task_path/environment passed to _create_environment
- preserves temp-task Dockerfile mutations from skills injection and dependency staging
- falls back to task.paths.environment_dir when the effective path has no environment directory

## Why
Skills injection writes into a temporary task copy, but Harbor environments were still built from the original task.paths.environment_dir. Modal oracle tasks that rely on environment/skills therefore could not see the injected skills.

## Tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff format src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff check src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/test_env_setup.py tests/test_sandbox.py tests/test_yaml_config.py tests/test_job.py
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ty check src/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
