### PR TITLE
fix: traces split handling, COPY staging, exec env secrecy (audit findings)

### DIFF
--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import asyncio
 import asyncio.subprocess
+import base64
 import contextlib
 import json
 import logging
@@ -16,6 +17,7 @@ import shlex
 import shutil
 import subprocess
 import sys
+import uuid
 from pathlib import Path
 from typing import ClassVar
 
@@ -451,18 +453,43 @@ class DockerSandbox(BaseSandbox):
         if cwd:
             exec_command.extend(["-w", cwd])
 
-        if env:
-            for key, value in env.items():
-                exec_command.extend(["-e", f"{key}={value}"])
-
         if user is not None:
             exec_command.extend(["-u", str(user)])
 
         exec_command.append(service)
+
+        # Env vars are written to a file inside the container and sourced,
+        # rather than passed as `-e KEY=VALUE` flags. The flags are visible in
+        # `ps aux` on the host, which would leak secrets — e.g. the verifier's
+        # [verifier.env] LLM-judge API keys. DockerProcess/DaytonaProcess avoid
+        # `-e` for the same reason; this keeps `exec` consistent with them.
+        if env:
+            command = self._wrap_command_with_env_file(env, command)
+
         exec_command.extend(["bash", "-c", command])
 
         return await self._run_docker_compose_command(
             exec_command, check=False, timeout_sec=timeout_sec
+        )
+
+    @staticmethod
+    def _wrap_command_with_env_file(env: dict[str, str], command: str) -> str:
+        """Return *command* prefixed to materialize *env* from a file.
+
+        The env vars are base64-encoded into the command string (not visible
+        as individual ``KEY=VALUE`` args in ``ps aux``), decoded to a
+        mode-0600 file inside the container, sourced, then deleted before the
+        real command runs.
+        """
+        env_body = "".join(f"export {k}={shlex.quote(v)}\n" for k, v in env.items())
+        encoded = base64.b64encode(env_body.encode()).decode()
+        # Unique suffix so concurrent exec() calls in one container can't
+        # clobber each other's env file.
+        env_path = f"/tmp/.benchflow_exec_env_{uuid.uuid4().hex[:16]}"
+        return (
+            f"umask 077 && printf %s {shlex.quote(encoded)} | base64 -d > "
+            f"{env_path} && set -a && . {env_path} && set +a && "
+            f"rm -f {env_path} && {command}"
         )
 
     async def attach(self) -> None:

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -321,41 +321,120 @@ def stage_dockerfile_deps(
     new_lines = []
 
     for line in lines:
-        copy_match = re.match(r"^(\s*COPY\s+(?:--\S+\s+)*)(\S+)\s+(\S+)\s*$", line)
-        if copy_match:
-            prefix = copy_match.group(1)
-            src_path = copy_match.group(2)
-            dst_path = copy_match.group(3)
-
-            # Skip sources already relative to env dir, absolute, or using build args
-            if src_path.startswith("/") or src_path.startswith("$") or src_path == ".":
-                new_lines.append(line)
-                continue
-
-            abs_src = context_root / src_path
-            if abs_src.exists():
-                dep_name = _dep_local_name(src_path)
-                local_dest = env_dir / "_deps" / dep_name
-
-                if abs_src.is_dir():
-                    if local_dest.exists():
-                        shutil.rmtree(local_dest)
-                    shutil.copytree(
-                        abs_src,
-                        local_dest,
-                        ignore=shutil.ignore_patterns(*_IGNORE_DIRS),
-                    )
-                else:
-                    local_dest.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(abs_src, local_dest)
-
-                new_lines.append(f"{prefix}_deps/{dep_name} {dst_path}")
-            else:
-                new_lines.append(line)
-        else:
-            new_lines.append(line)
+        rewritten = _rewrite_copy_line(line, env_dir, context_root)
+        new_lines.append(rewritten if rewritten is not None else line)
 
     dockerfile_path.write_text("\n".join(new_lines))
+
+
+def _stage_copy_source(src_path: str, env_dir: Path, context_root: Path) -> str:
+    """Stage a single COPY source into ``_deps/`` and return its rewritten path.
+
+    Returns the original ``src_path`` unchanged when it cannot or should not be
+    staged (absolute path, build arg, ``.``, glob, or a source that does not
+    exist under ``context_root``).
+    """
+    # Skip sources already relative to env dir, absolute, or using build args.
+    if src_path.startswith("/") or src_path.startswith("$") or src_path == ".":
+        return src_path
+    # Globs can't be resolved to a single staged path — leave them alone.
+    if any(ch in src_path for ch in "*?["):
+        return src_path
+
+    abs_src = context_root / src_path
+    if not abs_src.exists():
+        return src_path
+
+    dep_name = _dep_local_name(src_path)
+    local_dest = env_dir / "_deps" / dep_name
+
+    if abs_src.is_dir():
+        if local_dest.exists():
+            shutil.rmtree(local_dest)
+        shutil.copytree(
+            abs_src,
+            local_dest,
+            ignore=shutil.ignore_patterns(*_IGNORE_DIRS),
+        )
+    else:
+        local_dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(abs_src, local_dest)
+
+    return f"_deps/{dep_name}"
+
+
+def _rewrite_copy_line(
+    line: str, env_dir: Path, context_root: Path
+) -> str | None:
+    """Rewrite a single Dockerfile ``COPY`` line, staging its sources.
+
+    Handles both the shell form (``COPY src... dst``, including multiple
+    sources) and the JSON/exec form (``COPY ["src", "dst"]``). Every source
+    argument is staged into ``_deps/``. Returns the rewritten line, or
+    ``None`` if the line is not a ``COPY`` that needs staging.
+
+    A ``COPY`` line that looks like it has sources but cannot be parsed
+    emits a warning rather than being silently skipped.
+    """
+    # Shell form: COPY [--flags...] src... dst
+    shell_match = re.match(r"^(\s*COPY\s+(?:--\S+\s+)*)(\S.*\S|\S)\s*$", line)
+    if shell_match:
+        prefix = shell_match.group(1)
+        args_str = shell_match.group(2)
+
+        # JSON/exec form: COPY ["src", ..., "dst"]
+        if args_str.startswith("["):
+            try:
+                args = json.loads(args_str)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "stage_dockerfile_deps: could not parse JSON-form COPY, "
+                    "leaving unchanged: %s",
+                    line.strip(),
+                )
+                return None
+            if not isinstance(args, list) or len(args) < 2:
+                logger.warning(
+                    "stage_dockerfile_deps: malformed JSON-form COPY, "
+                    "leaving unchanged: %s",
+                    line.strip(),
+                )
+                return None
+            *sources, dst = [str(a) for a in args]
+            new_sources = [
+                _stage_copy_source(s, env_dir, context_root) for s in sources
+            ]
+            if new_sources == sources:
+                return None  # nothing staged
+            return f"{prefix}{json.dumps([*new_sources, dst])}"
+
+        # Shell form: split into whitespace-separated args. The last arg is
+        # the destination; everything before it is a source (>= 1 source).
+        try:
+            args = shlex.split(args_str)
+        except ValueError:
+            logger.warning(
+                "stage_dockerfile_deps: could not parse COPY arguments, "
+                "leaving unchanged: %s",
+                line.strip(),
+            )
+            return None
+        if len(args) < 2:
+            logger.warning(
+                "stage_dockerfile_deps: COPY has fewer than 2 arguments, "
+                "leaving unchanged: %s",
+                line.strip(),
+            )
+            return None
+        *sources, dst = args
+        new_sources = [
+            _stage_copy_source(s, env_dir, context_root) for s in sources
+        ]
+        if new_sources == sources:
+            return None  # nothing staged
+        return f"{prefix}{' '.join(new_sources)} {dst}"
+
+    return None
 
 
 def _inject_skills_into_dockerfile(task_path: Path, skills_dir: Path) -> None:

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -363,9 +363,7 @@ def _stage_copy_source(src_path: str, env_dir: Path, context_root: Path) -> str:
     return f"_deps/{dep_name}"
 
 
