### PR TITLE
fix: disjoint error/verifier_error result buckets + skill_eval glob collision

### DIFF
--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -678,8 +678,14 @@ class Evaluation:
                 for r in all_results.values()
                 if r.get("error") and r.get("rewards") is None
             ),
+            # Disjoint from `errored`: a result with both `error` and
+            # `verifier_error` is counted only as `errored`, so the
+            # passed+failed+errored+verifier_errored == total invariant holds.
             verifier_errored=sum(
-                1 for r in all_results.values() if r.get("verifier_error")
+                1
+                for r in all_results.values()
+                if r.get("verifier_error")
+                and not (r.get("error") and r.get("rewards") is None)
             ),
             elapsed_sec=elapsed,
         )

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -55,8 +55,16 @@ class TaskMetrics:
 
     @property
     def verifier_errored(self) -> bool:
-        """True when task failed due to verifier error (not agent error)."""
-        return self.reward is None and self.verifier_error is not None
+        """True when task failed due to verifier error (not agent error).
+
+        Disjoint from `errored`: a task with both `error` and `verifier_error`
+        is classified as `errored` only, so the count buckets never overlap.
+        """
+        return (
+            self.reward is None
+            and self.verifier_error is not None
+            and self.error is None
+        )
 
     @property
     def completed(self) -> bool:

--- a/src/benchflow/skill_eval.py
+++ b/src/benchflow/skill_eval.py
@@ -590,12 +590,15 @@ class SkillEvaluator:
         jobs_path = Path(jobs_dir)
         for case in self.dataset.cases:
             case_id = case.id
