### PR TITLE
fix: deploy skills and forward solution.env for oracle runs

### DIFF
--- a/src/benchflow/_agent_setup.py
+++ b/src/benchflow/_agent_setup.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ORACLE_SKILL_PATHS = [
+    "$HOME/.claude/skills",
+    "$HOME/.codex/skills",
+    "$HOME/.opencode/skills",
+    "$HOME/.agents/skills",
+    "$WORKSPACE/skills",
+]
+
 
 def _intermediate_dirs(prefix: str, leaf: str) -> list[str]:
     """Dirs strictly under prefix down to leaf inclusive, in creation order.
@@ -234,15 +242,23 @@ async def deploy_skills(
             logger.info("Skills already injected via Dockerfile")
 
     # Distribute to agent-specific discovery paths
-    if effective_skills and agent_cfg and agent_cfg.skill_paths:
-        home = f"/home/{sandbox_user}" if sandbox_user else "/root"
+    if agent_cfg is not None:
+        skill_paths = agent_cfg.skill_paths
+    else:
+        skill_paths = _ORACLE_SKILL_PATHS
+    if effective_skills and skill_paths:
+        if agent_cfg is None:
+            home = "/root"
+        else:
+            home = f"/home/{sandbox_user}" if sandbox_user else "/root"
         count = await _link_skill_paths(
             env,
             effective_skills,
-            agent_cfg.skill_paths,
+            skill_paths,
             home,
             agent_cwd,
             sandbox_user,
         )
+        label = agent_cfg.name if agent_cfg else "oracle"
         if count:
-            logger.info(f"Skills distributed to {count} paths for {agent_cfg.name}")
+            logger.info(f"Skills distributed to {count} paths for {label}")

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -97,6 +97,7 @@ from typing import Any, cast
 
 from harbor.models.task.task import Task
 from harbor.models.trial.paths import TrialPaths
+from harbor.utils.env import resolve_env_vars
 from harbor.verifier.verifier import Verifier
 
 from benchflow._env_setup import (
@@ -433,9 +434,13 @@ class SDK:
             )
         else:
             cmd = "bash /solution/solve.sh"
+        oracle_env: dict[str, str] = {"DEBIAN_FRONTEND": "noninteractive"}
+        task = Task(task_path)
+        if task.config.solution.env:
+            oracle_env.update(resolve_env_vars(task.config.solution.env))
         result = await env.exec(
             f"{cmd} > /logs/agent/oracle.txt 2>&1",
-            env={"DEBIAN_FRONTEND": "noninteractive"},
+            env=oracle_env,
             timeout_sec=timeout,
         )
         if result.return_code != 0:

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -472,6 +472,15 @@ class Trial:
             await _seed_verifier_workspace(
                 self._env, workspace=self._agent_cwd, sandbox_user=cfg.sandbox_user
             )
+            await deploy_skills(
+                self._env,
+                cfg.task_path,
+                cfg.skills_dir,
+                None,
+                cfg.sandbox_user,
+                self._agent_cwd,
+                self._task,
+            )
             await lockdown_paths(self._env, self._effective_locked)
             self._phase = "installed"
             return

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -196,6 +196,64 @@ async def test_deploy_skills_falls_back_when_local_skills_dir_is_missing(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_oracle_uses_default_paths_and_root_home(tmp_path):
+    """When agent_cfg is None (oracle), skills go to _ORACLE_SKILL_PATHS under /root."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+
+    skills = tmp_path / "skills"
+    skills.mkdir()
+    (skills / "my-skill").mkdir()
+
+    await deploy_skills(
+        env=env,
+        task_path=tmp_path,
+        skills_dir=str(skills),
+        agent_cfg=None,
+        sandbox_user="agent",
+        agent_cwd="/app",
+        task=_make_task(None),
+    )
+
+    env.upload_dir.assert_awaited_once()
+    assert env.exec.await_count == 1
+    link_cmd = env.exec.await_args_list[0].args[0]
+    assert "/root/.claude/skills" in link_cmd
+    assert "/root/.codex/skills" in link_cmd
+    assert "/app/skills" in link_cmd
+    assert "/home/agent" not in link_cmd
+
+
+@pytest.mark.asyncio
+async def test_deploy_skills_agent_with_empty_skill_paths_does_not_use_oracle_paths(tmp_path):
+    """An agent with skill_paths=[] should NOT get oracle fallback paths."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+    agent_cfg = AgentConfig(
+        name="minimal-agent",
+        install_cmd="true",
+        launch_cmd="true",
+        skill_paths=[],
+    )
+
+    await deploy_skills(
+        env=env,
+        task_path=tmp_path,
+        skills_dir=None,
+        agent_cfg=agent_cfg,
+        sandbox_user=None,
+        agent_cwd="/app",
+        task=_make_task("/skills"),
+    )
+
+    for call in env.exec.await_args_list:
+        cmd = call.args[0]
+        assert "/root/.claude/skills" not in cmd
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_raises_when_skill_linking_fails(tmp_path):
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=17, stdout="link failed"))

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -226,7 +226,9 @@ async def test_deploy_skills_oracle_uses_default_paths_and_root_home(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_deploy_skills_agent_with_empty_skill_paths_does_not_use_oracle_paths(tmp_path):
+async def test_deploy_skills_agent_with_empty_skill_paths_does_not_use_oracle_paths(
+    tmp_path,
+):
     """An agent with skill_paths=[] should NOT get oracle fallback paths."""
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -79,10 +79,13 @@ async def test_run_oracle_passes_solution_env(tmp_path):
     """solution.env from task.toml is forwarded to the oracle exec call."""
     from benchflow.sdk import SDK
 
-    _scaffold_task(tmp_path, solution_env={
-        "MY_TOKEN": "secret123",
-        "REPO_ID": "org/repo",
-    })
+    _scaffold_task(
+        tmp_path,
+        solution_env={
+            "MY_TOKEN": "secret123",
+            "REPO_ID": "org/repo",
+        },
+    )
     env = _oracle_env()
 
     await SDK()._run_oracle(env, tmp_path, timeout=60)

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -15,13 +15,26 @@ def _oracle_env():
     return env
 
 
+def _scaffold_task(tmp_path, solution_env=None):
+    """Create minimal task structure for Task() to parse."""
+    solve = tmp_path / "solution" / "solve.sh"
+    solve.parent.mkdir(parents=True, exist_ok=True)
+    solve.write_text("#!/bin/sh\necho ok\n")
+    (tmp_path / "instruction.md").write_text("Solve the task.\n")
+    env_section = ""
+    if solution_env:
+        env_section = "\n[solution.env]\n" + "\n".join(
+            f'{k} = "{v}"' for k, v in solution_env.items()
+        )
+    (tmp_path / "task.toml").write_text(f'version = "1.0"\n{env_section}\n')
+    (tmp_path / "environment").mkdir(exist_ok=True)
+
+
 @pytest.mark.asyncio
 async def test_run_oracle_redirects_to_container_log(tmp_path):
     from benchflow.sdk import SDK
 
-    solve = tmp_path / "solution" / "solve.sh"
-    solve.parent.mkdir()
-    solve.write_text("#!/bin/sh\necho ok\n")
+    _scaffold_task(tmp_path)
     env = _oracle_env()
 
     trajectory, agent_name = await SDK()._run_oracle(env, tmp_path, timeout=123)
@@ -47,9 +60,7 @@ async def test_run_oracle_redirects_to_container_log(tmp_path):
 async def test_run_oracle_redirects_sandbox_user_output(tmp_path):
     from benchflow.sdk import SDK
 
-    solve = tmp_path / "solution" / "solve.sh"
-    solve.parent.mkdir()
-    solve.write_text("#!/bin/sh\necho ok\n")
+    _scaffold_task(tmp_path)
     env = _oracle_env()
 
     await SDK()._run_oracle(env, tmp_path, timeout=123, sandbox_user="agent")
@@ -61,3 +72,52 @@ async def test_run_oracle_redirects_sandbox_user_output(tmp_path):
         "> /logs/agent/oracle.txt 2>&1"
     )
     assert "tee" not in solve_cmd
+
+
+@pytest.mark.asyncio
+async def test_run_oracle_passes_solution_env(tmp_path):
+    """solution.env from task.toml is forwarded to the oracle exec call."""
+    from benchflow.sdk import SDK
+
+    _scaffold_task(tmp_path, solution_env={
+        "MY_TOKEN": "secret123",
+        "REPO_ID": "org/repo",
+    })
+    env = _oracle_env()
+
+    await SDK()._run_oracle(env, tmp_path, timeout=60)
+
+    solve_call = env.exec.call_args_list[0]
+    passed_env = solve_call.kwargs["env"]
+    assert passed_env["MY_TOKEN"] == "secret123"
+    assert passed_env["REPO_ID"] == "org/repo"
+    assert passed_env["DEBIAN_FRONTEND"] == "noninteractive"
+
+
+@pytest.mark.asyncio
+async def test_run_oracle_no_solution_env_only_has_debian_frontend(tmp_path):
+    """Without [solution.env], only DEBIAN_FRONTEND is passed."""
+    from benchflow.sdk import SDK
+
+    _scaffold_task(tmp_path)
+    env = _oracle_env()
+
+    await SDK()._run_oracle(env, tmp_path, timeout=60)
+
+    solve_call = env.exec.call_args_list[0]
+    assert solve_call.kwargs["env"] == {"DEBIAN_FRONTEND": "noninteractive"}
+
+
+@pytest.mark.asyncio
+async def test_run_oracle_solution_env_resolves_host_vars(tmp_path, monkeypatch):
+    """${VAR} references in solution.env are resolved from the host environment."""
+    from benchflow.sdk import SDK
+
+    monkeypatch.setenv("HOST_SECRET", "resolved_value")
+    _scaffold_task(tmp_path, solution_env={"TOKEN": "${HOST_SECRET}"})
+    env = _oracle_env()
+
+    await SDK()._run_oracle(env, tmp_path, timeout=60)
+
+    solve_call = env.exec.call_args_list[0]
+    assert solve_call.kwargs["env"]["TOKEN"] == "resolved_value"

--- a/tests/test_trial_install_agent_timeout.py
+++ b/tests/test_trial_install_agent_timeout.py
@@ -76,7 +76,7 @@ async def test_install_agent_forwards_sandbox_setup_timeout(
     if agent == "oracle":
         install_agent_mock.assert_not_awaited()
         write_credential_files_mock.assert_not_awaited()
-        deploy_skills_mock.assert_not_awaited()
+        deploy_skills_mock.assert_awaited_once()
         assert trial._agent_cwd == "/workspace"
     else:
         install_agent_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary

Oracle runs were missing two capabilities that agent runs have, causing 10+ SkillsBench task oracles to fail:

- **Skills not deployed**: PR #720 moved skill injection from Dockerfile `COPY` to runtime `deploy_skills()`, but the oracle path in `install_agent()` returned early before reaching it. Oracle `solve.sh` scripts that import from skills failed with `ModuleNotFoundError`.
- **`[solution.env]` not forwarded**: `_run_oracle()` hardcoded `env={"DEBIAN_FRONTEND": "noninteractive"}`, ignoring `[solution.env]` from `task.toml`. Harbor's `OracleAgent` already handles this via `resolve_env_vars()`, but the SDK's inline implementation missed it.

## Changes

| File | What |
|---|---|
| `trial.py` | Call `deploy_skills()` in the oracle branch of `install_agent()` |
| `_agent_setup.py` | When `agent_cfg` is `None` (oracle), use `_ORACLE_SKILL_PATHS` for common agent discovery paths; fix home to `/root` since oracle runs as root |
| `sdk.py` | Read `task.config.solution.env`, resolve `${VAR}` templates, merge into oracle exec env |
| `test_oracle.py` | 3 new tests for solution.env (present, absent, `${VAR}` resolution) |
| `test_agent_setup.py` | 2 new tests (oracle default paths, empty agent skill_paths not falling back to oracle) |

## Context

Discovered during a full SkillsBench oracle integration test (84 tasks). Companion SkillsBench PR with task-level infra fixes: benchflow-ai/skillsbench#TBD

## Test plan

- [x] `pytest tests/test_oracle.py tests/test_oracle_chokepoint.py tests/test_agent_setup.py` — 29 passed
- [x] Integration-tested on 4090 server: 9 skills-dependent tasks pass with runtime injection (no Dockerfile `COPY skills`)
- [x] `fix-build-agentops` / `fix-build-google-auto` receive `bugswarm_image_tag` from `[solution.env]`
- [x] Normal agent runs unaffected (agent_cfg present → original code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/223" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
