### PR TITLE
fix: prevent TypeError in metrics collect_metrics when reward is None

### DIFF
--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -166,6 +166,16 @@ class BenchmarkMetrics:
         }
 
 
+def _safe_reward(rewards: dict) -> float:
+    """Extract reward value from a rewards dict, defaulting to 0 if None/missing.
+
+    Prevents TypeError when comparing reward values where one is None
+    (e.g. rewards={"reward": None, "rubric": [...]}).
+    """
+    val = rewards.get("reward")
+    return val if isinstance(val, (int, float)) else 0.0
+
+
 def collect_metrics(
     results_dir: str | Path,
     benchmark: str = "",
@@ -190,8 +200,8 @@ def collect_metrics(
                 or (
                     r.get("rewards")
                     and best[task].get("rewards")
-                    and r["rewards"].get("reward", 0)
-                    > best[task]["rewards"].get("reward", 0)
+                    and _safe_reward(r["rewards"])
+                    > _safe_reward(best[task]["rewards"])
                 )
             ):
                 best[task] = r


### PR DESCRIPTION
collect_metrics picks the best result per task across retries by comparing reward values. When a verifier returns `rewards={"reward": None, "rubric": [...]}` (a truthy dict with a None reward), the comparison `float > None` raises `TypeError`.

This can happen when a rubric verifier returns partial results — individual items pass but the overall reward is unresolved.

Fix: add `_safe_reward()` helper that normalizes None/missing reward values to 0.0 before comparison.

Repro:
```python
# First attempt: rewards with None reward (rubric verifier partial result)
# Second attempt: rewards with 0.5 reward
# Comparison: 0.5 > None → TypeError!
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/243" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->