### PR TITLE
fix: ORS reward adapter preserves space/granularity tags (#391)

### DIFF
--- a/src/benchflow/adapters/ors.py
+++ b/src/benchflow/adapters/ors.py
@@ -24,11 +24,17 @@ def _json_safe_float(value: float) -> float:
 
 
 def _event_to_dict(event: RewardEvent) -> dict[str, Any]:
+    # space/granularity are the architecture's mandatory ``(space, granularity,
+    # value)`` reward-record tag (docs/architecture.md, "Every reward record is
+    # tagged"). Preserve them on the outbound ORS seam so memory/action/
+    # reasoning process events stay distinguishable downstream.
     return {
         "type": event.type,
         "reward": _json_safe_float(event.reward),
         "source": event.source,
         "step": event.step,
+        "space": event.space,
+        "granularity": event.granularity,
         "timestamp": event.ts,
     }
 
@@ -59,6 +65,11 @@ class ORSAdapter:
             "items": items,
             "events": [_event_to_dict(e) for e in result.events],
             "error": metadata_error,
+            # Headline ``(space, granularity)`` tag of the aggregate reward —
+            # mirrors the per-event tags above so downstream trainers know
+            # which evaluation space the top-level ``reward`` belongs to.
+            "space": result.space,
+            "granularity": result.granularity,
         }
         if not reward_is_valid:
             metadata["raw_reward"] = repr(result.reward)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -162,6 +162,8 @@ class TestORSAdapter:
             "reward": 0.5,
             "source": "mid-check",
             "step": 3,
+            "space": "output",
+            "granularity": "terminal",
             "timestamp": "2025-06-01T12:00:00",
         }
 
@@ -169,6 +171,75 @@ class TestORSAdapter:
         vr = VerifyResult(reward=1.0, items={"A": 1.0}, events=[])
         ors = ORSAdapter.verify_result_to_ors(vr)
         assert ors["metadata"]["events"] == []
+
+    def test_reward_event_preserves_non_output_space_and_step_granularity(
+        self,
+    ) -> None:
+        """ORS event dict carries (space, granularity) — issue #391.
+
+        Without these tags, memory/action/reasoning process rewards become
+        indistinguishable from output-space terminal rewards after export.
+        """
+        event = RewardEvent(
+            type="dense",
+            reward=0.5,
+            source="memory-scorer",
+            step=2,
+            space="memory",
+            granularity="step",
+        )
+        d = ORSAdapter.reward_event_to_ors(event)
+        assert d["space"] == "memory"
+        assert d["granularity"] == "step"
+
+    def test_verify_result_preserves_headline_space_and_granularity(self) -> None:
+        """ORS metadata carries the aggregate ``(space, granularity)`` tag."""
+        vr = VerifyResult(
+            reward=0.7,
+            items={"action-scorer": 0.7},
+            events=[],
+            space="action",
+            granularity="step",
+        )
+        ors = ORSAdapter.verify_result_to_ors(vr)
+        assert ors["metadata"]["space"] == "action"
+        assert ors["metadata"]["granularity"] == "step"
+
+    def test_verify_result_events_keep_per_event_tags(self) -> None:
+        """A mixed event list keeps each event's own ``(space, granularity)``."""
+        events = [
+            RewardEvent(
+                type="terminal",
+                reward=1.0,
+                source="output-judge",
+                space="output",
+                granularity="terminal",
+            ),
+            RewardEvent(
+                type="dense",
+                reward=0.4,
+                source="reasoning-scorer",
+                step=1,
+                space="reasoning",
+                granularity="step",
+            ),
+            RewardEvent(
+                type="dense",
+                reward=0.2,
+                source="memory-scorer",
+                step=2,
+                space="memory",
+                granularity="step",
+            ),
+        ]
+        vr = VerifyResult(reward=0.6, items={}, events=events)
+        ors = ORSAdapter.verify_result_to_ors(vr)
+        exported = ors["metadata"]["events"]
+        assert [(e["space"], e["granularity"]) for e in exported] == [
+            ("output", "terminal"),
+            ("reasoning", "step"),
+            ("memory", "step"),
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trajectories/test_export.py
+++ b/tests/trajectories/test_export.py
@@ -7,6 +7,7 @@ metrics, is_completed, is_truncated, example_id, info.
 
 import json
 
+from benchflow.rewards.events import RewardEvent
 from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories.export import (
     export_trajectories_to_jsonl,
@@ -117,3 +118,40 @@ def test_export_creates_parent_directory(tmp_path):
     out = tmp_path / "nested" / "deep" / "dataset.jsonl"
     export_trajectories_to_jsonl([], out)
     assert out.exists()
+
+
+def test_record_preserves_reward_space_and_granularity_tags():
+    """Trainer JSONL keeps ``(space, granularity)`` per event and headline.
+
+    Regression for issue #391: ORS reward-event export dropped both tags,
+    so memory/action/reasoning process events lost their evaluation-space
+    metadata at the trainer seam.
+    """
+    events = [
+        RewardEvent(
+            type="dense",
+            reward=0.4,
+            source="memory-scorer",
+            step=2,
+            space="memory",
+            granularity="step",
+        ),
+    ]
+    rec = trajectory_to_verifiers_record(
+        task_id="t",
+        messages=_sample_trajectory(),
+        verify_result=VerifyResult(
+            reward=0.4,
+            items={"memory-scorer": 0.4},
+            events=events,
+            space="memory",
+            granularity="step",
+        ),
+        model="m",
+        environment="clawsbench",
+    )
+    meta = rec["info"]["reward_metadata"]
+    assert meta["space"] == "memory"
+    assert meta["granularity"] == "step"
+    assert meta["events"][0]["space"] == "memory"
+    assert meta["events"][0]["granularity"] == "step"


### PR DESCRIPTION
Closes #391. `_event_to_dict` and `verify_result_to_ors` now emit `space`/`granularity` on every event dict and headline aggregate. Trainer JSONL via `trajectory_to_verifiers_record` now carries it under `info.reward_metadata`. 4 new regression tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive metadata fields on ORS/JSONL export with regression tests; no auth or scoring logic changes.
> 
> **Overview**
> Fixes **#391** by threading mandatory **`(space, granularity)`** reward tags through the ORS export seam so trainers can tell output, memory, action, and reasoning rewards apart.
> 
> **`ORSAdapter`** now includes **`space`** and **`granularity`** on each serialized **`RewardEvent`** and on the aggregate **`VerifyResult`** metadata. Verifiers/JSONL export already maps **`reward_metadata`** from that adapter, so headline and per-event tags show up under **`info.reward_metadata`** without a separate export change.
> 
> Existing expectations were updated for default tags; new regression tests cover non-output spaces, mixed event lists, and trajectory records.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4742850e0f081590461483cd6e2b875c541695e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->