### PR TITLE
feat: add Azure AI Foundry provider routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Azure AI Foundry providers** — new `azure-foundry-openai/` and `azure-foundry-anthropic/` prefixes routing through Foundry's unified resource. Export `AZURE_API_KEY` plus `AZURE_API_ENDPOINT` (e.g. `https://<resource>.openai.azure.com/`); benchflow derives the resource name from the endpoint host, builds the per-surface base URL, and maps the key onto the agent-native auth env automatically. Missing/unrecognized endpoints fail fast with a clear error instead of falling through to `api.openai.com`.
+- **Azure AI Foundry providers** — new `azure-foundry-openai/` and `azure-foundry-anthropic/` prefixes routing through Foundry's unified resource. Export `AZURE_API_KEY` plus `AZURE_API_ENDPOINT` (e.g. `https://<resource>.openai.azure.com/`); benchflow derives the resource name from the endpoint host, builds the per-surface base URL, and maps the key onto the agent-native auth env automatically. Missing/unrecognized endpoints and unsupported agent/provider protocol pairings fail fast with clear errors instead of falling through to the wrong endpoint.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Azure AI Foundry providers** — new `azure-foundry-openai/` and `azure-foundry-anthropic/` prefixes routing through Foundry's unified resource. Set `AZURE_API_KEY` and `AZURE_API_ENDPOINT` (or any of the `AZURE_OPENAI_*` / `AZURE_AI_FOUNDRY_*` aliases) and benchflow derives the resource name, base URL, and per-surface auth env automatically.
+
 ### Fixed
 
 - Inherit `BENCHFLOW_PROVIDER_BASE_URL` / `BENCHFLOW_PROVIDER_API_KEY` from the host environment so self-hosted / OpenAI-compatible endpoints route correctly instead of falling back to `api.openai.com`; empty or whitespace-only host values are skipped so they cannot shadow the resolved provider URL (benchflow-ai/skillsbench#817).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- **Azure AI Foundry providers** — new `azure-foundry-openai/` and `azure-foundry-anthropic/` prefixes routing through Foundry's unified resource. Set `AZURE_API_KEY` and `AZURE_API_ENDPOINT` (or any of the `AZURE_OPENAI_*` / `AZURE_AI_FOUNDRY_*` aliases) and benchflow derives the resource name, base URL, and per-surface auth env automatically.
+- **Azure AI Foundry providers** — new `azure-foundry-openai/` and `azure-foundry-anthropic/` prefixes routing through Foundry's unified resource. Export `AZURE_API_KEY` plus `AZURE_API_ENDPOINT` (e.g. `https://<resource>.openai.azure.com/`); benchflow derives the resource name from the endpoint host, builds the per-surface base URL, and maps the key onto the agent-native auth env automatically. Missing/unrecognized endpoints fail fast with a clear error instead of falling through to `api.openai.com`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Azure AI Foundry providers** — new `azure-foundry-openai/` and `azure-foundry-anthropic/` prefixes routing through Foundry's unified resource. Export `AZURE_API_KEY` plus `AZURE_API_ENDPOINT` (e.g. `https://<resource>.openai.azure.com/`); benchflow derives the resource name from the endpoint host, builds the per-surface base URL, and maps the key onto the agent-native auth env automatically. Missing/unrecognized endpoints and unsupported agent/provider protocol pairings fail fast with clear errors instead of falling through to the wrong endpoint.
+- **Azure Foundry auth guidance** — agent discovery output and docs now call out that provider-prefixed models can use provider-specific credentials instead of the agent's native/default API key.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ BenchFlow runs AI agents against benchmark tasks in sandboxed environments. Sing
 uv tool install benchflow
 ```
 
-Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/). Set `DAYTONA_API_KEY` for Daytona runs or configure Modal auth for Modal runs; export the relevant agent API key (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) or run `claude login` / `codex --login` for subscription auth.
+Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/). Set `DAYTONA_API_KEY` for Daytona runs or configure Modal auth for Modal runs; export the relevant agent API key (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) or run `claude login` / `codex --login` for subscription auth. Provider-prefixed models may use provider-specific credentials; Azure Foundry models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
 
 ## Documentation
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,13 +65,26 @@ export OPENAI_API_KEY=sk-...
 export CODEX_API_KEY=sk-...       # Codex alias for OPENAI_API_KEY
 export GEMINI_API_KEY=...
 export LLM_API_KEY=...           # OpenHands / LiteLLM-compatible providers
+export AZURE_API_KEY=...
+export AZURE_API_ENDPOINT=https://<resource>.openai.azure.com/
 ```
 
 benchflow auto-inherits well-known API key env vars from your shell into the sandbox.
+Provider-prefixed models can use credentials that differ from the agent's
+native default auth. For Azure Foundry, use models such as
+`azure-foundry-openai/gpt-5.5` or
+`azure-foundry-anthropic/claude-opus-4-5`; benchflow derives the Azure resource
+from `AZURE_API_ENDPOINT` and maps `AZURE_API_KEY` onto the selected agent's
+native auth env inside the sandbox.
 
 ### Precedence
 
-If multiple credentials are set, benchflow / the agent CLI uses (high to low): cloud provider creds → `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `apiKeyHelper` → `CLAUDE_CODE_OAUTH_TOKEN` → host subscription OAuth. To force a lower-priority option, unset the higher one in your shell before running.
+If multiple credentials are set, benchflow / the agent CLI uses provider-specific
+credentials selected by the model prefix first, then the agent's native auth
+precedence. For Claude, native auth is (high to low): cloud provider creds →
+`ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `apiKeyHelper` →
+`CLAUDE_CODE_OAUTH_TOKEN` → host subscription OAuth. To force a lower-priority
+option, unset the higher one in your shell before running.
 
 ## Run your first eval
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -13,6 +13,10 @@ The core matrix runs 9 SkillsBench tasks across all 8 registered agents on Dayto
 | `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` | claude-agent-acp |
 | `OPENAI_API_KEY` | codex-acp |
 
+This table covers the default integration suite models. Provider-specific
+integration lanes may require different credentials; Azure Foundry lanes use
+`AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
+
 ## Quick Start
 
 ```bash
@@ -246,6 +250,10 @@ All 8 registered agents run by default:
 | openhands | gemini-3.1-flash-lite-preview | |
 
 Agents missing credentials are automatically skipped.
+
+The notes above describe the default integration configs. Provider-prefixed
+model lanes can override the native agent auth requirements; Azure Foundry
+models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
 
 ## Standalone YAML Configs
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,9 @@ BenchFlow uses a resource-verb pattern: `bench <resource> <verb>`.
 
 ### bench agent list
 
-List all registered agents with their protocol and auth requirements.
+List all registered agents with their protocol and native/default auth
+requirements. Provider-prefixed models may use provider-specific credentials;
+Azure Foundry models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
 
 ```bash
 bench agent list
@@ -15,7 +17,8 @@ bench agent list
 
 ### bench agent show
 
-Show details for a specific agent.
+Show details for a specific agent, including native/default auth and a note
+about provider-specific credentials.
 
 ```bash
 bench agent show gemini

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -276,6 +276,12 @@ result = await bf.run(config)
 | `pi-acp` | ACP | ANTHROPIC_API_KEY | `pi` |
 | `openclaw` | ACP | inferred from model | — |
 
+The Auth column shows each agent's native/default credentials. Provider-prefixed
+models can use provider-specific credentials instead; for example, Azure
+Foundry models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT` with prefixes such
+as `azure-foundry-openai/gpt-5.5` or
+`azure-foundry-anthropic/claude-opus-4-5`.
+
 Any agent can be prefixed with `acpx/` to run via [ACPX](https://acpx.sh/) (e.g. `acpx/gemini`, `acpx/claude`). ACPX is a headless ACP client with persistent sessions and crash recovery. The underlying agent's install, env, credentials, and skill paths are preserved.
 
 ## Retry and Error Handling

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -237,6 +237,12 @@ Common choices:
 | OpenHands | `openhands` (alias: `oh`) | `LLM_API_KEY` |
 | Harvey LAB harness | `harvey-lab-harness` (alias: `harvey-lab`) | Provider key matching model |
 
+The auth column shows each agent's native/default credentials. Provider-prefixed
+models can use provider-specific credentials instead; for example, Azure
+Foundry models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT` with prefixes such
+as `azure-foundry-openai/gpt-5.5` or
+`azure-foundry-anthropic/claude-opus-4-5`.
+
 Any agent can also be run via [ACPX](https://acpx.sh/) by prefixing with `acpx/`:
 
 ```bash

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -119,6 +119,8 @@ cases also need a supported judge key available in the environment. Exact-match
 cases can avoid the judge model, but they still need a working agent.
 For Codex agents, that auth can be `OPENAI_API_KEY`, `CODEX_API_KEY`,
 `CODEX_ACCESS_TOKEN`, or a host `~/.codex/auth.json` login.
+Provider-prefixed models can use provider-specific credentials instead; Azure
+Foundry models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
 
 When a supported judge key is present on the host (`GOOGLE_API_KEY`,
 `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, or `OPENAI_API_KEY`), generated tasks

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 from benchflow._dotenv import load_dotenv_env
 from benchflow.agents.registry import AGENTS
@@ -31,6 +32,14 @@ _AUTH_CONTEXT_GROUPS = (
     frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}),
     frozenset({"GEMINI_API_KEY", "GOOGLE_API_KEY"}),
     frozenset({"OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"}),
