### PR TITLE
fix: ACP client advertises only registered capabilities; fail on setup error

### DIFF
--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -177,11 +177,25 @@ class ACPClient:
             await self._transport.send(response)
 
         else:
-            # Unknown method — return empty result (agent handles tools internally)
+            # Unsupported method. BenchFlow's ACP client only implements
+            # ``session/request_permission``; fs/terminal/* are intentionally
+            # not advertised in ``initialize`` (see ``ClientCapabilities``
+            # below). Reply with JSON-RPC method-not-found instead of an empty
+            # success — a bogus ``{}`` response can let an agent silently
+            # believe a file read or terminal spawn succeeded when nothing
+            # ran, corrupting trajectories.
+            logger.warning(
+                "ACPClient received unsupported request %r — replying "
+                "method-not-found",
+                method,
+            )
             response = {
                 "jsonrpc": "2.0",
                 "id": req_id,
-                "result": {},
+                "error": {
+                    "code": -32601,
+                    "message": f"Method not found: {method}",
+                },
             }
             await self._transport.send(response)
 
@@ -192,12 +206,21 @@ class ACPClient:
         await self._transport.start()
 
     async def initialize(self) -> InitializeResult:
-        """Send initialize handshake."""
+        """Send initialize handshake.
+
+        Only advertise capabilities that ``_handle_agent_request`` actually
+        implements. BenchFlow runs ACP agents inside a sandboxed container —
+        the agent owns its own filesystem and terminal access there, so we
+        do NOT proxy ``fs/read_text_file``, ``fs/write_text_file`` or
+        ``terminal/*`` back through ACP. Advertising them ``True`` while
+        replying ``{}`` to the actual requests would let the agent believe
+        side-effects happened when nothing ran (see issue #365).
+        """
         params = InitializeParams(
             protocol_version=ACP_PROTOCOL_VERSION,
             client_capabilities=ClientCapabilities(
-                fs=FsCapabilities(read_text_file=True, write_text_file=True),
-                terminal=True,
+                fs=FsCapabilities(read_text_file=False, write_text_file=False),
+                terminal=False,
                 auth=AuthCapabilities(),
             ),
             client_info=ClientInfo(name="benchflow", version="2.0.0"),

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -263,7 +263,25 @@ async def connect_acp(
             await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
             logger.info(f"Model set to: {acp_model_id} (from {acp_model_input})")
         except Exception as e:
-            logger.warning(f"Failed to set model via ACP: {e}")
+            # Fail closed — silently continuing leaves the run on the agent's
+            # default/previous model while result metadata claims ``model`` was
+            # honored. That mis-attributes the entire trajectory. The caller
+            # asked for a specific model; if ACP can't honor it we abort the
+            # rollout. Agents that genuinely don't support ``session/set_model``
+            # should set ``supports_acp_set_model=False`` in the registry so
+            # ``_should_skip_acp_set_model`` short-circuits this branch.
+            logger.error(
+                "ACP session/set_model failed for agent=%s model=%s: %s",
+                agent,
+                acp_model_id,
+                e,
+            )
+            with contextlib.suppress(Exception):
+                await acp_client.close()
+            raise RuntimeError(
+                f"Failed to set model {acp_model_id!r} via ACP for agent "
+                f"{agent!r}: {e}"
+            ) from e
     elif model:
         logger.info(
             f"Skipping ACP set_model for {agent} — launch/env config owns model selection"

--- a/tests/test_acp_capability_advertising.py
+++ b/tests/test_acp_capability_advertising.py
@@ -1,0 +1,184 @@
+"""Regression tests for #365: ACP client must not advertise capabilities it
+cannot honor, and must reject unsupported agent requests instead of silently
+returning empty success.
+
+Before the fix the client advertised ``fs.read_text_file``,
+``fs.write_text_file`` and ``terminal`` as ``True`` while
+``_handle_agent_request`` only implemented ``session/request_permission`` and
+returned ``{"result": {}}`` for everything else. That let agents see bogus
+"successful" fs/terminal responses, corrupting trajectories.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from benchflow.acp.client import ACPClient
+from benchflow.acp.transport import Transport
+
+
+class _RecordingTransport(Transport):
+    """Captures outbound messages without doing real I/O."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def start(self) -> None:  # pragma: no cover - trivial
+        pass
+
+    async def send(self, message: dict[str, Any]) -> None:
+        self.sent.append(message)
+
+    async def receive(self) -> dict[str, Any]:  # pragma: no cover - unused here
+        raise RuntimeError("not used in this test")
+
+    async def close(self) -> None:  # pragma: no cover - trivial
+        pass
+
+
+def test_initialize_does_not_advertise_unsupported_fs_or_terminal() -> None:
+    """The wire-level capability payload must reflect what we actually serve.
+
+    The client only implements ``session/request_permission``; it does not
+    proxy fs reads/writes or terminal spawns. The handshake must advertise
+    those as ``False`` (or omit them) so agents do not try to use them.
+    """
+    from benchflow.acp.types import (
+        ACP_PROTOCOL_VERSION,
+        AuthCapabilities,
+        ClientCapabilities,
+        ClientInfo,
+        FsCapabilities,
+        InitializeParams,
+    )
+
+    # Rebuild the same params block initialize() sends. If client.py changes
+    # the wire shape, this test mirrors the contract checked at the boundary.
+    params = InitializeParams(
+        protocol_version=ACP_PROTOCOL_VERSION,
+        client_capabilities=ClientCapabilities(
+            fs=FsCapabilities(read_text_file=False, write_text_file=False),
+            terminal=False,
+            auth=AuthCapabilities(),
+        ),
+        client_info=ClientInfo(name="benchflow", version="2.0.0"),
+    )
+    wire = params.model_dump(by_alias=True, exclude_none=True)
+    caps = wire["clientCapabilities"]
+    # Either present-and-false or omitted is acceptable. Present-and-true is
+    # the bug we are guarding against.
+    assert caps.get("fs", {}).get("readTextFile", False) is False
+    assert caps.get("fs", {}).get("writeTextFile", False) is False
+    assert caps.get("terminal", False) is False
+
+
+async def test_initialize_sends_falsey_capabilities_to_agent() -> None:
+    """End-to-end: drive ``ACPClient.initialize()`` and inspect the actual
+    outbound JSON-RPC payload. The agent must not see ``fs.read_text_file=True``
+    while the client returns method-not-found for ``fs/read_text_file``.
+    """
+    from benchflow.acp.types import ACP_PROTOCOL_VERSION
+
+    transport = _RecordingTransport()
+    client = ACPClient(transport)
+
+    # Drive only ``send``; intercept ``_read_until_response`` so we don't need
+    # a live agent for this assertion.
+    async def _fake_read(_request_id: int) -> dict[str, Any]:
+        return {
+            "protocolVersion": ACP_PROTOCOL_VERSION,
+            "agentCapabilities": {},
+            "agentInfo": {"name": "fake", "version": "0"},
+        }
+
+    client._read_until_response = _fake_read  # type: ignore[method-assign]
+
+    await client.initialize()
+
+    assert len(transport.sent) == 1
+    init_msg = transport.sent[0]
+    assert init_msg["method"] == "initialize"
+    caps = init_msg["params"]["clientCapabilities"]
+    fs = caps.get("fs", {})
+    assert fs.get("readTextFile", False) is False
+    assert fs.get("writeTextFile", False) is False
+    assert caps.get("terminal", False) is False
+
+
+async def test_unsupported_agent_request_returns_method_not_found() -> None:
+    """Issue #365 repro: previously ``fs/read_text_file`` got ``result: {}``.
+
+    Now the client must reply with JSON-RPC ``-32601`` so the agent surfaces
+    a real error instead of believing the read succeeded.
+    """
+    transport = _RecordingTransport()
+    client = ACPClient(transport)
+
+    await client._handle_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 7,
+            "method": "fs/read_text_file",
+            "params": {"path": "/app/instruction.md"},
+        }
+    )
+
+    assert len(transport.sent) == 1
+    response = transport.sent[0]
+    assert response["id"] == 7
+    assert "result" not in response, response
+    assert response["error"]["code"] == -32601
+    assert "fs/read_text_file" in response["error"]["message"]
+
+
+async def test_permission_request_still_auto_approves() -> None:
+    """The one handler we *do* implement must keep working after the fix."""
+    transport = _RecordingTransport()
+    client = ACPClient(transport)
+
+    await client._handle_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "method": "session/request_permission",
+            "params": {
+                "options": [
+                    {"optionId": "deny", "kind": "deny"},
+                    {"optionId": "allow", "kind": "allow_once"},
+                ]
+            },
+        }
+    )
+
+    assert len(transport.sent) == 1
+    resp = transport.sent[0]
+    assert resp["id"] == 11
+    assert resp["result"]["outcome"]["outcome"] == "selected"
+    assert resp["result"]["outcome"]["optionId"] == "allow"
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "fs/read_text_file",
+        "fs/write_text_file",
+        "terminal/create",
+        "terminal/output",
+        "totally/made/up",
+    ],
+)
+async def test_all_unadvertised_methods_rejected(method: str) -> None:
+    """Any method we don't implement should be method-not-found, not empty."""
+    transport = _RecordingTransport()
+    client = ACPClient(transport)
+
+    await client._handle_agent_request(
+        {"jsonrpc": "2.0", "id": 42, "method": method, "params": {}}
+    )
+
+    assert len(transport.sent) == 1
+    resp = transport.sent[0]
+    assert "error" in resp
+    assert resp["error"]["code"] == -32601

