### PR TITLE
Fix Docker sandbox exec for AgentBeats runtime

### DIFF
--- a/docs/agentbeats-a2a-adapter-audit.md
+++ b/docs/agentbeats-a2a-adapter-audit.md
@@ -1,0 +1,240 @@
+# AgentBeats A2A Adapter Audit
+
+Date: 2026-05-21
+
+Branch: `codex/agentbeats-a2a-adapter-audit`
+
+## Decision
+
+BenchFlow should add AgentBeats A2A as a sibling participant adapter, not as an
+ACP rename or an ACP transport flag.
+
+The reusable surfaces are `Role`, `Scene`, `Rollout`, sandbox lifecycle, skill
+deployment, trajectory/artifact directories, and verifier handoff. The
+non-reusable surface is the current participant execution path:
+`Rollout.connect_as()` -> `connect_acp()` -> `ACPClient` ->
+`execute_prompts()`. That path is ACP-specific from process launch through
+session updates.
+
+## Evidence
+
+- `src/benchflow/_types.py` has protocol-neutral `Role`, `Scene`, and `Turn`
+  declarations, but `Role.agent` currently names a local registered ACP agent.
+- `src/benchflow/rollout.py` owns setup, skill deployment, sandbox lockdown,
+  provider credential mapping, trajectory publication, verifier execution, and
+  result serialization.
+- `Rollout.connect_as()` installs a local agent binary, writes credentials, and
+  calls `connect_acp()` for every role turn.
+- `src/benchflow/acp/runtime.py` and `src/benchflow/acp/client.py` implement ACP
+  JSON-RPC session setup, prompt execution, cancellation, and update capture.
+- Multi-role scenes currently exchange messages through `/app/.outbox` prompt
+  injection. They do not target endpoint-based participants.
+- `Rollout.verify()` already publishes captured trajectory to
+  `/logs/agent/acp_trajectory.jsonl` and delegates scoring to the existing
+  verifier path.
+
+## Contract And Initial Implementation
+
+The future A2A participant adapter should live under
+`src/benchflow/agents/a2a.py` and expose a small contract independent from ACP:
+
+- `A2AParticipantRequest`: endpoint URL, role name, visible prompt, workspace,
+  optional skills directory, role timeout, role idle timeout, and redacted
+  metadata.
+- `A2ATaskHandle`: opaque started-task handle with task id, endpoint URL, and
+  role name.
+- `A2AParticipantResult`: terminal status, normalized A2A trajectory events,
+  artifact references, optional final response, and redacted error type.
+- `A2AParticipantAdapter`: `start(request)`, `wait(handle)`, and
+  `cancel(handle, reason)`.
+
+The module now also includes `A2AClientParticipantAdapter`, a small
+`a2a-sdk==0.3.20` backed implementation that sends one visible prompt to an A2A
+endpoint, normalizes task/message events, records artifact references, and
+returns a terminal `A2AParticipantResult`. The runtime dependency remains the
+client SDK; the `http-server` extra is a dev dependency for the toy endpoint
+smoke test.
+
+Rollout wiring now has a first implementation. `Role.transport` defaults to
+`"acp"`, and explicit A2A roles use `Role.transport="a2a"` plus
+`Role.endpoint_url`. ACP roles still use the existing `connect_acp()` and
+`execute_prompts()` path.
+
+## Done Signal
+
+The adapter must not infer completion from free-form text. A purple participant
+is done only when the A2A task reaches a terminal state:
+
+- `completed`: final response or artifact is available for verifier handoff.
+- `failed`: participant task failed without trustworthy output.
+- `cancelled`: BenchFlow or the caller cancelled the participant task.
+- `timeout`: BenchFlow timeout handling cancelled or abandoned the task.
+
+Only `completed` proceeds as a normal model attempt. Other terminal states
+should still persist trajectory and produce a classified run result.
+
+## Timeout And Cancellation
+
+- Use `Role.timeout_sec` when present, otherwise the task `[agent].timeout_sec`.
+- Use `Role.idle_timeout_sec` when present, otherwise rollout idle timeout.
+- On timeout, call `A2AParticipantAdapter.cancel()` before verifier handoff.
+- Persist timeout/cancel as participant communication failures, not verifier
+  failures.
+- Preserve ACP timeout behavior; do not route ACP roles through A2A timeout code.
+
+## Trajectory And Artifacts
+
+A2A updates are written separately from ACP trajectory data:
+
+- `trajectory/a2a_trajectory.jsonl` for normalized A2A task updates.
+- `artifacts/a2a_artifacts.json` for A2A artifact references.
+- A2A final responses may include file artifacts under a `files[]` payload;
+  BenchFlow materializes those files under the rollout workspace only, then
+  records them as `sandbox://...` refs in `artifacts/a2a_artifacts.json`.
+- Existing `trajectory/acp_trajectory.jsonl` remains ACP-only.
+- Public rows may reference redacted artifact ids or digests, not private paths,
+  raw provider payloads, credentials, or verifier logs.
+
+## Verifier Handoff
+
+The A2A adapter is not a verifier. It only drives the purple participant to a
+terminal state and materializes the participant output into the same sandbox or
+artifact layout that existing verifiers already consume.
+
+After a `completed` A2A result:
+
+1. Persist normalized A2A trajectory.
+2. Persist or reference participant artifacts.
+3. Publish any verifier-visible trajectory/artifact data required by the task.
+4. Call the existing `_verify_rollout()` path.
+5. Serialize result fields without changing ACP result semantics.
+
+AgentBeats/Amber worker runs add one Docker-sandbox caveat: the task container
+can run through Amber's Docker gateway while its bind-mounted verifier log path
+is not visible from inside the worker container. Set
+`BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED=false` in that worker environment so
+BenchFlow downloads `/logs/verifier` from the task container before parsing
+`reward.txt`. The default remains `true` for normal local Docker runs where the
+host mount is visible.
+
+## Runtime File Changes
+
+Phase 4 implementation has stayed scoped to these files:
+
+- `src/benchflow/agents/a2a.py`: concrete AgentBeats A2A participant
+  client/adapter.
+- `src/benchflow/_types.py`: explicit participant transport discriminator and
+  endpoint field on `Role`, with ACP as the default.
+- `src/benchflow/_utils/yaml_loader.py`: YAML role parsing for transport,
+  endpoint, role timeouts, role skills, and capabilities.
+- `src/benchflow/rollout.py`: branch role execution to ACP or A2A while keeping
+  setup, verifier, cleanup, and result serialization shared.
+- `src/benchflow/sandbox/docker.py`: allow worker environments to disable the
+  verifier-log host-mount fast path and avoid `--rmi all` cleanup for prebuilt
+  task images.
+- `src/benchflow/models.py`: add `a2a` as a trajectory source.
+- `tests/test_a2a_participant_adapter_contract.py`: convert pending runtime
+  tests into passing implementation tests.
+- `tests/test_docker_uploads.py`: cover the Docker log-mount flag and prebuilt
+  cleanup behavior.
+
+## Runtime Tests
+
+`tests/test_a2a_participant_adapter_contract.py` now contains:
+
+- passing contract-shape tests for request/result/artifact fields
+- passing client tests for message normalization, cancellation, unknown
+  handles, and a toy SDK-backed A2A endpoint smoke
+- passing runtime tests for endpoint invocation, timeout cancellation, artifact
+  capture, file materialization, verifier handoff, and A2A trajectory
+  persistence
+
+These tests deliberately keep ACP behavior untouched while documenting the
+implementation surface.
+
+## Verification
+
+Baseline before edits:
+
+```bash
+uv sync --extra dev
+uv run pytest tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+```
+
+Result: `69 passed, 3 skipped`.
+
+Post-edit focused verification:
+
+```bash
+uv run pytest tests/test_a2a_participant_adapter_contract.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run ruff check src/benchflow/agents/a2a.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py tests/test_a2a_participant_adapter_contract.py
+```
+
+Result: `71 passed, 3 skipped, 5 xfailed`; ruff check passed; ruff format
+reported `2 files already formatted`.
+
+Adapter implementation verification:
+
+```bash
+uv run pytest tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run ruff check src/benchflow/agents/a2a.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ty check src/benchflow/agents/a2a.py
+```
+
+Result: `74 passed, 3 skipped, 5 xfailed`; ruff check passed; ruff format
+reported `3 files already formatted`; `ty` passed.
+
+Rollout wiring verification:
+
+```bash
+uv run pytest tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py tests/test_scene_outbox_trial.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run pytest tests/test_yaml_config.py tests/test_adapters.py tests/test_connect_as_env.py tests/test_internet_policy.py -q
+uv run ruff check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ty check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py
+```
+
+Results: `95 passed, 3 skipped, 1 warning`; `59 passed, 6 warnings`; ruff
+check passed; ruff format reported `7 files already formatted`; `ty` passed.
+
+After adding file materialization:
+
+```bash
+uv run pytest tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py tests/test_scene_outbox_trial.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run pytest tests/test_yaml_config.py tests/test_adapters.py tests/test_connect_as_env.py tests/test_internet_policy.py -q
+uv run ruff check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ty check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py
+```
+
+Results: `96 passed, 3 skipped, 1 warning`; `59 passed, 6 warnings`; ruff
+check passed; ruff format reported `7 files already formatted`; `ty` passed.
+
+Docker sandbox worker-gateway verification:
+
+```bash
+uv run pytest tests/test_docker_uploads.py tests/test_verifier_multi_container.py -q
+```
+
+Result: `19 passed, 20 warnings`.
+
+Real SkillsBench smoke:
+
+- Task:
+  `/Users/liu.10379/Documents/work/skillsbench/tasks/perf-cycle-optimization`.
+- Participant:
+  toy SDK-backed A2A endpoint through `A2AClientParticipantAdapter`.
+- Result:
+  success `true`, reward `0.13043478260869565`, trajectory source `a2a`,
+  verifier error `null`.
+- Important environment note:
+  the smoke failed when `jobs_dir` was under `/tmp` because Docker did not
+  surface the verifier reward file through the bind mount. The same smoke
+  passed when `jobs_dir` was under the `/Users/...` worktree path.
+
+Remaining implementation proof:
+
+- deployed or public-packaged green-agent worker integration using this A2A role
+  path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "pyyaml>=6.0",
     "rich>=13.0",
     "typer>=0.9",
