### PR TITLE
fix(agents): repair acpx agent resolution; complete register_agent fields

### DIFF
--- a/src/benchflow/_utils/config.py
+++ b/src/benchflow/_utils/config.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
-from benchflow.agents.registry import parse_agent_spec
+from benchflow.agents.registry import resolve_agent_key
 
 
 def normalize_agent_name(agent: str) -> str:
-    """Return the canonical registry name for an ACP agent alias."""
-    protocol, canonical = parse_agent_spec(agent)
-    if protocol == "acp":
-        return canonical
-    return agent
+    """Return a stable registry key for an agent spec.
+
+    For plain ACP agents this is the canonical agent name. For ``acpx/<agent>``
+    specs the acpx-wrapped config is registered into the agent registry and its
+    stable runtime key is returned, so the Rollout/Evaluation path resolves
+    acpx install/launch commands instead of the literal spec string.
+
+    Unknown specs are returned unchanged.
+    """
+    return resolve_agent_key(agent)
 
 
 def normalize_sandbox_user(sandbox_user: str | None) -> str | None:

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -701,6 +701,11 @@ def resolve_agent(spec: str) -> AgentConfig:
             f"Unknown protocol: {protocol!r}. Valid: {', '.join(sorted(VALID_PROTOCOLS))}"
         )
 
+    # An already-resolved acpx runtime key (e.g. "acpx:claude-agent-acp")
+    # round-trips: parse_agent_spec leaves it whole and it lives in AGENTS.
+    if protocol == "acp" and name in AGENTS:
+        return AGENTS[name]
+
     if name not in AGENTS:
         from difflib import get_close_matches
 
@@ -715,6 +720,30 @@ def resolve_agent(spec: str) -> AgentConfig:
     if protocol == "acpx":
         return _acpx_wrap(config)
     return config
+
+
+def resolve_agent_key(spec: str) -> str:
+    """Resolve an agent spec to a stable registry key.
+
+    For plain ACP agents this is the canonical agent name. For ``acpx/<agent>``
+    specs the acpx-wrapped config (acpx install/launch commands) is registered
+    into ``AGENTS``/``AGENT_INSTALLERS``/``AGENT_LAUNCH`` under a stable runtime
+    key (``acpx:<canonical>``) so that name-keyed lookups in the
+    Rollout/Evaluation path use the wrapped commands instead of the literal
+    spec string.
+
+    Unknown agents are returned unchanged so callers can still surface their
+    own diagnostics (raw-command fallback).
+    """
+    try:
+        config = resolve_agent(spec)
+    except KeyError:
+        return spec
+    if config.name not in AGENTS:
+        AGENTS[config.name] = config
+        AGENT_INSTALLERS[config.name] = config.install_cmd
+        AGENT_LAUNCH[config.name] = config.launch_cmd
+    return config.name
 
 
 def get_agent(name: str) -> tuple[AgentConfig, str]:
@@ -745,12 +774,16 @@ def register_agent(
     description: str = "",
     skill_paths: list[str] | None = None,
     install_timeout: int = 900,
+    default_model: str = "",
+    api_protocol: str = "",
     env_mapping: dict[str, str] | None = None,
     credential_files: list[CredentialFile] | None = None,
     home_dirs: list[str] | None = None,
     subscription_auth: SubscriptionAuth | None = None,
     acp_model_format: str = "bare",
     supports_acp_set_model: bool = True,
+    disallow_web_tools_setup_cmd: str = "",
+    disallow_web_tools_launch_suffix: str = "",
 ) -> AgentConfig:
     """Register a custom agent at runtime.
 
@@ -776,12 +809,16 @@ def register_agent(
         description=description,
         skill_paths=skill_paths or [],
         install_timeout=install_timeout,
+        default_model=default_model,
+        api_protocol=api_protocol,
         env_mapping=env_mapping or {},
         credential_files=credential_files or [],
         home_dirs=home_dirs or [],
         subscription_auth=subscription_auth,
         acp_model_format=acp_model_format,
         supports_acp_set_model=supports_acp_set_model,
+        disallow_web_tools_setup_cmd=disallow_web_tools_setup_cmd,
+        disallow_web_tools_launch_suffix=disallow_web_tools_launch_suffix,
     )
     AGENTS[name] = config
     AGENT_INSTALLERS[name] = install_cmd

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -5,9 +5,16 @@ Negative invariants ("agent X should NOT have feature Y configured") live in
 test_registry_invariants.py — search there for the consolidated tripwire.
 """
 
+import pytest
+
 from benchflow.agents.env import resolve_provider_env
 from benchflow.agents.providers import PROVIDERS
-from benchflow.agents.registry import AGENTS
+from benchflow.agents.registry import (
+    AGENT_INSTALLERS,
+    AGENT_LAUNCH,
+    AGENTS,
+    register_agent,
+)
 
 
 class TestEnvMappingField:
