### PR TITLE
fix: avoid module-level Docker monkey patch on rollout import

### DIFF
--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -760,14 +760,16 @@ def _ensure_canonical_rewards(rewards: dict | None) -> dict:
     return validate_reward_map(rewards, source="verifier")
 
 
-# Apply Docker DinD patch at import time.
-def _apply_dind_patch() -> None:
+def _install_docker_compat() -> None:
+    """Activate the Docker DinD compatibility shim.
+
+    Called from ``Rollout.__init__`` so importing ``benchflow.rollout`` has
+    no side effects on the Docker sandbox. The underlying patch is
+    idempotent — safe to call once per rollout construction.
+    """
     from benchflow.sandbox.setup import _patch_docker_dind
 
     _patch_docker_dind()
-
-
-_apply_dind_patch()
 
 
 __all__ = [
@@ -921,6 +923,11 @@ class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
 
     def __init__(self, config: RolloutConfig) -> None:
+        # Activate Docker DinD compatibility shim on first rollout
+        # construction (idempotent). Keeps `import benchflow.rollout`
+        # side-effect free with respect to sandbox/provider behavior.
+        _install_docker_compat()
+
         self._config = config
         self._phase = "created"
 

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -506,12 +506,24 @@ def _detect_dind_mount() -> tuple[str, str] | None:
         return None
 
 
+_DIND_PATCH_APPLIED = False
+
+
 def _patch_docker_dind() -> None:
     """Monkey-patch DockerSandboxEnvVars for DinD path translation.
 
     When running inside a devcontainer, HOST_*_PATH env vars need to use
-    host filesystem paths, not container paths. Applied once at import time.
+    host filesystem paths, not container paths.
+
+    Idempotent: safe to call repeatedly; only applies the wrapper once.
+    Called from ``Rollout.__init__`` so importing ``benchflow.rollout`` has
+    no side effects on sandbox/provider behavior — only constructing a
+    rollout activates the DinD compatibility shim.
     """
+    global _DIND_PATCH_APPLIED
+    if _DIND_PATCH_APPLIED:
+        return
+
     dind_mount = _detect_dind_mount()
     if not dind_mount:
         return
@@ -536,6 +548,7 @@ def _patch_docker_dind() -> None:
         return env
 
     DockerSandboxEnvVars.to_env_dict = _patched  # type: ignore[assignment, ty:invalid-assignment]
+    _DIND_PATCH_APPLIED = True
 
 
 def _create_sandbox_environment(

--- a/tests/test_rollout_import_no_side_effects.py
+++ b/tests/test_rollout_import_no_side_effects.py
@@ -1,0 +1,137 @@
+"""Importing ``benchflow.rollout`` must not mutate Docker sandbox behavior.
+
+Regression test for #421: a module-level monkey patch caused
+``DockerSandboxEnvVars.to_env_dict`` to be replaced as a side effect of
+``import benchflow.rollout``. The shim is now activated only when a
+``Rollout`` is constructed.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_python(code: str) -> subprocess.CompletedProcess[str]:
+    """Run a Python snippet in a fresh subprocess.
+
+    Each call gets a clean module-import context — no pollution from the
+    pytest process where ``benchflow.rollout`` may already be loaded.
+    """
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_importing_rollout_does_not_patch_docker_sandbox_env() -> None:
+    """``import benchflow.rollout`` must leave ``to_env_dict`` untouched."""
+    result = _run_python(
+        """
+        from benchflow.sandbox.docker import DockerSandboxEnvVars
+
+        before = DockerSandboxEnvVars.to_env_dict
+
+        import benchflow.rollout  # noqa: F401
+
+        after = DockerSandboxEnvVars.to_env_dict
+
+        assert before is after, (
+            "benchflow.rollout import mutated "
+            "DockerSandboxEnvVars.to_env_dict — module-level side effect leaked"
+        )
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_importing_rollout_does_not_flag_dind_patch_applied() -> None:
+    """The setup-module flag should remain False after a bare import."""
+    result = _run_python(
+        """
+        import benchflow.rollout  # noqa: F401
+        from benchflow.sandbox import setup
+
+        assert setup._DIND_PATCH_APPLIED is False, (
+            "rollout import set _DIND_PATCH_APPLIED — patch leaked at import time"
+        )
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_install_docker_compat_is_idempotent_and_explicit() -> None:
+    """Calling the explicit compat hook twice must not double-wrap."""
+    result = _run_python(
+        """
+        from unittest.mock import patch
+
+        from benchflow.sandbox.docker import DockerSandboxEnvVars
+        from benchflow.sandbox import setup as sandbox_setup
+        from benchflow.rollout import _install_docker_compat
+
+        original = DockerSandboxEnvVars.to_env_dict
+
+        # Force the DinD-detection branch so the patch actually applies.
+        with patch.object(
+            sandbox_setup,
+            "_detect_dind_mount",
+            return_value=("/host/work", "/workspaces"),
+        ):
+            _install_docker_compat()
+            after_first = DockerSandboxEnvVars.to_env_dict
+            _install_docker_compat()
+            after_second = DockerSandboxEnvVars.to_env_dict
+
+        assert after_first is not original, "first call should install the wrapper"
+        assert after_second is after_first, "second call must be a no-op (idempotent)"
+        assert sandbox_setup._DIND_PATCH_APPLIED is True
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout
+
+
+def test_without_dind_environment_patch_does_not_apply() -> None:
+    """When ``_detect_dind_mount`` returns None, ``to_env_dict`` stays original."""
+    result = _run_python(
+        """
+        from unittest.mock import patch
+
+        from benchflow.sandbox.docker import DockerSandboxEnvVars
+        from benchflow.sandbox import setup as sandbox_setup
+        from benchflow.rollout import _install_docker_compat
+
+        original = DockerSandboxEnvVars.to_env_dict
+
+        with patch.object(
+            sandbox_setup, "_detect_dind_mount", return_value=None
+        ):
+            _install_docker_compat()
+
+        assert DockerSandboxEnvVars.to_env_dict is original, (
+            "no DinD mount detected — patch should not be installed"
+        )
+        assert sandbox_setup._DIND_PATCH_APPLIED is False
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout


### PR DESCRIPTION
Closes #421.

Importing `benchflow.rollout` no longer mutates `DockerSandboxEnvVars.to_env_dict` as a side effect. The DinD compat patch is now applied from `Rollout.__init__` (idempotent via a module-level flag). 4 new tests using subprocess for clean import state.

**Review findings:**
- Wrong-layer: activation should move to `sandbox/setup.py:_create_sandbox_environment` (where `_apply_daytona_patches` precedent lives), not `Rollout.__init__`.
- Use `@functools.cache` instead of bool flag.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrows when global Docker sandbox env patching runs; behavior for real rollouts in DinD should match before, with new tests guarding import-time leakage.
> 
> **Overview**
> Fixes **#421** by stopping a **module-level Docker DinD monkey patch** from running when `benchflow.rollout` is imported. **`DockerSandboxEnvVars.to_env_dict`** is no longer replaced at import time.
> 
> The DinD host-path shim is now triggered only when a **`Rollout`** is constructed: **`Rollout.__init__`** calls **`_install_docker_compat()`**, which delegates to **`_patch_docker_dind()`** in **`sandbox/setup.py`**. That path is **idempotent** via a **`_DIND_PATCH_APPLIED`** guard so repeated rollout construction does not double-wrap.
> 
> Adds **`tests/test_rollout_import_no_side_effects.py`**, using **fresh subprocesses** to assert bare imports leave **`to_env_dict`** and the patch flag unchanged, and that explicit install / no-DinD paths behave as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed326161068831a4766663ff935b9d0ccbccadbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->