### PR TITLE
fix: refuse to follow symlinks during dashboard/judge/sandbox ingestion

### DIFF
--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -60,6 +60,7 @@ JOBS_ROOT_ENV = "BENCHFLOW_DASHBOARD_JOBS_ROOT"
 _ROADMAP_MODULE: ModuleType | None = None
 _SCORING_MODULE: ModuleType | None = None
 _REWARD_EVENTS_MODULE: ModuleType | None = None
+_PATHS_MODULE: ModuleType | None = None
 
 
 def _load_local_module(module_name: str, path: Path) -> ModuleType:
@@ -169,6 +170,28 @@ def _load_reward_events_module() -> ModuleType:
 
 def _memory_score_from_result(result: dict) -> float | None:
     return _load_reward_events_module().memory_score_from_result(result)
+
+
+def _load_paths_module() -> ModuleType:
+    """Load the symlink-safe traversal helpers without importing ``benchflow``."""
+    global _PATHS_MODULE
+    if _PATHS_MODULE is not None:
+        return _PATHS_MODULE
+    paths_path = SRC / "benchflow" / "_paths.py"
+    _PATHS_MODULE = _load_local_module("_benchflow_dashboard_paths", paths_path)
+    return _PATHS_MODULE
+
+
+def _is_safe_regular_file(p: Path) -> bool:
+    return bool(_load_paths_module().is_safe_regular_file(p))
+
+
+def _iter_safe_children(directory: Path, *, context: str):
+    yield from _load_paths_module().iter_safe_children(directory, context=context)
+
+
+def _iter_safe_tree(root: Path, *, context: str):
+    yield from _load_paths_module().iter_safe_tree(root, context=context)
 
 
 def remembered_jobs_root(out: Path) -> Path | None:
@@ -382,10 +405,15 @@ def _lang_for(p: Path) -> str:
 def _file_payload(p: Path) -> tuple[str | None, int, bool, str]:
     """Read a text file, capped. Returns (content, total_lines, truncated, lang).
 
-    Binary and unreadable files return ``(None, 0, False, lang)``. The line
-    count is the file's *real* length even when the embedded content is capped.
+    Binary and unreadable files return ``(None, 0, False, lang)``. Symlinks
+    are refused outright (#390, #416) — an attacker-placed link inside an
+    artifact or labs directory must never push host-readable content into
+    ``data.json``. The line count is the file's *real* length even when the
+    embedded content is capped.
     """
     lang = _lang_for(p)
+    if not _is_safe_regular_file(p):
+        return None, 0, False, lang
     try:
         raw = p.read_bytes()
     except Exception:
