### PR TITLE
fix: Bedrock OpenAI Responses translator handles function_call/tool_result

### DIFF
--- a/src/benchflow/providers/bedrock_runtime.py
+++ b/src/benchflow/providers/bedrock_runtime.py
@@ -259,30 +259,78 @@ def anthropic_request_to_bedrock_converse(body: dict[str, Any]) -> dict[str, Any
     return payload
 
 
+def _responses_function_call_to_bedrock_block(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "toolUse": {
+            "toolUseId": item["call_id"],
+            "name": item["name"],
+            "input": json.loads(item.get("arguments") or "{}"),
+        }
+    }
+
+
+def _responses_function_call_output_to_bedrock_block(
+    item: dict[str, Any],
+) -> dict[str, Any]:
+    output = item.get("output", "")
+    if not isinstance(output, str):
+        output = json.dumps(output)
+    return {
+        "toolResult": {
+            "toolUseId": item["call_id"],
+            "content": [{"text": output}] if output else [],
+            "status": "success",
+        }
+    }
+
+
 def openai_responses_request_to_bedrock_converse(
     body: dict[str, Any],
 ) -> dict[str, Any]:
-    """Translate an OpenAI Responses request to Converse kwargs."""
+    """Translate an OpenAI Responses request to Converse kwargs.
+
+    OpenAI Responses ``input`` may contain message items with a role and content,
+    plus top-level tool-flow items (``function_call``, ``function_call_output``,
+    ``reasoning``) that do not carry a role. Top-level tool items are folded into
+    adjacent assistant/user messages so Bedrock Converse sees a valid alternating
+    transcript; reasoning items are dropped (Bedrock has no equivalent surface).
+    """
     input_items = body.get("input", [])
     if isinstance(input_items, str):
         input_items = [
             {"role": "user", "content": [{"type": "input_text", "text": input_items}]}
         ]
-    messages = []
-    for item in input_items:
-        if item.get("type") == "message":
-            role = item["role"]
-            content = item.get("content", [])
+    messages: list[dict[str, Any]] = []
+
+    def _append(role: str, block: dict[str, Any]) -> None:
+        if messages and messages[-1]["role"] == role:
+            messages[-1]["content"].append(block)
         else:
-            role = item["role"]
-            content = item.get("content", [])
-        assert isinstance(role, str)
-        messages.append(
-            {
-                "role": role,
-                "content": _responses_content_to_bedrock(role, content),
-            }
-        )
+            messages.append({"role": role, "content": [block]})
+
+    for item in input_items:
+        item_type = item.get("type")
+        if item_type == "function_call":
+            _append("assistant", _responses_function_call_to_bedrock_block(item))
+            continue
+        if item_type == "function_call_output":
+            _append("user", _responses_function_call_output_to_bedrock_block(item))
+            continue
+        if item_type == "reasoning":
+            # Bedrock Converse has no input-side reasoning surface; drop it.
+            continue
+        if item_type is not None and item_type != "message":
+            raise ValueError(
+                f"Unsupported OpenAI Responses input item type: {item_type!r}"
+            )
+        role = item.get("role")
+        if not isinstance(role, str):
+            raise ValueError(
+                f"OpenAI Responses message item missing string role: {item!r}"
+            )
+        content = item.get("content", [])
+        for block in _responses_content_to_bedrock(role, content):
+            _append(role, block)
 
     payload: dict[str, Any] = {
         "modelId": body["model"],

--- a/tests/test_bedrock_responses_translator.py
+++ b/tests/test_bedrock_responses_translator.py
@@ -1,0 +1,221 @@
+"""Regression tests for OpenAI Responses -> Bedrock Converse translation.
+
+Covers the multi-item ``input`` shape the real OpenAI Responses API emits, where
+``function_call``, ``function_call_output``, and ``reasoning`` are top-level
+items without a ``role`` field. See issue #364.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchflow.providers.bedrock_runtime import (
+    openai_responses_request_to_bedrock_converse,
+)
+
+
+class TestTopLevelToolItems:
+    def test_top_level_function_call_and_output_do_not_crash(self):
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "lookup",
+                    "arguments": '{"q":"x"}',
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": "ok",
+                },
+            ],
+        }
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        assert payload["modelId"] == body["model"]
+        # user "hi", assistant tool call, user tool result -> 3 messages
+        assert [m["role"] for m in payload["messages"]] == [
+            "user",
+            "assistant",
+            "user",
+        ]
+        assert payload["messages"][0]["content"] == [{"text": "hi"}]
+        tool_use = payload["messages"][1]["content"][0]["toolUse"]
+        assert tool_use["toolUseId"] == "c1"
+        assert tool_use["name"] == "lookup"
+        assert tool_use["input"] == {"q": "x"}
+        tool_result = payload["messages"][2]["content"][0]["toolResult"]
+        assert tool_result["toolUseId"] == "c1"
+        assert tool_result["status"] == "success"
+        assert tool_result["content"] == [{"text": "ok"}]
+
+    def test_function_call_output_with_non_string_output_is_json_encoded(self):
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": {"temperature": "70F"},
+                },
+            ],
+        }
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        result_text = payload["messages"][0]["content"][0]["toolResult"]["content"][0][
+            "text"
+        ]
+        assert json.loads(result_text) == {"temperature": "70F"}
+
+    def test_function_call_with_empty_arguments(self):
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "noop",
+                    "arguments": "",
+                },
+            ],
+        }
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        assert (
+            payload["messages"][0]["content"][0]["toolUse"]["input"] == {}
+        )
+
+    def test_reasoning_items_are_skipped(self):
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+                {
+                    "type": "reasoning",
+                    "id": "rs_1",
+                    "summary": [{"type": "summary_text", "text": "thinking"}],
+                },
+            ],
+        }
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        # reasoning item dropped; only the user message survives
+        assert len(payload["messages"]) == 1
+        assert payload["messages"][0]["role"] == "user"
+        assert payload["messages"][0]["content"] == [{"text": "hi"}]
+
+    def test_adjacent_tool_items_coalesce_into_one_message(self):
+        """Two consecutive function_calls should land in one assistant turn."""
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "a",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "c2",
+                    "name": "b",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": "r1",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "c2",
+                    "output": "r2",
+                },
+            ],
+        }
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        assert [m["role"] for m in payload["messages"]] == ["assistant", "user"]
+        assert len(payload["messages"][0]["content"]) == 2
+        assert len(payload["messages"][1]["content"]) == 2
+        ids = [b["toolUse"]["toolUseId"] for b in payload["messages"][0]["content"]]
+        assert ids == ["c1", "c2"]
+        result_ids = [
+            b["toolResult"]["toolUseId"] for b in payload["messages"][1]["content"]
+        ]
+        assert result_ids == ["c1", "c2"]
+
+    def test_text_input_only_string_form_still_works(self):
+        body = {"model": "openai.gpt-oss-20b-1:0", "input": "hello world"}
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        assert payload["messages"] == [
+            {"role": "user", "content": [{"text": "hello world"}]}
+        ]
+
+    def test_unknown_item_type_raises_value_error(self):
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [{"type": "image_generation_call", "id": "ig_1"}],
+        }
+
+        with pytest.raises(ValueError, match="Unsupported OpenAI Responses input"):
+            openai_responses_request_to_bedrock_converse(body)
+
+    def test_message_item_without_role_raises_value_error(self):
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {"type": "message", "content": [{"type": "input_text", "text": "hi"}]}
+            ],
+        }
+
+        with pytest.raises(ValueError, match="missing string role"):
+            openai_responses_request_to_bedrock_converse(body)
+
+    def test_repro_from_issue_364(self):
+        """Exact body from issue #364 must translate without raising."""
+        body = {
+            "model": "openai.gpt-oss-20b-1:0",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "hi"}],
+                },
+                {
+                    "type": "function_call",
+                    "call_id": "c1",
+                    "name": "lookup",
+                    "arguments": "{}",
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "c1",
+                    "output": "ok",
+                },
+            ],
+        }
+
+        # Must not raise KeyError('role') anymore.
+        payload = openai_responses_request_to_bedrock_converse(body)
+        assert "messages" in payload


