### PR TITLE
fix: dense LLM-judge rewards declare correct space/granularity (#396)

### DIFF
--- a/src/benchflow/rewards/builtins.py
+++ b/src/benchflow/rewards/builtins.py
@@ -16,6 +16,7 @@ from benchflow.rewards.rubric_config import (
     JudgeConfig,
     RubricConfig,
     ScoringConfig,
+    _coerce_space,
     load_rubric,
 )
 from benchflow.rewards.validation import is_valid_reward_number
@@ -223,6 +224,7 @@ class LLMJudgeRewardFunc:
                         max=raw.get("max", 100.0),
                         weight=raw.get("weight", 1.0),
                         files=raw.get("files", []),
+                        space=_coerce_space(raw.get("space")),
                     )
                 )
             return RubricConfig(
@@ -339,6 +341,15 @@ class LLMJudgeRewardFunc:
                     reward=norm_score,
                     source=f"criterion:{criterion.id}",
                     step=idx,
+                    # Dense per-criterion events are step-granularity by
+                    # construction (``step=idx`` is set). The space is whatever
+                    # the rubric declared for the criterion — defaults to
+                    # ``"output"`` to preserve back-compat, but a process-like
+                    # criterion can opt into ``"action"`` / ``"reasoning"`` /
+                    # ``"memory"`` so trainers and ORS adapters can tell a
+                    # dense signal from a terminal outcome (#396).
+                    space=criterion.space,
+                    granularity="step",
                 )
             )
 

--- a/src/benchflow/rewards/rubric_config.py
+++ b/src/benchflow/rewards/rubric_config.py
@@ -12,10 +12,36 @@ try:
 except ModuleNotFoundError:  # Python < 3.11
     import tomli as tomllib  # type: ignore[no-redef]  # ty: ignore[unresolved-import]
 
+from benchflow.rewards.events import Space
 
 # ------------------------------------------------------------------
 # Data models
 # ------------------------------------------------------------------
+
+# The valid evaluation spaces a criterion may declare. Mirrors
+# ``benchflow.rewards.events.Space`` so rubrics can tag a criterion as
+# ``"action"``, ``"reasoning"``, ``"memory"``, or ``"latent"`` instead of
+# letting it default to ``"output"`` — the architecture's outcome space.
+_VALID_SPACES: frozenset[str] = frozenset(
+    {"output", "action", "reasoning", "memory", "latent"}
+)
+
+
+def _coerce_space(raw: object) -> Space:
+    """Validate a raw ``space`` value from a rubric file.
+
+    Falls back to ``"output"`` when the field is absent. A present-but-invalid
+    value is rejected loudly — silently downgrading to ``"output"`` would
+    hide a misconfigured rubric and re-introduce the very mistag this
+    contract is meant to prevent.
+    """
+    if raw is None:
+        return "output"
+    if isinstance(raw, str) and raw in _VALID_SPACES:
+        return raw  # type: ignore[return-value]
+    raise ValueError(
+        f"Rubric criterion 'space' must be one of {sorted(_VALID_SPACES)}; got {raw!r}"
+    )
 
 
 @dataclass
@@ -30,6 +56,12 @@ class Criterion:
     max: float = 100.0
     weight: float = 1.0
     files: list[str] = field(default_factory=list)
+    # Evaluation space this criterion scores — propagated to every dense
+    # ``RewardEvent`` it emits. Defaults to ``"output"`` (the architecture's
+    # outcome space) so existing rubrics keep their current behaviour; tag a
+    # process-like criterion as ``"action"`` / ``"reasoning"`` / ``"memory"``
+    # to keep dense events from being mistaken for terminal outcome rewards.
+    space: Space = "output"
 
     @property
     def id(self) -> str:
@@ -97,6 +129,7 @@ def _parse_criterion(raw: dict) -> Criterion:
         max=raw.get("max", 100.0),
         weight=raw.get("weight", 1.0),
         files=raw.get("files", []),
+        space=_coerce_space(raw.get("space")),
     )
 
 
@@ -169,6 +202,7 @@ def load_rubric_json(path: Path) -> RubricConfig:
                 max=raw.get("max", 100.0),
                 weight=raw.get("weight", 1.0),
                 files=raw.get("files", []),
