### PR TITLE
feat(sandbox): multi-container service selection for vulhub-style tasks (#248)

### DIFF
--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -53,6 +53,42 @@ env             = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }  # host vars to injec
 
 ---
 
+## Multi-container tasks
+
+A task may ship an `environment/docker-compose.yaml` alongside (or instead of)
+the `Dockerfile`. The agent always runs in the `main` service; any additional
+services you declare become sibling containers on the same Docker network.
+This supports vulhub-style CVE tasks where the agent attacks a separate target
+container over the network.
+
+```yaml
+# environment/docker-compose.yaml
+services:
+  main: {}            # agent container — BenchFlow injects build/image/limits
+  target:             # vulnerable service the agent must exploit
+    image: vulhub/struts2-s2-001:latest
+    expose: ["8080"]
+```
+
+`main` reaches `target` by service name (`http://target:8080`). The verifier
+can inspect *target-side* state — not just the agent's workspace — by passing
+a `service` argument when running commands:
+
+```python
+# In a Python-driven run or pre/post hook
+await env.exec_in_service("target", "test -f /tmp/exploit_proof.txt")
+await env.exec("cat /flag", service="target")          # equivalent form
+services = await env.inner.services()                  # ["main", "target"]
+```
+
+`exec(..., service=...)` works on the Docker sandbox and the Daytona DinD
+(compose) sandbox. Single-container backends (Modal, direct Daytona) raise a
+clear error for any non-`main` service. This lets a verifier check
+write-based oracles (`/tmp/exploit.txt` in the target), database modifications,
+or RCE markers without trusting the agent container.
+
+---
+
 ## instruction.md
 
 The first prompt sent to the agent. Write it as you would for a skilled developer:

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -107,7 +107,22 @@ class Environment:
             self._started = False
 
     async def exec(self, cmd: str, **kwargs) -> Any:
+        """Run a command in the sandbox.
+
+        Pass ``service="<name>"`` to target an additional compose service
+        (a vulhub-style target container) instead of the default agent
+        container ``"main"`` — see #248.
+        """
         return await self._inner.exec(cmd, **kwargs)
+
+    async def exec_in_service(self, service: str, cmd: str, **kwargs) -> Any:
+        """Run a command in a named compose service container (#248).
+
+        Ergonomic wrapper for ``exec(cmd, service=service)``. Useful for
+        injecting flags into, or verifying state of, a multi-container
+        task's target container.
+        """
+        return await self._inner.exec(cmd, service=service, **kwargs)
 
     async def upload_file(self, src: str | Path, dst: str) -> None:
         await self._inner.upload_file(src, dst)

--- a/src/benchflow/sandbox/_base.py
+++ b/src/benchflow/sandbox/_base.py
@@ -171,17 +171,61 @@ class BaseSandbox(ABC):
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
-    ) -> ExecResult: ...
+        service: str = "main",
+    ) -> ExecResult:
+        """Run a command inside the sandbox.
 
-    async def is_dir(self, path: str, user: str | int | None = None) -> bool:
+        ``service`` selects which compose service (container) the command
+        runs in. The default ``"main"`` is the agent container. Multi-
+        container (vulhub-style) tasks define additional services in the
+        task's ``docker-compose.yaml`` and target them via this argument
+        — for flag injection into a vulnerable target before the agent
+        runs, or target-side verification afterwards (#248). Sandbox
+        backends without compose support reject non-``main`` values.
+        """
+        ...
+
+    async def exec_in_service(
+        self,
+        service: str,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_sec: int | None = None,
+        user: str | int | None = None,
+    ) -> ExecResult:
+        """Run a command in a named compose service — ergonomic wrapper around ``exec``.
+
+        Sugar for ``exec(command, ..., service=service)``. Useful for
+        multi-container tasks where verifier code needs to inspect a
+        target container's state, e.g.::
+
+            await sandbox.exec_in_service("target", "test -f /tmp/pwned")
+
+        See #248.
+        """
+        return await self.exec(
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_sec=timeout_sec,
+            user=user,
+            service=service,
+        )
+
+    async def is_dir(
+        self, path: str, user: str | int | None = None, service: str = "main"
+    ) -> bool:
         result = await self.exec(
-            f"test -d {shlex.quote(path)}", timeout_sec=10, user=user
+            f"test -d {shlex.quote(path)}", timeout_sec=10, user=user, service=service
         )
         return result.return_code == 0
 