+    frozenset(
+        {
+            "AZURE_AI_FOUNDRY_API_KEY",
+            "AZURE_API_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
+        }
+    ),
 )
 _EXPLICIT_AGENT_NATIVE_BRIDGE_KEYS = frozenset({"LLM_API_KEY"})
 _BEDROCK_PROXY_PLACEHOLDER_API_KEY = "bedrock-proxy"
@@ -39,6 +48,59 @@ _CODEX_ACCESS_TOKEN_ENV = "CODEX_ACCESS_TOKEN"
 _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
 )
+_AZURE_FOUNDRY_API_KEY_ENV = "AZURE_AI_FOUNDRY_API_KEY"
+_AZURE_FOUNDRY_API_KEY_ALIASES = (
+    "AZURE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
+)
+_AZURE_FOUNDRY_RESOURCE_ENV = "AZURE_AI_FOUNDRY_RESOURCE"
+_AZURE_FOUNDRY_RESOURCE_ALIASES = (
+    "AZURE_OPENAI_RESOURCE",
+    "AZURE_RESOURCE",
+)
+_AZURE_FOUNDRY_ENDPOINT_ALIASES = (
+    "AZURE_API_ENDPOINT",
+    "AZURE_OPENAI_ENDPOINT",
+    "AZURE_AI_FOUNDRY_ENDPOINT",
+)
+
+
+def _azure_resource_from_endpoint(endpoint: str) -> str | None:
+    """Extract the Azure resource name from a public Azure AI endpoint."""
+    candidate = endpoint.strip()
+    if not candidate:
+        return None
+    if "://" not in candidate:
+        candidate = f"https://{candidate}"
+    parsed = urlparse(candidate)
+    host = (parsed.netloc or parsed.path.split("/", 1)[0]).split("@")[-1]
+    host = host.split(":", 1)[0].strip().lower()
+    for suffix in (".openai.azure.com", ".services.ai.azure.com"):
+        if host.endswith(suffix):
+            resource = host[: -len(suffix)]
+            return resource or None
+    return None
+
+
+def _mirror_azure_foundry_env(agent_env: dict[str, str]) -> None:
+    """Normalize Azure aliases to BenchFlow's canonical Foundry env names."""
+    if _AZURE_FOUNDRY_API_KEY_ENV not in agent_env:
+        for alias in _AZURE_FOUNDRY_API_KEY_ALIASES:
+            if agent_env.get(alias):
+                agent_env[_AZURE_FOUNDRY_API_KEY_ENV] = agent_env[alias]
+                break
+    if _AZURE_FOUNDRY_RESOURCE_ENV not in agent_env:
+        for alias in _AZURE_FOUNDRY_RESOURCE_ALIASES:
+            if agent_env.get(alias):
+                agent_env[_AZURE_FOUNDRY_RESOURCE_ENV] = agent_env[alias]
+                break
+    if _AZURE_FOUNDRY_RESOURCE_ENV not in agent_env:
+        for alias in _AZURE_FOUNDRY_ENDPOINT_ALIASES:
+            resource = _azure_resource_from_endpoint(agent_env.get(alias, ""))
+            if resource:
+                agent_env[_AZURE_FOUNDRY_RESOURCE_ENV] = resource
+                break
 
 
 def _normalize_openhands_model(model: str) -> str:
@@ -94,6 +156,9 @@ def auto_inherit_env(
         "BENCHFLOW_PROVIDER_BASE_URL",
         "BENCHFLOW_PROVIDER_API_KEY",
         "BENCHFLOW_PROVIDER_PROMPT_CACHE_RETENTION",
+        *_AZURE_FOUNDRY_API_KEY_ALIASES,
+        *_AZURE_FOUNDRY_RESOURCE_ALIASES,
+        *_AZURE_FOUNDRY_ENDPOINT_ALIASES,
     }
     for cfg in PROVIDERS.values():
         if cfg.auth_env:
@@ -125,6 +190,7 @@ def auto_inherit_env(
         "AWS_REGION" in explicit_keys and "AWS_DEFAULT_REGION" not in explicit_keys
     ) or ("AWS_REGION" in agent_env and "AWS_DEFAULT_REGION" not in agent_env):
         agent_env["AWS_DEFAULT_REGION"] = agent_env["AWS_REGION"]
