### PR TITLE
test: harden async tests against event-loop order-dependence

### DIFF
--- a/tests/test_oracle_chokepoint.py
+++ b/tests/test_oracle_chokepoint.py
@@ -89,8 +89,6 @@ class TestEvalCreateRouting:
 
     def test_eval_create_normalizes_agent_alias(self, tmp_path: Path):
         """Guards ENG-86: eval create normalizes aliases before launch."""
-        import asyncio
-
         from benchflow.cli.main import eval_create
 
         task = tmp_path / "task"
@@ -110,36 +108,31 @@ class TestEvalCreateRouting:
                 n_tool_calls=0,
             )
 
-        try:
-            with patch("benchflow.sdk.SDK.run", new=fake_run):
-                eval_create(
-                    config_file=None,
-                    tasks_dir=task,
-                    source_repo=None,
-                    source_path=None,
-                    source_ref=None,
-                    agent="codex",
-                    model="gpt-4o",
-                    environment="docker",
-                    concurrency=1,
-                    jobs_dir=str(tmp_path / "jobs"),
-                    sandbox_user="agent",
-                    sandbox_setup_timeout=120,
-                    skills_dir=None,
-                    skill_mode="default",
-                    skill_creator_dir=None,
-                    self_gen_no_internet=False,
-                    agent_env=None,
-                )
-        finally:
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        with patch("benchflow.sdk.SDK.run", new=fake_run):
+            eval_create(
+                config_file=None,
+                tasks_dir=task,
+                source_repo=None,
+                source_path=None,
+                source_ref=None,
+                agent="codex",
+                model="gpt-4o",
+                environment="docker",
+                concurrency=1,
+                jobs_dir=str(tmp_path / "jobs"),
+                sandbox_user="agent",
+                sandbox_setup_timeout=120,
+                skills_dir=None,
+                skill_mode="default",
+                skill_creator_dir=None,
+                self_gen_no_internet=False,
+                agent_env=None,
+            )
 
         assert captured["agent"] == "codex-acp"
 
     def test_eval_create_normalizes_sandbox_user_none(self, tmp_path: Path):
         """Guards ENG-91 P0 dogfood sandbox-user CLI regression."""
-        import asyncio
-
         from benchflow.cli.main import eval_create
 
         task = tmp_path / "task"
@@ -159,29 +152,26 @@ class TestEvalCreateRouting:
                 n_tool_calls=0,
             )
 
-        try:
-            with patch("benchflow.sdk.SDK.run", new=fake_run):
-                eval_create(
-                    config_file=None,
-                    tasks_dir=task,
-                    source_repo=None,
-                    source_path=None,
-                    source_ref=None,
-                    agent="oracle",
-                    model=None,
-                    environment="docker",
-                    concurrency=1,
-                    jobs_dir=str(tmp_path / "jobs"),
-                    sandbox_user="none",
-                    sandbox_setup_timeout=120,
-                    skills_dir=None,
-                    skill_mode="default",
-                    skill_creator_dir=None,
-                    self_gen_no_internet=False,
-                    agent_env=None,
-                )
-        finally:
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        with patch("benchflow.sdk.SDK.run", new=fake_run):
+            eval_create(
+                config_file=None,
+                tasks_dir=task,
+                source_repo=None,
+                source_path=None,
+                source_ref=None,
+                agent="oracle",
+                model=None,
+                environment="docker",
+                concurrency=1,
+                jobs_dir=str(tmp_path / "jobs"),
+                sandbox_user="none",
+                sandbox_setup_timeout=120,
+                skills_dir=None,
+                skill_mode="default",
+                skill_creator_dir=None,
+                self_gen_no_internet=False,
+                agent_env=None,
+            )
 
         assert captured["sandbox_user"] is None
 
@@ -205,7 +195,6 @@ class TestEvalCreateRouting:
         self, tmp_path: Path
     ):
         """Guards the ENG-86 fix from commit b69bdf4 for config-file agents."""
-        import asyncio
         from types import SimpleNamespace
 
         from benchflow.cli.main import eval_create
@@ -222,11 +211,8 @@ class TestEvalCreateRouting:
             captured["model"] = self._config.model
             return SimpleNamespace(passed=0, total=0, score=0.0, errored=0)
 