-    async def is_file(self, path: str, user: str | int | None = None) -> bool:
+    async def is_file(
+        self, path: str, user: str | int | None = None, service: str = "main"
+    ) -> bool:
         result = await self.exec(
-            f"test -f {shlex.quote(path)}", timeout_sec=10, user=user
+            f"test -f {shlex.quote(path)}", timeout_sec=10, user=user, service=service
         )
         return result.return_code == 0
 

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -153,6 +153,7 @@ class _DaytonaStrategy:
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
+        service: str = "main",
     ) -> ExecResult: ...
 
     @abstractmethod
@@ -283,7 +284,14 @@ class _DaytonaDirect(_DaytonaStrategy):
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
+        service: str = "main",
     ) -> ExecResult:
+        if service != "main":
+            raise ValueError(
+                f"Direct (non-compose) Daytona sandbox is single-container "
+                f"and cannot target service {service!r}. Multi-container "
+                "(vulhub-style) tasks require a docker-compose.yaml (#248)."
+            )
         return await self._env._sandbox_exec(
             command, cwd=cwd, env=env, timeout_sec=timeout_sec, user=user
         )
@@ -591,7 +599,14 @@ class _DaytonaDinD(_DaytonaStrategy):
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
+        service: str = "main",
     ) -> ExecResult:
+        """Run a command in a compose service inside the DinD VM.
+
+        ``service`` defaults to ``"main"`` (the agent container); pass
+        another name to target an additional container declared in the
+        task's ``docker-compose.yaml`` (vulhub-style targets — see #248).
+        """
         parts: list[str] = ["exec", "-T"]
         if cwd:
             parts.extend(["-w", cwd])
@@ -600,7 +615,7 @@ class _DaytonaDinD(_DaytonaStrategy):
                 parts.extend(["-e", f"{k}={v}"])
         if user is not None:
             parts.extend(["-u", str(user)])
-        parts.extend(["main", "bash", "-lc", command])
+        parts.extend([service, "bash", "-lc", command])
 
         return await self._compose_exec(parts, timeout_sec=timeout_sec)
 
@@ -1048,11 +1063,17 @@ class DaytonaSandbox(BaseSandbox):
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
+        service: str = "main",
     ) -> ExecResult:
         user = self._resolve_user(user)
         env = self._merge_env(env)
         return await self._strategy.exec(
-            command, cwd=cwd, env=env, timeout_sec=timeout_sec, user=user
+            command,
+            cwd=cwd,
+            env=env,
+            timeout_sec=timeout_sec,
+            user=user,
+            service=service,
         )
 
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
@@ -1067,10 +1088,18 @@ class DaytonaSandbox(BaseSandbox):
     async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
         return await self._strategy.download_dir(source_dir, target_dir)
 
-    async def is_dir(self, path: str, user: str | int | None = None) -> bool:
+    async def is_dir(
+        self, path: str, user: str | int | None = None, service: str = "main"
+    ) -> bool:
+        if service != "main":
+            return await super().is_dir(path, user=user, service=service)
         return await self._strategy.is_dir(path, user=self._resolve_user(user))
 
-    async def is_file(self, path: str, user: str | int | None = None) -> bool:
+    async def is_file(
+        self, path: str, user: str | int | None = None, service: str = "main"
+    ) -> bool:
+        if service != "main":
+            return await super().is_file(path, user=user, service=service)
         return await self._strategy.is_file(path, user=self._resolve_user(user))
 
     async def attach(self) -> None:

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -405,6 +405,18 @@ class DockerSandbox(BaseSandbox):
             check=True,
         )
 
