### PR TITLE
fix: change codex-api from openai-completions to response

### DIFF
--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -18,7 +18,8 @@ Required fields
                      tokens that get expanded from env vars via
                      ``url_params``. Empty string is allowed for
                      "user-supplied at runtime" providers (e.g. ``vllm``).
-- ``api_protocol``   "anthropic-messages" or "openai-completions" — the
+- ``api_protocol``   "anthropic-messages", "openai-completions", or
+                     "openai-responses" — the
                      wire protocol the primary ``base_url`` speaks.
 - ``auth_type``      "api_key" | "adc" | "none".
                      - "api_key": ``auth_env`` **must** be set.
@@ -61,9 +62,7 @@ class ProviderConfig:
     base_url: (
         str  # primary endpoint; may contain {placeholders} expanded via url_params
     )
-    api_protocol: (
-        str  # protocol for base_url: "openai-completions" | "anthropic-messages"
-    )
+    api_protocol: str  # protocol for base_url: "openai-completions" | "openai-responses" | "anthropic-messages"
     auth_type: str  # "api_key" | "adc" | "none"
     auth_env: str | None = None  # env var holding the API key (None for ADC)
     url_params: dict[str, str] = field(default_factory=dict)  # {placeholder: ENV_VAR}
@@ -142,6 +141,7 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_env="ZAI_API_KEY",
         endpoints={
             "openai-completions": "https://api.z.ai/api/paas/v4",
+            "openai-responses": "https://api.z.ai/api/paas/v4",
             "anthropic-messages": "https://api.z.ai/api/anthropic",
         },
         models=[

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -20,7 +20,8 @@ Common optional fields
                          sandbox (e.g. ``["ANTHROPIC_API_KEY"]``). Validated at
                          run start; missing keys raise before the container
                          spins up.
-- ``api_protocol``       "anthropic-messages" | "openai-completions" | "" — the
+- ``api_protocol``       "anthropic-messages" | "openai-completions" |
+                         "openai-responses" | "" — the
                          LLM API the agent natively speaks. Used to pick the
                          right endpoint when a provider exposes multiple
                          (e.g. zai). Empty means "agent infers from model name".
@@ -160,7 +161,8 @@ class AgentConfig:
     default_model: str = ""  # default model ID when --model is omitted
     api_protocol: str = ""
     # The LLM API protocol the agent natively speaks:
-    # "anthropic-messages" | "openai-completions" | "" (runtime/native).
+    # "anthropic-messages" | "openai-completions" | "openai-responses" |
+    # "" (runtime/native).
     # Used to pick the correct provider endpoint when a provider exposes
     # multiple (e.g. zai has both anthropic-messages and openai-completions).
     env_mapping: dict[str, str] = field(default_factory=dict)
@@ -286,10 +288,12 @@ AGENTS: dict[str, AgentConfig] = {
             "npm install -g @zed-industries/codex-acp@latest >/dev/null 2>&1 ) && "
             "command -v codex-acp >/dev/null 2>&1"
         ),
-        launch_cmd="codex-acp",
+        launch_cmd=(
+            "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
+        ),
         protocol="acp",
         requires_env=["OPENAI_API_KEY"],
-        api_protocol="openai-completions",
+        api_protocol="openai-responses",
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "OPENAI_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY": "OPENAI_API_KEY",

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -62,14 +62,20 @@ class Environment:
         trial_name: str | None = None,
     ) -> Environment:
         """Create an environment from a task directory."""
+        from uuid import uuid4
+
         from harbor.models.task.task import Task
+        from harbor.models.trial.paths import TrialPaths
 
         from benchflow._env_setup import _create_environment
 
         task_path = Path(task_path)
         task = Task(task_path)
         trial_name = trial_name or task_path.name