@@ -117,3 +124,52 @@ class TestProviderCredentialFiles:
     def test_zai_no_credential_files(self):
         cfg = PROVIDERS["zai"]
         assert cfg.credential_files == []
+
+
+class TestRegisterAgent:
+    """register_agent() must pass through every AgentConfig field a runtime
+    agent may need — including no-web-policy and provider-protocol routing.
+    """
+
+    @pytest.fixture
+    def cleanup_agent(self):
+        registered: list[str] = []
+        yield registered
+        for name in registered:
+            AGENTS.pop(name, None)
+            AGENT_INSTALLERS.pop(name, None)
+            AGENT_LAUNCH.pop(name, None)
+
+    def test_defaults(self, cleanup_agent):
+        cleanup_agent.append("rt-defaults-agent")
+        cfg = register_agent(
+            name="rt-defaults-agent",
+            install_cmd="install rt",
+            launch_cmd="launch rt",
+        )
+        assert cfg.default_model == ""
+        assert cfg.api_protocol == ""
+        assert cfg.disallow_web_tools_setup_cmd == ""
+        assert cfg.disallow_web_tools_launch_suffix == ""
+
+    def test_passes_through_new_fields(self, cleanup_agent):
+        cleanup_agent.append("rt-full-agent")
+        cfg = register_agent(
+            name="rt-full-agent",
+            install_cmd="install rt",
+            launch_cmd="launch rt",
+            default_model="rt-model-1",
+            api_protocol="openai-completions",
+            disallow_web_tools_setup_cmd="printf 'no web' > /tmp/policy",
+            disallow_web_tools_launch_suffix=" --no-web",
+        )
+        assert cfg.default_model == "rt-model-1"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.disallow_web_tools_setup_cmd == "printf 'no web' > /tmp/policy"
+        assert cfg.disallow_web_tools_launch_suffix == " --no-web"
+
+        # And the registered entry reflects them.
+        registered = AGENTS["rt-full-agent"]
+        assert registered.default_model == "rt-model-1"
+        assert registered.api_protocol == "openai-completions"
+        assert registered.disallow_web_tools_launch_suffix == " --no-web"

--- a/tests/test_agent_spec.py
+++ b/tests/test_agent_spec.py
@@ -4,8 +4,12 @@ import pytest
 
 from benchflow.agents.registry import (
     AGENT_ALIASES,
+    AGENT_INSTALLERS,
+    AGENT_LAUNCH,
+    AGENTS,
     parse_agent_spec,
     resolve_agent,
+    resolve_agent_key,
 )
 
 
@@ -79,3 +83,81 @@ class TestResolveAgent:
         for alias, target in AGENT_ALIASES.items():
             config = resolve_agent(alias)
             assert config.name == target
+
+
+class TestResolveAgentKey:
+    """resolve_agent_key() must register acpx-wrapped configs so the
+    Rollout/Evaluation path (which keys lookups by bare name against
+    AGENTS/AGENT_LAUNCH/AGENT_INSTALLERS) resolves the acpx launch/install
+    commands instead of the literal spec string.
+    """
+
+    def test_plain_agent_returns_canonical_name(self):
+        assert resolve_agent_key("claude-agent-acp") == "claude-agent-acp"
+        assert resolve_agent_key("claude") == "claude-agent-acp"
+        assert resolve_agent_key("acp/codex-acp") == "codex-acp"
+
+    def test_acpx_agent_registers_wrapped_config(self):
+        key = resolve_agent_key("acpx/claude")
+        # Stable runtime key, distinct from the bare spec.
+        assert key == "acpx:claude-agent-acp"
+        assert key != "acpx/claude"
+
+        # The key is registered in all three lookup tables.
+        assert key in AGENTS
+        assert key in AGENT_LAUNCH
+        assert key in AGENT_INSTALLERS
+
+        # The registered commands are the acpx commands — NOT the literal spec.
+        launch = AGENT_LAUNCH[key]
+        install = AGENT_INSTALLERS[key]
+        assert launch != "acpx/claude"
+        assert "acpx" in launch and "--approve-all" in launch
+        assert "acpx" in install
+        # The underlying claude install command is preserved (chained).
+        assert AGENTS["claude-agent-acp"].install_cmd in install
+
+    def test_acpx_lookup_does_not_fall_back_to_literal_string(self):
+        """Regression: AGENT_LAUNCH.get(<resolved key>) must not return the
+        bogus literal 'acpx/claude' default.
+        """
+        key = resolve_agent_key("acpx/claude")
+        assert AGENT_LAUNCH.get(key, key) != "acpx/claude"
+        assert AGENT_INSTALLERS.get(key) is not None
+
+    def test_acpx_key_round_trips_through_resolve_agent(self):
+        """A resolved acpx runtime key must resolve back to the same config."""
+        key = resolve_agent_key("acpx/claude")
+        config = resolve_agent(key)
+        assert config.name == key
+        assert "acpx" in config.launch_cmd
+
+    def test_unknown_agent_passes_through(self):
+        assert resolve_agent_key("totally-unknown-agent") == "totally-unknown-agent"
+
+    def test_idempotent(self):
+        first = resolve_agent_key("acpx/codex")
+        second = resolve_agent_key("acpx/codex")
+        assert first == second
+        # Re-resolving the runtime key itself is stable too.
+        assert resolve_agent_key(first) == first
+
+
+class TestNormalizeAgentName:
+    """normalize_agent_name() is the Rollout/Evaluation chokepoint that turns
+    user-facing specs into registered runtime keys.
+    """
+
+    def test_acpx_spec_normalizes_to_registered_key(self):
+        from benchflow._utils.config import normalize_agent_name
+
+        key = normalize_agent_name("acpx/claude")
+        assert key == "acpx:claude-agent-acp"
+        assert key in AGENTS
+        assert "acpx" in AGENT_LAUNCH[key]
+
+    def test_plain_spec_normalizes_to_canonical(self):
+        from benchflow._utils.config import normalize_agent_name
+
+        assert normalize_agent_name("claude") == "claude-agent-acp"
+        assert normalize_agent_name("acp/codex-acp") == "codex-acp"


