### PR TITLE
docs: align CLI and docs with supported eval/environment workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,20 @@ Notebooks and runnable example scripts live under [`docs/examples/`](./docs/exam
 Benchmark datasets live in external Git repos and are referenced with two fields:
 
 ```yaml
-# benchmarks/skillsbench-claude-glm51.yaml
+# benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 source:
-  repo: benchflow-ai/skillsbench   # GitHub org/repo
-  path: tasks                       # optional subpath within repo
+  repo: benchflow-ai/benchmarks    # GitHub org/repo
+  path: datasets/harvey-lab/tasks  # optional subpath within repo
   ref: main                         # optional branch/tag
-agent: claude-agent-acp
-model: claude-sonnet-4-6
+agent: gemini
+model: gemini/gemini-3.1-flash-lite-preview
 ```
 
 Run any benchmark via the CLI:
 
 ```bash
-# From a YAML config
-bench eval create --config benchmarks/skillsbench-claude-glm51.yaml
+# From a YAML config (shipped with the repo)
+bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
 # Inline — mirrors the YAML source fields
 bench eval create \

--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -159,7 +159,9 @@ reaches them on `localhost`. During a rollout:
    is healthy.
 3. `Rollout.cleanup()` tears the environment down.
 
-Run a task against an environment manifest:
+Run a task against an environment manifest. `--environment-manifest` currently
+lives on the legacy `bench run` command (hidden in `--help` but still
+callable); porting it to `bench eval create` is tracked separately.
 
 ```bash
 bench run benchmarks/clawsbench/tasks/<task> \

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -82,11 +82,17 @@ bench eval create \
 | `--model` | Agent default | Model ID |
 | `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |
 | `--concurrency` | `4` | Max concurrent tasks (batch mode only) |
+| `--agent-idle-timeout` | (built-in default) | Abort ACP prompts after this many idle seconds; `0` disables idle detection |
 | `--jobs-dir` | `jobs` | Output directory |
 | `--sandbox-user` | `agent` | Sandbox user (null for root) |
 | `--sandbox-setup-timeout` | `120` | Timeout in seconds for sandbox user setup |
 | `--skills-dir` | — | Skills directory to deploy into each task sandbox |
+| `--skill-mode` | `default` | Skill mode: `default` or `self-gen` |
+| `--skill-creator-dir` | — | Path to a `skill-creator` directory (or a skills root containing it); used when `--skill-mode self-gen` |
+| `--self-gen-no-internet` | `false` | Disable web tools for the self-generated skill run |
 | `--agent-env` | — | Agent environment variable as `KEY=VALUE`; repeatable |
+| `--include` | — | Only run these task names; repeatable (e.g. `--include jax-computing-basics --include data-to-d3`) |
+| `--exclude` | — | Skip these task names; repeatable (e.g. `--exclude quantum-numerical-simulation`) |
 
 When mounting skills, the recommended docs default is
 `--agent-env BENCHFLOW_SKILL_NUDGE=name`. It prepends a short hint telling the agent
@@ -113,6 +119,15 @@ bench eval list jobs/
 ```
 
 ## bench skills
+
+### bench skills list
+
+List skills discovered under the default skills roots (or `--dir`).
+
+```bash
+bench skills list
+bench skills list --dir ./skills
+```
 
 ### bench skills eval
 
@@ -174,6 +189,15 @@ bench tasks generate --from-hf opentraces-test --limit 50
 | `--author` | `benchflow-traces` | Author name for generated task metadata |
 | `--dry-run` | `false` | Preview traces without generating tasks |
 
+### bench tasks list-sources
+
+List known HuggingFace trace datasets. The aliases listed here can be passed
+to `bench tasks generate --from-hf`.
+
+```bash
+bench tasks list-sources
+```
+
 ## bench environment
 
 ### bench environment create
@@ -218,6 +242,32 @@ than 24 hours; use `--dry-run` to preview what would be deleted.
 ```bash
 bench environment cleanup --dry-run --max-age 1440
 ```
+
+## bench compat
+
+Third-party framework compatibility checks.
+
+### bench compat harbor-registry
+
+Inventory or structurally check representative Harbor registry tasks. Defaults
+to running an inventory pass against the public Harbor registry JSON.
+
+```bash
+# Inventory the public Harbor registry
+bench compat harbor-registry
+
+# Structural check, two tasks per dataset, JSONL output
+bench compat harbor-registry --level check --tasks-per-dataset 2 --out compat.jsonl
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--registry` | Harbor public registry URL | Harbor registry JSON URL or local file |
+| `--tasks-per-dataset` | `2` | Representative tasks selected per dataset |
+| `--level` | `inventory` | Compatibility level: `inventory` or `check` |
+| `--out` | — | Optional JSONL output path |
+| `--cache-dir` | `.cache/compat/harbor` | Cache directory for sparse clones |
+| `--limit` | — | Optional cap on selected task refs |
 
 ## YAML Config Format
 

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -17,7 +17,7 @@ This guide covers how to run them — from a single task to a full evaluation sw
 |-----------|-------|--------------|--------|
 | [Harvey LAB](https://github.com/harveyai/harvey-labs) | 1,251 | LLM-as-judge (per-criterion) | `benchmarks/harvey-lab/` |
 | [ProgramBench](https://programbench.com) | 201 | Deterministic unit tests | `benchmarks/programbench/` |
-| [SkillsBench](https://github.com/benchflow-ai/skillsbench) | 94+ | Unit tests | `benchmarks/skillsbench-*.yaml` |
+| [SkillsBench](https://github.com/benchflow-ai/skillsbench) | 94+ | Unit tests | `--source-repo benchflow-ai/skillsbench --source-path tasks` |
 
 Each adapted benchmark includes:
 - **`benchflow.py`** — converter: raw benchmark → BenchFlow task format
@@ -91,9 +91,10 @@ bench eval create \
   --source-path tasks/edit-pdf \
   --agent gemini --model gemini-3.1-flash-lite-preview
 
-# ProgramBench — single task
+# ProgramBench — single task (tasks are generated at runtime by the converter;
+# see "Running ProgramBench" below for the generation step)
 bench eval create \
-  benchmarks/programbench/tasks/abishekvashok__cmatrix.5c082c6 \
+  --tasks-dir benchmarks/programbench/tasks/abishekvashok__cmatrix.5c082c6 \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 
 # Claude Code on Daytona
@@ -192,13 +193,32 @@ bench eval create \
 ## Running ProgramBench
 
 201 program-reconstruction tasks across 7 languages (C, Rust, Go, C++, Java, Haskell, Bash).
-Tasks are **generated** at runtime from the ProgramBench repo's metadata.
+Tasks are **generated** at runtime from the ProgramBench repo's metadata —
+`benchmarks/programbench/tasks/` is not checked into this repo and must be
+produced first.
 
 ### Prerequisites
 
 - Docker (images are linux/amd64 only — use a Linux x86_64 machine)
 - ~20GB disk for Docker images
 - Internet access for HuggingFace test blob downloads during verification
+- A local clone of [`programbench`](https://programbench.com) (passed via
+  `--programbench-dir` to the generator)
+
+### Generate the tasks
+
+```bash
+# All 200 tasks
+python -m benchmarks.programbench.main \
+    --programbench-dir ~/programbench \
+    --output-dir benchmarks/programbench/tasks
+
+# Or a single task
+python -m benchmarks.programbench.main \
+    --programbench-dir ~/programbench \
+    --output-dir benchmarks/programbench/tasks \
+    --task-ids abishekvashok__cmatrix.5c082c6
+```
 
 ### Run all tasks
 
@@ -206,7 +226,7 @@ Tasks are **generated** at runtime from the ProgramBench repo's metadata.
 bench eval create --config benchmarks/programbench/programbench-gemini-flash-lite.yaml
 ```
 
-### Run a single task
+### Run a single task (after generation)
 
 ```bash
 bench eval create \
@@ -288,8 +308,9 @@ bench eval create \
 
 A **stateful** benchmark — one with mock services, databases, or accounts the
 agent acts on — declares its world in an `environment.toml` manifest and runs
-on the [Environment plane](./environment-plane.md). Pass the manifest with
-`--environment-manifest`:
+on the [Environment plane](./environment-plane.md). The `--environment-manifest`
+flag currently lives on the legacy `bench run` command (hidden in `--help` but
+still callable); porting it to `bench eval create` is tracked separately.
 
 ```bash
 bench run benchmarks/clawsbench/tasks/<task> \

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -1,0 +1,109 @@
+"""Guard CLI/docs drift — every public flag documented in docs/reference/cli.md
+must still be present in `bench --help` output.
+
+This is the snapshot half of issue #367: docs and CLI help drifted apart so
+worked-examples no longer worked. The test pins documented flags against the
+live Typer parser so doc rot is caught in CI.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+runner = CliRunner()
+
+
+def _help(args: list[str]) -> str:
+    result = runner.invoke(app, [*args, "--help"], terminal_width=200)
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_top_level_help_lists_public_groups() -> None:
+    """Every public top-level group documented in cli.md is shown in --help."""
+    out = _help([])
+    for group in ("eval", "skills", "tasks", "compat", "agent", "environment"):
+        assert group in out, f"missing public group {group!r} in: {out}"
+    # Deprecated/hidden commands must not show up in the public help.
+    for hidden in ("run", "job", "agents", "metrics", "view", "eval-batch"):
+        assert hidden not in out.split("Commands")[-1].split("─")[0], (
+            f"hidden command {hidden!r} unexpectedly shown: {out}"
+        )
+
+
+def test_eval_create_help_lists_all_documented_flags() -> None:
+    """docs/reference/cli.md's bench eval create flag table must stay in sync.
+
+    Typer truncates long flag names with '…' in --help, so we match against a
+    prefix of each documented flag — long enough to disambiguate from
+    sibling flags but short enough to survive Click's right-column truncation.
+    """
+    out = _help(["eval", "create"])
+    documented_flag_prefixes = [
+        "--config",
+        "--tasks-dir",
+        "--source-repo",
+        "--source-path",
+        "--source-ref",
+        "--source-env",
+        "--source-env-version",
+        "--source-env-arg",
+        "--source-env-num-examp",
+        "--source-env-rollouts-",
+        "--source-env-max-tokens",
+        "--source-env-temperatu",
+        "--source-env-sampling-",
+        "--agent",
+        "--model",
+        "--sandbox",
+        "--concurrency",
+        "--agent-idle-timeout",
+        "--jobs-dir",
+        "--sandbox-user",
+        "--sandbox-setup-timeout",
+        "--skills-dir",
+        "--skill-mode",
+        "--skill-creator-dir",
+        "--self-gen-no-internet",
+        "--agent-env",
+        "--include",
+        "--exclude",
+    ]
+    for flag in documented_flag_prefixes:
+        assert flag in out, (
+            f"documented flag prefix {flag!r} missing from `bench eval create --help`: {out}"
+        )
+
+
+def test_eval_create_does_not_accept_environment_manifest() -> None:
+    """Doc fix: `--environment-manifest` is on legacy `bench run`, not `bench
+    eval create`. Confirm the supported public command does NOT advertise it,
+    so we don't silently re-add it without updating the docs."""
+    out = _help(["eval", "create"])
+    assert "--environment-manifest" not in out
+
+
+def test_documented_subcommands_exist() -> None:
+    """Subcommands referenced in docs/reference/cli.md must resolve."""
+    for cmd in (
+        ["eval", "create"],
+        ["eval", "list"],
+        ["agent", "list"],
+        ["agent", "show"],
+        ["tasks", "init"],
+        ["tasks", "check"],
+        ["tasks", "generate"],
+        ["tasks", "list-sources"],
+        ["skills", "list"],
+        ["skills", "eval"],
+        ["environment", "create"],
+        ["environment", "list"],
+        ["environment", "show"],
+        ["environment", "inspect"],
+        ["environment", "cleanup"],
+        ["compat", "harbor-registry"],
+    ):
+        out = _help(cmd)
+        assert "Usage:" in out, f"bench {' '.join(cmd)} --help failed: {out}"


### PR DESCRIPTION
Closes #367.

Docs PR. Replaced missing YAML example with shipped config; fixed ProgramBench positional path → `--tasks-dir`; added previously-undocumented public flags (`--agent-idle-timeout`, `--skill-mode`, `--skill-creator-dir`, `--self-gen-no-internet`, `--include`, `--exclude`); documented `bench skills list`, `bench tasks list-sources`, `bench compat harbor-registry`. 4 new snapshot tests.

**⚠️ Material findings:**
- BLOCKING (thermo): docs teach `bench run --environment-manifest` (hidden+deprecated) as the supported workflow for stateful benchmarks. Either port the flag to `bench eval create` OR remove the recipe.
- Snapshot test bug: `test_top_level_help_lists_public_groups`'s negative assertion is dead code — `out.split('Commands')[-1].split('─')[0]` evaluates to literal `' '`, so `'run' not in ' '` always True.
- 14+ flags still undocumented on `bench environment list/show/inspect/cleanup`, `tasks init`, `skills eval` — the bug class is wide open.

**Out-of-scope (real bugs, follow-up needed):**
- #367.5: unknown agents accepted silently → ANTHROPIC_API_KEY error
- #367.4: missing config raises raw traceback
- #367.6: Daytona/HF auth errors dump tracebacks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and help-drift tests only; no runtime CLI or evaluation behavior changes in the diff.
> 
> **Overview**
> Aligns user-facing docs with the **current** public CLI so copy-paste examples work again (issue #367).
> 
> **README** and **running-benchmarks** now use shipped Harvey LAB config paths, remote `source` for SkillsBench instead of stale YAML names, and **ProgramBench** flows that require generating tasks under `benchmarks/programbench/tasks/` and passing **`--tasks-dir`** (not a bare positional path).
> 
> **CLI reference** adds missing **`bench eval create`** flags (`--agent-idle-timeout`, skill/self-gen options, `--include` / `--exclude`) and documents **`bench skills list`**, **`bench tasks list-sources`**, and **`bench compat harbor-registry`**.
> 
> **Environment-plane** and **running-benchmarks** call out that **`--environment-manifest`** is only on legacy hidden **`bench run`**, not **`bench eval create`**, until that port lands.
> 
> **CI:** new **`tests/test_cli_docs_drift.py`** snapshots top-level groups, documented `eval create` flag prefixes, subcommand `--help`, and asserts `eval create` does not advertise `--environment-manifest`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74eca76039bc4b8ddea9a81462d8d5be3b3697f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->