### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use benchflow in your research, please cite it as below."
+title: "benchflow: Multi-turn agent benchmarking with ACP"
+abstract: "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
+type: software
+authors:
+  - name: "BenchFlow team"
+    website: "https://github.com/benchflow-ai/benchflow"
+repository-code: "https://github.com/benchflow-ai/benchflow"
+url: "https://github.com/benchflow-ai/benchflow"
+license: Apache-2.0
+version: 0.3.2
+keywords:
+  - benchmark
+  - llm-agents
+  - acp
+  - agent-evaluation
+  - multi-turn
+  - terminal-bench
+  - skillsbench

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use benchflow in your research, please cite it as below."
-title: "benchflow: Multi-turn agent benchmarking with ACP"
-abstract: "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
+title: "BenchFlow: framework for RL environments for LLM agents"
+abstract: "BenchFlow is a framework for building RL environments to evaluate and train LLM agents. Built on the Agent Client Protocol (ACP), it provides Scene-based multi-turn, multi-agent, and multi-model evaluation in shared sandboxes — without Docker Compose or sidecar containers. Supported use cases include interactive user simulation, code-review loops, bring-your-own-skill (BYOS) skill generation, multi-turn iterative refinement, cross-model review (cheap coder + strong reviewer), and stateful service tasks against live mock APIs (Gmail, Calendar, Docs, Drive, Slack). See docs/use-cases.md."
 type: software
 authors:
   - name: "BenchFlow team"


### PR DESCRIPTION
## Summary
- Add `CITATION.cff` so GitHub renders a "Cite this repository" button.
- Author set to BenchFlow team; license Apache-2.0; version pinned to latest tag `v0.3.2`.

## Test plan
- [x] File parses as valid CFF (standard schema, cff-version 1.2.0)
- [ ] Verify GitHub shows the "Cite this repository" widget after merge
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/246" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->