### PR TITLE
fix: rewards.jsonl records carry space/granularity tags (#399)

### DIFF
--- a/src/benchflow/_utils/reward_events.py
+++ b/src/benchflow/_utils/reward_events.py
@@ -6,7 +6,6 @@ from collections.abc import Mapping
 from typing import Any
 
 _EVENT_FIELDS = ("type", "reward", "source", "space", "granularity", "step")
-_JSONL_META_FIELDS = ("space", "granularity")
 
 
 def reward_event_to_dict(event: Any) -> dict[str, Any]:
@@ -25,9 +24,14 @@ def reward_event_to_dict(event: Any) -> dict[str, Any]:
 
 
 def reward_event_to_jsonl_record(event: Any, *, ts: str) -> dict[str, Any]:
-    """Serialize one reward event into the rollout ``rewards.jsonl`` shape."""
+    """Serialize one reward event into the rollout ``rewards.jsonl`` shape.
+
+    ``space`` and ``granularity`` are first-class fields on the line —
+    the architecture tags every reward record ``(space, granularity, value)``,
+    so consumers (dashboard, trainer, monitor) must not have to dig into
+    ``meta`` to distinguish Output/Action/Reasoning/Memory/Latent signal.
+    """
     data = reward_event_to_dict(event)
-    meta = {field: data[field] for field in _JSONL_META_FIELDS if data.get(field)}
     return {
         "ts": ts,
         "type": data.get("type"),
@@ -35,7 +39,9 @@ def reward_event_to_jsonl_record(event: Any, *, ts: str) -> dict[str, Any]:
         "value": data.get("reward"),
         "tag": data.get("space") or data.get("source") or "reward",
         "step_index": data.get("step"),
-        "meta": meta,
+        "space": data.get("space") or "output",
+        "granularity": data.get("granularity") or "terminal",
+        "meta": {},
     }
 
 

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -257,7 +257,15 @@ def _write_rewards_jsonl(
     rewards: dict | None,
     finished_at: datetime,
 ) -> None:
-    """Write rewards.jsonl — one JSON line per reward event."""
+    """Write rewards.jsonl — one JSON line per reward event.
+
+    Architecture (``docs/architecture.md``, "Evaluation — the five spaces"):
+    every reward record is tagged ``(space, granularity, value)``. Promote
+    those tags from any verifier-supplied per-item dict to first-class
+    fields on each line, falling back to the ``RewardEvent`` defaults
+    (``space="output"``; ``granularity="step"`` for rubric items,
+    ``"terminal"`` for the scalar reward) when the verifier omits them.
+    """
     from typing import cast
 
     if not rewards:
@@ -277,16 +285,18 @@ def _write_rewards_jsonl(
                     "value": rubric_item.get("score", 0.0),
                     "tag": rubric_item.get("name", f"rubric_{i}"),
                     "step_index": i,
+                    "space": rubric_item.get("space", "output"),
+                    "granularity": rubric_item.get("granularity", "step"),
                     "meta": {
                         k: v
                         for k, v in rubric_item.items()
-                        if k not in ("score", "name")
+                        if k not in ("score", "name", "space", "granularity")
                     },
                 }
             )
     scalar = rewards.get("reward")
     if scalar is not None:
-        non_event_keys = {"reward", "rubric"}
+        non_event_keys = {"reward", "rubric", "space", "granularity"}
         events.append(
             {
                 "ts": finished_at.isoformat(),
@@ -295,6 +305,8 @@ def _write_rewards_jsonl(
                 "value": scalar,
                 "tag": "reward",
                 "step_index": None,
+                "space": rewards.get("space", "output"),
+                "granularity": rewards.get("granularity", "terminal"),
                 "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
             }
         )

--- a/tests/test_job_sequential_shared.py
+++ b/tests/test_job_sequential_shared.py
@@ -451,7 +451,9 @@ async def test_sequential_shared_surfaces_memory_scores_in_summary_and_artifacts
         "value": 0.5,
         "tag": "memory",
         "step_index": None,
-        "meta": {"space": "memory", "granularity": "terminal"},
+        "space": "memory",
+        "granularity": "terminal",
+        "meta": {},
     }
     serialized_rewards = json.dumps(reward_lines)
     assert "expected_skills" not in serialized_rewards

