### PR TITLE
feat: expose agent_idle_timeout in CLI and YAML config

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1049,13 +1049,13 @@ def eval_create(
         typer.Option("--concurrency", help="Max concurrent tasks"),
     ] = None,
     agent_idle_timeout: Annotated[
-        int | None,
+        str | None,
         typer.Option(
             "--agent-idle-timeout",
-            min=0,
             help=(
-                "Abort ACP prompts after this many idle seconds; "
-                "0 disables idle detection."
+                "Abort ACP prompts after this many idle seconds (default: 600). "
+                "Pass 0 or 'none' to disable the idle watchdog and fall back to "
+                "the task's wall-clock timeout."
             ),
         ),
     ] = None,
@@ -1140,11 +1140,15 @@ def eval_create(
     eval_environment = environment or "docker"
     sandbox_user = normalize_sandbox_user(sandbox_user)
     eval_concurrency = concurrency if concurrency is not None else 4
-    eval_agent_idle_timeout = normalize_agent_idle_timeout(
-        agent_idle_timeout
-        if agent_idle_timeout is not None
-        else DEFAULT_AGENT_IDLE_TIMEOUT_SEC
-    )
+    try:
+        eval_agent_idle_timeout = normalize_agent_idle_timeout(
+            agent_idle_timeout
+            if agent_idle_timeout is not None
+            else DEFAULT_AGENT_IDLE_TIMEOUT_SEC
+        )
+    except ValueError as exc:
+        console.print(f"[red]Invalid --agent-idle-timeout {agent_idle_timeout!r}: {exc}[/red]")
+        raise typer.Exit(1) from None
     output_jobs_dir = jobs_dir or "jobs"
 
     if config_file:

--- a/tests/test_agent_idle_timeout_cli.py
+++ b/tests/test_agent_idle_timeout_cli.py
@@ -1,0 +1,149 @@
+"""Tests for the ``--agent-idle-timeout`` CLI flag on ``bench eval create``.
+
+Closes #338: long-running optimization tasks need to extend or disable the
+ACP idle watchdog without patching the installed source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import typer
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app, eval_create
+from benchflow.evaluation import EvaluationResult
+
+
+def _make_tasks_dir(tmp_path: Path) -> Path:
+    """Build a minimal directory with two task subdirs for batch dispatch."""
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    for name in ("alpha", "beta"):
+        d = tasks / name
+        d.mkdir()
+        (d / "task.toml").write_text('schema_version = "1.1"\n')
+        (d / "instruction.md").write_text("solve\n")
+    return tasks
+
+
+def _stub_evaluation_run(captured: dict):
+    """Patch ``Evaluation.run`` to capture the constructed config and short-circuit."""
+
+    async def fake_run(self):
+        captured["config"] = self._config
+        return EvaluationResult(
+            job_name="test",
+            config=self._config,
+            total=0,
+            passed=0,
+            errored=0,
+        )
+
+    return patch("benchflow.evaluation.Evaluation.run", new=fake_run)
+
+
+def test_eval_create_integer_idle_timeout_lands_in_config(tmp_path: Path):
+    """Integer arg propagates verbatim into EvaluationConfig.agent_idle_timeout."""
+    tasks = _make_tasks_dir(tmp_path)
+    captured: dict = {}
+
+    with _stub_evaluation_run(captured):
+        eval_create(
+            tasks_dir=tasks,
+            agent_idle_timeout="300",
+            jobs_dir=str(tmp_path / "jobs"),
+        )
+
+    assert captured["config"].agent_idle_timeout == 300
+
+
+def test_eval_create_none_string_disables_idle_watchdog(tmp_path: Path):
+    """`--agent-idle-timeout none` maps to None so the watchdog is disabled."""
+    tasks = _make_tasks_dir(tmp_path)
+    captured: dict = {}
+
+    with _stub_evaluation_run(captured):
+        eval_create(
+            tasks_dir=tasks,
+            agent_idle_timeout="none",
+            jobs_dir=str(tmp_path / "jobs"),
+        )
+
+    assert captured["config"].agent_idle_timeout is None
+
+
+def test_eval_create_zero_string_disables_idle_watchdog(tmp_path: Path):
+    """`--agent-idle-timeout 0` also disables (parity with the YAML contract)."""
+    tasks = _make_tasks_dir(tmp_path)
+    captured: dict = {}
+
+    with _stub_evaluation_run(captured):
+        eval_create(
+            tasks_dir=tasks,
+            agent_idle_timeout="0",
+            jobs_dir=str(tmp_path / "jobs"),
+        )
+
+    assert captured["config"].agent_idle_timeout is None
+
+
+def test_eval_create_default_idle_timeout_is_600(tmp_path: Path):
+    """No flag keeps the 600s default that the issue body asked us to preserve."""
+    tasks = _make_tasks_dir(tmp_path)
+    captured: dict = {}
+
+    with _stub_evaluation_run(captured):
+        eval_create(
+            tasks_dir=tasks,
+            jobs_dir=str(tmp_path / "jobs"),
+        )
+
+    assert captured["config"].agent_idle_timeout == 600
+
+
+def test_eval_create_rejects_invalid_idle_timeout(tmp_path: Path):
+    """Non-numeric, non-sentinel strings raise typer.Exit with a friendly message."""
+    tasks = _make_tasks_dir(tmp_path)
+
+    try:
+        eval_create(
+            tasks_dir=tasks,
+            agent_idle_timeout="forever",
+            jobs_dir=str(tmp_path / "jobs"),
+        )
+    except typer.Exit as exc:
+        assert exc.exit_code == 1
+    else:
+        raise AssertionError("expected typer.Exit for invalid idle timeout")
+
+
+def test_eval_create_idle_timeout_overrides_yaml_config(tmp_path: Path):
+    """Explicit CLI flag overrides any ``agent_idle_timeout`` set in the YAML."""
+    tasks = _make_tasks_dir(tmp_path)
+    yaml_path = tmp_path / "config.yaml"
+    yaml_path.write_text(
+        "tasks_dir: " + str(tasks) + "\n"
+        "agent: claude-agent-acp\n"
+        "agent_idle_timeout: 1800\n"
+    )
+    captured: dict = {}
+
+    with _stub_evaluation_run(captured):
+        eval_create(
+            config_file=yaml_path,
+            agent_idle_timeout="none",
+            jobs_dir=str(tmp_path / "jobs"),
+        )
+
+    # CLI explicit "none" wins over YAML's 1800
+    assert captured["config"].agent_idle_timeout is None
+
+
+def test_cli_runner_help_documents_none_sentinel():
+    """Help text should describe both integer and 'none' usage."""
+    result = CliRunner().invoke(app, ["eval", "create", "--help"])
+    assert result.exit_code == 0
+    assert "--agent-idle-timeout" in result.output
+    assert "none" in result.output


### PR DESCRIPTION
Closes #338.

`bench eval create --agent-idle-timeout <seconds|none>` flag now works. YAML/SDK wiring was already present from prior PRs — this widens the CLI flag type to accept the documented `none` sentinel and routes through the existing `normalize_agent_idle_timeout` helper. 7 new tests.

**Review findings:**
- MANDATORY: use Typer's `parser=` hook to keep `int | None` contract end-to-end instead of widening to `str | None`.
- NICE: add flag to `bench run` for parity (SDK already takes it).
- Sentinel set inconsistency: `normalize_sandbox_user` accepts `{none,null}`, `normalize_agent_idle_timeout` accepts `{'', none, null}` — unify.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/453" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI-only parsing and config wiring for eval idle timeouts; no auth, data, or core execution path changes beyond existing normalization.
> 
> **Overview**
> **`bench eval create --agent-idle-timeout`** now accepts string values (e.g. seconds as `"300"`, or **`none`** / **`0`**) instead of a strict integer Typer option, so the CLI can use the same **`normalize_agent_idle_timeout`** rules as YAML/SDK. Help text documents the **600s** default and that **`none`** / **`0`** turn off the ACP idle watchdog in favor of the task wall-clock timeout. Invalid values surface a red error and **`typer.Exit(1)`** instead of failing opaquely.
> 
> Seven tests cover propagation into **`EvaluationConfig`**, disable sentinels, default **600**, validation, YAML override, and help mentioning **`none`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5ca504859d0388680b742359840a468d902153b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->