### PR TITLE
fix(agents): isolate JS agent runtime installs

### DIFF
--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -35,23 +35,13 @@ logger = logging.getLogger(__name__)
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic output in ACP updates
 _TOOL_RESULT_TRUNCATE = 1000  # max chars for tool result text
 _TOOL_INPUT_TRUNCATE = 500  # max chars for tool input echoed in ACP updates
-_BENCHFLOW_JS_PATH = (
-    "/opt/benchflow/bin:/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin"
-)
+_OPENCLAW_BIN = "/opt/benchflow/bin/openclaw"
 
 _PARAM_MAP = {
     "BENCHFLOW_MODEL_TEMPERATURE": "agents.defaults.params.temperature",
     "BENCHFLOW_MODEL_TOP_P": "agents.defaults.params.topP",
     "BENCHFLOW_MODEL_MAX_TOKENS": "agents.defaults.params.maxTokens",
 }
-
-
-def prepend_benchflow_js_path():
-    """Expose BenchFlow's isolated JS agent binaries to subprocess calls."""
-    current = os.environ.get("PATH", "")
-    os.environ["PATH"] = (
-        f"{_BENCHFLOW_JS_PATH}:{current}" if current else _BENCHFLOW_JS_PATH
-    )
 
 
 # ── ACP stdio I/O ─────────────────────────────────────────────────────────────
@@ -148,7 +138,7 @@ def setup_gcloud_adc():
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = str(adc_path)
     # Enable the google plugin so openclaw recognizes google-vertex/ models
     subprocess.run(
-        ["openclaw", "plugins", "enable", "google"],
+        [_OPENCLAW_BIN, "plugins", "enable", "google"],
         capture_output=True,
         timeout=10,
     )
@@ -532,7 +522,6 @@ def parse_session_jsonl(path: Path, session_id: str) -> list[dict]:
 
 
 def main():
-    prepend_benchflow_js_path()
     setup_openai_auth()
     setup_gcloud_adc()
     session_id = "openclaw-shim"
@@ -602,7 +591,7 @@ def main():
                     model = f"{_infer_provider_prefix(model)}/{model}"
 
                 subprocess.run(
-                    ["openclaw", "config", "set", "agents.defaults.model", model],
+                    [_OPENCLAW_BIN, "config", "set", "agents.defaults.model", model],
                     capture_output=True,
                     timeout=10,
                 )
@@ -612,7 +601,7 @@ def main():
                 val = os.environ.get(env_key)
                 if val:
                     subprocess.run(
-                        ["openclaw", "config", "set", config_path, val],
+                        [_OPENCLAW_BIN, "config", "set", config_path, val],
                         capture_output=True,
                         timeout=10,
                     )