@@ -491,14 +519,17 @@ def _task_artifacts(d: Path) -> list[dict]:
     verbatim.
     """
     arts: list[dict] = []
-    for child in sorted(d.iterdir()):
-        if child.is_file() and not _is_empty(child):  # R1: skip 0-byte files
+    for child in _iter_safe_children(d, context="rollout artifacts"):
+        if _is_safe_regular_file(child) and not _is_empty(child):  # R1: skip 0-byte files
             arts.append(_artifact(child.name, _ART_KIND.get(child.name, "file"), child))
     for sub in ("trajectory", "verifier", "agent", "artifacts"):
         subdir = d / sub
         if not subdir.is_dir():
             continue
-        for f in sorted(p for p in subdir.rglob("*") if p.is_file()):
+        # `iter_safe_tree` walks with followlinks=False and rejects symlinked
+        # files; this is the #390 fix — agent-controlled artifact symlinks
+        # must never embed host file content into ``data.json``.
+        for f in _iter_safe_tree(subdir, context=f"rollout artifacts/{sub}"):
             if _is_empty(f):  # R1: skip 0-byte files
                 continue
             rel = f.relative_to(d).as_posix()
@@ -952,8 +983,10 @@ def collect_experiments() -> list[dict]:
     exp = ROOT / "experiments"
     if exp.is_dir():
         buckets: dict[str, dict] = {}
-        for f in sorted(exp.iterdir()):
-            if not f.is_file() or f.name.startswith(".") or _is_empty(f):
+        # Symlinks under experiments/ are refused (#416) so an attacker
+        # cannot leak host files through the experiments timeline.
+        for f in _iter_safe_children(exp, context="experiments timeline"):
+            if not _is_safe_regular_file(f) or f.name.startswith(".") or _is_empty(f):
                 continue
             low = f.name.lower()
             match = next((r for r in EXP_RULES if r[0] in low), None)
@@ -988,13 +1021,16 @@ def collect_experiments() -> list[dict]:
 
     labs = ROOT / "labs"
     if labs.is_dir():
-        for sub in sorted(labs.iterdir()):
+        # Symlinks under labs/<sub> are refused (#416). `iter_safe_children`
+        # rejects symlinked lab roots; `iter_safe_tree` walks without
+        # following links inside each lab.
+        for sub in _iter_safe_children(labs, context="labs timeline"):
             if not sub.is_dir() or sub.name.startswith("."):
                 continue
             all_files = [
                 p
-                for p in sorted(sub.rglob("*"))
-                if p.is_file() and not p.name.startswith(".") and not _is_empty(p)
+                for p in _iter_safe_tree(sub, context=f"labs/{sub.name}")
+                if not p.name.startswith(".") and not _is_empty(p)
             ]
             cap = 60
             files = all_files[:cap]

--- a/src/benchflow/_paths.py
+++ b/src/benchflow/_paths.py
@@ -1,0 +1,147 @@
+"""Path-safety helpers shared across ingestion and upload code paths.
+
+``Path.is_file()`` and ``Path.rglob("*")`` both follow symlinks by default.
+When walking a directory we do not own — agent artifacts, task deliverables,
+dependency stages, skill trees — that means an attacker-placed symlink can
+pull arbitrary host-readable files into a dashboard payload, a judge prompt,
+or a remote sandbox upload.
+
+The fix shape is the same everywhere:
+
+* check ``Path.is_symlink()`` (which does *not* follow links) before reading,
+* fall back to ``os.lstat`` and ``stat.S_ISREG`` to confirm we're looking at
+  a regular file rather than a fifo/socket/device, and
+* emit one warning per skipped entry so missing artifacts are explainable.
+
+A parallel PR (path-traversal hardening) adds ``safe_path_segment`` and
+``assert_within`` to this same module. The two function sets are independent;
+when both PRs land the file is a flat union.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from collections.abc import Iterator
+from pathlib import Path
+
+__all__ = [
+    "is_safe_regular_file",
+    "is_safe_regular_dir",
+    "iter_safe_children",
+    "iter_safe_tree",
+    "ignore_symlinks",
+]
+
+logger = logging.getLogger(__name__)
+
+
+def is_safe_regular_file(path: Path) -> bool:
+    """True if *path* exists, is a regular file, and is not a symlink.
+
+    Uses ``os.lstat`` so symlinks, fifos, sockets, and device files all
+    return False. A non-existent path also returns False.
+    """
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return False
+    return stat.S_ISREG(st.st_mode) and not stat.S_ISLNK(st.st_mode)
+
+
+def is_safe_regular_dir(path: Path) -> bool:
+    """True if *path* is a directory and not a symlink to one."""
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return False
+    return stat.S_ISDIR(st.st_mode) and not stat.S_ISLNK(st.st_mode)
+
+
+def iter_safe_children(
+    directory: Path,
+    *,
+    context: str = "directory walk",
+) -> Iterator[Path]:
+    """Yield direct children of *directory*, skipping symlinks with a warning.
+
+    Symlinks are skipped regardless of where they point — confirming
+    containment on every entry is cheaper than re-checking ``realpath``
+    upstream, and a same-tree symlink usually still indicates abuse.
+    """
+    try:
+        entries = sorted(directory.iterdir())
+    except (OSError, NotADirectoryError):
+        return
+    for child in entries:
+        if child.is_symlink():
+            logger.warning(
+                "%s: skipping symlink %s (refusing to follow)", context, child
+            )
+            continue
+        yield child
+
+
+def iter_safe_tree(
+    root: Path,
+    *,
+    context: str = "tree walk",
+) -> Iterator[Path]:
+    """Recursively yield regular files under *root*, never following symlinks.
+
+    Uses ``os.walk(followlinks=False)`` so directory symlinks are also not
+    descended into. Both symlinked files and symlinked directories produce a
+    single warning each.
+    """
+    if not is_safe_regular_dir(root):
+        if Path(root).is_symlink():
+            logger.warning(
+                "%s: refusing to descend into symlinked root %s", context, root
+            )
+        return
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        base = Path(dirpath)
+        kept_dirs: list[str] = []
+        for name in dirnames:
+            child = base / name
+            if child.is_symlink():
+                logger.warning(
+                    "%s: skipping symlinked directory %s (refusing to follow)",
+                    context,
+                    child,
+                )
+                continue
+            kept_dirs.append(name)
+        # In-place edit controls os.walk traversal.
+        dirnames[:] = sorted(kept_dirs)
+        for name in sorted(filenames):
+            f = base / name
+            if not is_safe_regular_file(f):
+                logger.warning(
+                    "%s: skipping non-regular path %s (symlink or special file)",
+                    context,
+                    f,
+                )
+                continue
+            yield f
+
+
+def ignore_symlinks(directory: str, contents: list[str]) -> list[str]:
+    """``shutil.copytree`` ``ignore=`` callback that drops every symlink.
+
+    Use together with ``symlinks=False`` (the default) so that links are
+    neither copied as links nor followed and resolved. Combine with any
+    existing ignore predicate via a small wrapper if needed.
+    """
+    skipped: list[str] = []
+    for name in contents:
+        if Path(directory, name).is_symlink():
+            skipped.append(name)
+    if skipped:
+        logger.warning(
+            "copytree: skipping symlinked entries under %s: %s",
+            directory,
+            ", ".join(sorted(skipped)),
+        )
+    return skipped

--- a/src/benchflow/rewards/file_readers.py
+++ b/src/benchflow/rewards/file_readers.py
@@ -11,6 +11,8 @@ import logging
 import subprocess
 from pathlib import Path
 
