### PR TITLE
Integrate v0.5 Daytona, dashboard, and SkillsBench audit fixes

### DIFF
--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -31,6 +31,7 @@ import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from types import ModuleType
@@ -170,30 +171,31 @@ def _memory_score_from_result(result: dict) -> float | None:
     return _load_reward_events_module().memory_score_from_result(result)
 
 
-def _jobs_tree_has_rollouts(jobs: Path) -> bool:
-    if not jobs.is_dir():
-        return False
-    with contextlib.suppress(Exception):
-        return any(
-            p.name in {"result.json", "config.json", "timing.json", "prompts.json"}
-            for p in jobs.rglob("*")
-            if p.is_file()
-        )
-    return False
-
-
-def _remembered_jobs_root() -> Path | None:
-    if not OUT.is_file():
+def remembered_jobs_root(out: Path) -> Path | None:
+    if not out.is_file():
         return None
     with contextlib.suppress(Exception):
-        data = json.loads(OUT.read_text())
+        data = json.loads(out.read_text())
         raw = ((data.get("jobs") or {}).get("source") or {}).get("path")
         if not raw:
             return None
         remembered = Path(str(raw)).expanduser().resolve()
-        if remembered.is_dir() and _jobs_tree_has_rollouts(remembered):
+        if remembered.is_dir() and jobs_tree_has_rollouts(remembered):
             return remembered
     return None
+
+
+def resolve_dashboard_jobs_root(root: Path, out: Path, raw: str | None = None) -> Path:
+    raw = os.environ.get(JOBS_ROOT_ENV) if raw is None else raw
+    if not raw:
+        local_jobs = root / "jobs"
+        if jobs_tree_has_rollouts(local_jobs):
+            return local_jobs
+        return remembered_jobs_root(out) or local_jobs
+    candidate = Path(raw).expanduser()
+    if candidate.name != "jobs" and (candidate / "jobs").is_dir():
+        candidate = candidate / "jobs"
+    return candidate.resolve()
 
 
 def dashboard_jobs_root() -> Path:
