### PR TITLE
feat(opaquetoolsbench): add runnable BFCL adapter

### DIFF
--- a/benchmarks/opaquetoolsbench/README.md
+++ b/benchmarks/opaquetoolsbench/README.md
@@ -1,0 +1,113 @@
+# OpaqueToolsBench — BFCL Adapter
+
+BenchFlow adapter for the **BFCL (Berkeley Function Calling Leaderboard)**
+environment from [OpaqueToolsBench](https://github.com/shallinan1/OpaqueToolsBench).
+
+## What is OpaqueToolsBench?
+
+OpaqueToolsBench ([paper](https://arxiv.org/abs/2602.15197)) studies whether
+LLM agents can recover the meaning of *opacified* tools — tools whose names,
+descriptions, and parameters have been deliberately obscured. It includes three
+environments: BFCL, Chess, and BrowseCompPlus.
+
+This adapter covers the **BFCL environment** only.
+
+## BFCL Environment
+
+BFCL tests general function-calling ability: given a natural-language query and
+a set of tool (function) definitions, the agent must produce the correct
+function call(s).
+
+| Category                       | Tasks | Description                    |
+|--------------------------------|-------|--------------------------------|
+| `executable_simple`            |   100 | Single function call           |
+| `executable_multiple_function` |    50 | Multiple function calls        |
+| **Total**                      | **150** |                              |
+
+### Evaluation
+
+Evaluation is **deterministic** — no LLM judge required. The verifier parses
+the agent's function-call JSON output and compares it against ground-truth
+function-call strings using AST-based matching:
+
+- Function name must match exactly.
+- All ground-truth parameters must be present with matching values.
+- Float comparison uses 5% relative tolerance.
+- Reward is binary: **1.0** (all calls correct) or **0.0**.
+
+## Quick Start
+
+### 1. Generate Tasks
+
+```bash
+# Clone OpaqueToolsBench if you haven't already
+git clone https://github.com/shallinan1/OpaqueToolsBench.git /tmp/OpaqueToolsBench
+
+# Generate all 150 tasks
+python benchmarks/opaquetoolsbench/benchflow.py \
+    --opaquetoolsbench-dir /tmp/OpaqueToolsBench \
+    --output-dir /tmp/opaquetoolsbench-tasks
+
+# Or generate a subset
+python benchmarks/opaquetoolsbench/benchflow.py \
+    --opaquetoolsbench-dir /tmp/OpaqueToolsBench \
+    --output-dir /tmp/opaquetoolsbench-tasks \
+    --limit 10
+```
+
+### 2. Validate Structure
+
+```bash
+python benchmarks/opaquetoolsbench/parity_test.py \
+    --tasks-dir /tmp/opaquetoolsbench-tasks
+```
+
+### 3. Run Benchmark
+
+```bash
+python benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
+```
+
+## Generated Task Structure
+
+Each task directory contains:
+
+```
+<task-id>/
+├── task.toml                  # BenchFlow task metadata
+├── instruction.md             # NL query + function descriptions for the agent
+├── environment/
+│   └── Dockerfile             # Python 3.13 slim environment
+└── tests/
+    ├── test.sh                # Runs evaluate.py, writes reward
+    ├── evaluate.py            # AST-based function-call comparison
+    └── ground_truth.json      # Expected function call(s)
+```
+
+## Agent Response Format
+
+The agent must write a JSON array of function-call objects to
+`/app/output/response.json`:
+
+```json
+[
+  {
+    "function": "calc_binomial_probability",
+    "args": {
+      "n": 20,
+      "k": 5,
+      "p": 0.6
+    }
+  }
+]
+```
+
+## CLI Flags
+
+| Flag                     | Description                                |
+|--------------------------|--------------------------------------------|
+| `--opaquetoolsbench-dir` | Path to OpaqueToolsBench repo checkout     |
+| `--output-dir`           | Where to write generated task directories  |
+| `--limit N`              | Cap number of tasks to generate            |
+| `--overwrite`            | Regenerate existing task directories       |
+| `--task-ids ID1,ID2,...` | Comma-separated list of specific task IDs  |

--- a/benchmarks/opaquetoolsbench/README.md
+++ b/benchmarks/opaquetoolsbench/README.md
@@ -66,6 +66,10 @@ python benchmarks/opaquetoolsbench/parity_test.py \
 
 ```bash
 python benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
+
+# Or pass an explicit config
+python benchmarks/opaquetoolsbench/run_opaquetoolsbench.py \
+    benchmarks/opaquetoolsbench/opaquetoolsbench-gemini-flash-lite.yaml
 ```
 
 ## Generated Task Structure

--- a/benchmarks/opaquetoolsbench/benchflow.py
+++ b/benchmarks/opaquetoolsbench/benchflow.py
@@ -232,7 +232,13 @@ def _render_instruction(task: BFCLTask) -> str:
 
 
 def _render_dockerfile() -> str:
-    """Generate Dockerfile for the evaluation environment."""
+    """Generate Dockerfile for the evaluation environment.
+
+    Test files (test.sh, evaluate.py, ground_truth.json) are uploaded
+    at runtime by BenchFlow/Harbor — they are NOT copied during the
+    Docker build. The build context is ``environment/`` which does not
+    include the sibling ``tests/`` directory.
+    """
     return """\
 # Pinned by digest for reproducibility.
 FROM python:3.13-slim@sha256:dc1546eefcbe8caaa1f004f16ab76b204b5e1dbd58ff81b899f21cd40541232f
@@ -240,12 +246,6 @@ FROM python:3.13-slim@sha256:dc1546eefcbe8caaa1f004f16ab76b204b5e1dbd58ff81b899f
 WORKDIR /app
 
 RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts /app/output
-
-# Copy test files
-COPY ground_truth.json /tests/ground_truth.json
-COPY evaluate.py /tests/evaluate.py
-COPY test.sh /tests/test.sh
-RUN chmod +x /tests/test.sh
 """
 
 

--- a/benchmarks/opaquetoolsbench/benchflow.py
+++ b/benchmarks/opaquetoolsbench/benchflow.py
@@ -209,13 +209,13 @@ def _render_instruction(task: BFCLTask) -> str:
             "",
             "Each function call object must have this format:",
             "```json",
-            '{',
+            "{",
             '  "function": "<function_name>",',
             '  "args": {',
             '    "<param1>": <value1>,',
             '    "<param2>": <value2>',
-            '  }',
-            '}',
+            "  }",
+            "}",
             "```",
             "",
             "Example (array with one call):",
@@ -262,6 +262,51 @@ python3 /tests/evaluate.py \\
     --ground-truth /tests/ground_truth.json \\
     --reward-file /logs/verifier/reward.txt
 """).safe_substitute(instance_id=task.instance_id)
+
+
+def _render_solution_sh(task: BFCLTask) -> str:
+    ground_truth = json.dumps(task.ground_truth)
+    return Template("""\
+#!/bin/bash
+# Oracle solution for OpaqueToolsBench BFCL task: $instance_id
+set -euo pipefail
+
+mkdir -p /app/output
+python3 - <<'PY'
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+ground_truth = $ground_truth
+
+
+def parse_python_call(call_str: str) -> dict:
+    tree = ast.parse(call_str)
+    if not isinstance(tree.body[0], ast.Expr):
+        raise ValueError(f"Expected expression: {call_str}")
+    node = tree.body[0].value
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+        raise ValueError(f"Expected function call: {call_str}")
+
+    args: dict = {}
+    for kw in node.keywords:
+        if kw.arg:
+            args[kw.arg] = ast.literal_eval(kw.value)
+    for i, arg in enumerate(node.args):
+        args[f"_positional_{i}"] = ast.literal_eval(arg)
+
+    return {"function": node.func.id, "args": args}
+
+
+calls = [parse_python_call(call) for call in ground_truth]
+Path("/app/output/response.json").write_text(json.dumps(calls, indent=2))
+PY
+""").safe_substitute(
+        instance_id=task.instance_id,
+        ground_truth=ground_truth,
+    )
 
 
 # ── evaluate.py (copied into every task's tests/) ───────────────────
@@ -452,9 +497,7 @@ if __name__ == "__main__":
 # ── Task generation ─────────────────────────────────────────────────
 
 
-def generate_task(
-    task: BFCLTask, output_dir: Path, *, overwrite: bool = False
-) -> Path:
+def generate_task(task: BFCLTask, output_dir: Path, *, overwrite: bool = False) -> Path:
     """Generate a single BenchFlow task directory for one BFCL test item."""
     task_dir = output_dir / task.instance_id
     if task_dir.exists():
@@ -494,6 +537,13 @@ def generate_task(
     if task.execution_result is not None:
         gt_data["execution_result"] = task.execution_result
     (tests_dir / "ground_truth.json").write_text(json.dumps(gt_data, indent=2))
+
+    # solution/
+    solution_dir = task_dir / "solution"
+    solution_dir.mkdir()
+    solve_sh = solution_dir / "solve.sh"
+    solve_sh.write_text(_render_solution_sh(task))
+    solve_sh.chmod(0o755)
 
     return task_dir
 

--- a/benchmarks/opaquetoolsbench/benchflow.py
+++ b/benchmarks/opaquetoolsbench/benchflow.py
@@ -1,0 +1,594 @@
+"""Generate BenchFlow task directories from OpaqueToolsBench BFCL instances.
+
+OpaqueToolsBench studies whether LLM agents can recover the meaning of
+opacified tools — tools whose names, descriptions, and parameters have
+been deliberately obscured.  The BFCL (Berkeley Function Calling
+Leaderboard) environment tests general function calling: given a natural
+language query and tool definitions, the agent must produce the correct
+function call(s).
+
+This module generates one BenchFlow task directory per BFCL test item
+from the ``executable_simple`` and ``executable_multiple_function``
+categories shipped in the OpaqueToolsBench repo.
+
+Requires a local checkout of the OpaqueToolsBench repo for the
+``tool_configs/`` JSON files.
+
+Usage:
+    python benchmarks/opaquetoolsbench/benchflow.py \\
+        --opaquetoolsbench-dir ~/OpaqueToolsBench \\
+        --output-dir /tmp/opaquetoolsbench-tasks
+
+    python benchmarks/opaquetoolsbench/benchflow.py \\
+        --opaquetoolsbench-dir ~/OpaqueToolsBench \\
+        --output-dir /tmp/opaquetoolsbench-tasks \\
+        --limit 10
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import shutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from string import Template
+
+logger = logging.getLogger(__name__)
+
+# ── Categories we convert ────────────────────────────────────────────
+
+BFCL_CATEGORIES = [
+    "executable_simple",
+    "executable_multiple_function",
+]
+
+# ── Timeout presets ──────────────────────────────────────────────────
+
+_AGENT_TIMEOUT = 600  # 10 min — single function-call tasks are fast
+_VERIFIER_TIMEOUT = 120  # 2 min — evaluation is lightweight
+
+
+def _sanitize_name(raw: str) -> str:
+    """Lowercase, replace non-alphanumeric with hyphens, collapse runs."""
+    name = raw.lower().strip()
+    name = re.sub(r"[^a-z0-9]+", "-", name)
+    return name.strip("-")
+
+
+# ── Data classes ─────────────────────────────────────────────────────
+
+
+@dataclass
+class BFCLTask:
+    """One BFCL test item ready for BenchFlow conversion."""
+
+    test_id: int
+    category: str
+    question: str
+    tools: list[dict]
+    ground_truth: list[str]
+    name_mapping: dict[str, str]
+    execution_result_type: list[str]
+    execution_result: list | None = None
+    metadata: dict = field(default_factory=dict)
+
+    @property
+    def instance_id(self) -> str:
+        return f"{_sanitize_name(self.category)}-{self.test_id}"
+
+    @property
+    def task_name(self) -> str:
+        return f"opaquetoolsbench/{self.instance_id}"
+
+    @property
+    def n_tools(self) -> int:
+        return len(self.tools)
+
+    @property
+    def n_ground_truth(self) -> int:
+        return len(self.ground_truth)
+
+
+# ── Loader ───────────────────────────────────────────────────────────
+
+
+def load_tasks(opaquetoolsbench_dir: Path) -> list[BFCLTask]:
+    """Load all BFCL base-config tasks from OpaqueToolsBench repo."""
+    configs_dir = opaquetoolsbench_dir / "src" / "datasets" / "bfcl" / "tool_configs"
+    if not configs_dir.exists():
+        raise FileNotFoundError(
+            f"BFCL tool_configs not found at {configs_dir}. "
+            "Clone OpaqueToolsBench and pass --opaquetoolsbench-dir."
+        )
+
+    tasks: list[BFCLTask] = []
+    for category in BFCL_CATEGORIES:
+        config_file = configs_dir / f"{category}_base_config.json"
+        if not config_file.exists():
+            logger.warning("Config not found: %s", config_file)
+            continue
+
+        config = json.loads(config_file.read_text())
+        for test in config.get("tests", []):
+            tasks.append(
+                BFCLTask(
+                    test_id=test["test_id"],
+                    category=category,
+                    question=test["question"],
+                    tools=test.get("tools", []),
+                    ground_truth=test.get("ground_truth", []),
+                    name_mapping=test.get("name_mapping", {}),
+                    execution_result_type=test.get(
+                        "execution_result_type", ["exact_match"]
+                    ),
+                    execution_result=test.get("execution_result"),
+                    metadata=test.get("metadata", {}),
+                )
+            )
+
+    return tasks
+
+
+# ── Renderers ────────────────────────────────────────────────────────
+
+
+def _render_task_toml(task: BFCLTask) -> str:
+    tag_list = ", ".join(
+        f'"{t}"'
+        for t in [
+            "function-calling",
+            _sanitize_name(task.category),
+        ]
+    )
+    return f"""\
+version = "1.0"
+
+[task]
+name = "{task.task_name}"
+
+[metadata]
+author_name = "OpaqueToolsBench (Hallinan et al.)"
+difficulty = "easy"
+category = "function-calling"
+tags = [{tag_list}]
+
+[agent]
+timeout_sec = {_AGENT_TIMEOUT}
+
+[verifier]
+timeout_sec = {_VERIFIER_TIMEOUT}
+
+[environment]
+cpus = 1
+memory_mb = 1024
+storage_mb = 2048
+allow_internet = false
+"""
+
+
+def _render_instruction(task: BFCLTask) -> str:
+    """Generate instruction.md for the agent."""
+    lines = [
+        "# Function Calling Task",
+        "",
+        "## Query",
+        "",
+        task.question,
+        "",
+        "## Available Functions",
+        "",
+    ]
+
+    for tool in task.tools:
+        lines.append(f"### `{tool['name']}`")
+        desc = tool.get("description", "")
+        if desc:
+            lines.append(f"\n{desc}\n")
+        params = tool.get("parameters", {})
+        props = params.get("properties", {})
+        required = set(params.get("required", []))
+        if props:
+            lines.append("**Parameters:**\n")
+            for pname, pdef in props.items():
+                ptype = pdef.get("type", "any")
+                pdesc = pdef.get("description", "")
+                req = " *(required)*" if pname in required else ""
+                lines.append(f"- `{pname}` ({ptype}){req}: {pdesc}")
+            lines.append("")
+
+    lines.extend(
+        [
+            "## Instructions",
+            "",
+            "Determine the correct function call(s) to answer the query above.",
+            "Write your response as a JSON array of function call objects to "
+            "`/app/output/response.json`.",
+            "",
+            "Each function call object must have this format:",
+            "```json",
+            '{',
+            '  "function": "<function_name>",',
+            '  "args": {',
+            '    "<param1>": <value1>,',
+            '    "<param2>": <value2>',
+            '  }',
+            '}',
+            "```",
+            "",
+            "Example (array with one call):",
+            "```json",
+            "[",
+            '  {"function": "my_func", "args": {"x": 42, "y": "hello"}}',
+            "]",
+            "```",
+            "",
+        ]
+    )
+
+    return "\n".join(lines)
+
+
+def _render_dockerfile() -> str:
+    """Generate Dockerfile for the evaluation environment."""
+    return """\
+# Pinned by digest for reproducibility.
+FROM python:3.13-slim@sha256:dc1546eefcbe8caaa1f004f16ab76b204b5e1dbd58ff81b899f21cd40541232f
+
+WORKDIR /app
+
+RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts /app/output
+
+# Copy test files
+COPY ground_truth.json /tests/ground_truth.json
+COPY evaluate.py /tests/evaluate.py
+COPY test.sh /tests/test.sh
+RUN chmod +x /tests/test.sh
+"""
+
+
+def _render_test_sh(task: BFCLTask) -> str:
+    return Template("""\
+#!/bin/bash
+# Verifier for OpaqueToolsBench BFCL task: $instance_id
+set -o pipefail
+
+exec > >(tee /logs/verifier/verifier.log) 2>&1
+
+python3 /tests/evaluate.py \\
+    --response /app/output/response.json \\
+    --ground-truth /tests/ground_truth.json \\
+    --reward-file /logs/verifier/reward.txt
+""").safe_substitute(instance_id=task.instance_id)
+
+
+# ── evaluate.py (copied into every task's tests/) ───────────────────
+
+EVALUATE_PY = '''\
+"""OpaqueToolsBench BFCL verifier for BenchFlow.
+
+Compares the agent's function call response against ground truth using
+AST-based matching. Writes a binary reward (1.0 or 0.0) to the reward
+file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import sys
+from pathlib import Path
+
+
+def parse_python_call(call_str: str) -> tuple[str, dict] | None:
+    """Parse a Python function call string into (name, kwargs)."""
+    try:
+        tree = ast.parse(call_str)
+        if not isinstance(tree.body[0], ast.Expr):
+            return None
+        node = tree.body[0].value
+        if not isinstance(node, ast.Call):
+            return None
+
+        if isinstance(node.func, ast.Name):
+            func_name = node.func.id
+        else:
+            return None
+
+        kwargs: dict = {}
+        for kw in node.keywords:
+            if kw.arg:
+                try:
+                    val = ast.literal_eval(kw.value)
+                except (ValueError, SyntaxError):
+                    try:
+                        val = eval(  # noqa: S307
+                            compile(ast.Expression(kw.value), "", "eval")
+                        )
+                    except Exception:
+                        val = ast.unparse(kw.value)
+                kwargs[kw.arg] = val
+
+        for i, arg in enumerate(node.args):
+            try:
+                val = ast.literal_eval(arg)
+            except (ValueError, SyntaxError):
+                try:
+                    val = eval(  # noqa: S307
+                        compile(ast.Expression(arg), "", "eval")
+                    )
+                except Exception:
+                    val = ast.unparse(arg)
+            kwargs[f"_positional_{i}"] = val
+
+        return func_name, kwargs
+    except (SyntaxError, AttributeError, TypeError, IndexError):
+        return None
+
+
+def parse_call(data):
+    """Parse a function call from JSON dict or Python call string."""
+    if isinstance(data, str):
+        try:
+            data = json.loads(data)
+        except json.JSONDecodeError:
+            return parse_python_call(data)
+
+    if isinstance(data, dict):
+        name = data.get("function", "")
+        args = data.get("args", {})
+        if isinstance(args, dict):
+            return name, args
+    return None
+
+
+def values_match(v1, v2, tolerance=0.05):
+    """Compare two values with tolerance for floats."""
+    if isinstance(v1, (int, float)) and isinstance(v2, (int, float)):
+        if v2 == 0:
+            return v1 == 0
+        return abs(v1 - v2) <= abs(v2) * tolerance
+    if isinstance(v1, str) and isinstance(v2, str):
+        return v1.strip().lower() == v2.strip().lower()
+    if isinstance(v1, list) and isinstance(v2, list):
+        if len(v1) != len(v2):
+            return False
+        return all(values_match(a, b, tolerance) for a, b in zip(v1, v2))
+    if isinstance(v1, dict) and isinstance(v2, dict):
+        if set(v1.keys()) != set(v2.keys()):
+            return False
+        return all(values_match(v1[k], v2[k], tolerance) for k in v1)
+    return v1 == v2
+
+
+def call_matches(model_call, gt_call_str):
+    """Check if a model call matches a ground-truth call string."""
+    model_parsed = parse_call(model_call)
+    gt_parsed = parse_python_call(gt_call_str)
+
+    if model_parsed is None or gt_parsed is None:
+        return False
+
+    m_name, m_args = model_parsed
+    g_name, g_args = gt_parsed
+
+    if m_name != g_name:
+        return False
+
+    # Check all ground-truth params are present and correct
+    for key, g_val in g_args.items():
+        if key not in m_args:
+            return False
+        if not values_match(m_args[key], g_val):
+            return False
+
+    return True
+
+
+def evaluate(response_path: Path, gt_path: Path) -> float:
+    """Evaluate agent response against ground truth. Returns 1.0 or 0.0."""
+    gt_data = json.loads(gt_path.read_text())
+    gt_calls = gt_data.get("ground_truth", [])
+
+    if not response_path.exists():
+        print("No response file found at", response_path)
+        return 0.0
+
+    try:
+        response = json.loads(response_path.read_text())
+    except json.JSONDecodeError:
+        print("Invalid JSON in response file")
+        return 0.0
+
+    if not isinstance(response, list):
+        response = [response]
+
+    if len(response) < len(gt_calls):
+        print(
+            f"Not enough function calls: got {len(response)}, "
+            f"expected {len(gt_calls)}"
+        )
+        return 0.0
+
+    # Each ground truth call must be matched by exactly one model call
+    matched = [False] * len(gt_calls)
+    used = [False] * len(response)
+
+    for gi, gt_call in enumerate(gt_calls):
+        for ri, resp_call in enumerate(response):
+            if used[ri]:
+                continue
+            if call_matches(resp_call, gt_call):
+                matched[gi] = True
+                used[ri] = True
+                break
+
+    if all(matched):
+        print(f"All {len(gt_calls)} ground-truth call(s) matched.")
+        return 1.0
+    else:
+        n_matched = sum(matched)
+        print(
+            f"Matched {n_matched}/{len(gt_calls)} ground-truth call(s)."
+        )
+        return 0.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="OpaqueToolsBench BFCL verifier"
+    )
+    parser.add_argument("--response", required=True, type=Path)
+    parser.add_argument("--ground-truth", required=True, type=Path)
+    parser.add_argument("--reward-file", required=True, type=Path)
+    args = parser.parse_args()
+
+    reward_file: Path = args.reward_file
+    reward_file.parent.mkdir(parents=True, exist_ok=True)
+
+    reward = evaluate(args.response, args.ground_truth)
+    reward_file.write_text(f"{reward:.6f}")
+    print(f"Reward: {reward:.4f}")
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+# ── Task generation ─────────────────────────────────────────────────
+
+
+def generate_task(
+    task: BFCLTask, output_dir: Path, *, overwrite: bool = False
+) -> Path:
+    """Generate a single BenchFlow task directory for one BFCL test item."""
+    task_dir = output_dir / task.instance_id
+    if task_dir.exists():
+        if not overwrite:
+            logger.debug("Skipping existing task %s", task.instance_id)
+            return task_dir
+        shutil.rmtree(task_dir)
+
+    task_dir.mkdir(parents=True)
+
+    # task.toml
+    (task_dir / "task.toml").write_text(_render_task_toml(task))
+
+    # instruction.md
+    (task_dir / "instruction.md").write_text(_render_instruction(task))
+
+    # environment/Dockerfile
+    env_dir = task_dir / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text(_render_dockerfile())
+
+    # tests/
+    tests_dir = task_dir / "tests"
+    tests_dir.mkdir()
+
+    test_sh = tests_dir / "test.sh"
+    test_sh.write_text(_render_test_sh(task))
+    test_sh.chmod(0o755)
+
+    (tests_dir / "evaluate.py").write_text(EVALUATE_PY)
+
+    # Ground truth JSON
+    gt_data = {
+        "ground_truth": task.ground_truth,
+        "execution_result_type": task.execution_result_type,
+    }
+    if task.execution_result is not None:
+        gt_data["execution_result"] = task.execution_result
+    (tests_dir / "ground_truth.json").write_text(json.dumps(gt_data, indent=2))
+
+    return task_dir
+
+
+def generate_all(
+    opaquetoolsbench_dir: Path,
+    output_dir: Path,
+    *,
+    overwrite: bool = False,
+    limit: int | None = None,
+    task_ids: list[str] | None = None,
+) -> list[Path]:
+    """Generate BenchFlow task directories for all BFCL tasks."""
+    tasks = load_tasks(opaquetoolsbench_dir)
+
+    if task_ids:
+        id_set = set(task_ids)
+        tasks = [t for t in tasks if t.instance_id in id_set]
+
+    if limit is not None:
+        tasks = tasks[:limit]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated: list[Path] = []
+    for task in tasks:
+        path = generate_task(task, output_dir, overwrite=overwrite)
+        generated.append(path)
+        logger.info("Generated %s", task.instance_id)
+
+    logger.info("Generated %d tasks in %s", len(generated), output_dir)
+    return generated
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate BenchFlow tasks from OpaqueToolsBench BFCL"
+    )
+    parser.add_argument(
+        "--opaquetoolsbench-dir",
+        type=Path,
+        required=True,
+        help="Path to OpaqueToolsBench repo checkout",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Where to write generated task directories",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="Cap number of tasks to generate",
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Regenerate existing task directories",
+    )
+    parser.add_argument(
+        "--task-ids",
+        type=str,
+        default=None,
+        help="Comma-separated list of specific task IDs to generate",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s"
+    )
+
+    tid_list = args.task_ids.split(",") if args.task_ids else None
+    generated = generate_all(
+        args.opaquetoolsbench_dir,
+        args.output_dir,
+        overwrite=args.overwrite,
+        limit=args.limit,
+        task_ids=tid_list,
+    )
+    print(f"Generated {len(generated)} tasks in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/opaquetoolsbench/benchflow.py
+++ b/benchmarks/opaquetoolsbench/benchflow.py
@@ -304,24 +304,14 @@ def parse_python_call(call_str: str) -> tuple[str, dict] | None:
                 try:
                     val = ast.literal_eval(kw.value)
                 except (ValueError, SyntaxError):
-                    try:
-                        val = eval(  # noqa: S307
-                            compile(ast.Expression(kw.value), "", "eval")
-                        )
-                    except Exception:
-                        val = ast.unparse(kw.value)
+                    val = ast.unparse(kw.value)
                 kwargs[kw.arg] = val
 
         for i, arg in enumerate(node.args):
             try:
                 val = ast.literal_eval(arg)
             except (ValueError, SyntaxError):
-                try:
-                    val = eval(  # noqa: S307
-                        compile(ast.Expression(arg), "", "eval")
-                    )
-                except Exception:
-                    val = ast.unparse(arg)
+                val = ast.unparse(arg)
             kwargs[f"_positional_{i}"] = val
 
         return func_name, kwargs

--- a/benchmarks/opaquetoolsbench/benchmark.yaml
+++ b/benchmarks/opaquetoolsbench/benchmark.yaml
@@ -1,0 +1,69 @@
+# benchmark.yaml — standard benchmark descriptor for BenchFlow.
+#
+# Every benchmark in benchmarks/<name>/ ships this file. It declares what
+# the benchmark is, where it comes from, how tasks are verified, and
+# parity validation results.
+
+name: opaquetoolsbench
+description: "OpaqueToolsBench BFCL — 150 function-calling tasks (executable_simple + executable_multiple_function) testing tool use under opacity"
+url: https://github.com/shallinan1/OpaqueToolsBench
+paper: https://arxiv.org/abs/2602.15197
+repo: https://github.com/shallinan1/OpaqueToolsBench
+author: "Hallinan et al."
+converted_by: BenchFlow
+
+# ── Tasks ────────────────────────────────────────────────────────────
+tasks:
+  count: 150
+  categories:
+    - executable_simple          # 100 tasks — single function call
+    - executable_multiple_function  # 50 tasks — multiple function calls
+  tags: [function-calling, tool-use, opacity, bfcl]
+  splits:
+    main: 150                    # all base-config tasks
+    executable_simple: 100
+    executable_multiple_function: 50
+
+# ── Conversion ───────────────────────────────────────────────────────
+# How raw benchmark data is converted to BenchFlow task format.
+conversion:
+  script: benchflow.py           # CLI: --output-dir, --limit, --overwrite, --task-ids
+  source_format: "JSON config files in tool_configs/"
+  has_oracle_solutions: false
+  oracle_notes: >
+    Ground truth is provided as Python function-call strings
+    (e.g. "calc_binomial_probability(n=20, k=5, p=0.6)"). The
+    agent must produce equivalent function call(s) as JSON.
+  docker_image_pinned: true      # python:3.13-slim pinned by digest
+
+# ── Verification ─────────────────────────────────────────────────────
+verification:
+  method: deterministic_script
+  reward: binary                 # 1.0 (all calls match) or 0.0
+  aggregation: per-task          # each task scored independently
+  test_source: "OpaqueToolsBench repo (tool_configs/*.json)"
+  anti_cheat: false
+
+# ── Environment ──────────────────────────────────────────────────────
+environment:
+  base_image: "python:3.13-slim"
+  platform: linux/amd64
+  allow_internet: false
+  cpus: 1
+  memory_mb: 1024
+  storage_mb: 2048
+
+# ── Parity ───────────────────────────────────────────────────────────
+# Results from validating that the conversion preserves benchmark semantics.
+parity:
+  structural:
+    description: "Structural parity — all generated task directories have correct file structure"
+    tasks_tested: 150
+    all_passed: true
+    checks:
+      - required files present (task.toml, instruction.md, Dockerfile, test.sh, evaluate.py, ground_truth.json)
+      - task.toml has valid structure and opaquetoolsbench/ prefix
+      - instruction.md contains Query, Available Functions, and output path
+      - ground_truth.json is valid JSON with ground_truth key
+      - test.sh has executable bit set
+      - Dockerfile contains FROM directive and /logs/verifier directory

--- a/benchmarks/opaquetoolsbench/opaquetoolsbench-gemini-flash-lite.yaml
+++ b/benchmarks/opaquetoolsbench/opaquetoolsbench-gemini-flash-lite.yaml
@@ -1,0 +1,7 @@
+tasks_dir: .cache/opaquetoolsbench-benchflow
+jobs_dir: jobs/opaquetoolsbench-gemini-flash-lite
+agent: gemini
+model: gemini-3.1-flash-lite-preview
+environment: docker
+concurrency: 4
+max_retries: 1

--- a/benchmarks/opaquetoolsbench/parity_experiment.json
+++ b/benchmarks/opaquetoolsbench/parity_experiment.json
@@ -102,5 +102,23 @@
       }
     ],
     "notes": "AST-based deterministic matching. All test cases produce correct binary rewards (1.0/0.0). No LLM judge variance."
+  },
+  "security_parity": {
+    "experiment": "opaquetoolsbench_security_eval",
+    "description": "Verify that adversarial agent payloads cannot execute arbitrary code via eval() in the verifier. After removing eval() fallbacks in parse_python_call(), ast.unparse() is used instead.",
+    "date": "2026-05-17",
+    "status": "passed",
+    "test_cases": [
+      {
+        "name": "adversarial_payload",
+        "input": "__import__(\"os\").system(\"echo PWNED\")",
+        "expected_reward": 0.0,
+        "actual_reward": 0.0,
+        "code_executed": false,
+        "result": "pass"
+      }
+    ],
+    "fix_applied": "Replaced eval(compile(ast.Expression(...), '', 'eval')) with ast.unparse() at both keyword-arg and positional-arg locations in parse_python_call()",
+    "notes": "ast.unparse() returns a safe string representation without executing the AST node. Adversarial payloads are treated as non-matching function names and receive reward 0.0."
   }
 }

--- a/benchmarks/opaquetoolsbench/parity_experiment.json
+++ b/benchmarks/opaquetoolsbench/parity_experiment.json
@@ -1,0 +1,68 @@
+{
+  "experiment": "structural-parity",
+  "benchmark": "opaquetoolsbench",
+  "environment": "bfcl",
+  "date": "2026-05-17",
+  "description": "Structural parity validation of generated BenchFlow task directories from OpaqueToolsBench BFCL base configs",
+  "source": {
+    "repo": "https://github.com/shallinan1/OpaqueToolsBench",
+    "configs": [
+      "executable_simple_base_config.json",
+      "executable_multiple_function_base_config.json"
+    ]
+  },
+  "results": {
+    "total_tasks": 150,
+    "passed": 150,
+    "failed": 0,
+    "pass_rate": 1.0,
+    "categories": {
+      "executable_simple": {
+        "count": 100,
+        "passed": 100
+      },
+      "executable_multiple_function": {
+        "count": 50,
+        "passed": 50
+      }
+    }
+  },
+  "checks": [
+    {
+      "name": "required_files_present",
+      "description": "task.toml, instruction.md, Dockerfile, test.sh, evaluate.py, ground_truth.json all exist and are non-empty",
+      "passed": 150,
+      "failed": 0
+    },
+    {
+      "name": "task_toml_valid",
+      "description": "task.toml contains opaquetoolsbench/ prefix, [agent], [verifier], timeout_sec",
+      "passed": 150,
+      "failed": 0
+    },
+    {
+      "name": "instruction_md_valid",
+      "description": "instruction.md contains ## Query, ## Available Functions, and output path reference",
+      "passed": 150,
+      "failed": 0
+    },
+    {
+      "name": "ground_truth_valid",
+      "description": "ground_truth.json is valid JSON with non-empty ground_truth key",
+      "passed": 150,
+      "failed": 0
+    },
+    {
+      "name": "test_sh_executable",
+      "description": "test.sh has executable permission bit set",
+      "passed": 150,
+      "failed": 0
+    },
+    {
+      "name": "dockerfile_valid",
+      "description": "Dockerfile contains FROM directive and /logs/verifier directory creation",
+      "passed": 150,
+      "failed": 0
+    }
+  ]
+}

--- a/benchmarks/opaquetoolsbench/parity_experiment.json
+++ b/benchmarks/opaquetoolsbench/parity_experiment.json
@@ -64,5 +64,43 @@
       "passed": 150,
       "failed": 0
     }
-  ]
+  ],
+  "eval_parity": {
+    "experiment": "opaquetoolsbench_eval_parity",
+    "description": "End-to-end evaluation parity: build Docker image, run evaluate.py with correct/wrong/missing agent responses, verify binary rewards.",
+    "date": "2026-05-17",
+    "status": "passed",
+    "docker_build": "success (python:3.13-slim pinned by digest)",
+    "test_cases": [
+      {
+        "name": "correct_response",
+        "input": "calc_binomial_probability(n=20, k=5, p=0.6)",
+        "expected_reward": 1.0,
+        "actual_reward": 1.0,
+        "result": "pass"
+      },
+      {
+        "name": "wrong_response",
+        "input": "wrong_function(x=1)",
+        "expected_reward": 0.0,
+        "actual_reward": 0.0,
+        "result": "pass"
+      },
+      {
+        "name": "missing_response",
+        "input": null,
+        "expected_reward": 0.0,
+        "actual_reward": 0.0,
+        "result": "pass"
+      },
+      {
+        "name": "multi_function_correct",
+        "input": "calculate_cosine_similarity(...)",
+        "expected_reward": 1.0,
+        "actual_reward": 1.0,
+        "result": "pass"
+      }
+    ],
+    "notes": "AST-based deterministic matching. All test cases produce correct binary rewards (1.0/0.0). No LLM judge variance."
+  }
 }

--- a/benchmarks/opaquetoolsbench/parity_test.py
+++ b/benchmarks/opaquetoolsbench/parity_test.py
@@ -1,0 +1,189 @@
+"""Structural parity test for OpaqueToolsBench BFCL → BenchFlow pipeline.
+
+Validates that generated task directories have the correct structure,
+required files, and valid content.
+
+Usage::
+
+    python benchmarks/opaquetoolsbench/parity_test.py \\
+        --tasks-dir /tmp/opaquetoolsbench-tasks
+
+    python benchmarks/opaquetoolsbench/parity_test.py \\
+        --tasks-dir /tmp/opaquetoolsbench-tasks \\
+        --task-ids executable-simple-0,executable-simple-1
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger(__name__)
+
+REQUIRED_FILES = [
+    "task.toml",
+    "instruction.md",
+    "environment/Dockerfile",
+    "tests/test.sh",
+    "tests/evaluate.py",
+    "tests/ground_truth.json",
+]
+
+
+def _validate_task(task_dir: Path) -> list[str]:
+    """Validate a single task directory. Returns list of error messages."""
+    errors: list[str] = []
+    task_id = task_dir.name
+
+    # Check required files
+    for rel in REQUIRED_FILES:
+        fpath = task_dir / rel
+        if not fpath.exists():
+            errors.append(f"[{task_id}] Missing file: {rel}")
+        elif fpath.stat().st_size == 0:
+            errors.append(f"[{task_id}] Empty file: {rel}")
+
+    # Validate task.toml
+    toml_path = task_dir / "task.toml"
+    if toml_path.exists():
+        content = toml_path.read_text()
+        if 'name = "opaquetoolsbench/' not in content:
+            errors.append(
+                f"[{task_id}] task.toml missing opaquetoolsbench/ prefix in name"
+            )
+        if "[agent]" not in content:
+            errors.append(f"[{task_id}] task.toml missing [agent] section")
+        if "[verifier]" not in content:
+            errors.append(f"[{task_id}] task.toml missing [verifier] section")
+        if "timeout_sec" not in content:
+            errors.append(f"[{task_id}] task.toml missing timeout_sec")
+
+    # Validate instruction.md
+    instr_path = task_dir / "instruction.md"
+    if instr_path.exists():
+        content = instr_path.read_text()
+        if "## Query" not in content:
+            errors.append(f"[{task_id}] instruction.md missing ## Query section")
+        if "## Available Functions" not in content:
+            errors.append(
+                f"[{task_id}] instruction.md missing ## Available Functions"
+            )
+        if "/app/output/response.json" not in content:
+            errors.append(
+                f"[{task_id}] instruction.md missing output path reference"
+            )
+
+    # Validate ground_truth.json
+    gt_path = task_dir / "tests" / "ground_truth.json"
+    if gt_path.exists():
+        try:
+            gt = json.loads(gt_path.read_text())
+            if "ground_truth" not in gt:
+                errors.append(
+                    f"[{task_id}] ground_truth.json missing 'ground_truth' key"
+                )
+            elif not gt["ground_truth"]:
+                errors.append(
+                    f"[{task_id}] ground_truth.json has empty ground_truth list"
+                )
+        except json.JSONDecodeError as e:
+            errors.append(f"[{task_id}] ground_truth.json invalid JSON: {e}")
+
+    # Validate test.sh is executable
+    test_sh = task_dir / "tests" / "test.sh"
+    if test_sh.exists():
+        import stat
+
+        mode = test_sh.stat().st_mode
+        if not (mode & stat.S_IXUSR):
+            errors.append(f"[{task_id}] test.sh is not executable")
+
+    # Validate Dockerfile
+    dockerfile = task_dir / "environment" / "Dockerfile"
+    if dockerfile.exists():
+        content = dockerfile.read_text()
+        if "FROM" not in content:
+            errors.append(f"[{task_id}] Dockerfile missing FROM directive")
+        if "/logs/verifier" not in content:
+            errors.append(
+                f"[{task_id}] Dockerfile missing /logs/verifier directory"
+            )
+
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="OpaqueToolsBench structural parity test"
+    )
+    parser.add_argument(
+        "--tasks-dir",
+        type=Path,
+        required=True,
+        help="Path to generated task directories",
+    )
+    parser.add_argument(
+        "--task-ids",
+        nargs="*",
+        default=None,
+        help="Specific task IDs to validate (default: all)",
+    )
+    args = parser.parse_args()
+
+    if not args.tasks_dir.exists():
+        log.error("Tasks directory not found: %s", args.tasks_dir)
+        sys.exit(1)
+
+    # Discover tasks
+    if args.task_ids:
+        task_dirs = [args.tasks_dir / tid for tid in args.task_ids]
+    else:
+        task_dirs = sorted(
+            d for d in args.tasks_dir.iterdir() if d.is_dir()
+        )
+
+    if not task_dirs:
+        log.error("No task directories found in %s", args.tasks_dir)
+        sys.exit(1)
+
+    log.info("Validating %d task directories...", len(task_dirs))
+
+    all_errors: list[str] = []
+    passed = 0
+    failed = 0
+
+    for task_dir in task_dirs:
+        if not task_dir.exists():
+            log.error("Task dir not found: %s", task_dir)
+            all_errors.append(f"[{task_dir.name}] Directory does not exist")
+            failed += 1
+            continue
+
+        errors = _validate_task(task_dir)
+        if errors:
+            failed += 1
+            all_errors.extend(errors)
+            for e in errors:
+                log.error(e)
+        else:
+            passed += 1
+
+    print("\n=== Structural Parity Results ===")
+    print(f"  Passed: {passed}/{len(task_dirs)}")
+    print(f"  Failed: {failed}/{len(task_dirs)}")
+
+    if all_errors:
+        print(f"\n  Errors ({len(all_errors)}):")
+        for e in all_errors:
+            print(f"    {e}")
+        sys.exit(1)
+    else:
+        print("  All tasks passed structural validation.")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/opaquetoolsbench/parity_test.py
+++ b/benchmarks/opaquetoolsbench/parity_test.py
@@ -31,6 +31,7 @@ REQUIRED_FILES = [
     "tests/test.sh",
     "tests/evaluate.py",
     "tests/ground_truth.json",
+    "solution/solve.sh",
 ]
 
 
@@ -69,13 +70,9 @@ def _validate_task(task_dir: Path) -> list[str]:
         if "## Query" not in content:
             errors.append(f"[{task_id}] instruction.md missing ## Query section")
         if "## Available Functions" not in content:
-            errors.append(
-                f"[{task_id}] instruction.md missing ## Available Functions"
-            )
+            errors.append(f"[{task_id}] instruction.md missing ## Available Functions")
         if "/app/output/response.json" not in content:
-            errors.append(
-                f"[{task_id}] instruction.md missing output path reference"
-            )
+            errors.append(f"[{task_id}] instruction.md missing output path reference")
 
     # Validate ground_truth.json
     gt_path = task_dir / "tests" / "ground_truth.json"
@@ -94,13 +91,15 @@ def _validate_task(task_dir: Path) -> list[str]:
             errors.append(f"[{task_id}] ground_truth.json invalid JSON: {e}")
 
     # Validate test.sh is executable
-    test_sh = task_dir / "tests" / "test.sh"
-    if test_sh.exists():
+    for rel in ("tests/test.sh", "solution/solve.sh"):
+        script = task_dir / rel
+        if not script.exists():
+            continue
         import stat
 
-        mode = test_sh.stat().st_mode
+        mode = script.stat().st_mode
         if not (mode & stat.S_IXUSR):
-            errors.append(f"[{task_id}] test.sh is not executable")
+            errors.append(f"[{task_id}] {rel} is not executable")
 
     # Validate Dockerfile
     dockerfile = task_dir / "environment" / "Dockerfile"
@@ -109,9 +108,7 @@ def _validate_task(task_dir: Path) -> list[str]:
         if "FROM" not in content:
             errors.append(f"[{task_id}] Dockerfile missing FROM directive")
         if "/logs/verifier" not in content:
-            errors.append(
-                f"[{task_id}] Dockerfile missing /logs/verifier directory"
-            )
+            errors.append(f"[{task_id}] Dockerfile missing /logs/verifier directory")
 
     return errors
 
@@ -142,9 +139,7 @@ def main() -> None:
     if args.task_ids:
         task_dirs = [args.tasks_dir / tid for tid in args.task_ids]
     else:
-        task_dirs = sorted(
-            d for d in args.tasks_dir.iterdir() if d.is_dir()
-        )
+        task_dirs = sorted(d for d in args.tasks_dir.iterdir() if d.is_dir())
 
     if not task_dirs:
         log.error("No task directories found in %s", args.tasks_dir)

--- a/benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
+++ b/benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
@@ -1,24 +1,67 @@
-"""Run OpaqueToolsBench BFCL — generates tasks if needed, runs via Job."""
+"""Run OpaqueToolsBench BFCL — converts source tasks and runs via Evaluation.
 
+Usage:
+    python benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
+    python benchmarks/opaquetoolsbench/run_opaquetoolsbench.py path/to/config.yaml
+"""
+
+import argparse
 import asyncio
 import logging
 import sys
 from pathlib import Path
 
-from benchflow.job import Job
-from benchflow.task_download import ensure_tasks
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _SCRIPT_DIR.parents[1]
+_SRC_ROOT = _REPO_ROOT / "src"
+if str(_SCRIPT_DIR) in sys.path:
+    sys.path.remove(str(_SCRIPT_DIR))
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+if str(_SRC_ROOT) not in sys.path:
+    sys.path.insert(0, str(_SRC_ROOT))
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run OpaqueToolsBench via BenchFlow.")
+    parser.add_argument(
+        "config",
+        nargs="?",
+        default=str(_SCRIPT_DIR / "opaquetoolsbench-gemini-flash-lite.yaml"),
+        help="BenchFlow evaluation YAML config.",
+    )
+    return parser.parse_args()
+
+
+def ensure_converted_tasks() -> Path:
+    """Clone OpaqueToolsBench and convert BFCL configs to BenchFlow tasks."""
+    from benchflow._utils.benchmark_repos import resolve_source
+    from benchmarks.opaquetoolsbench.benchflow import generate_all
+
+    raw_repo = resolve_source("shallinan1/OpaqueToolsBench", ref="main")
+    converted_dir = _REPO_ROOT / ".cache" / "opaquetoolsbench-benchflow"
+    if converted_dir.exists() and any(converted_dir.glob("*/task.toml")):
+        logger.info("Converted tasks already exist at %s", converted_dir)
+        return converted_dir
+
+    logger.info("Converting OpaqueToolsBench BFCL tasks from %s", raw_repo)
+    generated = generate_all(raw_repo, converted_dir)
+    logger.info(
+        "Generated %d OpaqueToolsBench tasks in %s", len(generated), converted_dir
+    )
+    return converted_dir
 
 
 async def main():
-    config = (
-        sys.argv[1]
-        if len(sys.argv) > 1
-        else str(Path(__file__).parent / "opaquetoolsbench-experiment.yaml")
-    )
-    ensure_tasks("opaquetoolsbench")
-    job = Job.from_yaml(config)
+    from benchflow.evaluation import Evaluation
+
+    args = _parse_args()
+    tasks_dir = ensure_converted_tasks()
+    job = Evaluation.from_yaml(args.config)
+    job._tasks_dir = tasks_dir  # type: ignore[attr-defined]
     result = await job.run()
     print(f"\nScore: {result.passed}/{result.total} ({result.score:.1%})")
 

--- a/benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
+++ b/benchmarks/opaquetoolsbench/run_opaquetoolsbench.py
@@ -1,0 +1,27 @@
+"""Run OpaqueToolsBench BFCL — generates tasks if needed, runs via Job."""
+
+import asyncio
+import logging
+import sys
+from pathlib import Path
+
+from benchflow.job import Job
+from benchflow.task_download import ensure_tasks
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+
+async def main():
+    config = (
+        sys.argv[1]
+        if len(sys.argv) > 1
+        else str(Path(__file__).parent / "opaquetoolsbench-experiment.yaml")
+    )
+    ensure_tasks("opaquetoolsbench")
+    job = Job.from_yaml(config)
+    result = await job.run()
+    print(f"\nScore: {result.passed}/{result.total} ({result.score:.1%})")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_adapter_scripts.py
+++ b/tests/test_adapter_scripts.py
@@ -1,3 +1,4 @@
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -50,3 +51,63 @@ def test_opaquetoolsbench_run_script_help_works():
 
     assert result.returncode == 0
     assert "Run OpaqueToolsBench via BenchFlow" in result.stdout
+
+
+def test_opaquetoolsbench_converter_emits_oracle_solution(tmp_path):
+    """Guards ENG-101: converted tasks can run with oracle evidence."""
+    repo = Path(__file__).resolve().parents[1]
+    otb_dir = tmp_path / "OpaqueToolsBench"
+    configs_dir = otb_dir / "src" / "datasets" / "bfcl" / "tool_configs"
+    configs_dir.mkdir(parents=True)
+    (configs_dir / "executable_simple_base_config.json").write_text(
+        json.dumps(
+            {
+                "tests": [
+                    {
+                        "test_id": 0,
+                        "question": "Call the function.",
+                        "tools": [
+                            {
+                                "name": "lookup_city",
+                                "description": "Look up a city.",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {
+                                        "city": {
+                                            "type": "string",
+                                            "description": "City name",
+                                        }
+                                    },
+                                    "required": ["city"],
+                                },
+                            }
+                        ],
+                        "ground_truth": ['lookup_city(city="Paris")'],
+                        "name_mapping": {},
+                        "execution_result_type": ["exact_match"],
+                    }
+                ]
+            }
+        )
+    )
+
+    output_dir = tmp_path / "tasks"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "benchmarks/opaquetoolsbench/benchflow.py",
+            "--opaquetoolsbench-dir",
+            str(otb_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    solve_sh = output_dir / "executable-simple-0" / "solution" / "solve.sh"
+    assert solve_sh.exists()
+    assert "/app/output/response.json" in solve_sh.read_text()

--- a/tests/test_adapter_scripts.py
+++ b/tests/test_adapter_scripts.py
@@ -31,3 +31,22 @@ def test_programbench_run_script_help_works():
 
     assert result.returncode == 0
     assert "Run ProgramBench via BenchFlow" in result.stdout
+
+
+def test_opaquetoolsbench_run_script_help_works():
+    """Guards ENG-89: OpaqueToolsBench run script is invokable by path."""
+    repo = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [
+            sys.executable,
+            "benchmarks/opaquetoolsbench/run_opaquetoolsbench.py",
+            "--help",
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Run OpaqueToolsBench via BenchFlow" in result.stdout


### PR DESCRIPTION
## Summary

- replace raw PR #280 with the adapter plus current-main runner/config fixes
- add OpaqueToolsBench conversion, runner, parity tooling, default config, and docs
- keep verifier parsing safe via AST-based behavior instead of executing payloads

## Queue

- Branch: `codex/eng-89-pr280-opaquetoolsbench-ready`
- Base: `main`
- Prepared tip: `4ff6e9c10d28fabeb8fb059994d43022ef5b0567`
- Queue parent: ENG-97

## Linear

Closes ENG-101.
Part of ENG-89 and ENG-97.
Supersedes #280.

## Verification

- Fresh local validation on 2026-05-20:
  - `uv run --extra dev python -m pytest tests/test_adapter_scripts.py` -> `3 passed`
  - `uv run --extra dev ruff check tests/test_adapter_scripts.py benchmarks/opaquetoolsbench` -> passed
  - `uv run --extra dev ty check tests/test_adapter_scripts.py benchmarks/opaquetoolsbench` -> passed
  - `git diff --check origin/main...codex/eng-89-pr280-opaquetoolsbench-ready` -> passed
- `uv run python benchmarks/opaquetoolsbench/run_opaquetoolsbench.py --help`
- adapter script tests -> `3 passed`
- generated 150/150 tasks from `/tmp/OpaqueToolsBench`
- structural parity `150/150`
- `bench tasks check` passed for representative generated tasks
- verifier smoke: correct response `1.000000`; adversarial AST payload `0.000000` and did not execute marker payload
- `uv run --extra dev ruff check .`
- `uv run --extra dev ty check src/ benchmarks/opaquetoolsbench`
- full tests -> `1131 passed, 14 skipped, 1 deselected, 38 warnings`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new benchmark conversion pipeline and deterministic verifier script; main risk is correctness and safety of the AST-based call parsing/matching used to score tasks.
> 
> **Overview**
> Adds a new `benchmarks/opaquetoolsbench` adapter that converts OpaqueToolsBench BFCL base configs into BenchFlow task directories (`task.toml`, `instruction.md`, pinned `Dockerfile`, verifier `test.sh`/`evaluate.py`, and `ground_truth.json`).
> 
> Introduces a deterministic, AST-based verifier (binary reward; float tolerance; per-ground-truth call matching) plus an oracle `solution/solve.sh`, a `run_opaquetoolsbench.py` runner that auto-clones the source repo via `resolve_source`, and structural parity tooling/docs/config (`benchmark.yaml`, `parity_test.py`, `parity_experiment.json`, default eval YAML).
> 
> Extends `tests/test_adapter_scripts.py` to cover the new run script `--help` and to assert the converter emits an oracle solution script for generated tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 348fa851378e79c88ed6084249fa6db7bb968eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->