-def _rewrite_copy_line(
-    line: str, env_dir: Path, context_root: Path
-) -> str | None:
+def _rewrite_copy_line(line: str, env_dir: Path, context_root: Path) -> str | None:
     """Rewrite a single Dockerfile ``COPY`` line, staging its sources.
 
     Handles both the shell form (``COPY src... dst``, including multiple
@@ -427,9 +425,7 @@ def _rewrite_copy_line(
             )
             return None
         *sources, dst = args
-        new_sources = [
-            _stage_copy_source(s, env_dir, context_root) for s in sources
-        ]
+        new_sources = [_stage_copy_source(s, env_dir, context_root) for s in sources]
         if new_sources == sources:
             return None  # nothing staged
         return f"{prefix}{' '.join(new_sources)} {dst}"

--- a/src/benchflow/traces/huggingface.py
+++ b/src/benchflow/traces/huggingface.py
@@ -63,9 +63,7 @@ def _cache_dir() -> Path:
     return cache
 
 
-def _pick_split_file(
-    repo_files: list[str], split: str, suffix: str
-) -> str | None:
+def _pick_split_file(repo_files: list[str], split: str, suffix: str) -> str | None:
     """Pick the repo file matching *split* and *suffix*, if any.
 
     Matches files under ``data/`` whose basename starts with the split name

