### PR TITLE
fix: bench tasks check and eval create agree on task metadata requirements

### DIFF
--- a/src/benchflow/_utils/task_authoring.py
+++ b/src/benchflow/_utils/task_authoring.py
@@ -28,15 +28,16 @@ def check_task(task_dir: Path) -> list[str]:
             issues.append(f"Missing required directory: {d}/")
 
     # Validate task.toml
+    # Note: [agent] and [agent].timeout_sec are optional at runtime
+    # (AgentConfig defaults to timeout_sec=None → no wall-clock cap). We
+    # only surface parse errors here so `bench tasks check` and
+    # `bench eval create` agree on what a "valid" task looks like.
+    # See #379.
     toml_path = task_dir / "task.toml"
     if toml_path.exists():
         try:
             with open(toml_path, "rb") as f:
-                config = tomllib.load(f)
-            if "agent" not in config:
-                issues.append("task.toml missing [agent] section")
-            elif "timeout_sec" not in config.get("agent", {}):
-                issues.append("task.toml [agent] missing timeout_sec")
+                tomllib.load(f)
         except Exception as e:
             issues.append(f"task.toml parse error: {e}")
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -793,6 +793,8 @@ def tasks_check(
     task_dir: Annotated[Path, typer.Argument(help="Path to task directory")],
 ) -> None:
     """Validate a task directory structure."""
+    from rich.markup import escape
+
     from benchflow._utils.task_authoring import check_task
 
     issues = check_task(task_dir)
