### PR TITLE
fix: copy eval requirements.txt into Docker build context

### DIFF
--- a/src/benchflow/skill_eval.py
+++ b/src/benchflow/skill_eval.py
@@ -272,6 +272,11 @@ def generate_tasks(
                 ignore=shutil.ignore_patterns("evals", "__pycache__", ".git"),
             )
 
+        # Copy eval requirements.txt into build context so Docker COPY can find it
+        eval_reqs = dataset.skill_dir / "evals" / "requirements.txt"
+        if eval_reqs.exists():
+            shutil.copy2(eval_reqs, env_dir / "requirements.txt")
+
         # tests/
         tests_dir = task_dir / "tests"
         tests_dir.mkdir(exist_ok=True)


### PR DESCRIPTION
_default_dockerfile generates `COPY requirements.txt /tmp/requirements.txt` when a skill has `evals/requirements.txt`. However, this file lives at `skill_dir/evals/requirements.txt`, which is outside the Docker build context (`task_dir/environment/`). The `evals/` directory is also explicitly excluded from the skills `copytree` via `shutil.ignore_patterns("evals", ...)`.

This causes `docker build` to fail with:
```
COPY failed: file not found in build context: requirements.txt
```

Fix: copy `evals/requirements.txt` into the environment directory during task generation so the Dockerfile COPY can find it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/245" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->