### PR TITLE
fix(tests): remove order-dependent flake in test_config_mismatch_warning

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -183,7 +183,8 @@ class TestJobResume:
         assert "task-a" in completed
         assert len(completed) == 1
 
-    def test_config_mismatch_warning(self, tmp_path, caplog):
+    @pytest.mark.asyncio
+    async def test_config_mismatch_warning(self, tmp_path, caplog):
         jobs_dir = self._setup_jobs_dir(tmp_path)
         trial_dir = self._write_result(jobs_dir, "task-a", rewards={"reward": 1.0})
         (trial_dir / "config.json").write_text(json.dumps({"agent": "old-agent"}))
@@ -207,9 +208,7 @@ class TestJobResume:
             return_value=RunResult(task_name="task-b", rewards={"reward": 1.0})
         )
         with caplog.at_level(logging.WARNING):
-            import asyncio
-
-            asyncio.get_event_loop().run_until_complete(job.run())
+            await job.run()
         assert any("old-agent" in msg for msg in caplog.messages)
 
     def test_no_rewards_is_incomplete(self, tmp_path):


### PR DESCRIPTION
## Problem

`tests/test_job.py::TestJobResume::test_config_mismatch_warning` is an order-dependent flake — it fails under the full suite but passes in isolation.

The test drove `job.run()` via the deprecated `asyncio.get_event_loop().run_until_complete(...)` pattern. With no running loop, `get_event_loop()`'s behavior depends on whether a loop already exists / has been closed — which depends on test collection order. When a test file using `asyncio.run()` (which closes and clears the loop) is collected first, `get_event_loop()` raises `RuntimeError: There is no current event loop`.

Deterministic repro on the pre-fix code:

```bash
uv run --extra dev python -m pytest tests/test_rewards.py "tests/test_job.py::TestJobResume::test_config_mismatch_warning"
# -> 1 failed: RuntimeError: There is no current event loop
```

## Fix

Convert the test to `async def` + `@pytest.mark.asyncio` + `await job.run()`, letting `pytest-asyncio` (already configured with `asyncio_mode = "auto"`) own the event loop — consistent with the other async tests in `test_job.py`. Net change: one line removed, deprecated API gone.

```diff
-    def test_config_mismatch_warning(self, tmp_path, caplog):
+    @pytest.mark.asyncio
+    async def test_config_mismatch_warning(self, tmp_path, caplog):
...
         with caplog.at_level(logging.WARNING):
-            import asyncio
-
-            asyncio.get_event_loop().run_until_complete(job.run())
+            await job.run()
```

## Verification

Reviewed and verified by 4 independent agents (audit, test, root-cause, code-quality):

- `await job.run()` is semantically equivalent — `Evaluation.run()` is an `async def` coroutine; the config-mismatch warning still fires and the assertion stays meaningful.
- Pre-fix failure **deterministically reproduced**, then confirmed fixed.
- Full suite: **1230 passed, 20 skipped** — green across 3 runs and 3 file-ordering permutations, including the original repro order (`test_verify` + `test_sdk_internals` + `test_job`).
- Zero `get_event_loop` / `run_until_complete` patterns remain in `test_job.py`.

## Follow-up (out of scope)

`test_rewards.py`, `test_sdk_lockdown.py`, and `test_skill_eval_dryrun.py` use `asyncio.run()` in sync tests without restoring the loop. No active flake remains, but a future sync test using `get_event_loop()` would reintroduce this class of bug — worth a separate hardening pass.

Fixes #317
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/318" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that switches the async execution pattern to pytest-managed event loops, reducing flakiness without affecting production code.
> 
> **Overview**
> Removes an order-dependent flake in `tests/test_job.py::test_config_mismatch_warning` by converting the test to `@pytest.mark.asyncio` + `async def` and directly `await`ing `job.run()`.
> 
> This drops the deprecated `asyncio.get_event_loop().run_until_complete(...)` usage so the test no longer depends on whether a global event loop exists from prior tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5b4d1c5d1471eb18a3ceaa351868629b06d0d12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->