@@ -203,16 +205,7 @@ def dashboard_jobs_root() -> Path:
     from the run-producing worktree. Operators can point the dashboard at
     either that worktree root or at its ``jobs/`` directory directly.
     """
-    raw = os.environ.get(JOBS_ROOT_ENV)
-    if not raw:
-        local_jobs = ROOT / "jobs"
-        if _jobs_tree_has_rollouts(local_jobs):
-            return local_jobs
-        return _remembered_jobs_root() or local_jobs
-    candidate = Path(raw).expanduser()
-    if candidate.name != "jobs" and (candidate / "jobs").is_dir():
-        candidate = candidate / "jobs"
-    return candidate.resolve()
+    return resolve_dashboard_jobs_root(ROOT, OUT)
 
 
 def _jobs_source(jobs: Path) -> dict:
@@ -617,13 +610,39 @@ def _task_record(d: Path) -> tuple[dict, RunTaskEvidence]:
     return task, _task_visibility_evidence(d, task, result, config)
 
 
-def _run_summary(run_dir: Path, group_dir: Path, n_group_runs: int) -> dict:
-    summary = _read_json(run_dir / "summary.json")
-    if summary:
-        return summary
-    if n_group_runs == 1:
-        return _read_json(group_dir / "summary.json")
+@dataclass(frozen=True)
+class RunRecord:
+    id: str
+    run_dir: Path
+    task_dirs: list[Path]
+    summary_dir: Path | None = None
+
+
+def _run_summary(run: RunRecord) -> dict:
+    for summary_dir in (run.run_dir, run.summary_dir):
+        if summary_dir is None:
+            continue
+        summary = _read_json(summary_dir / "summary.json")
+        if summary:
+            return summary
     return {}
+
+
+def _run_summary_row(summary: dict) -> dict:
+    keys = (
+        "total",
+        "passed",
+        "failed",
+        "errored",
+        "verifier_errored",
+        "score",
+        "score_excl_errors",
+        "concurrency",
+        "agent",
+        "model",
+        "environment",
+    )
+    return {key: summary[key] for key in keys if key in summary}
 
 
 def _is_task_dir(d: Path) -> bool:
@@ -650,6 +669,117 @@ def _is_task_dir(d: Path) -> bool:
     )
 
 
+def _task_dirs(run_dir: Path) -> list[Path]:
+    return [c for c in sorted(run_dir.iterdir()) if c.is_dir() and _is_task_dir(c)]
+
+
+_IGNORED_JOB_DIR_NAMES = {"configs", "_self_gen", "notes", "__pycache__"}
+
+
+def _is_ignored_jobs_dir(d: Path) -> bool:
+    return d.name in _IGNORED_JOB_DIR_NAMES or d.name.startswith(".")
+
+
+def _job_child_dirs(root: Path) -> list[Path]:
+    return [
+        child
+        for child in sorted(root.iterdir())
+        if child.is_dir() and not _is_ignored_jobs_dir(child)
+    ]
+
+
+def _nested_run_dirs(root: Path, group_dir: Path) -> list[RunRecord]:
+    """Return explicit parent/timestamp and parent/mode/timestamp run dirs.
+
+    The dashboard intentionally does not recurse arbitrary helper trees. Nested
+    runs are used for bounded benchmark comparisons such as
+    ``e2e/<experiment>/<timestamp>/<task rollout>`` and
+    ``e2e/<experiment>/<mode>/<timestamp>/<task rollout>``.
+    """
+    runs: list[RunRecord] = []
+    if (root / "summary.json").is_file():
+        for run_dir in sorted(root.iterdir()):
+            if not run_dir.is_dir() or _is_ignored_jobs_dir(run_dir):
+                continue
+            if not TS_RE.match(run_dir.name):
+                continue
+            task_dirs = _task_dirs(run_dir)
+            if task_dirs:
+                runs.append(
+                    RunRecord(
+                        id=run_dir.relative_to(group_dir).as_posix(),
+                        run_dir=run_dir,
+                        task_dirs=task_dirs,
+                        summary_dir=root,
+                    )
+                )
+    for mode_dir in sorted(root.iterdir()):
+        if not mode_dir.is_dir() or _is_ignored_jobs_dir(mode_dir):
+            continue
+        if not (mode_dir / "summary.json").is_file():
+            continue
+        for run_dir in sorted(mode_dir.iterdir()):
+            if not run_dir.is_dir() or _is_ignored_jobs_dir(run_dir):
+                continue
+            if not TS_RE.match(run_dir.name):
+                continue
+            task_dirs = _task_dirs(run_dir)
+            if task_dirs:
+                runs.append(
+                    RunRecord(
+                        id=run_dir.relative_to(group_dir).as_posix(),
+                        run_dir=run_dir,
+                        task_dirs=task_dirs,
+                        summary_dir=mode_dir,
+                    )
+                )
+    return runs
+
+
+def jobs_tree_runs(jobs: Path) -> dict[str, list[RunRecord]]:
+    """Return the canonical dashboard groups/runs grammar for a jobs tree."""
+    groups: dict[str, list[RunRecord]] = {}
+    if not jobs.is_dir():
+        return groups
+
+    for top in _job_child_dirs(jobs):
+        if TS_RE.match(top.name):
+            groups.setdefault("main", []).append(
+                RunRecord(id=top.name, run_dir=top, task_dirs=_task_dirs(top))
+            )
+            continue
+
+        runs = groups.setdefault(top.name, [])
+        direct: list[Path] = []
+        for child in _job_child_dirs(top):
+            if _is_task_dir(child):
+                direct.append(child)
+                continue
+            task_dirs = _task_dirs(child)
+            if task_dirs:
+                runs.append(RunRecord(id=child.name, run_dir=child, task_dirs=task_dirs))
+                continue
+            nested_runs = _nested_run_dirs(child, top)
+            if nested_runs:
+                runs.extend(nested_runs)
+            else:
+                runs.append(RunRecord(id=child.name, run_dir=child, task_dirs=[]))
+        if direct:
+            runs.append(
+                RunRecord(id="(tasks)", run_dir=top, task_dirs=direct, summary_dir=top)
+            )
+    return groups
+
+
+def jobs_tree_has_rollouts(jobs: Path) -> bool:
+    """Return true when ``jobs`` contains a shape ``collect_jobs`` can collect."""
+    with contextlib.suppress(Exception):
+        return any(
+            run.task_dirs for runs in jobs_tree_runs(jobs).values() for run in runs
+        )
+    return False
+
+
 def collect_jobs() -> dict:
     """Scan jobs/ into groups → runs → tasks, mirroring the folder layout."""
     jobs = dashboard_jobs_root()
@@ -664,42 +794,7 @@ def collect_jobs() -> dict:
             "source": source,
         }
 
-    # group name -> { run id -> [task dirs] }, plus paths for run-level evidence.
-    groups: dict[str, dict[str, list[Path]]] = {}
-    run_dirs: dict[tuple[str, str], Path] = {}
-    group_dirs: dict[str, Path] = {}
-    for top in sorted(jobs.iterdir()):
-        if not top.is_dir():
-            continue
-        if TS_RE.match(top.name):
-            # an ungrouped run directly under jobs/
-            runs = groups.setdefault("main", {})
-            runs[top.name] = [
-                c for c in sorted(top.iterdir()) if c.is_dir() and _is_task_dir(c)
-            ]
-            group_dirs.setdefault("main", jobs)
-            run_dirs[("main", top.name)] = top
-        else:
-            # a named group: e2e / e2e-branch / environment. Its children
-            # are either run dirs (holding task dirs) or task dirs directly.
-            runs = groups.setdefault(top.name, {})
-            group_dirs[top.name] = top
-            direct: list[Path] = []
-            for child in sorted(top.iterdir()):
-                if not child.is_dir():
-                    continue
-                if _is_task_dir(child):
-                    direct.append(child)
-                else:
-                    runs[child.name] = [
-                        c
-                        for c in sorted(child.iterdir())
-                        if c.is_dir() and _is_task_dir(c)
-                    ]
-                    run_dirs[(top.name, child.name)] = child
-            if direct:
-                runs["(tasks)"] = direct
-                run_dirs[(top.name, "(tasks)")] = top
+    groups = jobs_tree_runs(jobs)
 
     total = 0
     archived_tasks = 0
@@ -712,21 +807,18 @@ def collect_jobs() -> dict:
             name, {"label": name, "blurb": "", "capability": None, "advisories": []}
         )
         run_list: list[dict] = []
-        n_group_runs = len(groups[name])
-        group_dir = group_dirs.get(name, jobs / name)
-        for run_id in sorted(groups[name], reverse=True):
-            task_dirs = groups[name][run_id]
+        for run in sorted(groups[name], key=lambda item: item.id, reverse=True):
+            task_dirs = run.task_dirs
             records = [_task_record(d) for d in task_dirs]
             tasks = [task for task, _evidence in records]
             task_evidence = [evidence for _task, evidence in records]
             total_runs += 1
-            run_dir = run_dirs.get((name, run_id), group_dir / run_id)
-            summary = _run_summary(run_dir, group_dir, n_group_runs)
+            summary = _run_summary(run)
             visibility = decide_run_visibility(
                 RunVisibilityContext(
                     group_name=name,
-                    run_id=run_id,
-                    run_path=run_dir.as_posix(),
+                    run_id=run.id,
+                    run_path=run.run_dir.as_posix(),
                     summary=summary,
                     tasks=task_evidence,
                 )
@@ -738,12 +830,13 @@ def collect_jobs() -> dict:
             total += len(tasks)
             run_list.append(
                 {
-                    "id": run_id,
+                    "id": run.id,
                     "latest_modified_at": _latest_timestamp(
                         [task.get("latest_modified_at") for task in tasks]
                     ),
                     "signals": list(visibility.signals),
                     "targets": list(visibility.targets),
+                    "summary": _run_summary_row(summary),
                     "tasks": tasks,
                 }
             )
@@ -1293,9 +1386,9 @@ def main() -> int:
     print(f"wrote {OUT.relative_to(ROOT)}")
     print(
         f"  tests: {s['passed']}p/{s['failed']}f/{s['skipped']}s   "
-        f"jobs: {jobs['total_tasks']} tasks in {len(jobs['groups'])} groups   "
+        f"jobs: {jobs['total_tasks']} rollout rows in {len(jobs['groups'])} groups   "
         f"archived: {jobs.get('archived_runs', 0)} runs/"
-        f"{jobs.get('archived_tasks', 0)} tasks   "
+        f"{jobs.get('archived_tasks', 0)} rollout rows   "
         f"experiments: {len(experiments)}   "
         f"capabilities: {data['summary']['capabilities_shipped']}/"
         f"{data['summary']['capabilities_total']}"

--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -716,8 +716,9 @@ def _nested_run_dirs(root: Path, group_dir: Path) -> list[RunRecord]:
     for mode_dir in sorted(root.iterdir()):
         if not mode_dir.is_dir() or _is_ignored_jobs_dir(mode_dir):
             continue
-        if not (mode_dir / "summary.json").is_file():
+        if TS_RE.match(mode_dir.name):
             continue
+        mode_summary_dir = mode_dir if (mode_dir / "summary.json").is_file() else None
         for run_dir in sorted(mode_dir.iterdir()):
             if not run_dir.is_dir() or _is_ignored_jobs_dir(run_dir):
                 continue
@@ -730,7 +731,7 @@ def _nested_run_dirs(root: Path, group_dir: Path) -> list[RunRecord]:
                         id=run_dir.relative_to(group_dir).as_posix(),
                         run_dir=run_dir,
                         task_dirs=task_dirs,
-                        summary_dir=mode_dir,
+                        summary_dir=mode_summary_dir,
                     )
                 )
     return runs
@@ -762,8 +763,6 @@ def jobs_tree_runs(jobs: Path) -> dict[str, list[RunRecord]]:
             nested_runs = _nested_run_dirs(child, top)
             if nested_runs:
                 runs.extend(nested_runs)
-            else:
-                runs.append(RunRecord(id=child.name, run_dir=child, task_dirs=[]))
         if direct:
             runs.append(
                 RunRecord(id="(tasks)", run_dir=top, task_dirs=direct, summary_dir=top)

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1444,7 +1444,7 @@ function runNode(run, firstPath) {
   const summaryBits = [];
   if (summary.total != null && Number(summary.total) !== (run.tasks || []).length)
     summaryBits.push(`${summary.total} benchmark tasks`);
-  if (summary.score) summaryBits.push(`score ${summary.score}`);
+  if (summary.score != null) summaryBits.push(`score ${summary.score}`);
   if (summary.passed != null || summary.failed != null || summary.errored != null || summary.verifier_errored != null)
     summaryBits.push(`${summary.passed || 0} pass/${summary.failed || 0} fail/${summary.errored || 0} err/${summary.verifier_errored || 0} verifier`);
   return {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1386,7 +1386,8 @@ function artifactBadge(a) {
 function taskOutcomeBadge(outcome) {
   if (outcome === "verifier_errored") return { text: "verifier", cls: "verifier" };
   if (outcome === "errored") return { text: "error", cls: "error" };
-  if (outcome === "passed" || outcome === "failed") return { text: "ok", cls: "ok" };
+  if (outcome === "failed") return { text: "failed", cls: "error" };
+  if (outcome === "passed") return { text: "ok", cls: "ok" };
   return { text: "pending", cls: "warn" };
 }
 
@@ -1433,9 +1434,18 @@ function runNode(run, firstPath) {
   const target = (run.targets || []).slice(0, 3).join(", ");
   const signal = (run.signals || []).slice(0, 3).join(", ");
   const tags = [target, signal].filter(Boolean).join(" · ");
+  const summary = run.summary || {};
+  const summaryBits = [];
+  if (summary.total != null && Number(summary.total) !== (run.tasks || []).length)
+    summaryBits.push(`${summary.total} benchmark tasks`);
+  if (summary.score) summaryBits.push(`score ${summary.score}`);
+  if (summary.passed != null || summary.failed != null || summary.errored != null || summary.verifier_errored != null)
+    summaryBits.push(`${summary.passed || 0} pass/${summary.failed || 0} fail/${summary.errored || 0} err/${summary.verifier_errored || 0} verifier`);
   return {
     type: "folder", label: run.id + "/",
-    meta: `${run.tasks.length} task${run.tasks.length === 1 ? "" : "s"}${latest}` +
+    meta: `${run.tasks.length} rollout row${run.tasks.length === 1 ? "" : "s"}` +
+          (summaryBits.length ? ` · ${summaryBits.join(" · ")}` : "") +
+          latest +
           (tags ? ` · ${tags}` : ""),
     open: !!firstPath,
     children: (run.tasks || []).map((tk, ti) => taskNode(tk, firstPath && ti === 0)),
@@ -1485,6 +1495,8 @@ function renderJobs() {
     : "";
   const archivedRuns = Number(j.archived_runs || 0);
   const archivedTasks = Number(j.archived_tasks || 0);
+  const totalRows = Number(j.total_tasks || 0);
+  const totalRowLabel = `${totalRows} rollout row${totalRows === 1 ? "" : "s"}`;
   const archiveParts = [];
   if (archivedRuns) archiveParts.push(`${archivedRuns} low-signal run${archivedRuns === 1 ? "" : "s"}`);
   if (archivedTasks) archiveParts.push(`${archivedTasks} task${archivedTasks === 1 ? "" : "s"}`);
@@ -1493,7 +1505,7 @@ function renderJobs() {
     : "";
   wrap.appendChild(el("h1", "page", "Jobs &amp; artifacts"));
   wrap.appendChild(el("div", "sub-ttl",
-    `Every rollout under <code title="${esc(sourcePath)}">${esc(sourceDisplay)}</code> — ${j.total_tasks} tasks in ${j.groups.length} groups.` +
+    `Every rollout under <code title="${esc(sourcePath)}">${esc(sourceDisplay)}</code> — ${totalRowLabel} in ${j.groups.length} groups.` +
     latestNote + archiveNote + sourceNote + ` Browse the tree; click a file to view it. Each group links to its advisories.`));
   if (!j.total_tasks) {
     const hint = source.configured

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -705,6 +705,7 @@ function dataSignature(d) {
     d.jobs && d.jobs.source && d.jobs.source.available,
     d.jobs && d.jobs.source && d.jobs.source.remembered,
     d.jobs && d.jobs.source && d.jobs.source.latest_modified_at,
+    d.sync_error,
     d.jobs && d.jobs.total_tasks,
     jobGroups,
   ].join("|");
@@ -725,13 +726,18 @@ function repoLine() {
     parts.push(`<span class="mono">${esc(r.head || "")}</span>`);
     parts.push(`<span>${esc(state)}</span>`);
   }
-  if (SYNC_ERROR) parts.push(`<span class="bad">sync failed: ${esc(SYNC_ERROR)}</span>`);
+  const syncError = dataSyncError(DATA);
+  if (syncError) parts.push(`<span class="bad">sync failed: ${esc(syncError)}</span>`);
   return parts.length ? `<div class="repo-line">${parts.join("")}</div>` : "";
 }
+function dataSyncError(d) {
+  return SYNC_ERROR || (d && d.sync_error) || null;
+}
 function syncBanner() {
-  if (!SYNC_ERROR) return null;
+  const syncError = dataSyncError(DATA);
+  if (!syncError) return null;
   return el("div", "sync-banner",
-    `<b>Dashboard data is not refreshing.</b><span>${esc(SYNC_ERROR)}</span>`);
+    `<b>Dashboard data is not refreshing.</b><span>${esc(syncError)}</span>`);
 }
 
 // ---- file-content viewer (one component, used by Jobs + Timeline) ----------
@@ -1688,7 +1694,8 @@ function updateGenerated(d) {
   const repo = d.repo && d.repo.available
     ? `<br>${esc(d.repo.branch || "")} @ ${esc(d.repo.head || "")}${d.repo.dirty ? ` · ${esc(d.repo.changes)} changed` : ""}`
     : "";
-  const sync = SYNC_ERROR ? `<br><span class="bad">sync failed: ${esc(SYNC_ERROR)}</span>` : "";
+  const syncError = dataSyncError(d);
+  const sync = syncError ? `<br><span class="bad">sync failed: ${esc(syncError)}</span>` : "";
   const latestJob = d.jobs && d.jobs.source && d.jobs.source.latest_modified_at
     ? `<br>jobs latest ${esc(d.jobs.source.latest_modified_at)}`
     : "";
@@ -1708,7 +1715,7 @@ function renderCurrent() {
 
 function applyData(d, initial) {
   const previous = DATA_SIGNATURE;
-  const hadSyncError = !!SYNC_ERROR;
+  const hadSyncError = !!dataSyncError(DATA);
   DATA = d;
   DATA_SIGNATURE = dataSignature(d);
   SYNC_ERROR = null;

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import http.server
+import json
 import os
 import socketserver
 import subprocess
@@ -40,7 +41,6 @@ except ModuleNotFoundError:  # pragma: no cover - used when run as dashboard/ser
 
 DASH = Path(__file__).resolve().parent
 ROOT = DASH.parent
-JOBS_ROOT_ENV = "BENCHFLOW_DASHBOARD_JOBS_ROOT"
 
 
 def _git_bytes(args: list[str]) -> bytes:
@@ -51,22 +51,18 @@ def _dashboard_jobs_root() -> Path:
     return resolve_dashboard_jobs_root(ROOT, DASH / "data.json")
 
 
-def _digest_tree(digest: hashlib._Hash, root: Path, *, label: str) -> None:
-    digest.update(label.encode())
-    digest.update(b"\0")
-    digest.update(str(root).encode())
-    digest.update(b"\0")
-    if not root.is_dir():
-        digest.update(b"missing")
-        return
-    for path in sorted(p for p in root.rglob("*") if p.is_file()):
-        rel = path.relative_to(root).as_posix()
-        digest.update(rel.encode())
-        with contextlib.suppress(Exception):
-            stat = path.stat()
-            digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode())
-            if stat.st_size <= 1_000_000:
-                digest.update(path.read_bytes())
+def _data_json_exists() -> bool:
+    return (DASH / "data.json").is_file()
+
+
+def _mark_cached_data_refresh_error(message: str) -> None:
+    data_path = DASH / "data.json"
+    with contextlib.suppress(Exception):
+        data = json.loads(data_path.read_text())
+        if isinstance(data, dict):
+            data["sync_error"] = message
+            data["sync_failed_at"] = time.strftime("%Y-%m-%d %H:%M:%S")
+            data_path.write_text(json.dumps(data, indent=2))
 
 
 def repo_fingerprint() -> str:
@@ -98,7 +94,6 @@ def repo_fingerprint() -> str:
                 digest.update(f"{stat.st_size}:{stat.st_mtime_ns}".encode())
                 if stat.st_size <= 1_000_000:
                     digest.update(path.read_bytes())
-    _digest_tree(digest, _dashboard_jobs_root(), label=JOBS_ROOT_ENV)
     return digest.hexdigest()
 
 
@@ -119,6 +114,8 @@ class SyncingDashboardHandler(http.server.SimpleHTTPRequestHandler):
 
     def _sync_data_json(self) -> bool:
         if self._in_failure_backoff():
+            if _data_json_exists():
+                return True
             self.send_error(503, "data.json refresh failed; retrying after cooldown")
             return False
 
@@ -130,6 +127,8 @@ class SyncingDashboardHandler(http.server.SimpleHTTPRequestHandler):
             return True
         with type(self).sync_lock:
             if self._in_failure_backoff():
+                if _data_json_exists():
+                    return True
                 self.send_error(
                     503, "data.json refresh failed; retrying after cooldown"
                 )
@@ -147,14 +146,19 @@ class SyncingDashboardHandler(http.server.SimpleHTTPRequestHandler):
             result = subprocess.run(type(self).gen_cmd, check=False)
             if result.returncode != 0:
                 type(self).last_failed_refresh_at = time.monotonic()
-                type(
-                    self
-                ).failed_refresh_error = (
-                    "data.json refresh failed; refusing to serve stale dashboard data"
+                type(self).failed_refresh_error = (
+                    "data.json refresh failed; serving last successful data.json"
                 )
+                if _data_json_exists():
+                    _mark_cached_data_refresh_error(type(self).failed_refresh_error)
+                    print(
+                        "data.json refresh failed; serving last successful data.json",
+                        flush=True,
+                    )
+                    return True
                 self.send_error(
                     503,
-                    "data.json refresh failed; refusing to serve stale dashboard data",
+                    "data.json refresh failed and no cached data.json is available",
                 )
                 return False
             type(self).last_repo_fingerprint = repo_fingerprint()
@@ -184,7 +188,15 @@ def main() -> int:
     print("refreshing data.json ...", flush=True)
     result = subprocess.run(gen, check=False)
     if result.returncode != 0:
-        return result.returncode
+        if not _data_json_exists():
+            return result.returncode
+        _mark_cached_data_refresh_error(
+            "initial data.json refresh failed; serving last successful data.json"
+        )
+        print(
+            "initial data.json refresh failed; serving last successful data.json",
+            flush=True,
+        )
 
     SyncingDashboardHandler.gen_cmd = gen
     SyncingDashboardHandler.last_repo_fingerprint = repo_fingerprint()

--- a/dashboard/serve.py
+++ b/dashboard/serve.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 import contextlib
 import hashlib
 import http.server
-import json
 import os
 import socketserver
 import subprocess
@@ -34,6 +33,11 @@ from functools import partial
 from pathlib import Path
 from typing import ClassVar
 
+try:
+    from dashboard.generate import resolve_dashboard_jobs_root
+except ModuleNotFoundError:  # pragma: no cover - used when run as dashboard/serve.py
+    from generate import resolve_dashboard_jobs_root  # type: ignore[no-redef]
+
 DASH = Path(__file__).resolve().parent
 ROOT = DASH.parent
 JOBS_ROOT_ENV = "BENCHFLOW_DASHBOARD_JOBS_ROOT"
@@ -44,43 +48,7 @@ def _git_bytes(args: list[str]) -> bytes:
 
 
 def _dashboard_jobs_root() -> Path:
-    raw = os.environ.get(JOBS_ROOT_ENV)
-    if not raw:
-        local_jobs = ROOT / "jobs"
-        if _jobs_tree_has_rollouts(local_jobs):
-            return local_jobs
-        return _remembered_jobs_root() or local_jobs
-    candidate = Path(raw).expanduser()
-    if candidate.name != "jobs" and (candidate / "jobs").is_dir():
-        candidate = candidate / "jobs"
-    return candidate.resolve()
-
-
-def _jobs_tree_has_rollouts(jobs: Path) -> bool:
-    if not jobs.is_dir():
-        return False
-    with contextlib.suppress(Exception):
-        return any(
-            p.name in {"result.json", "config.json", "timing.json", "prompts.json"}
-            for p in jobs.rglob("*")
-            if p.is_file()
-        )
-    return False
-
-
-def _remembered_jobs_root() -> Path | None:
-    data_path = DASH / "data.json"
-    if not data_path.is_file():
-        return None
-    with contextlib.suppress(Exception):
-        data = json.loads(data_path.read_text())
-        raw = ((data.get("jobs") or {}).get("source") or {}).get("path")
-        if not raw:
-            return None
-        remembered = Path(str(raw)).expanduser().resolve()
-        if remembered.is_dir() and _jobs_tree_has_rollouts(remembered):
-            return remembered
-    return None
+    return resolve_dashboard_jobs_root(ROOT, DASH / "data.json")
 
 
 def _digest_tree(digest: hashlib._Hash, root: Path, *, label: str) -> None:

--- a/docs/reports/2026-05-23-skillsbench-3mode-subset-audit.md
+++ b/docs/reports/2026-05-23-skillsbench-3mode-subset-audit.md
@@ -1,0 +1,94 @@
+# SkillsBench 9-Task Three-Mode Subset Audit
+
+Generated: 2026-05-23 13:41:16
+
+This is the complete 27-row trajectory/artifact audit for the 9-task SkillsBench subset across baseline, with-task-skills, and self-gen modes. It was produced from saved artifacts, not from a new run.
+
+## Scope
+
+- Run root: `/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset`
+- Modes: `baseline`, `with-task-skills`, `self-gen`
+- Benchmark source: `benchflow-ai/skillsbench@main`
+- Resolved source SHA in every row: `20149520474cfc8d7eb3c8000ec403d10145a9fd`
+- Current `main` SHA verified during audit: `20149520474cfc8d7eb3c8000ec403d10145a9fd`
+- Model/environment: `gemini-3.1-flash-lite-preview` / `daytona`
+- Evidence caveat: the self-gen mode started at `2026-05-23 00:44:33 -0400` and summary finished before commit `4946481`. These self-gen rows do not validate the current ACP-native generated-skill handoff fix.
+
+## Verdict
+
+All 27 primary rows were audited. There were no retries in this subset (`max_retries: 0`). The subset is useful as pre-fix evidence, but it is not a release-quality validation of SkillsBench self-generation because generated solver skill packs were not persisted in artifacts and several solver trajectories did not activate generated skills. Only one row passed: `lake-warming-attribution` in `with-task-skills` mode.
+
+## Mode Summaries
+
+| Mode | Total | Passed | Failed | Errored | Verifier errored | Score | Model | Environment | Concurrency | Idle timeout |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| baseline | 9 | 0 | 8 | 0 | 1 | 0.0% | gemini-3.1-flash-lite-preview | daytona | 9 | 600 |
+| with-task-skills | 9 | 1 | 6 | 1 | 1 | 11.1% | gemini-3.1-flash-lite-preview | daytona | 9 | 600 |
+| self-gen | 9 | 0 | 8 | 0 | 1 | 0.0% | gemini-3.1-flash-lite-preview | daytona | 9 | 600 |
+
+## Task Comparison Matrix
+
+| Task | Baseline outcome/reward | With-task-skills outcome/reward | Self-gen outcome/reward | Self-gen audit note |
+| --- | --- | --- | --- | --- |
+| data-to-d3 | fail / 0.0 | fail / 0.0 | fail / 0.0 | CTRF 11/15; creator hit /app/generated-skills path write failure; no generated solver skill persisted |
+| grid-dispatch-operator | fail / 0.0 | fail / 0.0 | fail / 0.0 | idle timeout 600s; only creator user message; CTRF 0/6; solver handoff did not complete |
+| jax-computing-basics | fail / 0.0 | fail / 0.0 | fail / 0.0 | CTRF 4/5; generated skill activated, but stale evidence; numerical mismatch in jit_mlp |
+| jpg-ocr-stat | fail / 0.0 | fail / 0.0 | fail / 0.0 | CTRF 0/1; skill created under /app/workspace/generated-skills, not solver mount |
+| lake-warming-attribution | fail / 0.0 | pass / 1.0 | fail / 0.0 | CTRF 0/2; generated skill activated but had TODO-quality content; stale evidence |
+| python-scala-translation | fail / 0.0 | fail / 0.0 | fail / 0.0 | solver did not show generated skill activation; /root/Tokenizer.scala missing |
+| shock-analysis-supply | fail / 0.0 | fail / 0.0 | fail / 0.0 | CTRF 1/9; generated skill not activated; workbook failures remain |
+| threejs-to-obj | verifier_error / n/a | verifier_error / n/a | verifier_error / n/a | CTRF 2/3; generated skill not persisted; same verifier exit-status issue |
+| weighted-gdp-calc | fail / 0.0 | error / n/a | fail / 0.0 | CTRF 14/27; generated skill not activated; spreadsheet/stat failures remain |
+
+## ACP-Native Self-Gen Findings
+
+- Self-gen scenes point the solver at `/app/generated-skills`, but persisted host artifacts under `_self_gen` contain only copied `creator-skills/skill-creator`; no generated solver skill pack was found outside creator-skill scaffolding.
+- Several self-gen solver trajectories never show generated skill activation. This is exactly the kind of issue the ACP-native handoff fix in `4946481` is meant to address, so this subset must be rerun before it can validate current architecture.
+- Generated-skill artifact persistence is itself an audit gap: even if a solver activates a skill, the generated `SKILL.md` should be retained as first-class rollout evidence.
+
+## Standards Gaps Against Release-Quality Adapter Evidence
+
+- `threejs-to-obj` has reward and CTRF evidence for ordinary assertion failure, but BenchFlow records `verifier_error` because the verifier exits nonzero after failed tests.
+- `python-scala-translation` uses custom verifier output without CTRF by task design, so dashboard/audit parity is weaker than the adapter tutorial standard.
+- `weighted-gdp-calc` with task skills hit the ACP 400 token limit before verifier, creating a partial trajectory and no score.
+- Token/cost telemetry remains unavailable across rows.
+
+## Generated-Skill Artifact Check
+
+| Check | Value |
+| --- | --- |
+| Creator skill SKILL.md files under _self_gen | 9 |
+| Generated solver skill SKILL.md files persisted outside creator-skills | 0 |
+| Retry rows found | 0 |
+
+## Complete 27-Row Ledger
+
+| Task | Mode | Outcome | Reward | Class | Tools | Partial trajectory | Trajectory | Scenes | Skills dirs | Verifier artifacts | Audit note |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| data-to-d3 | baseline | fail | 0.0 | model/verifier fail | 13 | False | present | 1 |  | ctrf.json: 10/15 pass, 5 fail, 0 skipped | CTRF 10/15; missing copied indiv-stock plus bubble render/tooltip/linking/legend failures |
+| data-to-d3 | with-task-skills | fail | 0.0 | model/verifier fail | 12 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/data-to-d3/environment/skills | ctrf.json: 8/15 pass, 7 fail, 0 skipped | CTRF 8/15; task skills present but chart/table/tooltip/linking failures remain |
+| data-to-d3 | self-gen | fail | 0.0 | stale self-gen/dashboard mismatch | 33 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/data-to-d3-27b87141/creator-skills, /app/generated-skills | ctrf.json: 11/15 pass, 4 fail, 0 skipped | CTRF 11/15; creator hit /app/generated-skills path write failure; no generated solver skill persisted |
+| grid-dispatch-operator | baseline | fail | 0.0 | model/verifier fail | 15 | False | present | 1 |  | ctrf.json: 4/6 pass, 2 fail, 0 skipped | CTRF 4/6; reserve constraint and optimality failures |
+| grid-dispatch-operator | with-task-skills | fail | 0.0 | model/verifier fail | 12 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/grid-dispatch-operator/environment/skills | ctrf.json: 5/6 pass, 1 fail, 0 skipped | CTRF 5/6; infeasible/invalid optimality result |
+| grid-dispatch-operator | self-gen | fail | 0.0 | infra failure | 9 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/grid-dispatch-operator-6fc136e4/creator-skills, /app/generated-skills | ctrf.json: 0/6 pass, 6 fail, 0 skipped | idle timeout 600s; only creator user message; CTRF 0/6; solver handoff did not complete |
+| jax-computing-basics | baseline | fail | 0.0 | model/verifier fail | 23 | False | present | 1 |  | ctrf.json: 4/5 pass, 1 fail, 0 skipped | CTRF 4/5; numerical mismatch in scan_rnn |
+| jax-computing-basics | with-task-skills | fail | 0.0 | model/verifier fail | 12 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/jax-computing-basics/environment/skills | ctrf.json: 4/5 pass, 1 fail, 0 skipped | CTRF 4/5; skill activated; numerical mismatch in jit_mlp |
+| jax-computing-basics | self-gen | fail | 0.0 | model/verifier fail | 30 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/jax-computing-basics-92fd5389/creator-skills, /app/generated-skills | ctrf.json: 4/5 pass, 1 fail, 0 skipped | CTRF 4/5; generated skill activated, but stale evidence; numerical mismatch in jit_mlp |
+| jpg-ocr-stat | baseline | fail | 0.0 | model/verifier fail | 14 | False | present | 1 |  | ctrf.json: 0/1 pass, 1 fail, 0 skipped | CTRF 0/1; OCR workbook content/null-handling mismatch |
+| jpg-ocr-stat | with-task-skills | fail | 0.0 | model/verifier fail | 16 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/jpg-ocr-stat/environment/skills | ctrf.json: 0/1 pass, 1 fail, 0 skipped | CTRF 0/1; OCR/xlsx skills present; workbook mismatch |
+| jpg-ocr-stat | self-gen | fail | 0.0 | stale self-gen/dashboard mismatch | 27 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/jpg-ocr-stat-c1268f6a/creator-skills, /app/generated-skills | ctrf.json: 0/1 pass, 1 fail, 0 skipped | CTRF 0/1; skill created under /app/workspace/generated-skills, not solver mount |
+| lake-warming-attribution | baseline | fail | 0.0 | model/verifier fail | 9 | False | present | 1 |  | ctrf.json: 0/2 pass, 2 fail, 0 skipped | CTRF 0/2; trend p-value missed threshold and dominant factor failed |
+| lake-warming-attribution | with-task-skills | pass | 1.0 | pass | 15 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/lake-warming-attribution/environment/skills | ctrf.json: 2/2 pass, 0 fail, 0 skipped | CTRF 2/2; only passing row in 27-row subset |
+| lake-warming-attribution | self-gen | fail | 0.0 | model/verifier fail | 28 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/lake-warming-attribution-867b8434/creator-skills, /app/generated-skills | ctrf.json: 0/2 pass, 2 fail, 0 skipped | CTRF 0/2; generated skill activated but had TODO-quality content; stale evidence |
+| python-scala-translation | baseline | fail | 0.0 | model/verifier fail | 7 | False | present | 1 |  | reward.txt: reward only; no CTRF | custom verifier log, no CTRF by task design; Scala compile failed |
+| python-scala-translation | with-task-skills | fail | 0.0 | model/verifier fail | 17 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/python-scala-translation/environment/skills | reward.txt: reward only; no CTRF | verifier says /root/Tokenizer.scala missing |
+| python-scala-translation | self-gen | fail | 0.0 | stale self-gen/dashboard mismatch | 48 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/python-scala-translation-7b5470de/creator-skills, /app/generated-skills | reward.txt: reward only; no CTRF | solver did not show generated skill activation; /root/Tokenizer.scala missing |
+| shock-analysis-supply | baseline | fail | 0.0 | model/verifier fail | 4 | False | present | 1 |  | ctrf.json: 1/9 pass, 8 fail, 0 skipped | CTRF 1/9; workbook mostly incomplete |
+| shock-analysis-supply | with-task-skills | fail | 0.0 | model/verifier fail | 21 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/shock-analysis-supply/environment/skills | ctrf.json: 1/9 pass, 8 fail, 0 skipped | CTRF 1/9; xlsx skill present but workbook failures remain |
+| shock-analysis-supply | self-gen | fail | 0.0 | stale self-gen/dashboard mismatch | 27 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/shock-analysis-supply-569aa7cf/creator-skills, /app/generated-skills | ctrf.json: 1/9 pass, 8 fail, 0 skipped | CTRF 1/9; generated skill not activated; workbook failures remain |
+| threejs-to-obj | baseline | verifier_error |  | verifier/task issue | 13 | False | present | 1 |  | ctrf.json: 2/3 pass, 1 fail, 0 skipped | CTRF 2/3 and reward.txt=0, but verifier rc=1 made BenchFlow record verifier_error |
+| threejs-to-obj | with-task-skills | verifier_error |  | verifier/task issue | 17 | False | present | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/threejs-to-obj/environment/skills | ctrf.json: 2/3 pass, 1 fail, 0 skipped | CTRF 2/3; Chamfer distance mismatch; same verifier exit-status issue |
+| threejs-to-obj | self-gen | verifier_error |  | verifier/task issue | 20 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/threejs-to-obj-6d9f3cb3/creator-skills, /app/generated-skills | ctrf.json: 2/3 pass, 1 fail, 0 skipped | CTRF 2/3; generated skill not persisted; same verifier exit-status issue |
+| weighted-gdp-calc | baseline | fail | 0.0 | model/verifier fail | 19 | False | present | 1 |  | ctrf.json: 23/27 pass, 4 fail, 0 skipped | CTRF 23/27; percentile and weighted-mean calculations wrong/missing |
+| weighted-gdp-calc | with-task-skills | error |  | infra failure | 10 | True | present-partial | 1 | /Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/.cache/datasets/benchflow-ai/skillsbench__snapshots/20149520474cfc8d7eb3c8000ec403d10145a9fd/tasks/weighted-gdp-calc/environment/skills | none: no verifier artifacts found | ACP 400 token limit exceeded before verifier; partial ACP trajectory |
+| weighted-gdp-calc | self-gen | fail | 0.0 | stale self-gen/dashboard mismatch | 99 | False | present | 2 | jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/_self_gen/weighted-gdp-calc-adea9b4a/creator-skills, /app/generated-skills | ctrf.json: 14/27 pass, 13 fail, 0 skipped | CTRF 14/27; generated skill not activated; spreadsheet/stat failures remain |

--- a/docs/reports/2026-05-23-skillsbench-full94-baseline-audit.md
+++ b/docs/reports/2026-05-23-skillsbench-full94-baseline-audit.md
@@ -1,0 +1,305 @@
+# SkillsBench Full 94-Task Baseline Audit
+
+Generated: 2026-05-23 13:41:16
+
+This is a durable per-task audit of the full SkillsBench baseline run. It was produced from the saved BenchFlow artifacts, not from a new run.
+
+## Scope
+
+- Run root: `/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64`
+- Summary: `/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/summary.json`
+- Benchmark source: `benchflow-ai/skillsbench@main`
+- Resolved source SHA in artifacts: `20149520474cfc8d7eb3c8000ec403d10145a9fd`
+- Current `main` SHA verified during audit: `20149520474cfc8d7eb3c8000ec403d10145a9fd`
+- Agent/model/environment: `gemini` / `gemini-3.1-flash-lite-preview` / `daytona`
+- Concurrency and idle timeout: `64` / `600s`
+- BenchFlow fix commit after this evidence: `4946481`
+
+## Verdict
+
+The full baseline did execute the latest SkillsBench `main` SHA now visible from GitHub, and the summary is internally consistent: 94 unique tasks, 109 rollout rows including retries, final summary 8 passed / 76 failed / 7 errored / 3 verifier_errored. It is not a clean release-quality validation set because retry rows include no-reward infra failures and three final verifier errors appear to be verifier-contract bugs rather than true missing-evidence cases.
+
+## Aggregate Checks
+
+| Metric | Value |
+| --- | --- |
+| Unique tasks | 94 |
+| Rollout rows / retries | 109 |
+| Task-final outcomes | error=7, fail=76, pass=8, verifier_error=3 |
+| Retry-row outcomes | error=16, fail=80, pass=8, verifier_error=5 |
+| Summary score | 8.5% |
+| Score excluding errors | 9.5% |
+| Token/cost telemetry | tokens=0, cost=0, coverage=0.0 |
+
+## Pass List
+
+| Task | Final rollout | Tool calls | Trajectory |
+| --- | --- | --- | --- |
+| 3d-scan-calc | 3d-scan-calc__41391d68 | 11 | present |
+| citation-check | citation-check__a62a53c2 | 20 | present |
+| econ-detrending-correlation | econ-detrending-correlation__21386bf8 | 16 | present |
+| mars-clouds-clustering | mars-clouds-clustering__0d36d57e | 12 | present |
+| parallel-tfidf-search | parallel-tfidf-search__67cba0d7 | 25 | present |
+| pddl-tpp-planning | pddl-tpp-planning__785326e4 | 13 | present |
+| radar-vital-signs | radar-vital-signs__45b21344 | 11 | present |
+| spring-boot-jakarta-migration | spring-boot-jakarta-migration__2382b67d | 101 | present |
+
+## P0 Invalid Measurement Blockers
+
+| Blocker | Retry rows | Tasks | Affected tasks |
+| --- | --- | --- | --- |
+| Agent install failed | 9 | 3 | fix-visual-stability, gh-repo-analytics, pedestrian-traffic-counting |
+| Artifact copy/setup failed | 2 | 2 | drone-planning-control, pg-essay-to-audiobook |
+| ACP transport/stdout closed | 5 | 3 | mars-clouds-clustering, quantum-numerical-simulation, video-filler-word-remover |
+| Verifier timeout | 2 | 1 | quantum-numerical-simulation |
+| Verifier crash/contract refusal | 3 | 3 | dynamic-object-aware-egomotion, threejs-structure-parser, threejs-to-obj |
+| Idle timeout with reward 0 diagnostics gap | 5 | 3 | court-form-filling, shock-analysis-supply, video-tutorial-indexer |
+
+## Final Classification Counts
+
+| Class | Task count |
+| --- | --- |
+| invalid: ACP transport/stdout closed | 2 |
+| invalid: agent install failure | 3 |
+| invalid: artifact copy/setup failure | 2 |
+| pass | 8 |
+| valid model failure: missing/incorrect artifact | 9 |
+| valid model failure: reward only/no structured detail | 5 |
+| valid model failure: verifier assertion/quality threshold | 62 |
+| verifier contract/artifact error | 3 |
+
+## Retry Reconciliation
+
+Final task status is taken from the latest chronological rollout for that task. Summary semantics are `verifier_error` first, then reward, then agent error. This preserves BenchFlow's summary counts while exposing invalid retry rows for release gating.
+
+| Task | Attempts | Attempt outcomes by rollout hash |
+| --- | --- | --- |
+| court-form-filling | 2 | 4d161ed7:fail, f5fed20d:fail |
+| fix-visual-stability | 3 | f44ddba9:error, 371cbee3:error, da2e2eaa:error |
+| gh-repo-analytics | 3 | 7e9bee41:error, 6e43ee2e:error, a40ea886:error |
+| mars-clouds-clustering | 2 | 387d89ca:error, 0d36d57e:pass |
+| pedestrian-traffic-counting | 3 | 87121f5c:error, 04c45e9c:error, 4daa7b37:error |
+| quantum-numerical-simulation | 3 | 3031c9cf:verifier_error, a43c7238:verifier_error, 32f8a92b:error |
+| shock-analysis-supply | 2 | d95da6be:fail, 78b391ae:fail |
+| video-filler-word-remover | 3 | 4b9e74b6:error, bc926eda:error, 4f64d2f0:error |
+| video-tutorial-indexer | 3 | 7fe67e9d:fail, fb0bedbb:fail, f1b368f8:fail |
+
+## Standards Gaps Against Release-Quality Adapter Evidence
+
+- Three final tasks wrote reward/verifier artifacts but were counted as `verifier_error` because the verifier process exited nonzero after normal assertion failures: `dynamic-object-aware-egomotion`, `threejs-structure-parser`, and `threejs-to-obj`.
+- Several tasks rely on reward-only or task-specific logs instead of consistent CTRF-style structured failure details, which weakens dashboard and audit parity with the adapter tutorial standard.
+- No token/cost telemetry was captured: all aggregate usage fields are zero or unavailable.
+- At least 21 retry rows are invalid no-reward infra/verifier measurements and must not be used as clean agent-quality evidence.
+
+## Final Per-Task Ledger
+
+| Task | Attempts | Final outcome | Reward | Class | Tools | Trajectory | Verifier artifacts | Notes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 3d-scan-calc | 1 | pass | 1.0 | pass | 11 | present | ctrf.json: 2/2 pass, 0 fail, 0 skipped | final accepted pass |
+| ada-bathroom-plan-repair | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 43 | present | ctrf.json: 0/6 pass, 6 fail, 0 skipped | agent completed; verifier rejected output |
+| adaptive-cruise-control | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 6/12 pass, 6 fail, 0 skipped | agent completed; verifier rejected output |
+| azure-bgp-oscillation-route-leak | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 5 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| bike-rebalance | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 19/20 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| citation-check | 1 | pass | 1.0 | pass | 20 | present | ctrf.json: 9/9 pass, 0 fail, 0 skipped | final accepted pass |
+| civ6-adjacency-optimizer | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 2 | present | ctrf.json: 0/10 pass, 3 fail, 7 skipped | agent completed; verifier rejected output |
+| court-form-filling | 2 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 11 | present | ctrf.json: 2/5 pass, 1 fail, 2 skipped | 2 attempts; idle timeout row still produced reward 0; diagnostics need improvement |
+| crystallographic-wyckoff-position-analysis | 1 | fail | 0.91 | valid model failure: verifier assertion/quality threshold | 9 | present | reward.txt: reward only; no CTRF | agent completed; verifier rejected output |
+| dapt-intrusion-detection | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 11/14 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| data-to-d3 | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 15 | present | ctrf.json: 12/15 pass, 3 fail, 0 skipped | required output artifact wrong or missing |
+| debug-trl-grpo | 1 | fail | 0.25 | valid model failure: verifier assertion/quality threshold | 32 | present | reward.txt: reward only; no CTRF | agent completed; verifier rejected output |
+| dialogue-parser | 1 | fail | 0.667 | valid model failure: verifier assertion/quality threshold | 19 | present | ctrf.json: 4/6 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| drone-planning-control | 1 | error |  | invalid: artifact copy/setup failure | 0 | missing | none: no verifier artifacts found | historical /app/skills upload/setup failure; rerun needed after upload fix |
+| dynamic-object-aware-egomotion | 1 | verifier_error |  | verifier contract/artifact error | 11 | present | ctrf.json: 8/10 pass, 2 fail, 0 skipped | reward artifact says 0 but verifier rc=1 made BenchFlow classify verifier_error |
+| earthquake-phase-association | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 0/1 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| earthquake-plate-calculation | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 14 | present | ctrf.json: 7/8 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| econ-detrending-correlation | 1 | pass | 1.0 | pass | 16 | present | ctrf.json: 4/4 pass, 0 fail, 0 skipped | final accepted pass |
+| edit-pdf | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 0/9 pass, 9 fail, 0 skipped | agent completed; verifier rejected output |
+| energy-ac-optimal-power-flow | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 10 | present | ctrf.json: 12/24 pass, 11 fail, 1 skipped | agent completed; verifier rejected output |
+| energy-market-pricing | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 20 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| energy-unit-commitment | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 26 | present | ctrf.json: 9/14 pass, 5 fail, 0 skipped | agent completed; verifier rejected output |
+| enterprise-information-search | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 26 | present | ctrf.json: 1/3 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| exam-block-sequencing | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 18 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| exceltable-in-ppt | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 15 | present | ctrf.json: 6/8 pass, 2 fail, 0 skipped | required output artifact wrong or missing |
+| exoplanet-detection-period | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 17 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| financial-modeling-qa | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 21 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| find-topk-similiar-chemicals | 1 | fail | 0.0 | valid model failure: reward only/no structured detail | 13 | present | reward.txt: reward only; no CTRF | reward present, structured failure details incomplete or task-specific |
+| fix-build-agentops | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 42 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| fix-build-google-auto | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 50 | present | ctrf.json: 0/3 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| fix-druid-loophole-cve | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 67 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| fix-erlang-ssh-cve | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 28 | present | ctrf.json: 0/3 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| fix-visual-stability | 3 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found | 3 attempts; historical JS ACP install pipefail row; rerun needed after fix |
+| flink-query | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 22 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| flood-risk-analysis | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 14 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| gh-repo-analytics | 3 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found | 3 attempts; historical JS ACP install pipefail row; rerun needed after fix |
+| glm-lake-mendota | 1 | fail | 0.0 | valid model failure: reward only/no structured detail | 70 | present | reward.txt: reward only; no CTRF | reward present, structured failure details incomplete or task-specific |
+| gravitational-wave-detection | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 8/9 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| grid-dispatch-operator | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 20 | present | ctrf.json: 2/6 pass, 4 fail, 0 skipped | agent completed; verifier rejected output |
+| hvac-control | 1 | fail | 0.0 | valid model failure: reward only/no structured detail | 18 | present | ctrf-report.json: 6/7 pass, 1 fail, 0 skipped | reward present, structured failure details incomplete or task-specific |
+| invoice-fraud-detection | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 19 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| jax-computing-basics | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 4/5 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| jpg-ocr-stat | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 22 | present | ctrf.json: 0/1 pass, 1 fail, 0 skipped | required output artifact wrong or missing |
+| lab-unit-harmonization | 1 | fail | 0.312 | valid model failure: verifier assertion/quality threshold | 10 | present | ctrf.json: 15/48 pass, 33 fail, 0 skipped | agent completed; verifier rejected output |
+| lake-warming-attribution | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 0/2 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| latex-formula-extraction | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 6 | present | ctrf.json: 4/7 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| lean4-proof | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 60 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| llm-prefix-cache-replay | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 7 | present | ctrf.json: 2/6 pass, 4 fail, 0 skipped | agent completed; verifier rejected output |
+| manufacturing-codebook-normalization | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 9 | present | ctrf.json: 13/16 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| manufacturing-equipment-maintenance | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 31 | present | ctrf.json: 3/7 pass, 4 fail, 0 skipped | agent completed; verifier rejected output |
+| manufacturing-fjsp-optimization | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 31 | present | ctrf.json: 13/15 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| mario-coin-counting | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 6 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| mars-clouds-clustering | 2 | pass | 1.0 | pass | 12 | present | ctrf.json: 8/8 pass, 0 fail, 0 skipped | 2 attempts; rc=255/stdout close seen in retry set; final accepted pass |
+| multilingual-video-dubbing | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 0/8 pass, 8 fail, 0 skipped | agent completed; verifier rejected output |
+| offer-letter-generator | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 6 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| organize-messy-files | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 35 | present | ctrf.json: 4/6 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| paper-anonymizer | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 16 | present | ctrf.json: 5/6 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| parallel-tfidf-search | 1 | pass | 1.0 | pass | 25 | present | ctrf.json: 5/5 pass, 0 fail, 0 skipped | final accepted pass |
+| paratransit-routing | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 4/7 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| pddl-airport-planning | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 16 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| pddl-tpp-planning | 1 | pass | 1.0 | pass | 13 | present | ctrf.json: 2/2 pass, 0 fail, 0 skipped | final accepted pass |
+| pdf-excel-diff | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 15 | present | ctrf.json: 6/11 pass, 5 fail, 0 skipped | required output artifact wrong or missing |
+| pedestrian-traffic-counting | 3 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found | 3 attempts; historical JS ACP install pipefail row; rerun needed after fix |
+| pg-essay-to-audiobook | 1 | error |  | invalid: artifact copy/setup failure | 0 | missing | none: no verifier artifacts found | historical /app/skills upload/setup failure; rerun needed after upload fix |
+| powerlifting-coef-calc | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 9/11 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| pptx-reference-formatting | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 14 | present | ctrf.json: 8/12 pass, 4 fail, 0 skipped | agent completed; verifier rejected output |
+| protein-expression-analysis | 1 | fail | 0.0 | valid model failure: reward only/no structured detail | 12 | present | reward.txt: reward only; no CTRF | reward present, structured failure details incomplete or task-specific |
+| python-scala-translation | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 9 | present | reward.txt: reward only; no CTRF | required output artifact wrong or missing |
+| quantum-numerical-simulation | 3 | error |  | invalid: ACP transport/stdout closed | 6 | present-partial | none: no verifier artifacts found | 3 attempts; rc=255/stdout close seen in retry set; verifier hit 240s timeout in retries |
+| r2r-mpc-control | 1 | fail | 0.0 | valid model failure: reward only/no structured detail | 43 | present | ctrf-report.json: 5/6 pass, 1 fail, 0 skipped | reward present, structured failure details incomplete or task-specific |
+| radar-vital-signs | 1 | pass | 1.0 | pass | 11 | present | ctrf.json: 5/5 pass, 0 fail, 0 skipped | final accepted pass |
+| react-performance-debugging | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 24 | present | reward.txt: reward only; no CTRF | agent completed; verifier rejected output |
+| reserves-at-risk-calc | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 31 | present | ctrf.json: 1/5 pass, 4 fail, 0 skipped | agent completed; verifier rejected output |
+| sales-pivot-analysis | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 13 | present | ctrf.json: 6/10 pass, 3 fail, 1 skipped | required output artifact wrong or missing |
+| sec-financial-report | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 26 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| seismic-phase-picking | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 35 | present | ctrf.json: 0/2 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| setup-fuzzing-py | 1 | fail | 0.16 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 2/2 pass, 0 fail, 0 skipped | agent completed; verifier rejected output |
+| shock-analysis-demand | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 4 | present | ctrf.json: 2/5 pass, 3 fail, 0 skipped | agent completed; verifier rejected output |
+| shock-analysis-supply | 2 | fail | 0.0 | valid model failure: missing/incorrect artifact | 11 | present | ctrf.json: 2/9 pass, 7 fail, 0 skipped | 2 attempts; idle timeout row still produced reward 0; diagnostics need improvement |
+| simpo-code-reproduction | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 69 | present | reward.txt: reward only; no CTRF | agent completed; verifier rejected output |
+| software-dependency-audit | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 10 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped | agent completed; verifier rejected output |
+| spring-boot-jakarta-migration | 1 | pass | 1.0 | pass | 101 | present | ctrf.json: 10/10 pass, 0 fail, 0 skipped | final accepted pass |
+| suricata-custom-exfil | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 38 | present | reward.txt: reward only; no CTRF | agent completed; verifier rejected output |
+| syzkaller-ppdev-syzlang | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 16 | present | ctrf.json: 1/7 pass, 6 fail, 0 skipped | agent completed; verifier rejected output |
+| taxonomy-tree-merge | 1 | fail | 0.6962 | valid model failure: verifier assertion/quality threshold | 11 | present | ctrf.json: 15/22 pass, 7 fail, 0 skipped | agent completed; verifier rejected output |
+| threejs-structure-parser | 1 | verifier_error |  | verifier contract/artifact error | 6 | present | ctrf.json: 1/3 pass, 2 fail, 0 skipped | reward artifact says 0 but verifier rc=1 made BenchFlow classify verifier_error |
+| threejs-to-obj | 1 | verifier_error |  | verifier contract/artifact error | 8 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped | reward artifact says 0 but verifier rc=1 made BenchFlow classify verifier_error |
+| tictoc-unnecessary-abort-detection | 1 | fail | 0.1 | valid model failure: verifier assertion/quality threshold | 17 | present | ctrf.json: 3/3 pass, 0 fail, 0 skipped | agent completed; verifier rejected output |
+| travel-planning | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 11 | present | ctrf.json: 9/10 pass, 1 fail, 0 skipped | agent completed; verifier rejected output |
+| video-filler-word-remover | 3 | error |  | invalid: ACP transport/stdout closed | 1 | present-partial | none: no verifier artifacts found | 3 attempts; rc=255/stdout close seen in retry set |
+| video-silence-remover | 1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 30 | present | ctrf.json: 5/9 pass, 4 fail, 0 skipped | agent completed; verifier rejected output |
+| video-tutorial-indexer | 3 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 12 | present-partial | ctrf.json: 0/2 pass, 2 fail, 0 skipped | 3 attempts; idle timeout row still produced reward 0; diagnostics need improvement |
+| weighted-gdp-calc | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 7 | present | ctrf.json: 14/27 pass, 13 fail, 0 skipped | required output artifact wrong or missing |
+| xlsx-recover-data | 1 | fail | 0.0 | valid model failure: missing/incorrect artifact | 22 | present | ctrf.json: 1/8 pass, 7 fail, 0 skipped | required output artifact wrong or missing |
+
+## Rollout Row Ledger
+
+| Task | Rollout | Outcome | Reward | Class | Tools | Trajectory | Verifier artifacts |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 3d-scan-calc | 3d-scan-calc__41391d68 | pass | 1.0 | pass | 11 | present | ctrf.json: 2/2 pass, 0 fail, 0 skipped |
+| ada-bathroom-plan-repair | ada-bathroom-plan-repair__c22b215b | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 43 | present | ctrf.json: 0/6 pass, 6 fail, 0 skipped |
+| adaptive-cruise-control | adaptive-cruise-control__246ffab4 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 6/12 pass, 6 fail, 0 skipped |
+| azure-bgp-oscillation-route-leak | azure-bgp-oscillation-route-leak__249d5823 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 5 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped |
+| bike-rebalance | bike-rebalance__5d63d4b1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 19/20 pass, 1 fail, 0 skipped |
+| citation-check | citation-check__a62a53c2 | pass | 1.0 | pass | 20 | present | ctrf.json: 9/9 pass, 0 fail, 0 skipped |
+| civ6-adjacency-optimizer | civ6-adjacency-optimizer__8346496c | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 2 | present | ctrf.json: 0/10 pass, 3 fail, 7 skipped |
+| court-form-filling | court-form-filling__4d161ed7 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 1 | present-partial | ctrf.json: 0/5 pass, 5 fail, 0 skipped |
+| court-form-filling | court-form-filling__f5fed20d | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 11 | present | ctrf.json: 2/5 pass, 1 fail, 2 skipped |
+| crystallographic-wyckoff-position-analysis | crystallographic-wyckoff-position-analysis__42671fe2 | fail | 0.91 | valid model failure: verifier assertion/quality threshold | 9 | present | reward.txt: reward only; no CTRF |
+| dapt-intrusion-detection | dapt-intrusion-detection__ed48011e | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 11/14 pass, 3 fail, 0 skipped |
+| data-to-d3 | data-to-d3__1b008b61 | fail | 0.0 | valid model failure: missing/incorrect artifact | 15 | present | ctrf.json: 12/15 pass, 3 fail, 0 skipped |
+| debug-trl-grpo | debug-trl-grpo__54fced2d | fail | 0.25 | valid model failure: verifier assertion/quality threshold | 32 | present | reward.txt: reward only; no CTRF |
+| dialogue-parser | dialogue-parser__bd2a954a | fail | 0.667 | valid model failure: verifier assertion/quality threshold | 19 | present | ctrf.json: 4/6 pass, 2 fail, 0 skipped |
+| drone-planning-control | drone-planning-control__67030ee5 | error |  | invalid: artifact copy/setup failure | 0 | missing | none: no verifier artifacts found |
+| dynamic-object-aware-egomotion | dynamic-object-aware-egomotion__c905a992 | verifier_error |  | verifier contract/artifact error | 11 | present | ctrf.json: 8/10 pass, 2 fail, 0 skipped |
+| earthquake-phase-association | earthquake-phase-association__4accf70e | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 0/1 pass, 1 fail, 0 skipped |
+| earthquake-plate-calculation | earthquake-plate-calculation__7f006690 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 14 | present | ctrf.json: 7/8 pass, 1 fail, 0 skipped |
+| econ-detrending-correlation | econ-detrending-correlation__21386bf8 | pass | 1.0 | pass | 16 | present | ctrf.json: 4/4 pass, 0 fail, 0 skipped |
+| edit-pdf | edit-pdf__7f298015 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 0/9 pass, 9 fail, 0 skipped |
+| energy-ac-optimal-power-flow | energy-ac-optimal-power-flow__7c6e0167 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 10 | present | ctrf.json: 12/24 pass, 11 fail, 1 skipped |
+| energy-market-pricing | energy-market-pricing__975ad1b3 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 20 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped |
+| energy-unit-commitment | energy-unit-commitment__f5da9b1e | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 26 | present | ctrf.json: 9/14 pass, 5 fail, 0 skipped |
+| enterprise-information-search | enterprise-information-search__ec530a1c | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 26 | present | ctrf.json: 1/3 pass, 2 fail, 0 skipped |
+| exam-block-sequencing | exam-block-sequencing__c155d345 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 18 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped |
+| exceltable-in-ppt | exceltable-in-ppt__9bfd48fd | fail | 0.0 | valid model failure: missing/incorrect artifact | 15 | present | ctrf.json: 6/8 pass, 2 fail, 0 skipped |
+| exoplanet-detection-period | exoplanet-detection-period__fea4ca91 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 17 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped |
+| financial-modeling-qa | financial-modeling-qa__0fe80c20 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 21 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped |
+| find-topk-similiar-chemicals | find-topk-similiar-chemicals__efe101d9 | fail | 0.0 | valid model failure: reward only/no structured detail | 13 | present | reward.txt: reward only; no CTRF |
+| fix-build-agentops | fix-build-agentops__668a8ca7 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 42 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped |
+| fix-build-google-auto | fix-build-google-auto__11e51550 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 50 | present | ctrf.json: 0/3 pass, 3 fail, 0 skipped |
+| fix-druid-loophole-cve | fix-druid-loophole-cve__459daafd | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 67 | present | ctrf.json: 3/4 pass, 1 fail, 0 skipped |
+| fix-erlang-ssh-cve | fix-erlang-ssh-cve__edaf079b | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 28 | present | ctrf.json: 0/3 pass, 3 fail, 0 skipped |
+| fix-visual-stability | fix-visual-stability__f44ddba9 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| fix-visual-stability | fix-visual-stability__371cbee3 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| fix-visual-stability | fix-visual-stability__da2e2eaa | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| flink-query | flink-query__10b16917 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 22 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped |
+| flood-risk-analysis | flood-risk-analysis__832bc2bf | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 14 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped |
+| gh-repo-analytics | gh-repo-analytics__7e9bee41 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| gh-repo-analytics | gh-repo-analytics__6e43ee2e | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| gh-repo-analytics | gh-repo-analytics__a40ea886 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| glm-lake-mendota | glm-lake-mendota__78fd070b | fail | 0.0 | valid model failure: reward only/no structured detail | 70 | present | reward.txt: reward only; no CTRF |
+| gravitational-wave-detection | gravitational-wave-detection__0c3773ce | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 8/9 pass, 1 fail, 0 skipped |
+| grid-dispatch-operator | grid-dispatch-operator__7b781233 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 20 | present | ctrf.json: 2/6 pass, 4 fail, 0 skipped |
+| hvac-control | hvac-control__9b5f745a | fail | 0.0 | valid model failure: reward only/no structured detail | 18 | present | ctrf-report.json: 6/7 pass, 1 fail, 0 skipped |
+| invoice-fraud-detection | invoice-fraud-detection__834dca0f | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 19 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped |
+| jax-computing-basics | jax-computing-basics__4eab7e57 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 4/5 pass, 1 fail, 0 skipped |
+| jpg-ocr-stat | jpg-ocr-stat__7e726840 | fail | 0.0 | valid model failure: missing/incorrect artifact | 22 | present | ctrf.json: 0/1 pass, 1 fail, 0 skipped |
+| lab-unit-harmonization | lab-unit-harmonization__2669d398 | fail | 0.312 | valid model failure: verifier assertion/quality threshold | 10 | present | ctrf.json: 15/48 pass, 33 fail, 0 skipped |
+| lake-warming-attribution | lake-warming-attribution__04583e77 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 13 | present | ctrf.json: 0/2 pass, 2 fail, 0 skipped |
+| latex-formula-extraction | latex-formula-extraction__9ee9a39e | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 6 | present | ctrf.json: 4/7 pass, 3 fail, 0 skipped |
+| lean4-proof | lean4-proof__187bc290 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 60 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped |
+| llm-prefix-cache-replay | llm-prefix-cache-replay__9fc3c18a | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 7 | present | ctrf.json: 2/6 pass, 4 fail, 0 skipped |
+| manufacturing-codebook-normalization | manufacturing-codebook-normalization__de94e7b5 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 9 | present | ctrf.json: 13/16 pass, 3 fail, 0 skipped |
+| manufacturing-equipment-maintenance | manufacturing-equipment-maintenance__e38cbcd2 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 31 | present | ctrf.json: 3/7 pass, 4 fail, 0 skipped |
+| manufacturing-fjsp-optimization | manufacturing-fjsp-optimization__2823d4a1 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 31 | present | ctrf.json: 13/15 pass, 2 fail, 0 skipped |
+| mario-coin-counting | mario-coin-counting__0c5dea26 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 6 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped |
+| mars-clouds-clustering | mars-clouds-clustering__387d89ca | error |  | invalid: ACP transport/stdout closed | 13 | present-partial | none: no verifier artifacts found |
+| mars-clouds-clustering | mars-clouds-clustering__0d36d57e | pass | 1.0 | pass | 12 | present | ctrf.json: 8/8 pass, 0 fail, 0 skipped |
+| multilingual-video-dubbing | multilingual-video-dubbing__41a28b1a | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 0/8 pass, 8 fail, 0 skipped |
+| offer-letter-generator | offer-letter-generator__1a728e32 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 6 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped |
+| organize-messy-files | organize-messy-files__f21683ae | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 35 | present | ctrf.json: 4/6 pass, 2 fail, 0 skipped |
+| paper-anonymizer | paper-anonymizer__55dae684 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 16 | present | ctrf.json: 5/6 pass, 1 fail, 0 skipped |
+| parallel-tfidf-search | parallel-tfidf-search__67cba0d7 | pass | 1.0 | pass | 25 | present | ctrf.json: 5/5 pass, 0 fail, 0 skipped |
+| paratransit-routing | paratransit-routing__7018fe1d | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 4/7 pass, 3 fail, 0 skipped |
+| pddl-airport-planning | pddl-airport-planning__3e023f0f | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 16 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped |
+| pddl-tpp-planning | pddl-tpp-planning__785326e4 | pass | 1.0 | pass | 13 | present | ctrf.json: 2/2 pass, 0 fail, 0 skipped |
+| pdf-excel-diff | pdf-excel-diff__c9cac2fd | fail | 0.0 | valid model failure: missing/incorrect artifact | 15 | present | ctrf.json: 6/11 pass, 5 fail, 0 skipped |
+| pedestrian-traffic-counting | pedestrian-traffic-counting__87121f5c | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| pedestrian-traffic-counting | pedestrian-traffic-counting__04c45e9c | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| pedestrian-traffic-counting | pedestrian-traffic-counting__4daa7b37 | error |  | invalid: agent install failure | 0 | missing | none: no verifier artifacts found |
+| pg-essay-to-audiobook | pg-essay-to-audiobook__fe4537cc | error |  | invalid: artifact copy/setup failure | 0 | missing | none: no verifier artifacts found |
+| powerlifting-coef-calc | powerlifting-coef-calc__127d6e7e | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 8 | present | ctrf.json: 9/11 pass, 2 fail, 0 skipped |
+| pptx-reference-formatting | pptx-reference-formatting__037ea65a | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 14 | present | ctrf.json: 8/12 pass, 4 fail, 0 skipped |
+| protein-expression-analysis | protein-expression-analysis__8e93c6da | fail | 0.0 | valid model failure: reward only/no structured detail | 12 | present | reward.txt: reward only; no CTRF |
+| python-scala-translation | python-scala-translation__5c9bcd0f | fail | 0.0 | valid model failure: missing/incorrect artifact | 9 | present | reward.txt: reward only; no CTRF |
+| quantum-numerical-simulation | quantum-numerical-simulation__3031c9cf | verifier_error |  | invalid: verifier timeout | 11 | present | none: no verifier artifacts found |
+| quantum-numerical-simulation | quantum-numerical-simulation__a43c7238 | verifier_error |  | invalid: verifier timeout | 10 | present | none: no verifier artifacts found |
+| quantum-numerical-simulation | quantum-numerical-simulation__32f8a92b | error |  | invalid: ACP transport/stdout closed | 6 | present-partial | none: no verifier artifacts found |
+| r2r-mpc-control | r2r-mpc-control__788d8a67 | fail | 0.0 | valid model failure: reward only/no structured detail | 43 | present | ctrf-report.json: 5/6 pass, 1 fail, 0 skipped |
+| radar-vital-signs | radar-vital-signs__45b21344 | pass | 1.0 | pass | 11 | present | ctrf.json: 5/5 pass, 0 fail, 0 skipped |
+| react-performance-debugging | react-performance-debugging__50a6157a | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 24 | present | reward.txt: reward only; no CTRF |
+| reserves-at-risk-calc | reserves-at-risk-calc__afacb5a0 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 31 | present | ctrf.json: 1/5 pass, 4 fail, 0 skipped |
+| sales-pivot-analysis | sales-pivot-analysis__3695b886 | fail | 0.0 | valid model failure: missing/incorrect artifact | 13 | present | ctrf.json: 6/10 pass, 3 fail, 1 skipped |
+| sec-financial-report | sec-financial-report__c6f115db | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 26 | present | ctrf.json: 1/2 pass, 1 fail, 0 skipped |
+| seismic-phase-picking | seismic-phase-picking__a1615427 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 35 | present | ctrf.json: 0/2 pass, 2 fail, 0 skipped |
+| setup-fuzzing-py | setup-fuzzing-py__092b7ff9 | fail | 0.16 | valid model failure: verifier assertion/quality threshold | 15 | present | ctrf.json: 2/2 pass, 0 fail, 0 skipped |
+| shock-analysis-demand | shock-analysis-demand__40298df2 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 4 | present | ctrf.json: 2/5 pass, 3 fail, 0 skipped |
+| shock-analysis-supply | shock-analysis-supply__d95da6be | fail | 0.0 | valid model failure: missing/incorrect artifact | 21 | present-partial | ctrf.json: 1/9 pass, 8 fail, 0 skipped |
+| shock-analysis-supply | shock-analysis-supply__78b391ae | fail | 0.0 | valid model failure: missing/incorrect artifact | 11 | present | ctrf.json: 2/9 pass, 7 fail, 0 skipped |
+| simpo-code-reproduction | simpo-code-reproduction__82e67221 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 69 | present | reward.txt: reward only; no CTRF |
+| software-dependency-audit | software-dependency-audit__4100e80d | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 10 | present | ctrf.json: 2/4 pass, 2 fail, 0 skipped |
+| spring-boot-jakarta-migration | spring-boot-jakarta-migration__2382b67d | pass | 1.0 | pass | 101 | present | ctrf.json: 10/10 pass, 0 fail, 0 skipped |
+| suricata-custom-exfil | suricata-custom-exfil__dbff8ae8 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 38 | present | reward.txt: reward only; no CTRF |
+| syzkaller-ppdev-syzlang | syzkaller-ppdev-syzlang__241dfb9c | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 16 | present | ctrf.json: 1/7 pass, 6 fail, 0 skipped |
+| taxonomy-tree-merge | taxonomy-tree-merge__de2f6499 | fail | 0.6962 | valid model failure: verifier assertion/quality threshold | 11 | present | ctrf.json: 15/22 pass, 7 fail, 0 skipped |
+| threejs-structure-parser | threejs-structure-parser__94aa9b66 | verifier_error |  | verifier contract/artifact error | 6 | present | ctrf.json: 1/3 pass, 2 fail, 0 skipped |
+| threejs-to-obj | threejs-to-obj__fd7de03b | verifier_error |  | verifier contract/artifact error | 8 | present | ctrf.json: 2/3 pass, 1 fail, 0 skipped |
+| tictoc-unnecessary-abort-detection | tictoc-unnecessary-abort-detection__e53a4d34 | fail | 0.1 | valid model failure: verifier assertion/quality threshold | 17 | present | ctrf.json: 3/3 pass, 0 fail, 0 skipped |
+| travel-planning | travel-planning__ba35e17e | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 11 | present | ctrf.json: 9/10 pass, 1 fail, 0 skipped |
+| video-filler-word-remover | video-filler-word-remover__4b9e74b6 | error |  | invalid: ACP transport/stdout closed | 8 | present-partial | none: no verifier artifacts found |
+| video-filler-word-remover | video-filler-word-remover__bc926eda | error |  | invalid: ACP transport/stdout closed | 13 | present-partial | none: no verifier artifacts found |
+| video-filler-word-remover | video-filler-word-remover__4f64d2f0 | error |  | invalid: ACP transport/stdout closed | 1 | present-partial | none: no verifier artifacts found |
+| video-silence-remover | video-silence-remover__008c6bef | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 30 | present | ctrf.json: 5/9 pass, 4 fail, 0 skipped |
+| video-tutorial-indexer | video-tutorial-indexer__7fe67e9d | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 10 | present-partial | ctrf.json: 0/2 pass, 2 fail, 0 skipped |
+| video-tutorial-indexer | video-tutorial-indexer__fb0bedbb | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 4 | present-partial | ctrf.json: 0/2 pass, 2 fail, 0 skipped |
+| video-tutorial-indexer | video-tutorial-indexer__f1b368f8 | fail | 0.0 | valid model failure: verifier assertion/quality threshold | 12 | present-partial | ctrf.json: 0/2 pass, 2 fail, 0 skipped |
+| weighted-gdp-calc | weighted-gdp-calc__be41ce68 | fail | 0.0 | valid model failure: missing/incorrect artifact | 7 | present | ctrf.json: 14/27 pass, 13 fail, 0 skipped |
+| xlsx-recover-data | xlsx-recover-data__597fd77d | fail | 0.0 | valid model failure: missing/incorrect artifact | 22 | present | ctrf.json: 1/8 pass, 7 fail, 0 skipped |

--- a/docs/reports/2026-05-23-v05-integration-handoff.md
+++ b/docs/reports/2026-05-23-v05-integration-handoff.md
@@ -1,0 +1,391 @@
+# BenchFlow v0.5 Integration Handoff
+
+Generated: 2026-05-23
+
+This handoff is for the `codex/v05-integration-merge-main` branch targeting
+`v0.5-integration`.
+
+## Current State
+
+- Branch head before this handoff doc: `e70d724`
+- Base branch for PR: `origin/v0.5-integration`
+- Latest production dashboard after Linear grooming:
+  `https://dashboard-benchflow.vercel.app`
+- Latest deploy verified:
+  `https://dashboard-1an74s6pw-benchflow.vercel.app`
+- Dashboard data after grooming: 50 Linear issues, 15 active issues, 158
+  visible rollout rows, 77 archived jobs, 5 archived runs.
+- Do not use Docker unless the goal is specifically testing Docker. Use
+  Daytona for all cloud validation and large experiments.
+
+## What This Branch Adds
+
+The branch contains five integration commits over `v0.5-integration`:
+
+1. Fix Daytona live env transport secret handling.
+2. Fix Daytona PTY env transport secret handling.
+3. Fix Daytona verifier and upload setup.
+4. Fix dashboard evidence visibility and ACP self-gen handoff.
+5. Document SkillsBench rollout audits.
+
+Important code areas:
+
+- `src/benchflow/sandbox/process.py`
+- `src/benchflow/sandbox/daytona.py`
+- `src/benchflow/sandbox/_compose.py`
+- `src/benchflow/sandbox/lockdown.py`
+- `src/benchflow/task/verifier.py`
+- `src/benchflow/rollout.py`
+- `src/benchflow/self_gen.py`
+- `dashboard/generate.py`
+- `dashboard/serve.py`
+- `dashboard/index.html`
+
+Important durable reports:
+
+- `docs/reports/2026-05-23-skillsbench-full94-baseline-audit.md`
+- `docs/reports/2026-05-23-skillsbench-3mode-subset-audit.md`
+
+## Handoff Verdict
+
+BenchFlow v0.5 is substantially closer, but not release-ready as a benchmark
+product. SDK/orchestration plumbing is real, dashboard data is live, and the
+full SkillsBench baseline did execute current SkillsBench `main`. The remaining
+release blockers are evidence quality, self-gen post-fix validation, failure
+semantics, and full three-mode coverage.
+
+Do not call the full 94-task baseline a clean release validation set. It is a
+useful evidence run with several invalid/no-reward infra measurements and
+verifier-contract failures that must be repaired or explicitly excluded.
+
+## Linear Grooming State
+
+All `ENG-148` through `ENG-161` have triage comments with source and trajectory
+evidence.
+
+Parent/state changes already applied:
+
+| Issue | State | Parent | Status |
+|---|---|---|---|
+| `ENG-148` | Todo | `ENG-130` | Confirmed ACP transport rc=255 invalid measurement |
+| `ENG-149` | Todo | `ENG-130` | Confirmed idle-timeout diagnostic/scoring gap |
+| `ENG-150` | Todo | `ENG-130` | Confirmed verifier contract/classification bug |
+| `ENG-151` | Todo | `ENG-130` | Confirmed verifier dependency/index failure |
+| `ENG-152` | Todo | `ENG-130` | Confirmed quantum verifier timeout/heavy-task gap |
+| `ENG-153` | Todo | `ENG-127` | Confirmed structured artifact contract gap |
+| `ENG-154` | Todo | `ENG-98` | Partially done; needs clean post-fix reruns |
+| `ENG-155` | Todo | `ENG-126` | Not done; self-gen run predates fix |
+| `ENG-156` | Todo | `ENG-98` | Not done; full 94 x 3 modes missing |
+| `ENG-157` | Todo | none | Not done; stale dashboard advisory still open |
+| `ENG-158` | Todo | none | Not done; file:// fetch UX still poor |
+| `ENG-159` | Todo | `ENG-131` | Not done; CLI lacks first-class `--include` |
+| `ENG-160` | Todo | `ENG-127` | Not done; resume/job_name orphan risk remains |
+| `ENG-161` | In Review | `ENG-155` | Done as audit work; close after human acceptance |
+
+## Previous Run Audit Summary
+
+### Full 94-Task SkillsBench Baseline
+
+Run root:
+
+```text
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64
+```
+
+Summary:
+
+- Source: `benchflow-ai/skillsbench@main`
+- Resolved SHA: `20149520474cfc8d7eb3c8000ec403d10145a9fd`
+- Current `main` verified at the same SHA during audit.
+- Agent/model/env: `gemini` / `gemini-3.1-flash-lite-preview` / `daytona`
+- Concurrency: 64
+- Summary total: 94 tasks
+- Rollout rows including retries: 109
+- Final outcomes: 8 pass / 76 fail / 7 error / 3 verifier_error
+- Retry-row outcomes: 8 pass / 80 fail / 16 error / 5 verifier_error
+
+Passing tasks:
+
+- `3d-scan-calc`
+- `citation-check`
+- `econ-detrending-correlation`
+- `mars-clouds-clustering`
+- `parallel-tfidf-search`
+- `pddl-tpp-planning`
+- `radar-vital-signs`
+- `spring-boot-jakarta-migration`
+
+Invalid or release-blocking measurement classes:
+
+- Agent install failed: `fix-visual-stability`, `gh-repo-analytics`,
+  `pedestrian-traffic-counting`
+- Artifact copy/setup failed: `drone-planning-control`,
+  `pg-essay-to-audiobook`
+- ACP transport/stdout closed: `mars-clouds-clustering`,
+  `quantum-numerical-simulation`, `video-filler-word-remover`
+- Verifier timeout: `quantum-numerical-simulation`
+- Verifier contract/refusal after reward zero: `dynamic-object-aware-egomotion`,
+  `threejs-structure-parser`, `threejs-to-obj`
+- Idle timeout diagnostics gap: `court-form-filling`,
+  `shock-analysis-supply`, `video-tutorial-indexer`
+
+Durable audit:
+
+```text
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/docs/reports/2026-05-23-skillsbench-full94-baseline-audit.md
+```
+
+### 9-Task Three-Mode SkillsBench Subset
+
+Run root:
+
+```text
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset
+```
+
+Modes:
+
+- `baseline`: 0/9 pass, 8 fail, 1 verifier_error
+- `with-task-skills`: 1/9 pass, 6 fail, 1 error, 1 verifier_error
+- `self-gen`: 0/9 pass, 8 fail, 1 verifier_error
+
+Only pass in the 27-row subset:
+
+- `lake-warming-attribution` in `with-task-skills` mode
+
+Critical caveat:
+
+The self-gen run started before commit `4946481`, so it does not validate the
+current ACP-native generated-skill handoff. It found that only
+`creator-skills/skill-creator` was persisted under `_self_gen`; no generated
+solver skill `SKILL.md` was persisted outside creator scaffolding.
+
+Durable audit:
+
+```text
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/docs/reports/2026-05-23-skillsbench-3mode-subset-audit.md
+```
+
+## Actual Trajectory Paths
+
+### 9-Task Three-Mode Subset
+
+All 27 task-mode rows have ACP trajectory files:
+
+```text
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/data-to-d3__534b3e2e/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/grid-dispatch-operator__10b5966a/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/jax-computing-basics__f523cdb4/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/jpg-ocr-stat__97d1d558/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/lake-warming-attribution__daffb946/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/python-scala-translation__ac3cca33/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/shock-analysis-supply__de031190/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/threejs-to-obj__1d751567/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/baseline/2026-05-23__00-31-36/weighted-gdp-calc__5be9271b/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/data-to-d3__f4fd1d1c/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/grid-dispatch-operator__76c38257/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/jax-computing-basics__8c52e991/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/jpg-ocr-stat__6b929da7/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/lake-warming-attribution__128f6494/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/python-scala-translation__c3ff7696/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/shock-analysis-supply__57c6e480/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/threejs-to-obj__b68a7407/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/with-task-skills/2026-05-23__00-37-02/weighted-gdp-calc__879537c2/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/data-to-d3__b846c3e8/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/grid-dispatch-operator__8bb95f14/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/jax-computing-basics__2b9a9b0a/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/jpg-ocr-stat__310a5a20/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/lake-warming-attribution__39207e39/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/python-scala-translation__d766a9ce/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/shock-analysis-supply__d7e84e66/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/threejs-to-obj__f84eb30a/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260523-003051-skillsbench-3modes-gemini31-flash-lite-daytona-release-subset/self-gen/2026-05-23__00-44-33/weighted-gdp-calc__971d72ce/trajectory/acp_trajectory.jsonl
+```
+
+### Full-Run P0/P1 Trajectory Examples
+
+The full 94-task audit report contains the complete rollout ledger. The most
+important repair targets are:
+
+```text
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/video-filler-word-remover__4b9e74b6/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/quantum-numerical-simulation__3031c9cf/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/quantum-numerical-simulation__a43c7238/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/dynamic-object-aware-egomotion__c905a992/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/threejs-structure-parser__94aa9b66/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/threejs-to-obj__fd7de03b/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/simpo-code-reproduction__82e67221/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/court-form-filling__4d161ed7/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/shock-analysis-supply__d95da6be/trajectory/acp_trajectory.jsonl
+/Users/lixiangyi/.codex/worktrees/v05-integration-merge-20260522114632/jobs/e2e/20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64/2026-05-22__16-54-22/video-tutorial-indexer__7fe67e9d/trajectory/acp_trajectory.jsonl
+```
+
+## How To Fix All Previous-Run Issues
+
+Work in small vertical slices. For each concrete fix, follow the operating
+rule from the goal: one fix subagent using TDD, then four audit/test/verify
+subagents. Keep commits scoped.
+
+### P0: Invalid Measurements
+
+1. `ENG-148` ACP rc=255:
+   - Add structured result metadata for process source: agent process,
+     Daytona shell/SSH/session, ACP protocol, or sandbox lifecycle.
+   - Capture last sandbox health probe and process exit evidence in
+     `result.json`.
+   - Rerun `video-filler-word-remover` on Daytona.
+
+2. `ENG-149` idle timeouts:
+   - Keep watchdog counters, but surface idle timeout as a structured
+     invalid-measurement class when partial trajectory or timeout error is
+     present.
+   - Dashboard should badge `error + reward` rows as diagnostic/invalid when
+     the agent did not complete cleanly.
+   - Rerun `court-form-filling`, `shock-analysis-supply`,
+     `video-tutorial-indexer`, and self-gen `grid-dispatch-operator`.
+
+3. `ENG-150` verifier rc=1 after reward zero:
+   - Do not globally accept reward files from failed verifiers without a
+     contract decision.
+   - Preferred fix: SkillsBench verifiers that intentionally score reward 0
+     should exit 0 after writing `reward.txt` and CTRF.
+   - Rerun `dynamic-object-aware-egomotion`, `threejs-structure-parser`, and
+     `threejs-to-obj`.
+
+4. `ENG-151` `simpo-code-reproduction` dependency/index:
+   - Fix the SkillsBench verifier dependency declaration or uv index policy for
+     `torch==2.1.2+cpu`.
+   - If dependency setup fails, classify it as structured setup failure rather
+     than ordinary reward zero.
+   - Rerun only `simpo-code-reproduction` first.
+
+5. `ENG-152` quantum verifier timeout:
+   - Profile verifier runtime.
+   - Either reduce verifier runtime, raise timeout only for this heavy task, or
+     mark it outside the release-gated subset.
+   - Rerun `quantum-numerical-simulation`.
+
+6. `ENG-153` structured verifier artifacts:
+   - Define canonical artifact names: `reward.txt`, `ctrf.json`, verifier
+     stdout/stderr, and optional task-specific attachments.
+   - Treat `ctrf-report.json` as an alias only during migration.
+   - Make `check_results.py` report missing structured evidence by task, not
+     just by rollout schema.
+
+### P1: Evidence And DX Gaps
+
+1. `ENG-154` invalidated SkillsBench rows:
+   - The branch has fixes for JS ACP install and Daytona upload setup.
+   - Acceptance still needs clean rerun evidence for every invalidated task.
+
+2. `ENG-155` post-fix self-gen:
+   - Rerun the 9-task self-gen subset after `4946481`.
+   - Audit that generated solver skills are persisted and activated.
+
+3. `ENG-156` full 94 x 3:
+   - Run all 94 SkillsBench tasks in baseline, with-task-skills, and self-gen
+     modes with Gemini 3.1 Flash Lite on Daytona.
+   - Use staged concurrency: 16 to shake out infra, 64 for release validation,
+     then 100 only for large validation.
+
+4. `ENG-157` stale dashboard advisory:
+   - Resolve, archive, or update `OPEN-2` in `dashboard/generate.py`.
+   - Regenerate and redeploy dashboard.
+
+5. `ENG-158` file:// fetch UX:
+   - Update `dashboard/index.html` error recovery text to direct users to
+     `uv run python dashboard/serve.py` and `http://localhost:8777/`.
+
+6. `ENG-159` CLI include:
+   - Add `bench eval create --include` and wire it to existing
+     `Evaluation.from_yaml` `include_tasks` behavior.
+   - Cover with CLI tests and one real subset dry run.
+
+7. `ENG-160` resume/job_name:
+   - Scope resume scanning to the exact job root/name.
+   - Do not recursively include sibling/orphan `result.json` files.
+   - Add regression tests using orphan retry dirs.
+
+## How To Complete The Vision Fast
+
+### Fast Sequence
+
+1. Land this PR into `v0.5-integration`.
+2. Immediately fix P0 invalid-measurement semantics:
+   `ENG-148`, `ENG-149`, `ENG-150`, `ENG-153`.
+3. Rerun the invalidated task set only, using Daytona:
+   install-failed tasks, upload-failed tasks, verifier-contract tasks,
+   timeout tasks.
+4. Rerun 9-task self-gen on the fixed branch and audit all generated skills:
+   this closes or unblocks `ENG-155`.
+5. Run the full SkillsBench 94 x 3 modes with Gemini 3.1 Flash Lite:
+   this is the real `ENG-156` gate.
+6. Run the adapter and architecture lanes in parallel:
+   trace-to-task, Harvey LAB, ProgramBench, Terminal-Bench-style smoke,
+   hosted env compatibility, sandbox/agent decoupling.
+7. Regenerate dashboard, redeploy production, and close only issues with
+   audited evidence.
+
+### Release Evidence Standard
+
+Every release-gating run should have:
+
+- `summary.json`
+- one `result.json` per rollout
+- nonempty `trajectory/acp_trajectory.jsonl`
+- `reward.txt`
+- structured verifier report (`ctrf.json` preferred)
+- verifier stdout/stderr artifacts
+- source repo and resolved SHA
+- model, sandbox, concurrency, timeout, and retry policy in the summary
+- dashboard visibility after generation
+- one durable audit report under `docs/reports/`
+
+### Concurrency Plan
+
+- Use concurrency 8 to 16 for diagnosis and post-fix shakedown.
+- Use concurrency 64 for release validation.
+- Use concurrency 100 only after no invalid-measurement classes remain.
+
+### What Not To Do
+
+- Do not count pre-`4946481` self-gen evidence as validation of current
+  ACP-native generated-skill handoff.
+- Do not mark reward-zero verifier crashes as solved until the verifier
+  contract is explicit.
+- Do not use Docker except for Docker-specific sandbox tests.
+- Do not close Linear release blockers based only on passing unit tests.
+- Do not ship v0.5 as "validated" until full 94 x 3 and adapter release lanes
+  have audited evidence.
+
+## Useful Commands
+
+```bash
+set -a; source .env; set +a
+uv run python tests/integration/check_results.py <jobs-root>
+uv run python tests/integration/check_adapter_evidence.py <jobs-root>
+uv run python tests/integration/check_trace_to_task_evidence.py <jobs-root>
+uv run ruff check .
+uv run ty check src
+PYTHONDONTWRITEBYTECODE=1 uv run python -m pytest -p no:cacheprovider tests -q
+uv run python dashboard/generate.py
+```
+
+## Dashboard And Linear
+
+Latest dashboard deployment after grooming:
+
+```text
+https://dashboard-1an74s6pw-benchflow.vercel.app
+https://dashboard-benchflow.vercel.app
+```
+
+The dashboard was verified to show:
+
+- `ENG-148` through `ENG-161`
+- `ENG-161` in `In Review`
+- `ENG-148` parented to `ENG-130`
+- `ENG-161` parented to `ENG-155`
+- 50 total Linear issues
+- 158 visible rollout rows
+- 77 archived jobs

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -91,7 +91,6 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
 _NODE_INSTALL = (
-    "set -o pipefail; "
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
     "BF_NODE_VERSION=22.14.0; "

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -670,11 +670,11 @@ async def _verify_rollout(
     from benchflow.task import Verifier
 
     rollout_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
-    await harden_before_verify(env, task, sandbox_user, workspace=workspace)
-    logger.info("Running verifier...")
     t0 = datetime.now()
     verifier_error = None
     try:
+        await harden_before_verify(env, task, sandbox_user, workspace=workspace)
+        logger.info("Running verifier...")
         verifier = Verifier(task=task, rollout_paths=rollout_paths, sandbox=env)
         verifier_result = await asyncio.wait_for(
             verifier.verify(),
@@ -1406,7 +1406,10 @@ class Rollout:
         verify() still does full hardening.
         """
         from benchflow.sandbox.lockdown import (
+            _CLEAR_VERIFIER_DIR_CMD,
+            _ENSURE_APP_DIR_CMD,
             _build_cleanup_cmd,
+            _checked_exec,
             _read_hardening_config,
         )
         from benchflow.task import Verifier
