### PR TITLE
fix: gemini agent default_model and env auth

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -101,9 +101,16 @@ def auto_inherit_env(
     for key in keys:
         if key in source:
             agent_env.setdefault(key, source[key])
-    # Mirror GEMINI_API_KEY as GOOGLE_API_KEY (some agents expect one or the other)
+    # Mirror GEMINI_API_KEY / GOOGLE_API_KEY in both directions. The Gemini
+    # CLI reads GEMINI_API_KEY natively; other tooling (and the public Gemini
+    # docs) advertise GOOGLE_API_KEY. Users following either convention must
+    # work — without the reverse mirror, setting only GOOGLE_API_KEY on the
+    # host passes the requires_env check but the in-sandbox CLI fails auth
+    # (#342).
     if "GEMINI_API_KEY" in agent_env and "GOOGLE_API_KEY" not in agent_env:
         agent_env["GOOGLE_API_KEY"] = agent_env["GEMINI_API_KEY"]
+    if "GOOGLE_API_KEY" in agent_env and "GEMINI_API_KEY" not in agent_env:
+        agent_env["GEMINI_API_KEY"] = agent_env["GOOGLE_API_KEY"]
     # Mirror GEMINI_API_KEY as GOOGLE_GENERATIVE_AI_API_KEY (opencode/models.dev convention)
     if (
         "GEMINI_API_KEY" in agent_env

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -396,14 +396,23 @@ AGENTS: dict[str, AgentConfig] = {
         install_cmd=_js_agent_install("gemini", "@google/gemini-cli@0.42.0"),
         launch_cmd=_js_agent_launch("gemini", "--acp --yolo"),
         protocol="acp",
-        requires_env=["GOOGLE_API_KEY"],
+        # The Gemini CLI reads GEMINI_API_KEY natively. GOOGLE_API_KEY is
+        # accepted as an alias: auto_inherit_env mirrors it both ways so users
+        # can set either one. Advertise GEMINI_API_KEY here so `agent show`
+        # matches what the CLI actually reads (#342).
+        requires_env=["GEMINI_API_KEY"],
+        # Default to a sane Gemini model so `--agent gemini` works without
+        # --model and never cross-wires to a Claude default (#343).
+        default_model="gemini-2.5-flash",
         # api_protocol intentionally empty: Gemini speaks Google's native
         # GenerateContent format, which no current PROVIDERS entry exposes as
         # a multi-endpoint option. Set this when a Gemini-compatible provider
         # with multiple endpoints (e.g. OpenRouter) is added.
         env_mapping={
             "BENCHFLOW_PROVIDER_BASE_URL": "GEMINI_API_BASE_URL",
-            "BENCHFLOW_PROVIDER_API_KEY": "GOOGLE_API_KEY",
+            # Map to the CLI-native var; auto_inherit_env mirrors it to
+            # GOOGLE_API_KEY for compatibility with users who set that alias.
+            "BENCHFLOW_PROVIDER_API_KEY": "GEMINI_API_KEY",
         },
         subscription_auth=SubscriptionAuth(
             replaces_env="GEMINI_API_KEY",

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -134,6 +134,14 @@ DEFAULT_JOB_MODE = "parallel-independent"
 def effective_model(agent: str, model: str | None) -> str | None:
     """Resolve the model an agent should run with.
 
+    Resolution order:
+      1. An explicit ``--model`` always wins.
+      2. The agent's own ``default_model`` (e.g. ``gemini-2.5-flash`` for the
+         gemini agent) — keeps each agent on its native provider.
+      3. ``DEFAULT_MODEL`` only when the caller is on the default agent.
+         Substituting it under any other agent silently cross-wires providers
+         and was the root cause of #343 (gemini eval demanding ANTHROPIC_API_KEY).
+
     Oracle runs solve.sh and never calls an LLM, so it never receives a model
     (the chokepoint in resolve_agent_env defends, but callers should also stop
     materializing DEFAULT_MODEL into oracle configs to keep the data honest —
@@ -141,7 +149,21 @@ def effective_model(agent: str, model: str | None) -> str | None:
     """
     if agent == "oracle":
         return None
-    return model or DEFAULT_MODEL
+    if model:
+        return model
+    # Look up the agent's own default. Unknown agents (raw-command fallback)
+    # bypass the registry lookup and use the global default.
+    from benchflow.agents.registry import AGENTS
+
+    agent_cfg = AGENTS.get(agent)
+    if agent_cfg and agent_cfg.default_model:
+        return agent_cfg.default_model
+    if agent == DEFAULT_AGENT or agent_cfg is None:
+        return DEFAULT_MODEL
+    raise ValueError(
+        f"agent {agent!r} has no default model; pass --model "
+        f"(refusing to fall back to {DEFAULT_MODEL!r} from a different provider)"
+    )
 
 
 @dataclass

--- a/tests/test_agent_env_resolution.py
+++ b/tests/test_agent_env_resolution.py
@@ -1,0 +1,127 @@
+"""Tests for gemini agent env auth resolution (issue #342).
+
+Users may set either ``GEMINI_API_KEY`` (the CLI-native var) or
+``GOOGLE_API_KEY`` (the public-docs alias). Both must satisfy auth, and
+both must make it into the sandbox environment so the Gemini CLI itself
+can read whichever variable it expects.
+
+Without the bidirectional mirror, setting only GOOGLE_API_KEY passed the
+host requires_env check but failed inside the sandbox with
+``ACP error -32000: Gemini API key is missing or not configured.``
+"""
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.agents.env import auto_inherit_env, resolve_agent_env
+
+
+def _patch_no_subscription(monkeypatch, tmp_path):
+    """Redirect ~/ lookups to an empty tmp_path so subscription-auth detection
+    does not see real host files (otherwise it would mask the API-key path)."""
+    orig = Path.expanduser
+
+    def fake(self):
+        s = str(self)
+        if s.startswith("~"):
+            return tmp_path / s[2:]
+        return orig(self)
+
+    monkeypatch.setattr(Path, "expanduser", fake)
+
+
+def _clear_keys(monkeypatch):
+    for k in (
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OPENAI_API_KEY",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+class TestAutoInheritEnvBidirectionalMirror:
+    """auto_inherit_env mirrors GEMINI_API_KEY ↔ GOOGLE_API_KEY both ways."""
+
+    def test_gemini_only_mirrors_to_google(self):
+        env = {"GEMINI_API_KEY": "gk-test"}
+        auto_inherit_env(env)
+        assert env["GEMINI_API_KEY"] == "gk-test"
+        assert env["GOOGLE_API_KEY"] == "gk-test"
+
+    def test_google_only_mirrors_to_gemini(self):
+        """Issue #342: setting GOOGLE_API_KEY alone must populate GEMINI_API_KEY
+        so the in-sandbox Gemini CLI can authenticate."""
+        env = {"GOOGLE_API_KEY": "gk-test"}
+        auto_inherit_env(env)
+        assert env["GOOGLE_API_KEY"] == "gk-test"
+        assert env["GEMINI_API_KEY"] == "gk-test"
+
+    def test_both_set_preserves_explicit_values(self):
+        env = {"GEMINI_API_KEY": "gemini-val", "GOOGLE_API_KEY": "google-val"}
+        auto_inherit_env(env)
+        assert env["GEMINI_API_KEY"] == "gemini-val"
+        assert env["GOOGLE_API_KEY"] == "google-val"
+
+
+class TestResolveAgentEnvGemini:
+    """End-to-end env resolution for the gemini agent with each auth shape."""
+
+    def test_gemini_api_key_only_succeeds(self, monkeypatch, tmp_path):
+        _clear_keys(monkeypatch)
+        _patch_no_subscription(monkeypatch, tmp_path)
+        monkeypatch.setenv("GEMINI_API_KEY", "gk-only-gemini")
+
+        result = resolve_agent_env(
+            agent="gemini", model="gemini-2.5-flash", agent_env=None
+        )
+        assert result["GEMINI_API_KEY"] == "gk-only-gemini"
+        assert result["GOOGLE_API_KEY"] == "gk-only-gemini"
+
+    def test_google_api_key_only_succeeds(self, monkeypatch, tmp_path):
+        """Regression for #342: GOOGLE_API_KEY alone must satisfy auth and
+        also populate GEMINI_API_KEY for the in-sandbox CLI."""
+        _clear_keys(monkeypatch)
+        _patch_no_subscription(monkeypatch, tmp_path)
+        monkeypatch.setenv("GOOGLE_API_KEY", "gk-only-google")
+
+        result = resolve_agent_env(
+            agent="gemini", model="gemini-2.5-flash", agent_env=None
+        )
+        assert result["GOOGLE_API_KEY"] == "gk-only-google"
+        assert result["GEMINI_API_KEY"] == "gk-only-google", (
+            "GOOGLE_API_KEY alone must mirror to GEMINI_API_KEY so the "
+            "Gemini CLI can authenticate inside the sandbox"
+        )
+
+    def test_neither_key_set_raises_clear_error(self, monkeypatch, tmp_path):
+        _clear_keys(monkeypatch)
+        _patch_no_subscription(monkeypatch, tmp_path)
+        # also clear the dotenv path so it can't supply keys
+        monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(tmp_path / "no.env"))
+
+        with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+            resolve_agent_env(
+                agent="gemini", model="gemini-2.5-flash", agent_env=None
+            )
+
+    def test_explicit_agent_env_overrides_host(self, monkeypatch, tmp_path):
+        """Explicit --agent-env GEMINI_API_KEY=... wins over the host env."""
+        _clear_keys(monkeypatch)
+        _patch_no_subscription(monkeypatch, tmp_path)
+        monkeypatch.setenv("GOOGLE_API_KEY", "host-google")
+
+        result = resolve_agent_env(
+            agent="gemini",
+            model="gemini-2.5-flash",
+            agent_env={"GEMINI_API_KEY": "explicit"},
+        )
+        assert result["GEMINI_API_KEY"] == "explicit"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xvs"])

--- a/tests/test_agent_gemini_defaults.py
+++ b/tests/test_agent_gemini_defaults.py
@@ -1,0 +1,84 @@
+"""Tests for the gemini agent's default model wiring (issue #343).
+
+Guards against the silent fallback to ``DEFAULT_MODEL`` (a Claude model) when
+a user runs ``--agent gemini`` without ``--model``. The fallback cross-wires
+providers and previously demanded ``ANTHROPIC_API_KEY`` even though the user
+selected the Gemini agent.
+"""
+
+import pytest
+
+from benchflow.agents.registry import AGENTS, get_agent, infer_env_key_for_model
+from benchflow.evaluation import effective_model
+
+
+class TestGeminiHasDefaultModel:
+    """The gemini AgentConfig must declare its own default model."""
+
+    def test_gemini_default_model_non_empty(self):
+        config, default_model = get_agent("gemini")
+        assert config.name == "gemini"
+        assert default_model, (
+            "gemini AgentConfig must declare a default_model so --agent gemini "
+            "without --model does not silently substitute a Claude default"
+        )
+
+    def test_gemini_default_model_is_gemini_family(self):
+        _, default_model = get_agent("gemini")
+        assert "gemini" in default_model.lower(), (
+            f"default_model {default_model!r} must be a Gemini-family model"
+        )
+
+    def test_gemini_default_model_resolves_to_gemini_api_key(self):
+        """The agent default must require GEMINI_API_KEY, not ANTHROPIC_API_KEY."""
+        _, default_model = get_agent("gemini")
+        assert infer_env_key_for_model(default_model) == "GEMINI_API_KEY"
+
+
+class TestEffectiveModelHonorsAgentDefault:
+    """effective_model must prefer the agent's own default_model over the
+    global DEFAULT_MODEL when --model is omitted."""
+
+    def test_no_model_uses_agent_default_model(self):
+        _, default_model = get_agent("gemini")
+        assert effective_model("gemini", None) == default_model
+
+    def test_no_model_for_gemini_is_not_claude(self):
+        """The user-visible bug from #343: --agent gemini → claude-haiku."""
+        result = effective_model("gemini", None)
+        assert result is not None
+        assert "claude" not in result.lower(), (
+            f"effective_model('gemini', None) returned {result!r} — must not "
+            "fall back to a Claude model when the gemini agent is selected"
+        )
+
+    def test_explicit_model_overrides_agent_default(self):
+        assert (
+            effective_model("gemini", "gemini-3.1-pro") == "gemini-3.1-pro"
+        )
+
+    def test_default_agent_still_uses_global_default(self):
+        """Backwards-compat: the DEFAULT_AGENT still falls back to DEFAULT_MODEL
+        so `benchflow eval create` with no flags keeps working."""
+        from benchflow.evaluation import DEFAULT_AGENT, DEFAULT_MODEL
+
+        assert effective_model(DEFAULT_AGENT, None) == DEFAULT_MODEL
+
+
+class TestGeminiAgentEnv:
+    """The gemini agent must advertise an env requirement consistent with
+    what its native CLI actually reads."""
+
+    def test_gemini_requires_env_matches_cli_native(self):
+        """Issue #342: ``agent show gemini`` previously advertised GOOGLE_API_KEY
+        but the Gemini CLI reads GEMINI_API_KEY. The advertised key must be
+        what the CLI consumes (the reverse alias is handled by env mirroring)."""
+        cfg = AGENTS["gemini"]
+        assert "GEMINI_API_KEY" in cfg.requires_env, (
+            f"gemini requires_env={cfg.requires_env!r} should advertise "
+            "GEMINI_API_KEY (what the CLI reads); GOOGLE_API_KEY is an alias"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xvs"])

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -42,7 +42,10 @@ class TestEnvMappingField:
     def test_gemini_has_mapping(self):
         cfg = AGENTS["gemini"]
         assert cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"] == "GEMINI_API_BASE_URL"
-        assert cfg.env_mapping["BENCHFLOW_PROVIDER_API_KEY"] == "GOOGLE_API_KEY"
+        # #342: map BENCHFLOW_PROVIDER_API_KEY to the CLI-native var. The
+        # bidirectional mirror in auto_inherit_env handles GOOGLE_API_KEY
+        # callers transparently.
+        assert cfg.env_mapping["BENCHFLOW_PROVIDER_API_KEY"] == "GEMINI_API_KEY"
 
     def test_openhands_has_mapping(self):
         cfg = AGENTS["openhands"]

--- a/tests/test_no_cross_provider_fallback.py
+++ b/tests/test_no_cross_provider_fallback.py
@@ -1,0 +1,86 @@
+"""Defense-in-depth: never silently fall back to a cross-provider DEFAULT_MODEL.
+
+When an agent has no ``default_model`` set and the user passes no ``--model``,
+the historical behavior was to substitute ``DEFAULT_MODEL`` (a Claude haiku
+model) regardless of which agent was selected. That cross-wired providers and
+produced confusing ANTHROPIC_API_KEY errors for users running, e.g., the
+gemini agent (#343).
+
+These tests pin the new contract: such a configuration must raise a clear
+"no default model" error instead of silently picking a Claude default.
+"""
+
+import pytest
+
+from benchflow.agents.registry import AGENTS, AgentConfig
+from benchflow.evaluation import DEFAULT_AGENT, DEFAULT_MODEL, effective_model
+
+
+class TestNoCrossProviderFallback:
+    def test_unknown_default_model_non_default_agent_raises(self, monkeypatch):
+        """An agent with empty default_model that is not DEFAULT_AGENT must
+        refuse to substitute the global default."""
+        fake = AgentConfig(
+            name="fake-no-default",
+            install_cmd="true",
+            launch_cmd="true",
+            requires_env=[],
+            default_model="",  # no default
+        )
+        monkeypatch.setitem(AGENTS, "fake-no-default", fake)
+
+        with pytest.raises(ValueError, match="no default model"):
+            effective_model("fake-no-default", None)
+
+    def test_error_does_not_mention_claude_haiku_as_answer(self, monkeypatch):
+        """The error must not silently suggest a cross-provider default — it
+        names the offending fallback only as context, and tells the user to
+        pass --model."""
+        fake = AgentConfig(
+            name="fake-no-default-2",
+            install_cmd="true",
+            launch_cmd="true",
+            requires_env=[],
+            default_model="",
+        )
+        monkeypatch.setitem(AGENTS, "fake-no-default-2", fake)
+
+        with pytest.raises(ValueError) as excinfo:
+            effective_model("fake-no-default-2", None)
+        msg = str(excinfo.value)
+        assert "--model" in msg
+        assert "fake-no-default-2" in msg
+
+    def test_empty_string_model_still_raises_for_non_default_agent(
+        self, monkeypatch
+    ):
+        """Empty string == no model (legacy YAML shape) must also raise."""
+        fake = AgentConfig(
+            name="fake-no-default-3",
+            install_cmd="true",
+            launch_cmd="true",
+            requires_env=[],
+            default_model="",
+        )
+        monkeypatch.setitem(AGENTS, "fake-no-default-3", fake)
+
+        with pytest.raises(ValueError, match="no default model"):
+            effective_model("fake-no-default-3", "")
+
+    def test_default_agent_with_no_model_still_works(self):
+        """Backwards-compat: the DEFAULT_AGENT keeps falling back to
+        DEFAULT_MODEL so `benchflow eval create` with no flags works."""
+        assert effective_model(DEFAULT_AGENT, None) == DEFAULT_MODEL
+
+    def test_oracle_short_circuits_before_default_check(self):
+        """Oracle never gets a model regardless of default_model rules."""
+        assert effective_model("oracle", None) is None
+
+    def test_unknown_agent_falls_back_to_default(self):
+        """Raw-command agents not in the registry stay on the legacy path so
+        users can still run arbitrary commands as agents."""
+        assert effective_model("totally-unregistered-agent", None) == DEFAULT_MODEL
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xvs"])

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -279,7 +279,12 @@ datasets:
 
 
 def test_from_legacy_yaml_defaults(tmp_path):
-    """Test legacy YAML with minimal config."""
+    """Test legacy YAML with minimal config.
+
+    Non-default agents must declare a model (either via ``model_name`` here or
+    via ``AgentConfig.default_model``) — #343 stopped silent fallback to a
+    Claude default for cross-provider agents like ``pi-acp``.
+    """
     tasks = tmp_path / "tasks" / "task-a"
     tasks.mkdir(parents=True)
     (tasks / "task.toml").write_text('version = "1.0"')
@@ -288,6 +293,7 @@ def test_from_legacy_yaml_defaults(tmp_path):
     config.write_text("""
 agents:
   - name: pi-acp
+    model_name: claude-haiku-4-5-20251001
 datasets:
   - path: tasks
 """)
@@ -348,6 +354,7 @@ jobs_dir: jobs/my-run
 skills_dir: skills
 agents:
   - name: pi-acp
+    model_name: claude-haiku-4-5-20251001
 datasets:
   - path: tasks
 """)


### PR DESCRIPTION
Closes #343. Closes #342.

- #343: gemini AgentConfig now has `default_model='gemini-2.5-flash'`. `effective_model()` reads `AgentConfig.default_model` first and raises (instead of falling through to claude-haiku) when an agent has no default and no `--model`.
- #342: gemini `requires_env=['GEMINI_API_KEY']` matches what the CLI actually reads. Bidirectional `GOOGLE_API_KEY ↔ GEMINI_API_KEY` mirror in `auto_inherit_env`.

8 files / +351/-6, 21 new tests + 296 regression pass.

**Review findings:**
- Cleaner ENG-164 fix: move `DEFAULT_MODEL` onto `claude-agent-acp.default_model` (the only agent missing one) to eliminate the `DEFAULT_AGENT` special case.
- Promote env aliases to a typed `ENV_ALIAS_GROUPS` table.
- Add parametric test for every registered agent without default_model.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible model and credential resolution for eval/YAML paths; behavior is well covered by new tests but misconfiguration now fails loudly instead of silently using Claude defaults.
> 
> **Overview**
> Fixes **Gemini** runs when users omit `--model` or use the docs-style **`GOOGLE_API_KEY`** alias.
> 
> **Model resolution (#343):** The `gemini` agent now declares **`default_model='gemini-2.5-flash'`**. **`effective_model()`** prefers an explicit `--model`, then the agent’s `default_model`, and only uses the global Claude **`DEFAULT_MODEL`** for the default agent (or unregistered raw commands). Other registered agents without a default **raise** instead of silently picking Claude—avoiding wrong-provider API key errors.
> 
> **Auth/env (#342):** Gemini registry metadata aligns with the CLI: **`requires_env`** and provider **`env_mapping`** target **`GEMINI_API_KEY`**. **`auto_inherit_env`** mirrors **`GEMINI_API_KEY` ↔ `GOOGLE_API_KEY`** both ways so host checks and in-sandbox CLI auth agree.
> 
> YAML/fixture tests for legacy configs now require an explicit **`model_name`** for non-default agents like **`pi-acp`** where there is no agent default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d824cf1ec8cfd2fbd377ca0a1f10c0fdbd0b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->