+                space=_coerce_space(raw.get("space")),
             )
         )
 

--- a/tests/test_llm_judge_event_tags.py
+++ b/tests/test_llm_judge_event_tags.py
@@ -1,0 +1,213 @@
+"""Guards #396: dense LLM-judge reward events declare correct space/granularity.
+
+Per-criterion ``RewardEvent`` instances emitted by ``LLMJudgeRewardFunc`` carry
+``step=idx`` and are *not* the terminal outcome of a trial. Before #396 they
+serialized as ``space="output"`` / ``granularity="terminal"`` because the
+``RewardEvent`` defaults were left untouched — masquerading as the final
+verifier signal and corrupting credit assignment for trainers and ORS
+exporters. This module pins the contract: dense events are
+``granularity="step"``, and the space follows whatever the rubric / inline
+criterion declared.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from benchflow.rewards.builtins import LLMJudgeRewardFunc
+from benchflow.rewards.rubric_config import (
+    Criterion,
+    load_rubric_json,
+    load_rubric_toml,
+)
+
+_MOCK_PASS = '```json\n{"verdict": "pass", "reasoning": "good"}\n```'
+
+
+# ---------------------------------------------------------------------------
+# Dense event tags
+# ---------------------------------------------------------------------------
+
+
+class TestDenseEventTags:
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    async def test_dense_event_is_step_granularity(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """A per-criterion event with ``step`` set must be tagged
+        ``granularity="step"``. The pre-#396 default of ``"terminal"`` made a
+        step-indexed event indistinguishable from the final outcome."""
+        mock_judge.return_value = _MOCK_PASS
+        (tmp_path / "output.txt").write_text("answer")
+
+        func = LLMJudgeRewardFunc(criteria=[{"description": "A", "id": "a"}])
+        await func.score(tmp_path)
+
+        ev = func.events[0]
+        assert ev.step == 0
+        assert ev.granularity == "step"
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    async def test_dense_event_defaults_to_output_space(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Back-compat: an untagged criterion still emits ``space="output"`` —
+        but with the correct step granularity."""
+        mock_judge.return_value = _MOCK_PASS
+        (tmp_path / "output.txt").write_text("answer")
+
+        func = LLMJudgeRewardFunc(criteria=[{"description": "A", "id": "a"}])
+        await func.score(tmp_path)
+
+        ev = func.events[0]
+        assert ev.space == "output"
+        assert ev.granularity == "step"
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    async def test_inline_criterion_declares_action_space(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """A process-like criterion can opt into a non-output space — the dense
+        event carries the declared space."""
+        mock_judge.return_value = _MOCK_PASS
+        (tmp_path / "output.txt").write_text("answer")
+
+        func = LLMJudgeRewardFunc(
+            criteria=[
+                {"description": "Tool choice quality", "id": "tools", "space": "action"},
+            ],
+        )
+        await func.score(tmp_path)
+
+        ev = func.events[0]
+        assert ev.space == "action"
+        assert ev.granularity == "step"
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    async def test_multiple_criteria_carry_distinct_spaces(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """Per-criterion spaces propagate independently to each dense event."""
+        mock_judge.return_value = _MOCK_PASS
+        (tmp_path / "output.txt").write_text("answer")
+
+        func = LLMJudgeRewardFunc(
+            criteria=[
+                {"description": "Reasoning quality", "id": "r", "space": "reasoning"},
+                {"description": "Memory update", "id": "m", "space": "memory"},
+                {"description": "Final answer", "id": "o"},  # defaults to output
+            ],
+        )
+        await func.score(tmp_path)
+
+        assert [e.space for e in func.events] == ["reasoning", "memory", "output"]
+        assert all(e.granularity == "step" for e in func.events)
+        assert [e.step for e in func.events] == [0, 1, 2]
+
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    async def test_invalid_inline_space_rejected(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """A bogus space value is rejected loudly, not silently downgraded —
+        otherwise a misconfigured rubric would re-introduce the original
+        mistag bug under a different name. Inline criteria are parsed
+        lazily in ``_load_rubric``; the error must surface from ``score()``."""
+        mock_judge.return_value = _MOCK_PASS
+        func = LLMJudgeRewardFunc(
+            criteria=[{"description": "x", "space": "bogus"}],
+        )
+        with pytest.raises(ValueError, match="space"):
+            await func.score(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Rubric-file parsing
+# ---------------------------------------------------------------------------
+
+
+class TestRubricSpaceParsing:
+    def test_toml_criterion_space(self, tmp_path: Path) -> None:
+        path = tmp_path / "rubric.toml"
+        path.write_text(
+            """\
+[[criterion]]
+description = "Tool choice quality"
+space = "action"
+
+[[criterion]]
+description = "Final answer"
+"""
+        )
+
+        rubric = load_rubric_toml(path)
+        assert rubric.criteria[0].space == "action"
+        # Unset -> default output for back-compat.
+        assert rubric.criteria[1].space == "output"
+
+    def test_json_criterion_space(self, tmp_path: Path) -> None:
+        path = tmp_path / "rubric.json"
+        path.write_text(
+            '{"criteria": ['
+            '{"id": "c1", "match_criteria": "tool quality", "space": "action"},'
+            '{"id": "c2", "match_criteria": "final answer"}'
+            "]}"
+        )
+
+        rubric = load_rubric_json(path)
+        assert rubric.criteria[0].space == "action"
+        assert rubric.criteria[1].space == "output"
+
+    def test_toml_invalid_space_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "rubric.toml"
+        path.write_text(
+            """\
+[[criterion]]
+description = "anything"
+space = "not-a-real-space"
+"""
+        )
+
+        with pytest.raises(ValueError, match="space"):
+            load_rubric_toml(path)
+
+    def test_criterion_dataclass_default_space(self) -> None:
+        """Constructing a ``Criterion`` directly defaults to ``"output"`` so
+        existing programmatic uses keep working."""
+        c = Criterion(description="anything")
+        assert c.space == "output"
+
+
+# ---------------------------------------------------------------------------
+# Regression: the exact symptom from #396
+# ---------------------------------------------------------------------------
+
+
+class TestIssue396Repro:
+    @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
+    async def test_issue_repro_no_longer_emits_terminal_output_tag(
+        self, mock_judge: AsyncMock, tmp_path: Path
+    ) -> None:
+        """The exact repro from #396: a dense criterion event must no longer
+        serialize as ``space="output"`` / ``granularity="terminal"``."""
+        mock_judge.return_value = (
+            '```json\n{"verdict": "pass", "score": 1.0, "reasoning": "ok"}\n```'
+        )
+        (tmp_path / "output.txt").write_text("answer")
+
+        func = LLMJudgeRewardFunc(
+            criteria=[
+                {"description": "Check action quality", "id": "action_quality"},
+            ],
+        )
+        await func.score(tmp_path)
+
+        ev = func.events[0]
+        # The bug: ``granularity="terminal"`` paired with a non-None ``step``.
+        # Post-fix: ``step`` -> ``granularity="step"``, never both.
+        assert (ev.step, ev.granularity) == (0, "step")
+        # ``space`` may still default to ``"output"`` (back-compat) — what
+        # mattered was that the *granularity* mistag is gone.
+        assert ev.source == "criterion:action_quality"


### PR DESCRIPTION
Closes #396. Step-indexed dense events now emit `granularity='step'` (was 'terminal') and propagate per-criterion `space`. Added `space` field to Criterion config (TOML+JSON parsers honor it). 10 new tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward event metadata used downstream for training/export; behavior is narrow and well-tested but mis-tagged rewards previously affected credit assignment.
> 
> **Overview**
> Fixes **#396**: per-criterion dense `RewardEvent`s from `LLMJudgeRewardFunc` were left at default **`granularity="terminal"`** even when **`step`** was set, so step-level judge signals looked like final outcomes and could skew credit assignment for trainers/ORS.
> 
> Dense events now always use **`granularity="step"`** and **`space`** from the criterion. Rubric **`Criterion`** gains an optional **`space`** (`output`, `action`, `reasoning`, `memory`, `latent`) via **`_coerce_space`**, wired through TOML/JSON/inline parsing; missing **`space`** stays **`output`**, invalid values raise **`ValueError`**. New tests lock parsing, tagging, and the regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9357e0ea37870e02cfb16ac194d5a4edd1382af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->