### PR TITLE
fix(daytona): raise memory clamp default 8 GB -> 16 GB

### DIFF
--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -17,11 +17,11 @@ from benchflow.task import RolloutPaths, Task
 
 logger = logging.getLogger(__name__)
 
-# Daytona's per-sandbox cap on the default tier is 4 CPU / 8 GB. Tasks declaring
-# more fail at sandbox creation. Clamp here so tasks degrade gracefully (slower
-# build) instead of erroring out. Override via env if running on a paid tier.
+# Daytona's per-sandbox caps are 4 CPU / 16 GB RAM / 10 GB disk. Tasks declaring
+# more fail at sandbox creation, so clamp here to degrade gracefully (slower
+# build) instead of erroring out. Override via env if you have higher limits.
 _DAYTONA_MAX_CPUS = int(os.environ.get("BENCHFLOW_DAYTONA_MAX_CPUS", "4"))
-_DAYTONA_MAX_MEMORY_MB = int(os.environ.get("BENCHFLOW_DAYTONA_MAX_MEMORY_MB", "8192"))
+_DAYTONA_MAX_MEMORY_MB = int(os.environ.get("BENCHFLOW_DAYTONA_MAX_MEMORY_MB", "16384"))
 _DAYTONA_MAX_STORAGE_MB = int(
     os.environ.get("BENCHFLOW_DAYTONA_MAX_STORAGE_MB", "10240")
 )


### PR DESCRIPTION
## What

Raise the default Daytona per-sandbox **memory** clamp from 8 GB to 16 GB.

## Why

`src/benchflow/sandbox/setup.py` clamps a task's requested resources down to
Daytona's per-sandbox limits, so an over-large task degrades gracefully (slower
build) instead of failing at sandbox creation.

The memory default was `8192` MB, but Daytona's standard per-sandbox tier now
allows **16 GB** RAM. The stale 8 GB default *silently* shrinks tasks that
legitimately declare up to 16 GB — e.g. Lean 4 / Mathlib builds, which OOM at
8 GB during elaboration.

## Change

- `_DAYTONA_MAX_MEMORY_MB` default `8192` -> `16384`.
- CPU (`4`) and disk (`10240` MB) defaults are **unchanged** — those still match
  Daytona's current per-sandbox caps. (Verified: a 20 GB disk request is rejected
  with `Disk request 20GB exceeds maximum allowed per sandbox (10GB)`.)
- The `BENCHFLOW_DAYTONA_MAX_MEMORY_MB` env override is unchanged.

One-line constant change in `src/benchflow/sandbox/setup.py` plus the comment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Daytona sandbox resource clamp defaults and comments, affecting how much memory tasks can request before being down-clamped.
> 
> **Overview**
> Updates the Daytona sandbox resource clamping defaults to reflect current per-sandbox limits by raising `_DAYTONA_MAX_MEMORY_MB` from `8192` to `16384` (16GB) and adjusting the accompanying comment. This allows tasks requesting up to 16GB RAM to run without being silently reduced to 8GB unless overridden via `BENCHFLOW_DAYTONA_MAX_MEMORY_MB`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ab35eaacd3987c3d1d19940d3b1fb59feb42b1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->