@@ -1415,17 +1418,36 @@ class Rollout:
         # Clean verifier output dir — chmod 777 so non-root verifier processes can write.
         # Keep /app present for task/verifier paths that still use the legacy
         # rootdir fallback; tasks that populate /app are unaffected.
-        await self._env.exec(
-            "rm -rf /logs/verifier && mkdir -p /logs/verifier /app && "
-            "chmod 777 /logs/verifier",
-            user="root",
-            timeout_sec=10,
-        )
-        # Purge agent-injected conftest/sitecustomize/.pth without
-        # killing processes or restoring workspace.
-        # Honor per-task [verifier.hardening] opt-outs from task.toml.
-        hardening = _read_hardening_config(getattr(self._task, "task_dir", None))
-        await self._env.exec(_build_cleanup_cmd(hardening), user="root", timeout_sec=10)
+        try:
+            await _checked_exec(
+                self._env,
+                _CLEAR_VERIFIER_DIR_CMD,
+                "Soft verifier setup failed: clearing verifier output directory",
+                user="root",
+                timeout_sec=10,
+            )
+            await _checked_exec(
+                self._env,
+                _ENSURE_APP_DIR_CMD,
+                "Soft verifier setup failed: preparing /app",
+                user="root",
+                timeout_sec=10,
+            )
+            # Purge agent-injected conftest/sitecustomize/.pth without
+            # killing processes or restoring workspace.
+            # Honor per-task [verifier.hardening] opt-outs from task.toml.
+            hardening = _read_hardening_config(getattr(self._task, "task_dir", None))
+            await _checked_exec(
+                self._env,
+                _build_cleanup_cmd(hardening),
+                "Soft verifier setup failed: purging Python injection hooks",
+                user="root",
+                timeout_sec=10,
+            )
+        except Exception as e:
+            verifier_error = f"soft verifier crashed: {e}"
+            logger.error(verifier_error)
+            return None, None, verifier_error
 
         rewards = None
         verifier_output = None
