### PR TITLE
fix(verifier): address PR #311 llm-judge verification follow-ups

### DIFF
--- a/docs/llm-judge.md
+++ b/docs/llm-judge.md
@@ -98,7 +98,7 @@ passed (or the configured aggregation), a partial float in `[0, 1]`.
 | `model` | string | `"claude-sonnet-4-6"` | Judge model; provider routed from prefix |
 | `rubric_path` | string | `"tests/rubric.toml"` | Rubric file relative to the task dir (`.toml` or `.json`) |
 | `input_dir` | string | `"/app"` | Sandbox dir whose contents are graded |
-| `input_type` | string | `"deliverables"` | `"deliverables"`, `"trajectory"`, or `"both"` |
+| `input_type` | string | `"deliverables"` | Only `"deliverables"` is supported — trajectory judging is not available at verify time |
 | `context` | string | `""` | Extra judge context (defaults to the task instruction) |
 
 ---

--- a/src/benchflow/rewards/builtins.py
+++ b/src/benchflow/rewards/builtins.py
@@ -165,14 +165,24 @@ class LLMJudgeRewardFunc:
         judge_model: str | None = None,
     ) -> None:
         self.prompt = prompt
+        # ``judge_model`` (an explicit ``[verifier.judge].model`` from
+        # ``task.toml``) takes precedence over ``model`` and over any model
+        # declared inside a rubric file. ``self.model`` is the single resolved
+        # default; rubric files supply their own default via ``_resolve_model``.
         self.model = judge_model or model
+        self._explicit_model = judge_model
         self.mode = mode
         self._rubric_path = rubric_path
         self._inline_criteria = criteria
         self._events: list[RewardEvent] = []
-        # An explicit judge model overrides the model declared inside a rubric
-        # file — so a task can configure the judge per ``task.toml`` (#270).
-        self._model_override = judge_model
+
+    def _resolve_model(self, rubric_default: str) -> str:
+        """Resolve the judge model for a rubric.
+
+        An explicit ``judge_model`` (from ``[verifier.judge].model``) wins;
+        otherwise the rubric file's own model is used.
+        """
+        return self._explicit_model or rubric_default
 
     @property
     def events(self) -> list[RewardEvent]:
@@ -254,9 +264,7 @@ class LLMJudgeRewardFunc:
         from benchflow.rewards.file_readers import find_deliverables
         from benchflow.rewards.llm import call_judge, parse_verdict
 
-        # An explicit judge model (e.g. from [verifier.judge].model) overrides
-        # the model declared inside the rubric file.
-        model = self._model_override or rubric.judge.model
+        model = self._resolve_model(rubric.judge.model)
         deliverables = find_deliverables(rollout_dir)
 
         # Also check common subdirectories

--- a/src/benchflow/rewards/rubric_config.py
+++ b/src/benchflow/rewards/rubric_config.py
@@ -148,12 +148,18 @@ def load_rubric_json(path: Path) -> RubricConfig:
     judge = _parse_judge(data.get("judge", {}))
     scoring = _parse_scoring(data.get("scoring", {}))
     criteria: list[Criterion] = []
