### PR TITLE
fix: address PR #309/#310 verification findings

### DIFF
--- a/src/benchflow/sandbox/_base.py
+++ b/src/benchflow/sandbox/_base.py
@@ -9,6 +9,7 @@ Internalized from Harbor's BaseEnvironment with RL-first terminology:
 from __future__ import annotations
 
 import logging
+import re
 import shlex
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -21,6 +22,25 @@ from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths
 
 logger = logging.getLogger("benchflow")
+
+# Docker Compose service names are restricted to this grammar. Used to filter
+# `docker compose config --services` output, whose stdout may be polluted with
+# warning lines because the compose command merges stderr into stdout.
+_COMPOSE_SERVICE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_.-]*$")
+
+
+def _filter_compose_service_names(output: str) -> list[str]:
+    """Extract valid compose service names from `config --services` output.
+
+    Drops blank lines and anything that does not match the Docker Compose
+    service-name grammar, so a warning line merged into stdout cannot be
+    mistaken for a service (#248).
+    """
+    return [
+        line
+        for raw in output.splitlines()
+        if (line := raw.strip()) and _COMPOSE_SERVICE_NAME_RE.match(line)
+    ]
 
 
 class ExecResult(BaseModel):
@@ -211,6 +231,25 @@ class BaseSandbox(ABC):
             timeout_sec=timeout_sec,
             user=user,
             service=service,