+    _mirror_azure_foundry_env(agent_env)
     # CLAUDE_CODE_OAUTH_TOKEN is a separate auth path — Claude CLI reads it
     # directly. Don't map to ANTHROPIC_API_KEY (different auth mechanism).
 

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -16,7 +16,6 @@ Does not own:
     - Setting model via ACP session/set_model — see _acp_run.py
 """
 
-import contextlib
 import json
 import logging
 import os
@@ -101,6 +100,29 @@ def _mirror_azure_foundry_env(agent_env: dict[str, str]) -> None:
             if resource:
                 agent_env[_AZURE_FOUNDRY_RESOURCE_ENV] = resource
                 break
+
+
+def _missing_provider_base_url_message(
+    *,
+    provider_name: str,
+    model: str,
+    required_envs: list[str],
+) -> str:
+    """Return a user-facing error when a provider URL template cannot resolve."""
+    required = ", ".join(required_envs)
+    if provider_name.startswith("azure-foundry-"):
+        endpoint_aliases = ", ".join(_AZURE_FOUNDRY_ENDPOINT_ALIASES)
+        return (
+            f"Azure AI Foundry model {model!r} requires "
+            f"{_AZURE_FOUNDRY_RESOURCE_ENV} or a public Azure endpoint alias "
+            f"({endpoint_aliases}) to build the provider base URL. "
+            "Export AZURE_API_ENDPOINT=https://<resource>.openai.azure.com/ "
+            f"or pass --agent-env {_AZURE_FOUNDRY_RESOURCE_ENV}=<resource>."
+        )
+    return (
+        f"Provider {provider_name!r} for model {model!r} requires {required} "
+        "to build the provider base URL."
+    )
 
 
 def _normalize_openhands_model(model: str) -> str:
@@ -322,11 +344,22 @@ def resolve_provider_env(
     if _prov:
         _prov_name, _prov_cfg = _prov
         agent_env.setdefault("BENCHFLOW_PROVIDER_NAME", _prov_name)
-        # URL params missing — will fail later with clear error
-        with contextlib.suppress(KeyError):
+        if "BENCHFLOW_PROVIDER_BASE_URL" not in agent_env:
+            try:
+                base_url = resolve_base_url(
+                    _prov_cfg, agent_env, protocol=agent_protocol or None
+                )
+            except KeyError as exc:
+                raise ValueError(
+                    _missing_provider_base_url_message(
+                        provider_name=_prov_name,
+                        model=model,
+                        required_envs=list(_prov_cfg.url_params.values()),
+                    )
+                ) from exc
             agent_env.setdefault(
                 "BENCHFLOW_PROVIDER_BASE_URL",
-                resolve_base_url(_prov_cfg, agent_env, protocol=agent_protocol or None),
+                base_url,
             )
         agent_env.setdefault(
             "BENCHFLOW_PROVIDER_PROTOCOL",

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -31,14 +31,6 @@ _AUTH_CONTEXT_GROUPS = (
     frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"}),
     frozenset({"GEMINI_API_KEY", "GOOGLE_API_KEY"}),
     frozenset({"OPENAI_API_KEY", "CODEX_API_KEY", "CODEX_ACCESS_TOKEN"}),
-    frozenset(
-        {
-            "AZURE_AI_FOUNDRY_API_KEY",
-            "AZURE_API_KEY",
-            "AZURE_OPENAI_API_KEY",
-            "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
-        }
-    ),
 )
 _EXPLICIT_AGENT_NATIVE_BRIDGE_KEYS = frozenset({"LLM_API_KEY"})
 _BEDROCK_PROXY_PLACEHOLDER_API_KEY = "bedrock-proxy"
@@ -47,59 +39,29 @@ _CODEX_ACCESS_TOKEN_ENV = "CODEX_ACCESS_TOKEN"
 _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
 )
-_AZURE_FOUNDRY_API_KEY_ENV = "AZURE_AI_FOUNDRY_API_KEY"
-_AZURE_FOUNDRY_API_KEY_ALIASES = (
-    "AZURE_API_KEY",
-    "AZURE_OPENAI_API_KEY",
-    "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
-)
-_AZURE_FOUNDRY_RESOURCE_ENV = "AZURE_AI_FOUNDRY_RESOURCE"
-_AZURE_FOUNDRY_RESOURCE_ALIASES = (
-    "AZURE_OPENAI_RESOURCE",
-    "AZURE_RESOURCE",
-)
-_AZURE_FOUNDRY_ENDPOINT_ALIASES = (
-    "AZURE_API_ENDPOINT",
-    "AZURE_OPENAI_ENDPOINT",
-    "AZURE_AI_FOUNDRY_ENDPOINT",
-)
+_AZURE_RESOURCE_ENV = "AZURE_RESOURCE"
+_AZURE_ENDPOINT_ENV = "AZURE_API_ENDPOINT"
+_AZURE_HOST_SUFFIXES = (".openai.azure.com", ".services.ai.azure.com")
 
 
-def _azure_resource_from_endpoint(endpoint: str) -> str | None:
-    """Extract the Azure resource name from a public Azure AI endpoint."""
-    candidate = endpoint.strip()
-    if not candidate:
-        return None
-    if "://" not in candidate:
-        candidate = f"https://{candidate}"
-    parsed = urlparse(candidate)
+def _derive_azure_resource(agent_env: dict[str, str]) -> None:
+    """Populate AZURE_RESOURCE from AZURE_API_ENDPOINT when not already set."""
+    if agent_env.get(_AZURE_RESOURCE_ENV):
+        return
+    endpoint = agent_env.get(_AZURE_ENDPOINT_ENV, "").strip()
+    if not endpoint:
+        return
+    if "://" not in endpoint:
+        endpoint = f"https://{endpoint}"
+    parsed = urlparse(endpoint)
     host = (parsed.netloc or parsed.path.split("/", 1)[0]).split("@")[-1]
-    host = host.split(":", 1)[0].strip().lower()
-    for suffix in (".openai.azure.com", ".services.ai.azure.com"):
+    host = host.split(":", 1)[0].lower()
+    for suffix in _AZURE_HOST_SUFFIXES:
         if host.endswith(suffix):
             resource = host[: -len(suffix)]
-            return resource or None
-    return None
-
-
-def _mirror_azure_foundry_env(agent_env: dict[str, str]) -> None:
-    """Normalize Azure aliases to BenchFlow's canonical Foundry env names."""
-    if _AZURE_FOUNDRY_API_KEY_ENV not in agent_env:
-        for alias in _AZURE_FOUNDRY_API_KEY_ALIASES:
-            if agent_env.get(alias):
-                agent_env[_AZURE_FOUNDRY_API_KEY_ENV] = agent_env[alias]
-                break
-    if _AZURE_FOUNDRY_RESOURCE_ENV not in agent_env:
-        for alias in _AZURE_FOUNDRY_RESOURCE_ALIASES:
-            if agent_env.get(alias):
-                agent_env[_AZURE_FOUNDRY_RESOURCE_ENV] = agent_env[alias]
-                break
-    if _AZURE_FOUNDRY_RESOURCE_ENV not in agent_env:
-        for alias in _AZURE_FOUNDRY_ENDPOINT_ALIASES:
-            resource = _azure_resource_from_endpoint(agent_env.get(alias, ""))
             if resource:
