### PR TITLE
fix(rewards): concurrency-safe judge env + restore unknown-prefix fallback

### DIFF
--- a/src/benchflow/rewards/builtins.py
+++ b/src/benchflow/rewards/builtins.py
@@ -163,6 +163,7 @@ class LLMJudgeRewardFunc:
         criteria: list[dict] | None = None,
         mode: Literal["batched", "individual"] = "individual",
         judge_model: str | None = None,
+        judge_env: dict[str, str] | None = None,
     ) -> None:
         self.prompt = prompt
         # ``judge_model`` (an explicit ``[verifier.judge].model`` from
@@ -171,6 +172,10 @@ class LLMJudgeRewardFunc:
         # default; rubric files supply their own default via ``_resolve_model``.
         self.model = judge_model or model
         self._explicit_model = judge_model
+        # Resolved ``[verifier.env]`` credentials, threaded explicitly into
+        # ``call_judge`` so concurrent judge runs do not race on a shared
+        # ``os.environ`` (see ``call_judge``).
+        self._judge_env = judge_env or {}
         self.mode = mode
         self._rubric_path = rubric_path
         self._inline_criteria = criteria
@@ -290,7 +295,7 @@ class LLMJudgeRewardFunc:
             prompt_text = self._build_prompt(criterion, agent_text, context)
 
             try:
-                raw_response = await call_judge(model, prompt_text)
+                raw_response = await call_judge(model, prompt_text, env=self._judge_env)
                 verdict = parse_verdict(raw_response)
                 norm_score = self._extract_score(criterion, verdict)
             except JudgeEnvironmentError:

--- a/src/benchflow/rewards/llm.py
+++ b/src/benchflow/rewards/llm.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import logging
 import re
+from collections.abc import Mapping
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -99,18 +100,42 @@ async def call_judge(
     *,
     max_tokens: int = 2048,
     retries: int = 3,
+    env: Mapping[str, str] | None = None,
 ) -> str:
     """Call an LLM judge, routing by model name prefix.
 
+    ``env`` carries the resolved ``[verifier.judge]`` credentials (API keys
+    etc.). They are passed explicitly into the provider clients rather than
+    being written into the process-global ``os.environ`` — concurrent judge
+    runs (``asyncio.gather`` with concurrency > 1) would otherwise race on
+    the shared environment and see each other's credentials. ``env`` keys
+    are layered over (and take precedence on a per-call basis without
+    mutating) the ambient process environment.
+
     Tries Anthropic, OpenAI, and Google SDKs in order based on the
-    model string.  Cross-provider fallback only applies when an SDK is
-    *not installed* (``ImportError``): a model name only makes sense for
-    the provider it belongs to, so a real API failure (bad key, model
-    not found, retries exhausted) is raised as-is rather than being
-    masked by a different provider rejecting the same model name.
+    model string.
+
+    When the model name carries a *known* provider prefix (``claude-``,
+    ``gpt-``, ``gemini``, ...), only that provider can serve it: a real
+    API failure (bad key, model not found, retries exhausted) is raised
+    as-is rather than being masked by a different provider rejecting the
+    same model name.
+
+    When the prefix is *unknown* (``mistral-large``, ``deepseek-chat``, a
+    custom name), the provider cannot be determined up front, so every
+    provider is tried in turn. A real API failure from one provider then
+    falls through to the next instead of aborting the whole call.
+
+    In both cases a missing SDK (``ImportError``) always falls through to
+    the next provider.
     """
     bare_model = _strip_provider_prefix(model)
+    creds: Mapping[str, str] = env or {}
     providers: list[str] = []
+    # ``matched_provider`` is True only when the model name confidently
+    # identifies a single provider. For an unknown prefix the providers
+    # list is a best-effort "try all", so an API failure must not abort.
+    matched_provider = True
 
     if _is_anthropic_model(model):
         providers = ["anthropic", "openai", "google"]
