### PR TITLE
fix(daytona): skip host telemetry proxy for unreachable remote sandboxes

### DIFF
--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -115,6 +115,29 @@ def _docker_host_address() -> str:
     return "host.docker.internal"
 
 
+# Sandbox environments where the agent runs on the same host as the proxy
+# (the host's loopback / docker bridge is reachable from the agent process).
+_LOCAL_REACHABLE_ENVIRONMENTS = {"docker", "local", "host", ""}
+
+
+def host_proxy_reachable_from_agent(environment: str) -> bool:
+    """True when a host-side proxy bound to the host can be reached by the agent.
+
+    The host telemetry/Bedrock proxy binds to the *host* machine. An agent
+    only reaches it when it shares the host's network namespace:
+
+    - ``docker``: the container reaches the host via the docker bridge /
+      ``host.docker.internal``.
+    - ``local``/``host``: the agent runs directly on the host.
+
+    Remote cloud sandboxes (e.g. ``daytona``) run the agent on a different
+    machine. ``127.0.0.1`` there is the *sandbox's* own loopback, and the
+    Daytona SSH gateway rejects ``ssh -R`` reverse tunnels, so there is no
+    address that routes back to the host proxy.
+    """
+    return environment in _LOCAL_REACHABLE_ENVIRONMENTS
+
+
 def _bedrock_proxy_command(
     *,
     environment: str,
@@ -259,9 +282,27 @@ async def ensure_usage_proxy_runtime(
     environment: str,
     session_id: str = "",
 ) -> tuple[dict[str, str], ProviderRuntime | None]:
-    """Start the host-side usage proxy and wire env vars to it."""
+    """Start the host-side usage proxy and wire env vars to it.
+
+    For remote cloud sandboxes (e.g. Daytona) the host proxy is unreachable
+    from the agent — it runs on a different machine and there is no reverse
+    tunnel back to the host. In that case the proxy is skipped: the agent
+    talks to the provider directly with its real key and host-side usage
+    telemetry reports ``usage_source: "unavailable"``.
+    """
     if agent == "oracle":
         return agent_env, runtime
+    if not host_proxy_reachable_from_agent(environment):
+        if runtime is not None:
+            await stop_provider_runtime(runtime)
+        logger.info(
+            "Skipping host-side usage telemetry proxy: the '%s' sandbox runs "
+            "the agent on a remote host unreachable from the host proxy; the "
+            "agent will call the provider directly and usage telemetry will "
+            "be unavailable for this run.",
+            environment or "unknown",
+        )
+        return agent_env, None
     target = _resolve_usage_proxy_target(agent, agent_env, model)
     if not target:
         return agent_env, runtime

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -465,6 +465,93 @@ async def test_no_proxy_for_oracle():
     assert runtime is None
 
 
+@pytest.mark.asyncio
+async def test_no_proxy_for_daytona_remote_sandbox(monkeypatch):
+    """Daytona runs the agent on a remote host the host proxy cannot reach.
+
+    The usage proxy must be skipped so the agent talks to the provider
+    directly instead of being pointed at an unreachable 127.0.0.1 address
+    (the regression that produced ACP ECONNREFUSED errors).
+    """
+    from benchflow.providers import runtime as provider_runtime_mod
+    from benchflow.providers.runtime import ensure_usage_proxy_runtime
+
+    def _fail_start(*_args, **_kwargs):
+        raise AssertionError("TrajectoryProxy must not start for daytona")
+
+    monkeypatch.setattr(provider_runtime_mod, "TrajectoryProxy", _fail_start)
+
+    env = {
+        "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+        "ANTHROPIC_API_KEY": "sk-real-key",
+    }
+    updated, runtime = await ensure_usage_proxy_runtime(
+        agent="claude-agent-acp",
+        agent_env=env,
+        model="claude-haiku-4-5-20251001",
+        runtime=None,
+        environment="daytona",
+        session_id="rollout-1",
+    )
+
+    # Proxy skipped: env left untouched (no loopback rewrite), no runtime.
+    assert runtime is None
+    assert updated == env
+    assert updated["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
+
+
+@pytest.mark.asyncio
+async def test_daytona_runtime_retired_when_environment_unreachable(monkeypatch):
+    """A stale runtime from an earlier env must be stopped, not reused."""
+    from benchflow.providers import runtime as provider_runtime_mod
+    from benchflow.providers.runtime import (
+        ProviderRuntime,
+        ensure_usage_proxy_runtime,
+    )
+
+    stopped = []
+
+    class _StaleServer:
+        target = "https://api.anthropic.com"
+
+        async def stop(self):
+            stopped.append(True)
+
+    stale = ProviderRuntime(
+        kind="usage-proxy", host="127.0.0.1", port=999, server=_StaleServer()
+    )
+
+    monkeypatch.setattr(
+        provider_runtime_mod,
+        "TrajectoryProxy",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not start")),
+    )
+
+    updated, runtime = await ensure_usage_proxy_runtime(
+        agent="claude-agent-acp",
+        agent_env={"ANTHROPIC_BASE_URL": "https://api.anthropic.com"},
+        model="claude-haiku-4-5-20251001",
+        runtime=stale,
+        environment="daytona",
+        session_id="rollout-1",
+    )
+
+    assert runtime is None
+    assert stopped == [True]
+    assert updated["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
+
+
+def test_host_proxy_reachable_only_for_local_environments():
+    from benchflow.providers.runtime import host_proxy_reachable_from_agent
+
+    assert host_proxy_reachable_from_agent("docker") is True
+    assert host_proxy_reachable_from_agent("local") is True
+    assert host_proxy_reachable_from_agent("host") is True
+    assert host_proxy_reachable_from_agent("") is True
+    assert host_proxy_reachable_from_agent("daytona") is False
+    assert host_proxy_reachable_from_agent("modal") is False
+
+
 def test_total_tokens_is_sum_of_parts():
     from benchflow.providers.runtime import ProviderRuntime, extract_usage
 


### PR DESCRIPTION
## The bug

The host-side usage/token-telemetry proxy (telemetry work in #289/#307) broke ACP runs on the **Daytona** cloud sandbox.

`ensure_usage_proxy_runtime` (in `src/benchflow/providers/runtime.py`) injected `ANTHROPIC_BASE_URL=http://127.0.0.1:<port>` (and equivalents) into the agent env via `_bedrock_proxy_command`, which returns `127.0.0.1` for any non-`docker` environment. But the agent runs **inside** the Daytona cloud sandbox, where `127.0.0.1` is the sandbox's own loopback — the host proxy is on a different machine and is unreachable. The agent failed with:

```
ACP error -32603 ... Unable to connect to API (ECONNREFUSED)
```

## Fix approach: B (skip the proxy for unreachable sandboxes) — and why

**Approach A (SSH reverse tunnel) was ruled out empirically.** Daytona's SSH access is a multi-tenant gateway (`ssh.app.daytona.io` with a token username), not a real shell on the sandbox. A probe run of `ssh -R <port>:127.0.0.1:<port>` against a live Daytona sandbox failed:

```
Error: remote port forwarding failed for listen port <port>
```

The gateway rejects remote port forwarding outright (and with `ExitOnForwardFailure=yes` the connection dies). `get_preview_link` only exposes ports *inside* the sandbox to the public internet — the wrong direction. There is no address that routes from a Daytona sandbox back to the host's loopback.

**So Approach B:** added `host_proxy_reachable_from_agent(environment)`. `ensure_usage_proxy_runtime` now skips the host telemetry proxy when the agent runs on a remote host (`daytona`, `modal`, etc.). The agent then calls the provider directly with its real API key; host-side usage telemetry reports `usage_source: "unavailable"` — honest rather than broken. A clear one-line message is logged. Docker/local runs are unchanged (proxy still used, telemetry still works).

Any stale runtime carried over from a prior role/env is correctly stopped before skipping.

## Verification

Real Daytona ACP e2e run completed successfully (no ECONNREFUSED):

```
uv run benchflow eval create --tasks-dir src/benchflow/demo_task \
  --agent claude-agent-acp --model claude-haiku-4-5-20251001 \
  --sandbox daytona --jobs-dir jobs/daytona-proxy-fix-verify
```

```
Skipping host-side usage telemetry proxy: the 'daytona' sandbox runs the agent
on a remote host unreachable from the host proxy; the agent will call the
provider directly and usage telemetry will be unavailable for this run.
...
Rewards: {'reward': 1.0}
```

`result.json`: `reward: 1.0`, `usage_source: "unavailable"`, `cost_usd: null`.

## Tests

Added regression tests in `tests/test_usage_proxy.py`:
- `test_no_proxy_for_daytona_remote_sandbox` — daytona env skips the proxy and leaves agent env untouched
- `test_daytona_runtime_retired_when_environment_unreachable` — a stale runtime is stopped, not reused
- `test_host_proxy_reachable_from_agent` — the reachability predicate

CI gate all green: `ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` (1317 passed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes in `ensure_usage_proxy_runtime` for non-local environments, which could disable telemetry or alter env var rewrites if environment detection is wrong. Core provider calls remain direct and unchanged for local/docker runs.
> 
> **Overview**
> Prevents ACP/agent runs in remote sandboxes (e.g. `daytona`) from being pointed at an unreachable host-loopback usage proxy by adding `host_proxy_reachable_from_agent()` and **skipping the usage proxy entirely** when the sandbox can’t reach the host.
> 
> When skipping, any existing/stale usage-proxy runtime is stopped, the agent env is left untouched (no base URL rewrite), and a clear log message indicates usage telemetry will be reported as `usage_source: "unavailable"`. Adds regression tests covering daytona skip behavior, stale runtime retirement, and the reachability predicate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d28c0c43c1f2608451654167863d284bf210113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->