+    async def services(self) -> list[str]:
+        """List compose service names defined for this sandbox.
+
+        Includes BenchFlow's own ``main`` service plus any additional
+        services the task declares in its ``docker-compose.yaml``
+        (vulhub-style target/database containers — see #248).
+        """
+        result = await self._run_docker_compose_command(
+            ["config", "--services"], check=True
+        )
+        return [s for s in (result.stdout or "").splitlines() if s.strip()]
+
     async def exec(
         self,
         command: str,
@@ -412,7 +424,16 @@ class DockerSandbox(BaseSandbox):
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
+        service: str = "main",
     ) -> ExecResult:
+        """Run a command in a compose service container.
+
+        ``service`` defaults to ``"main"`` (the agent container). Pass a
+        different service name to target an additional container declared
+        in the task's ``docker-compose.yaml`` — e.g. to inject a flag into
+        a vulnerable target before the agent runs, or to verify exploit
+        success by inspecting target-side state afterwards (#248).
+        """
         user = self._resolve_user(user)
         env = self._merge_env(env)
 
@@ -428,7 +449,7 @@ class DockerSandbox(BaseSandbox):
         if user is not None:
             exec_command.extend(["-u", str(user)])
 
-        exec_command.append("main")
+        exec_command.append(service)
         exec_command.extend(["bash", "-c", command])
 
         return await self._run_docker_compose_command(

--- a/src/benchflow/sandbox/modal_impl.py
+++ b/src/benchflow/sandbox/modal_impl.py
@@ -318,7 +318,15 @@ class ModalSandbox(BaseSandbox):
         env: dict[str, str] | None = None,
         timeout_sec: int | None = None,
         user: str | int | None = None,
+        service: str = "main",
     ) -> ExecResult:
+        if service != "main":
+            raise ValueError(
+                f"Modal sandbox is single-container and cannot target "
+                f"service {service!r}. Multi-container (vulhub-style) tasks "
+                "require the Docker sandbox (#248)."
+            )
+
         from modal import Secret
 
         user = self._resolve_user(user)

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -142,8 +142,14 @@ class DockerProcess(LiveProcess):
         self._service = service
 
     @classmethod
-    def from_sandbox_env(cls, env: Any) -> "DockerProcess":
-        """Create from a sandbox environment (DockerSandbox)."""
+    def from_sandbox_env(cls, env: Any, service: str = "main") -> "DockerProcess":
+        """Create from a sandbox environment (DockerSandbox).
+
+        ``service`` selects which compose service the agent process runs
+        in. Defaults to ``"main"``. Multi-container (vulhub-style) tasks
+        may run the agent in a dedicated attacker container — e.g. a Kali
+        service — while keeping target containers separate (#248).
+        """
         project_name = env.session_id.lower().replace(".", "-")
         project_dir = str(env.environment_dir.resolve().absolute())
         compose_files = [str(p.resolve().absolute()) for p in env._docker_compose_paths]
@@ -151,6 +157,7 @@ class DockerProcess(LiveProcess):
             project_name=project_name,
             project_dir=project_dir,
             compose_files=compose_files,
