### PR TITLE
docs: add Mintlify config

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,16 @@
+.claude/
+.devcontainer/
+.github/
+.ruff_cache/
+.venv/
+
+benchmarks/
+experiments/
+labs/
+src/
+tests/
+
+docs/examples/*.ipynb
+docs/examples/*.py
+docs/examples/nanofirm-task/
+docs/examples/user_dogfood_results/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/
 
 Notebooks and runnable example scripts live under [`docs/examples/`](./docs/examples/) so examples stay versioned with the docs that explain them.
 
+## Benchmark task sources
+
+BenchFlow's helper scripts can materialize benchmark task repos under `.ref/`.
+For SkillsBench, [`benchmarks/run_skillsbench.py`](./benchmarks/run_skillsbench.py)
+calls `ensure_tasks("skillsbench")`, which clones
+[`benchflow-ai/skillsbench`](https://github.com/benchflow-ai/skillsbench) from
+the `main` branch into `.ref/skillsbench/tasks` when the local task cache is
+missing.
+
+SkillsBench itself sources BenchFlow from GitHub `main` in its
+[`pyproject.toml`](https://github.com/benchflow-ai/skillsbench/blob/main/pyproject.toml).
+After a BenchFlow change lands, run `uv lock --upgrade-package benchflow` in
+SkillsBench when you need its lockfile to point at the newest BenchFlow commit.
+
 ## Featured
 
 - **Progressive disclosure on SWE-bench Pro** — the `BaseUser` abstraction drives a multi-round trial: terse round-0 prompt → failing-test hints → full spec. 5/5 oracle on Daytona, runnable demo at [`docs/examples/swebench_pro_progressive_disclosure.ipynb`](./docs/examples/swebench_pro_progressive_disclosure.ipynb). Also benchflow's [Harbor #1316](https://github.com/harbor-ai/harbor/issues/1316) parity answer for the no-second-LLM case. See [Progressive disclosure](./docs/progressive-disclosure.md).

--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "name": "BenchFlow",
+  "theme": "mint",
+  "colors": {
+    "primary": "#2563EB",
+    "light": "#2563EB",
+    "dark": "#60A5FA"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Get Started",
+        "pages": [
+          "docs/getting-started",
+          "docs/concepts"
+        ]
+      },
+      {
+        "group": "Guides",
+        "pages": [
+          "docs/task-authoring",
+          "docs/skill-eval",
+          "docs/use-cases",
+          "docs/progressive-disclosure",
+          "docs/sandbox-hardening"
+        ]
+      },
+      {
+        "group": "Reference",
+        "pages": [
+          "docs/reference/cli",
+          "docs/reference/python-api"
+        ]
+      },
+      {
+        "group": "Examples",
+        "pages": [
+          "docs/examples/scene-patterns"
+        ]
+      }
+    ]
+  }
+}

--- a/src/benchflow/task_download.py
+++ b/src/benchflow/task_download.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 TASK_REPOS = {
     "skillsbench": {
         "repo": "https://github.com/benchflow-ai/skillsbench.git",
+        "ref": "main",
         "subdir": "tasks",
     },
     "terminal-bench-2": {
@@ -51,10 +52,11 @@ def ensure_tasks(benchmark: str) -> Path:
     clone_dir = target.parent / "_clone"
 
     try:
-        subprocess.run(
-            ["git", "clone", "--depth", "1", info["repo"], str(clone_dir)],
-            check=True,
-        )
+        clone_cmd = ["git", "clone", "--depth", "1"]
+        if ref := info.get("ref"):
+            clone_cmd.extend(["--branch", ref])
+        clone_cmd.extend([info["repo"], str(clone_dir)])
+        subprocess.run(clone_cmd, check=True)
         if info.get("subdir"):
             (clone_dir / info["subdir"]).rename(target)
         else:

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -1,0 +1,68 @@
+"""Tests for benchmark task repository materialization."""
+
+from pathlib import Path
+
+from benchflow import task_download
+
+
+def test_skillsbench_download_clones_main_branch(tmp_path, monkeypatch):
+    """Guards PR #226: SkillsBench downloads must track GitHub main explicitly."""
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+        assert check is True
+        clone_dir = Path(cmd[-1])
+        (clone_dir / "tasks" / "sample-task").mkdir(parents=True)
+
+    monkeypatch.setattr(task_download.subprocess, "run", fake_run)
+
+    target = task_download.ensure_tasks("skillsbench")
+
+    assert target == tmp_path / ".ref" / "skillsbench" / "tasks"
+    assert target.exists()
+    assert calls == [
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "--branch",
+            "main",
+            "https://github.com/benchflow-ai/skillsbench.git",
+            str(tmp_path / ".ref" / "skillsbench" / "_clone"),
+        ]
+    ]
+
+
+def test_download_without_ref_omits_branch_flag(tmp_path, monkeypatch):
+    """Guards PR #226: existing task repos without refs keep their clone shape."""
+    monkeypatch.chdir(tmp_path)
+    calls = []
+
+    def fake_run(cmd, check):
+        calls.append(cmd)
+        assert check is True
+        clone_dir = Path(cmd[-1])
+        clone_dir.mkdir(parents=True)
+        (clone_dir / ".git").mkdir()
+        (clone_dir / "README.md").write_text("tasks\n")
+
+    monkeypatch.setattr(task_download.subprocess, "run", fake_run)
+
+    target = task_download.ensure_tasks("terminal-bench-2")
+
+    assert target == tmp_path / ".ref" / "terminal-bench-2"
+    assert target.exists()
+    assert "--branch" not in calls[0]
+    assert calls == [
+        [
+            "git",
+            "clone",
+            "--depth",
+            "1",
+            "https://github.com/harbor-framework/terminal-bench-2.git",
+            str(tmp_path / ".ref" / "_clone"),
+        ]
+    ]


### PR DESCRIPTION
## Summary

- add root `docs.json` and `.mintignore` so Mintlify can find and validate the docs site
- make SkillsBench task materialization clone the SkillsBench `main` branch explicitly
- document that BenchFlow downloads SkillsBench tasks from `main`, and that SkillsBench sources BenchFlow from GitHub `main` through `tool.uv.sources`
- add regression tests for the task downloader clone command shape

## Test Plan

- `npx -p node@22 -p mint -c 'node --version && mint validate'`\n- `.venv/bin/python -m pytest tests/test_task_download.py tests/test_eval_cli.py`\n- `env -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT uv run ruff check src/benchflow/task_download.py tests/test_task_download.py`\n- `git diff --check`\n- `rg -n "python examples|bash examples|started automatically|doubles the win rate|0\\.3 Limitations" README.md docs docs.json .mintignore || true`\n\nNote: local default Node is v25, which Mintlify rejects; validation was run with Node v22.22.2 via `npx -p node@22`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