+    "a2a-sdk==0.3.20",
 ]
 authors = [
     { name = "Xiangyi Li", email = "xiangyi@benchflow.ai" },
@@ -148,4 +149,9 @@ exclude = [
     "src/benchflow/rewards/rubric_config.py",
     "src/benchflow/providers/bedrock_runtime.py",
     "src/benchflow/experimental/mcp/reviewer_server.py",
+]
+
+[dependency-groups]
+dev = [
+    "a2a-sdk[http-server]==0.3.20",
 ]

--- a/src/benchflow/_types.py
+++ b/src/benchflow/_types.py
@@ -20,6 +20,9 @@ Concretely:
   environment variables and skills, and wires up the ACP transport.
 * BenchFlow ensures sandbox networking allows inter-agent communication
   (all roles in a scene share a sandbox, so localhost is reachable).
+* AgentBeats A2A participants are an explicit role transport boundary, not an
+  ACP alias. A2A roles supply a participant endpoint and skip ACP process
+  installation/connection.
 * The ``capabilities`` field on :class:`Role` is a **declaration** — it
   tells downstream tooling / dashboards what the agent supports, but
   BenchFlow itself does not act on it.
@@ -34,6 +37,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
+
+RoleTransport = Literal["acp", "a2a"]
 
 
 @dataclass
@@ -55,6 +61,8 @@ class Role:
     idle_timeout_sec: int | None = None
     skills_dir: str | Path | None = None
     capabilities: list[str] | None = None  # e.g. ["tool-use", "agent-as-tool", "loop"]
+    transport: RoleTransport = "acp"
+    endpoint_url: str | None = None
 
 
 @dataclass

--- a/src/benchflow/_utils/yaml_loader.py
+++ b/src/benchflow/_utils/yaml_loader.py
@@ -150,6 +150,12 @@ def _parse_role(raw: dict) -> Role:
         agent=raw["agent"],
         model=raw.get("model"),
         env=raw.get("env", {}),
+        timeout_sec=raw.get("timeout_sec"),
+        idle_timeout_sec=raw.get("idle_timeout_sec"),
+        skills_dir=raw.get("skills_dir"),
+        capabilities=raw.get("capabilities"),
+        transport=raw.get("transport", "acp"),
+        endpoint_url=raw.get("endpoint_url"),
     )
 
 