-            # Evaluation writes timestamped rollout dirs; support both the old
-            # direct layout and the current nested layout.
+            # Evaluation writes rollout dirs as `{case_id}__{uuid8}`; match the
+            # exact naming contract so e.g. `case-1` never picks up `case-10`.
+            # Also accept a dir named exactly `case_id` (old direct layout).
             rollout_dirs = [
                 path
                 for path in jobs_path.glob(f"**/{case_id}*")
-                if path.is_dir() and (path / "result.json").exists()
+                if path.is_dir()
+                and (path.name == case_id or path.name.startswith(f"{case_id}__"))
+                and (path / "result.json").exists()
             ]
             if rollout_dirs:
                 rollout_dir = sorted(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -92,6 +92,38 @@ class TestJobCounting:
         assert counts["errored"] == 0
         assert counts["failed"] == 1
 
+    def test_error_and_verifier_error_counted_once(self):
+        """A result with BOTH error and verifier_error (rewards=None) must be
+        classified into exactly one bucket so the count invariant holds.
+
+        Mirrors the disjoint bucketing in Evaluation.run(): a result is
+        ``errored`` when it has an agent error, and ``verifier_errored`` only
+        when it has a verifier error AND no agent error.
+        """
+        results = {
+            "a": {
+                "rewards": None,
+                "error": "agent crashed",
+                "verifier_error": "verifier also failed",
+            },
+        }
+        errored = sum(
+            1 for r in results.values() if r.get("error") and r.get("rewards") is None
+        )
+        verifier_errored = sum(
+            1
+            for r in results.values()
+            if r.get("verifier_error")
+            and not (r.get("error") and r.get("rewards") is None)
+        )
+        # Exactly one bucket — never double-counted.
+        assert errored == 1
+        assert verifier_errored == 0
+        counts = self._count(results)
+        assert counts["passed"] + counts["failed"] + errored + verifier_errored == len(
+            results
+        )
+
 
 class TestRunTaskLoop:
     """Tests for Evaluation._run_task — retry loop behavior."""
@@ -296,6 +328,37 @@ class TestJobRunOrchestration:
 
         assert result.errored == 1
         assert any("unexpected exception: boom" in m for m in caplog.messages)
+
+    @pytest.mark.asyncio
+    async def test_error_and_verifier_error_does_not_crash_invariant(self, tmp_path):
+        """A result with BOTH error and verifier_error (rewards=None) must not
+        be double-counted — otherwise the passed+failed+errored+verifier_errored
+        == total assertion in Evaluation.run() crashes the whole evaluation.
+
+        Regression for audit Finding 6.
+        """
+        job = self._make_job(tmp_path, n_tasks=1, concurrency=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(
+                task_name="task-0",
+                rewards=None,
+                error="agent crashed",
+                verifier_error="verifier also failed",
+            )
+        )
+
+        # Must not raise the "Counting bug" AssertionError.
+        result = await job.run()
+
+        assert (
+            result.passed + result.failed + result.errored + result.verifier_errored
+            == result.total
+            == 1
+        )
+        # Agent error takes precedence: counted as errored, not verifier_errored.
+        assert result.errored == 1
+        assert result.verifier_errored == 0
 
     @pytest.mark.asyncio
     async def test_summary_json_includes_usage_aggregation(self, tmp_path):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -267,6 +267,41 @@ def test_collect_metrics_partial_reward(tmp_path):
     assert s["failed"] == 1
 
 
+def test_collect_metrics_error_and_verifier_error_counted_once(tmp_path):
+    """A result with BOTH error and verifier_error (rewards=None) must land in
+    exactly one bucket — errored — so the count buckets stay disjoint and
+    passed+failed+errored+verifier_errored == total.
+
+    Regression for audit Finding 6 (metrics.py side).
+    """
+    trial = tmp_path / "job" / "task-x__abc123"
+    trial.mkdir(parents=True)
+    (trial / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-x",
+                "rewards": None,
+                "error": "agent crashed",
+                "verifier_error": "verifier also failed",
+                "n_tool_calls": 0,
+                "started_at": "2026-03-24 10:00:00.000000",
+                "finished_at": "2026-03-24 10:05:00.000000",
+            }
+        )
+    )
+
+    metrics = collect_metrics(str(tmp_path))
+    s = metrics.summary()
+
+    assert s["total"] == 1
+    # Agent error takes precedence — counted once as errored, never as both.
+    assert s["errored"] == 1
+    assert s["verifier_errored"] == 0
+    assert (
+        s["passed"] + s["failed"] + s["errored"] + s["verifier_errored"] == s["total"]
+    )
+
+
 def test_collect_metrics_usage_aggregation_mixed_telemetry(tmp_path):
     rows = [
         (

--- a/tests/test_skill_eval.py
+++ b/tests/test_skill_eval.py
@@ -499,6 +499,68 @@ class TestSkillEvaluatorResultCollection:
         ]
         assert collected["calc-002"].reward is None
 
+    @pytest.mark.asyncio
+    async def test_case_result_glob_does_not_match_prefix_sibling(
+        self, tmp_path, monkeypatch
+    ):
+        """`case-1` must resolve to its own rollout dir, not `case-10`'s.
+
+        The rollout-dir contract is `{case_id}__{uuid8}`; a trailing-`*` glob
+        (`**/{case_id}*`) also matches `case-10__...`, `case-11__...`, etc. and
+        can mis-attribute rewards. Regression for audit Finding 7.
+        """
+        from benchflow.evaluation import EvaluationResult
+
+        # Skill with two cases whose ids are prefixes of each other.
+        skill = tmp_path / "globskill"
+        (skill / "evals").mkdir(parents=True)
+        (skill / "evals" / "evals.json").write_text(
+            json.dumps(
+                {
+                    "cases": [
+                        {"id": "case-1", "question": "q1", "ground_truth": "a1"},
+                        {"id": "case-10", "question": "q10", "ground_truth": "a10"},
+                    ],
+                }
+            )
+        )
+
+        async def fake_run(self):
+            # Write rollout dirs following the {case_id}__{uuid8} contract.
+            for case_id, reward in (("case-1", 0.0), ("case-10", 1.0)):
+                rollout_dir = (
+                    self._jobs_dir / "2026-05-21__09-00-00" / f"{case_id}__deadbeef"
+                )
+                rollout_dir.mkdir(parents=True)
+                (rollout_dir / "result.json").write_text(
+                    json.dumps(
+                        {
+                            "task_name": case_id,
+                            "rewards": {"reward": reward},
+                            "n_tool_calls": 1,
+                        }
+                    )
+                )
+            return EvaluationResult(job_name="fake", config=self._config, total=2)
+
+        monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_run)
+
+        evaluator = SkillEvaluator(skill)
+        results = await evaluator._run_job(
+            tasks_dir=tmp_path / "tasks",
+            agent="gemini",
+            model="",
+            environment="docker",
+            jobs_dir=str(tmp_path / "jobs"),
+            concurrency=1,
+            with_skill=True,
+        )
+
+        collected = {result.case_id: result for result in results}
+        # case-1 must pick its OWN dir (reward 0.0), not case-10's (reward 1.0).
+        assert collected["case-1"].reward == 0.0
+        assert collected["case-10"].reward == 1.0
+
 
 # ---------------------------------------------------------------------------
 # GEPA export


