### PR TITLE
fix: emit JSON-compliant trajectory JSONL (no NaN/Infinity)

### DIFF
--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -14,11 +14,29 @@ reward is validated and JSON-safe.
 from __future__ import annotations
 
 import json
+import math
 from pathlib import Path
 from typing import Any
 
 from benchflow.adapters.ors import ORSAdapter
 from benchflow.rewards.protocol import VerifyResult
+
+
+def _scrub_non_finite(value: Any) -> Any:
+    """Replace ``NaN`` / ``Infinity`` floats with ``None`` recursively.
+
+    Plain ``json.dumps`` emits non-finite floats as the bare tokens ``NaN``,
+    ``Infinity``, ``-Infinity`` — valid Python but rejected by strict JSON
+    parsers (jq, serde, Node ``JSON.parse``). We normalize to ``null`` so
+    downstream trainer ingestion never sees an invalid JSONL line.
+    """
+    if isinstance(value, float):
+        return value if math.isfinite(value) else None
+    if isinstance(value, dict):
+        return {k: _scrub_non_finite(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_scrub_non_finite(v) for v in value]
+    return value
 
 
 def _split_prompt_completion(
@@ -75,9 +93,17 @@ def trajectory_to_verifiers_record(
 def export_trajectories_to_jsonl(
     records: list[dict[str, Any]], path: str | Path
 ) -> None:
-    """Write Verifiers records to a JSONL file — one JSON object per line."""
+    """Write Verifiers records to a JSONL file — one JSON object per line.
+
+    Non-finite floats (``NaN``, ``±Infinity``) anywhere in a record are
+    normalized to ``null`` before serialization, and ``allow_nan=False`` is
+    set as defense-in-depth so any future regression that lets a non-finite
+    slip through raises ``ValueError`` instead of producing JSONL that
+    strict parsers reject.
+    """
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w") as f:
         for rec in records:
-            f.write(json.dumps(rec, default=str) + "\n")
+            clean = _scrub_non_finite(rec)
+            f.write(json.dumps(clean, default=str, allow_nan=False) + "\n")

--- a/tests/trajectories/test_export_nan_handling.py
+++ b/tests/trajectories/test_export_nan_handling.py
@@ -1,0 +1,103 @@
+"""Non-finite float handling in trainer JSONL export.
+
+``json.dumps`` happily emits the bare tokens ``NaN``, ``Infinity``, and
+``-Infinity`` for non-finite floats — accepted by Python's permissive
+parser, rejected by strict JSON parsers (jq, serde, Node ``JSON.parse``).
+The trainer export normalizes non-finite floats to ``null`` and passes
+``allow_nan=False`` so any regression raises rather than silently
+producing invalid JSONL. See issue #409.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+
+import pytest
+
+from benchflow.trajectories.export import export_trajectories_to_jsonl
+
+
+def test_nan_reward_emits_null_not_nan_token(tmp_path):
+    out = tmp_path / "dataset.jsonl"
+    export_trajectories_to_jsonl(
+        [{"example_id": 1, "reward": math.nan}], out
+    )
+    raw = out.read_text()
+    # Bare NaN token would be invalid JSON for strict parsers.
+    assert "NaN" not in raw
+    assert "Infinity" not in raw
+    parsed = json.loads(raw)
+    assert parsed["example_id"] == 1
+    assert parsed["reward"] is None
+
+
+def test_positive_infinity_metric_becomes_null(tmp_path):
+    out = tmp_path / "dataset.jsonl"
+    export_trajectories_to_jsonl(
+        [{"example_id": 2, "metrics": {"latency_ms": math.inf}}], out
+    )
+    parsed = json.loads(out.read_text())
+    assert parsed["metrics"]["latency_ms"] is None
+
+
+def test_negative_infinity_in_nested_list_becomes_null(tmp_path):
+    out = tmp_path / "dataset.jsonl"
+    export_trajectories_to_jsonl(
+        [{"example_id": 3, "info": {"values": [1.0, -math.inf, 2.5]}}], out
+    )
+    parsed = json.loads(out.read_text())
+    assert parsed["info"]["values"] == [1.0, None, 2.5]
+
+
+def test_finite_floats_pass_through_unchanged(tmp_path):
+    out = tmp_path / "dataset.jsonl"
+    export_trajectories_to_jsonl(
+        [{"example_id": 4, "reward": 0.75, "metrics": {"a": 0.0, "b": -1.5}}],
+        out,
+    )
+    parsed = json.loads(out.read_text())
+    assert parsed["reward"] == 0.75
+    assert parsed["metrics"] == {"a": 0.0, "b": -1.5}
+
+
+def test_emitted_lines_are_strict_json(tmp_path):
+    """``json.loads`` with default args is strict-enough for the regression."""
+    out = tmp_path / "dataset.jsonl"
+    export_trajectories_to_jsonl(
+        [
+            {"example_id": 0, "reward": math.nan},
+            {"example_id": 1, "reward": 1.0, "metrics": {"x": math.inf}},
+        ],
+        out,
+    )
+    lines = out.read_text().strip().splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        # Would raise on bare NaN / Infinity tokens — that's the bug we
+        # are fixing.
+        json.loads(line)
+
+
+def test_scrubbed_record_does_not_mutate_input(tmp_path):
+    rec = {"example_id": 5, "reward": math.nan, "metrics": {"x": math.inf}}
+    export_trajectories_to_jsonl([rec], tmp_path / "out.jsonl")
+    # Caller's dict is unchanged — scrubbing returns a fresh structure.
+    assert math.isnan(rec["reward"])
+    assert math.isinf(rec["metrics"]["x"])
+
+
+def test_allow_nan_false_is_active_defense(monkeypatch, tmp_path):
+    """If the scrubber is ever bypassed, serialization must still raise.
+
+    Patch ``_scrub_non_finite`` to a no-op so a NaN reaches ``json.dumps``;
+    ``allow_nan=False`` should turn that into ``ValueError`` rather than
+    silently writing an invalid JSONL line.
+    """
+    from benchflow.trajectories import export as export_mod
+
+    monkeypatch.setattr(export_mod, "_scrub_non_finite", lambda v: v)
+    with pytest.raises(ValueError):
+        export_trajectories_to_jsonl(
+            [{"example_id": 6, "reward": math.nan}], tmp_path / "out.jsonl"
+        )


### PR DESCRIPTION
Closes #409.

`export_trajectories_to_jsonl` now scrubs non-finite floats (`NaN`, `±Infinity`) to `None` via `_scrub_non_finite`, and serializes with `allow_nan=False` as defense-in-depth. Strict parsers (jq, serde, Node `JSON.parse`) now accept output. 7 new tests.

**Review findings:**
- Move scrubber to `src/benchflow/_utils/json_safe.py` — same pattern repeats at `trajectories/types.py:158`, `traces/huggingface.py:207,250`, `_utils/learner_memory.py:100`, `rollout.py:303,510,699,1875,2043`.
- Parametrize 3 duplicate NaN tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized export serialization change with regression tests; no auth or runtime rollout logic changes.
> 
> **Overview**
> Trajectory JSONL export now produces **strict JSON** by recursively replacing non-finite floats (`NaN`, `±Infinity`) with `null` before writing each line, and by serializing with `allow_nan=False` so any missed non-finite value fails loudly instead of emitting invalid tokens.
> 
> Adds focused tests for rewards, nested metrics/lists, unchanged finite values, multi-line strict parsing, non-mutation of caller records, and the `allow_nan=False` safety net.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b15698fe7ecce10e820ea0ebdec41d0847acf4a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->