### PR TITLE
[codex] Guard ACP transports against JSON scalar logs

### DIFF
--- a/src/benchflow/acp/container_transport.py
+++ b/src/benchflow/acp/container_transport.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from benchflow.process import LiveProcess
 
-from .transport import Transport
+from .transport import Transport, decode_json_rpc_message
 
 logger = logging.getLogger(__name__)
 
@@ -60,15 +60,14 @@ class ContainerTransport(Transport):
             text = line.decode(errors="replace").strip()
             if not text:
                 continue
-            try:
-                return json.loads(text)
-            except json.JSONDecodeError:
-                # Capture non-JSON output (agent debug logs, errors, warnings)
-                if self._agent_log_file:
-                    self._agent_log_file.write(text + "\n")
-                    self._agent_log_file.flush()
-                logger.debug(f"Non-JSON from container agent: {text[:200]}")
-                continue
+            message = decode_json_rpc_message(text)
+            if message is not None:
+                return message
+            # Capture non-protocol output (agent debug logs, errors, warnings).
+            if self._agent_log_file:
+                self._agent_log_file.write(text + "\n")
+                self._agent_log_file.flush()
+            logger.debug(f"Non-JSON-RPC from container agent: {text[:200]}")
 
     async def close(self) -> None:
         """Terminate the agent process."""

--- a/src/benchflow/acp/transport.py
+++ b/src/benchflow/acp/transport.py
@@ -11,6 +11,21 @@ from benchflow.process import drain_oversized_line
 logger = logging.getLogger(__name__)
 
 
+def decode_json_rpc_message(text: str) -> dict[str, Any] | None:
+    """Decode one JSON-RPC message line.
+
+    ACP transports are line-delimited JSON, but the protocol message itself
+    must be a JSON object. Some agents write JSON-encoded log scalars to
+    stdout; treat those like non-protocol output instead of returning them to
+    the client.
+    """
+    try:
+        message = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return message if isinstance(message, dict) else None
+
+
 class Transport(ABC):
     """Base class for ACP transports."""
 
@@ -90,11 +105,10 @@ class StdioTransport(Transport):
             text = line.decode().strip()
             if not text:
                 continue
-            try:
-                return json.loads(text)
-            except json.JSONDecodeError:
-                logger.debug(f"Non-JSON line from agent: {text}")
-                continue
+            message = decode_json_rpc_message(text)
+            if message is not None:
+                return message
+            logger.debug(f"Non-JSON-RPC line from agent: {text[:200]}")
 
     async def close(self) -> None:
         if self._process:

--- a/src/benchflow/acp/transport.py
+++ b/src/benchflow/acp/transport.py
@@ -15,7 +15,7 @@ def decode_json_rpc_message(text: str) -> dict[str, Any] | None:
     """Decode one JSON-RPC message line.
 
     ACP transports are line-delimited JSON, but the protocol message itself
-    must be a JSON object. Some agents write JSON-encoded log scalars to
+    must be a JSON-RPC 2.0 object. Some agents write JSON-encoded logs to
     stdout; treat those like non-protocol output instead of returning them to
     the client.
     """
@@ -23,7 +23,18 @@ def decode_json_rpc_message(text: str) -> dict[str, Any] | None:
         message = json.loads(text)
     except json.JSONDecodeError:
         return None
-    return message if isinstance(message, dict) else None
+    if not isinstance(message, dict) or message.get("jsonrpc") != "2.0":
+        return None
+
+    has_result = "result" in message
+    has_error = "error" in message
+    if "method" in message:
+        if isinstance(message["method"], str) and not has_result and not has_error:
+            return message
+        return None
+    if "id" in message and has_result != has_error:
+        return message
+    return None
 
 
 class Transport(ABC):

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -266,6 +266,7 @@ class TestTransportProtocolFiltering:
 
     @pytest.mark.asyncio
     async def test_stdio_transport_skips_json_scalars(self) -> None:
+        """Guards PR #236 against treating JSON scalars as ACP responses."""
         reader = asyncio.StreamReader()
         reader.feed_data(b'"debug string from agent"\n')
         reader.feed_data(b'["debug", "list"]\n')