-                agent_env[_AZURE_FOUNDRY_RESOURCE_ENV] = resource
-                break
+                agent_env[_AZURE_RESOURCE_ENV] = resource
+            return
 
 
 def _missing_provider_base_url_message(
@@ -111,13 +73,11 @@ def _missing_provider_base_url_message(
     """Return a user-facing error when a provider URL template cannot resolve."""
     required = ", ".join(required_envs)
     if provider_name.startswith("azure-foundry-"):
-        endpoint_aliases = ", ".join(_AZURE_FOUNDRY_ENDPOINT_ALIASES)
         return (
-            f"Azure AI Foundry model {model!r} requires "
-            f"{_AZURE_FOUNDRY_RESOURCE_ENV} or a public Azure endpoint alias "
-            f"({endpoint_aliases}) to build the provider base URL. "
-            "Export AZURE_API_ENDPOINT=https://<resource>.openai.azure.com/ "
-            f"or pass --agent-env {_AZURE_FOUNDRY_RESOURCE_ENV}=<resource>."
+            f"Azure AI Foundry model {model!r} requires {_AZURE_RESOURCE_ENV} "
+            f"or {_AZURE_ENDPOINT_ENV} to build the provider base URL. "
+            f"Export {_AZURE_ENDPOINT_ENV}=https://<resource>.openai.azure.com/ "
+            f"or pass --agent-env {_AZURE_RESOURCE_ENV}=<resource>."
         )
     return (
         f"Provider {provider_name!r} for model {model!r} requires {required} "
@@ -178,9 +138,11 @@ def auto_inherit_env(
         "BENCHFLOW_PROVIDER_BASE_URL",
         "BENCHFLOW_PROVIDER_API_KEY",
         "BENCHFLOW_PROVIDER_PROMPT_CACHE_RETENTION",
-        *_AZURE_FOUNDRY_API_KEY_ALIASES,
-        *_AZURE_FOUNDRY_RESOURCE_ALIASES,
-        *_AZURE_FOUNDRY_ENDPOINT_ALIASES,
+        # AZURE_API_KEY / AZURE_RESOURCE are picked up automatically below via
+        # cfg.auth_env / cfg.url_params; only AZURE_API_ENDPOINT is listed
+        # explicitly because it is a user-facing convenience input, not a
+        # provider-config field.
+        _AZURE_ENDPOINT_ENV,
     }
     for cfg in PROVIDERS.values():
         if cfg.auth_env:
@@ -212,7 +174,7 @@ def auto_inherit_env(
         "AWS_REGION" in explicit_keys and "AWS_DEFAULT_REGION" not in explicit_keys
     ) or ("AWS_REGION" in agent_env and "AWS_DEFAULT_REGION" not in agent_env):
         agent_env["AWS_DEFAULT_REGION"] = agent_env["AWS_REGION"]
-    _mirror_azure_foundry_env(agent_env)
+    _derive_azure_resource(agent_env)
     # CLAUDE_CODE_OAUTH_TOKEN is a separate auth path — Claude CLI reads it
     # directly. Don't map to ANTHROPIC_API_KEY (different auth mechanism).
 

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -85,6 +85,33 @@ def _missing_provider_base_url_message(
     )
 
 
+def _provider_supports_agent_protocol(provider, agent_protocol: str) -> bool:
+    """Return True when a registered provider can serve the agent protocol."""
+    if not agent_protocol:
+        return True
+    if agent_protocol in provider.all_endpoints:
+        return True
+    # Providers like vllm have no canonical URL; the caller supplies both URL
+    # and semantics at runtime, so preserve their existing flexible behavior.
+    return not provider.base_url
+
+
+def _unsupported_provider_protocol_message(
+    *,
+    agent: str,
+    agent_protocol: str,
+    provider_name: str,
+    model: str,
+    supported_protocols: list[str],
+) -> str:
+    supported = ", ".join(supported_protocols)
+    return (
+        f"Agent {agent!r} requires provider protocol {agent_protocol!r}, but "
+        f"provider {provider_name!r} for model {model!r} only supports "
+        f"{supported}. Use a provider prefix that matches the agent protocol."
+    )
+
+
 def _normalize_openhands_model(model: str) -> str:
     """Translate benchflow model IDs to OpenHands/LiteLLM model IDs.
 
@@ -306,6 +333,16 @@ def resolve_provider_env(
     if _prov:
         _prov_name, _prov_cfg = _prov
         agent_env.setdefault("BENCHFLOW_PROVIDER_NAME", _prov_name)
+        if not _provider_supports_agent_protocol(_prov_cfg, agent_protocol):
+            raise ValueError(
+                _unsupported_provider_protocol_message(
+                    agent=agent,
+                    agent_protocol=agent_protocol,
+                    provider_name=_prov_name,
+                    model=model,
+                    supported_protocols=sorted(_prov_cfg.all_endpoints),
+                )
+            )
         if "BENCHFLOW_PROVIDER_BASE_URL" not in agent_env:
             try:
                 base_url = resolve_base_url(

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -136,12 +136,14 @@ PROVIDERS: dict[str, ProviderConfig] = {
     "azure-foundry-openai": ProviderConfig(
         name="azure-foundry-openai",
         base_url="https://{resource}.openai.azure.com/openai/v1",
-        api_protocol="openai-responses",
+        # Use the broadest OpenAI-compatible default for agents that do not
+        # declare their own protocol (e.g. pi-acp). Responses-native agents
+        # still select the explicit openai-responses endpoint below.
+        api_protocol="openai-completions",
         auth_type="api_key",
         auth_env="AZURE_API_KEY",
         url_params={"resource": "AZURE_RESOURCE"},
         endpoints={
-            "openai-completions": "https://{resource}.openai.azure.com/openai/v1",
             "openai-responses": "https://{resource}.openai.azure.com/openai/v1",
         },
     ),

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -131,15 +131,15 @@ PROVIDERS: dict[str, ProviderConfig] = {
     #
     # Foundry exposes different protocol surfaces. Keep those surfaces explicit
     # in provider prefixes, while sharing one Azure resource/key env contract.
+    # AZURE_RESOURCE is normally derived from AZURE_API_ENDPOINT in env.py;
+    # users can also set it directly via --agent-env.
     "azure-foundry-openai": ProviderConfig(
         name="azure-foundry-openai",
         base_url="https://{resource}.openai.azure.com/openai/v1",
         api_protocol="openai-responses",
         auth_type="api_key",
-        auth_env="AZURE_AI_FOUNDRY_API_KEY",
-        url_params={
-            "resource": "AZURE_AI_FOUNDRY_RESOURCE",
-        },
+        auth_env="AZURE_API_KEY",
+        url_params={"resource": "AZURE_RESOURCE"},
         endpoints={
             "openai-completions": "https://{resource}.openai.azure.com/openai/v1",
             "openai-responses": "https://{resource}.openai.azure.com/openai/v1",
@@ -150,10 +150,8 @@ PROVIDERS: dict[str, ProviderConfig] = {
         base_url="https://{resource}.services.ai.azure.com/anthropic",
         api_protocol="anthropic-messages",
         auth_type="api_key",
-        auth_env="AZURE_AI_FOUNDRY_API_KEY",
-        url_params={
-            "resource": "AZURE_AI_FOUNDRY_RESOURCE",
-        },
+        auth_env="AZURE_API_KEY",
+        url_params={"resource": "AZURE_RESOURCE"},
     ),
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -127,6 +127,34 @@ PROVIDERS: dict[str, ProviderConfig] = {
             }
         ],
     ),
+    # ── Azure AI Foundry providers ──
+    #
+    # Foundry exposes different protocol surfaces. Keep those surfaces explicit
+    # in provider prefixes, while sharing one Azure resource/key env contract.
+    "azure-foundry-openai": ProviderConfig(
+        name="azure-foundry-openai",
+        base_url="https://{resource}.openai.azure.com/openai/v1",
+        api_protocol="openai-responses",
+        auth_type="api_key",
+        auth_env="AZURE_AI_FOUNDRY_API_KEY",
+        url_params={
+            "resource": "AZURE_AI_FOUNDRY_RESOURCE",
+        },
+        endpoints={
+            "openai-completions": "https://{resource}.openai.azure.com/openai/v1",
+            "openai-responses": "https://{resource}.openai.azure.com/openai/v1",
+        },
+    ),
+    "azure-foundry-anthropic": ProviderConfig(
+        name="azure-foundry-anthropic",
+        base_url="https://{resource}.services.ai.azure.com/anthropic",
+        api_protocol="anthropic-messages",
+        auth_type="api_key",
+        auth_env="AZURE_AI_FOUNDRY_API_KEY",
+        url_params={
+            "resource": "AZURE_AI_FOUNDRY_RESOURCE",
+        },
+    ),
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(
         name="vllm",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -91,7 +91,7 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
 _NODE_INSTALL = (
-    "set -o pipefail; "
+    "set -e; "
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
     "BF_NODE_VERSION=22.14.0; "

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -91,7 +91,7 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
 _NODE_INSTALL = (
-    "set -e; "
+    "set -o pipefail; "
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
     "BF_NODE_VERSION=22.14.0; "

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -33,6 +33,24 @@ app = typer.Typer(
 )
 
 
+_PROVIDER_AUTH_MESSAGE = (
+    "Provider-prefixed models may use different credentials; Azure Foundry "
+    "models use AZURE_API_KEY + AZURE_API_ENDPOINT."
+)
+_REQUIRES_AUTH_NOTE = (
+    "Requires shows native/default agent auth. " + _PROVIDER_AUTH_MESSAGE
+)
+
+
+def _format_requires(agent) -> str:
+    sub_env = agent.subscription_auth.replaces_env if agent.subscription_auth else None
+    requires = [
+        f"{env_var} (or login)" if env_var == sub_env else env_var
+        for env_var in agent.requires_env
+    ]
+    return ", ".join(requires)
+
+
 def _parse_agent_env(entries: list[str] | None) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for entry in entries or []:
@@ -390,20 +408,15 @@ def agents() -> None:
     table.add_column("Requires", style="yellow")
 
     for agent in list_agents():
-        sub_env = (
-            agent.subscription_auth.replaces_env if agent.subscription_auth else None
-        )
-        requires = [
-            f"{e} (or login)" if e == sub_env else e for e in agent.requires_env
-        ]
         table.add_row(
             agent.name,
             agent.description,
             agent.protocol,
-            ", ".join(requires),
+            _format_requires(agent),
         )
 
     console.print(table)
+    console.print(f"[dim]{_REQUIRES_AUTH_NOTE}[/dim]")
 
 
 @app.command(hidden=True, deprecated=True)
@@ -889,12 +902,11 @@ def agent_list() -> None:
     table.add_column("Requires", style="yellow")
 
     for a in list_agents():
-        sub_env = a.subscription_auth.replaces_env if a.subscription_auth else None
-        requires = [f"{e} (or login)" if e == sub_env else e for e in a.requires_env]
         aliases = ", ".join(sorted(reverse_aliases.get(a.name, [])))
-        table.add_row(a.name, aliases, a.description, a.protocol, ", ".join(requires))
+        table.add_row(a.name, aliases, a.description, a.protocol, _format_requires(a))
 
     console.print(table)
+    console.print(f"[dim]{_REQUIRES_AUTH_NOTE}[/dim]")
 
 
 @agent_app.command("show")
@@ -921,7 +933,8 @@ def agent_show(
     console.print(f"  Description: {cfg.description}")
     console.print(f"  Protocol:    {cfg.protocol}")
     console.print(f"  Launch:      {cfg.launch_cmd}")
-    console.print(f"  Requires:    {', '.join(cfg.requires_env) or '(none)'}")
+    console.print(f"  Requires:    {_format_requires(cfg) or '(none)'}")
+    console.print(f"  Provider auth: {_PROVIDER_AUTH_MESSAGE}")
     if cfg.subscription_auth:
         console.print(
             f"  Auth:        subscription via {cfg.subscription_auth.detect_file}"

--- a/tests/test_agent_cli.py
+++ b/tests/test_agent_cli.py
@@ -1,0 +1,29 @@
+import click
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+
+def test_agent_list_mentions_provider_specific_azure_auth() -> None:
+    """Guards PR #422: agent discovery must not hide Azure provider auth."""
+    result = CliRunner().invoke(app, ["agent", "list"])
+
+    assert result.exit_code == 0
+    output = click.unstyle(result.output)
+    assert "OPENAI_API_KEY" in output
+    assert "(or login)" in output
+    assert "AZURE_API_KEY" in output
+    assert "AZURE_API_ENDPOINT" in output
+
+
+def test_agent_show_mentions_provider_specific_azure_auth() -> None:
+    """Guards PR #422: per-agent details explain provider-prefixed auth."""
+    result = CliRunner().invoke(app, ["agent", "show", "codex"])
+
+    assert result.exit_code == 0
+    output = click.unstyle(result.output)
+    assert "Requires:" in output
+    assert "OPENAI_API_KEY (or login)" in output
+    assert "Provider auth:" in output
+    assert "AZURE_API_KEY" in output
+    assert "AZURE_API_ENDPOINT" in output

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -63,6 +63,59 @@ class TestSetupProviderOpenAI:
         assert provider["apiKey"] == "test-key"
         assert provider["models"][0]["id"] == "Qwen3.5-35B"
 
+    def test_azure_foundry_openai_routes_through_models_json(
+        self, monkeypatch, tmp_path
+    ):
+        """Guards the fix from PR #422: pi-acp + Azure OpenAI must not fall
+        through to Pi's Anthropic env path.
+        """
+        import os
+
+        from benchflow.agents.env import resolve_agent_env
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        empty_dotenv = tmp_path / "empty.env"
+        empty_dotenv.write_text("")
+        monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(empty_dotenv))
+        for key in (
+            "AZURE_API_ENDPOINT",
+            "AZURE_API_KEY",
+            "AZURE_RESOURCE",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        resolved = resolve_agent_env(
+            "pi-acp",
+            "azure-foundry-openai/gpt-5.5",
+            {
+                "AZURE_API_KEY": "az-test",
+                "AZURE_RESOURCE": "example-resource",
+            },
+        )
+        for key in (
+            "BENCHFLOW_PROVIDER_PROTOCOL",
+            "BENCHFLOW_PROVIDER_BASE_URL",
+            "BENCHFLOW_PROVIDER_API_KEY",
+            "BENCHFLOW_PROVIDER_MODEL",
+            "BENCHFLOW_PROVIDER_NAME",
+        ):
+            monkeypatch.setenv(key, resolved[key])
+
+        setup_provider()
+
+        config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
+        provider = config["providers"]["azure-foundry-openai"]
+        assert provider["api"] == "openai-completions"
+        assert (
+            provider["baseUrl"]
+            == "https://example-resource.openai.azure.com/openai/v1"
+        )
+        assert provider["apiKey"] == "az-test"
+        assert provider["models"][0]["id"] == "gpt-5.5"
+        assert "ANTHROPIC_BASE_URL" not in os.environ
+
     def test_merges_with_existing_providers(self, monkeypatch, tmp_path):
         """Manually-added providers survive when a new one is registered."""
         config_dir = tmp_path / ".pi" / "agent"

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -109,8 +109,7 @@ class TestSetupProviderOpenAI:
         provider = config["providers"]["azure-foundry-openai"]
         assert provider["api"] == "openai-completions"
         assert (
-            provider["baseUrl"]
-            == "https://example-resource.openai.azure.com/openai/v1"
+            provider["baseUrl"] == "https://example-resource.openai.azure.com/openai/v1"
         )
         assert provider["apiKey"] == "az-test"
         assert provider["models"][0]["id"] == "gpt-5.5"

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -41,6 +41,19 @@ class TestFindProvider:
         assert name == "aws-bedrock"
         assert cfg.auth_type == "aws"
 
+    @pytest.mark.parametrize(
+        ("model", "expected_protocol"),
+        [
+            ("azure-foundry-openai/gpt-5.5", "openai-responses"),
+            ("azure-foundry-anthropic/claude-opus-4-5", "anthropic-messages"),
+        ],
+    )
+    def test_azure_foundry_prefixes(self, model, expected_protocol):
+        name, cfg = find_provider(model)
+        assert name in {"azure-foundry-openai", "azure-foundry-anthropic"}
+        assert cfg.api_protocol == expected_protocol
+        assert cfg.auth_env == "AZURE_AI_FOUNDRY_API_KEY"
+
 
 # ── resolve_base_url: template expansion ──
 
@@ -111,6 +124,22 @@ class TestResolveBaseUrl:
             == "https://api.z.ai/api/paas/v4"
         )
 
+    def test_azure_openai_resource_expansion(self):
+        p = PROVIDERS["azure-foundry-openai"]
+        env = {"AZURE_AI_FOUNDRY_RESOURCE": "example-resource"}
+        assert (
+            resolve_base_url(p, env)
+            == "https://example-resource.openai.azure.com/openai/v1"
+        )
+
+    def test_azure_anthropic_resource_expansion(self):
+        p = PROVIDERS["azure-foundry-anthropic"]
+        env = {"AZURE_AI_FOUNDRY_RESOURCE": "example-resource"}
+        assert (
+            resolve_base_url(p, env)
+            == "https://example-resource.services.ai.azure.com/anthropic"
+        )
+
 
 # ── resolve_auth_env: which env var does this provider need? ──
 
@@ -127,6 +156,16 @@ class TestResolveAuthEnv:
 
     def test_aws_bedrock_returns_none(self):
         assert resolve_auth_env("aws-bedrock/openai.gpt-oss-20b-1:0") is None
+
+    def test_azure_foundry_uses_shared_key(self):
+        assert (
+            resolve_auth_env("azure-foundry-openai/gpt-5.5")
+            == "AZURE_AI_FOUNDRY_API_KEY"
+        )
+        assert (
+            resolve_auth_env("azure-foundry-anthropic/claude-opus-4-5")
+            == "AZURE_AI_FOUNDRY_API_KEY"
+        )
 
 
 # ── Integration: backward compat with registry.py ──
@@ -145,6 +184,14 @@ class TestRegistryIntegration:
         from benchflow.agents.registry import infer_env_key_for_model
 
         assert infer_env_key_for_model("aws-bedrock/openai.gpt-oss-20b-1:0") is None
+
+    def test_infer_env_key_for_azure_foundry(self):
+        from benchflow.agents.registry import infer_env_key_for_model
+
+        assert (
+            infer_env_key_for_model("azure-foundry-openai/gpt-5.5")
+            == "AZURE_AI_FOUNDRY_API_KEY"
+        )
 
     def test_is_vertex_model_zai_direct(self):
         """zai/ (direct API) is NOT vertex."""

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -44,7 +44,7 @@ class TestFindProvider:
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [
-            ("azure-foundry-openai/gpt-5.5", "openai-responses"),
+            ("azure-foundry-openai/gpt-5.5", "openai-completions"),
             ("azure-foundry-anthropic/claude-opus-4-5", "anthropic-messages"),
         ],
     )

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -52,7 +52,7 @@ class TestFindProvider:
         name, cfg = find_provider(model)
         assert name in {"azure-foundry-openai", "azure-foundry-anthropic"}
         assert cfg.api_protocol == expected_protocol
-        assert cfg.auth_env == "AZURE_AI_FOUNDRY_API_KEY"
+        assert cfg.auth_env == "AZURE_API_KEY"
 
 
 # ── resolve_base_url: template expansion ──
@@ -126,7 +126,7 @@ class TestResolveBaseUrl:
 
     def test_azure_openai_resource_expansion(self):
         p = PROVIDERS["azure-foundry-openai"]
-        env = {"AZURE_AI_FOUNDRY_RESOURCE": "example-resource"}
+        env = {"AZURE_RESOURCE": "example-resource"}
         assert (
             resolve_base_url(p, env)
             == "https://example-resource.openai.azure.com/openai/v1"
@@ -134,7 +134,7 @@ class TestResolveBaseUrl:
 
     def test_azure_anthropic_resource_expansion(self):
         p = PROVIDERS["azure-foundry-anthropic"]
-        env = {"AZURE_AI_FOUNDRY_RESOURCE": "example-resource"}
+        env = {"AZURE_RESOURCE": "example-resource"}
         assert (
             resolve_base_url(p, env)
             == "https://example-resource.services.ai.azure.com/anthropic"
@@ -158,13 +158,10 @@ class TestResolveAuthEnv:
         assert resolve_auth_env("aws-bedrock/openai.gpt-oss-20b-1:0") is None
 
     def test_azure_foundry_uses_shared_key(self):
-        assert (
-            resolve_auth_env("azure-foundry-openai/gpt-5.5")
-            == "AZURE_AI_FOUNDRY_API_KEY"
-        )
+        assert resolve_auth_env("azure-foundry-openai/gpt-5.5") == "AZURE_API_KEY"
         assert (
             resolve_auth_env("azure-foundry-anthropic/claude-opus-4-5")
-            == "AZURE_AI_FOUNDRY_API_KEY"
+            == "AZURE_API_KEY"
         )
 
 
@@ -189,8 +186,7 @@ class TestRegistryIntegration:
         from benchflow.agents.registry import infer_env_key_for_model
 
         assert (
-            infer_env_key_for_model("azure-foundry-openai/gpt-5.5")
-            == "AZURE_AI_FOUNDRY_API_KEY"
+            infer_env_key_for_model("azure-foundry-openai/gpt-5.5") == "AZURE_API_KEY"
         )
 
     def test_is_vertex_model_zai_direct(self):

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -129,6 +129,7 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
     assert (
         "exec /opt/benchflow/node/bin/node /opt/benchflow/js-agents/bin/" in install_cmd
     )
+    assert "set -o pipefail" not in install_cmd
     assert launch_cmd.split()[0].startswith("/opt/benchflow/bin/")
     assert launch_cmd.split()[0] not in {"export", "env"}
     assert not launch_cmd.startswith("PATH=")
@@ -300,6 +301,8 @@ def test_provider_models_and_credentials(name, cfg):
     [
         ("google-vertex/gemini-2.5-pro", "google-vertex"),
         ("anthropic-vertex/claude-sonnet-4-6", "anthropic-vertex"),
+        ("azure-foundry-openai/gpt-5.5", "azure-foundry-openai"),
+        ("azure-foundry-anthropic/claude-opus-4-5", "azure-foundry-anthropic"),
         ("aws-bedrock/openai.gpt-oss-20b-1:0", "aws-bedrock"),
         ("zai/glm-5", "zai"),
         ("vllm/local-model", "vllm"),

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -129,7 +129,6 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
     assert (
         "exec /opt/benchflow/node/bin/node /opt/benchflow/js-agents/bin/" in install_cmd
     )
-    assert "set -o pipefail" not in install_cmd
     assert launch_cmd.split()[0].startswith("/opt/benchflow/bin/")
     assert launch_cmd.split()[0] not in {"export", "env"}
     assert not launch_cmd.startswith("PATH=")

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -659,6 +659,47 @@ class TestResolveAgentEnvAzureFoundry:
             == "https://example-resource.services.ai.azure.com/anthropic"
         )
 
+    def test_azure_openai_rejects_anthropic_agent_protocol(self, monkeypatch):
+        """Guards PR #422: unsupported agent/provider protocol pairs fail fast."""
+        monkeypatch.setenv("AZURE_API_KEY", "az-test")
+        monkeypatch.setenv(
+            "AZURE_API_ENDPOINT", "https://example-resource.openai.azure.com/"
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"claude-agent-acp.*requires provider protocol "
+                r"'anthropic-messages'.*azure-foundry-openai.*only supports "
+                r"openai-completions, openai-responses"
+            ),
+        ):
+            resolve_agent_env(
+                "claude-agent-acp",
+                "azure-foundry-openai/gpt-5.5",
+                {},
+            )
+
+    def test_azure_anthropic_rejects_openai_agent_protocol(self, monkeypatch):
+        """Guards PR #422: fallback must not send OpenAI traffic to Anthropic."""
+        monkeypatch.setenv("AZURE_API_KEY", "az-test")
+        monkeypatch.setenv(
+            "AZURE_API_ENDPOINT", "https://example-resource.openai.azure.com/"
+        )
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                r"codex-acp.*requires provider protocol 'openai-responses'.*"
+                r"azure-foundry-anthropic.*only supports anthropic-messages"
+            ),
+        ):
+            resolve_agent_env(
+                "codex-acp",
+                "azure-foundry-anthropic/claude-opus-4-5",
+                {},
+            )
+
     def test_azure_api_key_without_endpoint_fails_fast(self, monkeypatch):
         """Guards PR #3: Azure routes must not fall through to default OpenAI."""
         monkeypatch.setenv("AZURE_API_KEY", "az-test")

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -34,6 +34,7 @@ class TestAutoInheritEnv:
             pytest.param("AWS_BEARER_TOKEN_BEDROCK", "bedrock-token", id="bedrock"),
             pytest.param("AWS_REGION", "us-east-1", id="bedrock-region"),
             pytest.param("ZAI_API_KEY", "zk-host", id="provider"),
