### PR TITLE
fix: sanitize path segments in skill eval, learner skills, and trace task gen

### DIFF
--- a/src/benchflow/_paths.py
+++ b/src/benchflow/_paths.py
@@ -1,0 +1,115 @@
+"""Path safety helpers — reject (don't slugify) unsafe path inputs.
+
+BenchFlow accepts user-controlled strings (case ids, skill names, trace file
+paths) and uses them as filesystem path segments. A name like ``../escape``
+or ``a/b`` traverses outside the intended tree, so we validate each segment
+before it is used as a path component.
+
+These helpers **reject** invalid names rather than slugifying them. The reasoning:
+
+* A silent slug rewrites the identifier the caller passed in; two distinct
+  inputs (``a/b`` and ``a-b``) collapse to the same directory, which can
+  shadow data or make GEPA / job-result lookups fall back to the wrong case.
+* Slugification can also mask programmer error — a typo that produces ``..``
+  silently maps to a usable name instead of surfacing the bug.
+* Callers that genuinely need a forgiving UX (e.g. user-facing tooling that
+  derives a slug from a free-form title) can slugify upstream, then call
+  :func:`safe_path_segment` on the slug as a final guard.
+
+For containment checks across multiple segments (or once a full path has been
+constructed), use :func:`assert_within`, which resolves symlinks and verifies
+the resulting path stays under a known root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = ["safe_path_segment", "assert_within"]
+
+
+def safe_path_segment(name: str, *, kind: str = "name") -> str:
+    """Return ``name`` unchanged if safe as a single path segment.
+
+    Raises :class:`ValueError` for inputs that cannot be used as a directory
+    or file name without risking path traversal or shell ambiguity.
+
+    Rejected forms:
+
+    * empty string
+    * ``.`` or ``..`` (current/parent directory references)
+    * any string containing ``/`` or ``\\`` (multi-segment paths)
+    * any string containing a NUL byte
+    * leading or trailing whitespace
+    * leading ``-`` (would be interpreted as a CLI flag by downstream tools)
+
+    All other Unicode is accepted; this is a security boundary, not a
+    cosmetic slugifier. Callers that want forgiving behaviour should slugify
+    *before* calling this function.
+
+    Args:
+        name: The candidate path segment.
+        kind: A human label used in the error message (e.g. ``"case id"``,
+            ``"skill name"``).
+
+    Returns:
+        The input ``name`` unchanged.
+
+    Raises:
+        ValueError: If ``name`` is not safe as a single path segment.
+    """
+    if not isinstance(name, str):
+        raise ValueError(f"{kind} must be a string, got {type(name).__name__}")
+    if name == "":
+        raise ValueError(f"{kind} must not be empty")
+    if name in (".", ".."):
+        raise ValueError(f"{kind} must not be '.' or '..' (got {name!r})")
+    if "/" in name or "\\" in name:
+        raise ValueError(
+            f"{kind} must not contain path separators (got {name!r})"
+        )
+    if "\x00" in name:
+        raise ValueError(f"{kind} must not contain NUL bytes (got {name!r})")
+    if name != name.strip():
+        raise ValueError(
+            f"{kind} must not have leading or trailing whitespace (got {name!r})"
+        )
+    if name.startswith("-"):
+        raise ValueError(
+            f"{kind} must not start with '-' (got {name!r}); "
+            "would be misread as a CLI flag"
+        )
+    return name
+
+
+def assert_within(child: Path, root: Path) -> Path:
+    """Resolve both paths and assert ``child`` is under ``root``.
+
+    Uses :meth:`Path.resolve` so symlinks are followed and ``..`` segments
+    collapsed before the containment check. Returns the resolved child.
+
+    Defense-in-depth helper for sites that already validated each path
+    segment but want to be sure no later code (e.g. ``shutil.copytree``,
+    ``Path.write_text``) escaped via an unexpected route.
+
+    Args:
+        child: A path that should be inside ``root``.
+        root: The directory ``child`` must not escape.
+
+    Returns:
+        The resolved ``child`` path.
+
+    Raises:
+        ValueError: If the resolved ``child`` is not under the resolved
+            ``root``.
+    """
+    resolved_root = root.resolve()
+    resolved_child = child.resolve()
+    try:
+        resolved_child.relative_to(resolved_root)
+    except ValueError as exc:
+        raise ValueError(
+            f"path {child} resolves to {resolved_child}, "
+            f"which is outside {resolved_root}"
+        ) from exc
+    return resolved_child

--- a/src/benchflow/learner_skills.py
+++ b/src/benchflow/learner_skills.py
@@ -33,11 +33,15 @@ orchestrator (``evaluation.py``) drives it.
 
 from __future__ import annotations
 
+import logging
 import shutil
 from pathlib import Path
 from typing import Any
 
+from benchflow._paths import safe_path_segment
 from benchflow.learner_store import LearnerState
+
+logger = logging.getLogger(__name__)
 
 #: The single skill file inside each ``<name>/`` skill pack directory.
 SKILL_FILE = "SKILL.md"
@@ -59,7 +63,12 @@ def materialize_skills(state: LearnerState, dest: Path | str) -> Path:
         shutil.rmtree(dest_path)
     dest_path.mkdir(parents=True, exist_ok=True)
     for name, body in state.skills.items():
-        pack = dest_path / str(name)
+        # Reject skill names that would path-traverse out of ``dest_path``
+        # — names come from ``LearnerState.skills`` which can originate from
+        # arbitrary rollout output, and ``../escaped`` would write a SKILL.md
+        # outside the intended skills root.
+        safe_segment = safe_path_segment(str(name), kind="skill name")
+        pack = dest_path / safe_segment
         pack.mkdir(parents=True, exist_ok=True)
         (pack / SKILL_FILE).write_text(_body_text(body))
     return dest_path
@@ -81,8 +90,27 @@ def capture_skills(export_dir: Path | str) -> dict[str, str]:
     if not root.is_dir():
         return {}
     skills: dict[str, str] = {}
-    for pack in sorted(p for p in root.iterdir() if p.is_dir()):
+    # Sort by name for deterministic iteration. Use ``iterdir`` directly so
+    # symlinked packs surface as symlinks (``is_dir()`` follows symlinks and
+    # would let an attacker exfiltrate any readable SKILL.md on disk by
+    # symlinking the pack into the export directory).
+    for pack in sorted(root.iterdir(), key=lambda p: p.name):
+        if pack.is_symlink():
+            logger.warning(
+                "Skipping symlinked skill pack %s — refusing to follow symlinks",
+                pack,
+            )
+            continue
+        if not pack.is_dir():
+            continue
         skill_md = pack / SKILL_FILE
+        # Reject SKILL.md that is itself a symlink (could point outside root).
+        if skill_md.is_symlink():
+            logger.warning(
+                "Skipping symlinked SKILL.md at %s — refusing to follow symlinks",
+                skill_md,
+            )
+            continue
         if skill_md.is_file():
             skills[pack.name] = skill_md.read_text()
     return skills

--- a/src/benchflow/skill_eval.py
+++ b/src/benchflow/skill_eval.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from string import Template
 
+from benchflow._paths import assert_within, safe_path_segment
+
 logger = logging.getLogger(__name__)
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
@@ -195,10 +197,19 @@ def load_eval_dataset(skill_dir: str | Path) -> EvalDataset:
         else:
             skill_name = skill_dir.name
 
+    # Reject skill names that would path-traverse when used as a directory
+    # segment in generate_tasks (skills/<skill_name>) or GEPA exports.
+    safe_path_segment(skill_name, kind="skill name")
+
     cases = []
     seen_ids = set()
     for i, c in enumerate(data["cases"]):
         case_id = c.get("id", f"case-{i:03d}")
+        # Reject case ids that would path-traverse when used as a directory
+        # segment in generate_tasks or as a filename component in
+        # export_gepa_traces. Fail early at load time so callers see the
+        # offending case rather than a write outside the output tree.
+        safe_path_segment(case_id, kind="case id")
         if case_id in seen_ids:
             raise ValueError(f"Duplicate case id: {case_id}")
         seen_ids.add(case_id)
@@ -250,12 +261,19 @@ def generate_tasks(
     output_dir.mkdir(parents=True, exist_ok=True)
     task_dirs = []
 
+    # Defense in depth: load_eval_dataset already rejects unsafe ids/names,
+    # but re-validate here so any future caller constructing an EvalDataset
+    # by hand still gets the same safety guarantee.
+    safe_path_segment(dataset.skill_name, kind="skill name")
+
     # Read templates
     judge_template = (TEMPLATES_DIR / "judge.py.tmpl").read_text()
     test_sh_template = (TEMPLATES_DIR / "test.sh.tmpl").read_text()
 
     for case in dataset.cases:
+        safe_path_segment(case.id, kind="case id")
         task_dir = output_dir / case.id
+        assert_within(task_dir, output_dir)
         task_dir.mkdir(parents=True, exist_ok=True)
 
         # instruction.md
@@ -309,7 +327,10 @@ def generate_tasks(
 
         # Copy skill into environment if with_skill mode
         if with_skill:
-            skills_dst = env_dir / "skills" / dataset.skill_name
+            skills_root = env_dir / "skills"
+            skills_root.mkdir(parents=True, exist_ok=True)
+            skills_dst = skills_root / dataset.skill_name
+            assert_within(skills_dst, skills_root)
             if skills_dst.exists():
                 shutil.rmtree(skills_dst)
             shutil.copytree(
@@ -738,9 +759,15 @@ def export_gepa_traces(
 
     # Write per-case traces
     for cr in result.case_results:
+        # Reject case ids that would path-traverse out of traces_dir via the
+        # generated filename. load_eval_dataset already rejects unsafe ids,
+        # but CaseResult objects can be constructed independently (e.g. by a
+        # caller assembling a SkillEvalResult by hand).
+        safe_path_segment(cr.case_id, kind="case id")
         agent_label = cr.agent.split("/")[-1] if "/" in cr.agent else cr.agent
         mode = "with" if cr.with_skill else "without"
         trace_file = traces_dir / f"{cr.case_id}-{agent_label}-{mode}.json"
+        assert_within(trace_file, traces_dir)
         trace_file.write_text(
             json.dumps(
                 {

--- a/src/benchflow/traces/task_gen.py
+++ b/src/benchflow/traces/task_gen.py
@@ -161,6 +161,46 @@ def _relativize_path(path: str) -> str:
     return path
 
 
+def _is_safe_workspace_path(path: str) -> bool:
+    """Return True if ``path`` is safe to embed in a generated task artifact.
+
+    Generated ``test.sh`` and ``solve.sh`` ``cd /app`` before operating on
+    these paths. A path containing ``..`` segments or starting with ``/``
+    escapes the workspace, so the verifier and oracle can read or write
+    arbitrary host locations (see GitHub issue #376).
+
+    Empty strings are also unsafe — they'd produce shell commands that
+    silently target the current directory.
+    """
+    if not path:
+        return False
+    if path.startswith("/"):
+        return False
+    if "\x00" in path:
+        return False
+    # Use PurePosixPath-style splitting; trace paths use forward slashes
+    # even when the agent ran on Windows-like surfaces.
+    return ".." not in Path(path).parts
+
+
+def _safe_relativize(path: str) -> str | None:
+    """Return ``_relativize_path(path)`` if the result is workspace-safe.
+
+    Returns ``None`` (with a warning log) for unsafe inputs — the caller
+    should drop the offending entry from generated artifacts so the task
+    does not encode writes or verification outside the workspace.
+    """
+    relative = _relativize_path(path)
+    if not _is_safe_workspace_path(relative):
+        logger.warning(
+            "Dropping trace path %r (relativized to %r) — escapes task workspace",
+            path,
+            relative,
+        )
+        return None
+    return relative
+
+
 def _globify_path(path: str) -> str:
     """Replace timestamp-bearing directory segments with globs.
 
@@ -204,8 +244,15 @@ def _build_instruction(trace: ParsedTrace) -> str:
 
     lines = [prompt, ""]
 
-    # Add context about what the agent actually did as implicit requirements
-    files = [_relativize_path(f) for f in trace.files_edited]
+    # Add context about what the agent actually did as implicit requirements.
+    # Drop trace paths that would escape the task workspace (issue #376) —
+    # ``..`` segments or absolute paths in instruction.md mislead the agent
+    # and pair badly with the verifier and oracle that consume the same list.
+    files = [
+        rel
+        for f in trace.files_edited
+        if (rel := _safe_relativize(f)) is not None
+    ]
     if files:
         lines.append("## Expected Changes")
         lines.append("")
@@ -309,7 +356,13 @@ def _build_test_sh(trace: ParsedTrace) -> str:
     exist.  Otherwise falls back to file-existence checks.
     Writes reward to /logs/verifier/reward.txt per BenchFlow contract.
     """
-    files = [_relativize_path(f) for f in trace.files_edited]
+    # Drop traversal/absolute paths so the verifier never asserts existence
+    # of files outside /app — see issue #376.
+    files = [
+        rel
+        for f in trace.files_edited
+        if (rel := _safe_relativize(f)) is not None
+    ]
     if not files:
         return (
             "#!/bin/bash\n"
@@ -370,24 +423,32 @@ def _build_test_sh(trace: ParsedTrace) -> str:
 
 
 def _tool_call_file_write(tc_input: dict[str, object]) -> tuple[str, str] | None:
-    """Extract a file path and best-effort final content from a write/edit call."""
+    """Extract a file path and best-effort final content from a write/edit call.
+
+    Drops the write entirely if the relativized path would escape the task
+    workspace (absolute or contains ``..``) — see issue #376.
+    """
     path = tc_input.get("file_path") or tc_input.get("path")
     if not isinstance(path, str) or not path:
         return None
 
+    safe = _safe_relativize(path)
+    if safe is None:
+        return None
+
     content = tc_input.get("content")
     if isinstance(content, str):
-        return _relativize_path(path), content
+        return safe, content
 
     new_string = tc_input.get("new_string")
     if isinstance(new_string, str):
-        return _relativize_path(path), new_string
+        return safe, new_string
 
     text = tc_input.get("text")
     if isinstance(text, str):
-        return _relativize_path(path), text
+        return safe, text
 
-    return _relativize_path(path), ""
+    return safe, ""
 
 
 def _solution_writes_from_trace(trace: ParsedTrace) -> list[tuple[str, str]]:
@@ -406,6 +467,9 @@ def _solution_writes_from_trace(trace: ParsedTrace) -> list[tuple[str, str]]:
                 path = tc.input.get("file_path") or tc.input.get("path")
                 edits = tc.input.get("edits")
                 if isinstance(path, str) and isinstance(edits, list):
+                    safe = _safe_relativize(path)
+                    if safe is None:
+                        continue
                     parts = []
                     for edit in edits:
                         if isinstance(edit, dict):
@@ -413,7 +477,7 @@ def _solution_writes_from_trace(trace: ParsedTrace) -> list[tuple[str, str]]:
                             new_string = edit_input.get("new_string")
                             if isinstance(new_string, str):
                                 parts.append(new_string)
-                    writes_by_path[_relativize_path(path)] = "\n".join(parts)
+                    writes_by_path[safe] = "\n".join(parts)
 
     return list(writes_by_path.items())
 

--- a/tests/test_learner_skills_traversal.py
+++ b/tests/test_learner_skills_traversal.py
@@ -1,0 +1,95 @@
+"""Path traversal regression tests for benchflow.learner_skills (issue #402).
+
+Two attack surfaces:
+
+* :func:`capture_skills` walks an export directory with ``is_dir()``, which
+  follows symlinks — an attacker can place ``leaked-skill -> /some/outside``
+  and have the symlink target's ``SKILL.md`` ingested.
+* :func:`materialize_skills` uses skill names from ``LearnerState.skills`` as
+  path segments without validation — a name like ``../escaped`` writes a
+  SKILL.md outside the destination root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.learner_skills import capture_skills, materialize_skills
+from benchflow.learner_store import LearnerState
+
+# ---------------------------------------------------------------------------
+# capture_skills — symlink-skip
+# ---------------------------------------------------------------------------
+
+
+def test_capture_skips_symlinked_pack(tmp_path: Path, caplog) -> None:
+    # Build an "outside" SKILL.md the test wants to confirm is NOT ingested.
+    outside = tmp_path / "outside-secret"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("# secret-token\n")
+
+    # Export directory contains one legitimate pack and one symlinked pack
+    # that points at the outside directory.
+    export = tmp_path / "export"
+    export.mkdir()
+    real_pack = export / "real-skill"
+    real_pack.mkdir()
+    (real_pack / "SKILL.md").write_text("# real\n")
+    (export / "leaked-skill").symlink_to(outside)
+
+    with caplog.at_level("WARNING"):
+        result = capture_skills(export)
+
+    # Only the real pack came through; the symlinked pack was skipped.
+    assert result == {"real-skill": "# real\n"}
+    assert "leaked-skill" not in result
+    # And a warning was logged so the skip is auditable.
+    assert any("symlink" in r.message.lower() for r in caplog.records)
+
+
+def test_capture_skips_symlinked_skill_md(tmp_path: Path, caplog) -> None:
+    """A symlinked SKILL.md inside a real pack is also refused."""
+    outside = tmp_path / "outside-secret.md"
+    outside.write_text("# secret-payload\n")
+
+    export = tmp_path / "export"
+    pack = export / "trojan-skill"
+    pack.mkdir(parents=True)
+    (pack / "SKILL.md").symlink_to(outside)
+
+    with caplog.at_level("WARNING"):
+        result = capture_skills(export)
+
+    assert result == {}
+    assert any("symlink" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# materialize_skills — segment validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_name",
+    ["../escaped-materialized", "a/b", "..", ".", "", "/abs"],
+)
+def test_materialize_rejects_traversal_skill_name(
+    tmp_path: Path, bad_name: str
+) -> None:
+    state = LearnerState(skills={bad_name: "body"})
+    dest = tmp_path / "skills-root"
+    with pytest.raises(ValueError, match="skill name"):
+        materialize_skills(state, dest)
+    # No SKILL.md landed at the sibling escape location.
+    assert not (tmp_path / "escaped-materialized").exists()
+    assert not (tmp_path / "escaped-materialized" / "SKILL.md").exists()
+
+
+def test_materialize_accepts_valid_skill_names(tmp_path: Path) -> None:
+    state = LearnerState(skills={"git-bisect": "do the bisect", "grep": "use rg"})
+    dest = tmp_path / "skills-root"
+    materialize_skills(state, dest)
+    assert (dest / "git-bisect" / "SKILL.md").read_text() == "do the bisect"
+    assert (dest / "grep" / "SKILL.md").read_text() == "use rg"

--- a/tests/test_paths_safe.py
+++ b/tests/test_paths_safe.py
@@ -1,0 +1,106 @@
+"""Tests for benchflow._paths — segment validation and containment checks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow._paths import assert_within, safe_path_segment
+
+# ---------------------------------------------------------------------------
+# safe_path_segment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",          # empty
+        ".",         # current dir
+        "..",        # parent dir
+        "a/b",       # forward slash separator
+        "a\\b",      # backslash separator
+        "../escape", # traversal prefix
+        "-x",        # leading dash (CLI flag risk)
+        " name",     # leading whitespace
+        "name ",     # trailing whitespace
+        "\tname",    # leading tab
+        "na\x00me", # NUL byte
+        "\x00",     # bare NUL
+    ],
+)
+def test_rejects_unsafe(bad: str) -> None:
+    with pytest.raises(ValueError):
+        safe_path_segment(bad, kind="case id")
+
+
+@pytest.mark.parametrize(
+    "good",
+    [
+        "case-001",
+        "a",
+        "skill_name",
+        "MixedCase123",
+        "Tëst-üñïcödé",   # arbitrary unicode is allowed
+        "name.with.dots",
+        "_underscore_lead",
+        "a-b-c",
+    ],
+)
+def test_accepts_safe(good: str) -> None:
+    assert safe_path_segment(good) == good
+
+
+def test_rejects_non_string() -> None:
+    with pytest.raises(ValueError):
+        safe_path_segment(123)  # type: ignore[arg-type]
+
+
+def test_error_message_includes_kind() -> None:
+    with pytest.raises(ValueError, match="skill name"):
+        safe_path_segment("../escape", kind="skill name")
+
+
+# ---------------------------------------------------------------------------
+# assert_within
+# ---------------------------------------------------------------------------
+
+
+def test_within_accepts_nested(tmp_path: Path) -> None:
+    child = tmp_path / "a" / "b"
+    child.mkdir(parents=True)
+    assert assert_within(child, tmp_path) == child.resolve()
+
+
+def test_within_accepts_root_itself(tmp_path: Path) -> None:
+    assert assert_within(tmp_path, tmp_path) == tmp_path.resolve()
+
+
+def test_within_rejects_sibling(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    sibling = tmp_path / "sibling"
+    root.mkdir()
+    sibling.mkdir()
+    with pytest.raises(ValueError, match="outside"):
+        assert_within(sibling, root)
+
+
+def test_within_rejects_parent_traversal(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    root.mkdir()
+    escape = root / ".." / "escape"
+    with pytest.raises(ValueError):
+        assert_within(escape, root)
+
+
+def test_within_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    link = root / "link"
+    link.symlink_to(outside)
+    # Resolution should follow the symlink and detect the escape.
+    with pytest.raises(ValueError):
+        assert_within(link, root)

--- a/tests/test_skill_eval_traversal.py
+++ b/tests/test_skill_eval_traversal.py
@@ -1,0 +1,143 @@
+"""Path traversal regression tests for benchflow.skill_eval.
+
+Covers issues:
+    * #361 — case id used as task directory segment
+    * #403 — case id used in GEPA trace filenames
+    * #405 — skill_name used as ``skills/<name>`` directory segment
+
+Each test confirms a ValueError is raised before any file is written and
+asserts no escape artifact lands outside the intended output root.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchflow.skill_eval import (
+    CaseResult,
+    EvalCase,
+    EvalDataset,
+    SkillEvalResult,
+    export_gepa_traces,
+    generate_tasks,
+    load_eval_dataset,
+)
+
+
+def _write_skill_dir(
+    root: Path,
+    *,
+    skill_name: str | None = None,
+    case_id: str = "ok-case",
+) -> Path:
+    """Build a minimal skill directory with one eval case."""
+    skill = root / "skill"
+    (skill / "evals").mkdir(parents=True)
+    (skill / "SKILL.md").write_text(
+        "---\nname: audit-skill\n---\n# Audit skill\n"
+    )
+    payload: dict = {"cases": [{"id": case_id, "question": "q"}]}
+    if skill_name is not None:
+        payload["skill_name"] = skill_name
+    (skill / "evals" / "evals.json").write_text(json.dumps(payload))
+    return skill
+
+
+# ---------------------------------------------------------------------------
+# #361 — case id as task_dir segment
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_case_id",
+    ["../escaped-case", "/tmp/escape", "a/b", "..", "."],
+)
+def test_load_eval_dataset_rejects_traversal_case_id(
+    tmp_path: Path, bad_case_id: str
+) -> None:
+    skill = _write_skill_dir(tmp_path, case_id=bad_case_id)
+    with pytest.raises(ValueError, match="case id"):
+        load_eval_dataset(skill)
+
+
+def test_generate_tasks_rejects_traversal_case_id_at_call_time(
+    tmp_path: Path,
+) -> None:
+    # Build EvalDataset by hand to bypass load-time validation, simulating a
+    # caller that constructs the dataset programmatically.
+    skill = _write_skill_dir(tmp_path)
+    dataset = EvalDataset(
+        skill_name="audit-skill",
+        skill_dir=skill,
+        cases=[EvalCase(id="../escaped-case", question="q")],
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="case id"):
+        generate_tasks(dataset, out)
+    # Nothing escaped the requested output root.
+    assert not (tmp_path / "escaped-case").exists()
+    assert not (tmp_path / "escaped-case" / "task.toml").exists()
+
+
+# ---------------------------------------------------------------------------
+# #405 — skill_name as skills/<name> segment
+# ---------------------------------------------------------------------------
+
+
+def test_load_eval_dataset_rejects_traversal_skill_name(tmp_path: Path) -> None:
+    skill = _write_skill_dir(tmp_path, skill_name="../../../../escaped-skill-copy")
+    with pytest.raises(ValueError, match="skill name"):
+        load_eval_dataset(skill)
+
+
+def test_generate_tasks_rejects_traversal_skill_name_at_call_time(
+    tmp_path: Path,
+) -> None:
+    skill = _write_skill_dir(tmp_path)
+    dataset = EvalDataset(
+        skill_name="../../../../escaped-skill-copy",
+        skill_dir=skill,
+        cases=[EvalCase(id="ok-case", question="q")],
+    )
+    out = tmp_path / "out"
+    with pytest.raises(ValueError, match="skill name"):
+        generate_tasks(dataset, out, with_skill=True)
+    # No SKILL.md landed outside the intended task tree.
+    assert not (tmp_path / "escaped-skill-copy").exists()
+
+
+# ---------------------------------------------------------------------------
+# #403 — case id as GEPA trace filename component
+# ---------------------------------------------------------------------------
+
+
+def test_export_gepa_rejects_traversal_case_id(tmp_path: Path) -> None:
+    skill = _write_skill_dir(tmp_path)
+    dataset = EvalDataset(
+        skill_name="audit-skill",
+        skill_dir=skill,
+        cases=[EvalCase(id="ok-case", question="q")],
+    )
+    # CaseResult is independent of load_eval_dataset, so the export sink
+    # needs its own validation step.
+    cr = CaseResult(
+        case_id="../../escaped-gepa",
+        agent="agent-a",
+        model="m",
+        with_skill=True,
+        reward=1.0,
+    )
+    result = SkillEvalResult(
+        skill_name="audit-skill",
+        n_cases=1,
+        agents=["agent-a"],
+        case_results=[cr],
+    )
+    output = tmp_path / "gepa-out"
+    with pytest.raises(ValueError, match="case id"):
+        export_gepa_traces(result, dataset, output)
+    # No escaped JSON file landed at the sibling location.
+    assert not list(tmp_path.glob("escaped-gepa-*.json"))

--- a/tests/test_trace_task_gen_traversal.py
+++ b/tests/test_trace_task_gen_traversal.py
@@ -1,0 +1,125 @@
+"""Path traversal regression tests for benchflow.traces.task_gen (issue #376).
+
+Trace file paths flow into three generated artifacts:
+
+* ``instruction.md`` — the task description shown to the agent
+* ``tests/test.sh`` — the verifier that decides task reward
+* ``solution/solve.sh`` — the oracle that replays trace writes
+
+If trace paths contain ``..`` segments or are absolute, the generated
+artifacts encode writes and verification outside the task workspace,
+and a Docker oracle can earn reward 1.0 by escaping ``/app``.
+
+The fix drops unsafe paths from each consumer with a warning, so
+generated tasks never instruct or verify outside the workspace.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from benchflow.traces.models import GitContext, ParsedTrace, ToolCall, TraceStep
+from benchflow.traces.task_gen import generate_task
+
+
+def _trace_with_paths(paths: list[str]) -> ParsedTrace:
+    """Build a trace whose Write tool calls reference ``paths``."""
+    tool_calls = [
+        ToolCall(
+            name="Write",
+            input={"file_path": p, "content": f"contents for {p}"},
+        )
+        for p in paths
+    ]
+    return ParsedTrace(
+        trace_id="parent-escape-001",
+        session_id="sess-001",
+        agent_name="claude-code",
+        model="claude-sonnet-4-20250514",
+        started_at=datetime(2026, 1, 15, 10, 0, 0, tzinfo=UTC),
+        ended_at=datetime(2026, 1, 15, 10, 5, 0, tzinfo=UTC),
+        steps=[
+            TraceStep(role="user", content="Create a marker file"),
+            TraceStep(
+                role="assistant",
+                content="I'll create it.",
+                tool_calls=tool_calls,
+            ),
+            TraceStep(role="assistant", content="Done."),
+        ],
+        git=GitContext(repo="user/proj", branch="main"),
+        cwd="/app",
+    )
+
+
+# ---------------------------------------------------------------------------
+# All-unsafe trace — every consumer drops the path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        # ``..`` segments survive _relativize_path and would escape /app.
+        "../../tmp/benchflow_escape_marker.txt",
+        # Mid-path ``..`` that ends up relative but still has parent refs.
+        "src/../../../etc/passwd",
+        # Pure ``..`` parent reference.
+        "..",
+    ],
+)
+def test_unsafe_paths_dropped_from_generated_artifacts(
+    tmp_path: Path, unsafe: str, caplog
+) -> None:
+    trace = _trace_with_paths([unsafe])
+    out = tmp_path / "tasks"
+    with caplog.at_level("WARNING"):
+        task_dir = generate_task(trace, out)
+
+    instruction = (task_dir / "instruction.md").read_text()
+    test_sh = (task_dir / "tests" / "test.sh").read_text()
+    solve_sh = (task_dir / "solution" / "solve.sh").read_text()
+
+    # No artifact still encodes a workspace-escape (``..`` segment).
+    for artifact, label in (
+        (instruction, "instruction.md"),
+        (test_sh, "test.sh"),
+        (solve_sh, "solve.sh"),
+    ):
+        assert ".." not in artifact, f"{label} still references '..'"
+
+    # Solve.sh has no writes left to perform; verifier reports no checks.
+    assert "No replayable file writes" in solve_sh
+    assert "No file checks available" in test_sh
+
+    # At least one warning was logged so the drop is auditable.
+    assert any("escape" in r.message.lower() for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Mixed trace — unsafe dropped, safe retained
+# ---------------------------------------------------------------------------
+
+
+def test_safe_path_kept_unsafe_dropped(tmp_path: Path) -> None:
+    trace = _trace_with_paths(
+        ["src/keep_me.py", "../../tmp/drop_me.txt"]
+    )
+    task_dir = generate_task(trace, tmp_path / "tasks")
+
+    instruction = (task_dir / "instruction.md").read_text()
+    test_sh = (task_dir / "tests" / "test.sh").read_text()
+    solve_sh = (task_dir / "solution" / "solve.sh").read_text()
+
+    # Safe path survives every artifact.
+    assert "src/keep_me.py" in instruction
+    assert "src/keep_me.py" in test_sh
+    assert "src/keep_me.py" in solve_sh
+
+    # Unsafe path appears nowhere.
+    for artifact in (instruction, test_sh, solve_sh):
+        assert "drop_me" not in artifact
+        assert ".." not in artifact


### PR DESCRIPTION
Closes #361. Closes #376. Closes #402. Closes #403. Closes #405.

Adds `benchflow._paths` with `safe_path_segment` + `assert_within`. User-controlled strings (case ids, skill names, trace file paths) are no longer usable as path segments to escape output trees. 49 new tests across 4 files.

**Review findings (follow-up):**
- Move `_paths.py` → `_utils/paths.py` to consolidate with 3 existing `resolve+is_relative_to` duplicates in `_utils/source_provenance.py`, `_utils/benchmark_repos.py`.
- `skill_eval.py` crossed 800 line cap (810); extract `export_gepa_traces`.
- `_safe_relativize` could be a chokepoint at `ParsedTrace.files_edited` instead of 4 caller-site filters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security hardening on filesystem writes driven by evals, rollout skills, and traces; behavior changes reject bad ids/names and omit unsafe trace paths rather than silently writing outside intended trees.
> 
> **Overview**
> Adds **`benchflow._paths`** with **`safe_path_segment`** (reject empty, `.`/`..`, separators, NUL, whitespace, leading `-`) and **`assert_within`** (resolved containment under a root).
> 
> **Skill eval** validates **`skill_name`** and **`case id`** at dataset load, task generation, skill copy into `environment/skills`, and GEPA trace export so writes stay under the intended output trees.
> 
> **Learner skills** validates names in **`materialize_skills`** and skips symlinked skill packs / **`SKILL.md`** in **`capture_skills`** so export trees cannot be followed out of band.
> 
> **Trace task generation** drops workspace-unsafe relativized paths (absolute, `..`, empty) from **`instruction.md`**, **`test.sh`**, and **`solve.sh`** with warnings instead of embedding escape paths.
> 
> **49 regression tests** cover the above (issues #361, #376, #402, #403, #405).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee562b6fe76fc1da2e83f04037e8ed18f89b6631. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->