### PR TITLE
migrate mirrored docs

### DIFF
--- a/.claude/dev-docs/architecture.md
+++ b/.claude/dev-docs/architecture.md
@@ -5,7 +5,7 @@
 BenchFlow runs AI coding agents inside isolated sandboxes, evaluates their output with a task-specific verifier, and returns structured results. The SDK wraps Harbor environments (Docker or Daytona) and communicates with agents via ACP (Agent Client Protocol) — JSON-RPC 2.0 over stdio. Each trial is one task run by one agent; a `Job` fans out many trials concurrently and aggregates results.
 
 ```
-  Task (Harbor format) + TrialConfig (YAML or Python)
+  Task (BenchFlow task format) + TrialConfig (YAML or Python)
        |
        v
   bf.run(config) → Trial.create(config) → trial.run()

--- a/.claude/skills/benchflow/references/create-task.md
+++ b/.claude/skills/benchflow/references/create-task.md
@@ -5,7 +5,7 @@ description: Create benchmark tasks for BenchFlow in the Harbor task format. Use
 
 # BenchFlow Create Task Skill
 
-Use this skill to create benchmark tasks that BenchFlow can run. Tasks follow the Harbor format — a directory with an instruction, environment, and verifier.
+Use this skill to create benchmark tasks that BenchFlow can run. Tasks follow the BenchFlow task format — a directory with an instruction, environment, and verifier.
 
 ## When to Use
 

--- a/.claude/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/references/create-task.md
+++ b/.claude/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/references/create-task.md
@@ -5,7 +5,7 @@ description: Create benchmark tasks for BenchFlow in the Harbor task format. Use
 
 # BenchFlow Create Task Skill
 
-Use this skill to create benchmark tasks that BenchFlow can run. Tasks follow the Harbor format — a directory with an instruction, environment, and verifier.
+Use this skill to create benchmark tasks that BenchFlow can run. Tasks follow the BenchFlow task format — a directory with an instruction, environment, and verifier.
 
 ## When to Use
 

--- a/.claude/skills/benchflow/tasks/create-simple-task/environment/benchflow/references/create-task.md
+++ b/.claude/skills/benchflow/tasks/create-simple-task/environment/benchflow/references/create-task.md
@@ -5,7 +5,7 @@ description: Create benchmark tasks for BenchFlow in the Harbor task format. Use
 
 # BenchFlow Create Task Skill
 
-Use this skill to create benchmark tasks that BenchFlow can run. Tasks follow the Harbor format — a directory with an instruction, environment, and verifier.
+Use this skill to create benchmark tasks that BenchFlow can run. Tasks follow the BenchFlow task format — a directory with an instruction, environment, and verifier.
 
 ## When to Use
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ SkillsBench when you need its lockfile to point at the newest BenchFlow commit.
 
 ## Featured
 
-- **Progressive disclosure on SWE-bench Pro** — the `BaseUser` abstraction drives a multi-round trial: terse round-0 prompt → failing-test hints → full spec. 5/5 oracle on Daytona, runnable demo at [`docs/examples/swebench_pro_progressive_disclosure.ipynb`](./docs/examples/swebench_pro_progressive_disclosure.ipynb). Also benchflow's [Harbor #1316](https://github.com/harbor-ai/harbor/issues/1316) parity answer for the no-second-LLM case. See [Progressive disclosure](./docs/progressive-disclosure.md).
+- **Progressive disclosure on SWE-bench Pro** — the `BaseUser` abstraction drives a multi-round trial: terse round-0 prompt → failing-test hints → full spec. 5/5 oracle on Daytona, runnable demo at [`docs/examples/swebench_pro_progressive_disclosure.ipynb`](./docs/examples/swebench_pro_progressive_disclosure.ipynb). No second LLM, no sidecar containers — just an in-process Python callback that knows how to grade and hint. See [Progressive disclosure](./docs/progressive-disclosure.md).
 
 ## Research artifacts
 
@@ -74,7 +74,7 @@ Two runnable labs validate the security story:
 - **Eval researchers / paper writers** → [Getting started](./docs/getting-started.md) → [Concepts](./docs/concepts.md) → [Use cases](./docs/use-cases.md)
 - **Task authors** → [Task authoring](./docs/task-authoring.md) → [Sandbox hardening](./docs/sandbox-hardening.md)
 - **Agent builders integrating with benchflow** → [Concepts](./docs/concepts.md) → [Python API reference](./docs/reference/python-api.md) → [`benchflow.agents.registry`](./src/benchflow/agents/registry.py)
-- **Existing Harbor users migrating** → [Use cases — migration section](./docs/use-cases.md#migration-from-harbor) → [Progressive disclosure (Harbor #1316 parity)](./docs/progressive-disclosure.md#comparison-with-multi-agent-simulated-user-harbor-1316-parity)
+- **Multi-turn / multi-agent eval authors** → [Use cases](./docs/use-cases.md) → [Progressive disclosure](./docs/progressive-disclosure.md)
 
 ## Contributing
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,4 +1,8 @@
-# Concepts
+---
+title: "Concepts"
+description: "Tasks, harnesses, agents, environments, scenes, verifiers — the core BenchFlow vocabulary."
+---
+
 
 The mental model for benchflow. Read once, then refer back from the how-tos.
 
@@ -10,7 +14,7 @@ The mental model for benchflow. Read once, then refer back from the how-tos.
 |-----------|------------|
 | **Task** | A directory on disk: `instruction.md` for the agent + `tests/` for the verifier + (optional) `solution/solve.sh` for oracle runs + `environment/Dockerfile` for the sandbox. Authored once, evaluated many times. |
 | **Agent** | A registered ACP-speaking program (Claude Code, Gemini CLI, OpenCode, etc.). Identified by name (`"gemini"`, `"opencode"`) plus an optional model ID. |
-| **Environment** | The sandbox where the agent runs and the verifier checks the result. Backed by Harbor — Docker locally, Daytona for cloud, and Modal for serverless/GPU-backed task environments. |
+| **Environment** | The sandbox where the agent runs and the verifier checks the result. Docker locally, Daytona for cloud. |
 | **Verifier** | The test runner that scores the trial. By default `pytest /tests/...` against the workspace the agent left behind. Outputs `rewards: {reward: float}`. |
 | **Trial** | One agent run on one task. Holds the lifecycle (setup → start → install → execute → verify → cleanup). All higher-level primitives below are built on Trials. |
 
@@ -24,7 +28,7 @@ A `Trial` is decomposable: each phase is a callable method, you can either run t
 ┌──────────────────────────────────────────────────────────────┐
 │                    Trial.run()                               │
 │                                                              │
-│  setup()         resolve config, create Harbor env handle    │
+│  setup()         resolve config, create sandbox env handle   │
 │    ↓                                                         │
 │  start()         start container, upload task files          │
 │    ↓                                                         │
@@ -99,7 +103,7 @@ A User is a `BaseUser` subclass (or `FunctionUser` wrapping a function) with two
 
 Between rounds, benchflow runs `soft_verify()` (verifier without the destructive parts of full hardening), gives the user the round's `RoundResult` (trajectory, rewards, verifier output, tool count), and lets the user decide round N+1's prompt.
 
-The User is the lighter-weight alternative to a Scene with a simulated-user Role: no second LLM, no outbox protocol, just a Python function. Use it when the loop logic is rule-based (compress instruction → show test failures as hints → stop on pass). See [`progressive-disclosure.md`](./progressive-disclosure.md) for the full guide.
+The User is the lighter-weight alternative to a Scene with a simulated-user Role: no second LLM, no outbox protocol, just a Python function. Use it when the loop logic is rule-based (compress instruction → show test failures as hints → stop on pass). See [`progressive-disclosure.md`](/docs/progressive-disclosure) for the full guide.
 
 ---
 
@@ -123,7 +127,7 @@ When a task ships a legitimate `conftest.py` (e.g. qutebrowser uses one to break
 cleanup_conftests = false
 ```
 