+            pytest.param("AZURE_API_KEY", "az-host", id="azure-api-key-alias"),
         ],
     )
     def test_inherits_key(self, monkeypatch, env_name, env_value):
@@ -138,6 +139,34 @@ class TestAutoInheritEnv:
         auto_inherit_env(env)
         assert "OPENAI_BASE_URL" not in env
 
+    @pytest.mark.parametrize(
+        "alias",
+        [
+            "AZURE_API_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
+        ],
+    )
+    def test_azure_key_aliases_mirror_to_foundry_key(self, alias):
+        env = {alias: "az-test"}
+        auto_inherit_env(env)
+        assert env["AZURE_AI_FOUNDRY_API_KEY"] == "az-test"
+
+    def test_azure_endpoint_alias_derives_resource(self):
+        env = {
+            "AZURE_API_ENDPOINT": "https://example-resource.openai.azure.com/"
+        }
+        auto_inherit_env(env)
+        assert env["AZURE_AI_FOUNDRY_RESOURCE"] == "example-resource"
+
+    def test_azure_resource_alias_takes_precedence_over_endpoint(self):
+        env = {
+            "AZURE_OPENAI_RESOURCE": "explicit-resource",
+            "AZURE_API_ENDPOINT": "https://endpoint-resource.openai.azure.com/",
+        }
+        auto_inherit_env(env)
+        assert env["AZURE_AI_FOUNDRY_RESOURCE"] == "explicit-resource"
+
 
 # ── inject_vertex_credentials ──
 