--- a/src/benchflow/traces/huggingface.py
+++ b/src/benchflow/traces/huggingface.py
@@ -63,6 +63,51 @@ def _cache_dir() -> Path:
     return cache
 
 
+def _pick_split_file(
+    repo_files: list[str], split: str, suffix: str
+) -> str | None:
+    """Pick the repo file matching *split* and *suffix*, if any.
+
+    Matches files under ``data/`` whose basename starts with the split name
+    (e.g. ``data/test-00000-of-00001.parquet`` or ``data/test.jsonl`` for
+    ``split="test"``). Returns ``None`` when no file matches so the caller
+    can fall back to constructed filename candidates.
+    """
+    candidates = [
+        f
+        for f in repo_files
+        if f.endswith(suffix)
+        and (Path(f).name == f"{split}{suffix}" or Path(f).name.startswith(f"{split}-"))
+    ]
+    if not candidates:
+        return None
+    # Prefer files under data/, then the shortest path for determinism.
+    candidates.sort(key=lambda f: (not f.startswith("data/"), len(f), f))
+    return candidates[0]
+
+
+def _split_filename_candidates(
+    matched: str | None, split: str, suffix: str
+) -> list[str]:
+    """Build an ordered list of filenames to try for *split* and *suffix*.
+
+    If a file was matched from the repo listing it is tried first; otherwise
+    fall back to the conventional ``data/{split}-00000-of-00001`` and
+    ``data/{split}`` layouts. All candidates are split-specific so a
+    ``split="test"`` request never resolves to ``train`` data.
+    """
+    candidates: list[str] = []
+    if matched:
+        candidates.append(matched)
+    for guess in (
+        f"data/{split}-00000-of-00001{suffix}",
+        f"data/{split}{suffix}",
+    ):
+        if guess not in candidates:
+            candidates.append(guess)
+    return candidates
+
+
 def _download_hf_dataset(
     repo_id: str,
     *,
@@ -87,32 +132,46 @@ def _download_hf_dataset(
 
     # Try huggingface_hub first
     try:
-        from huggingface_hub import hf_hub_download
+        from huggingface_hub import hf_hub_download, list_repo_files
 
-        # Try to download a data file directly
+        # List repo files so we can pick a file matching the requested split,
+        # rather than hardcoding `train`. Picking the wrong file would silently
+        # mislabel data (e.g. caching `train` rows under a `__test` filename).
+        repo_files: list[str] = []
         try:
-            downloaded = hf_hub_download(
-                repo_id=repo_id,
-                filename="data/train-00000-of-00001.parquet",
-                repo_type="dataset",
-            )
+            repo_files = list(list_repo_files(repo_id, repo_type="dataset"))
+        except Exception:
+            logger.debug("Could not list files for %s", repo_id, exc_info=True)
+
+        parquet_file = _pick_split_file(repo_files, split, ".parquet")
+        jsonl_file = _pick_split_file(repo_files, split, ".jsonl")
+
+        # Try to download a parquet data file for the split
+        for filename in _split_filename_candidates(parquet_file, split, ".parquet"):
+            try:
+                downloaded = hf_hub_download(
+                    repo_id=repo_id,
+                    filename=filename,
+                    repo_type="dataset",
+                )
+            except Exception:
+                continue
             # Convert parquet to JSONL
             _parquet_to_jsonl(Path(downloaded), out_path, max_rows=max_rows)
             return out_path
-        except Exception:
-            pass
 
-        # Try JSONL file
-        try:
-            downloaded = hf_hub_download(
-                repo_id=repo_id,
-                filename="data/train.jsonl",
-                repo_type="dataset",
-            )
+        # Try a JSONL data file for the split
+        for filename in _split_filename_candidates(jsonl_file, split, ".jsonl"):
+            try:
+                downloaded = hf_hub_download(
+                    repo_id=repo_id,
+                    filename=filename,
+                    repo_type="dataset",
+                )
+            except Exception:
+                continue
             _copy_jsonl(Path(downloaded), out_path, max_rows=max_rows)
             return out_path
-        except Exception:
-            pass
 
     except ImportError:
         logger.debug("huggingface_hub not installed, using API fallback")

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,5 +1,7 @@
 """Tests for sandbox user config/auth directory derivation from agent registry."""
 
+import pytest
+
 from benchflow.agents.registry import (
     AGENTS,
     AgentConfig,
@@ -95,3 +97,58 @@ class TestSandboxDirs:
         assert isinstance(dirs, set)
         assert all(isinstance(d, str) for d in dirs)
         assert all(d.startswith(".") for d in dirs)
+
+
+class TestDockerExecEnvSecrecy:
+    """DockerSandbox.exec must not leak env vars via `-e KEY=VALUE` flags.
+
+    `-e` flags are visible in `ps aux` on the host. The verifier's
+    [verifier.env] often carries LLM-judge API keys, so exec routes env
+    through a sourced container file instead — matching DockerProcess.
+    """
+
+    def test_wrap_command_does_not_inline_secret_values(self):
+        from benchflow.sandbox.docker import DockerSandbox
+
+        env = {"OPENAI_API_KEY": "sk-secret-value", "FOO": "bar"}
+        wrapped = DockerSandbox._wrap_command_with_env_file(env, "run-verifier")
+
+        # The raw secret value must not appear verbatim in the command
+        # string (it would otherwise show up in `ps aux`).
+        assert "sk-secret-value" not in wrapped
+        assert "bar" not in wrapped or "base64" in wrapped
+        # The command sources a file and cleans it up.
+        assert "base64 -d" in wrapped
+        assert "rm -f" in wrapped
+        assert wrapped.endswith("run-verifier")
+        # Restrictive perms on the env file.
+        assert "umask 077" in wrapped
+
+    @pytest.mark.asyncio
+    async def test_exec_passes_no_dash_e_flags(self, monkeypatch):
+        from unittest.mock import AsyncMock
+
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.docker import DockerSandbox
+
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        monkeypatch.setattr(sandbox, "_resolve_user", lambda u: u, raising=False)
+        monkeypatch.setattr(sandbox, "_merge_env", lambda e: e or {}, raising=False)
+
+        captured: dict = {}
+
+        async def fake_run(command, check=True, timeout_sec=None):
+            captured["command"] = command
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        monkeypatch.setattr(
+            sandbox, "_run_docker_compose_command", AsyncMock(side_effect=fake_run)
+        )
+
+        await sandbox.exec("verify", env={"API_KEY": "sk-leak"})
+
+        cmd = captured["command"]
+        # No `-e KEY=VALUE` argument anywhere.
+        assert "-e" not in cmd
+        for arg in cmd:
+            assert "sk-leak" not in arg

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -92,7 +92,13 @@ class TestDockerSandboxServiceExec:
         assert cmd[cmd.index("bash") - 1] == "attacker"
         assert "-w" in cmd and "/work" in cmd
         assert "-u" in cmd and "root" in cmd
-        assert "-e" in cmd and "K=v" in cmd
+        # Env vars are sourced from a file inside the container, never passed
+        # as `-e KEY=VALUE` flags (which leak onto host `ps aux`).
+        assert "-e" not in cmd
+        bash_cmd = cmd[cmd.index("bash") + 2]
+        assert "base64 -d" in bash_cmd
+        for arg in cmd:
+            assert "K=v" not in arg
 
     @pytest.mark.asyncio
     async def test_services_lists_compose_services(self) -> None:

--- a/tests/test_sandbox_setup.py
+++ b/tests/test_sandbox_setup.py
@@ -182,9 +182,7 @@ class TestStageDockerfileDeps:
         rewritten = (task_path / "environment" / "Dockerfile").read_text()
         assert "_deps/only /app/" in rewritten
 
-    def test_malformed_json_copy_warns_and_leaves_unchanged(
-        self, tmp_path, caplog
-    ):
+    def test_malformed_json_copy_warns_and_leaves_unchanged(self, tmp_path, caplog):
         """An unparseable JSON-form COPY emits a warning, not silent skip."""
         import logging
 
@@ -198,6 +196,4 @@ class TestStageDockerfileDeps:
 
         assert any("COPY" in r.message for r in caplog.records)
         # Line left untouched so the build error is at least visible.
-        assert (
-            "broken" in (task_path / "environment" / "Dockerfile").read_text()
-        )
+        assert "broken" in (task_path / "environment" / "Dockerfile").read_text()

--- a/tests/test_sandbox_setup.py
+++ b/tests/test_sandbox_setup.py
@@ -108,3 +108,96 @@ class TestSetupSandboxUser:
             assert heavy_dir not in copy_loop_dirs, (
                 f"sandbox copy loop must not include heavy tool dir {heavy_dir!r}"
             )
+
+
+class TestStageDockerfileDeps:
+    """Tests for stage_dockerfile_deps COPY parsing (multi-source / JSON form)."""
+
+    @staticmethod
+    def _setup(tmp_path, dockerfile_body):
+        """Create a task dir + context root, return (task_path, context_root)."""
+        from pathlib import Path
+
+        context_root = tmp_path / "repo"
+        context_root.mkdir()
+        task_path = context_root / "tasks" / "demo"
+        env_dir = task_path / "environment"
+        env_dir.mkdir(parents=True)
+        (env_dir / "Dockerfile").write_text(dockerfile_body)
+        return Path(task_path), Path(context_root)
+
+    def test_multi_source_copy_stages_every_source(self, tmp_path):
+        """COPY with multiple sources stages all of them into _deps/."""
+        from benchflow.sandbox.setup import stage_dockerfile_deps
+
+        task_path, context_root = self._setup(
+            tmp_path,
+            "FROM python:3.12\nCOPY pkg/a pkg/b pkg/c /app/\n",
+        )
+        for name in ("a", "b", "c"):
+            (context_root / "pkg").mkdir(exist_ok=True)
+            (context_root / "pkg" / name).write_text(f"file {name}\n")
+
+        stage_dockerfile_deps(task_path, context_root)
+
+        deps = task_path / "environment" / "_deps"
+        for name in ("a", "b", "c"):
+            assert (deps / name).exists(), f"source {name} not staged"
+
+        rewritten = (task_path / "environment" / "Dockerfile").read_text()
+        assert "_deps/a _deps/b _deps/c /app/" in rewritten
+
+    def test_json_exec_form_copy_is_staged(self, tmp_path):
+        """COPY in JSON/exec form stages its source and is rewritten."""
+        from benchflow.sandbox.setup import stage_dockerfile_deps
+
+        task_path, context_root = self._setup(
+            tmp_path,
+            'FROM python:3.12\nCOPY ["pkg/runtime", "/app/runtime"]\n',
+        )
+        (context_root / "pkg").mkdir()
+        (context_root / "pkg" / "runtime").write_text("runtime\n")
+
+        stage_dockerfile_deps(task_path, context_root)
+
+        assert (task_path / "environment" / "_deps" / "runtime").exists()
+        rewritten = (task_path / "environment" / "Dockerfile").read_text()
+        assert "_deps/runtime" in rewritten
+        assert rewritten.count("[") == 1  # still JSON form
+
+    def test_single_source_copy_still_works(self, tmp_path):
+        """The original two-arg COPY case is unchanged."""
+        from benchflow.sandbox.setup import stage_dockerfile_deps
+
+        task_path, context_root = self._setup(
+            tmp_path,
+            "FROM python:3.12\nCOPY pkg/only /app/\n",
+        )
+        (context_root / "pkg").mkdir()
+        (context_root / "pkg" / "only").write_text("only\n")
+
+        stage_dockerfile_deps(task_path, context_root)
+
+        assert (task_path / "environment" / "_deps" / "only").exists()
+        rewritten = (task_path / "environment" / "Dockerfile").read_text()
+        assert "_deps/only /app/" in rewritten
+
+    def test_malformed_json_copy_warns_and_leaves_unchanged(
+        self, tmp_path, caplog
+    ):
+        """An unparseable JSON-form COPY emits a warning, not silent skip."""
+        import logging
+
+        from benchflow.sandbox.setup import stage_dockerfile_deps
+
+        body = 'FROM python:3.12\nCOPY ["pkg/lib", broken\n'
+        task_path, context_root = self._setup(tmp_path, body)
+
+        with caplog.at_level(logging.WARNING):
+            stage_dockerfile_deps(task_path, context_root)
+
+        assert any("COPY" in r.message for r in caplog.records)
+        # Line left untouched so the build error is at least visible.
+        assert (
+            "broken" in (task_path / "environment" / "Dockerfile").read_text()
+        )

--- a/tests/test_traces_huggingface.py
+++ b/tests/test_traces_huggingface.py
@@ -1,0 +1,56 @@
+"""Tests for benchflow.traces.huggingface — split-aware dataset download."""
+
+from __future__ import annotations
+
+from benchflow.traces.huggingface import (
+    _pick_split_file,
+    _split_filename_candidates,
+)
+
+
+def test_pick_split_file_matches_split_specific_parquet() -> None:
+    """A non-train split resolves to its own parquet file, not train."""
+    repo_files = [
+        "data/train-00000-of-00001.parquet",
+        "data/test-00000-of-00001.parquet",
+        "README.md",
+    ]
+    picked = _pick_split_file(repo_files, "test", ".parquet")
+    assert picked == "data/test-00000-of-00001.parquet"
+    # The train file must never be returned for split="test".
+    assert picked is not None
+    assert "train" not in picked
+
+
+def test_pick_split_file_matches_plain_jsonl() -> None:
+    """Plain `data/{split}.jsonl` layout resolves to the split file."""
+    repo_files = ["data/train.jsonl", "data/validation.jsonl"]
+    assert _pick_split_file(repo_files, "validation", ".jsonl") == (
+        "data/validation.jsonl"
+    )
+    assert _pick_split_file(repo_files, "train", ".jsonl") == "data/train.jsonl"
+
+
+def test_pick_split_file_returns_none_when_no_match() -> None:
+    """Missing split returns None so the caller can fall back to guesses."""
+    repo_files = ["data/train-00000-of-00001.parquet"]
+    assert _pick_split_file(repo_files, "test", ".parquet") is None
+
+
+def test_split_filename_candidates_are_all_split_specific() -> None:
+    """Constructed candidates for a non-train split never reference train."""
+    candidates = _split_filename_candidates(None, "test", ".parquet")
+    assert candidates  # non-empty
+    for filename in candidates:
+        assert "train" not in filename
+        assert "test" in filename
+    # Conventional sharded + plain layouts are both attempted.
+    assert "data/test-00000-of-00001.parquet" in candidates
+    assert "data/test.parquet" in candidates
+
+
+def test_split_filename_candidates_prefers_matched_file() -> None:
+    """A matched repo file is tried before constructed guesses."""
+    matched = "data/test-00000-of-00002.parquet"
+    candidates = _split_filename_candidates(matched, "test", ".parquet")
+    assert candidates[0] == matched


### PR DESCRIPTION
Fixes three independent findings from the benchflow-core audit. Each is a separate commit.

## Finding 5 [P2] — `split` ignored in the `huggingface_hub` download path
`src/benchflow/traces/huggingface.py` — the `hf_hub_download` branch hardcoded `data/train-00000-of-00001.parquet` and `data/train.jsonl` regardless of the `split` argument. A caller requesting `split="test"` silently got `train` data, cached under a `__test` filename — permanently mislabeled.

Fix: list repo files and pick the file whose basename matches the requested split; fall back to split-specific `data/{split}-00000-of-00001` / `data/{split}` filename guesses. No candidate references `train`, so a non-train split can never resolve to train data. Added `tests/test_traces_huggingface.py`.

## Finding 8 [P3] — `stage_dockerfile_deps` silently skipped multi-source / JSON-form `COPY`
`src/benchflow/sandbox/setup.py` — the regex only matched `COPY <src> <dst>` with exactly two args. `COPY a b c /dst` (multiple sources) and `COPY ["src","dst"]` (exec form) did not match, so those sources were never staged into `_deps/` and the Docker build failed with "file not found" when `context_root` was set.

Fix: parse `COPY` into source/destination args (`shlex` for shell form, `json` for exec form), stage every source, and rewrite preserving the original form. An unparseable `COPY` now emits a warning instead of being silently skipped. Tests added to `tests/test_sandbox_setup.py`.

## Finding 9 [P3] — `DockerSandbox.exec()` leaked env vars onto host `ps aux`
`src/benchflow/sandbox/docker.py` — `exec` passed env via `-e KEY=VALUE` to `docker compose exec`, making values visible in `ps aux` on the host. `exec` runs the verifier, whose `[verifier.env]` often carries LLM-judge API keys. `DockerProcess`/`DaytonaProcess` deliberately avoid `-e` for this reason.

Fix: route env through a base64-encoded, mode-0600 file written inside the container and sourced before the command runs (then deleted), matching the process classes. A unique per-call filename avoids concurrent-exec clobbering. Tests added to `tests/test_sandbox.py` and updated in `tests/test_sandbox_multi_service.py`.

## CI
`ruff format --check`, `ruff check`, `ty check src/`, and `pytest tests/` (1261 passed, 24 skipped) all pass locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes how `DockerSandbox.exec()` injects env vars (now via sourced temp file) and rewrites Dockerfile `COPY` lines, which could affect task execution/builds if parsing or shell wrapping is off; also adjusts dataset download selection logic for HuggingFace splits.
> 
> **Overview**
> Fixes three audit issues across traces and sandboxing.
> 
> **HuggingFace trace downloads** now respect the requested `split` in the `huggingface_hub` path by listing repo files, selecting a split-matching `.parquet`/`.jsonl`, and trying split-specific filename candidates to avoid caching mislabeled data.
> 
> **Docker task setup** makes `stage_dockerfile_deps` handle multi-source shell-form `COPY` and JSON/exec-form `COPY [...]`, staging each source into `environment/_deps/` and warning (instead of silently skipping) on unparseable `COPY` lines.
> 
> **DockerSandbox exec secrecy** stops passing env via `docker compose exec -e KEY=VALUE` and instead base64-encodes env into a per-call temp file inside the container (0600, sourced then deleted) before running `bash -c`. Tests were added/updated to enforce split selection, COPY staging behavior, and the absence of `-e`/secret values in exec commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42da56e19991f287d15b8636916a2b9b6aecd96b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->