@@ -1454,11 +1476,10 @@ class Rollout:
                 f"soft verifier timed out after "
                 f"{self._task.config.verifier.timeout_sec}s"
             )
-            logger.warning(verifier_error)
+            logger.error(verifier_error)
         except Exception as e:
             verifier_error = f"soft verifier crashed: {e}"
-            logger.warning(verifier_error)
-
+            logger.error(verifier_error)
         return rewards, verifier_output, verifier_error
 
     # ── Phase 5: CLEANUP ──

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1406,11 +1406,9 @@ class Rollout:
         verify() still does full hardening.
         """
         from benchflow.sandbox.lockdown import (
-            _CLEAR_VERIFIER_DIR_CMD,
-            _ENSURE_APP_DIR_CMD,
-            _build_cleanup_cmd,
-            _checked_exec,
-            _read_hardening_config,
+            cleanup_verifier_python_hooks,
+            clear_verifier_output_dir,
+            ensure_legacy_app_dir,
         )
         from benchflow.task import Verifier
 
@@ -1419,16 +1417,14 @@ class Rollout:
         # Keep /app present for task/verifier paths that still use the legacy
         # rootdir fallback; tasks that populate /app are unaffected.
         try:
-            await _checked_exec(
+            await clear_verifier_output_dir(
                 self._env,
-                _CLEAR_VERIFIER_DIR_CMD,
                 "Soft verifier setup failed: clearing verifier output directory",
                 user="root",
                 timeout_sec=10,
             )
-            await _checked_exec(
+            await ensure_legacy_app_dir(
                 self._env,
-                _ENSURE_APP_DIR_CMD,
                 "Soft verifier setup failed: preparing /app",
                 user="root",
                 timeout_sec=10,
@@ -1436,10 +1432,9 @@ class Rollout:
             # Purge agent-injected conftest/sitecustomize/.pth without
             # killing processes or restoring workspace.
             # Honor per-task [verifier.hardening] opt-outs from task.toml.
-            hardening = _read_hardening_config(getattr(self._task, "task_dir", None))
-            await _checked_exec(
+            await cleanup_verifier_python_hooks(
                 self._env,
-                _build_cleanup_cmd(hardening),
+                getattr(self._task, "task_dir", None),
                 "Soft verifier setup failed: purging Python injection hooks",
                 user="root",
                 timeout_sec=10,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1650,14 +1650,19 @@ class Rollout:
         if self._env is None:
             raise RuntimeError("Environment is not started")
 
-        source = str(scene.skills_dir)
+        source_value = scene.skills_dir
+        source = str(source_value)
         local_source = Path(source).expanduser()
-        if local_source.is_dir():
+        if isinstance(source_value, os.PathLike) and local_source.is_dir():
             remote_source = f"/skills/{_safe_skill_name(scene.name)}"
             await _ensure_sandbox_dir(self._env, Path(remote_source).parent)
             await self._env.upload_dir(local_source, remote_source)
         elif source.startswith("/"):
             remote_source = source
+        elif local_source.is_dir():
+            remote_source = f"/skills/{_safe_skill_name(scene.name)}"
+            await _ensure_sandbox_dir(self._env, Path(remote_source).parent)
+            await self._env.upload_dir(local_source, remote_source)
         else:
             raise FileNotFoundError(f"Scene skills_dir not found: {scene.skills_dir}")
 

--- a/src/benchflow/sandbox/_compose.py
+++ b/src/benchflow/sandbox/_compose.py
@@ -1,9 +1,28 @@
-"""Compose file paths for Docker and Daytona DinD backends."""
+"""Compose helpers for Docker and Daytona DinD backends."""
 
-from pathlib import Path
+import shlex
+from pathlib import Path, PurePosixPath
 
 COMPOSE_DIR = Path(__file__).parent / "_compose_files"
 COMPOSE_BASE_PATH = COMPOSE_DIR / "docker-compose-base.yaml"
 COMPOSE_BUILD_PATH = COMPOSE_DIR / "docker-compose-build.yaml"
 COMPOSE_PREBUILT_PATH = COMPOSE_DIR / "docker-compose-prebuilt.yaml"
 COMPOSE_NO_NETWORK_PATH = COMPOSE_DIR / "docker-compose-no-network.yaml"
+
+
+def compose_cp_destination(service: str, container_path: str) -> str:
+    """Return the service-qualified destination used by compose cp."""
+    return f"{service}:{container_path}"
+
+
+def compose_mkdir_p_command(container_path: str) -> str:
+    """Return a POSIX shell command that creates a container path."""
+    return f"mkdir -p {shlex.quote(container_path)}"
+
+
+def compose_parent_mkdir_p_command(container_path: str) -> str | None:
+    """Return a mkdir command for a container path parent, if it has one."""
+    parent = str(PurePosixPath(container_path).parent)
+    if parent in {"", "."}:
+        return None
+    return compose_mkdir_p_command(parent)

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -29,6 +29,9 @@ from benchflow.sandbox._compose import (
     COMPOSE_BUILD_PATH,
     COMPOSE_NO_NETWORK_PATH,
     COMPOSE_PREBUILT_PATH,
+    compose_cp_destination,
+    compose_mkdir_p_command,
+    compose_parent_mkdir_p_command,
 )
 from benchflow.task.config import SandboxConfig
 from benchflow.task.env import resolve_env_vars
@@ -76,6 +79,15 @@ logger = logging.getLogger("benchflow")
 
 _SandboxParams = CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams
 _DAYTONA_COMMAND_POLL_INTERVAL_SEC = 1.0
+
+
+def _exec_failure_output(result: ExecResult) -> str:
+    output = " ".join(
+        text.strip()
+        for text in (result.stdout or "", result.stderr or "")
+        if text and text.strip()
+    )
+    return output[:4000]
 
 
 def _daytona_preflight() -> None:
@@ -661,8 +673,22 @@ class _DaytonaDinD(_DaytonaStrategy):
         temp = f"/tmp/benchflow_{uuid4().hex}"
         try:
             await self._env._sdk_upload_file(source_path, temp)
+            target_parent_cmd = compose_parent_mkdir_p_command(target_path)
+            if target_parent_cmd is not None:
+                prep_result = await self.exec(
+                    target_parent_cmd,
+                    timeout_sec=30,
+                    user="root",
+                    service="main",
+                )
+                if prep_result.return_code != 0:
+                    raise RuntimeError(
+                        "docker compose upload_file destination prep failed: "
+                        f"{_exec_failure_output(prep_result)}"
+                    )
             result = await self._compose_exec(
-                ["cp", temp, f"main:{target_path}"], timeout_sec=60
+                ["cp", temp, compose_cp_destination("main", target_path)],
+                timeout_sec=60,
             )
             if result.return_code != 0:
                 raise RuntimeError(
@@ -682,8 +708,20 @@ class _DaytonaDinD(_DaytonaStrategy):
         temp = f"/tmp/benchflow_{uuid4().hex}"
         try:
             await self._env._sdk_upload_dir(source_dir, temp)
+            prep_result = await self.exec(
+                compose_mkdir_p_command(target_dir),
+                timeout_sec=30,
+                user="root",
+                service=service,
+            )
+            if prep_result.return_code != 0:
+                raise RuntimeError(
+                    "docker compose upload_dir destination prep failed: "
+                    f"{_exec_failure_output(prep_result)}"
+                )
             result = await self._compose_exec(
-                ["cp", f"{temp}/.", f"{service}:{target_dir}"], timeout_sec=120
+                ["cp", f"{temp}/.", compose_cp_destination(service, target_dir)],
+                timeout_sec=120,
             )
             if result.return_code != 0:
                 raise RuntimeError(

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -332,6 +332,16 @@ class _DaytonaDirect(_DaytonaStrategy):
                 f"and cannot target service {service!r}. Multi-container "
                 "(vulhub-style) tasks require a docker-compose.yaml (#248)."
             )
+        prep_result = await self._env._sandbox_exec(
+            f"mkdir -p {shlex.quote(target_dir)}",
+            timeout_sec=30,
+            user="root",
+        )
+        if prep_result.return_code != 0:
+            raise RuntimeError(
+                "Daytona direct upload_dir destination prep failed: "
+                f"{_exec_failure_output(prep_result)}"
+            )
         await self._env._sdk_upload_dir(source_dir, target_dir)
 
     async def download_file(self, source_path: str, target_path: Path | str) -> None:

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -689,6 +689,41 @@ async def _checked_exec(env: Any, command: str, label: str, **kwargs: Any) -> An
         )
     return result
 
+
+async def clear_verifier_output_dir(
+    env: Any,
+    label: str = "Verifier setup failed: clearing verifier output directory",
+    **kwargs: Any,
+) -> Any:
+    """Clear verifier outputs while preserving bind mounts.
+
+    This helper is intentionally service-aware: final anti-tamper hardening
+    stays on the agent container, but a verifier running in another service may
+    still need its own writable ``/logs/verifier`` output directory.
+    """
+    return await _checked_exec(env, _CLEAR_VERIFIER_DIR_CMD, label, **kwargs)
+
+
+async def ensure_legacy_app_dir(
+    env: Any,
+    label: str = "Verifier setup failed: preparing /app",
+    **kwargs: Any,
+) -> Any:
+    """Prepare the legacy verifier ``/app`` rootdir fallback."""
+    return await _checked_exec(env, _ENSURE_APP_DIR_CMD, label, **kwargs)
+
+
+async def cleanup_verifier_python_hooks(
+    env: Any,
+    task_dir: "Path | str | None",
+    label: str = "Verifier setup failed: purging Python injection hooks",
+    **kwargs: Any,
+) -> Any:
+    """Purge agent-injected Python hook files using task hardening settings."""
+    hardening = _read_hardening_config(task_dir)
+    return await _checked_exec(env, _build_cleanup_cmd(hardening), label, **kwargs)
+
+
 # Per-task hardening opt-outs. Tasks declare these in task.toml under
 # [verifier.hardening] when their legitimate test setup conflicts with the
 # default cleanup (e.g. qutebrowser ships a real conftest.py that the cleanup

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -17,7 +17,7 @@ import os
 import re
 import shlex
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from benchflow.agents.registry import get_sandbox_home_dirs
 
@@ -640,12 +640,54 @@ async def _trusted_verifier_pythonpath(
     return ":".join(e for e in extras if isinstance(e, str))
 
 
-# Wipe and recreate /logs/verifier/ before the verifier runs.
-# rm -rf severs hardlinks, removes symlink replacements, and eliminates
-# variant filenames/subdirs the agent may have pre-staged.
+# Wipe /logs/verifier/ contents before the verifier runs. Do not remove the
+# directory itself: Daytona DinD bind-mounts it from the remote VM, so deleting
+# the mountpoint fails with "Device or resource busy". ``find ... -exec ... +``
+# avoids glob ARG_MAX failures if an agent floods the world-writable log dir.
 _CLEAR_VERIFIER_DIR_CMD = (
-    "rm -rf /logs/verifier && mkdir -p /logs/verifier /app && chmod 777 /logs/verifier"
+    "command -v find >/dev/null 2>&1 || "
+    "{ echo 'BenchFlow verifier cleanup requires find' >&2; exit 127; }; "
+    "if [ -L /logs/verifier ]; then rm -f /logs/verifier; fi && "
+    "mkdir -p /logs/verifier && "
+    "find /logs/verifier -mindepth 1 -exec rm -rf -- {} + && "
+    "chmod 777 /logs/verifier"
 )
+
+# Legacy verifier rootdir fallback for main-container verification paths.
+_ENSURE_APP_DIR_CMD = "mkdir -p /app"
+
+
+def _exec_return_code(result: Any) -> int:
+    if result is None:
+        return 0
+    for name in ("return_code", "exit_code"):
+        value = getattr(result, name, None)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+    return 0
+
+
+def _exec_failure_detail(result: Any) -> str:
+    parts = []
+    for name in ("stdout", "stderr"):
+        value = getattr(result, name, None)
+        if value:
+            text = str(value).strip()
+            if text:
+                parts.append(f"{name}: {text[:2000]}")
+    if not parts:
+        return ""
+    return "\n" + "\n".join(parts)
+
+
+async def _checked_exec(env: Any, command: str, label: str, **kwargs: Any) -> Any:
+    result = await env.exec(command, **kwargs)
+    return_code = _exec_return_code(result)
+    if return_code != 0:
+        raise RuntimeError(
+            f"{label} exited with rc={return_code}{_exec_failure_detail(result)}"
+        )
+    return result
 
 # Per-task hardening opt-outs. Tasks declare these in task.toml under
 # [verifier.hardening] when their legitimate test setup conflicts with the
@@ -742,8 +784,8 @@ async def harden_before_verify(
     """Neutralize agent tampering before running the verifier.
 
     1. Kill sandbox-user processes (prevent concurrent writes during teardown).
-    2. Assert all sandbox-user processes are dead, then wipe/recreate
-       /logs/verifier/ with a clean root-owned directory.
+    2. Assert all sandbox-user processes are dead, then clear /logs/verifier/
+       contents while preserving remote bind mounts.
     3. Optionally restore the workspace from the pre-agent snapshot. This is
        destructive to legitimate workspace-edit answers, so it is opt-in.
     4. Purge symlinks and __pycache__ trees from workspace.
