### PR TITLE
fix: shell injection in scene outbox file handling

### DIFF
--- a/src/benchflow/_scene.py
+++ b/src/benchflow/_scene.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import json
 import logging
+import shlex
 import uuid
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -190,7 +191,8 @@ class Scene:
         ]
         messages = []
         for fpath in files:
-            cat_result = await env.exec(f"cat {fpath}")
+            qpath = shlex.quote(fpath)
+            cat_result = await env.exec(f"cat {qpath}")
             try:
                 data = json.loads(cat_result.stdout or "{}")
                 recipient = data.get("to", "")
@@ -212,7 +214,7 @@ class Scene:
                     messages.append(msg)
             except json.JSONDecodeError:
                 logger.warning(f"[Scene] invalid JSON in outbox file: {fpath}")
-            await env.exec(f"rm -f {fpath}")
+            await env.exec(f"rm -f {qpath}")
         return messages
 
     # ------------------------------------------------------------------

--- a/src/benchflow/_snapshot.py
+++ b/src/benchflow/_snapshot.py
@@ -13,6 +13,8 @@ filesystem approach covers the rewind use case and is provable now.
 """
 
 import logging
+import shlex
+import re as _re
 from pathlib import PurePosixPath
 
 logger = logging.getLogger(__name__)
@@ -26,16 +28,14 @@ async def snapshot(env, name: str, workspace: str = "/app") -> str:
     Returns a reference string suitable for restore() and for recording
     in trial metadata / rewards.jsonl.
     """
-    import re
-
-    if not re.match(r"^[a-zA-Z0-9_-]+$", name):
+    if not _re.match(r"^[a-zA-Z0-9_-]+$", name):
         raise ValueError(
             f"Snapshot name must be alphanumeric/dash/underscore, got: {name!r}"
         )
     await env.exec(f"mkdir -p {_SNAP_DIR}")
     snap_path = f"{_SNAP_DIR}/{name}.tar.gz"
     result = await env.exec(
-        f"tar czf {snap_path} -C {workspace} .",
+        f"tar czf {shlex.quote(snap_path)} -C {shlex.quote(workspace)} .",
         timeout_sec=120,
     )
     if result.return_code != 0:
@@ -54,12 +54,17 @@ async def restore(env, ref: str, workspace: str = "/app") -> None:
     if len(parts) != 3 or parts[0] != "fs":
         raise ValueError(f"invalid snapshot ref: {ref}")
     snap_path = parts[2]
-    check = await env.exec(f"test -f {snap_path} && echo ok || echo missing")
+    # Validate snap_path: must be under _SNAP_DIR and a .tar.gz file
+    if not snap_path.startswith(_SNAP_DIR + "/") or not snap_path.endswith(".tar.gz"):
+        raise ValueError(f"invalid snapshot ref: path must be under {_SNAP_DIR}")
+    if ".." in snap_path.split("/"):
+        raise ValueError("invalid snapshot ref: path traversal not allowed")
+    check = await env.exec(f"test -f {shlex.quote(snap_path)} && echo ok || echo missing")
     if "missing" in (check.stdout or ""):
         raise FileNotFoundError(f"snapshot not found: {snap_path}")
     result = await env.exec(
-        f"rm -rf {workspace}/* {workspace}/.[!.]* 2>/dev/null; "
-        f"tar xzf {snap_path} -C {workspace}",
+        f"rm -rf {shlex.quote(workspace)}/* {shlex.quote(workspace)}/.[!.]* 2>/dev/null; "
+        f"tar xzf {shlex.quote(snap_path)} -C {shlex.quote(workspace)}",
         timeout_sec=120,
     )
     if result.return_code != 0:


### PR DESCRIPTION
Agent-controlled filenames from /app/.outbox/ were interpolated into
shell commands (cat/rm) without quoting. A sandboxed agent could create
a file like `x$(evil).json` to inject arbitrary commands running as root
inside the container.

The _read_outbox method lists .json files in the outbox, then runs
`cat {fpath}` and `rm -f {fpath}` where fpath comes from ls output.
Since the agent writes these files, it controls the filenames.

Fix: use shlex.quote() on the file path before interpolation.

Impact: privilege escalation from sandbox_user to root inside the
container during multi-agent scene execution.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->