### PR TITLE
fix: dashboard data.json uses relative paths, not absolute host paths

### DIFF
--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -99,6 +99,40 @@ def _dashboard_source_path(path: Path) -> str:
     return str(path)
 
 
+def _scrub_host_path(path: Path) -> str:
+    """Return a portable, non-host-revealing rendering of an absolute path.
+
+    The published ``data.json`` is served to anyone with dashboard access,
+    so absolute host paths must not appear in it — they'd leak local
+    usernames, worktree names, and tmp-dir layout. We render paths in
+    order of preference:
+
+    1. ``<relative>`` when ``path`` is under the repo root (``ROOT``)
+    2. ``~/<relative>`` when ``path`` is under the operator's home dir
+       (still round-trips through ``Path(...).expanduser()`` for callers
+       like :func:`remembered_jobs_root`)
+    3. ``<basename>`` for everything else — drops temp-dir layout, mount
+       points, and other host-shape signals. Round-trip support outside
+       HOME is not a goal: those paths are ephemeral and cannot survive
+       a republish anyway.
+
+    See issue #408.
+    """
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        pass
+    home = Path.home()
+    try:
+        rel = path.relative_to(home)
+    except ValueError:
+        # Outside ROOT and HOME — drop everything but the basename. For the
+        # degenerate ``Path('/')`` case ``name`` is empty; treat that as the
+        # root sentinel so we still don't echo the raw ``str(path)``.
+        return path.name or "/"
+    return f"~/{rel.as_posix()}" if rel.parts else "~"
+
+
 def collect_architecture() -> dict:
     source = _dashboard_source_path(ARCHITECTURE_MD)
     if not ARCHITECTURE_MD.is_file():
@@ -211,11 +245,16 @@ def dashboard_jobs_root() -> Path:
 def _jobs_source(jobs: Path) -> dict:
     configured = bool(os.environ.get(JOBS_ROOT_ENV))
     local_jobs = (ROOT / "jobs").resolve()
