### PR TITLE
chore: start 0.4.1 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.4.0"
+version = "0.4.1.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.4.0"
+version = "0.4.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary
- bump package metadata from 0.4.0 to 0.4.1.dev0 after v0.4.0 release tag
- refresh uv.lock for the editable package version

## Validation
- uv lock --check
- uv run python - <<'PY'
import importlib.metadata
print(importlib.metadata.version('benchflow'))
PY
- uv run --extra dev python -m pytest tests/test_reexport.py tests/test_yaml_config.py
- uv run ruff check .
- uv run ty check src/
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a metadata/lockfile version bump with no runtime logic changes; primary risk is accidental dependency resolution drift via the refreshed `uv.lock`.
> 
> **Overview**
> Bumps the package version from `0.4.0` to `0.4.1.dev0` in `pyproject.toml` to start the next development cycle.
> 
> Refreshes `uv.lock` accordingly (lock revision update and editable `benchflow` package entry now reflecting `0.4.1.dev0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da26943a7dd368faeb53061f07a34ea2511b8cc6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->