@@ -228,6 +257,48 @@ class TestResolveProviderEnv:
         assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.z.ai/api/paas/v4"
         assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
         assert env["OPENAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
+
+    def test_azure_foundry_openai_maps_to_codex_env(self):
+        env = {
+            "AZURE_AI_FOUNDRY_API_KEY": "az-test",
+            "AZURE_AI_FOUNDRY_RESOURCE": "example-resource",
+        }
+        resolve_provider_env(env, "azure-foundry-openai/gpt-5.5", "codex-acp")
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "azure-foundry-openai"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "gpt-5.5"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
+        assert (
+            env["BENCHFLOW_PROVIDER_BASE_URL"]
+            == "https://example-resource.openai.azure.com/openai/v1"
+        )
+        assert env["OPENAI_API_KEY"] == "az-test"
+        assert (
+            env["OPENAI_BASE_URL"]
+            == "https://example-resource.openai.azure.com/openai/v1"
+        )
+
+    def test_azure_foundry_anthropic_maps_to_claude_env(self):
+        env = {
+            "AZURE_AI_FOUNDRY_API_KEY": "az-test",
+            "AZURE_AI_FOUNDRY_RESOURCE": "example-resource",
+        }
+        resolve_provider_env(
+            env,
+            "azure-foundry-anthropic/claude-opus-4-5",
+            "claude-agent-acp",
+        )
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "azure-foundry-anthropic"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "claude-opus-4-5"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "anthropic-messages"
+        assert (
+            env["BENCHFLOW_PROVIDER_BASE_URL"]
+            == "https://example-resource.services.ai.azure.com/anthropic"
+        )
+        assert env["ANTHROPIC_AUTH_TOKEN"] == "az-test"
+        assert (
+            env["ANTHROPIC_BASE_URL"]
+            == "https://example-resource.services.ai.azure.com/anthropic"
+        )
 
     def test_aws_bedrock_sets_placeholder_provider_key_for_codex(self):
         env = {
@@ -531,6 +602,71 @@ class TestResolveAgentEnvOracle:
         # Provider env never resolved — oracle never calls an LLM.
         assert "BENCHFLOW_PROVIDER_MODEL" not in result
         assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
+
+class TestResolveAgentEnvAzureFoundry:
+    """Azure aliases resolve through the same provider/env pipeline as other providers."""
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch, tmp_path):
+        """Isolate from the host environment and any real .env file."""
+        for k in (
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_AUTH_TOKEN",
+            "AZURE_AI_FOUNDRY_API_KEY",
+            "AZURE_AI_FOUNDRY_RESOURCE",
+            "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
+            "AZURE_AI_FOUNDRY_ENDPOINT",
+            "AZURE_API_ENDPOINT",
+            "AZURE_API_KEY",
+            "AZURE_OPENAI_API_KEY",
+            "AZURE_OPENAI_ENDPOINT",
+            "AZURE_OPENAI_RESOURCE",
+            "AZURE_RESOURCE",
+            "CODEX_ACCESS_TOKEN",
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+        ):
+            monkeypatch.delenv(k, raising=False)
+        empty = tmp_path / "empty.env"
+        empty.write_text("")
+        monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(empty))
+
+    def test_codex_uses_azure_api_key_and_endpoint_aliases(self, monkeypatch):
+        monkeypatch.setenv("AZURE_API_KEY", "az-test")
+        monkeypatch.setenv(
+            "AZURE_API_ENDPOINT", "https://example-resource.openai.azure.com/"
+        )
+
+        result = resolve_agent_env("codex-acp", "azure-foundry-openai/gpt-5.5", {})
+
+        assert result["AZURE_AI_FOUNDRY_API_KEY"] == "az-test"
+        assert result["AZURE_AI_FOUNDRY_RESOURCE"] == "example-resource"
+        assert result["OPENAI_API_KEY"] == "az-test"
+        assert (
+            result["OPENAI_BASE_URL"]
+            == "https://example-resource.openai.azure.com/openai/v1"
+        )
+
+    def test_claude_uses_same_azure_key_on_anthropic_surface(self, monkeypatch):
+        monkeypatch.setenv("AZURE_API_KEY", "az-test")
+        monkeypatch.setenv(
+            "AZURE_API_ENDPOINT", "https://example-resource.openai.azure.com/"
+        )
+
+        result = resolve_agent_env(
+            "claude-agent-acp",
+            "azure-foundry-anthropic/claude-opus-4-5",
+            {},
+        )
+
+        assert result["AZURE_AI_FOUNDRY_API_KEY"] == "az-test"
+        assert result["AZURE_AI_FOUNDRY_RESOURCE"] == "example-resource"
+        assert result["ANTHROPIC_AUTH_TOKEN"] == "az-test"
+        assert (
+            result["ANTHROPIC_BASE_URL"]
+            == "https://example-resource.services.ai.azure.com/anthropic"
+        )
 
 
 class TestResolveAgentEnvHostProviderEndpoint:

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -623,6 +623,8 @@ class TestResolveAgentEnvAzureFoundry:
             "AZURE_OPENAI_ENDPOINT",
             "AZURE_OPENAI_RESOURCE",
             "AZURE_RESOURCE",
