### PR TITLE
fix: emit Verifiers/ORS JSONL artifacts in train-mode rollouts

### DIFF
--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -1225,6 +1225,15 @@ class Evaluation:
         # expects summary.json at the top level.
         (self._jobs_dir / "summary.json").write_text(summary_text)
 
+        # Aggregate per-rollout trainer artifacts into job_dir/verifiers.jsonl
+        # — the architecture's train-mode seam (issue #385).
+        try:
+            from benchflow.trajectories.export import write_job_verifiers_jsonl
+
+            write_job_verifiers_jsonl(job_dir)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Job-level trainer artifact aggregation failed: %s", e)
+
         idle_count = error_category_counts.get(IDLE_TIMEOUT, 0)
         if idle_count > 0:
             pct = idle_count / job_result.total * 100

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -606,7 +606,50 @@ def _build_rollout_result(
     (rollout_dir / "timing.json").write_text(json.dumps(timing, indent=2))
     (rollout_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
     _write_rewards_jsonl(rollout_dir, rewards, finished_at)
+    _write_trainer_artifact(
+        rollout_dir,
+        task_name=task_name,
+        prompts=prompts,
+        trajectory=trajectory,
+        rewards=rewards,
+        model=model,
+        verifier_error=verifier_error,
+    )
     return result
+
+
+def _write_trainer_artifact(
+    rollout_dir: Path,
+    *,
+    task_name: str,
+    prompts: list[str],
+    trajectory: list[dict],
+    rewards: dict | None,
+    model: str | None,
+    verifier_error: str | None,
+) -> None:
+    """Emit ``rollout_dir/trainer/verifiers.jsonl`` for this scored rollout.
+
+    The architecture's train-mode seam (issue #385): every scored rollout
+    that reaches result-building should produce a trainer-ready Verifiers /
+    ORS record so prime-rl / Verifiers can ingest the run directly. Failures
+    here are logged but never block result writing.
+    """
+    from benchflow.trajectories.export import write_rollout_verifiers_jsonl
+
+    try:
+        write_rollout_verifiers_jsonl(
+            rollout_dir,
+            task_id=task_name,
+            prompts=prompts,
+            trajectory=trajectory,
+            rewards=rewards,
+            model=model,
+            environment=task_name,
+            error=verifier_error,
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Trainer artifact write failed: %s", e)
 
 
 def _resolve_prompts(

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -9,17 +9,36 @@ The record shape is pinned against the Verifiers ``RolloutOutput`` type
 ``reward``, ``metrics``, ``is_completed``, ``is_truncated``, ``example_id``,
 ``info``. The reward conversion reuses the existing ``ORSAdapter`` so the
 reward is validated and JSON-safe.
+
+This module also provides the live wiring used by ``Rollout`` and
+``Evaluation`` to emit trainer-ready ``verifiers.jsonl`` artifacts:
+
+- :func:`acp_events_to_messages` — convert BenchFlow's ACP-style trajectory
+  events to the ``[{"role", "content"}, ...]`` shape the record expects.
+- :func:`reward_map_to_verify_result` — adapt the canonical verifier reward
+  ``dict`` produced by ``Rollout.verify()`` back to a :class:`VerifyResult`.
+- :func:`write_rollout_verifiers_jsonl` — write one rollout's record to
+  ``rollout_dir/trainer/verifiers.jsonl``.
+- :func:`write_job_verifiers_jsonl` — concatenate per-rollout records into a
+  single ``job_dir/verifiers.jsonl`` dataset.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import math
 from pathlib import Path
 from typing import Any
 
 from benchflow.adapters.ors import ORSAdapter
 from benchflow.rewards.protocol import VerifyResult
+
+logger = logging.getLogger(__name__)
+
+# Canonical artifact locations (see issue #385).
+ROLLOUT_ARTIFACT_RELPATH = "trainer/verifiers.jsonl"
+JOB_ARTIFACT_FILENAME = "verifiers.jsonl"
 
 
 def _scrub_non_finite(value: Any) -> Any:
@@ -107,3 +126,184 @@ def export_trajectories_to_jsonl(
         for rec in records:
             clean = _scrub_non_finite(rec)
             f.write(json.dumps(clean, default=str, allow_nan=False) + "\n")
+
+
+def _tool_call_to_content(event: dict[str, Any]) -> str:
+    """Render an ACP ``tool_call`` event as a single text block.
+
+    Verifiers' record uses message-format strings, so the tool call's title
+    and any text-bearing content are summarised into one assistant string.
+    """
+    title = str(event.get("title") or event.get("kind") or "tool_call")
+    parts: list[str] = [f"[tool_call: {title}]"]
+    content = event.get("content")
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text") or item.get("content") or ""
+                if text:
+                    parts.append(str(text))
+    elif isinstance(content, str) and content:
+        parts.append(content)
+    return "\n".join(parts)
+
+
+def acp_events_to_messages(
+    events: list[dict[str, Any]],
+    prompts: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert BenchFlow ACP trajectory events to message format.
+
+    The live rollout trajectory is a list of typed events
+    (``user_message``, ``agent_message``, ``agent_thought``, ``tool_call``)
+    captured in :mod:`benchflow.trajectories._capture`. The Verifiers /
+    ORS record expects ``[{"role", "content"}, ...]`` — typical OpenAI
+    chat message shape.
+
+    *prompts* are the user-facing prompts handed to the agent before any
+    ACP event is captured (instruction.md, scene turns, etc.). They are
+    materialised as leading ``user`` messages so the record's ``prompt``
+    half is non-empty when ``trajectory_to_verifiers_record`` splits the
+    sequence at the first ``assistant`` message.
+
+    Tool calls are rendered into a single assistant text block via
+    :func:`_tool_call_to_content` — this keeps the record's shape stable
+    without coupling to a specific tool-call schema. ``agent_thought``
+    events fold into the prior or following assistant message under the
+    same role to avoid breaking the user→assistant→... ordering.
+    """
+    messages: list[dict[str, Any]] = []
+    for prompt in prompts or []:
+        if prompt:
+            messages.append({"role": "user", "content": str(prompt)})
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "user_message":
+            text = str(event.get("text") or "")
+            if text:
+                messages.append({"role": "user", "content": text})
+        elif etype in ("agent_message", "agent_thought"):
+            text = str(event.get("text") or "")
+            if text:
+                messages.append({"role": "assistant", "content": text})
+        elif etype == "tool_call":
+            messages.append(
+                {"role": "assistant", "content": _tool_call_to_content(event)}
+            )
+        elif etype == "oracle":
+            # Oracle rollouts have no agent dialogue; surface the command so
+            # the record still carries a non-empty completion.
+            cmd = str(event.get("command") or "oracle")
+            messages.append({"role": "assistant", "content": f"[oracle: {cmd}]"})
+    return messages
+
+
+def reward_map_to_verify_result(
+    rewards: dict[str, Any] | None,
+    *,
+    error: str | None = None,
+) -> VerifyResult:
+    """Adapt a canonical verifier reward ``dict`` to :class:`VerifyResult`.
+
+    ``Rollout.verify()`` produces a validated reward map with the shape
+    ``{"reward": float, "rubric": [...], ...other scalars...}``. The
+    Verifiers record helper expects a :class:`VerifyResult`, so we lift the
+    headline ``reward`` and any per-item scalars into ``VerifyResult.items``.
+
+    A ``None`` rewards map (verifier crashed/timed out) yields a 0.0 reward
+    with ``error`` populated so the exported record's ``reward_valid`` flag
+    is ``False``.
+    """
+    if rewards is None:
+        return VerifyResult(reward=0.0, items={}, error=error or "no rewards")
+
+    reward = rewards.get("reward")
+    headline = float(reward) if isinstance(reward, (int, float)) else 0.0
+
+    items: dict[str, float] = {}
+    for key, value in rewards.items():
+        if key in ("reward", "rubric"):
+            continue
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            items[str(key)] = float(value)
+
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            score = item.get("score")
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                continue
+            name = str(item.get("name") or f"rubric_{i}")
+            items[name] = float(score)
+
+    return VerifyResult(reward=headline, items=items, error=error)
+
+
+def write_rollout_verifiers_jsonl(
+    rollout_dir: str | Path,
+    *,
+    task_id: str,
+    prompts: list[str] | None,
+    trajectory: list[dict[str, Any]],
+    rewards: dict[str, Any] | None,
+    model: str | None,
+    environment: str,
+    example_id: int = 0,
+    is_completed: bool = True,
+    is_truncated: bool = False,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Write one trainer-ready Verifiers/ORS record into the rollout dir.
+
+    Output path is ``rollout_dir/trainer/verifiers.jsonl`` — the
+    architecture's trainer seam (issue #385). Returns the written record so
+    callers can aggregate across a job.
+    """
+    messages = acp_events_to_messages(trajectory, prompts)
+    verify_result = reward_map_to_verify_result(rewards, error=error)
+    record = trajectory_to_verifiers_record(
+        task_id=task_id,
+        messages=messages,
+        verify_result=verify_result,
+        model=model or "",
+        environment=environment,
+        example_id=example_id,
+        is_completed=is_completed,
+        is_truncated=is_truncated,
+    )
+    out = Path(rollout_dir) / ROLLOUT_ARTIFACT_RELPATH
+    export_trajectories_to_jsonl([record], out)
+    return record
+
+
+def write_job_verifiers_jsonl(job_dir: str | Path) -> Path | None:
+    """Aggregate per-rollout trainer JSONLs into ``job_dir/verifiers.jsonl``.
+
+    Scans ``job_dir/*/trainer/verifiers.jsonl`` (rollouts produced by the
+    train-mode seam) and concatenates their lines into one job-level
+    dataset. Returns the artifact path, or ``None`` when no rollouts have
+    emitted records yet.
+    """
+    job_path = Path(job_dir)
+    if not job_path.is_dir():
+        return None
+    rollout_files = sorted(job_path.glob(f"*/{ROLLOUT_ARTIFACT_RELPATH}"))
+    if not rollout_files:
+        return None
+    out = job_path / JOB_ARTIFACT_FILENAME
+    with out.open("w") as fout:
+        for src in rollout_files:
+            try:
+                text = src.read_text()
+            except OSError as e:
+                logger.warning("Skipping unreadable trainer artifact %s: %s", src, e)
+                continue
+            if not text.endswith("\n"):
+                text = text + "\n"
+            fout.write(text)
+    return out

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -1,0 +1,222 @@
+"""Train-mode trainer artifact emission (issue #385).
+
+Scored rollouts must emit trainer-ready Verifiers / ORS JSONL artifacts:
+
+- per-rollout:  ``rollout_dir/trainer/verifiers.jsonl``
+- per-job:      ``job_dir/verifiers.jsonl``
+
+These tests drive the artifact path without standing up a real sandbox —
+they invoke the exporters with simulated scored-rollout inputs and
+``_build_rollout_result`` to assert the artifacts land where the
+architecture says they should.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from benchflow.rollout import _build_rollout_result
+from benchflow.trajectories.export import (
+    ROLLOUT_ARTIFACT_RELPATH,
+    acp_events_to_messages,
+    reward_map_to_verify_result,
+    write_job_verifiers_jsonl,
+    write_rollout_verifiers_jsonl,
+)
+
+
+def _acp_trajectory() -> list[dict]:
+    """A representative ACP trajectory shape (see _capture._capture_session_trajectory)."""
+    return [
+        {"type": "user_message", "text": "Archive the email from Alice."},
+        {"type": "agent_thought", "text": "Reading inbox first."},
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "bash",
+            "title": "ls inbox",
+            "status": "completed",
+            "content": [{"text": "alice@example.com"}],
+        },
+        {"type": "agent_message", "text": "Archived 1 email."},
+    ]
+
+
+# ── unit-level helpers ────────────────────────────────────────────────
+
+
+def test_acp_events_to_messages_prepends_prompts_and_keeps_order():
+    msgs = acp_events_to_messages(_acp_trajectory(), prompts=["Solve the task."])
+    # Leading user message comes from the prompt list, then the ACP-captured
+    # user_message, then assistant turns (thought + tool_call + message).
+    assert msgs[0] == {"role": "user", "content": "Solve the task."}
+    assert msgs[1]["role"] == "user"
+    assert msgs[1]["content"] == "Archive the email from Alice."
+    roles = [m["role"] for m in msgs]
+    # user → user → assistant (thought) → assistant (tool_call) → assistant (message)
+    assert roles == ["user", "user", "assistant", "assistant", "assistant"]
+    # Tool-call rendering preserves the title so the trainer keeps something
+    # to anchor on.
+    assert "ls inbox" in msgs[3]["content"]
+
+
+def test_acp_events_to_messages_handles_empty_trajectory():
+    msgs = acp_events_to_messages([], prompts=["only prompt"])
+    assert msgs == [{"role": "user", "content": "only prompt"}]
+
+
+def test_reward_map_to_verify_result_lifts_scalars_and_rubric():
+    rewards = {
+        "reward": 0.75,
+        "exact_match": 1.0,
+        "rubric": [
+            {"name": "clarity", "score": 0.5},
+            {"name": "correctness", "score": 1.0},
+        ],
+    }
+    vr = reward_map_to_verify_result(rewards)
+    assert vr.reward == 0.75
+    assert vr.items["exact_match"] == 1.0
+    assert vr.items["clarity"] == 0.5
+    assert vr.items["correctness"] == 1.0
+    assert vr.error is None
+
+
+def test_reward_map_to_verify_result_handles_none():
+    vr = reward_map_to_verify_result(None, error="verifier crashed")
+    assert vr.reward == 0.0
+    assert vr.items == {}
+    assert vr.error == "verifier crashed"
+
+
+# ── rollout-level write ───────────────────────────────────────────────
+
+
+def test_write_rollout_verifiers_jsonl_emits_canonical_path(tmp_path):
+    rollout_dir = tmp_path / "rollout-1"
+    rollout_dir.mkdir()
+    record = write_rollout_verifiers_jsonl(
+        rollout_dir,
+        task_id="t1",
+        prompts=["Do the thing."],
+        trajectory=_acp_trajectory(),
+        rewards={"reward": 1.0, "exact_match": 1.0},
+        model="claude-haiku-4-5",
+        environment="bench",
+    )
+    artifact = rollout_dir / ROLLOUT_ARTIFACT_RELPATH
+    assert artifact.exists(), "trainer/verifiers.jsonl must exist after a scored rollout"
+    lines = artifact.read_text().splitlines()
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    # The record on disk is what the helper returned.
+    assert parsed["reward"] == 1.0
+    assert parsed == record
+    # Verifiers RolloutOutput required fields are present.
+    for field in (
+        "prompt",
+        "completion",
+        "reward",
+        "metrics",
+        "is_completed",
+        "is_truncated",
+        "example_id",
+        "info",
+    ):
+        assert field in parsed
+    assert parsed["info"]["task_id"] == "t1"
+    assert parsed["info"]["model"] == "claude-haiku-4-5"
+    # Reward survived the ORS round-trip with valid metadata.
+    assert parsed["info"]["reward_valid"] is True
+
+
+def test_write_rollout_verifiers_jsonl_marks_invalid_when_no_rewards(tmp_path):
+    rollout_dir = tmp_path / "rollout-failed"
+    rollout_dir.mkdir()
+    write_rollout_verifiers_jsonl(
+        rollout_dir,
+        task_id="t1",
+        prompts=["Do the thing."],
+        trajectory=_acp_trajectory(),
+        rewards=None,
+        model="claude-haiku-4-5",
+        environment="bench",
+        error="verifier timed out",
+    )
+    parsed = json.loads((rollout_dir / ROLLOUT_ARTIFACT_RELPATH).read_text().strip())
+    assert parsed["reward"] == 0.0
+    assert parsed["info"]["reward_valid"] is False
+
+
+# ── job-level aggregation ─────────────────────────────────────────────
+
+
+def test_write_job_verifiers_jsonl_aggregates_all_rollouts(tmp_path):
+    job_dir = tmp_path / "job-x"
+    for i in range(3):
+        rdir = job_dir / f"rollout-{i}"
+        rdir.mkdir(parents=True)
+        write_rollout_verifiers_jsonl(
+            rdir,
+            task_id=f"task-{i}",
+            prompts=["Do the thing."],
+            trajectory=_acp_trajectory(),
+            rewards={"reward": float(i) / 2.0},
+            model="m",
+            environment="bench",
+            example_id=i,
+        )
+    artifact = write_job_verifiers_jsonl(job_dir)
+    assert artifact == job_dir / "verifiers.jsonl"
+    lines = artifact.read_text().splitlines()
+    assert len(lines) == 3
+    example_ids = sorted(json.loads(line)["example_id"] for line in lines)
+    assert example_ids == [0, 1, 2]
+
+
+def test_write_job_verifiers_jsonl_returns_none_when_no_rollouts(tmp_path):
+    empty_job = tmp_path / "empty-job"
+    empty_job.mkdir()
+    assert write_job_verifiers_jsonl(empty_job) is None
+    assert not (empty_job / "verifiers.jsonl").exists()
+
+
+# ── end-to-end: _build_rollout_result wires the seam ─────────────────
+
+
+def test_build_rollout_result_emits_trainer_artifact(tmp_path):
+    """Every scored rollout that reaches result-building must emit the artifact.
+
+    Drives ``_build_rollout_result`` with simulated scored-rollout inputs —
+    the integration boundary issue #385 says was missing.
+    """
+    rollout_dir = tmp_path / "rollout-final"
+    rollout_dir.mkdir()
+    _build_rollout_result(
+        rollout_dir,
+        task_name="archive-alice",
+        rollout_name="r1",
+        agent="claude-agent-acp",
+        agent_name="claude-agent-acp",
+        model="claude-haiku-4-5",
+        n_tool_calls=1,
+        prompts=["Archive the email from Alice."],
+        error=None,
+        verifier_error=None,
+        trajectory=_acp_trajectory(),
+        partial_trajectory=False,
+        trajectory_source="acp",
+        rewards={"reward": 1.0, "exact_match": 1.0},
+        started_at=datetime.now(),
+        timing={},
+    )
+    artifact = rollout_dir / ROLLOUT_ARTIFACT_RELPATH
+    assert artifact.exists(), (
+        "scored rollouts must emit trainer/verifiers.jsonl from "
+        "_build_rollout_result (issue #385)"
+    )
+    parsed = json.loads(artifact.read_text().strip())
+    assert parsed["reward"] == 1.0
+    assert parsed["info"]["task_id"] == "archive-alice"
+    assert parsed["info"]["model"] == "claude-haiku-4-5"


### PR DESCRIPTION
Closes #385.

Trainer-ready artifacts now land at `rollout_dir/trainer/verifiers.jsonl` and `job_dir/verifiers.jsonl`. Added adapters `acp_events_to_messages`, `reward_map_to_verify_result` (bridge for plain-dict rewards pre-VerifyResult migration). Wired from `_build_rollout_result` (covers run/bf.run/sdk.SDK.run) + `Evaluation` job summary. 9 new tests.

**⚠️ Merge coordination with PR-#409** (NaN scrubber): both PRs touch `export_trajectories_to_jsonl` — keep #409's `_scrub_non_finite` + `allow_nan=False`; route job-level aggregator through `export_trajectories_to_jsonl` to inherit scrubber.

**Review findings:**
- BLOCKING: `_write_trainer_artifact` is 32-line wrapper in rollout.py (2268 lines, over cap) — inline or move to writer.
- Misleading docstring (`agent_thought folds` — code actually emits separate).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core result-building (`_build_rollout_result`) and job completion paths with new on-disk artifacts; failures are isolated via try/except but job aggregation currently concatenates raw JSONL rather than re-exporting through shared scrubbing (noted coordination with PR #409).
> 
> **Overview**
> Implements the **train-mode trainer seam** (issue #385): scored rollouts now emit **Verifiers / ORS** JSONL that prime-rl / Verifiers can ingest without a separate export step.
> 
> **Per rollout**, `_build_rollout_result` writes `trainer/verifiers.jsonl` by converting ACP trajectory events and verifier reward maps into a single `RolloutOutput`-shaped record (`acp_events_to_messages`, `reward_map_to_verify_result`, then existing `trajectory_to_verifiers_record` / `ORSAdapter`). Missing or failed verifier rewards still produce a record with `reward_valid: false`; write failures are logged and do not block `result.json`.
> 
> **Per job**, after `summary.json`, `Evaluation.run` concatenates each rollout’s `*/trainer/verifiers.jsonl` into `job_dir/verifiers.jsonl`.
> 
> New tests cover adapters, per-rollout and job aggregation, and the `_build_rollout_result` integration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 979d980151011f6d8e7732ef6abaf7b8d5e4eeb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->