+            service=service,
         )
 
     def _compose_cmd(self) -> list[str]:

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -1,0 +1,268 @@
+"""Tests for multi-container / multi-service sandbox exec support.
+
+Covers issue #248: vulhub-style tasks need to run commands in a specific
+compose service (target/database container) rather than only the agent's
+``main`` container — for flag injection before the agent runs and for
+target-side verification afterwards.
+
+All tests are unit tests with mocked subprocess/strategy layers — no
+Docker or Daytona infrastructure required.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from benchflow.sandbox._base import ExecResult
+from benchflow.sandbox.docker import DockerSandbox
+from benchflow.sandbox.process import DockerProcess
+
+
+class TestDockerSandboxServiceExec:
+    """#248: DockerSandbox.exec must be able to target any compose service."""
+
+    def _make_sandbox(self) -> DockerSandbox:
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._persistent_env = {}
+        sandbox.default_user = None
+        return sandbox
+
+    @pytest.mark.asyncio
+    async def test_exec_defaults_to_main_service(self) -> None:
+        """#248: default exec still targets the agent's ``main`` container."""
+        sandbox = self._make_sandbox()
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec("echo hi")
+
+        assert captured[0] == ["exec", "main", "bash", "-c", "echo hi"]
+
+    @pytest.mark.asyncio
+    async def test_exec_targets_named_service(self) -> None:
+        """#248: exec(service=...) runs the command in the named target container."""
+        sandbox = self._make_sandbox()
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec("test -f /tmp/pwned", service="target")
+
+        assert captured[0] == ["exec", "target", "bash", "-c", "test -f /tmp/pwned"]
+
+    @pytest.mark.asyncio
+    async def test_exec_in_service_wrapper(self) -> None:
+        """#248: exec_in_service is sugar for exec(..., service=...)."""
+        sandbox = self._make_sandbox()
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec_in_service("db", "mysql -e 'SELECT 1'")
+
+        assert captured[0] == ["exec", "db", "bash", "-c", "mysql -e 'SELECT 1'"]
+
+    @pytest.mark.asyncio
+    async def test_exec_service_with_user_and_cwd(self) -> None:
+        """#248: service selection composes with user/cwd/env flags."""
+        sandbox = self._make_sandbox()
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec(
+            "id", cwd="/work", user="root", env={"K": "v"}, service="attacker"
+        )
+
+        cmd = captured[0]
+        # service name precedes `bash -c`, after all flags
+        assert cmd[cmd.index("bash") - 1] == "attacker"
+        assert "-w" in cmd and "/work" in cmd
+        assert "-u" in cmd and "root" in cmd
+        assert "-e" in cmd and "K=v" in cmd
+
+    @pytest.mark.asyncio
+    async def test_services_lists_compose_services(self) -> None:
+        """#248: services() enumerates every container defined in the task."""
+        sandbox = self._make_sandbox()
+
+        async def fake_run(command, check=True, timeout_sec=None):
+            assert command == ["config", "--services"]
+            return ExecResult(stdout="main\ntarget\ndb\n", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        services = await sandbox.services()
+
+        assert services == ["main", "target", "db"]
+
+
+class TestDockerProcessServiceSelection:
+    """#248: ACP agent process can be launched into a non-main service."""
+
+    def test_from_sandbox_env_defaults_to_main(self) -> None:
+        """#248: by default the agent process runs in the main container."""
+        env = MagicMock()
+        env.session_id = "task.abc"
+        env.environment_dir.resolve.return_value.absolute.return_value = "/env"
+        env._docker_compose_paths = []
+
+        proc = DockerProcess.from_sandbox_env(env)
+        assert proc._service == "main"
+
+    def test_from_sandbox_env_honors_service(self) -> None:
+        """#248: agent can run in a dedicated attacker container (e.g. Kali)."""
+        env = MagicMock()
+        env.session_id = "task.abc"
+        env.environment_dir.resolve.return_value.absolute.return_value = "/env"
+        env._docker_compose_paths = []
+
+        proc = DockerProcess.from_sandbox_env(env, service="kali")
+        assert proc._service == "kali"
+
+    @pytest.mark.asyncio
+    async def test_started_process_targets_selected_service(self) -> None:
+        """#248: the docker compose exec command uses the selected service."""
+        from unittest.mock import patch
+
+        proc = DockerProcess(
+            project_name="p",
+            project_dir="/d",
+            compose_files=["/d/docker-compose.yml"],
+            service="kali",
+        )
+        captured: list[list[str]] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured.append(list(args))
+            mock_proc = AsyncMock()
+            mock_proc.pid = 1
+            mock_proc.returncode = 0
+            mock_proc.stdin = AsyncMock()
+            mock_proc.stdout = AsyncMock()
+            mock_proc.stderr = AsyncMock()
+            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
+            return mock_proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await proc.start(command="echo hi")
+
+        # `<service> bash -c <command>` — service is the arg before "bash"
+        cmd = captured[0]
+        assert cmd[cmd.index("bash") - 1] == "kali"
+
+
+class TestEnvironmentServicePassthrough:
+    """#248: Runtime Environment exposes service selection to task authors."""
+
+    @pytest.mark.asyncio
+    async def test_environment_exec_threads_service(self) -> None:
+        """#248: Environment.exec forwards a service kwarg to the sandbox."""
+        from benchflow.runtime import Environment
+
+        inner = MagicMock()
+        inner.exec = AsyncMock(
+            return_value=ExecResult(stdout="", stderr="", return_code=0)
+        )
+        env = Environment.__new__(Environment)
+        env._inner = inner
+
+        await env.exec("cat /flag", service="target")
+        inner.exec.assert_awaited_once_with("cat /flag", service="target")
+
+    @pytest.mark.asyncio
+    async def test_environment_exec_in_service(self) -> None:
+        """#248: Environment.exec_in_service is sugar for exec(service=...)."""
+        from benchflow.runtime import Environment
+
+        inner = MagicMock()
+        inner.exec = AsyncMock(
+            return_value=ExecResult(stdout="", stderr="", return_code=0)
+        )
+        env = Environment.__new__(Environment)
+        env._inner = inner
+
+        await env.exec_in_service("db", "mysql -e 'SELECT 1'")
+        inner.exec.assert_awaited_once_with("mysql -e 'SELECT 1'", service="db")
+
+
+class TestDaytonaServiceExec:
+    """#248: Daytona DinD compose strategy must support service selection."""
+
+    @pytest.mark.asyncio
+    async def test_dind_exec_targets_named_service(self) -> None:
+        """#248: DinD compose exec runs the command in the named service."""
+        pytest.importorskip("tenacity")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        await strategy.exec("cat /flag", service="target")
+
+        sub = captured[0]
+        assert sub[sub.index("bash") - 1] == "target"
+
+    @pytest.mark.asyncio
+    async def test_dind_exec_defaults_to_main(self) -> None:
+        """#248: DinD compose exec still defaults to the agent's main container."""
+        pytest.importorskip("tenacity")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        await strategy.exec("echo hi")
+
+        sub = captured[0]
+        assert sub[sub.index("bash") - 1] == "main"
+
+    @pytest.mark.asyncio
+    async def test_direct_strategy_rejects_non_main_service(self) -> None:
+        """#248: direct (non-compose) Daytona sandbox rejects multi-service."""
+        pytest.importorskip("tenacity")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDirect
+
+        strategy = _DaytonaDirect.__new__(_DaytonaDirect)
+
+        with pytest.raises(ValueError, match="single-container"):
+            await strategy.exec("echo hi", service="target")
+
+
+class TestModalRejectsMultiService:
+    """#248: single-container backends reject non-main services with a clear error."""
+
+    @pytest.mark.asyncio
+    async def test_modal_exec_rejects_non_main_service(self) -> None:
+        """#248: Modal is single-container — targeting another service must error."""
+        pytest.importorskip("tenacity")  # modal_impl optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        sandbox._persistent_env = {}
+        sandbox.default_user = None
+
+        with pytest.raises(ValueError, match="single-container"):
+            await sandbox.exec("echo hi", service="target")


### PR DESCRIPTION
## Summary

Addresses #248 — adds **multi-container / docker-network support** for vulhub-style CVE tasks by making compose **service selection** a first-class concept across the sandbox `exec` path. The agent still runs in the `main` container, but task authors and verifier code can now run commands in *any* additional compose service (target / database containers) on the same Docker network.

This is a complete, well-scoped increment — it directly resolves issue limitations #1 (hardcoded service in `DockerProcess`) and #2 (no multi-service exec API), and unblocks the Python/hook-driven path for target-side flag injection and verification.

## What's implemented

- **`BaseSandbox.exec(..., service="main")`** — new `service` parameter on the abstract exec surface, plus an `exec_in_service(service, command, ...)` ergonomic wrapper. `is_dir`/`is_file` also accept `service`.
- **`DockerSandbox`** — `exec` runs the command in the named compose service; new `DockerSandbox.services()` enumerates every service declared in the task (`docker compose config --services`).
- **Daytona** — the DinD compose strategy honors `service`; the direct (non-compose) Daytona strategy and **Modal** (both single-container) reject non-`main` services with a clear, actionable error.
- **`DockerProcess.from_sandbox_env(env, service=...)`** — the ACP agent process can be launched into a dedicated attacker container (e.g. a Kali service) instead of always `main`. (The `DockerProcess.service` field already existed; this exposes it.)
- **`Environment.exec` / `Environment.exec_in_service`** — `service` threads through to task authors and pre/post-agent hooks.
- **Docs** — new "Multi-container tasks" section in `docs/task-authoring.md` showing `environment/docker-compose.yaml` with a target service and the verification pattern.

### Tests

`tests/test_sandbox_multi_service.py` — 14 unit tests (no Docker/Daytona infra; optional-backend tests `importorskip`). Covers Docker service selection, `services()` enumeration, `DockerProcess` service launch, Environment passthrough, Daytona DinD service exec, and single-container rejection. Full suite: **1227 passed, 20 skipped**.

## What's deferred (needs product/design decisions)

The issue describes 6 sub-problems. The remaining items need design choices and are intentionally **not** guess-built:

- **Item 3 (sandbox hardening across containers)** — `setup_sandbox_user` / `lockdown_paths` still apply only to `main`. Whether (and how) to harden target containers is a policy question — vulnerable targets are often deliberately unhardened.
- **Item 4 (`test.sh`-based target-side verification)** — `test.sh` runs *inside* the `main` container and cannot reach `docker compose`. Target-side checks today work via the **Python/hook API** added here (`env.exec_in_service(...)`). A declarative `[verifier] service = "target"` knob, or a host-side verifier runner, is a follow-up.
- **Item 5 (cross-container state / flag plumbing)** — flag values flowing from target → verifier need a task-schema convention (e.g. a `[multi_container]` section). Deferred pending schema design.
- **Item 6 (host-side script execution)** — running verifier scripts on the *host* via `docker exec` is a security-model change (host trust boundary) and is out of scope for this increment.

## Design notes & assumptions

- The agent container is always `main`; additional services are siblings on the default compose network and reachable by service name.
- `service` is keyword, defaults to `"main"` — fully backward compatible; no existing call site changes behavior.
- Single-container backends fail loud rather than silently running in the wrong place.
- No new task.toml schema — multi-container topology lives entirely in the task's existing `environment/docker-compose.yaml`.

## CI

`ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` all green locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the core `exec` API across multiple sandbox backends (Docker/Daytona/Modal) and affects how commands are dispatched to containers, though defaults preserve existing single-container behavior.
> 
> **Overview**
> Enables multi-container tasks by threading a compose `service` selector through the sandbox execution surface, so task authors/verifiers can run commands in non-`main` containers and add target-side checks.
> 
> Updates Docker and Daytona DinD backends to honor `service` in `exec`, adds `exec_in_service` helpers plus `is_file`/`is_dir` service support, and makes single-container backends (Modal, direct Daytona) fail loudly on non-`main` services. Also exposes service selection when launching the live agent process via `DockerProcess.from_sandbox_env(..., service=...)`, documents multi-container authoring, and adds unit tests covering service routing, enumeration, and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e12c76e211a8fa139c427fa6a7b3a4a6103a2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->