### PR TITLE
Fix v0.5 follow-up stress regressions

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -52,6 +52,8 @@ def _normalize_openhands_model(model: str) -> str:
 
     if model.startswith(("gemini/", "vertex_ai/", "openhands/")):
         return model
+    if model.startswith("google/gemini"):
+        return f"gemini/{model.split('/', 1)[1]}"
     stripped = strip_provider_prefix(model)
     lower = model.lower()
     if is_vertex_model(model) and "gemini" in lower:

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -452,14 +452,18 @@ AGENTS: dict[str, AgentConfig] = {
             # Install Harvey LAB's Python dependencies
             "( command -v pip3 >/dev/null 2>&1 || "
             "  (apt-get update -qq && apt-get install -y -qq python3-pip >/dev/null 2>&1) ) && "
-            "pip3 install -q anthropic openai google-genai "
+            "( python3 -m venv /opt/benchflow/harvey-lab-venv 2>/dev/null || "
+            "  (apt-get update -qq && apt-get install -y -qq python3-venv >/dev/null 2>&1 && "
+            "   python3 -m venv /opt/benchflow/harvey-lab-venv) ) && "
+            "/opt/benchflow/harvey-lab-venv/bin/python -m pip install -q "
+            "anthropic openai google-genai "
             "python-docx pdfplumber openpyxl python-pptx markitdown pandas && "
             # Deploy ACP shim
             + _install_python_script(
                 f"{_BENCHFLOW_BIN_PREFIX}/harvey-lab-acp-shim", _HARVEY_LAB_SHIM
             )
         ),
-        launch_cmd=f"HARVEY_LABS_ROOT=/opt/harvey-labs python3 {_BENCHFLOW_BIN_PREFIX}/harvey-lab-acp-shim",
+        launch_cmd=f"HARVEY_LABS_ROOT=/opt/harvey-labs /opt/benchflow/harvey-lab-venv/bin/python {_BENCHFLOW_BIN_PREFIX}/harvey-lab-acp-shim",
         protocol="acp",
         requires_env=[],  # inferred from model at runtime (ANTHROPIC_API_KEY, etc.)
         # env_mapping intentionally empty — Harvey LAB adapters read

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -356,12 +356,16 @@ class DockerSandbox(BaseSandbox):
                 self.logger.warning(f"Docker compose down failed: {e}")
 
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
+        target_parent = str(Path(target_path).parent)
+        if target_parent not in {"", "."}:
+            await self.exec(f"mkdir -p {shlex.quote(target_parent)}", user="root")
         await self._run_docker_compose_command(
             ["cp", str(source_path), f"main:{target_path}"],
             check=True,
         )
 
     async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+        await self.exec(f"mkdir -p {shlex.quote(target_dir)}", user="root")
         await self._run_docker_compose_command(
             ["cp", f"{source_dir}/.", f"main:{target_dir}"],
             check=True,

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -76,6 +76,20 @@ class TestOpenHandsConfig:
         cfg = AGENTS["openhands"]
         assert cfg.supports_acp_set_model is False
 
+    def test_harvey_lab_installs_python_deps_in_venv(self):
+        """Guards the v0.5 stress failure where pip hit PEP 668 in Ubuntu."""
+        cfg = AGENTS["harvey-lab-harness"]
+        assert "python3 -m venv /opt/benchflow/harvey-lab-venv" in cfg.install_cmd
+        assert (
+            "/opt/benchflow/harvey-lab-venv/bin/python -m pip install"
+            in cfg.install_cmd
+        )
+        assert "pip3 install -q anthropic" not in cfg.install_cmd
+        assert cfg.launch_cmd.startswith(
+            "HARVEY_LABS_ROOT=/opt/harvey-labs "
+            "/opt/benchflow/harvey-lab-venv/bin/python "
+        )
+
 
 class TestAgentCredentialFiles:
     def test_codex_has_auth_json(self):

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from benchflow.sandbox.docker import DockerSandbox
+
+
+@pytest.mark.asyncio
+async def test_docker_upload_dir_creates_target_before_compose_cp() -> None:
+    """Guards the v0.5 edit-pdf Docker failure where /app did not exist."""
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox.exec = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock()
+
+    await sandbox.upload_dir("local/skills", "/app/skills")
+
+    sandbox.exec.assert_awaited_once_with("mkdir -p /app/skills", user="root")
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["cp", "local/skills/.", "main:/app/skills"],
+        check=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_docker_upload_file_creates_parent_before_compose_cp() -> None:
+    """Guards uploads into task images whose Dockerfile uses a non-/app WORKDIR."""
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox.exec = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock()
+
+    await sandbox.upload_file(Path("instruction.md"), "/app/instruction.md")
+
+    sandbox.exec.assert_awaited_once_with("mkdir -p /app", user="root")
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["cp", "instruction.md", "main:/app/instruction.md"],
+        check=True,
+    )

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -147,6 +147,21 @@ class TestResolveAgentEnv:
         assert result["LLM_MODEL"] == "gemini/gemini-3.1-flash-lite-preview"
         assert result["LLM_API_KEY"] == "test-gemini-key"
 