@@ -772,8 +814,19 @@ async def harden_before_verify(
             f"(sleep 1 && pkill -9 -u {sandbox_user}; sleep 1)",
             user="root",
         )
-    # Wipe and recreate /logs/verifier/ with a clean root-owned directory.
-    await env.exec(_CLEAR_VERIFIER_DIR_CMD, user="root")
+    # Wipe /logs/verifier/ contents while preserving remote bind mounts.
+    await _checked_exec(
+        env,
+        _CLEAR_VERIFIER_DIR_CMD,
+        "Verifier hardening failed: clearing verifier output directory",
+        user="root",
+    )
+    await _checked_exec(
+        env,
+        _ENSURE_APP_DIR_CMD,
+        "Verifier hardening failed: preparing /app",
+        user="root",
+    )
     if workspace and restore_workspace:
         await _restore_build_config(env, workspace)
         await _refresh_verifier_workspace(env, workspace)

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -644,12 +644,17 @@ async def _trusted_verifier_pythonpath(
 # directory itself: Daytona DinD bind-mounts it from the remote VM, so deleting
 # the mountpoint fails with "Device or resource busy". ``find ... -exec ... +``
 # avoids glob ARG_MAX failures if an agent floods the world-writable log dir.
+# When ``find`` is unavailable (minimal service images), fall back to
+# ``rm -rf /logs/verifier/* ...`` which handles the common case but may miss
+# dot-files and can hit ARG_MAX on extreme floods.
 _CLEAR_VERIFIER_DIR_CMD = (
-    "command -v find >/dev/null 2>&1 || "
-    "{ echo 'BenchFlow verifier cleanup requires find' >&2; exit 127; }; "
     "if [ -L /logs/verifier ]; then rm -f /logs/verifier; fi && "
     "mkdir -p /logs/verifier && "
-    "find /logs/verifier -mindepth 1 -exec rm -rf -- {} + && "
+    "if command -v find >/dev/null 2>&1; then "
+    "find /logs/verifier -mindepth 1 -exec rm -rf -- {} +; "
+    "else "
+    "rm -rf /logs/verifier/* /logs/verifier/.[!.]* /logs/verifier/..?* 2>/dev/null; true; "
+    "fi && "
     "chmod 777 /logs/verifier"
 )
 

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -26,6 +26,46 @@ _BOOTSTRAP_DONE = "__BENCHFLOW_BOOTSTRAP_DONE__"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+async def _cleanup_daytona_remote_env_file(
+    sandbox: Any,
+    remote_env_path: str,
+) -> None:
+    with contextlib.suppress(Exception):
+        await sandbox.process.exec(
+            f"rm -f {shlex.quote(remote_env_path)}",
+            timeout=10,
+        )
+
+
+async def _bootstrap_daytona_env_file(
+    sandbox: Any,
+    *,
+    remote_env_path: str,
+    env: dict[str, str],
+    shell_exports: bool,
+    error_label: str,
+) -> None:
+    env_keys = list(env)
+    invalid = [key for key in env_keys if not _ENV_KEY_RE.match(key)]
+    if invalid:
+        raise ValueError(
+            "Invalid environment variable name(s): " + ", ".join(sorted(invalid))
+        )
+    command = DaytonaProcess._bootstrap_env_command(
+        remote_env_path=remote_env_path,
+        env_keys=env_keys,
+        shell_exports=shell_exports,
+    )
+    response = await sandbox.process.exec(command, env=env, timeout=30)
+    stdout_text = str(getattr(response, "result", "") or "")
+    exit_code = getattr(response, "exit_code", 1)
+    if exit_code != 0 or _BOOTSTRAP_DONE not in stdout_text.splitlines():
+        raise RuntimeError(
+            f"Failed to bootstrap {error_label} "
+            f"(rc={exit_code}): {stdout_text[:_DIAG_TRUNCATE]}"
+        )
+
+
 async def drain_oversized_line(reader: asyncio.StreamReader) -> int:
     """Drain an oversized line from *reader* after a buffer overflow.
 
@@ -412,11 +452,7 @@ class DaytonaProcess(LiveProcess):
         return f"sh -c {shlex.quote(script)}"
 
     async def _cleanup_remote_env_file(self, remote_env_path: str) -> None:
-        with contextlib.suppress(Exception):
-            await self._sandbox.process.exec(
-                f"rm -f {shlex.quote(remote_env_path)}",
-                timeout=10,
-            )
+        await _cleanup_daytona_remote_env_file(self._sandbox, remote_env_path)
 
     async def _bootstrap_env_file(
         self,
@@ -425,26 +461,13 @@ class DaytonaProcess(LiveProcess):
         env: dict[str, str],
         shell_exports: bool,
     ) -> None:
-        env_keys = list(env)
-        invalid = [key for key in env_keys if not _ENV_KEY_RE.match(key)]
-        if invalid:
-            raise ValueError(
-                "Invalid environment variable name(s): "
-                + ", ".join(sorted(invalid))
-            )
-        command = self._bootstrap_env_command(
+        await _bootstrap_daytona_env_file(
+            self._sandbox,
             remote_env_path=remote_env_path,
-            env_keys=env_keys,
+            env=env,
             shell_exports=shell_exports,
+            error_label="Daytona agent env",
         )
-        response = await self._sandbox.process.exec(command, env=env, timeout=30)
-        stdout_text = str(getattr(response, "result", "") or "")
-        exit_code = getattr(response, "exit_code", 1)
-        if exit_code != 0 or _BOOTSTRAP_DONE not in stdout_text.splitlines():
-            raise RuntimeError(
-                "Failed to bootstrap Daytona agent env "
-                f"(rc={exit_code}): {stdout_text[:_DIAG_TRUNCATE]}"
-            )
 
     async def start(
         self,
@@ -464,33 +487,33 @@ class DaytonaProcess(LiveProcess):
                 inner_parts = ["docker", "compose", "exec", "-i", "-T"]
             if cwd:
                 inner_parts.extend(["-w", cwd])
-            # Write env vars to a temp file on the remote VM instead of passing
-            # as -e K=V args (which are visible in ps aux on the remote host).
-            # Use a Python-generated unique suffix instead of a shell `$$`
-            # expansion: shlex.join() (below) single-quotes the --env-file arg,
-            # so `$$` would survive as a literal in the docker compose call
-            # while the SDK bootstrap shell would expand it — the file would
-            # be written to one path and read from another. uuid.uuid4
-            # sidesteps the entire shell-expansion-vs-quoting problem.
+            # Source provider values into the remote shell, then pass only
+            # env names through `docker compose exec --env KEY`. Compose exec
+            # does not accept --env-file, and `--env KEY=value` would leak
+            # provider values into the remote command line.
             if env:
                 remote_env_path = f"/tmp/benchflow_env_{uuid.uuid4().hex[:16]}.env"
                 await self._bootstrap_env_file(
                     remote_env_path=remote_env_path,
                     env=env,
-                    shell_exports=False,
+                    shell_exports=True,
                 )
-                inner_parts.extend(["--env-file", remote_env_path])
+                for key in env:
+                    inner_parts.extend(["--env", key])
             inner_parts.extend(["main", "bash", "-c", command])
             inner_cmd = shlex.join(inner_parts)
 
-            if self._compose_cmd_prefix:
-                remote_cmd = f"{self._compose_cmd_prefix} {inner_cmd}"
-            else:
-                remote_cmd = inner_cmd
-
+            remote_cmd = (
+                f"{self._compose_cmd_prefix} {inner_cmd}"
+                if self._compose_cmd_prefix
+                else inner_cmd
+            )
             if remote_env_path:
+                remote_env_path_q = shlex.quote(remote_env_path)
                 remote_cmd = (
-                    f"trap 'rm -f {shlex.quote(remote_env_path)}' EXIT; {remote_cmd}"
+                    f"trap 'rm -f {remote_env_path_q}' EXIT; "
+                    f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
+                    f"{remote_cmd}"
                 )
         else:
             # Direct sandbox — run command via SSH.
@@ -575,6 +598,7 @@ class DaytonaPtyProcess(LiveProcess):
         self._line_buffer = asyncio.Queue()
         self._partial = b""
         self._closed = False
+        self._remote_env_path: str | None = None
 
     @classmethod
     async def from_sandbox_env(cls, env: Any) -> "DaytonaPtyProcess":
@@ -599,12 +623,33 @@ class DaytonaPtyProcess(LiveProcess):
             line = line.replace(b"\r", b"")
             await self._line_buffer.put(line + b"\n")
 
+    async def _bootstrap_env_file(
+        self,
+        *,
+        remote_env_path: str,
+        env: dict[str, str],
+    ) -> None:
+        await _bootstrap_daytona_env_file(
+            self._sandbox,
+            remote_env_path=remote_env_path,
+            env=env,
+            shell_exports=True,
+            error_label="Daytona PTY agent env",
+        )
+
+    async def _cleanup_started_env_file(self) -> None:
+        remote_env_path = self._remote_env_path
+        self._remote_env_path = None
+        if remote_env_path:
+            await _cleanup_daytona_remote_env_file(self._sandbox, remote_env_path)
+
     async def start(
         self,
         command: str,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
     ) -> None:
+        remote_env_path = None
         session_id = f"acp-{uuid.uuid4().hex[:8]}"
         pty_env = {}
         if self._compose_cmd_prefix:
@@ -613,57 +658,69 @@ class DaytonaPtyProcess(LiveProcess):
                     k, v = part.split("=", 1)
                     pty_env[k] = v
 
-        self._pty = await self._sandbox.process.create_pty_session(
-            id=session_id,
-            on_data=self._on_pty_data,
-            envs=pty_env if pty_env else None,
-        )
-        await self._pty.wait_for_connection()
-        logger.info(f"DaytonaPtyProcess: PTY connected (session={session_id})")
-
-        compose_parts = (
-            shlex.split(self._compose_cmd_base)
-            if self._compose_cmd_base
-            else ["docker", "compose"]
-        )
-        exec_parts = [*compose_parts, "exec", "-i", "-T"]
-        if cwd:
-            exec_parts.extend(["-w", cwd])
-        # Write env vars to a file inside the container (not visible in ps aux),
-        # matching the approach in DaytonaProcess.start().
-        env_file_cmd = ""
-        if env:
-            env_file_path = f"/tmp/.benchflow_env_{uuid.uuid4().hex[:16]}"
-            env_lines = "\n".join(
-                f"export {k}={shlex.quote(v)}" for k, v in env.items()
+        try:
+            self._pty = await self._sandbox.process.create_pty_session(
+                id=session_id,
+                on_data=self._on_pty_data,
+                envs=pty_env if pty_env else None,
             )
-            env_file_cmd = (
-                f"cat > {env_file_path} <<'__EOF__'\n{env_lines}\n__EOF__\n"
-                f". {env_file_path} && rm -f {env_file_path} && "
+            await self._pty.wait_for_connection()
+            logger.info(f"DaytonaPtyProcess: PTY connected (session={session_id})")
+
+            compose_parts = (
+                shlex.split(self._compose_cmd_base)
+                if self._compose_cmd_base
+                else ["docker", "compose"]
             )
-        exec_parts.extend(["main", "bash", "-lc", f"{env_file_cmd}{command}"])
-        exec_cmd = shlex.join(exec_parts)
+            exec_parts = [*compose_parts, "exec", "-i", "-T"]
+            if cwd:
+                exec_parts.extend(["-w", cwd])
+            if env:
+                remote_env_path = f"/tmp/benchflow_env_{uuid.uuid4().hex[:16]}.env"
+                self._remote_env_path = remote_env_path
+                await self._bootstrap_env_file(
+                    remote_env_path=remote_env_path,
+                    env=env,
+                )
+                for key in env:
+                    exec_parts.extend(["--env", key])
+            exec_parts.extend(["main", "bash", "-lc", command])
+            exec_cmd = shlex.join(exec_parts)
+            if remote_env_path:
+                remote_env_path_q = shlex.quote(remote_env_path)
+                setup_exec_cmd = (
+                    f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
+                    f"exec {exec_cmd}"
+                )
+            else:
+                setup_exec_cmd = f"exec {exec_cmd}"
 
-        # Use a marker + stty to cleanly hand over the PTY to the agent.
-        # 1. Disable echo so typed commands don't appear in output
-        # 2. Print marker so we know when to start reading ACP output
-        # 3. exec into compose exec so the agent owns the PTY
-        marker = f"__BENCHFLOW_ACP_{session_id}__"
-        setup = f"stty -echo 2>/dev/null; echo '{marker}'; exec {exec_cmd}\n"
-        await self._pty.send_input(setup)
-        logger.info("DaytonaPtyProcess: sent setup, waiting for marker...")
+            # Use a marker + stty to cleanly hand over the PTY to the agent.
+            # 1. Disable echo so typed commands don't appear in output
+            # 2. Print marker so we know when to start reading ACP output
+            # 3. exec into compose exec so the agent owns the PTY
+            marker = f"__BENCHFLOW_ACP_{session_id}__"
+            setup = f"stty -echo 2>/dev/null; echo '{marker}'; {setup_exec_cmd}\n"
+            await self._pty.send_input(setup)
+            logger.info("DaytonaPtyProcess: sent setup, waiting for marker...")
 
-        while True:
-            try:
-                line = await asyncio.wait_for(self._line_buffer.get(), timeout=120)
-                decoded = line.decode(errors="replace").strip()
-                logger.debug(f"DaytonaPtyProcess drain: {decoded[:120]}")
-                if marker in decoded:
-                    break
-            except TimeoutError as e:
-                raise ConnectionError(
-                    "DaytonaPtyProcess: timeout waiting for agent start marker"
-                ) from e
+            while True:
+                try:
+                    line = await asyncio.wait_for(
+                        self._line_buffer.get(), timeout=120
+                    )
+                    decoded = line.decode(errors="replace").strip()
+                    logger.debug(f"DaytonaPtyProcess drain: {decoded[:120]}")
+                    if marker in decoded:
+                        break
+                except TimeoutError as e:
+                    raise ConnectionError(
+                        "DaytonaPtyProcess: timeout waiting for agent start marker"
+                    ) from e
+        except Exception:
+            await self._cleanup_started_env_file()
+            await self.close()
+            raise
 
         logger.info("DaytonaPtyProcess: marker seen, agent starting")
 
@@ -685,12 +742,15 @@ class DaytonaPtyProcess(LiveProcess):
 
     async def close(self) -> None:
         self._closed = True
-        if self._pty:
-            with contextlib.suppress(Exception):
-                await self._pty.kill()
-            with contextlib.suppress(Exception):
-                await self._pty.disconnect()
-            logger.info("DaytonaPtyProcess terminated")
+        try:
+            if self._pty:
+                with contextlib.suppress(Exception):
+                    await self._pty.kill()
+                with contextlib.suppress(Exception):
+                    await self._pty.disconnect()
+                logger.info("DaytonaPtyProcess terminated")
+        finally:
+            await self._cleanup_started_env_file()
 
     @property
     def is_running(self) -> bool:

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -11,7 +11,9 @@ import asyncio
 import contextlib
 import logging
 import os
+import re
 import shlex
+import tempfile
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any
@@ -20,6 +22,8 @@ logger = logging.getLogger(__name__)
 
 _BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB readline buffer
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stderr in error messages
+_BOOTSTRAP_DONE = "__BENCHFLOW_BOOTSTRAP_DONE__"
+_ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 async def drain_oversized_line(reader: asyncio.StreamReader) -> int:
@@ -289,6 +293,53 @@ class DaytonaProcess(LiveProcess):
         self._is_dind = is_dind
         self._compose_cmd_prefix = compose_cmd_prefix
         self._compose_cmd_base = compose_cmd_base
+        self._ssh_config_path: str | None = None
+        self._ssh_config_cleanup_task: asyncio.Task[None] | None = None
+
+    @staticmethod
+    def _write_ssh_config(ssh_user: str) -> str:
+        fd, path = tempfile.mkstemp(prefix="benchflow_daytona_ssh_", text=True)
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write("Host benchflow-daytona\n")
+                f.write("  HostName ssh.app.daytona.io\n")
+                f.write(f"  User {ssh_user}\n")
+                f.write("  StrictHostKeyChecking no\n")
+                f.write("  UserKnownHostsFile /dev/null\n")
+                f.write("  LogLevel ERROR\n")
+            os.chmod(path, 0o600)
+        except Exception:
+            with contextlib.suppress(Exception):
+                os.close(fd)
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(path)
+            raise
+        return path
+
+    @staticmethod
+    def _ssh_args(ssh_config_path: str, remote_cmd: str) -> list[str]:
+        return [
+            "ssh",
+            "-F",
+            ssh_config_path,
+            "benchflow-daytona",
+            remote_cmd,
+        ]
+
+    def _unlink_ssh_config(self, path: str) -> None:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(path)
+        if self._ssh_config_path == path:
+            self._ssh_config_path = None
+
+    async def _cleanup_ssh_config_after_exit(
+        self,
+        process: asyncio.subprocess.Process,
+        path: str,
+    ) -> None:
+        with contextlib.suppress(Exception):
+            await process.wait()
+        self._unlink_ssh_config(path)
 
     @classmethod
     async def from_sandbox_env(cls, env: Any) -> "DaytonaProcess":
@@ -321,15 +372,87 @@ class DaytonaProcess(LiveProcess):
             compose_cmd_base=compose_cmd_base,
         )
 
+    @staticmethod
+    def _bootstrap_env_command(
+        *,
+        remote_env_path: str,
+        env_keys: list[str],
+        shell_exports: bool,
+    ) -> str:
+        remote_env_path_q = shlex.quote(remote_env_path)
+        keys = " ".join(shlex.quote(key) for key in env_keys)
+        if shell_exports:
+            write_value = (
+                "  printf 'export %s=' \"$key\" >> \"$env_file\"\n"
+                "  quote_env_value \"$(printenv \"$key\")\" >> \"$env_file\"\n"
+                "  printf '\\n' >> \"$env_file\"\n"
+            )
+        else:
+            write_value = (
+                "  printf '%s=%s\\n' \"$key\" \"$(printenv \"$key\")\" "
+                '>> "$env_file"\n'
+            )
+        script = (
+            f"env_file={remote_env_path_q}\n"
+            "success=0\n"
+            "umask 077\n"
+            'trap \'[ "$success" = 1 ] || rm -f "$env_file"\' EXIT\n'
+            ': > "$env_file"\n'
+            "quote_env_value() {\n"
+            "  printf \"'\"\n"
+            "  printf '%s' \"$1\" | sed \"s/'/'\\\\\\\\''/g\"\n"
+            "  printf \"'\"\n"
+            "}\n"
+            f"for key in {keys}; do\n"
+            f"{write_value}"
+            "done\n"
+            "success=1\n"
+            f"echo {_BOOTSTRAP_DONE}\n"
+        )
+        return f"sh -c {shlex.quote(script)}"
+
+    async def _cleanup_remote_env_file(self, remote_env_path: str) -> None:
+        with contextlib.suppress(Exception):
+            await self._sandbox.process.exec(
+                f"rm -f {shlex.quote(remote_env_path)}",
+                timeout=10,
+            )
+
+    async def _bootstrap_env_file(
+        self,
+        *,
+        remote_env_path: str,
+        env: dict[str, str],
+        shell_exports: bool,
+    ) -> None:
+        env_keys = list(env)
+        invalid = [key for key in env_keys if not _ENV_KEY_RE.match(key)]
+        if invalid:
+            raise ValueError(
+                "Invalid environment variable name(s): "
+                + ", ".join(sorted(invalid))
+            )
+        command = self._bootstrap_env_command(
+            remote_env_path=remote_env_path,
+            env_keys=env_keys,
+            shell_exports=shell_exports,
+        )
+        response = await self._sandbox.process.exec(command, env=env, timeout=30)
+        stdout_text = str(getattr(response, "result", "") or "")
+        exit_code = getattr(response, "exit_code", 1)
+        if exit_code != 0 or _BOOTSTRAP_DONE not in stdout_text.splitlines():
+            raise RuntimeError(
+                "Failed to bootstrap Daytona agent env "
+                f"(rc={exit_code}): {stdout_text[:_DIAG_TRUNCATE]}"
+            )
+
     async def start(
         self,
         command: str,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
     ) -> None:
-        # Get SSH credentials
-        ssh_access = await self._sandbox.create_ssh_access()
-        ssh_target = f"{ssh_access.token}@ssh.app.daytona.io"
+        remote_env_path = None
 
         if self._is_dind:
             # Build the docker compose exec command to run inside the DinD VM.
@@ -346,13 +469,16 @@ class DaytonaProcess(LiveProcess):
             # Use a Python-generated unique suffix instead of a shell `$$`
             # expansion: shlex.join() (below) single-quotes the --env-file arg,
             # so `$$` would survive as a literal in the docker compose call
-            # while the cat > ... heredoc would expand it — the file would be
-            # written to one path and read from another. uuid.uuid4 sidesteps
-            # the entire shell-expansion-vs-quoting problem.
-            remote_env_path = None
+            # while the SDK bootstrap shell would expand it — the file would
+            # be written to one path and read from another. uuid.uuid4
+            # sidesteps the entire shell-expansion-vs-quoting problem.
             if env:
                 remote_env_path = f"/tmp/benchflow_env_{uuid.uuid4().hex[:16]}.env"
-                env_lines = "\n".join(f"{k}={v}" for k, v in env.items())
+                await self._bootstrap_env_file(
+                    remote_env_path=remote_env_path,
+                    env=env,
+                    shell_exports=False,
+                )
                 inner_parts.extend(["--env-file", remote_env_path])
             inner_parts.extend(["main", "bash", "-c", command])
             inner_cmd = shlex.join(inner_parts)
@@ -363,63 +489,72 @@ class DaytonaProcess(LiveProcess):
                 remote_cmd = inner_cmd
 
             if remote_env_path:
-                # Write env file, set trap for cleanup, then run the command
-                write_cmd = (
-                    f"umask 077 && cat > {remote_env_path} <<'__BENCHFLOW_ENV__'\n"
-                    f"{env_lines}\n__BENCHFLOW_ENV__"
-                )
                 remote_cmd = (
-                    f"{write_cmd}\ntrap 'rm -f {remote_env_path}' EXIT\n{remote_cmd}"
+                    f"trap 'rm -f {shlex.quote(remote_env_path)}' EXIT; {remote_cmd}"
                 )
         else:
             # Direct sandbox — run command via SSH.
             # Write env vars to a file on the remote host and source it,
             # instead of passing as `env K=V` args visible in ps aux.
             env_prefix = ""
-            remote_env_path = None
             if env:
                 # Python-generated unique suffix; see DinD branch above for why
                 # $$ shell expansion is fragile across quoting boundaries.
                 remote_env_path = f"/tmp/benchflow_env_{uuid.uuid4().hex[:16]}.env"
-                env_lines = "\n".join(
-                    f"export {k}={shlex.quote(v)}" for k, v in env.items()
+                await self._bootstrap_env_file(
+                    remote_env_path=remote_env_path,
+                    env=env,
+                    shell_exports=True,
                 )
-                env_prefix = f". {remote_env_path} && "
+                remote_env_path_q = shlex.quote(remote_env_path)
+                env_prefix = f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
             if cwd:
                 remote_cmd = f"cd {shlex.quote(cwd)} && {env_prefix}{command}"
             else:
                 remote_cmd = f"{env_prefix}{command}"
-
             if remote_env_path:
-                write_cmd = (
-                    f"umask 077 && cat > {remote_env_path} <<'__BENCHFLOW_ENV__'\n"
-                    f"{env_lines}\n__BENCHFLOW_ENV__"
-                )
                 remote_cmd = (
-                    f"{write_cmd}\ntrap 'rm -f {remote_env_path}' EXIT\n{remote_cmd}"
+                    f"trap 'rm -f {shlex.quote(remote_env_path)}' EXIT; {remote_cmd}"
                 )
 
-        cmd = [
-            "ssh",
-            "-o",
-            "StrictHostKeyChecking=no",
-            "-o",
-            "UserKnownHostsFile=/dev/null",
-            "-o",
-            "LogLevel=ERROR",
-            ssh_target,
-            remote_cmd,
-        ]
+        try:
+            ssh_access = await self._sandbox.create_ssh_access()
+            ssh_config_path = self._write_ssh_config(ssh_access.token)
+            self._ssh_config_path = ssh_config_path
+            cmd = self._ssh_args(ssh_config_path, remote_cmd)
 
-        logger.debug(f"DaytonaProcess: ssh {ssh_target} {remote_cmd[:100]}...")
-        self._process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            limit=_BUFFER_LIMIT,
+            logger.debug(
+                "DaytonaProcess: ssh benchflow-daytona %s...",
+                remote_cmd[:100],
+            )
+            self._process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                limit=_BUFFER_LIMIT,
+            )
+        except Exception:
+            if remote_env_path:
+                await self._cleanup_remote_env_file(remote_env_path)
+            await self.close()
+            raise
+        self._ssh_config_cleanup_task = asyncio.create_task(
+            self._cleanup_ssh_config_after_exit(self._process, ssh_config_path)
         )
         logger.info(f"Daytona process started (pid={self._process.pid})")
+
+    async def close(self) -> None:
+        try:
+            await super().close()
+        finally:
+            if self._ssh_config_cleanup_task:
+                self._ssh_config_cleanup_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._ssh_config_cleanup_task
+                self._ssh_config_cleanup_task = None
+            if self._ssh_config_path:
+                self._unlink_ssh_config(self._ssh_config_path)
 
 
 class DaytonaPtyProcess(LiveProcess):

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -510,9 +510,13 @@ class DaytonaProcess(LiveProcess):
             )
             if remote_env_path:
                 remote_env_path_q = shlex.quote(remote_env_path)
+                # Source the env file to populate vars, then exec compose.
+                # The EXIT trap handles cleanup; we intentionally keep the file
+                # alive until exit so that compose_cmd_prefix wrappers (which
+                # may re-exec the shell) still inherit the sourced vars.
                 remote_cmd = (
                     f"trap 'rm -f {remote_env_path_q}' EXIT; "
-                    f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
+                    f". {remote_env_path_q} && "
                     f"{remote_cmd}"
                 )
         else:

--- a/src/benchflow/self_gen.py
+++ b/src/benchflow/self_gen.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shlex
 import shutil
 from dataclasses import replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from uuid import uuid4
 
 from benchflow.rollout import (
@@ -21,6 +21,11 @@ from benchflow.rollout import (
     _self_gen_prompt,
     _skill_frontmatter_name,
 )
+
+
+def _normalize_sandbox_path(path: str) -> str:
+    normalized = PurePosixPath(path).as_posix().rstrip("/")
+    return normalized or "/"
 
 
 def _find_skill_creator_dir(skills_root: Path, skill_name: str) -> Path:
@@ -93,19 +98,24 @@ def _solver_scene(config: RolloutConfig) -> Scene:
     )
 
 
+def _self_gen_setup_commands(generated_skills_root: str) -> list[str]:
+    generated_skills_root = _normalize_sandbox_path(generated_skills_root)
+    q_root = shlex.quote(generated_skills_root)
+    return [f"mkdir -p {q_root} && chmod 777 {q_root}"]
+
+
 def _ensure_generated_skills_hook(config: RolloutConfig):
     generated_skills_root = config.generated_skills_root or GENERATED_SKILLS_ROOT
+    setup_commands = _self_gen_setup_commands(generated_skills_root)
 
     async def ensure_generated_skills(env):
-        q_root = shlex.quote(generated_skills_root)
-        result = await env.exec(
-            f"mkdir -p {q_root} && chmod 777 {q_root}", timeout_sec=10
-        )
-        if result.return_code != 0:
-            raise RuntimeError(
-                "Failed to create self-gen generated skills directory: "
-                f"{result.stderr or result.stdout}"
-            )
+        for command in setup_commands:
+            result = await env.exec(command, timeout_sec=10)
+            if result.return_code != 0:
+                raise RuntimeError(
+                    "Failed to prepare self-gen generated skills paths: "
+                    f"{result.stderr or result.stdout}"
+                )
 
     return ensure_generated_skills
 

--- a/src/benchflow/self_gen.py
+++ b/src/benchflow/self_gen.py
@@ -121,7 +121,10 @@ def _ensure_generated_skills_hook(config: RolloutConfig):
 
 
 def _single_trial_config(
-    config: RolloutConfig, creator_skills_root: Path, skill_creator_name: str
+    config: RolloutConfig,
+    creator_skills_root: Path,
+    skill_creator_name: str,
+    artifact_root: Path,
 ) -> RolloutConfig:
     return replace(
         config,
@@ -137,6 +140,9 @@ def _single_trial_config(
             _ensure_generated_skills_hook(config),
         ],
         include_task_skills=False,
+        export_generated_skills_to=(
+            config.export_generated_skills_to or artifact_root / "generated-skills"
+        ),
     )
 
 
@@ -156,6 +162,6 @@ async def run_self_gen(config: RolloutConfig):
         skill_creator_dir, artifact_root / "creator-skills"
     )
     trial = await Rollout.create(
-        _single_trial_config(config, creator_skills_root, skill_creator_name)
+        _single_trial_config(config, creator_skills_root, skill_creator_name, artifact_root)
     )
     return await trial.run()

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -21,7 +21,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from benchflow.rewards.validation import is_valid_reward_number, validate_reward_map
-from benchflow.sandbox.lockdown import clear_verifier_output_dir
+from benchflow.sandbox.lockdown import _exec_return_code, clear_verifier_output_dir
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
 
@@ -383,13 +383,3 @@ class Verifier:
             json.dumps({"reward": score}, indent=2, allow_nan=False)
         )
         return VerifierResult(rewards={"reward": score})
-
-
-def _exec_return_code(result: Any) -> int:
-    if result is None:
-        return 0
-    for name in ("return_code", "exit_code"):
-        value = getattr(result, name, None)
-        if isinstance(value, int) and not isinstance(value, bool):
-            return value
-    return 0

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -21,6 +21,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from benchflow.rewards.validation import is_valid_reward_number, validate_reward_map
+from benchflow.sandbox.lockdown import _CLEAR_VERIFIER_DIR_CMD, _exec_failure_detail
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
 
@@ -167,8 +168,7 @@ class Verifier:
         )
         if not verifier_outputs_are_mounted:
             result = await self._sandbox.exec(
-                "rm -rf /logs/verifier && mkdir -p /logs/verifier && "
-                "chmod 777 /logs/verifier",
+                _CLEAR_VERIFIER_DIR_CMD,
                 user="root",
                 service=service,
                 timeout_sec=10,
@@ -177,7 +177,7 @@ class Verifier:
             if return_code != 0:
                 raise VerifierOutputParseError(
                     "Verifier setup failed: clearing verifier output directory "
-                    f"exited with rc={return_code}"
+                    f"exited with rc={return_code}{_exec_failure_detail(result)}"
                 )
 
         try:

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -21,7 +21,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from benchflow.rewards.validation import is_valid_reward_number, validate_reward_map
-from benchflow.sandbox.lockdown import _CLEAR_VERIFIER_DIR_CMD, _exec_failure_detail
+from benchflow.sandbox.lockdown import clear_verifier_output_dir
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
 
@@ -167,18 +167,15 @@ class Verifier:
             self._sandbox, "is_mounted", False
         )
         if not verifier_outputs_are_mounted:
-            result = await self._sandbox.exec(
-                _CLEAR_VERIFIER_DIR_CMD,
-                user="root",
-                service=service,
-                timeout_sec=10,
-            )
-            return_code = _exec_return_code(result)
-            if return_code != 0:
-                raise VerifierOutputParseError(
-                    "Verifier setup failed: clearing verifier output directory "
-                    f"exited with rc={return_code}{_exec_failure_detail(result)}"
+            try:
+                await clear_verifier_output_dir(
+                    self._sandbox,
+                    user="root",
+                    service=service,
+                    timeout_sec=10,
                 )
+            except RuntimeError as e:
+                raise VerifierOutputParseError(str(e)) from e
 
         try:
             await self._sandbox.upload_dir(

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -81,11 +81,17 @@ def test_repo_fingerprint_changes_when_dirty_file_content_changes(
     assert untracked_once != untracked_twice
 
 
-def test_syncing_handler_returns_503_on_failed_refresh(monkeypatch):
-    """Guards the dashboard repo sync added after v0.5-integration@ffef85d."""
+def test_syncing_handler_serves_cached_data_on_failed_refresh(
+    tmp_path: Path, monkeypatch
+):
+    """Guards v0.5-integration dashboard polling against transient refresh failures."""
     handler = object.__new__(serve.SyncingDashboardHandler)
     sent: list[tuple[int, str | None]] = []
     handler.send_error = lambda code, message=None: sent.append((code, message))  # type: ignore[method-assign]
+    dash = tmp_path / "dashboard"
+    dash.mkdir()
+    (dash / "data.json").write_text("{}")
+    monkeypatch.setattr(serve, "DASH", dash)
 
     class FailedResult:
         returncode = 1
@@ -111,14 +117,16 @@ def test_syncing_handler_returns_503_on_failed_refresh(monkeypatch):
         lambda _cmd, check=False: runs.append(_cmd) or FailedResult(),
     )
 
-    assert handler._sync_data_json() is False
-    assert handler._sync_data_json() is False
-    assert sent == [
-        (503, "data.json refresh failed; refusing to serve stale dashboard data"),
-        (503, "data.json refresh failed; retrying after cooldown"),
-    ]
+    assert handler._sync_data_json() is True
+    assert handler._sync_data_json() is True
+    assert sent == []
     assert len(runs) == 1
     assert len(fingerprints) == 2
+    cached = json.loads((dash / "data.json").read_text())
+    assert cached["sync_error"] == (
+        "data.json refresh failed; serving last successful data.json"
+    )
+    assert cached["sync_failed_at"]
 
 
 def test_index_ticket_view_and_sync_contract():
@@ -138,6 +146,8 @@ def test_index_ticket_view_and_sync_contract():
         ".vleft",
         ".sync-banner",
         "Dashboard data is not refreshing.",
+        "dataSyncError",
+        "sync_error",
         "safeLinearUrl",
         "linearLink",
         'target="_blank"',
@@ -882,6 +892,7 @@ const document = {
 
 const data = {
   generated_at: "2026-05-22 00:00:00",
+  sync_error: "refresh failed; serving cached data",
   summary: {
     tests: { passed: 1, failed: 0, skipped: 0, total: 1 },
     jobs_total: 1,
@@ -939,6 +950,12 @@ if (!nav.textContent.includes("jobs/main/")) {
 }
 if (!main.textContent.includes("Memory 50%")) {
   throw new Error("Jobs task meta did not render memory score: " + main.textContent);
+}
+if (!main.textContent.includes("Dashboard data is not refreshing") || !main.textContent.includes("refresh failed; serving cached data")) {
+  throw new Error("cached-data sync error banner did not render: " + main.textContent);
+}
+if (!gen.textContent.includes("sync failed: refresh failed; serving cached data")) {
+  throw new Error("cached-data sync error did not render in generated header: " + gen.textContent);
 }
 """
 
@@ -1546,10 +1563,10 @@ def test_collect_jobs_reuses_remembered_external_jobs_root(tmp_path: Path, monke
     assert jobs["groups"][0]["name"] == "main"
 
 
-def test_repo_fingerprint_changes_when_configured_jobs_root_changes(
+def test_repo_fingerprint_does_not_walk_configured_jobs_root_contents(
     tmp_path: Path, monkeypatch
 ):
-    """Guards v0.5-integration@ffef85d auto-refresh for external jobs artifacts."""
+    """Guards dashboard polling against request-path scans of large jobs trees."""
     repo = tmp_path / "repo"
     repo.mkdir()
     subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
@@ -1578,76 +1595,91 @@ def test_repo_fingerprint_changes_when_configured_jobs_root_changes(
     artifact.write_text("[]\n")
     after = serve.repo_fingerprint()
 
-    assert before != after
+    assert before == after
 
 
-def test_repo_fingerprint_changes_when_configured_jobs_root_gets_first_artifact(
+def test_syncing_handler_refreshes_by_interval_when_fingerprint_is_stable(
     tmp_path: Path, monkeypatch
 ):
-    """Guards data.json refresh when an external jobs root goes 0 -> nonzero."""
-    repo = tmp_path / "repo"
-    repo.mkdir()
-    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
-    )
-    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
-    tracked = repo / "tracked.txt"
-    tracked.write_text("one\n")
-    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL
-    )
-
-    previous_worktree = tmp_path / "previous-worktree"
-    (previous_worktree / "jobs").mkdir(parents=True)
-    monkeypatch.setattr(serve, "ROOT", repo)
-    monkeypatch.setenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", str(previous_worktree))
-
-    before = serve.repo_fingerprint()
-    rollout = previous_worktree / "jobs" / "2026-05-21__23-57-23" / "task__abc123"
-    rollout.mkdir(parents=True)
-    (rollout / "result.json").write_text("{}\n")
-    after = serve.repo_fingerprint()
-
-    assert before != after
-
-
-def test_repo_fingerprint_tracks_remembered_external_jobs_root(
-    tmp_path: Path, monkeypatch
-):
-    """Guards dashboard refresh after restart without the jobs-root env var."""
-    repo = tmp_path / "repo"
-    dash = repo / "dashboard"
-    (repo / "jobs").mkdir(parents=True)
-    dash.mkdir(parents=True)
-    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
-    subprocess.run(
-        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
-    )
-    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
-    tracked = repo / "tracked.txt"
-    tracked.write_text("one\n")
-    subprocess.run(["git", "add", "tracked.txt"], cwd=repo, check=True)
-    subprocess.run(
-        ["git", "commit", "-m", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL
-    )
-
-    previous_jobs = tmp_path / "previous-worktree" / "jobs"
-    rollout = previous_jobs / "2026-05-21__23-57-23" / "task__abc123"
-    rollout.mkdir(parents=True)
-    artifact = rollout / "result.json"
-    artifact.write_text("{}\n")
-    (dash / "data.json").write_text(
-        json.dumps({"jobs": {"source": {"path": str(previous_jobs)}}})
-    )
-
-    monkeypatch.delenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", raising=False)
-    monkeypatch.setattr(serve, "ROOT", repo)
+    """Guards live jobs refresh after removing jobs-tree hashing from polling."""
+    handler = object.__new__(serve.SyncingDashboardHandler)
+    sent: list[tuple[int, str | None]] = []
+    handler.send_error = lambda code, message=None: sent.append((code, message))  # type: ignore[method-assign]
+    dash = tmp_path / "dashboard"
+    dash.mkdir()
+    (dash / "data.json").write_text("{}")
     monkeypatch.setattr(serve, "DASH", dash)
 
-    before = serve.repo_fingerprint()
-    artifact.write_text("[]\n")
-    after = serve.repo_fingerprint()
+    class OkResult:
+        returncode = 0
 
-    assert before != after
+    serve.SyncingDashboardHandler.gen_cmd = ["generate"]
+    serve.SyncingDashboardHandler.last_repo_fingerprint = "same"
+    serve.SyncingDashboardHandler.last_refresh_at = time.monotonic() - 61
+    serve.SyncingDashboardHandler.refresh_interval = 60
+    serve.SyncingDashboardHandler.last_failed_refresh_at = None
+    serve.SyncingDashboardHandler.failed_refresh_error = None
+    serve.SyncingDashboardHandler.sync_lock = threading.Lock()
+
+    runs = []
+    monkeypatch.setattr(serve, "repo_fingerprint", lambda: "same")
+    monkeypatch.setattr(
+        serve.subprocess,
+        "run",
+        lambda _cmd, check=False: runs.append(_cmd) or OkResult(),
+    )
+
+    assert handler._sync_data_json() is True
+    assert runs == [["generate"]]
+    assert sent == []
+
+
+def test_dashboard_startup_serves_cached_data_when_initial_refresh_fails(
+    tmp_path: Path, monkeypatch
+):
+    """Guards local dashboard availability when startup generation is transiently down."""
+    dash = tmp_path / "dashboard"
+    dash.mkdir()
+    (dash / "data.json").write_text("{}")
+    monkeypatch.setattr(serve, "DASH", dash)
+    monkeypatch.setattr(serve, "ROOT", tmp_path)
+    monkeypatch.setattr(serve.sys, "argv", ["serve.py", "--port", "0"])
+    monkeypatch.setattr(serve, "repo_fingerprint", lambda: "cached")
+
+    class FailedResult:
+        returncode = 1
+
+    runs = []
+    monkeypatch.setattr(
+        serve.subprocess,
+        "run",
+        lambda _cmd, check=False: runs.append(_cmd) or FailedResult(),
+    )
+
+    class FakeServer:
+        allow_reuse_address = False
+        daemon_threads = False
+
+        def __init__(self, address, handler):
+            self.address = address
+            self.handler = handler
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def serve_forever(self):
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(serve.socketserver, "ThreadingTCPServer", FakeServer)
+    monkeypatch.setattr(serve.webbrowser, "open", lambda _url: None)
+
+    assert serve.main() == 0
+    assert len(runs) == 1
+    cached = json.loads((dash / "data.json").read_text())
+    assert cached["sync_error"] == (
+        "initial data.json refresh failed; serving last successful data.json"
+    )
+    assert cached["sync_failed_at"]

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -519,7 +519,12 @@ def test_collect_jobs_archives_acp_smoke_without_target_evidence(
 def test_collect_jobs_archives_empty_task_dirs_and_target_named_placeholders(
     tmp_path: Path, monkeypatch
 ):
-    """Guards codex/v05-integration-followup@5f05423 placeholder cleanup."""
+    """Guards codex/v05-integration-followup@5f05423 placeholder cleanup.
+
+    Updated after PR #346 stopped emitting phantom empty RunRecords for
+    unrecognized group children (e.g. smoke-test/programbench-daytona with
+    no timestamp dirs or task rollouts).
+    """
     jobs = tmp_path / "jobs"
     (jobs / "2026-05-22__03-45-00" / "task__empty").mkdir(parents=True)
     (jobs / "smoke-test" / "programbench-daytona").mkdir(parents=True)
@@ -533,7 +538,7 @@ def test_collect_jobs_archives_empty_task_dirs_and_target_named_placeholders(
 
     assert data["groups"] == []
     assert data["total_tasks"] == 0
-    assert data["archived_runs"] == 3
+    assert data["archived_runs"] == 2
     assert data["archived_tasks"] == 1
 
 

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -248,6 +248,206 @@ def test_collect_jobs_reports_latest_artifact_timestamp(tmp_path: Path, monkeypa
     assert run["tasks"][0]["latest_modified_at"] == "2026-05-21 17:28:03"
 
 
+def test_collect_jobs_keeps_nested_three_mode_runs_visible(
+    tmp_path: Path, monkeypatch
+):
+    """Guards current branch commit f7d382b against the real 3-mode job shape."""
+    jobs = tmp_path / "jobs"
+    parent_name = (
+        "20260523-003051-skillsbench-3modes-gemini31-flash-lite-"
+        "daytona-release-subset"
+    )
+    timestamp = "2026-05-23__00-31-36"
+    parent = jobs / "e2e" / parent_name
+    (parent / "configs").mkdir(parents=True)
+    (parent / "configs" / "baseline.toml").write_text("mode = 'baseline'\n")
+    for helper_name in ("configs", "_self_gen", "notes", ".scratch", "__pycache__"):
+        helper_dir = parent / helper_name
+        helper_dir.mkdir(parents=True, exist_ok=True)
+        (helper_dir / "summary.json").write_text(json.dumps({"concurrency": 64}))
+        task_name = f"skill-eval-{helper_name.replace('_', '-')}"
+        task_dir = helper_dir / timestamp / f"{task_name}__abc123"
+        task_dir.mkdir(parents=True)
+        (task_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": task_name,
+                    "agent": "codex",
+                    "rewards": {"reward": 1.0},
+                    "timing": {},
+                }
+            )
+        )
+        (task_dir / "config.json").write_text(json.dumps({"agent": "codex"}))
+    modes = ("baseline", "with-task-skills", "self-gen")
+    for mode in modes:
+        mode_dir = parent / mode
+        mode_dir.mkdir(parents=True)
+        (mode_dir / "summary.json").write_text(json.dumps({"concurrency": 32}))
+        run = mode_dir / timestamp
+        task_dir = run / f"skill-eval-{mode}__abc123"
+        task_dir.mkdir(parents=True)
+        (task_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": f"skill-eval-{mode}",
+                    "agent": "codex",
+                    "rewards": {"reward": 1.0},
+                    "timing": {},
+                }
+            )
+        )
+        (task_dir / "config.json").write_text(json.dumps({"agent": "codex"}))
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs))
+
+    data = generate.collect_jobs()
+
+    assert data["archived_runs"] == 0
+    assert data["archived_tasks"] == 0
+    assert data["total_tasks"] == 3
+    assert data["total_runs"] == 3
+    group = data["groups"][0]
+    assert group["name"] == "e2e"
+    runs = {run["id"]: run for run in group["runs"]}
+    assert set(runs) == {
+        f"{parent_name}/baseline/{timestamp}",
+        f"{parent_name}/with-task-skills/{timestamp}",
+        f"{parent_name}/self-gen/{timestamp}",
+    }
+    for run in runs.values():
+        assert "SkillsBench" in run["targets"]
+        assert "high-concurrency" in run["signals"]
+        assert len(run["tasks"]) == 1
+
+
+def test_collect_jobs_keeps_parent_summary_timestamp_runs_visible(
+    tmp_path: Path, monkeypatch
+):
+    """Guards current branch commit f7d382b against archiving all-task runs."""
+    jobs = tmp_path / "jobs"
+    parent_name = "20260522-165420-skillsbench-all-gemini31-flash-lite-daytona-c64"
+    timestamp = "2026-05-22__16-54-22"
+    parent = jobs / "e2e" / parent_name
+    parent.mkdir(parents=True)
+    (parent / "summary.json").write_text(
+        json.dumps(
+            {
+                "total": 94,
+                "score": "8.5%",
+                "concurrency": 64,
+                "source": {"repo": "benchflow-ai/skillsbench", "path": "tasks"},
+            }
+        )
+    )
+    task_dir = parent / timestamp / "jax-computing-basics__abc123"
+    task_dir.mkdir(parents=True)
+    (task_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "jax-computing-basics",
+                "agent": "gemini",
+                "model": "gemini-3.1-flash-lite-preview",
+                "environment": "daytona",
+                "rewards": {"reward": 0.0},
+                "timing": {},
+            }
+        )
+    )
+    (task_dir / "config.json").write_text(json.dumps({"agent": "gemini"}))
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs))
+
+    data = generate.collect_jobs()
+
+    assert data["archived_runs"] == 0
+    assert data["total_tasks"] == 1
+    run = data["groups"][0]["runs"][0]
+    assert run["id"] == f"{parent_name}/{timestamp}"
+    assert run["summary"]["total"] == 94
+    assert run["summary"]["score"] == "8.5%"
+    assert "SkillsBench" in run["targets"]
+    assert "high-concurrency" in run["signals"]
+
+
+def test_collect_jobs_keeps_parent_summary_mode_timestamp_runs_visible(
+    tmp_path: Path, monkeypatch
+):
+    """Guards current branch commit f7d382b against archiving mixed summary runs."""
+    jobs = tmp_path / "jobs"
+    parent_name = "20260523-004433-skillsbench-mixed-gemini31-flash-lite"
+    timestamp = "2026-05-23__00-44-33"
+    parent = jobs / "e2e" / parent_name
+    parent.mkdir(parents=True)
+    source = {"repo": "benchflow-ai/skillsbench", "path": "tasks"}
+    (parent / "summary.json").write_text(
+        json.dumps({"total": 3, "concurrency": 64, "source": source})
+    )
+    mode = parent / "self-gen"
+    mode.mkdir()
+    (mode / "summary.json").write_text(
+        json.dumps({"total": 1, "concurrency": 9, "source": source})
+    )
+    task_dir = mode / timestamp / "jax-computing-basics__abc123"
+    task_dir.mkdir(parents=True)
+    (task_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "jax-computing-basics",
+                "agent": "codex",
+                "rewards": {"reward": 1.0},
+                "timing": {},
+            }
+        )
+    )
+    (task_dir / "config.json").write_text(json.dumps({"agent": "codex"}))
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs))
+
+    data = generate.collect_jobs()
+
+    assert data["archived_runs"] == 0
+    assert data["total_tasks"] == 1
+    run = data["groups"][0]["runs"][0]
+    assert run["id"] == f"{parent_name}/self-gen/{timestamp}"
+    assert run["summary"]["total"] == 1
+    assert run["summary"]["concurrency"] == 9
+    assert "SkillsBench" in run["targets"]
+
+
+def test_collect_jobs_does_not_leak_group_summary_into_many_direct_runs(
+    tmp_path: Path, monkeypatch
+):
+    """Guards current branch commit f7d382b against broad summary fallback."""
+    jobs = tmp_path / "jobs"
+    group = jobs / "custom"
+    group.mkdir(parents=True)
+    (group / "summary.json").write_text(json.dumps({"concurrency": 64}))
+    for name in ("2026-05-22__01-00-00", "2026-05-22__02-00-00"):
+        task_dir = group / name / f"task-{name[-8:-6]}__abc123"
+        task_dir.mkdir(parents=True)
+        (task_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task",
+                    "agent": "oracle",
+                    "rewards": {"reward": 1.0},
+                    "timing": {},
+                }
+            )
+        )
+        (task_dir / "config.json").write_text(json.dumps({"agent": "oracle"}))
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs))
+
+    data = generate.collect_jobs()
+
+    assert data["groups"] == []
+    assert data["total_tasks"] == 0
+    assert data["archived_runs"] == 2
+    assert data["archived_tasks"] == 2
+
+
 def test_collect_jobs_archives_generic_timestamp_rollouts(tmp_path: Path, monkeypatch):
     """Guards codex/v05-integration-followup@5f05423 dashboard cleanup."""
     jobs = tmp_path / "jobs"
