### PR TITLE
fix(agents): inherit BENCHFLOW_PROVIDER_BASE_URL/API_KEY from host env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Inherit `BENCHFLOW_PROVIDER_BASE_URL` / `BENCHFLOW_PROVIDER_API_KEY` from the host environment so self-hosted / OpenAI-compatible endpoints route correctly instead of falling back to `api.openai.com`; empty-string host values are skipped (benchflow-ai/skillsbench#817).
+- Inherit `BENCHFLOW_PROVIDER_BASE_URL` / `BENCHFLOW_PROVIDER_API_KEY` from the host environment so self-hosted / OpenAI-compatible endpoints route correctly instead of falling back to `api.openai.com`; empty or whitespace-only host values are skipped so they cannot shadow the resolved provider URL (benchflow-ai/skillsbench#817).
 
 ## 0.3.3 — 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Inherit `BENCHFLOW_PROVIDER_BASE_URL` / `BENCHFLOW_PROVIDER_API_KEY` from the host environment so self-hosted / OpenAI-compatible endpoints route correctly instead of falling back to `api.openai.com`; empty-string host values are skipped (benchflow-ai/skillsbench#817).
+
 ## 0.3.3 — 2026-05-15
 
 ### Added

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -102,10 +102,11 @@ def auto_inherit_env(
             keys.add(env_var)
     for key in keys:
         value = source.get(key)
-        # An exported-but-empty var ("export X=") is effectively unset;
-        # copying "" can shadow a real value resolved downstream (e.g. an
-        # empty BENCHFLOW_PROVIDER_BASE_URL blocks provider URL resolution).
-        if value:
+        # An exported-but-blank var ("export X=" or "export X=' '") is
+        # effectively unset; copying it can shadow a real value resolved
+        # downstream (e.g. a blank BENCHFLOW_PROVIDER_BASE_URL blocks
+        # provider URL resolution).
+        if value and value.strip():
             agent_env.setdefault(key, value)
     # Mirror GEMINI_API_KEY as GOOGLE_API_KEY (some agents expect one or the other)
     if "GEMINI_API_KEY" in agent_env and "GOOGLE_API_KEY" not in agent_env:

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -91,6 +91,8 @@ def auto_inherit_env(
         "GOOGLE_CLOUD_LOCATION",
         "LLM_API_KEY",
         "LLM_BASE_URL",
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "BENCHFLOW_PROVIDER_API_KEY",
         "BENCHFLOW_PROVIDER_PROMPT_CACHE_RETENTION",
     }
     for cfg in PROVIDERS.values():
@@ -99,8 +101,12 @@ def auto_inherit_env(
         for env_var in cfg.url_params.values():
             keys.add(env_var)
     for key in keys:
-        if key in source:
-            agent_env.setdefault(key, source[key])
+        value = source.get(key)
+        # An exported-but-empty var ("export X=") is effectively unset;
+        # copying "" can shadow a real value resolved downstream (e.g. an
+        # empty BENCHFLOW_PROVIDER_BASE_URL blocks provider URL resolution).
+        if value:
+            agent_env.setdefault(key, value)
     # Mirror GEMINI_API_KEY as GOOGLE_API_KEY (some agents expect one or the other)
     if "GEMINI_API_KEY" in agent_env and "GOOGLE_API_KEY" not in agent_env:
         agent_env["GOOGLE_API_KEY"] = agent_env["GEMINI_API_KEY"]

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -116,6 +116,28 @@ class TestAutoInheritEnv:
         auto_inherit_env(env)
         assert "BENCHFLOW_PROVIDER_BASE_URL" not in env
 
+    def test_whitespace_only_host_value_not_inherited(self, monkeypatch):
+        """A whitespace-only host var ('export X=" "') is also effectively unset.
+
+        '   ' is truthy, so a bare `if value:` guard would still copy it and
+        shadow downstream resolution exactly like an empty string does.
+        """
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "   ")
+        env: dict[str, str] = {}
+        auto_inherit_env(env)
+        assert "BENCHFLOW_PROVIDER_BASE_URL" not in env
+
+    def test_empty_openai_base_url_not_inherited(self, monkeypatch):
+        """Empty-skip applies to every allowlisted key, not just the #817 keys.
+
+        OPENAI_BASE_URL has always been on the allowlist, so this pins the
+        empty-skip guard itself — independent of the #817 allowlist additions.
+        """
+        monkeypatch.setenv("OPENAI_BASE_URL", "")
+        env: dict[str, str] = {}
+        auto_inherit_env(env)
+        assert "OPENAI_BASE_URL" not in env
+
 
 # ── inject_vertex_credentials ──
 
@@ -616,3 +638,33 @@ class TestResolveAgentEnvHostProviderEndpoint:
 
         assert result["LLM_BASE_URL"] == "http://my-vllm-host:8000/v1"
         assert result["LLM_API_KEY"] == "sk-provider-host"
+
+    def test_whitespace_host_base_url_does_not_shadow_resolved_url(self, monkeypatch):
+        """'export BENCHFLOW_PROVIDER_BASE_URL=" "' must not blank a real URL.
+
+        A whitespace-only value is the same operator mistake as an empty one
+        and must not shadow the provider's resolved endpoint.
+        """
+        monkeypatch.setenv("ZAI_API_KEY", "zk-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "   ")
+
+        result = resolve_agent_env("codex-acp", "zai/glm-5", {})
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+    def test_empty_host_provider_api_key_does_not_shadow_resolved_key(
+        self, monkeypatch
+    ):
+        """'export BENCHFLOW_PROVIDER_API_KEY=' must not shadow the resolved key.
+
+        The empty-string class of bug applies to the API key too: an empty host
+        value must not block resolve_provider_env from filling it from the
+        provider's own credential (ZAI_API_KEY here).
+        """
+        monkeypatch.setenv("ZAI_API_KEY", "zk-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "")
+
+        result = resolve_agent_env("codex-acp", "zai/glm-5", {})
+
+        assert result["BENCHFLOW_PROVIDER_API_KEY"] == "zk-test"
+        assert result["OPENAI_API_KEY"] == "zk-test"

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -86,6 +86,36 @@ class TestAutoInheritEnv:
         auto_inherit_env(env)
         assert env["OPENAI_BASE_URL"] == "https://custom.openai.example/v1"
 
+    def test_inherits_benchflow_provider_api_key(self, monkeypatch):
+        """Guards issue #817: host BENCHFLOW_PROVIDER_API_KEY must be inherited.
+
+        Users on self-hosted / proxy endpoints export BENCHFLOW_PROVIDER_API_KEY
+        directly; without it on the allowlist the host value is silently dropped.
+        """
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "sk-provider-host")
+        env: dict[str, str] = {}
+        auto_inherit_env(env)
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-provider-host"
+
+    def test_inherits_benchflow_provider_base_url(self, monkeypatch):
+        """Guards issue #817: host BENCHFLOW_PROVIDER_BASE_URL must be inherited."""
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://my-vllm-host:8000/v1")
+        env: dict[str, str] = {}
+        auto_inherit_env(env)
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "http://my-vllm-host:8000/v1"
+
+    def test_empty_string_host_value_not_inherited(self, monkeypatch):
+        """An exported-but-empty host var ('export X=') must not be inherited.
+
+        Copying '' would shadow a real value resolved downstream — an empty
+        BENCHFLOW_PROVIDER_BASE_URL would block resolve_provider_env's
+        setdefault from filling the provider's real endpoint.
+        """
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "")
+        env: dict[str, str] = {}
+        auto_inherit_env(env)
+        assert "BENCHFLOW_PROVIDER_BASE_URL" not in env
+
 
 # ── inject_vertex_credentials ──
 
@@ -479,3 +509,110 @@ class TestResolveAgentEnvOracle:
         # Provider env never resolved — oracle never calls an LLM.
         assert "BENCHFLOW_PROVIDER_MODEL" not in result
         assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
+
+class TestResolveAgentEnvHostProviderEndpoint:
+    """Guards issue #817: host BENCHFLOW_PROVIDER_* must reach the agent env.
+
+    Users running self-hosted / OpenAI-compatible endpoints export
+    BENCHFLOW_PROVIDER_BASE_URL (and BENCHFLOW_PROVIDER_API_KEY) on the host.
+    auto_inherit_env's allowlist must include them — otherwise the host value
+    is silently dropped, resolve_provider_env fills BENCHFLOW_PROVIDER_BASE_URL
+    with the vllm provider's empty default, and the agent falls back to
+    api.openai.com (401 Unauthorized).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch, tmp_path):
+        """Isolate from the host environment and any real .env file."""
+        for k in (
+            "BENCHFLOW_PROVIDER_BASE_URL",
+            "BENCHFLOW_PROVIDER_API_KEY",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "ZAI_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        empty = tmp_path / "empty.env"
+        empty.write_text("")
+        monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(empty))
+
+    def test_host_provider_base_url_survives_into_resolved_env(self, monkeypatch):
+        """vllm has an empty registry base_url — the host value must fill it."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-vllm-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://my-vllm-host:8000/v1")
+
+        result = resolve_agent_env("codex-acp", "vllm/Qwen-test", {})
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "http://my-vllm-host:8000/v1"
+        # codex-acp env_mapping translates it to the agent-native var too.
+        assert result["OPENAI_BASE_URL"] == "http://my-vllm-host:8000/v1"
+
+    def test_explicit_agent_env_beats_host_provider_base_url(self, monkeypatch):
+        """An explicit --agent-env override wins over the host value end-to-end."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-vllm-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://host/v1")
+
+        result = resolve_agent_env(
+            "codex-acp",
+            "vllm/Qwen-test",
+            {"BENCHFLOW_PROVIDER_BASE_URL": "http://explicit/v1"},
+        )
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "http://explicit/v1"
+
+    def test_host_provider_base_url_overrides_resolved_provider_url(self, monkeypatch):
+        """For a provider with a real registry URL (zai), the host value wins.
+
+        vllm resolves to an empty base_url; zai resolves to a real endpoint, so
+        this proves the host override beats a *non-empty* resolved value.
+        """
+        monkeypatch.setenv("ZAI_API_KEY", "zk-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://host-proxy:9000/v1")
+
+        result = resolve_agent_env("codex-acp", "zai/glm-5", {})
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "http://host-proxy:9000/v1"
+
+    def test_no_host_override_keeps_resolved_provider_url(self, monkeypatch):
+        """Sanity counterpart: without a host override zai's own endpoint is used."""
+        monkeypatch.setenv("ZAI_API_KEY", "zk-test")
+
+        result = resolve_agent_env("codex-acp", "zai/glm-5", {})
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+    def test_empty_host_base_url_does_not_shadow_resolved_url(self, monkeypatch):
+        """'export BENCHFLOW_PROVIDER_BASE_URL=' must not blank a real URL."""
+        monkeypatch.setenv("ZAI_API_KEY", "zk-test")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "")
+
+        result = resolve_agent_env("codex-acp", "zai/glm-5", {})
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+    def test_provider_keys_inherited_from_dotenv_file(self, monkeypatch, tmp_path):
+        """resolve_agent_env also inherits BENCHFLOW_PROVIDER_* from a .env file."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "BENCHFLOW_PROVIDER_BASE_URL=http://dotenv-host:8000/v1\n"
+            "BENCHFLOW_PROVIDER_API_KEY=sk-from-dotenv\n"
+        )
+        monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(env_file))
+
+        result = resolve_agent_env("codex-acp", "vllm/Qwen-test", {})
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "http://dotenv-host:8000/v1"
+        assert result["OPENAI_BASE_URL"] == "http://dotenv-host:8000/v1"
+        assert result["OPENAI_API_KEY"] == "sk-from-dotenv"
+
+    def test_openhands_host_provider_keys_map_to_llm_vars(self, monkeypatch):
+        """openhands maps BENCHFLOW_PROVIDER_{BASE_URL,API_KEY} → LLM_{BASE_URL,API_KEY}."""
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://my-vllm-host:8000/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "sk-provider-host")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-vllm")
+
+        result = resolve_agent_env("openhands", "vllm/Qwen-test", {})
+
+        assert result["LLM_BASE_URL"] == "http://my-vllm-host:8000/v1"
+        assert result["LLM_API_KEY"] == "sk-provider-host"


### PR DESCRIPTION
## Summary

Fixes benchflow-ai/skillsbench#817. Users running self-hosted / OpenAI-compatible LLM endpoints export `BENCHFLOW_PROVIDER_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY` in their shell, but `auto_inherit_env()` did not inherit them from the host — so they were silently dropped, `resolve_provider_env()` filled `BENCHFLOW_PROVIDER_BASE_URL` with the `vllm` provider's empty default, and the agent fell back to `api.openai.com` (401 Unauthorized).

`OPENAI_BASE_URL` was already inherited (#255); this completes the set.

## Changes

- `auto_inherit_env()` allowlist now includes `BENCHFLOW_PROVIDER_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY`.
- `auto_inherit_env()` skips empty-string host values — an exported-but-empty var (`export X=`) is effectively unset, and copying `""` would shadow a real provider URL resolved downstream (caught in review).
- `setdefault` semantics preserve explicit `--agent-env` overrides and resolved provider values.

## Testing

Test-driven (red → green). 137 lines of new tests in `tests/test_resolve_env_helpers.py`:
- unit: both keys inherited from host; empty-string host values skipped
- integration via `resolve_agent_env`: vllm empty-URL fill, explicit `--agent-env` precedence, non-vllm (zai) override, `.env`-file source, openhands `LLM_*` env_mapping

Full suite: **1242 passed, 0 failed**. `ruff check` / `ruff format` clean.

End-to-end verified on Daytona + Gemini (`jax-computing-basics`, reward 1.0) with the patched benchflow; a deterministic check confirms a host `BENCHFLOW_PROVIDER_BASE_URL` propagates to both `BENCHFLOW_PROVIDER_BASE_URL` and the agent-native `OPENAI_BASE_URL`.

## Note

A non-empty host `BENCHFLOW_PROVIDER_BASE_URL` now also takes precedence over a *registered* provider's registry URL (e.g. `zai`), matching how host `OPENAI_BASE_URL` already behaves — exporting a provider base URL is treated as an intentional endpoint override.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/313" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent environment resolution and provider endpoint/auth routing; mistakes could misroute traffic or break auth for some configurations, but the change is small and covered by new unit/integration tests.
> 
> **Overview**
> Fixes self-hosted/OpenAI-compatible endpoint routing by adding `BENCHFLOW_PROVIDER_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY` to `auto_inherit_env()`’s inherited env allowlist.
> 
> Also changes inheritance to **skip empty/whitespace-only host values** so exported-but-blank vars don’t shadow resolved provider URLs/keys, with expanded tests (including `resolve_agent_env` precedence and `.env` inheritance) and a changelog entry for #817.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d8675c3209423ab7398a4c3fc6748cb0e037587. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->