### PR TITLE
fix: make JS agent installs POSIX sh compatible

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -91,7 +91,6 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
 _NODE_INSTALL = (
-    "set -o pipefail; "
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
     "BF_NODE_VERSION=22.14.0; "

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -165,6 +165,16 @@ def test_js_acp_agent_npm_failures_are_visible(name):
     )
 
 
+@pytest.mark.parametrize("name", sorted(JS_ACP_AGENTS))
+def test_js_acp_agent_install_commands_are_posix_sh_compatible(name):
+    """Guards the fix for commit 6c9e733 against the regression where Docker
+    JS-agent installs failed before launch because install_cmd used bash-only
+    `set -o pipefail` under DockerSandbox.exec()'s POSIX `sh -c`.
+    """
+    install_cmd = AGENTS[name].install_cmd
+    assert "set -o pipefail" not in install_cmd
+
+
 @pytest.mark.parametrize("name,cfg", AGENTS.items(), ids=list(AGENTS.keys()))
 def test_agent_credential_and_subscription_auth(name, cfg):
     """Optional credential_files and subscription_auth structures."""

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -167,7 +167,7 @@ def test_js_acp_agent_npm_failures_are_visible(name):
 
 @pytest.mark.parametrize("name", sorted(JS_ACP_AGENTS))
 def test_js_acp_agent_install_commands_are_posix_sh_compatible(name):
-    """Guards the fix for commit 6c9e733 against the regression where Docker
+    """Guards the fix from PR #423 against the regression where Docker
     JS-agent installs failed before launch because install_cmd used bash-only
     `set -o pipefail` under DockerSandbox.exec()'s POSIX `sh -c`.
     """


### PR DESCRIPTION
## Summary

Fixes local Docker runs for JavaScript ACP agents by removing the bash-only `set -o pipefail` from the shared JS-agent install snippet.

`DockerSandbox.exec()` intentionally invokes task containers with POSIX `sh -c` so it can work across minimal images. The JS install command was the outlier: it started with `set -o pipefail`, which exits immediately under `dash`/POSIX `sh` before Node or the agent package can install.

This keeps the fix deliberately small:

- Remove the non-POSIX shell option from `_NODE_INSTALL`
- Add a registry invariant covering every JS ACP agent install command

## Real eval evidence

Reproduced the failure before this change with local Docker + `codex-acp` on `src/benchflow/demo_task`:

- Install failed before agent launch with `sh: 1: set: Illegal option -o pipefail`

Validated after this change with local Docker + `codex-acp` using the repo's mock OpenAI Responses server:

- JS agent install completed successfully
- Node `v22.14.0` and npm output were logged in `agent/install-stdout.txt`
- Sandbox user setup completed
- Codex ACP launched successfully
- ACP `session/new` and `set_model` completed
- The run then failed later with the mock provider's intentional API error, and the proxy captured 13 exchanges, confirming the original install-time blocker was gone

## Testing

- `uv run python -m pytest tests/test_registry_invariants.py -q` (`74 passed`)
- `uv run python -m pytest tests/` (`1365 passed, 9 skipped, 1 deselected`)
- `uv run ty check src/`
- `uv run ruff check .`
- Local Docker smoke with `codex-acp` + mock Responses server reached ACP/provider routing instead of failing during install

## Review & Testing Checklist for Human

- [ ] Verify no JS ACP install command depends on bash-only shell options
- [ ] Run a local Docker JS-agent smoke (`codex-acp`, `claude-agent-acp`, or `gemini`) and confirm install reaches agent launch
- [ ] Confirm the new invariant is broad enough to catch future shell-compat regressions across all JS ACP agents

### Notes

This PR is intentionally independent from the Azure Foundry support PR. It only fixes the local Docker JS-agent install path.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/423" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->