+            "BENCHFLOW_PROVIDER_API_KEY",
+            "BENCHFLOW_PROVIDER_BASE_URL",
             "CODEX_ACCESS_TOKEN",
             "OPENAI_API_KEY",
             "OPENAI_BASE_URL",
@@ -667,6 +669,41 @@ class TestResolveAgentEnvAzureFoundry:
             result["ANTHROPIC_BASE_URL"]
             == "https://example-resource.services.ai.azure.com/anthropic"
         )
+
+    def test_azure_api_key_without_endpoint_fails_fast(self, monkeypatch):
+        """Guards PR #3: Azure aliases must not fall through to default OpenAI."""
+        monkeypatch.setenv("AZURE_API_KEY", "az-test")
+
+        with pytest.raises(
+            ValueError,
+            match=r"Azure AI Foundry model .* requires AZURE_AI_FOUNDRY_RESOURCE",
+        ):
+            resolve_agent_env("codex-acp", "azure-foundry-openai/gpt-4o", {})
+
+    def test_azure_api_key_with_unrecognized_endpoint_fails_fast(self, monkeypatch):
+        """Guards PR #3: non-Azure endpoint aliases must fail before launch."""
+        monkeypatch.setenv("AZURE_API_KEY", "az-test")
+        monkeypatch.setenv("AZURE_API_ENDPOINT", "https://example.com/")
+
+        with pytest.raises(
+            ValueError,
+            match=r"AZURE_API_ENDPOINT=https://<resource>\.openai\.azure\.com/",
+        ):
+            resolve_agent_env("codex-acp", "azure-foundry-openai/gpt-4o", {})
+
+    def test_explicit_provider_base_url_can_override_azure_resource(self):
+        """Guards PR #3: explicit provider base URL remains a valid override."""
+        result = resolve_agent_env(
+            "codex-acp",
+            "azure-foundry-openai/gpt-4o",
+            {
+                "AZURE_API_KEY": "az-test",
+                "BENCHFLOW_PROVIDER_BASE_URL": "https://proxy.example/openai/v1",
+            },
+        )
+
+        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://proxy.example/openai/v1"
+        assert result["OPENAI_BASE_URL"] == "https://proxy.example/openai/v1"
 
 
 class TestResolveAgentEnvHostProviderEndpoint:

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -34,7 +34,12 @@ class TestAutoInheritEnv:
             pytest.param("AWS_BEARER_TOKEN_BEDROCK", "bedrock-token", id="bedrock"),
             pytest.param("AWS_REGION", "us-east-1", id="bedrock-region"),
             pytest.param("ZAI_API_KEY", "zk-host", id="provider"),
-            pytest.param("AZURE_API_KEY", "az-host", id="azure-api-key-alias"),
+            pytest.param("AZURE_API_KEY", "az-host", id="azure-api-key"),
+            pytest.param(
+                "AZURE_API_ENDPOINT",
+                "https://example.openai.azure.com/",
+                id="azure-api-endpoint",
+            ),
         ],
     )
     def test_inherits_key(self, monkeypatch, env_name, env_value):
@@ -139,33 +144,24 @@ class TestAutoInheritEnv:
         auto_inherit_env(env)
         assert "OPENAI_BASE_URL" not in env
 
-    @pytest.mark.parametrize(
-        "alias",
-        [
-            "AZURE_API_KEY",
-            "AZURE_OPENAI_API_KEY",
-            "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
-        ],
-    )
-    def test_azure_key_aliases_mirror_to_foundry_key(self, alias):
-        env = {alias: "az-test"}
+    def test_azure_endpoint_derives_resource(self):
+        env = {"AZURE_API_ENDPOINT": "https://example-resource.openai.azure.com/"}
         auto_inherit_env(env)
-        assert env["AZURE_AI_FOUNDRY_API_KEY"] == "az-test"
+        assert env["AZURE_RESOURCE"] == "example-resource"
 
-    def test_azure_endpoint_alias_derives_resource(self):
+    def test_azure_resource_takes_precedence_over_endpoint(self):
         env = {
-            "AZURE_API_ENDPOINT": "https://example-resource.openai.azure.com/"
-        }
-        auto_inherit_env(env)
-        assert env["AZURE_AI_FOUNDRY_RESOURCE"] == "example-resource"
-
-    def test_azure_resource_alias_takes_precedence_over_endpoint(self):
-        env = {
-            "AZURE_OPENAI_RESOURCE": "explicit-resource",
+            "AZURE_RESOURCE": "explicit-resource",
             "AZURE_API_ENDPOINT": "https://endpoint-resource.openai.azure.com/",
         }
         auto_inherit_env(env)
-        assert env["AZURE_AI_FOUNDRY_RESOURCE"] == "explicit-resource"
+        assert env["AZURE_RESOURCE"] == "explicit-resource"
+
+    def test_azure_anthropic_endpoint_alias_derives_resource(self):
+        """AZURE_API_ENDPOINT also derives resource from the Anthropic-surface host."""
+        env = {"AZURE_API_ENDPOINT": "https://example-resource.services.ai.azure.com/"}
+        auto_inherit_env(env)
+        assert env["AZURE_RESOURCE"] == "example-resource"
 
 
 # ── inject_vertex_credentials ──