-        trial_paths: Any = None
+        trial_paths = TrialPaths(
+            Path.cwd() / "jobs" / "environment" / f"{trial_name}__{uuid4().hex[:8]}"
+        )
+        trial_paths.mkdir()
         inner = _create_environment(
             environment_type=backend,
             task=task,

--- a/tests/conformance/run_conformance.py
+++ b/tests/conformance/run_conformance.py
@@ -13,6 +13,8 @@ import logging
 import os
 import sys
 import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
@@ -27,7 +29,7 @@ AGENT_MODELS = {
     "claude-agent-acp": "claude-haiku-4-5-20251001",
     "pi-acp": "gemini-3.1-flash-lite-preview",
     "openclaw": "gemini-3.1-flash-lite-preview",
-    "codex-acp": "gpt-5.4-nano",
+    "codex-acp": "gpt-5.4-mini",
     "gemini": "gemini-3.1-flash-lite-preview",
 }
 
@@ -54,6 +56,30 @@ def has_creds(agent_name: str) -> bool:
         return True
     sub_file = SUBSCRIPTION_AUTH_FILES.get(agent_name)
     return bool(sub_file and Path(sub_file).expanduser().exists())
+
+
+def openai_model_preflight(model: str) -> str | None:
+    """Return an error string if OPENAI_API_KEY cannot access *model*."""
+    key = os.environ.get("OPENAI_API_KEY")
+    if not key:
+        return None
+    req = urllib.request.Request(
+        "https://api.openai.com/v1/models",
+        headers={"Authorization": f"Bearer {key}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")[:500]
+        return f"OpenAI model preflight failed ({exc.code}): {body}"
+    except Exception as exc:
+        return f"OpenAI model preflight failed: {type(exc).__name__}: {exc}"
+
+    model_ids = {item.get("id") for item in payload.get("data", [])}
+    if model not in model_ids:
+        return f"OpenAI model {model!r} is not available for this API key"
+    return None
 
 
 async def run_one(agent_name: str) -> dict:
@@ -104,8 +130,15 @@ async def main() -> None:
             print(f"SKIP {name} — no credentials in env ({ENV_KEYS[name]})")
             results.append({"agent": name, "status": "SKIP (no creds)"})
             continue
+        model = AGENT_MODELS.get(name, "claude-haiku-4-5-20251001")
+        if name == "codex-acp" and (reason := openai_model_preflight(model)):
+            print(f"ERROR {name} — {reason}")
+            results.append(
+                {"agent": name, "model": model, "status": f"ERROR: {reason}"}
+            )
+            continue
         print(f"\n{'=' * 60}")
-        print(f"CONFORMANCE: {name} (model={AGENT_MODELS.get(name, '?')})")
+        print(f"CONFORMANCE: {name} (model={model})")
         print(f"{'=' * 60}")
         r = await run_one(name)
         results.append(r)

--- a/tests/examples/test_codex.sh
+++ b/tests/examples/test_codex.sh
@@ -7,8 +7,9 @@
 #
 # Usage:
 #   bash examples/test_codex.sh                  # run all
-#   bash examples/test_codex.sh subscription     # subscription auth only
-#   bash examples/test_codex.sh apikey           # API key only
+#   bash examples/test_codex.sh subscription     # subscription auth / API-key fallback
+#   bash examples/test_codex.sh apikey           # API key, full model
+#   bash examples/test_codex.sh apikey-mini      # API key, mini model
 #   bash examples/test_codex.sh --daytona        # use Daytona
 
 set -euo pipefail
@@ -57,11 +58,51 @@ show_failure() {
   fi
 }
 
+check_openai_model_available() {
+  local model="$1"
+  if [ -z "${OPENAI_API_KEY:-}" ]; then
+    return 0
+  fi
+
+  MODEL="$model" python3 - <<'PY'
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+model = os.environ["MODEL"]
+key = os.environ.get("OPENAI_API_KEY", "")
+req = urllib.request.Request(
+    "https://api.openai.com/v1/models",
+    headers={"Authorization": f"Bearer {key}"},
+)
+try:
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        payload = json.loads(resp.read())
+except urllib.error.HTTPError as exc:
+    body = exc.read().decode("utf-8", "replace")[:500]
+    print(f"ERROR: could not check OpenAI models ({exc.code}): {body}")
+    sys.exit(2)
+except Exception as exc:
+    print(f"ERROR: could not check OpenAI models: {type(exc).__name__}: {exc}")
+    sys.exit(2)
+
+models = {item.get("id") for item in payload.get("data", [])}
+if model not in models:
+    close = sorted(m for m in models if m.startswith(model.rsplit("-", 1)[0]))[:10]
+    suffix = f" Close matches: {', '.join(close)}" if close else ""
+    print(f"ERROR: OpenAI model '{model}' is not available for this API key.{suffix}")
+    sys.exit(1)
+PY
+}
+
 # ── Model definitions ──
 declare -A MODELS
 MODELS=(
-  [subscription]="gpt-5.4"
-  [apikey]="gpt-5.4"
+  [subscription]="gpt-5.5"
+  [apikey]="gpt-5.5"
+  [apikey-mini]="gpt-5.4-mini"
 )
 
 # Extra --ae flags per model
@@ -69,6 +110,7 @@ declare -A EXTRA_ARGS
 EXTRA_ARGS=(
   [subscription]="--ae OPENAI_REASONING_EFFORT=$REASONING"
   [apikey]="--ae OPENAI_REASONING_EFFORT=$REASONING"
+  [apikey-mini]="--ae OPENAI_REASONING_EFFORT=$REASONING"
 )
 
 # ── Pre-flight checks ──
@@ -101,6 +143,13 @@ check_env() {
         echo "SKIP: $label — OPENAI_API_KEY not set"
         return 1
       fi ;;
+    apikey-mini)
+      if [ -n "${OPENAI_API_KEY:-}" ]; then
+        echo "NOTE: $label — using OPENAI_API_KEY (API key auth)"
+      else
+        echo "SKIP: $label — OPENAI_API_KEY not set"
+        return 1
+      fi ;;
   esac
   return 0
 }
@@ -110,7 +159,7 @@ check_env() {
 if [ $# -gt 0 ]; then
   SELECTED=("$@")
 else
-  SELECTED=("subscription" "apikey")
+  SELECTED=("subscription" "apikey" "apikey-mini")
 fi
 
 echo "=== $AGENT provider sweep ==="
@@ -137,6 +186,12 @@ for label in "${SELECTED[@]}"; do
 
   if ! check_env "$label"; then
     SKIP=$((SKIP + 1))
+    echo ""
+    continue
+  fi
+
+  if ! check_openai_model_available "$model"; then
+    FAIL=$((FAIL + 1))
     echo ""
     continue
   fi

--- a/tests/examples/test_codex_custom_provider.sh
+++ b/tests/examples/test_codex_custom_provider.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Test codex-acp routing to a local custom /v1/responses stub.
+#
+# This is a routing test, not a model-capability test. The run is expected
+# to fail with a mocked 401. The test passes if codex-acp sends a request to
+# the local stub instead of api.openai.com.
+#
+# Usage:
+#   bash tests/examples/test_codex_custom_provider.sh
+#
+# Optional env:
+#   BENCHFLOW_HOST_ALIAS=host.docker.internal   # override for Linux setups
+#   PORT=8765                                   # stub port
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TASK="$SCRIPT_DIR/hello-world-task"
+HOST_ALIAS="${BENCHFLOW_HOST_ALIAS:-host.docker.internal}"
+PORT="${PORT:-8765}"
+JOBS_DIR="${REPO_ROOT}/jobs/test-codex-custom-provider"
+LOG_FILE="${REPO_ROOT}/jobs/test-codex-custom-provider.stub.jsonl"
+SERVER_LOG="${REPO_ROOT}/jobs/test-codex-custom-provider.server.log"
+STUB_URL="http://${HOST_ALIAS}:${PORT}/v1"
+
+mkdir -p "${REPO_ROOT}/jobs"
+rm -rf "$JOBS_DIR"
+rm -f "$LOG_FILE" "$SERVER_LOG"
+
+cleanup() {
+  if [ -n "${SERVER_PID:-}" ]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+python3 "$REPO_ROOT/tests/fixtures/mock_openai_responses_server.py" \
+  --port "$PORT" \
+  --log-file "$LOG_FILE" \
+  >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+for _ in $(seq 1 50); do
+  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+echo "=== codex-acp custom provider routing check ==="
+echo "Stub URL:  $STUB_URL"
+echo "Task:      $TASK"
+echo "Jobs dir:  $JOBS_DIR"
+echo ""
+
+set +e
+env -u CODEX_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_KEY \
+  OPENAI_API_KEY="dummy-local-key" \
+  uv run benchflow run \
+    "$TASK" \
+    -a codex-acp \
+    -m vllm/mock-model \
+    -b docker \
+    -o "$JOBS_DIR" \
+    --ae "BENCHFLOW_PROVIDER_BASE_URL=${STUB_URL}"
+RUN_RC=$?
+set -e
+
+echo "benchflow exit code: $RUN_RC"
+echo ""
+
+if [ ! -s "$LOG_FILE" ]; then
+  echo "FAIL: local stub did not receive any request"
+  exit 1
+fi
+
+if ! grep -q '"path": "/v1/responses"' "$LOG_FILE"; then
+  echo "FAIL: request did not hit /v1/responses"
+  cat "$LOG_FILE"
+  exit 1
+fi
+
+if ! grep -q '"authorization": "Bearer dummy-local-key"' "$LOG_FILE" && \
+   ! grep -q '"Authorization": "Bearer dummy-local-key"' "$LOG_FILE"; then
+  echo "FAIL: Authorization header not observed at stub"
+  cat "$LOG_FILE"
+  exit 1
+fi
+
+LATEST="$(ls -td "$JOBS_DIR"/*/ 2>/dev/null | head -1 || true)"
+if [ -n "$LATEST" ]; then
+  echo "Latest trial: $LATEST"
+  rg -n "responses|mock-auth-failure|host.docker.internal|${HOST_ALIAS}|api.openai.com" "$LATEST" -S || true
+fi
+
+echo ""
+echo "PASS: codex-acp routed to the local /v1/responses stub"

--- a/tests/fixtures/mock_openai_responses_server.py
+++ b/tests/fixtures/mock_openai_responses_server.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Minimal local /v1/responses stub for custom-provider routing checks.
+
+This server is intentionally tiny. It does not try to emulate the full
+Responses API or support WebSockets. Its job is to:
+
+1. Accept POSTs to /v1/responses over plain HTTP
+2. Record the request path, headers, and body to a JSONL log
+3. Return a deterministic OpenAI-style 401 error
+
+That is enough to prove whether codex-acp actually routed to the custom base
+URL. The expected benchflow run still fails; the test passes if the request
+hits this server instead of api.openai.com.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+
+class _Handler(BaseHTTPRequestHandler):
+    server_version = "MockResponses/0.1"
+    log_path: Path
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+    def _write_log(self, body: bytes) -> None:
+        entry = {
+            "method": self.command,
+            "path": self.path,
+            "headers": {k: v for k, v in self.headers.items()},
+            "body": body.decode("utf-8", errors="replace"),
+        }
+        with self.log_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(entry) + "\n")
+
+    def do_GET(self) -> None:
+        if self.path == "/health":
+            payload = {"ok": True}
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        self.send_error(404, "not found")
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        self._write_log(body)
+
+        if self.path != "/v1/responses":
+            self.send_error(404, "not found")
+            return
+
+        payload = {
+            "error": {
+                "message": "mock-auth-failure",
+                "type": "authentication_error",
+            }
+        }
+        response = json.dumps(payload).encode("utf-8")
+        self.send_response(401)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(response)))
+        self.end_headers()
+        self.wfile.write(response)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8765)
+    parser.add_argument("--log-file", required=True)
+    args = parser.parse_args()
+
+    _Handler.log_path = Path(args.log_file)
+    _Handler.log_path.parent.mkdir(parents=True, exist_ok=True)
+    _Handler.log_path.write_text("", encoding="utf-8")
+
+    server = ThreadingHTTPServer((args.host, args.port), _Handler)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -28,6 +28,7 @@ class TestEnvMappingField:
         cfg = AGENTS["codex-acp"]
         assert cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"] == "OPENAI_BASE_URL"
         assert cfg.env_mapping["BENCHFLOW_PROVIDER_API_KEY"] == "OPENAI_API_KEY"
