### PR TITLE
feat(verifier): target-side test.sh verification for multi-container tasks (#248)

### DIFF
--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -87,6 +87,40 @@ clear error for any non-`main` service. This lets a verifier check
 write-based oracles (`/tmp/exploit.txt` in the target), database modifications,
 or RCE markers without trusting the agent container.
 
+### Target-side `test.sh` verification
+
+For tasks whose success oracle lives in a target container — an RCE marker
+file, a modified database row — point the `test.sh` verifier at that service
+with `[verifier].service`:
+
+```toml
+[verifier]
+service = "target"     # run tests/test.sh inside the `target` container
+```
+
+With this set, BenchFlow uploads the task's `tests/` directory into the
+**target** container, runs `test.sh` there, and copies the resulting
+`reward.txt` / `reward.json` back to the host. `service` defaults to `"main"`
+(the agent container), so existing single-container tasks are unaffected.
+
+`[verifier].service` is the declarative, task-schema way to do cross-container
+verification; the `env.exec_in_service(...)` Python API above is the
+imperative equivalent for hook-driven runs.
+
+> Use the same `service` name you declared in `docker-compose.yaml`. A
+> `test.sh` running in the target reaches `main` (and vice versa) by service
+> name over the Docker network, just like the agent does.
+
+### Hardening policy for multi-container tasks
+
+BenchFlow's pre-verification hardening — killing the sandbox user's
+processes, scrubbing `PATH`/`PYTHONPATH`, restoring build-config files —
+applies **only to the `main` (agent) container**. Target containers are
+deliberately left unhardened: a vulhub-style target is *meant* to be
+vulnerable, the agent never has a shell inside it, and hardening it would
+risk breaking the very vulnerability the task exercises. `[verifier].service`
+selects where `test.sh` *runs*; it does not move hardening off `main`.
+
 ---
 
 ## instruction.md

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -127,11 +127,28 @@ class Environment:
     async def upload_file(self, src: str | Path, dst: str) -> None:
         await self._inner.upload_file(src, dst)
 
-    async def upload_dir(self, src: str | Path, dst: str) -> None:
-        await self._inner.upload_dir(src, dst)
+    async def upload_dir(
+        self, src: str | Path, dst: str, service: str = "main"
+    ) -> None:
+        """Upload a directory into the sandbox.
+
+        Pass ``service="<name>"`` to target a non-``main`` compose service
+        (a vulhub-style target container) — see #248.
+        """
+        await self._inner.upload_dir(src, dst, service=service)
 
     async def download_file(self, src: str, dst: str | Path) -> None:
         await self._inner.download_file(src, dst)
+
+    async def download_dir(
+        self, src: str, dst: str | Path, service: str = "main"
+    ) -> None:
+        """Download a directory from the sandbox.
+
+        Pass ``service="<name>"`` to fetch from a non-``main`` compose service
+        (a vulhub-style target container) — see #248.
+        """
+        await self._inner.download_dir(src, dst, service=service)
 
     async def __aenter__(self) -> Environment:
         await self.start()

--- a/src/benchflow/sandbox/_base.py
+++ b/src/benchflow/sandbox/_base.py
@@ -173,7 +173,18 @@ class BaseSandbox(ABC):
     async def upload_file(self, source_path: Path | str, target_path: str) -> None: ...
 
     @abstractmethod
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None: ...
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None:
+        """Upload a directory into a compose service container.
+
+        ``service`` selects which container receives the files. The default
+        ``"main"`` is the agent container. Multi-container (vulhub-style)
+        tasks pass a target service so the test-script verifier's ``/tests``
+        dir lands in the container being inspected (#248). Single-container
+        backends reject non-``main`` values.
+        """
+        ...
 
     @abstractmethod
     async def download_file(
@@ -181,7 +192,18 @@ class BaseSandbox(ABC):
     ) -> None: ...
 
     @abstractmethod
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None: ...
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None:
+        """Download a directory from a compose service container.
+
+        ``service`` selects which container the files come from. The default
+        ``"main"`` is the agent container. Multi-container (vulhub-style)
+        tasks pass a target service so target-side verifier output — e.g. a
+        ``reward.txt`` written by a ``test.sh`` running in the target — can be
+        retrieved (#248). Single-container backends reject non-``main`` values.
+        """
+        ...
 
     @abstractmethod
     async def exec(

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -164,7 +164,9 @@ class _DaytonaStrategy:
     async def upload_file(self, source_path: Path | str, target_path: str) -> None: ...
 
     @abstractmethod
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None: ...
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None: ...
 
     @abstractmethod
     async def download_file(
@@ -172,7 +174,9 @@ class _DaytonaStrategy:
     ) -> None: ...
 
     @abstractmethod
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None: ...
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None: ...
 
     @abstractmethod
     async def is_dir(self, path: str, user: str | int | None = None) -> bool: ...
@@ -306,13 +310,29 @@ class _DaytonaDirect(_DaytonaStrategy):
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
         await self._env._sdk_upload_file(source_path, target_path)
 
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None:
+        if service != "main":
+            raise ValueError(
+                f"Direct (non-compose) Daytona sandbox is single-container "
+                f"and cannot target service {service!r}. Multi-container "
+                "(vulhub-style) tasks require a docker-compose.yaml (#248)."
+            )
         await self._env._sdk_upload_dir(source_dir, target_dir)
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         await self._env._sdk_download_file(source_path, target_path)
 
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None:
+        if service != "main":
+            raise ValueError(
+                f"Direct (non-compose) Daytona sandbox is single-container "
+                f"and cannot target service {service!r}. Multi-container "
+                "(vulhub-style) tasks require a docker-compose.yaml (#248)."
+            )
         await self._env._sdk_download_dir(source_dir, target_dir)
 
     async def is_dir(self, path: str, user: str | int | None = None) -> bool:
@@ -647,12 +667,19 @@ class _DaytonaDinD(_DaytonaStrategy):
         finally:
             await self._vm_exec(f"rm -f {shlex.quote(temp)}", timeout_sec=10)
 
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None:
+        """Upload a directory into a compose service inside the DinD VM.
+
+        ``service`` defaults to ``"main"``; pass a target service to land the
+        directory in an additional vulhub-style container (#248).
+        """
         temp = f"/tmp/benchflow_{uuid4().hex}"
         try:
             await self._env._sdk_upload_dir(source_dir, temp)
             result = await self._compose_exec(
-                ["cp", f"{temp}/.", f"main:{target_dir}"], timeout_sec=120
+                ["cp", f"{temp}/.", f"{service}:{target_dir}"], timeout_sec=120
             )
             if result.return_code != 0:
                 raise RuntimeError(
@@ -693,17 +720,28 @@ class _DaytonaDinD(_DaytonaStrategy):
         finally:
             await self._vm_exec(f"rm -f {shlex.quote(temp)}", timeout_sec=10)
 
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
-        sandbox_path = self._sandbox_log_path(source_dir)
-        if sandbox_path:
-            await self._env._sdk_download_dir(sandbox_path, target_dir)
-            return
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None:
+        """Download a directory from a compose service inside the DinD VM.
+
+        ``service`` defaults to ``"main"``; pass a target service to fetch
+        target-side verifier output from a vulhub-style container (#248).
+        The host-mounted-log fast path only applies to ``main`` — target
+        services have no host bind mount, so their contents are always
+        copied out via ``docker compose cp``.
+        """
+        if service == "main":
+            sandbox_path = self._sandbox_log_path(source_dir)
+            if sandbox_path:
+                await self._env._sdk_download_dir(sandbox_path, target_dir)
+                return
 
         temp = f"/tmp/benchflow_{uuid4().hex}"
         try:
             await self._vm_exec(f"mkdir -p {shlex.quote(temp)}", timeout_sec=10)
             result = await self._compose_exec(
-                ["cp", f"main:{source_dir}/.", temp], timeout_sec=120
+                ["cp", f"{service}:{source_dir}/.", temp], timeout_sec=120
             )
             if result.return_code != 0:
                 self._env.logger.error(
@@ -1113,14 +1151,20 @@ class DaytonaSandbox(BaseSandbox):
     async def upload_file(self, source_path: Path | str, target_path: str) -> None:
         return await self._strategy.upload_file(source_path, target_path)
 
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
-        return await self._strategy.upload_dir(source_dir, target_dir)
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None:
+        return await self._strategy.upload_dir(source_dir, target_dir, service=service)
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
         return await self._strategy.download_file(source_path, target_path)
 
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
-        return await self._strategy.download_dir(source_dir, target_dir)
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None:
+        return await self._strategy.download_dir(
+            source_dir, target_dir, service=service
+        )
 
     async def is_dir(
         self, path: str, user: str | int | None = None, service: str = "main"

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -368,17 +368,26 @@ class DockerSandbox(BaseSandbox):
             check=True,
         )
 
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
-        await self.exec(f"mkdir -p {shlex.quote(target_dir)}", user="root")
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None:
+        """Upload a directory into a compose service container.
+
+        ``service`` defaults to ``"main"``; pass a target service to land the
+        directory in an additional vulhub-style container (#248).
+        """
+        await self.exec(
+            f"mkdir -p {shlex.quote(target_dir)}", user="root", service=service
+        )
         await self._run_docker_compose_command(
-            ["cp", f"{source_dir}/.", f"main:{target_dir}"],
+            ["cp", f"{source_dir}/.", f"{service}:{target_dir}"],
             check=True,
         )
         if sys.platform == "win32":
             await self._run_docker_compose_command(
                 [
                     "exec",
-                    "main",
+                    service,
                     "bash",
                     "-c",
                     f"find {target_dir} -type f \\( -name '*.sh' -o -name '*.py' \\) "
@@ -387,12 +396,16 @@ class DockerSandbox(BaseSandbox):
                 check=False,
             )
 
-    async def _chown_to_host_user(self, path: str, recursive: bool = False) -> None:
+    async def _chown_to_host_user(
+        self, path: str, recursive: bool = False, service: str = "main"
+    ) -> None:
         if not hasattr(os, "getuid"):
             return
         flag = "-R " if recursive else ""
         await self.exec(
-            f"chown {flag}{os.getuid()}:{os.getgid()} {shlex.quote(path)}", user="root"
+            f"chown {flag}{os.getuid()}:{os.getgid()} {shlex.quote(path)}",
+            user="root",
+            service=service,
         )
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:
@@ -402,10 +415,17 @@ class DockerSandbox(BaseSandbox):
             check=True,
         )
 
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
-        await self._chown_to_host_user(source_dir, recursive=True)
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None:
+        """Download a directory from a compose service container.
+
+        ``service`` defaults to ``"main"``; pass a target service to fetch
+        target-side verifier output from a vulhub-style container (#248).
+        """
+        await self._chown_to_host_user(source_dir, recursive=True, service=service)
         await self._run_docker_compose_command(
-            ["cp", f"main:{source_dir}/.", str(target_dir)],
+            ["cp", f"{service}:{source_dir}/.", str(target_dir)],
             check=True,
         )
 

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -750,6 +750,14 @@ async def harden_before_verify(
     5. chown workspace to root (belt-and-suspenders against zombie sandbox writes).
     6. Remove injected conftest.py, sitecustomize.py, .pth files.
     7. Merge trusted env vars into task.config.verifier.env.
+
+    Cross-container hardening policy (#248): every step here runs against the
+    ``main`` (agent) container only — ``env.exec`` is never passed a
+    ``service``. This is deliberate. In multi-container (vulhub-style) tasks
+    the agent has a shell only in ``main``; the target/database containers are
+    intentionally vulnerable and the agent cannot tamper with them, so they
+    need no anti-tamper hardening. ``[verifier].service`` chooses where
+    ``test.sh`` *runs*; it does not relocate hardening off ``main``.
     """
 
     if sandbox_user:

--- a/src/benchflow/sandbox/modal_impl.py
+++ b/src/benchflow/sandbox/modal_impl.py
@@ -223,7 +223,15 @@ class ModalSandbox(BaseSandbox):
                         break
                     await file_handle.write.aio(chunk)
 
-    async def upload_dir(self, source_dir: Path | str, target_dir: str) -> None:
+    async def upload_dir(
+        self, source_dir: Path | str, target_dir: str, service: str = "main"
+    ) -> None:
+        if service != "main":
+            raise ValueError(
+                f"Modal sandbox is single-container and cannot target "
+                f"service {service!r}. Multi-container (vulhub-style) tasks "
+                "require the Docker sandbox (#248)."
+            )
         if not self._sandbox:
             raise RuntimeError("Sandbox not found. Please start the environment first.")
 
@@ -264,7 +272,15 @@ class ModalSandbox(BaseSandbox):
                         break
                     local_file.write(chunk)
 
-    async def download_dir(self, source_dir: str, target_dir: Path | str) -> None:
+    async def download_dir(
+        self, source_dir: str, target_dir: Path | str, service: str = "main"
+    ) -> None:
+        if service != "main":
+            raise ValueError(
+                f"Modal sandbox is single-container and cannot target "
+                f"service {service!r}. Multi-container (vulhub-style) tasks "
+                "require the Docker sandbox (#248)."
+            )
         if not self._sandbox:
             raise RuntimeError("Sandbox not found. Please start the environment first.")
 

--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -139,6 +139,19 @@ class VerifierConfig(BaseModel):
         default=None,
         description="Username or UID to run the verifier as.",
     )
+    service: str = Field(
+        default="main",
+        description=(
+            "Compose service the test-script verifier runs in. Defaults to "
+            "'main' (the agent container). Multi-container (vulhub-style) "
+            "tasks set this to a target/database service so test.sh can "
+            "inspect target-side state — RCE markers, DB modifications — "
+            "rather than only the agent's workspace. The agent's "
+            "anti-tamper hardening only applies to 'main'; deliberately "
+            "vulnerable target containers are intentionally not hardened. "
+            "See #248."
+        ),
+    )
     judge: JudgeVerifierConfig = Field(
         default_factory=JudgeVerifierConfig,
         description="LLM-judge configuration (used when type == 'llm-judge').",

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -139,11 +139,20 @@ class Verifier:
     # ------------------------------------------------------------------
 
     async def _verify_test_script(self) -> VerifierResult:
-        """Run the task's ``test.sh`` verifier and return the reward result."""
+        """Run the task's ``test.sh`` verifier and return the reward result.
+
+        ``[verifier].service`` selects which compose service ``test.sh`` runs
+        in. The default ``"main"`` is the agent container (Harbor-compatible).
+        Multi-container (vulhub-style) tasks set it to a target/database
+        service so the verifier can inspect *target-side* state — RCE markers,
+        DB modifications — instead of only the agent workspace (#248).
+        """
+        service = getattr(self._task.config.verifier, "service", "main")
         try:
             await self._sandbox.upload_dir(
                 source_dir=self._task.paths.tests_dir,
                 target_dir="/tests",
+                service=service,
             )
         except Exception as e:
             raise AddTestsDirError("Failed to add tests directory to sandbox.") from e
@@ -181,20 +190,25 @@ class Verifier:
         await self._sandbox.exec(
             f"chmod +x {test_script_path}",
             user="root",
+            service=service,
         )
         await self._sandbox.exec(
             command=f"{test_script_path} > {test_stdout_path} 2>&1",
             env=env,
             user=self._task.config.verifier.user,
+            service=service,
         )
 
-        # Download verifier output if sandbox doesn't mount locally
-        is_mounted = getattr(self._sandbox, "is_mounted", False)
+        # Download verifier output if it is not host-mounted. Only the agent's
+        # ``main`` container has the rollout dir bind-mounted; a target service
+        # never does, so target-side rewards (#248) are always downloaded.
+        is_mounted = service == "main" and getattr(self._sandbox, "is_mounted", False)
         if not is_mounted:
             try:
                 await self._sandbox.download_dir(
                     source_dir=str(sandbox_paths.verifier_dir),
                     target_dir=self._rollout_paths.verifier_dir,
+                    service=service,
                 )
             except Exception as e:
                 raise DownloadVerifierDirError(

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -15,7 +15,10 @@ async def test_docker_upload_dir_creates_target_before_compose_cp() -> None:
 
     await sandbox.upload_dir("local/skills", "/app/skills")
 
-    sandbox.exec.assert_awaited_once_with("mkdir -p /app/skills", user="root")
+    # upload_dir threads the compose `service` selector through to mkdir (#248).
+    sandbox.exec.assert_awaited_once_with(
+        "mkdir -p /app/skills", user="root", service="main"
+    )
     sandbox._run_docker_compose_command.assert_awaited_once_with(
         ["cp", "local/skills/.", "main:/app/skills"],
         check=True,

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -136,6 +136,102 @@ class TestDockerSandboxServiceExec:
         assert services == ["main", "target"]
 
 
+class TestDockerSandboxServiceFileTransfer:
+    """#248: upload_dir/download_dir must be able to target any service.
+
+    Target-side ``test.sh`` verification needs the ``/tests`` dir copied into
+    the target container and the resulting ``reward.txt`` copied back out.
+    """
+
+    def _make_sandbox(self) -> DockerSandbox:
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._persistent_env = {}
+        sandbox.default_user = None
+        return sandbox
+
+    @pytest.mark.asyncio
+    async def test_upload_dir_targets_named_service(self) -> None:
+        """#248: upload_dir(service=...) copies into the target container."""
+        sandbox = self._make_sandbox()
+        cp_calls: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            cp_calls.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.upload_dir("/host/tests", "/tests", service="target")
+
+        cp = next(c for c in cp_calls if c and c[0] == "cp")
+        assert cp == ["cp", "/host/tests/.", "target:/tests"]
+
+    @pytest.mark.asyncio
+    async def test_upload_dir_defaults_to_main(self) -> None:
+        """#248: upload_dir without a service still copies into main."""
+        sandbox = self._make_sandbox()
+        cp_calls: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            cp_calls.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.upload_dir("/host/tests", "/tests")
+
+        cp = next(c for c in cp_calls if c and c[0] == "cp")
+        assert cp == ["cp", "/host/tests/.", "main:/tests"]
+
+    @pytest.mark.asyncio
+    async def test_download_dir_targets_named_service(self) -> None:
+        """#248: download_dir(service=...) copies out of the target container."""
+        sandbox = self._make_sandbox()
+        cp_calls: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            cp_calls.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.download_dir("/logs/verifier", "/host/out", service="target")
+
+        cp = next(c for c in cp_calls if c and c[0] == "cp")
+        assert cp == ["cp", "target:/logs/verifier/.", "/host/out"]
+
+
+class TestSingleContainerFileTransferRejection:
+    """#248: single-container backends reject non-main dir transfers."""
+
+    @pytest.mark.asyncio
+    async def test_modal_upload_dir_rejects_non_main(self) -> None:
+        """#248: Modal upload_dir cannot target a non-main service."""
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        with pytest.raises(ValueError, match="single-container"):
+            await sandbox.upload_dir("/host/tests", "/tests", service="target")
+
+    @pytest.mark.asyncio
+    async def test_modal_download_dir_rejects_non_main(self) -> None:
+        """#248: Modal download_dir cannot target a non-main service."""
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        with pytest.raises(ValueError, match="single-container"):
+            await sandbox.download_dir("/logs/verifier", "/host/out", service="target")
+
+    @pytest.mark.asyncio
+    async def test_daytona_direct_upload_dir_rejects_non_main(self) -> None:
+        """#248: direct (non-compose) Daytona upload_dir rejects multi-service."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDirect
+
+        strategy = _DaytonaDirect.__new__(_DaytonaDirect)
+        with pytest.raises(ValueError, match="single-container"):
+            await strategy.upload_dir("/host/tests", "/tests", service="target")
+
+
 class TestDockerProcessServiceSelection:
     """#248: ACP agent process can be launched into a non-main service."""
 

--- a/tests/test_verifier_multi_container.py
+++ b/tests/test_verifier_multi_container.py
@@ -1,0 +1,209 @@
+"""Tests for the deferred multi-container verification items of #248.
+
+PR #310 shipped first-class compose *service selection* on the ``exec`` path
+but deferred the verification-side wiring. This file covers the follow-up:
+
+- **Item 4** — target-side ``test.sh`` verification: the test-script verifier
+  can run inside a non-``main`` compose service so it can inspect target-side
+  state (RCE markers, DB modifications) instead of only the agent workspace.
+- **Item 5** — cross-container flag plumbing / task-schema convention: the
+  ``[verifier].service`` knob in ``task.toml`` is the declarative convention
+  task authors use to point verification at a target container.
+- **Item 3** — cross-container hardening policy: ``harden_before_verify``
+  intentionally hardens only ``main``; deliberately vulnerable target
+  containers are never hardened.
+
+All tests are unit tests with mocked sandboxes — no Docker/Daytona infra.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from benchflow.sandbox._base import ExecResult
+from benchflow.task import RolloutPaths, Verifier
+from benchflow.task.config import TaskConfig
+
+# ---------------------------------------------------------------------------
+# Item 5 — [verifier].service task-schema convention
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierServiceConfig:
+    """#248 item 5: [verifier].service is the cross-container schema knob."""
+
+    def test_service_defaults_to_main(self) -> None:
+        """#248: omitting [verifier].service keeps the agent container."""
+        cfg = TaskConfig.model_validate_toml('version = "1.0"\n[verifier]\n')
+        assert cfg.verifier.service == "main"
+
+    def test_service_can_target_a_named_container(self) -> None:
+        """#248: task.toml can point the verifier at a target service."""
+        toml = """\
+version = "1.0"
+
+[verifier]
+service = "target"
+"""
+        cfg = TaskConfig.model_validate_toml(toml)
+        assert cfg.verifier.service == "target"
+
+    def test_service_is_keyword_compatible_with_existing_tasks(self) -> None:
+        """#248: existing task.toml files (no service key) are unaffected."""
+        toml = """\
+version = "1.0"
+
+[verifier]
+timeout_sec = 120
+user = "root"
+"""
+        cfg = TaskConfig.model_validate_toml(toml)
+        assert cfg.verifier.service == "main"
+        assert cfg.verifier.user == "root"
+
+
+# ---------------------------------------------------------------------------
+# Item 4 — target-side test.sh verification
+# ---------------------------------------------------------------------------
+
+
+def _make_task(tmp_path: Path, toml: str) -> MagicMock:
+    """Build a task stub backed by a real ``tests/`` directory."""
+    task_dir = tmp_path / "task"
+    tests_dir = task_dir / "tests"
+    tests_dir.mkdir(parents=True, exist_ok=True)
+    (tests_dir / "test.sh").write_text(
+        "#!/bin/bash\necho 1 > /logs/verifier/reward.txt\n"
+    )
+    task = MagicMock()
+    task.task_dir = task_dir
+    task.paths.task_dir = task_dir
+    task.paths.tests_dir = tests_dir
+    task.paths.test_path = tests_dir / "test.sh"
+    task.config = TaskConfig.model_validate_toml(toml)
+    task.instruction = "Exploit the target."
+    return task
+
+
+class _RecordingSandbox:
+    """Sandbox stub that records the ``service`` used for each operation."""
+
+    def __init__(self, rollout_paths: RolloutPaths, reward: str = "1.0") -> None:
+        self.is_mounted = False
+        self._rollout_paths = rollout_paths
+        self._reward = reward
+        self.upload_calls: list[dict] = []
+        self.download_calls: list[dict] = []
+        self.exec_calls: list[dict] = []
+
+    async def upload_dir(self, source_dir, target_dir, service: str = "main") -> None:
+        self.upload_calls.append(
+            {"source": source_dir, "target": target_dir, "service": service}
+        )
+
+    async def download_dir(self, source_dir, target_dir, service: str = "main") -> None:
+        self.download_calls.append(
+            {"source": source_dir, "target": target_dir, "service": service}
+        )
+        # Mimic a target-side test.sh that wrote a reward file.
+        dest = Path(target_dir)
+        dest.mkdir(parents=True, exist_ok=True)
+        (dest / "reward.txt").write_text(self._reward)
+
+    async def exec(self, command, service: str = "main", **kwargs) -> ExecResult:
+        self.exec_calls.append({"command": command, "service": service, **kwargs})
+        return ExecResult(stdout="", stderr="", return_code=0)
+
+
+class TestTargetSideTestScriptVerification:
+    """#248 item 4: the test-script verifier can run inside a target service."""
+
+    @pytest.mark.asyncio
+    async def test_default_verifier_runs_test_script_in_main(
+        self, tmp_path: Path
+    ) -> None:
+        """#248: with no [verifier].service the test.sh still runs in main."""
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        sandbox = _RecordingSandbox(rollout_paths)
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        assert {c["service"] for c in sandbox.upload_calls} == {"main"}
+        assert {c["service"] for c in sandbox.exec_calls} == {"main"}
+
+    @pytest.mark.asyncio
+    async def test_verifier_runs_test_script_in_target_service(
+        self, tmp_path: Path
+    ) -> None:
+        """#248: [verifier].service routes test.sh into the target container."""
+        toml = 'version = "1.0"\n[verifier]\nservice = "target"\n'
+        task = _make_task(tmp_path, toml)
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        sandbox = _RecordingSandbox(rollout_paths)
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+        # tests/ uploaded into the target container, test.sh exec'd there.
+        assert {c["service"] for c in sandbox.upload_calls} == {"target"}
+        assert {c["service"] for c in sandbox.exec_calls} == {"target"}
+        assert result.rewards == {"reward": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_target_side_reward_downloaded_from_target_service(
+        self, tmp_path: Path
+    ) -> None:
+        """#248: the reward file is fetched from the target, not main."""
+        toml = 'version = "1.0"\n[verifier]\nservice = "target"\n'
+        task = _make_task(tmp_path, toml)
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        sandbox = _RecordingSandbox(rollout_paths, reward="1.0")
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        assert sandbox.download_calls, "reward must be downloaded from the target"
+        assert {c["service"] for c in sandbox.download_calls} == {"target"}
+
+
+# ---------------------------------------------------------------------------
+# Item 3 — cross-container hardening policy
+# ---------------------------------------------------------------------------
+
+
+class TestCrossContainerHardeningPolicy:
+    """#248 item 3: anti-tamper hardening applies to ``main`` only.
+
+    A vulhub-style target is deliberately vulnerable. Running the agent
+    anti-tamper hardening (kill user processes, scrub PATH, restore build
+    config) inside it would be wrong — and pointless, since the agent never
+    has a shell there. The verifier hardening therefore only touches
+    ``main``; ``[verifier].service`` selects where ``test.sh`` *runs*, not
+    where hardening happens.
+    """
+
+    @pytest.mark.asyncio
+    async def test_harden_before_verify_only_touches_main(self, tmp_path: Path) -> None:
+        """#248: harden_before_verify never execs into a non-main service."""
+        from benchflow.sandbox.lockdown import harden_before_verify
+
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\nservice = "target"\n')
+        env = MagicMock()
+        services_seen: list[str] = []
+
+        async def fake_exec(command, service: str = "main", **kwargs) -> ExecResult:
+            services_seen.append(service)
+            return ExecResult(stdout="[]", stderr="", return_code=0)
+
+        env.exec = AsyncMock(side_effect=fake_exec)
+
+        await harden_before_verify(env, task, sandbox_user=None, workspace="/app")
+
+        # Every hardening command stayed in the agent container.
+        assert services_seen, "hardening should issue at least one exec"
+        assert set(services_seen) == {"main"}


### PR DESCRIPTION
## Summary

Implements the design-heavy verification-side items that PR #310 deferred from issue #248. PR #310 shipped first-class compose **service selection** on the `exec` path; this PR completes the verification side — running `test.sh` inside a target container, the task-schema convention for it, and the cross-container hardening policy.

Builds directly on PR #310's `service` / `exec_in_service` foundation and PR #311's first-class `[verifier]` config.

## Per-item status

### Item 3 — cross-container sandbox hardening policy — **implemented (policy locked in)**

The deferred "policy question" has a correct, idiomatic default: **harden `main` only**. A vulhub-style target is *deliberately* vulnerable, the agent never has a shell inside it, and the agent cannot tamper with it — so anti-tamper hardening of target containers is both wrong (risks breaking the vulnerability the task exercises) and pointless.

- `harden_before_verify` already only ran against `main` (never passes a `service`); this PR makes that an **explicit, documented contract** in the docstring and locks it in with a regression test (`test_harden_before_verify_only_touches_main`) that asserts every hardening `exec` stays in `main`, even when `[verifier].service` points elsewhere.
- Documented in `docs/task-authoring.md` ("Hardening policy for multi-container tasks").

Rationale: there is no real fork here — the safe default is self-evident once you note targets are intentionally unhardened. No product decision needed.

### Item 4 — target-side `test.sh`-based verification — **implemented**

The test-script verifier can now run `test.sh` inside any compose service:

- `Verifier._verify_test_script()` honors `[verifier].service`: it uploads the task's `tests/` dir into that service, `chmod +x` and execs `test.sh` there, and downloads `reward.txt` / `reward.json` back from that service.
- A target service is never host-bind-mounted, so the reward files are always copied out via `docker compose cp` (the `is_mounted` fast path is correctly scoped to `main`).
- `upload_dir` / `download_dir` gain a keyword `service` parameter across `BaseSandbox`, `DockerSandbox`, and the Daytona DinD compose strategy. The Daytona DinD `download_dir` host-mounted-log fast path is correctly restricted to `main`.

### Item 5 — cross-container flag plumbing / task-schema convention — **implemented**

`[verifier].service` in `task.toml` **is** the declarative task-schema convention for cross-container verification (default `"main"` — fully backward compatible). It is the counterpart to the imperative `env.exec_in_service(...)` API from PR #310. No speculative `[multi_container]` section was added — topology already lives in the task's `docker-compose.yaml`, and pointing the verifier at a service is the only new knob actually needed.

### Item 6 — host-side script execution — **deferred (genuine product decision)**

This one is a real fork with no safe default, so it is not guess-built.

**The blocking decision:** "host-side script execution" means running a task-authored verifier script on the **orchestrator host** (outside every container), rather than via `docker exec` into a container. That crosses the host trust boundary — a task package would execute arbitrary code on the machine running BenchFlow (CI runners, researchers' laptops, shared infra). The materially different user-facing options, none obviously right:

1. **Don't support it** — keep all verification container-side; "host-side" checks are expressed as the host already does `docker compose cp` + `exec` from a trusted Python verifier (the pattern this PR enables). Safe, but doesn't literally satisfy "run a script on the host."
2. **Support it behind an explicit trust opt-in** — e.g. a CLI `--allow-host-scripts` flag or per-task signing, so untrusted task packages cannot silently run host code. Requires a trust/provenance model that does not exist yet.
3. **Support it unconditionally** — simplest, but turns every task package into arbitrary host RCE. Almost certainly unacceptable.

This needs a product call on BenchFlow's task-trust model before any implementation. Items 3-5 are fully shipped independently of it.

## Design notes

- `service` is keyword-only with `"main"` default everywhere — zero behavior change for existing single-container tasks.
- Single-container backends (Modal, direct Daytona) reject non-`main` services on `upload_dir` / `download_dir` with the same clear, actionable error PR #310 established for `exec`.
- No new task.toml top-level section — `[verifier].service` reuses the existing first-class `[verifier]` block from PR #311.

## Tests

Test-first (red-green); docstrings reference #248.

- `tests/test_verifier_multi_container.py` (new, 10 tests): `[verifier].service` config parsing/back-compat, test-script verifier routing into a target service, target-side reward download, and the `main`-only hardening regression test.
- `tests/test_sandbox_multi_service.py` (extended): `upload_dir` / `download_dir` service routing on Docker, single-container rejection on Modal / direct Daytona.
- `tests/test_docker_uploads.py`: updated assertion for the new `service` kwarg.

CI gate green locally: `ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` — **1260 passed, 27 skipped**.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes verifier execution and file-transfer plumbing across multiple sandbox backends, which could affect verification behavior and artifact collection for existing tasks if service routing or mount assumptions are wrong.
> 
> **Overview**
> Enables **target-side `test.sh` verification** for multi-container (docker-compose) tasks via a new `[verifier].service` config (default `"main"`), so the verifier can run inside a target/database container and pull back `reward.txt`/`reward.json`.
> 
> Plumbs a `service` selector through directory transfer APIs (`upload_dir`/`download_dir`) across `Environment`, `BaseSandbox`, Docker sandbox, and Daytona DinD compose strategy; single-container backends (Modal, direct Daytona) now explicitly reject non-`main` transfers.
> 
> Adjusts verifier download/mount logic so only `main` can use host-mounted fast paths, documents the **main-only hardening policy**, and adds/updates unit tests covering service routing, rejection behavior, and hardening staying in `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e8b144cabec9518b890567cc6aa3b3457b0b94b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->