@@ -284,6 +285,7 @@ class TestTransportProtocolFiltering:
 
     @pytest.mark.asyncio
     async def test_container_transport_skips_json_scalars(self, tmp_path) -> None:
+        """Guards PR #236 against treating JSON scalars as ACP responses."""
         fake_process = AsyncMock()
         fake_process.readline = AsyncMock(
             side_effect=[

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from benchflow.acp.client import ACPClient, ACPError
+from benchflow.acp.container_transport import ContainerTransport
 from benchflow.acp.session import ACPSession
 from benchflow.acp.transport import StdioTransport
 from benchflow.acp.types import StopReason, ToolCallStatus
@@ -258,6 +259,56 @@ class TestStdioTransportOversizedLine:
         finally:
             await feeder
         assert msg == {"ok": True}
+
+
+class TestTransportProtocolFiltering:
+    """Transports skip JSON-encoded log scalars and wait for JSON-RPC objects."""
+
+    @pytest.mark.asyncio
+    async def test_stdio_transport_skips_json_scalars(self) -> None:
+        reader = asyncio.StreamReader()
+        reader.feed_data(b'"debug string from agent"\n')
+        reader.feed_data(b'["debug", "list"]\n')
+        reader.feed_data(b"123\n")
+        reader.feed_data(b'{"jsonrpc": "2.0", "id": 1, "result": {"ok": true}}\n')
+        reader.feed_eof()
+
+        transport = StdioTransport(sys.executable, [])
+        fake_process = MagicMock()
+        fake_process.stdout = reader
+        fake_process.stdin = MagicMock()
+        transport._process = fake_process
+
+        msg = await asyncio.wait_for(transport.receive(), timeout=5)
+        assert msg == {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
+
+    @pytest.mark.asyncio
+    async def test_container_transport_skips_json_scalars(self, tmp_path) -> None:
+        fake_process = AsyncMock()
+        fake_process.readline = AsyncMock(
+            side_effect=[
+                b'"debug string from agent"\n',
+                b'["debug", "list"]\n',
+                b'{"jsonrpc": "2.0", "id": 2, "result": {"ok": true}}\n',
+            ]
+        )
+        agent_log = tmp_path / "agent.log"
+        transport = ContainerTransport(
+            container_process=fake_process,
+            command="agent acp",
+            agent_log_path=agent_log,
+        )
+
+        await transport.start()
+        try:
+            msg = await asyncio.wait_for(transport.receive(), timeout=5)
+        finally:
+            await transport.close()
+
+        assert msg == {"jsonrpc": "2.0", "id": 2, "result": {"ok": True}}
+        log_text = agent_log.read_text()
+        assert '"debug string from agent"' in log_text
+        assert '["debug", "list"]' in log_text
 
 
 class TestACPInterleaving:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -222,12 +222,12 @@ class TestStdioTransportOversizedLine:
 
     @pytest.mark.asyncio
     async def test_stdio_transport_drain_oversized_line(self) -> None:
-        """Oversized line on stdout is skipped; following valid JSON returns normally.
+        """Oversized line on stdout is skipped; following JSON-RPC returns normally.
 
         Feeds the oversized chunk first, lets receive() hit LimitOverrunError and
         call drain_oversized_line (which clears the buffer), then feeds the next
-        valid JSON line so readline() can find it. This matches the real ordering
-        (stdin -> drain -> next line) that a live process would produce.
+        valid JSON-RPC line so readline() can find it. This matches the real
+        ordering (stdin -> drain -> next line) that a live process would produce.
         """
         limit = 64
         reader = asyncio.StreamReader(limit=limit)
@@ -246,11 +246,11 @@ class TestStdioTransportOversizedLine:
             # drain_oversized_line clears the buffer and consumes up to the
             # next \n (the oversized newline was flushed with the clear), so
             # we feed a dummy newline to satisfy drain's readuntil, then the
-            # real JSON line that receive() should return.
+            # real JSON-RPC line that receive() should return.
             await asyncio.sleep(0.05)
             reader.feed_data(b"\n")
             await asyncio.sleep(0.05)
-            reader.feed_data(b'{"ok": true}\n')
+            reader.feed_data(b'{"jsonrpc": "2.0", "id": 1, "result": {"ok": true}}\n')
             reader.feed_eof()
 
         feeder = asyncio.create_task(feed_valid_later())
@@ -258,7 +258,7 @@ class TestStdioTransportOversizedLine:
             msg = await asyncio.wait_for(transport.receive(), timeout=5)
         finally:
             await feeder
-        assert msg == {"ok": True}
+        assert msg == {"jsonrpc": "2.0", "id": 1, "result": {"ok": True}}
 
 
 class TestTransportProtocolFiltering:
@@ -309,6 +309,54 @@ class TestTransportProtocolFiltering:
         log_text = agent_log.read_text()
         assert '"debug string from agent"' in log_text
         assert '["debug", "list"]' in log_text
+
+    @pytest.mark.asyncio
+    async def test_stdio_transport_skips_structured_json_logs(self) -> None:
+        """Guards PR #236 against treating JSON object logs as ACP responses."""
+        reader = asyncio.StreamReader()
+        reader.feed_data(b'{"id": 100001, "level": "info", "message": "startup"}\n')
+        reader.feed_data(b'{"jsonrpc": "2.0", "id": 100001, "result": {"ok": true}}\n')
+        reader.feed_eof()
+
+        transport = StdioTransport(sys.executable, [])
+        fake_process = MagicMock()
+        fake_process.stdout = reader
+        fake_process.stdin = MagicMock()
+        transport._process = fake_process
+        client = ACPClient(transport)
+
+        result = await asyncio.wait_for(client._read_until_response(100001), timeout=5)
+        assert result == {"ok": True}
+
+    @pytest.mark.asyncio
+    async def test_container_transport_logs_structured_json_logs(
+        self, tmp_path
+    ) -> None:
+        """Guards PR #236 against treating JSON object logs as ACP responses."""
+        fake_process = AsyncMock()
+        fake_process.readline = AsyncMock(
+            side_effect=[
+                b'{"id": 2, "level": "info", "message": "startup"}\n',
+                b'{"jsonrpc": "2.0", "id": 2, "result": {"ok": true}}\n',
+            ]
+        )
+        agent_log = tmp_path / "agent.log"
+        transport = ContainerTransport(
+            container_process=fake_process,
+            command="agent acp",
+            agent_log_path=agent_log,
+        )
+
+        await transport.start()
+        try:
+            msg = await asyncio.wait_for(transport.receive(), timeout=5)
+        finally:
+            await transport.close()
+
+        assert msg == {"jsonrpc": "2.0", "id": 2, "result": {"ok": True}}
+        assert '{"id": 2, "level": "info", "message": "startup"}' in (
+            agent_log.read_text()
+        )
 
 
 class TestACPInterleaving:


### PR DESCRIPTION
## Summary

- Treat only valid JSON-RPC 2.0 envelopes as ACP protocol messages in stdio and container transports.
- Skip JSON-encoded scalars, lists, and structured non-protocol objects as agent log output instead of passing them to `ACPClient`.
- Add regression coverage for both `StdioTransport` and `ContainerTransport`.

## Root Cause

Some ACP agents can write JSON-encoded logs to stdout while BenchFlow is waiting for a JSON-RPC response. The transports parsed those lines with `json.loads(...)` and returned parsed Python values without validating the JSON-RPC envelope. Scalars crashed `ACPClient._read_until_response()` at `msg.get(...)`; structured JSON object logs could also be misclassified as responses when their `id` matched the pending request.

## Validation

- `uv run --extra dev pytest tests/test_acp.py`
- `uv run --extra dev ruff check src/benchflow/acp/transport.py src/benchflow/acp/container_transport.py tests/test_acp.py`
- `uv run --extra dev ruff format --check src/benchflow/acp/transport.py src/benchflow/acp/container_transport.py tests/test_acp.py`
- `git diff --check`