### PR TITLE
fix(pi-acp): preserve provider prefix for set_model

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -61,12 +61,17 @@ def _format_acp_model(model: str, agent: str) -> str:
     Most agents expect a bare model name (e.g. "claude-sonnet-4-6").
     Agents with acp_model_format="provider/model" (e.g. opencode) need the
     models.dev provider prefix (e.g. "google/gemini-3.1-pro-preview").
+    Agents with acp_model_format="registered-provider/model" (e.g. pi-acp)
+    need BenchFlow's registered provider prefix preserved for custom providers
+    because the launcher registers that provider key in the agent config.
 
     Strips benchflow's custom provider prefixes first, then re-adds the
     models.dev provider prefix when the agent requires it.
     """
     bare = strip_provider_prefix(model)
     agent_cfg = AGENTS.get(agent)
+    if agent_cfg and agent_cfg.acp_model_format == "registered-provider/model":
+        return model if find_provider(model) else bare
     if not agent_cfg or agent_cfg.acp_model_format != "provider/model":
         return bare
     # Already has a slash — assume it's provider/model already

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -251,6 +251,9 @@ class AgentConfig:
     # "provider/model" — models.dev convention (e.g. "google/gemini-3.1-pro-preview").
     #                    Required by opencode, which uses Provider.parseModel()
     #                    to split on "/" and treats the first segment as provider ID.
+    # "registered-provider/model" — BenchFlow provider prefix plus model ID
+    #                    (e.g. "vllm/Qwen/Qwen3.5-35B"). Required by pi-acp,
+    #                    whose launcher registers that provider key in models.json.
     subscription_auth: SubscriptionAuth | None = None
     # Host CLI login that can substitute for an API key (e.g. OAuth tokens
     # from `claude login`). Detected automatically; API keys take precedence.
@@ -314,6 +317,7 @@ AGENTS: dict[str, AgentConfig] = {
         ),
         launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher",
         protocol="acp",
+        acp_model_format="registered-provider/model",
         requires_env=[],  # inferred from --model at runtime
         # Pi is multi-protocol: speaks Anthropic natively and OpenAI via
         # models.json.  Empty lets the provider determine the protocol so

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -450,6 +450,64 @@ class TestConnectAcpModelSelection:
         mock_acp.set_model.assert_awaited_once_with(expected_model)
 
     @pytest.mark.asyncio
+    async def test_pi_acp_preserves_registered_provider_prefix(self, tmp_path):
+        """Guards PR #291: Pi set_model needs the registered provider key."""
+        from benchflow.acp.runtime import connect_acp
+
+        mock_acp = self._make_mocks()
+        mock_env = AsyncMock()
+        with (
+            patch(
+                "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+                return_value=MagicMock(),
+            ),
+            patch("benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="pi-acp",
+                agent_launch="pi-acp",
+                agent_env={},
+                sandbox_user=None,
+                model="vllm/Qwen/Qwen3.5-35B-A3B",
+                rollout_dir=tmp_path,
+                environment="docker",
+                agent_cwd="/app",
+            )
+
+        mock_acp.set_model.assert_awaited_once_with("vllm/Qwen/Qwen3.5-35B-A3B")
+
+    @pytest.mark.asyncio
+    async def test_opencode_keeps_modelsdev_formatting(self, tmp_path):
+        """Registered BenchFlow providers must not become models.dev provider IDs."""
+        from benchflow.acp.runtime import connect_acp
+
+        mock_acp = self._make_mocks()
+        mock_env = AsyncMock()
+        with (
+            patch(
+                "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+                return_value=MagicMock(),
+            ),
+            patch("benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="opencode",
+                agent_launch="opencode acp",
+                agent_env={},
+                sandbox_user=None,
+                model="vllm/Qwen/Qwen3.5-35B-A3B",
+                rollout_dir=tmp_path,
+                environment="docker",
+                agent_cwd="/app",
+            )
+
+        mock_acp.set_model.assert_awaited_once_with("Qwen/Qwen3.5-35B-A3B")
+
+    @pytest.mark.asyncio
     async def test_openhands_skips_set_model(self, tmp_path):
         from benchflow.acp.runtime import connect_acp
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -23,6 +23,7 @@ class TestEnvMappingField:
         """pi-acp is multi-protocol — launch wrapper handles env translation."""
         cfg = AGENTS["pi-acp"]
         assert cfg.env_mapping == {}
+        assert cfg.acp_model_format == "registered-provider/model"
 
     def test_codex_acp_has_mapping(self):
         cfg = AGENTS["codex-acp"]

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -67,8 +67,7 @@ def test_agent_field_shapes(name, cfg):
         f"api_protocol={cfg.api_protocol!r} not in {VALID_API_PROTOCOLS}"
     )
     assert cfg.acp_model_format in VALID_ACP_MODEL_FORMATS, (
-        f"acp_model_format={cfg.acp_model_format!r} not in "
-        f"{VALID_ACP_MODEL_FORMATS}"
+        f"acp_model_format={cfg.acp_model_format!r} not in {VALID_ACP_MODEL_FORMATS}"
     )
     assert isinstance(cfg.install_timeout, int) and cfg.install_timeout > 0
     assert isinstance(cfg.supports_acp_set_model, bool)

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -36,6 +36,11 @@ VALID_API_PROTOCOLS = {
 }
 VALID_PROVIDER_API_PROTOCOLS = VALID_API_PROTOCOLS - {""}
 VALID_AUTH_TYPES = {"api_key", "adc", "aws", "none"}
+VALID_ACP_MODEL_FORMATS = {
+    "bare",
+    "provider/model",
+    "registered-provider/model",
+}
 JS_ACP_AGENTS = {
     "claude-agent-acp",
     "pi-acp",
@@ -60,6 +65,10 @@ def test_agent_field_shapes(name, cfg):
     )
     assert cfg.api_protocol in VALID_API_PROTOCOLS, (
         f"api_protocol={cfg.api_protocol!r} not in {VALID_API_PROTOCOLS}"
+    )
+    assert cfg.acp_model_format in VALID_ACP_MODEL_FORMATS, (
+        f"acp_model_format={cfg.acp_model_format!r} not in "
+        f"{VALID_ACP_MODEL_FORMATS}"
     )
     assert isinstance(cfg.install_timeout, int) and cfg.install_timeout > 0
     assert isinstance(cfg.supports_acp_set_model, bool)


### PR DESCRIPTION
## Summary

- replace conflicted PR #291 with a clean current-main branch
- add a dedicated `registered-provider/model` ACP model format
- preserve registered BenchFlow provider prefixes for `pi-acp` without changing OpenCode's models.dev formatting

## Queue

- Branch: `codex/eng-89-pr291-pi-acp-prefix`
- Base: `main`
- Prepared tip: `0d9da6e343e5e397acb37c5b9759a7ccdf00777a`
- Queue parent: ENG-97

## Linear

Closes ENG-100.
Part of ENG-89 and ENG-97.
Supersedes #291.

## Verification

- Fresh local validation on 2026-05-20:
  - `uv run --extra dev python -m pytest tests/test_acp.py tests/test_agent_registry.py tests/test_registry_invariants.py` -> `111 passed`
  - `uv run --extra dev ruff check src/benchflow/acp/runtime.py src/benchflow/agents/registry.py tests/test_acp.py tests/test_agent_registry.py tests/test_registry_invariants.py` -> passed
  - `uv run --extra dev ty check src/benchflow/acp/runtime.py src/benchflow/agents/registry.py` -> passed
  - `git diff --check origin/main...codex/eng-89-pr291-pi-acp-prefix` -> passed
- focused ACP/registry/pi launcher tests -> `111 passed`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ty check src/`
- `uv run --extra dev python -m pytest tests/` -> `1146 passed, 1 deselected, 44 warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how ACP `set_model` formats model IDs based on per-agent configuration; mistakes could route models to the wrong provider or break agent startup. Scoped to ACP model formatting and registry config, with targeted tests added for pi-acp and opencode behavior.
> 
> **Overview**
> Fixes ACP model-id formatting by introducing a third `acp_model_format`, `registered-provider/model`, which preserves BenchFlow’s registered provider prefix when sending `session/set_model`.
> 
> Updates `pi-acp` to use this new format so custom providers like `vllm/...` keep their provider key, while keeping `opencode` on `provider/model` behavior (still strips BenchFlow prefixes and applies models.dev formatting). Adds/extends tests and registry invariants to cover the new format and prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12f4e0d9d7076fbedec7391e9b008149b758fe8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->