### PR TITLE
fix(registry): carry api_protocol/default_model through _acpx_wrap

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -700,6 +700,12 @@ def _acpx_wrap(config: AgentConfig) -> AgentConfig:
             acpx_agent_name = alias
             break
 
+    # The acpx wrapper only overrides name/install_cmd/launch_cmd. Every other
+    # AgentConfig field must pass through from the underlying agent so that
+    # routing-relevant attributes (api_protocol, default_model, env_mapping,
+    # requires_env, credentials, …) survive when the wrapped config is cached
+    # into AGENTS and later read by resolve_provider_env. ``protocol`` stays
+    # "acp" because acpx itself speaks ACP regardless of the inner agent.
     return AgentConfig(
         # ``acpx:`` runtime key — see acpx_runtime_key / module-level contract.
         name=acpx_runtime_key(config.name),
@@ -712,6 +718,8 @@ def _acpx_wrap(config: AgentConfig) -> AgentConfig:
         description=f"{config.description} (via acpx)",
         skill_paths=config.skill_paths,
         install_timeout=config.install_timeout,
+        default_model=config.default_model,
+        api_protocol=config.api_protocol,
         env_mapping=config.env_mapping,
         credential_files=config.credential_files,
         home_dirs=config.home_dirs,

--- a/tests/test_agent_spec.py
+++ b/tests/test_agent_spec.py
@@ -66,6 +66,49 @@ class TestResolveAgent:
         assert config.name == "acpx:claude-agent-acp"
         assert "acpx" in config.launch_cmd
 
+    def test_acpx_wrap_carries_routing_fields(self):
+        """Regression for PR #322: _acpx_wrap must inherit api_protocol and
+        default_model (and all other non-overridden fields) from the underlying
+        agent. The wrapped config is cached into AGENTS and later read by
+        resolve_provider_env; if api_protocol is dropped, multi-endpoint
+        providers route to the wrong base URL/protocol.
+        """
+        underlying = AGENTS["claude-agent-acp"]
+        wrapped = resolve_agent("acpx/claude")
+
+        # The two fields the PR #322 review flagged as dropped.
+        assert wrapped.api_protocol == underlying.api_protocol
+        assert wrapped.api_protocol == "anthropic-messages"
+        assert wrapped.default_model == underlying.default_model
+
+        # The acpx wrapper only legitimately overrides name/install/launch.
+        # Everything else routing-relevant must pass through unchanged.
+        assert wrapped.requires_env == underlying.requires_env
+        assert wrapped.env_mapping == underlying.env_mapping
+        assert wrapped.skill_paths == underlying.skill_paths
+        assert wrapped.credential_files == underlying.credential_files
+        assert wrapped.home_dirs == underlying.home_dirs
+        assert wrapped.acp_model_format == underlying.acp_model_format
+        assert wrapped.subscription_auth == underlying.subscription_auth
+        assert wrapped.supports_acp_set_model == underlying.supports_acp_set_model
+        assert wrapped.install_timeout == underlying.install_timeout
+        assert (
+            wrapped.disallow_web_tools_setup_cmd
+            == underlying.disallow_web_tools_setup_cmd
+        )
+        assert (
+            wrapped.disallow_web_tools_launch_suffix
+            == underlying.disallow_web_tools_launch_suffix
+        )
+
+    def test_acpx_cached_config_keeps_api_protocol(self):
+        """Regression for PR #322: the cached acpx runtime key in AGENTS must
+        expose the underlying agent's api_protocol so resolve_provider_env
+        picks the agent-required endpoint for multi-endpoint providers.
+        """
+        key = resolve_agent_key("acpx/claude")
+        assert AGENTS[key].api_protocol == "anthropic-messages"
+
     def test_resolve_unknown_raises(self):
         with pytest.raises(KeyError, match="Unknown agent"):
             resolve_agent("nonexistent-agent")


### PR DESCRIPTION
## Bug F — `_acpx_wrap` drops `api_protocol` / `default_model`

Addresses an unaddressed review-bot comment (Codex P1 + Cursor High) on merged PR #322.

### Problem

`_acpx_wrap` in `src/benchflow/agents/registry.py` builds a new `AgentConfig` for the `acpx:`-wrapped agent but does not carry over `api_protocol` (or `default_model`) from the underlying agent config. PR #322 caches that wrapped config into `AGENTS`.

Provider routing reads `AGENTS[agent].api_protocol` in `resolve_provider_env` to pick endpoints. Cached entries like `acpx:claude-agent-acp` got `api_protocol=""`, so multi-endpoint providers (e.g. `zai`, which has both OpenAI and Anthropic endpoints) fell back to the provider default protocol instead of the agent-required one — routing `acpx/<agent>` to the wrong base URL/protocol.

Confirmed live on `main`: `resolve_agent_key("acpx/claude-agent-acp")` yields a cached config with `api_protocol=''` while the underlying `claude-agent-acp` has `api_protocol='anthropic-messages'`.

### Fix

`_acpx_wrap` now carries `api_protocol` and `default_model` through. The acpx wrapper only legitimately overrides `name`, `install_cmd`, and `launch_cmd` (`protocol` stays `"acp"` since acpx itself speaks ACP); every other `AgentConfig` field passes through from the underlying agent.

### Tests

Two regression tests added to `tests/test_agent_spec.py` (docstrings name PR #322 per AGENTS.md):
- `test_acpx_wrap_carries_routing_fields` — audits the full field set passes through.
- `test_acpx_cached_config_keeps_api_protocol` — the cached `acpx:` runtime key exposes the underlying `api_protocol`.

CI gate: ruff format, ruff check, ty check, full pytest (1312 passed) all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how `acpx/` agent configs are materialized/cached in `AGENTS`, which affects provider endpoint selection and runtime behavior for wrapped agents; scope is small and covered by targeted regression tests.
> 
> **Overview**
> Fixes `acpx`-wrapped agent configs so they inherit routing-critical fields from the underlying `AgentConfig` when `_acpx_wrap` builds the wrapped entry.
> 
> `_acpx_wrap` now carries through `api_protocol` and `default_model` (in addition to existing pass-through fields), preventing cached `acpx:` entries from losing endpoint/protocol hints used during provider resolution. Adds regression tests asserting the wrapped config and the cached `acpx:` runtime key preserve these fields and other non-overridden attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ab385cc2338adc0d5bdfefc31c36b0a08ab7b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->