### PR TITLE
fix(verifier): restore [verifier] pytest_plugins task.toml field (#192 bug 2)

### DIFF
--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -518,12 +518,11 @@ async def _discover_pytest_plugin_flags(env, task: "Task") -> str:
     except Exception as e:
         logger.warning(f"Pytest plugin discovery failed, using task.toml fallback: {e}")
 
-    # Merge task.toml declarations as fallback
-    declared = getattr(task.config.verifier, "pytest_plugins", None)
-    if declared:
-        for name in declared:
-            if isinstance(name, str):
-                add_plugin(name)
+    # Merge task.toml [verifier] pytest_plugins declarations as fallback.
+    declared = getattr(task.config.verifier, "pytest_plugins", None) or []
+    for name in declared:
+        if isinstance(name, str):
+            add_plugin(name)
 
     # The standard task template runs pytest-ctrf through `uvx --with`,
     # so the plugin is not visible during pre-verifier entry-point discovery.

--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -92,6 +92,15 @@ class VerifierConfig(BaseModel):
         default=None,
         description="Username or UID to run the verifier as.",
     )
+    pytest_plugins: list[str] = Field(
+        default_factory=list,
+        description=(
+            "pytest11 plugin names to allow under PYTEST_DISABLE_PLUGIN_AUTOLOAD=1. "
+            "Container-side auto-discovery handles most cases; this is the "
+            "explicit fallback for plugins that discovery cannot see "
+            "(e.g. ctrf, playwright)."
+        ),
+    )
 
 
 class AgentConfig(BaseModel):

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -860,6 +860,37 @@ class TestVerifierEnv:
         assert "-p myplug" in addopts
         assert final_env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
 
+    def test_verifier_config_keeps_pytest_plugins_from_toml(self):
+        """Guards issue #192 bug 2: a [verifier] pytest_plugins declaration in
+        task.toml must survive parsing into VerifierConfig.
+
+        lockdown._discover_pytest_plugin_flags reads
+        task.config.verifier.pytest_plugins as the fallback when container-side
+        plugin auto-discovery cannot see a plugin (e.g. pytest-json-ctrf's
+        'ctrf' entry point, pytest-playwright's 'page' fixture). Before this
+        fix, VerifierConfig had no pytest_plugins field, so pydantic silently
+        dropped the key and the documented fallback was dead code — the
+        video-tutorial-indexer verifier ran zero tests with `No module named
+        'ctrf'`. The previous mock-based tests passed because they set the
+        attribute directly on a MagicMock, hiding the missing field.
+        """
+        from benchflow.task.config import TaskConfig, VerifierConfig
+
+        # Default is an empty list, not None — safe to iterate unconditionally.
+        assert VerifierConfig().pytest_plugins == []
+
+        toml = (
+            "[verifier]\n"
+            "timeout_sec = 120\n"
+            "pytest_plugins = ['ctrf', 'playwright']\n"
+            "[verifier.hardening]\n"
+            "cleanup_conftests = false\n"
+        )
+        cfg = TaskConfig.model_validate_toml(toml)
+        assert cfg.verifier.pytest_plugins == ["ctrf", "playwright"], (
+            "pytest_plugins declared in task.toml [verifier] was dropped"
+        )
+
     @pytest.mark.asyncio
     @pytest.mark.parametrize("plugins", [None, []])
     async def test_no_extra_addopts_when_no_plugins(self, plugins):


### PR DESCRIPTION
## Summary

Audit of the 14 infrastructure bugs from #192 (SkillsBench Opus 4.7 Trial 1, April) against current `main` after the v0.4→v0.5 migration.

