### PR TITLE
feat: support LLM-as-judge as a first-class task verification method

### DIFF
--- a/docs/llm-judge.md
+++ b/docs/llm-judge.md
@@ -8,24 +8,48 @@ Use an LLM to evaluate agent outputs against a rubric instead of deterministic t
 Use LLM-as-judge when the task output is subjective, open-ended, or hard to verify with unit tests — legal analysis, code review quality, document drafting, research summaries. For tasks with a clear right answer (e.g. "write fizzbuzz"), stick with deterministic `test.sh` verifiers.
 
 BenchFlow's LLM judge supports:
+- **First-class `[verifier]` type** — `type = "llm-judge"` in `task.toml`, no `test.sh` needed
 - **Multi-criterion rubrics** with binary, likert, and numeric scoring
 - **Per-criterion weights** for non-uniform importance
 - **Dense reward events** emitted per criterion during evaluation
 - **Multi-provider routing** across Anthropic, OpenAI, and Google models
 - **Configurable aggregation** (weighted mean, all-pass, any-pass, threshold)
 
+The judge is a **first-class verification method** alongside the deterministic
+`test.sh` verifier. A task selects it with one line of config — the framework
+handles deliverable collection, prompting, provider routing, retries, and
+reward aggregation.
+
 ---
 
 ## Quick start
 
-### 1. Write a `rubric.toml`
-
-Place this alongside your task's `tests/` directory:
+### 1. Select the judge verifier in `task.toml`
 
 ```toml
-[judge]
-model = "claude-sonnet-4-6"
+[verifier]
+type = "llm-judge"
+timeout_sec = 600
 
+[verifier.judge]
+model = "claude-sonnet-4-6"          # judge model (provider routed from prefix)
+rubric_path = "tests/rubric.toml"    # rubric file, relative to the task dir
+input_dir = "/app"                   # sandbox dir holding agent deliverables
+
+# API keys for the judge — resolved from the host environment / .env
+[verifier.env]
+ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"
+```
+
+That's the entire verifier. There is **no `tests/test.sh`** to write — the
+`Verifier` downloads the agent's deliverables from `input_dir`, scores them
+against the rubric, and writes `reward.json` itself.
+
+### 2. Write a `rubric.toml`
+
+Place it where `rubric_path` points (by convention `tests/rubric.toml`):
+
+```toml
 [[criterion]]
 name = "accuracy"
 description = "The response accurately addresses the question with correct facts"
@@ -43,7 +67,46 @@ weight = 1.0
 aggregation = "weighted_mean"
 ```
 
-### 2. Use `LLMJudgeRewardFunc` in your verifier
+A Harvey LAB style `rubric.json` works too — set `rubric_path = "tests/rubric.json"`:
+
+```json
+{
+  "title": "Task Title",
+  "criteria": [
+    {"id": "criterion-1", "title": "...", "match_criteria": "What constitutes a pass"}
+  ]
+}
+```
+
+That's it. Run the task as usual — the reward is the proportion of criteria
+passed (or the configured aggregation), a partial float in `[0, 1]`.
+
+---
+
+## `[verifier]` reference
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `type` | string | `"test-script"` | `"test-script"` (run `tests/test.sh`) or `"llm-judge"` |
+| `timeout_sec` | float | `600` | Overall verifier timeout |
+| `env` | table | `{}` | Env vars for the verifier — judge API keys go here |
+
+### `[verifier.judge]` (used when `type = "llm-judge"`)
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `model` | string | `"claude-sonnet-4-6"` | Judge model; provider routed from prefix |
+| `rubric_path` | string | `"tests/rubric.toml"` | Rubric file relative to the task dir (`.toml` or `.json`) |
+| `input_dir` | string | `"/app"` | Sandbox dir whose contents are graded |
+| `input_type` | string | `"deliverables"` | `"deliverables"`, `"trajectory"`, or `"both"` |
+| `context` | string | `""` | Extra judge context (defaults to the task instruction) |
+
+---
+
+## Library use — `LLMJudgeRewardFunc`
+
+The judge is also a composable `RewardFunc`, usable directly or from a custom
+`test.sh` verifier:
 
 ```python
 import asyncio
@@ -55,27 +118,12 @@ score = asyncio.run(func.score(Path("/app")))
 print(f"Score: {score:.2f}")
 ```
 
-Or use auto-discovery — if `rubric.toml` is in the rollout directory or its parent, it's found automatically:
+Auto-discovery — if `rubric.toml`/`rubric.json` is in the rollout directory or
+its parent, it's found automatically:
 
 ```python
 func = LLMJudgeRewardFunc()
-score = asyncio.run(func.score(Path("/app")))  # finds rubric.toml in /app/ or /
-```
-
-### 3. Write the reward
-
-```bash
-#!/bin/bash
-# tests/test.sh
-python3 -c "
-import asyncio
-from pathlib import Path
-from benchflow.rewards import LLMJudgeRewardFunc
-
-func = LLMJudgeRewardFunc(rubric_path=Path('/tests/rubric.toml'))
-score = asyncio.run(func.score(Path('/app')))
-print(score)
-" > /logs/verifier/reward.txt
+score = asyncio.run(func.score(Path("/app")))
 ```
 
 ---