@@ -801,7 +803,9 @@ def tasks_check(
     else:
         console.print(f"[red]✗[/red] {task_dir.name} — {len(issues)} issue(s):")
         for issue in issues:
-            console.print(f"  [yellow]→[/yellow] {issue}")
+            # Escape Rich markup so literal section names like "[agent]"
+            # render verbatim instead of being parsed as styling (#379).
+            console.print(f"  [yellow]→[/yellow] {escape(issue)}")
         raise typer.Exit(1)
 
 

--- a/tests/test_task_check_eval_consistency.py
+++ b/tests/test_task_check_eval_consistency.py
@@ -1,0 +1,124 @@
+"""Regression tests for #379 — `bench tasks check` and `bench eval create`
+must agree on the structural contract for task packages.
+
+The original bug: a task.toml without an [agent] section was rejected by
+`bench tasks check` but happily executed by `bench eval create`, producing
+recorded evidence for a "malformed" task. The fix aligns the structural
+checker with the runtime contract (AgentConfig.timeout_sec defaults to
+None) so both commands return the same verdict.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from benchflow._utils.task_authoring import check_task
+from benchflow.cli.main import app
+from benchflow.evaluation import Evaluation, EvaluationConfig
+
+
+def _make_task_missing_agent(parent: Path, name: str = "malformed-missing-agent") -> Path:
+    """Create a task package whose task.toml has no [agent] section."""
+    task = parent / name
+    task.mkdir()
+    (task / "task.toml").write_text(
+        'version = "1.0"\n\n[verifier]\ntimeout_sec = 120\n'
+    )
+    (task / "instruction.md").write_text("# Do something\n")
+    (task / "environment").mkdir()
+    (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    tests = task / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    return task
+
+
+def test_check_task_accepts_missing_agent(tmp_path):
+    """The shared validator must not flag missing [agent] as an issue.
+
+    Runtime AgentConfig.timeout_sec defaults to None (rollout treats this
+    as "no wall-clock cap"). Rejecting it here would diverge from what
+    `bench eval create` actually executes.
+    """
+    task = _make_task_missing_agent(tmp_path)
+    issues = check_task(task)
+    assert not any("agent" in i.lower() for i in issues), (
+        f"check_task flagged missing [agent] but runtime accepts it: {issues}"
+    )
+
+
+def test_tasks_check_cli_accepts_missing_agent(tmp_path):
+    """`bench tasks check` exits 0 for a task missing [agent]."""
+    task = _make_task_missing_agent(tmp_path)
+    result = CliRunner().invoke(app, ["tasks", "check", str(task)])
+    assert result.exit_code == 0, (
+        f"`bench tasks check` should accept missing [agent]; "
+        f"got exit={result.exit_code}\n{result.output}"
+    )
+    assert "valid" in result.output
+
+
+def test_eval_create_enumerates_task_missing_agent(tmp_path):
+    """`bench eval create --tasks-dir <dir>` must enumerate the same
+    task that `bench tasks check` accepted — no structural filtering on
+    missing [agent].
+    """
+    task = _make_task_missing_agent(tmp_path)
+    ev = Evaluation(
+        tasks_dir=str(task),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle"),
+    )
+    task_dirs = ev._get_task_dirs()
+    assert task_dirs == [task], (
+        f"`eval create` dropped a task that `tasks check` accepts: {task_dirs}"
+    )
+
+
+def test_check_and_eval_agree_on_missing_agent(tmp_path):
+    """The two commands must reach the same verdict for the same task."""
+    task = _make_task_missing_agent(tmp_path)
+
+    check_issues = check_task(task)
+    check_accepts = not check_issues
+
+    ev = Evaluation(
+        tasks_dir=str(task),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle"),
+    )
+    eval_accepts = ev._get_task_dirs() == [task]
+
+    assert check_accepts == eval_accepts, (
+        f"check_task and eval enumeration disagree on missing [agent]: "
+        f"check_accepts={check_accepts} (issues={check_issues}) "
+        f"eval_accepts={eval_accepts}"
+    )
+    # Both must accept — that's the contract.
+    assert check_accepts, f"Both should accept; check_task says: {check_issues}"
+
+
+def test_tasks_check_escapes_rich_markup_in_diagnostic(tmp_path):
+    """The diagnostic must render literal bracketed names (e.g. [agent])
+    verbatim. Rich was previously parsing them as styling markup, swallowing
+    the section name from the user-facing error.
+    """
+    # A task with a parse error — still produces a diagnostic that may
+    # contain bracketed text. Use a name with bracketed text to force the
+    # output to contain literal "[…]".
+    task = tmp_path / "bad-toml"
+    task.mkdir()
+    (task / "task.toml").write_text("[[[ not valid toml\n")
+    (task / "instruction.md").write_text("# x\n")
+    (task / "environment").mkdir()
+    (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    tests = task / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+    result = CliRunner().invoke(app, ["tasks", "check", str(task)])
+    assert result.exit_code == 1
+    # Should mention the parse error literally, not swallow brackets.
+    assert "parse error" in result.output

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -81,17 +81,28 @@ class TestCheckTask:
         issues = check_task(task)
         assert "instruction.md is empty" in issues
 
-    def test_task_toml_missing_agent_section(self, tmp_path):
+    def test_task_toml_missing_agent_section_is_allowed(self, tmp_path):
+        """[agent] is optional — runtime AgentConfig defaults to no timeout.
+
+        Guards #379: bench tasks check and bench eval create must agree on
+        the missing-[agent] contract. The runtime accepts it, so check_task
+        does too.
+        """
         task = self._make_valid_task(tmp_path)
         (task / "task.toml").write_text("[verifier]\ntimeout_sec = 120\n")
         issues = check_task(task)
-        assert "task.toml missing [agent] section" in issues
+        assert not any("agent" in i for i in issues)
 
-    def test_task_toml_missing_timeout_sec(self, tmp_path):
+    def test_task_toml_missing_timeout_sec_is_allowed(self, tmp_path):
+        """[agent].timeout_sec is optional — defaults to no wall-clock cap.
+
+        Guards #379: keeps check_task in sync with AgentConfig (timeout_sec
+        defaults to None).
+        """
         task = self._make_valid_task(tmp_path)
         (task / "task.toml").write_text("[agent]\n")
         issues = check_task(task)
-        assert "task.toml [agent] missing timeout_sec" in issues
+        assert not any("timeout_sec" in i for i in issues)
 
     def test_task_toml_parse_error(self, tmp_path):
         task = self._make_valid_task(tmp_path)


### PR DESCRIPTION
Closes #379.

Aligned `check_task` with runtime `AgentConfig` (both treat `[agent]` and `[agent].timeout_sec` as optional). Also escapes Rich markup in CLI diagnostics so bracketed section names render literally. 5 new tests.

**Review findings:**
- MANDATORY: `check_task` should call `TaskConfig.model_validate_toml` (canonical reuse — current parse-and-discard is duplication).
- MANDATORY: `_get_task_dirs` should apply the same validator (otherwise the next #379-shape recurs).
- Test `test_tasks_check_escapes_rich_markup_in_diagnostic` uses `[[[` which has no `[…]` in the rendered message — passes under both buggy and fixed code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation and CLI display only; no auth, rollout, or verifier execution paths changed beyond accepting the same task.toml eval already ran.
> 
> **Overview**
> Fixes **#379** by aligning **`check_task`** with runtime behavior: **`[agent]`** and **`[agent].timeout_sec`** are no longer required in **`task.toml`**—only TOML parse failures are reported, matching **`AgentConfig`** (optional timeout → no wall-clock cap) and **`bench eval create`** enumeration.
> 
> **`bench tasks check`** now **escapes Rich markup** in issue text so literals like **`[agent]`** show up in diagnostics instead of being swallowed as styling.
> 
> Tests were updated and a dedicated consistency module added so **`bench tasks check`** and eval task discovery agree on tasks missing **`[agent]`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be66556d8c78de99a4ec724524f1620e57730f66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->