**Key finding:** 13 of the 14 bugs have their root cause in the external `benchflow-ai/skillsbench` task repo (per-task `test.sh`, `Dockerfile`, datagen scripts) or in the upstream Daytona SDK — none of those files live in this repo, so they cannot be fixed here. Exactly one bug (#2) has a genuine root cause in benchflow infrastructure (`src/benchflow/`), and this PR fixes it.

## What this PR fixes — issue #192 bug 2

`VerifierConfig` had no `pytest_plugins` field. A `[verifier] pytest_plugins = [...]` declaration in `task.toml` was silently dropped by pydantic (`extra="ignore"`). `lockdown._discover_pytest_plugin_flags` reads `task.config.verifier.pytest_plugins` as the documented fallback when container-side pytest11 entry-point auto-discovery cannot see a plugin (because `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1`) — so that fallback was dead code.

- Added `pytest_plugins: list[str]` to `VerifierConfig` (default `[]`).
- Simplified the `lockdown.py` read now that the field reliably exists.
- Added a regression test that exercises the real `TaskConfig` parse path. The prior `pytest_plugins` tests passed only because they set the attribute directly on a `MagicMock`, masking the missing field.

This unblocks the task.toml-side remediation for bug 2 (pytest-json-ctrf `ctrf` plugin) and bug 14 (pytest-playwright `page` fixture) — the SkillsBench task authors can now declare `pytest_plugins` and have it actually take effect.

## 14-bug status table

| # | Bug | Category | Status | Notes |
|---|-----|----------|--------|-------|
| 1 | suricata-custom-exfil — `pip install pytest` to wrong Python | Verifier | Task-repo | Per-task `tests/test.sh` in `benchflow-ai/skillsbench`; not in this repo |
| 2 | video-tutorial-indexer — `pytest -p ctrf` fails, plugin invisible | Verifier | **Fixed here** | `[verifier] pytest_plugins` was silently dropped; now a real `VerifierConfig` field |
| 3 | sales-pivot-analysis — `test.sh` misses `openpyxl` | Verifier | Task-repo | Per-task `tests/test.sh`; not in this repo |
| 4 | pddl-tpp-planning — reference `task01.pkl` not provisioned | Verifier | Task-repo | Per-task `tests/` contents; not in this repo |
| 5 | fix-build-google-auto — `uv` not installed, verifier calls it | Verifier | Task-repo | Per-task `environment/Dockerfile`; not in this repo |
| 6 | syzkaller-ppdev-syzlang — `/opt/syzkaller/sys/linux/` root-owned | Permissions | Task-repo | Output path is task-specific; fix is `chmod` in that task's Dockerfile |
| 7 | taxonomy-tree-merge — `/root/output/` root-owned + 369s build | Permissions | Task-repo | Output path + build time are task-specific (Dockerfile) |
| 8 | lean4-proof — `/root/.elan/` toolchain not agent-accessible | Permissions | Task-repo | Toolchain install path is task-specific (Dockerfile) |
| 9 | multilingual-video-dubbing — `/outputs` root-owned; verifier missing `torch` | Permissions | Task-repo | Output path + verifier deps are task-specific |
| 10 | organize-messy-files — input PDFs missing from sandbox | Provisioning | Task-repo | Docker build context / `COPY` step in that task |
| 11 | azure-bgp-oscillation-route-leak — DATAGEN heredoc produced empty `/app/data/` | Provisioning | Task-repo | Inline datagen script in that task's Dockerfile |
| 12 | fix-build-agentops — `claude-agent-acp` not found (rc=127), bugswarm base image PATH | Agent launch | Task-repo | Base-image PATH issue is specific to that task's `bugswarm/cached-images` Dockerfile |
| 13 | latex-formula-extraction — Daytona SDK `SessionCommandLogsResponse` pydantic error | Agent launch | Upstream | Upstream Daytona SDK bug; not fixable in this repo |
| 14 | react-performance-debugging — pytest-playwright `page` fixture not found | Agent launch | Task-repo (mechanism fixed here) | Needs `pytest_plugins=["playwright"]` in task.toml — that mechanism is what bug 2's fix restores |

Summary: **1 fixed here** (#2), **11 task-repo** (need PRs against `benchflow-ai/skillsbench`), **1 upstream** (#13, Daytona SDK), **1 unblocked** (#14 — task.toml remediation now works thanks to the bug-2 fix).

None of the 13 task-repo / upstream bugs were independently "already fixed" or "no longer applicable" — they remain live, but their fixes belong in other repos, not in `src/benchflow/`.

## CI

`ruff format --check`, `ruff check`, `ty check src/`, and `pytest tests/` (1218 passed, 16 skipped) all green.

Refs #192. Issue #192 stays open — a follow-up comment lists the 13 bugs still requiring task-repo / upstream fixes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mainly adds a missing config field and a regression test; behavior changes only for tasks that already set `[verifier] pytest_plugins`, which will now take effect.
> 
> **Overview**
> Restores the documented `[verifier] pytest_plugins` `task.toml` setting by adding a first-class `pytest_plugins: list[str]` field to `VerifierConfig` (defaulting to `[]`), preventing pydantic from silently dropping the key.
> 
> Simplifies `lockdown._discover_pytest_plugin_flags` to always iterate the parsed list (using it as a fallback when container-side plugin discovery can’t see a plugin), and adds a regression test that validates TOML parsing preserves `pytest_plugins` end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87034acc96af30bffa499a5e769ed17d981db16a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->