--- a/tests/test_rewards_jsonl.py
+++ b/tests/test_rewards_jsonl.py
@@ -106,3 +106,69 @@ def test_empty_rubric_list_only_terminal(tmp_path: Path) -> None:
     ]
     assert len(lines) == 1
     assert lines[0]["type"] == "terminal"
+
+
+# --- Space / granularity tags (issue #399) ----------------------------------
+#
+# The architecture tags every reward record with ``(space, granularity, value)``.
+# Native ``rewards.jsonl`` must surface those tags as first-class fields so
+# dashboard / trainer / monitor consumers can distinguish Output / Action /
+# Reasoning / Memory / Latent signals without unpacking ``meta``.
+
+
+def test_terminal_carries_default_space_and_granularity(tmp_path: Path) -> None:
+    _write_rewards_jsonl(tmp_path, {"reward": 1.0}, datetime.now())
+    line = json.loads((tmp_path / "rewards.jsonl").read_text().strip())
+    assert line["space"] == "output"
+    assert line["granularity"] == "terminal"
+
+
+def test_terminal_preserves_verifier_supplied_tags(tmp_path: Path) -> None:
+    rewards = {"reward": 0.4, "space": "memory", "granularity": "terminal"}
+    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    line = json.loads((tmp_path / "rewards.jsonl").read_text().strip())
+    assert line["space"] == "memory"
+    assert line["granularity"] == "terminal"
+    # Promoted out of meta, not duplicated underneath it.
+    assert "space" not in line["meta"]
+    assert "granularity" not in line["meta"]
+
+
+def test_rubric_items_default_to_step_granularity(tmp_path: Path) -> None:
+    rewards = {
+        "reward": 0.5,
+        "rubric": [{"name": "check_a", "score": 0.5}],
+    }
+    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    lines = [
+        json.loads(ln)
+        for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
+    ]
+    process = next(ln for ln in lines if ln["type"] == "process")
+    assert process["space"] == "output"
+    assert process["granularity"] == "step"
+
+
+def test_rubric_items_preserve_per_item_tags(tmp_path: Path) -> None:
+    rewards = {
+        "reward": 0.25,
+        "rubric": [
+            {
+                "name": "asked_when_needed",
+                "score": 0.25,
+                "space": "action",
+                "granularity": "step",
+            }
+        ],
+    }
+    _write_rewards_jsonl(tmp_path, rewards, datetime.now())
+    lines = [
+        json.loads(ln)
+        for ln in (tmp_path / "rewards.jsonl").read_text().strip().splitlines()
+    ]
+    process = next(ln for ln in lines if ln["type"] == "process")
+    assert process["space"] == "action"
+    assert process["granularity"] == "step"
+    # First-class fields, not buried under meta.
+    assert "space" not in process["meta"]
+    assert "granularity" not in process["meta"]


### PR DESCRIPTION
Closes #399. `_write_rewards_jsonl` now emits `space`/`granularity` as first-class per-record fields (was buried in `meta`). Defaults: `space=output`, terminal=`terminal`, rubric=`step`. 4 new tests + 175 regression pass. Coordinates with #391 (ORS adapter) — same schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema additive for consumers that read top-level fields; only changes rollout reward artifact shape and serialization defaults, with no auth or runtime behavior changes.
> 
> **Overview**
> **`rewards.jsonl` now exposes `space` and `granularity` as top-level fields** on every line (issue #399), aligned with the evaluation model where each record is tagged `(space, granularity, value)`.
> 
> Serialization in `reward_event_to_jsonl_record` and `_write_rewards_jsonl` **promotes** verifier- or event-supplied tags instead of nesting them under `meta`, with defaults **`output` / `terminal`** for scalar rewards and **`output` / `step`** for rubric process lines. **`space` and `granularity` are excluded from `meta`** so they are not duplicated.
> 
> Tests were updated for memory-space artifacts and **four new cases** cover defaults, verifier overrides, and per-rubric tags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 210d890a911dbff9f81bd2929ca6753959fffc35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->