### PR TITLE
fix(sandbox): POSIX sh for service exec + Modal is_dir/is_file service param

### DIFF
--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -649,7 +649,10 @@ class _DaytonaDinD(_DaytonaStrategy):
                 parts.extend(["-e", f"{k}={v}"])
         if user is not None:
             parts.extend(["-u", str(user)])
-        parts.extend([service, "bash", "-lc", command])
+        # Use POSIX ``sh`` rather than ``bash``: with multi-service support
+        # (#248), ``service`` can target arbitrary task containers, and
+        # Alpine/distroless/minimal images often ship no ``/bin/bash``.
+        parts.extend([service, "sh", "-c", command])
 
         return await self._compose_exec(parts, timeout_sec=timeout_sec)
 

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -486,7 +486,12 @@ class DockerSandbox(BaseSandbox):
         if env:
             command = self._wrap_command_with_env_file(env, command)
 
-        exec_command.extend(["bash", "-c", command])
+        # Use POSIX ``sh`` rather than ``bash``: with multi-service support
+        # (#248), ``exec(..., service=...)`` can target arbitrary task
+        # containers — Alpine/distroless/minimal DB images frequently ship no
+        # ``/bin/bash``. The wrapped command (env-file sourcing, ``trap``,
+        # ``base64 -d``, ``set -a``/``. file``) uses only POSIX constructs.
+        exec_command.extend(["sh", "-c", command])
 
         return await self._run_docker_compose_command(
             exec_command, check=False, timeout_sec=timeout_sec

--- a/src/benchflow/sandbox/modal_impl.py
+++ b/src/benchflow/sandbox/modal_impl.py
@@ -309,7 +309,15 @@ class ModalSandbox(BaseSandbox):
             for p in file_paths:
                 tg.create_task(_download_one(p))
 
-    async def is_dir(self, path: str, user: str | int | None = None) -> bool:
+    async def is_dir(
+        self, path: str, user: str | int | None = None, service: str = "main"
+    ) -> bool:
+        if service != "main":
+            raise ValueError(
+                f"Modal sandbox is single-container and cannot target "
+                f"service {service!r}. Multi-container (vulhub-style) tasks "
+                "require the Docker sandbox (#248)."
+            )
         if not self._sandbox:
             raise RuntimeError("Sandbox not found. Please start the environment first.")
         try:
@@ -318,7 +326,15 @@ class ModalSandbox(BaseSandbox):
         except NotADirectoryError:
             return False
 
-    async def is_file(self, path: str, user: str | int | None = None) -> bool:
+    async def is_file(
+        self, path: str, user: str | int | None = None, service: str = "main"
+    ) -> bool:
+        if service != "main":
+            raise ValueError(
+                f"Modal sandbox is single-container and cannot target "
+                f"service {service!r}. Multi-container (vulhub-style) tasks "
+                "require the Docker sandbox (#248)."
+            )
         if not self._sandbox:
             raise RuntimeError("Sandbox not found. Please start the environment first.")
         try:

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -40,7 +40,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec("echo hi")
 
-        assert captured[0] == ["exec", "main", "bash", "-c", "echo hi"]
+        assert captured[0] == ["exec", "main", "sh", "-c", "echo hi"]
 
     @pytest.mark.asyncio
     async def test_exec_targets_named_service(self) -> None:
@@ -55,7 +55,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec("test -f /tmp/pwned", service="target")
 
-        assert captured[0] == ["exec", "target", "bash", "-c", "test -f /tmp/pwned"]
+        assert captured[0] == ["exec", "target", "sh", "-c", "test -f /tmp/pwned"]
 
     @pytest.mark.asyncio
     async def test_exec_in_service_wrapper(self) -> None:
@@ -70,7 +70,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec_in_service("db", "mysql -e 'SELECT 1'")
 
-        assert captured[0] == ["exec", "db", "bash", "-c", "mysql -e 'SELECT 1'"]
+        assert captured[0] == ["exec", "db", "sh", "-c", "mysql -e 'SELECT 1'"]
 
     @pytest.mark.asyncio
     async def test_exec_service_with_user_and_cwd(self) -> None:
@@ -88,15 +88,15 @@ class TestDockerSandboxServiceExec:
         )
 
         cmd = captured[0]
