### PR TITLE
fix: preserve Dockerfile Python for Modal

### DIFF
--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -41,6 +41,11 @@ _IGNORE_DIRS = {
 
 
 _HEREDOC_RE = re.compile(r"<<-?\s*['\"]?([A-Za-z0-9_.-]+)['\"]?")
+_MODAL_PYTHON_SYMLINK = (
+    "RUN if command -v python3 >/dev/null 2>&1 "
+    "&& ! command -v python >/dev/null 2>&1; then "
+    'ln -sf "$(command -v python3)" /usr/local/bin/python || true; fi'
+)
 
 
 def _modal_dockerfile_uses_python_base(dockerfile_path: Path) -> bool:
@@ -63,10 +68,30 @@ def _modal_dockerfile_uses_python_base(dockerfile_path: Path) -> bool:
     return False
 
 
+def _modal_dockerfile_installs_python(dockerfile_path: Path) -> bool:
+    try:
+        text = dockerfile_path.read_text().lower()
+    except OSError:
+        return False
+    return any(
+        token in text
+        for token in (
+            "python3-pip",
+            "python-is-python3",
+            "pip3 install",
+            "python3 -m pip",
+            "pip install",
+        )
+    )
+
+
 def _modal_add_python_version(dockerfile_path: Path) -> str | None:
     """Python version Modal should add to Dockerfile images that lack Python."""
     configured = os.environ.get("BENCHFLOW_MODAL_ADD_PYTHON")
-    if configured is None and _modal_dockerfile_uses_python_base(dockerfile_path):
+    if configured is None and (
+        _modal_dockerfile_uses_python_base(dockerfile_path)
+        or _modal_dockerfile_installs_python(dockerfile_path)
+    ):
         return None
     value = (configured if configured is not None else "3.12").strip()
     return value or None
@@ -137,6 +162,12 @@ def _modal_builder_dockerfile(
 ) -> tuple[Path, Callable[[], None]]:
     text = dockerfile_path.read_text()
     rewritten = _modal_rewrite_dockerfile_heredocs(text)
+    if (
+        not _modal_dockerfile_uses_python_base(dockerfile_path)
+        and _modal_dockerfile_installs_python(dockerfile_path)
+        and _MODAL_PYTHON_SYMLINK not in rewritten
+    ):
+        rewritten = rewritten.rstrip() + "\n\n" + _MODAL_PYTHON_SYMLINK + "\n"
     if rewritten == text:
         return dockerfile_path, lambda: None
 

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -7,12 +7,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from benchflow._env_setup import (
+    _MODAL_PYTHON_SYMLINK,
     _create_benchflow_modal_environment_class,
     _create_environment,
     _dep_local_name,
     _get_agent_skill_paths,
     _inject_skills_into_dockerfile,
     _modal_add_python_version,
+    _modal_builder_dockerfile,
     _modal_rewrite_dockerfile_heredocs,
     stage_dockerfile_deps,
 )
@@ -307,6 +309,23 @@ class TestCreateEnvironment:
         dockerfile.write_text("FROM python:3.12-slim\n")
 
         assert _modal_add_python_version(dockerfile) is None
+
+    def test_modal_add_python_skips_dockerfile_python_install(self, tmp_path):
+        dockerfile = tmp_path / "Dockerfile"
+        dockerfile.write_text(
+            "FROM ubuntu:24.04\n"
+            "RUN apt-get update && apt-get install -y python3 python3-pip\n"
+            "RUN pip3 install PyMuPDF==1.24.10\n"
+        )
+
+        assert _modal_add_python_version(dockerfile) is None
+
+        modal_dockerfile, cleanup = _modal_builder_dockerfile(dockerfile)
+        try:
+            assert modal_dockerfile != dockerfile
+            assert _MODAL_PYTHON_SYMLINK in modal_dockerfile.read_text()
+        finally:
+            cleanup()
 
     def test_modal_rewrites_run_python_heredoc(self):
         rewritten = _modal_rewrite_dockerfile_heredocs(


### PR DESCRIPTION
## Summary
- skip Modal add_python when a task Dockerfile already installs Python or pip
- append a python -> python3 symlink for those images so Modal requirements installation can still use python
- cover the behavior with a regression test

## Validation
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff format src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff check src tests
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/test_env_setup.py tests/test_sandbox.py tests/test_yaml_config.py tests/test_job.py
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run pytest tests/
- env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ty check src/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/222" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
