### PR TITLE
docs: align task-authoring docs with compose-only tasks and string task_path

### DIFF
--- a/docs/examples/swebench_pro_user_dogfood.py
+++ b/docs/examples/swebench_pro_user_dogfood.py
@@ -21,9 +21,8 @@ import argparse
 import asyncio
 import logging
 
-from benchflow.user import FunctionUser, RoundResult
-
 import benchflow as bf
+from benchflow import FunctionUser, RoundResult
 from benchflow.rollout import RolloutConfig, Scene
 
 logging.basicConfig(level=logging.INFO, format="%(name)s %(message)s")

--- a/docs/examples/user_dogfood.py
+++ b/docs/examples/user_dogfood.py
@@ -12,9 +12,8 @@ Usage:
 import asyncio
 import logging
 
-from benchflow.user import FunctionUser, RoundResult
-
 import benchflow as bf
+from benchflow import FunctionUser, RoundResult
 from benchflow.rollout import RolloutConfig, Scene
 
 logging.basicConfig(level=logging.INFO, format="%(name)s %(message)s")

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -55,11 +55,17 @@ env             = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }  # host vars to injec
 
 ## Multi-container tasks
 
-A task may ship an `environment/docker-compose.yaml` alongside (or instead of)
-the `Dockerfile`. The agent always runs in the `main` service; any additional
+A task may ship an `environment/docker-compose.yaml` alongside the
+`Dockerfile`. The agent always runs in the `main` service; any additional
 services you declare become sibling containers on the same Docker network.
 This supports vulhub-style CVE tasks where the agent attacks a separate target
 container over the network.
+
+> `environment/Dockerfile` is always required — `bench tasks check` rejects
+> a task that ships only a `docker-compose.yaml`. If your `main` service
+> uses a prebuilt `image:` and needs no build context, still include a
+> minimal `Dockerfile` (e.g. `FROM <same-image>`) so structural validation
+> and other tooling agree on the task package shape.
 
 ```yaml
 # environment/docker-compose.yaml

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -133,7 +133,7 @@ For stronger isolation, use the MCP reviewer server pattern. The reviewer runs a
 ```python
 from pathlib import Path
 
-from benchflow.mcp.hooks import mcp_reviewer_hook
+from benchflow.experimental.mcp.hooks import mcp_reviewer_hook
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 
 config = RolloutConfig(
@@ -152,7 +152,7 @@ config = RolloutConfig(
 result = await bf.run(config)
 ```
 
-The MCP reviewer server (`benchflow.mcp.reviewer_server`) runs as a background process in the sandbox. It exposes `review_code` and `get_review_status` tools via streamable-http. The reviewer LLM reads the code but has **no ability to write files** -- all it can do is return feedback text.
+The MCP reviewer server (`benchflow.experimental.mcp.reviewer_server`) runs as a background process in the sandbox. It exposes `review_code` and `get_review_status` tools via streamable-http. The reviewer LLM reads the code but has **no ability to write files** -- all it can do is return feedback text.
 
 ### Results
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import json
 from pathlib import Path
+
+import pytest
 
 
 def _load_nanofirm_evaluator():
@@ -56,3 +59,63 @@ def test_nanofirm_perfect_analysis_reaches_full_reward(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "ANALYSIS_PATH", str(analysis_path))
 
     assert module.evaluate() == 1.0
+
+
+# ── Issue #368 guards ────────────────────────────────────────────────
+# Example scripts under docs/examples/ must import from real, public
+# modules. ModuleNotFoundError on import is a hard regression.
+
+_DOCS_EXAMPLE_SCRIPTS = [
+    Path("docs/examples/user_dogfood.py"),
+    Path("docs/examples/swebench_pro_user_dogfood.py"),
+]
+
+
+def _imports_from(path: Path) -> set[str]:
+    """Return the set of module names this script imports from."""
+    tree = ast.parse(path.read_text())
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+    return names
+
+
+@pytest.mark.parametrize("script", _DOCS_EXAMPLE_SCRIPTS, ids=lambda p: p.name)
+def test_docs_example_imports_resolve(script: Path) -> None:
+    """ENG-368: docs/examples scripts must not reference removed modules."""
+    assert script.exists(), f"missing example script: {script}"
+    imports = _imports_from(script)
+    # benchflow.user was removed; FunctionUser/RoundResult now live at top-level
+    # benchflow (re-exported from benchflow.sandbox.user).
+    assert "benchflow.user" not in imports, (
+        f"{script} imports the removed `benchflow.user` module; "
+        "use `from benchflow import FunctionUser, RoundResult` instead"
+    )
+
+
+def test_use_cases_mcp_import_path_is_experimental() -> None:
+    """ENG-368: docs/use-cases.md must use benchflow.experimental.mcp.*."""
+    text = Path("docs/use-cases.md").read_text()
+    # Reject the stale path; require the current one.
+    assert "from benchflow.mcp.hooks" not in text, (
+        "docs/use-cases.md references the stale benchflow.mcp.hooks path; "
+        "use benchflow.experimental.mcp.hooks instead"
+    )
+    assert "benchflow.experimental.mcp.hooks" in text
+
+
+def test_task_authoring_docs_require_dockerfile() -> None:
+    """ENG-368: task-authoring.md must not say compose can replace Dockerfile.
+
+    `check_task` always requires `environment/Dockerfile`, so the multi-container
+    section must not promise compose-only tasks.
+    """
+    text = Path("docs/task-authoring.md").read_text()
+    assert "alongside (or instead of)" not in text, (
+        "task-authoring.md still claims docker-compose can replace the "
+        "Dockerfile, but `bench tasks check` rejects compose-only tasks"
+    )


### PR DESCRIPTION
Closes #368.

Fixed 3 of 4 issue findings: compose-only docs misleading → callout that Dockerfile is always required; `benchflow.user` import → `from benchflow import FunctionUser, RoundResult`; `benchflow.mcp` → `benchflow.experimental.mcp.hooks` / `.reviewer_server`. 4 new tests.

**⚠️ #368.2 NOT FIXED**: PR claimed `RolloutConfig` string task_path coercion was "already fixed upstream in 81a63a3" — that commit lives on `cursor/user-audit-benchflow-0d54`, **never merged to v0.5-integration**. Repro still fails: `RolloutConfig(task_path='tasks/foo', scenes=[...])` → AttributeError. Fix-up branch in flight to cherry-pick the coercion block.

**Cross-PR conflict**: docs/task-authoring.md:36, 257 still claim `[agent].timeout_sec` is REQUIRED but PR-#379 (#431) deletes that requirement.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and test-only changes with no runtime or security impact.
> 
> **Overview**
> Updates **docs and example scripts** so they match the current package layout and `bench tasks check` behavior.
> 
> Example dogfood scripts now import **`FunctionUser`** and **`RoundResult`** from the top-level **`benchflow`** package instead of the removed **`benchflow.user`** module. **Task authoring** docs clarify that **`environment/Dockerfile`** is always required (compose cannot replace it), with a note on minimal `FROM` stubs when `main` uses a prebuilt image. **Use cases** docs point MCP reviewer hooks and the reviewer server at **`benchflow.experimental.mcp.*`** instead of **`benchflow.mcp`**.
> 
> Adds **AST- and text-based regression tests** in `tests/test_docs_examples.py` so those three doc/example drift cases fail CI if reintroduced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fd8b0b2f0e082e22d82d1a6b1fa715c0acd7af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->