-        # service name precedes `bash -c`, after all flags
-        assert cmd[cmd.index("bash") - 1] == "attacker"
+        # service name precedes `sh -c`, after all flags
+        assert cmd[cmd.index("sh") - 1] == "attacker"
         assert "-w" in cmd and "/work" in cmd
         assert "-u" in cmd and "root" in cmd
         # Env vars are sourced from a file inside the container, never passed
         # as `-e KEY=VALUE` flags (which leak onto host `ps aux`).
         assert "-e" not in cmd
-        bash_cmd = cmd[cmd.index("bash") + 2]
-        assert "base64 -d" in bash_cmd
+        sh_cmd = cmd[cmd.index("sh") + 2]
+        assert "base64 -d" in sh_cmd
         for arg in cmd:
             assert "K=v" not in arg
 
@@ -347,7 +347,7 @@ class TestDaytonaServiceExec:
         await strategy.exec("cat /flag", service="target")
 
         sub = captured[0]
-        assert sub[sub.index("bash") - 1] == "target"
+        assert sub[sub.index("sh") - 1] == "target"
 
     @pytest.mark.asyncio
     async def test_dind_exec_defaults_to_main(self) -> None:
@@ -366,7 +366,7 @@ class TestDaytonaServiceExec:
         await strategy.exec("echo hi")
 
         sub = captured[0]
-        assert sub[sub.index("bash") - 1] == "main"
+        assert sub[sub.index("sh") - 1] == "main"
 
     @pytest.mark.asyncio
     async def test_direct_strategy_rejects_non_main_service(self) -> None:
@@ -461,3 +461,121 @@ class TestModalRejectsMultiService:
 
         with pytest.raises(NotImplementedError, match="single-container"):
             await sandbox.services()