@@ -712,6 +912,7 @@ const context = {
   document,
   location: { hash: "#Jobs" },
   window: { scrollTo() {} },
+  scrollTo() {},
   MouseEvent: class { constructor(type) { this.type = type; } },
   setTimeout: fn => fn(),
   setInterval() {},
@@ -730,7 +931,7 @@ if (!main.textContent.includes("Could not load data.json")) {
   throw new Error("initial failure did not render the load error");
 }
 await context.loadData(false);
-if (!main.textContent.includes("1 tasks in 1 groups")) {
+if (!main.textContent.includes("1 rollout row in 1 groups")) {
   throw new Error("late successful poll did not render Jobs counts: " + main.textContent);
 }
 if (!nav.textContent.includes("jobs/main/")) {
@@ -900,10 +1101,55 @@ def test_task_row_falls_back_to_memory_reward_event(tmp_path: Path):
 
 
 def test_index_renders_canonical_task_outcome():
-    """Guards dashboard status rendering against local reclassification drift."""
-    html = Path("dashboard/index.html").read_text()
-    assert "function taskOutcomeBadge(outcome)" in html
-    assert "const status = taskOutcomeBadge(tk.outcome)" in html
+    """Guards v0.5-integration@f7d382b against dashboard status reclassification drift."""
+    if not shutil.which("node"):
+        pytest.skip("node is required for the dashboard DOM outcome contract")
+
+    code = r"""
+import fs from "node:fs";
+import vm from "node:vm";
+const html = fs.readFileSync("dashboard/index.html", "utf8");
+let script = html.match(/<script>([\s\S]*)<\/script>/)[1];
+script = script.replace(/loadData\(true\);\s*setInterval\(\(\) => loadData\(false\), 5000\);/, "");
+
+const document = {
+  createElement: () => ({ className: "", style: {}, dataset: {} }),
+  querySelectorAll: () => [],
+  getElementById: () => ({ innerHTML: "", appendChild() {} }),
+};
+
+const context = {
+  console,
+  document,
+  location: { hash: "" },
+  window: { scrollTo() {} },
+  scrollTo() {},
+  setTimeout: fn => fn(),
+  setInterval() {},
+  fetch() { throw new Error("fetch should not run in this badge test"); },
+};
+context.window = context;
+
+vm.createContext(context);
+vm.runInContext(script, context);
+
+const failed = context.taskOutcomeBadge("failed");
+if (failed.text !== "failed" || !/\berror\b/.test(failed.cls) || /\bok\b/.test(failed.cls) || /\bgood\b/.test(failed.cls)) {
+  throw new Error("failed badge was not rendered as non-green error: " + JSON.stringify(failed));
+}
+const passed = context.taskOutcomeBadge("passed");
+if (passed.text !== "ok" || !/\bok\b/.test(passed.cls)) {
+  throw new Error("passed outcome badge was not rendered as ok: " + JSON.stringify(passed));
+}
+"""
+
+    subprocess.run(
+        ["node", "--input-type=module", "-e", code],
+        cwd=generate.ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
 
 
 def test_index_jobs_empty_state_uses_total_tasks():
@@ -1123,6 +1369,149 @@ def test_collect_jobs_transitions_from_empty_to_nonempty_external_root(
     assert after["groups"][0]["name"] == "main"
     assert after["groups"][0]["runs"][0]["id"] == "2026-05-21__23-57-23"
     assert after["groups"][0]["runs"][0]["tasks"][0]["name"] == "external-evidence"
+
+
+def _write_collectable_rollout(jobs_root: Path) -> Path:
+    rollout = jobs_root / "2026-05-21__23-57-23" / "task__abc123"
+    rollout.mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {"task_name": "external-evidence", "rewards": {"reward": 1.0}, "timing": {}}
+        )
+    )
+    (rollout / "config.json").write_text(json.dumps({"agent": "codex"}))
+    return rollout
+
+
+def test_dashboard_jobs_root_ignores_stale_remembered_deep_result_json(
+    tmp_path: Path, monkeypatch
+):
+    """Guards v0.5-integration@ffef85d against stale deep artifact roots."""
+    repo = tmp_path / "repo"
+    dash = repo / "dashboard"
+    local_jobs = repo / "jobs"
+    local_jobs.mkdir(parents=True)
+    dash.mkdir(parents=True)
+    previous_jobs = tmp_path / "previous-worktree" / "jobs"
+    deep_artifact = (
+        previous_jobs / "archive" / "scratch" / "nested" / "not-a-task" / "result.json"
+    )
+    deep_artifact.parent.mkdir(parents=True)
+    deep_artifact.write_text("{}\n")
+    out = dash / "data.json"
+    out.write_text(json.dumps({"jobs": {"source": {"path": str(previous_jobs)}}}))
+
+    monkeypatch.delenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", raising=False)
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setattr(generate, "DASH", dash)
+    monkeypatch.setattr(generate, "OUT", out)
+    monkeypatch.setattr(serve, "ROOT", repo)
+    monkeypatch.setattr(serve, "DASH", dash)
+
+    assert generate.dashboard_jobs_root() == local_jobs.resolve()
+    assert serve._dashboard_jobs_root() == local_jobs.resolve()
+
+
+def test_dashboard_jobs_root_accepts_valid_remembered_jobs_root(
+    tmp_path: Path, monkeypatch
+):
+    """Guards v0.5-integration@ffef85d remembered jobs-root restarts."""
+    repo = tmp_path / "repo"
+    dash = repo / "dashboard"
+    (repo / "jobs").mkdir(parents=True)
+    dash.mkdir(parents=True)
+    previous_jobs = tmp_path / "previous-worktree" / "jobs"
+    _write_collectable_rollout(previous_jobs)
+    out = dash / "data.json"
+    out.write_text(json.dumps({"jobs": {"source": {"path": str(previous_jobs)}}}))
+
+    monkeypatch.delenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", raising=False)
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setattr(generate, "DASH", dash)
+    monkeypatch.setattr(generate, "OUT", out)
+    monkeypatch.setattr(serve, "ROOT", repo)
+    monkeypatch.setattr(serve, "DASH", dash)
+
+    assert generate.dashboard_jobs_root() == previous_jobs.resolve()
+    assert serve._dashboard_jobs_root() == previous_jobs.resolve()
+
+
+def test_dashboard_jobs_root_accepts_parent_summary_timestamp_jobs_root(
+    tmp_path: Path, monkeypatch
+):
+    """Guards v0.5-integration@f7d382b remembered all-task run roots."""
+    repo = tmp_path / "repo"
+    dash = repo / "dashboard"
+    (repo / "jobs").mkdir(parents=True)
+    dash.mkdir(parents=True)
+    previous_jobs = tmp_path / "previous-worktree" / "jobs"
+    parent = previous_jobs / "e2e" / "skillsbench-all"
+    parent.mkdir(parents=True)
+    (parent / "summary.json").write_text(json.dumps({"concurrency": 64}))
+    rollout = parent / "2026-05-22__16-54-22" / "task__abc123"
+    rollout.mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps({"task_name": "task", "rewards": {"reward": 1.0}, "timing": {}})
+    )
+    out = dash / "data.json"
+    out.write_text(json.dumps({"jobs": {"source": {"path": str(previous_jobs)}}}))
+
+    monkeypatch.delenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", raising=False)
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setattr(generate, "DASH", dash)
+    monkeypatch.setattr(generate, "OUT", out)
+    monkeypatch.setattr(serve, "ROOT", repo)
+    monkeypatch.setattr(serve, "DASH", dash)
+
+    assert generate.dashboard_jobs_root() == previous_jobs.resolve()
+    assert serve._dashboard_jobs_root() == previous_jobs.resolve()
+
+
+def test_dashboard_jobs_root_accepts_parent_summary_with_mode_runs(
+    tmp_path: Path, monkeypatch
+):
+    """Guards current branch commit f7d382b against mixed nested run shapes."""
+    repo = tmp_path / "repo"
+    dash = repo / "dashboard"
+    (repo / "jobs").mkdir(parents=True)
+    dash.mkdir(parents=True)
+    previous_jobs = tmp_path / "previous-worktree" / "jobs"
+    parent = previous_jobs / "e2e" / "skillsbench-mixed"
+    parent.mkdir(parents=True)
+    (parent / "summary.json").write_text(json.dumps({"concurrency": 64}))
+    mode = parent / "self-gen"
+    mode.mkdir()
+    (mode / "summary.json").write_text(json.dumps({"concurrency": 9}))
+    rollout = mode / "2026-05-23__00-44-33" / "task__abc123"
+    rollout.mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps({"task_name": "task", "rewards": {"reward": 1.0}, "timing": {}})
+    )
+    out = dash / "data.json"
+    out.write_text(json.dumps({"jobs": {"source": {"path": str(previous_jobs)}}}))
+
+    monkeypatch.delenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", raising=False)
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setattr(generate, "DASH", dash)
+    monkeypatch.setattr(generate, "OUT", out)
+    monkeypatch.setattr(serve, "ROOT", repo)
+    monkeypatch.setattr(serve, "DASH", dash)
+
+    assert generate.dashboard_jobs_root() == previous_jobs.resolve()
+    assert serve._dashboard_jobs_root() == previous_jobs.resolve()
+
+
+def test_dashboard_jobs_root_preserves_configured_empty_worktree_root(
+    tmp_path: Path, monkeypatch
+):
+    """Guards v0.5-integration@ffef85d explicit jobs-root configuration."""
+    previous_worktree = tmp_path / "previous-worktree"
+    (previous_worktree / "jobs").mkdir(parents=True)
+
+    monkeypatch.setenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", str(previous_worktree))
+
+    assert generate.dashboard_jobs_root() == (previous_worktree / "jobs").resolve()
+    assert serve._dashboard_jobs_root() == (previous_worktree / "jobs").resolve()
 
 
 def test_collect_jobs_reuses_remembered_external_jobs_root(tmp_path: Path, monkeypatch):

--- a/tests/test_llm_judge_verifier.py
+++ b/tests/test_llm_judge_verifier.py
@@ -607,7 +607,7 @@ class TestTestScriptStillDefault:
         sandbox.is_mounted = False
 
         async def fake_exec(command: str, **_kwargs: object) -> MagicMock:
-            if "rm -rf /logs/verifier" in command:
+            if "find /logs/verifier" in command:
                 remote_rewards.clear()
             return MagicMock(return_code=0, stdout="")
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from benchflow.sandbox.process import DaytonaProcess, DockerProcess
+from benchflow.sandbox.process import DaytonaProcess, DaytonaPtyProcess, DockerProcess
 
 
 class _FakeStdin:
@@ -60,6 +60,55 @@ def _make_daytona_sandbox(token="abc", exit_code=0, result=None):
         return_value=MagicMock(exit_code=exit_code, result=result)
     )
     return sandbox
