### PR TITLE
v0.4 rollout, sandbox, and reward foundations

### DIFF
--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -46,7 +46,7 @@ from benchflow.environments import (
 from benchflow.job import Job, JobConfig, JobResult, RetryConfig
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RunResult
-from benchflow.rollouts import Role, Scene, Turn
+from benchflow.rollouts import Role, RolloutConfig, Scene, Turn
 from benchflow.runtime import (
     Agent,
     Environment,
@@ -100,6 +100,7 @@ __all__ = [
     "AgentInstallError",
     "AgentTimeoutError",
     "RunResult",
+    "RolloutConfig",
     # Runtime (0.3 primary API)
     "Agent",
     "Environment",

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -25,7 +25,7 @@ from harbor import (
 
 # benchflow's additions
 from benchflow._env_setup import stage_dockerfile_deps
-from benchflow._scene import MailboxTransport, Message, MessageTransport, Role, Scene
+from benchflow._scene import MailboxTransport, Message, MessageTransport
 from benchflow._snapshot import list_snapshots, restore, snapshot
 from benchflow.acp.client import ACPClient
 from benchflow.acp.session import ACPSession
@@ -46,6 +46,7 @@ from benchflow.environments import (
 from benchflow.job import Job, JobConfig, JobResult, RetryConfig
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RunResult
+from benchflow.rollouts import Role, Scene, Turn
 from benchflow.runtime import (
     Agent,
     Environment,
@@ -59,9 +60,7 @@ from benchflow.skills import SkillInfo, discover_skills, install_skill, parse_sk
 from benchflow.trajectories.otel import OTelCollector
 from benchflow.trajectories.proxy import TrajectoryProxy
 from benchflow.trajectories.types import Trajectory
-from benchflow.trial import Role as TrialRole
-from benchflow.trial import Scene as TrialScene
-from benchflow.trial import Trial, TrialConfig, Turn
+from benchflow.trial import Trial, TrialConfig
 from benchflow.trial_yaml import trial_config_from_yaml
 from benchflow.user import BaseUser, FunctionUser, PassthroughUser, RoundResult
 
@@ -121,8 +120,6 @@ __all__ = [
     # Trial (decomposed lifecycle)
     "Trial",
     "TrialConfig",
-    "TrialRole",
-    "TrialScene",
     "Turn",
     "trial_config_from_yaml",
     # User abstraction (progressive disclosure)

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -46,7 +46,7 @@ from benchflow.environments import (
 from benchflow.job import Job, JobConfig, JobResult, RetryConfig
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RunResult
-from benchflow.rollouts import Role, RolloutConfig, Scene, Turn
+from benchflow.rollouts import Role, RolloutConfig, RolloutResult, Scene, Turn
 from benchflow.runtime import (
     Agent,
     Environment,
@@ -101,6 +101,7 @@ __all__ = [
     "AgentTimeoutError",
     "RunResult",
     "RolloutConfig",
+    "RolloutResult",
     # Runtime (0.3 primary API)
     "Agent",
     "Environment",

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -48,6 +48,7 @@ from benchflow.job import Job, JobConfig, JobResult, RetryConfig
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RunResult
 from benchflow.rollouts import Role, RolloutConfig, RolloutResult, Scene, Turn
+from benchflow.rollouts.yaml import rollout_config_from_yaml
 from benchflow.runtime import (
     Agent,
     Environment,
@@ -126,6 +127,7 @@ __all__ = [
     "TrialConfig",
     "Turn",
     "trial_config_from_yaml",
+    "rollout_config_from_yaml",
     # User abstraction (progressive disclosure)
     "BaseUser",
     "FunctionUser",

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -31,6 +31,7 @@ from benchflow.acp.client import ACPClient
 from benchflow.acp.session import ACPSession
 from benchflow.agents.registry import (
     AGENTS,
+    AgentCapability,
     get_agent,
     infer_env_key_for_model,
     is_vertex_model,
@@ -83,6 +84,7 @@ __all__ = [
     "ACPSession",
     # Agent registry
     "AGENTS",
+    "AgentCapability",
     "get_agent",
     "infer_env_key_for_model",
     "is_vertex_model",

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -48,21 +48,12 @@ from benchflow.job import Job, JobConfig, JobResult, RetryConfig
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RunResult
 from benchflow.rollouts import Role, RolloutConfig, RolloutResult, Scene, Turn
+from benchflow.rollouts.runner import run
 from benchflow.rollouts.yaml import rollout_config_from_yaml
-from benchflow.runtime import (
-    Agent,
-    Environment,
-    Runtime,
-    RuntimeConfig,
-    RuntimeResult,
-    run,  # bf.run(agent, env) — the primary 0.3 API
-)
-from benchflow.sdk import SDK
 from benchflow.skills import SkillInfo, discover_skills, install_skill, parse_skill
 from benchflow.trajectories.otel import OTelCollector
 from benchflow.trajectories.proxy import TrajectoryProxy
 from benchflow.trajectories.types import Trajectory
-from benchflow.trial import Trial, TrialConfig
 from benchflow.trial_yaml import trial_config_from_yaml
 from benchflow.user import BaseUser, FunctionUser, PassthroughUser, RoundResult
 
@@ -105,12 +96,6 @@ __all__ = [
     "RunResult",
     "RolloutConfig",
     "RolloutResult",
-    # Runtime (0.3 primary API)
-    "Agent",
-    "Environment",
-    "Runtime",
-    "RuntimeConfig",
-    "RuntimeResult",
     "run",
     # Multi-agent scene
     "Scene",
@@ -122,9 +107,6 @@ __all__ = [
     "snapshot",
     "restore",
     "list_snapshots",
-    # Trial (decomposed lifecycle)
-    "Trial",
-    "TrialConfig",
     "Turn",
     "trial_config_from_yaml",
     "rollout_config_from_yaml",
@@ -133,8 +115,6 @@ __all__ = [
     "FunctionUser",
     "PassthroughUser",
     "RoundResult",
-    # SDK (backwards compat)
-    "SDK",
     # Environments / dep staging
     "SERVICES",
     "build_service_hooks",

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -1,29 +1,12 @@
 """benchflow — ACP-native agent benchmarking framework.
 
-Re-exports environment APIs and adds:
-- ACP client for multi-turn agent communication
-- Trajectory capture (HTTP proxy, OTel collector, ACP native)
-- SDK for programmatic usage
-- Job orchestration with retries and concurrency
-- Metrics collection and aggregation
+Public API for rollout-based agent evaluation.
 """
 
 from importlib.metadata import version as _version
 
 __version__ = _version("benchflow")
 
-# Re-export Harbor's core types for downstream task authors
-from harbor import (
-    BaseAgent,
-    BaseEnvironment,
-    ExecResult,
-    Task,
-    TaskConfig,
-    Verifier,
-    VerifierResult,
-)
-
-# benchflow's additions
 from benchflow._env_setup import stage_dockerfile_deps
 from benchflow._scene import MailboxTransport, Message, MessageTransport
 from benchflow._snapshot import list_snapshots, restore, snapshot
@@ -50,7 +33,9 @@ from benchflow.models import AgentInstallError, AgentTimeoutError, RunResult
 from benchflow.rollouts import Role, RolloutConfig, RolloutResult, Scene, Turn
 from benchflow.rollouts.runner import run
 from benchflow.rollouts.yaml import rollout_config_from_yaml
+from benchflow.sandboxes import ExecResult, SandboxSpec
 from benchflow.skills import SkillInfo, discover_skills, install_skill, parse_skill
+from benchflow.tasks import Task, TaskConfig
 from benchflow.trajectories.otel import OTelCollector
 from benchflow.trajectories.proxy import TrajectoryProxy
 from benchflow.trajectories.types import Trajectory
@@ -63,14 +48,9 @@ from benchflow.user import BaseUser, FunctionUser, PassthroughUser, RoundResult
 # what.
 __all__ = [
     "__version__",
-    # Harbor re-exports
-    "BaseAgent",
-    "BaseEnvironment",
     "ExecResult",
     "Task",
     "TaskConfig",
-    "Verifier",
-    "VerifierResult",
     # ACP
     "ACPClient",
     "ACPSession",
@@ -96,6 +76,7 @@ __all__ = [
     "RunResult",
     "RolloutConfig",
     "RolloutResult",
+    "SandboxSpec",
     "run",
     # Multi-agent scene
     "Scene",
@@ -131,19 +112,3 @@ __all__ = [
     "TrajectoryProxy",
     "Trajectory",
 ]
-
-
-def __getattr__(name: str):
-    """Fall through to harbor for names not explicitly re-exported."""
-    import harbor
-
-    if hasattr(harbor, name):
-        import warnings
-
-        warnings.warn(
-            f"'{name}' is not directly re-exported by benchflow. Use 'from harbor import {name}' instead.",
-            ImportWarning,
-            stacklevel=2,
-        )
-        return getattr(harbor, name)
-    raise AttributeError(f"module 'benchflow' has no attribute {name!r}")

--- a/src/benchflow/_agent_setup.py
+++ b/src/benchflow/_agent_setup.py
@@ -19,13 +19,12 @@ Does not own:
 import logging
 import shlex
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 
 from benchflow.agents.registry import AGENT_INSTALLERS, AGENTS, AgentConfig
 from benchflow.models import AgentInstallError
 
-if TYPE_CHECKING:
-    from harbor.models.task.task import Task
+Task = Any
 
 logger = logging.getLogger(__name__)
 

--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -442,8 +442,8 @@ def _patch_harbor_dind() -> None:
         return env
 
     # Monkey-patch Harbor's DockerEnvironmentEnvVars to rewrite host paths
-    # for DinD nesting. ty flags this as an implicit signature shadowing.
-    DockerEnvironmentEnvVars.to_env_dict = _patched  # ty: ignore[invalid-assignment]
+    # for DinD nesting.
+    DockerEnvironmentEnvVars.to_env_dict = _patched
 
 
 def _create_environment(

--- a/src/benchflow/_env_setup.py
+++ b/src/benchflow/_env_setup.py
@@ -12,9 +12,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from harbor.models.task.task import Task
-from harbor.models.trial.paths import TrialPaths
-
+import benchflow._harbor as harbor_compat
 from benchflow.agents.registry import AGENTS
 
 logger = logging.getLogger(__name__)
@@ -148,13 +146,14 @@ def _modal_builder_dockerfile(
 
 def _create_benchflow_modal_environment_class():
     """Create a ModalEnvironment subclass with BenchFlow's image-build defaults."""
-    from harbor.environments.modal import ModalEnvironment
+    ModalEnvironment = harbor_compat.modal_environment_class()
 
     class BenchFlowModalEnvironment(ModalEnvironment):
         async def start(self, force_build: bool) -> None:
             """Starts the Modal sandbox, adding Python for plain Linux images."""
-            from harbor.models.trial.paths import EnvironmentPaths
             from modal import App, Image, Secret, Volume
+
+            EnvironmentPaths = harbor_compat.modal_environment_paths_class()
 
             def noop_cleanup_dockerfile() -> None:
                 return None
@@ -424,7 +423,7 @@ def _patch_harbor_dind() -> None:
     logger.info(f"DinD detected: {container_dest} → {host_source}")
 
     try:
-        from harbor.environments.docker.docker import DockerEnvironmentEnvVars
+        DockerEnvironmentEnvVars = harbor_compat.docker_environment_env_vars_class()
     except ImportError:
         return
 
@@ -449,10 +448,10 @@ def _patch_harbor_dind() -> None:
 
 def _create_environment(
     environment_type: str,
-    task: Task,
+    task: Any,
     task_path: Path,
     trial_name: str,
-    trial_paths: TrialPaths,
+    trial_paths: Any,
     preserve_agent_network: bool = False,
 ) -> Any:
     """Create a Harbor environment (Docker, Daytona, or Modal)."""
@@ -469,7 +468,7 @@ def _create_environment(
         env_config.allow_internet = True
 
     if environment_type == "docker":
-        from harbor.environments.docker.docker import DockerEnvironment
+        DockerEnvironment = harbor_compat.docker_environment_class()
 
         return DockerEnvironment(
             environment_dir=environment_dir,
@@ -479,7 +478,7 @@ def _create_environment(
             task_env_config=env_config,
         )
     elif environment_type == "daytona":
-        from harbor.environments.daytona import DaytonaEnvironment
+        DaytonaEnvironment = harbor_compat.daytona_environment_class()
 
         from benchflow._daytona_patches import apply as _apply_daytona_patches
 

--- a/src/benchflow/_harbor.py
+++ b/src/benchflow/_harbor.py
@@ -39,3 +39,43 @@ def make_verifier(task: Any, trial_paths: Any, environment: Any) -> HarborVerifi
     """Create the current Harbor verifier."""
 
     return HarborVerifier(task=task, trial_paths=trial_paths, environment=environment)
+
+
+def docker_environment_env_vars_class() -> type:
+    """Return Harbor's Docker env-var helper class."""
+
+    from harbor.environments.docker.docker import DockerEnvironmentEnvVars
+
+    return DockerEnvironmentEnvVars
+
+
+def docker_environment_class() -> type:
+    """Return Harbor's Docker environment class."""
+
+    from harbor.environments.docker.docker import DockerEnvironment
+
+    return DockerEnvironment
+
+
+def daytona_environment_class() -> type:
+    """Return Harbor's Daytona environment class."""
+
+    from harbor.environments.daytona import DaytonaEnvironment
+
+    return DaytonaEnvironment
+
+
+def modal_environment_class() -> type:
+    """Return Harbor's Modal environment class."""
+
+    from harbor.environments.modal import ModalEnvironment
+
+    return ModalEnvironment
+
+
+def modal_environment_paths_class() -> type:
+    """Return Harbor's environment-path constants used by Modal setup."""
+
+    from harbor.models.trial.paths import EnvironmentPaths
+
+    return EnvironmentPaths

--- a/src/benchflow/_harbor.py
+++ b/src/benchflow/_harbor.py
@@ -41,7 +41,7 @@ def make_verifier(task: Any, trial_paths: Any, environment: Any) -> HarborVerifi
     return HarborVerifier(task=task, trial_paths=trial_paths, environment=environment)
 
 
-def docker_environment_env_vars_class() -> type:
+def docker_environment_env_vars_class() -> Any:
     """Return Harbor's Docker env-var helper class."""
 
     from harbor.environments.docker.docker import DockerEnvironmentEnvVars
@@ -49,7 +49,7 @@ def docker_environment_env_vars_class() -> type:
     return DockerEnvironmentEnvVars
 
 
-def docker_environment_class() -> type:
+def docker_environment_class() -> Any:
     """Return Harbor's Docker environment class."""
 
     from harbor.environments.docker.docker import DockerEnvironment
@@ -57,7 +57,7 @@ def docker_environment_class() -> type:
     return DockerEnvironment
 
 
-def daytona_environment_class() -> type:
+def daytona_environment_class() -> Any:
     """Return Harbor's Daytona environment class."""
 
     from harbor.environments.daytona import DaytonaEnvironment
@@ -65,7 +65,7 @@ def daytona_environment_class() -> type:
     return DaytonaEnvironment
 
 
-def modal_environment_class() -> type:
+def modal_environment_class() -> Any:
     """Return Harbor's Modal environment class."""
 
     from harbor.environments.modal import ModalEnvironment
@@ -73,7 +73,7 @@ def modal_environment_class() -> type:
     return ModalEnvironment
 
 
-def modal_environment_paths_class() -> type:
+def modal_environment_paths_class() -> Any:
     """Return Harbor's environment-path constants used by Modal setup."""
 
     from harbor.models.trial.paths import EnvironmentPaths

--- a/src/benchflow/_harbor.py
+++ b/src/benchflow/_harbor.py
@@ -1,0 +1,41 @@
+"""Internal Harbor compatibility adapter.
+
+BenchFlow v0.4 is moving to native task, path, sandbox, and verifier
+interfaces. Until each callsite is migrated, all remaining Harbor runtime
+touchpoints should pass through this module instead of importing Harbor
+directly from orchestration code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from harbor.models.task.task import Task as HarborTask
+from harbor.models.trial.paths import TrialPaths as HarborTrialPaths
+from harbor.utils.env import resolve_env_vars as harbor_resolve_env_vars
+from harbor.verifier.verifier import Verifier as HarborVerifier
+
+
+def make_task(task_path: str | Path) -> HarborTask:
+    """Create the current Harbor-backed task object."""
+
+    return HarborTask(Path(task_path))
+
+
+def make_trial_paths(trial_dir: str | Path) -> HarborTrialPaths:
+    """Create the current Harbor-backed trial path object."""
+
+    return HarborTrialPaths(Path(trial_dir))
+
+
+def resolve_env_vars(env_config: Any) -> dict[str, str]:
+    """Resolve Harbor-style env var declarations."""
+
+    return harbor_resolve_env_vars(env_config)
+
+
+def make_verifier(task: Any, trial_paths: Any, environment: Any) -> HarborVerifier:
+    """Create the current Harbor verifier."""
+
+    return HarborVerifier(task=task, trial_paths=trial_paths, environment=environment)

--- a/src/benchflow/_sandbox.py
+++ b/src/benchflow/_sandbox.py
@@ -17,12 +17,11 @@ import os
 import re
 import shlex
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import Any
 
 from benchflow.agents.registry import get_sandbox_home_dirs
 
-if TYPE_CHECKING:
-    from harbor.models.task.task import Task
+Task = Any
 
 logger = logging.getLogger(__name__)
 

--- a/src/benchflow/_scene.py
+++ b/src/benchflow/_scene.py
@@ -28,21 +28,14 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from benchflow.rollouts.config import Role
+
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
 # Core types
 # ---------------------------------------------------------------------------
-
-
-@dataclass
-class Role:
-    name: str
-    agent: str
-    model: str
-    instruction: str
-    tools: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -90,12 +83,12 @@ class MailboxTransport(MessageTransport):
 
 
 # ---------------------------------------------------------------------------
-# Scene
+# Scene runtime
 # ---------------------------------------------------------------------------
 
 
-class Scene:
-    """Turn-based multi-agent scene.
+class SceneRuntime:
+    """Turn-based runtime for a canonical multi-agent scene.
 
     Scheduler rule (0.3):
       - exactly 2 roles (enforced at init)
@@ -160,7 +153,7 @@ class Scene:
 
     def build_prompt_for_role(self, role: Role, inbox: list[Message]) -> str:
         """Build the prompt for a role, injecting any pending messages."""
-        parts = [role.instruction]
+        parts = [role.instruction or f"You are the {role.name} role."]
         if inbox:
             parts.append("\n---\nYou have received the following messages:\n")
             for msg in inbox:
@@ -287,3 +280,8 @@ class Scene:
         ]
         path.write_text("\n".join(lines) + "\n" if lines else "")
         logger.info(f"Scene trajectory saved: {len(self.trajectory)} messages → {path}")
+
+
+# Backward-compatible module-local name for the 0.3 scene runtime. The
+# canonical scene config dataclass lives in benchflow.rollouts.config.
+Scene = SceneRuntime

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -217,6 +217,19 @@ class SubscriptionAuth:
 
 
 @dataclass
+class AgentCapability:
+    """Capability declared by an agent integration.
+
+    BenchFlow records capabilities and validates sandbox preconditions; native
+    loops and agent-as-tool behavior remain agent-owned.
+    """
+
+    name: str
+    description: str = ""
+    metadata: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
 class AgentConfig:
     """Configuration for a supported agent."""
 
@@ -263,6 +276,8 @@ class AgentConfig:
     disallow_web_tools_launch_suffix: str = ""
     # String appended to launch_cmd when BenchFlow's no-web policy is active.
     # Use for agents whose supported toggle is a launch/config override.
+    capabilities: list[AgentCapability] = field(default_factory=list)
+    # Declarative capabilities such as native-loop, mcp, or agent-as-tool.
 
 
 # Agent registry — all supported agents
@@ -697,6 +712,7 @@ def register_agent(
     subscription_auth: SubscriptionAuth | None = None,
     acp_model_format: str = "bare",
     supports_acp_set_model: bool = True,
+    capabilities: list[AgentCapability] | None = None,
 ) -> AgentConfig:
     """Register a custom agent at runtime.
 
@@ -728,6 +744,7 @@ def register_agent(
         subscription_auth=subscription_auth,
         acp_model_format=acp_model_format,
         supports_acp_set_model=supports_acp_set_model,
+        capabilities=capabilities or [],
     )
     AGENTS[name] = config
     AGENT_INSTALLERS[name] = install_cmd

--- a/src/benchflow/cli/eval.py
+++ b/src/benchflow/cli/eval.py
@@ -228,22 +228,24 @@ def _run_single(
 ) -> None:
     from typing import cast
 
-    from benchflow.sdk import SDK
+    from benchflow.rollouts.config import RolloutConfig
+    from benchflow.rollouts.runner import run as run_rollout
 
-    sdk = SDK()
     eff_model = _effective_model(agent, model)
     result = asyncio.run(
-        sdk.run(
-            task_path=task_dir,
-            agent=agent,
-            model=eff_model,
-            environment=environment,
-            prompts=cast("list[str | None] | None", prompt),
-            agent_env=agent_env,
-            job_name="eval-create",
-            jobs_dir=jobs_dir,
-            skills_dir=skills_dir,
-            sandbox_user=None if sandbox_user == "none" else sandbox_user,
+        run_rollout(
+            RolloutConfig(
+                task_path=task_dir,
+                agent=agent,
+                model=eff_model,
+                environment=environment,
+                prompts=cast("list[str | None] | None", prompt),
+                agent_env=agent_env,
+                job_name="eval-create",
+                jobs_dir=jobs_dir,
+                skills_dir=skills_dir,
+                sandbox_user=None if sandbox_user == "none" else sandbox_user,
+            )
         )
     )
     reward = getattr(result, "reward", None)

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -112,7 +112,8 @@ def run(
         bench run --source-repo benchflow-ai/skillsbench --source-path tasks/edit-pdf
         bench run tasks/edit-pdf --agent gemini --model gemini-3.1-flash-lite-preview
     """
-    from benchflow.sdk import SDK
+    from benchflow.rollouts.config import RolloutConfig
+    from benchflow.rollouts.runner import run as run_rollout
 
     if source_repo:
         from benchflow.task_download import resolve_source
@@ -134,23 +135,22 @@ def run(
         key, value = entry.split("=", 1)
         parsed_env[key] = value
 
-    sdk = SDK()
-    # CLI only ever passes plain strings; cast to widen for the SDK's
-    # `list[str | None] | None` API (None entries mean "use default").
     result = asyncio.run(
-        sdk.run(
-            task_path=resolved_task_dir,
-            agent=agent,
-            model=model,
-            prompts=cast("list[str | None] | None", prompt),
-            agent_env=parsed_env,
-            jobs_dir=jobs_dir,
-            environment=environment,
-            skills_dir=str(skills_dir) if skills_dir else None,
-            sandbox_user=sandbox_user,
-            skill_mode=skill_mode,
-            skill_creator_dir=str(skill_creator_dir) if skill_creator_dir else None,
-            self_gen_no_internet=self_gen_no_internet,
+        run_rollout(
+            RolloutConfig(
+                task_path=resolved_task_dir,
+                agent=agent,
+                model=model,
+                prompts=cast("list[str | None] | None", prompt),
+                agent_env=parsed_env,
+                jobs_dir=jobs_dir,
+                environment=environment,
+                skills_dir=str(skills_dir) if skills_dir else None,
+                sandbox_user=sandbox_user,
+                skill_mode=skill_mode,
+                skill_creator_dir=str(skill_creator_dir) if skill_creator_dir else None,
+                self_gen_no_internet=self_gen_no_internet,
+            )
         )
     )
 
@@ -878,25 +878,28 @@ def eval_create(
         eff_model = effective_model(agent, model)
         # Smart detection: if tasks_dir has task.toml, it's a single task
         if (resolved_tasks_dir / "task.toml").exists():
-            from benchflow.sdk import SDK
+            from benchflow.rollouts.config import RolloutConfig
+            from benchflow.rollouts.runner import run as run_rollout
 
             async def _run():
-                return await SDK().run(
-                    task_path=resolved_tasks_dir,
-                    agent=agent,
-                    model=eff_model,
-                    job_name=None,
-                    trial_name=None,
-                    jobs_dir=jobs_dir,
-                    environment=environment,
-                    skills_dir=str(skills_dir) if skills_dir else None,
-                    sandbox_user=sandbox_user,
-                    sandbox_setup_timeout=sandbox_setup_timeout,
-                    skill_mode=skill_mode,
-                    skill_creator_dir=(
-                        str(skill_creator_dir) if skill_creator_dir else None
-                    ),
-                    self_gen_no_internet=self_gen_no_internet,
+                return await run_rollout(
+                    RolloutConfig(
+                        task_path=resolved_tasks_dir,
+                        agent=agent,
+                        model=eff_model,
+                        job_name=None,
+                        trial_name=None,
+                        jobs_dir=jobs_dir,
+                        environment=environment,
+                        skills_dir=str(skills_dir) if skills_dir else None,
+                        sandbox_user=sandbox_user,
+                        sandbox_setup_timeout=sandbox_setup_timeout,
+                        skill_mode=skill_mode,
+                        skill_creator_dir=(
+                            str(skill_creator_dir) if skill_creator_dir else None
+                        ),
+                        self_gen_no_internet=self_gen_no_internet,
+                    )
                 )
 
             run_result = asyncio.run(_run())
@@ -937,25 +940,28 @@ def eval_create(
         eff_model = effective_model(agent, model)
         # Smart detection: if tasks_dir has task.toml, it's a single task
         if (resolved_tasks_dir / "task.toml").exists():
-            from benchflow.sdk import SDK
+            from benchflow.rollouts.config import RolloutConfig
+            from benchflow.rollouts.runner import run as run_rollout
 
             async def _run():
-                return await SDK().run(
-                    task_path=resolved_tasks_dir,
-                    agent=agent,
-                    model=eff_model,
-                    job_name=None,
-                    trial_name=None,
-                    jobs_dir=jobs_dir,
-                    environment=environment,
-                    skills_dir=str(skills_dir) if skills_dir else None,
-                    sandbox_user=sandbox_user,
-                    sandbox_setup_timeout=sandbox_setup_timeout,
-                    skill_mode=skill_mode,
-                    skill_creator_dir=(
-                        str(skill_creator_dir) if skill_creator_dir else None
-                    ),
-                    self_gen_no_internet=self_gen_no_internet,
+                return await run_rollout(
+                    RolloutConfig(
+                        task_path=resolved_tasks_dir,
+                        agent=agent,
+                        model=eff_model,
+                        job_name=None,
+                        trial_name=None,
+                        jobs_dir=jobs_dir,
+                        environment=environment,
+                        skills_dir=str(skills_dir) if skills_dir else None,
+                        sandbox_user=sandbox_user,
+                        sandbox_setup_timeout=sandbox_setup_timeout,
+                        skill_mode=skill_mode,
+                        skill_creator_dir=(
+                            str(skill_creator_dir) if skill_creator_dir else None
+                        ),
+                        self_gen_no_internet=self_gen_no_internet,
+                    )
                 )
 
             run_result = asyncio.run(_run())

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -89,7 +89,8 @@ from benchflow._scoring import (
     pass_rate_excl_errors,
 )
 from benchflow.models import RunResult
-from benchflow.sdk import SDK
+from benchflow.rollouts.config import RolloutConfig
+from benchflow.rollouts.runner import run as run_rollout
 
 logger = logging.getLogger(__name__)
 
@@ -239,7 +240,7 @@ class Job:
         self._config = config or JobConfig()
         self._job_name = job_name or datetime.now().strftime("%Y-%m-%d__%H-%M-%S")
         self._on_result = on_result
-        self._sdk = SDK()  # kept for test mocking compat; _run_task prefers Trial
+        self._run_rollout = run_rollout
 
     @classmethod
     def from_yaml(cls, path: str | Path, **kwargs) -> "Job":
@@ -457,10 +458,8 @@ class Job:
         return skills_dir
 
     async def _run_single_task(self, task_dir: Path, cfg: JobConfig) -> RunResult:
-        """Execute one trial via Trial."""
-        from benchflow.trial import Trial, TrialConfig
-
-        trial_config = TrialConfig.from_legacy(
+        """Execute one task through the rollout-native run path."""
+        rollout_config = RolloutConfig.from_single(
             task_path=task_dir,
             agent=cfg.agent,
             model=cfg.model,
@@ -478,35 +477,7 @@ class Job:
             skill_creator_dir=cfg.skill_creator_dir,
             self_gen_no_internet=cfg.self_gen_no_internet,
         )
-        if cfg.skill_mode == "self-gen":
-            from benchflow.self_gen import run_self_gen
-
-            return await run_self_gen(trial_config)
-        trial = await Trial.create(trial_config)
-        return await trial.run()
-
-    async def _run_single_task_legacy(
-        self, task_dir: Path, cfg: JobConfig
-    ) -> RunResult:
-        """SDK.run() path — used when _sdk is mocked in tests."""
-        return await self._sdk.run(
-            task_path=task_dir,
-            agent=cfg.agent,
-            model=cfg.model,
-            prompts=cfg.prompts,
-            agent_env=cfg.agent_env,
-            job_name=self._job_name,
-            jobs_dir=str(self._jobs_dir),
-            environment=cfg.environment,
-            skills_dir=self._resolve_skills_dir(task_dir, cfg.skills_dir),
-            sandbox_user=cfg.sandbox_user,
-            sandbox_locked_paths=cfg.sandbox_locked_paths,
-            sandbox_setup_timeout=cfg.sandbox_setup_timeout,
-            context_root=cfg.context_root,
-            skill_mode=cfg.skill_mode,
-            skill_creator_dir=cfg.skill_creator_dir,
-            self_gen_no_internet=cfg.self_gen_no_internet,
-        )
+        return await self._run_rollout(rollout_config)
 
     async def _run_task(self, task_dir: Path) -> RunResult:
         """Run a single task with retries."""
@@ -519,11 +490,7 @@ class Job:
                 logger.info(f"Retry backoff: {delay:.1f}s before attempt {attempt}")
                 await asyncio.sleep(delay)
                 self._prune_docker()
-            # Use legacy SDK path if _sdk has been replaced (test compat)
-            if not isinstance(self._sdk, SDK):
-                result = await self._run_single_task_legacy(task_dir, cfg)
-            else:
-                result = await self._run_single_task(task_dir, cfg)
+            result = await self._run_single_task(task_dir, cfg)
             last_result = result
 
             # If succeeded, verifier-errored (terminal), or non-retryable, stop

--- a/src/benchflow/job.py
+++ b/src/benchflow/job.py
@@ -76,6 +76,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
+from typing import cast
 
 import yaml
 
@@ -477,7 +478,7 @@ class Job:
             skill_creator_dir=cfg.skill_creator_dir,
             self_gen_no_internet=cfg.self_gen_no_internet,
         )
-        return await self._run_rollout(rollout_config)
+        return cast(RunResult, await self._run_rollout(rollout_config))
 
     async def _run_task(self, task_dir: Path) -> RunResult:
         """Run a single task with retries."""

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -1,14 +1,10 @@
-"""Data classes and exceptions for benchflow SDK results.
+"""Data classes and exceptions for benchflow results.
 
-Related: sdk.py (produces RunResult), job.py (aggregates RunResults),
-_scoring.py (extracts rewards and classifies errors from RunResults).
+Related: rollout execution produces RolloutResult, job.py aggregates results,
+_scoring.py extracts rewards and classifies errors from result dicts.
 """
 
-from datetime import datetime
-from typing import Any, Literal
-
-TrajectorySource = Literal["acp", "scraped", "partial_acp"]
-"""Provenance label for a captured trajectory. See RunResult.trajectory_source."""
+from benchflow.rollouts.result import RolloutResult, TrajectorySource
 
 
 class AgentInstallError(RuntimeError):
@@ -48,82 +44,5 @@ class AgentTimeoutError(RuntimeError):
         super().__init__(f"Agent {agent} timed out after {timeout_sec}s")
 
 
-class RunResult:
-    """Outcome of a single SDK.run() trial.
-
-    Attributes:
-        task_name:    Task directory name (e.g. "swe-bench/django__django-11848").
-        trial_name:   Unique trial identifier within a job run.
-        rewards:      Verifier-produced reward dict (e.g. {"exact_match": 1.0}).
-                      None if verification was skipped or failed.
-        trajectory:   Ordered list of ACP session-update dicts (tool calls,
-                      messages, thoughts) captured during execution.
-        agent:        Harness name from the registry (e.g. "openclaw").
-        agent_name:   Name reported by the agent via ACP initialize handshake.
-        model:        Model ID used (e.g. "google/gemini-3.1-flash-lite-preview").
-        n_tool_calls: Total tool calls observed during the session.
-        n_prompts:    Number of user prompts sent to the agent.
-        error:        Error description string, or None on success.
-        verifier_error: Verifier error description, or None if verifier succeeded
-                      or was not reached. Separate from ``error`` (agent errors).
-        partial_trajectory: True when the trajectory was salvaged from a timed-out
-                      or crashed session and may be incomplete.
-        trajectory_source: Provenance label for ``trajectory`` — one of
-                      ``"acp"`` (trusted), ``"scraped"`` (UNTRUSTED, agent-writable,
-                      forgeable), ``"partial_acp"`` (partial ACP capture). Verifier
-                      and metrics consumers decide trust per source. None if no
-                      trajectory was captured.
-        started_at:   Wall-clock start time.
-        finished_at:  Wall-clock end time.
-    """
-
-    def __init__(
-        self,
-        task_name: str,
-        trial_name: str = "",
-        rewards: dict[str, float | int] | None = None,
-        trajectory: list[dict[str, Any]] | None = None,
-        agent: str = "",
-        agent_name: str = "",
-        model: str = "",
-        n_tool_calls: int = 0,
-        n_prompts: int = 0,
-        error: str | None = None,
-        verifier_error: str | None = None,
-        partial_trajectory: bool = False,
-        trajectory_source: TrajectorySource | None = None,
-        started_at: datetime | None = None,
-        finished_at: datetime | None = None,
-    ):
-        self.task_name = task_name
-        self.trial_name = trial_name
-        self.rewards = rewards
-        self.trajectory = trajectory or []
-        self.agent = agent
-        self.agent_name = agent_name
-        self.model = model
-        self.n_tool_calls = n_tool_calls
-        self.n_prompts = n_prompts
-        self.error = error
-        self.verifier_error = verifier_error
-        self.partial_trajectory = partial_trajectory
-        self.trajectory_source = trajectory_source
-        self.started_at = started_at
-        self.finished_at = finished_at
-
-    @property
-    def success(self) -> bool:
-        """True when the trial completed without agent or verifier error.
-
-        Agent errors (error) and verifier errors (verifier_error) both
-        indicate an incomplete trial. Rewards may still be zero on success.
-        """
-        return self.error is None and self.verifier_error is None
-
-    def __repr__(self) -> str:
-        status = "OK" if self.success else f"ERROR: {self.error or self.verifier_error}"
-        return (
-            f"RunResult(task={self.task_name}, {status}, "
-            f"rewards={self.rewards}, "
-            f"trajectory={len(self.trajectory)} events)"
-        )
+class RunResult(RolloutResult):
+    """Compatibility name for RolloutResult during the v0.4 migration."""

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -4,7 +4,12 @@ Related: rollout execution produces RolloutResult, job.py aggregates results,
 _scoring.py extracts rewards and classifies errors from result dicts.
 """
 
-from benchflow.rollouts.result import RolloutResult, TrajectorySource
+from benchflow.rollouts.result import (
+    RolloutResult,
+)
+from benchflow.rollouts.result import (
+    TrajectorySource as TrajectorySource,
+)
 
 
 class AgentInstallError(RuntimeError):

--- a/src/benchflow/rewards/__init__.py
+++ b/src/benchflow/rewards/__init__.py
@@ -1,0 +1,16 @@
+"""Native reward and rubric primitives."""
+
+from benchflow.rewards.builtin import TestRewardFunc
+from benchflow.rewards.events import RewardEvent, rewards_from_verifier_dict
+from benchflow.rewards.rubric import RewardContext, RewardFunc, Rubric
+from benchflow.rewards.serialization import write_rewards_jsonl
+
+__all__ = [
+    "RewardContext",
+    "RewardEvent",
+    "RewardFunc",
+    "Rubric",
+    "TestRewardFunc",
+    "rewards_from_verifier_dict",
+    "write_rewards_jsonl",
+]

--- a/src/benchflow/rewards/builtin.py
+++ b/src/benchflow/rewards/builtin.py
@@ -1,0 +1,27 @@
+"""Built-in reward functions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from benchflow.rewards.events import RewardEvent
+from benchflow.rewards.rubric import RewardContext
+
+
+@dataclass
+class TestRewardFunc:
+    """Compatibility reward function for ``test.sh -> reward.txt`` tasks."""
+
+    __test__ = False
+
+    reward_path: str = "verifier/reward.txt"
+
+    async def score(self, ctx: RewardContext) -> RewardEvent:
+        path = ctx.rollout_dir / self.reward_path
+        value = float(path.read_text().strip())
+        return RewardEvent(
+            type="terminal",
+            source="test_reward_func",
+            value=value,
+            tag="reward",
+        )

--- a/src/benchflow/rewards/events.py
+++ b/src/benchflow/rewards/events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 
 @dataclass(frozen=True)
@@ -54,8 +54,9 @@ def rewards_from_verifier_dict(
         for i, item in enumerate(rubric):
             if not isinstance(item, dict):
                 continue
-            score = float(item.get("score", 0.0))
-            name = item.get("name", f"rubric_{i}")
+            rubric_item = cast(dict[str, Any], item)
+            score = float(rubric_item.get("score", 0.0))
+            name = rubric_item.get("name", f"rubric_{i}")
             events.append(
                 RewardEvent(
                     ts=ts,
@@ -64,7 +65,11 @@ def rewards_from_verifier_dict(
                     value=score,
                     tag=str(name),
                     step_index=i,
-                    meta={k: v for k, v in item.items() if k not in ("score", "name")},
+                    meta={
+                        k: v
+                        for k, v in rubric_item.items()
+                        if k not in ("score", "name")
+                    },
                 )
             )
     scalar = rewards.get("reward")

--- a/src/benchflow/rewards/events.py
+++ b/src/benchflow/rewards/events.py
@@ -1,0 +1,87 @@
+"""Reward event schema and current verifier-dict conversion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RewardEvent:
+    """One terminal, process, or dense reward signal."""
+
+    type: str
+    value: float
+    source: str
+    tag: str = "reward"
+    step_index: int | None = None
+    ts: datetime = field(default_factory=datetime.now)
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def to_json(self) -> dict[str, Any]:
+        """Return the persisted JSONL event shape."""
+
+        return {
+            "ts": self.ts.isoformat(),
+            "type": self.type,
+            "source": self.source,
+            "value": self.value,
+            "tag": self.tag,
+            "step_index": self.step_index,
+            "meta": self.meta,
+        }
+
+
+def rewards_from_verifier_dict(
+    rewards: dict[str, Any] | None,
+    *,
+    finished_at: datetime | None = None,
+) -> list[RewardEvent]:
+    """Convert the current verifier reward dict into reward events.
+
+    This preserves the existing rewards.jsonl semantics:
+    rubric entries become ``process`` events and the scalar ``reward`` becomes
+    the terminal event.
+    """
+
+    if not rewards:
+        return []
+    ts = finished_at or datetime.now()
+    events: list[RewardEvent] = []
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            score = float(item.get("score", 0.0))
+            name = item.get("name", f"rubric_{i}")
+            events.append(
+                RewardEvent(
+                    ts=ts,
+                    type="process",
+                    source="verifier_rubric",
+                    value=score,
+                    tag=str(name),
+                    step_index=i,
+                    meta={k: v for k, v in item.items() if k not in ("score", "name")},
+                )
+            )
+    scalar = rewards.get("reward")
+    if scalar is not None:
+        events.append(
+            RewardEvent(
+                ts=ts,
+                type="terminal",
+                source="verifier",
+                value=float(scalar),
+                tag="reward",
+                step_index=None,
+                meta={
+                    k: v
+                    for k, v in rewards.items()
+                    if k not in {"reward", "rubric"}
+                },
+            )
+        )
+    return events

--- a/src/benchflow/rewards/rubric.py
+++ b/src/benchflow/rewards/rubric.py
@@ -1,0 +1,69 @@
+"""Composable reward functions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from benchflow.rewards.events import RewardEvent
+
+RewardValue = float | RewardEvent | list[RewardEvent]
+
+
+@dataclass(frozen=True)
+class RewardContext:
+    """Inputs available to reward functions."""
+
+    rollout_dir: Path
+    task_dir: Path | None = None
+    trajectory: list[dict] = field(default_factory=list)
+    metadata: dict = field(default_factory=dict)
+
+
+class RewardFunc(Protocol):
+    """Scoring interface for terminal, process, or dense rewards."""
+
+    async def score(self, ctx: RewardContext) -> RewardValue: ...
+
+
+@dataclass
+class Rubric:
+    """Weighted collection of reward functions."""
+
+    reward_funcs: list[RewardFunc]
+    weights: list[float] | None = None
+
+    async def score(self, ctx: RewardContext) -> list[RewardEvent]:
+        if self.weights is not None and len(self.weights) != len(self.reward_funcs):
+            raise ValueError("weights length must match reward_funcs length")
+
+        events: list[RewardEvent] = []
+        for i, reward_func in enumerate(self.reward_funcs):
+            value = await reward_func.score(ctx)
+            weight = self.weights[i] if self.weights is not None else 1.0
+            for event in _coerce_events(value, source=reward_func.__class__.__name__):
+                meta = {**event.meta}
+                if weight != 1.0:
+                    meta["raw_value"] = event.value
+                    meta["weight"] = weight
+                events.append(
+                    RewardEvent(
+                        ts=event.ts,
+                        type=event.type,
+                        source=event.source,
+                        value=event.value * weight,
+                        tag=event.tag,
+                        step_index=event.step_index,
+                        meta=meta,
+                    )
+                )
+        return events
+
+
+def _coerce_events(value: RewardValue, *, source: str) -> list[RewardEvent]:
+    if isinstance(value, RewardEvent):
+        return [value]
+    if isinstance(value, list):
+        return value
+    return [RewardEvent(type="terminal", source=source, value=float(value))]

--- a/src/benchflow/rewards/serialization.py
+++ b/src/benchflow/rewards/serialization.py
@@ -1,0 +1,39 @@
+"""Reward event persistence."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from benchflow.rewards.events import RewardEvent, rewards_from_verifier_dict
+
+
+def write_rewards_jsonl(
+    rollout_dir: Path,
+    rewards: dict[str, Any] | None = None,
+    finished_at: datetime | None = None,
+    *,
+    events: list[RewardEvent] | None = None,
+) -> None:
+    """Write reward events to ``rewards.jsonl``.
+
+    ``rewards`` is the current verifier-produced dict shape. New rubric code can
+    pass explicit ``events`` once scoring is fully native.
+    """
+
+    reward_events = list(events or [])
+    reward_events.extend(
+        rewards_from_verifier_dict(rewards, finished_at=finished_at)
+        if rewards is not None
+        else []
+    )
+    if not reward_events:
+        return
+
+    path = rollout_dir / "rewards.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(event.to_json(), default=str) for event in reward_events)
+        + "\n"
+    )

--- a/src/benchflow/rollouts/__init__.py
+++ b/src/benchflow/rollouts/__init__.py
@@ -14,13 +14,16 @@ from benchflow.rollouts.config import (
     Scene,
     Turn,
 )
+from benchflow.rollouts.result import RolloutResult, TrajectorySource
 
 __all__ = [
     "GENERATED_SKILLS_ROOT",
     "Role",
     "RolloutConfig",
+    "RolloutResult",
     "SKILL_MODE_DEFAULT",
     "SKILL_MODE_SELF_GEN",
     "Scene",
+    "TrajectorySource",
     "Turn",
 ]

--- a/src/benchflow/rollouts/__init__.py
+++ b/src/benchflow/rollouts/__init__.py
@@ -15,6 +15,7 @@ from benchflow.rollouts.config import (
     Turn,
 )
 from benchflow.rollouts.result import RolloutResult, TrajectorySource
+from benchflow.rollouts.yaml import rollout_config_from_dict, rollout_config_from_yaml
 
 __all__ = [
     "GENERATED_SKILLS_ROOT",
@@ -26,4 +27,6 @@ __all__ = [
     "Scene",
     "TrajectorySource",
     "Turn",
+    "rollout_config_from_dict",
+    "rollout_config_from_yaml",
 ]

--- a/src/benchflow/rollouts/__init__.py
+++ b/src/benchflow/rollouts/__init__.py
@@ -5,6 +5,22 @@ roles, turns, and scenes. Legacy modules may temporarily re-export them during
 the migration, but new code should import from ``benchflow.rollouts``.
 """
 
-from benchflow.rollouts.config import Role, Scene, Turn
+from benchflow.rollouts.config import (
+    GENERATED_SKILLS_ROOT,
+    SKILL_MODE_DEFAULT,
+    SKILL_MODE_SELF_GEN,
+    Role,
+    RolloutConfig,
+    Scene,
+    Turn,
+)
 
-__all__ = ["Role", "Scene", "Turn"]
+__all__ = [
+    "GENERATED_SKILLS_ROOT",
+    "Role",
+    "RolloutConfig",
+    "SKILL_MODE_DEFAULT",
+    "SKILL_MODE_SELF_GEN",
+    "Scene",
+    "Turn",
+]

--- a/src/benchflow/rollouts/__init__.py
+++ b/src/benchflow/rollouts/__init__.py
@@ -1,0 +1,10 @@
+"""Rollout configuration primitives.
+
+The v0.4 architecture uses these dataclasses as the canonical definitions for
+roles, turns, and scenes. Legacy modules may temporarily re-export them during
+the migration, but new code should import from ``benchflow.rollouts``.
+"""
+
+from benchflow.rollouts.config import Role, Scene, Turn
+
+__all__ = ["Role", "Scene", "Turn"]

--- a/src/benchflow/rollouts/_helpers.py
+++ b/src/benchflow/rollouts/_helpers.py
@@ -1,0 +1,334 @@
+"""Private rollout lifecycle helpers.
+
+These functions are the rollout-native home for logic that used to live on
+``SDK`` static/private methods. Keeping them module-level makes the lifecycle
+independent from the legacy SDK shim while preserving current artifact shapes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shlex
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import benchflow._harbor as harbor_compat
+from benchflow._sandbox import harden_before_verify
+from benchflow.models import RunResult
+from benchflow.rewards import write_rewards_jsonl
+from benchflow.rollouts.result import TrajectorySource
+
+logger = logging.getLogger(__name__)
+
+_DIAG_TRUNCATE = 2000
+
+
+def init_rollout(
+    task_path: Path,
+    job_name: str | None,
+    rollout_name: str | None,
+    jobs_dir: str | Path,
+) -> tuple[Any, Path, Any, datetime, str, str]:
+    """Set up rollout directory tree and return core objects."""
+
+    from uuid import uuid4
+
+    task = harbor_compat.make_task(task_path)
+    job_name = job_name or datetime.now().strftime("%Y-%m-%d__%H-%M-%S")
+    rollout_name = rollout_name or f"{task_path.name}__{uuid4().hex[:8]}"
+    rollout_dir = Path(jobs_dir) / job_name / rollout_name
+    rollout_paths = harbor_compat.make_trial_paths(rollout_dir)
+    started_at = datetime.now()
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    for subdir in ("agent", "verifier", "artifacts", "trajectory"):
+        (rollout_dir / subdir).mkdir(exist_ok=True)
+    return task, rollout_dir, rollout_paths, started_at, job_name, rollout_name
+
+
+def write_config(
+    rollout_dir: Path,
+    *,
+    task_path: Path,
+    agent: str,
+    model: str | None,
+    environment: str,
+    skills_dir: str | Path | None,
+    sandbox_user: str | None,
+    context_root: str | Path | None,
+    sandbox_locked_paths: list[str] | None = None,
+    sandbox_setup_timeout: int = 120,
+    timeout: int,
+    started_at: datetime,
+    agent_env: dict[str, str],
+) -> None:
+    """Write config.json with secrets filtered out."""
+
+    secret_substrings = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIALS")
+    recorded_env = {
+        k: v
+        for k, v in agent_env.items()
+        if not any(s in k.upper() for s in secret_substrings)
+    }
+    config_data = {
+        "task_path": str(task_path),
+        "agent": agent,
+        "model": model,
+        "environment": environment,
+        "skills_dir": str(skills_dir) if skills_dir else None,
+        "sandbox_user": sandbox_user,
+        "sandbox_locked_paths": sandbox_locked_paths,
+        "sandbox_setup_timeout": sandbox_setup_timeout,
+        "context_root": str(context_root) if context_root else None,
+        "timeout_sec": timeout,
+        "started_at": str(started_at),
+        "agent_env": recorded_env,
+    }
+    (rollout_dir / "config.json").write_text(json.dumps(config_data, indent=2))
+
+
+def build_result(
+    rollout_dir: Path,
+    *,
+    task_name: str,
+    rollout_name: str,
+    agent: str,
+    agent_name: str,
+    model: str,
+    n_tool_calls: int,
+    prompts: list[str],
+    error: str | None,
+    verifier_error: str | None,
+    trajectory: list[dict],
+    partial_trajectory: bool,
+    trajectory_source: TrajectorySource | None = None,
+    rewards: dict | None,
+    started_at: datetime,
+    timing: dict[str, float],
+) -> RunResult:
+    """Build RunResult and write result/timing/prompt/trajectory artifacts."""
+
+    finished_at = datetime.now()
+    result = RunResult(
+        task_name=task_name,
+        trial_name=rollout_name,
+        rewards=rewards,
+        trajectory=trajectory,
+        agent=agent,
+        agent_name=agent_name,
+        model=model,
+        n_tool_calls=n_tool_calls,
+        n_prompts=len(prompts),
+        error=error,
+        verifier_error=verifier_error,
+        partial_trajectory=partial_trajectory,
+        trajectory_source=trajectory_source,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    timing["total"] = (finished_at - started_at).total_seconds()
+    timing = {k: round(v, 1) for k, v in timing.items()}
+    traj_dir = rollout_dir / "trajectory"
+    traj_dir.mkdir(parents=True, exist_ok=True)
+    (traj_dir / "acp_trajectory.jsonl").write_text(
+        "\n".join(json.dumps(e, default=str) for e in trajectory)
+    )
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    (rollout_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": result.task_name,
+                "trial_name": result.trial_name,
+                "rollout_name": result.rollout_name,
+                "rewards": result.rewards,
+                "agent": result.agent,
+                "agent_name": result.agent_name,
+                "model": result.model,
+                "n_tool_calls": result.n_tool_calls,
+                "n_prompts": result.n_prompts,
+                "error": result.error,
+                "verifier_error": result.verifier_error,
+                "partial_trajectory": result.partial_trajectory,
+                "trajectory_source": result.trajectory_source,
+                "started_at": str(result.started_at),
+                "finished_at": str(result.finished_at),
+                "timing": timing,
+            },
+            indent=2,
+        )
+    )
+    (rollout_dir / "timing.json").write_text(json.dumps(timing, indent=2))
+    (rollout_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
+    write_rewards_jsonl(rollout_dir, rewards, finished_at)
+    return result
+
+
+def resolve_prompts(
+    task_path: Path,
+    prompts: list[str | None] | None,
+    skills_dir: str | Path | None = None,
+    skill_nudge: str = "",
+    agent: str | None = None,
+) -> list[str]:
+    """Read instruction.md and resolve prompt list."""
+
+    instruction_path = task_path / "instruction.md"
+    if not instruction_path.exists():
+        raise FileNotFoundError(f"Task missing instruction.md: {task_path}")
+    instruction = instruction_path.read_text().strip()
+
+    if skill_nudge:
+        from benchflow.agents.registry import AGENTS
+
+        skill_display_path = "~/.claude/skills"
+        if agent:
+            agent_cfg = AGENTS.get(agent)
+            if agent_cfg and agent_cfg.skill_paths:
+                skill_display_path = agent_cfg.skill_paths[0].replace("$HOME", "~")
+
+        skills = []
+        for src in [skills_dir, task_path / "environment" / "skills"]:
+            if src and Path(src).is_dir():
+                for d in sorted(Path(src).iterdir()):
+                    if d.is_dir() and (d / "SKILL.md").exists():
+                        content = d.joinpath("SKILL.md").read_text()
+                        name = d.name
+                        desc = ""
+                        if content.startswith("---"):
+                            parts = content.split("---", 2)
+                            if len(parts) >= 3:
+                                import yaml
+
+                                try:
+                                    fm = yaml.safe_load(parts[1])
+                                    desc = fm.get("description", "") if fm else ""
+                                except Exception:
+                                    pass
+                        skills.append({"name": name, "desc": desc, "content": content})
+                if skills:
+                    break
+
+        if skills:
+            if skill_nudge == "name":
+                names = ", ".join(s["name"] for s in skills)
+                nudge = f"Skills available at {skill_display_path}: {names}. Read them before starting."
+                instruction = nudge + "\n\n" + instruction
+            elif skill_nudge == "description":
+                lines = [f"Skills available at {skill_display_path}:\n"]
+                for s in skills:
+                    lines.append(f"- **{s['name']}**: {s['desc']}")
+                lines.append("\nRead the relevant skills before starting.")
+                instruction = "\n".join(lines) + "\n\n" + instruction
+            elif skill_nudge == "full":
+                blocks = []
+                for s in skills:
+                    blocks.append(
+                        f'<skill name="{s["name"]}">\n{s["content"]}\n</skill>'
+                    )
+                instruction = "\n\n".join(blocks) + "\n\n" + instruction
+
+    if prompts is None:
+        return [instruction]
+    return [p if p is not None else instruction for p in prompts]
+
+
+async def start_env_and_upload(env, task_path: Path, timing: dict) -> None:
+    """Start environment and upload standard task files."""
+
+    logger.info(f"Starting environment: {task_path.name}")
+    t0 = datetime.now()
+    await env.start(force_build=False)
+    timing["environment_setup"] = (datetime.now() - t0).total_seconds()
+    if (task_path / "instruction.md").exists():
+        await env.upload_file(task_path / "instruction.md", "/instruction.md")
+    if (task_path / "solution").is_dir():
+        await env.upload_dir(task_path / "solution", "/solution")
+
+
+async def run_oracle(
+    env,
+    task_path: Path,
+    timeout: int,
+    sandbox_user: str | None = None,
+) -> tuple[list[dict], str]:
+    """Run oracle mode (solution/solve.sh), return (trajectory, agent_name)."""
+
+    logger.info("Oracle mode: running solution/solve.sh")
+    if not (task_path / "solution" / "solve.sh").exists():
+        raise FileNotFoundError(f"Oracle requires solution/solve.sh: {task_path}")
+    if sandbox_user:
+        oracle_cmd = "DEBIAN_FRONTEND=noninteractive bash /solution/solve.sh"
+        cmd = (
+            f"su -s /bin/bash {shlex.quote(sandbox_user)} "
+            f"-c {shlex.quote(oracle_cmd)}"
+        )
+    else:
+        cmd = "bash /solution/solve.sh"
+    oracle_env: dict[str, str] = {"DEBIAN_FRONTEND": "noninteractive"}
+    task = harbor_compat.make_task(task_path)
+    if task.config.solution.env:
+        oracle_env.update(harbor_compat.resolve_env_vars(task.config.solution.env))
+    result = await env.exec(
+        f"{cmd} > /logs/agent/oracle.txt 2>&1",
+        env=oracle_env,
+        timeout_sec=timeout,
+    )
+    if result.return_code != 0:
+        logger.warning(f"Oracle solve.sh exited with rc={result.return_code}")
+    preview = await env.exec(
+        f"tail -c {shlex.quote(str(_DIAG_TRUNCATE))} /logs/agent/oracle.txt 2>/dev/null || true",
+        user="root",
+        timeout_sec=10,
+    )
+    trajectory = [
+        {
+            "type": "oracle",
+            "command": "solution/solve.sh",
+            "return_code": result.return_code,
+            "stdout": (preview.stdout or "")[:_DIAG_TRUNCATE],
+        }
+    ]
+    return trajectory, "oracle"
+
+
+async def verify(
+    env,
+    task: Any,
+    rollout_paths: Any,
+    timing: dict,
+    sandbox_user: str | None = None,
+    workspace: str | None = None,
+) -> tuple[dict | None, str | None]:
+    """Run verifier with pre-verification hardening."""
+
+    rollout_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
+    await harden_before_verify(env, task, sandbox_user, workspace=workspace)
+    logger.info("Running verifier...")
+    t0 = datetime.now()
+    verifier_error = None
+    try:
+        verifier = harbor_compat.make_verifier(
+            task=task,
+            trial_paths=rollout_paths,
+            environment=env,
+        )
+        verifier_result = await asyncio.wait_for(
+            verifier.verify(),
+            timeout=task.config.verifier.timeout_sec,
+        )
+        timing["verifier"] = (datetime.now() - t0).total_seconds()
+        rewards = verifier_result.rewards
+        logger.info(f"Rewards: {rewards}")
+    except TimeoutError:
+        timing["verifier"] = (datetime.now() - t0).total_seconds()
+        verifier_error = f"verifier timed out after {task.config.verifier.timeout_sec}s"
+        rewards = None
+        logger.error(verifier_error)
+    except Exception as e:
+        timing["verifier"] = (datetime.now() - t0).total_seconds()
+        verifier_error = f"verifier crashed: {e}"
+        rewards = None
+        logger.error(verifier_error)
+    return rewards, verifier_error

--- a/src/benchflow/rollouts/config.py
+++ b/src/benchflow/rollouts/config.py
@@ -1,0 +1,80 @@
+"""Canonical rollout configuration types.
+
+These types are intentionally small, serializable dataclasses. They are the
+single source of truth for v0.4 scene configuration while the execution
+lifecycle is migrated from ``Trial`` to ``Rollout``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class Role:
+    """One participant in a rollout scene.
+
+    Runtime budgets belong on roles, not in the agent registry. ``None`` means
+    inherit from the surrounding rollout/task defaults.
+    """
+
+    name: str
+    agent: str
+    model: str | None = None
+    env: dict[str, str] = field(default_factory=dict)
+    timeout_sec: int | None = None
+    idle_timeout_sec: int | None = None
+    skills_dir: str | Path | None = None
+    capabilities: list[str] = field(default_factory=list)
+    instruction: str | None = None
+    tools: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Turn:
+    """One role action opportunity within a scene."""
+
+    role: str
+    prompt: str | None = None  # None = expand from task instruction.md
+
+
+@dataclass
+class Scene:
+    """A flat rollout phase containing roles and ordered turns."""
+
+    name: str = "default"
+    roles: list[Role] = field(default_factory=list)
+    turns: list[Turn] = field(default_factory=list)
+    skills_dir: str | Path | None = None
+    parallel_group: str | None = None
+
+    @classmethod
+    def single(
+        cls,
+        *,
+        agent: str,
+        model: str | None = None,
+        prompts: list[str | None] | None = None,
+        role_name: str = "agent",
+        skills_dir: str | Path | None = None,
+        timeout_sec: int | None = None,
+        idle_timeout_sec: int | None = None,
+    ) -> Scene:
+        """Shortcut for a single-role scene using task instructions by default."""
+
+        prompts = prompts or [None]
+        return cls(
+            roles=[
+                Role(
+                    name=role_name,
+                    agent=agent,
+                    model=model,
+                    timeout_sec=timeout_sec,
+                    idle_timeout_sec=idle_timeout_sec,
+                    skills_dir=skills_dir,
+                )
+            ],
+            turns=[Turn(role=role_name, prompt=p) for p in prompts],
+            skills_dir=skills_dir,
+        )

--- a/src/benchflow/rollouts/config.py
+++ b/src/benchflow/rollouts/config.py
@@ -10,6 +10,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from benchflow.user import BaseUser
+
+SKILL_MODE_DEFAULT = "default"
+SKILL_MODE_SELF_GEN = "self-gen"
+GENERATED_SKILLS_ROOT = "/app/generated-skills"
+
 
 @dataclass
 class Role:
@@ -78,3 +84,134 @@ class Scene:
             turns=[Turn(role=role_name, prompt=p) for p in prompts],
             skills_dir=skills_dir,
         )
+
+
+@dataclass
+class RolloutConfig:
+    """Declarative config for one task attempt in one sandbox.
+
+    During the v0.4 migration this preserves the current TrialConfig fields so
+    execution can move independently from public naming.
+    """
+
+    task_path: Path
+    scenes: list[Scene] = field(default_factory=list)
+    environment: str = "docker"
+    sandbox_user: str | None = "agent"
+    sandbox_locked_paths: list[str] | None = None
+    sandbox_setup_timeout: int = 120
+    services: list[str] | None = None
+    job_name: str | None = None
+    trial_name: str | None = None
+    jobs_dir: str | Path = "jobs"
+    context_root: str | Path | None = None
+    pre_agent_hooks: list | None = None
+    agent_idle_timeout: int | None = 600
+
+    # User-driven progressive-disclosure loop
+    user: BaseUser | None = None
+    max_user_rounds: int = 5
+    oracle_access: bool = False
+
+    # Legacy flat single-agent fields. Ignored when scenes is set.
+    agent: str = "claude-agent-acp"
+    prompts: list[str | None] | None = None
+    model: str | None = None
+    agent_env: dict[str, str] | None = None
+    skills_dir: str | Path | None = None
+    skill_mode: str = SKILL_MODE_DEFAULT
+    skill_creator_dir: str | Path | None = None
+    generated_skills_root: str = GENERATED_SKILLS_ROOT
+    self_gen_no_internet: bool = False
+    include_task_skills: bool = True
+    skip_verify: bool = False
+    export_generated_skills_to: str | Path | None = None
+
+    @classmethod
+    def from_single(
+        cls,
+        *,
+        task_path: Path,
+        agent: str = "claude-agent-acp",
+        model: str | None = None,
+        prompts: list[str | None] | None = None,
+        skills_dir: str | Path | None = None,
+        skill_mode: str = SKILL_MODE_DEFAULT,
+        skill_creator_dir: str | Path | None = None,
+        generated_skills_root: str = GENERATED_SKILLS_ROOT,
+        self_gen_no_internet: bool = False,
+        **kwargs,
+    ) -> RolloutConfig:
+        """Construct from flat single-agent arguments."""
+
+        scenes = []
+        if skill_mode not in {SKILL_MODE_DEFAULT, SKILL_MODE_SELF_GEN}:
+            raise ValueError(f"Unknown skill_mode: {skill_mode}")
+        if skill_mode == SKILL_MODE_DEFAULT:
+            scenes = [
+                Scene.single(
+                    agent=agent,
+                    model=model,
+                    prompts=prompts,
+                    skills_dir=skills_dir,
+                )
+            ]
+        return cls(
+            task_path=task_path,
+            scenes=scenes,
+            agent=agent,
+            model=model,
+            prompts=prompts,
+            skills_dir=skills_dir,
+            skill_mode=skill_mode,
+            skill_creator_dir=skill_creator_dir,
+            generated_skills_root=generated_skills_root,
+            self_gen_no_internet=self_gen_no_internet,
+            **kwargs,
+        )
+
+    @classmethod
+    def from_legacy(cls, **kwargs) -> RolloutConfig:
+        """Compatibility constructor while callsites migrate to from_single()."""
+
+        return cls.from_single(**kwargs)
+
+    @property
+    def effective_scenes(self) -> list[Scene]:
+        """Scenes to execute, falling back to flat single-agent fields."""
+
+        if self.skill_mode == SKILL_MODE_SELF_GEN:
+            raise ValueError(
+                "self-gen requires the runtime orchestrator. Use the high-level "
+                "run path instead of direct rollout scenes."
+            )
+        if self.scenes:
+            return self.scenes
+        if self.skill_mode != SKILL_MODE_DEFAULT:
+            raise ValueError(f"Unknown skill_mode: {self.skill_mode}")
+        return [
+            Scene.single(
+                agent=self.agent,
+                model=self.model,
+                prompts=self.prompts,
+                skills_dir=self.skills_dir,
+            )
+        ]
+
+    @property
+    def primary_agent(self) -> str:
+        """Agent name for the first role of the first scene."""
+
+        scenes = self.effective_scenes
+        if scenes and scenes[0].roles:
+            return scenes[0].roles[0].agent
+        return self.agent
+
+    @property
+    def primary_model(self) -> str | None:
+        """Model for the first role of the first scene."""
+
+        scenes = self.effective_scenes
+        if scenes and scenes[0].roles:
+            return scenes[0].roles[0].model
+        return self.model

--- a/src/benchflow/rollouts/result.py
+++ b/src/benchflow/rollouts/result.py
@@ -1,0 +1,69 @@
+"""Rollout result model."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+TrajectorySource = Literal["acp", "scraped", "partial_acp"]
+"""Provenance label for captured trajectory events."""
+
+
+class RolloutResult:
+    """Outcome of one rollout attempt."""
+
+    def __init__(
+        self,
+        task_name: str,
+        trial_name: str = "",
+        rewards: dict[str, float | int] | None = None,
+        trajectory: list[dict[str, Any]] | None = None,
+        agent: str = "",
+        agent_name: str = "",
+        model: str = "",
+        n_tool_calls: int = 0,
+        n_prompts: int = 0,
+        error: str | None = None,
+        verifier_error: str | None = None,
+        partial_trajectory: bool = False,
+        trajectory_source: TrajectorySource | None = None,
+        started_at: datetime | None = None,
+        finished_at: datetime | None = None,
+    ):
+        self.task_name = task_name
+        # ``trial_name`` is retained in artifacts during migration; rollout_name
+        # is exposed as the rollout-native spelling.
+        self.trial_name = trial_name
+        self.rewards = rewards
+        self.trajectory = trajectory or []
+        self.agent = agent
+        self.agent_name = agent_name
+        self.model = model
+        self.n_tool_calls = n_tool_calls
+        self.n_prompts = n_prompts
+        self.error = error
+        self.verifier_error = verifier_error
+        self.partial_trajectory = partial_trajectory
+        self.trajectory_source = trajectory_source
+        self.started_at = started_at
+        self.finished_at = finished_at
+
+    @property
+    def rollout_name(self) -> str:
+        """Rollout-native name for the current artifact ``trial_name``."""
+
+        return self.trial_name
+
+    @property
+    def success(self) -> bool:
+        """True when the rollout completed without agent or verifier error."""
+
+        return self.error is None and self.verifier_error is None
+
+    def __repr__(self) -> str:
+        status = "OK" if self.success else f"ERROR: {self.error or self.verifier_error}"
+        return (
+            f"{self.__class__.__name__}(task={self.task_name}, {status}, "
+            f"rewards={self.rewards}, "
+            f"trajectory={len(self.trajectory)} events)"
+        )

--- a/src/benchflow/rollouts/rollout.py
+++ b/src/benchflow/rollouts/rollout.py
@@ -7,8 +7,23 @@ commits will remove the legacy module name once all callsites move here.
 
 from __future__ import annotations
 
+from benchflow.rollouts.config import RolloutConfig
 from benchflow.trial import Trial
 
 
 class Rollout(Trial):
     """One attempt on one task in one sandbox."""
+
+    def __init__(self, config: RolloutConfig) -> None:
+        super().__init__(config)
+
+    @classmethod
+    async def create(cls, config: RolloutConfig) -> Rollout:
+        """Create a rollout lifecycle instance."""
+
+        if config.skill_mode == "self-gen":
+            raise ValueError(
+                "self-gen requires the runtime orchestrator. Use the high-level "
+                "run path instead of Rollout.create()."
+            )
+        return cls(config)

--- a/src/benchflow/rollouts/rollout.py
+++ b/src/benchflow/rollouts/rollout.py
@@ -1,0 +1,14 @@
+"""Rollout lifecycle entry point.
+
+This module is the v0.4 home for the execution lifecycle. During the migration
+it delegates to the existing decomposed lifecycle implementation; follow-up
+commits will remove the legacy module name once all callsites move here.
+"""
+
+from __future__ import annotations
+
+from benchflow.trial import Trial
+
+
+class Rollout(Trial):
+    """One attempt on one task in one sandbox."""

--- a/src/benchflow/rollouts/runner.py
+++ b/src/benchflow/rollouts/runner.py
@@ -1,0 +1,18 @@
+"""Rollout run helpers."""
+
+from __future__ import annotations
+
+from benchflow.rollouts.config import RolloutConfig
+from benchflow.rollouts.result import RolloutResult
+from benchflow.rollouts.rollout import Rollout
+
+
+async def run(config: RolloutConfig) -> RolloutResult:
+    """Execute a rollout config and return its result."""
+
+    if config.skill_mode == "self-gen":
+        from benchflow.self_gen import run_self_gen
+
+        return await run_self_gen(config)
+    rollout = await Rollout.create(config)
+    return await rollout.run()

--- a/src/benchflow/rollouts/yaml.py
+++ b/src/benchflow/rollouts/yaml.py
@@ -1,0 +1,147 @@
+"""YAML rollout config loader."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from benchflow.rollouts.config import Role, RolloutConfig, Scene, Turn
+
+logger = logging.getLogger(__name__)
+
+
+def load_rollout_yaml(path: str | Path) -> dict:
+    """Load and normalize a rollout YAML file."""
+
+    with open(path) as f:
+        raw = yaml.safe_load(f)
+    if not isinstance(raw, dict):
+        raise ValueError(f"Expected dict at top level, got {type(raw).__name__}")
+    return raw
+
+
+def rollout_config_from_yaml(
+    path: str | Path,
+    task_path: Path | None = None,
+) -> RolloutConfig:
+    """Parse a YAML file into a RolloutConfig."""
+
+    raw = load_rollout_yaml(path)
+    return rollout_config_from_dict(raw, task_path=task_path)
+
+
+def rollout_config_from_dict(
+    raw: dict[str, Any],
+    task_path: Path | None = None,
+) -> RolloutConfig:
+    """Convert a raw dict into a RolloutConfig."""
+
+    tp = task_path or Path(raw.get("task_dir", raw.get("task_path", ".")))
+
+    if "scenes" in raw:
+        scenes = [_parse_scene(s) for s in raw["scenes"]]
+    elif "agent" in raw:
+        prompts_raw = raw.get("prompts")
+        prompts: list[str | None]
+        if isinstance(prompts_raw, list):
+            prompts = []
+            for prompt in prompts_raw:
+                if prompt is not None and not isinstance(prompt, str):
+                    raise ValueError("YAML prompts entries must be strings or null")
+                prompts.append(prompt)
+        elif isinstance(prompts_raw, str):
+            prompts = [prompts_raw]
+        else:
+            prompts = [None]
+        scenes = [
+            Scene.single(
+                agent=raw["agent"],
+                model=raw.get("model"),
+                prompts=prompts,
+                skills_dir=raw.get("skills_dir"),
+            )
+        ]
+    else:
+        raise ValueError("YAML must have either 'scenes' or 'agent' at top level")
+
+    return RolloutConfig(
+        task_path=tp,
+        scenes=scenes,
+        environment=raw.get("environment", "docker"),
+        sandbox_user=raw.get("sandbox_user", "agent"),
+        sandbox_locked_paths=raw.get("sandbox_locked_paths"),
+        sandbox_setup_timeout=raw.get("sandbox_setup_timeout", 120),
+        job_name=raw.get("job_name"),
+        trial_name=raw.get("trial_name"),
+        jobs_dir=raw.get("jobs_dir", "jobs"),
+        context_root=raw.get("context_root"),
+        agent=raw.get("agent", "claude-agent-acp"),
+        model=raw.get("model"),
+        agent_env=raw.get("agent_env"),
+        skills_dir=raw.get("skills_dir"),
+        skill_mode=raw.get("skill_mode", "default"),
+        skill_creator_dir=raw.get("skill_creator_dir"),
+        self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
+    )
+
+
+def _parse_scene(raw: dict) -> Scene:
+    """Parse a scene dict from YAML."""
+
+    roles = [_parse_role(r) for r in raw.get("roles", [])]
+    turns = [_parse_turn(t) for t in raw.get("turns", [])]
+    if not turns and roles:
+        turns = [Turn(role=r.name) for r in roles]
+    return Scene(
+        name=raw.get("name", "default"),
+        roles=roles,
+        turns=turns,
+        skills_dir=raw.get("skills_dir"),
+        parallel_group=raw.get("parallel_group"),
+    )
+
+
+def _parse_role(raw: dict) -> Role:
+    """Parse a role dict from YAML."""
+
+    return Role(
+        name=raw["name"],
+        agent=raw["agent"],
+        model=raw.get("model"),
+        env=raw.get("env", {}),
+        timeout_sec=raw.get("timeout_sec"),
+        idle_timeout_sec=raw.get("idle_timeout_sec"),
+        skills_dir=raw.get("skills_dir"),
+        capabilities=raw.get("capabilities", []),
+        instruction=raw.get("instruction"),
+        tools=raw.get("tools", []),
+    )
+
+
+def _parse_turn(raw: dict) -> Turn:
+    """Parse a turn dict from YAML."""
+
+    return Turn(
+        role=raw["role"],
+        prompt=raw.get("prompt"),
+    )
+
+
+def job_config_from_yaml(path: str | Path) -> dict:
+    """Parse a YAML file and return job-level plus rollout-level config."""
+
+    raw = load_rollout_yaml(path)
+    task_dir = Path(raw.get("task_dir", raw.get("tasks_dir", ".")))
+    concurrency = raw.get("concurrency", 4)
+    max_retries = raw.get("max_retries", 2)
+    return {
+        "task_dir": task_dir,
+        "concurrency": concurrency,
+        "max_retries": max_retries,
+        "trial_config": rollout_config_from_dict(raw, task_path=task_dir),
+        "rollout_config": rollout_config_from_dict(raw, task_path=task_dir),
+        "raw": raw,
+    }

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -64,15 +64,13 @@ class Environment:
         """Create an environment from a task directory."""
         from uuid import uuid4
 
-        from harbor.models.task.task import Task
-        from harbor.models.trial.paths import TrialPaths
-
         from benchflow._env_setup import _create_environment
+        import benchflow._harbor as harbor_compat
 
         task_path = Path(task_path)
-        task = Task(task_path)
+        task = harbor_compat.make_task(task_path)
         trial_name = trial_name or task_path.name
-        trial_paths = TrialPaths(
+        trial_paths = harbor_compat.make_trial_paths(
             Path.cwd() / "jobs" / "environment" / f"{trial_name}__{uuid4().hex[:8]}"
         )
         trial_paths.mkdir()
@@ -92,9 +90,9 @@ class Environment:
 
     @property
     def task(self) -> Any:
-        from harbor.models.task.task import Task
+        import benchflow._harbor as harbor_compat
 
-        return Task(self.task_path)
+        return harbor_compat.make_task(self.task_path)
 
     async def start(self, force_build: bool = False) -> None:
         await self._inner.start(force_build=force_build)

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -64,8 +64,8 @@ class Environment:
         """Create an environment from a task directory."""
         from uuid import uuid4
 
-        from benchflow._env_setup import _create_environment
         import benchflow._harbor as harbor_compat
+        from benchflow._env_setup import _create_environment
 
         task_path = Path(task_path)
         task = harbor_compat.make_task(task_path)

--- a/src/benchflow/sandboxes/__init__.py
+++ b/src/benchflow/sandboxes/__init__.py
@@ -1,9 +1,12 @@
 """Sandbox protocols and specifications."""
 
+from benchflow.sandboxes.docker import DockerSandbox, DockerSandboxConfig
 from benchflow.sandboxes.protocols import ImageBuilder, Sandbox, SandboxProvider
 from benchflow.sandboxes.specs import ExecResult, ImageConfig, ImageRef, SandboxSpec
 
 __all__ = [
+    "DockerSandbox",
+    "DockerSandboxConfig",
     "ExecResult",
     "ImageBuilder",
     "ImageConfig",

--- a/src/benchflow/sandboxes/__init__.py
+++ b/src/benchflow/sandboxes/__init__.py
@@ -1,0 +1,14 @@
+"""Sandbox protocols and specifications."""
+
+from benchflow.sandboxes.protocols import ImageBuilder, Sandbox, SandboxProvider
+from benchflow.sandboxes.specs import ExecResult, ImageConfig, ImageRef, SandboxSpec
+
+__all__ = [
+    "ExecResult",
+    "ImageBuilder",
+    "ImageConfig",
+    "ImageRef",
+    "Sandbox",
+    "SandboxProvider",
+    "SandboxSpec",
+]

--- a/src/benchflow/sandboxes/docker.py
+++ b/src/benchflow/sandboxes/docker.py
@@ -1,0 +1,248 @@
+"""Native Docker sandbox provider.
+
+This module owns Docker execution directly instead of routing through Harbor.
+It intentionally has a small surface: build/start/stop, command execution, and
+file transfer. Rollout orchestration should depend on the Sandbox protocol, not
+on Docker-specific details.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import os
+import shlex
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from uuid import uuid4
+
+from benchflow.sandboxes.specs import ExecResult, SandboxSpec
+
+
+@dataclass(frozen=True)
+class _CompletedProcess:
+    returncode: int
+    stdout: bytes
+    stderr: bytes
+
+
+@dataclass(frozen=True)
+class DockerSandboxConfig:
+    """Docker-specific sandbox startup config."""
+
+    task_path: Path
+    session_id: str = field(default_factory=lambda: f"bf-{uuid4().hex[:12]}")
+    image_tag: str | None = None
+    workdir: str = "/app"
+    command: tuple[str, ...] = ("sleep", "infinity")
+    force_build: bool = False
+
+    @property
+    def environment_dir(self) -> Path:
+        return self.task_path / "environment"
+
+    @property
+    def dockerfile(self) -> Path:
+        return self.environment_dir / "Dockerfile"
+
+    @property
+    def resolved_image_tag(self) -> str:
+        if self.image_tag:
+            return self.image_tag
+        safe_task = self.task_path.name.lower().replace("_", "-")
+        return f"benchflow-{safe_task}:{self.session_id}"
+
+
+class DockerSandbox:
+    """Isolated Docker container sandbox."""
+
+    def __init__(
+        self,
+        config: DockerSandboxConfig,
+        spec: SandboxSpec | None = None,
+    ) -> None:
+        self.config = config
+        self.spec = spec or SandboxSpec(provider="docker")
+        self.container_name = f"benchflow-{config.session_id}"
+        self._started = False
+
+    async def start(self) -> None:
+        """Build the task image if needed and start a fresh container."""
+
+        image = self.config.resolved_image_tag
+        if self.config.force_build or not await self._image_exists(image):
+            await self._check(
+                [
+                    "docker",
+                    "build",
+                    "-t",
+                    image,
+                    "-f",
+                    str(self.config.dockerfile),
+                    str(self.config.environment_dir),
+                ]
+            )
+
+        run_cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            self.container_name,
+            "--label",
+            f"benchflow.session={self.config.session_id}",
+            "--workdir",
+            self.config.workdir,
+        ]
+        if not self.spec.allow_internet:
+            run_cmd.extend(["--network", "none"])
+        if self.spec.cpus is not None:
+            run_cmd.extend(["--cpus", str(self.spec.cpus)])
+        if self.spec.memory_mb is not None:
+            run_cmd.extend(["--memory", f"{self.spec.memory_mb}m"])
+        for key, value in self.spec.env.items():
+            run_cmd.extend(["--env", f"{key}={value}"])
+        run_cmd.append(image)
+        run_cmd.extend(self.config.command)
+        await self._check(run_cmd)
+        self._started = True
+
+    async def stop(self, *, delete: bool = True) -> None:
+        """Stop and optionally delete the container."""
+
+        if not self._started:
+            return
+        await self._run(["docker", "stop", self.container_name])
+        if delete:
+            await self._run(["docker", "rm", "-f", self.container_name])
+        self._started = False
+
+    async def exec(
+        self,
+        cmd: str | Sequence[str],
+        *,
+        user: str = "root",
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_sec: int = 30,
+    ) -> ExecResult:
+        """Execute a command in the running container."""
+
+        docker_cmd = ["docker", "exec", "-i"]
+        if user:
+            docker_cmd.extend(["--user", user])
+        if cwd:
+            docker_cmd.extend(["--workdir", cwd])
+        for key, value in (env or {}).items():
+            docker_cmd.extend(["--env", f"{key}={value}"])
+        docker_cmd.append(self.container_name)
+        if isinstance(cmd, str):
+            docker_cmd.extend(["bash", "-lc", cmd])
+        else:
+            docker_cmd.extend(cmd)
+        result = await self._run(docker_cmd, timeout_sec=timeout_sec)
+        return ExecResult(
+            stdout=result.stdout.decode(errors="replace"),
+            stderr=result.stderr.decode(errors="replace"),
+            return_code=result.returncode,
+        )
+
+    async def read_file(self, path: str) -> bytes:
+        """Read a file from the container."""
+
+        result = await self._check(
+            [
+                "docker",
+                "exec",
+                self.container_name,
+                "bash",
+                "-lc",
+                f"base64 -w0 {shlex.quote(path)}",
+            ]
+        )
+        return base64.b64decode(result.stdout)
+
+    async def write_file(self, path: str, content: bytes) -> None:
+        """Write bytes to a file in the container."""
+
+        parent = shlex.quote(str(Path(path).parent))
+        q_path = shlex.quote(path)
+        encoded = base64.b64encode(content).decode()
+        await self._check(
+            [
+                "docker",
+                "exec",
+                self.container_name,
+                "bash",
+                "-lc",
+                f"mkdir -p {parent} && base64 -d > {q_path}",
+            ],
+            stdin=encoded.encode(),
+        )
+
+    async def upload_dir(self, src: Path, dst: str) -> None:
+        """Copy a host directory into the container."""
+
+        await self._check(["docker", "cp", str(src), f"{self.container_name}:{dst}"])
+
+    async def download_dir(self, src: str, dst: Path) -> None:
+        """Copy a container directory to the host."""
+
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        await self._check(["docker", "cp", f"{self.container_name}:{src}", str(dst)])
+
+    async def _image_exists(self, image: str) -> bool:
+        result = await self._run(["docker", "image", "inspect", image])
+        return result.returncode == 0
+
+    async def _check(
+        self,
+        cmd: Sequence[str],
+        *,
+        stdin: bytes | None = None,
+        timeout_sec: int = 600,
+    ) -> _CompletedProcess:
+        result = await self._run(cmd, stdin=stdin, timeout_sec=timeout_sec)
+        if result.returncode != 0:
+            stderr = result.stderr.decode(errors="replace")
+            stdout = result.stdout.decode(errors="replace")
+            rendered = " ".join(shlex.quote(part) for part in cmd)
+            raise RuntimeError(
+                f"Command failed rc={result.returncode}: {rendered}\n{stderr or stdout}"
+            )
+        return result
+
+    async def _run(
+        self,
+        cmd: Sequence[str],
+        *,
+        stdin: bytes | None = None,
+        timeout_sec: int = 600,
+    ) -> _CompletedProcess:
+        env = os.environ.copy()
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(stdin),
+            timeout=timeout_sec,
+        )
+
+        return _CompletedProcess(proc.returncode or 0, stdout, stderr)
+
+
+class DockerSandboxProvider:
+    """Factory for native Docker sandboxes."""
+
+    name = "docker"
+
+    def __init__(self, task_path: Path) -> None:
+        self.task_path = task_path
+
+    async def create(self, spec: SandboxSpec) -> DockerSandbox:
+        return DockerSandbox(DockerSandboxConfig(task_path=self.task_path), spec=spec)

--- a/src/benchflow/sandboxes/protocols.py
+++ b/src/benchflow/sandboxes/protocols.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Mapping, Protocol, Sequence
+from typing import Protocol
 
 from benchflow.sandboxes.specs import ExecResult, ImageConfig, ImageRef, SandboxSpec
 

--- a/src/benchflow/sandboxes/protocols.py
+++ b/src/benchflow/sandboxes/protocols.py
@@ -1,0 +1,50 @@
+"""Protocols for sandbox runtimes and image builders."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Protocol, Sequence
+
+from benchflow.sandboxes.specs import ExecResult, ImageConfig, ImageRef, SandboxSpec
+
+
+class Sandbox(Protocol):
+    """Run-only isolated execution environment."""
+
+    async def start(self) -> None: ...
+
+    async def stop(self, *, delete: bool = True) -> None: ...
+
+    async def exec(
+        self,
+        cmd: str | Sequence[str],
+        *,
+        user: str = "root",
+        cwd: str | None = None,
+        env: Mapping[str, str] | None = None,
+        timeout_sec: int = 30,
+    ) -> ExecResult: ...
+
+    async def read_file(self, path: str) -> bytes: ...
+
+    async def write_file(self, path: str, content: bytes) -> None: ...
+
+    async def upload_dir(self, src: Path, dst: str) -> None: ...
+
+    async def download_dir(self, src: str, dst: Path) -> None: ...
+
+
+class SandboxProvider(Protocol):
+    """Factory for sandbox sessions."""
+
+    name: str
+
+    async def create(self, spec: SandboxSpec) -> Sandbox: ...
+
+
+class ImageBuilder(Protocol):
+    """Build-only interface that produces image references."""
+
+    async def cached(self, config: ImageConfig) -> ImageRef | None: ...
+
+    async def build(self, context_dir: Path, config: ImageConfig) -> ImageRef: ...

--- a/src/benchflow/sandboxes/specs.py
+++ b/src/benchflow/sandboxes/specs.py
@@ -1,0 +1,54 @@
+"""Sandbox and image value types."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    """Result of a command executed inside a sandbox."""
+
+    stdout: str = ""
+    stderr: str = ""
+    return_code: int = 0
+
+    @property
+    def success(self) -> bool:
+        return self.return_code == 0
+
+
+@dataclass(frozen=True)
+class ImageRef:
+    """Provider-specific immutable image/template/snapshot reference."""
+
+    provider: str
+    ref: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ImageConfig:
+    """Build inputs for an image builder."""
+
+    dockerfile: Path | None = None
+    docker_image: str | None = None
+    build_args: dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class SandboxSpec:
+    """Requested isolated compute for a rollout."""
+
+    provider: str = "docker"
+    image: ImageRef | None = None
+    cpus: int | None = None
+    memory_mb: int | None = None
+    storage_mb: int | None = None
+    gpus: int | None = None
+    allow_internet: bool = True
+    env: dict[str, str] = field(default_factory=dict)
+    labels: dict[str, str] = field(default_factory=dict)

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -95,14 +95,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
 
-from harbor.models.task.task import Task
-from harbor.models.trial.paths import TrialPaths
-from harbor.utils.env import resolve_env_vars
-from harbor.verifier.verifier import Verifier
-
 from benchflow._env_setup import (
     _patch_harbor_dind,
 )
+import benchflow._harbor as harbor_compat
 from benchflow._sandbox import (
     harden_before_verify,
 )
@@ -201,15 +197,15 @@ class SDK:
         job_name: str | None,
         trial_name: str | None,
         jobs_dir: str | Path,
-    ) -> tuple["Task", Path, "TrialPaths", datetime, str, str]:
+    ) -> tuple[Any, Path, Any, datetime, str, str]:
         """Set up trial directory tree and return core trial objects."""
         from uuid import uuid4
 
-        task = Task(task_path)
+        task = harbor_compat.make_task(task_path)
         job_name = job_name or datetime.now().strftime("%Y-%m-%d__%H-%M-%S")
         trial_name = trial_name or f"{task_path.name}__{uuid4().hex[:8]}"
         trial_dir = Path(jobs_dir) / job_name / trial_name
-        trial_paths = TrialPaths(trial_dir)
+        trial_paths = harbor_compat.make_trial_paths(trial_dir)
         started_at = datetime.now()
         # Pre-create trial directory tree so Docker doesn't create them as root.
         trial_dir.mkdir(parents=True, exist_ok=True)
@@ -435,9 +431,9 @@ class SDK:
         else:
             cmd = "bash /solution/solve.sh"
         oracle_env: dict[str, str] = {"DEBIAN_FRONTEND": "noninteractive"}
-        task = Task(task_path)
+        task = harbor_compat.make_task(task_path)
         if task.config.solution.env:
-            oracle_env.update(resolve_env_vars(task.config.solution.env))
+            oracle_env.update(harbor_compat.resolve_env_vars(task.config.solution.env))
         result = await env.exec(
             f"{cmd} > /logs/agent/oracle.txt 2>&1",
             env=oracle_env,
@@ -463,8 +459,8 @@ class SDK:
     async def _verify(
         self,
         env,
-        task: "Task",
-        trial_paths: "TrialPaths",
+        task: Any,
+        trial_paths: Any,
         timing: dict,
         sandbox_user: str | None = None,
         workspace: str | None = None,
@@ -476,7 +472,11 @@ class SDK:
         t0 = datetime.now()
         verifier_error = None
         try:
-            verifier = Verifier(task=task, trial_paths=trial_paths, environment=env)
+            verifier = harbor_compat.make_verifier(
+                task=task,
+                trial_paths=trial_paths,
+                environment=env,
+            )
             verifier_result = await asyncio.wait_for(
                 verifier.verify(),
                 timeout=task.config.verifier.timeout_sec,

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -492,9 +492,10 @@ class SDK:
         Returns:
             RunResult with rewards, trajectory, and metadata.
         """
-        from benchflow.trial import Trial, TrialConfig
+        from benchflow.rollouts.config import RolloutConfig
+        from benchflow.rollouts.runner import run as run_rollout
 
-        config = TrialConfig(
+        config = RolloutConfig(
             task_path=Path(task_path),
             agent=agent,
             prompts=prompts,
@@ -514,9 +515,4 @@ class SDK:
             skill_creator_dir=skill_creator_dir,
             self_gen_no_internet=self_gen_no_internet,
         )
-        if skill_mode == "self-gen":
-            from benchflow.self_gen import run_self_gen
-
-            return await run_self_gen(config)
-        trial = await Trial.create(config)
-        return await trial.run()
+        return await run_rollout(config)

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -93,7 +93,7 @@ import logging
 import shlex
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from benchflow._env_setup import (
     _patch_harbor_dind,
@@ -103,71 +103,11 @@ from benchflow._sandbox import (
     harden_before_verify,
 )
 from benchflow.models import RunResult, TrajectorySource
+from benchflow.rewards import write_rewards_jsonl
 
 logger = logging.getLogger(__name__)
 
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stdout/stderr in logs
-
-
-def _write_rewards_jsonl(
-    trial_dir: Path,
-    rewards: dict | None,
-    finished_at: datetime,
-) -> None:
-    """Write rewards.jsonl — one JSON line per reward event.
-
-    Emits rubric items (if present) as type="process" lines, then the
-    terminal reward as the final type="terminal" line.  Schema is
-    ORS-reward-signal compatible: one streamed event per line.
-
-    Rubric format in rewards dict::
-
-        {"reward": 0.75, "rubric": [
-            {"name": "file_exists", "score": 1.0, "weight": 1.0},
-            {"name": "content_correct", "score": 0.5, "weight": 1.0}
-        ]}
-    """
-    if not rewards:
-        return
-    events: list[dict[str, Any]] = []
-    rubric = rewards.get("rubric")
-    if isinstance(rubric, list):
-        for i, item in enumerate(rubric):
-            if not isinstance(item, dict):
-                continue
-            rubric_item = cast(dict[str, Any], item)
-            events.append(
-                {
-                    "ts": finished_at.isoformat(),
-                    "type": "process",
-                    "source": "verifier_rubric",
-                    "value": rubric_item.get("score", 0.0),
-                    "tag": rubric_item.get("name", f"rubric_{i}"),
-                    "step_index": i,
-                    "meta": {
-                        k: v
-                        for k, v in rubric_item.items()
-                        if k not in ("score", "name")
-                    },
-                }
-            )
-    scalar = rewards.get("reward")
-    if scalar is not None:
-        non_event_keys = {"reward", "rubric"}
-        events.append(
-            {
-                "ts": finished_at.isoformat(),
-                "type": "terminal",
-                "source": "verifier",
-                "value": scalar,
-                "tag": "reward",
-                "step_index": None,
-                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
-            }
-        )
-    if events:
-        path = trial_dir / "rewards.jsonl"
-        path.write_text("\n".join(json.dumps(e, default=str) for e in events) + "\n")
 
 
 # Apply at import time so any Harbor DockerEnvironment in this process
@@ -328,7 +268,7 @@ class SDK:
         )
         (trial_dir / "timing.json").write_text(json.dumps(timing, indent=2))
         (trial_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
-        _write_rewards_jsonl(trial_dir, rewards, finished_at)
+        write_rewards_jsonl(trial_dir, rewards, finished_at)
         return result
 
     @staticmethod

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -93,7 +93,7 @@ import logging
 import shlex
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import benchflow._harbor as harbor_compat
 from benchflow._env_setup import (
@@ -515,4 +515,4 @@ class SDK:
             skill_creator_dir=skill_creator_dir,
             self_gen_no_internet=self_gen_no_internet,
         )
-        return await run_rollout(config)
+        return cast(RunResult, await run_rollout(config))

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -95,10 +95,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+import benchflow._harbor as harbor_compat
 from benchflow._env_setup import (
     _patch_harbor_dind,
 )
-import benchflow._harbor as harbor_compat
 from benchflow._sandbox import (
     harden_before_verify,
 )

--- a/src/benchflow/self_gen.py
+++ b/src/benchflow/self_gen.py
@@ -8,14 +8,16 @@ from dataclasses import replace
 from pathlib import Path
 from uuid import uuid4
 
-from benchflow.trial import (
+from benchflow.rollouts.config import (
     GENERATED_SKILLS_ROOT,
     SKILL_MODE_DEFAULT,
     Role,
+    RolloutConfig,
     Scene,
-    Trial,
-    TrialConfig,
     Turn,
+)
+from benchflow.rollouts.rollout import Rollout
+from benchflow.trial import (
     _resolve_skill_creator_root,
     _safe_skill_name,
     _self_gen_prompt,
@@ -53,7 +55,7 @@ def _copy_single_skill(skill_dir: Path, dest_root: Path) -> Path:
     return dest_root
 
 
-def _self_gen_artifact_root(config: TrialConfig) -> Path:
+def _self_gen_artifact_root(config: RolloutConfig) -> Path:
     return (
         Path(config.jobs_dir)
         / "_self_gen"
@@ -62,7 +64,7 @@ def _self_gen_artifact_root(config: TrialConfig) -> Path:
 
 
 def _creator_scene(
-    config: TrialConfig, creator_skills_root: Path, skill_creator_name: str
+    config: RolloutConfig, creator_skills_root: Path, skill_creator_name: str
 ) -> Scene:
     return Scene(
         name="self-gen-creator",
@@ -81,7 +83,7 @@ def _creator_scene(
     )
 
 
-def _solver_scene(config: TrialConfig) -> Scene:
+def _solver_scene(config: RolloutConfig) -> Scene:
     return Scene(
         name="self-gen-solver",
         roles=[Role("solver", config.agent, config.model)],
@@ -93,7 +95,7 @@ def _solver_scene(config: TrialConfig) -> Scene:
     )
 
 
-def _ensure_generated_skills_hook(config: TrialConfig):
+def _ensure_generated_skills_hook(config: RolloutConfig):
     generated_skills_root = config.generated_skills_root or GENERATED_SKILLS_ROOT
 
     async def ensure_generated_skills(env):
@@ -111,8 +113,8 @@ def _ensure_generated_skills_hook(config: TrialConfig):
 
 
 def _single_trial_config(
-    config: TrialConfig, creator_skills_root: Path, skill_creator_name: str
-) -> TrialConfig:
+    config: RolloutConfig, creator_skills_root: Path, skill_creator_name: str
+) -> RolloutConfig:
     return replace(
         config,
         scenes=[
@@ -130,7 +132,7 @@ def _single_trial_config(
     )
 
 
-async def run_self_gen(config: TrialConfig):
+async def run_self_gen(config: RolloutConfig):
     """Run creator and solver as normal BYOS-style scenes in one trial.
 
     The creator scene gets only skill-creator. The solver scene gets only the
@@ -145,7 +147,7 @@ async def run_self_gen(config: TrialConfig):
     creator_skills_root = _copy_single_skill(
         skill_creator_dir, artifact_root / "creator-skills"
     )
-    trial = await Trial.create(
+    trial = await Rollout.create(
         _single_trial_config(config, creator_skills_root, skill_creator_name)
     )
     return await trial.run()

--- a/src/benchflow/tasks/__init__.py
+++ b/src/benchflow/tasks/__init__.py
@@ -1,0 +1,24 @@
+"""Native task models and task-authoring helpers."""
+
+from benchflow.tasks.authoring import check_task, init_task
+from benchflow.tasks.config import (
+    AgentTaskConfig,
+    EnvironmentTaskConfig,
+    Task,
+    TaskConfig,
+    TaskPaths,
+    VerifierTaskConfig,
+    load_task_config,
+)
+
+__all__ = [
+    "AgentTaskConfig",
+    "EnvironmentTaskConfig",
+    "Task",
+    "TaskConfig",
+    "TaskPaths",
+    "VerifierTaskConfig",
+    "check_task",
+    "init_task",
+    "load_task_config",
+]

--- a/src/benchflow/tasks/authoring.py
+++ b/src/benchflow/tasks/authoring.py
@@ -1,4 +1,4 @@
-"""Task authoring — init and check benchmark tasks."""
+"""Task authoring helpers — init and check benchmark tasks."""
 
 import logging
 import tomllib
@@ -8,25 +8,23 @@ logger = logging.getLogger(__name__)
 
 REQUIRED_FILES = ["task.toml", "instruction.md"]
 REQUIRED_DIRS = ["environment"]
-OPTIONAL_FILES = ["environment/Dockerfile"]
-OPTIONAL_DIRS = ["tests", "solution"]
 
 
 def check_task(task_dir: Path) -> list[str]:
-    """Validate a task directory structure. Returns list of issues (empty = valid)."""
+    """Validate a task directory structure. Returns list of issues."""
+
     issues = []
     if not task_dir.is_dir():
         return [f"Not a directory: {task_dir}"]
 
-    for f in REQUIRED_FILES:
-        if not (task_dir / f).exists():
-            issues.append(f"Missing required file: {f}")
+    for filename in REQUIRED_FILES:
+        if not (task_dir / filename).exists():
+            issues.append(f"Missing required file: {filename}")
 
-    for d in REQUIRED_DIRS:
-        if not (task_dir / d).is_dir():
-            issues.append(f"Missing required directory: {d}/")
+    for dirname in REQUIRED_DIRS:
+        if not (task_dir / dirname).is_dir():
+            issues.append(f"Missing required directory: {dirname}/")
 
-    # Validate task.toml
     toml_path = task_dir / "task.toml"
     if toml_path.exists():
         try:
@@ -39,25 +37,20 @@ def check_task(task_dir: Path) -> list[str]:
         except Exception as e:
             issues.append(f"task.toml parse error: {e}")
 
-    # Check instruction.md is non-empty
-    instr = task_dir / "instruction.md"
-    if instr.exists() and instr.stat().st_size == 0:
+    instruction = task_dir / "instruction.md"
+    if instruction.exists() and instruction.stat().st_size == 0:
         issues.append("instruction.md is empty")
 
-    # Check Dockerfile exists
     dockerfile = task_dir / "environment" / "Dockerfile"
     if not dockerfile.exists():
         issues.append("Missing environment/Dockerfile")
 
-    # Check tests
     tests_dir = task_dir / "tests"
     if tests_dir.is_dir():
         if not any(tests_dir.iterdir()):
             issues.append("tests/ directory is empty")
     else:
-        issues.append(
-            "Missing tests/ directory (verifier needs test.sh or evaluate.py)"
-        )
+        issues.append("Missing tests/ directory (verifier needs test.sh or evaluate.py)")
 
     return issues
 
@@ -68,14 +61,13 @@ def init_task(
     no_pytest: bool = False,
     no_solution: bool = False,
 ) -> Path:
-    """Scaffold a new task directory with standard structure."""
+    """Scaffold a new task directory with the standard BenchFlow shape."""
+
     task_dir = parent_dir / name
     if task_dir.exists():
         raise FileExistsError(f"Task directory already exists: {task_dir}")
 
     task_dir.mkdir(parents=True)
-
-    # task.toml
     (task_dir / "task.toml").write_text("""version = "1.0"
 
 [metadata]
@@ -95,7 +87,6 @@ cpus = 1
 memory_mb = 2048
 """)
 
-    # instruction.md
     (task_dir / "instruction.md").write_text(f"""# {name}
 
 <!-- Write clear, specific instructions for the agent. -->
@@ -103,7 +94,6 @@ memory_mb = 2048
 
 """)
 
-    # environment/
     env_dir = task_dir / "environment"
     env_dir.mkdir()
     (env_dir / "Dockerfile").write_text("""FROM ubuntu:24.04
@@ -118,7 +108,6 @@ WORKDIR /app
 RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts
 """)
 
-    # tests/
     tests_dir = task_dir / "tests"
     tests_dir.mkdir()
     (tests_dir / "test.sh").write_text("""#!/bin/bash
@@ -130,25 +119,22 @@ echo "1.0" > /logs/verifier/reward.txt
     (tests_dir / "test.sh").chmod(0o755)
 
     if not no_pytest:
-        (
-            tests_dir / "test_outputs.py"
-        ).write_text("""\"\"\"Pytest-based verifier. Run by Harbor after agent completes.\"\"\"
+        (tests_dir / "test_outputs.py").write_text(
+            '"""Pytest-based verifier. Run after agent completes."""\n\n'
+            "def test_placeholder():\n"
+            "    # Replace with actual verification logic\n"
+            "    assert True\n"
+        )
 
-def test_placeholder():
-    # Replace with actual verification logic
-    assert True
-""")
-
-    # solution/
     if not no_solution:
-        sol_dir = task_dir / "solution"
-        sol_dir.mkdir()
-        (sol_dir / "solve.sh").write_text("""#!/bin/bash
+        solution_dir = task_dir / "solution"
+        solution_dir.mkdir()
+        (solution_dir / "solve.sh").write_text("""#!/bin/bash
 # Oracle solution — demonstrates the task is solvable.
 # Used by: benchflow run -a oracle -t tasks/{name}
 
 echo "TODO: implement oracle solution"
 """)
-        (sol_dir / "solve.sh").chmod(0o755)
+        (solution_dir / "solve.sh").chmod(0o755)
 
     return task_dir

--- a/src/benchflow/tasks/config.py
+++ b/src/benchflow/tasks/config.py
@@ -1,0 +1,133 @@
+"""Native BenchFlow task config models."""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from benchflow.sandboxes import SandboxSpec
+
+
+@dataclass(frozen=True)
+class AgentTaskConfig:
+    timeout_sec: int = 300
+
+
+@dataclass(frozen=True)
+class VerifierTaskConfig:
+    timeout_sec: int = 120
+    env: dict[str, str] = field(default_factory=dict)
+    user: str = "root"
+    pytest_plugins: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EnvironmentTaskConfig:
+    docker_image: str | None = None
+    cpus: int | None = None
+    memory_mb: int | None = None
+    storage_mb: int | None = None
+    gpus: int | None = None
+    allow_internet: bool = True
+    env: dict[str, str] = field(default_factory=dict)
+
+    def to_sandbox_spec(self, provider: str = "docker") -> SandboxSpec:
+        """Convert task environment requirements into a sandbox request."""
+
+        return SandboxSpec(
+            provider=provider,
+            cpus=self.cpus,
+            memory_mb=self.memory_mb,
+            storage_mb=self.storage_mb,
+            gpus=self.gpus,
+            allow_internet=self.allow_internet,
+            env=dict(self.env),
+        )
+
+
+@dataclass(frozen=True)
+class TaskConfig:
+    raw: dict[str, Any]
+    agent: AgentTaskConfig = field(default_factory=AgentTaskConfig)
+    verifier: VerifierTaskConfig = field(default_factory=VerifierTaskConfig)
+    environment: EnvironmentTaskConfig = field(default_factory=EnvironmentTaskConfig)
+
+
+@dataclass(frozen=True)
+class TaskPaths:
+    task_dir: Path
+
+    @property
+    def instruction(self) -> Path:
+        return self.task_dir / "instruction.md"
+
+    @property
+    def environment_dir(self) -> Path:
+        return self.task_dir / "environment"
+
+    @property
+    def dockerfile(self) -> Path:
+        return self.environment_dir / "Dockerfile"
+
+    @property
+    def tests_dir(self) -> Path:
+        return self.task_dir / "tests"
+
+    @property
+    def solution_dir(self) -> Path:
+        return self.task_dir / "solution"
+
+
+@dataclass(frozen=True)
+class Task:
+    task_dir: Path
+    config: TaskConfig
+    paths: TaskPaths
+
+    @classmethod
+    def from_dir(cls, task_dir: str | Path) -> Task:
+        path = Path(task_dir)
+        return cls(
+            task_dir=path,
+            config=load_task_config(path / "task.toml"),
+            paths=TaskPaths(path),
+        )
+
+
+def load_task_config(path: Path) -> TaskConfig:
+    """Load a BenchFlow/Harbor-compatible task.toml into native dataclasses."""
+
+    with path.open("rb") as f:
+        raw = tomllib.load(f)
+
+    agent_raw = raw.get("agent", {})
+    verifier_raw = raw.get("verifier", {})
+    env_raw = raw.get("environment", {})
+
+    return TaskConfig(
+        raw=raw,
+        agent=AgentTaskConfig(timeout_sec=int(agent_raw.get("timeout_sec", 300))),
+        verifier=VerifierTaskConfig(
+            timeout_sec=int(verifier_raw.get("timeout_sec", 120)),
+            env=dict(verifier_raw.get("env", {})),
+            user=str(verifier_raw.get("user", "root")),
+            pytest_plugins=list(verifier_raw.get("pytest_plugins", [])),
+        ),
+        environment=EnvironmentTaskConfig(
+            docker_image=env_raw.get("docker_image"),
+            cpus=_optional_int(env_raw.get("cpus")),
+            memory_mb=_optional_int(env_raw.get("memory_mb", env_raw.get("memory"))),
+            storage_mb=_optional_int(env_raw.get("storage_mb", env_raw.get("storage"))),
+            gpus=_optional_int(env_raw.get("gpus")),
+            allow_internet=bool(env_raw.get("allow_internet", True)),
+            env=dict(env_raw.get("env", {})),
+        ),
+    )
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    return int(value)

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -768,8 +768,7 @@ class Trial:
         Returns (rewards, verifier_output, verifier_error). The final
         verify() still does full hardening.
         """
-        from harbor import Verifier
-
+        import benchflow._harbor as harbor_compat
         from benchflow._sandbox import _build_cleanup_cmd, _read_hardening_config
 
         self._trial_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
@@ -792,7 +791,7 @@ class Trial:
         verifier_output = None
         verifier_error = None
         try:
-            verifier = Verifier(
+            verifier = harbor_compat.make_verifier(
                 task=self._task,
                 trial_paths=self._trial_paths,
                 environment=self._env,

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -73,15 +73,10 @@ from benchflow._trajectory import (
 from benchflow.acp.client import ACPClient, ACPError
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
 from benchflow.models import RunResult, TrajectorySource
-from benchflow.rollouts.config import (
-    GENERATED_SKILLS_ROOT,
-    SKILL_MODE_DEFAULT,
-    SKILL_MODE_SELF_GEN,
-    Role,
-    RolloutConfig,
-    Scene,
-    Turn,
-)
+from benchflow.rollouts.config import GENERATED_SKILLS_ROOT as GENERATED_SKILLS_ROOT
+from benchflow.rollouts.config import SKILL_MODE_DEFAULT as SKILL_MODE_DEFAULT
+from benchflow.rollouts.config import SKILL_MODE_SELF_GEN, Role, RolloutConfig, Scene
+from benchflow.rollouts.config import Turn as Turn
 from benchflow.user import RoundResult
 
 logger = logging.getLogger(__name__)

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -235,7 +235,7 @@ class TrialConfig(RolloutConfig):
 class Trial:
     """Decomposed trial lifecycle with independently-callable phases."""
 
-    def __init__(self, config: TrialConfig) -> None:
+    def __init__(self, config: RolloutConfig) -> None:
         self._config = config
         self._phase = "created"
 

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -74,6 +74,7 @@ from benchflow._trajectory import (
 from benchflow.acp.client import ACPClient, ACPError
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
 from benchflow.models import RunResult, TrajectorySource
+from benchflow.rollouts.config import Role, Scene, Turn
 from benchflow.user import BaseUser, RoundResult
 
 logger = logging.getLogger(__name__)
@@ -224,54 +225,6 @@ async def _ensure_sandbox_dir(
         raise RuntimeError(
             f"Failed to create sandbox directory {path}: "
             f"{result.stderr or result.stdout}"
-        )
-
-
-@dataclass
-class Role:
-    """One agent participant in a scene."""
-
-    name: str
-    agent: str
-    model: str | None = None
-    env: dict[str, str] = field(default_factory=dict)
-
-
-@dataclass
-class Turn:
-    """One prompt in a scene. role selects which Role acts."""
-
-    role: str
-    prompt: str | None = None  # None = expand from instruction.md
-
-
-@dataclass
-class Scene:
-    """One interaction region — roles take turns executing prompts."""
-
-    name: str = "default"
-    roles: list[Role] = field(default_factory=list)
-    turns: list[Turn] = field(default_factory=list)
-    skills_dir: str | Path | None = None
-    # Future (xiangyi li): snapshot_before, snapshot_after for stateful envs
-    # Future: scoring config (None = unscored warmup scene)
-
-    @classmethod
-    def single(
-        cls,
-        *,
-        agent: str,
-        model: str | None = None,
-        prompts: list[str | None] | None = None,
-        role_name: str = "agent",
-        skills_dir: str | Path | None = None,
-    ) -> Scene:
-        """Shortcut for single-agent, single-role scene."""
-        prompts = prompts or [None]
-        return cls(
-            roles=[Role(name=role_name, agent=agent, model=model)],
-            turns=[Turn(role=role_name, prompt=p) for p in prompts],
-            skills_dir=skills_dir,
         )
 
 

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -41,7 +41,6 @@ import json
 import logging
 import os
 import shlex
-from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -74,15 +73,20 @@ from benchflow._trajectory import (
 from benchflow.acp.client import ACPClient, ACPError
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
 from benchflow.models import RunResult, TrajectorySource
-from benchflow.rollouts.config import Role, Scene, Turn
-from benchflow.user import BaseUser, RoundResult
+from benchflow.rollouts.config import (
+    GENERATED_SKILLS_ROOT,
+    SKILL_MODE_DEFAULT,
+    SKILL_MODE_SELF_GEN,
+    Role,
+    RolloutConfig,
+    Scene,
+    Turn,
+)
+from benchflow.user import RoundResult
 
 logger = logging.getLogger(__name__)
 
 _DISALLOW_WEB_TOOLS_ENV = "BENCHFLOW_DISALLOW_WEB_TOOLS"
-SKILL_MODE_DEFAULT = "default"
-SKILL_MODE_SELF_GEN = "self-gen"
-GENERATED_SKILLS_ROOT = "/app/generated-skills"
 
 
 def _task_disallows_internet(task: Any) -> bool:
@@ -228,126 +232,8 @@ async def _ensure_sandbox_dir(
         )
 
 
-@dataclass
-class TrialConfig:
-    """Declarative trial configuration.
-
-    A trial is a sequence of scenes executed in a shared sandbox.
-    Single-agent runs are a trial with one scene containing one role.
-    """
-
-    task_path: Path
-    scenes: list[Scene] = field(default_factory=list)
-    environment: str = "docker"
-    sandbox_user: str | None = "agent"
-    sandbox_locked_paths: list[str] | None = None
-    sandbox_setup_timeout: int = 120
-    services: list[str] | None = None
-    job_name: str | None = None
-    trial_name: str | None = None
-    jobs_dir: str | Path = "jobs"
-    context_root: str | Path | None = None
-    pre_agent_hooks: list | None = None
-    # Abort the prompt if no tool call arrives for this many seconds.
-    # Catches agents that hung silently while the local process is alive
-    # (e.g. gemini-cli not responding). None disables idle detection and
-    # falls back to the agent's wall-clock timeout (task.toml [agent]).
-    agent_idle_timeout: int | None = 600
-
-    # User-driven progressive-disclosure loop
-    user: BaseUser | None = None
-    max_user_rounds: int = 5
-    oracle_access: bool = False
-
-    # Legacy compat fields — used by SDK.run() shim. Ignored when scenes is set.
-    agent: str = "claude-agent-acp"
-    prompts: list[str | None] | None = None
-    model: str | None = None
-    agent_env: dict[str, str] | None = None
-    skills_dir: str | Path | None = None
-    skill_mode: str = SKILL_MODE_DEFAULT
-    skill_creator_dir: str | Path | None = None
-    generated_skills_root: str = GENERATED_SKILLS_ROOT
-    self_gen_no_internet: bool = False
-    include_task_skills: bool = True
-    skip_verify: bool = False
-    export_generated_skills_to: str | Path | None = None
-
-    @classmethod
-    def from_legacy(
-        cls,
-        *,
-        task_path: Path,
-        agent: str = "claude-agent-acp",
-        model: str | None = None,
-        prompts: list[str | None] | None = None,
-        skills_dir: str | Path | None = None,
-        skill_mode: str = SKILL_MODE_DEFAULT,
-        skill_creator_dir: str | Path | None = None,
-        generated_skills_root: str = GENERATED_SKILLS_ROOT,
-        self_gen_no_internet: bool = False,
-        **kwargs,
-    ) -> TrialConfig:
-        """Construct from flat SDK.run()-style args."""
-        scenes = []
-        if skill_mode not in {SKILL_MODE_DEFAULT, SKILL_MODE_SELF_GEN}:
-            raise ValueError(f"Unknown skill_mode: {skill_mode}")
-        if skill_mode == SKILL_MODE_DEFAULT:
-            scenes = [
-                Scene.single(
-                    agent=agent, model=model, prompts=prompts, skills_dir=skills_dir
-                )
-            ]
-        return cls(
-            task_path=task_path,
-            scenes=scenes,
-            agent=agent,
-            model=model,
-            prompts=prompts,
-            skills_dir=skills_dir,
-            skill_mode=skill_mode,
-            skill_creator_dir=skill_creator_dir,
-            generated_skills_root=generated_skills_root,
-            self_gen_no_internet=self_gen_no_internet,
-            **kwargs,
-        )
-
-    @property
-    def effective_scenes(self) -> list[Scene]:
-        """Scenes to execute — falls back to legacy fields if scenes is empty."""
-        if self.skill_mode == SKILL_MODE_SELF_GEN:
-            raise ValueError(
-                "self-gen requires the runtime orchestrator. Use SDK.run(), "
-                "Job.run(), or bf.run(TrialConfig(...)) instead of Trial scenes."
-            )
-        if self.scenes:
-            return self.scenes
-        if self.skill_mode != SKILL_MODE_DEFAULT:
-            raise ValueError(f"Unknown skill_mode: {self.skill_mode}")
-        return [
-            Scene.single(
-                agent=self.agent,
-                model=self.model,
-                prompts=self.prompts,
-                skills_dir=self.skills_dir,
-            )
-        ]
-
-    @property
-    def primary_agent(self) -> str:
-        """Agent name for the first role of the first scene."""
-        scenes = self.effective_scenes
-        if scenes and scenes[0].roles:
-            return scenes[0].roles[0].agent
-        return self.agent
-
-    @property
-    def primary_model(self) -> str | None:
-        """Model for the first role of the first scene."""
-        scenes = self.effective_scenes
-        if scenes and scenes[0].roles:
-            return scenes[0].roles[0].model
-        return self.model
+class TrialConfig(RolloutConfig):
+    """Compatibility name while the lifecycle class migrates to Rollout."""
 
 
 class Trial:

--- a/src/benchflow/trial.py
+++ b/src/benchflow/trial.py
@@ -73,6 +73,7 @@ from benchflow._trajectory import (
 from benchflow.acp.client import ACPClient, ACPError
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
 from benchflow.models import RunResult, TrajectorySource
+from benchflow.rollouts import _helpers as rollout_helpers
 from benchflow.rollouts.config import GENERATED_SKILLS_ROOT as GENERATED_SKILLS_ROOT
 from benchflow.rollouts.config import SKILL_MODE_DEFAULT as SKILL_MODE_DEFAULT
 from benchflow.rollouts.config import SKILL_MODE_SELF_GEN, Role, RolloutConfig, Scene
@@ -320,8 +321,6 @@ class Trial:
 
     async def setup(self) -> None:
         """Resolve config, create environment object (not yet started)."""
-        from benchflow.sdk import SDK
-
         cfg = self._config
 
         if cfg.sandbox_user is None:
@@ -345,7 +344,9 @@ class Trial:
             self._started_at,
             self._job_name,
             self._trial_name,
-        ) = SDK._init_trial(cfg.task_path, cfg.job_name, cfg.trial_name, cfg.jobs_dir)
+        ) = rollout_helpers.init_rollout(
+            cfg.task_path, cfg.job_name, cfg.trial_name, cfg.jobs_dir
+        )
 
         self._disallow_web_tools = (
             _task_disallows_internet(self._task) or cfg.self_gen_no_internet
@@ -354,7 +355,7 @@ class Trial:
             resolve_agent_env(cfg.primary_agent, cfg.primary_model, cfg.agent_env),
             disallow=self._disallow_web_tools,
         )
-        self._resolved_prompts = SDK._resolve_prompts(
+        self._resolved_prompts = rollout_helpers.resolve_prompts(
             cfg.task_path,
             cfg.prompts,
             skills_dir=cfg.skills_dir,
@@ -394,7 +395,7 @@ class Trial:
         )
         self._timeout = int(self._task.config.agent.timeout_sec or 0)
 
-        SDK._write_config(
+        rollout_helpers.write_config(
             self._trial_dir,
             task_path=cfg.task_path,
             agent=cfg.primary_agent,
@@ -416,10 +417,9 @@ class Trial:
 
     async def start(self) -> None:
         """Start the environment and upload task files."""
-        from benchflow.sdk import SDK
-
-        sdk = SDK()
-        await sdk._start_env_and_upload(self._env, self._config.task_path, self._timing)
+        await rollout_helpers.start_env_and_upload(
+            self._env, self._config.task_path, self._timing
+        )
 
         for hook in self._config.pre_agent_hooks or []:
             await hook(self._env)
@@ -623,10 +623,7 @@ class Trial:
                     f"Using scraped trajectory ({len(scraped)} events) — UNTRUSTED"
                 )
 
-        from benchflow.sdk import SDK
-
-        sdk = SDK()
-        self._rewards, self._verifier_error = await sdk._verify(
+        self._rewards, self._verifier_error = await rollout_helpers.verify(
             self._env,
             self._task,
             self._trial_paths,
@@ -768,10 +765,7 @@ class Trial:
                     user="root",
                     timeout_sec=10,
                 )
-                from benchflow.sdk import SDK
-
-                sdk = SDK()
-                self._trajectory, self._agent_name = await sdk._run_oracle(
+                self._trajectory, self._agent_name = await rollout_helpers.run_oracle(
                     self._env, cfg.task_path, self._timeout, sandbox_user=None
                 )
             else:
@@ -1228,13 +1222,11 @@ class Trial:
         return str(e)
 
     def _build_result(self) -> RunResult:
-        from benchflow.sdk import SDK
-
         trial_dir = self._require_trial_dir()
-        return SDK._build_result(
+        return rollout_helpers.build_result(
             trial_dir,
             task_name=self._config.task_path.name,
-            trial_name=self._trial_name or "",
+            rollout_name=self._trial_name or "",
             agent=self._config.primary_agent,
             agent_name=self._agent_name,
             model=self._config.primary_model or "",

--- a/src/benchflow/trial_yaml.py
+++ b/src/benchflow/trial_yaml.py
@@ -43,7 +43,8 @@ from typing import Any
 
 import yaml
 
-from benchflow.trial import Role, Scene, TrialConfig, Turn
+from benchflow.rollouts.config import Role, Scene, Turn
+from benchflow.trial import TrialConfig
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +140,7 @@ def _parse_scene(raw: dict) -> Scene:
         roles=roles,
         turns=turns,
         skills_dir=raw.get("skills_dir"),
+        parallel_group=raw.get("parallel_group"),
     )
 
 
@@ -149,6 +151,12 @@ def _parse_role(raw: dict) -> Role:
         agent=raw["agent"],
         model=raw.get("model"),
         env=raw.get("env", {}),
+        timeout_sec=raw.get("timeout_sec"),
+        idle_timeout_sec=raw.get("idle_timeout_sec"),
+        skills_dir=raw.get("skills_dir"),
+        capabilities=raw.get("capabilities", []),
+        instruction=raw.get("instruction"),
+        tools=raw.get("tools", []),
     )
 
 

--- a/src/benchflow/trial_yaml.py
+++ b/src/benchflow/trial_yaml.py
@@ -1,188 +1,22 @@
-"""YAML trial config loader.
+"""Compatibility wrappers for rollout YAML loading."""
 
-Parses trial YAML files into TrialConfig with Scene support.
-Handles both new scene-based format and legacy flat format.
+from benchflow.rollouts.yaml import (
+    job_config_from_yaml,
+    rollout_config_from_dict,
+    rollout_config_from_yaml,
+)
+from benchflow.rollouts.yaml import (
+    load_rollout_yaml as load_trial_yaml,
+)
 
-New format::
+trial_config_from_yaml = rollout_config_from_yaml
+trial_config_from_dict = rollout_config_from_dict
 
-    task_dir: tasks/
-    environment: daytona
-    concurrency: 64
-
-    scenes:
-      - name: skill-gen
-        roles:
-          - name: creator
-            agent: gemini
-            model: gemini-3.1-flash-lite-preview
-        turns:
-          - role: creator
-            prompt: "Generate a skill for this task..."
-      - name: solve
-        roles:
-          - name: solver
-            agent: gemini
-            model: gemini-3.1-flash-lite-preview
-        turns:
-          - role: solver
-
-Legacy format (auto-converted)::
-
-    task_dir: tasks/
-    agent: gemini
-    model: gemini-3.1-flash-lite-preview
-    environment: daytona
-    concurrency: 64
-"""
-
-from __future__ import annotations
-
-import logging
-from pathlib import Path
-from typing import Any
-
-import yaml
-
-from benchflow.rollouts.config import Role, Scene, Turn
-from benchflow.trial import TrialConfig
-
-logger = logging.getLogger(__name__)
-
-
-def load_trial_yaml(path: str | Path) -> dict:
-    """Load and normalize a trial YAML file."""
-    with open(path) as f:
-        raw = yaml.safe_load(f)
-    if not isinstance(raw, dict):
-        raise ValueError(f"Expected dict at top level, got {type(raw).__name__}")
-    return raw
-
-
-def trial_config_from_yaml(
-    path: str | Path,
-    task_path: Path | None = None,
-) -> TrialConfig:
-    """Parse a YAML file into a TrialConfig.
-
-    If task_path is provided, it overrides task_dir from the YAML.
-    """
-    raw = load_trial_yaml(path)
-    return trial_config_from_dict(raw, task_path=task_path)
-
-
-def trial_config_from_dict(
-    raw: dict[str, Any],
-    task_path: Path | None = None,
-) -> TrialConfig:
-    """Convert a raw dict (from YAML or programmatic) into a TrialConfig."""
-    tp = task_path or Path(raw.get("task_dir", raw.get("task_path", ".")))
-
-    # Scene-based format
-    if "scenes" in raw:
-        scenes = [_parse_scene(s) for s in raw["scenes"]]
-    elif "agent" in raw:
-        # Legacy flat format
-        prompts_raw = raw.get("prompts")
-        prompts: list[str | None]
-        if isinstance(prompts_raw, list):
-            prompts = []
-            for prompt in prompts_raw:
-                if prompt is not None and not isinstance(prompt, str):
-                    raise ValueError("YAML prompts entries must be strings or null")
-                prompts.append(prompt)
-        elif isinstance(prompts_raw, str):
-            prompts = [prompts_raw]
-        else:
-            prompts = [None]
-        scenes = [
-            Scene.single(
-                agent=raw["agent"],
-                model=raw.get("model"),
-                prompts=prompts,
-                skills_dir=raw.get("skills_dir"),
-            )
-        ]
-    else:
-        raise ValueError("YAML must have either 'scenes' or 'agent' at top level")
-
-    return TrialConfig(
-        task_path=tp,
-        scenes=scenes,
-        environment=raw.get("environment", "docker"),
-        sandbox_user=raw.get("sandbox_user", "agent"),
-        sandbox_locked_paths=raw.get("sandbox_locked_paths"),
-        sandbox_setup_timeout=raw.get("sandbox_setup_timeout", 120),
-        job_name=raw.get("job_name"),
-        trial_name=raw.get("trial_name"),
-        jobs_dir=raw.get("jobs_dir", "jobs"),
-        context_root=raw.get("context_root"),
-        agent=raw.get("agent", "claude-agent-acp"),
-        model=raw.get("model"),
-        agent_env=raw.get("agent_env"),
-        skills_dir=raw.get("skills_dir"),
-        skill_mode=raw.get("skill_mode", "default"),
-        skill_creator_dir=raw.get("skill_creator_dir"),
-        self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
-    )
-
-
-def _parse_scene(raw: dict) -> Scene:
-    """Parse a scene dict from YAML."""
-    roles = [_parse_role(r) for r in raw.get("roles", [])]
-    turns = [_parse_turn(t) for t in raw.get("turns", [])]
-
-    # If no turns specified but roles exist, create one turn per role
-    if not turns and roles:
-        turns = [Turn(role=r.name) for r in roles]
-
-    return Scene(
-        name=raw.get("name", "default"),
-        roles=roles,
-        turns=turns,
-        skills_dir=raw.get("skills_dir"),
-        parallel_group=raw.get("parallel_group"),
-    )
-
-
-def _parse_role(raw: dict) -> Role:
-    """Parse a role dict from YAML."""
-    return Role(
-        name=raw["name"],
-        agent=raw["agent"],
-        model=raw.get("model"),
-        env=raw.get("env", {}),
-        timeout_sec=raw.get("timeout_sec"),
-        idle_timeout_sec=raw.get("idle_timeout_sec"),
-        skills_dir=raw.get("skills_dir"),
-        capabilities=raw.get("capabilities", []),
-        instruction=raw.get("instruction"),
-        tools=raw.get("tools", []),
-    )
-
-
-def _parse_turn(raw: dict) -> Turn:
-    """Parse a turn dict from YAML."""
-    return Turn(
-        role=raw["role"],
-        prompt=raw.get("prompt"),
-    )
-
-
-def job_config_from_yaml(path: str | Path) -> dict:
-    """Parse a YAML file and return both job-level and trial-level config.
-
-    Returns a dict with keys: task_dir, concurrency, max_retries,
-    trial_config (TrialConfig), and any other job-level fields.
-    """
-    raw = load_trial_yaml(path)
-    task_dir = Path(raw.get("task_dir", raw.get("tasks_dir", ".")))
-    concurrency = raw.get("concurrency", 4)
-    max_retries = raw.get("max_retries", 2)
-
-    return {
-        "task_dir": task_dir,
-        "concurrency": concurrency,
-        "max_retries": max_retries,
-        "trial_config": trial_config_from_dict(raw, task_path=task_dir),
-        "raw": raw,
-    }
+__all__ = [
+    "job_config_from_yaml",
+    "load_trial_yaml",
+    "rollout_config_from_dict",
+    "rollout_config_from_yaml",
+    "trial_config_from_dict",
+    "trial_config_from_yaml",
+]

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -1,0 +1,83 @@
+"""Tests for native Docker sandbox command construction."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchflow.sandboxes import DockerSandbox, DockerSandboxConfig, SandboxSpec
+
+
+class FakeDockerSandbox(DockerSandbox):
+    def __init__(self, config: DockerSandboxConfig, spec: SandboxSpec | None = None):
+        super().__init__(config, spec)
+        self.commands: list[list[str]] = []
+        self.inputs: list[bytes | None] = []
+        self.images: set[str] = set()
+
+    async def _image_exists(self, image: str) -> bool:
+        return image in self.images
+
+    async def _run(self, cmd, *, stdin=None, timeout_sec=600):
+        self.commands.append(list(cmd))
+        self.inputs.append(stdin)
+
+        class Completed:
+            returncode = 0
+            stdout = b"stdout"
+            stderr = b""
+
+        return Completed()
+
+
+def _task(tmp_path: Path) -> Path:
+    task = tmp_path / "task"
+    env = task / "environment"
+    env.mkdir(parents=True)
+    (env / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    return task
+
+
+async def test_start_builds_and_runs_container(tmp_path: Path) -> None:
+    sandbox = FakeDockerSandbox(
+        DockerSandboxConfig(task_path=_task(tmp_path), session_id="abc"),
+        SandboxSpec(provider="docker", allow_internet=False, cpus=2, memory_mb=512),
+    )
+
+    await sandbox.start()
+
+    assert sandbox.commands[0][:3] == ["docker", "build", "-t"]
+    run = sandbox.commands[1]
+    assert run[:4] == ["docker", "run", "-d", "--name"]
+    assert "--network" in run and "none" in run
+    assert "--cpus" in run and "2" in run
+    assert "--memory" in run and "512m" in run
+
+
+async def test_exec_uses_docker_exec_with_env_and_user(tmp_path: Path) -> None:
+    sandbox = FakeDockerSandbox(DockerSandboxConfig(task_path=_task(tmp_path)))
+
+    result = await sandbox.exec(
+        "echo hi",
+        user="agent",
+        cwd="/work",
+        env={"A": "B"},
+        timeout_sec=5,
+    )
+
+    cmd = sandbox.commands[-1]
+    assert cmd[:3] == ["docker", "exec", "-i"]
+    assert cmd[3:5] == ["--user", "agent"]
+    assert "--workdir" in cmd and "/work" in cmd
+    assert "--env" in cmd and "A=B" in cmd
+    assert cmd[-3:] == ["bash", "-lc", "echo hi"]
+    assert result.return_code == 0
+    assert result.stdout == "stdout"
+
+
+async def test_write_file_streams_base64_to_container(tmp_path: Path) -> None:
+    sandbox = FakeDockerSandbox(DockerSandboxConfig(task_path=_task(tmp_path)))
+
+    await sandbox.write_file("/app/data.txt", b"hello")
+
+    assert sandbox.commands[-1][:3] == ["docker", "exec", sandbox.container_name]
+    assert sandbox.inputs[-1] == b"aGVsbG8="

--- a/tests/test_harbor_internal.py
+++ b/tests/test_harbor_internal.py
@@ -1,0 +1,38 @@
+"""Tests for the internal Harbor compatibility adapter."""
+
+from pathlib import Path
+
+from benchflow import _harbor
+
+
+def _minimal_task_dir(tmp_path: Path) -> Path:
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text(
+        'version = "1.0"\n\n[verifier]\ntimeout_sec = 60\n\n'
+        "[agent]\ntimeout_sec = 60\n\n[environment]\n"
+    )
+    (task_dir / "instruction.md").write_text("Solve it.")
+    return task_dir
+
+
+def test_make_task_returns_current_harbor_task(tmp_path: Path) -> None:
+    task = _harbor.make_task(_minimal_task_dir(tmp_path))
+    assert task.__class__.__module__.startswith("harbor")
+    assert task.config.agent.timeout_sec == 60
+
+
+def test_make_trial_paths_preserves_current_shape(tmp_path: Path) -> None:
+    paths = _harbor.make_trial_paths(tmp_path / "trial")
+    paths.mkdir()
+    assert paths.trial_dir == tmp_path / "trial"
+    assert paths.agent_dir == tmp_path / "trial" / "agent"
+    assert paths.verifier_dir == tmp_path / "trial" / "verifier"
+
+
+def test_make_verifier_constructs_harbor_verifier(tmp_path: Path) -> None:
+    task = _harbor.make_task(_minimal_task_dir(tmp_path))
+    paths = _harbor.make_trial_paths(tmp_path / "trial")
+    env = object()
+    verifier = _harbor.make_verifier(task, paths, env)
+    assert verifier.__class__.__module__.startswith("harbor")

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -98,16 +98,15 @@ class TestRunTaskLoop:
 
     @pytest.mark.asyncio
     async def test_exhausts_retries(self, job_factory):
-        """SDK called 1 + max_retries times when all attempts fail with retryable error."""
+        """Rollout runner called 1 + max_retries times for retryable errors."""
         job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
         fail_result = RunResult(
             task_name="task-0", error="Agent install failed (rc=1): boom"
         )
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=fail_result)
+        job._run_rollout = AsyncMock(return_value=fail_result)
 
         result = await job._run_task(tasks_dir / "task-0")
-        assert job._sdk.run.call_count == 3  # 1 + 2 retries
+        assert job._run_rollout.call_count == 3  # 1 + 2 retries
         assert result.error == "Agent install failed (rc=1): boom"
 
     @pytest.mark.asyncio
@@ -117,11 +116,10 @@ class TestRunTaskLoop:
         timeout_result = RunResult(
             task_name="task-0", error="Agent timed out after 900.0s"
         )
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(return_value=timeout_result)
+        job._run_rollout = AsyncMock(return_value=timeout_result)
 
         result = await job._run_task(tasks_dir / "task-0")
-        assert job._sdk.run.call_count == 1
+        assert job._run_rollout.call_count == 1
         assert result.error == "Agent timed out after 900.0s"
 
     @pytest.mark.asyncio
@@ -132,11 +130,10 @@ class TestRunTaskLoop:
             task_name="task-0", error="Agent install failed (rc=1): boom"
         )
         ok_result = RunResult(task_name="task-0", rewards={"reward": 1.0})
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(side_effect=[fail_result, ok_result])
+        job._run_rollout = AsyncMock(side_effect=[fail_result, ok_result])
 
         result = await job._run_task(tasks_dir / "task-0")
-        assert job._sdk.run.call_count == 2
+        assert job._run_rollout.call_count == 2
         assert result.rewards == {"reward": 1.0}
 
 
@@ -202,8 +199,7 @@ class TestJobResume:
         cfg = JobConfig(agent="new-agent")
         job = Job(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=cfg)
         # Patch _run_task so run() doesn't actually run anything real
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(
+        job._run_rollout = AsyncMock(
             return_value=RunResult(task_name="task-b", rewards={"reward": 1.0})
         )
         with caplog.at_level(logging.WARNING):
@@ -253,7 +249,7 @@ class TestJobRunOrchestration:
         lock = asyncio.Lock()
         enough_in_flight = asyncio.Event()
 
-        async def fake_sdk_run(*args, **kwargs):
+        async def fake_run_rollout(*args, **kwargs):
             nonlocal counter, max_in_flight
             async with lock:
                 counter += 1
@@ -268,26 +264,24 @@ class TestJobRunOrchestration:
                 counter -= 1
             return RunResult(task_name="task", rewards={"reward": 1.0})
 
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(side_effect=fake_sdk_run)
+        job._run_rollout = AsyncMock(side_effect=fake_run_rollout)
 
         await job.run()
         assert max_in_flight == concurrency
 
     @pytest.mark.asyncio
-    async def test_unexpected_sdk_exception_becomes_errored_result(
+    async def test_unexpected_rollout_exception_becomes_errored_result(
         self, tmp_path, caplog
     ):
         """Prove the gather(return_exceptions=True) catch branch at job.py:491-502
         catches a non-classified exception, increments ``errored``, and logs.
 
         The synthesized RunResult(error="Unexpected: ...") is built in-Python
-        and never written to result.json (SDK._build_result never runs when
-        SDK.run raises), so we assert via JobResult and caplog, not disk.
+        and never written to result.json, so we assert via JobResult and caplog,
+        not disk.
         """
         job = self._make_job(tmp_path, n_tasks=1, concurrency=1)
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(side_effect=RuntimeError("boom"))
+        job._run_rollout = AsyncMock(side_effect=RuntimeError("boom"))
 
         with caplog.at_level(logging.ERROR):
             result = await job.run()

--- a/tests/test_oracle_chokepoint.py
+++ b/tests/test_oracle_chokepoint.py
@@ -226,7 +226,7 @@ class TestEvalCreateOracleCLI:
             return trial
 
         try:
-            with patch("benchflow.trial.Trial.create", new=fake_create):
+            with patch("benchflow.rollouts.rollout.Rollout.create", new=fake_create):
                 eval_create(
                     config_file=None,
                     tasks_dir=task,

--- a/tests/test_reexport.py
+++ b/tests/test_reexport.py
@@ -58,12 +58,14 @@ def test_public_api_reexports():
         AgentInstallError,
         AgentTimeoutError,
         RolloutConfig,
+        RolloutResult,
         RunResult,
         stage_dockerfile_deps,
     )
 
     assert callable(SDK)
     assert callable(RolloutConfig)
+    assert callable(RolloutResult)
     assert callable(RunResult)
     assert callable(AgentInstallError)
     assert callable(AgentTimeoutError)

--- a/tests/test_reexport.py
+++ b/tests/test_reexport.py
@@ -1,15 +1,19 @@
-"""Verify Harbor re-exports and benchflow additions work."""
+"""Verify benchflow public API re-exports."""
 
 
-def test_harbor_reexports():
-    """Harbor classes should be importable from benchflow."""
+def test_native_task_and_sandbox_reexports():
+    """Native task and sandbox classes should be importable from benchflow."""
     from benchflow import (
-        BaseEnvironment,
+        ExecResult,
+        SandboxSpec,
+        Task,
         TaskConfig,
     )
 
-    assert TaskConfig.__module__.startswith("harbor")
-    assert BaseEnvironment.__module__.startswith("harbor")
+    assert Task.__module__.startswith("benchflow.tasks")
+    assert TaskConfig.__module__.startswith("benchflow.tasks")
+    assert ExecResult.__module__.startswith("benchflow.sandboxes")
+    assert SandboxSpec.__module__.startswith("benchflow.sandboxes")
 
 
 def test_benchflow_job_shadows_harbor():
@@ -59,11 +63,13 @@ def test_public_api_reexports():
         RolloutConfig,
         RolloutResult,
         RunResult,
+        SandboxSpec,
         stage_dockerfile_deps,
     )
 
     assert callable(RolloutConfig)
     assert callable(RolloutResult)
+    assert callable(SandboxSpec)
     assert callable(RunResult)
     assert callable(AgentInstallError)
     assert callable(AgentTimeoutError)

--- a/tests/test_reexport.py
+++ b/tests/test_reexport.py
@@ -74,7 +74,7 @@ def test_public_api_reexports():
 
 def test_register_agent():
     """Custom agents can be registered at runtime."""
-    from benchflow import AGENTS, get_agent, register_agent
+    from benchflow import AGENTS, AgentCapability, get_agent, register_agent
     from benchflow.agents.registry import AGENT_INSTALLERS, AGENT_LAUNCH
 
     try:
@@ -84,12 +84,14 @@ def test_register_agent():
             launch_cmd="test-agent --acp",
             requires_env=["TEST_KEY"],
             description="Test agent",
+            capabilities=[AgentCapability("agent-as-tool")],
         )
 
         assert "test-custom-agent" in AGENTS
         cfg, alias_model = get_agent("test-custom-agent")
         assert cfg.launch_cmd == "test-agent --acp"
         assert cfg.requires_env == ["TEST_KEY"]
+        assert cfg.capabilities == [AgentCapability("agent-as-tool")]
         assert alias_model == ""
     finally:
         # register_agent writes to all three dicts; clean up all three to keep

--- a/tests/test_reexport.py
+++ b/tests/test_reexport.py
@@ -30,11 +30,11 @@ def test_benchflow_additions():
     assert TrajectoryProxy.__module__.startswith("benchflow")
 
 
-def test_sdk_importable():
-    from benchflow.sdk import SDK
+def test_rollout_runner_importable():
+    from benchflow import RolloutConfig, run
 
-    sdk = SDK()
-    assert hasattr(sdk, "run")
+    assert callable(run)
+    assert callable(RolloutConfig)
 
 
 def test_extracted_modules_importable():
@@ -54,7 +54,6 @@ def test_extracted_modules_importable():
 def test_public_api_reexports():
     """Public API symbols are still importable from benchflow top-level."""
     from benchflow import (
-        SDK,
         AgentInstallError,
         AgentTimeoutError,
         RolloutConfig,
@@ -63,7 +62,6 @@ def test_public_api_reexports():
         stage_dockerfile_deps,
     )
 
-    assert callable(SDK)
     assert callable(RolloutConfig)
     assert callable(RolloutResult)
     assert callable(RunResult)

--- a/tests/test_reexport.py
+++ b/tests/test_reexport.py
@@ -57,11 +57,13 @@ def test_public_api_reexports():
         SDK,
         AgentInstallError,
         AgentTimeoutError,
+        RolloutConfig,
         RunResult,
         stage_dockerfile_deps,
     )
 
     assert callable(SDK)
+    assert callable(RolloutConfig)
     assert callable(RunResult)
     assert callable(AgentInstallError)
     assert callable(AgentTimeoutError)

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -23,6 +23,7 @@ from benchflow.agents.registry import (
     AGENT_INSTALLERS,
     AGENT_LAUNCH,
     AGENTS,
+    AgentCapability,
 )
 
 VALID_AGENT_PROTOCOLS = {"acp", "cli"}
@@ -63,6 +64,7 @@ def test_agent_field_shapes(name, cfg):
     )
     assert isinstance(cfg.install_timeout, int) and cfg.install_timeout > 0
     assert isinstance(cfg.supports_acp_set_model, bool)
+    assert all(isinstance(cap, AgentCapability) for cap in cfg.capabilities)
 
 
 @pytest.mark.parametrize("name,cfg", AGENTS.items(), ids=list(AGENTS.keys()))
@@ -87,6 +89,13 @@ def test_agent_collection_invariants(name, cfg):
         )
     for d in cfg.home_dirs:
         assert d.startswith("."), f"home_dirs entry {d!r} must start with '.'"
+    for cap in cfg.capabilities:
+        assert isinstance(cap.name, str) and cap.name
+        assert isinstance(cap.description, str)
+        assert all(
+            isinstance(k, str) and isinstance(v, str)
+            for k, v in cap.metadata.items()
+        )
 
 
 @pytest.mark.parametrize("name,cfg", AGENTS.items(), ids=list(AGENTS.keys()))

--- a/tests/test_rewards_jsonl.py
+++ b/tests/test_rewards_jsonl.py
@@ -1,16 +1,22 @@
-"""Tests for _write_rewards_jsonl — dense reward persistence."""
+"""Tests for native reward event persistence."""
 
 import json
 from datetime import datetime
 from pathlib import Path
 
-from benchflow.sdk import _write_rewards_jsonl
+from benchflow.rewards import (
+    RewardContext,
+    RewardEvent,
+    Rubric,
+    TestRewardFunc,
+    write_rewards_jsonl,
+)
 
 
 def test_terminal_reward_written(tmp_path: Path) -> None:
     rewards = {"reward": 1.0}
     ts = datetime(2026, 4, 17, 15, 0, 0)
-    _write_rewards_jsonl(tmp_path, rewards, ts)
+    write_rewards_jsonl(tmp_path, rewards, ts)
     path = tmp_path / "rewards.jsonl"
     assert path.exists()
     lines = [json.loads(ln) for ln in path.read_text().strip().splitlines()]
@@ -22,18 +28,18 @@ def test_terminal_reward_written(tmp_path: Path) -> None:
 
 
 def test_no_file_when_rewards_none(tmp_path: Path) -> None:
-    _write_rewards_jsonl(tmp_path, None, datetime.now())
+    write_rewards_jsonl(tmp_path, None, datetime.now())
     assert not (tmp_path / "rewards.jsonl").exists()
 
 
 def test_no_file_when_rewards_empty(tmp_path: Path) -> None:
-    _write_rewards_jsonl(tmp_path, {}, datetime.now())
+    write_rewards_jsonl(tmp_path, {}, datetime.now())
     assert not (tmp_path / "rewards.jsonl").exists()
 
 
 def test_extra_keys_in_meta(tmp_path: Path) -> None:
     rewards = {"reward": 0.75, "exact_match": 1.0, "partial": 0.5}
-    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    write_rewards_jsonl(tmp_path, rewards, datetime.now())
     lines = [
         json.loads(ln)
         for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
@@ -52,7 +58,7 @@ def test_rubric_items_emitted_as_process(tmp_path: Path) -> None:
             {"name": "content_correct", "score": 0.5, "weight": 1.0},
         ],
     }
-    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    write_rewards_jsonl(tmp_path, rewards, datetime.now())
     lines = [
         json.loads(ln)
         for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
@@ -76,7 +82,7 @@ def test_rubric_without_terminal_still_works(tmp_path: Path) -> None:
     rewards = {
         "rubric": [{"name": "check_a", "score": 0.8}],
     }
-    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    write_rewards_jsonl(tmp_path, rewards, datetime.now())
     lines = [
         json.loads(ln)
         for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
@@ -88,7 +94,7 @@ def test_rubric_without_terminal_still_works(tmp_path: Path) -> None:
 
 def test_rubric_plus_terminal_no_rubric_in_meta(tmp_path: Path) -> None:
     rewards = {"reward": 0.6, "rubric": [{"name": "x", "score": 0.6}]}
-    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    write_rewards_jsonl(tmp_path, rewards, datetime.now())
     lines = [
         json.loads(ln)
         for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
@@ -99,10 +105,46 @@ def test_rubric_plus_terminal_no_rubric_in_meta(tmp_path: Path) -> None:
 
 def test_empty_rubric_list_only_terminal(tmp_path: Path) -> None:
     rewards = {"reward": 1.0, "rubric": []}
-    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    write_rewards_jsonl(tmp_path, rewards, datetime.now())
     lines = [
         json.loads(ln)
         for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
     ]
     assert len(lines) == 1
     assert lines[0]["type"] == "terminal"
+
+
+class ConstantReward:
+    async def score(self, ctx: RewardContext) -> float:
+        return 0.5
+
+
+class EventReward:
+    async def score(self, ctx: RewardContext) -> RewardEvent:
+        return RewardEvent(type="process", source="custom", value=0.25, tag="hint")
+
+
+async def test_rubric_scores_reward_funcs_with_weights(tmp_path: Path) -> None:
+    rubric = Rubric(
+        reward_funcs=[ConstantReward(), EventReward()],
+        weights=[2.0, 1.0],
+    )
+    events = await rubric.score(RewardContext(rollout_dir=tmp_path))
+
+    assert [e.value for e in events] == [1.0, 0.25]
+    assert events[0].type == "terminal"
+    assert events[0].meta == {"raw_value": 0.5, "weight": 2.0}
+    assert events[1].type == "process"
+    assert events[1].tag == "hint"
+
+
+async def test_test_reward_func_reads_legacy_reward_file(tmp_path: Path) -> None:
+    verifier_dir = tmp_path / "verifier"
+    verifier_dir.mkdir()
+    (verifier_dir / "reward.txt").write_text("0.8")
+
+    event = await TestRewardFunc().score(RewardContext(rollout_dir=tmp_path))
+
+    assert event.type == "terminal"
+    assert event.source == "test_reward_func"
+    assert event.value == 0.8

--- a/tests/test_rollout_api.py
+++ b/tests/test_rollout_api.py
@@ -1,0 +1,25 @@
+"""Tests for the rollout-native lifecycle entry points."""
+
+from pathlib import Path
+
+from benchflow.rollouts.config import RolloutConfig
+from benchflow.rollouts.rollout import Rollout
+from benchflow.rollouts.runner import run
+from benchflow.trial import Trial
+
+
+def test_rollout_lifecycle_class_available() -> None:
+    assert issubclass(Rollout, Trial)
+
+
+def test_rollout_config_create_uses_rollout_class() -> None:
+    config = RolloutConfig.from_single(
+        task_path=Path("tasks/example"),
+        agent="gemini",
+    )
+    rollout = Rollout(config)
+    assert isinstance(rollout, Rollout)
+
+
+def test_rollout_runner_callable() -> None:
+    assert callable(run)

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -126,7 +126,7 @@ class TestHardenSequence:
         env = _make_env(side_effect=_manifest_env(_blank_manifest()))
         mock_v = MagicMock()
         mock_v.verify = AsyncMock(return_value=MagicMock(rewards={"reward": 1.0}))
-        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+        with patch("benchflow._harbor.make_verifier", return_value=mock_v):
             await sdk._verify(
                 env, task, tp, {}, sandbox_user="agent", workspace="/testbed"
             )
@@ -165,7 +165,7 @@ class TestHardenSequence:
         sdk, env, task, tp = harness
         mock_v = MagicMock()
         mock_v.verify = AsyncMock(return_value=MagicMock(rewards={"reward": 1.0}))
-        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+        with patch("benchflow._harbor.make_verifier", return_value=mock_v):
             await sdk._verify(env, task, tp, {}, sandbox_user=None)
 
         cmds = [c.args[0] for c in env.exec.call_args_list]
@@ -184,7 +184,7 @@ class TestHardenSequence:
         task.config.verifier.env = {"PATH": "/custom/bin", "MY_VAR": "hello"}
         mock_v = MagicMock()
         mock_v.verify = AsyncMock(return_value=MagicMock(rewards={"reward": 1.0}))
-        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+        with patch("benchflow._harbor.make_verifier", return_value=mock_v):
             await sdk._verify(env, task, tp, {})
         injected = task.config.verifier.env
         assert injected["PATH"] == VERIFIER_ENV["PATH"]

--- a/tests/test_sandbox_primitives.py
+++ b/tests/test_sandbox_primitives.py
@@ -1,0 +1,25 @@
+"""Tests for native sandbox value types and protocols."""
+
+from pathlib import Path
+
+from benchflow.sandboxes import ExecResult, ImageConfig, ImageRef, SandboxSpec
+
+
+def test_exec_result_success_property() -> None:
+    assert ExecResult(return_code=0).success is True
+    assert ExecResult(return_code=2).success is False
+
+
+def test_sandbox_spec_defaults_match_current_backend() -> None:
+    spec = SandboxSpec()
+    assert spec.provider == "docker"
+    assert spec.allow_internet is True
+    assert spec.env == {}
+
+
+def test_image_config_and_ref_are_provider_neutral() -> None:
+    config = ImageConfig(dockerfile=Path("environment/Dockerfile"))
+    ref = ImageRef(provider="docker", ref="benchflow-task:latest")
+    assert config.dockerfile == Path("environment/Dockerfile")
+    assert ref.provider == "docker"
+    assert ref.ref == "benchflow-task:latest"

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from benchflow._scene import MailboxTransport, Message, SceneRuntime
-from benchflow.rollouts import Role, Scene, Turn
+from benchflow.rollouts import RolloutConfig, Role, Scene, Turn
 
 
 @pytest.fixture
@@ -241,3 +241,22 @@ def test_canonical_scene_single_and_parallel_group() -> None:
         Turn(role="agent", prompt="Review your solution."),
     ]
     assert scene.parallel_group == "pass-k"
+
+
+def test_rollout_config_from_single_uses_canonical_scene() -> None:
+    config = RolloutConfig.from_single(
+        task_path=Path("tasks/example"),
+        agent="gemini",
+        model="gemini-3.1-flash-lite-preview",
+        prompts=[None],
+    )
+
+    assert config.primary_agent == "gemini"
+    assert config.primary_model == "gemini-3.1-flash-lite-preview"
+    assert config.effective_scenes == [
+        Scene.single(
+            agent="gemini",
+            model="gemini-3.1-flash-lite-preview",
+            prompts=[None],
+        )
+    ]

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from benchflow._scene import MailboxTransport, Message, SceneRuntime
-from benchflow.rollouts import RolloutConfig, Role, Scene, Turn
+from benchflow.rollouts import Role, RolloutConfig, Scene, Turn
 
 
 @pytest.fixture

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -1,4 +1,4 @@
-"""Tests for _scene.py — multi-agent scene runtime."""
+"""Tests for canonical scene types and _scene.py runtime."""
 
 import asyncio
 import json
@@ -6,7 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from benchflow._scene import MailboxTransport, Message, Role, Scene
+from benchflow._scene import MailboxTransport, Message, SceneRuntime
+from benchflow.rollouts import Role, Scene, Turn
 
 
 @pytest.fixture
@@ -30,11 +31,11 @@ def two_roles() -> dict[str, Role]:
 def test_scene_requires_two_roles() -> None:
     r = Role(name="solo", agent="x", model="y", instruction="z")
     with pytest.raises(ValueError, match="exactly 2 roles"):
-        Scene(roles={"solo": r})
+        SceneRuntime(roles={"solo": r})
 
 
 def test_scene_init(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles, max_rounds=5)
+    scene = SceneRuntime(roles=two_roles, max_rounds=5)
     assert scene.role_names == ["coder", "reviewer"]
     assert scene.max_rounds == 5
     assert not scene.is_done
@@ -42,13 +43,13 @@ def test_scene_init(two_roles: dict[str, Role]) -> None:
 
 
 def test_next_active_role(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles)
+    scene = SceneRuntime(roles=two_roles)
     assert scene.next_active_role("coder") == "reviewer"
     assert scene.next_active_role("reviewer") == "coder"
 
 
 async def test_send_message(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles, max_rounds=10)
+    scene = SceneRuntime(roles=two_roles, max_rounds=10)
     result = await scene.send_message("coder", "reviewer", "please review")
     assert "delivered" in result
     assert len(scene.trajectory) == 1
@@ -60,14 +61,14 @@ async def test_send_message(two_roles: dict[str, Role]) -> None:
 
 
 async def test_send_to_unknown_recipient(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles)
+    scene = SceneRuntime(roles=two_roles)
     result = await scene.send_message("coder", "nobody", "hi")
     assert "Error" in result
     assert len(scene.trajectory) == 0
 
 
 async def test_round_counting(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles, max_rounds=3)
+    scene = SceneRuntime(roles=two_roles, max_rounds=3)
     await scene.send_message("coder", "reviewer", "msg1")
     await scene.send_message("reviewer", "coder", "msg2")
     assert not scene.is_done
@@ -76,7 +77,7 @@ async def test_round_counting(two_roles: dict[str, Role]) -> None:
 
 
 async def test_end_scene(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles)
+    scene = SceneRuntime(roles=two_roles)
     assert not scene.is_done
     await scene.end_scene("reviewer", reward=1.0)
     assert scene.is_done
@@ -99,7 +100,7 @@ async def test_mailbox_transport() -> None:
 
 
 async def test_build_prompt_for_role(two_roles: dict[str, Role]) -> None:
-    scene = Scene(roles=two_roles)
+    scene = SceneRuntime(roles=two_roles)
     inbox = [
         Message(
             id="x", sender="reviewer", recipient="coder", content="looks good", turn=1
@@ -151,7 +152,7 @@ class FakeExecResult:
 
 async def test_scene_run_two_rounds(two_roles: dict[str, Role]) -> None:
     env = FakeEnv()
-    scene = Scene(roles=two_roles, max_rounds=4)
+    scene = SceneRuntime(roles=two_roles, max_rounds=4)
     call_count = 0
 
     async def mock_runner(e, role, prompt):
@@ -173,7 +174,7 @@ async def test_scene_run_two_rounds(two_roles: dict[str, Role]) -> None:
 
 async def test_scene_run_stops_when_no_message(two_roles: dict[str, Role]) -> None:
     env = FakeEnv()
-    scene = Scene(roles=two_roles, max_rounds=10)
+    scene = SceneRuntime(roles=two_roles, max_rounds=10)
 
     async def mock_runner(e, role, prompt):
         if role.name == "coder":
@@ -185,7 +186,7 @@ async def test_scene_run_stops_when_no_message(two_roles: dict[str, Role]) -> No
 
 
 def test_save_trajectory(two_roles: dict[str, Role], tmp_path: Path) -> None:
-    scene = Scene(roles=two_roles)
+    scene = SceneRuntime(roles=two_roles)
     asyncio.get_event_loop().run_until_complete(
         scene.send_message("coder", "reviewer", "check this")
     )
@@ -200,3 +201,43 @@ def test_save_trajectory(two_roles: dict[str, Role], tmp_path: Path) -> None:
     assert lines[1]["sender"] == "reviewer"
     assert lines[0]["turn"] == 1
     assert lines[1]["turn"] == 2
+
+
+def test_canonical_role_budget_fields() -> None:
+    role = Role(
+        name="solver",
+        agent="claude-agent-acp",
+        model="claude-sonnet-4-6",
+        timeout_sec=900,
+        idle_timeout_sec=120,
+        capabilities=["native-loop"],
+    )
+    assert role.timeout_sec == 900
+    assert role.idle_timeout_sec == 120
+    assert role.capabilities == ["native-loop"]
+
+
+def test_canonical_scene_single_and_parallel_group() -> None:
+    scene = Scene.single(
+        agent="gemini",
+        model="gemini-3.1-flash-lite-preview",
+        prompts=[None, "Review your solution."],
+        timeout_sec=300,
+        idle_timeout_sec=60,
+    )
+    scene.parallel_group = "pass-k"
+
+    assert scene.roles == [
+        Role(
+            name="agent",
+            agent="gemini",
+            model="gemini-3.1-flash-lite-preview",
+            timeout_sec=300,
+            idle_timeout_sec=60,
+        )
+    ]
+    assert scene.turns == [
+        Turn(role="agent", prompt=None),
+        Turn(role="agent", prompt="Review your solution."),
+    ]
+    assert scene.parallel_group == "pass-k"

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -451,7 +451,7 @@ class TestRunWiring:
             )
             return trial
 
-        monkeypatch.setattr("benchflow.trial.Trial.create", fake_create)
+        monkeypatch.setattr("benchflow.rollouts.rollout.Rollout.create", fake_create)
 
         result = await SDK().run(
             task_path=tmp_path,

--- a/tests/test_self_gen_orchestration.py
+++ b/tests/test_self_gen_orchestration.py
@@ -78,7 +78,7 @@ async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_
             run_configs.append(self._config)
             return solver_result
 
-    monkeypatch.setattr("benchflow.self_gen.Trial", FakeTrial)
+    monkeypatch.setattr("benchflow.self_gen.Rollout", FakeTrial)
 
     result = await SDK().run(
         task_path=task,
@@ -195,7 +195,7 @@ async def test_job_self_gen_uses_strict_orchestration(
             run_configs.append(self._config)
             return solver_result
 
-    monkeypatch.setattr("benchflow.self_gen.Trial", FakeTrial)
+    monkeypatch.setattr("benchflow.self_gen.Rollout", FakeTrial)
 
     result = await job._run_single_task(task, job._config)
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,4 @@
-"""Live smoke test for SDK.run() against a real environment.
+"""Live smoke test for bf.run(RolloutConfig) against a real environment.
 
 Run:
     pytest -m live tests/test_smoke.py
@@ -6,10 +6,6 @@ Run:
 Bare ``pytest tests/test_smoke.py`` will silently report "1 deselected" because
 the ``addopts = "-m 'not live'"`` filter in pyproject.toml applies to direct
 file invocation too.
-
-Importing ``benchflow.sdk`` triggers ``_patch_harbor_dind()`` at sdk.py:135.
-That patch is gated on ``/.dockerenv`` and runs ``docker info`` with a 5s
-timeout, swallowing all exceptions — safe but worth flagging.
 
 Cost / runtime budget (for the green path against claude-agent-acp + Haiku 4.5):
 - Cold: 90-180s (apt + node 22 + npm install @zed-industries/claude-agent-acp,
@@ -30,7 +26,8 @@ from pathlib import Path
 
 import pytest
 
-from benchflow import SDK
+import benchflow as bf
+from benchflow import RolloutConfig
 from benchflow._env_setup import _detect_dind_mount
 
 HELLO_TASK = Path(__file__).parent / "examples" / "hello-world-task"
@@ -135,11 +132,13 @@ async def test_hello_world_smoke(smoke_prereqs: bool, smoke_jobs_dir: Path) -> N
       overwritten by scraped fallback — see sdk.py:83-84,540)
     - Trajectory file exists and is non-empty
     """
-    result = await SDK().run(
-        task_path=HELLO_TASK,
-        agent="claude-agent-acp",
-        model="claude-haiku-4-5-20251001",
-        jobs_dir=smoke_jobs_dir,
+    result = await bf.run(
+        RolloutConfig(
+            task_path=HELLO_TASK,
+            agent="claude-agent-acp",
+            model="claude-haiku-4-5-20251001",
+            jobs_dir=smoke_jobs_dir,
+        )
     )
 
     assert result.rewards is not None
@@ -148,7 +147,7 @@ async def test_hello_world_smoke(smoke_prereqs: bool, smoke_jobs_dir: Path) -> N
     assert result.verifier_error is None
     assert result.n_tool_calls > 0
 
-    # trial_dir = jobs_dir / job_name / trial_name (sdk.py:166).
+    # rollout_dir = jobs_dir / job_name / rollout_name.
     # job_name is an auto-generated timestamp, so glob for it.
     matches = list(
         smoke_jobs_dir.glob(f"*/{result.trial_name}/trajectory/acp_trajectory.jsonl")

--- a/tests/test_task_config.py
+++ b/tests/test_task_config.py
@@ -1,0 +1,62 @@
+"""Tests for native task config models."""
+
+from pathlib import Path
+
+from benchflow.tasks import Task, load_task_config
+
+
+def test_load_task_config_parses_core_sections(tmp_path: Path) -> None:
+    task_toml = tmp_path / "task.toml"
+    task_toml.write_text(
+        """
+[agent]
+timeout_sec = 42
+
+[verifier]
+timeout_sec = 11
+env = { FOO = "bar" }
+pytest_plugins = ["pytester"]
+
+[environment]
+cpus = 2
+memory_mb = 2048
+storage_mb = 4096
+allow_internet = false
+env = { A = "B" }
+"""
+    )
+
+    config = load_task_config(task_toml)
+
+    assert config.agent.timeout_sec == 42
+    assert config.verifier.timeout_sec == 11
+    assert config.verifier.env == {"FOO": "bar"}
+    assert config.verifier.pytest_plugins == ["pytester"]
+    assert config.environment.cpus == 2
+    assert config.environment.memory_mb == 2048
+    assert config.environment.storage_mb == 4096
+    assert config.environment.allow_internet is False
+    assert config.environment.env == {"A": "B"}
+
+
+def test_environment_config_to_sandbox_spec(tmp_path: Path) -> None:
+    task_toml = tmp_path / "task.toml"
+    task_toml.write_text("[environment]\ncpus = 4\nallow_internet = false\n")
+
+    spec = load_task_config(task_toml).environment.to_sandbox_spec("docker")
+
+    assert spec.provider == "docker"
+    assert spec.cpus == 4
+    assert spec.allow_internet is False
+
+
+def test_task_from_dir_exposes_paths(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "task.toml").write_text("[agent]\ntimeout_sec = 1\n")
+
+    task = Task.from_dir(task_dir)
+
+    assert task.task_dir == task_dir
+    assert task.paths.instruction == task_dir / "instruction.md"
+    assert task.paths.dockerfile == task_dir / "environment" / "Dockerfile"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -339,10 +339,10 @@ class TestSoftVerify:
         trial = _make_user_trial(PassthroughUser())
 
         with (
-            patch("harbor.Verifier") as MockVerifier,
+            patch("benchflow._harbor.make_verifier") as make_verifier,
             patch("benchflow._sandbox.CLEANUP_CMD", "true"),
         ):
-            mock_instance = MockVerifier.return_value
+            mock_instance = make_verifier.return_value
             mock_instance.verify = AsyncMock(side_effect=TimeoutError())
 
             rewards, output, error = await trial.soft_verify()
@@ -356,10 +356,10 @@ class TestSoftVerify:
         trial = _make_user_trial(PassthroughUser())
 
         with (
-            patch("harbor.Verifier") as MockVerifier,
+            patch("benchflow._harbor.make_verifier") as make_verifier,
             patch("benchflow._sandbox.CLEANUP_CMD", "true"),
         ):
-            mock_instance = MockVerifier.return_value
+            mock_instance = make_verifier.return_value
             mock_instance.verify = AsyncMock(side_effect=RuntimeError("boom"))
 
             rewards, _output, error = await trial.soft_verify()
@@ -375,10 +375,10 @@ class TestSoftVerify:
         mock_result = type("VR", (), {"rewards": {"exact_match": 1.0}})()
 
         with (
-            patch("harbor.Verifier") as MockVerifier,
+            patch("benchflow._harbor.make_verifier") as make_verifier,
             patch("benchflow._sandbox.CLEANUP_CMD", "true"),
         ):
-            mock_instance = MockVerifier.return_value
+            mock_instance = make_verifier.return_value
             mock_instance.verify = AsyncMock(return_value=mock_result)
 
             rewards, _output, error = await trial.soft_verify()
@@ -393,13 +393,13 @@ class TestSoftVerify:
         mock_result = type("VR", (), {"rewards": {}})()
 
         with (
-            patch("harbor.Verifier") as MockVerifier,
+            patch("benchflow._harbor.make_verifier") as make_verifier,
             patch(
                 "benchflow._sandbox._build_cleanup_cmd",
                 return_value="echo cleanup_sentinel",
             ),
         ):
-            mock_instance = MockVerifier.return_value
+            mock_instance = make_verifier.return_value
             mock_instance.verify = AsyncMock(return_value=mock_result)
 
             await trial.soft_verify()

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -154,30 +154,28 @@ class TestRetry:
     async def test_verifier_error_is_terminal(self, job_factory):
         """Verifier errors exit after 1 attempt — no retry."""
         job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(
+        job._run_rollout = AsyncMock(
             return_value=RunResult(
                 task_name="task-0",
                 verifier_error="verifier crashed: x",
             )
         )
         result = await job._run_task(tasks_dir / "task-0")
-        assert job._sdk.run.call_count == 1
+        assert job._run_rollout.call_count == 1
         assert result.verifier_error == "verifier crashed: x"
 
     @pytest.mark.asyncio
     async def test_agent_error_still_retries(self, job_factory):
         """Agent install errors are retried."""
         job, tasks_dir = job_factory(n_tasks=1, max_retries=2)
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(
+        job._run_rollout = AsyncMock(
             return_value=RunResult(
                 task_name="task-0",
                 error="Agent claude-agent-acp install failed (rc=1)",
             )
         )
         await job._run_task(tasks_dir / "task-0")
-        assert job._sdk.run.call_count == 3  # 1 + 2 retries
+        assert job._run_rollout.call_count == 3  # 1 + 2 retries
 
 
 class TestResume:
@@ -227,8 +225,7 @@ class TestJobRunLogs:
     @pytest.mark.asyncio
     async def test_bounded_log_shows_verifier_error(self, job_factory, caplog):
         job, _ = job_factory(n_tasks=1)
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(
+        job._run_rollout = AsyncMock(
             return_value=RunResult(
                 task_name="task-0",
                 verifier_error="verifier crashed: KeyError",
@@ -243,7 +240,7 @@ class TestJobRunLogs:
         job, _ = job_factory(n_tasks=3)
         call_count = 0
 
-        async def make_result(**kwargs):
+        async def make_result(_config):
             nonlocal call_count
             r = RunResult(
                 task_name=f"task-{call_count}", verifier_error="verifier crashed: x"
@@ -251,8 +248,7 @@ class TestJobRunLogs:
             call_count += 1
             return r
 
-        job._sdk = AsyncMock()
-        job._sdk.run = make_result
+        job._run_rollout = make_result
         with caplog.at_level(logging.WARNING):
             await job.run()
         warning_records = [
@@ -270,14 +266,13 @@ class TestJobRunLogs:
         ] + [RunResult(task_name="task-4", verifier_error="verifier crashed: x")]
         idx = 0
 
-        async def make_result(**kwargs):
+        async def make_result(_config):
             nonlocal idx
             r = results[idx]
             idx += 1
             return r
 
-        job._sdk = AsyncMock()
-        job._sdk.run = make_result
+        job._run_rollout = make_result
         with caplog.at_level(logging.WARNING):
             await job.run()
         assert any("had verifier errors" in r.message for r in caplog.records)
@@ -286,8 +281,7 @@ class TestJobRunLogs:
     @pytest.mark.asyncio
     async def test_summary_json_includes_verifier_errored(self, job_factory):
         job, _ = job_factory(n_tasks=1)
-        job._sdk = AsyncMock()
-        job._sdk.run = AsyncMock(
+        job._run_rollout = AsyncMock(
             return_value=RunResult(
                 task_name="task-0",
                 verifier_error="verifier crashed: x",

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -107,7 +107,7 @@ class TestSdkVerify:
         mock_v = MagicMock()
         mock_v.verify = lambda: asyncio.sleep(10)
         timing = {}
-        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+        with patch("benchflow._harbor.make_verifier", return_value=mock_v):
             rewards, verifier_error = await sdk._verify(env, task, tp, timing)
         assert rewards is None
         assert "timed out" in verifier_error
@@ -119,7 +119,7 @@ class TestSdkVerify:
         mock_v = MagicMock()
         mock_v.verify = AsyncMock(side_effect=RuntimeError("kaboom"))
         timing = {}
-        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+        with patch("benchflow._harbor.make_verifier", return_value=mock_v):
             rewards, verifier_error = await sdk._verify(env, task, tp, timing)
         assert rewards is None
         assert "crashed" in verifier_error and "kaboom" in verifier_error
@@ -132,7 +132,7 @@ class TestSdkVerify:
         mock_v = MagicMock()
         mock_v.verify = AsyncMock(return_value=mock_result)
         timing = {}
-        with patch("benchflow.sdk.Verifier", return_value=mock_v):
+        with patch("benchflow._harbor.make_verifier", return_value=mock_v):
             rewards, verifier_error = await sdk._verify(env, task, tp, timing)
         assert rewards == {"reward": 1.0}
         assert verifier_error is None

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -15,6 +15,7 @@ from benchflow._scoring import (
 )
 from benchflow.metrics import BenchmarkMetrics, TaskMetrics
 from benchflow.models import RunResult
+from benchflow.rollouts import RolloutResult
 
 # ---------------------------------------------------------------------------
 # classify_verifier_error
@@ -58,6 +59,11 @@ class TestRunResultVerifierError:
     def test_repr_shows_verifier_error(self):
         r = RunResult(task_name="t", verifier_error="verifier timed out after 900s")
         assert "ERROR: verifier timed out after 900s" in repr(r)
+
+    def test_rollout_result_native_name(self):
+        r = RolloutResult(task_name="t", trial_name="rollout-1")
+        assert r.rollout_name == "rollout-1"
+        assert r.success is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from benchflow.job import Job
+from benchflow.trial_yaml import trial_config_from_dict
 
 
 @pytest.fixture
@@ -282,3 +283,39 @@ sandbox_user: testuser
         assert job._config.agent_env == {}
         assert job._config.sandbox_user == "agent"
         assert job._config.sandbox_setup_timeout == 120
+
+
+def test_trial_yaml_parses_canonical_scene_role_fields() -> None:
+    cfg = trial_config_from_dict(
+        {
+            "task_dir": "tasks",
+            "scenes": [
+                {
+                    "name": "review",
+                    "parallel_group": "pass-k",
+                    "roles": [
+                        {
+                            "name": "coder",
+                            "agent": "gemini",
+                            "model": "gemini-3.1-flash-lite-preview",
+                            "timeout_sec": 300,
+                            "idle_timeout_sec": 60,
+                            "capabilities": ["agent-as-tool"],
+                            "instruction": "Write the solution.",
+                            "tools": ["bash"],
+                        }
+                    ],
+                    "turns": [{"role": "coder", "prompt": None}],
+                }
+            ],
+        }
+    )
+
+    scene = cfg.scenes[0]
+    role = scene.roles[0]
+    assert scene.parallel_group == "pass-k"
+    assert role.timeout_sec == 300
+    assert role.idle_timeout_sec == 60
+    assert role.capabilities == ["agent-as-tool"]
+    assert role.instruction == "Write the solution."
+    assert role.tools == ["bash"]

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from benchflow.job import Job
+from benchflow.rollouts.yaml import rollout_config_from_dict
 from benchflow.trial_yaml import trial_config_from_dict
 
 
@@ -286,7 +287,7 @@ sandbox_user: testuser
 
 
 def test_trial_yaml_parses_canonical_scene_role_fields() -> None:
-    cfg = trial_config_from_dict(
+    cfg = rollout_config_from_dict(
         {
             "task_dir": "tasks",
             "scenes": [
@@ -319,3 +320,10 @@ def test_trial_yaml_parses_canonical_scene_role_fields() -> None:
     assert role.capabilities == ["agent-as-tool"]
     assert role.instruction == "Write the solution."
     assert role.tools == ["bash"]
+
+
+def test_trial_yaml_compat_delegates_to_rollout_loader() -> None:
+    raw = {"task_dir": "tasks", "agent": "gemini"}
+    compat_cfg = trial_config_from_dict(raw)
+    rollout_cfg = rollout_config_from_dict(raw)
+    assert compat_cfg == rollout_cfg


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR lays the v0.4 architecture foundation around rollout-first execution and native BenchFlow boundaries:

- adds canonical rollout config/types (`Role`, `Turn`, `Scene`, `RolloutConfig`, `RolloutResult`)
- routes public `benchflow.run`, jobs, CLI single-run paths, and self-gen through rollout-native entry points
- moves lifecycle helper logic out of `SDK` toward `benchflow.rollouts`
- adds native sandbox protocols/specs and a native `DockerSandbox` provider (no core `HarborSandbox` wrapper)
- converts `benchflow.tasks` into a package with native task config/path models
- adds native rewards primitives (`RewardEvent`, `Rubric`, `RewardFunc`, `TestRewardFunc`)
- adds agent capability declarations
- removes top-level Harbor reexports/fallback in favor of native `Task`, `TaskConfig`, `ExecResult`, and `SandboxSpec`

Compatibility modules (`sdk.py`, `runtime.py`, `trial.py`, `trial_yaml.py`) still exist internally for incremental migration, but they are no longer top-level public API.

## Validation

- `uv run python -m pytest tests/`
  - 835 passed, 1 skipped, 1 deselected
- `uv run ruff check .`
- `uv run ty check src/`

## Notes

Harbor runtime removal is intentionally not completed in this PR. The direction is native providers first (`DockerSandbox`, then Daytona/Modal), with Harbor kept only as a temporary internal bridge until rollout execution no longer depends on it.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb98b5f1-bc91-4ced-9468-467fd21cccbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb98b5f1-bc91-4ced-9468-467fd21cccbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

