### PR TITLE
test: name guarding PRs in regression-test docstrings

### DIFF
--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -320,7 +320,7 @@ class TestJobRunOrchestration:
         be double-counted — otherwise the passed+failed+errored+verifier_errored
         == total assertion in Evaluation.run() crashes the whole evaluation.
 
-        Regression for audit Finding 6.
+        Guards the fix from PR #320 for audit Finding 6.
         """
         job = self._make_job(tmp_path, n_tasks=1, concurrency=1)
         job._sdk = AsyncMock()

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -55,6 +55,9 @@ class TestParseVerdict:
 
 
 class TestCallJudgeProviderFallback:
+    """Guards the fix from PR #319 (rewards-code audit) for cross-provider
+    judge fallback."""
+
     async def test_api_failure_surfaces_original_error(self) -> None:
         """A real API failure on the matching provider is raised as-is.
 
@@ -138,6 +141,9 @@ class _FakeResponse:
 
 
 class TestCallAnthropicContent:
+    """Guards the fix from PR #319 (rewards-code audit) for `_call_anthropic`
+    content-block extraction."""
+
     def _patch_sdk(self, response: _FakeResponse) -> AbstractContextManager[None]:
         client = AsyncMock()
         client.messages.create = AsyncMock(return_value=response)
@@ -396,6 +402,7 @@ description = "B"
     async def test_likert_criterion(
         self, mock_judge: AsyncMock, tmp_path: Path
     ) -> None:
+        """Guards the fix from PR #319 (rewards-code audit) for likert scoring."""
         mock_judge.return_value = '{"score": 4, "reasoning": "pretty good"}'
         (tmp_path / "output.txt").write_text("output")
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -272,7 +272,7 @@ def test_collect_metrics_error_and_verifier_error_counted_once(tmp_path):
     exactly one bucket — errored — so the count buckets stay disjoint and
     passed+failed+errored+verifier_errored == total.
 
-    Regression for audit Finding 6 (metrics.py side).
+    Guards the fix from PR #320 for audit Finding 6 (metrics.py side).
     """
     trial = tmp_path / "job" / "task-x__abc123"
     trial.mkdir(parents=True)

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -225,9 +225,10 @@ class TestBedrockProxyRuntime:
 
 
 class TestBedrockProxyRemoteSandbox:
-    """The Bedrock proxy is load-bearing; on a remote sandbox where the host
-    proxy is unreachable the run must fail fast rather than inject an
-    unreachable 127.0.0.1 base URL (the Daytona telemetry-proxy twin bug)."""
+    """Guards the fix from PR #329: the Bedrock proxy is load-bearing; on a
+    remote sandbox where the host proxy is unreachable the run must fail fast
+    rather than inject an unreachable 127.0.0.1 base URL (the Daytona
+    telemetry-proxy twin bug)."""
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("environment", ["daytona", "modal"])

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -862,8 +862,9 @@ class TestVerifierEnv:
         assert final_env.get("PYTEST_DISABLE_PLUGIN_AUTOLOAD") == "1"
 
     def test_verifier_config_keeps_pytest_plugins_from_toml(self):
-        """Guards issue #192 bug 2: a [verifier] pytest_plugins declaration in
-        task.toml must survive parsing into VerifierConfig.
+        """Guards the fix from PR #309 for issue #192 bug 2: a [verifier]
+        pytest_plugins declaration in task.toml must survive parsing into
+        VerifierConfig.
 
         lockdown._discover_pytest_plugin_flags reads
         task.config.verifier.pytest_plugins as the fallback when container-side

--- a/tests/test_skill_eval.py
+++ b/tests/test_skill_eval.py
@@ -507,7 +507,8 @@ class TestSkillEvaluatorResultCollection:
 
         The rollout-dir contract is `{case_id}__{uuid8}`; a trailing-`*` glob
         (`**/{case_id}*`) also matches `case-10__...`, `case-11__...`, etc. and
-        can mis-attribute rewards. Regression for audit Finding 7.
+        can mis-attribute rewards. Guards the fix from PR #320 for audit
+        Finding 7.
         """
         from benchflow.evaluation import EvaluationResult
 