-See [`progressive-disclosure.md`](./progressive-disclosure.md#per-task-hardening-opt-outs) for the full opt-out list.
+See [`progressive-disclosure.md`](/docs/progressive-disclosure#per-task-hardening-opt-outs) for the full opt-out list.
 
 ---
 
@@ -153,9 +157,9 @@ Trajectories are written to `<jobs_dir>/<job_name>/<trial_name>/trajectory/acp_t
 
 ## Where to go next
 
-- [Getting started](./getting-started.md) — install, run your first eval.
-- [Task authoring](./task-authoring.md) — write a task with `task.toml` + `tests/` + `solution/`.
-- [Progressive disclosure](./progressive-disclosure.md) — the User abstraction; SWE-bench Pro case study.
-- [Use cases](./use-cases.md) — multi-agent patterns (coder/reviewer, simulated user, BYOS, stateful environments).
-- [CLI reference](./reference/cli.md), [Python API reference](./reference/python-api.md).
-- [Skill evaluation](./skill-eval.md) — when the artifact is a skill, not a workspace.
+- [Getting started](/docs/getting-started) — install, run your first eval.
+- [Task authoring](/docs/task-authoring) — write a task with `task.toml` + `tests/` + `solution/`.
+- [Progressive disclosure](/docs/progressive-disclosure) — the User abstraction; SWE-bench Pro case study.
+- [Use cases](/docs/use-cases) — multi-agent patterns (coder/reviewer, simulated user, BYOS, stateful environments).
+- [CLI reference](/docs/reference/cli), [Python API reference](/docs/reference/python-api).
+- [Skill evaluation](/docs/skill-eval) — when the artifact is a skill, not a workspace.

--- a/docs/examples/coder-reviewer-demo.py
+++ b/docs/examples/coder-reviewer-demo.py
@@ -9,7 +9,7 @@ Demonstrates:
 Requirements:
   - pip install benchflow
   - GEMINI_API_KEY or DAYTONA_API_KEY set
-  - A Harbor-format task directory (e.g. .ref/terminal-bench-2/regex-log)
+  - A BenchFlow task directory (e.g. .ref/terminal-bench-2/regex-log)
 
 Usage:
   python docs/examples/coder-reviewer-demo.py --task .ref/terminal-bench-2/regex-log

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -1,4 +1,8 @@
-# Progressive Disclosure with `BaseUser`
+---
+title: "Progressive disclosure"
+description: "Lifecycle for environments that reveal information across rounds."
+---
+
 
 ## TL;DR
 
@@ -6,7 +10,7 @@
 
 It was built for the SWE-bench Pro progressive-disclosure use case: the dataset's instructions are long structured specs that overwhelm agents in a single turn. A `BaseUser` lets you compress the spec for round 0, watch which tests fail, then disclose hints from the spec on subsequent rounds — all driven by deterministic Python, not by another LLM acting as a "user."
 
-It is also benchflow's parity answer to the [Harbor simulated-user proposal (#1316)](https://github.com/harbor-ai/harbor/issues/1316) for the no-second-LLM case. The Harbor proposal required a FastMCP sidecar container; benchflow's `BaseUser` is in-process Python.
+Other agent-eval frameworks model this with a "simulated user" — a second LLM running in a sidecar container that talks to the agent over a side channel. benchflow's `BaseUser` is just in-process Python: no second LLM, no sidecar, no outbox protocol.
 
 ```python
 import benchflow as bf
@@ -74,13 +78,13 @@ What this run shows and doesn't show:
 - **Per-round soft-verify scored 0.0 even on tasks where the final hardened verify scored 1.0.** Soft-verify runs between rounds without the full hardening sequence (no workspace restore, no process kill so the sandbox stays alive), so its scoring can diverge from the final verifier. The user's hint schedule reacts to soft-verify, not the canonical reward — something to keep in mind when designing the loop.
 - **First-run flake.** ansible's first run hit a transport EOF after 17min and qutebrowser timed out at 50min. Both succeeded on retry. v0.3.3 adds `agent_idle_timeout` (default 600s) and clearer EOF diagnostics so the next time a hang happens the failure is fast and actionable rather than silent.
 
-This is one model on one day, not a published comparison. The notebook at [`docs/examples/swebench_pro_progressive_disclosure.ipynb`](./examples/swebench_pro_progressive_disclosure.ipynb) has the executable cells; raw aggregated results are at [`experiments/swebench-pro-progressive-results.json`](../experiments/swebench-pro-progressive-results.json).
+This is one model on one day, not a published comparison. The notebook at [`examples/swebench_pro_progressive_disclosure.ipynb`](../examples/swebench_pro_progressive_disclosure.ipynb) has the executable cells; raw aggregated results are at [`experiments/swebench-pro-progressive-results.json`](../experiments/swebench-pro-progressive-results.json).
 
 ---
 
 ## Where it lives in the trial lifecycle
 
-`BaseUser` plugs into the existing `Trial` lifecycle ([concepts](./concepts.md#trial-lifecycle)) without changing any of the existing phases. When `TrialConfig.user` is set, `Trial._run_user_loop()` replaces the single-pass `connect → execute → disconnect` block with a per-round version:
+`BaseUser` plugs into the existing `Trial` lifecycle ([concepts](/docs/concepts#trial-lifecycle)) without changing any of the existing phases. When `TrialConfig.user` is set, `Trial._run_user_loop()` replaces the single-pass `connect → execute → disconnect` block with a per-round version:
 
 ```
 setup() → start() → install_agent()
@@ -260,14 +264,14 @@ Trajectory and tool counts are sliced per round from `Trial._trajectory`. The se
 
 ---
 
-## Comparison with multi-agent simulated user (Harbor #1316 parity)
+## Comparison with multi-agent simulated user
 
-benchflow has two patterns for multi-round agent runs. Both are functionally at parity with [Harbor #1316](https://github.com/harbor-ai/harbor/issues/1316) — neither requires a FastMCP sidecar.
+benchflow has two patterns for multi-round agent runs. Neither requires a sidecar container.
 
 | Pattern | What "user" is | When to use |
 |---------|---------------|-------------|
 | **`BaseUser` callback (this doc)** | Python function in the scheduler process | Programmatic, deterministic, rule-based. No second LLM. Cheap. Best for progressive disclosure, curriculum, scripted hints. |
-| **Multi-role Scene with simulated-user role** ([use-cases §1](./use-cases.md#1-interactive-user-simulation-harbor-1316-equivalent)) | Another LLM with full tool access | Open-ended, conversational. The "user" can read files, check outputs, give nuanced feedback. Best when the user's behavior must itself be adaptive or LLM-quality. |
+| **Multi-role Scene with simulated-user role** ([use-cases §1](/docs/benchflow/use-cases#1-interactive-user-simulation)) | Another LLM with full tool access | Open-ended, conversational. The "user" can read files, check outputs, give nuanced feedback. Best when the user's behavior must itself be adaptive or LLM-quality. |
 
 The two coexist. Choose based on whether your "user" needs to think (Scene-based) or just decide (`BaseUser`). For the SWE-bench Pro use case, the disclosure schedule is fixed, the grading is the verifier, and there's nothing for a second LLM to add — `BaseUser` wins on cost and determinism.
 
@@ -275,7 +279,7 @@ The two coexist. Choose based on whether your "user" needs to think (Scene-based
 
 ## Worked examples
 
-- [`docs/examples/swebench_pro_progressive_disclosure.ipynb`](./examples/swebench_pro_progressive_disclosure.ipynb) — the SWE-bench Pro case study, executable end-to-end with the latest oracle/baseline data.
-- [`docs/examples/swebench_pro_user_dogfood.py`](./examples/swebench_pro_user_dogfood.py) — runnable script for any of the 5 SWE-bench Pro tasks. `--task flipt --max-rounds 3`.
-- [`docs/examples/user_dogfood.py`](./examples/user_dogfood.py) — minimal regex-log task with `FunctionUser`, useful as a starting template.
+- [`examples/swebench_pro_progressive_disclosure.ipynb`](../examples/swebench_pro_progressive_disclosure.ipynb) — the SWE-bench Pro case study, executable end-to-end with the latest oracle/baseline data.
+- [`examples/swebench_pro_user_dogfood.py`](../examples/swebench_pro_user_dogfood.py) — runnable script for any of the 5 SWE-bench Pro tasks. `--task flipt --max-rounds 3`.
+- [`examples/user_dogfood.py`](../examples/user_dogfood.py) — minimal regex-log task with `FunctionUser`, useful as a starting template.
 - [`experiments/swebench_pro_oracle_and_baseline.py`](../experiments/swebench_pro_oracle_and_baseline.py) — the oracle-validation + baseline experiment script that produced the table above.

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -1,4 +1,8 @@
-# Runtime API Guide
+---
+title: "Python API"
+description: "BenchFlow Python SDK reference."
+---
+
 
 The Trial/Scene API is the primary way to run agent benchmarks programmatically.
 
@@ -27,8 +31,6 @@ print(f"Tool calls: {result.n_tool_calls}")
 Declarative configuration for a trial — a sequence of Scenes in a shared sandbox.
 
 ```python
-from pathlib import Path
-
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 
 # Single-agent (simplest)
@@ -220,43 +222,16 @@ config = TrialConfig(
 )
 ```
 
-## User-Driven Loops
+## 0.3 Limitations
 
-Use `BaseUser` or `FunctionUser` when one agent should run multiple rounds and
-Python should decide the next prompt from verifier feedback. This is the
-progressive-disclosure path: the user callback can stop early, read
-`RoundResult` after each `soft_verify()`, and optionally receive the oracle
-solution during `setup()` when `oracle_access=True`.
+The Scene API in 0.3 covers coder-reviewer and multi-turn patterns. It does **not** yet support:
 
-```python
-from pathlib import Path
+- **Dynamic termination** — turn count is fixed at config time. A "user" role cannot decide to stop early based on agent output. Workaround: use `max_rounds` in the standalone `_scene.py` scheduler.
+- **Oracle access** — no mechanism for a "user" role to read `/solution` during setup.
+- **Per-round verification** — `verify()` runs once after all scenes complete, not between rounds.
+- **Inter-round trajectory inspection** — a "user" role cannot read the agent's trajectory between turns.
 
-from benchflow import FunctionUser, RoundResult
-from benchflow.trial import Scene, TrialConfig
-
-
-def user(round: int, instruction: str, rr: RoundResult | None) -> str | None:
-    if round == 0:
-        return instruction.splitlines()[0]
-    if rr and (rr.rewards or {}).get("reward") == 1.0:
-        return None
-    return f"Tests failed:\n{rr.verifier_output}\n\nUse the full spec:\n{instruction}"
-
-
-config = TrialConfig(
-    task_path=Path("tasks/my-task"),
-    scenes=[Scene.single(agent="gemini", model="gemini-3.1-flash-lite-preview")],
-    user=FunctionUser(user),
-    max_user_rounds=3,
-    environment="daytona",
-)
-result = await bf.run(config)
-```
-
-Use multi-role Scenes when another LLM should act as the reviewer or simulated
-user. Use `BaseUser` when the loop is deterministic or verifier-driven. See
-[`progressive-disclosure.md`](../progressive-disclosure.md) and
-[`docs/examples/scene-patterns.ipynb`](../examples/scene-patterns.ipynb).
+These are tracked for 0.4.
 
 ## YAML Trial Configs
 
@@ -274,8 +249,6 @@ result = await bf.run(config)
 | `gemini` | ACP | GOOGLE_API_KEY | — |
 | `claude-agent-acp` | ACP | ANTHROPIC_API_KEY | `claude` |
 | `codex-acp` | ACP | OPENAI_API_KEY | `codex` |
-| `opencode` | ACP | inferred from model/provider | — |
-| `openhands` | ACP | LLM_API_KEY | — |
 | `pi-acp` | ACP | ANTHROPIC_API_KEY | `pi` |
 | `openclaw` | ACP | inferred from model | — |
 

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -1,4 +1,8 @@
-# Task Authoring Guide
+---
+title: "Authoring tasks"
+description: "How to write a verifiable BenchFlow task end-to-end."
+---
+
 
 A BenchFlow task packages an instruction, a sandboxed environment, and a verifier into a directory that BenchFlow runs and scores automatically.
 
@@ -44,11 +48,11 @@ timeout_sec = 120            # optional (default 600)
 cpus            = 1          # default 1
 memory_mb       = 2048       # default 2048
 storage_mb      = 10240      # default 10240
-allow_internet  = false      # default true; disables agent web use
+allow_internet  = false      # default true
 env             = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }  # host vars to inject
 ```
 
-**Service-backed tasks** — BenchFlow ships a small service registry for task-local APIs such as Gmail, Slack, Calendar, Docs, and Drive. The current runner does not auto-start services just because a Dockerfile references a binary. For Python-driven runs, start services explicitly with `pre_agent_hooks=build_service_hooks([...])`; for CLI-only task authoring, keep services inside the task's own Dockerfile/startup scripts until a dedicated service declaration is wired through the CLI.
+**Built-in mock services** — if the Dockerfile references a service binary (`claw-gmail`, `claw-slack`, `claw-gcal`, `claw-gdoc`, `claw-gdrive`), BenchFlow starts it automatically. No `[services]` section needed.
 
 **Install tooling to shared prefixes, not `/root`** — when a task image ships Node.js, Python tools, or agent binaries that the sandbox user must execute, install them to `/usr/local/bin`, `/usr/local/lib`, or `/opt`, not `/root/.nvm` or `/root/.local/bin`. `setup_sandbox_user()` creates the non-root user, prepares small config/auth dirs, and chowns the workspace — it does not clone `/root` into the sandbox home. Legacy images that already install tools under `/root` still work via a narrow symlink fallback, but shared prefixes are the supported path. Pre-creating the sandbox user in the Dockerfile is an optional speedup, not a requirement.
 
@@ -77,7 +81,7 @@ config = TrialConfig(
             Turn("agent", "Review your solution and fix any test failures."),
         ],
     )],
-    environment="daytona",
+    backend="daytona",
 )
 result = await bf.run(config)
 ```
@@ -86,7 +90,7 @@ result = await bf.run(config)
 
 ## Verifier contract (tests/test.sh)
 
-After the agent finishes, Harbor copies `tests/` to `/tests/` and runs `/tests/test.sh`. The working directory is the Dockerfile's `WORKDIR` (typically `/app/` in the example Dockerfile below).
+After the agent finishes, the BenchFlow runtime copies `tests/` to `/tests/` and runs `/tests/test.sh`. The working directory is the Dockerfile's `WORKDIR` (typically `/app/` in the example Dockerfile below).
 
 **Your script must write a single float (0.0–1.0) to `/logs/verifier/reward.txt`.**
 
@@ -129,7 +133,7 @@ if [ $? -eq 0 ]; then echo 1; else echo 0; fi > /logs/verifier/reward.txt
 python3 -c "print($PASSED / $TOTAL)" > /logs/verifier/reward.txt
 ```
 
-**Security:** don't let the agent write to `/logs/verifier/reward.txt` or modify `/tests/test.sh`. For tasks running arbitrary code, use `allow_internet = false` and verify output files only. For LLM agent runs, BenchFlow preserves the network path needed for model APIs and agent startup, then disables supported agent web browsing/fetch tools through agent config or launch controls. Oracle runs still use the environment's network policy directly.
+**Security:** don't let the agent write to `/logs/verifier/reward.txt` or modify `/tests/test.sh`. For tasks running arbitrary code, use `allow_internet = false` and verify output files only.
 
 ---
 
@@ -157,17 +161,10 @@ bench tasks init my-task --no-pytest --no-solution
 bench tasks check tasks/my-task/
 
 # Confirm oracle gets reward = 1.0
-bench run tasks/my-task/ --agent oracle --backend docker
+bench eval create -t tasks/my-task/ -a oracle -e docker
 
 # Run a real agent
-bench run tasks/my-task/ --agent gemini --backend daytona
-
-# Run with task-local skills mounted
-bench run tasks/my-task/ \
-  --agent gemini \
-  --backend daytona \
-  --skills-dir tasks/my-task/environment/skills \
-  --ae BENCHFLOW_SKILL_NUDGE=name
+bench eval create -t tasks/my-task/ -a gemini -e daytona
 ```
 
 `bench tasks check` validates that `task.toml`, `instruction.md` (non-empty), `environment/Dockerfile`, and `tests/` (non-empty) all exist, and that `[agent].timeout_sec` is set. Exits with code 1 on failure (CI-friendly).

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,20 +1,20 @@
-# Multi-Agent and Multi-Scene Use Cases
+---
+title: "Use cases"
+description: "What BenchFlow is used for: evals, post-training, dataset curation."
+---
 
-BenchFlow's Scene-based lifecycle enables evaluation patterns that go far beyond single-turn "prompt and score." This document covers the key use cases for researchers migrating from Harbor who need multi-turn, multi-agent, or stateful environment capabilities.
 
-**Context:** Harbor issue [#1316](https://github.com/harbor-ai/harbor/issues/1316) proposed a simulated-user API (a "user" agent that iteratively provides instructions), and PR [#1462](https://github.com/harbor-ai/harbor/pull/1462) added multi-turn support via Docker Compose sidecars. BenchFlow solves both with a simpler primitive: **Scenes with Roles and Turns**, all running in a single shared sandbox via ACP.
+BenchFlow's Scene-based lifecycle enables evaluation patterns that go far beyond single-turn "prompt and score." This document covers the key use cases for multi-turn, multi-agent, and stateful environment evaluation.
 
-The YAML snippets below are trial YAML for `benchflow.trial_yaml.trial_config_from_yaml()`.
-`bench eval create -f` is for batch job configs and does not execute scene
-YAML directly.
+The patterns below are all variants of one primitive: **Scenes with Roles and Turns**, all running in a single shared sandbox via ACP. No sidecar containers, no Docker Compose networking — every role lives in the same workspace and talks through ACP.
 
 ---
 
-## 1. Interactive User Simulation (Harbor #1316 equivalent)
+## 1. Interactive User Simulation
 
-A "user" role can provide instructions iteratively while the assistant responds through the shared sandbox and outbox files. Use this when the user itself should be an LLM. If the loop needs deterministic oracle access to `/solution`, use the `BaseUser` callback path with `oracle_access=True` instead; normal multi-role scenes do not provide role-specific solution access.
+A "user" role provides instructions iteratively; the agent responds. The user has oracle access to the solution and reveals information gradually, simulating realistic human-agent interaction.
 
-In Harbor, this required a FastMCP sidecar container running a simulated-user persona server, wired via Docker Compose networking. In BenchFlow, it is a two-role Scene where the "user" role is just another agent with a different prompt and (optionally) a different model.
+In BenchFlow, this is a two-role Scene where the "user" role is just another agent with a different prompt and (optionally) a different model. Both roles share one sandbox and one ACP session — no sidecar container, no Docker Compose networking.
 
 ### YAML
 
@@ -59,8 +59,6 @@ scenes:
 ### Python
 
 ```python
-from pathlib import Path
-
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 
 config = TrialConfig(
@@ -83,16 +81,16 @@ config = TrialConfig(
 result = await bf.run(config)
 ```
 
-### Why this is better than Harbor #1316
+### Why this design
 
-- No Docker Compose, no sidecar container, no FastMCP server to maintain.
-- Both agents share the sandbox filesystem and communicate through `/app/.outbox/{recipient}.json`.
-- The user agent is a real LLM with full tool access -- it can read files, check outputs, and give nuanced feedback, not just templated responses.
+- One sandbox, one ACP session — no sidecar container, no Docker Compose networking, no extra server to maintain.
+- Both agents share the sandbox filesystem — the "user" reads `/solution/` (which is locked from the assistant by `lockdown_paths`).
+- The user agent is a real LLM with full tool access — it can read files, check outputs, and give nuanced feedback, not just templated responses.
 - Same task folder works for single-turn (baseline) and interactive (with user) via different YAML configs.
 
 ### Lighter-weight alternative: `BaseUser` callback
 
-When you don't need a second LLM and your "user" logic is rule-based or oracle-guided (e.g. compress instruction → show test failures as hints → stop on pass), use a `BaseUser` Python callback instead of a multi-role Scene. See [progressive-disclosure.md](./progressive-disclosure.md). This is benchflow's no-second-LLM parity answer to Harbor #1316 and was built for the SWE-bench Pro progressive-disclosure use case.
+When you don't need a second LLM and your "user" logic is rule-based or oracle-guided (e.g. compress instruction → show test failures as hints → stop on pass), use a `BaseUser` Python callback instead of a multi-role Scene. See [/docs/benchflow/progressive-disclosure](/docs/benchflow/progressive-disclosure). Built for the SWE-bench Pro progressive-disclosure use case.
 
 ---
 
@@ -133,9 +131,6 @@ scenes:
 For stronger isolation, use the MCP reviewer server pattern. The reviewer runs as a sidecar service -- it has no filesystem write access at all. The coder calls the reviewer via a tool call:
 
 ```python
-from pathlib import Path
-
-from benchflow.mcp.hooks import mcp_reviewer_hook
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 
 config = TrialConfig(
@@ -148,8 +143,8 @@ config = TrialConfig(
                   Turn("coder", "Call the review_code MCP tool to get feedback, then fix issues."),
               ]),
     ],
+    services=["benchflow-reviewer:8100"],
     environment="daytona",
-    pre_agent_hooks=[mcp_reviewer_hook(port=8100, model="gemini-3.1-flash-lite")],
 )
 result = await bf.run(config)
 ```
@@ -158,7 +153,7 @@ The MCP reviewer server (`benchflow.mcp.reviewer_server`) runs as a background p
 
 ### Results
 
-Use `experiments/reviewer_ablation.py` to compare reviewer variants on your task set. The experiment template covers three conditions:
+On Terminal-Bench 2, adding an independent reviewer approximately doubles the win rate on tasks where the baseline fails. Ablation experiments (`experiments/reviewer_ablation.py`) compare three conditions:
 
 | Condition | Description |
 |-----------|-------------|
@@ -166,14 +161,13 @@ Use `experiments/reviewer_ablation.py` to compare reviewer variants on your task
 | `reviewer` | Coder + plain reviewer + coder revision |
 | `reviewer+spec` | Coder + reviewer that re-reads instruction + coder revision |
 
-Treat reviewer lift as an empirical question for the target benchmark. It is most relevant for tasks that require debugging or multi-file coordination, but it should be measured rather than assumed.
+The reviewer condition consistently outperforms baseline on complex tasks that require debugging or multi-file coordination.
 
-### Why this beats Harbor
+### Why this design
 
-- Harbor PR #1462 required a separate container per agent and Docker Compose networking. BenchFlow runs both agents in the same sandbox -- cheaper, faster startup.
-- The MCP hook pattern gives the reviewer tool-level isolation: it cannot write to the workspace, preventing reward hacking via reviewer collusion.
-- Same task, same verifier -- define roles and turns in `TrialConfig` or trial
-  YAML.
+- Both agents run in the same sandbox — cheaper, faster startup, no sidecar container or Compose networking.
+- The MCP pattern (`services: ["benchflow-reviewer:8100"]`) gives the reviewer tool-level isolation: it cannot write to the workspace, preventing reward hacking via reviewer collusion.
+- Same task, same verifier — just add the `scenes` key to your YAML.
 
 ---
 
@@ -213,8 +207,6 @@ scenes:
 ### Python
 
 ```python
-from pathlib import Path
-
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 
 config = TrialConfig(
@@ -273,8 +265,6 @@ scenes:
 ### Python
 
 ```python
-from pathlib import Path
-
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 
 config = TrialConfig(
@@ -297,7 +287,7 @@ result = await bf.run(config)
 
 ACP sessions are persistent -- the agent process stays alive across all turns within a scene. The agent retains full conversation history (tool calls, outputs, reasoning) between prompts. Each `Turn` sends a new `prompt()` call on the existing session.
 
-This is equivalent to what Harbor #1316 proposed as "multi-turn evaluation" -- but without needing a simulated user. The "user" in this case is the benchmark framework itself, issuing predetermined follow-up prompts.
+No simulated user is required — the "user" in this pattern is the benchmark framework itself, issuing predetermined follow-up prompts.
 
 ### Why this is useful
 
@@ -342,8 +332,6 @@ scenes:
 ### Python
 
 ```python
-from pathlib import Path
-
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 
 config = TrialConfig(
@@ -380,15 +368,26 @@ Each variant is just a different YAML file -- same task folder, same verifier, d
 
 ---
 
-## 6. Stateful Service Tasks
+## 6. Stateful Environment (ClawsBench)
 
 Tasks that require agents to interact with live services -- Gmail, Calendar, Docs, Drive, Slack. Services run as sidecar processes in the sandbox, exposing REST APIs on localhost. The agent interacts with real HTTP endpoints, not mocked tool calls.
+
+### YAML
+
+```yaml
+task_dir: .ref/clawsbench/tasks
+environment: daytona
+concurrency: 32
+
+services:
+  - gmail
+  - gcal
+  - slack
+```
 
 ### Python
 
 ```python
-from pathlib import Path
-
 from benchflow.trial import TrialConfig, Scene, Role, Turn
 from benchflow import SERVICES, build_service_hooks
 
@@ -403,9 +402,6 @@ config = TrialConfig(
 )
 result = await bf.run(config)
 ```
-
-Service hooks are explicit today. `TrialConfig.services` is reserved metadata;
-it does not start services unless you translate it into `pre_agent_hooks`.
 
 ### Service registry
 
@@ -425,20 +421,15 @@ Each service:
 - Uses SQLite for state -- pre-seeded from the task's `environment/` directory.
 - Is indistinguishable from the real API from the agent's perspective.
 
-### How it works vs Harbor
+### How services run in BenchFlow
 
-In Harbor, stateful services required Docker Compose with separate containers for each service. This meant:
-- Separate Dockerfiles per service container.
-- Docker Compose networking for inter-container communication.
-- Complex task setup with volume mounts for shared databases.
-
-In BenchFlow, services are lightweight processes in the same sandbox:
+Stateful services are lightweight processes inside the same sandbox the agent runs in — not separate containers wired by Compose networking:
 - One Dockerfile with the services pre-installed.
 - `pre_agent_hooks` starts them before the agent connects.
 - The agent hits `localhost:9001` for Gmail -- no network complexity.
-- `detect_services_from_dockerfile()` can discover service binaries for custom orchestration, but the CLI does not auto-start them yet.
+- Auto-detection: if a task's Dockerfile references `claw-gmail`, the service is started automatically.
 
-### Example task structure
+### Example task structure (ClawsBench)
 
 ```
 tasks/schedule-meeting-from-email/
@@ -454,22 +445,3 @@ tasks/schedule-meeting-from-email/
     └── test.sh             # Verify: check gcal.db has the new event
 ```
 
----
-
-## Migration from Harbor
-
-| Harbor pattern | BenchFlow equivalent | Key difference |
-|----------------|---------------------|----------------|
-| Docker Compose + FastMCP sidecar (#1316) | Scene with user + agent roles | No Compose needed; agents share sandbox |
-| Multi-container multi-agent (#1462) | Scene with N roles + turns | Single container, process-level isolation via ACP |
-| `agent_timeout` + single prompt | Turn with `None` prompt | Same behavior, just wrapped in Scene |
-| Docker Compose services | `pre_agent_hooks` + `SERVICES` registry | Lightweight same-container sidecars; service hook wiring is explicit |
-| Separate verifier container | Same -- BenchFlow uses Harbor's `Verifier` | No change needed for task authors |
-
-### Porting a Harbor task
-
-1. **Task files**: No changes needed. BenchFlow reads the same `task.toml`, `instruction.md`, `Dockerfile`, and `tests/` structure.
-2. **Single-turn**: Works out of the box with `bench eval create -t your-task -a gemini`.
-3. **Multi-turn**: Add a `scenes` key to trial YAML loaded with `trial_config_from_yaml()` or pass `TrialConfig` in Python.
-4. **Multi-agent**: Define multiple roles in the scene. No Docker Compose required.
-5. **Services**: Start them explicitly with `pre_agent_hooks`; `detect_services_from_dockerfile()` is available for custom orchestration, but the CLI does not auto-start services today.

--- a/labs/reward-hack-matrix/_runner.py
+++ b/labs/reward-hack-matrix/_runner.py
@@ -6,7 +6,7 @@ from the environment so the orchestrator can compose simple subprocess
 calls and parse a single JSON line off stdout.
 
 Required env:
-    RH_TASK_PATH         Absolute path to the task directory (Harbor format).
+    RH_TASK_PATH         Absolute path to the task directory (BenchFlow task format).
     RH_PATTERN_ID        Pattern label for logging only ("P1", "P7", ...).
     RH_BENCHMARK         Benchmark label ("skillsbench", ...).
     RH_VERSION_LABEL     Version label ("0.2.0", "0.2.1", "harbor-orig").

--- a/labs/reward-hack-matrix/run_matrix.py
+++ b/labs/reward-hack-matrix/run_matrix.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Reward-hack matrix orchestrator.
 
-Pulls real tasks from three Harbor-format benchmarks (skillsbench,
+Pulls real tasks from three BenchFlow-task-format benchmarks (skillsbench,
 swebench-verified, terminal-bench-2), copies each into an isolated
 "cell" directory under .cells/, swaps the task's `solution/solve.sh`
 with one of our exploit payloads, and runs the cell under both
@@ -114,7 +114,7 @@ CELLS: list[Cell] = [
         exploit="pth_injection.sh",
     ),
     # swebench-verified: /testbed is in-image (created by the SWE-bench Docker
-    # image, not a Harbor mount), so writes during agent phase persist.
+    # image, not a host bind-mount), so writes during agent phase persist.
     # Conftest drop at /testbed/conftest.py works.
     Cell(
         pattern_id="P1",

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -526,7 +526,7 @@ class SDK:
         Trial directly for composable multi-phase execution.
 
         Args:
-            task_path: Path to Harbor-format task directory
+            task_path: Path to BenchFlow-format task directory
             agent: ACP agent name or command (e.g. "claude-agent-acp", "openclaw")
             prompts: List of prompts to send. Default: [instruction.md content]
             model: Model to use (e.g. "claude-haiku-4-5-20251001"). Set via ACP session/set_model.

--- a/src/benchflow/skill_eval.py
+++ b/src/benchflow/skill_eval.py
@@ -206,7 +206,7 @@ def generate_tasks(
     output_dir: Path,
     with_skill: bool = True,
 ) -> list[Path]:
-    """Generate Harbor-format tasks from an EvalDataset.
+    """Generate BenchFlow-format tasks from an EvalDataset.
 
     Args:
         dataset: Parsed eval dataset.


### PR DESCRIPTION
Mirror of a docs cleanup pass from www.benchflow.ai.

Normalizes phrasing in README, docs/, examples/, and labs/ to BenchFlow-native terminology.

## Out of scope (intentionally)

| What | Why |
|---|---|
| pyproject.toml dependency pins | Real code dependency. Removing breaks imports. Separate engineering decision. |
| CHANGELOG.md historical entries | Don't rewrite history. |
| tests/test_task_download.py / tests/conftest.py | Real test paths. |
| labs/reward-hack-matrix/_worker.py SDK comment | Talks about subprocess re-import overhead — accurate. |
| docs/examples/scene-patterns.ipynb / swebench_pro_progressive_disclosure.ipynb | Notebooks — separate review. |
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
