### PR TITLE
fix: Runtime API uses Environment's live sandbox instead of creating a new one

### DIFF
--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -632,12 +632,24 @@ def _resolve_prompts(
     return [p if p is not None else instruction for p in prompts]
 
 
-async def _start_env_and_upload(env: Any, task_path: Path, timing: dict) -> None:
-    """Start environment and upload task files."""
-    logger.info(f"Starting environment: {task_path.name}")
-    t0 = datetime.now()
-    await env.start(force_build=False)
-    timing["environment_setup"] = (datetime.now() - t0).total_seconds()
+async def _start_env_and_upload(
+    env: Any, task_path: Path, timing: dict, *, skip_start: bool = False
+) -> None:
+    """Start environment and upload task files.
+
+    ``skip_start=True`` is used when the sandbox was created and started
+    by the caller (Runtime with a live Environment, #388) — we still
+    upload task files but must not re-run ``start()`` since most sandbox
+    backends (e.g. daytona) are not idempotent.
+    """
+    if skip_start:
+        logger.info(f"Reusing caller-owned environment: {task_path.name}")
+        timing["environment_setup"] = 0.0
+    else:
+        logger.info(f"Starting environment: {task_path.name}")
+        t0 = datetime.now()
+        await env.start(force_build=False)
+        timing["environment_setup"] = (datetime.now() - t0).total_seconds()
     if (task_path / "instruction.md").exists():
         await env.upload_file(task_path / "instruction.md", "/instruction.md")
     task_skills = task_path / "environment" / "skills"
@@ -935,6 +947,10 @@ class Rollout:
         self._resolved_prompts: list[str] = []
         self._agent_launch: str = ""
         self._env: Any = None
+        # When True, Rollout treats _env as caller-owned: setup() skips
+        # creating a new sandbox and cleanup() skips stopping it. Set via
+        # use_prebuilt_env() — see Runtime.execute() for the public path.
+        self._env_externally_owned: bool = False
         self._environment: ManifestEnvironment | None = None
         self._timeout: int = 0
         self._timing: dict[str, float] = {}
@@ -988,6 +1004,22 @@ class Rollout:
                 "Evaluation.run(), or bf.run(RolloutConfig(...)) instead of Rollout.create()."
             )
         return cls(config)
+
+    def use_prebuilt_env(self, inner: Any) -> None:
+        """Inject a caller-owned sandbox; skip creation and teardown.
+
+        When the public Runtime API receives a live ``Environment`` (one
+        the caller already constructed, possibly started, and may want to
+        reuse), the Rollout must evaluate inside that same sandbox rather
+        than spinning up a second one. Call this before ``setup()``/
+        ``run()``: ``setup()`` will then skip ``_create_environment`` and
+        ``cleanup()`` will skip stopping the sandbox — the caller owns the
+        lifecycle. Fixes #388.
+        """
+        if inner is None:
+            raise ValueError("use_prebuilt_env() requires a non-None sandbox")
+        self._env = inner
+        self._env_externally_owned = True
 
     @property
     def env(self) -> Any:
@@ -1098,14 +1130,19 @@ class Rollout:
 
         self._effective_task_path = effective_task_path
 
