### PR TITLE
[codex] Fix agent timeout reward fallback

### DIFF
--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -750,6 +750,7 @@ class Trial:
         scene containing one role — no special case.
         """
         cfg = self._config
+        agent_timed_out = False
         try:
             await self.setup()
             await self.start()
@@ -774,11 +775,17 @@ class Trial:
             else:
                 await self.install_agent()
                 try:
-                    if cfg.user is not None:
-                        await self._run_user_loop()
-                    else:
-                        for scene in cfg.effective_scenes:
-                            await self._run_scene(scene)
+                    try:
+                        if cfg.user is not None:
+                            await self._run_user_loop()
+                        else:
+                            for scene in cfg.effective_scenes:
+                                await self._run_scene(scene)
+                    except TimeoutError as e:
+                        agent_timed_out = True
+                        detail = str(e).strip()
+                        self._error = detail or f"Agent timed out after {self._timeout}s"
+                        logger.error(self._error)
                 finally:
                     if cfg.oracle_access:
                         await self._env.exec(
@@ -788,6 +795,9 @@ class Trial:
                         )
 
             await self.verify()
+            if agent_timed_out and self._rewards is None:
+                self._rewards = {"reward": 0.0}
+                self._verifier_error = None
 
         except TimeoutError as e:
             # Preserve the watchdog's diagnostic message ("Agent idle for 600s

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -784,7 +784,9 @@ class Trial:
                     except TimeoutError as e:
                         agent_timed_out = True
                         detail = str(e).strip()
-                        self._error = detail or f"Agent timed out after {self._timeout}s"
+                        self._error = (
+                            detail or f"Agent timed out after {self._timeout}s"
+                        )
                         logger.error(self._error)
                 finally:
                     if cfg.oracle_access:

--- a/tests/test_trial_agent_timeout_verify.py
+++ b/tests/test_trial_agent_timeout_verify.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+
+import pytest
+
+from benchflow.models import RunResult
+from benchflow.trial import Scene, Trial, TrialConfig
+
+
+@pytest.mark.asyncio
+async def test_agent_timeout_without_verifier_reward_counts_as_zero(
+    tmp_path: Path, monkeypatch
+):
+    """Guards the 2026-05-05 agent-timeout reward fallback fix."""
+    cfg = TrialConfig(
+        task_path=tmp_path / "task",
+        scenes=[Scene.single(agent="dummy")],
+    )
+    trial = Trial(cfg)
+    calls: list[str] = []
+
+    async def setup():
+        calls.append("setup")
+        trial._trial_dir = tmp_path / "trial"
+        trial._trial_dir.mkdir()
+        trial._trial_name = "trial-1"
+
+    async def start():
+        calls.append("start")
+
+    async def install_agent():
+        calls.append("install_agent")
+
+    async def run_scene(_scene):
+        calls.append("run_scene")
+        raise TimeoutError("Agent prompt exceeded wall-clock budget 5s")
+
+    async def verify():
+        calls.append("verify")
+        trial._rewards = None
+        trial._verifier_error = "verifier crashed: No reward file found"
+        return trial._rewards
+
+    async def cleanup():
+        calls.append("cleanup")
+
+    def build_result():
+        calls.append("build_result")
+        return RunResult(
+            task_name="task",
+            trial_name=trial._trial_name or "",
+            rewards=trial._rewards,
+            error=trial._error,
+            verifier_error=trial._verifier_error,
+        )
+
+    monkeypatch.setattr(trial, "setup", setup)
+    monkeypatch.setattr(trial, "start", start)
+    monkeypatch.setattr(trial, "install_agent", install_agent)
+    monkeypatch.setattr(trial, "_run_scene", run_scene)
+    monkeypatch.setattr(trial, "verify", verify)
+    monkeypatch.setattr(trial, "cleanup", cleanup)
+    monkeypatch.setattr(trial, "_build_result", build_result)
+
+    result = await trial.run()
+
+    assert calls == [
+        "setup",
+        "start",
+        "install_agent",
+        "run_scene",
+        "verify",
+        "cleanup",
+        "build_result",
+    ]
+    assert result.error == "Agent prompt exceeded wall-clock budget 5s"
+    assert result.rewards == {"reward": 0.0}
+    assert result.verifier_error is None


### PR DESCRIPTION
## What changed

- Catch agent execution `TimeoutError` inside `Trial.run()` after agent installation, record the timeout error, and continue into the normal verifier path.
- When an agent timed out and the verifier produces no rewards, finalize the trial with `{"reward": 0.0}` and clear the verifier error so the run counts as a failed task rather than an errored verifier task.
- Added a focused regression test for the timed-out-agent/no-reward verifier path.

## Why

BenchFlow previously skipped the final reward verification path when the agent run itself timed out. After preserving verifier execution, a timed-out agent can still leave no reward file for the verifier to read; that should be a zero reward for the agent, not a verifier error that drops the reward field.

## Validation

- `PYTHONPATH=/tmp/benchflow-agent-timeout-pr/src /Users/yimin/work/benchflow/.venv/bin/python -m pytest tests/test_trial_agent_timeout_verify.py -q`
- `PYTHONPATH=/tmp/benchflow-agent-timeout-pr/src /Users/yimin/work/benchflow/.venv/bin/python -m pytest tests/test_trial_agent_timeout_verify.py tests/test_job.py tests/test_verify.py -q`
- `PYTHONPATH=/tmp/benchflow-agent-timeout-pr/src /Users/yimin/work/benchflow/.venv/bin/python -m pytest tests/test_user.py tests/test_runtime.py -q`
- `/Users/yimin/work/benchflow/.venv/bin/python -m ruff check src/benchflow/trial.py tests/test_trial_agent_timeout_verify.py`
- Live smoke: `citation-check` copied to `/tmp/benchflow-citation-check-timeout10` with `agent.timeout_sec = 10.0`, run with `claude/haiku45`; result had `error = "Agent prompt exceeded wall-clock budget 10s"`, `rewards = {"reward": 0.0}`, and `verifier_error = null`.