-        try:
-            with patch.object(Evaluation, "run", new=fake_run):
-                eval_create(config_file=config)
-        finally:
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        with patch.object(Evaluation, "run", new=fake_run):
+            eval_create(config_file=config)
 
         assert captured == {"agent": "oracle", "model": None}
 
@@ -234,8 +220,6 @@ class TestEvalCreateRouting:
         self, tmp_path: Path, monkeypatch
     ):
         """Guards ENG-78: CLI runs inherit provider keys without --agent-env."""
-        import asyncio
-
         from benchflow.cli.main import eval_create
 
         task = tmp_path / "task"
@@ -262,29 +246,26 @@ class TestEvalCreateRouting:
                 n_tool_calls=0,
             )
 
-        try:
-            with patch("benchflow.sdk.SDK.run", new=fake_run):
-                eval_create(
-                    config_file=None,
-                    tasks_dir=task,
-                    source_repo=None,
-                    source_path=None,
-                    source_ref=None,
-                    agent="gemini",
-                    model="gemini-3.1-flash-lite-preview",
-                    environment="docker",
-                    concurrency=1,
-                    jobs_dir=str(tmp_path / "jobs"),
-                    sandbox_user="agent",
-                    sandbox_setup_timeout=120,
-                    skills_dir=None,
-                    skill_mode="default",
-                    skill_creator_dir=None,
-                    self_gen_no_internet=False,
-                    agent_env=None,
-                )
-        finally:
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        with patch("benchflow.sdk.SDK.run", new=fake_run):
+            eval_create(
+                config_file=None,
+                tasks_dir=task,
+                source_repo=None,
+                source_path=None,
+                source_ref=None,
+                agent="gemini",
+                model="gemini-3.1-flash-lite-preview",
+                environment="docker",
+                concurrency=1,
+                jobs_dir=str(tmp_path / "jobs"),
+                sandbox_user="agent",
+                sandbox_setup_timeout=120,
+                skills_dir=None,
+                skill_mode="default",
+                skill_creator_dir=None,
+                self_gen_no_internet=False,
+                agent_env=None,
+            )
 
         assert captured["kwargs"]["agent_env"] == {}
         assert captured["resolved_agent_env"]["GEMINI_API_KEY"] == "from-host"
@@ -294,7 +275,6 @@ class TestEvalCreateRouting:
         self, tmp_path: Path, monkeypatch
     ):
         """Guards release smokes: .env sandbox credentials reach provider SDKs."""
-        import asyncio
         import os
 
         from benchflow.cli.main import eval_create
@@ -324,29 +304,26 @@ class TestEvalCreateRouting:
                 n_tool_calls=0,
             )
 