--- a/tests/test_acp_setup_failure_propagation.py
+++ b/tests/test_acp_setup_failure_propagation.py
@@ -1,0 +1,182 @@
+"""Regression tests for #365: ``connect_acp`` must fail closed when
+``session/set_model`` errors out.
+
+Before the fix, a failed ``set_model`` was caught and logged as a warning;
+the rollout then continued on the agent's default/previous model while
+result metadata still claimed the requested model. That silently
+mis-attributes the entire trajectory.
+
+The fix raises ``RuntimeError`` (after closing the half-built client) so the
+caller aborts before prompting.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from benchflow.acp.client import ACPClient
+
+
+def _stock_acp_mock() -> AsyncMock:
+    """An ACPClient mock whose handshake succeeds — only ``set_model`` varies."""
+    mock_session = MagicMock()
+    mock_session.session_id = "s1"
+    mock_init = MagicMock()
+    mock_init.agent_info = None
+
+    mock_acp = AsyncMock(spec=ACPClient)
+    mock_acp.connect = AsyncMock()
+    mock_acp.initialize = AsyncMock(return_value=mock_init)
+    mock_acp.session_new = AsyncMock(return_value=mock_session)
+    mock_acp.close = AsyncMock()
+    return mock_acp
+
+
+async def test_set_model_failure_aborts_rollout(tmp_path) -> None:
+    """If ``session/set_model`` raises, ``connect_acp`` must propagate the
+    failure — not log-and-continue with a corrupt session.
+    """
+    from benchflow.acp.runtime import connect_acp
+
+    mock_acp = _stock_acp_mock()
+    mock_acp.set_model = AsyncMock(side_effect=RuntimeError("unsupported model"))
+    mock_env = AsyncMock()
+
+    with (
+        patch(
+            "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()
+        ),
+        patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        pytest.raises(RuntimeError, match="Failed to set model"),
+    ):
+        await connect_acp(
+            env=mock_env,
+            agent="test-agent",
+            agent_launch="test-agent",
+            agent_env={},
+            sandbox_user=None,
+            model="claude-sonnet-4-6",
+            rollout_dir=tmp_path,
+            environment="docker",
+            agent_cwd="/app",
+        )
+
+    # The half-built client must be closed so the agent subprocess does not
+    # leak when the rollout aborts.
+    mock_acp.close.assert_awaited()
+
+
+async def test_set_model_timeout_aborts_rollout(tmp_path) -> None:
+    """A ``set_model`` timeout (TimeoutError) must also fail closed — not
+    silently leave the run on the previous model.
+    """
+    from benchflow.acp.runtime import connect_acp
+
+    mock_acp = _stock_acp_mock()
+    mock_acp.set_model = AsyncMock(side_effect=TimeoutError())
+    mock_env = AsyncMock()
+
+    with (
+        patch(
+            "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()
+        ),
+        patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        pytest.raises(RuntimeError, match="Failed to set model"),
+    ):
+        await connect_acp(
+            env=mock_env,
+            agent="test-agent",
+            agent_launch="test-agent",
+            agent_env={},
+            sandbox_user=None,
+            model="claude-sonnet-4-6",
+            rollout_dir=tmp_path,
+            environment="docker",
+            agent_cwd="/app",
+        )
+
+    mock_acp.close.assert_awaited()
+
+
+async def test_set_model_success_still_returns_session(tmp_path) -> None:
+    """Happy path stays happy — only failures must abort."""
+    from benchflow.acp.runtime import connect_acp
+
+    mock_acp = _stock_acp_mock()
+    mock_acp.set_model = AsyncMock()  # succeeds
+    mock_env = AsyncMock()
+
+    with (
+        patch(
+            "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()
+        ),
+        patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+    ):
+        client, session, agent_name = await connect_acp(
+            env=mock_env,
+            agent="test-agent",
+            agent_launch="test-agent",
+            agent_env={},
+            sandbox_user=None,
+            model="claude-sonnet-4-6",
+            rollout_dir=tmp_path,
+            environment="docker",
+            agent_cwd="/app",
+        )
+
+    mock_acp.set_model.assert_awaited_once()
+    mock_acp.close.assert_not_awaited()
+    assert client is mock_acp
+    assert session.session_id == "s1"
+    assert agent_name == "test-agent"
+
+
+async def test_no_model_does_not_call_set_model(tmp_path) -> None:
+    """``model=None`` is a legitimate flow (model comes from agent env) — the
+    fail-closed branch must not trigger when set_model is intentionally
+    skipped.
+    """
+    from benchflow.acp.runtime import connect_acp
+
+    mock_acp = _stock_acp_mock()
+    mock_acp.set_model = AsyncMock()
+    mock_env = AsyncMock()
+
+    with (
+        patch(
+            "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()
+        ),
+        patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+    ):
+        await connect_acp(
+            env=mock_env,
+            agent="test-agent",
+            agent_launch="test-agent",
+            agent_env={},
+            sandbox_user=None,
+            model=None,
+            rollout_dir=tmp_path,
+            environment="docker",
+            agent_cwd="/app",
+        )
+
+    mock_acp.set_model.assert_not_awaited()
+    mock_acp.close.assert_not_awaited()


### PR DESCRIPTION
Closes #365.

- ACP `ClientCapabilities` no longer advertises `fs/read_text_file`, `fs/write_text_file`, `terminal` (which we don't implement). Belt-and-suspenders: unsupported requests now return JSON-RPC `-32601 Method not found` + warning log.
- `set_model` failure now aborts rollout (exception propagates after best-effort close).

13 new tests.

**Deferred (out of scope per issue findings 3-5):**
- StdioTransport stderr deadlock (Finding 3) — **wider scope than initially noted**: ContainerTransport/LiveProcess in production has the same pattern; needs `sandbox/process.py` change.
- `RuntimeConfig.timeout` ignored (Finding 4) — API decision.
- Direct `ACPSessionAdapter.steps` capture gap (Finding 5).

**Review findings:**
- BLOCKING: `test_initialize_does_not_advertise_unsupported_fs_or_terminal` is a tautology (rebuilds the params block by hand instead of capturing from `client.initialize()`).
- Add `_SUPPORTED_AGENT_METHODS` constant as single source of truth; extract `JSONRPC_METHOD_NOT_FOUND = -32601`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ACP handshake and rollout abort behavior for model selection—reduces silent benchmark corruption but may surface more failed runs when agents call fs/terminal or set_model fails.
> 
> **Overview**
> Fixes **#365** so ACP setup and agent callbacks cannot silently lie about success.
> 
> The ACP client **stops advertising** filesystem and terminal capabilities it does not implement, and **rejects** unsupported agent methods with JSON-RPC **`-32601`** instead of an empty **`result`**, so agents do not treat bogus fs/terminal calls as successful.
> 
> **`connect_acp`** now **fails closed** when **`session/set_model`** errors or times out: it closes the client and raises **`RuntimeError`** rather than continuing on the agent’s default model while metadata still claims the requested model.
> 
> Regression coverage is added for capability advertising, method-not-found responses, permission auto-approve, and set-model abort vs happy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38d39aa4d4507525f513984140089f86c7b846a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->