+
+
+class _FakeDaytonaPty:
+    def __init__(self, on_data, send_error=None, reject_exec_env_file=True):
+        self._on_data = on_data
+        self._send_error = send_error
+        self._reject_exec_env_file = reject_exec_env_file
+        self.inputs = []
+        self.killed = False
+        self.disconnected = False
+
+    async def wait_for_connection(self):
+        return None
+
+    async def send_input(self, payload):
+        self.inputs.append(payload)
+        if self._reject_exec_env_file:
+            parts = shlex.split(payload)
+            if "exec" in parts:
+                exec_index = parts.index("exec")
+                assert "--env-file" not in parts[exec_index + 1 :]
+        if self._send_error:
+            raise self._send_error
+        marker = payload.split("echo '", 1)[1].split("'", 1)[0]
+        await self._on_data(f"{marker}\n".encode())
+
+    async def kill(self):
+        self.killed = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+
+def _make_daytona_pty_sandbox(result=None, send_error=None, exit_code=0):
+    sandbox = MagicMock()
+    if result is None:
+        result = "__BENCHFLOW_BOOTSTRAP_DONE__\n"
+    ptys = []
+
+    async def create_pty_session(*, id, on_data, envs=None):
+        pty = _FakeDaytonaPty(on_data=on_data, send_error=send_error)
+        ptys.append(pty)
+        return pty
+
+    sandbox.process.exec = AsyncMock(
+        return_value=MagicMock(exit_code=exit_code, result=result)
+    )
+    sandbox.process.create_pty_session = AsyncMock(side_effect=create_pty_session)
+    return sandbox, ptys
 
 
 class TestDockerProcessEnv:
@@ -265,10 +314,10 @@ class TestDaytonaProcessEnvFilePath:
     Guards the fix from PR #198 against the regression introduced by PR #193
     (DinD compose ACP via Daytona PTY WebSocket, commit cdccac7).
 
-    The DinD branch builds an inner compose command with `--env-file PATH`
-    through `shlex.join()`, while the env file is written by an SDK process
-    bootstrap. A literal `$$` path risks mismatched expansion across these
-    shell boundaries, so both Daytona branches use a uuid path.
+    The DinD branch writes provider values through a Daytona SDK process
+    bootstrap, then sources that remote env file before running compose with
+    only env names in argv. A literal `$$` path risks mismatched expansion
+    across these shell boundaries, so both Daytona branches use a uuid path.
     """
 
     @pytest.mark.asyncio
@@ -300,7 +349,10 @@ class TestDaytonaProcessEnvFilePath:
         assert "$$" not in bootstrap_cmd
         assert "/tmp/benchflow_env_" in bootstrap_cmd
         assert sandbox.process.exec.await_args.kwargs["env"] == {"FOO": "bar"}
-        assert "--env-file" in live_cmd
+        assert "--env FOO" in live_cmd
+        assert "--env-file" not in live_cmd
+        assert "bar" not in live_cmd
+        assert ". /tmp/benchflow_env_" in live_cmd
         assert "rm -f /tmp/benchflow_env_" in live_cmd
 
     @pytest.mark.asyncio
@@ -549,3 +601,112 @@ class TestDaytonaProcessSecretArgv:
         assert calls[0].args[0].startswith("sh -c ")
         assert calls[1].args[0].startswith("rm -f /tmp/benchflow_env_")
         assert proc._ssh_config_path is None
+
+
+class TestDaytonaPtyProcessSecretTransport:
+    """Regression tests for Daytona PTY env values staying out of PTY input."""
+
+    @pytest.mark.asyncio
+    async def test_provider_env_value_not_sent_through_pty_input(self):
+        """Guards the 2026-05-22 Daytona PTY env transport leak fix."""
+        sandbox, ptys = _make_daytona_pty_sandbox()
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+        secret = "bf_pty_provider_key_should_not_be_in_input"
+
+        await proc.start(command="codex-acp", env={"GEMINI_API_KEY": secret})
+
+        assert ptys
+        sent_payload = "\n".join(ptys[0].inputs)
+        assert secret not in sent_payload
+        bootstrap_call = sandbox.process.exec.await_args_list[0]
+        assert bootstrap_call.kwargs["env"] == {"GEMINI_API_KEY": secret}
+        assert secret not in bootstrap_call.args[0]
+        assert ". /tmp/benchflow_env_" in sent_payload
+        assert "rm -f /tmp/benchflow_env_" in sent_payload
+        assert "--env GEMINI_API_KEY" in sent_payload
+        assert "--env-file" not in sent_payload
+        assert "exec ." not in sent_payload
+        assert "&& exec docker compose -p test exec" in sent_payload
+
+        await proc.close()
+
+        cleanup_call = sandbox.process.exec.await_args_list[-1]
+        assert cleanup_call.args[0].startswith("rm -f /tmp/benchflow_env_")
+        assert secret not in cleanup_call.args[0]
+
+    @pytest.mark.asyncio
+    async def test_bootstrapped_env_file_is_removed_when_pty_handoff_fails(self):
+        """Guards remote env cleanup when Daytona PTY start fails after bootstrap."""
+        sandbox, ptys = _make_daytona_pty_sandbox(
+            send_error=RuntimeError("pty handoff failed")
+        )
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+
+        with pytest.raises(RuntimeError, match="pty handoff failed"):
+            await proc.start(command="codex-acp", env={"GEMINI_API_KEY": "secret"})
+
+        assert ptys
+        assert ptys[0].killed
+        assert ptys[0].disconnected
+        calls = sandbox.process.exec.await_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0].startswith("sh -c ")
+        assert calls[0].kwargs["env"] == {"GEMINI_API_KEY": "secret"}
+        assert calls[1].args[0].startswith("rm -f /tmp/benchflow_env_")
+        assert "secret" not in calls[1].args[0]
+
+    @pytest.mark.asyncio
+    async def test_bootstrapped_env_file_is_removed_when_pty_bootstrap_marker_missing(
+        self,
+    ):
+        """Guards remote env cleanup when Daytona PTY SDK bootstrap is ambiguous."""
+        sandbox, ptys = _make_daytona_pty_sandbox(result="no marker\n")
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to bootstrap Daytona PTY"):
+            await proc.start(command="codex-acp", env={"GEMINI_API_KEY": "secret"})
+
+        assert ptys
+        assert ptys[0].killed
+        assert ptys[0].disconnected
+        calls = sandbox.process.exec.await_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0].startswith("sh -c ")
+        assert calls[0].kwargs["env"] == {"GEMINI_API_KEY": "secret"}
+        assert calls[1].args[0].startswith("rm -f /tmp/benchflow_env_")
+        assert "secret" not in calls[1].args[0]
+
+    @pytest.mark.asyncio
+    async def test_bootstrapped_env_file_is_removed_when_pty_bootstrap_fails(self):
+        """Guards remote env cleanup when Daytona PTY env bootstrap fails."""
+        sandbox, ptys = _make_daytona_pty_sandbox(result="boom", exit_code=1)
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+
+        with pytest.raises(RuntimeError, match="Failed to bootstrap Daytona PTY"):
+            await proc.start(command="codex-acp", env={"GEMINI_API_KEY": "secret"})
+
+        assert ptys
+        assert ptys[0].killed
+        assert ptys[0].disconnected
+        calls = sandbox.process.exec.await_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0].startswith("sh -c ")
+        assert calls[0].kwargs["env"] == {"GEMINI_API_KEY": "secret"}
+        assert calls[1].args[0].startswith("rm -f /tmp/benchflow_env_")
+        assert "secret" not in calls[1].args[0]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,10 +1,65 @@
 """Tests for process.py env handling (no Docker required)."""
 
-from unittest.mock import AsyncMock, patch
+import os
+import shlex
+import subprocess
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from benchflow.sandbox.process import DockerProcess
+from benchflow.sandbox.process import DaytonaProcess, DockerProcess
+
+
+class _FakeStdin:
+    def __init__(self):
+        self.writes = []
+        self.drain = AsyncMock()
+        self.closed = False
+
+    def write(self, data):
+        self.writes.append(data)
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        *,
+        stdin=None,
+        stdout=None,
+        stderr=None,
+        communicate=None,
+        returncode=0,
+    ):
+        self.pid = 12345
+        self.returncode = returncode
+        self.stdin = stdin if stdin is not None else AsyncMock()
+        self.stdout = stdout if stdout is not None else AsyncMock()
+        self.stderr = stderr if stderr is not None else AsyncMock()
+        self.communicate = communicate if communicate is not None else AsyncMock()
+
+
+class _DaytonaExecHarness:
+    def __init__(self):
+        self.calls = []
+        self.live_stdin = _FakeStdin()
+
+    async def fake_exec(self, *args, **kwargs):
+        self.calls.append(list(args))
+        return _FakeProcess(stdin=self.live_stdin)
+
+
+def _make_daytona_sandbox(token="abc", exit_code=0, result=None):
+    sandbox = MagicMock()
+    sandbox.create_ssh_access = AsyncMock(return_value=MagicMock(token=token))
+    if result is None:
+        result = "__BENCHFLOW_BOOTSTRAP_DONE__\n"
+    sandbox.process.exec = AsyncMock(
+        return_value=MagicMock(exit_code=exit_code, result=result)
+    )
+    return sandbox
 
 
 class TestDockerProcessEnv:
@@ -210,27 +265,16 @@ class TestDaytonaProcessEnvFilePath:
     Guards the fix from PR #198 against the regression introduced by PR #193
     (DinD compose ACP via Daytona PTY WebSocket, commit cdccac7).
 
-    The DinD branch builds an inner `docker compose exec --env-file PATH ...`
-    command and runs it through `shlex.join()`, which single-quotes any `$$`
-    (preventing remote shell expansion). The `cat > PATH` heredoc that writes
-    the file uses raw f-string interpolation where `$$` IS expanded. If the
-    path contains `$$`, the file is written to one path and read from another
-    — env vars silently disappear.
-
-    The direct (non-DinD) branch uses raw f-string in both write and read, so
-    `$$` would expand consistently — but uuid is robust against future quoting
-    changes. Pin both branches.
+    The DinD branch builds an inner compose command with `--env-file PATH`
+    through `shlex.join()`, while the env file is written by an SDK process
+    bootstrap. A literal `$$` path risks mismatched expansion across these
+    shell boundaries, so both Daytona branches use a uuid path.
     """
 
     @pytest.mark.asyncio
     async def test_dind_env_file_path_does_not_use_shell_pid_expansion(self):
         """DinD path must not use $$ — shlex.join would quote it literally."""
-        from unittest.mock import MagicMock
-
-        from benchflow.sandbox.process import DaytonaProcess
-
-        sandbox = MagicMock()
-        sandbox.create_ssh_access = AsyncMock(return_value=MagicMock(token="abc"))
+        sandbox = _make_daytona_sandbox()
         proc = DaytonaProcess(
             sandbox=sandbox,
             is_dind=True,
@@ -238,59 +282,270 @@ class TestDaytonaProcessEnvFilePath:
             compose_cmd_base="docker compose -p test",
         )
 
-        captured = []
+        harness = _DaytonaExecHarness()
 
-        async def fake_exec(*args, **kwargs):
-            captured.append(list(args))
-            mock_proc = AsyncMock()
-            mock_proc.pid = 12345
-            mock_proc.returncode = 0
-            mock_proc.stdin = AsyncMock()
-            mock_proc.stdout = AsyncMock()
-            mock_proc.stderr = AsyncMock()
-            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
-            return mock_proc
-
-        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with patch("asyncio.create_subprocess_exec", side_effect=harness.fake_exec):
             await proc.start(command="echo hi", env={"FOO": "bar"})
 