-    for raw in data.get("criteria", []):
+    for idx, raw in enumerate(data.get("criteria", [])):
+        description = (
+            raw.get("match_criteria") or raw.get("description") or raw.get("title")
+        )
+        if not description:
+            raise ValueError(
+                f"Rubric criterion #{idx} in {path} has no description: set one "
+                f"of 'match_criteria', 'description', or 'title'."
+            )
         criteria.append(
             Criterion(
-                description=raw.get("match_criteria")
-                or raw.get("description")
-                or raw.get("title", ""),
+                description=description,
                 type=raw.get("type", "binary"),
                 name=raw.get("id") or raw.get("name") or raw.get("title"),
                 points=raw.get("points", 5),

--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -105,10 +105,11 @@ class JudgeVerifierConfig(BaseModel):
         description="Directory inside the sandbox holding the agent's "
         "deliverables. Its contents are downloaded and shown to the judge.",
     )
-    input_type: Literal["deliverables", "trajectory", "both"] = Field(
+    input_type: Literal["deliverables"] = Field(
         default="deliverables",
-        description="What the judge evaluates: agent output files "
-        "('deliverables'), the ACP trajectory ('trajectory'), or both.",
+        description="What the judge evaluates. Only 'deliverables' (agent "
+        "output files) is supported — trajectory judging is not available at "
+        "verify time.",
     )
     context: str = Field(
         default="",

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -15,6 +15,8 @@ import json
 import logging
 import os
 import shlex
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -54,6 +56,27 @@ class DownloadVerifierDirError(Exception):
 
 class RubricNotFoundError(Exception):
     """Raised when an llm-judge verifier cannot locate its rubric file."""
+
+
+@contextmanager
+def _scoped_env(env: Mapping[str, str]) -> Iterator[None]:
+    """Temporarily apply *env* to ``os.environ``, restoring prior state on exit.
+
+    Keys not already set are removed afterwards; keys that existed are restored
+    to their original value. This keeps the judge's API keys from leaking into
+    the host process for subsequent rollouts.
+    """
+    previous: dict[str, str | None] = {key: os.environ.get(key) for key in env}
+    try:
+        for key, value in env.items():
+            os.environ[key] = value
+        yield
+    finally:
+        for key, prior in previous.items():
+            if prior is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = prior
 
 
 class Verifier:
@@ -107,8 +130,7 @@ class Verifier:
 
     async def verify(self) -> VerifierResult:
         """Run the configured verifier and return the reward result."""
-        verifier_type = getattr(self._task.config.verifier, "type", "test-script")
-        if verifier_type == "llm-judge":
+        if self._task.config.verifier.type == "llm-judge":
             return await self._verify_llm_judge()
         return await self._verify_test_script()
 
@@ -200,7 +222,7 @@ class Verifier:
         judge = self._task.config.verifier.judge
         rubric_path = Path(judge.rubric_path)
         if not rubric_path.is_absolute():
-            rubric_path = Path(self._task.task_dir) / rubric_path
+            rubric_path = Path(self._task.paths.task_dir) / rubric_path
         if not rubric_path.exists():
             raise RubricNotFoundError(
                 f"llm-judge rubric not found at {rubric_path}. Set "
@@ -233,24 +255,25 @@ class Verifier:
 
         judge = self._task.config.verifier.judge
 
-        # API keys for the judge come from [verifier.env]; export them so the
-        # provider SDKs (anthropic / openai / google) pick them up.
+        # API keys for the judge come from [verifier.env]; scope them to the
+        # judge call so the provider SDKs (anthropic / openai / google) pick
+        # them up without permanently polluting the host process env.
+        judge_env: dict[str, str] = {}
         if self._task.config.verifier.env:
-            resolved = resolve_env_vars(self._task.config.verifier.env)
-            for key, value in resolved.items():
-                os.environ.setdefault(key, value)
+            judge_env = resolve_env_vars(self._task.config.verifier.env)
 
         rubric_path = self._resolve_rubric_path()
         deliverables_dir = await self._download_deliverables()
 
-        context = judge.context or getattr(self._task, "instruction", "") or ""
+        context = judge.context or self._task.instruction or ""
 
         reward_func = LLMJudgeRewardFunc(
             prompt=context,
             rubric_path=rubric_path,
             judge_model=judge.model,
         )
-        score = await reward_func.score(deliverables_dir)
+        with _scoped_env(judge_env):
+            score = await reward_func.score(deliverables_dir)
 
         self._logger.info(
             "llm-judge verifier: %d criteria → reward %.4f",

--- a/tests/test_llm_judge_verifier.py
+++ b/tests/test_llm_judge_verifier.py
@@ -220,13 +220,24 @@ class TestLLMJudgeVerifier:
 
     @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
     @pytest.mark.asyncio
-    async def test_judge_env_exported(
+    async def test_judge_env_scoped_to_judge_call(
         self, mock_judge: AsyncMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """#270: [verifier.env] keys are exported for the judge SDK."""
-        mock_judge.return_value = _MOCK_PASS
+        """#270: [verifier.env] keys are applied during the judge call but
+        not leaked into the host process afterwards."""
+        import os
+
         monkeypatch.setenv("MY_JUDGE_KEY", "secret-123")
         monkeypatch.delenv("RESOLVED_KEY", raising=False)
+
+        seen_during_call: dict[str, str | None] = {}
+
+        async def capture_env(*_args: object, **_kwargs: object) -> str:
+            seen_during_call["RESOLVED_KEY"] = os.environ.get("RESOLVED_KEY")
+            return _MOCK_PASS
+
+        mock_judge.side_effect = capture_env
+
         toml = _judge_toml() + '\n[verifier.env]\nRESOLVED_KEY = "${MY_JUDGE_KEY}"\n'
         task = _make_task(tmp_path, toml)
         (task.task_dir / "tests").mkdir()
@@ -237,10 +248,70 @@ class TestLLMJudgeVerifier:
         rollout_paths = RolloutPaths(tmp_path / "rollout")
         rollout_paths.mkdir()
 
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        # applied for the duration of the judge call ...
+        assert seen_during_call["RESOLVED_KEY"] == "secret-123"
+        # ... but not leaked into the host env afterwards.
+        assert os.environ.get("RESOLVED_KEY") is None
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_judge_env_restores_prior_value(
+        self, mock_judge: AsyncMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """#270: a [verifier.env] key that already exists is restored to its
+        original value after the judge call."""
         import os
 
+        mock_judge.return_value = _MOCK_PASS
+        monkeypatch.setenv("MY_JUDGE_KEY", "secret-123")
+        monkeypatch.setenv("RESOLVED_KEY", "preexisting")
+
+        toml = _judge_toml() + '\n[verifier.env]\nRESOLVED_KEY = "${MY_JUDGE_KEY}"\n'
+        task = _make_task(tmp_path, toml)
+        (task.task_dir / "tests").mkdir()
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps({"criteria": [{"id": "c1", "match_criteria": "ok"}]})
+        )
+        sandbox = _make_sandbox({"out.txt": "output"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
         await Verifier(task, rollout_paths, sandbox).verify()
-        assert os.environ.get("RESOLVED_KEY") == "secret-123"
+        assert os.environ.get("RESOLVED_KEY") == "preexisting"
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    @pytest.mark.asyncio
+    async def test_judge_model_override_reaches_call_judge(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """#270: the [verifier.judge].model declared in task.toml is the model
+        actually passed to call_judge."""
+        mock_judge.return_value = _MOCK_PASS
+        task = _make_task(
+            tmp_path,
+            _judge_toml().replace("claude-haiku-4-5", "claude-haiku-4-5-20251001"),
+        )
+        (task.task_dir / "tests").mkdir()
+        # Rubric declares a *different* model — the task.toml override must win.
+        (task.task_dir / "tests" / "rubric.json").write_text(
+            json.dumps(
+                {
+                    "judge": {"model": "claude-sonnet-4-6"},
+                    "criteria": [{"id": "c1", "match_criteria": "ok"}],
+                }
+            )
+        )
+        sandbox = _make_sandbox({"out.txt": "output"})
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        mock_judge.assert_awaited()
+        assert mock_judge.await_args is not None
+        assert mock_judge.await_args.args[0] == "claude-haiku-4-5-20251001"
 
     @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
     @pytest.mark.asyncio

--- a/tests/test_rubric_config.py
+++ b/tests/test_rubric_config.py
@@ -243,6 +243,15 @@ class TestLoadRubricJson:
         cfg = load_rubric_json(rubric_file)
         assert cfg.criteria[0].description == "Be correct"
 
+    def test_rubric_json_criterion_without_description_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """A criterion with no description/match_criteria/title fails loudly."""
+        rubric_file = tmp_path / "rubric.json"
+        rubric_file.write_text(json.dumps({"criteria": [{"id": "c1"}]}))
+        with pytest.raises(ValueError, match="no description"):
+            load_rubric_json(rubric_file)
+
 
 class TestLoadRubricDispatch:
     def test_dispatches_to_json(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Follow-up fixes for findings raised by the verification review of merged PR #311 (LLM-as-judge first-class verifier, issue #270).

## P1a — `input_type` config field lied about behavior
`JudgeVerifierConfig.input_type` accepted `"deliverables"`, `"trajectory"`, and `"both"`, but `_verify_llm_judge()` never read the field — `"trajectory"` and `"both"` were silently ignored. Trajectory judging genuinely can't be done at verify time, so the `Literal` is now restricted to `Literal["deliverables"]` (still the default). A task can no longer declare an unsupported value that gets ignored. `docs/llm-judge.md` updated to match.

## P1b — global env mutation
`_verify_llm_judge()` called `os.environ.setdefault(key, value)` per `[verifier.env]` key, permanently polluting the host process env for every subsequent rollout in the same process. Replaced with a `_scoped_env` capture-and-restore context manager: the judge's API keys are applied only for the duration of the judge call and prior values are restored in a `finally`. The test formerly named `test_judge_env_exported` (which asserted the leak) is replaced by `test_judge_env_scoped_to_judge_call` and `test_judge_env_restores_prior_value`, which assert the env is applied *during* the judge call and not leaked afterward.

## P2a — redundant model fields in `LLMJudgeRewardFunc`
`LLMJudgeRewardFunc` held `self.model`, `self.mode`, and `self._model_override`, producing two divergent precedence rules. Collapsed to a single resolved-model concept: `_resolve_model(rubric_default)` states the precedence rule once (explicit `[verifier.judge].model` wins over a rubric file's model). `_model_override` removed. Behavior preserved.

## P2b — `getattr` defensive smells
`Verifier.verify()` used `getattr(self._task.config.verifier, "type", "test-script")` and `_verify_llm_judge()` used `getattr(self._task, "instruction", "")`. `VerifierConfig.type` is a non-optional field with a default and `Task.instruction` is always a string; the test stub (`_make_task`) already provides a real `TaskConfig` and an explicit `instruction`, so both `getattr`s are now direct attribute access. No test refactor needed.

## Test gap — judge-model override not asserted end-to-end
Added `test_judge_model_override_reaches_call_judge`: a rubric declares one model, `task.toml` declares another, and the test asserts the `task.toml` model is the one passed to `call_judge` — catching a regression that drops the override.

## P3 — minor
- `_resolve_rubric_path` now uses `task.paths.task_dir` (consistent with `_verify_test_script`'s use of `task.paths`).
- `load_rubric_json` now raises `ValueError` when a criterion has none of `match_criteria`/`description`/`title`, instead of silently yielding an empty description. Added a test for the failure.

## CI
`ruff format --check`, `ruff check`, `ty check src/`, and the full pytest suite (1250 passed, 20 skipped) all pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the `llm-judge` verification path by changing how env vars and model selection are resolved, which could affect judge execution and scoring in production. Changes are well-covered by new/updated tests, reducing regression risk.
> 
> **Overview**
> **Tightens and hardens the `llm-judge` verifier configuration and runtime behavior.** `input_type` is now restricted to `"deliverables"` (docs + config) to avoid silently accepting unsupported trajectory options.
> 
> **Prevents judge API keys from leaking across rollouts.** The verifier now applies `[verifier.env]` via a scoped context manager during the judge call and restores prior `os.environ` state afterward, with tests asserting both non-leakage and restoration.
> 
> **Clarifies judge model precedence and rubric validation.** `LLMJudgeRewardFunc` centralizes model resolution so an explicit task-level judge model consistently overrides rubric defaults, and `rubric.json` parsing now errors if a criterion lacks any description field; new tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3ec45f50b2db1fa3c39c941de68fc97cd87bf4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->