-        self._env = _create_environment(
-            cfg.environment,
-            self._task,
-            effective_task_path,
-            self._rollout_name,
-            self._rollout_paths,
-            preserve_agent_network=self._disallow_web_tools,
-        )
+        # Honour an externally-supplied sandbox (use_prebuilt_env, set by
+        # Runtime.execute() when the caller passes a live Environment).
+        # Without this guard, every Runtime.execute() would build a second
+        # sandbox and silently discard the caller's prepared one — #388.
+        if self._env is None:
+            self._env = _create_environment(
+                cfg.environment,
+                self._task,
+                effective_task_path,
+                self._rollout_name,
+                self._rollout_paths,
+                preserve_agent_network=self._disallow_web_tools,
+            )
         self._timeout = int(self._task.config.agent.timeout_sec or 0)
 
         _write_config(
@@ -1134,7 +1171,12 @@ class Rollout:
 
     async def start(self) -> None:
         """Start the environment and upload task files."""
-        await _start_env_and_upload(self._env, self._config.task_path, self._timing)
+        await _start_env_and_upload(
+            self._env,
+            self._config.task_path,
+            self._timing,
+            skip_start=self._env_externally_owned,
+        )
 
         for hook in self._config.pre_agent_hooks or []:
             await hook(self._env)
@@ -1582,10 +1624,15 @@ class Rollout:
                 self._provider_runtime = None
             except Exception as e:
                 logger.warning(f"Provider runtime stop failed: {e}")
-            try:
-                await self._env.stop(delete=True)
-            except Exception as e:
-                logger.warning(f"Cleanup failed: {e}")
+            # An externally-owned sandbox (use_prebuilt_env) belongs to the
+            # caller — leave it running so they can reuse it or stop it
+            # themselves. #388. getattr() keeps tests that bypass __init__
+            # via Rollout.__new__() working.
+            if not getattr(self, "_env_externally_owned", False):
+                try:
+                    await self._env.stop(delete=True)
+                except Exception as e:
+                    logger.warning(f"Cleanup failed: {e}")
 
         if hasattr(self, "_task_tmp") and self._task_tmp:
             import shutil

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -319,6 +319,12 @@ class Runtime:
 
         Runtime is the stable user-facing surface. Trial owns the
         decomposed lifecycle phases underneath.
+
+        Honours the caller-supplied :class:`Environment`: the live
+        ``env.inner`` sandbox is reused instead of creating a second one
+        (fixes #388). If the caller has not yet called ``env.start()``
+        we start it now so ``env`` stays in a consistent state and the
+        underlying sandbox is brought up exactly once.
         """
         from benchflow._types import Scene
         from benchflow.rollout import Rollout, RolloutConfig
@@ -347,6 +353,16 @@ class Runtime:
         )
 
         rollout = await Rollout.create(trial_config)
+
+        # If the caller has not started the Environment yet, do it now so
+        # the Environment's _started flag stays accurate and the caller's
+        # later env.stop() works. Then hand the live sandbox to Rollout —
+        # this is what makes Runtime honour the input Environment instead
+        # of silently building a second one. #388.
+        if not self.env._started:
+            await self.env.start()
+        rollout.use_prebuilt_env(self.env.inner)
+
         run_result = await rollout.run()
 
         reward = (run_result.rewards or {}).get("reward")

--- a/tests/test_runtime_live_sandbox.py
+++ b/tests/test_runtime_live_sandbox.py
@@ -1,0 +1,261 @@
+"""Runtime honours the live sandbox of a caller-supplied Environment (#388).
+
+Before this fix, ``Runtime(env, agent).execute()`` built a brand-new
+sandbox via ``Rollout.setup()`` and silently discarded ``env.inner``.
+Callers could prepare state, upload fixtures, or start services on one
+Environment and unknowingly evaluate inside a different sandbox.
+
+These tests guard the wiring at three layers:
+
+* ``Rollout.use_prebuilt_env`` marks the sandbox externally-owned.
+* ``Rollout.setup`` reuses the injected sandbox instead of creating one.
+* ``Rollout.cleanup`` skips stopping a sandbox the caller owns.
+* ``Runtime.execute`` wires ``env.inner`` into the Rollout and starts an
+  unstarted Environment exactly once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.rollout import Rollout, RolloutConfig
+from benchflow.runtime import Agent, Environment, Runtime, RuntimeConfig
+
+TASK_PATH = Path(__file__).parent / "examples" / "hello-world-task"
+
+
+class _FakeInner:
+    """Records lifecycle calls so we can assert sandbox identity is preserved."""
+
+    def __init__(self) -> None:
+        self.started = 0
+        self.stopped = 0
+        self.uploads: list[tuple[str, str]] = []
+        self.execs: list[str] = []
+
+    async def start(self, *args: Any, **kwargs: Any) -> None:
+        self.started += 1
+
+    async def stop(self, *args: Any, **kwargs: Any) -> None:
+        self.stopped += 1
+
+    async def exec(self, cmd: str, **kwargs: Any) -> Any:
+        self.execs.append(cmd)
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    async def upload_file(self, src: str | Path, dst: str) -> None:
+        self.uploads.append((str(src), dst))
+
+    async def upload_dir(self, src: str | Path, dst: str, **kwargs: Any) -> None:
+        self.uploads.append((str(src), dst))
+
+
+def test_use_prebuilt_env_marks_externally_owned() -> None:
+    """use_prebuilt_env stashes the sandbox and flips the ownership flag."""
+    cfg = RolloutConfig(task_path=TASK_PATH)
+    rollout = Rollout(cfg)
+    inner = _FakeInner()
+
+    rollout.use_prebuilt_env(inner)
+
+    assert rollout.env is inner
+    assert rollout._env_externally_owned is True
+
+
+def test_use_prebuilt_env_rejects_none() -> None:
+    """Passing None is a programmer error — fail loud, don't silently rebuild."""
+    rollout = Rollout(RolloutConfig(task_path=TASK_PATH))
+    with pytest.raises(ValueError, match="non-None"):
+        rollout.use_prebuilt_env(None)
+
+
+@pytest.mark.asyncio
+async def test_setup_reuses_prebuilt_env_no_new_sandbox(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """setup() must NOT call _create_environment when a sandbox is injected.
+
+    This is the core of #388: the bug was setup() always calling
+    _create_environment(cfg.environment, ...) and replacing self._env.
+    """
+    cfg = RolloutConfig(task_path=TASK_PATH, environment="docker")
+    rollout = Rollout(cfg)
+    inner = _FakeInner()
+    rollout.use_prebuilt_env(inner)
+
+    create_calls: list[Any] = []
+
+    def fake_create_environment(*args: Any, **kwargs: Any) -> Any:
+        create_calls.append((args, kwargs))
+        return _FakeInner()
+
+    monkeypatch.setattr(
+        "benchflow.rollout._create_environment", fake_create_environment
+    )
+
+    await rollout.setup()
+
+    assert create_calls == [], "setup() created a new sandbox despite pre-built env"
+    assert rollout.env is inner, "setup() must keep the injected sandbox identity"
+
+
+@pytest.mark.asyncio
+async def test_setup_without_prebuilt_env_still_creates_one(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative case: no pre-built env => setup() must build one.
+
+    Guards against the obvious over-correction where we accidentally
+    skip env creation in the default path too.
+    """
+    cfg = RolloutConfig(task_path=TASK_PATH, environment="docker")
+    rollout = Rollout(cfg)
+
+    created = _FakeInner()
+    create_calls: list[Any] = []
+
+    def fake_create_environment(*args: Any, **kwargs: Any) -> Any:
+        create_calls.append((args, kwargs))
+        return created
+
+    monkeypatch.setattr(
+        "benchflow.rollout._create_environment", fake_create_environment
+    )
+
+    await rollout.setup()
+
+    assert len(create_calls) == 1, "setup() must create a sandbox when none injected"
+    assert rollout.env is created
+    assert rollout._env_externally_owned is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_stop_externally_owned_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """cleanup() must not stop a caller-owned sandbox — caller owns lifecycle."""
+    cfg = RolloutConfig(task_path=TASK_PATH)
+    rollout = Rollout(cfg)
+    inner = _FakeInner()
+    rollout.use_prebuilt_env(inner)
+
+    # Skip noise paths that cleanup() runs through.
+    rollout._provider_runtime = None
+    rollout._usage_runtime = None
+
+    await rollout.cleanup()
+
+    assert inner.stopped == 0, "cleanup() stopped a sandbox the caller owns"
+
+
+@pytest.mark.asyncio
+async def test_cleanup_stops_internally_created_env() -> None:
+    """Default ownership: cleanup() stops the sandbox it created."""
+    cfg = RolloutConfig(task_path=TASK_PATH)
+    rollout = Rollout(cfg)
+    inner = _FakeInner()
+    rollout._env = inner  # simulate internally-created env, owned by rollout
+    rollout._provider_runtime = None
+    rollout._usage_runtime = None
+
+    await rollout.cleanup()
+
+    assert inner.stopped == 1, "cleanup() must stop a sandbox it created"
+
+
+@pytest.mark.asyncio
+async def test_runtime_execute_uses_environment_inner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Runtime.execute() pipes env.inner through to the Rollout.
+
+    Direct reproduction of the #388 issue body: a caller passes a live
+    Environment, Runtime must use it and start it exactly once. Before
+    the fix, env.inner.start was never called and the rollout failed
+    with "Unknown sandbox_type: <whatever>".
+    """
+    inner = _FakeInner()
+    env = Environment(inner=inner, task_path=TASK_PATH, sandbox="not-a-real-sandbox")
+    agent = Agent(name="claude-agent-acp", model="claude-haiku-4-5-20251001")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run(self: Rollout) -> Any:
+        captured["rollout_env"] = self._env
+        captured["externally_owned"] = self._env_externally_owned
+        from benchflow.models import RolloutResult
+
+        return RolloutResult(
+            task_name=TASK_PATH.name,
+            rollout_name="rt-388",
+            rewards={"reward": 1.0},
+            trajectory=[],
+            agent="",
+            agent_name="",
+            model="",
+            n_tool_calls=0,
+            n_prompts=0,
+            error=None,
+            verifier_error=None,
+            partial_trajectory=False,
+            trajectory_source=None,
+            started_at=None,
+            finished_at=None,
+        )
+
+    monkeypatch.setattr(Rollout, "run", fake_run)
+
+    result = await Runtime(env, agent, RuntimeConfig()).execute()
+
+    assert captured["rollout_env"] is inner, "Rollout did not receive env.inner"
+    assert captured["externally_owned"] is True
+    assert inner.started == 1, "Runtime should start the Environment exactly once"
+    assert env._started is True, "Environment._started must stay consistent"
+    assert result.reward == 1.0
+
+
+@pytest.mark.asyncio
+async def test_runtime_execute_does_not_restart_already_started_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the caller already started the Environment, don't start it again.
+
+    Most sandbox backends (e.g. daytona) are not idempotent under
+    repeated start() — a second call would build a second container.
+    """
+    inner = _FakeInner()
+    env = Environment(inner=inner, task_path=TASK_PATH, sandbox="docker")
+    await env.start()  # caller starts it themselves
+    assert inner.started == 1
+
+    agent = Agent(name="claude-agent-acp", model="claude-haiku-4-5-20251001")
+
+    async def fake_run(self: Rollout) -> Any:
+        from benchflow.models import RolloutResult
+
+        return RolloutResult(
+            task_name=TASK_PATH.name,
+            rollout_name="rt-388-restart",
+            rewards={"reward": 0.0},
+            trajectory=[],
+            agent="",
+            agent_name="",
+            model="",
+            n_tool_calls=0,
+            n_prompts=0,
+            error=None,
+            verifier_error=None,
+            partial_trajectory=False,
+            trajectory_source=None,
+            started_at=None,
+            finished_at=None,
+        )
+
+    monkeypatch.setattr(Rollout, "run", fake_run)
+
+    await Runtime(env, agent, RuntimeConfig()).execute()
+
+    assert inner.started == 1, "Runtime restarted an already-started Environment"


### PR DESCRIPTION
Closes #388.

Adds `Rollout.use_prebuilt_env(inner)` so the Runtime can hand in a pre-started sandbox. `_start_env_and_upload` got a `skip_start` kwarg because daytona/modal/docker backends are NOT idempotent on repeated `start()` (daytona literally creates a second sandbox). 8 new tests.

**Review findings:**
- 4 mechanisms (use_prebuilt_env setter, _env_externally_owned flag, skip_start kwarg, defensive getattr) for what should be 1 constructor attribute. Recommended: `Rollout(config, external_env=...)`.
- `_start_env_and_upload(skip_start=)` violates Standard 7 — split into 2 functions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/443" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core sandbox lifecycle in Runtime/Rollout; behavior is well-covered by new tests but affects all Runtime.execute() paths.
> 
> **Overview**
> Fixes **#388**: `Runtime(env, agent).execute()` no longer spins up a second sandbox and drops the caller’s prepared `Environment`.
> 
> **Runtime** starts `Environment` once if needed, then passes `env.inner` into the rollout via **`Rollout.use_prebuilt_env`**. **Rollout** skips `_create_environment` when a sandbox is injected, uses **`skip_start`** on `_start_env_and_upload` so caller-started sandboxes aren’t started again (important for non-idempotent backends like Daytona), and **cleanup** leaves caller-owned sandboxes running.
> 
> Eight new tests cover injection, setup/cleanup ownership, and Runtime wiring (including no double-start).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3c84596d136fa507e7bd1891a444eaff4532432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->