--- a/src/benchflow/agents/a2a.py
+++ b/src/benchflow/agents/a2a.py
@@ -1,0 +1,325 @@
+"""AgentBeats A2A participant adapter contract.
+
+This module intentionally defines the contract only. Runtime wiring belongs in
+the later implementation phase after the SkillsBench green-agent skeleton can
+exercise this boundary against AgentBeats-style assessment requests.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import DataPart, Message, Part, TextPart
+from a2a.types import Role as A2ARole
+
+A2ATaskStatus = Literal["running", "completed", "failed", "cancelled", "timeout"]
+A2AUpdateKind = Literal["task_update", "artifact", "final_response", "error"]
+
+
+@dataclass(frozen=True)
+class A2AParticipantRequest:
+    """Visible task payload sent from BenchFlow to a purple A2A endpoint."""
+
+    endpoint_url: str
+    role_name: str
+    prompt: str
+    workspace: str = "/app"
+    skills_dir: str | None = None
+    timeout_sec: int | None = None
+    idle_timeout_sec: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class A2ATaskHandle:
+    """Opaque handle for a started participant task."""
+
+    task_id: str
+    endpoint_url: str
+    role_name: str
+
+
+@dataclass(frozen=True)
+class A2ATrajectoryEvent:
+    """One normalized A2A update for BenchFlow trajectory persistence."""
+
+    kind: A2AUpdateKind
+    timestamp: str | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class A2AArtifactRef:
+    """Reference to an artifact produced by the participant endpoint."""
+
+    name: str
+    uri: str
+    media_type: str | None = None
+    digest: str | None = None
+
+
+@dataclass(frozen=True)
+class A2AParticipantResult:
+    """Terminal normalized result from a purple A2A participant."""
+
+    status: A2ATaskStatus
+    trajectory: Sequence[A2ATrajectoryEvent] = field(default_factory=tuple)
+    artifacts: Sequence[A2AArtifactRef] = field(default_factory=tuple)
+    final_response: Mapping[str, Any] | None = None
+    error_type: str | None = None
+
+    @property
+    def done(self) -> bool:
+        return self.status in {"completed", "failed", "cancelled", "timeout"}
+
+
+class A2AParticipantAdapter(Protocol):
+    """Protocol a future BenchFlow A2A participant adapter must satisfy."""
+
+    async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
+        """Create a fresh participant task for one BenchFlow role turn."""
+
+    async def wait(self, handle: A2ATaskHandle) -> A2AParticipantResult:
+        """Wait until the participant task reaches a terminal status."""
+
+    async def cancel(self, handle: A2ATaskHandle, reason: str) -> None:
+        """Cancel an in-flight participant task before verifier handoff."""
+
+
+HTTPXClientFactory = Callable[[int], httpx.AsyncClient]
+
+
+class A2AClientParticipantAdapter:
+    """A2A SDK-backed participant adapter.
+
+    The adapter deliberately does not know about Rollout or verifier semantics.
+    It sends one visible prompt to a participant endpoint, records normalized A2A
+    events, and returns a terminal participant result for the caller to persist
+    and hand to the existing verifier path.
+    """
+
+    def __init__(
+        self,
+        *,
+        default_timeout_sec: int = 300,
+        streaming: bool = True,
+        httpx_client_factory: HTTPXClientFactory | None = None,
+    ):
+        self.default_timeout_sec = default_timeout_sec
+        self.streaming = streaming
+        self.httpx_client_factory = httpx_client_factory
+        self._pending: dict[str, A2AParticipantRequest] = {}
+        self._cancelled: dict[str, str] = {}
+
+    async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
+        task_id = uuid4().hex
+        self._pending[task_id] = request
+        return A2ATaskHandle(
+            task_id=task_id,
+            endpoint_url=request.endpoint_url,
+            role_name=request.role_name,
+        )
+
+    async def wait(self, handle: A2ATaskHandle) -> A2AParticipantResult:
+        if handle.task_id in self._cancelled:
+            reason = self._cancelled.pop(handle.task_id)
+            self._pending.pop(handle.task_id, None)
+            return A2AParticipantResult(
+                status="cancelled",
+                trajectory=(
+                    A2ATrajectoryEvent(
+                        kind="error",
+                        payload={"error_type": "cancelled", "reason": reason},
+                    ),
+                ),
+                error_type="cancelled",
+            )
+
+        request = self._pending.pop(handle.task_id, None)
+        if request is None:
+            raise KeyError(f"Unknown A2A task handle: {handle.task_id}")
+
+        events = [
+            event
+            async for event in self._send_message(
+                request,
+                message_id=handle.task_id,
+            )
+        ]
+        return _participant_result_from_events(handle, events)
+
+    async def cancel(self, handle: A2ATaskHandle, reason: str) -> None:
+        self._cancelled[handle.task_id] = reason
+
+    async def _send_message(
+        self,
+        request: A2AParticipantRequest,
+        *,
+        message_id: str,
+    ) -> AsyncIterator[object]:
+        timeout = request.timeout_sec or self.default_timeout_sec
+        client_factory = self.httpx_client_factory or (
+            lambda timeout_sec: httpx.AsyncClient(timeout=timeout_sec)
+        )
+        async with client_factory(timeout) as httpx_client:
+            resolver = A2ACardResolver(
+                httpx_client=httpx_client,
+                base_url=request.endpoint_url,
+            )
+            agent_card = await resolver.get_agent_card()
+            client = ClientFactory(
+                ClientConfig(httpx_client=httpx_client, streaming=self.streaming)
+            ).create(agent_card)
+            message = Message(
+                kind="message",
+                role=A2ARole.user,
+                parts=[Part(TextPart(kind="text", text=request.prompt))],
+                message_id=message_id,
+            )
+            async for event in client.send_message(message):
+                yield event
+
+
+def _participant_result_from_events(
+    handle: A2ATaskHandle,
+    events: Sequence[object],
+) -> A2AParticipantResult:
+    trajectory: list[A2ATrajectoryEvent] = []
+    artifacts: list[A2AArtifactRef] = []
+    artifact_uris: set[str] = set()
+    final_response: Mapping[str, Any] | None = None
+    status: A2ATaskStatus = "failed"
+    error_type: str | None = None
+
+    for event in events:
+        if isinstance(event, Message):
+            text = _merge_parts(event.parts)
+            trajectory.append(
+                A2ATrajectoryEvent(
+                    kind="final_response",
+                    payload={"message": text},
+                )
+            )
+            final_response = _final_response_from_message(event.parts, text)
+            status = "completed"
+            continue
+
+        if not isinstance(event, tuple) or not event:
+            trajectory.append(
+                A2ATrajectoryEvent(
+                    kind="error",
+                    payload={"error_type": "unknown_event", "repr": repr(event)},
+                )
+            )
+            error_type = error_type or "unknown_event"
+            continue
+
+        task = event[0]
+        update = event[1] if len(event) > 1 else None
+        dumped = _model_dump(task)
+        task_status = _task_status(task)
+        if task_status:
+            status = _normalize_task_status(task_status)
+        trajectory.append(
+            A2ATrajectoryEvent(
+                kind="task_update",
+                payload={"task": dumped, "update": _model_dump(update)},
+            )
+        )
+        task_artifacts = getattr(task, "artifacts", None) or []
+        for index, artifact in enumerate(task_artifacts):
+            name = getattr(artifact, "name", None) or f"artifact-{index}"
+            uri = f"a2a://{handle.task_id}/artifacts/{index}"
+            if uri in artifact_uris:
+                continue
+            artifact_uris.add(uri)
+            artifacts.append(
+                A2AArtifactRef(
+                    name=name,
+                    uri=uri,
+                    media_type=None,
+                    digest=None,
+                )
+            )
+        if task_artifacts and final_response is None:
+            final_response = {"artifacts": [_model_dump(a) for a in task_artifacts]}
+        if status in {"failed", "cancelled", "timeout"}:
+            error_type = error_type or f"a2a_{status}"
+
+    return A2AParticipantResult(
+        status=status,
+        trajectory=tuple(trajectory),
+        artifacts=tuple(artifacts),
+        final_response=final_response,
+        error_type=error_type,
+    )
+
+
+def _normalize_task_status(value: str) -> A2ATaskStatus:
+    if value == "completed":
+        return "completed"
+    if value in {"canceled", "cancelled"}:
+        return "cancelled"
+    if value == "working":
+        return "running"
+    if value == "submitted":
+        return "running"
+    return "failed"
+
+
+def _task_status(task: object) -> str | None:
+    status = getattr(task, "status", None)
+    state = getattr(status, "state", None)
+    value = getattr(state, "value", None)
+    return value if isinstance(value, str) else None
+
+
+def _merge_parts(parts: Sequence[Part]) -> str:
+    chunks: list[str] = []
+    for part in parts:
+        root = part.root
+        if isinstance(root, TextPart):
+            chunks.append(root.text)
+        elif isinstance(root, DataPart):
+            chunks.append(json.dumps(root.data, sort_keys=True))
+    return "\n".join(chunks)
+
+
+def _final_response_from_message(
+    parts: Sequence[Part],
+    text: str,
+) -> Mapping[str, Any]:
+    data_parts = [part.root.data for part in parts if isinstance(part.root, DataPart)]
+    if len(data_parts) == 1 and isinstance(data_parts[0], Mapping):
+        return {"message": text, **dict(data_parts[0])}
+    if data_parts:
+        return {"message": text, "data": data_parts}
+    return {"message": text}
+
+
+def _model_dump(value: object) -> Any:
+    if value is None:
+        return None
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        return dump(mode="json")
+    return repr(value)
+
+
+__all__ = [
+    "A2AClientParticipantAdapter",
+    "A2AArtifactRef",
+    "A2AParticipantAdapter",
+    "A2AParticipantRequest",
+    "A2AParticipantResult",
+    "A2ATaskHandle",
+    "A2ATaskStatus",
+    "A2ATrajectoryEvent",
+    "A2AUpdateKind",
+]

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from benchflow.rewards.events import RewardEvent
 
-TrajectorySource = Literal["acp", "scraped", "partial_acp"]
+TrajectorySource = Literal["acp", "a2a", "scraped", "partial_acp"]
 """Provenance label for a captured trajectory. See RunResult.trajectory_source."""
 
 

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -42,12 +42,13 @@ import contextlib
 import json
 import logging
 import os
+import posixpath
 import shlex
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from benchflow._types import Role, Scene, Turn
 from benchflow._utils.config import normalize_agent_name, normalize_sandbox_user
@@ -90,6 +91,9 @@ from benchflow.trajectories._capture import (
     _scrape_agent_trajectory,
 )
 
+if TYPE_CHECKING:
+    from benchflow.agents.a2a import A2AParticipantAdapter
+
 logger = logging.getLogger(__name__)
 
 _DISALLOW_WEB_TOOLS_ENV = "BENCHFLOW_DISALLOW_WEB_TOOLS"
@@ -109,6 +113,10 @@ def _apply_web_policy(agent_env: dict[str, str], *, disallow: bool) -> dict[str,
     if not disallow:
         return agent_env
     return {**agent_env, _DISALLOW_WEB_TOOLS_ENV: "1"}
+
+
+def _is_a2a_role(role: Role) -> bool:
+    return role.transport == "a2a"
 
 
 def _agent_launch_with_web_policy(agent: str, *, disallow: bool) -> str:
@@ -369,6 +377,8 @@ def _role_metadata(role: Role) -> dict[str, Any]:
         "idle_timeout_sec": role.idle_timeout_sec,
         "skills_dir": str(role.skills_dir) if role.skills_dir else None,
         "capabilities": role.capabilities,
+        "transport": role.transport,
+        "endpoint_url": role.endpoint_url if role.transport == "a2a" else None,
         "env_keys": sorted(role.env),
     }
 
@@ -387,6 +397,26 @@ def _scene_metadata(scenes: list[Scene]) -> list[dict[str, Any]]:
         }
         for scene in scenes
     ]
+
+
+def _split_protocol_trajectory(
+    trajectory: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    a2a = [
+        event
+        for event in trajectory
+        if isinstance(event, dict) and event.get("protocol") == "a2a"
+    ]
+    acp = [
+        event
+        for event in trajectory
+        if not (isinstance(event, dict) and event.get("protocol") == "a2a")
+    ]
+    return acp, a2a
+
+
+def _write_jsonl(path: Path, events: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(e, default=str) for e in events))
 
 
 def _build_rollout_result(
@@ -448,9 +478,11 @@ def _build_rollout_result(
     timing = {k: round(v, 1) for k, v in timing.items()}
     traj_dir = rollout_dir / "trajectory"
     traj_dir.mkdir(parents=True, exist_ok=True)
-    (traj_dir / "acp_trajectory.jsonl").write_text(
-        "\n".join(json.dumps(e, default=str) for e in trajectory)
-    )
+    acp_trajectory, a2a_trajectory = _split_protocol_trajectory(trajectory)
+    if a2a_trajectory:
+        _write_jsonl(traj_dir / "a2a_trajectory.jsonl", a2a_trajectory)
+    if acp_trajectory or not a2a_trajectory:
+        _write_jsonl(traj_dir / "acp_trajectory.jsonl", acp_trajectory)
     rollout_dir.mkdir(parents=True, exist_ok=True)
     (rollout_dir / "result.json").write_text(
         json.dumps(
@@ -619,8 +651,10 @@ async def _run_oracle(
     return trajectory, "oracle"
 
 
-async def _publish_trajectory_for_verifier(env, trajectory: list[dict]) -> None:
-    """Make the captured ACP trajectory available inside /logs for verifiers."""
+async def _publish_trajectory_for_verifier(
+    env, trajectory: list[dict], filename: str = "acp_trajectory.jsonl"
+) -> None:
+    """Make a captured participant trajectory available inside /logs for verifiers."""
     if not trajectory:
         return
     await env.exec("mkdir -p /logs/agent", user="root", timeout_sec=10)
@@ -629,7 +663,7 @@ async def _publish_trajectory_for_verifier(env, trajectory: list[dict]) -> None:
         f.write("\n")
         tmp_path = f.name
     try:
-        await env.upload_file(tmp_path, "/logs/agent/acp_trajectory.jsonl")
+        await env.upload_file(tmp_path, f"/logs/agent/{filename}")
     finally:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(tmp_path)
@@ -737,6 +771,7 @@ class RolloutConfig:
     include_task_skills: bool = True
     skip_verify: bool = False
     export_generated_skills_to: str | Path | None = None
+    a2a_adapter: A2AParticipantAdapter | None = None
 
     def __post_init__(self) -> None:
         self.agent = normalize_agent_name(self.agent)
@@ -744,6 +779,8 @@ class RolloutConfig:
         for scene in self.scenes:
             for role in scene.roles:
                 role.agent = normalize_agent_name(role.agent)
+                if role.transport not in {"acp", "a2a"}:
+                    raise ValueError(f"Unknown role transport: {role.transport}")
 
     @classmethod
     def from_legacy(
@@ -821,6 +858,15 @@ class RolloutConfig:
             return scenes[0].roles[0].model
         return self.model
 
+    @property
+    def first_acp_role(self) -> Role | None:
+        """First role that still uses BenchFlow's ACP coding-agent transport."""
+        for scene in self.effective_scenes:
+            for role in scene.roles:
+                if role.transport == "acp":
+                    return role
+        return None
+
 
 class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
