### PR TITLE
fix(rewards): _call_google returns '' instead of None on empty text

### DIFF
--- a/src/benchflow/rewards/llm.py
+++ b/src/benchflow/rewards/llm.py
@@ -110,7 +110,6 @@ async def call_judge(
         # Unknown prefix — try all
         providers = ["anthropic", "openai", "google"]
 
-    last_error: Exception | None = None
     for provider in providers:
         for attempt in range(retries):
             try:
@@ -124,7 +123,6 @@ async def call_judge(
                 logger.debug("SDK for %s not installed, skipping", provider)
                 break  # SDK missing — fall through to the next provider
             except Exception as e:
-                last_error = e
                 if attempt < retries - 1:
                     await asyncio.sleep(2**attempt)
                     continue
@@ -139,10 +137,13 @@ async def call_judge(
                 )
                 raise
 
-    msg = f"All LLM providers failed for model {model}"
-    if last_error:
-        msg += f": {last_error}"
-    raise RuntimeError(msg)
+    # Every provider's SDK was missing (each ImportError ``break``s to the
+    # next).  A real API failure raises directly above, so this is the only
+    # state that reaches here.
+    raise RuntimeError(
+        f"No LLM provider SDK is installed for model {model} "
+        "(install one of: anthropic, openai, google-genai)"
+    )
 
 
 # ------------------------------------------------------------------
@@ -192,4 +193,7 @@ async def _call_google(model: str, prompt: str) -> str:
         raise RuntimeError("GOOGLE_API_KEY / GEMINI_API_KEY not set")
     client = genai.Client(api_key=api_key)
     response = await client.aio.models.generate_content(model=model, contents=prompt)
-    return response.text
+    # ``response.text`` is ``None`` when the response has no text part
+    # (e.g. content blocked by a safety filter, or a non-text part leads
+    # the response).  Return "" so the ``-> str`` contract holds.
+    return response.text or ""

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -14,7 +14,12 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from benchflow.rewards.builtins import LLMJudgeRewardFunc
-from benchflow.rewards.llm import _call_anthropic, call_judge, parse_verdict
+from benchflow.rewards.llm import (
+    _call_anthropic,
+    _call_google,
+    call_judge,
+    parse_verdict,
+)
 from benchflow.rewards.protocol import RewardFunc
 from benchflow.rewards.rubric_config import ScoringConfig
 
@@ -144,6 +149,49 @@ class TestCallAnthropicContent:
         with self._patch_sdk(_FakeResponse([_FakeTextBlock("hello")])):
             result = asyncio.run(_call_anthropic("claude-haiku-4-5", "prompt", 100))
         assert result == "hello"
+
+
+# ---------------------------------------------------------------------------
+# _call_google: text-part handling
+# ---------------------------------------------------------------------------
+
+
+class _FakeGoogleResponse:
+    def __init__(self, text: str | None) -> None:
+        self.text = text
+
+
+class TestCallGoogleContent:
+    def _patch_sdk(self, response: _FakeGoogleResponse) -> AbstractContextManager[None]:
+        client = AsyncMock()
+        client.aio.models.generate_content = AsyncMock(return_value=response)
+        fake_genai = type(
+            "FakeGenai",
+            (),
+            {"Client": staticmethod(lambda api_key=None: client)},
+        )
+        fake_google = type("FakeGoogle", (), {"genai": fake_genai})
+        return patch.dict(
+            "sys.modules",
+            {"google": fake_google, "google.genai": fake_genai},
+        )
+
+    def test_none_text_returns_empty_string(self) -> None:
+        """``response.text`` is None (e.g. safety-filtered) -> "" not None."""
+        with (
+            patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+            self._patch_sdk(_FakeGoogleResponse(None)),
+        ):
+            result = asyncio.run(_call_google("gemini-2.0-flash", "prompt"))
+        assert result == ""
+
+    def test_text_returns_text(self) -> None:
+        with (
+            patch.dict("os.environ", {"GOOGLE_API_KEY": "test-key"}),
+            self._patch_sdk(_FakeGoogleResponse("the verdict")),
+        ):
+            result = asyncio.run(_call_google("gemini-2.0-flash", "prompt"))
+        assert result == "the verdict"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Primary fix — `_call_google` returns `None`, violating `-> str`

`_call_google` in `src/benchflow/rewards/llm.py` ended with `return response.text`. The google-genai SDK's `response.text` returns `None` when the response has no text part (content blocked by a safety filter, or a non-text part leads the response). This violated the function's `-> str` return type and propagated `None` to callers.

This is the same bug class PR #319 fixed for `_call_anthropic` (now loops over content blocks, returns `""` if no text block), and that `_call_openai` already handles via `content or ""`. The fix makes `_call_google` return `""` when `response.text` is falsy, consistent with the other two providers.

Added `TestCallGoogleContent` in `tests/test_llm_judge.py` covering the None-text case (asserts `""`, not `None`) and the normal text case.

## Secondary cleanup — dead `last_error` plumbing in `call_judge`

Flagged by PR #319's review. After PR #319 made non-`ImportError` failures `raise` instead of `break`, the `last_error` variable and the trailing `if last_error:` branch became unreachable: a real API failure raises directly, so the terminal `RuntimeError` is only reached when *every* provider hits `ImportError`, at which point `last_error` is always `None`.

Removed the dead `last_error` plumbing and made the terminal error message accurate for the only state that reaches it — all provider SDKs missing.

Both changes stem from PR #319's review.

## CI

`ruff format --check`, `ruff check`, `ty check src/`, and `pytest tests/` (1283 passed) all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, well-tested behavior change limited to LLM provider wrappers and an unreachable error-path cleanup.
> 
> **Overview**
> Ensures `_call_google` always returns a `str` by converting empty/`None` `response.text` to `""` (e.g., safety-filtered responses).
> 
> Removes dead `last_error` plumbing in `call_judge` and replaces the terminal error with a clearer message indicating that **no provider SDK is installed** when all providers fail via `ImportError`. Adds unit tests covering Google `None`/text responses with a mocked `google-genai` client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e04506320cdbef714ee59a2d2b2a890bce5fefcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->