+
+    @pytest.mark.asyncio
+    async def test_modal_is_dir_rejects_non_main_service(self) -> None:
+        """Guards PR #310: ModalSandbox.is_dir gained a ``service`` param.
+
+        PR #310 added ``service`` to ``BaseSandbox.is_dir``/``is_file`` but
+        left ``ModalSandbox``'s overrides on the old ``(path, user)``
+        signature, so ``is_dir(path, service="target")`` raised an opaque
+        ``TypeError`` instead of the actionable ``ValueError`` that
+        ``ModalSandbox.exec`` raises for non-main services.
+        """
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+
+        with pytest.raises(ValueError, match="single-container"):
+            await sandbox.is_dir("/etc", service="target")
+
+    @pytest.mark.asyncio
+    async def test_modal_is_file_rejects_non_main_service(self) -> None:
+        """Guards PR #310: ModalSandbox.is_file gained a ``service`` param.
+
+        Same regression as ``is_dir`` — without the ``service`` parameter,
+        ``is_file(path, service="target")`` raised ``TypeError`` rather than
+        the clear ``ValueError`` Modal uses for unsupported multi-service
+        access.
+        """
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+
+        with pytest.raises(ValueError, match="single-container"):
+            await sandbox.is_file("/etc/hosts", service="target")
+
+
+class TestServiceExecUsesPosixShell:
+    """Guards PR #310: service-targeted exec must use POSIX ``sh``, not ``bash``.
+
+    PR #310 made ``exec(..., service=...)`` route commands to arbitrary task
+    containers, but the Docker and Daytona-DinD exec paths hardcoded
+    ``bash -c`` / ``bash -lc``. Alpine/distroless/minimal DB images ship no
+    ``/bin/bash``, so service-targeted verifier/setup commands failed even on
+    healthy containers. The exec wrapper uses only POSIX constructs, so the
+    fix is to invoke ``sh -c``.
+    """
+
+    def _make_docker_sandbox(self) -> DockerSandbox:
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._persistent_env = {}
+        sandbox.default_user = None
+        return sandbox
+
+    @pytest.mark.asyncio
+    async def test_docker_exec_invokes_sh_not_bash(self) -> None:
+        """Guards PR #310: DockerSandbox.exec must invoke ``sh``, never ``bash``."""
+        sandbox = self._make_docker_sandbox()
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec("echo hi", service="target")
+
+        cmd = captured[0]
+        assert "sh" in cmd
+        assert "bash" not in cmd
+        # ``sh -c <command>`` is the tail of the exec invocation.
+        assert cmd[-3:] == ["sh", "-c", "echo hi"]
+
+    @pytest.mark.asyncio
+    async def test_docker_exec_env_wrapper_stays_posix(self) -> None:
+        """Guards PR #310: the env-file wrapper sourced under ``sh`` is POSIX.
+
+        The wrapper relies on ``trap``, ``printf``, ``base64 -d``, ``umask``,
+        ``set -a`` and ``. file`` — all POSIX, so it runs correctly under
+        ``sh`` on shells without ``bash``.
+        """
+        sandbox = self._make_docker_sandbox()
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec("id", env={"K": "v"}, service="target")
+
+        cmd = captured[0]
+        assert cmd[cmd.index("sh") - 1] == "target"
+        wrapped = cmd[cmd.index("sh") + 2]
+        # ``source`` is a bashism; the wrapper must use the POSIX ``.`` builtin.
+        assert "source " not in wrapped
+        assert ". /tmp/.benchflow_exec_env_" in wrapped
+
+    @pytest.mark.asyncio
+    async def test_daytona_dind_exec_invokes_sh_not_bash(self) -> None:
+        """Guards PR #310: Daytona DinD exec must invoke ``sh``, never ``bash``."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        await strategy.exec("cat /flag", service="target")
+
+        sub = captured[0]
+        assert "sh" in sub
+        assert "bash" not in sub
+        assert sub[-3:] == ["sh", "-c", "cat /flag"]


### PR DESCRIPTION
Fixes two bugs that review bots flagged on merged PR #310 (multi-container service selection) but were never addressed.

## Bug A [Codex P1] — `exec(service=...)` hardcoded `bash`

`DockerSandbox.exec` (`src/benchflow/sandbox/docker.py`) and the Daytona DinD compose exec path (`src/benchflow/sandbox/daytona.py`) invoked `bash -c` / `bash -lc`. With multi-service support, `exec(..., service=...)` now runs against arbitrary task containers — Alpine/distroless/minimal DB images frequently have no `/bin/bash`, so service-targeted verifier/setup commands failed even on healthy containers.

Fix: both paths now invoke `sh -c`. The Docker exec env-file wrapper (`_wrap_command_with_env_file`) uses only POSIX constructs — `trap`, `printf`, `base64 -d`, `umask`, `set -a`, and the `.` source builtin — so plain POSIX `sh` is the clean fix; no bash-isms, no fallback needed. The Daytona DinD path passes the command verbatim with env via `-e` flags, so a login shell was unnecessary and `bash -lc` became `sh -c`. Existing bash-having `main`-container tasks are unaffected.

## Bug B [Devin + Cursor] — `ModalSandbox.is_dir`/`is_file` missing `service` param

PR #310 added `service: str = "main"` to `BaseSandbox.is_dir`/`is_file`. `DaytonaSandbox` was updated; `ModalSandbox.is_dir`/`is_file` (`src/benchflow/sandbox/modal_impl.py`) kept the old `(path, user=None)` signature, so `modal_sandbox.is_dir(path, service="target")` raised an opaque `TypeError` instead of the clear `ValueError` that `ModalSandbox.exec()` raises for non-`main` services.

Fix: added the `service` param to both methods, rejecting non-`main` with the same actionable `ValueError` Modal's `exec()` uses.

## Tests

Both bugs confirmed live on current `main` before fixing. Regression tests added in `tests/test_sandbox_multi_service.py` (docstrings name PR #310 per AGENTS.md): `TestServiceExecUsesPosixShell` (Docker + Daytona-DinD invoke `sh`, env wrapper stays POSIX) and two cases in `TestModalRejectsMultiService` for `is_dir`/`is_file`. Pre-existing assertions that hardcoded `bash` in command vectors were updated to `sh`.

CI gate green locally: `ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` (1312 passed, 30 skipped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the shell used to run sandbox commands (`bash`→`sh`) in Docker/Daytona multi-service exec paths, which could affect any bash-specific command strings. Modal changes are API-signature/validation only and are low risk.
> 
> **Overview**
> **Fixes multi-service sandbox command execution on minimal images** by invoking `sh -c` (instead of `bash -c`/`bash -lc`) for Docker compose `exec` and Daytona DinD compose `exec`, improving compatibility with Alpine/distroless containers.
> 
> **Aligns ModalSandbox API with multi-service signatures** by adding a `service` parameter to `ModalSandbox.is_dir`/`is_file` and explicitly rejecting non-`main` services with a clear `ValueError`. Tests are updated and expanded to assert `sh` usage and to cover the Modal `service`-param regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1ef4de3a288c926231cf5807d63d88af830cafb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->