@@ -859,6 +905,8 @@ class Rollout:
 
         # Populated by execute()
         self._trajectory: list[dict] = []
+        self._a2a_adapter: A2AParticipantAdapter | None = config.a2a_adapter
+        self._a2a_artifacts: list[dict[str, Any]] = []
         self._n_tool_calls: int = 0
         self._trajectory_source: TrajectorySource | None = None
         self._partial_trajectory: bool = False
@@ -939,13 +987,24 @@ class Rollout:
             self._rollout_name,
         ) = _init_rollout(cfg.task_path, cfg.job_name, cfg.rollout_name, cfg.jobs_dir)
 
+        first_acp_role = cfg.first_acp_role
+        env_agent = first_acp_role.agent if first_acp_role else cfg.primary_agent
+        env_model = first_acp_role.model if first_acp_role else cfg.primary_model
+        env_overrides = {**(cfg.agent_env or {})}
+        if first_acp_role:
+            env_overrides.update(first_acp_role.env or {})
         self._disallow_web_tools = (
-            _task_disallows_internet(self._task) or cfg.self_gen_no_internet
-        ) and cfg.primary_agent != "oracle"
-        self._agent_env = _apply_web_policy(
-            resolve_agent_env(cfg.primary_agent, cfg.primary_model, cfg.agent_env),
-            disallow=self._disallow_web_tools,
+            (_task_disallows_internet(self._task) or cfg.self_gen_no_internet)
+            and env_agent != "oracle"
+            and first_acp_role is not None
         )
+        if first_acp_role:
+            self._agent_env = _apply_web_policy(
+                resolve_agent_env(env_agent, env_model, env_overrides),
+                disallow=self._disallow_web_tools,
+            )
+        else:
+            self._agent_env = dict(cfg.agent_env or {})
         self._resolved_prompts = _resolve_prompts(
             cfg.task_path,
             cfg.prompts,
@@ -953,9 +1012,13 @@ class Rollout:
             skill_nudge=_skill_nudge(cfg.agent_env),
             agent=cfg.primary_agent,
         )
-        self._agent_launch = _agent_launch_with_web_policy(
-            cfg.primary_agent,
-            disallow=self._disallow_web_tools,
+        self._agent_launch = (
+            _agent_launch_with_web_policy(
+                env_agent,
+                disallow=self._disallow_web_tools,
+            )
+            if first_acp_role
+            else ""
         )
 
         # Copy task dir to temp when Dockerfile mutations are needed
@@ -1064,7 +1127,39 @@ class Rollout:
             self._phase = "installed"
             return
 
-        agent_name = cfg.primary_agent
+        install_role = cfg.first_acp_role
+        if install_role is None:
+            if cfg.sandbox_user:
+                self._agent_cwd = await setup_sandbox_user(
+                    self._env,
+                    cfg.sandbox_user,
+                    workspace=self._agent_cwd,
+                    timeout_sec=cfg.sandbox_setup_timeout,
+                )
+            await _snapshot_build_config(self._env, workspace=self._agent_cwd)
+            await _seed_verifier_workspace(
+                self._env, workspace=self._agent_cwd, sandbox_user=cfg.sandbox_user
+            )
+            await deploy_skills(
+                self._env,
+                getattr(self, "_effective_task_path", cfg.task_path),
+                cfg.skills_dir,
+                None,
+                cfg.sandbox_user,
+                self._agent_cwd,
+                self._task,
+                include_task_skills=cfg.include_task_skills,
+            )
+            if cfg.export_generated_skills_to:
+                await _ensure_sandbox_dir(
+                    self._env, cfg.generated_skills_root, cfg.sandbox_user
+                )
+            await lockdown_paths(self._env, self._effective_locked)
+            self._phase = "installed"
+            return
+
+        agent_name = install_role.agent
+        agent_model = install_role.model
         self._agent_cfg = await install_agent(self._env, agent_name, rollout_dir)
         if cfg.sandbox_user:
             self._agent_cwd = await setup_sandbox_user(
@@ -1079,7 +1174,7 @@ class Rollout:
             agent_name,
             self._agent_env,
             self._agent_cfg,
-            cfg.primary_model,
+            agent_model,
             cred_home,
         )
         if self._agent_env.get("_BENCHFLOW_SUBSCRIPTION_AUTH"):
@@ -1241,7 +1336,13 @@ class Rollout:
                     f"Using scraped trajectory ({len(scraped)} events) — UNTRUSTED"
                 )
 
-        await _publish_trajectory_for_verifier(self._env, self._trajectory)
+        acp_trajectory, a2a_trajectory = _split_protocol_trajectory(self._trajectory)
+        await _publish_trajectory_for_verifier(
+            self._env, acp_trajectory, "acp_trajectory.jsonl"
+        )
+        await _publish_trajectory_for_verifier(
+            self._env, a2a_trajectory, "a2a_trajectory.jsonl"
+        )
 
         self._rewards, self._verifier_error = await _verify_rollout(
             self._env,
@@ -1516,6 +1617,265 @@ class Rollout:
                 self._config.sandbox_user,
             )
 
