### PR TITLE
fix: redact COOKIE/AUTHORIZATION env vars; stop serializing secrets into argv

### DIFF
--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -326,6 +326,39 @@ def _init_rollout(
     return task, rollout_dir, rollout_paths, started_at, job_name, rollout_name
 
 
+# Substrings that flag an env var name as secret-bearing for ``config.json``
+# redaction. Matching is case-insensitive (callers ``.upper()`` the key first)
+# and uses substring containment so derived names like ``MY_AUTH_HEADER``,
+# ``SESSION_COOKIE``, or ``GH_TOKEN`` are caught. This stays a denylist (rather
+# than an allowlist of safe keys) because agent env varies per agent — the
+# union of safe keys is not knowable here — but the list now covers the common
+# auth-bearing names that issue #410 called out (COOKIE, AUTHORIZATION, AUTH,
+# BEARER, SESSION) on top of the original KEY/TOKEN/SECRET/PASSWORD/CREDENTIALS.
+_SECRET_ENV_SUBSTRINGS: tuple[str, ...] = (
+    "KEY",
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "CREDENTIALS",
+    "COOKIE",
+    "AUTHORIZATION",
+    "AUTH",
+    "BEARER",
+    "SESSION",
+)
+
+
+def _is_secret_env_key(name: str) -> bool:
+    """Return True if *name* looks like it carries a secret value.
+
+    Case-insensitive substring match against :data:`_SECRET_ENV_SUBSTRINGS`.
+    Used by :func:`_write_config` to drop secret-bearing entries before
+    persisting ``agent_env`` to the rollout's ``config.json``.
+    """
+    upper = name.upper()
+    return any(s in upper for s in _SECRET_ENV_SUBSTRINGS)
+
+
 def _write_config(
     rollout_dir: Path,
     *,
@@ -347,11 +380,8 @@ def _write_config(
     source_provenance: dict[str, Any] | None = None,
 ) -> None:
     """Write config.json to rollout_dir with secrets filtered out."""
-    _secret_substrings = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIALS")
     recorded_env = {
-        k: v
-        for k, v in agent_env.items()
-        if not any(s in k.upper() for s in _secret_substrings)
+        k: v for k, v in agent_env.items() if not _is_secret_env_key(k)
     }
     config_data = {
         "task_path": str(task_path),

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import asyncio
 import atexit
+import base64
 import importlib
 import logging
 import os
+import re
 import shlex
 from abc import abstractmethod
 from pathlib import Path
@@ -106,6 +108,53 @@ class SandboxStartupError(RuntimeError):
             "build_timeout_sec": build_timeout_sec,
             "raw_message": str(message)[:500],
         }
+
+
+# A POSIX shell identifier: a name the shell can ``export``. Keys outside this
+# grammar (e.g. containing ``.`` or ``-``) are valid process env keys but cannot
+# be assigned via ``export NAME=...``; sourcing such a line aborts the whole
+# ``. {env_path}`` step. Matches ``DockerSandbox._SHELL_IDENTIFIER_RE``.
+_DAYTONA_SHELL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _wrap_daytona_command_with_env_file(env: dict[str, str], command: str) -> str:
+    """Return *command* prefixed to materialize *env* from a file.
+
+    Mirrors :meth:`benchflow.sandbox.docker.DockerSandbox._wrap_command_with_env_file`
+    so secrets never reach the remote process argv (visible via ``ps``, Daytona
+    audit logs, or any provider-side command logging). The env vars are
+    base64-encoded into the command string (not visible as individual
+    ``KEY=VALUE`` argv entries), decoded to a mode-0600 file inside the sandbox,
+    sourced, and unconditionally removed via ``trap ... EXIT``.
+
+    Issue #412: previously this used ``env K=V ...`` argv, which placed raw
+    secret values into the remote command line.
+    """
+    exportable: dict[str, str] = {}
+    skipped: list[str] = []
+    for k, v in env.items():
+        if _DAYTONA_SHELL_IDENTIFIER_RE.match(k):
+            exportable[k] = v
+        else:
+            skipped.append(k)
+    if skipped:
+        logger.warning(
+            "Skipping env var(s) with non-identifier names (cannot be "
+            "exported by the shell): %s",
+            ", ".join(sorted(skipped)),
+        )
+
+    env_body = "".join(
+        f"export {k}={shlex.quote(v)}\n" for k, v in exportable.items()
+    )
+    encoded = base64.b64encode(env_body.encode()).decode()
+    env_path = f"/tmp/.benchflow_daytona_env_{uuid4().hex[:16]}"
+    return (
+        f"trap 'rm -f {env_path}' EXIT && "
+        f"(umask 077 && printf %s {shlex.quote(encoded)} | base64 -d > "
+        f"{env_path}) && set -a && . {env_path} && set +a && "
+        f"{command}"
+    )
 
 
 def _exec_failure_output(result: ExecResult) -> str:
@@ -1134,11 +1183,20 @@ class DaytonaSandbox(BaseSandbox):
         try:
             await self._sandbox.process.create_session(session_id)
 
-            command = f"{shell} {shlex.quote(command)}"
-
+            # Env vars are written to a temp file inside the sandbox and
+            # sourced rather than passed as ``env KEY=value ...`` argv. The
+            # argv form would leak verifier API keys / agent secrets into the
+            # remote process list and any provider-side command audit log
+            # (#412). The wrapping must happen before the ``timeout``/``su``
+            # prefixes so they too see the exported vars; the wrapper itself
+            # runs under ``sh``-compatible POSIX constructs so the surrounding
+            # ``bash -c`` / ``su -s /bin/bash -c`` shells handle it fine.
             if env:
-                env_args = " ".join(f"{k}={shlex.quote(v)}" for k, v in env.items())
-                command = f"env {env_args} {command}"
+                command = (
+                    f"{shell} {shlex.quote(_wrap_daytona_command_with_env_file(env, command))}"
+                )
+            else:
+                command = f"{shell} {shlex.quote(command)}"
 
             if timeout_sec:
                 command = f"timeout {timeout_sec} {command}"

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -333,6 +333,11 @@ def _stage_copy_source(src_path: str, env_dir: Path, context_root: Path) -> str:
     Returns the original ``src_path`` unchanged when it cannot or should not be
     staged (absolute path, build arg, ``.``, glob, or a source that does not
     exist under ``context_root``).
+
+    Sources that resolve outside ``context_root`` (e.g. ``../outside-secret``)
+    are rejected: with a permissive SDK ``context_root`` a malicious Dockerfile
+    could otherwise stage arbitrary host files into ``environment/_deps/``
+    where they then enter the build context (issue #363).
     """
     # Skip sources already relative to env dir, absolute, or using build args.
     if src_path.startswith("/") or src_path.startswith("$") or src_path == ".":
@@ -342,6 +347,28 @@ def _stage_copy_source(src_path: str, env_dir: Path, context_root: Path) -> str:
         return src_path
 
     abs_src = context_root / src_path
+    # Reject sources that escape ``context_root`` via ``..`` or symlinks.
+    # ``resolve(strict=False)`` collapses ``..`` segments without requiring the
+    # file to exist yet (Dockerfile lint can run before sources are present).
+    try:
+        resolved_src = abs_src.resolve(strict=False)
+        resolved_root = context_root.resolve(strict=False)
+    except (OSError, RuntimeError):
+        # Unresolvable paths (e.g. symlink loops) — refuse to stage them.
+        logger.warning(
+            "stage_dockerfile_deps: refusing to stage COPY source %r "
+            "(path could not be resolved)",
+            src_path,
+        )
+        return src_path
+    if not resolved_src.is_relative_to(resolved_root):
+        logger.warning(
+            "stage_dockerfile_deps: refusing to stage COPY source %r — "
+            "resolves outside context_root %s",
+            src_path,
+            resolved_root,
+        )
+        return src_path
     if not abs_src.exists():
         return src_path
 

--- a/tests/test_config_redaction.py
+++ b/tests/test_config_redaction.py
@@ -1,0 +1,118 @@
+"""Regression tests for ``config.json`` secret redaction (issue #410).
+
+``_write_config`` persists ``agent_env`` into the rollout's ``config.json``.
+Before #410, only KEY/TOKEN/SECRET/PASSWORD/CREDENTIALS substrings were
+filtered, which let common auth-bearing names like ``COOKIE`` and
+``AUTHORIZATION`` leak into the artifact (and from there into any dashboard
+that mirrors it).
+
+These tests pin the denylist via the underlying ``_is_secret_env_key``
+predicate so a future copy-paste of just the substring tuple cannot silently
+narrow the filter.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from benchflow.rollout import _is_secret_env_key, _write_config
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Original denylist — must remain covered.
+        "OPENAI_API_KEY",
+        "GITHUB_TOKEN",
+        "STRIPE_SECRET",
+        "DB_PASSWORD",
+        "AWS_CREDENTIALS",
+        # Names added in #410.
+        "COOKIE",
+        "SESSION_COOKIE",
+        "AUTHORIZATION",
+        "MY_AUTH_HEADER",
+        "BEARER_TOKEN",
+        "SESSION_ID",
+        # Case-insensitivity — env keys may be lowercase in user dicts even if
+        # the OS canonicalizes them. Redaction must catch them anyway.
+        "cookie",
+        "Authorization",
+        "my_auth",
+    ],
+)
+def test_secret_env_keys_are_redacted(name: str) -> None:
+    assert _is_secret_env_key(name), (
+        f"{name!r} should be flagged as secret-bearing for config.json"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "PATH",
+        "HOME",
+        "USER",
+        "LANG",
+        "NORMAL_VAR",
+        "HTTP_PROXY",
+        "PYTHONPATH",
+    ],
+)
+def test_non_secret_env_keys_are_preserved(name: str) -> None:
+    assert not _is_secret_env_key(name), (
+        f"{name!r} should not be flagged as secret-bearing"
+    )
+
+
+def test_write_config_drops_secret_env_vars(tmp_path: Path) -> None:
+    """End-to-end: ``config.json`` must not contain the issue #410 names."""
+    agent_env = {
+        # Should be redacted.
+        "COOKIE": "session=secret-cookie",
+        "AUTHORIZATION": "Bearer secret-auth",
+        "MY_AUTH_HEADER": "Bearer secret",
+        "GITHUB_TOKEN": "ghp_secret",
+        "OPENAI_API_KEY": "sk-secret",
+        # Should be preserved.
+        "NORMAL_VAR": "keep-me",
+        "PATH": "/usr/bin:/bin",
+    }
+
+    _write_config(
+        tmp_path,
+        task_path=tmp_path / "task",
+        agent="claude",
+        model="claude-haiku-4-5",
+        environment="docker",
+        skills_dir=None,
+        sandbox_user=None,
+        context_root=None,
+        timeout=300,
+        started_at=datetime(2026, 1, 1),
+        agent_env=agent_env,
+    )
+
+    config = json.loads((tmp_path / "config.json").read_text())
+    recorded = config["agent_env"]
+
+    # The dropped keys must not appear at all (even as a key with a redacted
+    # placeholder), and their values must not appear anywhere in the file.
+    raw = (tmp_path / "config.json").read_text()
+    for redacted_name, redacted_value in (
+        ("COOKIE", "secret-cookie"),
+        ("AUTHORIZATION", "secret-auth"),
+        ("MY_AUTH_HEADER", "Bearer secret"),
+        ("GITHUB_TOKEN", "ghp_secret"),
+        ("OPENAI_API_KEY", "sk-secret"),
+    ):
+        assert redacted_name not in recorded
+        assert redacted_value not in raw
+
+    # Non-secret entries are preserved unchanged.
+    assert recorded["NORMAL_VAR"] == "keep-me"
+    assert recorded["PATH"] == "/usr/bin:/bin"

--- a/tests/test_sandbox_exec_secret_handling.py
+++ b/tests/test_sandbox_exec_secret_handling.py
@@ -1,0 +1,148 @@
+"""Regression tests for sandbox exec secret handling (issue #412).
+
+Sandbox exec helpers must never serialize raw secret values into the remote
+process argv or command string. ``ps``, shell history, and provider-side
+command audit logs all see argv, so a leak there is equivalent to publishing
+the secret.
+
+DockerSandbox.exec already routes env through a base64-encoded file decoded
+inside the container (covered by ``tests/test_sandbox.py``). This module
+covers the Daytona path, where ``_sandbox_exec`` previously emitted
+``env KEY=value`` argv.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from benchflow.sandbox.daytona import _wrap_daytona_command_with_env_file
+
+
+class TestDaytonaExecEnvSecrecy:
+    """Daytona ``_sandbox_exec`` must not inline secret values into argv."""
+
+    def test_wrap_does_not_inline_secret_values(self) -> None:
+        env = {
+            "OPENAI_API_KEY": "sk-very-secret",
+            "AUTHORIZATION": "Bearer hunter2",
+            "SAFE_VAR": "ordinary-value",
+        }
+        wrapped = _wrap_daytona_command_with_env_file(env, "run-verifier")
+
+        # No raw value appears in the wrapper text — ``ps aux`` on the
+        # Daytona worker would otherwise reveal them. The values live only
+        # inside a base64 blob.
+        assert "sk-very-secret" not in wrapped
+        assert "hunter2" not in wrapped
+        # The ordinary value is *also* base64-encoded; this is a side effect
+        # of putting the whole env dict into one file, and is the desired
+        # behavior because it makes the wrapper indifferent to whether a
+        # given key is sensitive.
+        assert "ordinary-value" not in wrapped
+
+        # The command sources a file and cleans up on EXIT.
+        assert wrapped.startswith("trap 'rm -f ")
+        assert "EXIT" in wrapped
+        assert "base64 -d" in wrapped
+        assert "(umask 077 &&" in wrapped
+        assert wrapped.endswith("run-verifier")
+
+    def test_wrap_decoded_env_contains_all_values(self) -> None:
+        """The base64 payload sourced inside the sandbox must carry the env.
+
+        We decode the blob the same way the remote shell does and assert the
+        sourceable script exports each key/value pair.
+        """
+        env = {
+            "OPENAI_API_KEY": "sk-very-secret",
+            "AUTHORIZATION": "Bearer hunter2",
+        }
+        wrapped = _wrap_daytona_command_with_env_file(env, "tool")
+
+        token = wrapped.split("printf %s ", 1)[1].split(" |", 1)[0]
+        encoded = token.strip("'")
+        body = base64.b64decode(encoded).decode()
+
+        assert "export OPENAI_API_KEY=" in body
+        assert "sk-very-secret" in body
+        assert "export AUTHORIZATION=" in body
+        assert "hunter2" in body
+
+    def test_wrap_skips_non_identifier_env_keys(self) -> None:
+        """Keys that aren't valid POSIX identifiers cannot be ``export``-ed.
+
+        Emitting them would break ``. envfile`` and the user command would
+        never run, so they are dropped with a warning (matches the docker
+        wrapper's behavior).
+        """
+        env = {
+            "VALID_KEY": "keep-me",
+            "dotted.key": "drop-me",
+            "dashed-key": "drop-me-too",
+        }
+        wrapped = _wrap_daytona_command_with_env_file(env, "tool")
+
+        token = wrapped.split("printf %s ", 1)[1].split(" |", 1)[0]
+        encoded = token.strip("'")
+        body = base64.b64decode(encoded).decode()
+
+        assert "export VALID_KEY=" in body
+        assert "dotted.key" not in body
+        assert "dashed-key" not in body
+        # User command still reachable.
+        assert wrapped.endswith("tool")
+
+    @pytest.mark.asyncio
+    async def test_sandbox_exec_passes_no_env_kv_argv(self, monkeypatch) -> None:
+        """``_sandbox_exec`` must not emit ``env K=V ...`` argv anywhere.
+
+        Stubs ``execute_session_command`` and inspects the command string
+        that would be sent to the Daytona session API.
+        """
+        from benchflow.sandbox.daytona import DaytonaSandbox
+
+        sandbox = DaytonaSandbox.__new__(DaytonaSandbox)
+
+        captured: dict[str, str] = {}
+
+        class _Resp:
+            cmd_id = "fake-cmd-id"
+            exit_code = 0
+            result = ""
+
+        class _ProcessAPI:
+            async def create_session(self, session_id: str) -> None:
+                return None
+
+            async def execute_session_command(self, session_id, request, timeout=None):
+                captured["command"] = request.command
+                return _Resp()
+
+        class _FakeSandbox:
+            process = _ProcessAPI()
+
+        sandbox._sandbox = _FakeSandbox()
+
+        async def fake_poll(session_id, command_id, timeout_sec=None):  # type: ignore[no-untyped-def]
+            from benchflow.sandbox._base import ExecResult
+
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        monkeypatch.setattr(sandbox, "_poll_response", fake_poll, raising=False)
+
+        await sandbox._sandbox_exec(
+            "verify-now",
+            env={"OPENAI_API_KEY": "sk-leak", "AUTHORIZATION": "Bearer leak"},
+        )
+
+        cmd = captured["command"]
+        # The argv must not contain raw secret values...
+        assert "sk-leak" not in cmd
+        assert "Bearer leak" not in cmd
+        # ...nor the old ``env KEY=value KEY2=value2 ...`` argv prefix.
+        # (We allow the *string* "env" appearing in ``OPENAI_API_KEY`` etc.;
+        # the regression marker is ``env KEY=`` adjacency at a word boundary.)
+        assert "env OPENAI_API_KEY=" not in cmd
+        assert "env AUTHORIZATION=" not in cmd

--- a/tests/test_sandbox_isolation_copy_traversal.py
+++ b/tests/test_sandbox_isolation_copy_traversal.py
@@ -1,0 +1,107 @@
+"""Regression tests for Dockerfile COPY path traversal (issue #363, finding 3).
+
+``stage_dockerfile_deps`` copies COPY sources from ``context_root`` into
+``environment/_deps/`` and rewrites the Dockerfile to reference the staged
+path. A malicious Dockerfile with ``COPY ../outside-secret.txt /loot`` could
+previously stage arbitrary files from outside ``context_root`` into the build
+context — which is one of the few host-state leak vectors the sandbox
+otherwise forbids.
+
+The fix resolves both paths and refuses to stage sources that escape
+``context_root``. These tests exercise the boundary without exposing real
+secrets — the "outside" file just contains a sentinel string.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchflow.sandbox.setup import _stage_copy_source, stage_dockerfile_deps
+
+
+def _setup_context(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build ``tmp_path/{outside.txt, ctx/{environment/Dockerfile}}``.
+
+    Returns ``(context_root, env_dir, outside_path)``.
+    """
+    outside = tmp_path / "outside-secret.txt"
+    outside.write_text("HOST_ONLY_SECRET")
+
+    context_root = tmp_path / "ctx"
+    env_dir = context_root / "environment"
+    env_dir.mkdir(parents=True)
+    return context_root, env_dir, outside
+
+
+def test_stage_copy_source_rejects_dotdot_traversal(tmp_path: Path) -> None:
+    """`../outside-secret.txt` must not be staged into ``_deps/``."""
+    context_root, env_dir, outside = _setup_context(tmp_path)
+
+    rewritten = _stage_copy_source("../outside-secret.txt", env_dir, context_root)
+
+    # The path is returned unchanged (not rewritten to ``_deps/``) and no
+    # ``_deps/`` entry is created from outside the context.
+    assert rewritten == "../outside-secret.txt"
+    assert not (env_dir / "_deps").exists() or not any(
+        (env_dir / "_deps").iterdir()
+    )
+    # The outside file is untouched (we did not move/copy it).
+    assert outside.read_text() == "HOST_ONLY_SECRET"
+
+
+def test_stage_copy_source_rejects_deep_traversal(tmp_path: Path) -> None:
+    """``foo/../../outside`` resolves outside context_root and must be rejected."""
+    context_root, env_dir, _ = _setup_context(tmp_path)
+    # Create a real subdir so the literal prefix exists.
+    (context_root / "foo").mkdir()
+
+    rewritten = _stage_copy_source(
+        "foo/../../outside-secret.txt", env_dir, context_root
+    )
+
+    assert rewritten == "foo/../../outside-secret.txt"
+
+
+def test_stage_copy_source_allows_in_context_sources(tmp_path: Path) -> None:
+    """Legitimate in-context COPY sources still stage normally."""
+    context_root, env_dir, _ = _setup_context(tmp_path)
+    src = context_root / "app.py"
+    src.write_text("print('hi')")
+
+    rewritten = _stage_copy_source("app.py", env_dir, context_root)
+
+    assert rewritten == "_deps/app.py"
+    assert (env_dir / "_deps" / "app.py").read_text() == "print('hi')"
+
+
+def test_stage_dockerfile_deps_does_not_exfiltrate_outside(tmp_path: Path) -> None:
+    """End-to-end: a malicious Dockerfile cannot stage host secrets.
+
+    The Dockerfile's traversal COPY line is *left as-is* (so Docker itself
+    will fail the build, which is the safe outcome) and the secret is never
+    copied into ``environment/_deps/``.
+    """
+    context_root, env_dir, outside = _setup_context(tmp_path)
+    dockerfile = env_dir / "Dockerfile"
+    dockerfile.write_text(
+        "FROM scratch\n"
+        "COPY ../outside-secret.txt /loot\n"
+    )
+
+    # ``stage_dockerfile_deps`` expects ``task_path/environment/Dockerfile``;
+    # here task_path is ``env_dir.parent`` (i.e. ``context_root``).
+    stage_dockerfile_deps(env_dir.parent, context_root)
+
+    rewritten = dockerfile.read_text()
+    # The line is left untouched — the staged path was not substituted, so
+    # there is no ``_deps/outside-secret.txt`` written.
+    assert "../outside-secret.txt" in rewritten
+    deps_dir = env_dir / "_deps"
+    if deps_dir.exists():
+        # If a _deps dir exists, it must not contain the outside file.
+        for entry in deps_dir.rglob("*"):
+            assert "HOST_ONLY_SECRET" not in (
+                entry.read_text() if entry.is_file() else ""
+            )
+    # The outside file itself remains in place, unread/unwritten.
+    assert outside.read_text() == "HOST_ONLY_SECRET"


### PR DESCRIPTION
Closes #410. Partially addresses #412, #363.

- #410: `config.json` redaction denylist extended to catch `COOKIE`, `AUTHORIZATION`.
- #412: Direct Daytona exec path now wraps env via base64-encoded env-file (mirrors existing `DockerSandbox._wrap_command_with_env_file`).
- #363: COPY traversal closed via `resolve()+is_relative_to` in `_stage_copy_source`.

30 new tests.

**⚠️ #412 NOT FULLY CLOSED**: `_DaytonaDinD.exec` (daytona.py:748-776) still emits `docker compose exec -T -e KEY=VALUE` argv — verifier env (LLM judge API keys) leaks on every multi-service task. Fix-up branch in flight.

**Other deferred from #363:**
- `allow_internet` / `preserve_agent_network` rename
- Docker Compose receives raw `dict(os.environ)` (needs allowlist)

**Review findings (follow-up):**
- Hoist `_wrap_command_with_env_file` to `BaseSandbox` (currently duplicated docker/daytona).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch credential redaction and sandbox command construction; risk is moderated by tests but Daytona DinD compose exec still passes secrets via `-e` argv per the author's note.
> 
> **Overview**
> This PR tightens **secret handling** and **build-context isolation** in three areas, with regression tests.
> 
> **Rollout `config.json` (#410):** `agent_env` written by `_write_config` now drops keys matched by a shared `_is_secret_env_key()` denylist. The list adds **COOKIE**, **AUTHORIZATION**, **AUTH**, **BEARER**, and **SESSION** (case-insensitive substring match) on top of the existing KEY/TOKEN/SECRET/PASSWORD/CREDENTIALS rules.
> 
> **Daytona direct exec (#412, partial):** `_sandbox_exec` no longer prefixes commands with `env KEY=value …`. Env is applied via a **base64-encoded temp file** inside the sandbox (umask 077, sourced, removed on EXIT), aligned with `DockerSandbox`. Non–POSIX-identifier env names are skipped with a warning.
> 
> **Dockerfile staging (#363):** `_stage_copy_source` resolves paths and **refuses to stage** COPY sources that escape `context_root` (`..` / symlinks), so hostile Dockerfiles cannot pull arbitrary host files into `environment/_deps/`.
> 
> **Tests:** New coverage for redaction, Daytona wrapper/integration, and COPY traversal.
> 
> **Not in this diff:** Daytona **DinD** `docker compose exec -e KEY=VALUE` can still expose verifier secrets in argv (called out in the PR description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c94ecad30a4ccba4c0eda667173268adee609df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->