+    def test_openhands_google_gemini_model_strips_models_dev_provider(
+        self, monkeypatch
+    ):
+        """Guards the v0.5 stress failure where OpenHands received
+        gemini/google/gemini-* and LiteLLM queried models/google/gemini-*.
+        """
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        result = self._resolve(
+            agent="openhands",
+            model="google/gemini-3.1-flash-lite-preview",
+            agent_env={"GEMINI_API_KEY": "test-gemini-key"},
+        )
+        assert result["LLM_MODEL"] == "gemini/gemini-3.1-flash-lite-preview"
+        assert result["LLM_API_KEY"] == "test-gemini-key"
+
     def test_openhands_explicit_llm_model_is_preserved(self, monkeypatch):
         """User-provided LLM_MODEL must win over derived normalization."""
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)


### PR DESCRIPTION
## Summary
- create Docker upload targets before `docker compose cp` so tasks with non-`/app` workdirs can receive runtime files/skills
- normalize OpenHands `google/gemini-*` model IDs to LiteLLM `gemini/gemini-*`
- install Harvey LAB harness Python deps in a venv to avoid Ubuntu PEP 668 failures

## Validation
- `uv run python -m pytest tests/test_docker_uploads.py tests/test_agent_registry.py::TestOpenHandsConfig::test_harvey_lab_installs_python_deps_in_venv tests/test_sdk_internals.py::TestResolveAgentEnv::test_openhands_google_gemini_model_strips_models_dev_provider`
- `uv run ruff check src/benchflow/agents/env.py src/benchflow/agents/registry.py src/benchflow/sandbox/docker.py tests/test_docker_uploads.py tests/test_agent_registry.py tests/test_sdk_internals.py`
- `uv run ruff format --check src/benchflow/agents/env.py src/benchflow/agents/registry.py src/benchflow/sandbox/docker.py tests/test_docker_uploads.py tests/test_agent_registry.py tests/test_sdk_internals.py`
- `uv run ty check src/`
- real rollout: `edit-pdf` on Docker with `--concurrency 1`, one rollout, completed through verifier with no harness error
- real rollout: OpenHands/Gemini Daytona hello-world, reward `1.0`
- real rollout: Harvey LAB/Gemini Daytona hello-world, reward `1.0`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/306" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches sandbox file transfer behavior and agent bootstrap/model normalization logic; regressions could break uploads or agent startup across environments, though changes are small and covered by targeted tests.
> 
> **Overview**
> Fixes multiple v0.5 stress regressions across sandbox and agent bootstrapping.
> 
> `DockerSandbox.upload_file()` and `upload_dir()` now create the destination directory (or parent) inside the container before running `docker compose cp`, preventing failures when task images don’t already have the target paths.
> 
> OpenHands model normalization now rewrites `google/gemini-*` inputs to LiteLLM’s expected `gemini/gemini-*` format, avoiding double-prefixing/incorrect routing.
> 
> The `harvey-lab-harness` installer now creates and uses a dedicated venv under `/opt/benchflow/harvey-lab-venv` for pip installs (and launches via that interpreter) to avoid Ubuntu PEP 668/system-pip restrictions; new tests lock in these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af23eb5ae5079df198dd7a0d260e04b5f6403ed2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->