### PR TITLE
Support Codex subscription auth in Daytona

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,7 +53,7 @@ export CLAUDE_CODE_OAUTH_TOKEN=<paste-token>
 
 benchflow auto-inherits `CLAUDE_CODE_OAUTH_TOKEN` from your shell into the sandbox; the Claude CLI inside reads it directly. Same auth precedence as plain `claude` ([Anthropic docs](https://code.claude.com/docs/en/authentication#authentication-precedence)): API keys override OAuth tokens, so unset `ANTHROPIC_API_KEY` if you want the token to win.
 
-`claude setup-token` only authenticates Claude. Codex and Gemini do not have an equivalent today — use Option 1 (host login) or Option 3 (API key).
+`claude setup-token` only authenticates Claude. Codex can also use a provided subscription access token, such as `CODEX_ACCESS_TOKEN` from a host/orchestrator integration; benchflow passes it through to Codex without copying `~/.codex/auth.json`. Gemini does not have an equivalent today — use Option 1 (host login) or Option 3 (API key).
 
 ### Option 3 — API key
 
@@ -62,6 +62,7 @@ Set the API-key env var directly. Works with every agent:
 ```bash
 export ANTHROPIC_API_KEY=sk-ant-...
 export OPENAI_API_KEY=sk-...
+export CODEX_API_KEY=sk-...       # Codex alias for OPENAI_API_KEY
 export GEMINI_API_KEY=...
 export LLM_API_KEY=...           # OpenHands / LiteLLM-compatible providers
 ```

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -11,7 +11,7 @@ The core matrix runs 9 SkillsBench tasks across all 8 registered agents on Dayto
 | `GEMINI_API_KEY` (or `GOOGLE_API_KEY`) | gemini, pi-acp, openclaw, opencode, openhands |
 | `DAYTONA_API_KEY` | all agents (sandbox) |
 | `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` | claude-agent-acp |
-| `OPENAI_API_KEY` | codex-acp |
+| `OPENAI_API_KEY`, `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, or `~/.codex/auth.json` | codex-acp |
 
 ## Quick Start
 
@@ -173,7 +173,7 @@ All 8 registered agents run by default:
 | Agent | Default Model | Notes |
 |---|---|---|
 | claude-agent-acp | claude-haiku-4-5-20251001 | Needs `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` |
-| codex-acp | gpt-5.4-nano | Needs `OPENAI_API_KEY` |
+| codex-acp | gpt-5.4-nano | Needs `OPENAI_API_KEY`, `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, or host Codex login |
 | pi-acp | gemini-3.1-flash-lite-preview | |
 | openclaw | gemini-3.1-flash-lite-preview | |
 | gemini | gemini-3.1-flash-lite-preview | |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -270,7 +270,7 @@ result = await bf.run(config)
 |-------|----------|------|---------|
 | `gemini` | ACP | GEMINI_API_KEY | — |
 | `claude-agent-acp` | ACP | ANTHROPIC_API_KEY | `claude` |
-| `codex-acp` | ACP | OPENAI_API_KEY | `codex` |
+| `codex-acp` | ACP | OPENAI_API_KEY, CODEX_API_KEY, CODEX_ACCESS_TOKEN, or host login | `codex` |
 | `opencode` | ACP | inferred from model/provider | — |
 | `openhands` | ACP | LLM_API_KEY | `oh` |
 | `pi-acp` | ACP | ANTHROPIC_API_KEY | `pi` |

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -233,7 +233,7 @@ Common choices:
 |-------|-----|------|
 | Gemini | `gemini` | `GEMINI_API_KEY` or host login |
 | Claude Code | `claude-agent-acp` (alias: `claude`) | `ANTHROPIC_API_KEY` or host login |
-| Codex | `codex-acp` (alias: `codex`) | `OPENAI_API_KEY` or host login |
+| Codex | `codex-acp` (alias: `codex`) | `OPENAI_API_KEY`, `CODEX_API_KEY`, `CODEX_ACCESS_TOKEN`, or host login |
 | OpenHands | `openhands` (alias: `oh`) | `LLM_API_KEY` |
 | Harvey LAB harness | `harvey-lab-harness` (alias: `harvey-lab`) | Provider key matching model |
 

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -117,6 +117,8 @@ Skill eval: my-skill (1 cases)
 provider credentials or subscription auth it normally needs, and LLM-judge
 cases also need a supported judge key available in the environment. Exact-match
 cases can avoid the judge model, but they still need a working agent.
+For Codex agents, that auth can be `OPENAI_API_KEY`, `CODEX_API_KEY`,
+`CODEX_ACCESS_TOKEN`, or a host `~/.codex/auth.json` login.
 
 When a supported judge key is present on the host (`GOOGLE_API_KEY`,
 `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`), generated tasks

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -36,6 +36,9 @@ _EXPLICIT_AGENT_NATIVE_BRIDGE_KEYS = frozenset({"LLM_API_KEY"})
 _BEDROCK_PROXY_PLACEHOLDER_API_KEY = "bedrock-proxy"
 _CODEX_API_KEY_ENV = "CODEX_API_KEY"
 _CODEX_ACCESS_TOKEN_ENV = "CODEX_ACCESS_TOKEN"
+_CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
+    {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
+)
 
 
 def _normalize_openhands_model(model: str) -> str:
@@ -132,6 +135,42 @@ def _is_codex_native_openai_context(
     return find_provider(model) is None
 
 
+def _has_custom_openai_endpoint(agent_env: dict[str, str]) -> bool:
+    """True when Codex is being pointed at an OpenAI-compatible non-OpenAI URL."""
+    return any(agent_env.get(key) for key in _CUSTOM_OPENAI_ENDPOINT_KEYS)
+
+
+def _can_use_codex_subscription_auth(
+    agent: str,
+    model: str | None,
+    required_key: str | None,
+    agent_env: dict[str, str],
+) -> bool:
+    """Codex subscription auth is only valid for the native OpenAI endpoint."""
+    return _is_codex_native_openai_context(
+        agent,
+        model,
+        required_key,
+    ) and not _has_custom_openai_endpoint(agent_env)
+
+
+def _can_use_subscription_auth(
+    agent: str,
+    model: str | None,
+    required_key: str | None,
+    agent_env: dict[str, str],
+) -> bool:
+    """Return True when host subscription files can satisfy provider auth."""
+    if agent == "codex-acp" and required_key == "OPENAI_API_KEY":
+        return _can_use_codex_subscription_auth(
+            agent,
+            model,
+            required_key,
+            agent_env,
+        )
+    return True
+
+
 def _normalize_codex_auth_env(
     agent: str,
     model: str | None,
@@ -157,9 +196,12 @@ def _has_codex_access_token_auth(
     agent_env: dict[str, str],
 ) -> bool:
     """Return True when Codex's subscription access token satisfies OpenAI auth."""
-    return _is_codex_native_openai_context(agent, model, required_key) and bool(
-        agent_env.get(_CODEX_ACCESS_TOKEN_ENV)
-    )
+    return _can_use_codex_subscription_auth(
+        agent,
+        model,
+        required_key,
+        agent_env,
+    ) and bool(agent_env.get(_CODEX_ACCESS_TOKEN_ENV))
 
 
 def inject_vertex_credentials(agent_env: dict[str, str], model: str) -> None:
@@ -365,7 +407,12 @@ def resolve_agent_env(
             and not has_agent_native_bridge_key
             and not has_codex_access_token
         ):
-            if check_subscription_auth(agent, required_key):
+            if _can_use_subscription_auth(
+                agent,
+                model,
+                required_key,
+                agent_env,
+            ) and check_subscription_auth(agent, required_key):
                 agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
                 logger.info(
                     "Using host subscription auth (no %s set)",
@@ -389,6 +436,7 @@ def resolve_agent_env(
                         req_key,
                         agent_env,
                     )
+                    and _can_use_subscription_auth(agent, model, req_key, agent_env)
                     and check_subscription_auth(agent, req_key)
                 ):
                     agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -30,9 +30,12 @@ logger = logging.getLogger(__name__)
 _AUTH_CONTEXT_GROUPS = (
     frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}),
     frozenset({"GEMINI_API_KEY", "GOOGLE_API_KEY"}),
+    frozenset({"OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"}),
 )
 _EXPLICIT_AGENT_NATIVE_BRIDGE_KEYS = frozenset({"LLM_API_KEY"})
 _BEDROCK_PROXY_PLACEHOLDER_API_KEY = "bedrock-proxy"
+_CODEX_API_KEY_ENV = "CODEX_API_KEY"
+_CODEX_ACCESS_TOKEN_ENV = "CODEX_ACCESS_TOKEN"
 
 
 def _normalize_openhands_model(model: str) -> str:
@@ -72,6 +75,8 @@ def auto_inherit_env(
         "AWS_DEFAULT_REGION",
         "AWS_REGION",
         "CLAUDE_CODE_OAUTH_TOKEN",
+        "CODEX_ACCESS_TOKEN",
+        "CODEX_API_KEY",
         "OPENAI_API_KEY",
         "OPENAI_BASE_URL",
         "GOOGLE_API_KEY",
@@ -109,6 +114,52 @@ def auto_inherit_env(
         agent_env["AWS_DEFAULT_REGION"] = agent_env["AWS_REGION"]
     # CLAUDE_CODE_OAUTH_TOKEN is a separate auth path — Claude CLI reads it
     # directly. Don't map to ANTHROPIC_API_KEY (different auth mechanism).
+
+
+def _is_codex_native_openai_context(
+    agent: str,
+    model: str | None,
+    required_key: str | None,
+) -> bool:
+    """True when Codex can use its own OpenAI auth mechanisms directly."""
+    if agent != "codex-acp" or required_key != "OPENAI_API_KEY":
+        return False
+    if model is None:
+        return True
+
+    from benchflow.agents.providers import find_provider
+
+    return find_provider(model) is None
+
+
+def _normalize_codex_auth_env(
+    agent: str,
+    model: str | None,
+    agent_env: dict[str, str],
+) -> None:
+    """Bridge Codex's API-key alias to the auth file writer.
+
+    codex-acp advertises both CODEX_API_KEY and OPENAI_API_KEY, while
+    BenchFlow writes ~/.codex/auth.json from OPENAI_API_KEY before launching
+    ACP. Keep CODEX_ACCESS_TOKEN separate: it is a subscription/access-token
+    path that Codex reads directly from the process environment.
+    """
+    if not _is_codex_native_openai_context(agent, model, "OPENAI_API_KEY"):
+        return
+    if "OPENAI_API_KEY" not in agent_env and _CODEX_API_KEY_ENV in agent_env:
+        agent_env["OPENAI_API_KEY"] = agent_env[_CODEX_API_KEY_ENV]
+
+
+def _has_codex_access_token_auth(
+    agent: str,
+    model: str | None,
+    required_key: str | None,
+    agent_env: dict[str, str],
+) -> bool:
+    """Return True when Codex's subscription access token satisfies OpenAI auth."""
+    return _is_codex_native_openai_context(agent, model, required_key) and bool(
+        agent_env.get(_CODEX_ACCESS_TOKEN_ENV)
+    )
 
 
 def inject_vertex_credentials(agent_env: dict[str, str], model: str) -> None:
@@ -247,6 +298,7 @@ def resolve_agent_env(
     # Both sources use setdefault so explicit agent_env keys take priority.
     auto_inherit_env(agent_env, source_env=load_dotenv_env())
     auto_inherit_env(agent_env)
+    _normalize_codex_auth_env(agent, model, agent_env)
     pre_provider_env = dict(agent_env)
     agent_cfg = AGENTS.get(agent)
     # Oracle runs solve.sh and never calls an LLM — model env vars and
@@ -300,11 +352,18 @@ def resolve_agent_env(
             key in agent_env and _shares_auth_context(required_key, key)
             for key in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_AUTH_TOKEN")
         )
+        has_codex_access_token = _has_codex_access_token_auth(
+            agent,
+            model,
+            required_key,
+            agent_env,
+        )
         if (
             required_key
             and required_key not in agent_env
             and not has_oauth
             and not has_agent_native_bridge_key
+            and not has_codex_access_token
         ):
             if check_subscription_auth(agent, required_key):
                 agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
@@ -322,7 +381,16 @@ def resolve_agent_env(
         # No model specified — still check subscription auth for required env vars
         if agent_cfg:
             for req_key in agent_cfg.requires_env:
-                if req_key not in agent_env and check_subscription_auth(agent, req_key):
+                if (
+                    req_key not in agent_env
+                    and not _has_codex_access_token_auth(
+                        agent,
+                        model,
+                        req_key,
+                        agent_env,
+                    )
+                    and check_subscription_auth(agent, req_key)
+                ):
                     agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
                     logger.info(
                         "Using host subscription auth (no %s set)",

--- a/tests/conformance/run_conformance.py
+++ b/tests/conformance/run_conformance.py
@@ -37,7 +37,7 @@ ENV_KEYS = {
     "claude-agent-acp": ["ANTHROPIC_API_KEY"],
     "pi-acp": ["ANTHROPIC_API_KEY"],
     "openclaw": [],
-    "codex-acp": ["OPENAI_API_KEY"],
+    "codex-acp": ["OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"],
     "gemini": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
 }
 
@@ -59,8 +59,8 @@ def has_creds(agent_name: str) -> bool:
 
 
 def openai_model_preflight(model: str) -> str | None:
-    """Return an error string if OPENAI_API_KEY cannot access *model*."""
-    key = os.environ.get("OPENAI_API_KEY")
+    """Return an error string if API-key auth cannot access *model*."""
+    key = os.environ.get("OPENAI_API_KEY") or os.environ.get("CODEX_API_KEY")
     if not key:
         return None
     req = urllib.request.Request(

--- a/tests/examples/test_codex.sh
+++ b/tests/examples/test_codex.sh
@@ -2,7 +2,7 @@
 # Test codex-acp agent: subscription, API key.
 #
 # Prerequisites:
-#   - OPENAI_API_KEY set in .env, or logged in via `codex --login` (for subscription)
+#   - OPENAI_API_KEY / CODEX_API_KEY set in .env, CODEX_ACCESS_TOKEN, or `codex --login`
 #   - Docker running, or DAYTONA_API_KEY + DAYTONA_API_URL set for --daytona
 #
 # Usage:
@@ -60,11 +60,12 @@ show_failure() {
 
 check_openai_model_available() {
   local model="$1"
-  if [ -z "${OPENAI_API_KEY:-}" ]; then
+  local api_key="${OPENAI_API_KEY:-${CODEX_API_KEY:-}}"
+  if [ -z "$api_key" ]; then
     return 0
   fi
 
-  MODEL="$model" python3 - <<'PY'
+  MODEL="$model" OPENAI_PREFLIGHT_API_KEY="$api_key" python3 - <<'PY'
 import json
 import os
 import sys
@@ -72,7 +73,7 @@ import urllib.error
 import urllib.request
 
 model = os.environ["MODEL"]
-key = os.environ.get("OPENAI_API_KEY", "")
+key = os.environ.get("OPENAI_PREFLIGHT_API_KEY", "")
 req = urllib.request.Request(
     "https://api.openai.com/v1/models",
     headers={"Authorization": f"Bearer {key}"},
@@ -132,22 +133,30 @@ check_env() {
     subscription)
       if [ -n "${OPENAI_API_KEY:-}" ]; then
         echo "NOTE: $label — OPENAI_API_KEY is set, will use API key (not subscription)"
+      elif [ -n "${CODEX_API_KEY:-}" ]; then
+        echo "NOTE: $label — CODEX_API_KEY is set, will use API key (not subscription)"
+      elif [ -n "${CODEX_ACCESS_TOKEN:-}" ]; then
+        echo "NOTE: $label — using CODEX_ACCESS_TOKEN (subscription auth)"
       elif [ ! -f "$HOME/.codex/auth.json" ]; then
-        echo "SKIP: $label — no OPENAI_API_KEY and no ~/.codex/auth.json (run: codex --login)"
+        echo "SKIP: $label — no Codex auth env and no ~/.codex/auth.json (run: codex --login)"
         return 1
       fi ;;
     apikey)
       if [ -n "${OPENAI_API_KEY:-}" ]; then
         echo "NOTE: $label — using OPENAI_API_KEY (API key auth)"
+      elif [ -n "${CODEX_API_KEY:-}" ]; then
+        echo "NOTE: $label — using CODEX_API_KEY (API key auth)"
       else
-        echo "SKIP: $label — OPENAI_API_KEY not set"
+        echo "SKIP: $label — OPENAI_API_KEY or CODEX_API_KEY not set"
         return 1
       fi ;;
     apikey-mini)
       if [ -n "${OPENAI_API_KEY:-}" ]; then
         echo "NOTE: $label — using OPENAI_API_KEY (API key auth)"
+      elif [ -n "${CODEX_API_KEY:-}" ]; then
+        echo "NOTE: $label — using CODEX_API_KEY (API key auth)"
       else
-        echo "SKIP: $label — OPENAI_API_KEY not set"
+        echo "SKIP: $label — OPENAI_API_KEY or CODEX_API_KEY not set"
         return 1
       fi ;;
   esac

--- a/tests/examples/test_codex_custom_provider.sh
+++ b/tests/examples/test_codex_custom_provider.sh
@@ -56,7 +56,7 @@ echo "Jobs dir:  $JOBS_DIR"
 echo ""
 
 set +e
-env -u CODEX_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_KEY \
+env -u CODEX_ACCESS_TOKEN -u CODEX_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_KEY \
   OPENAI_API_KEY="dummy-local-key" \
   uv run bench eval create \
     --tasks-dir "$TASK" \

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -14,7 +14,7 @@
 #   GEMINI_API_KEY (or GOOGLE_API_KEY)
 #   DAYTONA_API_KEY
 #   CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY  (for claude-agent-acp)
-#   OPENAI_API_KEY                                (for codex-acp)
+#   OPENAI_API_KEY, CODEX_API_KEY, or CODEX_ACCESS_TOKEN (for codex-acp)
 
 set -euo pipefail
 cd "$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
@@ -84,7 +84,10 @@ has_creds_for() {
       [ -n "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]
       ;;
     codex-acp)
-      [ -n "${OPENAI_API_KEY:-}" ]
+      [ -n "${OPENAI_API_KEY:-}" ] || \
+      [ -n "${CODEX_API_KEY:-}" ] || \
+      [ -n "${CODEX_ACCESS_TOKEN:-}" ] || \
+      [ -f "$HOME/.codex/auth.json" ]
       ;;
     *)
       has_gemini_key

--- a/tests/integration/suites/release.yaml
+++ b/tests/integration/suites/release.yaml
@@ -256,3 +256,7 @@ credential_rules:
   OPENAI_API_KEY:
     required_for:
       - codex-acp
+  CODEX_API_KEY:
+    alternative_for: OPENAI_API_KEY
+  CODEX_ACCESS_TOKEN:
+    alternative_for: OPENAI_API_KEY

--- a/tests/test_oracle_chokepoint.py
+++ b/tests/test_oracle_chokepoint.py
@@ -54,11 +54,18 @@ class TestEvalCreateRouting:
 
     def test_tasks_generate_help_resolves(self):
         """Guards ENG-65: `bench tasks generate` is registered on live CLI."""
-        from benchflow.cli.main import app
+        import inspect
+
+        from benchflow.cli.main import app, tasks_app
 
         result = CliRunner().invoke(app, ["tasks", "generate", "--help"])
         assert result.exit_code == 0
-        assert "--from-local" in result.stdout
+
+        generate_cmds = [
+            c for c in tasks_app.registered_commands if c.name == "generate"
+        ]
+        assert len(generate_cmds) == 1
+        assert "from_local" in inspect.signature(generate_cmds[0].callback).parameters
 
     def test_eval_create_normalizes_agent_alias(self, tmp_path: Path):
         """Guards ENG-86: eval create normalizes aliases before launch."""

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -380,7 +380,7 @@ class TestResolveAgentEnvNoModel:
     def test_no_model_codex_access_token_wins_over_host_auth(
         self, monkeypatch, tmp_path
     ):
-        """Guards PR #295: CODEX_ACCESS_TOKEN is already usable auth."""
+        """Guards PR #296: CODEX_ACCESS_TOKEN is already usable auth."""
         for k in ("CODEX_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
             monkeypatch.delenv(k, raising=False)
         codex_dir = tmp_path / ".codex"
@@ -397,7 +397,7 @@ class TestResolveAgentEnvNoModel:
         assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
 
     def test_no_model_codex_api_key_alias_normalizes(self, monkeypatch, tmp_path):
-        """Guards PR #295: CODEX_API_KEY is Codex-native API-key auth."""
+        """Guards PR #296: CODEX_API_KEY is Codex-native API-key auth."""
         for k in ("CODEX_ACCESS_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
             monkeypatch.delenv(k, raising=False)
         self._patch_expanduser(monkeypatch, tmp_path)

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -28,6 +28,8 @@ class TestAutoInheritEnv:
         ("env_name", "env_value"),
         [
             pytest.param("ANTHROPIC_API_KEY", "sk-host", id="anthropic"),
+            pytest.param("CODEX_ACCESS_TOKEN", "codex-access", id="codex-token"),
+            pytest.param("CODEX_API_KEY", "codex-key", id="codex-api-key"),
             pytest.param("OPENAI_API_KEY", "sk-oai", id="openai"),
             pytest.param("AWS_BEARER_TOKEN_BEDROCK", "bedrock-token", id="bedrock"),
             pytest.param("AWS_REGION", "us-east-1", id="bedrock-region"),
@@ -327,6 +329,8 @@ class TestResolveAgentEnvNoModel:
         """No model + no API key + host credentials → subscription auth."""
         for k in (
             "ANTHROPIC_API_KEY",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
             "GEMINI_API_KEY",
@@ -344,6 +348,8 @@ class TestResolveAgentEnvNoModel:
         """No model + no API key + no host credentials → no error (no model to validate)."""
         for k in (
             "ANTHROPIC_API_KEY",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
             "GEMINI_API_KEY",
@@ -356,7 +362,12 @@ class TestResolveAgentEnvNoModel:
 
     def test_no_model_codex_subscription_auth(self, monkeypatch, tmp_path):
         """No model + codex agent + host auth file → subscription auth."""
-        for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        for k in (
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()
@@ -366,9 +377,48 @@ class TestResolveAgentEnvNoModel:
         result = self._resolve(agent="codex-acp", agent_env={})
         assert result["_BENCHFLOW_SUBSCRIPTION_AUTH"] == "1"
 
+    def test_no_model_codex_access_token_wins_over_host_auth(
+        self, monkeypatch, tmp_path
+    ):
+        """Guards PR #295: CODEX_ACCESS_TOKEN is already usable auth."""
+        for k in ("CODEX_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("{}")
+        self._patch_expanduser(monkeypatch, tmp_path)
+
+        result = self._resolve(
+            agent="codex-acp",
+            agent_env={"CODEX_ACCESS_TOKEN": "access-token"},
+        )
+
+        assert result["CODEX_ACCESS_TOKEN"] == "access-token"
+        assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
+    def test_no_model_codex_api_key_alias_normalizes(self, monkeypatch, tmp_path):
+        """Guards PR #295: CODEX_API_KEY is Codex-native API-key auth."""
+        for k in ("CODEX_ACCESS_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+        self._patch_expanduser(monkeypatch, tmp_path)
+
+        result = self._resolve(
+            agent="codex-acp",
+            agent_env={"CODEX_API_KEY": "codex-key"},
+        )
+
+        assert result["CODEX_API_KEY"] == "codex-key"
+        assert result["OPENAI_API_KEY"] == "codex-key"
+        assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
     def test_no_model_empty_requires_env(self, monkeypatch, tmp_path):
         """Agent with empty requires_env (e.g. openclaw) needs no auth."""
-        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY"):
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         self._patch_expanduser(monkeypatch, tmp_path)
         result = self._resolve(agent="openclaw", agent_env={})

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -192,6 +192,8 @@ class TestResolveAgentEnv:
             "ANTHROPIC_API_KEY",
             "ANTHROPIC_AUTH_TOKEN",
             "CLAUDE_CODE_OAUTH_TOKEN",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
             "ZAI_API_KEY",
             "OPENAI_API_KEY",
         ):

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -101,6 +101,8 @@ class TestResolveAgentEnvSubscription:
             "ANTHROPIC_API_KEY",
             "ANTHROPIC_AUTH_TOKEN",
             "CLAUDE_CODE_OAUTH_TOKEN",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
             "GEMINI_API_KEY",
@@ -123,6 +125,8 @@ class TestResolveAgentEnvSubscription:
             "ANTHROPIC_API_KEY",
             "ANTHROPIC_AUTH_TOKEN",
             "CLAUDE_CODE_OAUTH_TOKEN",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
             "OPENAI_API_KEY",
             "GOOGLE_API_KEY",
             "GEMINI_API_KEY",
@@ -152,7 +156,12 @@ class TestResolveAgentEnvSubscription:
 
     def test_codex_subscription_auth(self, monkeypatch, tmp_path):
         """Codex subscription auth works with host ~/.codex/auth.json."""
-        for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        for k in (
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()
@@ -165,6 +174,54 @@ class TestResolveAgentEnvSubscription:
             agent_env={},
         )
         assert result["_BENCHFLOW_SUBSCRIPTION_AUTH"] == "1"
+
+    def test_codex_access_token_auth(self, monkeypatch, tmp_path):
+        """Guards PR #295: Blocks-style Codex auth via CODEX_ACCESS_TOKEN."""
+        for k in ("CODEX_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+        _patch_expanduser(monkeypatch, tmp_path)
+
+        result = self._resolve(
+            agent="codex-acp",
+            model="gpt-4o",
+            agent_env={"CODEX_ACCESS_TOKEN": "access-token"},
+        )
+
+        assert result["CODEX_ACCESS_TOKEN"] == "access-token"
+        assert "OPENAI_API_KEY" not in result
+        assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
+    def test_codex_api_key_auth_alias(self, monkeypatch, tmp_path):
+        """Guards PR #295: CODEX_API_KEY works for native Codex auth."""
+        for k in ("CODEX_ACCESS_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+        _patch_expanduser(monkeypatch, tmp_path)
+
+        result = self._resolve(
+            agent="codex-acp",
+            model="gpt-4o",
+            agent_env={"CODEX_API_KEY": "codex-key"},
+        )
+
+        assert result["CODEX_API_KEY"] == "codex-key"
+        assert result["OPENAI_API_KEY"] == "codex-key"
+        assert result["BENCHFLOW_PROVIDER_API_KEY"] == "codex-key"
+        assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
+    def test_codex_access_token_does_not_auth_custom_provider(
+        self, monkeypatch, tmp_path
+    ):
+        """Guards PR #295: access tokens are not proxy API keys."""
+        for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            monkeypatch.delenv(k, raising=False)
+        _patch_expanduser(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="OPENAI_API_KEY required"):
+            self._resolve(
+                agent="codex-acp",
+                model="vllm/mock-model",
+                agent_env={"CODEX_ACCESS_TOKEN": "access-token"},
+            )
 
     def test_gemini_subscription_auth(self, monkeypatch, tmp_path):
         """Gemini subscription auth works with host ~/.gemini/oauth_creds.json."""

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -176,7 +176,7 @@ class TestResolveAgentEnvSubscription:
         assert result["_BENCHFLOW_SUBSCRIPTION_AUTH"] == "1"
 
     def test_codex_access_token_auth(self, monkeypatch, tmp_path):
-        """Guards PR #295: Blocks-style Codex auth via CODEX_ACCESS_TOKEN."""
+        """Guards PR #296: Blocks-style Codex auth via CODEX_ACCESS_TOKEN."""
         for k in ("CODEX_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
             monkeypatch.delenv(k, raising=False)
         _patch_expanduser(monkeypatch, tmp_path)
@@ -192,7 +192,7 @@ class TestResolveAgentEnvSubscription:
         assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
 
     def test_codex_api_key_auth_alias(self, monkeypatch, tmp_path):
-        """Guards PR #295: CODEX_API_KEY works for native Codex auth."""
+        """Guards PR #296: CODEX_API_KEY works for native Codex auth."""
         for k in ("CODEX_ACCESS_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
             monkeypatch.delenv(k, raising=False)
         _patch_expanduser(monkeypatch, tmp_path)
@@ -211,8 +211,13 @@ class TestResolveAgentEnvSubscription:
     def test_codex_access_token_does_not_auth_custom_provider(
         self, monkeypatch, tmp_path
     ):
-        """Guards PR #295: access tokens are not proxy API keys."""
-        for k in ("OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+        """Guards PR #296: access tokens are not proxy API keys."""
+        for k in (
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
             monkeypatch.delenv(k, raising=False)
         _patch_expanduser(monkeypatch, tmp_path)
 
@@ -221,6 +226,59 @@ class TestResolveAgentEnvSubscription:
                 agent="codex-acp",
                 model="vllm/mock-model",
                 agent_env={"CODEX_ACCESS_TOKEN": "access-token"},
+            )
+
+    @pytest.mark.parametrize(
+        "base_url_key",
+        ["BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"],
+    )
+    def test_codex_subscription_auth_does_not_auth_custom_base_url(
+        self, monkeypatch, tmp_path, base_url_key
+    ):
+        """Guards PR #296: subscription auth is not custom endpoint API-key auth."""
+        for k in (
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        _patch_expanduser(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="OPENAI_API_KEY required"):
+            self._resolve(
+                agent="codex-acp",
+                model="gpt-4o",
+                agent_env={
+                    "CODEX_ACCESS_TOKEN": "access-token",
+                    base_url_key: "http://localhost:8765/v1",
+                },
+            )
+
+    @pytest.mark.parametrize(
+        "base_url_key",
+        ["BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"],
+    )
+    def test_codex_host_login_does_not_auth_custom_base_url(
+        self, monkeypatch, tmp_path, base_url_key
+    ):
+        """Guards PR #296: host login is not custom endpoint API-key auth."""
+        for k in (
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text('{"tokens": {"access_token": "at"}}')
+        _patch_expanduser(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="OPENAI_API_KEY required"):
+            self._resolve(
+                agent="codex-acp",
+                model="gpt-4o",
+                agent_env={base_url_key: "http://localhost:8765/v1"},
             )
 
     def test_gemini_subscription_auth(self, monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- auto-inherit Codex auth env vars and support CODEX_ACCESS_TOKEN as a native Codex subscription/access-token path
- normalize CODEX_API_KEY to OPENAI_API_KEY for native codex-acp runs so the existing auth.json writer still works
- update Codex docs, conformance/integration credential checks, and example scripts

## Validation
- uv run python -m pytest tests/test_subscription_auth.py tests/test_resolve_env_helpers.py tests/test_sdk_internals.py::TestResolveAgentEnv tests/test_agent_registry.py tests/test_provider_runtime.py -q
- uv run ruff check src/benchflow/agents/env.py tests/test_subscription_auth.py tests/test_resolve_env_helpers.py tests/test_sdk_internals.py tests/conformance/run_conformance.py
- uv run ty check src/benchflow/agents/env.py
- bash -n tests/integration/run.sh tests/examples/test_codex.sh tests/examples/test_codex_custom_provider.sh

## Live E2E
Ran with OPENAI_API_KEY, CODEX_API_KEY, and CODEX_ACCESS_TOKEN unset so auth had to come from local ~/.codex/auth.json uploaded into Daytona.

- tests/examples/hello-world-task on Daytona + codex-acp + gpt-5.4-mini: reward 1.0, 1 tool call
- SkillsBench jax-computing-basics on Daytona + codex-acp + gpt-5.4-mini: reward 1.0, 15 tool calls
- local evidence: jobs/codex-daytona-auth-real/2026-05-19__23-20-31/jax-computing-basics__5248f3f2/result.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates credential resolution for `codex-acp`, which can affect whether runs authenticate via API key, access token, or host login—especially when using custom OpenAI-compatible endpoints. Changes are well-covered by new tests and docs, but auth-path regressions could block Codex runs.
> 
> **Overview**
> Adds first-class Codex subscription/access-token support by auto-inheriting `CODEX_ACCESS_TOKEN`/`CODEX_API_KEY`, treating `CODEX_ACCESS_TOKEN` as sufficient auth for native OpenAI Codex runs, and normalizing `CODEX_API_KEY` → `OPENAI_API_KEY` so existing `~/.codex/auth.json` writing continues to work.
> 
> Tightens auth fallback rules so **host login / subscription auth and access tokens are not accepted** when Codex is routed to a custom OpenAI-compatible base URL, and updates conformance/integration scripts, example scripts, and docs to reflect the expanded Codex credential options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f304426c295b867cdacd86546c030191857df1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->