-        try:
-            with patch("benchflow.sdk.SDK.run", new=fake_run):
-                eval_create(
-                    config_file=None,
-                    tasks_dir=task,
-                    source_repo=None,
-                    source_path=None,
-                    source_ref=None,
-                    agent="oracle",
-                    model=None,
-                    environment="daytona",
-                    concurrency=1,
-                    jobs_dir=str(tmp_path / "jobs"),
-                    sandbox_user="agent",
-                    sandbox_setup_timeout=120,
-                    skills_dir=None,
-                    skill_mode="default",
-                    skill_creator_dir=None,
-                    self_gen_no_internet=False,
-                    agent_env=None,
-                )
-        finally:
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        with patch("benchflow.sdk.SDK.run", new=fake_run):
+            eval_create(
+                config_file=None,
+                tasks_dir=task,
+                source_repo=None,
+                source_path=None,
+                source_ref=None,
+                agent="oracle",
+                model=None,
+                environment="daytona",
+                concurrency=1,
+                jobs_dir=str(tmp_path / "jobs"),
+                sandbox_user="agent",
+                sandbox_setup_timeout=120,
+                skills_dir=None,
+                skill_mode="default",
+                skill_creator_dir=None,
+                self_gen_no_internet=False,
+                agent_env=None,
+            )
 
         assert captured == {
             "daytona": "from-dotenv",
@@ -575,10 +552,8 @@ class TestEvalCreateOracleCLI:
 
     This is the user-visible bug the chokepoint test guards against at the
     unit level. Here we call the live handler (cli/main.py:eval_create)
-    directly — invoking via Typer's CliRunner triggers asyncio.run()
-    internally, which leaves no current event loop and breaks pre-existing
-    tests in the suite that use the deprecated asyncio.get_event_loop()
-    pattern. Calling the function directly still exercises the full
+    directly rather than through Typer's CliRunner; the handler still runs
+    asyncio.run() internally, exercising the full
     CLI → effective_model → RolloutConfig → resolve_agent_env path the bug
     originally lived in.
     """
@@ -604,16 +579,10 @@ class TestEvalCreateOracleCLI:
 
     def test_oracle_single_task_no_api_key_no_error(self, tmp_path: Path, monkeypatch):
         """The bug: oracle + missing API key → ANTHROPIC_API_KEY ValueError."""
-        import asyncio
         from types import SimpleNamespace
 
         from benchflow.cli.main import eval_create
         from benchflow.models import RunResult
-
-        # The CLI handler internally calls asyncio.run(), which leaves no
-        # current event loop. Pre-existing tests in the suite use the
-        # deprecated asyncio.get_event_loop() and break in that state, so
-        # restore a fresh loop after the test (teardown via finally below).
 
         self._strip_api_keys(monkeypatch)
         task = self._make_task(tmp_path)
@@ -640,21 +609,18 @@ class TestEvalCreateOracleCLI:
             )
             return trial
 
-        try:
-            with patch("benchflow.rollout.Rollout.create", new=fake_create):
-                eval_create(
-                    config_file=None,
-                    tasks_dir=task,
-                    agent="oracle",
-                    model=None,
-                    environment="docker",
-                    concurrency=1,
-                    jobs_dir=str(tmp_path / "jobs"),
-                    sandbox_user="agent",
-                    skills_dir=None,
-                )
-        finally:
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        with patch("benchflow.rollout.Rollout.create", new=fake_create):
+            eval_create(
+                config_file=None,
+                tasks_dir=task,
+                agent="oracle",
+                model=None,
+                environment="docker",
+                concurrency=1,
+                jobs_dir=str(tmp_path / "jobs"),
+                sandbox_user="agent",
+                skills_dir=None,
+            )
 
         cfg = captured["config"]
         # Layer 3: oracle never receives a model, even when CLI defaults exist.

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 from pathlib import Path
 
 import pytest
@@ -94,24 +93,24 @@ class TestVerifyResultConstruction:
 
 
 class TestRubricEqualWeights:
-    def test_single_func(self) -> None:
+    async def test_single_func(self) -> None:
         rubric = Rubric(reward_funcs=[ConstRewardFunc(0.8)])
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert result.reward == pytest.approx(0.8)
         assert len(result.items) == 1
 
-    def test_multiple_funcs_equal_weight(self) -> None:
+    async def test_multiple_funcs_equal_weight(self) -> None:
         rubric = Rubric(
             reward_funcs=[ConstRewardFunc(1.0), ConstRewardFunc(0.0)],
         )
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert result.reward == pytest.approx(0.5)
         assert result.items["ConstRewardFunc"] == 1.0
         assert result.items["ConstRewardFunc_1"] == 0.0
 
-    def test_empty_rubric(self) -> None:
+    async def test_empty_rubric(self) -> None:
         rubric = Rubric(reward_funcs=[])
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert result.reward == 0.0
 
 
@@ -121,12 +120,12 @@ class TestRubricEqualWeights:
 
 
 class TestRubricCustomWeights:
-    def test_custom_weights(self) -> None:
+    async def test_custom_weights(self) -> None:
         rubric = Rubric(
             reward_funcs=[ConstRewardFunc(1.0), ConstRewardFunc(0.5)],
             weights=[0.7, 0.3],
         )
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert result.reward == pytest.approx(0.7 * 1.0 + 0.3 * 0.5)
 
     def test_weight_length_mismatch_raises(self) -> None:
@@ -143,19 +142,19 @@ class TestRubricCustomWeights:
 
 
 class TestRubricErrorHandling:
-    def test_failing_func_returns_zero_and_reports_error(self) -> None:
+    async def test_failing_func_returns_zero_and_reports_error(self) -> None:
         rubric = Rubric(
             reward_funcs=[ConstRewardFunc(1.0), FailingRewardFunc()],
         )
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert result.error is not None
         assert "deliberate failure" in result.error
         assert result.items["FailingRewardFunc"] == 0.0
         assert result.items["ConstRewardFunc"] == 1.0
 
-    def test_all_failing_funcs(self) -> None:
+    async def test_all_failing_funcs(self) -> None:
         rubric = Rubric(reward_funcs=[FailingRewardFunc()])
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert result.reward == 0.0
         assert result.error is not None
 
@@ -166,11 +165,11 @@ class TestRubricErrorHandling:
 
 
 class TestRubricEvents:
-    def test_events_collected_from_successful_funcs(self) -> None:
+    async def test_events_collected_from_successful_funcs(self) -> None:
         rubric = Rubric(
             reward_funcs=[ConstRewardFunc(0.9), ConstRewardFunc(0.1)],
         )
-        result = asyncio.run(rubric.score(Path("/unused")))
+        result = await rubric.score(Path("/unused"))
         assert len(result.events) == 2
         assert all(ev.type == "terminal" for ev in result.events)
         sources = {ev.source for ev in result.events}
@@ -183,33 +182,33 @@ class TestRubricEvents:
 
 
 class TestTestRewardFunc:
-    def test_reads_reward_txt(self, tmp_path: Path) -> None:
+    async def test_reads_reward_txt(self, tmp_path: Path) -> None:
         (tmp_path / "reward.txt").write_text("0.85\n")
         func = TestRewardFunc()
-        score = asyncio.run(func.score(tmp_path))
+        score = await func.score(tmp_path)
         assert score == pytest.approx(0.85)
 
-    def test_missing_reward_txt(self, tmp_path: Path) -> None:
+    async def test_missing_reward_txt(self, tmp_path: Path) -> None:
         func = TestRewardFunc()
-        score = asyncio.run(func.score(tmp_path))
+        score = await func.score(tmp_path)
         assert score == 0.0
 
-    def test_empty_reward_txt(self, tmp_path: Path) -> None:
+    async def test_empty_reward_txt(self, tmp_path: Path) -> None:
         (tmp_path / "reward.txt").write_text("")
         func = TestRewardFunc()
-        score = asyncio.run(func.score(tmp_path))
+        score = await func.score(tmp_path)
         assert score == 0.0
 
-    def test_invalid_reward_txt(self, tmp_path: Path) -> None:
+    async def test_invalid_reward_txt(self, tmp_path: Path) -> None:
         (tmp_path / "reward.txt").write_text("not-a-number\n")
         func = TestRewardFunc()
-        score = asyncio.run(func.score(tmp_path))
+        score = await func.score(tmp_path)
         assert score == 0.0
 
-    def test_multiline_reward_txt(self, tmp_path: Path) -> None:
+    async def test_multiline_reward_txt(self, tmp_path: Path) -> None:
         (tmp_path / "reward.txt").write_text("1.0\nsome extra info\n")
         func = TestRewardFunc()
-        score = asyncio.run(func.score(tmp_path))
+        score = await func.score(tmp_path)
         assert score == pytest.approx(1.0)
 
 
@@ -219,29 +218,29 @@ class TestTestRewardFunc:
 
 
 class TestStringMatchRewardFunc:
-    def test_exact_match(self, tmp_path: Path) -> None:
+    async def test_exact_match(self, tmp_path: Path) -> None:
         (tmp_path / "answer.txt").write_text("hello world")
         func = StringMatchRewardFunc(expected="hello world")
-        assert asyncio.run(func.score(tmp_path)) == 1.0
+        assert await func.score(tmp_path) == 1.0
 
-    def test_exact_mismatch(self, tmp_path: Path) -> None:
+    async def test_exact_mismatch(self, tmp_path: Path) -> None:
         (tmp_path / "answer.txt").write_text("Hello World")
         func = StringMatchRewardFunc(expected="hello world")
-        assert asyncio.run(func.score(tmp_path)) == 0.0
+        assert await func.score(tmp_path) == 0.0
 
-    def test_fuzzy_match(self, tmp_path: Path) -> None:
+    async def test_fuzzy_match(self, tmp_path: Path) -> None:
         (tmp_path / "answer.txt").write_text("The answer is Hello World!")
         func = StringMatchRewardFunc(expected="hello world", fuzzy=True)
-        assert asyncio.run(func.score(tmp_path)) == 1.0
+        assert await func.score(tmp_path) == 1.0
 
-    def test_fuzzy_mismatch(self, tmp_path: Path) -> None:
+    async def test_fuzzy_mismatch(self, tmp_path: Path) -> None:
         (tmp_path / "answer.txt").write_text("something else")
         func = StringMatchRewardFunc(expected="hello world", fuzzy=True)
-        assert asyncio.run(func.score(tmp_path)) == 0.0
+        assert await func.score(tmp_path) == 0.0
 
-    def test_missing_answer_txt(self, tmp_path: Path) -> None:
+    async def test_missing_answer_txt(self, tmp_path: Path) -> None:
         func = StringMatchRewardFunc(expected="hello")
-        assert asyncio.run(func.score(tmp_path)) == 0.0
+        assert await func.score(tmp_path) == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -250,18 +249,18 @@ class TestStringMatchRewardFunc:
 
 
 class TestCodeExecRewardFunc:
-    def test_custom_function(self, tmp_path: Path) -> None:
+    async def test_custom_function(self, tmp_path: Path) -> None:
         (tmp_path / "result.txt").write_text("42")
 
         def scorer(d: Path) -> float:
             return float((d / "result.txt").read_text())
 
         func = CodeExecRewardFunc(scorer)
-        assert asyncio.run(func.score(tmp_path)) == pytest.approx(42.0)
+        assert await func.score(tmp_path) == pytest.approx(42.0)
 
-    def test_returns_zero(self, tmp_path: Path) -> None:
+    async def test_returns_zero(self, tmp_path: Path) -> None:
         func = CodeExecRewardFunc(lambda d: 0.0)
-        assert asyncio.run(func.score(tmp_path)) == 0.0
+        assert await func.score(tmp_path) == 0.0
 
 
 # ---------------------------------------------------------------------------
@@ -286,11 +285,11 @@ class TestProtocolConformance:
 
 
 class TestBackwardCompat:
-    def test_default_rubric_uses_test_reward_func(self, tmp_path: Path) -> None:
+    async def test_default_rubric_uses_test_reward_func(self, tmp_path: Path) -> None:
         """Tasks without a rubric config get Rubric([TestRewardFunc()])."""
         (tmp_path / "reward.txt").write_text("0.75\n")
         rubric = Rubric(reward_funcs=[TestRewardFunc()])
-        result = asyncio.run(rubric.score(tmp_path))
+        result = await rubric.score(tmp_path)
         assert result.reward == pytest.approx(0.75)
         assert "TestRewardFunc" in result.items
 

--- a/tests/test_sdk_lockdown.py
+++ b/tests/test_sdk_lockdown.py
@@ -1,6 +1,5 @@
 """Tests for path lockdown — _validate_locked_path, _resolve_locked_paths, lockdown_paths."""
 
-import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -117,30 +116,30 @@ class TestLockdownPaths:
         """Extract the lockdown command (single exec call)."""
         return mock_env.exec.call_args_list[0][0][0]
 
-    def test_noop_empty_paths(self, mock_env):
-        asyncio.run(lockdown_paths(mock_env, []))
+    async def test_noop_empty_paths(self, mock_env):
+        await lockdown_paths(mock_env, [])
         mock_env.exec.assert_not_called()
 
-    def test_chown_before_chmod_and_symlink_skip(self, mock_env):
-        asyncio.run(lockdown_paths(mock_env, ["/solution"]))
+    async def test_chown_before_chmod_and_symlink_skip(self, mock_env):
+        await lockdown_paths(mock_env, ["/solution"])
         assert mock_env.exec.call_count == 1
         cmd = self._get_lockdown_cmd(mock_env)
         assert cmd.index("chown root:root") < cmd.index("chmod 700")
         assert '[ -L "$d" ]' in cmd
 
-    def test_multiple_paths(self, mock_env):
-        asyncio.run(lockdown_paths(mock_env, ["/solution", "/tests", "/data"]))
+    async def test_multiple_paths(self, mock_env):
+        await lockdown_paths(mock_env, ["/solution", "/tests", "/data"])
         cmd = self._get_lockdown_cmd(mock_env)
         for p in ["/solution", "/tests", "/data"]:
             assert f"for d in {p}" in cmd
 
-    def test_glob_expansion(self, mock_env):
-        asyncio.run(lockdown_paths(mock_env, ["/app-*"]))
+    async def test_glob_expansion(self, mock_env):
+        await lockdown_paths(mock_env, ["/app-*"])
         assert "for d in /app-*" in self._get_lockdown_cmd(mock_env)
 
-    def test_validation_rejects_bad_path(self, mock_env):
+    async def test_validation_rejects_bad_path(self, mock_env):
         with pytest.raises(ValueError):
-            asyncio.run(lockdown_paths(mock_env, ["/solution/../etc"]))
+            await lockdown_paths(mock_env, ["/solution/../etc"])
         mock_env.exec.assert_not_called()
 
 

--- a/tests/test_self_gen_cli.py
+++ b/tests/test_self_gen_cli.py
@@ -16,8 +16,6 @@ def _make_task(tmp_path: Path) -> Path:
 
 def test_eval_create_single_task_self_gen_passes_trial_config(tmp_path: Path):
     """`bench eval create --skill-mode self-gen` reaches strict self-gen orchestration."""
-    import asyncio
-
     from benchflow.cli.main import eval_create
 
     task = _make_task(tmp_path)
@@ -39,25 +37,22 @@ def test_eval_create_single_task_self_gen_passes_trial_config(tmp_path: Path):
             n_tool_calls=0,
         )
 
-    try:
-        with patch("benchflow.self_gen.run_self_gen", new=fake_run_self_gen):
-            eval_create(
-                config_file=None,
-                tasks_dir=task,
-                agent="claude-agent-acp",
-                model="claude-haiku-4-5-20251001",
-                environment="docker",
-                concurrency=1,
-                jobs_dir=str(tmp_path / "jobs"),
-                sandbox_user="agent",
-                sandbox_setup_timeout=120,
-                skills_dir=provided_skills,
-                skill_mode="self-gen",
-                skill_creator_dir=skill_creator,
-                self_gen_no_internet=True,
-            )
-    finally:
-        asyncio.set_event_loop(asyncio.new_event_loop())
+    with patch("benchflow.self_gen.run_self_gen", new=fake_run_self_gen):
+        eval_create(
+            config_file=None,
+            tasks_dir=task,
+            agent="claude-agent-acp",
+            model="claude-haiku-4-5-20251001",
+            environment="docker",
+            concurrency=1,
+            jobs_dir=str(tmp_path / "jobs"),
+            sandbox_user="agent",
+            sandbox_setup_timeout=120,
+            skills_dir=provided_skills,
+            skill_mode="self-gen",
+            skill_creator_dir=skill_creator,
+            self_gen_no_internet=True,
+        )
 
     cfg = captured["config"]
     assert cfg.skill_mode == "self-gen"

--- a/tests/test_skill_eval_dryrun.py
+++ b/tests/test_skill_eval_dryrun.py
@@ -11,7 +11,6 @@ Mocks the Evaluation.run() to avoid Docker/API dependencies while verifying:
 8. Cleanup removes ephemeral tasks
 """
 
-import asyncio
 import json
 import tempfile
 from pathlib import Path
@@ -176,7 +175,7 @@ class TestDryRunPipeline:
         assert "COPY skills/" not in without_df
 
     @patch("benchflow.evaluation.Evaluation")
-    def test_evaluator_configures_job_correctly(self, MockJob, mock_skill):
+    async def test_evaluator_configures_job_correctly(self, MockJob, mock_skill):
         """Verify SkillEvaluator passes correct config to Evaluation."""
         mock_job_instance = MockJob.return_value
         mock_job_instance.run = AsyncMock(
@@ -195,14 +194,12 @@ class TestDryRunPipeline:
         )
 
         evaluator = SkillEvaluator(mock_skill)
-        asyncio.run(
-            evaluator.run(
-                agents=["claude-agent-acp"],
-                models=["claude-haiku-4-5-20251001"],
-                environment="docker",
-                concurrency=2,
-                no_baseline=True,
-            )
+        await evaluator.run(
+            agents=["claude-agent-acp"],
+            models=["claude-haiku-4-5-20251001"],
+            environment="docker",
+            concurrency=2,
+            no_baseline=True,
         )
 
         # Evaluation was called at least once (with-skill run)


### PR DESCRIPTION
## Context

Latent-flake hardening follow-up from PR #318 / issue #317.

PR #318 fixed one order-dependent asyncio flake (`test_config_mismatch_warning`) by converting a sync test that drove async code via `asyncio.get_event_loop().run_until_complete(...)` into a proper `async def` test. Its "Follow-up (out of scope)" note flagged that `test_rewards.py`, `test_sdk_lockdown.py`, and `test_skill_eval_dryrun.py` still drive async code via `asyncio.run()` in sync tests without restoring the loop — the same latent bug class. No active flake remains, but a future sync test using the deprecated `get_event_loop()` pattern would reintroduce it.

This is a mechanical async-conversion + loop-hygiene pass. **No test assertion is changed.** `pyproject.toml` has `asyncio_mode = "auto"`, so `async def` test functions are picked up directly by `pytest-asyncio`.

## Files converted

- **`tests/test_rewards.py`** — 15 sync tests driving `Rubric` / `RewardFunc` `.score()` via `asyncio.run()` converted to `async def` + `await`; removed the now-unused `import asyncio`.
- **`tests/test_sdk_lockdown.py`** — 5 `lockdown_paths` tests converted from `asyncio.run()` to `async def` + `await`; removed unused `import asyncio`. (Pure-sync tests in this file — path validation, config parsing, priv-drop command construction — left untouched.)
- **`tests/test_skill_eval_dryrun.py`** — `test_evaluator_configures_job_correctly` converted from `asyncio.run()` to `async def` + `await`. The other CLI test (`test_cli_dryrun_loads_dataset`) uses Typer's synchronous `CliRunner.invoke()` and was already loop-clean — left as-is.
- **`tests/test_oracle_chokepoint.py`** — the 5 `eval_create` tests drive the *synchronous* CLI handler, which calls `asyncio.run()` internally; they genuinely cannot become `async def` (`asyncio.run()` cannot be called from a running loop). Instead, removed the now-obsolete `try/finally: asyncio.set_event_loop(asyncio.new_event_loop())` workaround — it existed only to restore a current loop for *other* tests using the deprecated `get_event_loop()` pattern, and a repo-wide grep confirms none remain in `tests/`. Stale inline comment and the `TestEvalCreateOracleCLI` class docstring updated to match.
- **`tests/test_self_gen_cli.py`** — same as above: removed the obsolete loop-restore workaround around the synchronous `eval_create` call.

## Verification

CI gate — all green:
- `ruff format --check src tests` — 190 files formatted
- `ruff check .` — all checks passed
- `ty check src/` — all checks passed

Multi-ordering / order-dependence checks — all green:
- Full suite: **1250 passed, 24 skipped** (default order)
- Full suite, reverse-alphabetical file order: **1250 passed, 24 skipped**
- Full suite `-p no:randomly`: **1250 passed, 24 skipped**
- Cross-file: `test_rewards.py test_job.py` → 51 passed
- Cross-file: `test_oracle_chokepoint.py test_llm_judge.py test_self_gen_cli.py` → 56 passed
- Cross-file: `test_skill_eval_dryrun.py test_sdk_lockdown.py` → 46 passed
- Original PR #317 repro order (`test_verify test_sdk_internals test_job test_rewards test_sdk_lockdown`) → 165 passed
- The 5 converted files together → 103 passed

Refs #317. Follows up #318.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/325" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are isolated to test code and are largely mechanical conversions to `async def`/`await`, but they could surface if the suite’s async test configuration differs from expectations.
> 
> **Overview**
> Makes async-related tests order-independent by **migrating sync tests that used `asyncio.run()` into `async def` tests** (using `await`) in `test_rewards.py`, `test_sdk_lockdown.py`, and `test_skill_eval_dryrun.py`.
> 
> Cleans up CLI-focused tests (`test_oracle_chokepoint.py`, `test_self_gen_cli.py`) by **removing `try/finally` event-loop reset workarounds** around calls to the synchronous `eval_create` handler (which still uses `asyncio.run()` internally), and updates the associated commentary/docstrings accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a36f3a0583887c4f3f54307428f90e88c42fcfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->