### PR TITLE
fix: bench tasks init scaffolds fail until author replaces placeholders (#360)

### DIFF
--- a/src/benchflow/_utils/task_authoring.py
+++ b/src/benchflow/_utils/task_authoring.py
@@ -12,6 +12,11 @@ REQUIRED_DIRS = ["environment"]
 OPTIONAL_FILES = ["environment/Dockerfile"]
 OPTIONAL_DIRS = ["tests", "solution"]
 
+# Placeholder marker written by init_task — must be replaced before the task
+# is considered authored. Catching this in check_task prevents a freshly
+# scaffolded task from being mistaken for a real benchmark (#360).
+_PLACEHOLDER_MARKER = "[REPLACE:"
+
 
 def check_task(task_dir: Path) -> list[str]:
     """Validate a task directory structure. Returns list of issues (empty = valid)."""
@@ -40,10 +45,17 @@ def check_task(task_dir: Path) -> list[str]:
         except Exception as e:
             issues.append(f"task.toml parse error: {e}")
 
-    # Check instruction.md is non-empty
+    # Check instruction.md is non-empty and has no placeholder markers
     instr = task_dir / "instruction.md"
-    if instr.exists() and instr.stat().st_size == 0:
-        issues.append("instruction.md is empty")
+    if instr.exists():
+        if instr.stat().st_size == 0:
+            issues.append("instruction.md is empty")
+        elif _PLACEHOLDER_MARKER in instr.read_text():
+            issues.append(
+                f"instruction.md contains unreplaced placeholder "
+                f"('{_PLACEHOLDER_MARKER} ...' markers) — replace them with "
+                f"real task instructions"
+            )
 
     # Check Dockerfile exists
     dockerfile = task_dir / "environment" / "Dockerfile"
@@ -64,6 +76,19 @@ def check_task(task_dir: Path) -> list[str]:
     test_sh = task_dir / "tests" / "test.sh"
     if test_sh.exists():
         issues.extend(_check_ctrf_path(test_sh))
+        if _PLACEHOLDER_MARKER in test_sh.read_text():
+            issues.append(
+                "tests/test.sh contains unreplaced placeholder — "
+                "write real verifier logic before running the task"
+            )
+
+    # Detect placeholder solution that has not been replaced (#360).
+    solve_sh = task_dir / "solution" / "solve.sh"
+    if solve_sh.exists() and _PLACEHOLDER_MARKER in solve_sh.read_text():
+        issues.append(
+            "solution/solve.sh contains unreplaced placeholder — "
+            "write a real oracle solution before running the task"
+        )
 
     return issues
 
@@ -125,12 +150,21 @@ cpus = 1
 memory_mb = 2048
 """)
 
-    # instruction.md
+    # instruction.md — placeholders MUST be replaced (#360). Leaving them in
+    # place is a `bench tasks check` failure so a scaffolded task cannot be
+    # mistaken for an authored benchmark.
     (task_dir / "instruction.md").write_text(f"""# {name}
 
-<!-- Write clear, specific instructions for the agent. -->
-<!-- Describe the goal, constraints, and expected output. -->
+[REPLACE: one-sentence summary of what the agent must do.]
 
+## Goal
+
+[REPLACE: describe the goal, constraints, and expected outputs.
+Be specific — list files to produce, commands to run, or behaviours to verify.]
+
+## Success criteria
+
+[REPLACE: list the conditions the verifier in tests/test.sh checks for.]
 """)
 
     # environment/
@@ -151,33 +185,50 @@ RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts
     # tests/
     tests_dir = task_dir / "tests"
     tests_dir.mkdir()
+    # Verifier defaults to FAILURE (0.0) until the author replaces the
+    # placeholder. A scaffold that auto-passes would silently inflate eval
+    # results — see #360.
     (tests_dir / "test.sh").write_text("""#!/bin/bash
 # Verifier script — write reward to /logs/verifier/reward.txt (float 0.0-1.0).
 # Exit 0 after writing it; nonzero exit means verifier infrastructure failure.
 
-echo "1.0" > /logs/verifier/reward.txt
+# [REPLACE: write real verification logic here. The scaffold defaults to 0.0
+# so an unedited task cannot accidentally count as a passing benchmark.]
+echo "[REPLACE: write real verifier logic] — defaulting to failure" >&2
+echo "0.0" > /logs/verifier/reward.txt
 """)
     (tests_dir / "test.sh").chmod(0o755)
 
     if not no_pytest:
+        # Fails by default until the author writes real assertions (#360).
         (
             tests_dir / "test_outputs.py"
         ).write_text("""\"\"\"Pytest-based verifier. Run by Harbor after agent completes.\"\"\"
 
+import pytest
+
+
 def test_placeholder():
-    # Replace with actual verification logic
-    assert True
+    # [REPLACE: write real verification logic. Until then this test fails so
+    # a scaffolded task cannot accidentally count as passing.]
+    pytest.fail("[REPLACE: write real verifier assertions in tests/test_outputs.py]")
 """)
 
-    # solution/
+    # solution/ — placeholder MUST be replaced. The oracle solution should
+    # cause the verifier in tests/test.sh to write 1.0; the unedited scaffold
+    # deliberately does not, so an init+check round-trip can't be mistaken
+    # for a real benchmark (#360).
     if not no_solution:
         sol_dir = task_dir / "solution"
         sol_dir.mkdir()
-        (sol_dir / "solve.sh").write_text("""#!/bin/bash
+        (sol_dir / "solve.sh").write_text(f"""#!/bin/bash
 # Oracle solution — demonstrates the task is solvable.
 # Used by: bench eval create --agent oracle --tasks-dir tasks/{name}
 
-echo "TODO: implement oracle solution"
+# [REPLACE: implement the oracle solution. It must satisfy the verifier in
+# tests/test.sh so that running solve.sh → test.sh produces reward 1.0.]
+echo "[REPLACE: implement oracle solution for {name}]" >&2
+exit 1
 """)
         (sol_dir / "solve.sh").chmod(0o755)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -122,11 +122,73 @@ class TestInitTask:
         assert (task / "tests" / "test_outputs.py").exists()
         assert (task / "solution" / "solve.sh").exists()
 
-    def test_task_toml_is_valid(self, tmp_path):
-        """Scaffolded task.toml should pass check_task validation."""
-        task = init_task("valid-task", parent_dir=tmp_path)
+    def test_scaffold_fails_check_until_placeholders_replaced(self, tmp_path):
+        """Freshly scaffolded task must FAIL `bench tasks check` (#360).
+
+        Otherwise authors can `bench tasks init foo && bench tasks check foo`
+        and get a green ✓ on a task that auto-passes with reward 1.0 —
+        silent false positives in eval sets.
+        """
+        task = init_task("scaffolded", parent_dir=tmp_path)
         issues = check_task(task)
-        assert issues == []
+        assert issues, "scaffold must not pass check_task before editing"
+        # instruction.md, tests/test.sh and solution/solve.sh all carry the
+        # placeholder marker — each must be flagged so the author sees what
+        # to replace.
+        joined = "\n".join(issues)
+        assert "instruction.md" in joined
+        assert "tests/test.sh" in joined
+        assert "solution/solve.sh" in joined
+
+    def test_scaffold_passes_check_after_placeholders_replaced(self, tmp_path):
+        """Once the author replaces every [REPLACE: ...] marker, check passes."""
+        task = init_task("editable", parent_dir=tmp_path)
+        (task / "instruction.md").write_text("# editable\n\nDo the thing.\n")
+        (task / "tests" / "test.sh").write_text(
+            '#!/bin/bash\necho "1.0" > /logs/verifier/reward.txt\n'
+        )
+        (task / "solution" / "solve.sh").write_text(
+            "#!/bin/bash\ntouch /app/output.txt\n"
+        )
+        assert check_task(task) == []
+
+    def test_scaffold_test_sh_defaults_to_failure(self, tmp_path):
+        """Scaffolded verifier writes 0.0, not 1.0 (#360).
+
+        Fail-closed default means even if check_task were skipped, the task
+        cannot give a passing reward without explicit author edits.
+        """
+        task = init_task("fail-closed", parent_dir=tmp_path)
+        test_sh = (task / "tests" / "test.sh").read_text()
+        assert 'echo "0.0"' in test_sh
+        assert 'echo "1.0"' not in test_sh
+
+    def test_scaffold_solution_does_not_satisfy_verifier(self, tmp_path):
+        """The placeholder solution must NOT make the placeholder verifier
+        pass — issue #360 calls this out explicitly: solution and test must
+        not collide on a default-pass.
+
+        We simulate by reading both files and checking that solve.sh exits
+        nonzero (it does not produce side effects) while test.sh writes 0.0.
+        """
+        task = init_task("collision", parent_dir=tmp_path)
+        solve = (task / "solution" / "solve.sh").read_text()
+        test_sh = (task / "tests" / "test.sh").read_text()
+        # Solve.sh must not write a passing reward itself (no echo of 1.0
+        # into the reward file).
+        assert "reward.txt" not in solve
+        assert 'echo "1.0"' not in solve
+        # Test.sh must default to 0.0 reward.
+        assert 'echo "0.0"' in test_sh
+        # And the solve script signals it's a placeholder by exiting nonzero.
+        assert "exit 1" in solve
+
+    def test_scaffold_pytest_template_fails(self, tmp_path):
+        """The pytest verifier template fails until edited (#360)."""
+        task = init_task("py-fail", parent_dir=tmp_path)
+        text = (task / "tests" / "test_outputs.py").read_text()
+        assert "pytest.fail" in text
+        assert "assert True" not in text
 
     def test_no_pytest_skips_test_outputs(self, tmp_path):
         task = init_task("no-pytest", parent_dir=tmp_path, no_pytest=True)


### PR DESCRIPTION
Closes #360. Scaffold now uses `[REPLACE: ...]` markers; `tests/test.sh` defaults to reward 0.0; `solution/solve.sh` exits 1. `check_task` detects unreplaced markers. End-to-end CLI repro confirmed. 5 new tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Authoring/validation and test scaffolding only; reduces false-positive eval risk without changing runtime auth or production paths.
> 
> **Overview**
> **`bench tasks init`** scaffolds are now **fail-closed** so a fresh template cannot look like a real benchmark or inflate eval scores (#360).
> 
> Scaffolded files use **`[REPLACE: ...]`** markers in `instruction.md`, `tests/test.sh`, `tests/test_outputs.py`, and `solution/solve.sh`. **`check_task`** rejects any of those paths that still contain the marker. The default verifier writes reward **`0.0`** (not `1.0`), the pytest template calls **`pytest.fail`**, and the oracle script **`exit 1`** instead of auto-passing.
> 
> Tests were updated: a new scaffold no longer passes **`bench tasks check`** until placeholders are replaced; five tests cover placeholder detection, fail-closed defaults, and solution/verifier non-collision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f96dabfff24021dfd587bc5fca50495a65bee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->