### PR TITLE
fix(rewards): three rewards-code audit findings

### DIFF
--- a/src/benchflow/rewards/llm.py
+++ b/src/benchflow/rewards/llm.py
@@ -91,8 +91,11 @@ async def call_judge(
     """Call an LLM judge, routing by model name prefix.
 
     Tries Anthropic, OpenAI, and Google SDKs in order based on the
-    model string.  Falls back through providers if the primary is
-    unavailable.
+    model string.  Cross-provider fallback only applies when an SDK is
+    *not installed* (``ImportError``): a model name only makes sense for
+    the provider it belongs to, so a real API failure (bad key, model
+    not found, retries exhausted) is raised as-is rather than being
+    masked by a different provider rejecting the same model name.
     """
     bare_model = _strip_provider_prefix(model)
     providers: list[str] = []
@@ -119,19 +122,22 @@ async def call_judge(
                     return await _call_google(bare_model, prompt)
             except ImportError:
                 logger.debug("SDK for %s not installed, skipping", provider)
-                break  # No point retrying if SDK is missing
+                break  # SDK missing — fall through to the next provider
             except Exception as e:
                 last_error = e
                 if attempt < retries - 1:
                     await asyncio.sleep(2**attempt)
                     continue
+                # A real API failure for this provider's own model.
+                # Other providers cannot serve this model name, so do
+                # not advance — raise the original error directly.
                 logger.warning(
                     "%s call failed after %d attempts: %s",
                     provider,
                     retries,
                     e,
                 )
-                break  # Move to next provider
+                raise
 
     msg = f"All LLM providers failed for model {model}"
     if last_error:
@@ -153,7 +159,14 @@ async def _call_anthropic(model: str, prompt: str, max_tokens: int) -> str:
         max_tokens=max_tokens,
         messages=[{"role": "user", "content": prompt}],
     )
-    return response.content[0].text
+    # The response may have no content blocks, or lead with a non-text
+    # block (e.g. a tool-use block).  Return the first text block's text,
+    # or "" if none is present.
+    for block in response.content:
+        text = getattr(block, "text", None)
+        if isinstance(text, str):
+            return text
+    return ""
 
 
 async def _call_openai(model: str, prompt: str, max_tokens: int) -> str:

--- a/src/benchflow/rewards/rubric_config.py
+++ b/src/benchflow/rewards/rubric_config.py
@@ -41,7 +41,9 @@ class Criterion:
             return 1.0 if raw >= 0.5 else 0.0
         if self.type == "likert":
             denom = self.points - 1
-            return float((raw - 1) / denom) if denom > 0 else 0.0
+            if denom <= 0:
+                return 0.0
+            return max(0.0, min(1.0, (raw - 1) / denom))
         # numeric
         span = self.max - self.min
         if span <= 0:

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -7,13 +7,14 @@ from __future__ import annotations
 
 import asyncio
 import json
+from contextlib import AbstractContextManager
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from benchflow.rewards.builtins import LLMJudgeRewardFunc
-from benchflow.rewards.llm import parse_verdict
+from benchflow.rewards.llm import _call_anthropic, call_judge, parse_verdict
 from benchflow.rewards.protocol import RewardFunc
 from benchflow.rewards.rubric_config import ScoringConfig
 
@@ -41,6 +42,108 @@ class TestParseVerdict:
     def test_unparseable_raises(self) -> None:
         with pytest.raises(ValueError, match="Could not parse"):
             parse_verdict("no json here at all")
+
+
+# ---------------------------------------------------------------------------
+# call_judge: provider routing and fallback
+# ---------------------------------------------------------------------------
+
+
+class TestCallJudgeProviderFallback:
+    def test_api_failure_surfaces_original_error(self) -> None:
+        """A real API failure on the matching provider is raised as-is.
+
+        The cross-provider fallback must NOT advance to a provider whose
+        API cannot serve this model name — otherwise ``last_error`` ends
+        up holding a misleading model-not-found error from the wrong
+        provider instead of the genuine failure.
+        """
+        original = RuntimeError("anthropic: invalid x-api-key")
+        anthropic_mock = AsyncMock(side_effect=original)
+        openai_mock = AsyncMock(return_value="should not be reached")
+        google_mock = AsyncMock(return_value="should not be reached")
+
+        with (
+            patch("benchflow.rewards.llm._call_anthropic", anthropic_mock),
+            patch("benchflow.rewards.llm._call_openai", openai_mock),
+            patch("benchflow.rewards.llm._call_google", google_mock),
+            pytest.raises(RuntimeError, match="invalid x-api-key") as exc_info,
+        ):
+            asyncio.run(call_judge("claude-haiku-4-5", "prompt", retries=2))
+
+        # The exact original exception object propagates.
+        assert exc_info.value is original
+        # The matching provider was retried, but no other provider tried.
+        assert anthropic_mock.await_count == 2
+        openai_mock.assert_not_awaited()
+        google_mock.assert_not_awaited()
+
+    def test_import_error_falls_through_to_next_provider(self) -> None:
+        """A missing SDK (ImportError) still falls through to the next provider."""
+        anthropic_mock = AsyncMock(side_effect=ImportError("no anthropic SDK"))
+        openai_mock = AsyncMock(return_value="ok from openai")
+
+        with (
+            patch("benchflow.rewards.llm._call_anthropic", anthropic_mock),
+            patch("benchflow.rewards.llm._call_openai", openai_mock),
+        ):
+            result = asyncio.run(call_judge("claude-haiku-4-5", "prompt", retries=2))
+
+        assert result == "ok from openai"
+        # ImportError is not retried.
+        assert anthropic_mock.await_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _call_anthropic: content block handling
+# ---------------------------------------------------------------------------
+
+
+class _FakeTextBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeNonTextBlock:
+    """A block with no ``.text`` attribute (e.g. a tool-use block)."""
+
+
+class _FakeResponse:
+    def __init__(self, content: list) -> None:
+        self.content = content
+
+
+class TestCallAnthropicContent:
+    def _patch_sdk(self, response: _FakeResponse) -> AbstractContextManager[None]:
+        client = AsyncMock()
+        client.messages.create = AsyncMock(return_value=response)
+        fake_anthropic = type(
+            "FakeAnthropic",
+            (),
+            {"AsyncAnthropic": staticmethod(lambda: client)},
+        )
+        return patch.dict("sys.modules", {"anthropic": fake_anthropic})
+
+    def test_empty_content_returns_empty_string(self) -> None:
+        with self._patch_sdk(_FakeResponse([])):
+            result = asyncio.run(_call_anthropic("claude-haiku-4-5", "prompt", 100))
+        assert result == ""
+
+    def test_non_text_first_block_returns_empty_string(self) -> None:
+        with self._patch_sdk(_FakeResponse([_FakeNonTextBlock()])):
+            result = asyncio.run(_call_anthropic("claude-haiku-4-5", "prompt", 100))
+        assert result == ""
+
+    def test_non_text_block_before_text_block(self) -> None:
+        response = _FakeResponse([_FakeNonTextBlock(), _FakeTextBlock("the verdict")])
+        with self._patch_sdk(response):
+            result = asyncio.run(_call_anthropic("claude-haiku-4-5", "prompt", 100))
+        assert result == "the verdict"
+
+    def test_text_block_returns_text(self) -> None:
+        with self._patch_sdk(_FakeResponse([_FakeTextBlock("hello")])):
+            result = asyncio.run(_call_anthropic("claude-haiku-4-5", "prompt", 100))
+        assert result == "hello"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rubric_config.py
+++ b/tests/test_rubric_config.py
@@ -43,6 +43,14 @@ class TestCriterionNormalize:
         c = Criterion(description="test", type="likert", points=1)
         assert c.normalize(1) == 0.0
 
+    def test_likert_clamp_out_of_range(self) -> None:
+        """A judge returning a score above/below the scale is clamped to [0, 1]."""
+        c = Criterion(description="test", type="likert", points=5)
+        # 8 on a 5-point scale would be (8-1)/(5-1) = 1.75 unclamped.
+        assert c.normalize(8) == 1.0
+        # 0 on a 1-indexed scale would be (0-1)/4 = -0.25 unclamped.
+        assert c.normalize(0) == 0.0
+
     def test_numeric_normalization(self) -> None:
         c = Criterion(description="test", type="numeric", min=0.0, max=100.0)
         assert c.normalize(0) == pytest.approx(0.0)


### PR DESCRIPTION
Fixes three findings from the benchflow-core audit, all in the rewards code.

## Finding 3 [P2] — `call_judge` cross-provider fallback passes the wrong model name
`src/benchflow/rewards/llm.py` (`call_judge`): when an Anthropic model judge call fails on the API (bad key, retries exhausted), the loop fell through to `_call_openai`/`_call_google` with the *same* Claude model name. Those fail with model-not-found, so `last_error` ended up holding a misleading error from the wrong provider instead of the genuine Anthropic failure.

Cross-provider fallback only makes sense when an SDK is not installed (`ImportError` — already handled with `break`). On a real API failure, `call_judge` now retries within the same provider and then raises the original error directly, without advancing to a provider whose API cannot serve this model.

## Finding 4 [P3] — `_call_anthropic` assumes `content[0]` is a text block
`_call_anthropic` did `response.content[0].text`, which raises `IndexError`/`AttributeError` if the response has no content blocks or leads with a non-text block (e.g. a tool-use block). It now scans for the first text block and returns its text, or `""` when none is present.

## Finding 10 [P3] — `Criterion.normalize` for `likert` is not clamped
`src/benchflow/rewards/rubric_config.py` (`Criterion.normalize`): if a judge returned a score above `points` (e.g. 8 on a 5-point scale), `(raw-1)/(points-1)` exceeded 1.0 and was returned unclamped — unlike the `numeric` branch which already clamps to `[0, 1]`. The likert result is now clamped to `[0, 1]`.

## Tests
- `TestCallJudgeProviderFallback`: a mocked API failure surfaces the original error and tries no other provider; `ImportError` still falls through.
- `TestCallAnthropicContent`: empty content and leading non-text blocks return `""`.
- `test_likert_clamp_out_of_range`: out-of-range likert scores clamp to `[0, 1]`.

CI gate green locally: `ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` (1257 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error-handling/routing in `call_judge` and alters Anthropic response parsing, which could affect judge execution paths in production. Behavior is covered by new targeted unit tests, reducing regression risk.
> 
> **Overview**
> **Rewards LLM judging is made more correct and robust.** `call_judge` now only falls back across providers when a provider SDK is missing (`ImportError`); on real provider/API failures it retries and then raises the original exception instead of trying other providers with an incompatible model name.
> 
> **Anthropic and rubric scoring edge cases are hardened.** `_call_anthropic` now returns the first text content block (or `""` if none), avoiding `IndexError`/`AttributeError` on empty/non-text responses, and `Criterion.normalize` clamps *likert* scores to `[0, 1]`. New tests cover the fallback semantics, Anthropic block handling, and likert clamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99ab383c6ab80e725f1619616e04296f0604e64b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->