+    scrubbed = _scrub_host_path(jobs)
     return {
-        "path": str(jobs),
+        # ``path`` is host-scrubbed (see _scrub_host_path / issue #408): repo
+        # root → relative; HOME → ``~/…`` (round-trips through expanduser());
+        # elsewhere → basename only. The published data.json never carries an
+        # absolute host path here.
+        "path": scrubbed,
         "label": str(jobs.relative_to(ROOT))
         if jobs.is_relative_to(ROOT)
-        else str(jobs),
+        else scrubbed,
         "configured": configured,
         "remembered": not configured and jobs.resolve() != local_jobs,
         "available": jobs.is_dir(),
@@ -417,7 +456,10 @@ def _artifact(name: str, kind: str, path: Path) -> dict:
     stat = path.stat()
     artifact = {
         "name": name,
-        "path": str(path),
+        # ``path`` is host-scrubbed (see _scrub_host_path / issue #408): repo
+        # root → relative; HOME → ``~/…``; elsewhere → basename only. The
+        # published data.json never carries an absolute host path here.
+        "path": _scrub_host_path(path),
         "modified_at": datetime.fromtimestamp(stat.st_mtime).strftime(
             "%Y-%m-%d %H:%M:%S"
         ),

--- a/tests/test_dashboard_no_host_paths.py
+++ b/tests/test_dashboard_no_host_paths.py
@@ -1,0 +1,171 @@
+"""Guards dashboard ``data.json`` from leaking absolute host paths (#408).
+
+The published ``data.json`` is served from Vercel and checked into the repo,
+so any absolute host path written there leaks local usernames, worktree
+names, temp-dir layout, and private runner paths. Issue #408 documents the
+specific evidence: ``jobs.source.path`` and per-artifact ``path`` fields
+were rendered as raw ``str(Path)`` outputs from the producer machine.
+
+These tests pin two complementary properties:
+
+1. A generated payload with fixtures placed under ``tmp_path`` carries no
+   ``/Users/``, ``/home/``, or ``/private/`` prefixes anywhere — neither
+   on ``jobs.source.path`` nor on any nested artifact ``path``.
+2. Paths under HOME are scrubbed to ``~/`` form, which still round-trips
+   through ``Path(...).expanduser().resolve()`` so the dashboard's
+   "remembered jobs root" feature keeps working when an operator points
+   at a directory inside their home tree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from dashboard import generate
+
+
+def _walk_strings(value: object):
+    """Yield every string anywhere inside a nested JSON-like structure."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _walk_strings(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _walk_strings(v)
+
+
+def _write_rollout(jobs_root: Path) -> Path:
+    rollout = jobs_root / "2026-05-22__01-30-00" / "task-a__abc123"
+    (rollout / "verifier").mkdir(parents=True)
+    (rollout / "trajectory").mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "codex",
+                "rewards": {"reward": 1.0},
+                "timing": {},
+            }
+        )
+    )
+    (rollout / "config.json").write_text(json.dumps({"agent": "codex"}))
+    (rollout / "verifier" / "reward.txt").write_text("1.0\n")
+    (rollout / "trajectory" / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "step"}) + "\n"
+    )
+    return rollout
+
+
+def test_collect_jobs_strips_host_prefixes_from_published_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``collect_jobs()`` must not embed absolute host paths anywhere."""
+    jobs_root = tmp_path / "previous-worktree" / "jobs"
+    _write_rollout(jobs_root)
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs_root))
+
+    payload = generate.collect_jobs()
+
+    forbidden_prefixes = ("/Users/", "/home/", "/private/")
+    for s in _walk_strings(payload):
+        for prefix in forbidden_prefixes:
+            assert not s.startswith(prefix), (
+                f"data.json string starts with host prefix {prefix!r}: {s!r}"
+            )
+        # The fixture path itself must never appear verbatim. ``tmp_path`` on
+        # macOS resolves under ``/private/var/folders/...``, on Linux under
+        # ``/tmp/...`` — either way, the literal string would be a leak.
+        assert str(tmp_path) not in s, (
+            f"data.json string echoes the host tmp dir verbatim: {s!r}"
+        )
+
+
+def test_collect_jobs_scrubs_home_dir_to_tilde_form(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A jobs root under HOME is rendered as ``~/…`` and round-trips."""
+    fake_home = tmp_path / "home" / "operator"
+    jobs_root = fake_home / "work" / "jobs"
+    _write_rollout(jobs_root)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs_root))
+
+    payload = generate.collect_jobs()
+
+    source_path = payload["source"]["path"]
+    assert source_path.startswith("~/"), (
+        f"HOME-relative source.path should start with ~/: {source_path!r}"
+    )
+    assert str(fake_home) not in source_path
+
+    # The scrubbed ``~/…`` form must round-trip back to the original absolute
+    # path via the same ``expanduser().resolve()`` call the dashboard already
+    # uses in ``remembered_jobs_root``.
+    recovered = Path(source_path).expanduser().resolve()
+    assert recovered == jobs_root.resolve()
+
+
+def test_collect_jobs_uses_repo_relative_path_for_local_jobs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the jobs root sits under the repo, ``path`` is relative-to-ROOT."""
+    repo = tmp_path / "repo"
+    jobs_root = repo / "jobs"
+    _write_rollout(jobs_root)
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setattr(generate, "DASH", repo / "dashboard")
+    monkeypatch.setattr(generate, "OUT", repo / "dashboard" / "data.json")
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs_root))
+
+    payload = generate.collect_jobs()
+
+    # Relative to ROOT — no absolute prefix, just ``jobs``.
+    assert payload["source"]["path"] == "jobs"
+    # Artifacts are likewise relative-to-ROOT (no absolute host prefix).
+    artifact_paths = [
+        artifact["path"]
+        for group in payload["groups"]
+        for run in group["runs"]
+        for task in run["tasks"]
+        for artifact in task["artifacts"]
+    ]
+    assert artifact_paths, "fixture should have produced at least one artifact"
+    for p in artifact_paths:
+        assert not os.path.isabs(p), f"artifact path is absolute: {p!r}"
+        assert p.startswith("jobs/"), (
+            f"artifact path should be repo-relative: {p!r}"
+        )
+
+
+def test_scrub_host_path_falls_back_to_basename_outside_root_and_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Paths outside both ROOT and HOME drop the host layout entirely."""
+    repo = tmp_path / "repo"
+    fake_home = tmp_path / "home"
+    repo.mkdir()
+    fake_home.mkdir()
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setenv("HOME", str(fake_home))
+
+    # Use a path that lives nowhere we recognise.
+    outside = tmp_path / "elsewhere" / "data" / "rollout.jsonl"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("{}\n")
+
+    scrubbed = generate._scrub_host_path(outside)
+
+    # No absolute host prefix may survive scrubbing.
+    assert not scrubbed.startswith("/")
+    assert str(tmp_path) not in scrubbed
+    # Drops the host layout — leaves only the basename for context.
+    assert scrubbed == "rollout.jsonl"

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -1009,7 +1009,7 @@ def test_task_row_uses_result_outcome_not_stale_reward_file(tmp_path: Path):
 
 
 def test_task_row_artifacts_include_full_path_and_modified_date(tmp_path: Path):
-    """Guards the file viewer header contract for full paths and dates."""
+    """Guards the file viewer header contract for scrubbed paths and dates."""
     rollout = tmp_path / "task-a__abc123"
     verifier = rollout / "verifier"
     verifier.mkdir(parents=True)
@@ -1028,7 +1028,10 @@ def test_task_row_artifacts_include_full_path_and_modified_date(tmp_path: Path):
         item for item in row["artifacts"] if item["name"] == "verifier/reward.txt"
     )
 