@@ -119,18 +144,21 @@ async def call_judge(
     elif _is_gemini_model(model):
         providers = ["google", "anthropic", "openai"]
     else:
-        # Unknown prefix — try all
+        # Unknown prefix — try every provider in turn.
         providers = ["anthropic", "openai", "google"]
+        matched_provider = False
+
+    last_error: Exception | None = None
 
     for provider in providers:
         for attempt in range(retries):
             try:
                 if provider == "anthropic":
-                    return await _call_anthropic(bare_model, prompt, max_tokens)
+                    return await _call_anthropic(bare_model, prompt, max_tokens, creds)
                 if provider == "openai":
-                    return await _call_openai(bare_model, prompt, max_tokens)
+                    return await _call_openai(bare_model, prompt, max_tokens, creds)
                 if provider == "google":
-                    return await _call_google(bare_model, prompt)
+                    return await _call_google(bare_model, prompt, creds)
             except ImportError:
                 logger.debug("SDK for %s not installed, skipping", provider)
                 break  # SDK missing — fall through to the next provider
@@ -138,21 +166,33 @@ async def call_judge(
                 if attempt < retries - 1:
                     await asyncio.sleep(2**attempt)
                     continue
-                # A real API failure for this provider's own model.
-                # Other providers cannot serve this model name, so do
-                # not advance — raise the original error directly.
+                last_error = e
                 logger.warning(
                     "%s call failed after %d attempts: %s",
                     provider,
                     retries,
                     e,
                 )
-                raise
+                if matched_provider:
+                    # A real API failure for this provider's own model.
+                    # Other providers cannot serve this model name, so
+                    # do not advance — raise the original error directly.
+                    raise
+                # Unknown-prefix model: this provider could not serve it,
+                # but another one might — fall through to the next.
+                break
 
-    # Every provider's SDK was missing (each ImportError ``break``s to the
-    # next).  A real API failure raises directly above, so this is the only
-    # state that reaches here.  This is an environment failure, not a verdict —
-    # ``JudgeEnvironmentError`` lets callers tell it apart from a real score.
+    # Either every provider's SDK was missing (each ImportError ``break``s to
+    # the next), or — for an unknown-prefix model — every provider was tried
+    # and each failed at the API. If we have a recorded API failure, surface
+    # it so the caller sees a genuine error rather than a misleading
+    # missing-SDK message.
+    if last_error is not None:
+        raise last_error
+
+    # No API was ever reached: every provider's SDK was missing. This is an
+    # environment failure, not a verdict — ``JudgeEnvironmentError`` lets
+    # callers tell it apart from a real score.
     raise JudgeEnvironmentError(
         f"No LLM provider SDK is installed for model {model}. "
         "Install the judge extra: `uv sync --extra judge` "
@@ -165,10 +205,21 @@ async def call_judge(
 # ------------------------------------------------------------------
 
 
-async def _call_anthropic(model: str, prompt: str, max_tokens: int) -> str:
+async def _call_anthropic(
+    model: str, prompt: str, max_tokens: int, env: Mapping[str, str] | None = None
+) -> str:
     import anthropic  # ty: ignore[unresolved-import]
 
-    client = anthropic.AsyncAnthropic()
+    creds = env or {}
+    # Pass the resolved key explicitly so concurrent judge runs cannot race
+    # on a shared os.environ. Fall back to the SDK's own env lookup when no
+    # key was threaded through.
+    api_key = creds.get("ANTHROPIC_API_KEY")
+    client = (
+        anthropic.AsyncAnthropic(api_key=api_key)
+        if api_key
+        else anthropic.AsyncAnthropic()
+    )
     response = await client.messages.create(
         model=model,
         max_tokens=max_tokens,
@@ -184,10 +235,22 @@ async def _call_anthropic(model: str, prompt: str, max_tokens: int) -> str:
     return ""
 
 
-async def _call_openai(model: str, prompt: str, max_tokens: int) -> str:
+async def _call_openai(
+    model: str, prompt: str, max_tokens: int, env: Mapping[str, str] | None = None
+) -> str:
     import openai
 
-    client = openai.AsyncOpenAI()
+    creds = env or {}
+    # Pass the resolved key explicitly so concurrent judge runs cannot race
+    # on a shared os.environ.
+    api_key = creds.get("OPENAI_API_KEY")
+    base_url = creds.get("OPENAI_BASE_URL")
+    kwargs: dict[str, str] = {}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["base_url"] = base_url
+    client = openai.AsyncOpenAI(**kwargs)
     response = await client.chat.completions.create(
         model=model,
         max_tokens=max_tokens,
@@ -197,12 +260,22 @@ async def _call_openai(model: str, prompt: str, max_tokens: int) -> str:
     return content or ""
 
 
-async def _call_google(model: str, prompt: str) -> str:
+async def _call_google(
+    model: str, prompt: str, env: Mapping[str, str] | None = None
+) -> str:
     import os
 
     from google import genai  # ty: ignore[unresolved-import]
 
-    api_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+    creds = env or {}
+    # Prefer the explicitly threaded credentials (concurrency-safe); fall
+    # back to the ambient process env only when none were provided.
+    api_key = (
+        creds.get("GOOGLE_API_KEY")
+        or creds.get("GEMINI_API_KEY")
+        or os.environ.get("GOOGLE_API_KEY")
+        or os.environ.get("GEMINI_API_KEY")
+    )
     if not api_key:
         raise RuntimeError("GOOGLE_API_KEY / GEMINI_API_KEY not set")
     client = genai.Client(api_key=api_key)

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -13,10 +13,7 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 import shlex
-from collections.abc import Iterator, Mapping
-from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -56,27 +53,6 @@ class DownloadVerifierDirError(Exception):
 
 class RubricNotFoundError(Exception):
     """Raised when an llm-judge verifier cannot locate its rubric file."""
-
-
-@contextmanager
-def _scoped_env(env: Mapping[str, str]) -> Iterator[None]:
-    """Temporarily apply *env* to ``os.environ``, restoring prior state on exit.
-
-    Keys not already set are removed afterwards; keys that existed are restored
-    to their original value. This keeps the judge's API keys from leaking into
-    the host process for subsequent rollouts.
-    """
-    previous: dict[str, str | None] = {key: os.environ.get(key) for key in env}
-    try:
-        for key, value in env.items():
-            os.environ[key] = value
-        yield
-    finally:
-        for key, prior in previous.items():
-            if prior is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = prior
 
 
 class Verifier:
@@ -275,9 +251,13 @@ class Verifier:
 
         judge = self._task.config.verifier.judge
 
-        # API keys for the judge come from [verifier.env]; scope them to the
-        # judge call so the provider SDKs (anthropic / openai / google) pick
-        # them up without permanently polluting the host process env.
+        # API keys for the judge come from [verifier.env]. They are threaded
+        # explicitly into the judge call (and on into the provider clients)
+        # rather than written to the process-global ``os.environ``. Mutating
+        # the shared environment is not concurrency-safe: ``evaluation.py``
+        # runs verifications via ``asyncio.gather`` with concurrency > 1, so
+        # two judge runs in the same process would race on the env and see
+        # each other's (or missing) credentials.
         judge_env: dict[str, str] = {}
         if self._task.config.verifier.env:
             judge_env = resolve_env_vars(self._task.config.verifier.env)
@@ -291,9 +271,9 @@ class Verifier:
             prompt=context,
             rubric_path=rubric_path,
             judge_model=judge.model,
+            judge_env=judge_env,
         )
-        with _scoped_env(judge_env):
-            score = await reward_func.score(deliverables_dir)
+        score = await reward_func.score(deliverables_dir)
 
         self._logger.info(
             "llm-judge verifier: %d criteria → reward %.4f",

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -117,6 +117,161 @@ class TestCallJudgeProviderFallback:
         ``except RuntimeError`` handlers keep working."""
         assert issubclass(JudgeEnvironmentError, RuntimeError)
 
+    async def test_unknown_prefix_model_falls_through_after_api_failure(self) -> None:
+        """PR #319 follow-up: an unknown-prefix model whose first provider
+        fails at the API still reaches the remaining providers.
+
+        ``call_judge`` enters the "try all" branch for an unknown prefix
+        (``mistral-large``, ``deepseek-chat``, custom names). The pre-fix
+        code did an unconditional ``raise`` after the first provider
+        exhausted retries, so OpenAI/Google were never reached and the
+        fallback was dead. The fix only raises immediately for a model
+        confidently matched to a single provider.
+        """
+        anthropic_mock = AsyncMock(side_effect=RuntimeError("anthropic 404"))
+        openai_mock = AsyncMock(return_value="ok from openai")
+        google_mock = AsyncMock(return_value="should not be reached")
+
+        with (
+            patch("benchflow.rewards.llm._call_anthropic", anthropic_mock),
+            patch("benchflow.rewards.llm._call_openai", openai_mock),
+            patch("benchflow.rewards.llm._call_google", google_mock),
+        ):
+            result = await call_judge("mistral-large", "prompt", retries=2)
+
+        # Anthropic failed and was retried, then OpenAI served the call.
+        assert result == "ok from openai"
+        assert anthropic_mock.await_count == 2
+        assert openai_mock.await_count == 1
+        google_mock.assert_not_awaited()
+
+    async def test_unknown_prefix_all_providers_fail_raises_last_error(self) -> None:
+        """PR #319 follow-up: when every provider fails at the API for an
+        unknown-prefix model, the genuine API error surfaces — not a
+        misleading missing-SDK ``JudgeEnvironmentError``."""
+        anthropic_err = RuntimeError("anthropic refused")
+        google_err = RuntimeError("google refused")
+
+        with (
+            patch(
+                "benchflow.rewards.llm._call_anthropic",
+                AsyncMock(side_effect=anthropic_err),
+            ),
+            patch(
+                "benchflow.rewards.llm._call_openai",
+                AsyncMock(side_effect=RuntimeError("openai refused")),
+            ),
+            patch(
+                "benchflow.rewards.llm._call_google",
+                AsyncMock(side_effect=google_err),
+            ),
+            pytest.raises(RuntimeError, match="google refused") as exc_info,
+        ):
+            await call_judge("deepseek-chat", "prompt", retries=1)
+
+        # The last provider's real error is surfaced, not JudgeEnvironmentError.
+        assert exc_info.value is google_err
+        assert not isinstance(exc_info.value, JudgeEnvironmentError)
+
+    async def test_known_prefix_still_raises_immediately(self) -> None:
+        """PR #319 follow-up: the unknown-prefix fallback fix must not weaken
+        known-prefix routing — a ``claude-`` model that fails at the API still
+        raises at once without trying OpenAI/Google."""
+        original = RuntimeError("anthropic: invalid x-api-key")
+        openai_mock = AsyncMock(return_value="should not be reached")
+
+        with (
+            patch(
+                "benchflow.rewards.llm._call_anthropic",
+                AsyncMock(side_effect=original),
+            ),
+            patch("benchflow.rewards.llm._call_openai", openai_mock),
+            pytest.raises(RuntimeError, match="invalid x-api-key"),
+        ):
+            await call_judge("claude-haiku-4-5", "prompt", retries=1)
+
+        openai_mock.assert_not_awaited()
+
+
+class TestCallJudgeEnvThreading:
+    """PR #314 follow-up: judge credentials are threaded explicitly through
+    ``call_judge`` instead of mutating the process-global ``os.environ`` (the
+    pre-fix ``_scoped_env``), which is not concurrency-safe under
+    ``asyncio.gather``."""
+
+    async def test_env_passed_to_anthropic_client(self) -> None:
+        """The ``env`` kwarg's ANTHROPIC_API_KEY reaches the Anthropic client
+        as an explicit constructor argument."""
+        seen: dict[str, object] = {}
+
+        def fake_anthropic_ctor(*, api_key: str | None = None) -> AsyncMock:
+            seen["api_key"] = api_key
+            client = AsyncMock()
+            client.messages.create = AsyncMock(
+                return_value=_FakeResponse([_FakeTextBlock("ok")])
+            )
+            return client
+
+        fake_anthropic = type(
+            "FakeAnthropic",
+            (),
+            {"AsyncAnthropic": staticmethod(fake_anthropic_ctor)},
+        )
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}):
+            result = await call_judge(
+                "claude-haiku-4-5",
+                "prompt",
+                retries=1,
+                env={"ANTHROPIC_API_KEY": "key-from-verifier-env"},
+            )
+
+        assert result == "ok"
+        assert seen["api_key"] == "key-from-verifier-env"
+
+    async def test_concurrent_judge_calls_use_isolated_credentials(self) -> None:
+        """PR #314 follow-up: two judge calls running concurrently via
+        ``asyncio.gather`` each see *their own* credentials.
+
+        With the pre-fix ``_scoped_env`` global mutation, one coroutine could
+        restore/pop an env key while another was still mid-call, so the second
+        judge saw missing/wrong credentials. Threading the key explicitly
+        keeps the two calls fully isolated.
+        """
+        import asyncio
+
+        observed: list[str | None] = []
+
+        def fake_anthropic_ctor(*, api_key: str | None = None) -> AsyncMock:
+            client = AsyncMock()
+
+            async def create(**_kwargs: object) -> _FakeResponse:
+                # Record the key, then yield so the other coroutine runs
+                # interleaved — exactly the race _scoped_env could not survive.
+                observed.append(api_key)
+                await asyncio.sleep(0)
+                return _FakeResponse([_FakeTextBlock("ok")])
+
+            client.messages.create = create
+            return client
+
+        fake_anthropic = type(
+            "FakeAnthropic",
+            (),
+            {"AsyncAnthropic": staticmethod(fake_anthropic_ctor)},
+        )
+        with patch.dict("sys.modules", {"anthropic": fake_anthropic}):
+            await asyncio.gather(
+                call_judge(
+                    "claude-haiku-4-5", "p", retries=1, env={"ANTHROPIC_API_KEY": "A"}
+                ),
+                call_judge(
+                    "claude-haiku-4-5", "p", retries=1, env={"ANTHROPIC_API_KEY": "B"}
+                ),
+            )
+
+        # Both distinct keys were seen — neither call clobbered the other's.
+        assert set(observed) == {"A", "B"}
+
 
 # ---------------------------------------------------------------------------
 # _call_anthropic: content block handling

--- a/tests/test_llm_judge_verifier.py
+++ b/tests/test_llm_judge_verifier.py
@@ -220,23 +220,23 @@ class TestLLMJudgeVerifier:
 
     @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
     @pytest.mark.asyncio
-    async def test_judge_env_scoped_to_judge_call(
+    async def test_judge_env_threaded_into_call_judge(
         self, mock_judge: AsyncMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """#270: [verifier.env] keys are applied during the judge call but
-        not leaked into the host process afterwards."""
+        """PR #314 follow-up: [verifier.env] credentials are passed explicitly
+        into ``call_judge`` as the ``env`` kwarg.
+
+        The pre-fix ``_scoped_env`` context manager mutated the process-global
+        ``os.environ``, which is not concurrency-safe: ``evaluation.py`` runs
+        verifications via ``asyncio.gather`` (concurrency > 1), so two judge
+        runs could race on the shared env. Credentials are now threaded
+        through as a parameter instead of touching ``os.environ`` at all.
+        """
         import os
 
         monkeypatch.setenv("MY_JUDGE_KEY", "secret-123")
         monkeypatch.delenv("RESOLVED_KEY", raising=False)
-
-        seen_during_call: dict[str, str | None] = {}
-
-        async def capture_env(*_args: object, **_kwargs: object) -> str:
-            seen_during_call["RESOLVED_KEY"] = os.environ.get("RESOLVED_KEY")
-            return _MOCK_PASS
-
-        mock_judge.side_effect = capture_env
+        mock_judge.return_value = _MOCK_PASS
 
         toml = _judge_toml() + '\n[verifier.env]\nRESOLVED_KEY = "${MY_JUDGE_KEY}"\n'
         task = _make_task(tmp_path, toml)
@@ -250,18 +250,21 @@ class TestLLMJudgeVerifier:
 
         await Verifier(task, rollout_paths, sandbox).verify()
 
-        # applied for the duration of the judge call ...
-        assert seen_during_call["RESOLVED_KEY"] == "secret-123"
-        # ... but not leaked into the host env afterwards.
+        # The resolved credential reaches call_judge as the ``env`` kwarg ...
+        mock_judge.assert_awaited()
+        assert mock_judge.await_args is not None
+        assert mock_judge.await_args.kwargs["env"] == {"RESOLVED_KEY": "secret-123"}
+        # ... and the process-global env is never mutated.
         assert os.environ.get("RESOLVED_KEY") is None
 
     @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
     @pytest.mark.asyncio
-    async def test_judge_env_restores_prior_value(
+    async def test_judge_env_does_not_mutate_os_environ(
         self, mock_judge: AsyncMock, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """#270: a [verifier.env] key that already exists is restored to its
-        original value after the judge call."""
+        """PR #314 follow-up: a [verifier.env] key that already exists in the
+        process env is never overwritten — the verifier no longer touches
+        ``os.environ`` (the pre-fix ``_scoped_env`` capture/restore is gone)."""
         import os
 
         mock_judge.return_value = _MOCK_PASS
@@ -279,6 +282,7 @@ class TestLLMJudgeVerifier:
         rollout_paths.mkdir()
 
         await Verifier(task, rollout_paths, sandbox).verify()
+        # os.environ is left exactly as it was — value never overwritten.
         assert os.environ.get("RESOLVED_KEY") == "preexisting"
 
     @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)


### PR DESCRIPTION
Fixes two review-bot findings from merged PRs that were never addressed.

## Bug C [Codex P1] — `_scoped_env` is not concurrency-safe (PR #314 follow-up)

`src/benchflow/task/verifier.py` applied `[verifier.env]` judge credentials by mutating the process-global `os.environ` inside a `_scoped_env` context manager, restoring prior state on exit. But `evaluation.py` runs verifications via `asyncio.gather` with concurrency > 1: two `llm-judge` verifications in the same process can overlap, so one coroutine restores/pops an env key while another is still inside `await reward_func.score(...)`. The second judge then sees missing or wrong credentials — cross-task contamination under parallel evals.

Fix: credentials are no longer written to `os.environ`. The resolved `[verifier.env]` values are threaded explicitly through `LLMJudgeRewardFunc` → `call_judge` → the provider clients (`_call_anthropic` / `_call_openai` / `_call_google`) as an `env` parameter, so concurrent judge runs are fully isolated. `_scoped_env` is removed.

## Bug D [Devin + Codex P1] — unconditional `raise` breaks unknown-prefix fallback (PR #319 follow-up)

`src/benchflow/rewards/llm.py` `call_judge`: after a provider exhausted retries, the code did an unconditional `raise`. For a known-prefix model (`claude-*`, `gpt-*`) that is correct — only the matching provider can serve it. But for an unknown-prefix model the code enters the `else` "try all" branch (`providers = ["anthropic","openai","google"]`) and the `raise` killed it after the first (Anthropic) provider failed. So `mistral-large`, `deepseek-chat`, and custom model names never reached OpenAI/Google — the pre-#319 fallback was dead.

Fix: `call_judge` tracks a `matched_provider` flag. It `raise`s immediately only when the model was confidently matched to a single provider; for the unknown-prefix "try all" path it `break`s to the next provider. When every provider fails at the API, the genuine API error surfaces instead of a misleading missing-SDK `JudgeEnvironmentError`. Comments updated.

## Tests

Regression tests (docstrings name the PR per AGENTS.md):
- `tests/test_llm_judge.py` — `TestCallJudgeProviderFallback`: unknown-prefix model falls through after API failure, all-providers-fail surfaces the real error, known-prefix still raises immediately. `TestCallJudgeEnvThreading`: `env` reaches the Anthropic client, concurrent `asyncio.gather` judge calls use isolated credentials.
- `tests/test_llm_judge_verifier.py` — `test_judge_env_threaded_into_call_judge`, `test_judge_env_does_not_mutate_os_environ` (replace the old `_scoped_env`-based tests).

## CI

`ruff format --check`, `ruff check`, `ty check src/`, `pytest tests/` all green locally (1315 passed, 27 skipped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches LLM-judge verification and multi-provider routing; mistakes could break judge scoring or credential handling under concurrent evaluations, but changes are localized and covered by new regression tests.
> 
> **Overview**
> **Makes LLM-judge credential handling concurrency-safe.** `[verifier.env]` values are no longer applied by mutating `os.environ`; they’re resolved once in `Verifier` and threaded through `LLMJudgeRewardFunc` into `call_judge`, which now passes keys/base URLs directly to provider clients.
> 
> **Fixes provider fallback for unknown model prefixes.** `call_judge` now only raises immediately on API failure when the model prefix matches a known provider; for unknown prefixes it tries the remaining providers and, if all fail, surfaces the last real API error (instead of a misleading `JudgeEnvironmentError`). Tests were updated/added to cover env threading, concurrent calls, and the corrected fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714e60f2f2db7104a8490c64ea0c7c67fd441905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->