### PR DESCRIPTION
From the benchflow-core audit. Fixes two findings about agent resolution.

## Finding 1 [P1] — `acpx/` protocol broken in the Rollout/Evaluation path

`resolve_agent("acpx/...")` returns an `_acpx_wrap`-produced `AgentConfig`
(acpx install/launch commands), but that config was never registered in
`AGENTS`/`AGENT_LAUNCH`/`AGENT_INSTALLERS`. `Rollout` resolves agents by bare
name against those dicts, so for an `acpx/claude` spec
`AGENT_LAUNCH.get("acpx/claude", "acpx/claude")` returned the literal string
as the launch command, and `install_agent` found no installer. Net effect:
acpx agents launched the bogus command `acpx/claude` and skipped install.
The CLI's `_normalize_eval_agent_or_exit` deliberately produces `acpx/...`
specs and feeds them to `SDK.run`/`Evaluation`/`Rollout`, so the protocol was
unusable end to end.

**Fix:** new `resolve_agent_key()` resolves a spec via `resolve_agent()` and
registers the acpx-wrapped config under a stable runtime key
(`acpx:<canonical>`, e.g. `acpx:claude-agent-acp`) across all three lookup
tables. `normalize_agent_name()` — the single chokepoint both
`RolloutConfig.__post_init__` and `EvaluationConfig.__post_init__` already go
through — now routes acpx specs through it, so `cfg.primary_agent` becomes a
registered key. Every existing name-keyed lookup (`AGENT_LAUNCH.get`,
`AGENT_INSTALLERS`, `AGENTS.get` in env/credentials/model-format paths) then
resolves the acpx install/launch commands. `resolve_agent()` round-trips the
runtime key so it stays idempotent.

## Finding 2 [P3] — `register_agent()` could not set several `AgentConfig` fields

`register_agent()` omitted `default_model`, `api_protocol`,
`disallow_web_tools_setup_cmd`, and `disallow_web_tools_launch_suffix`, so
runtime-registered agents silently lost no-web-policy enforcement and
provider-protocol routing. Added the four missing pass-through parameters
with the same defaults as `AgentConfig`.

## Tests

- `tests/test_agent_spec.py` — `TestResolveAgentKey` / `TestNormalizeAgentName`:
  prove an `acpx/`-prefixed spec resolves to the acpx launch/install commands
  (registered in all three dicts), never the literal string, and round-trips.
- `tests/test_agent_registry.py` — `TestRegisterAgent`: prove the four new
  `register_agent()` parameters pass through to the registered `AgentConfig`.

CI: `ruff format --check`, `ruff check`, `ty check src/`, full `pytest` — all
green (1260 passed, 24 skipped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how agent specs are normalized and registered, which affects runtime install/launch command selection in Rollout/Evaluation. Failures would surface as missing agents or incorrect launch commands for `acpx/` and runtime-registered agents.
> 
> **Overview**
> Repairs `acpx/` agent handling by introducing `resolve_agent_key()` and updating `normalize_agent_name()` to return a **stable registry key** (e.g. `acpx:<canonical>`) while registering the wrapped acpx config into `AGENTS`, `AGENT_LAUNCH`, and `AGENT_INSTALLERS`, preventing Rollout/Evaluation from falling back to the literal spec string as a command.
> 
> Extends `register_agent()` to pass through additional `AgentConfig` fields (`default_model`, `api_protocol`, and no-web policy hooks) and adds tests covering acpx key round-tripping/registration and the new runtime registration parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efff33f6d914c0b76c0e4eef2f2bc1357ad5935e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->