@@ -316,11 +364,13 @@ from benchflow import (
     LLMJudgeRewardFunc,
     RubricConfig,
     ScoringConfig,
+    load_rubric,        # dispatches on extension (.toml / .json)
+    load_rubric_json,
     load_rubric_toml,
 )
 
-# Load and inspect a rubric
-rubric = load_rubric_toml(Path("rubric.toml"))
+# Load and inspect a rubric (TOML or Harvey LAB style JSON)
+rubric = load_rubric(Path("rubric.json"))
 print(f"Model: {rubric.judge.model}")
 print(f"Criteria: {len(rubric.criteria)}")
 for c in rubric.criteria:
@@ -331,12 +381,26 @@ for c in rubric.criteria:
 
 ## Worked example — Harvey LAB legal task
 
-A legal document analysis task with per-criterion judge scoring:
+A legal document analysis task scored entirely by config — no `test.sh`:
 
 ```toml
-# rubric.toml
-[judge]
+# task.toml
+[verifier]
+type = "llm-judge"
+timeout_sec = 600
+
+[verifier.judge]
 model = "claude-sonnet-4-6"
+rubric_path = "tests/rubric.toml"
+input_dir = "/app"
+
+[verifier.env]
+ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"
+```
+
+```toml
+# tests/rubric.toml
+[judge]
 files = ["analysis.md"]
 
 [[criterion]]
@@ -364,25 +428,8 @@ weight = 1.0
 aggregation = "weighted_mean"
 ```
 
-```bash
-# tests/test.sh
-#!/bin/bash
-pip install benchflow 2>/dev/null
-
-python3 << 'EOF'
-import asyncio
-from pathlib import Path
-from benchflow.rewards import LLMJudgeRewardFunc
-
-async def main():
-    func = LLMJudgeRewardFunc(rubric_path=Path("/tests/rubric.toml"))
-    score = await func.score(Path("/app"))
-    with open("/logs/verifier/reward.txt", "w") as f:
-        f.write(str(score))
-
-asyncio.run(main())
-EOF
-```
+The framework downloads the agent's deliverables from `/app`, grades each
+criterion, aggregates, and writes `reward.json` — no scripting required.
 
 ---
 

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -56,6 +56,8 @@ from benchflow.rewards import (
     StringMatchRewardFunc,
     TestRewardFunc,
     VerifyResult,
+    load_rubric,
+    load_rubric_json,
     load_rubric_toml,
 )
 from benchflow.rollout import Rollout, RolloutConfig
@@ -115,6 +117,8 @@ __all__ = [
     "JudgeConfig",
     "RubricConfig",
     "ScoringConfig",
+    "load_rubric",
+    "load_rubric_json",
     "load_rubric_toml",
     # Sandbox protocol
     "Sandbox",

--- a/src/benchflow/rewards/__init__.py
+++ b/src/benchflow/rewards/__init__.py
@@ -14,6 +14,8 @@ from benchflow.rewards.rubric_config import (
     JudgeConfig,
     RubricConfig,
     ScoringConfig,
+    load_rubric,
+    load_rubric_json,
     load_rubric_toml,
 )
 
@@ -30,5 +32,7 @@ __all__ = [
     "StringMatchRewardFunc",
     "TestRewardFunc",
     "VerifyResult",
+    "load_rubric",
+    "load_rubric_json",
     "load_rubric_toml",
 ]

--- a/src/benchflow/rewards/builtins.py
+++ b/src/benchflow/rewards/builtins.py
@@ -15,7 +15,7 @@ from benchflow.rewards.rubric_config import (
     JudgeConfig,
     RubricConfig,
     ScoringConfig,
-    load_rubric_toml,
+    load_rubric,
 )
 
 logger = logging.getLogger(__name__)
@@ -170,6 +170,9 @@ class LLMJudgeRewardFunc:
         self._rubric_path = rubric_path
         self._inline_criteria = criteria
         self._events: list[RewardEvent] = []
+        # An explicit judge model overrides the model declared inside a rubric
+        # file — so a task can configure the judge per ``task.toml`` (#270).
+        self._model_override = judge_model
 
     @property
     def events(self) -> list[RewardEvent]:
@@ -180,7 +183,7 @@ class LLMJudgeRewardFunc:
         """Resolve rubric config from explicit path, inline criteria, or
         auto-discovery in the rollout directory."""
         if self._rubric_path is not None:
-            return load_rubric_toml(self._rubric_path)
+            return load_rubric(self._rubric_path)
 
         if self._inline_criteria is not None:
             parsed = []
@@ -205,13 +208,15 @@ class LLMJudgeRewardFunc:
                 scoring=ScoringConfig(),
             )
 
-        # Auto-discover rubric.toml in rollout directory
+        # Auto-discover rubric.toml / rubric.json in rollout directory
         for candidate in [
             rollout_dir / "rubric.toml",
+            rollout_dir / "rubric.json",
             rollout_dir / ".." / "rubric.toml",
+            rollout_dir / ".." / "rubric.json",
         ]:
             if candidate.exists():