@@ -629,7 +618,7 @@ def main():
             try:
                 result = subprocess.run(
                     [
-                        "openclaw",
+                        _OPENCLAW_BIN,
                         "agent",
                         "--local",
                         "--agent",

--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -35,12 +35,23 @@ logger = logging.getLogger(__name__)
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic output in ACP updates
 _TOOL_RESULT_TRUNCATE = 1000  # max chars for tool result text
 _TOOL_INPUT_TRUNCATE = 500  # max chars for tool input echoed in ACP updates
+_BENCHFLOW_JS_PATH = (
+    "/opt/benchflow/bin:/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin"
+)
 
 _PARAM_MAP = {
     "BENCHFLOW_MODEL_TEMPERATURE": "agents.defaults.params.temperature",
     "BENCHFLOW_MODEL_TOP_P": "agents.defaults.params.topP",
     "BENCHFLOW_MODEL_MAX_TOKENS": "agents.defaults.params.maxTokens",
 }
+
+
+def prepend_benchflow_js_path():
+    """Expose BenchFlow's isolated JS agent binaries to subprocess calls."""
+    current = os.environ.get("PATH", "")
+    os.environ["PATH"] = (
+        f"{_BENCHFLOW_JS_PATH}:{current}" if current else _BENCHFLOW_JS_PATH
+    )
 
 
 # ── ACP stdio I/O ─────────────────────────────────────────────────────────────
@@ -521,6 +532,7 @@ def parse_session_jsonl(path: Path, session_id: str) -> list[dict]:
 
 
 def main():
+    prepend_benchflow_js_path()
     setup_openai_auth()
     setup_gcloud_adc()
     session_id = "openclaw-shim"

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -19,6 +19,7 @@ from pathlib import Path
 # overrides supply values. Conservative — most modern models exceed these.
 _DEFAULT_CONTEXT_WINDOW = 128000
 _DEFAULT_MAX_TOKENS = 16384
+_BENCHFLOW_BIN_DIR = "/opt/benchflow/bin"
 _PI_ACP_BIN = "/opt/benchflow/bin/pi-acp"
 
 
@@ -116,8 +117,19 @@ def setup_provider() -> None:
             os.environ.setdefault("ANTHROPIC_MODEL", model)
 
 
+def _prepend_benchflow_bin_path() -> None:
+    """Let pi-acp find the paired pi wrapper without exposing Node/npm."""
+    current = os.environ.get("PATH", "")
+    parts = current.split(":") if current else []
+    if _BENCHFLOW_BIN_DIR not in parts:
+        os.environ["PATH"] = (
+            f"{_BENCHFLOW_BIN_DIR}:{current}" if current else _BENCHFLOW_BIN_DIR
+        )
+
+
 def main() -> None:
     setup_provider()
+    _prepend_benchflow_bin_path()
     try:
         os.execv(_PI_ACP_BIN, [_PI_ACP_BIN, *sys.argv[1:]])
     except FileNotFoundError as e:

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -19,6 +19,17 @@ from pathlib import Path
 # overrides supply values. Conservative — most modern models exceed these.
 _DEFAULT_CONTEXT_WINDOW = 128000
 _DEFAULT_MAX_TOKENS = 16384
+_BENCHFLOW_JS_PATH = (
+    "/opt/benchflow/bin:/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin"
+)
+
+
+def _prepend_benchflow_js_path() -> None:
+    """Expose BenchFlow's isolated JS agent binaries to this launcher."""
+    current = os.environ.get("PATH", "")
+    os.environ["PATH"] = (
+        f"{_BENCHFLOW_JS_PATH}:{current}" if current else _BENCHFLOW_JS_PATH
+    )
 
 
 def _lookup_model_metadata(model: str) -> dict:
@@ -116,6 +127,7 @@ def setup_provider() -> None:
 
 
 def main() -> None:
+    _prepend_benchflow_js_path()
     setup_provider()
     try:
         os.execvp("pi-acp", ["pi-acp", *sys.argv[1:]])

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -19,17 +19,7 @@ from pathlib import Path
 # overrides supply values. Conservative — most modern models exceed these.
 _DEFAULT_CONTEXT_WINDOW = 128000
 _DEFAULT_MAX_TOKENS = 16384
-_BENCHFLOW_JS_PATH = (
-    "/opt/benchflow/bin:/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin"
-)
-
-
-def _prepend_benchflow_js_path() -> None:
-    """Expose BenchFlow's isolated JS agent binaries to this launcher."""
-    current = os.environ.get("PATH", "")
-    os.environ["PATH"] = (
-        f"{_BENCHFLOW_JS_PATH}:{current}" if current else _BENCHFLOW_JS_PATH
-    )
+_PI_ACP_BIN = "/opt/benchflow/bin/pi-acp"
 
 
 def _lookup_model_metadata(model: str) -> dict:
@@ -127,13 +117,12 @@ def setup_provider() -> None:
 
 
 def main() -> None:
-    _prepend_benchflow_js_path()
     setup_provider()
     try:
-        os.execvp("pi-acp", ["pi-acp", *sys.argv[1:]])
+        os.execv(_PI_ACP_BIN, [_PI_ACP_BIN, *sys.argv[1:]])
     except FileNotFoundError as e:
         raise SystemExit(
-            "pi-acp: 'pi-acp' binary not found on PATH. It should have been "
+            f"pi-acp: {_PI_ACP_BIN!r} not found. It should have been "
             "installed by the registry's install_cmd via "
             "'npm install -g pi-acp'. Check the container's install log."
         ) from e

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -66,30 +66,88 @@ def _install_python_script(container_path: str, source: str) -> str:
     after the third data point — divergence is cheap, premature abstraction isn't.
     """
     encoded = base64.b64encode(source.encode()).decode()
+    parent = shlex.quote(str(Path(container_path).parent))
+    q_path = shlex.quote(container_path)
     return (
         "( command -v python3 >/dev/null 2>&1 || "
         "(apt-get update -qq && apt-get install -y -qq python3 >/dev/null 2>&1) ) && "
-        f"echo {encoded} | base64 -d > {container_path} && "
-        f"chmod +x {container_path}"
+        f"mkdir -p {parent} && "
+        f"echo {encoded} | base64 -d > {q_path} && "
+        f"chmod +x {q_path}"
     )
 
 
-# Node.js bootstrap — handles missing node, old node (<22), Ubuntu + Debian slim
+# Isolated Node.js bootstrap for JavaScript-based ACP agents.
+#
+# Keep this out of system prefixes. Task images may need their own Node/npm
+# versions, so BenchFlow installs agent runtime bits under /opt/benchflow and
+# scopes PATH only to agent install/launch commands.
+_BENCHFLOW_NODE_PREFIX = "/opt/benchflow/node"
+_BENCHFLOW_JS_AGENT_PREFIX = "/opt/benchflow/js-agents"
+_BENCHFLOW_BIN_PREFIX = "/opt/benchflow/bin"
+_JS_AGENT_PATH = (
+    f"{_BENCHFLOW_BIN_PREFIX}:{_BENCHFLOW_JS_AGENT_PREFIX}/bin:"
+    f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
+)
 _NODE_INSTALL = (
     "set -o pipefail; "
     "export DEBIAN_FRONTEND=noninteractive; "
-    "NODE_OK=0; "
-    "if command -v node >/dev/null 2>&1; then "
-    "  NODE_VER=$(node -e 'console.log(process.versions.node.split(\".\")[0])' 2>/dev/null || echo 0); "
-    '  [ "$NODE_VER" -ge 22 ] 2>/dev/null && NODE_OK=1; '
+    f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
+    "BF_NODE_VERSION=22.12.0; "
+    'if [ ! -x "$BF_NODE_DIR/bin/node" ]; then '
+    "  if ! command -v curl >/dev/null 2>&1 || "
+    "     ! command -v tar >/dev/null 2>&1 || "
+    "     ! command -v xz >/dev/null 2>&1; then "
+    "    if command -v apt-get >/dev/null 2>&1; then "
+    "      apt-get update -qq && "
+    "      apt-get install -y -qq curl ca-certificates tar xz-utils; "
+    "    elif command -v dnf >/dev/null 2>&1; then "
+    "      dnf -y install curl ca-certificates tar xz; "
+    "    elif command -v apk >/dev/null 2>&1; then "
+    "      apk add --no-cache curl ca-certificates tar xz; "
+    "    else "
+    "      echo 'BenchFlow JS agent bootstrap requires curl, tar, and xz' >&2; "
+    "      exit 127; "
+    "    fi; "
+    "  fi; "
+    '  arch="$(uname -m)"; '
+    '  case "$arch" in '
+    "    x86_64|amd64) node_arch=x64 ;; "
+    "    aarch64|arm64) node_arch=arm64 ;; "
+    '    *) echo "Unsupported architecture for Node.js: $arch" >&2; exit 1 ;; '
+    "  esac; "
+    '  tmp="$(mktemp -d)"; '
+    "  mkdir -p /opt/benchflow; "
+    '  curl -fsSLo "$tmp/node.tar.xz" '
+    '"https://nodejs.org/dist/v${BF_NODE_VERSION}/node-v${BF_NODE_VERSION}-linux-${node_arch}.tar.xz"; '
+    '  rm -rf "$BF_NODE_DIR"; '
+    '  mkdir -p "$BF_NODE_DIR"; '
+    '  tar -xJf "$tmp/node.tar.xz" -C "$BF_NODE_DIR" --strip-components=1 --no-same-owner; '
+    '  rm -rf "$tmp"; '
     "fi; "
-    'if [ "$NODE_OK" = 0 ]; then '
-    "  apt-get update -qq && "
-    "  apt-get install -y -qq curl ca-certificates && "
-    "  curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && "
-    "  apt-get install -y -qq nodejs; "
-    "fi >/dev/null 2>&1"
+    f'export PATH="{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"; '
+    '"$BF_NODE_DIR/bin/node" --version; '
+    '"$BF_NODE_DIR/bin/npm" --version'
 )
+
+
+def _js_agent_install(binary: str, package: str) -> str:
+    """Install an npm-distributed agent into BenchFlow's isolated prefix."""
+    agent_bin = f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin/{binary}"
+    return (
+        f"{_NODE_INSTALL} && "
+        f"mkdir -p {_BENCHFLOW_JS_AGENT_PREFIX} && "
+        f'export PATH="{_JS_AGENT_PATH}" && '
+        f"( [ -x {agent_bin} ] || "
+        f"{_BENCHFLOW_NODE_PREFIX}/bin/npm install -g "
+        f"--prefix {_BENCHFLOW_JS_AGENT_PREFIX} {package}@latest ) && "
+        f"[ -x {agent_bin} ]"
+    )
+
+
+def _js_agent_launch(command: str) -> str:
+    """Launch a JS agent with BenchFlow's isolated runtime first on PATH."""
+    return f'export PATH="{_JS_AGENT_PATH}"; {command}'
 
 # Path to the openclaw ACP shim script
 _OPENCLAW_SHIM = (Path(__file__).parent / "openclaw_acp_shim.py").read_text()
@@ -201,13 +259,10 @@ AGENTS: dict[str, AgentConfig] = {
         name="claude-agent-acp",
         description="Claude Code via ACP (Anthropic's Agent Client Protocol)",
         skill_paths=["$HOME/.claude/skills"],
-        install_cmd=(
-            f"{_NODE_INSTALL} && "
-            "( command -v claude-agent-acp >/dev/null 2>&1 || "
-            "npm install -g @zed-industries/claude-agent-acp@latest >/dev/null 2>&1 ) && "
-            "command -v claude-agent-acp >/dev/null 2>&1"
+        install_cmd=_js_agent_install(
+            "claude-agent-acp", "@zed-industries/claude-agent-acp"
         ),
-        launch_cmd="claude-agent-acp",
+        launch_cmd=_js_agent_launch("claude-agent-acp"),
         protocol="acp",
         requires_env=["ANTHROPIC_API_KEY"],
         api_protocol="anthropic-messages",
@@ -237,16 +292,16 @@ AGENTS: dict[str, AgentConfig] = {
         description="Pi agent via ACP",
         skill_paths=["$HOME/.pi/agent/skills", "$HOME/.agents/skills"],
         install_cmd=(
-            f"{_NODE_INSTALL} && "
-            "( command -v pi >/dev/null 2>&1 || "
-            "npm install -g @mariozechner/pi-coding-agent@latest >/dev/null 2>&1 ) && "
-            "( command -v pi-acp >/dev/null 2>&1 || "
-            "npm install -g pi-acp@latest >/dev/null 2>&1 ) && "
-            "command -v pi-acp >/dev/null 2>&1 && "
+            f"{_js_agent_install('pi', '@mariozechner/pi-coding-agent')} && "
+            f"{_js_agent_install('pi-acp', 'pi-acp')} && "
             # Deploy launch wrapper (bridges BENCHFLOW_PROVIDER_* → Pi config)
-            + _install_python_script("/usr/local/bin/pi-acp-launcher", _PI_LAUNCHER)
+            + _install_python_script(
+                f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher", _PI_LAUNCHER
+            )
         ),
-        launch_cmd="python3 /usr/local/bin/pi-acp-launcher",
+        launch_cmd=_js_agent_launch(
+            f"python3 {_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher"
+        ),
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         # Pi is multi-protocol: speaks Anthropic natively and OpenAI via
@@ -262,18 +317,19 @@ AGENTS: dict[str, AgentConfig] = {
         description="OpenClaw agent via ACP shim — model set at runtime via --model",
         skill_paths=["$HOME/.claude/skills", "$WORKSPACE/skills"],
         install_cmd=(
-            f"{_NODE_INSTALL} && "
-            "( command -v openclaw >/dev/null 2>&1 || "
-            "npm install -g openclaw@latest >/dev/null 2>&1 ) && "
-            "command -v openclaw >/dev/null 2>&1 && "
+            f"{_js_agent_install('openclaw', 'openclaw')} && "
             # Configure: auto-approve tools (no model — set at runtime via ACP set_model)
             "mkdir -p ~/.openclaw && "
             'echo \'{"version":1,"defaults":{"allow_all":true}}\''
             " > ~/.openclaw/exec-approvals.json && "
             # Deploy ACP shim
-            + _install_python_script("/usr/local/bin/openclaw-acp-shim", _OPENCLAW_SHIM)
+            + _install_python_script(
+                f"{_BENCHFLOW_BIN_PREFIX}/openclaw-acp-shim", _OPENCLAW_SHIM
+            )
         ),
-        launch_cmd="python3 /usr/local/bin/openclaw-acp-shim",
+        launch_cmd=_js_agent_launch(
+            f"python3 {_BENCHFLOW_BIN_PREFIX}/openclaw-acp-shim"
+        ),
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         home_dirs=[".openclaw"],
@@ -282,13 +338,8 @@ AGENTS: dict[str, AgentConfig] = {
         name="codex-acp",
         description="OpenAI Codex agent via ACP",
         skill_paths=["$HOME/.agents/skills"],
-        install_cmd=(
-            f"{_NODE_INSTALL} && "
-            "( command -v codex-acp >/dev/null 2>&1 || "
-            "npm install -g @zed-industries/codex-acp@latest >/dev/null 2>&1 ) && "
-            "command -v codex-acp >/dev/null 2>&1"
-        ),
-        launch_cmd=(
+        install_cmd=_js_agent_install("codex-acp", "@zed-industries/codex-acp"),
+        launch_cmd=_js_agent_launch(
             "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
         ),
         protocol="acp",
@@ -318,13 +369,8 @@ AGENTS: dict[str, AgentConfig] = {
         name="gemini",
         description="Google Gemini CLI via ACP",
         skill_paths=["$HOME/.gemini/skills"],
-        install_cmd=(
-            f"{_NODE_INSTALL} && "
-            "( command -v gemini >/dev/null 2>&1 || "
-            "npm install -g @google/gemini-cli@latest >/dev/null 2>&1 ) && "
-            "command -v gemini >/dev/null 2>&1"
-        ),
-        launch_cmd="gemini --acp --yolo",
+        install_cmd=_js_agent_install("gemini", "@google/gemini-cli"),
+        launch_cmd=_js_agent_launch("gemini --acp --yolo"),
         protocol="acp",
         requires_env=["GOOGLE_API_KEY"],
         # api_protocol intentionally empty: Gemini speaks Google's native
@@ -362,13 +408,8 @@ AGENTS: dict[str, AgentConfig] = {
         description="OpenCode via ACP — open-source coding agent (TypeScript)",
         skill_paths=["$HOME/.opencode/skills"],
         home_dirs=[".opencode"],
-        install_cmd=(
-            f"{_NODE_INSTALL} && "
-            "( command -v opencode >/dev/null 2>&1 || "
-            "npm install -g opencode-ai@latest >/dev/null 2>&1 ) && "
-            "command -v opencode >/dev/null 2>&1"
-        ),
-        launch_cmd="opencode acp",
+        install_cmd=_js_agent_install("opencode", "opencode-ai"),
+        launch_cmd=_js_agent_launch("opencode acp"),
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         acp_model_format="provider/model",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -80,8 +80,9 @@ def _install_python_script(container_path: str, source: str) -> str:
 # Isolated Node.js bootstrap for JavaScript-based ACP agents.
 #
 # Keep this out of system prefixes. Task images may need their own Node/npm
-# versions, so BenchFlow installs agent runtime bits under /opt/benchflow and
-# scopes PATH only to agent install/launch commands.
+# versions, so BenchFlow installs agent runtime bits under /opt/benchflow.
+# Install commands can put that prefix on PATH, but launch wrappers call the
+# private Node binary explicitly so task subprocesses keep the task's PATH.
 _BENCHFLOW_NODE_PREFIX = "/opt/benchflow/node"
 _BENCHFLOW_JS_AGENT_PREFIX = "/opt/benchflow/js-agents"
 _BENCHFLOW_BIN_PREFIX = "/opt/benchflow/bin"
@@ -143,9 +144,8 @@ def _js_agent_install(binary: str, package: str) -> str:
         f"{_BENCHFLOW_NODE_PREFIX}/bin/npm install -g "
         f"--prefix {_BENCHFLOW_JS_AGENT_PREFIX} {package}@latest ) && "
         f"printf '%s\\n' '#!/bin/sh' "
-        f"'export PATH=\"{_BENCHFLOW_NODE_PREFIX}/bin:"
-        f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin:$PATH\"' "
-        f"'exec {agent_bin} \"$@\"' > {wrapper} && "
+        f"'exec {_BENCHFLOW_NODE_PREFIX}/bin/node {agent_bin} \"$@\"' "
+        f"> {wrapper} && "
         f"chmod +x {wrapper} && "
         f"chmod -R a+rX /opt/benchflow && "
         f"[ -x {agent_bin} ] && [ -x {wrapper} ]"

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -134,20 +134,28 @@ _NODE_INSTALL = (
 def _js_agent_install(binary: str, package: str) -> str:
     """Install an npm-distributed agent into BenchFlow's isolated prefix."""
     agent_bin = f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin/{binary}"
+    wrapper = f"{_BENCHFLOW_BIN_PREFIX}/{binary}"
     return (
         f"{_NODE_INSTALL} && "
-        f"mkdir -p {_BENCHFLOW_JS_AGENT_PREFIX} && "
+        f"mkdir -p {_BENCHFLOW_JS_AGENT_PREFIX} {_BENCHFLOW_BIN_PREFIX} && "
         f'export PATH="{_JS_AGENT_PATH}" && '
         f"( [ -x {agent_bin} ] || "
         f"{_BENCHFLOW_NODE_PREFIX}/bin/npm install -g "
         f"--prefix {_BENCHFLOW_JS_AGENT_PREFIX} {package}@latest ) && "
-        f"[ -x {agent_bin} ]"
+        f"printf '%s\\n' '#!/bin/sh' "
+        f"'export PATH=\"{_BENCHFLOW_NODE_PREFIX}/bin:"
+        f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin:$PATH\"' "
+        f"'exec {agent_bin} \"$@\"' > {wrapper} && "
+        f"chmod +x {wrapper} && "
+        f"chmod -R a+rX /opt/benchflow && "
+        f"[ -x {agent_bin} ] && [ -x {wrapper} ]"
     )
 
 
-def _js_agent_launch(command: str) -> str:
-    """Launch a JS agent with BenchFlow's isolated runtime first on PATH."""
-    return f'export PATH="{_JS_AGENT_PATH}"; {command}'
+def _js_agent_launch(binary: str, args: str = "") -> str:
+    """Launch a JS agent through its isolated BenchFlow wrapper."""
+    cmd = f"{_BENCHFLOW_BIN_PREFIX}/{binary}"
+    return f"{cmd} {args}".rstrip()
 
 
 # Path to the openclaw ACP shim script
@@ -300,7 +308,7 @@ AGENTS: dict[str, AgentConfig] = {
                 f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher", _PI_LAUNCHER
             )
         ),
-        launch_cmd=_js_agent_launch(f"python3 {_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher"),
+        launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher",
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         # Pi is multi-protocol: speaks Anthropic natively and OpenAI via
@@ -326,9 +334,7 @@ AGENTS: dict[str, AgentConfig] = {
                 f"{_BENCHFLOW_BIN_PREFIX}/openclaw-acp-shim", _OPENCLAW_SHIM
             )
         ),
-        launch_cmd=_js_agent_launch(
-            f"python3 {_BENCHFLOW_BIN_PREFIX}/openclaw-acp-shim"
-        ),
+        launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/openclaw-acp-shim",
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         home_dirs=[".openclaw"],
@@ -339,7 +345,7 @@ AGENTS: dict[str, AgentConfig] = {
         skill_paths=["$HOME/.agents/skills"],
         install_cmd=_js_agent_install("codex-acp", "@zed-industries/codex-acp"),
         launch_cmd=_js_agent_launch(
-            "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
+            "codex-acp", "${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
         ),
         protocol="acp",
         requires_env=["OPENAI_API_KEY"],
@@ -369,7 +375,7 @@ AGENTS: dict[str, AgentConfig] = {
         description="Google Gemini CLI via ACP",
         skill_paths=["$HOME/.gemini/skills"],
         install_cmd=_js_agent_install("gemini", "@google/gemini-cli"),
-        launch_cmd=_js_agent_launch("gemini --acp --yolo"),
+        launch_cmd=_js_agent_launch("gemini", "--acp --yolo"),
         protocol="acp",
         requires_env=["GOOGLE_API_KEY"],
         # api_protocol intentionally empty: Gemini speaks Google's native
@@ -408,7 +414,7 @@ AGENTS: dict[str, AgentConfig] = {
         skill_paths=["$HOME/.opencode/skills"],
         home_dirs=[".opencode"],
         install_cmd=_js_agent_install("opencode", "opencode-ai"),
-        launch_cmd=_js_agent_launch("opencode acp"),
+        launch_cmd=_js_agent_launch("opencode", "acp"),
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         acp_model_format="provider/model",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -149,6 +149,7 @@ def _js_agent_launch(command: str) -> str:
     """Launch a JS agent with BenchFlow's isolated runtime first on PATH."""
     return f'export PATH="{_JS_AGENT_PATH}"; {command}'
 
+
 # Path to the openclaw ACP shim script
 _OPENCLAW_SHIM = (Path(__file__).parent / "openclaw_acp_shim.py").read_text()
 
@@ -299,9 +300,7 @@ AGENTS: dict[str, AgentConfig] = {
                 f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher", _PI_LAUNCHER
             )
         ),
-        launch_cmd=_js_agent_launch(
-            f"python3 {_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher"
-        ),
+        launch_cmd=_js_agent_launch(f"python3 {_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher"),
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         # Pi is multi-protocol: speaks Anthropic natively and OpenAI via

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -94,7 +94,7 @@ _NODE_INSTALL = (
     "set -o pipefail; "
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
-    "BF_NODE_VERSION=22.12.0; "
+    "BF_NODE_VERSION=22.14.0; "
     'if [ ! -x "$BF_NODE_DIR/bin/node" ]; then '
     "  if ! command -v curl >/dev/null 2>&1 || "
     "     ! command -v tar >/dev/null 2>&1 || "

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -160,12 +160,12 @@ async def test_connect_as_applies_web_policy_to_role_env(tmp_path):
 
 
 def test_codex_launch_disable_is_gated_by_web_policy():
-    assert _agent_launch_with_web_policy("codex-acp", disallow=False) == (
-        "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
-    )
+    from benchflow.agents.registry import AGENT_LAUNCH
+
+    base_cmd = AGENT_LAUNCH["codex-acp"]
+    assert _agent_launch_with_web_policy("codex-acp", disallow=False) == base_cmd
     assert _agent_launch_with_web_policy("codex-acp", disallow=True) == (
-        "codex-acp ${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
-        " -c tools.web_search=false"
+        f"{base_cmd} -c tools.web_search=false"
     )
 
 

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -160,9 +160,10 @@ async def test_connect_as_applies_web_policy_to_role_env(tmp_path):
 
 
 def test_codex_launch_disable_is_gated_by_web_policy():
-    from benchflow.agents.registry import AGENT_LAUNCH
-
-    base_cmd = AGENT_LAUNCH["codex-acp"]
+    base_cmd = (
+        "/opt/benchflow/bin/codex-acp "
+        "${OPENAI_BASE_URL:+-c openai_base_url=$OPENAI_BASE_URL}"
+    )
     assert _agent_launch_with_web_policy("codex-acp", disallow=False) == base_cmd
     assert _agent_launch_with_web_policy("codex-acp", disallow=True) == (
         f"{base_cmd} -c tools.web_search=false"

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -286,12 +286,12 @@ class TestSetupProviderNameDerivation:
 
 
 @pytest.mark.usefixtures("_pi_env")
-class TestMainExecvpFailure:
+class TestMainExecv:
     """Missing pi-acp binary must surface a clear error, not a bare FileNotFoundError."""
 
     def test_missing_binary_raises_sysexit(self, monkeypatch):
         monkeypatch.setattr(
-            "os.execvp",
+            "os.execv",
             lambda *_: (_ for _ in ()).throw(FileNotFoundError(2, "No such file")),
         )
 
@@ -299,3 +299,30 @@ class TestMainExecvpFailure:
 
         with pytest.raises(SystemExit, match="pi-acp"):
             main()
+
+    def test_pi_acp_can_find_paired_pi_wrapper_without_node_path(self, monkeypatch):
+        import os
+
+        import benchflow.agents.pi_acp_launcher as launcher
+
+        captured = {}
+        monkeypatch.setenv("PATH", "/usr/bin")
+        monkeypatch.setattr(launcher, "setup_provider", lambda: None)
+
+        def fake_execv(path, argv):
+            captured["path"] = path
+            captured["argv"] = argv
+            captured["PATH"] = os.environ["PATH"]
+            raise RuntimeError("stop")
+
+        monkeypatch.setattr("os.execv", fake_execv)
+
+        with pytest.raises(RuntimeError, match="stop"):
+            launcher.main()
+
+        assert captured["path"] == "/opt/benchflow/bin/pi-acp"
+        assert captured["argv"][0] == "/opt/benchflow/bin/pi-acp"
+        path_entries = captured["PATH"].split(":")
+        assert path_entries[:2] == ["/opt/benchflow/bin", "/usr/bin"]
+        assert "/opt/benchflow/node/bin" not in path_entries
+        assert "/opt/benchflow/js-agents/bin" not in path_entries

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -36,6 +36,14 @@ VALID_API_PROTOCOLS = {
 }
 VALID_PROVIDER_API_PROTOCOLS = VALID_API_PROTOCOLS - {""}
 VALID_AUTH_TYPES = {"api_key", "adc", "none"}
+JS_ACP_AGENTS = {
+    "claude-agent-acp",
+    "pi-acp",
+    "openclaw",
+    "codex-acp",
+    "gemini",
+    "opencode",
+}
 
 
 # ── AgentConfig invariants ──────────────────────────────────────────────────
@@ -95,6 +103,49 @@ def test_agent_install_cmd_targets_shared_paths(name, cfg):
             f"{name!r} install_cmd writes under {prefix!r}; use /usr/local/bin "
             f"or another shared prefix so the sandbox user inherits the tool"
         )
+
+
+@pytest.mark.parametrize("name", sorted(JS_ACP_AGENTS))
+def test_js_acp_agents_use_isolated_node_runtime(name):
+    """JS agents must not mutate task-owned Node/npm installations."""
+    install_cmd = AGENTS[name].install_cmd
+    launch_cmd = AGENTS[name].launch_cmd
+
+    assert "/opt/benchflow/node" in install_cmd
+    assert "/opt/benchflow/js-agents" in install_cmd
+    assert "/opt/benchflow/bin" in install_cmd
+    assert "--prefix /opt/benchflow/js-agents" in install_cmd
+    assert "/opt/benchflow/bin" in launch_cmd
+    assert "/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin:$PATH" in launch_cmd
+
+    forbidden_fragments = [
+        "deb.nodesource.com",
+        "apt-get install -y -qq nodejs",
+        "apt-get install -y nodejs",
+        "/usr/bin/node",
+        "/usr/bin/npm",
+        "/usr/bin/npx",
+        "/usr/local/bin/node",
+        "/usr/local/bin/npm",
+        "/usr/local/bin/npx",
+        "/usr/local/bin/pi-acp-launcher",
+        "/usr/local/bin/openclaw-acp-shim",
+        "command -v node",
+    ]
+    for fragment in forbidden_fragments:
+        assert fragment not in install_cmd, (
+            f"{name!r} JS agent install must not mutate task Node/npm via {fragment!r}"
+        )
+
+
+@pytest.mark.parametrize("name", sorted(JS_ACP_AGENTS))
+def test_js_acp_agent_npm_failures_are_visible(name):
+    """Npm stderr should reach agent/install-stdout.txt on install failure."""
+    install_cmd = AGENTS[name].install_cmd
+    assert "npm install" in install_cmd
+    assert not re.search(r"npm install[^;&|)]*(?:2?>|&>)", install_cmd), (
+        f"{name!r} install redirects npm output before BenchFlow can log it"
+    )
 
 
 @pytest.mark.parametrize("name,cfg", AGENTS.items(), ids=list(AGENTS.keys()))

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -112,6 +112,7 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
     launch_cmd = AGENTS[name].launch_cmd
 
     assert "/opt/benchflow/node" in install_cmd
+    assert "BF_NODE_VERSION=22.14.0" in install_cmd
     assert "/opt/benchflow/js-agents" in install_cmd
     assert "/opt/benchflow/bin" in install_cmd
     assert "--prefix /opt/benchflow/js-agents" in install_cmd

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -117,11 +117,16 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
     assert "--prefix /opt/benchflow/js-agents" in install_cmd
     assert "/opt/benchflow/bin" in launch_cmd
     assert "/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin:$PATH" in install_cmd
+    assert (
+        "exec /opt/benchflow/node/bin/node /opt/benchflow/js-agents/bin/" in install_cmd
+    )
     assert launch_cmd.split()[0].startswith("/opt/benchflow/bin/")
     assert launch_cmd.split()[0] not in {"export", "env"}
     assert not launch_cmd.startswith("PATH=")
 
     forbidden_fragments = [
+        'export PATH="/opt/benchflow/node/bin:/opt/benchflow/js-agents/bin:$PATH"',
+        "exec /opt/benchflow/js-agents/bin/",
         "deb.nodesource.com",
         "apt-get install -y -qq nodejs",
         "apt-get install -y nodejs",

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -116,7 +116,10 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
     assert "/opt/benchflow/bin" in install_cmd
     assert "--prefix /opt/benchflow/js-agents" in install_cmd
     assert "/opt/benchflow/bin" in launch_cmd
-    assert "/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin:$PATH" in launch_cmd
+    assert "/opt/benchflow/js-agents/bin:/opt/benchflow/node/bin:$PATH" in install_cmd
+    assert launch_cmd.split()[0].startswith("/opt/benchflow/bin/")
+    assert launch_cmd.split()[0] not in {"export", "env"}
+    assert not launch_cmd.startswith("PATH=")
 
     forbidden_fragments = [
         "deb.nodesource.com",


### PR DESCRIPTION
## Summary

This moves JavaScript-based ACP agent provisioning out of task/system Node state and into an isolated BenchFlow-owned prefix.

The previous installer used NodeSource/apt and global npm installation, which made optional agents depend on each task image's package manager, Node version, and npm state. That forced task-side Dockerfile workarounds for agents such as OpenCode and OpenClaw. This PR keeps JS agent runtime state under `/opt/benchflow` and scopes it to agent install/launch commands instead of mutating the task image's system Node/npm installation.

## What Changed

- Install Node `22.14.0` from the official Node tarball into `/opt/benchflow/node`.
  - `22.14.0` is intentional because OpenClaw requires Node `>=22.14.0`.
- Install npm-distributed JS agents into `/opt/benchflow/js-agents` with `npm install -g --prefix /opt/benchflow/js-agents`.
- Put BenchFlow agent shims under `/opt/benchflow/bin` instead of `/usr/local/bin`.
- Launch JS agents with a scoped PATH prefix only for the agent process:
  - `/opt/benchflow/bin`
  - `/opt/benchflow/js-agents/bin`
  - `/opt/benchflow/node/bin`
- Preserve task runtime PATH outside the scoped agent launch.
- Let `pi-acp` find its paired `/opt/benchflow/bin/pi` wrapper without exposing BenchFlow Node/npm paths to task commands.
- Remove NodeSource and `apt-get install nodejs` from JS ACP agent provisioning.
- Keep npm stderr visible in `agent/install-stdout.txt` instead of hiding it.

## Why This Is Minimal

- No task metadata or task Dockerfiles are changed by BenchFlow.
- No task-owned `/usr/bin/node`, `/usr/local/bin/node`, system npm, or workspace `node_modules` are modified.
- Existing agent names, registry entries, and public CLI usage stay the same.
- The change is limited to shared agent registry install/launch strings, the Pi ACP launcher path handoff, and tests.

## Local Verification

Run on this PR branch at `2fadbdd98262fb352fe7219ded90487c4898a644`:

- `uv run ruff format --check`
- `uv run ruff check`
- `uv run python -m pytest`
  - `785 passed, 1 skipped, 1 deselected, 32 warnings`
- `uv run ty check`
- GitHub Actions `test`: passing
- Devin Review: passing

The registry tests assert that JS agent provisioning avoids NodeSource, avoids `apt-get install nodejs`, avoids `/usr/local/bin` agent shims, preserves npm stderr, uses `/opt/benchflow/*`, and uses Node `22.14.0`.

## Daytona Validation

I also ran a live Daytona startup/install probe against a scratch copy of the previously affected SkillsBench task `video-filler-word-remover`.

Scratch setup:

- SkillsBench source: `/Users/liu.10379/Documents/work/skillsbench-opencode-gemini3-daytona`
- SkillsBench head: `490dff98a823e94db435106493c8f3a47e4aa4e0`
- Scratch task: `video-filler-word-remover`
- Removed only the task-side Node 22 Dockerfile block from the scratch copy.
- Kept Whisper preload and all non-Node task dependencies.
- Dockerfile audit confirmed these markers were absent:
  - `NODE_VERSION`
  - `node-v`
  - `/usr/local/bin/node`
  - `/usr/bin/node`
  - `npm --version`
  - `corepack`
  - `deb.nodesource.com`

Run configuration:

- Backend: `daytona`
- Prompt: `Startup probe only: respond with exactly READY and do not modify files.`
- Model argument: `google/gemini-3-flash-preview`
- With skills enabled
- Run root: `/Users/liu.10379/Documents/work/skillsbench-opencode-gemini3-daytona-runs/20260503T222755Z-pr231-all7-gemini-unpatched-video`
- Summary artifact: `validation_summary_2fadbdd.json` under that run root

Results:

| Agent | Result | Classification |
| --- | --- | --- |
| `opencode` | exit 0, ACP trajectory, `READY`, verifier reward `0.0` | `startup_success` |
| `openclaw` | exit 0, ACP trajectory, `READY`, verifier reward `0.0` | `startup_success` |
| `pi-acp` | exit 0, ACP trajectory, `READY`, verifier reward `0.0` | `startup_success` |
| `claude-agent-acp` | install/start reached ACP, then Anthropic 401 with Gemini key/model routing | `model_auth_incompatible` |
| `codex-acp` | install/start reached ACP, then OpenAI auth/model path rejected the Gemini key | `model_auth_incompatible` |
| `gemini` | install/start reached ACP, then Gemini CLI returned 404 for the passed model string | `model_auth_incompatible` |
| `openhands` | install/start reached OpenHands, then LiteLLM/Gemini model lookup failed | `model_auth_incompatible` |

Coverage from the probe:

- `7/7` produced `result.json`.
- `7/7` produced `trajectory/acp_trajectory.jsonl`.
- `3/7` fully responded `READY` and ran the verifier.
- `0/7` had a build/install/ACP/verifier infra failure caused by removing task-side Node.
- JS/npm agents' install logs showed isolated BenchFlow paths:
  - `/opt/benchflow/node`
  - `/opt/benchflow/js-agents`
  - `/opt/benchflow/bin/<agent>`
- OpenHands is Python/uv-based, so the JS `/opt/benchflow` install markers are not expected there.

The four non-success cases are expected for this forced "Gemini everywhere" matrix: they are model/auth routing incompatibilities after agent install/startup, not task Dockerfile Node failures.

## Reviewer Notes

This PR is meant to remove the need for task-side Node 22 Dockerfile patches for JS ACP agents. It does not attempt to make every ACP agent accept `google/gemini-3-flash-preview` through the same auth/model path; that is a separate provider-routing question.