### PR DESCRIPTION
Fixes two P2 findings from the benchflow-core audit about result handling.

## Finding 6 — result counting can double-count a task with both `error` and `verifier_error`

`EvaluationResult` in `src/benchflow/evaluation.py` counted `errored` as
`error and rewards is None` and `verifier_errored` as `verifier_error`. A
`result.json` with **both** `error` and `verifier_error` (and `rewards=None`)
landed in both buckets, breaking the
`passed+failed+errored+verifier_errored == total` assertion and crashing the
entire evaluation. `src/benchflow/metrics.py` (`TaskMetrics.verifier_errored`)
had the same overlap with no assertion — silently inconsistent totals.

Fix: the buckets are now strictly **disjoint**. `verifier_errored` is only
counted when no agent `error` is present, so a result with both is classified
as `errored` (agent error takes precedence). Applied consistently in both
`evaluation.py` and `metrics.py`.

## Finding 7 — skill_eval case-result glob can match the wrong rollout directory

`src/benchflow/skill_eval.py` resolved per-case results with
`jobs_path.glob(f"**/{case_id}*")`. The trailing `*` collides: for
`case_id="case-1"` it also matched rollout dirs for `case-10`, `case-11`, etc.
(`Evaluation` writes rollout dirs as `{case_id}__{uuid8}`), so the wrong case's
`result.json` could be picked and rewards mis-attributed.

Fix: match the exact rollout-dir naming contract — a dir whose name equals
`case_id` or starts with `f"{case_id}__"`.

## Tests

Regression tests added:
- `tests/test_job.py` — a result with both `error` and `verifier_error` is
  counted once; `Evaluation.run()` does not crash the count invariant.
- `tests/test_metrics.py` — same disjoint-bucket check via `collect_metrics`.
- `tests/test_skill_eval.py` — with `case-1` and `case-10` present, `case-1`
  resolves to its own rollout dir.

The three integration-level tests were confirmed to fail against the unfixed
code. Full CI gate green: `ruff format --check`, `ruff check`, `ty check`,
`pytest` (1254 passed, 24 skipped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core result aggregation and metrics bucketing logic; while changes are small and covered by new regression tests, misclassification would affect evaluation totals and pass rates.
> 
> **Overview**
> Fixes a counting bug where a `result.json` containing both `error` and `verifier_error` could be double-counted as both `errored` and `verifier_errored`, breaking the `passed+failed+errored+verifier_errored==total` invariant. `Evaluation.run()` and `TaskMetrics.verifier_errored` now make these buckets **disjoint** by treating agent `error` as taking precedence.
> 
> Tightens `SkillEvaluator._run_job` result collection to only accept rollout directories named exactly `case_id` or starting with `{case_id}__`, preventing prefix collisions (e.g. `case-1` mistakenly matching `case-10`). Adds regression tests covering both issues in `tests/test_job.py`, `tests/test_metrics.py`, and `tests/test_skill_eval.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d6317986b5175468e10bda269b7f7a623264e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->