### PR TITLE
fix: route session/request_permission through Session.on_ask_user

### DIFF
--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -1,6 +1,7 @@
 """ACP client — benchflow acts as the client, agents are ACP servers."""
 
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .session import ACPSession
@@ -23,6 +24,33 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
+# Callable invoked when the agent issues ``session/request_permission``.
+# Receives the raw params dict and returns the option_id to select.
+AskUserHandler = Callable[[dict[str, Any]], Awaitable[str]]
+
+
+def _auto_approve_option_id(options: list[dict[str, Any]]) -> str:
+    """Pick the most permissive ``optionId`` from an ACP permission ``options`` list.
+
+    Default fall-back when no ``on_ask_user`` handler is registered — the
+    benchmark-mode behaviour BenchFlow has shipped since the ACP integration
+    landed. Preferred order: ``bypassPermissions`` → ``allow_always`` →
+    ``allow_once`` → the first option offered.
+    """
+    if not options:
+        return "default"
+    option_id = options[0].get("optionId", "default")
+    for opt in options:
+        if opt.get("optionId") == "bypassPermissions":
+            return "bypassPermissions"
+        if opt.get("kind") == "allow_always":
+            option_id = opt.get("optionId", option_id)
+            break
+        if opt.get("kind") == "allow_once":
+            option_id = opt.get("optionId", option_id)
+    return option_id
+
+
 class ACPClient:
     """Client that speaks ACP to an agent process.
 
@@ -34,6 +62,22 @@ class ACPClient:
         self._request_id = 100000  # High start to avoid collision with agent IDs
         self._session: ACPSession | None = None
         self._initialize_result: InitializeResult | None = None
+        self._ask_user_handler: AskUserHandler | None = None
+
+    def on_ask_user(self, handler: AskUserHandler | None) -> None:
+        """Register the agent-initiated ``session/request_permission`` handler.
+
+        The handler receives the raw ACP ``params`` dict (with ``options``,
+        ``toolCall``, etc.) and returns the ``optionId`` the client should
+        select. Pass ``None`` to clear the handler and restore the default
+        auto-approve policy.
+
+        ``ACPSessionAdapter.on_ask_user`` forwards to this method so that
+        registering through the Agent-plane :class:`Session` contract wires
+        the live ACP request path — without this hook, the contract is
+        bypassed and rollout-branching logic cannot intercept (#382).
+        """
+        self._ask_user_handler = handler
 
     @classmethod
     def from_config(
@@ -149,20 +193,28 @@ class ACPClient:
         params = msg.get("params", {})
 
         if method == "session/request_permission":
-            # Auto-approve all permissions in benchmark mode
-            # claude-agent-acp expects: outcome.outcome="selected", outcome.optionId
+            # If a Session.on_ask_user handler is registered, route the request
+            # through it so the user-facing dispatch (rollout branching, scripted
+            # policies, real-human) can decide. Fall back to auto-approve only
+            # when no handler is registered (preserves the benchmark-mode default
+            # so existing rollouts keep working). See #382.
+            # claude-agent-acp expects: outcome.outcome="selected", outcome.optionId.
             options = params.get("options", [])
-            # Pick the most permissive option available
-            option_id = options[0].get("optionId", "default") if options else "default"
-            for opt in options:
-                if opt.get("optionId") == "bypassPermissions":
-                    option_id = "bypassPermissions"
-                    break
-                if opt.get("kind") == "allow_always":
-                    option_id = opt.get("optionId", option_id)
-                    break
-                if opt.get("kind") == "allow_once":
-                    option_id = opt.get("optionId", option_id)
+            handler = self._ask_user_handler
+            if handler is not None:
+                try:
+                    option_id = await handler(params)
+                except Exception as e:
+                    # A misbehaving handler must not deadlock the agent — log and
+                    # fall back to auto-approve so the rollout makes progress.
+                    logger.warning(
+                        "on_ask_user handler raised %s; falling back to "
+                        "auto-approve for session/request_permission",
+                        e,
+                    )
+                    option_id = _auto_approve_option_id(options)
+            else:
+                option_id = _auto_approve_option_id(options)
 
             response = {
                 "jsonrpc": "2.0",

--- a/src/benchflow/agents/protocol.py
+++ b/src/benchflow/agents/protocol.py
@@ -165,17 +165,17 @@ class ACPSessionAdapter:
 
     This adapter is the thin, documented seam that re-unifies them into a
     single ``Session``. It is **not** an ACP rewrite — it delegates every
-    call straight through. Two gaps with the architecture's shape, kept
-    explicit here rather than papered over:
+    call straight through. One residual gap with the architecture's shape,
+    kept explicit here rather than papered over:
 
-    * ``ACPClient`` exposes no ``on_ask_user`` hook. ACP's agent-initiated
-      channel is ``session/request_permission``, which the client today
-      auto-approves in ``_handle_agent_request``. The adapter stores the
-      handler so the contract is honest; wiring it into the client's
-      permission path is a follow-up (NudgeBench forces it).
     * ``steps`` maps onto ``ACPSession.events`` — the chronological event
       log. The kernel's ``Step`` noun is not yet a typed object, so the
       adapter surfaces the raw event dicts.
+
+    ``on_ask_user`` forwards to ``ACPClient.on_ask_user`` so the registered
+    handler runs on the live ACP ``session/request_permission`` path; without
+    that forwarding the handler was bypassed and the auto-approve policy ran
+    unconditionally (#382).
     """
 
     def __init__(self, client: ACPClient) -> None:
@@ -199,10 +199,39 @@ class ACPSessionAdapter:
     def on_ask_user(self, handler: AskUserHandler) -> None:
         """Register the agent-initiated ``ask_user`` handler.
 
-        Stored on the adapter; see the class docstring for the gap with
-        ``ACPClient``'s current auto-approve permission path.
+        Translates the architecture-level :class:`AskUserHandler` (which
+        receives an :class:`AskUserRequest` and returns the answer text)
+        into the ACP-level callable :class:`ACPClient.on_ask_user` expects
+        (which receives the raw ACP ``params`` dict and returns the
+        ``optionId`` to select). Without this forwarding the handler is
+        registered but never invoked — the bug behind #382.
         """
         self._ask_user_handler = handler
+
+        async def _bridge(params: dict[str, Any]) -> str:
+            options_raw = params.get("options", []) or []
+            # Surface the enumerated option IDs as the branchable set. The
+            # raw ACP payload also carries ``kind`` / ``name`` per option,
+            # but the architecture-level ``AskUserRequest`` is intentionally
+            # minimal — handlers that need richer context can read the raw
+            # params via ``ACPClient.on_ask_user`` directly.
+            options = [
+                str(o.get("optionId", ""))
+                for o in options_raw
+                if isinstance(o, dict) and o.get("optionId")
+            ]
+            tool_call = params.get("toolCall") or {}
+            prompt = (
+                str(tool_call.get("title", "")) if isinstance(tool_call, dict) else ""
+            )
+            request = AskUserRequest(
+                prompt=prompt,
+                options=options,
+                request_id=str(params.get("sessionId", "")),
+            )
+            return await handler(request)
+
+        self._client.on_ask_user(_bridge)
 
     @property
     def steps(self) -> list[Any]:

--- a/tests/agents/test_protocol.py
+++ b/tests/agents/test_protocol.py
@@ -146,19 +146,32 @@ def test_adapter_steps_empty_without_session():
     assert adapter.steps == []
 
 
-def test_adapter_on_ask_user_stores_handler():
-    """The agent-initiated hook is registered on the adapter."""
+def test_adapter_on_ask_user_stores_and_forwards_handler():
+    """The agent-initiated hook is registered on the adapter and forwarded.
+
+    Forwarding to ``ACPClient.on_ask_user`` is the load-bearing fix for
+    #382: without it the handler was stored but never invoked, and the ACP
+    transport silently auto-approved every ``session/request_permission``.
+    """
 
     class FakeClient:
-        pass
+        def __init__(self):
+            self.bridge = None
 
-    adapter = ACPSessionAdapter(FakeClient())  # type: ignore[arg-type]
+        def on_ask_user(self, handler):
+            self.bridge = handler
+
+    client = FakeClient()
+    adapter = ACPSessionAdapter(client)  # type: ignore[arg-type]
 
     async def handler(request):
         return "answer"
 
     adapter.on_ask_user(handler)
     assert adapter._ask_user_handler is handler
+    # The adapter wires a bridge callable into the client; without this
+    # forwarding the live ACP request path can't invoke the handler.
+    assert client.bridge is not None
 
 
 def test_acp_client_is_not_yet_an_agent():

--- a/tests/test_session_request_permission_dispatch.py
+++ b/tests/test_session_request_permission_dispatch.py
@@ -1,0 +1,296 @@
+"""Guards #382: session/request_permission must dispatch through Session.on_ask_user.
+
+Before the fix, ``ACPClient._handle_agent_request`` handled
+``session/request_permission`` internally — picking the most permissive
+option and sending the response itself. The ``ACPSessionAdapter`` stored
+the handler the kernel passed to ``Session.on_ask_user`` but never wired
+it into the live request path, so rollout-branching policies and
+NudgeBench-style "should the agent ask?" rewards saw no events.
+
+These tests pin the dispatch path end-to-end:
+
+* the architecture-level handler runs when the agent issues
+  ``session/request_permission`` and its return value drives the wire
+  response;
+* the no-handler fallback still auto-approves with the
+  most-permissive-option policy the benchmark relied on before #382;
+* the bridge surfaces the option IDs to the handler so it can branch on
+  them.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from benchflow.acp.client import ACPClient, _auto_approve_option_id
+from benchflow.agents.protocol import ACPSessionAdapter, AskUserRequest
+
+
+class _FakeTransport:
+    """Minimal stand-in for ACP transport — captures outbound messages."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send(self, msg: dict) -> None:
+        self.sent.append(msg)
+
+
+def _make_client() -> ACPClient:
+    client = ACPClient.__new__(ACPClient)
+    client._transport = _FakeTransport()
+    client._ask_user_handler = None
+    return client
+
+
+def _request(req_id: int, options: list[dict]) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "session/request_permission",
+        "params": {"sessionId": "s1", "options": options},
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_permission_invokes_session_on_ask_user_handler():
+    """A handler registered through ``Session.on_ask_user`` runs and drives the response."""
+    client = _make_client()
+    adapter = ACPSessionAdapter(client)
+
+    received: list[AskUserRequest] = []
+
+    async def handler(request: AskUserRequest) -> str:
+        received.append(request)
+        return "deny"
+
+    adapter.on_ask_user(handler)
+
+    await client._handle_agent_request(
+        _request(
+            123,
+            [
+                {"optionId": "allow_once", "kind": "allow_once"},
+                {"optionId": "deny", "kind": "reject"},
+                {"optionId": "bypassPermissions", "kind": "allow_always"},
+            ],
+        )
+    )
+
+    # The handler ran, was given the enumerated options as the branchable set,
+    # and its return value drove the outcome.optionId on the wire.
+    assert len(received) == 1
+    assert received[0].options == ["allow_once", "deny", "bypassPermissions"]
+
+    sent = client._transport.sent
+    assert len(sent) == 1
+    assert sent[0]["id"] == 123
+    assert sent[0]["result"] == {
+        "outcome": {"outcome": "selected", "optionId": "deny"}
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_permission_falls_back_to_auto_approve_when_no_handler():
+    """No registered handler ⇒ keep the benchmark-mode auto-approve default."""
+    client = _make_client()
+
+    await client._handle_agent_request(
+        _request(
+            124,
+            [
+                {"optionId": "allow_once", "kind": "allow_once"},
+                {"optionId": "bypassPermissions", "kind": "allow_always"},
+            ],
+        )
+    )
+
+    sent = client._transport.sent
+    assert len(sent) == 1
+    # The hard-coded "most permissive option" policy still wins when no
+    # handler is registered — pre-#382 callers must keep working.
+    assert sent[0]["result"]["outcome"]["optionId"] == "bypassPermissions"
+
+
+@pytest.mark.asyncio
+async def test_request_permission_handler_exception_falls_back_to_auto_approve():
+    """A misbehaving handler must not deadlock the agent — fall back, log."""
+    client = _make_client()
+    adapter = ACPSessionAdapter(client)
+
+    async def handler(_request: AskUserRequest) -> str:
+        raise RuntimeError("policy error")
+
+    adapter.on_ask_user(handler)
+
+    await client._handle_agent_request(
+        _request(
+            125,
+            [{"optionId": "allow_once", "kind": "allow_once"}],
+        )
+    )
+
+    sent = client._transport.sent
+    assert len(sent) == 1
+    # Falls back to the auto-approve policy so the rollout keeps moving.
+    assert sent[0]["result"]["outcome"]["optionId"] == "allow_once"
+
+
+@pytest.mark.asyncio
+async def test_acp_client_on_ask_user_overrides_default_policy():
+    """Registering directly on the ACP client (lower-level path) also works."""
+    client = _make_client()
+
+    async def handler(params: dict) -> str:
+        # The lower-level handler gets the raw ACP params dict.
+        assert params["sessionId"] == "s1"
+        return "allow_once"
+
+    client.on_ask_user(handler)
+
+    await client._handle_agent_request(
+        _request(
+            126,
+            [
+                {"optionId": "allow_once", "kind": "allow_once"},
+                {"optionId": "bypassPermissions", "kind": "allow_always"},
+            ],
+        )
+    )
+
+    sent = client._transport.sent
+    assert sent[0]["result"]["outcome"]["optionId"] == "allow_once"
+
+
+@pytest.mark.asyncio
+async def test_acp_client_on_ask_user_can_be_cleared():
+    """Passing ``None`` clears the handler and restores the default policy."""
+    client = _make_client()
+
+    async def handler(_params: dict) -> str:
+        return "deny"
+
+    client.on_ask_user(handler)
+    client.on_ask_user(None)
+
+    await client._handle_agent_request(
+        _request(
+            127,
+            [
+                {"optionId": "allow_once", "kind": "allow_once"},
+                {"optionId": "bypassPermissions", "kind": "allow_always"},
+            ],
+        )
+    )
+
+    sent = client._transport.sent
+    # After clearing, the most-permissive policy is back in charge.
+    assert sent[0]["result"]["outcome"]["optionId"] == "bypassPermissions"
+
+
+def test_auto_approve_option_id_preserves_legacy_priority_order():
+    """The default policy is the same one the client used pre-#382.
+
+    Priority: bypassPermissions ▸ allow_always ▸ allow_once ▸ first option.
+    Locking the rule in a unit test guards against accidental drift while
+    we route the live path through ``on_ask_user``.
+    """
+    # bypassPermissions wins outright.
+    assert (
+        _auto_approve_option_id(
+            [
+                {"optionId": "allow_once", "kind": "allow_once"},
+                {"optionId": "bypassPermissions", "kind": "allow_always"},
+            ]
+        )
+        == "bypassPermissions"
+    )
+    # allow_always wins over allow_once.
+    assert (
+        _auto_approve_option_id(
+            [
+                {"optionId": "ao", "kind": "allow_once"},
+                {"optionId": "aa", "kind": "allow_always"},
+            ]
+        )
+        == "aa"
+    )
+    # allow_once wins over a no-kind first option.
+    assert (
+        _auto_approve_option_id(
+            [
+                {"optionId": "first"},
+                {"optionId": "second", "kind": "allow_once"},
+            ]
+        )
+        == "second"
+    )
+    # No recognised kinds — fall back to first option's id.
+    assert (
+        _auto_approve_option_id([{"optionId": "only", "kind": "reject"}])
+        == "only"
+    )
+    # Empty options — sentinel.
+    assert _auto_approve_option_id([]) == "default"
+
+
+@pytest.mark.asyncio
+async def test_repro_from_issue_382():
+    """Pin the exact reproduction from the issue body — handler must be called."""
+    client = _make_client()
+    adapter = ACPSessionAdapter(client)
+
+    calls: list[AskUserRequest] = []
+
+    async def handler(req: AskUserRequest) -> str:
+        calls.append(req)
+        return "deny"
+
+    adapter.on_ask_user(handler)
+
+    await client._handle_agent_request(
+        {
+            "jsonrpc": "2.0",
+            "id": 123,
+            "method": "session/request_permission",
+            "params": {
+                "options": [
+                    {"optionId": "allow_once", "kind": "allow_once"},
+                    {"optionId": "bypassPermissions", "kind": "allow_always"},
+                ]
+            },
+        }
+    )
+
+    # Pre-#382: handler_calls == 0 and option_id == "bypassPermissions".
+    # Post-#382: handler runs and option_id reflects its return.
+    assert len(calls) == 1
+    sent = client._transport.sent
+    assert sent[0]["result"]["outcome"]["optionId"] == "deny"
+    # Sanity: the response is valid JSON-RPC and correlates with the request id.
+    assert json.loads(json.dumps(sent[0]))["id"] == 123
+
+
+def test_synchronous_dispatch_with_event_loop():
+    """Same dispatch under ``asyncio.run`` — guards against loop-binding regressions."""
+    client = _make_client()
+    adapter = ACPSessionAdapter(client)
+
+    async def handler(_req: AskUserRequest) -> str:
+        return "allow_once"
+
+    adapter.on_ask_user(handler)
+
+    asyncio.run(
+        client._handle_agent_request(
+            _request(
+                200,
+                [{"optionId": "allow_once", "kind": "allow_once"}],
+            )
+        )
+    )
+
+    assert (
+        client._transport.sent[0]["result"]["outcome"]["optionId"] == "allow_once"
+    )


### PR DESCRIPTION
Closes #382.

Adds `ACPClient.on_ask_user(handler)` registration. `_handle_agent_request` for `session/request_permission` now routes through the registered handler when present, falling back to the auto-approve priority order (`bypassPermissions` → `allow_always` → `allow_once` → first). `ACPSessionAdapter.on_ask_user` forwards to the client. 8 new tests.

**⚠️ FUNCTIONAL GAP**: `rollout.py:1284,2121` calls `connect_acp()` and never uses `ACPSessionAdapter` — so production rollouts still get auto-approve unconditionally. Fix-up branch in flight to wire the adapter into the runtime.

**Review findings:**
- Handler exception silently falls back to auto-approve (fail-open security smell). Should propagate or fail-closed.
- 296-line test file is 2× density norm; `ACPClient.__new__()` bypass is fragile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent permission/tool approval behavior on the ACP wire; fail-open fallback on handler errors can grant permissive options, and production rollouts may still bypass the adapter until wired in `rollout.py`.
> 
> **Overview**
> Fixes **#382** so ACP `session/request_permission` is no longer answered only inside `ACPClient` with a hard-coded “most permissive” choice.
> 
> **`ACPClient`** gains `on_ask_user` (optional handler on raw ACP params → `optionId`). Permission handling now **awaits that handler** when registered; otherwise it uses extracted **`_auto_approve_option_id`** (same priority as before: `bypassPermissions` → `allow_always` → `allow_once` → first). Handler exceptions **log and fall back** to auto-approve so the agent does not hang.
> 
> **`ACPSessionAdapter.on_ask_user`** no longer only stores the kernel handler—it **bridges** `AskUserRequest` (options from `optionId`, prompt from `toolCall.title`) into `ACPClient.on_ask_user`.
> 
> New **`tests/test_session_request_permission_dispatch.py`** and updated protocol tests lock the dispatch path, fallback, clear-handler, and issue repro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b2b971ffed31539c32581d583d388c78f588ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->