+from benchflow._paths import is_safe_regular_file, iter_safe_children
+
 logger = logging.getLogger(__name__)
 
 # File extensions we know how to handle.
@@ -46,13 +48,15 @@ def read_file_as_text(path: Path) -> str:
 def find_deliverables(directory: Path) -> dict[str, str]:
     """Discover and read all deliverable files in *directory*.
 
-    Skips files larger than 50 MB and hidden/internal files.
+    Skips files larger than 50 MB and hidden/internal files. Symlinks are
+    refused (#404) so an agent cannot exfiltrate host files into the judge
+    prompt by dropping a link inside the deliverable tree.
     """
     texts: dict[str, str] = {}
     if not directory.is_dir():
         return texts
-    for f in sorted(directory.iterdir()):
-        if not f.is_file():
+    for f in iter_safe_children(directory, context="judge deliverables"):
+        if not is_safe_regular_file(f):
             continue
         if f.name.startswith(".") or f.name == "rubric.json":
             continue

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 
 from tenacity import retry, stop_after_attempt, wait_exponential
 
+from benchflow._paths import iter_safe_tree
 from benchflow.sandbox._base import (
     BaseSandbox,
     ExecResult,
@@ -1198,16 +1199,20 @@ class DaytonaSandbox(BaseSandbox):
         file_uploads = []
         source_dir = Path(source_dir)
 
-        for file_path in source_dir.rglob("*"):
-            if file_path.is_file():
-                relative_path = file_path.relative_to(source_dir).as_posix()
-                destination_path = f"{target_dir}/{relative_path}"
-                file_uploads.append(
-                    FileUpload(
-                        source=str(file_path),
-                        destination=destination_path,
-                    )
+        # Walk with followlinks=False and skip symlinks (#411): a task or
+        # workspace symlink under source_dir must not exfiltrate host files
+        # into the remote Daytona sandbox.
+        for file_path in iter_safe_tree(
+            source_dir, context=f"daytona upload_dir {source_dir}"
+        ):
+            relative_path = file_path.relative_to(source_dir).as_posix()
+            destination_path = f"{target_dir}/{relative_path}"
+            file_uploads.append(
+                FileUpload(
+                    source=str(file_path),
+                    destination=destination_path,
                 )
+            )
 
         if file_uploads:
             await self._sandbox.fs.upload_files(files=file_uploads)

--- a/src/benchflow/sandbox/modal_impl.py
+++ b/src/benchflow/sandbox/modal_impl.py
@@ -13,6 +13,7 @@ from pathlib import Path, PurePosixPath
 
 from tenacity import retry, stop_after_attempt, wait_exponential
 
+from benchflow._paths import iter_safe_tree
 from benchflow.sandbox._base import BaseSandbox, ExecResult
 from benchflow.task.config import SandboxConfig
 from benchflow.task.paths import RolloutPaths, SandboxPaths
@@ -241,16 +242,20 @@ class ModalSandbox(BaseSandbox):
 
         await self.exec(f"mkdir -p {target_dir}", user="root")
 
-        for file_path in source_path.rglob("*"):
-            if file_path.is_file():
-                relative_path = file_path.relative_to(source_path).as_posix()
-                target_file_path = str(PurePosixPath(target_dir) / relative_path)
+        # Walk with followlinks=False and skip symlinks (#411): a task or
+        # workspace symlink under source_path must not exfiltrate host files
+        # into the remote Modal sandbox.
+        for file_path in iter_safe_tree(
+            source_path, context=f"modal upload_dir {source_path}"
+        ):
+            relative_path = file_path.relative_to(source_path).as_posix()
+            target_file_path = str(PurePosixPath(target_dir) / relative_path)
 
-                target_file_parent = str(PurePosixPath(target_file_path).parent)
-                if target_file_parent != target_dir:
-                    await self.exec(f"mkdir -p {target_file_parent}", user="root")
+            target_file_parent = str(PurePosixPath(target_file_path).parent)
+            if target_file_parent != target_dir:
+                await self.exec(f"mkdir -p {target_file_parent}", user="root")
 
-                await self.upload_file(file_path, target_file_path)
+            await self.upload_file(file_path, target_file_path)
 
     @retry(
         stop=stop_after_attempt(2),

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NoReturn, cast
 
+from benchflow._paths import ignore_symlinks, is_safe_regular_file
 from benchflow.agents.registry import AGENTS
 from benchflow.task import RolloutPaths, Task
 
@@ -36,6 +37,18 @@ _IGNORE_DIRS = {
     ".mypy_cache",
     ".ruff_cache",
 }
+
+
+def _stage_ignore(directory: str, contents: list[str]) -> list[str]:
+    """``shutil.copytree`` ignore callback: drop noise dirs *and* every symlink.
+
+    Composes :func:`shutil.ignore_patterns` for ``_IGNORE_DIRS`` with
+    :func:`benchflow._paths.ignore_symlinks` so a task-controlled symlink
+    cannot smuggle host files into the Docker build context (#411).
+    """
+    pattern_skip = set(shutil.ignore_patterns(*_IGNORE_DIRS)(directory, contents))
+    link_skip = set(ignore_symlinks(directory, contents))
+    return sorted(pattern_skip | link_skip)
 
 
 _HEREDOC_RE = re.compile(r"<<-?\s*['\"]?([A-Za-z0-9_.-]+)['\"]?")
@@ -345,20 +358,40 @@ def _stage_copy_source(src_path: str, env_dir: Path, context_root: Path) -> str:
     if not abs_src.exists():
         return src_path
 
+    # Reject symlinked sources outright (#411). Following a symlink here
+    # would bake the link target into the Docker build context, which is an
+    # exfiltration sink. ``abs_src.is_symlink()`` does *not* follow the
+    # link, so this is checked before any read.
+    if abs_src.is_symlink():
+        logger.warning(
+            "stage_dockerfile_deps: refusing to stage symlinked source %s",
+            abs_src,
+        )
+        return src_path
+
     dep_name = _dep_local_name(src_path)
     local_dest = env_dir / "_deps" / dep_name
 
     if abs_src.is_dir():
         if local_dest.exists():
             shutil.rmtree(local_dest)
+        # ``symlinks=False`` is the default but we re-state it for
+        # readability; the composed ignore drops both noise dirs and any
+        # symlink found inside the tree.
         shutil.copytree(
             abs_src,
             local_dest,
-            ignore=shutil.ignore_patterns(*_IGNORE_DIRS),
+            symlinks=False,
+            ignore=_stage_ignore,
         )
-    else:
+    elif is_safe_regular_file(abs_src):
         local_dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(abs_src, local_dest)
+    else:
+        logger.warning(
+            "stage_dockerfile_deps: refusing non-regular source %s", abs_src
+        )
+        return src_path
 
     return f"_deps/{dep_name}"
 
@@ -451,7 +484,10 @@ def _inject_skills_into_dockerfile(task_path: Path, skills_dir: Path) -> None:
     dest = env_dir / "_deps" / "skills"
     if dest.exists():
         shutil.rmtree(dest)
-    shutil.copytree(skills_dir, dest, ignore=shutil.ignore_patterns(*_IGNORE_DIRS))
+    # Refuse to follow symlinks under skills_dir (#411). A symlink baked
+    # into the image would otherwise serve attacker-chosen content to every
+    # agent for the lifetime of the build.
+    shutil.copytree(skills_dir, dest, symlinks=False, ignore=_stage_ignore)
 
     lines = [
         "",

--- a/tests/test_dashboard_symlink_ingestion.py
+++ b/tests/test_dashboard_symlink_ingestion.py
@@ -1,0 +1,172 @@
+"""Symlink-defence regression tests for dashboard data ingestion.
+
+Covers issues #390 (rollout artifact ingestion) and #416 (experiments and labs
+ingestion). Each test plants a symlink under the dashboard's ingestion root
+that points to an out-of-tree secret and asserts:
+
+  * the secret content does NOT appear in the produced payload
+  * a warning is emitted naming the rejected symlink
+
+The dashboard package isn't an installed module; ``generate.py`` loads itself
+via a file-spec loader. We do the same in these tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+GENERATE = ROOT / "dashboard" / "generate.py"
+
+SECRET = "SECRET_FROM_HOST_DASHBOARD_LEAK"
+
+
+def _load_generate() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "dashboard_generate_under_test", GENERATE
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def generate() -> ModuleType:
+    return _load_generate()
+
+
+def _secret_outside(tmp_path: Path) -> Path:
+    secret = tmp_path / "host-secret.txt"
+    secret.write_text(SECRET)
+    return secret
+
+
+# ---------------------------------------------------------------------------
+# #390 — rollout artifact ingestion
+# ---------------------------------------------------------------------------
+
+
+def test_task_artifacts_skips_symlink_in_artifacts_subdir(
+    tmp_path: Path,
+    generate: ModuleType,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """`_task_artifacts` must not embed the target of a symlinked artifact."""
+    secret = _secret_outside(tmp_path)
+    rollout = tmp_path / "rollout"
+    (rollout / "artifacts").mkdir(parents=True)
+    (rollout / "artifacts" / "leak.txt").symlink_to(secret)
+
+    # Drop a real, in-tree artifact so we still exercise the happy path.
+    (rollout / "artifacts" / "ok.txt").write_text("legitimate-artifact")
+
+    with caplog.at_level(logging.WARNING):
+        arts = generate._task_artifacts(rollout)
+
+    contents = [a.get("content") or "" for a in arts]
+    assert SECRET not in "\n".join(contents), (
+        "dashboard ingested host secret through symlinked artifact"
+    )
+    # The in-tree artifact survived.
+    assert any("legitimate-artifact" in (c or "") for c in contents)
+    # Exactly one warning per skipped link.
+    assert any("leak.txt" in r.message for r in caplog.records)
+
+
+def test_task_artifacts_skips_symlink_at_rollout_root(
+    tmp_path: Path, generate: ModuleType, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Top-level rollout files are also iterated; a symlink there must not leak."""
+    secret = _secret_outside(tmp_path)
+    rollout = tmp_path / "rollout"
+    rollout.mkdir()
+    (rollout / "result.json").symlink_to(secret)
+
+    with caplog.at_level(logging.WARNING):
+        arts = generate._task_artifacts(rollout)
+
+    assert all(SECRET not in (a.get("content") or "") for a in arts)
+    assert any("result.json" in r.message for r in caplog.records)
+
+
+def test_file_payload_refuses_symlink(
+    tmp_path: Path, generate: ModuleType
+) -> None:
+    """The shared ``_file_payload`` helper must reject symlinks directly."""
+    secret = _secret_outside(tmp_path)
+    link = tmp_path / "link.txt"
+    link.symlink_to(secret)
+
+    content, lines, truncated, _lang = generate._file_payload(link)
+    assert content is None
+    assert lines == 0
+    assert truncated is False
+
+
+# ---------------------------------------------------------------------------
+# #416 — experiments and labs ingestion
+# ---------------------------------------------------------------------------
+
+
+def test_collect_experiments_skips_symlinks_in_experiments_dir(
+    tmp_path: Path,
+    generate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A symlink under experiments/ must not surface in any experiment file."""
+    secret = _secret_outside(tmp_path)
+    exp_root = tmp_path / "fake-repo"
+    (exp_root / "experiments").mkdir(parents=True)
+    (exp_root / "labs").mkdir()
+    (exp_root / "experiments" / "ablation_link.md").symlink_to(secret)
+    # Add a legitimate file so the bucket is non-empty.
+    (exp_root / "experiments" / "ablation_real.md").write_text("real-experiment")
+
+    monkeypatch.setattr(generate, "ROOT", exp_root)
+
+    with caplog.at_level(logging.WARNING):
+        timeline = generate.collect_experiments()
+
+    flat_content = "\n".join(
+        (f.get("content") or "") for entry in timeline for f in entry["files"]
+    )
+    assert SECRET not in flat_content
+    assert "real-experiment" in flat_content
+    assert any("ablation_link.md" in r.message for r in caplog.records)
+
+
+def test_collect_experiments_skips_symlinks_in_labs_subdir(
+    tmp_path: Path,
+    generate: ModuleType,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Labs walks an attacker-controllable subtree — must not follow links."""
+    secret = _secret_outside(tmp_path)
+    fake_repo = tmp_path / "fake-repo"
+    (fake_repo / "labs" / "my-lab").mkdir(parents=True)
+    (fake_repo / "labs" / "my-lab" / "leak.md").symlink_to(secret)
+    (fake_repo / "labs" / "my-lab" / "notes.md").write_text("real-lab-note")
+
+    monkeypatch.setattr(generate, "ROOT", fake_repo)
+
+    with caplog.at_level(logging.WARNING):
+        timeline = generate.collect_experiments()
+
+    labs_entries = [e for e in timeline if e["source"].startswith("labs/")]
+    assert labs_entries, "labs entry missing — fixture broken"
+    flat_content = "\n".join(
+        (f.get("content") or "") for e in labs_entries for f in e["files"]
+    )
+    assert SECRET not in flat_content
+    assert "real-lab-note" in flat_content
+    assert any("leak.md" in r.message for r in caplog.records)

--- a/tests/test_judge_symlink_ingestion.py
+++ b/tests/test_judge_symlink_ingestion.py
@@ -1,0 +1,64 @@
+"""Symlink-defence regression test for LLM judge deliverable ingestion (#404).
+
+`find_deliverables` is the sink that feeds the judge prompt. A deliverable
+symlink to a host-side file must NOT be read or sent downstream.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from benchflow.rewards.file_readers import find_deliverables
+
+SECRET = "SECRET_FROM_HOST_JUDGE_LEAK"
+
+
+def test_find_deliverables_skips_symlink_to_outside_secret(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    secret = tmp_path / "host-secret.txt"
+    secret.write_text(SECRET)
+
+    deliverables_dir = tmp_path / "deliverables"
+    deliverables_dir.mkdir()
+    # Symlink uses .txt so it would otherwise be picked up.
+    (deliverables_dir / "leak.txt").symlink_to(secret)
+    # A real deliverable so we know we aren't just returning empty.
+    (deliverables_dir / "real.txt").write_text("real-deliverable")
+
+    with caplog.at_level(logging.WARNING):
+        result = find_deliverables(deliverables_dir)
+
+    assert "leak.txt" not in result, "symlinked deliverable was read"
+    assert SECRET not in "\n".join(result.values())
+    assert result.get("real.txt") == "real-deliverable"
+    assert any("leak.txt" in r.message for r in caplog.records)
+
+
+def test_find_deliverables_skips_symlinked_subfile_by_lstat(tmp_path: Path) -> None:
+    """Even if a symlink target IS a regular file, the link itself is refused."""
+    secret = tmp_path / "host-secret.md"
+    secret.write_text(SECRET)
+
+    deliverables_dir = tmp_path / "deliverables"
+    deliverables_dir.mkdir()
+    (deliverables_dir / "link.md").symlink_to(secret)
+
+    result = find_deliverables(deliverables_dir)
+    assert result == {}, f"expected empty dict, got {result}"
+
+
+def test_find_deliverables_still_reads_regular_files(tmp_path: Path) -> None:
+    """Sanity guard — the symlink refusal must not break the happy path."""
+    deliverables_dir = tmp_path / "deliverables"
+    deliverables_dir.mkdir()
+    (deliverables_dir / "a.txt").write_text("alpha")
+    (deliverables_dir / "b.md").write_text("# beta")
+    (deliverables_dir / ".hidden").write_text("nope")  # dotfile filtered
+    (deliverables_dir / "rubric.json").write_text("{}")  # rubric filtered
+
+    result = find_deliverables(deliverables_dir)
+    assert result == {"a.txt": "alpha", "b.md": "# beta"}

--- a/tests/test_paths_symlink_helpers.py
+++ b/tests/test_paths_symlink_helpers.py
@@ -1,0 +1,95 @@
+"""Tests for the symlink-safe traversal helpers in ``benchflow._paths``.
+
+These cover the primitives (`is_safe_regular_file`, `iter_safe_children`,
+`iter_safe_tree`, `ignore_symlinks`) added for PR-B's symlink-defence work.
+The higher-level call sites have their own regression files:
+
+* ``test_dashboard_symlink_ingestion.py``  (#390, #416)
+* ``test_judge_symlink_ingestion.py``      (#404)
+* ``test_sandbox_upload_symlink.py``       (#411)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchflow._paths import (
+    ignore_symlinks,
+    is_safe_regular_dir,
+    is_safe_regular_file,
+    iter_safe_children,
+    iter_safe_tree,
+)
+
+
+def test_is_safe_regular_file_accepts_regular(tmp_path: Path) -> None:
+    f = tmp_path / "f.txt"
+    f.write_text("x")
+    assert is_safe_regular_file(f) is True
+
+
+def test_is_safe_regular_file_rejects_symlink(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("x")
+    link = tmp_path / "link.txt"
+    link.symlink_to(target)
+    assert is_safe_regular_file(link) is False
+
+
+def test_is_safe_regular_file_rejects_missing(tmp_path: Path) -> None:
+    assert is_safe_regular_file(tmp_path / "nope") is False
+
+
+def test_is_safe_regular_dir_rejects_symlinked_dir(tmp_path: Path) -> None:
+    target = tmp_path / "real_dir"
+    target.mkdir()
+    link = tmp_path / "linked_dir"
+    link.symlink_to(target)
+    assert is_safe_regular_dir(target) is True
+    assert is_safe_regular_dir(link) is False
+
+
+def test_iter_safe_children_skips_symlinks(tmp_path: Path) -> None:
+    secret = tmp_path / "secret.txt"
+    secret.write_text("secret")
+
+    parent = tmp_path / "dir"
+    parent.mkdir()
+    (parent / "real.txt").write_text("ok")
+    (parent / "leak.txt").symlink_to(secret)
+
+    names = {c.name for c in iter_safe_children(parent, context="test")}
+    assert names == {"real.txt"}
+
+
+def test_iter_safe_tree_does_not_descend_symlinked_dir(tmp_path: Path) -> None:
+    secret_dir = tmp_path / "secret_dir"
+    secret_dir.mkdir()
+    (secret_dir / "secret.txt").write_text("secret")
+
+    root = tmp_path / "root"
+    (root / "sub").mkdir(parents=True)
+    (root / "sub" / "real.txt").write_text("real")
+    (root / "linked_dir").symlink_to(secret_dir)
+    (root / "linked_file.txt").symlink_to(secret_dir / "secret.txt")
+
+    files = list(iter_safe_tree(root, context="test"))
+    names = {f.name for f in files}
+    # Only the real, in-tree file.
+    assert names == {"real.txt"}
+
+
+def test_iter_safe_tree_refuses_symlinked_root(tmp_path: Path) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    (real / "f.txt").write_text("x")
+    link = tmp_path / "link"
+    link.symlink_to(real)
+    assert list(iter_safe_tree(link, context="test")) == []
+
+
+def test_ignore_symlinks_returns_link_names(tmp_path: Path) -> None:
+    (tmp_path / "real.txt").write_text("x")
+    (tmp_path / "linked.txt").symlink_to(tmp_path / "real.txt")
+    skipped = ignore_symlinks(str(tmp_path), ["real.txt", "linked.txt"])
+    assert skipped == ["linked.txt"]

--- a/tests/test_sandbox_upload_symlink.py
+++ b/tests/test_sandbox_upload_symlink.py
@@ -1,0 +1,226 @@
+"""Symlink-defence regression tests for sandbox upload + staging helpers (#411).
+
+Covers four ingestion sinks called out in the issue:
+
+* ``DaytonaSandbox._sdk_upload_dir`` — Daytona FS upload helper
+* ``ModalSandbox.upload_dir`` — Modal sandbox upload helper
+* ``stage_dockerfile_deps`` / ``_stage_copy_source`` — Docker build context staging
+* ``_inject_skills_into_dockerfile`` — Skills tree injection
+
+The tests never reach a real sandbox; they assert that the symlinked secret
+file is *not* presented to the upload/copy code path.
+"""
+
+from __future__ import annotations
+
+import logging
+import textwrap
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+SECRET = "SECRET_FROM_HOST_SANDBOX_LEAK"
+
+
+def _planted_secret(tmp_path: Path) -> Path:
+    secret = tmp_path / "host-secret.txt"
+    secret.write_text(SECRET)
+    return secret
+
+
+# ---------------------------------------------------------------------------
+# Daytona _sdk_upload_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_daytona_sdk_upload_dir_skips_symlinked_files(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pytest.importorskip("daytona")
+    from benchflow.sandbox.daytona import DaytonaSandbox
+
+    secret = _planted_secret(tmp_path)
+    src = tmp_path / "src"
+    (src / "ok").mkdir(parents=True)
+    (src / "ok" / "real.txt").write_text("real")
+    (src / "leak.txt").symlink_to(secret)
+    (src / "sub").mkdir()
+    (src / "sub" / "linked").symlink_to(tmp_path)  # symlinked dir
+
+    upload_files = AsyncMock()
+    env = DaytonaSandbox.__new__(DaytonaSandbox)
+    env._sandbox = SimpleNamespace(fs=SimpleNamespace(upload_files=upload_files))
+
+    with caplog.at_level(logging.WARNING):
+        await env._sdk_upload_dir(src, "/remote/dst")
+
+    assert upload_files.await_count == 1
+    sources = [
+        u.source for u in upload_files.await_args.kwargs["files"]
+    ]
+    # The symlinked file is not in the upload set.
+    assert not any(str(secret) in s for s in sources)
+    assert not any(s.endswith("/leak.txt") for s in sources)
+    # The symlinked directory was never descended into.
+    assert not any("/linked/" in s for s in sources)
+    # The legitimate file is still uploaded.
+    assert any(s.endswith("/ok/real.txt") for s in sources)
+    assert any("leak.txt" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Modal upload_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_modal_upload_dir_skips_symlinked_files(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    pytest.importorskip("modal")
+    from benchflow.sandbox.modal_impl import ModalSandbox
+
+    secret = _planted_secret(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "real.txt").write_text("real")
+    (src / "leak.txt").symlink_to(secret)
+
+    sandbox = ModalSandbox.__new__(ModalSandbox)
+    sandbox._sandbox = SimpleNamespace()  # truthy; upload_file is mocked
+    sandbox.exec = AsyncMock(return_value=SimpleNamespace(exit_code=0))
+    sandbox.upload_file = AsyncMock()
+    sandbox.logger = logging.getLogger("modal-test")
+
+    with caplog.at_level(logging.WARNING):
+        await sandbox.upload_dir(src, "/remote/dst")
+
+    uploaded_sources = [
+        call.args[0] for call in sandbox.upload_file.await_args_list
+    ]
+    assert all(str(secret) not in str(s) for s in uploaded_sources)
+    assert not any(str(s).endswith("/leak.txt") for s in uploaded_sources)
+    assert any(str(s).endswith("/real.txt") for s in uploaded_sources)
+    assert any("leak.txt" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Docker build-context staging
+# ---------------------------------------------------------------------------
+
+
+def test_stage_copy_source_refuses_symlinked_file(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    from benchflow.sandbox.setup import _stage_copy_source
+
+    secret = _planted_secret(tmp_path)
+    context_root = tmp_path / "ctx"
+    env_dir = tmp_path / "task" / "environment"
+    context_root.mkdir()
+    env_dir.mkdir(parents=True)
+    (context_root / "deps_link.txt").symlink_to(secret)
+
+    with caplog.at_level(logging.WARNING):
+        rewritten = _stage_copy_source("deps_link.txt", env_dir, context_root)
+
+    # The COPY line is left unchanged — nothing was staged.
+    assert rewritten == "deps_link.txt"
+    assert not (env_dir / "_deps" / "deps_link.txt").exists()
+    assert any("deps_link.txt" in r.message for r in caplog.records)
+
+
+def test_stage_dockerfile_deps_does_not_bake_symlink_target(
+    tmp_path: Path,
+) -> None:
+    """Full ``stage_dockerfile_deps`` path: symlinked COPY source must not leak."""
+    from benchflow.sandbox.setup import stage_dockerfile_deps
+
+    _planted_secret(tmp_path)
+    context_root = tmp_path / "ctx"
+    task_path = tmp_path / "task"
+    env_dir = task_path / "environment"
+    context_root.mkdir()
+    env_dir.mkdir(parents=True)
+    (context_root / "link_pkg").symlink_to(tmp_path)  # symlinked dir source
+    (env_dir / "Dockerfile").write_text(
+        textwrap.dedent(
+            """\
+            FROM scratch
+            COPY link_pkg /loot
+            """
+        )
+    )
+
+    stage_dockerfile_deps(task_path, context_root)
+
+    # The Dockerfile keeps the original COPY (unchanged) and no _deps/link_pkg
+    # directory was created that would contain the secret.
+    dockerfile_text = (env_dir / "Dockerfile").read_text()
+    assert "COPY link_pkg /loot" in dockerfile_text
+    leaked = env_dir / "_deps" / "link_pkg"
+    if leaked.exists():
+        # If a dir was somehow created, it must not contain the host secret.
+        contents = "\n".join(p.read_text() for p in leaked.rglob("*") if p.is_file())
+        assert SECRET not in contents
+
+
+def test_stage_copytree_drops_symlinks_inside_source(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A symlink *inside* a directory COPY source is dropped, not followed."""
+    from benchflow.sandbox.setup import _stage_copy_source
+
+    secret = _planted_secret(tmp_path)
+    context_root = tmp_path / "ctx"
+    env_dir = tmp_path / "task" / "environment"
+    src_dir = context_root / "pkg"
+    src_dir.mkdir(parents=True)
+    env_dir.mkdir(parents=True)
+    (src_dir / "real.txt").write_text("real")
+    (src_dir / "evil_link.txt").symlink_to(secret)
+
+    with caplog.at_level(logging.WARNING):
+        rewritten = _stage_copy_source("pkg", env_dir, context_root)
+
+    assert rewritten == "_deps/pkg"
+    staged = env_dir / "_deps" / "pkg"
+    assert (staged / "real.txt").read_text() == "real"
+    # The symlinked file did not get materialised — neither as a link nor as
+    # the dereferenced target.
+    assert not (staged / "evil_link.txt").exists()
+    # And no file inside the staged dir contains the secret.
+    flat = "\n".join(p.read_text() for p in staged.rglob("*") if p.is_file())
+    assert SECRET not in flat
+    assert any("evil_link.txt" in r.message for r in caplog.records)
+
+
+def test_inject_skills_drops_symlinks(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Skills baked into the image must not include attacker-placed symlinks."""
+    from benchflow.sandbox.setup import _inject_skills_into_dockerfile
+
+    secret = _planted_secret(tmp_path)
+    task_path = tmp_path / "task"
+    env_dir = task_path / "environment"
+    env_dir.mkdir(parents=True)
+    (env_dir / "Dockerfile").write_text("FROM scratch\n")
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "real_skill.md").write_text("real")
+    (skills_dir / "evil.md").symlink_to(secret)
+
+    with caplog.at_level(logging.WARNING):
+        _inject_skills_into_dockerfile(task_path, skills_dir)
+
+    staged = env_dir / "_deps" / "skills"
+    assert (staged / "real_skill.md").read_text() == "real"
+    assert not (staged / "evil.md").exists()
+    flat = "\n".join(p.read_text() for p in staged.rglob("*") if p.is_file())
+    assert SECRET not in flat
+    assert any("evil.md" in r.message for r in caplog.records)


### PR DESCRIPTION
Closes #390. Closes #404. Closes #411. Closes #416.

Adds `benchflow._paths` with symlink-skip helpers (`iter_safe_tree`, `iter_safe_children`, `is_safe_regular_file`, `ignore_symlinks`). Dashboard artifact ingestion, LLM judge deliverable ingestion, and sandbox upload/staging now refuse to follow symlinks. 22 new tests.

**Merge note**: PR-A (#361 etc) also creates `src/benchflow/_paths.py` with different contents (segment-validation helpers). Both files need to be merged into a single `_utils/paths.py` — see PR-A body.

**Review findings (follow-up):**
- Consolidate with PR-A into `_utils/paths.py` BEFORE either merges.
- `benchmark_repos.py` and `source_provenance.py` have 4 more duplicates of symlink/containment logic — migrate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Security hardening across multiple data-exfiltration sinks (dashboard JSON, judge prompts, remote sandboxes, Docker build context); behavior change for trees that relied on symlinks, and `_paths.py` may conflict with a parallel PR until consolidated.
> 
> **Overview**
> Adds **`benchflow._paths`** with symlink-safe traversal helpers (`is_safe_regular_file`, `iter_safe_children`, `iter_safe_tree`, `ignore_symlinks`) and wires them into every path where untrusted trees get read or copied.
> 
> **Dashboard** (`generate.py`) no longer follows symlinks when embedding file content into `data.json`—rollout artifacts, `_file_payload`, and **experiments/labs** timeline scans skip links and log warnings (#390, #416).
> 
> **LLM judge** deliverable discovery (`find_deliverables`) refuses symlinked files so host paths cannot enter judge prompts (#404).
> 
> **Sandbox** paths use the same rules: Daytona/Modal **directory uploads** walk with `followlinks=False`; Docker **build-context staging** (COPY deps, skills injection) rejects symlinked sources and drops symlinks inside `copytree` (#411).
> 
> **22 regression tests** cover primitives plus dashboard, judge, and sandbox call sites. Merge note in the PR: this module may need consolidating with a parallel **`_paths` / `_utils/paths.py`** from another PR before landing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e61b4eeced58404f006226bcb9eb195031cf977a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->