### PR TITLE
fix(verifier): create /logs/verifier in non-main target services

### DIFF
--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -192,6 +192,20 @@ class Verifier:
             user="root",
             service=service,
         )
+
+        # The ``main`` (agent) container has ``/logs/verifier`` bind-mounted
+        # and re-created by ``harden_before_verify``. A non-``main`` target
+        # service (#248) has neither, so the ``test.sh`` stdout redirect below
+        # — and any ``test.sh`` that writes ``reward.txt`` there — would fail
+        # before verification even starts. Create it explicitly first.
+        if service != "main":
+            verifier_dir = shlex.quote(str(sandbox_paths.verifier_dir))
+            await self._sandbox.exec(
+                f"mkdir -p {verifier_dir} && chmod 777 {verifier_dir}",
+                user="root",
+                service=service,
+            )
+
         await self._sandbox.exec(
             command=f"{test_script_path} > {test_stdout_path} 2>&1",
             env=env,

--- a/tests/test_verifier_multi_container.py
+++ b/tests/test_verifier_multi_container.py
@@ -176,6 +176,75 @@ class TestTargetSideTestScriptVerification:
         assert {c["service"] for c in sandbox.download_calls} == {"target"}
 
     @pytest.mark.asyncio
+    async def test_target_service_logs_verifier_dir_created_before_test_sh(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards PR #321: create /logs/verifier in a non-main target service.
+
+        ``/logs/verifier`` is bind-mounted (and re-created by
+        ``harden_before_verify``) only in the ``main`` container. When the
+        verifier runs ``test.sh`` in a target service its stdout is redirected
+        to ``/logs/verifier/test-stdout.txt`` — a path that does not exist on a
+        typical target image. Without an explicit ``mkdir -p`` the redirect
+        fails before ``test.sh`` starts and target-side verification silently
+        produces no reward file. The verifier must create the directory in the
+        target container *before* the ``test.sh`` exec.
+        """
+        toml = 'version = "1.0"\n[verifier]\nservice = "target"\n'
+        task = _make_task(tmp_path, toml)
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        sandbox = _RecordingSandbox(rollout_paths)
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        commands = [c["command"] for c in sandbox.exec_calls]
+        mkdir_indices = [
+            i
+            for i, cmd in enumerate(commands)
+            if "mkdir" in cmd and "/logs/verifier" in cmd
+        ]
+        assert mkdir_indices, "verifier must mkdir /logs/verifier in the target service"
+        # The directory is created in the target service, as root.
+        mkdir_call = sandbox.exec_calls[mkdir_indices[0]]
+        assert mkdir_call["service"] == "target"
+        assert mkdir_call.get("user") == "root"
+        # It must run before test.sh redirects its stdout into that directory.
+        test_sh_indices = [
+            i for i, cmd in enumerate(commands) if "test-stdout.txt" in cmd
+        ]
+        assert test_sh_indices, "test.sh redirect exec not found"
+        assert mkdir_indices[0] < test_sh_indices[0], (
+            "/logs/verifier must be created before the test.sh stdout redirect"
+        )
+
+    @pytest.mark.asyncio
+    async def test_main_service_skips_redundant_logs_verifier_mkdir(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards PR #321: main-service runs are unaffected by the target fix.
+
+        The ``main`` container already has ``/logs/verifier`` bind-mounted and
+        re-created by ``harden_before_verify``, so the verifier must not issue
+        an extra ``mkdir`` for it — the fix is scoped to non-``main`` services.
+        """
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        sandbox = _RecordingSandbox(rollout_paths)
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        mkdir_calls = [
+            c
+            for c in sandbox.exec_calls
+            if "mkdir" in c["command"] and "/logs/verifier" in c["command"]
+        ]
+        assert not mkdir_calls, (
+            "main-service verifier must not mkdir /logs/verifier (already mounted)"
+        )
+
+    @pytest.mark.asyncio
     async def test_mounted_sandbox_still_downloads_from_target_service(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Bug E [Codex P1 + Cursor High] — `/logs/verifier` not created in the target service

From an unaddressed review-bot comment on the already-merged PR #321 (target-side `test.sh` verification, #248 item 4).

### Problem

`src/benchflow/task/verifier.py` `_verify_test_script` runs `test.sh` inside the compose service selected by `[verifier].service` and redirects its output to `/logs/verifier/test-stdout.txt`. But `/logs/verifier` only exists in the `main` service — it is bind-mounted in `docker-compose-base.yaml` and recreated by `harden_before_verify`. On a typical target image the directory does not exist, so the shell redirection fails **before `test.sh` even starts**. Reward files are never produced/downloaded and target-side verification silently fails, defeating the purpose of PR #321.

Confirmed live on current `main`: the new regression test fails without the fix.

### Fix

When the verifier runs in a non-`main` service, `mkdir -p /logs/verifier` (and `chmod 777`) in that container, as root, before running `test.sh`. `main`-service runs are unaffected — they already have the directory mounted/recreated.

### Tests

Added two regression tests to `tests/test_verifier_multi_container.py` (docstrings name PR #321 per AGENTS.md):
- `test_target_service_logs_verifier_dir_created_before_test_sh` — asserts the `mkdir` runs in the target service, as root, before the `test.sh` stdout redirect. Fails on current `main`.
- `test_main_service_skips_redundant_logs_verifier_mkdir` — asserts `main`-service runs do not issue a redundant `mkdir`.

### CI

`ruff format --check`, `ruff check`, `ty check src/`, full `pytest` (1312 passed) all green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, small change gated on `service != "main"` that only affects target-side test-script verification setup and adds focused unit coverage.
> 
> **Overview**
> Fixes a target-side verification regression where running `test.sh` in a non-`main` compose service could fail before start due to stdout redirection into missing `/logs/verifier`.
> 
> When `verifier.service` is not `main`, the verifier now `mkdir -p` (and `chmod 777`) the sandbox `verifier_dir` as `root` before executing `test.sh`, and new tests assert the mkdir happens in the target service *before* the redirect and that `main` runs do not perform the extra mkdir.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69543e9383e34a1613341ce281d7c59e26755153. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->