+        )
+
+    async def services(self) -> list[str]:
+        """List the compose service (container) names available in this sandbox.
+
+        Multi-container (vulhub-style) tasks declare extra services in their
+        ``docker-compose.yaml`` alongside the agent's ``main`` container; this
+        enumerates them so verifier code can target each via
+        ``exec(..., service=...)`` (#248).
+
+        Single-container backends (Modal, direct Daytona) have no compose
+        topology and raise a clear error — overriding backends must implement
+        this themselves.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} is a single-container backend; "
+            "services() requires a multi-container docker-compose task. "
+            "Use the Docker sandbox or the Daytona DinD (compose) sandbox "
+            "for vulhub-style tasks (#248)."
         )
 
     async def is_dir(

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -19,7 +19,11 @@ from uuid import uuid4
 
 from tenacity import retry, stop_after_attempt, wait_exponential
 
-from benchflow.sandbox._base import BaseSandbox, ExecResult
+from benchflow.sandbox._base import (
+    BaseSandbox,
+    ExecResult,
+    _filter_compose_service_names,
+)
 from benchflow.sandbox._compose import (
     COMPOSE_BASE_PATH,
     COMPOSE_BUILD_PATH,
@@ -177,6 +181,9 @@ class _DaytonaStrategy:
     async def is_file(self, path: str, user: str | int | None = None) -> bool: ...
 
     @abstractmethod
+    async def services(self) -> list[str]: ...
+
+    @abstractmethod
     async def attach(self) -> None: ...
 
 
@@ -319,6 +326,13 @@ class _DaytonaDirect(_DaytonaStrategy):
             raise RuntimeError("Sandbox not found. Please build the environment first.")
         file_info = await self._env._sandbox.fs.get_file_info(path)
         return not file_info.is_dir
+
+    async def services(self) -> list[str]:
+        raise NotImplementedError(
+            "Direct (non-compose) Daytona sandbox is single-container and has "
+            "no compose topology. services() requires a multi-container "
+            "docker-compose task (#248)."
+        )
 
     async def attach(self) -> None:
         env = self._env
@@ -714,6 +728,23 @@ class _DaytonaDinD(_DaytonaStrategy):
         )
         return result.return_code == 0
 
+    async def services(self) -> list[str]:
+        """List compose service names defined inside the DinD VM.
+
+        Runs ``docker compose config --services`` against the task's compose
+        stack — includes BenchFlow's ``main`` service plus any vulhub-style
+        target/database containers the task declares (#248). The output is
+        filtered to the compose service-name grammar so stray warning lines
+        cannot be mistaken for services.
+        """
+        result = await self._compose_exec(["config", "--services"], timeout_sec=30)
+        if result.return_code != 0:
+            raise RuntimeError(
+                f"docker compose config --services failed: "
+                f"{result.stdout} {result.stderr}"
+            )
+        return _filter_compose_service_names(result.stdout or "")
+
     async def attach(self) -> None:
         env = self._env
         if not env._sandbox:
@@ -1076,6 +1107,9 @@ class DaytonaSandbox(BaseSandbox):
             service=service,
         )
 
+    async def services(self) -> list[str]:
+        return await self._strategy.services()
+
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
         return await self._strategy.upload_file(source_path, target_path)
 
@@ -1091,6 +1125,9 @@ class DaytonaSandbox(BaseSandbox):
     async def is_dir(
         self, path: str, user: str | int | None = None, service: str = "main"
     ) -> bool:
+        # The strategy fast-path only knows the agent's `main` container; a
+        # non-main service must route through the generic `test -d` exec path
+        # so the compose `service` selector is honored.
         if service != "main":
             return await super().is_dir(path, user=user, service=service)
         return await self._strategy.is_dir(path, user=self._resolve_user(user))
@@ -1098,6 +1135,9 @@ class DaytonaSandbox(BaseSandbox):
     async def is_file(
         self, path: str, user: str | int | None = None, service: str = "main"
     ) -> bool:
+        # The strategy fast-path only knows the agent's `main` container; a
+        # non-main service must route through the generic `test -f` exec path
+        # so the compose `service` selector is honored.
         if service != "main":
             return await super().is_file(path, user=user, service=service)
         return await self._strategy.is_file(path, user=self._resolve_user(user))

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -21,7 +21,11 @@ from typing import ClassVar
 
 from pydantic import BaseModel
 
-from benchflow.sandbox._base import BaseSandbox, ExecResult
+from benchflow.sandbox._base import (
+    BaseSandbox,
+    ExecResult,
+    _filter_compose_service_names,
+)
 from benchflow.sandbox._compose import (
     COMPOSE_BASE_PATH,
     COMPOSE_BUILD_PATH,
@@ -411,11 +415,16 @@ class DockerSandbox(BaseSandbox):
         Includes BenchFlow's own ``main`` service plus any additional
         services the task declares in its ``docker-compose.yaml``
         (vulhub-style target/database containers — see #248).
+
+        ``_run_docker_compose_command`` merges stderr into stdout, so the
+        output is filtered to lines that match the Docker Compose service
+        naming grammar — a stray warning line cannot become a spurious
+        "service".
         """
         result = await self._run_docker_compose_command(
             ["config", "--services"], check=True
         )
-        return [s for s in (result.stdout or "").splitlines() if s.strip()]
+        return _filter_compose_service_names(result.stdout or "")
 
     async def exec(
         self,

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -519,10 +519,9 @@ async def _discover_pytest_plugin_flags(env, task: "Task") -> str:
         logger.warning(f"Pytest plugin discovery failed, using task.toml fallback: {e}")
 
     # Merge task.toml [verifier] pytest_plugins declarations as fallback.
-    declared = getattr(task.config.verifier, "pytest_plugins", None) or []
-    for name in declared:
-        if isinstance(name, str):
-            add_plugin(name)
+    # pytest_plugins is a guaranteed list[str] field on VerifierConfig.
+    for name in task.config.verifier.pytest_plugins:
+        add_plugin(name)
 
     # The standard task template runs pytest-ctrf through `uvx --with`,
     # so the plugin is not visible during pre-verifier entry-point discovery.

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -58,7 +58,8 @@ def _make_task(user=None):
     task = MagicMock()
     task.config.verifier.env = None
     task.config.verifier.user = user
-    task.config.verifier.pytest_plugins = None
+    # pytest_plugins is a guaranteed list[str] field on VerifierConfig.
+    task.config.verifier.pytest_plugins = []
     task.task_dir = None
     return task
 
@@ -892,9 +893,8 @@ class TestVerifierEnv:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("plugins", [None, []])
-    async def test_no_extra_addopts_when_no_plugins(self, plugins):
-        """PYTEST_ADDOPTS is not modified when pytest_plugins is None or empty list."""
+    async def test_no_extra_addopts_when_no_plugins(self):
+        """PYTEST_ADDOPTS is not modified when pytest_plugins is the empty list."""
         from benchflow.sandbox.lockdown import (
             _build_pytest_addopts,
             harden_before_verify,
@@ -902,7 +902,7 @@ class TestVerifierEnv:
 
         env = _make_env(side_effect=_manifest_env(_blank_manifest()))
         task = _make_task()
-        task.config.verifier.pytest_plugins = plugins
+        task.config.verifier.pytest_plugins = []
         await harden_before_verify(env, task, sandbox_user=None, workspace=None)
 
         assert task.config.verifier.env["PYTEST_ADDOPTS"] == _build_pytest_addopts(

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -108,6 +108,33 @@ class TestDockerSandboxServiceExec:
 
         assert services == ["main", "target", "db"]
 
+    @pytest.mark.asyncio
+    async def test_services_filters_merged_stderr_warnings(self) -> None:
+        """#248: warning lines merged into stdout are not mistaken for services.
+
+        ``_run_docker_compose_command`` redirects stderr into stdout, so a
+        compose warning could otherwise become a spurious service name.
+        """
+        sandbox = self._make_sandbox()
+
+        async def fake_run(command, check=True, timeout_sec=None):
+            assert command == ["config", "--services"]
+            return ExecResult(
+                stdout=(
+                    "WARN[0000] /env/docker-compose.yaml: `version` is obsolete\n"
+                    'time="2024-01-01" level=warning msg="foo"\n'
+                    "main\n"
+                    "target\n"
+                ),
+                stderr="",
+                return_code=0,
+            )
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        services = await sandbox.services()
+
+        assert services == ["main", "target"]
+
 
 class TestDockerProcessServiceSelection:
     """#248: ACP agent process can be launched into a non-main service."""
@@ -204,7 +231,7 @@ class TestDaytonaServiceExec:
     @pytest.mark.asyncio
     async def test_dind_exec_targets_named_service(self) -> None:
         """#248: DinD compose exec runs the command in the named service."""
-        pytest.importorskip("tenacity")  # sandbox-daytona optional dependency
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
         from benchflow.sandbox.daytona import _DaytonaDinD
 
         strategy = _DaytonaDinD.__new__(_DaytonaDinD)
@@ -223,7 +250,7 @@ class TestDaytonaServiceExec:
     @pytest.mark.asyncio
     async def test_dind_exec_defaults_to_main(self) -> None:
         """#248: DinD compose exec still defaults to the agent's main container."""
-        pytest.importorskip("tenacity")  # sandbox-daytona optional dependency
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
         from benchflow.sandbox.daytona import _DaytonaDinD
 
         strategy = _DaytonaDinD.__new__(_DaytonaDinD)
@@ -242,13 +269,68 @@ class TestDaytonaServiceExec:
     @pytest.mark.asyncio
     async def test_direct_strategy_rejects_non_main_service(self) -> None:
         """#248: direct (non-compose) Daytona sandbox rejects multi-service."""
-        pytest.importorskip("tenacity")  # sandbox-daytona optional dependency
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
         from benchflow.sandbox.daytona import _DaytonaDirect
 
         strategy = _DaytonaDirect.__new__(_DaytonaDirect)
 
         with pytest.raises(ValueError, match="single-container"):
             await strategy.exec("echo hi", service="target")
+
+    @pytest.mark.asyncio
+    async def test_dind_services_lists_compose_services(self) -> None:
+        """#248: DinD services() enumerates every compose service in the task."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="main\ntarget\ndb\n", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        services = await strategy.services()
+
+        assert captured[0] == ["config", "--services"]
+        assert services == ["main", "target", "db"]
+
+    @pytest.mark.asyncio
+    async def test_dind_services_filters_warning_lines(self) -> None:
+        """#248: warning lines merged into stdout are not mistaken for services."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            return ExecResult(
+                stdout=(
+                    "WARN[0000] /benchflow/environment/docker-compose.yaml: "
+                    "`version` is obsolete\n"
+                    "main\n"
+                    "target\n"
+                ),
+                stderr="",
+                return_code=0,
+            )
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        services = await strategy.services()
+
+        assert services == ["main", "target"]
+
+    @pytest.mark.asyncio
+    async def test_direct_strategy_services_rejects_single_container(self) -> None:
+        """#248: direct (non-compose) Daytona sandbox has no compose topology."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDirect
+
+        strategy = _DaytonaDirect.__new__(_DaytonaDirect)
+
+        with pytest.raises(NotImplementedError, match="single-container"):
+            await strategy.services()
 
 
 class TestModalRejectsMultiService:
@@ -257,7 +339,7 @@ class TestModalRejectsMultiService:
     @pytest.mark.asyncio
     async def test_modal_exec_rejects_non_main_service(self) -> None:
         """#248: Modal is single-container — targeting another service must error."""
-        pytest.importorskip("tenacity")  # modal_impl optional dependency
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
         from benchflow.sandbox.modal_impl import ModalSandbox
 
         sandbox = ModalSandbox.__new__(ModalSandbox)
@@ -266,3 +348,14 @@ class TestModalRejectsMultiService:
 
         with pytest.raises(ValueError, match="single-container"):
             await sandbox.exec("echo hi", service="target")
+
+    @pytest.mark.asyncio
+    async def test_modal_services_rejects_single_container(self) -> None:
+        """#248: Modal has no compose topology — services() must error clearly."""
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+
+        with pytest.raises(NotImplementedError, match="single-container"):
+            await sandbox.services()


### PR DESCRIPTION
Follow-up fixes for concrete issues raised by the verification teams for merged PRs #309 and #310.

## A. Wrong `importorskip` target (real test gap, PR #310)
Four backend tests in `tests/test_sandbox_multi_service.py`
(`test_dind_exec_targets_named_service`, `test_dind_exec_defaults_to_main`,
`test_direct_strategy_rejects_non_main_service`, `test_modal_exec_rejects_non_main_service`)
called `pytest.importorskip("tenacity")` but actually import `daytona` / `modal`.
When `tenacity` is installed but `daytona`/`modal` are not, those tests errored on
collection (`ModuleNotFoundError`) instead of skipping cleanly. Each test now
`importorskip`s the module it actually imports — `daytona` for the three
Daytona/DinD tests, `modal` for the Modal test. The file now collects and skips
cleanly with only the `dev` extra installed.

## B. `services()` backend asymmetry (PR #310)
`services()` existed only on `DockerSandbox`, but `docs/task-authoring.md`
advertises `await env.inner.services()` generically — a Daytona-DinD run would
`AttributeError`. Added `services()` to the `BaseSandbox` surface with a default
implementation that raises a clear, actionable error for single-container
backends, and implemented it for the Daytona DinD compose strategy
(`_DaytonaDinD`) via `docker compose config --services`. Direct Daytona and
Modal inherit/raise the single-container error. Added unit tests for the new
DinD `services()` and the single-container error paths.

## C. `services()` parsed merged stdout+stderr (PR #310)
`_run_docker_compose_command` merges stderr into stdout (`stderr=STDOUT`), so a
warning line could become a spurious "service". A shared
`_filter_compose_service_names` helper now filters output to lines matching the
Docker Compose service-name grammar. Covered by a new test feeding warning lines
into the output.

## D. Clarifying comment (PR #310)
Added a one-line comment in `src/benchflow/sandbox/daytona.py` explaining why
`is_dir`/`is_file` route non-`main` services through the generic `test -d`/`test -f`
exec path (the strategy fast-paths only know the single `main` container).

## E. `lockdown.py` cleanup (PR #309)
`pytest_plugins` is now a guaranteed `list[str]` field on `VerifierConfig`, so
the `getattr(task.config.verifier, "pytest_plugins", None) or []` defensive
lookup and the inner `isinstance(name, str)` check in
`_discover_pytest_plugin_flags` were dead defense. Simplified to a plain
attribute access + unconditional loop. Updated `test_sandbox_hardening.py`
fixtures (which set `pytest_plugins = None`, an impossible value) to match the
real model.

## Verification
- `uv run ruff format --check src tests` — pass
- `uv run ruff check .` — pass
- `uv run ty check src/` — pass
- `uv run python -m pytest tests/` — 1247 passed, 24 skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands the sandbox public interface and changes how compose service lists are parsed/used across Docker and Daytona backends, which could affect multi-container task execution and verification targeting.
> 
> **Overview**
> **Multi-service sandbox support is made consistent across backends.** `BaseSandbox` now exposes `services()` (with a clear single-container error by default), `DaytonaSandbox`/DinD implements it via `docker compose config --services`, and Docker/Daytona now share a `_filter_compose_service_names` helper to ignore warning lines merged into stdout.
> 
> **Related hardening/test fixes.** Daytona `is_dir`/`is_file` now route non-`main` services through the generic `exec` path, verifier hardening removes dead `pytest_plugins` `None` handling (now always `list[str]`), and tests add coverage for warning-line filtering plus fix `pytest.importorskip` to target the correct optional modules (`daytona`/`modal`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429dd661371aa54d8eb02e968e57c497ced8410a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->