### PR TITLE
fix: prevent double-count assertion crash when agent timeout overlaps verifier error

### DIFF
--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -637,9 +637,12 @@ class Job:
                 1
                 for r in all_results.values()
                 if r.get("error") and r.get("rewards") is None
+                and not r.get("verifier_error")
             ),
             verifier_errored=sum(
-                1 for r in all_results.values() if r.get("verifier_error")
+                1
+                for r in all_results.values()
+                if r.get("verifier_error")
             ),
             elapsed_sec=elapsed,
         )


### PR DESCRIPTION
When an agent times out AND the verifier also fails, the resulting RunResult has both `error` (agent timeout) and `verifier_error` set with `rewards=None`.

The counting logic classified this task as BOTH `errored` and `verifier_errored`, causing the `passed + failed + errored + verifier_errored == total` assertion to crash the entire job.

This happens because `run()` in trial.py catches the agent TimeoutError, sets `agent_timed_out=True` and `self._error`, then continues to `verify()`. If the verifier also fails, `self._verifier_error` gets set. The timeout reward override (`rewards = {"reward": 0.0}`) only triggers when `_rewards is None` after verify — but if verify set `verifier_error` and left rewards as None, the override fires... except it still has verifier_error set.

Fix: exclude verifier_errored tasks from the errored count so each task is counted exactly once.

Repro scenario:
```
Trial: agent timeout → error="Agent timed out after 300s" → verify() → verifier crashes → verifier_error="verifier crashed: exit code 1" → rewards remains None
Result: error + verifier_error + rewards=None → double-counted → assertion crash
```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->