-        # Last arg of ssh is the remote command. Search it for $$
-        remote_cmd = captured[0][-1]
-        assert "$$" not in remote_cmd, (
+        assert len(harness.calls) == 1
+        bootstrap_cmd = sandbox.process.exec.await_args.args[0]
+        live_cmd = harness.calls[0][-1]
+        assert "$$" not in live_cmd, (
             "$$ in remote command — shlex.join() will quote it, mismatching "
-            f"the cat heredoc that does expand it. Got: {remote_cmd[:200]!r}"
+            f"the SDK bootstrap command. Got: {live_cmd[:200]!r}"
         )
-        # And: a real path was used (literal hex suffix, no shell variable)
-        assert "/tmp/benchflow_env_" in remote_cmd
-        assert "--env-file" in remote_cmd
+
+        # And: a real path was used in the SDK bootstrap (literal hex suffix,
+        # no shell variable), while env values travel through Daytona's env map.
+        assert "$$" not in bootstrap_cmd
+        assert "/tmp/benchflow_env_" in bootstrap_cmd
+        assert sandbox.process.exec.await_args.kwargs["env"] == {"FOO": "bar"}
+        assert "--env-file" in live_cmd
+        assert "rm -f /tmp/benchflow_env_" in live_cmd
 
     @pytest.mark.asyncio
     async def test_direct_sandbox_env_file_path_does_not_use_shell_pid_expansion(self):
-        """Direct (non-DinD) path is currently safe with $$, but pin the uuid form for robustness."""
-        from unittest.mock import MagicMock
-
-        from benchflow.sandbox.process import DaytonaProcess
-
-        sandbox = MagicMock()
-        sandbox.create_ssh_access = AsyncMock(return_value=MagicMock(token="abc"))
+        """Direct (non-DinD) path must not rely on shell PID expansion."""
+        sandbox = _make_daytona_sandbox()
         proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
 
-        captured = []
+        harness = _DaytonaExecHarness()
 
-        async def fake_exec(*args, **kwargs):
-            captured.append(list(args))
-            mock_proc = AsyncMock()
-            mock_proc.pid = 12345
-            mock_proc.returncode = 0
-            mock_proc.stdin = AsyncMock()
-            mock_proc.stdout = AsyncMock()
-            mock_proc.stderr = AsyncMock()
-            mock_proc.communicate = AsyncMock(return_value=(b"", b""))
-            return mock_proc
-
-        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+        with patch("asyncio.create_subprocess_exec", side_effect=harness.fake_exec):
             await proc.start(command="echo hi", env={"FOO": "bar"})
 
-        remote_cmd = captured[0][-1]
-        assert "$$" not in remote_cmd
-        assert "/tmp/benchflow_env_" in remote_cmd
+        assert len(harness.calls) == 1
+        bootstrap_cmd = sandbox.process.exec.await_args.args[0]
+        live_cmd = harness.calls[0][-1]
+        assert "$$" not in live_cmd
+
+        assert "$$" not in bootstrap_cmd
+        assert "/tmp/benchflow_env_" in bootstrap_cmd
+        assert sandbox.process.exec.await_args.kwargs["env"] == {"FOO": "bar"}
+        assert "rm -f /tmp/benchflow_env_" in live_cmd
+
+    def test_direct_bootstrap_env_file_sources_single_quote_values(self, tmp_path):
+        """Guards the 2026-05-22 Daytona direct env quoting fix."""
+        env_file = tmp_path / "benchflow-env"
+        command = DaytonaProcess._bootstrap_env_command(
+            remote_env_path=str(env_file),
+            env_keys=["SAFE_QUOTE", "SPACE_VALUE"],
+            shell_exports=True,
+        )
+        env = {
+            **os.environ,
+            "SAFE_QUOTE": "it's fine",
+            "SPACE_VALUE": "hello world",
+        }
+
+        bootstrap = subprocess.run(
+            command,
+            shell=True,
+            executable="/bin/sh",
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert bootstrap.returncode == 0, bootstrap.stderr
+        assert "__BENCHFLOW_BOOTSTRAP_DONE__" in bootstrap.stdout.splitlines()
+
+        source = subprocess.run(
+            ". "
+            + shlex.quote(str(env_file))
+            + '; printf "%s\\n%s\\n" "$SAFE_QUOTE" "$SPACE_VALUE"',
+            shell=True,
+            executable="/bin/sh",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        assert source.returncode == 0, source.stderr
+        assert source.stdout.splitlines() == ["it's fine", "hello world"]
+
+
+class TestDaytonaProcessSecretArgv:
+    """Regression tests for Daytona env values staying out of local argv."""
+
+    @staticmethod
+    def _joined_calls(calls):
+        return "\n".join(" ".join(str(arg) for arg in call) for call in calls)
+
+    @pytest.mark.asyncio
+    async def test_direct_sandbox_env_value_not_passed_in_subprocess_argv(self):
+        """Guards the 2026-05-22 Daytona argv leak blocker fix."""
+        token = "ssh-token-abc"
+        sandbox = _make_daytona_sandbox(token=token)
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+
+        harness = _DaytonaExecHarness()
+        secret = "bf_live_provider_key_should_not_be_in_argv"
+
+        with patch("asyncio.create_subprocess_exec", side_effect=harness.fake_exec):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": secret})
+
+        assert harness.calls
+        for call in harness.calls:
+            for arg in call:
+                assert secret not in arg
+                assert token not in arg
+        bootstrap_cmd = sandbox.process.exec.await_args.args[0]
+        assert secret not in bootstrap_cmd
+        assert sandbox.process.exec.await_args.kwargs["env"] == {
+            "OPENAI_API_KEY": secret
+        }
+        ssh_config_path = harness.calls[0][2]
+        assert harness.calls[0][:2] == ["ssh", "-F"]
+        assert harness.calls[0][3] == "benchflow-daytona"
+        assert os.path.exists(ssh_config_path)
+
+        assert harness.live_stdin.writes == []
+        await proc.writeline('{"jsonrpc":"2.0"}')
+        assert harness.live_stdin.writes[-1] == b'{"jsonrpc":"2.0"}\n'
+        await proc.close()
+        assert not os.path.exists(ssh_config_path)
+
+    @pytest.mark.asyncio
+    async def test_dind_sandbox_env_value_not_passed_in_subprocess_argv(self):
+        """Guards the 2026-05-22 Daytona compose argv leak blocker fix."""
+        token = "ssh-token-abc"
+        sandbox = _make_daytona_sandbox(token=token)
+        proc = DaytonaProcess(
+            sandbox=sandbox,
+            is_dind=True,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+
+        harness = _DaytonaExecHarness()
+        secret = "bf_compose_provider_key_should_not_be_in_argv"
+
+        with patch("asyncio.create_subprocess_exec", side_effect=harness.fake_exec):
+            await proc.start(command="codex-acp", env={"ANTHROPIC_API_KEY": secret})
+
+        assert harness.calls
+        for call in harness.calls:
+            for arg in call:
+                assert secret not in arg
+                assert token not in arg
+        bootstrap_cmd = sandbox.process.exec.await_args.args[0]
+        assert secret not in bootstrap_cmd
+        assert sandbox.process.exec.await_args.kwargs["env"] == {
+            "ANTHROPIC_API_KEY": secret
+        }
+        ssh_config_path = harness.calls[0][2]
+        assert harness.calls[0][:2] == ["ssh", "-F"]
+        assert harness.calls[0][3] == "benchflow-daytona"
+        await proc.close()
+        assert not os.path.exists(ssh_config_path)
+
+    @pytest.mark.asyncio
+    async def test_daytona_debug_log_does_not_include_ssh_token(self, caplog):
+        """Daytona SSH access tokens must not be written to BenchFlow logs."""
+        sandbox = _make_daytona_sandbox()
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+        harness = _DaytonaExecHarness()
+
+        with patch("asyncio.create_subprocess_exec", side_effect=harness.fake_exec):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": "secret"})
+
+        assert "abc@ssh.app.daytona.io" not in caplog.text
+        assert "User=abc" not in caplog.text
+        await proc.close()
+
+    @pytest.mark.asyncio
+    async def test_two_step_bootstrap_leaves_live_stdin_for_agent_frames(self):
+        """Guards against bootstrap shell text reaching the live ACP stdin."""
+        sandbox = _make_daytona_sandbox()
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+        harness = _DaytonaExecHarness()
+
+        with patch("asyncio.create_subprocess_exec", side_effect=harness.fake_exec):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": "secret"})
+
+        sandbox.process.exec.assert_awaited_once()
+        assert harness.live_stdin.writes == []
+
+        first_frame = '{"jsonrpc":"2.0"}'
+        await proc.writeline(first_frame)
+        assert harness.live_stdin.writes == [b'{"jsonrpc":"2.0"}\n']
+        await proc.close()
+
+    @pytest.mark.asyncio
+    async def test_bootstrapped_env_file_is_removed_when_ssh_launch_fails(self):
+        """Guards the 2026-05-22 Daytona launch-failure cleanup fix."""
+        sandbox = _make_daytona_sandbox()
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+
+        with (
+            patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=OSError("ssh launch failed"),
+            ),
+            pytest.raises(OSError),
+        ):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": "secret"})
+
+        calls = sandbox.process.exec.await_args_list
+        assert len(calls) == 2
+        bootstrap_cmd = calls[0].args[0]
+        cleanup_cmd = calls[1].args[0]
+        assert "/tmp/benchflow_env_" in bootstrap_cmd
+        assert cleanup_cmd.startswith("rm -f /tmp/benchflow_env_")
+        assert "secret" not in cleanup_cmd
+        assert proc._ssh_config_path is None
+
+    @pytest.mark.asyncio
+    async def test_ssh_config_not_created_when_env_bootstrap_fails(self):
+        """Guards temp SSH config cleanup when SDK bootstrap fails early."""
+        sandbox = _make_daytona_sandbox(exit_code=1, result="boom")
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+
+        with (
+            patch.object(DaytonaProcess, "_write_ssh_config") as write_config,
+            pytest.raises(RuntimeError, match="Failed to bootstrap Daytona agent env"),
+        ):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": "secret"})
+
+        write_config.assert_not_called()
+        assert proc._ssh_config_path is None
+
+    @pytest.mark.asyncio
+    async def test_bootstrapped_env_file_is_removed_when_ssh_access_fails(self):
+        """Guards remote env cleanup when SSH access fails after bootstrap."""
+        sandbox = _make_daytona_sandbox()
+        sandbox.create_ssh_access = AsyncMock(side_effect=RuntimeError("ssh access"))
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+
+        with pytest.raises(RuntimeError, match="ssh access"):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": "secret"})
+
+        calls = sandbox.process.exec.await_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0].startswith("sh -c ")
+        assert calls[1].args[0].startswith("rm -f /tmp/benchflow_env_")
+        assert proc._ssh_config_path is None
+
+    @pytest.mark.asyncio
+    async def test_bootstrapped_env_file_is_removed_when_ssh_config_write_fails(self):
+        """Guards remote env cleanup when local SSH config creation fails."""
+        sandbox = _make_daytona_sandbox()
+        proc = DaytonaProcess(sandbox=sandbox, is_dind=False)
+
+        with (
+            patch.object(
+                DaytonaProcess,
+                "_write_ssh_config",
+                side_effect=OSError("config failed"),
+            ),
+            pytest.raises(OSError, match="config failed"),
+        ):
+            await proc.start(command="codex-acp", env={"OPENAI_API_KEY": "secret"})
+
+        calls = sandbox.process.exec.await_args_list
+        assert len(calls) == 2
+        assert calls[0].args[0].startswith("sh -c ")
+        assert calls[1].args[0].startswith("rm -f /tmp/benchflow_env_")
+        assert proc._ssh_config_path is None

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -43,12 +43,9 @@ VALID_ACP_MODEL_FORMATS = {
     "registered-provider/model",
 }
 JS_ACP_AGENTS = {
-    "claude-agent-acp",
-    "pi-acp",
-    "openclaw",
-    "codex-acp",
-    "gemini",
-    "opencode",
+    name
+    for name, cfg in AGENTS.items()
+    if cfg.protocol == "acp" and "npm install" in cfg.install_cmd
 }
 
 
@@ -159,6 +156,14 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
         assert fragment not in install_cmd, (
             f"{name!r} JS agent install must not mutate task Node/npm via {fragment!r}"
         )
+
+
+@pytest.mark.parametrize("name", sorted(JS_ACP_AGENTS))
+def test_js_acp_agent_install_is_posix_sh_compatible(name):
+    """Guards the full SkillsBench Daytona run against dash rejecting pipefail."""
+    install_cmd = AGENTS[name].install_cmd
+
+    assert "set -o pipefail" not in install_cmd
 
 
 def test_js_agent_install_respects_explicit_npm_package_specs():

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -135,7 +135,7 @@ class TestHardenSequence:
         cmds = [c.args[0] for c in env.exec.call_args_list]
         assert "pkill -u agent" in cmds[0]
         wipe_idx = next(
-            (i for i, c in enumerate(cmds) if "rm -rf /logs/verifier" in c), None
+            (i for i, c in enumerate(cmds) if "find /logs/verifier" in c), None
         )
         chown_idx = next(
             (i for i, c in enumerate(cmds) if "chown -R root:root /testbed" in c),
@@ -149,7 +149,7 @@ class TestHardenSequence:
         assert not any("rm -f /testbed/setup.py" in c for c in cmds)
         assert not any("rsync -a --delete /testbed_verify/" in c for c in cmds)
         assert any("mkdir -p /logs/verifier" in c for c in cmds)
-        assert any("mkdir -p /logs/verifier /app" in c for c in cmds)
+        assert any(c == "mkdir -p /app" for c in cmds)
         cleanup_cmd = next(c for c in cmds if "conftest.py" in c)
         assert "sitecustomize.py" in cleanup_cmd and ".pth" in cleanup_cmd
         assert "-not -path '/tests/*'" in cleanup_cmd
@@ -197,11 +197,11 @@ class TestHardenSequence:
 
 
 class TestVerifierDirWipe:
-    """Tier 1: /logs/verifier/ is wiped and recreated before the verifier runs."""
+    """Tier 1: /logs/verifier/ contents are wiped before the verifier runs."""
 
     @pytest.mark.asyncio
-    async def test_wipe_recreates_verifier_dir(self):
-        """rm -rf, mkdir -p, and chmod 777 are all in one atomic call; it runs as root."""
+    async def test_wipe_preserves_verifier_mountpoint(self):
+        """Clean children without deleting the Daytona DinD verifier mount."""
         from benchflow.sandbox.lockdown import harden_before_verify
 
         env = _make_env()
@@ -211,16 +211,37 @@ class TestVerifierDirWipe:
             (
                 c
                 for c in env.exec.call_args_list
-                if "rm -rf /logs/verifier" in c.args[0]
-                and "mkdir -p /logs/verifier /app" in c.args[0]
+                if "find /logs/verifier -mindepth 1" in c.args[0]
                 and "chmod 777 /logs/verifier" in c.args[0]
             ),
             None,
         )
         assert match is not None, (
-            "expected a single call with rm -rf, mkdir -p, and chmod 777 for /logs/verifier"
+            "expected a single call that clears /logs/verifier contents "
+            "without deleting the mountpoint"
         )
+        assert "rm -rf /logs/verifier &&" not in match.args[0]
+        assert "command -v find" in match.args[0]
+        assert "|| {" in match.args[0]
+        assert "|| (" not in match.args[0]
+        assert "-exec rm -rf -- {} +" in match.args[0]
         assert match.kwargs.get("user") == "root"
+
+    @pytest.mark.asyncio
+    async def test_wipe_failure_is_not_ignored(self):
+        """Verifier setup must not continue with stale reward outputs after wipe failure."""
+        from benchflow.sandbox.lockdown import harden_before_verify
+
+        def side_effect(cmd, **kwargs):
+            del kwargs
+            if "find /logs/verifier" in cmd:
+                return MagicMock(stdout="", stderr="Device or resource busy", exit_code=1)
+            return MagicMock(stdout="", stderr="", exit_code=0)
+
+        env = _make_env(side_effect=side_effect)
+
+        with pytest.raises(RuntimeError, match="Device or resource busy"):
+            await harden_before_verify(env, _make_task(), sandbox_user=None)
 
     def test_cleanup_cmd_no_maxdepth(self):
         """CLEANUP_CMD must not limit find depth so deeply nested conftest.py is caught."""

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -222,9 +222,10 @@ class TestVerifierDirWipe:
         )
         assert "rm -rf /logs/verifier &&" not in match.args[0]
         assert "command -v find" in match.args[0]
-        assert "|| {" in match.args[0]
-        assert "|| (" not in match.args[0]
+        # The find-preferred path uses -exec rm -rf; the else branch falls
+        # back to rm -rf /logs/verifier/* for images that lack find.
         assert "-exec rm -rf -- {} +" in match.args[0]
+        assert "else" in match.args[0]
         assert match.kwargs.get("user") == "root"
 
     @pytest.mark.asyncio

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -14,6 +14,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from benchflow.sandbox._base import ExecResult
+from benchflow.sandbox._compose import (
+    compose_cp_destination,
+    compose_mkdir_p_command,
+    compose_parent_mkdir_p_command,
+)
 from benchflow.sandbox.docker import DockerSandbox
 from benchflow.sandbox.process import DockerProcess
 
@@ -236,6 +241,132 @@ class TestSingleContainerFileTransferRejection:
         strategy = _DaytonaDirect.__new__(_DaytonaDirect)
         with pytest.raises(ValueError, match="single-container"):
             await strategy.upload_dir("/host/tests", "/tests", service="target")
+
+
+class TestDaytonaDinDServiceFileTransfer:
+    """Daytona DinD uploads must prepare compose-container destinations."""
+
+    def test_compose_upload_helpers_do_not_require_daytona_sdk(self) -> None:
+        """Guards Daytona path preparation in dev envs without sandbox-daytona."""
+        assert compose_mkdir_p_command("/app/skills") == "mkdir -p /app/skills"
+        assert (
+            compose_mkdir_p_command("/app with spaces/skills")
+            == "mkdir -p '/app with spaces/skills'"
+        )
+        assert (
+            compose_parent_mkdir_p_command("/app with spaces/instruction.md")
+            == "mkdir -p '/app with spaces'"
+        )
+        assert compose_parent_mkdir_p_command("instruction.md") is None
+        assert compose_cp_destination("target", "/app/skills") == "target:/app/skills"
+
+    def _make_strategy(self):
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        strategy._env = MagicMock()
+        strategy._env._sdk_upload_dir = AsyncMock()
+        strategy._env._sdk_upload_file = AsyncMock()
+        strategy._vm_exec = AsyncMock(
+            return_value=ExecResult(stdout="", stderr="", return_code=0)
+        )
+        return strategy
+
+    @pytest.mark.asyncio
+    async def test_dind_upload_dir_creates_target_before_compose_cp(self) -> None:
+        """Guards full SkillsBench Daytona tasks whose images have no /app."""
+        strategy = self._make_strategy()
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        await strategy.upload_dir("/host/skills", "/app/skills")
+
+        assert captured[0][-3:] == ["sh", "-c", "mkdir -p /app/skills"]
+        assert "-u" in captured[0]
+        assert captured[0][captured[0].index("-u") + 1] == "root"
+        assert captured[1][0] == "cp"
+        assert captured[1][1].endswith("/.")
+        assert captured[1][2] == "main:/app/skills"
+
+    @pytest.mark.asyncio
+    async def test_dind_upload_file_creates_parent_before_compose_cp(self) -> None:
+        """Guards file uploads into images whose Dockerfile uses WORKDIR /root."""
+        strategy = self._make_strategy()
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        await strategy.upload_file("/host/instruction.md", "/app dir/instruction.md")
+
+        assert captured[0][-3:] == ["sh", "-c", "mkdir -p '/app dir'"]
+        assert captured[1][0] == "cp"
+        assert captured[1][2] == "main:/app dir/instruction.md"
+
+    @pytest.mark.asyncio
+    async def test_dind_upload_file_reports_destination_prep_failure(self) -> None:
+        """Destination prep failures should not be hidden by a later compose cp."""
+        strategy = self._make_strategy()
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            del timeout_sec
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="mkdir denied", return_code=13)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="destination prep failed"):
+            await strategy.upload_file("/host/instruction.md", "/app/instruction.md")
+
+        assert len(captured) == 1
+        assert captured[0][-3:] == ["sh", "-c", "mkdir -p /app"]
+
+    @pytest.mark.asyncio
+    async def test_dind_upload_dir_creates_named_service_target(self) -> None:
+        """Guards Daytona DinD uploads into non-main compose services."""
+        strategy = self._make_strategy()
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+        await strategy.upload_dir("/host/skills", "/target app/skills", service="target")
+
+        assert captured[0][-4:] == ["target", "sh", "-c", "mkdir -p '/target app/skills'"]
+        assert "-u" in captured[0]
+        assert captured[0][captured[0].index("-u") + 1] == "root"
+        assert captured[1][0] == "cp"
+        assert captured[1][1].endswith("/.")
+        assert captured[1][2] == "target:/target app/skills"
+
+    @pytest.mark.asyncio
+    async def test_dind_upload_dir_reports_destination_prep_failure(self) -> None:
+        """Directory upload prep failures should mention mkdir stderr directly."""
+        strategy = self._make_strategy()
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            del timeout_sec
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="read-only target", return_code=30)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError, match="read-only target"):
+            await strategy.upload_dir("/host/skills", "/app/skills", service="target")
+
+        assert len(captured) == 1
+        assert captured[0][-3:] == ["sh", "-c", "mkdir -p /app/skills"]
 
 
 class TestDockerProcessServiceSelection:

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -243,6 +243,79 @@ class TestSingleContainerFileTransferRejection:
             await strategy.upload_dir("/host/tests", "/tests", service="target")
 
 
+class TestDaytonaDirectFileTransfer:
+    """Direct Daytona uploads should match single-container path prep semantics."""
+
+    @pytest.mark.asyncio
+    async def test_upload_dir_creates_target_before_sdk_upload(self) -> None:
+        """Guards the follow-up to f7d382b against direct Daytona images with no /app."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDirect
+
+        strategy = _DaytonaDirect.__new__(_DaytonaDirect)
+        strategy._env = MagicMock()
+        events: list[tuple[object, ...]] = []
+
+        async def fake_exec(
+            command,
+            cwd=None,
+            env=None,
+            timeout_sec=None,
+            user=None,
+        ):
+            del cwd, env
+            events.append(("exec", command, user, timeout_sec))
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        async def fake_upload(source_dir, target_dir):
+            events.append(("upload", source_dir, target_dir))
+
+        strategy._env._sandbox_exec = fake_exec
+        strategy._env._sdk_upload_dir = fake_upload
+
+        await strategy.upload_dir("/host/skills", "/app dir/skills")
+
+        assert events == [
+            ("exec", "mkdir -p '/app dir/skills'", "root", 30),
+            ("upload", "/host/skills", "/app dir/skills"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_upload_dir_reports_destination_prep_failure(self) -> None:
+        """Guards the follow-up to f7d382b against hidden direct Daytona mkdir failures."""
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox.daytona import _DaytonaDirect
+
+        strategy = _DaytonaDirect.__new__(_DaytonaDirect)
+        strategy._env = MagicMock()
+
+        async def fake_exec(
+            command,
+            cwd=None,
+            env=None,
+            timeout_sec=None,
+            user=None,
+        ):
+            del command, cwd, env, timeout_sec, user
+            return ExecResult(
+                stdout="mkdir stdout",
+                stderr="mkdir denied",
+                return_code=13,
+            )
+
+        strategy._env._sandbox_exec = fake_exec
+        strategy._env._sdk_upload_dir = AsyncMock()
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await strategy.upload_dir("/host/skills", "/app/skills")
+
+        message = str(exc_info.value)
+        assert "destination prep failed" in message
+        assert "mkdir stdout" in message
+        assert "mkdir denied" in message
+        strategy._env._sdk_upload_dir.assert_not_awaited()
+
+
 class TestDaytonaDinDServiceFileTransfer:
     """Daytona DinD uploads must prepare compose-container destinations."""
 

--- a/tests/test_scene_outbox_trial.py
+++ b/tests/test_scene_outbox_trial.py
@@ -520,3 +520,33 @@ async def test_scene_skills_link_remote_generated_root() -> None:
         "ln -sfn /app/generated-skills /home/agent/.claude/skills" in cmd
         for cmd in trial._env._exec_log
     )
+
+
+async def test_scene_skills_prefers_remote_string_path_over_matching_host_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """String sandbox paths stay remote even if the host has a matching path."""
+    original_is_dir = Path.is_dir
+
+    def fake_is_dir(path: Path) -> bool:
+        if path.as_posix() == "/app/generated-skills":
+            return True
+        return original_is_dir(path)
+
+    monkeypatch.setattr(Path, "is_dir", fake_is_dir)
+    scene = Scene(
+        name="solve",
+        roles=[Role("solver", "claude-agent-acp", "haiku")],
+        turns=[Turn("solver")],
+        skills_dir="/app/generated-skills",
+    )
+    trial = _make_trial(scene)
+    trial._agent_cwd = "/app"
+
+    await trial._activate_scene_skills(scene)
+
+    assert trial._env._uploads == []
+    assert any(
+        "ln -sfn /app/generated-skills /home/agent/.claude/skills" in cmd
+        for cmd in trial._env._exec_log
+    )

--- a/tests/test_self_gen_orchestration.py
+++ b/tests/test_self_gen_orchestration.py
@@ -46,7 +46,7 @@ def _skill_dir_names(root: Path) -> set[str]:
 async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_contexts(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """Guards PR #233: self-gen is one BYOS-style trial with two scenes."""
+    """Guards PR #233: self-gen uses two scenes and scene-local skill activation."""
     task = _make_task(tmp_path)
     skill_creator_root = _make_skill_creator_root(tmp_path)
     original_skills = tmp_path / "original-skills"
@@ -137,6 +137,9 @@ async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_
             {"timeout_sec": 10},
         )
     ]
+    assert all("/root/generated-skills" not in cmd for cmd, _ in env_commands)
+    assert all("/root/skills" not in cmd for cmd, _ in env_commands)
+    assert all("/app/workspace/generated-skills" not in cmd for cmd, _ in env_commands)
 
     assert [scene.name for scene in trial_cfg.scenes] == [
         "self-gen-creator",
@@ -210,6 +213,7 @@ async def test_job_self_gen_uses_strict_orchestration(
         "self-gen-creator",
         "self-gen-solver",
     ]
+    assert seen_configs[0].scenes[1].skills_dir == "/app/generated-skills"
 
 
 @pytest.mark.asyncio

--- a/tests/test_self_gen_orchestration.py
+++ b/tests/test_self_gen_orchestration.py
@@ -120,7 +120,10 @@ async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_
     assert trial_cfg.skills_dir is None
     assert trial_cfg.prompts is None
     assert trial_cfg.self_gen_no_internet is True
-    assert trial_cfg.export_generated_skills_to is None
+    export_target = Path(trial_cfg.export_generated_skills_to)
+    assert export_target.parent.parent == tmp_path / "jobs" / "_self_gen"
+    assert export_target.parent.name.startswith("task-")
+    assert export_target.name == "generated-skills"
     assert len(trial_cfg.pre_agent_hooks or []) == 1
 
     env_commands = []
@@ -159,6 +162,64 @@ async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_
     assert solver_scene.name == "self-gen-solver"
     assert solver_scene.skills_dir == "/app/generated-skills"
     assert solver_scene.turns[0].prompt is None
+
+
+@pytest.mark.asyncio
+async def test_sdk_self_gen_cleanup_exports_generated_skills_to_sidecar(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Guards PR #346: self-gen solver skills are durably exported for audit."""
+    task = _make_task(tmp_path)
+    skill_creator_root = _make_skill_creator_root(tmp_path)
+    seen_configs = []
+    solver_result = RunResult(task_name="task", rewards={"reward": 1.0})
+
+    class FakeTrial:
+        def __init__(self, config):
+            self._config = config
+
+        @classmethod
+        async def create(cls, config):
+            seen_configs.append(config)
+            return cls(config)
+
+        async def run(self):
+            return solver_result
+
+    monkeypatch.setattr("benchflow.self_gen.Rollout", FakeTrial)
+
+    await SDK().run(
+        task_path=task,
+        agent="opencode",
+        model="google/gemini-3.1-pro-preview",
+        jobs_dir=tmp_path / "jobs",
+        environment="daytona",
+        skill_mode="self-gen",
+        skill_creator_dir=skill_creator_root,
+    )
+
+    trial_cfg = seen_configs[0]
+    export_target = Path(trial_cfg.export_generated_skills_to)
+    downloads = []
+
+    class FakeEnv:
+        async def download_dir(self, source_dir, target_dir):
+            target = Path(target_dir)
+            downloads.append((source_dir, target))
+            skill = target / "solver-made"
+            skill.mkdir(parents=True)
+            (skill / "SKILL.md").write_text("# Solver Made\n")
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = trial_cfg
+    rollout._env = FakeEnv()
+
+    await Rollout._export_generated_skills(rollout)
+
+    assert downloads == [(trial_cfg.generated_skills_root, export_target)]
+    assert export_target.parent.parent == tmp_path / "jobs" / "_self_gen"
+    assert (export_target / "solver-made" / "SKILL.md").read_text() == "# Solver Made\n"
+    assert rollout._evolved_skills == {"solver-made": "# Solver Made\n"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -447,3 +447,19 @@ class TestSoftVerify:
         # Verify cleanup command was executed
         exec_log = trial._env._exec_log
         assert any("cleanup_sentinel" in cmd for cmd in exec_log)
+        assert any("find /logs/verifier -mindepth 1" in cmd for cmd in exec_log)
+        assert any(cmd == "mkdir -p /app" for cmd in exec_log)
+
+    @pytest.mark.asyncio
+    async def test_soft_verify_reports_cleanup_failure(self):
+        trial = _make_user_trial(PassthroughUser())
+        trial._env.exec = AsyncMock(
+            return_value=FakeExecResult(stderr="Device or resource busy", return_code=1)
+        )
+
+        rewards, output, error = await trial.soft_verify()
+
+        assert rewards is None
+        assert output is None
+        assert "Soft verifier setup failed" in error
+        assert "Device or resource busy" in error

--- a/tests/test_verifier_output_freshness.py
+++ b/tests/test_verifier_output_freshness.py
@@ -35,9 +35,10 @@ class _StatefulTargetSandbox:
 
     is_mounted = True
 
-    def __init__(self) -> None:
+    def __init__(self, *, fail_on_mountpoint_delete: bool = False) -> None:
         self.exec_calls: list[dict] = []
         self.remote_target_reward: str | None = "1.0"
+        self.fail_on_mountpoint_delete = fail_on_mountpoint_delete
 
     async def upload_dir(self, source_dir, target_dir, service: str = "main") -> None:
         del source_dir, target_dir, service
@@ -51,7 +52,13 @@ class _StatefulTargetSandbox:
 
     async def exec(self, command, service: str = "main", **kwargs) -> ExecResult:
         self.exec_calls.append({"command": command, "service": service, **kwargs})
-        if service == "target" and "rm -rf /logs/verifier" in command:
+        if self.fail_on_mountpoint_delete and "rm -rf /logs/verifier &&" in command:
+            return ExecResult(
+                stdout="",
+                stderr="rm: cannot remove '/logs/verifier': Device or resource busy",
+                return_code=1,
+            )
+        if service == "target" and "find /logs/verifier" in command:
             self.remote_target_reward = None
         return ExecResult(stdout="", stderr="", return_code=0)
 
@@ -64,17 +71,44 @@ async def test_mounted_target_verifier_clears_stale_remote_reward(
     task = _make_task(tmp_path)
     rollout_paths = RolloutPaths(tmp_path / "rollout")
     rollout_paths.mkdir()
-    sandbox = _StatefulTargetSandbox()
+    sandbox = _StatefulTargetSandbox(fail_on_mountpoint_delete=True)
 
     with pytest.raises(RewardFileNotFoundError):
         await Verifier(task, rollout_paths, sandbox).verify()
 
     commands = [call["command"] for call in sandbox.exec_calls]
     clear_index = next(
-        i for i, command in enumerate(commands) if "rm -rf /logs/verifier" in command
+        i for i, command in enumerate(commands) if "find /logs/verifier" in command
     )
     test_index = next(
         i for i, command in enumerate(commands) if "test-stdout.txt" in command
     )
     assert clear_index < test_index
     assert sandbox.exec_calls[clear_index]["service"] == "target"
+
+
+@pytest.mark.asyncio
+async def test_non_mounted_verifier_clears_contents_without_removing_mountpoint(
+    tmp_path: Path,
+) -> None:
+    """Guards v0.5-integration@2014952 from deleting Daytona DinD log mounts."""
+    task = _make_task(tmp_path)
+    task.config.verifier.service = "main"
+    rollout_paths = RolloutPaths(tmp_path / "rollout")
+    rollout_paths.mkdir()
+    sandbox = _StatefulTargetSandbox()
+    sandbox.is_mounted = False
+
+    with pytest.raises(RewardFileNotFoundError):
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+    clear_command = next(
+        call["command"]
+        for call in sandbox.exec_calls
+        if "find /logs/verifier" in call["command"]
+    )
+    assert "rm -rf /logs/verifier &&" not in clear_command
+    assert "mkdir -p /logs/verifier" in clear_command
+    assert "find /logs/verifier -mindepth 1" in clear_command
+    assert "-exec rm -rf -- {} +" in clear_command
+    assert "mkdir -p /app" not in clear_command


### PR DESCRIPTION
## Summary

This PR brings the v0.5 integration branch up to the latest Daytona/runtime hardening, dashboard evidence visibility, ACP self-gen handoff work, and durable SkillsBench audit documentation.

Key changes:
- Harden Daytona env transport, PTY handling, upload setup, and verifier output cleanup.
- Make dashboard jobs/evidence parsing more faithful to rollout trees and retry rows.
- Preserve raw rollout evidence while showing summary-level benchmark totals.
- Keep ACP self-gen handoff native by using the canonical generated skills root instead of hard-coded alias hacks.
- Add durable audit reports for the full 94-task SkillsBench baseline and 9-task three-mode subset.
- Add handoff doc for next-step issue repair and fast v0.5 completion.

### Review feedback fixes (new commits)

All 6 review comments from Codex Review and Cursor Bugbot have been addressed:

1. **`lockdown.py` — find fallback** (`cecf60e`): Verifier dir wipe now falls back to `rm -rf /logs/verifier/*` when `find` is unavailable, instead of hard-failing with exit 127. Both paths preserve bind-mount safety.

2. **`lockdown.py` — deduplicate `_exec_return_code`** (`cecf60e`): Consolidated into `lockdown.py`; `verifier.py` imports from there.

3. **`dashboard/generate.py` — nested mode runs** (`23e97a1`): `_nested_run_dirs` no longer requires `summary.json` in mode dirs. Task-directory presence is the primary signal; `summary_dir` is set only when `summary.json` exists.

4. **`dashboard/generate.py` — empty RunRecords** (`23e97a1`): `jobs_tree_runs` no longer emits phantom `RunRecord(task_dirs=[])` for unrecognized group children.

5. **`dashboard/index.html` — score truthiness** (`31439d0`): Changed `if (summary.score)` to `if (summary.score != null)` consistent with surrounding checks.

6. **`process.py` — DinD env transport** (`ac1195c`): Removed early `rm -f` of the env file in the DinD branch. The EXIT trap handles cleanup; keeping the file alive until exit ensures sourced vars survive `compose_cmd_prefix` wrappers.

## Handoff

Read this first for continuation:
- `docs/reports/2026-05-23-v05-integration-handoff.md`

## Review & Testing Checklist for Human

- [ ] Verify `_CLEAR_VERIFIER_DIR_CMD` fallback works on a minimal Docker image without `find` (e.g. `alpine:3.18` with `find` removed)
- [ ] Confirm nested mode runs without `summary.json` appear correctly in the dashboard
- [ ] Test `summary.score = 0` renders in the dashboard UI (not suppressed)
- [ ] Verify DinD env transport works with a non-trivial `compose_cmd_prefix`

### Notes

- 3 pre-existing test failures confirmed on the base branch (`v0.5-integration`): `test_check_results_dedupes_retried_task_results`, `test_eval_create_loads_dotenv_for_sandbox_provider_auth`, `test_task_config_public_toml_dump_omits_expected_skills_fixture` (missing `toml` module). Not introduced by this PR.
- Thermo-nuclear code quality audit running via subagent — results pending.
- Full test suite: 1820 passed, 38 skipped, 3 pre-existing failures.

Link to Devin session: https://app.devin.ai/sessions/7ffe743e0d494b8692b10babc75c992a
Requested by: @xdotli