### PR DESCRIPTION
Closes #364.

Root cause: `openai_responses_request_to_bedrock_converse` did `item['role']` unconditionally; real Responses bodies have top-level `function_call` / `function_call_output` / `reasoning` items without `role`. Fix: branch on `item['type']`. Adjacent same-role items coalesce. 9 new tests + 16 regression pass.

**Review findings:**
- Duplicate block-builders: keep the new `_responses_function_call_to_bedrock_block` helpers, delete the inline branches in `_responses_content_to_bedrock` (single source of truth).
- 5-branch `if/elif` should be `dict[str, Callable]` dispatch registry.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request-shaping for Bedrock OpenAI Responses proxy paths and tool transcripts; behavior is well-tested but incorrect mapping could break multi-turn tool calls.
> 
> **Overview**
> Fixes **OpenAI Responses → Bedrock Converse** translation when `input` includes top-level tool and reasoning items (no `role`), which previously caused `KeyError('role')` ([#364](https://github.com/...)).
> 
> `openai_responses_request_to_bedrock_converse` now branches on each item’s `type`: **`function_call`** → assistant `toolUse`, **`function_call_output`** → user `toolResult` (non-string outputs JSON-encoded), **`reasoning`** dropped, **`message`** still mapped via `_responses_content_to_bedrock`. An **`_append`** helper merges consecutive blocks with the same role into one Converse message. Unknown input types and messages without a string `role` raise **`ValueError`**.
> 
> Adds **`tests/test_bedrock_responses_translator.py`** with regression coverage for coalescing, empty arguments, string `input`, and the issue #364 payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb4298b24723616d4854d8e775b9fafd3fd7de3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->