-                return load_rubric_toml(candidate)
+                return load_rubric(candidate)
 
         return None
 
@@ -249,7 +254,9 @@ class LLMJudgeRewardFunc:
         from benchflow.rewards.file_readers import find_deliverables
         from benchflow.rewards.llm import call_judge, parse_verdict
 
-        model = rubric.judge.model
+        # An explicit judge model (e.g. from [verifier.judge].model) overrides
+        # the model declared inside the rubric file.
+        model = self._model_override or rubric.judge.model
         deliverables = find_deliverables(rollout_dir)
 
         # Also check common subdirectories

--- a/src/benchflow/rewards/rubric_config.py
+++ b/src/benchflow/rewards/rubric_config.py
@@ -1,7 +1,8 @@
-"""Declarative rubric configuration parsed from ``rubric.toml``."""
+"""Declarative rubric configuration parsed from ``rubric.toml`` / ``rubric.json``."""
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
@@ -125,3 +126,53 @@ def load_rubric_toml(path: Path) -> RubricConfig:
     scoring = _parse_scoring(data.get("scoring", {}))
 
     return RubricConfig(judge=judge, criteria=criteria, scoring=scoring)
+
+
+def load_rubric_json(path: Path) -> RubricConfig:
+    """Load and parse a ``rubric.json`` file (Harvey LAB style).
+
+    The JSON schema::
+
+        {
+          "title": "Task Title",
+          "criteria": [
+            {"id": "c-1", "title": "...", "match_criteria": "..."}
+          ]
+        }
+
+    Optional ``[judge]`` and ``[scoring]`` objects are also honoured so a
+    JSON rubric can be fully self-describing.
+    """
+    data = json.loads(path.read_text(encoding="utf-8"))
+
+    judge = _parse_judge(data.get("judge", {}))
+    scoring = _parse_scoring(data.get("scoring", {}))
+    criteria: list[Criterion] = []
+    for raw in data.get("criteria", []):
+        criteria.append(
+            Criterion(
+                description=raw.get("match_criteria")
+                or raw.get("description")
+                or raw.get("title", ""),
+                type=raw.get("type", "binary"),
+                name=raw.get("id") or raw.get("name") or raw.get("title"),
+                points=raw.get("points", 5),
+                min=raw.get("min", 0.0),
+                max=raw.get("max", 100.0),
+                weight=raw.get("weight", 1.0),
+                files=raw.get("files", []),
+            )
+        )
+
+    return RubricConfig(judge=judge, criteria=criteria, scoring=scoring)
+
+
+def load_rubric(path: Path) -> RubricConfig:
+    """Load a rubric from either a ``.toml`` or ``.json`` file.
+
+    Dispatches on the file extension; ``.json`` is parsed as a Harvey LAB
+    style rubric, anything else as native TOML.
+    """
+    if path.suffix.lower() == ".json":
+        return load_rubric_json(path)
+    return load_rubric_toml(path)

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -11,6 +11,7 @@
 from benchflow.task.config import (
     ORG_NAME_PATTERN,
     Author,
+    JudgeVerifierConfig,
     MCPServerConfig,
     PackageInfo,
     SandboxConfig,
@@ -33,6 +34,7 @@ from benchflow.task.verifier import (
     DownloadVerifierDirError,
     RewardFileEmptyError,
     RewardFileNotFoundError,
+    RubricNotFoundError,
     Verifier,
     VerifierOutputParseError,
     VerifierResult,
@@ -46,6 +48,7 @@ __all__ = [
     # Configuration ($C$)
     "SandboxConfig",
     "VerifierConfig",
+    "JudgeVerifierConfig",
     "TaskAgentConfig",
     "SolutionConfig",
     "MCPServerConfig",
@@ -61,6 +64,7 @@ __all__ = [
     "VerifierResult",
     "RewardFileEmptyError",
     "RewardFileNotFoundError",
+    "RubricNotFoundError",
     "VerifierOutputParseError",
     "AddTestsDirError",
     "DownloadVerifierDirError",

--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 import tomllib
 import warnings
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -83,14 +83,64 @@ class MCPServerConfig(BaseModel):
         return self
 
 
-class VerifierConfig(BaseModel):
-    """Verifier ($V$) configuration — maps completion → reward."""
+class JudgeVerifierConfig(BaseModel):
+    """The ``[verifier.judge]`` section — config for the LLM-as-judge verifier.
 
+    Used only when ``[verifier].type == "llm-judge"``.
+    """
+
+    model: str = Field(
+        default="claude-sonnet-4-6",
+        description="Judge model identifier. Provider is routed from the prefix "
+        "(claude-* / gpt-* / gemini-*).",
+    )
+    rubric_path: str = Field(
+        default="tests/rubric.toml",
+        description="Path to the rubric file, relative to the task directory. "
+        "Both rubric.toml (native) and rubric.json (Harvey LAB style) are "
+        "supported.",
+    )
+    input_dir: str = Field(
+        default="/app",
+        description="Directory inside the sandbox holding the agent's "
+        "deliverables. Its contents are downloaded and shown to the judge.",
+    )
+    input_type: Literal["deliverables", "trajectory", "both"] = Field(
+        default="deliverables",
+        description="What the judge evaluates: agent output files "
+        "('deliverables'), the ACP trajectory ('trajectory'), or both.",
+    )
+    context: str = Field(
+        default="",
+        description="Optional extra context passed to the judge prompt "
+        "(defaults to the task instruction when empty).",
+    )
+
+
+class VerifierConfig(BaseModel):
+    """Verifier ($V$) configuration — maps completion → reward.
+
+    ``type`` selects the verification method:
+
+    - ``"test-script"`` (default): run ``tests/test.sh`` in the sandbox and
+      parse ``reward.txt`` / ``reward.json``.
+    - ``"llm-judge"``: score the agent's deliverables against a human-authored
+      rubric using an LLM judge (see :class:`JudgeVerifierConfig`).
+    """
+
+    type: Literal["test-script", "llm-judge"] = Field(
+        default="test-script",
+        description="Verification method.",
+    )
     timeout_sec: float = 600.0
     env: dict[str, str] = Field(default_factory=dict)
     user: str | int | None = Field(
         default=None,
         description="Username or UID to run the verifier as.",
+    )
+    judge: JudgeVerifierConfig = Field(
+        default_factory=JudgeVerifierConfig,
+        description="LLM-judge configuration (used when type == 'llm-judge').",
     )
 
 

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -1,14 +1,21 @@
 """Verifier ($V$) — maps agent completion to a reward signal.
 
-Internalized from Harbor's Verifier class. Runs test.sh inside the sandbox
-and parses reward files.
+Internalized from Harbor's Verifier class. Supports two verification methods,
+selected by ``[verifier].type`` in ``task.toml``:
+
+- ``"test-script"`` (default): run ``tests/test.sh`` inside the sandbox and
+  parse ``reward.txt`` / ``reward.json``.
+- ``"llm-judge"``: download the agent's deliverables and grade them against a
+  human-authored rubric using an LLM judge (see #270).
 """
 
 from __future__ import annotations
 
 import json
 import logging
+import os
 import shlex
+from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel
@@ -45,13 +52,21 @@ class DownloadVerifierDirError(Exception):
     pass
 
 
-class Verifier:
-    """Runs the task's test.sh verifier inside the sandbox and parses rewards.
+class RubricNotFoundError(Exception):
+    """Raised when an llm-judge verifier cannot locate its rubric file."""
 
-    The verifier:
-    1. Uploads the task's tests/ directory into the sandbox at /tests
-    2. Runs test.sh with configured env vars and user
-    3. Parses reward from reward.txt or reward.json
+
+class Verifier:
+    """Runs the task's verifier and parses rewards.
+
+    Two verification methods are supported (selected by ``verifier.type``):
+
+    1. ``test-script`` — uploads the task's ``tests/`` directory into the
+       sandbox at ``/tests``, runs ``test.sh`` with configured env vars/user,
+       and parses the reward from ``reward.txt`` or ``reward.json``.
+    2. ``llm-judge`` — downloads the agent's deliverables from the sandbox and
+       grades them against a rubric using an LLM judge, writing the aggregate
+       reward to ``reward.json``.
     """
 
     def __init__(
@@ -91,7 +106,18 @@ class Verifier:
             ) from e
 
     async def verify(self) -> VerifierResult:
-        """Run the verifier and return the reward result."""
+        """Run the configured verifier and return the reward result."""
+        verifier_type = getattr(self._task.config.verifier, "type", "test-script")
+        if verifier_type == "llm-judge":
+            return await self._verify_llm_judge()
+        return await self._verify_test_script()
+
+    # ------------------------------------------------------------------
+    # test-script verifier (default — Harbor-compatible)
+    # ------------------------------------------------------------------
+
+    async def _verify_test_script(self) -> VerifierResult:
+        """Run the task's ``test.sh`` verifier and return the reward result."""
         try:
             await self._sandbox.upload_dir(
                 source_dir=self._task.paths.tests_dir,
@@ -164,3 +190,76 @@ class Verifier:
             )
 
         return VerifierResult(rewards=rewards)
+
+    # ------------------------------------------------------------------
+    # llm-judge verifier (#270)
+    # ------------------------------------------------------------------
+
+    def _resolve_rubric_path(self) -> Path:
+        """Locate the rubric file relative to the task directory."""
+        judge = self._task.config.verifier.judge
+        rubric_path = Path(judge.rubric_path)
+        if not rubric_path.is_absolute():
+            rubric_path = Path(self._task.task_dir) / rubric_path
+        if not rubric_path.exists():
+            raise RubricNotFoundError(
+                f"llm-judge rubric not found at {rubric_path}. Set "
+                f"[verifier.judge].rubric_path in task.toml."
+            )
+        return rubric_path
+
+    async def _download_deliverables(self) -> Path:
+        """Download the agent's deliverables from the sandbox.
+
+        Returns the local directory the judge should read from.
+        """
+        judge = self._task.config.verifier.judge
+        dest = self._rollout_paths.verifier_dir / "deliverables"
+        dest.mkdir(parents=True, exist_ok=True)
+        try:
+            await self._sandbox.download_dir(
+                source_dir=judge.input_dir,
+                target_dir=dest,
+            )
+        except Exception as e:
+            self._logger.warning(
+                "Failed to download deliverables from %s: %s", judge.input_dir, e
+            )
+        return dest
+
+    async def _verify_llm_judge(self) -> VerifierResult:
+        """Score agent deliverables against a rubric with an LLM judge."""
+        from benchflow.rewards.builtins import LLMJudgeRewardFunc
+
+        judge = self._task.config.verifier.judge
+
+        # API keys for the judge come from [verifier.env]; export them so the
+        # provider SDKs (anthropic / openai / google) pick them up.
+        if self._task.config.verifier.env:
+            resolved = resolve_env_vars(self._task.config.verifier.env)
+            for key, value in resolved.items():
+                os.environ.setdefault(key, value)
+
+        rubric_path = self._resolve_rubric_path()
+        deliverables_dir = await self._download_deliverables()
+
+        context = judge.context or getattr(self._task, "instruction", "") or ""
+
+        reward_func = LLMJudgeRewardFunc(
+            prompt=context,
+            rubric_path=rubric_path,
+            judge_model=judge.model,
+        )
+        score = await reward_func.score(deliverables_dir)
+
+        self._logger.info(
+            "llm-judge verifier: %d criteria → reward %.4f",
+            len(reward_func.events),
+            score,
+        )
+
+        # Persist the reward in the standard location for downstream tooling.
+        self._rollout_paths.reward_json_path.write_text(
+            json.dumps({"reward": score}, indent=2)
+        )
+        return VerifierResult(rewards={"reward": score})

--- a/tests/test_llm_judge_verifier.py
+++ b/tests/test_llm_judge_verifier.py
@@ -1,0 +1,292 @@
+"""Tests for the first-class llm-judge verifier wired into ``Verifier`` (#270).
+
+These tests exercise the integration between ``task.toml`` config
+(``[verifier].type = "llm-judge"``) and ``Verifier.verify()``. All LLM
+provider calls are mocked — no live API keys are required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from benchflow.task import RolloutPaths, Verifier
+from benchflow.task.config import TaskConfig
+from benchflow.task.verifier import RubricNotFoundError
+
+_MOCK_PASS = '```json\n{"verdict": "pass", "reasoning": "good"}\n```'
+_MOCK_FAIL = '```json\n{"verdict": "fail", "reasoning": "bad"}\n```'
+
+
+# ---------------------------------------------------------------------------
+# Config parsing (#270): [verifier].type and [verifier.judge]
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierConfig:
+    def test_default_type_is_test_script(self) -> None:
+        """#270: existing tasks keep the test-script verifier by default."""
+        cfg = TaskConfig.model_validate_toml('version = "1.0"\n[verifier]\n')
+        assert cfg.verifier.type == "test-script"
+
+    def test_llm_judge_type(self) -> None:
+        """#270: task.toml can opt into the llm-judge verifier."""
+        toml = """\
+version = "1.0"
+
+[verifier]
+type = "llm-judge"
+timeout_sec = 600
+
+[verifier.judge]
+model = "claude-haiku-4-5"
+rubric_path = "tests/rubric.json"
+input_dir = "/app/output"
+input_type = "deliverables"
+"""
+        cfg = TaskConfig.model_validate_toml(toml)
+        assert cfg.verifier.type == "llm-judge"
+        assert cfg.verifier.judge.model == "claude-haiku-4-5"
+        assert cfg.verifier.judge.rubric_path == "tests/rubric.json"
+        assert cfg.verifier.judge.input_dir == "/app/output"
+        assert cfg.verifier.judge.input_type == "deliverables"
+
+    def test_judge_defaults(self) -> None:
+        """#270: judge config has sensible defaults when omitted."""
+        cfg = TaskConfig.model_validate_toml(
+            'version = "1.0"\n[verifier]\ntype = "llm-judge"\n'
+        )
+        assert cfg.verifier.judge.model == "claude-sonnet-4-6"
+        assert cfg.verifier.judge.rubric_path == "tests/rubric.toml"
+        assert cfg.verifier.judge.input_dir == "/app"
+
+    def test_invalid_type_rejected(self) -> None:
+        """#270: an unknown verifier type fails validation."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            TaskConfig.model_validate_toml(
+                'version = "1.0"\n[verifier]\ntype = "magic"\n'
+            )
+
+
+# ---------------------------------------------------------------------------
+# Verifier.verify() — llm-judge branch
+# ---------------------------------------------------------------------------
+
+
+def _make_task(tmp_path: Path, toml: str, instruction: str = "Do the task.") -> object:
+    """Build a lightweight task stub backed by a real task directory."""
+    task_dir = tmp_path / "task"
+    task_dir.mkdir(exist_ok=True)
+    task = MagicMock()
+    task.task_dir = task_dir
+    task.paths.task_dir = task_dir
+    task.config = TaskConfig.model_validate_toml(toml)
+    task.instruction = instruction
+    return task
+
+
+def _judge_toml(rubric_path: str = "tests/rubric.json") -> str:
+    return f"""\
+version = "1.0"
+
+[verifier]
+type = "llm-judge"
+
+[verifier.judge]
+model = "claude-haiku-4-5"
+rubric_path = "{rubric_path}"
+input_dir = "/app"
+"""
+
+
+def _make_sandbox(deliverables: dict[str, str]) -> MagicMock:
+    """A sandbox stub whose download_dir drops the given files into dest."""
+    sandbox = MagicMock()
+
+    async def fake_download_dir(source_dir: str, target_dir: Path) -> None:
+        dest = Path(target_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        for name, content in deliverables.items():
+            (dest / name).write_text(content)
+
+    sandbox.download_dir = AsyncMock(side_effect=fake_download_dir)
+    return sandbox
+
+
+class TestLLMJudgeVerifier:
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_routes_to_llm_judge(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """#270: type=llm-judge routes verify() through the judge path."""
+        mock_judge.return_value = _MOCK_PASS
+        task = _make_task(tmp_path, _judge_toml())
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps({"criteria": [{"id": "c1", "match_criteria": "Correct?"}]})
+        )
+        sandbox = _make_sandbox({"answer.txt": "the answer"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        verifier = Verifier(task, rollout_paths, sandbox)
+        result = await verifier.verify()
+
+        assert result.rewards == {"reward": 1.0}
+        # never touches the test-script path
+        sandbox.upload_dir.assert_not_called()
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_partial_reward(self, mock_judge: AsyncMock, tmp_path: Path) -> None:
+        """#270: judge produces partial rewards in [0, 1]."""
+        mock_judge.side_effect = [_MOCK_PASS, _MOCK_FAIL]
+        task = _make_task(tmp_path, _judge_toml())
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps(
+                {
+                    "criteria": [
+                        {"id": "c1", "match_criteria": "A"},
+                        {"id": "c2", "match_criteria": "B"},
+                    ]
+                }
+            )
+        )
+        sandbox = _make_sandbox({"memo.md": "a memo"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+        assert result.rewards == {"reward": 0.5}
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_writes_reward_json(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """#270: judge reward is persisted to reward.json like test-script."""
+        mock_judge.return_value = _MOCK_PASS
+        task = _make_task(tmp_path, _judge_toml())
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps({"criteria": [{"id": "c1", "match_criteria": "ok"}]})
+        )
+        sandbox = _make_sandbox({"out.txt": "output"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        reward_json = rollout_paths.reward_json_path
+        assert reward_json.exists()
+        assert json.loads(reward_json.read_text())["reward"] == 1.0
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_toml_rubric_supported(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """#270: a native rubric.toml works as the judge rubric too."""
+        mock_judge.return_value = _MOCK_PASS
+        task = _make_task(tmp_path, _judge_toml(rubric_path="tests/rubric.toml"))
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.toml").write_text(
+            '[[criterion]]\ndescription = "Is it good?"\n'
+        )
+        sandbox = _make_sandbox({"out.txt": "output"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+        assert result.rewards == {"reward": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_missing_rubric_raises(self, tmp_path: Path) -> None:
+        """#270: a misconfigured rubric path fails loudly."""
+        task = _make_task(tmp_path, _judge_toml())
+        sandbox = _make_sandbox({})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        with pytest.raises(RubricNotFoundError, match="rubric not found"):
+            await Verifier(task, rollout_paths, sandbox).verify()
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_judge_env_exported(
+        self, mock_judge: AsyncMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#270: [verifier.env] keys are exported for the judge SDK."""
+        mock_judge.return_value = _MOCK_PASS
+        monkeypatch.setenv("MY_JUDGE_KEY", "secret-123")
+        monkeypatch.delenv("RESOLVED_KEY", raising=False)
+        toml = _judge_toml() + '\n[verifier.env]\nRESOLVED_KEY = "${MY_JUDGE_KEY}"\n'
+        task = _make_task(tmp_path, toml)
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps({"criteria": [{"id": "c1", "match_criteria": "ok"}]})
+        )
+        sandbox = _make_sandbox({"out.txt": "output"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        import os
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+        assert os.environ.get("RESOLVED_KEY") == "secret-123"
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_download_failure_is_tolerated(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """#270: a sandbox download error degrades to an empty deliverables set,
+        not a verifier crash."""
+        mock_judge.return_value = _MOCK_FAIL
+        task = _make_task(tmp_path, _judge_toml())
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps({"criteria": [{"id": "c1", "match_criteria": "ok"}]})
+        )
+        sandbox = MagicMock()
+        sandbox.download_dir = AsyncMock(side_effect=RuntimeError("network down"))
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+        # Judge still runs (against no deliverables) and returns a reward.
+        assert result.rewards == {"reward": 0.0}
+
+
+# ---------------------------------------------------------------------------
+# Verifier.verify() — test-script branch stays the default (regression)
+# ---------------------------------------------------------------------------
+
+
+class TestTestScriptStillDefault:
+    @pytest.mark.asyncio
+    async def test_default_runs_test_script(self, tmp_path: Path) -> None:
+        """#270: tasks without type still take the test-script path."""
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        task.paths.tests_dir = task.task_dir / "tests"
+        task.paths.test_path = task.task_dir / "tests" / "test.sh"
+
+        sandbox = MagicMock()
+        sandbox.upload_dir = AsyncMock()
+        sandbox.exec = AsyncMock()
+        sandbox.is_mounted = True
+
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+        rollout_paths.reward_text_path.write_text("0.75")
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+        assert result.rewards == {"reward": 0.75}
+        sandbox.upload_dir.assert_called_once()

--- a/tests/test_rubric_config.py
+++ b/tests/test_rubric_config.py
@@ -1,7 +1,8 @@
-"""Tests for rubric.toml parsing (ENG-55)."""
+"""Tests for rubric.toml / rubric.json parsing (ENG-55, #270)."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -11,6 +12,8 @@ from benchflow.rewards.rubric_config import (
     JudgeConfig,
     RubricConfig,
     ScoringConfig,
+    load_rubric,
+    load_rubric_json,
     load_rubric_toml,
 )
 
@@ -173,3 +176,88 @@ class TestDefaults:
         r = RubricConfig()
         assert r.criteria == []
         assert r.judge.model == "claude-sonnet-4-6"
+
+
+# ---------------------------------------------------------------------------
+# Harvey LAB style rubric.json parsing (#270)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadRubricJson:
+    def test_harvey_lab_rubric(self, tmp_path: Path) -> None:
+        """#270: a Harvey LAB rubric.json maps id/title/match_criteria."""
+        rubric_file = tmp_path / "rubric.json"
+        rubric_file.write_text(
+            json.dumps(
+                {
+                    "title": "Corporate M&A Analysis",
+                    "criteria": [
+                        {
+                            "id": "criterion-1",
+                            "title": "Identifies the purchase price",
+                            "match_criteria": "The memo states the $X price.",
+                        },
+                        {
+                            "id": "criterion-2",
+                            "title": "Flags the indemnity cap",
+                            "match_criteria": "The memo discusses the cap.",
+                        },
+                    ],
+                }
+            )
+        )
+
+        cfg = load_rubric_json(rubric_file)
+
+        assert len(cfg.criteria) == 2
+        assert cfg.criteria[0].name == "criterion-1"
+        assert cfg.criteria[0].id == "criterion-1"
+        assert cfg.criteria[0].description == "The memo states the $X price."
+        assert cfg.criteria[0].type == "binary"
+        # judge/scoring defaults apply when absent
+        assert cfg.judge.model == "claude-sonnet-4-6"
+        assert cfg.scoring.aggregation == "weighted_mean"
+
+    def test_rubric_json_with_judge_and_scoring(self, tmp_path: Path) -> None:
+        """#270: a JSON rubric may carry its own judge/scoring config."""
+        rubric_file = tmp_path / "rubric.json"
+        rubric_file.write_text(
+            json.dumps(
+                {
+                    "criteria": [{"id": "c1", "match_criteria": "ok"}],
+                    "judge": {"model": "gpt-4o"},
+                    "scoring": {"aggregation": "all_pass"},
+                }
+            )
+        )
+        cfg = load_rubric_json(rubric_file)
+        assert cfg.judge.model == "gpt-4o"
+        assert cfg.scoring.aggregation == "all_pass"
+
+    def test_rubric_json_title_fallback(self, tmp_path: Path) -> None:
+        """A criterion with no match_criteria falls back to its title."""
+        rubric_file = tmp_path / "rubric.json"
+        rubric_file.write_text(
+            json.dumps({"criteria": [{"id": "c1", "title": "Be correct"}]})
+        )
+        cfg = load_rubric_json(rubric_file)
+        assert cfg.criteria[0].description == "Be correct"
+
+
+class TestLoadRubricDispatch:
+    def test_dispatches_to_json(self, tmp_path: Path) -> None:
+        """#270: load_rubric routes .json files to the JSON parser."""
+        rubric_file = tmp_path / "rubric.json"
+        rubric_file.write_text(
+            json.dumps({"criteria": [{"id": "c1", "match_criteria": "ok"}]})
+        )
+        cfg = load_rubric(rubric_file)
+        assert len(cfg.criteria) == 1
+        assert cfg.criteria[0].id == "c1"
+
+    def test_dispatches_to_toml(self, tmp_path: Path) -> None:
+        """#270: load_rubric routes .toml files to the TOML parser."""
+        rubric_file = tmp_path / "rubric.toml"
+        rubric_file.write_text('[[criterion]]\ndescription = "Does it work?"\n')
+        cfg = load_rubric(rubric_file)
+        assert len(cfg.criteria) == 1


### PR DESCRIPTION
Closes #270

## Summary

Makes **LLM-as-judge** a first-class task verification method, selectable from `task.toml` alongside the deterministic `test.sh` verifier. Previously the rubric-based judge infrastructure (`LLMJudgeRewardFunc`, multi-provider routing, file readers, rubric parsing) existed but was **not wired into the `Verifier` execution path** — `Verifier` only ran `test.sh`. Benchmarks like Harvey LAB had to hand-code the entire judge pipeline inside a `test.sh`.

Now a task selects the judge with one config block — the framework downloads deliverables, prompts the LLM, routes the provider, retries, aggregates, and writes the reward.

## Design

### `task.toml` config

```toml
[verifier]
type = "llm-judge"          # "test-script" (default) | "llm-judge"
timeout_sec = 600

[verifier.judge]
model = "claude-sonnet-4-6"        # provider routed from the model prefix
rubric_path = "tests/rubric.toml"  # .toml (native) or .json (Harvey LAB style)
input_dir = "/app"                 # sandbox dir holding the agent's deliverables
input_type = "deliverables"        # "deliverables" | "trajectory" | "both"

[verifier.env]
ANTHROPIC_API_KEY = "${ANTHROPIC_API_KEY}"   # API keys for the judge
```

### What changed

- **`VerifierConfig`**: new `type: Literal["test-script", "llm-judge"]` (default `"test-script"`, fully backward compatible) and a `JudgeVerifierConfig` sub-model (`[verifier.judge]`).
- **`Verifier.verify()`**: branches on `verifier.type`. The `test-script` path is unchanged. The new `_verify_llm_judge()` path resolves the rubric, exports `[verifier.env]` keys so provider SDKs see them, downloads the agent's `input_dir` from the sandbox, runs `LLMJudgeRewardFunc`, and persists `reward.json` in the standard location — so all downstream tooling (metrics, resume, etc.) works unchanged.
- **Rubric formats**: `load_rubric_json()` parses the Harvey LAB `{"title", "criteria": [{"id", "title", "match_criteria"}]}` schema; `load_rubric()` dispatches on file extension. `rubric_path` and judge auto-discovery now accept both `.toml` and `.json`.
- **Judge model override**: an explicit `[verifier.judge].model` overrides the model declared inside the rubric file, so the judge is configurable per task (issue requirement) without editing the rubric.
- **Docs**: `docs/llm-judge.md` updated to document the first-class verifier as the primary path (the old `test.sh` + `LLMJudgeRewardFunc` recipe remains documented as the library-level API).

Partial rewards in `[0.0, 1.0]` are produced via the existing aggregation strategies (weighted mean / all-pass / any-pass / threshold).

## Assumptions

- **`test-script` stays the default.** Only tasks that explicitly set `type = "llm-judge"` change behavior — zero impact on existing tasks.
- **`input_type` v1 scope.** `"deliverables"` is fully wired (downloads `input_dir` and grades the files). `"trajectory"`/`"both"` are accepted by the config schema but the ACP trajectory isn't on disk at verify-time, so v1 grades deliverables; trajectory grading is a documented follow-up. This matches the issue's "v1" framing.
- **Default `rubric_path` is `tests/rubric.toml`**, following the existing convention of co-locating verifier assets with `tests/`.
- **API keys flow through `[verifier.env]`** (resolved via the existing `${VAR}` template syntax) and are exported into the verifier process environment for the provider SDKs — consistent with how LLM-based `test.sh` verifiers already receive keys.
- A misconfigured `rubric_path` raises `RubricNotFoundError` (fails loud); a sandbox download failure degrades gracefully (judge runs against an empty deliverable set rather than crashing).

## Testing

- `tests/test_llm_judge_verifier.py` (new): config parsing, `verify()` routing, partial rewards, `reward.json` output, `.toml`/`.json` rubrics, env export, download-failure tolerance, and a regression test that `test-script` stays the default. All LLM calls mocked.
- `tests/test_rubric_config.py`: added `load_rubric_json` / `load_rubric` coverage.
- Live smoke test with `claude-haiku-4-5-20251001`: a Paris/Berlin rubric scored 0.5 (correct criterion passed, incorrect failed) end-to-end.
- Full CI gate green: `ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` (1234 passed, 16 skipped).

## How to use

1. Set `[verifier].type = "llm-judge"` in `task.toml` and add a `[verifier.judge]` block.
2. Write a `tests/rubric.toml` (or `tests/rubric.json`) with criteria.
3. Add the judge's API key under `[verifier.env]`.
4. Run the task — the reward is the rubric's aggregated score. No `test.sh` needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `Verifier.verify()` execution path that downloads sandbox deliverables, sets judge-related env vars, and runs LLM scoring; misconfiguration or env handling could affect task evaluation even though the default `test-script` flow remains unchanged.
> 
> **Overview**
> Enables **LLM-as-judge as a first-class verifier** selectable via `task.toml` (`[verifier].type = "llm-judge"`), so tasks can be graded from a rubric without writing `tests/test.sh`.
> 
> Adds `[verifier.judge]` config (model, rubric path, input dir/type, optional context) and wires `Verifier` to resolve the rubric, export `[verifier.env]` for provider SDKs, download deliverables, run `LLMJudgeRewardFunc`, and persist `reward.json`.
> 
> Extends rubric support to **Harvey LAB-style `rubric.json`** alongside `rubric.toml` via new `load_rubric_json()`/`load_rubric()` dispatch, updates judge auto-discovery to find either format, and exports these loaders in the public API. Includes new integration/unit tests and updates `docs/llm-judge.md` to document the config-driven verifier workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a24cb48b9a5e8ed25723d99ee3f1e5e5783b373b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->