### PR TITLE
Add file-driven SkillsBench E2E integration tests

### DIFF
--- a/benchmarks/scripts/skillsbench_e2e_audit.py
+++ b/benchmarks/scripts/skillsbench_e2e_audit.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Re-run deterministic SkillsBench E2E audits on an existing output directory.
+
+Usage:
+    python benchmarks/scripts/skillsbench_e2e_audit.py jobs/skillsbench-e2e/<run-id>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SRC_ROOT = REPO_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(SRC_ROOT))
+
+def main() -> int:
+    from benchflow.integration.artifact_audit import write_artifact_audit
+    from benchflow.integration.audit_agent import write_audit_outputs
+    from benchflow.integration.parity import write_parity_report
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_dir", type=Path)
+    parser.add_argument("--baseline-dir", type=Path)
+    parser.add_argument(
+        "--audit-prompt",
+        type=Path,
+        default=REPO_ROOT
+        / "tasks"
+        / "skillsbench-e2e"
+        / "audit"
+        / "trajectory-result-auditor.md",
+    )
+    args = parser.parse_args()
+
+    run_dir = args.run_dir
+    if not run_dir.exists():
+        parser.error(f"run_dir does not exist: {run_dir}")
+
+    artifact = write_artifact_audit(run_dir)
+    parity = write_parity_report(run_dir, args.baseline_dir)
+    findings = write_audit_outputs(run_dir, args.audit_prompt)
+
+    print(
+        json.dumps(
+            {
+                "run_dir": str(run_dir),
+                "artifact_ok": artifact["ok"],
+                "artifact_errors": artifact["error_count"],
+                "artifact_warnings": artifact["warning_count"],
+                "current_results": parity["current_count"],
+                "baseline_results": parity["baseline_count"],
+                "failed_entries": findings["failed_entries"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -78,6 +78,9 @@ accepts a single task directory.
 # From YAML config
 bench eval create -f benchmarks/skillsbench-claude-glm51.yaml
 
+# File-driven SkillsBench E2E matrix (dry run; no sandboxes)
+bench eval create -f tasks/skillsbench-e2e/e2e.yaml --dry-run
+
 # From remote repo
 bench eval create \
   --source-repo benchflow-ai/skillsbench \
@@ -107,6 +110,30 @@ bench eval create -t ./tasks -a gemini -m gemini-3.1-flash-lite-preview
 | `--sandbox-user` | `agent` | Sandbox user (null for root) |
 | `--sandbox-setup-timeout` | `120` | Timeout in seconds for sandbox user setup |
 | `--skills-dir`, `-s` | — | Skills directory to deploy into each task sandbox |
+| `--dry-run` | `false` | For supported file-driven E2E configs, build the matrix without running agents |
+
+### File-driven SkillsBench E2E configs
+
+BenchFlow includes a gated integration config for ENG-6:
+
+```bash
+bench eval create -f tasks/skillsbench-e2e/e2e.yaml --dry-run
+```
+
+The live run is intentionally not part of normal CI. It requires explicit
+credentials and runs 9 SkillsBench tasks across all registered agents on
+Daytona with `gemini-3.1-flash-lite-preview`:
+
+```bash
+export BENCHFLOW_RUN_SKILLSBENCH_E2E=1
+export DAYTONA_API_KEY=...
+export GEMINI_API_KEY=...
+bench eval create -f tasks/skillsbench-e2e/e2e.yaml
+```
+
+Outputs land under `jobs/skillsbench-e2e/<run-id>/` and include
+`matrix_summary.json`, `artifact_audit.json`, `parity_report.json`,
+`audit_findings.json`, and `findings.md`.
 
 ### bench eval list
 

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -266,6 +266,49 @@ Recorded parity results are in `parity_experiment.json` and `benchmark.yaml`.
 
 ---
 
+## Running the SkillsBench E2E matrix
+
+BenchFlow's own ENG-6 E2E check is file-driven through the normal eval CLI:
+
+```bash
+bench eval create -f tasks/skillsbench-e2e/e2e.yaml --dry-run
+```
+
+The dry run validates the configured 9-task × all-agent matrix and writes a
+planned output bundle without creating sandboxes.
+
+The live run is intentionally gated and should not run on every commit:
+
+```bash
+export BENCHFLOW_RUN_SKILLSBENCH_E2E=1
+export DAYTONA_API_KEY=...
+export GEMINI_API_KEY=...
+bench eval create -f tasks/skillsbench-e2e/e2e.yaml
+```
+
+It runs the selected SkillsBench tasks across all registered BenchFlow agents
+with `gemini-3.1-flash-lite-preview`, Daytona backend, concurrency 30, and no
+skills. Agents that cannot run that Gemini model are recorded as findings rather
+than hidden.
+
+Each run writes:
+
+- `matrix_config.json`
+- `matrix_summary.json`
+- `artifact_audit.json`
+- `parity_report.json`
+- `audit_findings.json`
+- `findings.md`
+- `audit_agent_prompt.md`
+
+To re-run deterministic audits on an existing output directory:
+
+```bash
+python benchmarks/scripts/skillsbench_e2e_audit.py jobs/skillsbench-e2e/<run-id>
+```
+
+---
+
 ## YAML config reference
 
 Job configs use the two-field `source` pattern to reference remote benchmark repos:

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -307,6 +307,12 @@ To re-run deterministic audits on an existing output directory:
 python benchmarks/scripts/skillsbench_e2e_audit.py jobs/skillsbench-e2e/<run-id>
 ```
 
+The config also supports an optional post-processing audit agent. Set
+`audit.audit_agent.enabled: true` in `tasks/skillsbench-e2e/e2e.yaml` to create
+an internal audit task from `audit/trajectory-result-auditor.md`; BenchFlow will
+run the configured audit agent after deterministic scripts finish and write
+`audit_agent_result.json`.
+
 ---
 
 ## YAML config reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,8 @@ addopts = "-m 'not live'"
 testpaths = ["tests"]
 markers = [
     "live: requires real Anthropic API and Docker daemon (run with -m live)",
+    "integration: larger integration tests",
+    "e2e: end-to-end benchmark/backend tests",
 ]
 
 [tool.ruff]

--- a/src/benchflow/_agent_env.py
+++ b/src/benchflow/_agent_env.py
@@ -62,6 +62,7 @@ def auto_inherit_env(agent_env: dict[str, str]) -> None:
         "ANTHROPIC_AUTH_TOKEN",
         "CLAUDE_CODE_OAUTH_TOKEN",
         "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
         "GOOGLE_API_KEY",
         "GEMINI_API_KEY",
         "GOOGLE_GENERATIVE_AI_API_KEY",
@@ -69,6 +70,8 @@ def auto_inherit_env(agent_env: dict[str, str]) -> None:
         "GOOGLE_CLOUD_LOCATION",
         "LLM_API_KEY",
         "LLM_BASE_URL",
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "BENCHFLOW_PROVIDER_API_KEY",
     }
     for cfg in PROVIDERS.values():
         if cfg.auth_env:

--- a/src/benchflow/_agent_setup.py
+++ b/src/benchflow/_agent_setup.py
@@ -243,6 +243,7 @@ async def deploy_skills(
                 logger.warning(f"Skills dir not found: {skills_path}")
         else:
             logger.info("Skills already injected via Dockerfile")
+            effective_skills = "/skills"
 
     # Distribute to agent-specific discovery paths
     if agent_cfg is not None:

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -858,11 +858,29 @@ def eval_create(
             help="Disable web tools for the self-generated run",
         ),
     ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="For supported file-driven E2E configs, build the matrix without running agents.",
+        ),
+    ] = False,
 ) -> None:
     """Run an evaluation — single task or batch."""
     from benchflow.job import Job, JobConfig
 
     if config_file:
+        from benchflow.integration.skillsbench_e2e import is_skillsbench_e2e_config
+
+        if is_skillsbench_e2e_config(config_file):
+            from benchflow.integration.skillsbench_e2e import run_from_config_file
+
+            run_dir = asyncio.run(run_from_config_file(config_file, dry_run=dry_run))
+            console.print(f"[green]SkillsBench E2E output:[/green] {run_dir}")
+            return
+        if dry_run:
+            console.print("[red]--dry-run is only supported for E2E config files[/red]")
+            raise typer.Exit(1)
         j = Job.from_yaml(config_file)
         result = asyncio.run(j.run())
         console.print(

--- a/src/benchflow/integration/__init__.py
+++ b/src/benchflow/integration/__init__.py
@@ -1,0 +1,15 @@
+"""Integration/E2E helpers for BenchFlow's own benchmark validation."""
+
+from benchflow.integration.skillsbench_e2e import (
+    E2EConfig,
+    MatrixEntry,
+    is_skillsbench_e2e_config,
+    run_from_config_file,
+)
+
+__all__ = [
+    "E2EConfig",
+    "MatrixEntry",
+    "is_skillsbench_e2e_config",
+    "run_from_config_file",
+]

--- a/src/benchflow/integration/artifact_audit.py
+++ b/src/benchflow/integration/artifact_audit.py
@@ -64,13 +64,17 @@ def audit_trial_result(result_path: str | Path) -> dict[str, Any]:
             "task_name": None,
             "agent": None,
             "ok": False,
-            "issues": [{"severity": "error", "message": f"invalid result.json: {error}"}],
+            "issues": [
+                {"severity": "error", "message": f"invalid result.json: {error}"}
+            ],
             "files": {},
         }
 
     missing_fields = sorted(REQUIRED_RESULT_FIELDS - set(data))
     for field in missing_fields:
-        issues.append({"severity": "error", "message": f"missing result field: {field}"})
+        issues.append(
+            {"severity": "error", "message": f"missing result field: {field}"}
+        )
 
     files: dict[str, Any] = {}
     for rel in REQUIRED_SIBLINGS:
@@ -105,7 +109,9 @@ def audit_trial_result(result_path: str | Path) -> dict[str, Any]:
 
     timing = data.get("timing")
     if not isinstance(timing, dict):
-        issues.append({"severity": "error", "message": "result timing is not an object"})
+        issues.append(
+            {"severity": "error", "message": "result timing is not an object"}
+        )
     elif "total" not in timing:
         issues.append({"severity": "warning", "message": "timing.total missing"})
 
@@ -130,16 +136,10 @@ def audit_run(run_dir: str | Path) -> dict[str, Any]:
         if path.name == "result.json"
     ]
     error_count = sum(
-        1
-        for t in trials
-        for issue in t["issues"]
-        if issue.get("severity") == "error"
+        1 for t in trials for issue in t["issues"] if issue.get("severity") == "error"
     )
     warning_count = sum(
-        1
-        for t in trials
-        for issue in t["issues"]
-        if issue.get("severity") == "warning"
+        1 for t in trials for issue in t["issues"] if issue.get("severity") == "warning"
     )
     return {
         "run_dir": str(run_dir),

--- a/src/benchflow/integration/artifact_audit.py
+++ b/src/benchflow/integration/artifact_audit.py
@@ -1,0 +1,159 @@
+"""Deterministic artifact/schema audit for BenchFlow E2E runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+REQUIRED_RESULT_FIELDS = {
+    "task_name",
+    "trial_name",
+    "rewards",
+    "agent",
+    "agent_name",
+    "model",
+    "n_tool_calls",
+    "n_prompts",
+    "error",
+    "verifier_error",
+    "partial_trajectory",
+    "trajectory_source",
+    "started_at",
+    "finished_at",
+    "timing",
+}
+
+REQUIRED_SIBLINGS = ("config.json", "timing.json", "prompts.json")
+
+
+def _read_json(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        return json.loads(path.read_text()), None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def _jsonl_status(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"exists": False, "valid": False, "lines": 0, "error": "missing"}
+    if path.stat().st_size == 0:
+        return {"exists": True, "valid": True, "lines": 0, "error": None}
+    lines = 0
+    try:
+        for line in path.read_text().splitlines():
+            if line.strip():
+                json.loads(line)
+                lines += 1
+        return {"exists": True, "valid": True, "lines": lines, "error": None}
+    except Exception as exc:
+        return {"exists": True, "valid": False, "lines": lines, "error": str(exc)}
+
+
+def audit_trial_result(result_path: str | Path) -> dict[str, Any]:
+    """Audit one trial directory from its ``result.json`` path."""
+    result_path = Path(result_path)
+    trial_dir = result_path.parent
+    issues: list[dict[str, str]] = []
+
+    data, error = _read_json(result_path)
+    if data is None:
+        return {
+            "trial_dir": str(trial_dir),
+            "result_path": str(result_path),
+            "task_name": None,
+            "agent": None,
+            "ok": False,
+            "issues": [{"severity": "error", "message": f"invalid result.json: {error}"}],
+            "files": {},
+        }
+
+    missing_fields = sorted(REQUIRED_RESULT_FIELDS - set(data))
+    for field in missing_fields:
+        issues.append({"severity": "error", "message": f"missing result field: {field}"})
+
+    files: dict[str, Any] = {}
+    for rel in REQUIRED_SIBLINGS:
+        exists = (trial_dir / rel).exists()
+        files[rel] = {"exists": exists}
+        if not exists:
+            issues.append({"severity": "error", "message": f"missing file: {rel}"})
+
+    trajectory_path = trial_dir / "trajectory" / "acp_trajectory.jsonl"
+    files["trajectory/acp_trajectory.jsonl"] = _jsonl_status(trajectory_path)
+    if not files["trajectory/acp_trajectory.jsonl"]["exists"]:
+        issues.append(
+            {
+                "severity": "warning",
+                "message": "missing file: trajectory/acp_trajectory.jsonl",
+            }
+        )
+    elif not files["trajectory/acp_trajectory.jsonl"]["valid"]:
+        issues.append(
+            {
+                "severity": "error",
+                "message": "invalid JSONL: trajectory/acp_trajectory.jsonl",
+            }
+        )
+
+    install_log = trial_dir / "agent" / "install-stdout.txt"
+    files["agent/install-stdout.txt"] = {"exists": install_log.exists()}
+    if data.get("agent") != "oracle" and not install_log.exists():
+        issues.append(
+            {"severity": "warning", "message": "missing file: agent/install-stdout.txt"}
+        )
+
+    timing = data.get("timing")
+    if not isinstance(timing, dict):
+        issues.append({"severity": "error", "message": "result timing is not an object"})
+    elif "total" not in timing:
+        issues.append({"severity": "warning", "message": "timing.total missing"})
+
+    return {
+        "trial_dir": str(trial_dir),
+        "result_path": str(result_path),
+        "task_name": data.get("task_name"),
+        "agent": data.get("agent"),
+        "model": data.get("model"),
+        "ok": not any(i["severity"] == "error" for i in issues),
+        "issues": issues,
+        "files": files,
+    }
+
+
+def audit_run(run_dir: str | Path) -> dict[str, Any]:
+    """Audit every ``result.json`` under an E2E run directory."""
+    run_dir = Path(run_dir)
+    trials = [
+        audit_trial_result(path)
+        for path in sorted(run_dir.rglob("result.json"))
+        if path.name == "result.json"
+    ]
+    error_count = sum(
+        1
+        for t in trials
+        for issue in t["issues"]
+        if issue.get("severity") == "error"
+    )
+    warning_count = sum(
+        1
+        for t in trials
+        for issue in t["issues"]
+        if issue.get("severity") == "warning"
+    )
+    return {
+        "run_dir": str(run_dir),
+        "n_trials": len(trials),
+        "error_count": error_count,
+        "warning_count": warning_count,
+        "ok": error_count == 0,
+        "trials": trials,
+    }
+
+
+def write_artifact_audit(run_dir: str | Path) -> dict[str, Any]:
+    """Write ``artifact_audit.json`` into *run_dir* and return the report."""
+    run_dir = Path(run_dir)
+    report = audit_run(run_dir)
+    (run_dir / "artifact_audit.json").write_text(json.dumps(report, indent=2))
+    return report

--- a/src/benchflow/integration/audit_agent.py
+++ b/src/benchflow/integration/audit_agent.py
@@ -124,3 +124,68 @@ def write_audit_outputs(
             render_audit_prompt(run_dir, prompt_path)
         )
     return findings
+
+
+def create_audit_task(
+    run_dir: str | Path,
+    prompt_path: str | Path | None = None,
+) -> Path:
+    """Create a temporary BenchFlow task that asks an agent to audit outputs.
+
+    The task is intentionally generated inside the E2E run directory so it is
+    reproducible with the exact deterministic reports produced by that run.
+    The verifier only checks that the audit agent wrote a review file; the
+    deterministic scripts remain the source of truth for pass/fail.
+    """
+    run_dir = Path(run_dir)
+    prompt = render_audit_prompt(run_dir, prompt_path)
+    task_dir = run_dir / "_audit_task"
+    tests_dir = task_dir / "tests"
+    env_dir = task_dir / "environment"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    env_dir.mkdir(parents=True, exist_ok=True)
+
+    (task_dir / "task.toml").write_text(
+        """version = "1.0"
+
+[metadata]
+author_name = "benchflow"
+difficulty = "easy"
+category = "integration"
+tags = ["e2e", "audit"]
+
+[agent]
+timeout_sec = 900
+
+[verifier]
+timeout_sec = 60
+
+[environment]
+cpus = 1
+memory_mb = 2048
+"""
+    )
+    (task_dir / "instruction.md").write_text(
+        prompt
+        + "\n\nWrite your final audit report to `/app/audit_review.md` in Markdown.\n"
+    )
+    (env_dir / "Dockerfile").write_text(
+        """FROM ubuntu:24.04
+
+WORKDIR /app
+RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts
+"""
+    )
+    test_sh = tests_dir / "test.sh"
+    test_sh.write_text(
+        """#!/bin/bash
+set -e
+if [ -s /app/audit_review.md ]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi
+"""
+    )
+    test_sh.chmod(0o755)
+    return task_dir

--- a/src/benchflow/integration/audit_agent.py
+++ b/src/benchflow/integration/audit_agent.py
@@ -100,6 +100,7 @@ def render_audit_prompt(run_dir: str | Path, prompt_path: str | Path | None) -> 
         "artifact_audit": _load_json(run_dir / "artifact_audit.json"),
         "parity_report": _load_json(run_dir / "parity_report.json"),
         "deterministic_findings": _load_json(run_dir / "audit_findings.json"),
+        "sampled_artifacts": _sample_artifacts(run_dir),
     }
     return (
         f"{rubric.strip()}\n\n"
@@ -108,6 +109,37 @@ def render_audit_prompt(run_dir: str | Path, prompt_path: str | Path | None) -> 
         f"{json.dumps(bundle, indent=2)[:120000]}\n"
         "```\n"
     )
+
+
+def _sample_text(path: Path, limit: int = 4000) -> str:
+    try:
+        return path.read_text(errors="replace")[:limit]
+    except Exception as exc:
+        return f"<could not read {path}: {exc}>"
+
+
+def _sample_artifacts(run_dir: Path, max_trials: int = 8) -> list[dict[str, Any]]:
+    """Collect small result/log/trajectory excerpts for the audit-agent prompt."""
+    samples: list[dict[str, Any]] = []
+    for result_path in sorted(run_dir.rglob("result.json"))[:max_trials]:
+        trial_dir = result_path.parent
+        agent_logs = sorted((trial_dir / "agent").glob("*.txt"))
+        verifier_logs = sorted((trial_dir / "verifier").glob("*.txt"))
+        trajectory = trial_dir / "trajectory" / "acp_trajectory.jsonl"
+        samples.append(
+            {
+                "trial_dir": str(trial_dir),
+                "result_json": _load_json(result_path),
+                "agent_log_excerpt": _sample_text(agent_logs[0]) if agent_logs else "",
+                "verifier_log_excerpt": (
+                    _sample_text(verifier_logs[0]) if verifier_logs else ""
+                ),
+                "trajectory_excerpt": _sample_text(trajectory)
+                if trajectory.exists()
+                else "",
+            }
+        )
+    return samples
 
 
 def write_audit_outputs(

--- a/src/benchflow/integration/audit_agent.py
+++ b/src/benchflow/integration/audit_agent.py
@@ -20,7 +20,9 @@ def build_findings(run_dir: str | Path) -> dict[str, Any]:
     artifact = _load_json(run_dir / "artifact_audit.json")
     parity = _load_json(run_dir / "parity_report.json")
 
-    entries = matrix.get("entries", []) if isinstance(matrix.get("entries"), list) else []
+    entries = (
+        matrix.get("entries", []) if isinstance(matrix.get("entries"), list) else []
+    )
     failed_entries = [
         e
         for e in entries

--- a/src/benchflow/integration/audit_agent.py
+++ b/src/benchflow/integration/audit_agent.py
@@ -1,0 +1,126 @@
+"""Build deterministic findings and audit-agent prompt bundles for E2E runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def build_findings(run_dir: str | Path) -> dict[str, Any]:
+    """Create machine-readable findings from deterministic audit reports."""
+    run_dir = Path(run_dir)
+    matrix = _load_json(run_dir / "matrix_summary.json")
+    artifact = _load_json(run_dir / "artifact_audit.json")
+    parity = _load_json(run_dir / "parity_report.json")
+
+    entries = matrix.get("entries", []) if isinstance(matrix.get("entries"), list) else []
+    failed_entries = [
+        e
+        for e in entries
+        if e.get("status") not in {"completed", "passed", "failed", "planned"}
+        or e.get("error")
+    ]
+    gemini_compat = [
+        e
+        for e in failed_entries
+        if "gemini" in str(e.get("model", "")).lower()
+        and any(
+            token in str(e.get("error", "")).lower()
+            for token in ("model", "provider", "api key", "unsupported", "auth")
+        )
+    ]
+
+    missing_baselines = [
+        t.get("task_name")
+        for t in parity.get("tasks", [])
+        if isinstance(t, dict) and t.get("missing_baseline")
+    ]
+
+    return {
+        "run_dir": str(run_dir),
+        "total_entries": len(entries),
+        "failed_entries": len(failed_entries),
+        "gemini_compatibility_failures": gemini_compat,
+        "artifact_errors": artifact.get("error_count", 0),
+        "artifact_warnings": artifact.get("warning_count", 0),
+        "missing_baseline_tasks": sorted(t for t in missing_baselines if t),
+        "token_fields_present": parity.get("token_fields_present"),
+        "baseline_token_fields_present": parity.get("baseline_token_fields_present"),
+    }
+
+
+def render_findings_markdown(findings: dict[str, Any]) -> str:
+    """Render deterministic findings as Markdown."""
+    lines = [
+        "# SkillsBench E2E findings",
+        "",
+        f"- Run directory: `{findings.get('run_dir')}`",
+        f"- Matrix entries: {findings.get('total_entries', 0)}",
+        f"- Failed/problem entries: {findings.get('failed_entries', 0)}",
+        f"- Artifact errors: {findings.get('artifact_errors', 0)}",
+        f"- Artifact warnings: {findings.get('artifact_warnings', 0)}",
+        f"- Current token fields present: {findings.get('token_fields_present')}",
+        f"- Baseline token fields present: {findings.get('baseline_token_fields_present')}",
+        "",
+        "## Gemini compatibility failures",
+        "",
+    ]
+    compat = findings.get("gemini_compatibility_failures") or []
+    if compat:
+        lines.extend(
+            f"- `{e.get('agent')}` / `{e.get('task_name')}`: {e.get('error')}"
+            for e in compat
+        )
+    else:
+        lines.append("- None detected by deterministic rules.")
+
+    missing = findings.get("missing_baseline_tasks") or []
+    lines.extend(["", "## Missing baseline tasks", ""])
+    if missing:
+        lines.extend(f"- `{task}`" for task in missing)
+    else:
+        lines.append("- None.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_audit_prompt(run_dir: str | Path, prompt_path: str | Path | None) -> str:
+    """Render an audit-agent prompt bundle for a completed E2E output directory."""
+    run_dir = Path(run_dir)
+    rubric = Path(prompt_path).read_text() if prompt_path else ""
+    bundle = {
+        "matrix_summary": _load_json(run_dir / "matrix_summary.json"),
+        "artifact_audit": _load_json(run_dir / "artifact_audit.json"),
+        "parity_report": _load_json(run_dir / "parity_report.json"),
+        "deterministic_findings": _load_json(run_dir / "audit_findings.json"),
+    }
+    return (
+        f"{rubric.strip()}\n\n"
+        "## Output bundle JSON\n\n"
+        "```json\n"
+        f"{json.dumps(bundle, indent=2)[:120000]}\n"
+        "```\n"
+    )
+
+
+def write_audit_outputs(
+    run_dir: str | Path,
+    prompt_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Write deterministic findings, Markdown summary, and audit-agent prompt."""
+    run_dir = Path(run_dir)
+    findings = build_findings(run_dir)
+    (run_dir / "audit_findings.json").write_text(json.dumps(findings, indent=2))
+    (run_dir / "findings.md").write_text(render_findings_markdown(findings))
+    if prompt_path:
+        (run_dir / "audit_agent_prompt.md").write_text(
+            render_audit_prompt(run_dir, prompt_path)
+        )
+    return findings

--- a/src/benchflow/integration/parity.py
+++ b/src/benchflow/integration/parity.py
@@ -19,7 +19,9 @@ def _reward_from_mapping(rewards: Any) -> float | int | None:
     return None
 
 
-def normalize_result(data: dict[str, Any], *, path: str | None = None) -> dict[str, Any]:
+def normalize_result(
+    data: dict[str, Any], *, path: str | None = None
+) -> dict[str, Any]:
     """Normalize current BenchFlow and older SkillsBench trajectory result schemas."""
     # Current BenchFlow SDK._build_result schema.
     if "rewards" in data or "n_tool_calls" in data:
@@ -99,7 +101,9 @@ def collect_normalized_results(root: str | Path) -> list[dict[str, Any]]:
     records = []
     for path in sorted(root.rglob("result.json")):
         try:
-            records.append(normalize_result(json.loads(path.read_text()), path=str(path)))
+            records.append(
+                normalize_result(json.loads(path.read_text()), path=str(path))
+            )
         except Exception as exc:
             records.append(
                 {

--- a/src/benchflow/integration/parity.py
+++ b/src/benchflow/integration/parity.py
@@ -124,6 +124,7 @@ def _by_task(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
 def build_parity_report(
     run_dir: str | Path,
     baseline_dir: str | Path | None = None,
+    baseline_error: str | None = None,
 ) -> dict[str, Any]:
     """Build a broad parity report for current results and optional baselines."""
     run_dir = Path(run_dir)
@@ -159,6 +160,7 @@ def build_parity_report(
     return {
         "run_dir": str(run_dir),
         "baseline_dir": str(baseline_dir) if baseline_dir else None,
+        "baseline_error": baseline_error,
         "current_count": len(current),
         "baseline_count": len(baseline),
         "token_fields_present": token_fields_present,
@@ -170,9 +172,19 @@ def build_parity_report(
 def write_parity_report(
     run_dir: str | Path,
     baseline_dir: str | Path | None = None,
+    baseline_error: str | None = None,
 ) -> dict[str, Any]:
     """Write ``parity_report.json`` into *run_dir* and return the report."""
     run_dir = Path(run_dir)
-    report = build_parity_report(run_dir, baseline_dir)
+    report = build_parity_report(run_dir, baseline_dir, baseline_error)
     (run_dir / "parity_report.json").write_text(json.dumps(report, indent=2))
+    current = collect_normalized_results(run_dir)
+    (run_dir / "normalized_results.jsonl").write_text(
+        "".join(json.dumps(record, default=str) + "\n" for record in current)
+    )
+    if baseline_dir:
+        baseline = collect_normalized_results(baseline_dir)
+        (run_dir / "normalized_baseline.jsonl").write_text(
+            "".join(json.dumps(record, default=str) + "\n" for record in baseline)
+        )
     return report

--- a/src/benchflow/integration/parity.py
+++ b/src/benchflow/integration/parity.py
@@ -1,0 +1,180 @@
+"""Normalize BenchFlow and historical SkillsBench/Harbor result artifacts."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _reward_from_mapping(rewards: Any) -> float | int | None:
+    if isinstance(rewards, dict):
+        value = rewards.get("reward")
+        if isinstance(value, int | float):
+            return value
+    return None
+
+
+def normalize_result(data: dict[str, Any], *, path: str | None = None) -> dict[str, Any]:
+    """Normalize current BenchFlow and older SkillsBench trajectory result schemas."""
+    # Current BenchFlow SDK._build_result schema.
+    if "rewards" in data or "n_tool_calls" in data:
+        return {
+            "schema": "benchflow",
+            "path": path,
+            "task_name": data.get("task_name"),
+            "trial_name": data.get("trial_name"),
+            "agent": data.get("agent"),
+            "agent_name": data.get("agent_name"),
+            "model": data.get("model"),
+            "environment": None,
+            "reward": _reward_from_mapping(data.get("rewards")),
+            "error": data.get("error"),
+            "verifier_error": data.get("verifier_error"),
+            "n_tool_calls": data.get("n_tool_calls"),
+            "n_input_tokens": data.get("n_input_tokens"),
+            "n_output_tokens": data.get("n_output_tokens"),
+            "n_cache_tokens": data.get("n_cache_tokens"),
+            "cost_usd": data.get("cost_usd"),
+            "trajectory_source": data.get("trajectory_source"),
+            "partial_trajectory": data.get("partial_trajectory"),
+            "timing": data.get("timing") or {},
+        }
+
+    # Historical SkillsBench / Harbor-like result schema.
+    cfg = data.get("config") if isinstance(data.get("config"), dict) else {}
+    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
+    env_cfg = cfg.get("environment") if isinstance(cfg.get("environment"), dict) else {}
+    agent_result = (
+        data.get("agent_result") if isinstance(data.get("agent_result"), dict) else {}
+    )
+    verifier_result = (
+        data.get("verifier_result")
+        if isinstance(data.get("verifier_result"), dict)
+        else {}
+    )
+    exception_info = data.get("exception_info")
+    error = None
+    if exception_info:
+        if isinstance(exception_info, dict):
+            error = exception_info.get("message") or exception_info.get("type")
+        else:
+            error = str(exception_info)
+
+    return {
+        "schema": "skillsbench-historical",
+        "path": path,
+        "task_name": data.get("task_name"),
+        "trial_name": data.get("trial_name"),
+        "agent": agent_cfg.get("name"),
+        "agent_name": (data.get("agent_info") or {}).get("name")
+        if isinstance(data.get("agent_info"), dict)
+        else agent_cfg.get("name"),
+        "model": agent_cfg.get("model_name"),
+        "environment": env_cfg.get("type"),
+        "reward": _reward_from_mapping(verifier_result.get("rewards")),
+        "error": error,
+        "verifier_error": None,
+        "n_tool_calls": agent_result.get("n_tool_calls"),
+        "n_input_tokens": agent_result.get("n_input_tokens"),
+        "n_output_tokens": agent_result.get("n_output_tokens"),
+        "n_cache_tokens": agent_result.get("n_cache_tokens"),
+        "cost_usd": agent_result.get("cost_usd"),
+        "trajectory_source": None,
+        "partial_trajectory": None,
+        "timing": {
+            phase: data.get(phase)
+            for phase in (
+                "environment_setup",
+                "agent_setup",
+                "agent_execution",
+                "verifier",
+            )
+            if data.get(phase) is not None
+        },
+    }
+
+
+def collect_normalized_results(root: str | Path) -> list[dict[str, Any]]:
+    """Collect and normalize every result.json under *root*."""
+    root = Path(root)
+    records = []
+    for path in sorted(root.rglob("result.json")):
+        try:
+            records.append(normalize_result(json.loads(path.read_text()), path=str(path)))
+        except Exception as exc:
+            records.append(
+                {
+                    "schema": "invalid",
+                    "path": str(path),
+                    "task_name": None,
+                    "error": f"invalid result.json: {exc}",
+                }
+            )
+    return records
+
+
+def _by_task(records: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    out: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        task = record.get("task_name")
+        if task:
+            out.setdefault(task, []).append(record)
+    return out
+
+
+def build_parity_report(
+    run_dir: str | Path,
+    baseline_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Build a broad parity report for current results and optional baselines."""
+    run_dir = Path(run_dir)
+    current = collect_normalized_results(run_dir)
+    baseline = collect_normalized_results(baseline_dir) if baseline_dir else []
+    current_by_task = _by_task(current)
+    baseline_by_task = _by_task(baseline)
+
+    task_rows = []
+    for task in sorted(set(current_by_task) | set(baseline_by_task)):
+        cur = current_by_task.get(task, [])
+        base = baseline_by_task.get(task, [])
+        task_rows.append(
+            {
+                "task_name": task,
+                "current_trials": len(cur),
+                "baseline_trials": len(base),
+                "current_rewards": [r.get("reward") for r in cur],
+                "baseline_rewards": [r.get("reward") for r in base],
+                "missing_baseline": not bool(base),
+            }
+        )
+
+    token_fields_present = any(
+        r.get("n_input_tokens") is not None or r.get("n_output_tokens") is not None
+        for r in current
+    )
+    baseline_token_fields_present = any(
+        r.get("n_input_tokens") is not None or r.get("n_output_tokens") is not None
+        for r in baseline
+    )
+
+    return {
+        "run_dir": str(run_dir),
+        "baseline_dir": str(baseline_dir) if baseline_dir else None,
+        "current_count": len(current),
+        "baseline_count": len(baseline),
+        "token_fields_present": token_fields_present,
+        "baseline_token_fields_present": baseline_token_fields_present,
+        "tasks": task_rows,
+    }
+
+
+def write_parity_report(
+    run_dir: str | Path,
+    baseline_dir: str | Path | None = None,
+) -> dict[str, Any]:
+    """Write ``parity_report.json`` into *run_dir* and return the report."""
+    run_dir = Path(run_dir)
+    report = build_parity_report(run_dir, baseline_dir)
+    (run_dir / "parity_report.json").write_text(json.dumps(report, indent=2))
+    return report

--- a/src/benchflow/integration/parity.py
+++ b/src/benchflow/integration/parity.py
@@ -7,6 +7,10 @@ from pathlib import Path
 from typing import Any
 
 
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
 def _reward_from_mapping(rewards: Any) -> float | int | None:
     if isinstance(rewards, dict):
         value = rewards.get("reward")
@@ -42,17 +46,11 @@ def normalize_result(data: dict[str, Any], *, path: str | None = None) -> dict[s
         }
 
     # Historical SkillsBench / Harbor-like result schema.
-    cfg = data.get("config") if isinstance(data.get("config"), dict) else {}
-    agent_cfg = cfg.get("agent") if isinstance(cfg.get("agent"), dict) else {}
-    env_cfg = cfg.get("environment") if isinstance(cfg.get("environment"), dict) else {}
-    agent_result = (
-        data.get("agent_result") if isinstance(data.get("agent_result"), dict) else {}
-    )
-    verifier_result = (
-        data.get("verifier_result")
-        if isinstance(data.get("verifier_result"), dict)
-        else {}
-    )
+    cfg = _as_dict(data.get("config"))
+    agent_cfg = _as_dict(cfg.get("agent"))
+    env_cfg = _as_dict(cfg.get("environment"))
+    agent_result = _as_dict(data.get("agent_result"))
+    verifier_result = _as_dict(data.get("verifier_result"))
     exception_info = data.get("exception_info")
     error = None
     if exception_info:

--- a/src/benchflow/integration/skillsbench_e2e.py
+++ b/src/benchflow/integration/skillsbench_e2e.py
@@ -1,0 +1,376 @@
+"""File-driven SkillsBench E2E matrix runner used by ``bench eval create -f``."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from benchflow.agents.registry import AGENTS
+from benchflow.integration.artifact_audit import write_artifact_audit
+from benchflow.integration.audit_agent import write_audit_outputs
+from benchflow.integration.parity import write_parity_report
+from benchflow.models import RunResult
+from benchflow.sdk import SDK
+
+logger = logging.getLogger(__name__)
+
+KIND = "skillsbench-e2e"
+DEFAULT_MODEL = "gemini-3.1-flash-lite-preview"
+DEFAULT_TASKS = [
+    "jax-computing-basics",
+    "python-scala-translation",
+    "jpg-ocr-stat",
+    "grid-dispatch-operator",
+    "threejs-to-obj",
+    "data-to-d3",
+    "lake-warming-attribution",
+    "weighted-gdp-calc",
+    "shock-analysis-supply",
+]
+
+
+@dataclass(frozen=True)
+class MatrixEntry:
+    """One E2E matrix cell."""
+
+    agent: str
+    task_name: str
+    model: str
+    environment: str
+
+    @property
+    def id(self) -> str:
+        return f"{self.agent}/{self.task_name}"
+
+
+@dataclass(frozen=True)
+class E2EConfig:
+    """Parsed ``tasks/skillsbench-e2e/e2e.yaml``."""
+
+    path: Path
+    source_repo: str
+    source_path: str
+    source_ref: str | None
+    tasks_manifest: Path
+    jobs_dir: Path
+    model: str
+    environment: str
+    concurrency: int
+    agents: list[str]
+    max_retries: int
+    resume: bool
+    skills_dir: str | None
+    baseline_repo: str | None
+    baseline_ref: str | None
+    audit_prompt: Path | None
+    audit_agent_enabled: bool
+
+    @property
+    def config_dir(self) -> Path:
+        return self.path.parent
+
+
+def is_skillsbench_e2e_config(path: str | Path) -> bool:
+    """Return True when *path* is a SkillsBench E2E config file."""
+    try:
+        raw = yaml.safe_load(Path(path).read_text()) or {}
+    except Exception:
+        return False
+    return raw.get("kind") == KIND
+
+
+def _resolve_config_path(config_path: Path, value: str | None) -> Path | None:
+    if not value:
+        return None
+    p = Path(value)
+    return p if p.is_absolute() else config_path.parent / p
+
+
+def load_config(path: str | Path) -> E2EConfig:
+    """Parse an E2E YAML config."""
+    path = Path(path)
+    raw = yaml.safe_load(path.read_text()) or {}
+    if raw.get("kind") != KIND:
+        raise ValueError(f"Not a {KIND!r} config: {path}")
+
+    source = raw.get("source") or {}
+    if not source.get("repo"):
+        raise ValueError("skillsbench-e2e config requires source.repo")
+    if not source.get("path"):
+        raise ValueError("skillsbench-e2e config requires source.path")
+
+    agents_raw = raw.get("agents", "all")
+    agents = registered_matrix_agents() if agents_raw == "all" else list(agents_raw)
+
+    audit = raw.get("audit") or {}
+    audit_agent = audit.get("audit_agent") or {}
+    audit_prompt = _resolve_config_path(path, audit_agent.get("prompt"))
+
+    baseline = raw.get("baseline") or {}
+    manifest = _resolve_config_path(path, raw.get("tasks_manifest"))
+    if manifest is None:
+        raise ValueError("skillsbench-e2e config requires tasks_manifest")
+
+    return E2EConfig(
+        path=path,
+        source_repo=source["repo"],
+        source_path=source["path"],
+        source_ref=source.get("ref"),
+        tasks_manifest=manifest,
+        jobs_dir=Path(raw.get("jobs_dir", "jobs/skillsbench-e2e")),
+        model=raw.get("model") or DEFAULT_MODEL,
+        environment=raw.get("environment", "daytona"),
+        concurrency=int(raw.get("concurrency", 30)),
+        agents=agents,
+        max_retries=int(raw.get("max_retries", 0)),
+        resume=bool(raw.get("resume", True)),
+        skills_dir=raw.get("skills_dir"),
+        baseline_repo=baseline.get("repo"),
+        baseline_ref=baseline.get("ref"),
+        audit_prompt=audit_prompt,
+        audit_agent_enabled=bool(audit_agent.get("enabled", False)),
+    )
+
+
+def load_manifest(path: str | Path) -> list[str]:
+    """Load task names from a manifest file."""
+    tasks = []
+    for line in Path(path).read_text().splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            tasks.append(stripped)
+    if len(tasks) != len(set(tasks)):
+        raise ValueError(f"Duplicate task in manifest: {path}")
+    return tasks
+
+
+def registered_matrix_agents() -> list[str]:
+    """Return all current built-in agents, preserving registry order."""
+    return list(AGENTS)
+
+
+def build_matrix(
+    task_names: list[str],
+    agents: list[str],
+    model: str,
+    environment: str = "daytona",
+) -> list[MatrixEntry]:
+    """Build the agent × task matrix."""
+    unknown = [agent for agent in agents if agent not in AGENTS]
+    if unknown:
+        raise ValueError(f"Unknown E2E agents: {unknown}")
+    return [
+        MatrixEntry(agent=agent, task_name=task, model=model, environment=environment)
+        for agent in agents
+        for task in task_names
+    ]
+
+
+def materialize_subset(
+    source_tasks_dir: str | Path,
+    task_names: list[str],
+    output_dir: str | Path,
+) -> Path:
+    """Symlink/copy the selected SkillsBench tasks into *output_dir*."""
+    source_tasks_dir = Path(source_tasks_dir)
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    missing = [name for name in task_names if not (source_tasks_dir / name).is_dir()]
+    if missing:
+        raise FileNotFoundError(
+            f"Missing SkillsBench E2E tasks in {source_tasks_dir}: {', '.join(missing)}"
+        )
+
+    for name in task_names:
+        src = source_tasks_dir / name
+        dst = output_dir / name
+        if dst.exists() or dst.is_symlink():
+            continue
+        try:
+            dst.symlink_to(src, target_is_directory=True)
+        except OSError:
+            shutil.copytree(src, dst, symlinks=True)
+    return output_dir
+
+
+def _run_id(*, dry_run: bool) -> str:
+    prefix = "dry-run" if dry_run else "run"
+    return f"{prefix}-{datetime.now().strftime('%Y-%m-%d__%H-%M-%S')}"
+
+
+def _matrix_config_dict(config: E2EConfig, tasks: list[str]) -> dict[str, Any]:
+    return {
+        "kind": KIND,
+        "config_file": str(config.path),
+        "source": {
+            "repo": config.source_repo,
+            "path": config.source_path,
+            "ref": config.source_ref,
+        },
+        "tasks": tasks,
+        "agents": config.agents,
+        "model": config.model,
+        "environment": config.environment,
+        "concurrency": config.concurrency,
+        "max_retries": config.max_retries,
+        "resume": config.resume,
+        "skills_dir": config.skills_dir,
+    }
+
+
+def _entry_to_summary(entry: MatrixEntry, status: str, **extra: Any) -> dict[str, Any]:
+    row = {
+        "id": entry.id,
+        "agent": entry.agent,
+        "task_name": entry.task_name,
+        "model": entry.model,
+        "environment": entry.environment,
+        "status": status,
+    }
+    row.update(extra)
+    return row
+
+
+def _existing_result_path(run_dir: Path, entry: MatrixEntry) -> Path | None:
+    pattern = f"trials/{entry.agent}/results/{entry.task_name}__*/result.json"
+    matches = sorted(run_dir.glob(pattern))
+    return matches[-1] if matches else None
+
+
+async def _run_one_entry(
+    run_dir: Path,
+    tasks_dir: Path,
+    entry: MatrixEntry,
+    config: E2EConfig,
+) -> dict[str, Any]:
+    if config.resume and (existing := _existing_result_path(run_dir, entry)):
+        return _entry_to_summary(
+            entry,
+            "resumed",
+            result_path=str(existing),
+            trial_dir=str(existing.parent),
+        )
+
+    sdk = SDK()
+    jobs_dir = run_dir / "trials" / entry.agent
+    last: RunResult | None = None
+    start = time.time()
+
+    for attempt in range(config.max_retries + 1):
+        result = await sdk.run(
+            task_path=tasks_dir / entry.task_name,
+            agent=entry.agent,
+            model=entry.model,
+            jobs_dir=jobs_dir,
+            job_name="results",
+            environment=entry.environment,
+            skills_dir=config.skills_dir,
+        )
+        last = result
+        if result.rewards is not None or result.verifier_error or not result.error:
+            break
+        await asyncio.sleep(min(2**attempt, 30))
+
+    assert last is not None
+    result_path = jobs_dir / "results" / last.trial_name / "result.json"
+    reward = last.rewards.get("reward") if last.rewards else None
+    status = "completed"
+    if last.error:
+        status = "agent_error"
+    elif last.verifier_error:
+        status = "verifier_error"
+    elif reward == 1.0:
+        status = "passed"
+    elif reward is not None:
+        status = "failed"
+
+    return _entry_to_summary(
+        entry,
+        status,
+        reward=reward,
+        error=last.error,
+        verifier_error=last.verifier_error,
+        n_tool_calls=last.n_tool_calls,
+        trial_name=last.trial_name,
+        trial_dir=str(result_path.parent),
+        result_path=str(result_path),
+        elapsed_sec=round(time.time() - start, 1),
+    )
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2))
+
+
+async def run_from_config_file(
+    config_path: str | Path,
+    *,
+    dry_run: bool = False,
+) -> Path:
+    """Run or dry-run the SkillsBench E2E matrix from a YAML config file."""
+    config = load_config(config_path)
+    tasks = load_manifest(config.tasks_manifest)
+    matrix = build_matrix(tasks, config.agents, config.model, config.environment)
+
+    run_dir = config.jobs_dir / _run_id(dry_run=dry_run)
+    run_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(run_dir / "matrix_config.json", _matrix_config_dict(config, tasks))
+
+    if dry_run:
+        entries = [_entry_to_summary(entry, "planned") for entry in matrix]
+        _write_json(
+            run_dir / "matrix_summary.json",
+            {
+                "run_dir": str(run_dir),
+                "dry_run": True,
+                "total": len(entries),
+                "entries": entries,
+            },
+        )
+        write_artifact_audit(run_dir)
+        write_parity_report(run_dir)
+        write_audit_outputs(run_dir, config.audit_prompt)
+        return run_dir
+
+    from benchflow.task_download import resolve_source
+
+    source_tasks_dir = resolve_source(
+        config.source_repo, config.source_path, config.source_ref
+    )
+    tasks_dir = materialize_subset(source_tasks_dir, tasks, run_dir / "_tasks")
+
+    sem = asyncio.Semaphore(config.concurrency)
+
+    async def bounded(entry: MatrixEntry) -> dict[str, Any]:
+        async with sem:
+            try:
+                return await _run_one_entry(run_dir, tasks_dir, entry, config)
+            except Exception as exc:
+                logger.exception("SkillsBench E2E entry failed: %s", entry.id)
+                return _entry_to_summary(entry, "unexpected_error", error=str(exc))
+
+    entries = await asyncio.gather(*(bounded(entry) for entry in matrix))
+    _write_json(
+        run_dir / "matrix_summary.json",
+        {
+            "run_dir": str(run_dir),
+            "dry_run": False,
+            "total": len(entries),
+            "entries": entries,
+        },
+    )
+    write_artifact_audit(run_dir)
+    write_parity_report(run_dir)
+    write_audit_outputs(run_dir, config.audit_prompt)
+    return run_dir

--- a/src/benchflow/integration/skillsbench_e2e.py
+++ b/src/benchflow/integration/skillsbench_e2e.py
@@ -143,7 +143,9 @@ def load_config(path: str | Path) -> E2EConfig:
         audit_agent_enabled=bool(audit_agent.get("enabled", False)),
         audit_agent=audit_agent.get("agent", "gemini"),
         audit_model=audit_agent.get("model") or raw.get("model") or DEFAULT_MODEL,
-        audit_environment=audit_agent.get("environment", raw.get("environment", "daytona")),
+        audit_environment=audit_agent.get(
+            "environment", raw.get("environment", "daytona")
+        ),
     )
 
 

--- a/src/benchflow/integration/skillsbench_e2e.py
+++ b/src/benchflow/integration/skillsbench_e2e.py
@@ -73,6 +73,9 @@ class E2EConfig:
     baseline_ref: str | None
     audit_prompt: Path | None
     audit_agent_enabled: bool
+    audit_agent: str
+    audit_model: str
+    audit_environment: str
 
     @property
     def config_dir(self) -> Path:
@@ -138,6 +141,9 @@ def load_config(path: str | Path) -> E2EConfig:
         baseline_ref=baseline.get("ref"),
         audit_prompt=audit_prompt,
         audit_agent_enabled=bool(audit_agent.get("enabled", False)),
+        audit_agent=audit_agent.get("agent", "gemini"),
+        audit_model=audit_agent.get("model") or raw.get("model") or DEFAULT_MODEL,
+        audit_environment=audit_agent.get("environment", raw.get("environment", "daytona")),
     )
 
 
@@ -225,6 +231,12 @@ def _matrix_config_dict(config: E2EConfig, tasks: list[str]) -> dict[str, Any]:
         "max_retries": config.max_retries,
         "resume": config.resume,
         "skills_dir": config.skills_dir,
+        "audit_agent": {
+            "enabled": config.audit_agent_enabled,
+            "agent": config.audit_agent,
+            "model": config.audit_model,
+            "environment": config.audit_environment,
+        },
     }
 
 
@@ -373,4 +385,36 @@ async def run_from_config_file(
     write_artifact_audit(run_dir)
     write_parity_report(run_dir)
     write_audit_outputs(run_dir, config.audit_prompt)
+    if config.audit_agent_enabled:
+        await _run_audit_agent(run_dir, config)
     return run_dir
+
+
+async def _run_audit_agent(run_dir: Path, config: E2EConfig) -> None:
+    """Run the optional post-processing audit agent over deterministic outputs."""
+    from benchflow.integration.audit_agent import create_audit_task
+
+    task_dir = create_audit_task(run_dir, config.audit_prompt)
+    result = await SDK().run(
+        task_path=task_dir,
+        agent=config.audit_agent,
+        model=config.audit_model,
+        jobs_dir=run_dir / "audit_agent",
+        job_name="review",
+        environment=config.audit_environment,
+        sandbox_user="agent",
+    )
+    _write_json(
+        run_dir / "audit_agent_result.json",
+        {
+            "task_name": result.task_name,
+            "trial_name": result.trial_name,
+            "agent": result.agent,
+            "agent_name": result.agent_name,
+            "model": result.model,
+            "rewards": result.rewards,
+            "error": result.error,
+            "verifier_error": result.verifier_error,
+            "n_tool_calls": result.n_tool_calls,
+        },
+    )

--- a/src/benchflow/integration/skillsbench_e2e.py
+++ b/src/benchflow/integration/skillsbench_e2e.py
@@ -325,6 +325,19 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
     path.write_text(json.dumps(data, indent=2))
 
 
+def _resolve_baseline(config: E2EConfig) -> tuple[Path | None, str | None]:
+    """Resolve the optional historical baseline repo for parity comparison."""
+    if not config.baseline_repo:
+        return None, None
+    try:
+        from benchflow.task_download import resolve_source
+
+        return resolve_source(config.baseline_repo, ref=config.baseline_ref), None
+    except Exception as exc:
+        logger.warning("Could not resolve E2E baseline repo: %s", exc)
+        return None, str(exc)
+
+
 async def run_from_config_file(
     config_path: str | Path,
     *,
@@ -383,7 +396,8 @@ async def run_from_config_file(
         },
     )
     write_artifact_audit(run_dir)
-    write_parity_report(run_dir)
+    baseline_dir, baseline_error = _resolve_baseline(config)
+    write_parity_report(run_dir, baseline_dir, baseline_error)
     write_audit_outputs(run_dir, config.audit_prompt)
     if config.audit_agent_enabled:
         await _run_audit_agent(run_dir, config)

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -656,7 +656,9 @@ class Job:
             errored=sum(
                 1
                 for r in all_results.values()
-                if r.get("error") and r.get("rewards") is None
+                if r.get("error")
+                and r.get("rewards") is None
+                and not r.get("verifier_error")
             ),
             verifier_errored=sum(
                 1 for r in all_results.values() if r.get("verifier_error")

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -21,6 +21,20 @@ from benchflow._scoring import (
 logger = logging.getLogger(__name__)
 
 
+def _safe_reward(result: dict) -> float:
+    """Return a comparable reward value for retry selection.
+
+    Some rubric verifiers can emit ``{"reward": None, ...}`` while still
+    including process/rubric detail. Treat missing/None rewards as 0.0 for
+    ordering so metrics collection never raises ``TypeError``.
+    """
+    rewards = result.get("rewards")
+    if not isinstance(rewards, dict):
+        return 0.0
+    value = rewards.get("reward")
+    return float(value) if isinstance(value, int | float) else 0.0
+
+
 @dataclass
 class TaskMetrics:
     """Metrics for a single task."""
@@ -190,8 +204,7 @@ def collect_metrics(
                 or (
                     r.get("rewards")
                     and best[task].get("rewards")
-                    and r["rewards"].get("reward", 0)
-                    > best[task]["rewards"].get("reward", 0)
+                    and _safe_reward(r) > _safe_reward(best[task])
                 )
             ):
                 best[task] = r

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -419,6 +419,7 @@ class Trial:
         self._timing: dict[str, float] = {}
         self._effective_locked: list[str] = []
         self._disallow_web_tools: bool = False
+        self._effective_task_path: Path | None = None
 
         # Populated by install_agent()
         self._agent_cfg: Any = None
@@ -549,6 +550,7 @@ class Trial:
             stage_dockerfile_deps(effective_task_path, Path(cfg.context_root))
         if cfg.skills_dir:
             _inject_skills_into_dockerfile(effective_task_path, Path(cfg.skills_dir))
+        self._effective_task_path = effective_task_path
 
         self._env = _create_environment(
             cfg.environment,
@@ -622,7 +624,7 @@ class Trial:
             )
             await deploy_skills(
                 self._env,
-                cfg.task_path,
+                self._effective_task_path or cfg.task_path,
                 cfg.skills_dir,
                 None,
                 cfg.sandbox_user,
@@ -673,7 +675,7 @@ class Trial:
 
         await deploy_skills(
             self._env,
-            cfg.task_path,
+            self._effective_task_path or cfg.task_path,
             cfg.skills_dir,
             self._agent_cfg,
             cfg.sandbox_user,

--- a/tasks/skillsbench-e2e/README.md
+++ b/tasks/skillsbench-e2e/README.md
@@ -1,0 +1,31 @@
+# SkillsBench E2E matrix
+
+This directory contains the file-driven ENG-6 E2E configuration.
+
+Canonical dry run:
+
+```bash
+uv run bench eval create -f tasks/skillsbench-e2e/e2e.yaml --dry-run
+```
+
+Canonical live run:
+
+```bash
+export BENCHFLOW_RUN_SKILLSBENCH_E2E=1
+export DAYTONA_API_KEY=...
+export GEMINI_API_KEY=...
+uv run bench eval create -f tasks/skillsbench-e2e/e2e.yaml
+```
+
+The live run executes the 9 selected SkillsBench tasks across every registered
+BenchFlow agent using `gemini-3.1-flash-lite-preview` on Daytona with global
+concurrency 30. It is intentionally gated and should not run on every commit.
+
+Outputs are written under `jobs/skillsbench-e2e/<run-id>/`:
+
+- `matrix_config.json`
+- `matrix_summary.json`
+- `artifact_audit.json`
+- `parity_report.json`
+- `audit_findings.json`
+- `findings.md`

--- a/tasks/skillsbench-e2e/README.md
+++ b/tasks/skillsbench-e2e/README.md
@@ -29,3 +29,8 @@ Outputs are written under `jobs/skillsbench-e2e/<run-id>/`:
 - `parity_report.json`
 - `audit_findings.json`
 - `findings.md`
+
+If `audit.audit_agent.enabled` is set to `true`, BenchFlow also creates an
+internal audit task from `audit/trajectory-result-auditor.md` and runs the
+configured audit agent after the deterministic scripts finish. That review is
+saved under `audit_agent/` and summarized in `audit_agent_result.json`.

--- a/tasks/skillsbench-e2e/audit/trajectory-result-auditor.md
+++ b/tasks/skillsbench-e2e/audit/trajectory-result-auditor.md
@@ -1,0 +1,44 @@
+# Trajectory/result audit rubric
+
+You are auditing a BenchFlow E2E run output bundle. Treat deterministic JSON
+reports as the source of truth and use trajectory/log snippets only to explain
+root causes.
+
+Inputs you may receive:
+
+- `matrix_config.json` — requested agents, tasks, model, backend, and run paths.
+- `matrix_summary.json` — one row per `(agent, task)` entry.
+- `artifact_audit.json` — required-file and schema checks for each trial.
+- `parity_report.json` — normalized BenchFlow-vs-baseline comparisons.
+- sampled `result.json`, `timing.json`, `agent/*.txt`, verifier logs, and
+  `trajectory/acp_trajectory.jsonl` excerpts.
+
+Audit goals:
+
+1. Identify framework/runtime regressions separately from model/task failures.
+2. Record agents that fail specifically because `gemini-3.1-flash-lite-preview`
+   is unsupported or misconfigured for that agent.
+3. Check core artifact parity:
+   - `result.json`
+   - `timing.json`
+   - `prompts.json`
+   - `rewards.jsonl`
+   - `agent/install-stdout.txt`
+   - `agent/<agent>.txt`
+   - `trajectory/acp_trajectory.jsonl`
+   - verifier logs/artifacts
+4. Check schema parity for result fields, rewards, errors, trajectory source,
+   token/cost fields, and phase timings.
+5. Compare reward and error distributions with historical baseline artifacts
+   when baselines exist.
+6. Call out missing baselines explicitly without treating them as failures.
+7. Produce concise findings with evidence paths.
+
+Output:
+
+- A short executive summary.
+- A table of agent-level health.
+- A table of task-level verifier/task issues.
+- A list of actionable BenchFlow bugs.
+- A list of known/capability-gap findings.
+- A final pass/fail recommendation for whether the E2E run is trustworthy.

--- a/tasks/skillsbench-e2e/e2e.yaml
+++ b/tasks/skillsbench-e2e/e2e.yaml
@@ -1,0 +1,27 @@
+kind: skillsbench-e2e
+description: "ENG-6 SkillsBench E2E: 9 tasks across all registered BenchFlow agents"
+
+source:
+  repo: benchflow-ai/skillsbench
+  path: tasks
+  ref: main
+
+tasks_manifest: tasks.txt
+jobs_dir: jobs/skillsbench-e2e
+model: gemini-3.1-flash-lite-preview
+environment: daytona
+concurrency: 30
+max_retries: 0
+resume: true
+skills_dir: null
+agents: all
+
+baseline:
+  repo: benchflow-ai/skillsbench-trajectories
+  ref: main
+
+audit:
+  deterministic: true
+  audit_agent:
+    enabled: false
+    prompt: audit/trajectory-result-auditor.md

--- a/tasks/skillsbench-e2e/e2e.yaml
+++ b/tasks/skillsbench-e2e/e2e.yaml
@@ -24,4 +24,7 @@ audit:
   deterministic: true
   audit_agent:
     enabled: false
+    agent: gemini
+    model: gemini-3.1-flash-lite-preview
+    environment: daytona
     prompt: audit/trajectory-result-auditor.md

--- a/tasks/skillsbench-e2e/tasks.txt
+++ b/tasks/skillsbench-e2e/tasks.txt
@@ -1,0 +1,9 @@
+jax-computing-basics
+python-scala-translation
+jpg-ocr-stat
+grid-dispatch-operator
+threejs-to-obj
+data-to-d3
+lake-warming-attribution
+weighted-gdp-calc
+shock-analysis-supply

--- a/tests/integration/test_artifact_audit.py
+++ b/tests/integration/test_artifact_audit.py
@@ -1,0 +1,48 @@
+"""Tests for deterministic E2E artifact auditing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from benchflow.integration.artifact_audit import audit_trial_result
+
+
+def test_artifact_audit_accepts_fixture_result(tmp_path: Path) -> None:
+    trial = tmp_path / "trial"
+    (trial / "trajectory").mkdir(parents=True)
+    (trial / "agent").mkdir()
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "trial_name": "task-a__abc",
+                "rewards": {"reward": 1.0},
+                "agent": "gemini",
+                "agent_name": "gemini",
+                "model": "gemini-3.1-flash-lite-preview",
+                "n_tool_calls": 2,
+                "n_prompts": 1,
+                "error": None,
+                "verifier_error": None,
+                "partial_trajectory": False,
+                "trajectory_source": "acp",
+                "started_at": "2026-05-15 00:00:00",
+                "finished_at": "2026-05-15 00:01:00",
+                "timing": {"total": 60.0},
+            }
+        )
+    )
+    (trial / "config.json").write_text("{}")
+    (trial / "timing.json").write_text("{}")
+    (trial / "prompts.json").write_text("[]")
+    (trial / "agent" / "install-stdout.txt").write_text("ok")
+    (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "tool_call"}) + "\n"
+    )
+
+    report = audit_trial_result(trial / "result.json")
+
+    assert report["ok"] is True
+    assert report["issues"] == []
+    assert report["files"]["trajectory/acp_trajectory.jsonl"]["valid"] is True

--- a/tests/integration/test_parity_normalizer.py
+++ b/tests/integration/test_parity_normalizer.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from benchflow.integration.parity import normalize_result
+import json
+from pathlib import Path
+
+from benchflow.integration.parity import normalize_result, write_parity_report
 
 
 def test_parity_normalizes_current_benchflow_result() -> None:
@@ -59,3 +62,27 @@ def test_parity_normalizes_historical_skillsbench_result() -> None:
     assert record["environment"] == "docker"
     assert record["reward"] == 1.0
     assert record["n_input_tokens"] == 100
+
+
+def test_write_parity_report_records_baseline_error_and_jsonl(tmp_path: Path) -> None:
+    trial = tmp_path / "run" / "trial"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "trial_name": "task-a__abc",
+                "rewards": {"reward": 1.0},
+                "agent": "gemini",
+                "model": "gemini-3.1-flash-lite-preview",
+                "n_tool_calls": 1,
+            }
+        )
+    )
+
+    report = write_parity_report(tmp_path / "run", baseline_error="clone failed")
+
+    assert report["baseline_error"] == "clone failed"
+    assert (tmp_path / "run" / "parity_report.json").exists()
+    normalized = (tmp_path / "run" / "normalized_results.jsonl").read_text()
+    assert '"schema": "benchflow"' in normalized

--- a/tests/integration/test_parity_normalizer.py
+++ b/tests/integration/test_parity_normalizer.py
@@ -1,0 +1,61 @@
+"""Tests for E2E result-schema parity normalization."""
+
+from __future__ import annotations
+
+from benchflow.integration.parity import normalize_result
+
+
+def test_parity_normalizes_current_benchflow_result() -> None:
+    record = normalize_result(
+        {
+            "task_name": "task-a",
+            "trial_name": "task-a__abc",
+            "rewards": {"reward": 0.5},
+            "agent": "gemini",
+            "agent_name": "Gemini",
+            "model": "gemini-3.1-flash-lite-preview",
+            "n_tool_calls": 3,
+            "error": None,
+            "verifier_error": None,
+            "trajectory_source": "acp",
+            "partial_trajectory": False,
+            "timing": {"total": 1.2},
+        }
+    )
+
+    assert record["schema"] == "benchflow"
+    assert record["task_name"] == "task-a"
+    assert record["reward"] == 0.5
+    assert record["n_tool_calls"] == 3
+
+
+def test_parity_normalizes_historical_skillsbench_result() -> None:
+    record = normalize_result(
+        {
+            "task_name": "task-a",
+            "trial_name": "task-a__abc",
+            "config": {
+                "agent": {
+                    "name": "claude-code",
+                    "model_name": "minimax/MiniMax-M2.1",
+                },
+                "environment": {"type": "docker"},
+            },
+            "agent_info": {"name": "claude-code"},
+            "agent_result": {
+                "n_input_tokens": 100,
+                "n_output_tokens": 20,
+                "n_cache_tokens": 5,
+                "cost_usd": 0.01,
+            },
+            "verifier_result": {"rewards": {"reward": 1.0}},
+            "exception_info": None,
+        }
+    )
+
+    assert record["schema"] == "skillsbench-historical"
+    assert record["agent"] == "claude-code"
+    assert record["model"] == "minimax/MiniMax-M2.1"
+    assert record["environment"] == "docker"
+    assert record["reward"] == 1.0
+    assert record["n_input_tokens"] == 100

--- a/tests/integration/test_skillsbench_e2e.py
+++ b/tests/integration/test_skillsbench_e2e.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
+from benchflow.integration.audit_agent import create_audit_task
 from benchflow.integration.skillsbench_e2e import (
     DEFAULT_MODEL,
     build_matrix,
@@ -46,6 +47,10 @@ def test_e2e_config_builds_all_current_agents_matrix() -> None:
     assert cfg.model == DEFAULT_MODEL == "gemini-3.1-flash-lite-preview"
     assert cfg.concurrency == 30
     assert cfg.skills_dir is None
+    assert cfg.audit_agent_enabled is False
+    assert cfg.audit_agent == "gemini"
+    assert cfg.audit_model == DEFAULT_MODEL
+    assert cfg.audit_environment == "daytona"
     assert cfg.agents == registered_matrix_agents()
     assert len(matrix) == 9 * len(registered_matrix_agents())
     assert {entry.task_name for entry in matrix} == set(tasks)
@@ -95,6 +100,25 @@ audit:
     assert (run_dirs[0] / "artifact_audit.json").exists()
     assert (run_dirs[0] / "parity_report.json").exists()
     assert (run_dirs[0] / "findings.md").exists()
+
+
+def test_create_audit_task_uses_output_bundle(tmp_path: Path) -> None:
+    (tmp_path / "matrix_summary.json").write_text('{"entries": []}')
+    (tmp_path / "artifact_audit.json").write_text('{"error_count": 0}')
+    (tmp_path / "parity_report.json").write_text('{"tasks": []}')
+    (tmp_path / "audit_findings.json").write_text('{"failed_entries": 0}')
+    prompt = tmp_path / "rubric.md"
+    prompt.write_text("Audit rubric")
+
+    task_dir = create_audit_task(tmp_path, prompt)
+
+    assert (task_dir / "task.toml").exists()
+    assert (task_dir / "environment" / "Dockerfile").exists()
+    assert (task_dir / "tests" / "test.sh").exists()
+    instruction = (task_dir / "instruction.md").read_text()
+    assert "Audit rubric" in instruction
+    assert "Output bundle JSON" in instruction
+    assert "audit_review.md" in instruction
 
 
 @pytest.mark.live

--- a/tests/integration/test_skillsbench_e2e.py
+++ b/tests/integration/test_skillsbench_e2e.py
@@ -10,7 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
-from benchflow.integration.audit_agent import create_audit_task
+from benchflow.integration.audit_agent import create_audit_task, render_audit_prompt
 from benchflow.integration.skillsbench_e2e import (
     DEFAULT_MODEL,
     build_matrix,
@@ -119,6 +119,29 @@ def test_create_audit_task_uses_output_bundle(tmp_path: Path) -> None:
     assert "Audit rubric" in instruction
     assert "Output bundle JSON" in instruction
     assert "audit_review.md" in instruction
+
+
+def test_audit_prompt_includes_sampled_artifact_excerpts(tmp_path: Path) -> None:
+    trial = tmp_path / "trials" / "gemini" / "results" / "task-a__abc"
+    (trial / "agent").mkdir(parents=True)
+    (trial / "verifier").mkdir()
+    (trial / "trajectory").mkdir()
+    (trial / "result.json").write_text('{"task_name": "task-a"}')
+    (trial / "agent" / "gemini.txt").write_text("agent log sample")
+    (trial / "verifier" / "test-stdout.txt").write_text("verifier log sample")
+    (trial / "trajectory" / "acp_trajectory.jsonl").write_text(
+        '{"type": "tool_call"}\n'
+    )
+    (tmp_path / "matrix_summary.json").write_text('{"entries": []}')
+    (tmp_path / "artifact_audit.json").write_text("{}")
+    (tmp_path / "parity_report.json").write_text("{}")
+    (tmp_path / "audit_findings.json").write_text("{}")
+
+    prompt = render_audit_prompt(tmp_path, None)
+
+    assert "sampled_artifacts" in prompt
+    assert "agent log sample" in prompt
+    assert "verifier log sample" in prompt
 
 
 @pytest.mark.live

--- a/tests/integration/test_skillsbench_e2e.py
+++ b/tests/integration/test_skillsbench_e2e.py
@@ -1,0 +1,96 @@
+"""Tests for the file-driven SkillsBench E2E matrix config."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+from benchflow.integration.skillsbench_e2e import (
+    DEFAULT_MODEL,
+    build_matrix,
+    load_config,
+    load_manifest,
+    materialize_subset,
+    registered_matrix_agents,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+E2E_CONFIG = REPO_ROOT / "tasks" / "skillsbench-e2e" / "e2e.yaml"
+
+
+def test_manifest_has_expected_nine_tasks() -> None:
+    tasks = load_manifest(REPO_ROOT / "tasks" / "skillsbench-e2e" / "tasks.txt")
+    assert tasks == [
+        "jax-computing-basics",
+        "python-scala-translation",
+        "jpg-ocr-stat",
+        "grid-dispatch-operator",
+        "threejs-to-obj",
+        "data-to-d3",
+        "lake-warming-attribution",
+        "weighted-gdp-calc",
+        "shock-analysis-supply",
+    ]
+
+
+def test_e2e_config_builds_all_current_agents_matrix() -> None:
+    cfg = load_config(E2E_CONFIG)
+    tasks = load_manifest(cfg.tasks_manifest)
+    matrix = build_matrix(tasks, cfg.agents, cfg.model, cfg.environment)
+
+    assert cfg.model == DEFAULT_MODEL == "gemini-3.1-flash-lite-preview"
+    assert cfg.concurrency == 30
+    assert cfg.skills_dir is None
+    assert cfg.agents == registered_matrix_agents()
+    assert len(matrix) == 9 * len(registered_matrix_agents())
+    assert {entry.task_name for entry in matrix} == set(tasks)
+    assert {entry.agent for entry in matrix} == set(registered_matrix_agents())
+
+
+def test_materialize_subset_fails_fast_for_missing_task(tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    with pytest.raises(FileNotFoundError, match="missing-task"):
+        materialize_subset(source, ["missing-task"], tmp_path / "out")
+
+
+def test_cli_dry_run_writes_matrix_outputs(tmp_path: Path) -> None:
+    cfg = tmp_path / "e2e.yaml"
+    manifest = tmp_path / "tasks.txt"
+    manifest.write_text("task-a\ntask-b\n")
+    cfg.write_text(
+        """
+kind: skillsbench-e2e
+source:
+  repo: benchflow-ai/skillsbench
+  path: tasks
+tasks_manifest: tasks.txt
+jobs_dir: {jobs_dir}
+model: gemini-3.1-flash-lite-preview
+environment: daytona
+concurrency: 30
+agents:
+  - gemini
+  - opencode
+audit:
+  audit_agent:
+    enabled: false
+""".format(jobs_dir=tmp_path / "jobs")
+    )
+
+    result = CliRunner().invoke(app, ["eval", "create", "-f", str(cfg), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    run_dirs = sorted((tmp_path / "jobs").iterdir())
+    assert len(run_dirs) == 1
+    summary = json.loads((run_dirs[0] / "matrix_summary.json").read_text())
+    assert summary["dry_run"] is True
+    assert summary["total"] == 4
+    assert {entry["status"] for entry in summary["entries"]} == {"planned"}
+    assert (run_dirs[0] / "artifact_audit.json").exists()
+    assert (run_dirs[0] / "parity_report.json").exists()
+    assert (run_dirs[0] / "findings.md").exists()

--- a/tests/integration/test_skillsbench_e2e.py
+++ b/tests/integration/test_skillsbench_e2e.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -94,3 +95,25 @@ audit:
     assert (run_dirs[0] / "artifact_audit.json").exists()
     assert (run_dirs[0] / "parity_report.json").exists()
     assert (run_dirs[0] / "findings.md").exists()
+
+
+@pytest.mark.live
+@pytest.mark.e2e
+def test_live_skillsbench_e2e_matrix_is_file_driven() -> None:
+    """Gated live E2E entrypoint.
+
+    This test intentionally invokes the same file-driven path operators use:
+    ``bench eval create -f tasks/skillsbench-e2e/e2e.yaml``. It is excluded by
+    default via the repository's ``not live`` pytest config.
+    """
+    if os.environ.get("BENCHFLOW_RUN_SKILLSBENCH_E2E") != "1":
+        pytest.skip("Set BENCHFLOW_RUN_SKILLSBENCH_E2E=1 to run the live E2E matrix")
+    if not os.environ.get("DAYTONA_API_KEY"):
+        pytest.skip("DAYTONA_API_KEY is required for the live E2E matrix")
+    if not (os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")):
+        pytest.skip("GEMINI_API_KEY or GOOGLE_API_KEY is required")
+
+    result = CliRunner().invoke(app, ["eval", "create", "-f", str(E2E_CONFIG)])
+
+    assert result.exit_code == 0, result.output
+    assert "SkillsBench E2E output:" in result.output

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -120,6 +120,43 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_skips_runtime_upload_when_already_injected(tmp_path):
+    """Guards the fix from PR #230/#229: deploy_skills must inspect the
+    effective post-injection Dockerfile, see the baked COPY line, and skip the
+    second runtime upload to /skills."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+    agent_cfg = AgentConfig(
+        name="test-agent",
+        install_cmd="true",
+        launch_cmd="true",
+        skill_paths=["$HOME/.agents/skills"],
+    )
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    env_dir = tmp_path / "task" / "environment"
+    env_dir.mkdir(parents=True)
+    (env_dir / "Dockerfile").write_text(
+        "FROM python:3.12\nCOPY _deps/skills /skills/\n"
+    )
+
+    await deploy_skills(
+        env=env,
+        task_path=tmp_path / "task",
+        skills_dir=skills_dir,
+        agent_cfg=agent_cfg,
+        sandbox_user="agent",
+        agent_cwd="/workspace",
+        task=_make_task(None),
+    )
+
+    env.upload_dir.assert_not_called()
+    env.exec.assert_awaited_once()
+    assert "ln -sfn /skills /home/agent/.agents/skills" in env.exec.await_args.args[0]
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_chowns_full_dir_chain_for_pi_acp_layout(tmp_path):
     """Guards the fix from PR #211 against the regression where only the
     symlink's immediate parent (`~/.pi/agent`) was chowned, leaving the

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -209,7 +209,7 @@ class TestJobResume:
         with caplog.at_level(logging.WARNING):
             import asyncio
 
-            asyncio.get_event_loop().run_until_complete(job.run())
+            asyncio.run(job.run())
         assert any("old-agent" in msg for msg in caplog.messages)
 
     def test_no_rewards_is_incomplete(self, tmp_path):
@@ -294,3 +294,25 @@ class TestJobRunOrchestration:
 
         assert result.errored == 1
         assert any("unexpected exception: boom" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_error_plus_verifier_error_counts_once_as_verifier_errored(
+        self, tmp_path
+    ):
+        """Guards the fix from PR #244: an agent timeout followed by verifier
+        failure must not double-count as both errored and verifier_errored."""
+        job = self._make_job(tmp_path, n_tasks=1, concurrency=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(
+                task_name="task-0",
+                rewards=None,
+                error="Agent timed out after 300s",
+                verifier_error="verifier crashed: exit code 1",
+            )
+        )
+
+        result = await job.run()
+
+        assert result.errored == 0
+        assert result.verifier_errored == 1

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -265,3 +265,43 @@ def test_collect_metrics_partial_reward(tmp_path):
     # 0.5 is not 1.0, so not passed
     assert s["passed"] == 0
     assert s["failed"] == 1
+
+
+def test_collect_metrics_reward_none_does_not_crash_retry_comparison(tmp_path):
+    """Guards the fix from PR #243: rewards={"reward": None} must not
+    TypeError when compared against a numeric retry reward."""
+    trial_a = tmp_path / "attempt1" / "task-a__none"
+    trial_a.mkdir(parents=True)
+    (trial_a / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": None, "rubric": []},
+                "error": None,
+                "n_tool_calls": 1,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:01:00.000000",
+            }
+        )
+    )
+    trial_b = tmp_path / "attempt2" / "task-a__numeric"
+    trial_b.mkdir(parents=True)
+    (trial_b / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 0.5},
+                "error": None,
+                "n_tool_calls": 2,
+                "started_at": "2026-03-24 10:02:00.000000",
+                "finished_at": "2026-03-24 10:03:00.000000",
+            }
+        )
+    )
+
+    metrics = collect_metrics(str(tmp_path))
+    s = metrics.summary()
+
+    assert s["total"] == 1
+    assert s["failed"] == 1
+    assert metrics.tasks[0].reward == 0.5

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -28,7 +28,11 @@ class TestAutoInheritEnv:
         [
             pytest.param("ANTHROPIC_API_KEY", "sk-host", id="anthropic"),
             pytest.param("OPENAI_API_KEY", "sk-oai", id="openai"),
-            pytest.param("OPENAI_BASE_URL", "https://openai-compatible.test", id="openai-base-url"),
+            pytest.param(
+                "OPENAI_BASE_URL",
+                "https://openai-compatible.test",
+                id="openai-base-url",
+            ),
             pytest.param(
                 "BENCHFLOW_PROVIDER_BASE_URL",
                 "https://provider.test",

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -28,6 +28,17 @@ class TestAutoInheritEnv:
         [
             pytest.param("ANTHROPIC_API_KEY", "sk-host", id="anthropic"),
             pytest.param("OPENAI_API_KEY", "sk-oai", id="openai"),
+            pytest.param("OPENAI_BASE_URL", "https://openai-compatible.test", id="openai-base-url"),
+            pytest.param(
+                "BENCHFLOW_PROVIDER_BASE_URL",
+                "https://provider.test",
+                id="benchflow-provider-base-url",
+            ),
+            pytest.param(
+                "BENCHFLOW_PROVIDER_API_KEY",
+                "sk-provider",
+                id="benchflow-provider-api-key",
+            ),
             pytest.param("ZAI_API_KEY", "zk-host", id="provider"),
         ],
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a file-driven SkillsBench ENG-6 E2E config at `tasks/skillsbench-e2e/e2e.yaml` for 9 selected tasks × all registered BenchFlow agents with `gemini-3.1-flash-lite-preview` on Daytona concurrency 30.
- Route `bench eval create -f tasks/skillsbench-e2e/e2e.yaml` through a gated E2E matrix runner, with `--dry-run` support for matrix validation without launching sandboxes.
- Add deterministic artifact/schema auditing, result parity normalization, historical baseline import from `benchflow-ai/skillsbench-trajectories`, audit findings generation, sampled log/trajectory snippets for review, and a reusable audit script for existing E2E output directories.
- Add an optional post-processing audit-agent hook: when enabled, BenchFlow creates an internal audit task from `audit/trajectory-result-auditor.md`, runs the configured audit agent, and writes `audit_agent_result.json`.
- Add regressions for current E2E blockers: provider env inheritance, skills double-deploy, job double-counting, and metrics reward comparison with `reward: null`.
- Document the E2E workflow and outputs.

## Validation
- `python3 -m pytest tests/` → 827 passed, 1 skipped, 2 deselected
- `python3 -m ruff check .` → all checks passed
- `python3 -m ruff format --check src tests` → 122 files already formatted
- `PYTHONPATH="$HOME/.local/lib/python3.12/site-packages" python3 -m ty check src` → all checks passed
- `python3 -m benchflow.cli.main eval create -f tasks/skillsbench-e2e/e2e.yaml --dry-run` → wrote a planned E2E output bundle successfully

## Related
- Linear ENG-6
- GitHub issue #253
- SkillsBench issues considered: benchflow-ai/skillsbench#817, #788, #776, #763, #750, #708
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4aed5aeb-c547-4ee6-8a21-bf461bdcc812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4aed5aeb-c547-4ee6-8a21-bf461bdcc812"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

