### PR TITLE
test: guard issue #229 — deploy_skills receives effective task path

### DIFF
--- a/tests/test_trial_install_agent_timeout.py
+++ b/tests/test_trial_install_agent_timeout.py
@@ -90,6 +90,56 @@ async def test_install_agent_forwards_sandbox_setup_timeout(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("agent", ["claude-agent-acp", "oracle"])
+async def test_install_agent_passes_effective_task_path_to_deploy_skills(
+    tmp_path, monkeypatch, agent
+):
+    """Guards issue #229: deploy_skills double-deploys when skills_dir is set.
+
+    `_setup` copies the task to a temp dir and injects
+    `COPY _deps/skills /skills/` into that temp Dockerfile, recording the
+    copy as `_effective_task_path`. `deploy_skills` decides whether to skip
+    the runtime `/skills` upload by reading the Dockerfile at the path it is
+    given — so it must receive `_effective_task_path`, not the original
+    `cfg.task_path` (whose Dockerfile is never injected). Passing the
+    original path makes `already_injected` always False and triggers a
+    second `/skills` upload on top of the baked image, failing with
+    `cannot overwrite directory "/skills/..." with non-directory "/skills"`.
+    """
+    trial = _make_trial(tmp_path, agent=agent, sandbox_setup_timeout=41)
+    trial._config = trial._config.__class__.from_legacy(
+        task_path=tmp_path / "original-task",
+        agent=agent,
+        prompts=[None],
+        sandbox_user="agent",
+        sandbox_setup_timeout=41,
+        skills_dir=tmp_path / "skills",
+    )
+    effective_task_path = tmp_path / "benchflow-task-tmp" / "task"
+    trial._effective_task_path = effective_task_path
+
+    deploy_skills_mock = AsyncMock()
+    monkeypatch.setattr("benchflow.rollout.install_agent", AsyncMock())
+    monkeypatch.setattr("benchflow.rollout.write_credential_files", AsyncMock())
+    monkeypatch.setattr("benchflow.rollout.upload_subscription_auth", AsyncMock())
+    monkeypatch.setattr("benchflow.rollout._snapshot_build_config", AsyncMock())
+    monkeypatch.setattr("benchflow.rollout._seed_verifier_workspace", AsyncMock())
+    monkeypatch.setattr("benchflow.rollout.deploy_skills", deploy_skills_mock)
+    monkeypatch.setattr("benchflow.rollout.lockdown_paths", AsyncMock())
+    monkeypatch.setattr(
+        "benchflow.rollout.setup_sandbox_user", AsyncMock(return_value="/home/agent")
+    )
+    monkeypatch.setattr("benchflow.rollout.apply_web_tool_policy", AsyncMock())
+
+    await trial.install_agent()
+
+    deploy_skills_mock.assert_awaited_once()
+    passed_task_path = deploy_skills_mock.await_args.args[1]
+    assert passed_task_path == effective_task_path
+    assert passed_task_path != trial._config.task_path
+
+
+@pytest.mark.asyncio
 async def test_install_agent_applies_web_policy_after_sandbox_setup(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Issue #229 reported that `deploy_skills` double-deploys skills when `skills_dir` is set: once baked into the image via `_inject_skills_into_dockerfile`, and again at runtime via `env.upload_dir(..., "/skills")`, failing with `cannot overwrite directory "/skills/..." with non-directory "/skills"`.

**The product bug is already fixed on `main`.** The v0.3.4 refactor (PR #274) introduced `Rollout._effective_task_path` and both `deploy_skills` call sites in `rollout.py` already pass `getattr(self, "_effective_task_path", cfg.task_path)`. `deploy_skills`' `already_injected` Dockerfile check therefore reads the same (temp) Dockerfile that was actually built into the image, and the redundant runtime upload is correctly skipped. `test_deploy_skills_skips_runtime_upload_when_dockerfile_already_injected` covers `deploy_skills` in isolation.

**Gap closed by this PR:** no test pinned the *call site*. The isolated `deploy_skills` test still passes even if `install_agent` were reverted to pass the original `cfg.task_path` — which is exactly issue #229's root cause. This PR adds a call-site regression test asserting `install_agent` forwards `_effective_task_path` (not `cfg.task_path`) to `deploy_skills`, parametrized over the oracle and agent code paths.

Verified red-green: reverting both call sites to `cfg.task_path` makes the new test fail; restoring the fix makes it pass.

## Testing

- `uv run ruff format --check src tests` — pass
- `uv run ruff check .` — pass
- `uv run ty check src/` — pass
- `uv run python -m pytest tests/` — 1219 passed, 16 skipped

Closes #229

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a regression test only, with no production code changes. It mainly guards against future refactors breaking skills deployment behavior when `skills_dir` is used.
> 
> **Overview**
> Adds a new call-site regression test ensuring `Rollout.install_agent()` passes `self._effective_task_path` (not `cfg.task_path`) into `deploy_skills` when `skills_dir` is set, preventing a future reintroduction of the issue where skills get uploaded twice.
> 
> The test is parametrized over both the `oracle` and non-oracle agent install paths and asserts the effective task path is the one forwarded to `deploy_skills`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72d542adc2e5d6363cd4062e2321861dccd63d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->