--- a/tests/test_trial_install_agent_timeout.py
+++ b/tests/test_trial_install_agent_timeout.py
@@ -94,7 +94,8 @@ async def test_install_agent_forwards_sandbox_setup_timeout(
 async def test_install_agent_passes_effective_task_path_to_deploy_skills(
     tmp_path, monkeypatch, agent
 ):
-    """Guards issue #229: deploy_skills double-deploys when skills_dir is set.
+    """Guards the fix from PR #308 for issue #229: deploy_skills double-deploys
+    when skills_dir is set.
 
     `_setup` copies the task to a temp dir and injects
     `COPY _deps/skills /skills/` into that temp Dockerfile, recording the

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -469,9 +469,9 @@ async def test_no_proxy_for_oracle():
 async def test_no_proxy_for_daytona_remote_sandbox(monkeypatch):
     """Daytona runs the agent on a remote host the host proxy cannot reach.
 
-    The usage proxy must be skipped so the agent talks to the provider
-    directly instead of being pointed at an unreachable 127.0.0.1 address
-    (the regression that produced ACP ECONNREFUSED errors).
+    Guards the fix from PR #327: the usage proxy must be skipped so the agent
+    talks to the provider directly instead of being pointed at an unreachable
+    127.0.0.1 address (the regression that produced ACP ECONNREFUSED errors).
     """
     from benchflow.providers import runtime as provider_runtime_mod
     from benchflow.providers.runtime import ensure_usage_proxy_runtime
@@ -502,7 +502,8 @@ async def test_no_proxy_for_daytona_remote_sandbox(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_daytona_runtime_retired_when_environment_unreachable(monkeypatch):
-    """A stale runtime from an earlier env must be stopped, not reused."""
+    """Guards the fix from PR #327: a stale runtime from an earlier env must be
+    stopped, not reused."""
     from benchflow.providers import runtime as provider_runtime_mod
     from benchflow.providers.runtime import (
         ProviderRuntime,


### PR DESCRIPTION
## Summary

`AGENTS.md` requires: *"Regression tests must name the PR/commit they guard in the docstring (e.g. `Guards the fix from PR #198 against the regression introduced by PR #193`)."*

The review bots (Codex P1 / Devin) flagged this convention violation repeatedly across PRs #308, #309, #319, #320, #327, and #329 — the regression tests added there cited only a GitHub issue (`Guards issue #NNN`), an audit finding, or no reference at all, instead of naming the guarding **PR**.

This is a docstring-only, behavior-preserving change. No test logic or assertions were touched. Existing issue/finding references are kept alongside the new PR reference.

## Docstrings fixed

- `tests/test_trial_install_agent_timeout.py::test_install_agent_passes_effective_task_path_to_deploy_skills` → PR #308 (keeps issue #229)
- `tests/test_sandbox_hardening.py::test_verifier_config_keeps_pytest_plugins_from_toml` → PR #309 (keeps issue #192 bug 2)
- `tests/test_llm_judge.py` — `TestCallJudgeProviderFallback`, `TestCallAnthropicContent`, `test_likert_criterion` → PR #319
- `tests/test_job.py` / `tests/test_metrics.py` / `tests/test_skill_eval.py` — audit Finding 6/7 tests → PR #320
- `tests/test_usage_proxy.py` — `test_no_proxy_for_daytona_remote_sandbox`, `test_daytona_runtime_retired_when_environment_unreachable` → PR #327
- `tests/test_provider_runtime.py::TestBedrockProxyRemoteSandbox` → PR #329

## Verification

- `uv run ruff format --check src tests` — passes
- `uv run ruff check .` — passes
- `uv run ty check src/` — passes
- `uv run python -m pytest tests/` — 1310 passed, 27 skipped (unchanged; docstring-only)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/333" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: docstring-only edits in test files with no behavioral or assertion changes.
> 
> **Overview**
> Aligns regression-test docstrings with `AGENTS.md` by adding explicit **“Guards the fix from PR #…“** references (while keeping existing issue/audit identifiers) across several test modules.
> 
> No test logic, assertions, or production code is modified; only docstring wording/formatting is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 953900285ca4b3d5477e8d3b2bc790543be136cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->