### PR TITLE
Add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# benchflow
+
+Multi-turn agent benchmarking with ACP. See `CLAUDE.md` for conventions and `README.md` for full documentation.
+
+## Cursor Cloud specific instructions
+
+### Quick reference
+
+All standard commands are in `CLAUDE.md`:
+```bash
+uv sync --extra dev --locked
+uv run python -m pytest tests/
+uv run ty check src/
+uv run ruff check .
+```
+
+### Notes for cloud agents
+
+- **Python 3.12+ required.** The VM ships with 3.12; do not downgrade.
+- **`uv` must be on PATH.** The update script installs it to `~/.local/bin`. If a shell session doesn't find `uv`, run `export PATH="$HOME/.local/bin:$PATH"`.
+- **Tests skip live tests by default.** `pyproject.toml` sets `addopts = "-m 'not live'"`. Tests marked `@pytest.mark.live` require Docker and a real API key (e.g. `ANTHROPIC_API_KEY`). The default `pytest` run (811+ tests) uses only mocks.
+- **Running actual benchmarks** (`bench run`, `bench eval create`) requires Docker and at least one LLM API key. These are not needed for lint/test/type-check workflows.
+- **CLI entry points:** both `bench` and `benchflow` are registered as console scripts. Use `uv run bench <subcommand>`.
+- **Task validation:** `bench tasks check <dir>` validates task structure (needs `task.toml`). `bench tasks init <name>` scaffolds a new task.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section to help future cloud agents quickly orient in this codebase.

### What's in it
- Quick reference to the standard commands from `CLAUDE.md`
- Notes on Python version, `uv` PATH, test markers (`live` vs default), Docker/API key requirements, and CLI entry points

### Environment verification

All checks pass on a fresh VM with Python 3.12 and `uv`:

| Check | Command | Result |
|-------|---------|--------|
| Lint | `uv run ruff check .` | All checks passed |
| Type check | `uv run ty check src/` | All checks passed |
| Tests | `uv run python -m pytest tests/` | 811 passed, 1 skipped |
| CLI | `bench --help`, `bench agent list`, `bench tasks check`, `bench eval list` | All working |
| SDK import | `import benchflow` | v0.3.3.dev0 |

[pytest_output.log](https://cursor.com/agents/bc-0ed35aa5-25ff-42b8-9dc7-48819d20788f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpytest_output.log)
[cli_and_lint_output.log](https://cursor.com/agents/bc-0ed35aa5-25ff-42b8-9dc7-48819d20788f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_and_lint_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0ed35aa5-25ff-42b8-9dc7-48819d20788f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0ed35aa5-25ff-42b8-9dc7-48819d20788f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

