### PR TITLE
chore: start v0.5 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.4.0"
+version = "0.5.0.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -177,7 +177,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.4.0"
+version = "0.5.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

- start the post-v0.4.0 development line as `0.5.0.dev0`
- update the editable BenchFlow package entry in `uv.lock`
- replace the open #297 patch-train bump (`0.4.1.dev0`) for the v0.5 queue

## Queue

- Branch: `codex/eng-97-start-v0.5-dev`
- Base: `main`
- Prepared tip: `53f938bb307bffb5d9f0e63210d0af0112c4e41c`
- Queue parent: ENG-97

## Linear

Closes ENG-104.
Part of ENG-97.

## Verification

- Fresh local validation on 2026-05-20:
  - `uv lock --check` -> passed
  - `uv run python -c "import importlib.metadata as m; print(m.version('benchflow'))"` -> `0.5.0.dev0`
  - `git diff --check origin/main...codex/eng-97-start-v0.5-dev` -> passed
- `uv lock --check`
- installed package metadata reports `0.5.0.dev0`
- `git diff --check`
- `git merge-tree --write-tree origin/main codex/eng-97-start-v0.5-dev`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates package/version metadata in `pyproject.toml` and the corresponding editable `benchflow` entry/lock revision in `uv.lock`, with no runtime code changes.
> 
> **Overview**
> Starts the v0.5 development line by updating the project version to `0.5.0.dev0` in `pyproject.toml`.
> 
> Refreshes `uv.lock` to match, including bumping the lock `revision` and updating the editable `benchflow` package version entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53f938bb307bffb5d9f0e63210d0af0112c4e41c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->