@@ -260,8 +256,8 @@ class TestResolveProviderEnv:
 
     def test_azure_foundry_openai_maps_to_codex_env(self):
         env = {
-            "AZURE_AI_FOUNDRY_API_KEY": "az-test",
-            "AZURE_AI_FOUNDRY_RESOURCE": "example-resource",
+            "AZURE_API_KEY": "az-test",
+            "AZURE_RESOURCE": "example-resource",
         }
         resolve_provider_env(env, "azure-foundry-openai/gpt-5.5", "codex-acp")
         assert env["BENCHFLOW_PROVIDER_NAME"] == "azure-foundry-openai"
@@ -279,8 +275,8 @@ class TestResolveProviderEnv:
 
     def test_azure_foundry_anthropic_maps_to_claude_env(self):
         env = {
-            "AZURE_AI_FOUNDRY_API_KEY": "az-test",
-            "AZURE_AI_FOUNDRY_RESOURCE": "example-resource",
+            "AZURE_API_KEY": "az-test",
+            "AZURE_RESOURCE": "example-resource",
         }
         resolve_provider_env(
             env,
@@ -605,7 +601,7 @@ class TestResolveAgentEnvOracle:
 
 
 class TestResolveAgentEnvAzureFoundry:
-    """Azure aliases resolve through the same provider/env pipeline as other providers."""
+    """AZURE_API_KEY + AZURE_API_ENDPOINT resolve through the provider/env pipeline."""
 
     @pytest.fixture(autouse=True)
     def _clean_env(self, monkeypatch, tmp_path):
@@ -613,15 +609,8 @@ class TestResolveAgentEnvAzureFoundry:
         for k in (
             "ANTHROPIC_API_KEY",
             "ANTHROPIC_AUTH_TOKEN",
-            "AZURE_AI_FOUNDRY_API_KEY",
-            "AZURE_AI_FOUNDRY_RESOURCE",
-            "AZURE_AI_FOUNDRY_ANTHROPIC_API_KEY",
-            "AZURE_AI_FOUNDRY_ENDPOINT",
             "AZURE_API_ENDPOINT",
             "AZURE_API_KEY",
-            "AZURE_OPENAI_API_KEY",
-            "AZURE_OPENAI_ENDPOINT",
-            "AZURE_OPENAI_RESOURCE",
             "AZURE_RESOURCE",
             "BENCHFLOW_PROVIDER_API_KEY",
             "BENCHFLOW_PROVIDER_BASE_URL",
@@ -634,7 +623,7 @@ class TestResolveAgentEnvAzureFoundry:
         empty.write_text("")
         monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(empty))
 
-    def test_codex_uses_azure_api_key_and_endpoint_aliases(self, monkeypatch):
+    def test_codex_uses_azure_api_key_and_endpoint(self, monkeypatch):
         monkeypatch.setenv("AZURE_API_KEY", "az-test")
         monkeypatch.setenv(
             "AZURE_API_ENDPOINT", "https://example-resource.openai.azure.com/"
@@ -642,8 +631,8 @@ class TestResolveAgentEnvAzureFoundry:
 
         result = resolve_agent_env("codex-acp", "azure-foundry-openai/gpt-5.5", {})
 
-        assert result["AZURE_AI_FOUNDRY_API_KEY"] == "az-test"
-        assert result["AZURE_AI_FOUNDRY_RESOURCE"] == "example-resource"
+        assert result["AZURE_API_KEY"] == "az-test"
+        assert result["AZURE_RESOURCE"] == "example-resource"
         assert result["OPENAI_API_KEY"] == "az-test"
         assert (
             result["OPENAI_BASE_URL"]
@@ -662,8 +651,8 @@ class TestResolveAgentEnvAzureFoundry:
             {},
         )
 
-        assert result["AZURE_AI_FOUNDRY_API_KEY"] == "az-test"
-        assert result["AZURE_AI_FOUNDRY_RESOURCE"] == "example-resource"
+        assert result["AZURE_API_KEY"] == "az-test"
+        assert result["AZURE_RESOURCE"] == "example-resource"
         assert result["ANTHROPIC_AUTH_TOKEN"] == "az-test"
         assert (
             result["ANTHROPIC_BASE_URL"]
@@ -671,17 +660,17 @@ class TestResolveAgentEnvAzureFoundry:
         )
 
     def test_azure_api_key_without_endpoint_fails_fast(self, monkeypatch):
-        """Guards PR #3: Azure aliases must not fall through to default OpenAI."""
+        """Guards PR #3: Azure routes must not fall through to default OpenAI."""
         monkeypatch.setenv("AZURE_API_KEY", "az-test")
 
         with pytest.raises(
             ValueError,
-            match=r"Azure AI Foundry model .* requires AZURE_AI_FOUNDRY_RESOURCE",
+            match=r"Azure AI Foundry model .* requires AZURE_RESOURCE",
         ):
             resolve_agent_env("codex-acp", "azure-foundry-openai/gpt-4o", {})
 
     def test_azure_api_key_with_unrecognized_endpoint_fails_fast(self, monkeypatch):
-        """Guards PR #3: non-Azure endpoint aliases must fail before launch."""
+        """Guards PR #3: non-Azure endpoint hosts must fail before launch."""
         monkeypatch.setenv("AZURE_API_KEY", "az-test")
         monkeypatch.setenv("AZURE_API_ENDPOINT", "https://example.com/")
 
@@ -702,7 +691,9 @@ class TestResolveAgentEnvAzureFoundry:
             },
         )
 
-        assert result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://proxy.example/openai/v1"
+        assert (
+            result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://proxy.example/openai/v1"
+        )
         assert result["OPENAI_BASE_URL"] == "https://proxy.example/openai/v1"
 
 


### PR DESCRIPTION
## Summary

Adds first-class Azure AI Foundry routing for the two protocol surfaces we need today:

- `azure-foundry-openai/` for Codex/OpenAI-compatible Responses calls
- `azure-foundry-anthropic/` for Claude/Anthropic Messages calls

The user-facing env contract is intentionally small: export `AZURE_API_KEY` and `AZURE_API_ENDPOINT`, and BenchFlow derives `AZURE_RESOURCE`, builds the correct surface-specific base URL, and maps the shared Azure key into the agent-native env vars. Explicit `AZURE_RESOURCE` and `BENCHFLOW_PROVIDER_BASE_URL` overrides still work for advanced/provider-proxy cases.

This also fails fast when an Azure Foundry model is selected without a recognizable Azure endpoint, instead of falling through to a default public provider URL.

## Real eval evidence

Validated with the real Azure Foundry resource that currently has `gpt-5.5` and `claude-opus-4-5` deployed:

- Direct OpenAI Responses probe to `gpt-5.5`: HTTP 200
- Direct Anthropic Messages probe to `claude-opus-4-5`: HTTP 200
- Daytona E2E: `codex-acp` + `azure-foundry-openai/gpt-5.5` on `src/benchflow/demo_task` returned `reward=1.0`, `tool_calls=1`
- Daytona E2E: `claude-agent-acp` + `azure-foundry-anthropic/claude-opus-4-5` on `src/benchflow/demo_task` returned `reward=1.0`, `tool_calls=1`
- Persisted `config.json` did not include API key/token values

## Testing

- `uv sync --extra dev --locked`
- `uv run python -m pytest tests/` (`1364 passed, 30 skipped, 1 deselected`)
- `uv run ty check src/`
- `uv run ruff check .`
- `git diff --check upstream/main...HEAD`

## Review & Testing Checklist for Human

- [ ] Verify the `AZURE_API_KEY` + `AZURE_API_ENDPOINT` contract is the right public surface for Foundry users
- [ ] Verify the provider registry remains the canonical layer for surface-specific base URLs/protocols
- [ ] Optionally rerun the two Daytona demo-task commands against a Foundry resource with the same deployments

### Notes

The implementation keeps Azure-specific branching narrow: endpoint parsing and fail-fast messaging live in env resolution, while provider names/protocol/base URLs live in the provider registry.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/422" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->