+        assert "openai_base_url=$OPENAI_BASE_URL" in cfg.launch_cmd
 
     def test_gemini_has_mapping(self):
         cfg = AGENTS["gemini"]

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -160,9 +160,12 @@ async def test_connect_as_applies_web_policy_to_role_env(tmp_path):
 
 
 def test_codex_launch_disable_is_gated_by_web_policy():
-    assert _agent_launch_with_web_policy("codex-acp", disallow=False) == "codex-acp"
+    assert _agent_launch_with_web_policy("codex-acp", disallow=False) == (
+        "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
+    )
     assert _agent_launch_with_web_policy("codex-acp", disallow=True) == (
-        "codex-acp -c tools.web_search=false"
+        "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
+        " -c tools.web_search=false"
     )
 
 

--- a/tests/test_mock_openai_responses_server.py
+++ b/tests/test_mock_openai_responses_server.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _wait_for_health(port: int) -> None:
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(
+                f"http://127.0.0.1:{port}/health", timeout=0.2
+            ) as r:
+                if r.status == 200:
+                    return
+        except Exception:
+            time.sleep(0.05)
+    raise AssertionError("stub server did not become healthy")
+
+
+def test_mock_openai_responses_server_logs_and_401s(tmp_path: Path) -> None:
+    port = _free_port()
+    log_file = tmp_path / "stub.jsonl"
+    server = subprocess.Popen(
+        [
+            sys.executable,
+            "tests/fixtures/mock_openai_responses_server.py",
+            "--port",
+            str(port),
+            "--log-file",
+            str(log_file),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        _wait_for_health(port)
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/responses",
+            data=json.dumps({"model": "mock", "input": "hi"}).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer dummy",
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=1):  # pragma: no cover
+            raise AssertionError("expected 401 from stub")
+    except urllib.error.HTTPError as e:
+        assert e.code == 401
+        payload = json.loads(e.read().decode("utf-8"))
+        assert payload["error"]["message"] == "mock-auth-failure"
+    finally:
+        server.terminate()
+        server.wait(timeout=5)
+
+    entries = [json.loads(line) for line in log_file.read_text().splitlines()]
+    assert len(entries) == 1
+    assert entries[0]["path"] == "/v1/responses"
+    assert entries[0]["headers"]["Authorization"] == "Bearer dummy"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -85,7 +85,15 @@ class TestResolveBaseUrl:
             == "https://api.z.ai/api/anthropic"
         )
         assert (
+            resolve_base_url(p, {}, protocol="openai-responses")
+            == "https://api.z.ai/api/paas/v4"
+        )
+        assert (
             resolve_base_url(p, {}, protocol="openai-completions")
+            == "https://api.z.ai/api/paas/v4"
+        )
+        assert (
+            resolve_base_url(p, {}, protocol="openai-responses")
             == "https://api.z.ai/api/paas/v4"
         )
 

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -28,7 +28,12 @@ from benchflow.agents.registry import (
 VALID_AGENT_PROTOCOLS = {"acp", "cli"}
 # Empty api_protocol is valid for agents (they infer from the model name at
 # runtime); providers must always declare an explicit protocol.
-VALID_API_PROTOCOLS = {"", "anthropic-messages", "openai-completions"}
+VALID_API_PROTOCOLS = {
+    "",
+    "anthropic-messages",
+    "openai-completions",
+    "openai-responses",
+}
 VALID_PROVIDER_API_PROTOCOLS = VALID_API_PROTOCOLS - {""}
 VALID_AUTH_TYPES = {"api_key", "adc", "none"}
 

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -143,11 +143,11 @@ class TestResolveProviderEnv:
         assert env["ANTHROPIC_BASE_URL"] == "https://api.z.ai/api/anthropic"
 
     def test_zai_picks_openai_endpoint_for_codex_agent(self):
-        """codex-acp speaks openai-completions → routes to zai's openai endpoint."""
+        """codex-acp speaks openai-responses → routes to zai's OpenAI endpoint."""
         env = {"ZAI_API_KEY": "zk-test"}
         resolve_provider_env(env, "zai/glm-5", "codex-acp")
         assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
-        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-completions"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
         assert env["OPENAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
 
     def test_explicit_base_url_not_overwritten(self):


### PR DESCRIPTION
Related #213 and https://github.com/benchflow-ai/skillsbench/issues/750
This PR changes the chat/completion API to a response API

At runtime, Benchflow now forwards `OPENAI_BASE_URL` directly to Codex. Codex then sends requests to `${OPENAI_BASE_URL}/responses` instead of falling back to the default OpenAI endpoint.

Validation:
- unit tests for registry/provider/env routing pass
- local custom-provider stub confirms requests hit `/v1/responses`
- SkillsBench PR #747 task (`energy-unit-commitment`) with `codex-acp` + `gpt-5.5` runs successfully under `allow_internet = false`
- `gpt-5.1` still fails with `ACP error -32603: Internal error` in both `allow_internet = false` and `allow_internet = true`, suggesting that failure is not caused by this routing change

Trajectory: 
[benchflow-pr747-gpt55-nointernet.zip](https://github.com/user-attachments/files/27257349/benchflow-pr747-gpt55-nointernet.zip)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/224" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