+    def _get_a2a_adapter(self) -> A2AParticipantAdapter:
+        if self._a2a_adapter is None:
+            from benchflow.agents.a2a import A2AClientParticipantAdapter
+
+            self._a2a_adapter = A2AClientParticipantAdapter()
+        return self._a2a_adapter
+
+    def _a2a_request_for_role(
+        self,
+        role: Role,
+        scene: Scene,
+        prompts: list[str],
+    ):
+        if not role.endpoint_url:
+            raise ValueError(f"A2A role {role.name!r} requires endpoint_url")
+        from benchflow.agents.a2a import A2AParticipantRequest
+
+        skills_dir = role.skills_dir or scene.skills_dir or self._config.skills_dir
+        if skills_dir is None and self._config.include_task_skills:
+            skills_dir = "/app/skills"
+        timeout = role.timeout_sec if role.timeout_sec is not None else self._timeout
+        idle_timeout = (
+            role.idle_timeout_sec
+            if role.idle_timeout_sec is not None
+            else self._config.agent_idle_timeout
+        )
+        return A2AParticipantRequest(
+            endpoint_url=role.endpoint_url,
+            role_name=role.name,
+            prompt="\n\n".join(prompts),
+            workspace=self._agent_cwd,
+            skills_dir=str(skills_dir) if skills_dir else None,
+            timeout_sec=timeout,
+            idle_timeout_sec=idle_timeout,
+            metadata={
+                "task_name": self._config.task_path.name,
+                "rollout_name": self._rollout_name,
+                "scene": scene.name,
+                "role": role.name,
+                "transport": role.transport,
+            },
+        )
+
+    async def _execute_a2a_turn(
+        self,
+        role: Role,
+        scene: Scene,
+        prompts: list[str],
+    ) -> None:
+        """Execute one role turn through the AgentBeats A2A participant adapter."""
+        from benchflow.agents.a2a import A2AParticipantResult, A2ATrajectoryEvent
+
+        adapter = self._get_a2a_adapter()
+        request = self._a2a_request_for_role(role, scene, prompts)
+        timeout = request.timeout_sec if request.timeout_sec is not None else None
+        t0 = datetime.now()
+        handle = await adapter.start(request)
+        self._append_a2a_event(
+            role,
+            scene,
+            handle.task_id,
+            A2ATrajectoryEvent(
+                kind="task_update",
+                payload={
+                    "status": "started",
+                    "endpoint_url": request.endpoint_url,
+                    "workspace": request.workspace,
+                    "skills_dir": request.skills_dir,
+                },
+            ),
+        )
+        try:
+            result = await asyncio.wait_for(adapter.wait(handle), timeout=timeout)
+        except TimeoutError:
+            await adapter.cancel(handle, "timeout")
+            result = A2AParticipantResult(
+                status="timeout",
+                trajectory=(
+                    A2ATrajectoryEvent(
+                        kind="error",
+                        payload={
+                            "error_type": "a2a_timeout",
+                            "timeout_sec": timeout,
+                        },
+                    ),
+                ),
+                error_type="a2a_timeout",
+            )
+
+        for event in result.trajectory:
+            self._append_a2a_event(role, scene, handle.task_id, event)
+        self._append_a2a_event(
+            role,
+            scene,
+            handle.task_id,
+            A2ATrajectoryEvent(
+                kind="task_update",
+                payload={"status": result.status, "error_type": result.error_type},
+            ),
+        )
+        await self._materialize_a2a_files(role, scene, handle.task_id, result)
+        self._persist_a2a_artifacts(role, scene, handle.task_id, result)
+        if result.final_response is not None:
+            self._append_a2a_event(
+                role,
+                scene,
+                handle.task_id,
+                A2ATrajectoryEvent(
+                    kind="final_response",
+                    payload=dict(result.final_response),
+                ),
+            )
+
+        if result.status != "completed":
+            self._error = result.error_type or f"a2a_{result.status}"
+        self._agent_name = role.agent or role.name
+        self._trajectory_source = (
+            "a2a" if self._trajectory_source is None else self._trajectory_source
+        )
+        if "agent_execution" not in self._timing:
+            self._timing["agent_execution"] = (datetime.now() - t0).total_seconds()
+        self._phase = "executed"
+
+    def _append_a2a_event(
+        self,
+        role: Role,
+        scene: Scene,
+        task_id: str,
+        event: Any,
+    ) -> None:
+        payload = dict(getattr(event, "payload", {}) or {})
+        self._trajectory.append(
+            {
+                "protocol": "a2a",
+                "type": getattr(event, "kind", "task_update"),
+                "timestamp": getattr(event, "timestamp", None),
+                "task_id": task_id,
+                "scene": scene.name,
+                "role": role.name,
+                "participant": role.agent,
+                "payload": payload,
+            }
+        )
+
+    def _persist_a2a_artifacts(
+        self,
+        role: Role,
+        scene: Scene,
+        task_id: str,
+        result: Any,
+    ) -> None:
+        if not result.artifacts:
+            return
+        rollout_dir = self._require_rollout_dir()
+        artifact_dir = rollout_dir / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        for artifact in result.artifacts:
+            data = {
+                **asdict(artifact),
+                "protocol": "a2a",
+                "task_id": task_id,
+                "scene": scene.name,
+                "role": role.name,
+            }
+            self._a2a_artifacts.append(data)
+        self._write_a2a_artifact_manifest()
+
+    async def _materialize_a2a_files(
+        self,
+        role: Role,
+        scene: Scene,
+        task_id: str,
+        result: Any,
+    ) -> None:
+        file_specs = list(self._iter_a2a_file_specs(result.final_response))
+        if not file_specs:
+            return
+        artifact_dir = self._require_rollout_dir() / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        for index, spec in enumerate(file_specs):
+            raw_path = spec.get("path") or spec.get("name")
+            if not isinstance(raw_path, str) or not raw_path.strip():
+                raise ValueError("A2A file artifact requires a non-empty path")
+            remote_path = self._normalize_a2a_output_path(raw_path)
+            content = spec.get("content", "")
+            if not isinstance(content, str):
+                content = json.dumps(content, indent=2, sort_keys=True)
+            await self._upload_a2a_file(remote_path, content)
+            self._a2a_artifacts.append(
+                {
+                    "name": spec.get("name") or posixpath.basename(remote_path),
+                    "uri": f"sandbox://{remote_path}",
+                    "media_type": spec.get("media_type") or "text/plain",
+                    "digest": spec.get("digest"),
+                    "protocol": "a2a",
+                    "task_id": task_id,
+                    "scene": scene.name,
+                    "role": role.name,
+                    "materialized": True,
+                    "index": index,
+                }
+            )
+        self._write_a2a_artifact_manifest()
+
+    def _iter_a2a_file_specs(self, value: Any):
+        if isinstance(value, dict):
+            files = value.get("files")
+            if isinstance(files, list):
+                for item in files:
+                    if isinstance(item, dict):
+                        yield item
+            for key in ("data", "artifacts", "parts", "root"):
+                if key in value:
+                    yield from self._iter_a2a_file_specs(value[key])
+        elif isinstance(value, list):
+            for item in value:
+                yield from self._iter_a2a_file_specs(item)
+
+    def _normalize_a2a_output_path(self, path: str) -> str:
+        workspace = posixpath.normpath(self._agent_cwd or "/app")
+        candidate = (
+            posixpath.normpath(posixpath.join(workspace, path))
+            if not path.startswith("/")
+            else posixpath.normpath(path)
+        )
+        if candidate != workspace and not candidate.startswith(f"{workspace}/"):
+            raise ValueError(
+                "A2A materialized files must stay under the rollout workspace"
+            )
+        return candidate
+
+    async def _upload_a2a_file(self, remote_path: str, content: str) -> None:
+        parent = shlex.quote(posixpath.dirname(remote_path))
+        await self._env.exec(f"mkdir -p {parent}", user="root", timeout_sec=10)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".a2a", delete=False) as f:
+            f.write(content)
+            tmp_path = f.name
+        try:
+            await self._env.upload_file(tmp_path, remote_path)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp_path)
+        if self._config.sandbox_user:
+            user = shlex.quote(self._config.sandbox_user)
+            await self._env.exec(
+                f"chown {user}:{user} {shlex.quote(remote_path)}",
+                user="root",
+                timeout_sec=10,
+            )
+
+    def _write_a2a_artifact_manifest(self) -> None:
+        if not self._a2a_artifacts:
+            return
+        artifact_dir = self._require_rollout_dir() / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        (artifact_dir / "a2a_artifacts.json").write_text(
+            json.dumps(self._a2a_artifacts, indent=2, default=str)
+        )
+
     async def _run_scene(self, scene: Scene) -> None:
         """Execute one scene: for each turn, connect as the turn's role, execute, disconnect.
 
@@ -1534,6 +1894,7 @@ class Rollout:
 
         role_map = {r.name: r for r in scene.roles}
         current_role: str | None = None
+        current_transport: str | None = None
         multi_role = len(scene.roles) > 1
         scene_messages: list[dict] = []
 
@@ -1552,12 +1913,6 @@ class Rollout:
             if not role:
                 raise ValueError(f"Turn references unknown role {turn.role!r}")
 
-            if current_role != turn.role:
-                if current_role is not None:
-                    await self.disconnect()
-                await self.connect_as(role)
-                current_role = turn.role
-
             if turn.prompt:
                 base_prompt = turn.prompt
             elif self._resolved_prompts:
@@ -1574,7 +1929,20 @@ class Rollout:
             else:
                 prompts = [base_prompt]
 
-            await self.execute(prompts=prompts)
+            if _is_a2a_role(role):
+                if current_transport == "acp":
+                    await self.disconnect()
+                current_role = turn.role
+                current_transport = "a2a"
+                await self._execute_a2a_turn(role, scene, prompts)
+            else:
+                if current_role != turn.role or current_transport != "acp":
+                    if current_transport == "acp":
+                        await self.disconnect()
+                    await self.connect_as(role)
+                    current_role = turn.role
+                    current_transport = "acp"
+                await self.execute(prompts=prompts)
 
             if multi_role:
                 if current_role is None:
@@ -1594,7 +1962,7 @@ class Rollout:
                         }
                     )
 
-        if current_role is not None:
+        if current_transport == "acp":
             await self.disconnect()
 
         if scene_messages and self._rollout_dir:
@@ -1779,6 +2147,8 @@ class Rollout:
         from the primary agent (which was set up in install_agent()).
         Updates _agent_launch so disconnect() kills the correct process.
         """
