### PR TITLE
ci: run test workflow on merge_group events

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Adds the `merge_group:` trigger to `.github/workflows/test.yml` so the `test` job runs on a merge queue's merge groups.

Today `test` only triggers on `push` and `pull_request`. If a GitHub merge queue is enabled on `main` with `test` as a required status check, the check would never report on the queue's merge-group branches and entries would stall until timeout. This change makes `test` run on queued batches.

## Context

Prerequisite for enabling a merge queue on `main` (parallel to the `main-merge-queue` ruleset already active on `benchflow-ai/skillsbench`). No behavior change for normal `push` / `pull_request` runs.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/315" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change that only affects when the existing `test` workflow triggers; no application/runtime code is modified.
> 
> **Overview**
> Updates the GitHub Actions `test` workflow to also run on `merge_group` events, ensuring required checks execute for GitHub merge queue batches in addition to existing `push` and `pull_request` triggers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ae0958d87a4d186320b52077de769a23fe70c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->