### PR TITLE
fix: environment manifest controls sandbox image, tasks, and forwarded env

### DIFF
--- a/src/benchflow/environment/manifest.py
+++ b/src/benchflow/environment/manifest.py
@@ -19,11 +19,15 @@ The schema is honest to the two real stateful-multi-service benchmarks:
 
 from __future__ import annotations
 
+import logging
+import os
 import tomllib
 from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
+
+logger = logging.getLogger(__name__)
 
 
 class ServiceSpec(BaseModel):
@@ -173,3 +177,56 @@ def load_manifest(path: str | Path) -> EnvironmentManifest:
     """Load and validate an environment manifest from a TOML file."""
     text = Path(path).read_text()
     return EnvironmentManifest.model_validate_toml(text)
+
+
+def resolve_manifest_runtime_env(
+    manifest: EnvironmentManifest,
+    *,
+    task_id: str,
+    host_env: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Resolve the env vars the manifest contributes to the sandbox runtime.
+
+    Combines two manifest control points into a single dict:
+
+    * ``task_selection`` — when ``mechanism = "env_var"`` and
+      ``inject_into = "entrypoint"``, the task id is bound under the
+      configured key so the image entrypoint (or any in-sandbox service the
+      framework starts) sees it at PID 1.
+    * ``forward_env`` — each declared key is looked up in ``host_env``
+      (defaults to ``os.environ``) and forwarded into the container. Keys
+      missing on the host are silently skipped — the benchmark author owns
+      the policy of whether absence is an error.
+
+    The returned dict is suitable for merging into ``persistent_env`` so
+    every subsequent ``sandbox.exec`` call and the compose-up environment
+    both observe the values (see ``BaseSandbox._merge_env`` and Docker's
+    compose env injection).
+    """
+    resolved_env: dict[str, str] = {}
+    source_env = host_env if host_env is not None else dict(os.environ)
+
+    sel = manifest.task_selection
+    if sel.mechanism == "env_var" and sel.inject_into == "entrypoint":
+        resolved_env[sel.key] = task_id
+
+    for key in manifest.forward_env.keys:
+        if key in source_env:
+            resolved_env[key] = source_env[key]
+        else:
+            logger.debug(
+                "manifest forward_env: host env var %r not set; skipping", key
+            )
+
+    return resolved_env
+
+
+def resolve_manifest_image(manifest: EnvironmentManifest) -> str | None:
+    """Return the image the manifest declares as the sandbox run target.
+
+    ``image`` (a ready-to-run image, chi-bench style) is the run target when
+    set. ``base_image`` is what per-task images are built FROM (smolclaws
+    style) — it is *not* a runnable target on its own, so this returns
+    ``None`` and the existing task-built path remains in effect.
+    """
+    return manifest.image

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1105,6 +1105,7 @@ class Rollout:
             self._rollout_name,
             self._rollout_paths,
             preserve_agent_network=self._disallow_web_tools,
+            environment_manifest=cfg.environment_manifest,
         )
         self._timeout = int(self._task.config.agent.timeout_sec or 0)
 

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -545,8 +545,18 @@ def _create_sandbox_environment(
     rollout_name: str,
     rollout_paths: RolloutPaths,
     preserve_agent_network: bool = False,
+    environment_manifest: Any = None,
 ) -> Any:
-    """Create a sandbox environment (Docker, Daytona, or Modal)."""
+    """Create a sandbox environment (Docker, Daytona, or Modal).
+
+    When ``environment_manifest`` is provided, its declared controls take
+    effect at sandbox-construction time: the manifest's runnable ``image``
+    overrides ``task.config.environment.docker_image`` (so the manifest —
+    not the task's local Dockerfile — drives image selection), and the
+    manifest's ``task_selection`` + ``forward_env`` are resolved into a
+    persistent env overlay so the values reach the container's entrypoint
+    via compose and every subsequent ``sandbox.exec`` call.
+    """
     env_config = task.config.environment
     environment_dir = task_path / "environment"
     if not environment_dir.exists():
@@ -559,6 +569,25 @@ def _create_sandbox_environment(
         env_config = env_config.model_copy(deep=True)
         env_config.allow_internet = True
 
+    manifest_env: dict[str, str] = {}
+    if environment_manifest is not None:
+        from benchflow.environment.manifest import (
+            resolve_manifest_image,
+            resolve_manifest_runtime_env,
+        )
+
+        manifest_image = resolve_manifest_image(environment_manifest)
+        if manifest_image:
+            # Image control point — manifest's run target wins over task.toml's
+            # docker_image so a benchmark author can pin the runtime image
+            # from the manifest without editing every task.toml.
+            if env_config is task.config.environment:
+                env_config = env_config.model_copy(deep=True)
+            env_config.docker_image = manifest_image
+        manifest_env = resolve_manifest_runtime_env(
+            environment_manifest, task_id=task_path.name
+        )
+
     if sandbox_type == "docker":
         from benchflow.sandbox.docker import DockerSandbox
 
@@ -568,6 +597,7 @@ def _create_sandbox_environment(
             session_id=rollout_name,
             rollout_paths=rollout_paths,
             task_env_config=env_config,
+            persistent_env=manifest_env or None,
         )
     elif sandbox_type == "daytona":
         try:
@@ -608,6 +638,7 @@ def _create_sandbox_environment(
             task_env_config=env_config,
             auto_stop_interval_mins=1440,
             auto_delete_interval_mins=1440,
+            persistent_env=manifest_env or None,
         )
     elif sandbox_type == "modal":
         try:
@@ -622,6 +653,7 @@ def _create_sandbox_environment(
             session_id=rollout_name,
             rollout_paths=rollout_paths,
             task_env_config=env_config,
+            persistent_env=manifest_env or None,
         )
     else:
         raise ValueError(

--- a/tests/test_environment_manifest_controls.py
+++ b/tests/test_environment_manifest_controls.py
@@ -1,0 +1,301 @@
+"""Manifest control points actually steer the sandbox (#395).
+
+A RolloutConfig that carries an EnvironmentManifest must take effect:
+
+1. ``image`` overrides ``task.config.environment.docker_image`` so the
+   manifest — not the task's local Dockerfile — drives runtime image
+   selection.
+2. ``task_selection`` (mechanism=env_var, inject_into=entrypoint) binds
+   the task id under the configured key so the image entrypoint and any
+   subsequent ``sandbox.exec`` call observe it.
+3. ``forward_env`` pulls the named host env vars into the sandbox so the
+   environment can read declared host secrets/config.
+
+Before this fix the manifest was accepted but ignored — the sandbox was
+created from ``task.config.environment`` only, the env var never made it
+into the container, and host-side ``forward_env`` was never resolved.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from benchflow.environment.manifest import (
+    EnvironmentManifest,
+    resolve_manifest_image,
+    resolve_manifest_runtime_env,
+)
+from benchflow.sandbox.setup import _create_sandbox_environment
+from benchflow.task import Task
+
+# ── Manifests ────────────────────────────────────────────────────────────
+
+_CHI_MANIFEST = EnvironmentManifest.model_validate_toml(
+    """
+[environment]
+name           = "chi-bench"
+image          = "manifest-image:latest"
+ports          = [8023]
+owns_lifecycle = true
+
+[environment.task_selection]
+mechanism   = "env_var"
+key         = "TASK_ID"
+inject_into = "entrypoint"
+
+[environment.forward_env]
+keys = ["MANIFEST_FWD_API_KEY", "MANIFEST_FWD_MISSING"]
+"""
+)
+
+_CLAWS_MANIFEST = EnvironmentManifest.model_validate_toml(
+    """
+[environment]
+name           = "clawsbench"
+base_image     = "smolclaws-base:latest"
+owns_lifecycle = false
+
+[[environment.services]]
+name    = "gmail"
+command = "claw-gmail serve --port 9001"
+port    = 9001
+"""
+)
+
+
+# ── Fixtures ─────────────────────────────────────────────────────────────
+
+
+def _write_task(root: Path, name: str = "demo-task") -> Path:
+    """Materialize a minimal task tree with task.toml + Dockerfile."""
+    task_dir = root / name
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "tests").mkdir()
+    (task_dir / "instruction.md").write_text("Do it.\n")
+    (task_dir / "task.toml").write_text(
+        "version = \"1.0\"\n"
+        "[agent]\ntimeout_sec = 1\n"
+        "[verifier]\ntimeout_sec = 1\n"
+        "[environment]\ndocker_image = \"task-toml-image:latest\"\n"
+    )
+    (task_dir / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    return task_dir
+
+
+def _stub_rollout_paths(tmp_path: Path):
+    """Minimal RolloutPaths stand-in — sandbox factories only read three dirs."""
+    return type(
+        "P",
+        (),
+        {
+            "verifier_dir": tmp_path,
+            "agent_dir": tmp_path,
+            "artifacts_dir": tmp_path,
+            "rollout_dir": tmp_path,
+        },
+    )()
+
+
+# ── Unit-level: helper functions ─────────────────────────────────────────
+
+
+def test_resolve_manifest_image_prefers_image_over_base_image():
+    """Only a runnable ``image`` is returned; ``base_image`` alone yields None.
+
+    ``base_image`` is what per-task images build FROM; it cannot be run on
+    its own. Returning it would silently swap the runtime for a non-runnable
+    image, which is worse than leaving the task path in effect.
+    """
+    assert resolve_manifest_image(_CHI_MANIFEST) == "manifest-image:latest"
+    assert resolve_manifest_image(_CLAWS_MANIFEST) is None
+
+
+def test_resolve_manifest_runtime_env_binds_task_id_and_forwards_present_host_vars():
+    """Task selection key + forward_env keys are merged into one env dict.
+
+    Forward_env keys that are unset on the host are silently skipped — the
+    benchmark author can layer their own required-ness check upstream if
+    the policy is strict.
+    """
+    host = {
+        "MANIFEST_FWD_API_KEY": "secret-abc",
+        # MANIFEST_FWD_MISSING intentionally absent
+        "UNRELATED": "ignored",
+    }
+    env = resolve_manifest_runtime_env(
+        _CHI_MANIFEST, task_id="task-42", host_env=host
+    )
+    assert env == {"TASK_ID": "task-42", "MANIFEST_FWD_API_KEY": "secret-abc"}
+
+
+def test_resolve_manifest_runtime_env_skips_task_selection_when_inject_exec():
+    """``inject_into = "exec"`` is the framework's later-layer concern.
+
+    The setup-time helper only handles entrypoint-time injection; exec-time
+    binding is a per-call decoration that lives elsewhere. The helper must
+    not silently treat them as the same.
+    """
+    m = EnvironmentManifest.model_validate_toml(
+        """
+[environment]
+name           = "x"
+image          = "x:latest"
+[environment.task_selection]
+mechanism   = "env_var"
+key         = "TASK_ID"
+inject_into = "exec"
+"""
+    )
+    assert resolve_manifest_runtime_env(m, task_id="task-1", host_env={}) == {}
+
+
+# ── Sandbox-construction: the three control points end-to-end ───────────
+
+
+def test_manifest_image_overrides_task_docker_image(tmp_path):
+    """Control point 1: manifest ``image`` wins over task.toml docker_image."""
+    task_dir = _write_task(tmp_path)
+    task = Task(task_dir)
+    assert task.config.environment.docker_image == "task-toml-image:latest"
+
+    captured: dict = {}
+
+    class _FakeSandbox:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch("benchflow.sandbox.docker.DockerSandbox", _FakeSandbox):
+        _create_sandbox_environment(
+            "docker",
+            task,
+            task_dir,
+            "rollout-1",
+            _stub_rollout_paths(tmp_path),
+            environment_manifest=_CHI_MANIFEST,
+        )
+
+    # The sandbox sees the manifest's image, not the task.toml's.
+    assert captured["task_env_config"].docker_image == "manifest-image:latest"
+    # And the task's config is not mutated — the override is per-rollout.
+    assert task.config.environment.docker_image == "task-toml-image:latest"
+
+
+def test_manifest_task_selection_lands_in_sandbox_persistent_env(tmp_path, monkeypatch):
+    """Control point 2: task id binds under task_selection.key in the sandbox env.
+
+    The persistent_env dict the helper builds is what Docker/Daytona/Modal
+    forward into the container at compose-up + every ``exec`` call, so
+    proving it appears there is proving the entrypoint sees it.
+    """
+    monkeypatch.delenv("MANIFEST_FWD_API_KEY", raising=False)
+    task_dir = _write_task(tmp_path, name="task-xyz")
+    task = Task(task_dir)
+
+    captured: dict = {}
+
+    class _FakeSandbox:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch("benchflow.sandbox.docker.DockerSandbox", _FakeSandbox):
+        _create_sandbox_environment(
+            "docker",
+            task,
+            task_dir,
+            "rollout-1",
+            _stub_rollout_paths(tmp_path),
+            environment_manifest=_CHI_MANIFEST,
+        )
+
+    # task_path.name is the task id; it must be bound under the manifest's key.
+    assert captured["persistent_env"] == {"TASK_ID": "task-xyz"}
+
+
+def test_manifest_forward_env_pulls_host_vars_into_sandbox(tmp_path, monkeypatch):
+    """Control point 3: declared host env vars are forwarded into the sandbox."""
+    monkeypatch.setenv("MANIFEST_FWD_API_KEY", "forwarded-value")
+    monkeypatch.delenv("MANIFEST_FWD_MISSING", raising=False)
+    task_dir = _write_task(tmp_path, name="task-42")
+    task = Task(task_dir)
+
+    captured: dict = {}
+
+    class _FakeSandbox:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch("benchflow.sandbox.docker.DockerSandbox", _FakeSandbox):
+        _create_sandbox_environment(
+            "docker",
+            task,
+            task_dir,
+            "rollout-1",
+            _stub_rollout_paths(tmp_path),
+            environment_manifest=_CHI_MANIFEST,
+        )
+
+    persistent = captured["persistent_env"]
+    assert persistent["MANIFEST_FWD_API_KEY"] == "forwarded-value"
+    # Unset host vars are skipped — they don't appear as empty strings.
+    assert "MANIFEST_FWD_MISSING" not in persistent
+    # And task-selection still rides alongside.
+    assert persistent["TASK_ID"] == "task-42"
+
+
+# ── Negative: manifest=None preserves the legacy path ───────────────────
+
+
+def test_no_manifest_means_no_persistent_env_and_no_image_override(tmp_path):
+    """Without a manifest the sandbox is constructed exactly as before."""
+    task_dir = _write_task(tmp_path)
+    task = Task(task_dir)
+
+    captured: dict = {}
+
+    class _FakeSandbox:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch("benchflow.sandbox.docker.DockerSandbox", _FakeSandbox):
+        _create_sandbox_environment(
+            "docker",
+            task,
+            task_dir,
+            "rollout-1",
+            _stub_rollout_paths(tmp_path),
+            environment_manifest=None,
+        )
+
+    # task.toml's docker_image is untouched.
+    assert captured["task_env_config"].docker_image == "task-toml-image:latest"
+    # And no manifest-driven persistent_env overlay.
+    assert captured["persistent_env"] is None
+
+
+def test_base_image_only_manifest_does_not_override_image(tmp_path):
+    """A manifest with only ``base_image`` leaves the task's image intact.
+
+    ``base_image`` is a build-FROM marker, not a runnable target — overriding
+    docker_image with it would silently break per-task images.
+    """
+    task_dir = _write_task(tmp_path)
+    task = Task(task_dir)
+
+    captured: dict = {}
+
+    class _FakeSandbox:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    with patch("benchflow.sandbox.docker.DockerSandbox", _FakeSandbox):
+        _create_sandbox_environment(
+            "docker",
+            task,
+            task_dir,
+            "rollout-1",
+            _stub_rollout_paths(tmp_path),
+            environment_manifest=_CLAWS_MANIFEST,
+        )
+
+    assert captured["task_env_config"].docker_image == "task-toml-image:latest"


### PR DESCRIPTION
Closes #395.

Adds `resolve_manifest_image()` + `resolve_manifest_runtime_env()` helpers. `_create_sandbox_environment` now takes `environment_manifest=` kwarg, overrides docker_image from manifest, passes resolved env to all 3 sandbox backends. 8 new tests.

**⚠️ Material findings from review:**
- BLOCKING: `Environment.from_task_path()` (SDK path) also calls `_create_environment` but never forwards manifest — SDK callers still get 'manifest ignored' behavior. Fix: load manifest implicitly from `task_path/environment.toml` inside `_create_sandbox_environment`.
- BLOCKING: `mechanism='image'` and `inject_into='exec'` are accepted by schema but silently no-op — must raise NotImplementedError or implement.
- Bundled compose files have no `environment:` block, so `TASK_ID` reaches docker subprocess env but NOT container PID 1 — central #395 invariant unrealized for compose-mode.
- `forward_env.keys` collision with `task_selection.key` lets host silently overwrite framework-chosen task id.
- ⚠️ This PR ran in parent worktree, not isolated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all three sandbox backends pick images and container env when a manifest is present; misconfiguration could break chi-bench-style runs, though legacy no-manifest behavior is unchanged.
> 
> **Overview**
> **Environment manifests now drive sandbox setup** when `RolloutConfig.environment_manifest` is set, instead of being parsed but ignored.
> 
> New helpers **`resolve_manifest_image`** and **`resolve_manifest_runtime_env`** map manifest fields into runtime behavior: a declared **`image`** overrides `task.toml`’s `docker_image` (per-rollout copy, task config unchanged); **`base_image` only** does not override. For **`task_selection`** with `env_var` + `inject_into=entrypoint`, the task id is set under the configured key; **`forward_env`** copies present host vars (missing keys skipped with debug logging).
> 
> **`_create_sandbox_environment`** accepts `environment_manifest` and passes the merged env as **`persistent_env`** to Docker, Daytona, and Modal so compose startup and `exec` see the values. **`Rollout.setup`** forwards `cfg.environment_manifest` into that path.
> 
> Adds **`tests/test_environment_manifest_controls.py`** covering helpers and sandbox construction (including no-manifest and base-image-only cases).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0c7061c5658a38367fed11ce0392b5beadc2336. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->