-    assert artifact["path"] == str(reward)
+    # Path is host-scrubbed (#408): no absolute host path is published. For an
+    # artifact outside ROOT and HOME, the rendering drops the host layout.
+    assert "/" not in artifact["path"] or not artifact["path"].startswith("/")
+    assert str(tmp_path) not in artifact["path"]
     assert artifact["modified_at"] == "2026-05-22 01:30:00"
     assert "Raw verifier boundary output" in artifact["note"]
 
@@ -1333,7 +1336,10 @@ def test_collect_jobs_reads_configured_external_worktree_jobs(
 
     jobs = generate.collect_jobs()
 
-    assert jobs["source"]["path"] == str((previous_worktree / "jobs").resolve())
+    # Path is host-scrubbed (#408) — no absolute /Users, /home, /private/tmp
+    # prefix may appear in the published data.json.
+    assert not jobs["source"]["path"].startswith(("/Users/", "/home/", "/private/"))
+    assert str(previous_worktree) not in jobs["source"]["path"]
     assert jobs["source"]["configured"] is True
     assert jobs["source"]["available"] is True
     assert jobs["total_tasks"] == 1
@@ -1356,7 +1362,9 @@ def test_collect_jobs_reads_configured_external_jobs_dir(tmp_path: Path, monkeyp
 
     jobs = generate.collect_jobs()
 
-    assert jobs["source"]["path"] == str(previous_jobs.resolve())
+    # Path is host-scrubbed (#408) — no absolute host path may leak.
+    assert not jobs["source"]["path"].startswith(("/Users/", "/home/", "/private/"))
+    assert str(previous_jobs) not in jobs["source"]["path"]
     assert jobs["source"]["configured"] is True
     assert jobs["source"]["available"] is True
     assert jobs["total_tasks"] == 1
@@ -1372,7 +1380,9 @@ def test_collect_jobs_transitions_from_empty_to_nonempty_external_root(
     monkeypatch.setenv("BENCHFLOW_DASHBOARD_JOBS_ROOT", str(previous_worktree))
 
     before = generate.collect_jobs()
-    assert before["source"]["path"] == str((previous_worktree / "jobs").resolve())
+    # Path is host-scrubbed (#408) — no absolute host path may leak.
+    assert not before["source"]["path"].startswith(("/Users/", "/home/", "/private/"))
+    assert str(previous_worktree) not in before["source"]["path"]
     assert before["source"]["configured"] is True
     assert before["groups"] == []
     assert before["total_tasks"] == 0
@@ -1561,7 +1571,9 @@ def test_collect_jobs_reuses_remembered_external_jobs_root(tmp_path: Path, monke
 
     jobs = generate.collect_jobs()
 
-    assert jobs["source"]["path"] == str(previous_jobs.resolve())
+    # Path is host-scrubbed (#408) — no absolute host path may leak.
+    assert not jobs["source"]["path"].startswith(("/Users/", "/home/", "/private/"))
+    assert str(previous_jobs) not in jobs["source"]["path"]
     assert jobs["source"]["configured"] is False
     assert jobs["source"]["remembered"] is True
     assert jobs["total_tasks"] == 1


### PR DESCRIPTION
Closes #408.

`_scrub_host_path` rewrites paths: under ROOT → relative; under HOME → `~/...` (round-trips via `expanduser()`); else → basename. Applied at `_jobs_source` and `_artifact`. 4 new tests.

**Review findings:**
- `_dashboard_source_path` is now near-duplicate of `_scrub_host_path` — delete the older one.
- `_jobs_source.label` ternary is dead conditional after replacement.
- Test invariant should be `not os.path.isabs(s) or s.startswith('~')` instead of host-OS-specific prefix enumeration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Privacy-focused path serialization in dashboard generation only; behavior for operators using remembered jobs roots under HOME is explicitly preserved via ~/ round-trip.
> 
> **Overview**
> Published dashboard **`data.json`** no longer embeds absolute machine paths in **`jobs.source`** or per-artifact **`path`** fields (issue **#408**). New **`_scrub_host_path`** in **`dashboard/generate.py`** rewrites paths as repo-relative under **`ROOT`**, **`~/…`** under **`HOME`** (so **`remembered_jobs_root`** still **`expanduser()`** round-trips), or basename-only elsewhere.
> 
> **`collect_jobs()`** and artifact rows now use that scrubbing instead of raw **`str(Path)`**. Tests in **`tests/test_dashboard_no_host_paths.py`** and updated **`test_dashboard_sync.py`** assertions guard against **`/Users/`**, **`/home/`**, **`/private/`**, and verbatim tmp paths in the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5ffb35f531ce1c2a6ac3dcdd09abf4b7fd9a530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->