+        if _is_a2a_role(role):
+            raise RuntimeError("A2A roles must execute through _execute_a2a_turn()")
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
         t0 = datetime.now()

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pydantic import BaseModel
 
@@ -39,6 +39,16 @@ from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
 
 logger = logging.getLogger("benchflow")
+
+
+_FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+
+
+def _env_flag_enabled(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in _FALSE_ENV_VALUES
 
 
 def _sanitize_docker_image_name(name: str) -> str:
@@ -117,8 +127,8 @@ class DockerSandbox(BaseSandbox):
         task_env_config: SandboxConfig,
         keep_containers: bool = False,
         mounts_json: list[dict[str, str]] | None = None,
-        *args: object,
-        **kwargs: object,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             environment_dir=environment_dir,
@@ -188,7 +198,7 @@ class DockerSandbox(BaseSandbox):
 
     @property
     def is_mounted(self) -> bool:
-        return True
+        return _env_flag_enabled("BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED", default=True)
 
     @property
     def _dockerfile_path(self) -> Path:
@@ -350,9 +360,16 @@ class DockerSandbox(BaseSandbox):
                 self.logger.warning(f"Docker compose stop failed: {e}")
         elif delete:
             try:
-                await self._run_docker_compose_command(
-                    ["down", "--rmi", "all", "--volumes", "--remove-orphans"]
-                )
+                down_command = ["down", "--volumes", "--remove-orphans"]
+                if not self._use_prebuilt:
+                    down_command = [
+                        "down",
+                        "--rmi",
+                        "all",
+                        "--volumes",
+                        "--remove-orphans",
+                    ]
+                await self._run_docker_compose_command(down_command)
             except Exception as e:
                 self.logger.warning(f"Docker compose down failed: {e}")
         else:

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -360,8 +360,9 @@ class DockerSandbox(BaseSandbox):
                 self.logger.warning(f"Docker compose stop failed: {e}")
         elif delete:
             try:
-                down_command = ["down", "--volumes", "--remove-orphans"]
-                if not self._use_prebuilt:
+                if _env_flag_enabled("BENCHFLOW_DOCKER_SAFE_CLEANUP", default=False):
+                    down_command = ["down", "--remove-orphans"]
+                elif not self._use_prebuilt:
                     down_command = [
                         "down",
                         "--rmi",
@@ -369,6 +370,8 @@ class DockerSandbox(BaseSandbox):
                         "--volumes",
                         "--remove-orphans",
                     ]
+                else:
+                    down_command = ["down", "--volumes", "--remove-orphans"]
                 await self._run_docker_compose_command(down_command)
             except Exception as e:
                 self.logger.warning(f"Docker compose down failed: {e}")

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -485,7 +485,7 @@ class DockerSandbox(BaseSandbox):
         user = self._resolve_user(user)
         env = self._merge_env(env)
 
-        exec_command: list[str] = ["exec"]
+        exec_command: list[str] = ["exec", "-T"]
 
         if cwd:
             exec_command.extend(["-w", cwd])

--- a/tests/test_a2a_participant_adapter_contract.py
+++ b/tests/test_a2a_participant_adapter_contract.py
@@ -1,0 +1,342 @@
+"""Contract tests and pending runtime tests for AgentBeats A2A participants."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.agents.a2a import (
+    A2AArtifactRef,
+    A2AParticipantRequest,
+    A2AParticipantResult,
+    A2ATaskHandle,
+    A2ATrajectoryEvent,
+)
+from benchflow.rollout import Role, Rollout, RolloutConfig, Scene, Turn
+
+
+@dataclass
+class FakeExecResult:
+    stdout: str = ""
+    stderr: str = ""
+    return_code: int = 0
+
+
+class FakeEnv:
+    def __init__(self) -> None:
+        self.exec_log: list[str] = []
+        self.uploads: dict[str, str] = {}
+
+    async def exec(self, cmd: str, **kwargs: Any) -> FakeExecResult:
+        self.exec_log.append(cmd)
+        return FakeExecResult()
+
+    async def upload_file(self, src: str | Path, dst: str) -> None:
+        self.uploads[dst] = Path(src).read_text()
+
+
+@dataclass
+class FakeRolloutPaths:
+    verifier_dir: Path
+
+
+class FakeA2AAdapter:
+    def __init__(
+        self,
+        result: A2AParticipantResult | None = None,
+        *,
+        block_wait: bool = False,
+    ) -> None:
+        self.result = result or A2AParticipantResult(status="completed")
+        self.block_wait = block_wait
+        self.requests: list[A2AParticipantRequest] = []
+        self.waited: list[A2ATaskHandle] = []
+        self.cancelled: list[tuple[A2ATaskHandle, str]] = []
+
+    async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
+        self.requests.append(request)
+        return A2ATaskHandle(
+            task_id=f"a2a-task-{len(self.requests)}",
+            endpoint_url=request.endpoint_url,
+            role_name=request.role_name,
+        )
+
+    async def wait(self, handle: A2ATaskHandle) -> A2AParticipantResult:
+        self.waited.append(handle)
+        if self.block_wait:
+            await asyncio.sleep(60)
+        return self.result
+
+    async def cancel(self, handle: A2ATaskHandle, reason: str) -> None:
+        self.cancelled.append((handle, reason))
+
+
+def _a2a_role(**overrides: Any) -> Role:
+    data: dict[str, Any] = {
+        "name": "agent",
+        "agent": "registered-purple-agent",
+        "transport": "a2a",
+        "endpoint_url": "http://purple.example/a2a",
+    }
+    data.update(overrides)
+    return Role(**data)
+
+
+def _make_rollout(
+    tmp_path: Path,
+    adapter: FakeA2AAdapter,
+    scene: Scene,
+) -> Rollout:
+    task_path = tmp_path / "tasks" / "citation-check"
+    task_path.mkdir(parents=True)
+    (task_path / "instruction.md").write_text("Solve the task.")
+    rollout_dir = tmp_path / "jobs" / "run" / "trial"
+    (rollout_dir / "artifacts").mkdir(parents=True)
+    (rollout_dir / "trajectory").mkdir(parents=True)
+
+    trial = Rollout(
+        RolloutConfig(
+            task_path=task_path,
+            scenes=[scene],
+            a2a_adapter=adapter,
+        )
+    )
+    trial._env = FakeEnv()
+    trial._rollout_dir = rollout_dir
+    trial._rollout_paths = FakeRolloutPaths(verifier_dir=rollout_dir / "verifier")
+    trial._rollout_name = "trial"
+    trial._started_at = datetime.now()
+    trial._agent_cwd = "/app"
+    trial._timeout = 5
+    trial._task = object()
+    trial._resolved_prompts = ["Solve the task."]
+    return trial
+
+
+def test_a2a_contract_result_done_statuses() -> None:
+    assert A2AParticipantResult(status="running").done is False
+    for status in ("completed", "failed", "cancelled", "timeout"):
+        assert A2AParticipantResult(status=status).done is True
+
+
+def test_a2a_contract_carries_endpoint_visible_prompt_and_redactable_refs() -> None:
+    request = A2AParticipantRequest(
+        endpoint_url="https://purple.example/a2a",
+        role_name="agent",
+        prompt="Solve the task visible in /app.",
+        skills_dir="/skills",
+        timeout_sec=300,
+        metadata={"task_id": "citation-check", "condition": "with_skills"},
+    )
+    handle = A2ATaskHandle(
+        task_id="a2a-task-1",
+        endpoint_url=request.endpoint_url,
+        role_name=request.role_name,
+    )
+    result = A2AParticipantResult(
+        status="completed",
+        trajectory=(
+            A2ATrajectoryEvent(kind="task_update", payload={"state": "working"}),
+            A2ATrajectoryEvent(kind="final_response", payload={"ok": True}),
+        ),
+        artifacts=(
+            A2AArtifactRef(
+                name="answer",
+                uri="benchflow-private://rollout/artifacts/answer.json",
+                media_type="application/json",
+                digest="sha256:abc123",
+            ),
+        ),
+        final_response={"done": True},
+    )
+
+    assert handle.endpoint_url == "https://purple.example/a2a"
+    assert request.skills_dir == "/skills"
+    assert result.status == "completed"
+    assert result.artifacts[0].uri.startswith("benchflow-private://")
+
+
+async def test_a2a_endpoint_role_skips_acp_install_and_invokes_endpoint(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            trajectory=(
+                A2ATrajectoryEvent(
+                    kind="task_update",
+                    payload={"state": "completed"},
+                ),
+            ),
+            final_response={"message": "done"},
+        )
+    )
+    scene = Scene(
+        roles=[_a2a_role()],
+        turns=[Turn("agent", "Solve visible workspace task.")],
+    )
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    async def fail_acp(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("A2A roles must not use ACP execution")
+
+    trial.connect_as = fail_acp  # type: ignore[method-assign]
+    trial.execute = fail_acp  # type: ignore[method-assign]
+
+    await trial._run_scene(scene)
+
+    assert len(adapter.requests) == 1
+    request = adapter.requests[0]
+    assert request.endpoint_url == "http://purple.example/a2a"
+    assert request.prompt == "Solve visible workspace task."
+    assert request.skills_dir == "/app/skills"
+    assert adapter.waited[0].role_name == "agent"
+
+
+async def test_a2a_timeout_cancels_task_and_records_timeout_result(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(block_wait=True)
+    scene = Scene(
+        roles=[_a2a_role(timeout_sec=0)],
+        turns=[Turn("agent", "Solve visible workspace task.")],
+    )
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_scene(scene)
+
+    assert adapter.cancelled
+    assert adapter.cancelled[0][1] == "timeout"
+    assert trial._error == "a2a_timeout"
+    assert any(
+        event["payload"].get("error_type") == "a2a_timeout"
+        for event in trial.trajectory
+    )
+
+
+async def test_a2a_artifacts_are_persisted_before_verifier_handoff(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            artifacts=(
+                A2AArtifactRef(
+                    name="answer",
+                    uri="a2a://task/artifacts/0",
+                    media_type="application/json",
+                    digest="sha256:abc",
+                ),
+            ),
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_scene(scene)
+
+    artifact_path = trial._rollout_dir / "artifacts" / "a2a_artifacts.json"
+    artifacts = json.loads(artifact_path.read_text())
+    assert artifacts == [
+        {
+            "name": "answer",
+            "uri": "a2a://task/artifacts/0",
+            "media_type": "application/json",
+            "digest": "sha256:abc",
+            "protocol": "a2a",
+            "task_id": "a2a-task-1",
+            "scene": "default",
+            "role": "agent",
+        }
+    ]
+
+
+async def test_a2a_file_artifacts_are_materialized_under_workspace(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            final_response={
+                "files": [
+                    {
+                        "path": "reports/answer.txt",
+                        "content": "materialized answer",
+                        "media_type": "text/plain",
+                    }
+                ]
+            },
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_scene(scene)
+
+    assert trial._env.uploads["/app/reports/answer.txt"] == "materialized answer"
+    artifact_path = trial._rollout_dir / "artifacts" / "a2a_artifacts.json"
+    artifacts = json.loads(artifact_path.read_text())
+    assert artifacts[0]["uri"] == "sandbox:///app/reports/answer.txt"
+    assert artifacts[0]["materialized"] is True
+
+
+async def test_a2a_successful_done_signal_runs_existing_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            trajectory=(A2ATrajectoryEvent(kind="task_update", payload={}),),
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+    calls: dict[str, Any] = {}
+
+    async def fake_verify_rollout(*args: Any, **kwargs: Any):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return {"reward": 1.0}, None
+
+    monkeypatch.setattr("benchflow.rollout._verify_rollout", fake_verify_rollout)
+
+    await trial._run_scene(scene)
+    rewards = await trial.verify()
+
+    assert rewards == {"reward": 1.0}
+    assert calls["kwargs"]["workspace"] == "/app"
+    assert "/logs/agent/a2a_trajectory.jsonl" in trial._env.uploads
+
+
+async def test_a2a_updates_are_written_to_a2a_trajectory_jsonl(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            trajectory=(
+                A2ATrajectoryEvent(
+                    kind="task_update",
+                    payload={"state": "working"},
+                ),
+            ),
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_scene(scene)
+    trial._build_result()
+
+    trajectory_path = trial._rollout_dir / "trajectory" / "a2a_trajectory.jsonl"
+    assert trajectory_path.exists()
+    lines = [json.loads(line) for line in trajectory_path.read_text().splitlines()]
+    assert all(line["protocol"] == "a2a" for line in lines)
+    assert not (trial._rollout_dir / "trajectory" / "acp_trajectory.jsonl").exists()

--- a/tests/test_a2a_participant_client.py
+++ b/tests/test_a2a_participant_client.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    DataPart,
+    Message,
+    Part,
+    Role,
+    TaskState,
+    TextPart,
+    UnsupportedOperationError,
+)
+from a2a.utils import new_agent_text_message, new_task
+from a2a.utils.errors import ServerError
+
+from benchflow.agents.a2a import (
+    A2AClientParticipantAdapter,
+    A2AParticipantRequest,
+)
+
+
+@dataclass
+class FakeState:
+    value: str
+
+
+@dataclass
+class FakeStatus:
+    state: FakeState
+
+
+@dataclass
+class FakeArtifact:
+    name: str
+
+    def model_dump(self, *, mode: str = "json") -> dict[str, Any]:
+        return {"name": self.name, "mode": mode}
+
+
+@dataclass
+class FakeTask:
+    state: str
+    artifacts: list[FakeArtifact]
+
+    @property
+    def status(self) -> FakeStatus:
+        return FakeStatus(FakeState(self.state))
+
+    def model_dump(self, *, mode: str = "json") -> dict[str, Any]:
+        return {"status": {"state": self.state}, "mode": mode}
+
+
+class FakeAdapter(A2AClientParticipantAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_request: A2AParticipantRequest | None = None
+        self.seen_message_id: str | None = None
+
+    async def _send_message(
+        self,
+        request: A2AParticipantRequest,
+        *,
+        message_id: str,
+    ) -> AsyncIterator[object]:
+        self.seen_request = request
+        self.seen_message_id = message_id
+        yield Message(
+            kind="message",
+            role=Role.agent,
+            parts=[Part(TextPart(kind="text", text="participant finished"))],
+            message_id="reply-1",
+        )
+        yield (FakeTask("completed", [FakeArtifact("answer")]), None)
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_normalizes_completed_message_flow() -> None:
+    adapter = FakeAdapter()
+    request = A2AParticipantRequest(
+        endpoint_url="http://purple.example/",
+        role_name="agent",
+        prompt="Solve the visible task.",
+        skills_dir="/skills",
+    )
+
+    handle = await adapter.start(request)
+    result = await adapter.wait(handle)
+
+    assert adapter.seen_request == request
+    assert adapter.seen_message_id == handle.task_id
+    assert result.status == "completed"
+    assert result.done is True
+    assert result.final_response is not None
+    assert len(result.trajectory) == 2
+    assert result.artifacts[0].uri == f"a2a://{handle.task_id}/artifacts/0"
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_cancel_before_wait_returns_cancelled() -> None:
+    adapter = FakeAdapter()
+    handle = await adapter.start(
+        A2AParticipantRequest(
+            endpoint_url="http://purple.example/",
+            role_name="agent",
+            prompt="Solve the visible task.",
+        )
+    )
+
+    await adapter.cancel(handle, "outer timeout")
+    result = await adapter.wait(handle)
+
+    assert result.status == "cancelled"
+    assert result.error_type == "cancelled"
+    assert result.trajectory[0].payload["reason"] == "outer timeout"
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_rejects_unknown_handle() -> None:
+    adapter = FakeAdapter()
+    handle = await adapter.start(
+        A2AParticipantRequest(
+            endpoint_url="http://purple.example/",
+            role_name="agent",
+            prompt="Solve the visible task.",
+        )
+    )
+    await adapter.wait(handle)
+
+    with pytest.raises(KeyError):
+        await adapter.wait(handle)
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_toy_server_smoke() -> None:
+    app = _build_toy_a2a_app("http://toy.local/")
+
+    def client_factory(timeout_sec: int) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://toy.local",
+            timeout=timeout_sec,
+        )
+
+    adapter = A2AClientParticipantAdapter(httpx_client_factory=client_factory)
+    handle = await adapter.start(
+        A2AParticipantRequest(
+            endpoint_url="http://toy.local/",
+            role_name="agent",
+            prompt="Solve the visible toy task.",
+        )
+    )
+
+    result = await adapter.wait(handle)
+
+    assert result.status == "completed"
+    assert result.done is True
+    assert result.final_response is not None
+    assert result.artifacts
+    assert any(event.kind == "task_update" for event in result.trajectory)
+
+
+class ToyExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        message = context.message
+        if message is None:
+            return
+        task = new_task(message)
+        await event_queue.enqueue_event(task)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.update_status(
+            TaskState.working,
+            new_agent_text_message(
+                "Solving toy task.",
+                context_id=context.context_id,
+            ),
+        )
+        await updater.add_artifact(
+            parts=[
+                Part(root=TextPart(text="toy result")),
+                Part(root=DataPart(data={"echo": context.get_user_input()})),
+            ],
+            name="answer",
+        )
+        await updater.complete()
+
+    async def cancel(self, request: RequestContext, event_queue: EventQueue) -> None:
+        raise ServerError(error=UnsupportedOperationError())
+
+
+def _build_toy_a2a_app(card_url: str) -> Any:
+    request_handler = DefaultRequestHandler(
+        agent_executor=ToyExecutor(),
+        task_store=InMemoryTaskStore(),
+    )
+    server = A2AStarletteApplication(
+        agent_card=AgentCard(
+            name="Toy Purple Agent",
+            description="Toy A2A participant for BenchFlow smoke tests.",
+            url=card_url,
+            version="0.1.0",
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+            capabilities=AgentCapabilities(streaming=True),
+            skills=[
+                AgentSkill(
+                    id="toy-solve",
+                    name="Toy Solve",
+                    description="Return a toy artifact.",
+                    tags=["test"],
+                )
+            ],
+        ),
+        http_handler=request_handler,
+    )
+    return server.build()

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -3,7 +3,40 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from benchflow.sandbox._base import ExecResult
 from benchflow.sandbox.docker import DockerSandbox
+
+
+def test_docker_logs_mount_fast_path_enabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED", raising=False)
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+
+    assert sandbox.is_mounted is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off"])
+def test_docker_logs_mount_fast_path_can_be_disabled(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED", value)
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+
+    assert sandbox.is_mounted is False
+
+
+@pytest.mark.asyncio
+async def test_prebuilt_stop_does_not_remove_images() -> None:
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._keep_containers = False
+    sandbox._use_prebuilt = True
+    sandbox._chown_to_host_user = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock(
+        return_value=ExecResult(stdout="", stderr=None, return_code=0)
+    )
+
+    await sandbox.stop(delete=True)
+
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["down", "--volumes", "--remove-orphans"]
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -40,6 +40,24 @@ async def test_prebuilt_stop_does_not_remove_images() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agentbeats_safe_cleanup_skips_image_and_volume_removal(monkeypatch) -> None:
+    monkeypatch.setenv("BENCHFLOW_DOCKER_SAFE_CLEANUP", "true")
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._keep_containers = False
+    sandbox._use_prebuilt = False
+    sandbox._chown_to_host_user = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock(
+        return_value=ExecResult(stdout="", stderr=None, return_code=0)
+    )
+
+    await sandbox.stop(delete=True)
+
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["down", "--remove-orphans"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_docker_upload_dir_creates_target_before_compose_cp() -> None:
     """Guards the v0.5 edit-pdf Docker failure where /app did not exist."""
     sandbox = DockerSandbox.__new__(DockerSandbox)

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -40,7 +40,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec("echo hi")
 
-        assert captured[0] == ["exec", "main", "sh", "-c", "echo hi"]
+        assert captured[0] == ["exec", "-T", "main", "sh", "-c", "echo hi"]
 
     @pytest.mark.asyncio
     async def test_exec_targets_named_service(self) -> None:
@@ -55,7 +55,14 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec("test -f /tmp/pwned", service="target")
 
-        assert captured[0] == ["exec", "target", "sh", "-c", "test -f /tmp/pwned"]
+        assert captured[0] == [
+            "exec",
+            "-T",
+            "target",
+            "sh",
+            "-c",
+            "test -f /tmp/pwned",
+        ]
 
     @pytest.mark.asyncio
     async def test_exec_in_service_wrapper(self) -> None:
@@ -70,7 +77,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec_in_service("db", "mysql -e 'SELECT 1'")
 
-        assert captured[0] == ["exec", "db", "sh", "-c", "mysql -e 'SELECT 1'"]
+        assert captured[0] == ["exec", "-T", "db", "sh", "-c", "mysql -e 'SELECT 1'"]
 
     @pytest.mark.asyncio
     async def test_exec_service_with_user_and_cwd(self) -> None:

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -469,6 +469,8 @@ class TestWriteConfig:
                         "idle_timeout_sec": 3,
                         "skills_dir": "/role-skills",
                         "capabilities": ["tool-use"],
+                        "transport": "acp",
+                        "endpoint_url": None,
                         "env_keys": ["ROLE_TOKEN"],
                     }
                 ],

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,31 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "a2a-sdk"
+version = "0.3.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/c1/4c7968e44a318fbfaf82e142b2f63aedcf62ca8da5ee0cea6104a1a29580/a2a_sdk-0.3.20.tar.gz", hash = "sha256:f05bbdf4a8ada6be81dc7e7c73da3add767b20065195d94e8eb6d671d7ea658a", size = 229272, upload-time = "2025-12-03T15:48:22.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/33/719a9331421ee5df0338505548b58b4129a6aca82bba5c8e0593ac8864c7/a2a_sdk-0.3.20-py3-none-any.whl", hash = "sha256:35da261aae28fd22440b61f8eb16a8343b60809e1f7ef028a06d01f17b48a8b9", size = 141547, upload-time = "2025-12-03T15:48:20.812Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
 ]
 
 [[package]]
@@ -199,6 +223,7 @@ name = "benchflow"
 version = "0.5.0.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "a2a-sdk" },
     { name = "anyio" },
     { name = "httpx" },
     { name = "pydantic" },
@@ -232,8 +257,14 @@ sandbox-modal = [
     { name = "tenacity" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "a2a-sdk", extra = ["http-server"] },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", specifier = "==0.3.20" },
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
     { name = "anyio", specifier = ">=4.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40" },
@@ -255,6 +286,9 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9" },
 ]
 provides-extras = ["dev", "sandbox-daytona", "sandbox-modal", "bedrock", "judge"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "a2a-sdk", extras = ["http-server"], specifier = "==0.3.20" }]
 
 [[package]]
 name = "boto3"
@@ -679,6 +713,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.25.2"
 source = { registry = "https://pypi.org/simple" }
@@ -774,6 +824,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
     { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
     { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
 ]
 
 [[package]]
@@ -897,6 +963,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
 ]
 
 [[package]]
@@ -1525,6 +1600,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1852,6 +1939,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/2b/58abc2d1fd397e7dde08e947e05c884d8ef2f78d5e2588c17a12d42d6994/sse_starlette-3.4.4.tar.gz", hash = "sha256:07e0fa0460138baf25cdd5fb28683472c3995dc1642225191b3832d62526bcb0", size = 31819, upload-time = "2026-05-12T17:37:17.019Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl", hash = "sha256:3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973", size = 16514, upload-time = "2026-05-12T17:37:15.601Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/08/a3/84e821cc54b4ab50ae6dbc6ac3800a651b65ec35f045cc73785380654057/starlette-1.0.1.tar.gz", hash = "sha256:512399c5f1de7fac99c88572212ded9ddeddef2fb32afa82d724000e88b38f4f", size = 2659596, upload-time = "2026-05-21T21:58:58.433Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/e1/b2df4bc09a1e51ff664c1e17018a4274b42e5e9352e4a478ea540512dc88/starlette-1.0.1-py3-none-any.whl", hash = "sha256:7c0e69b2ee1c848bd54669d908500117a3ee13de603a21427e5c6fc1adf98dcd", size = 72802, upload-time = "2026-05-21T21:58:56.551Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- disable pseudo-TTY allocation for Docker sandbox exec commands with 
- keep multi-service exec behavior intact
- unblocks SkillsBench AgentBeats worker runs from nested/non-interactive runners

## Verification
- ......                                                                   [100%]
6 passed in 0.25s
- .........sss.....ssssssssss..s.......................                    [100%]
39 passed, 14 skipped in 0.30s

This branch is used by  via a pinned commit for the AgentBeats runtime image.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/345" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->