### PR TITLE
fix: ManifestEnvironment.reset() implements the contract (#383)

### DIFF
--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -207,9 +207,19 @@ a branch quiesces the agent and services, restores a snapshot, and explores
 an alternative continuation. An environment with no `[environment.state]`
 table is stateless — `snapshot`/`restore` raise `RuntimeError`.
 
+## Reset — `reset`
+
+`reset` returns the environment to the per-task baseline so it can be reused
+for a fresh episode without tearing down the sandbox (distinct from
+`restore`, which rolls back to an arbitrary snapshot). For an environment
+that declares an `[environment.state]` table, `provision` captures a
+baseline; `reset` then stops the framework-started services, restores the
+baseline, and restarts the services. For an `owns_lifecycle = true` manifest
+the framework cannot restart entrypoint-owned services; `reset` is then a
+no-op (and the host must recycle the container for a hard reset).
+
 ## Not yet implemented
 
-`ManifestEnvironment` raises `NotImplementedError` or does not exercise:
+`ManifestEnvironment` does not exercise:
 
-- **`reset`** — full environment reset (distinct from snapshot roll-back).
 - **Sidecar / shared-fleet topology** — host-exposed ports, `AccountBroker`.

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -17,10 +17,12 @@ probes ``command -v`` and starts only the services actually installed (the
 same idea as ``detect_services_from_dockerfile``).
 
 Environment-state ``snapshot``/``restore`` are real here — roll-back over the
-SQLite files an ``[environment.state]`` table declares. The sidecar /
-shared-fleet topology (host-exposed ports, ``wait_for_readiness`` over httpx)
-and ``reset`` remain the platform layer; this adapter raises
-``NotImplementedError`` for ``reset``.
+SQLite files an ``[environment.state]`` table declares. ``reset`` returns the
+environment to the per-task baseline by stopping the services the framework
+started, restoring the baseline snapshot captured during ``provision`` (when
+``[environment.state]`` is declared), and restarting the services. The sidecar
+/ shared-fleet topology (host-exposed ports, ``wait_for_readiness`` over
+httpx) remains the platform layer.
 """
 
 from __future__ import annotations
@@ -54,6 +56,10 @@ class ManifestEnvironment:
         self._sandbox = sandbox
         self._handle: EnvHandle | None = None
         self._started: list[ServiceSpec] = []
+        # Baseline captured during ``provision`` for stateful manifests so
+        # ``reset`` can return the environment to its initial per-task state
+        # (distinct from arbitrary snapshot roll-back).
+        self._baseline: StateSnapshot | None = None
 
     async def provision(self, ctx: Any) -> EnvHandle:
         """Start the manifest's services inside the sandbox.
@@ -89,6 +95,11 @@ class ManifestEnvironment:
                 self._started.append(svc)
         endpoints = {p: f"http://localhost:{p}" for p in m.all_ports}
         self._handle = EnvHandle(name=m.name, endpoints=endpoints)
+        # Capture a baseline of the declared state so ``reset`` can return the
+        # environment to its per-task initial state. Stateless manifests have
+        # no [environment.state] table — ``reset`` then just restarts services.
+        if m.state is not None:
+            self._baseline = await self._capture_baseline()
         return self._handle
 
     async def readiness(self) -> ReadinessProbe:
@@ -152,13 +163,21 @@ class ManifestEnvironment:
         ``sqlite3 .backup`` (a consistent online backup) into a per-snapshot
         directory inside the sandbox.
         """
-        spec = self._manifest.state
-        if spec is None:
+        if self._manifest.state is None:
             raise RuntimeError(
                 f"environment '{self._manifest.name}' declares no "
                 "[environment.state]; snapshot/restore are unsupported for a "
                 "stateless environment"
             )
+        return await self._capture_baseline()
+
+    async def _capture_baseline(self) -> StateSnapshot:
+        """Copy the declared state files into a fresh in-sandbox snapshot dir.
+
+        Caller guarantees ``self._manifest.state`` is not None.
+        """
+        spec = self._manifest.state
+        assert spec is not None  # caller checks
         snap_id = uuid4().hex[:12]
         snap_dir = f"/tmp/benchflow-snapshots/{snap_id}"
         cmds = [f"mkdir -p {shlex.quote(snap_dir)}"]
@@ -189,4 +208,47 @@ class ManifestEnvironment:
         await self._sandbox.exec(" && ".join(cmds), timeout_sec=120)
 
     async def reset(self) -> None:
-        raise NotImplementedError("environment reset is not yet implemented")
+        """Return the environment to its per-task initial state.
+
+        Distinct from ``restore`` (which rolls back to an arbitrary snapshot):
+        ``reset`` returns to the baseline captured during ``provision`` so the
+        environment can be reused for a fresh episode without tearing down the
+        sandbox. The sequence is the inverse of ``provision`` for the same
+        manifest:
+
+        1. Stop the services the framework started (best-effort ``pkill``).
+        2. Restore the baseline state snapshot, if a baseline exists. A
+           stateless manifest skips this step.
+        3. Restart the previously-started services so the environment is ready
+           for the next episode.
+
+        When the image entrypoint owns the lifecycle (``owns_lifecycle = true``)
+        the framework cannot restart services itself; ``reset`` then only
+        restores baseline state (if declared) and leaves the entrypoint-owned
+        services running.
+        """
+        if self._handle is None:
+            raise RuntimeError(
+                f"environment '{self._manifest.name}' has not been provisioned; "
+                "call provision() before reset()"
+            )
+        # 1. Stop framework-started services so the SQLite restore is consistent.
+        if self._started:
+            for svc in self._started:
+                binary = svc.command.split()[0]
+                with contextlib.suppress(Exception):
+                    await self._sandbox.exec(
+                        f"pkill -f {shlex.quote(binary)}", timeout_sec=10
+                    )
+        # 2. Restore the per-task baseline state, if any.
+        if self._baseline is not None:
+            await self.restore(self._baseline)
+        # 3. Restart the same services we previously started, in the same
+        #    background-with-log shape provision() uses. owns_lifecycle = true
+        #    manifests reach this with an empty self._started — nothing to do.
+        for svc in self._started:
+            log = f"/tmp/benchflow-env-{svc.name}.log"
+            await self._sandbox.exec(
+                f"{svc.command} > {log} 2>&1 &",
+                timeout_sec=15,
+            )

--- a/src/benchflow/environment/protocol.py
+++ b/src/benchflow/environment/protocol.py
@@ -10,8 +10,10 @@ The contract surface is **stable**, but split by altitude:
   for the verifier, and tear it down.
 * **Roll-back** — ``snapshot`` / ``restore``. The substrate ``Rollout.branch()``
   runs on; ``ManifestEnvironment`` implements them for SQLite-backed state.
-* **Platform layer** — ``reset``. Declared so it wires in later without a
-  contract change; ``ManifestEnvironment`` raises ``NotImplementedError``.
+* **Reset** — ``reset``. Returns the environment to its per-task initial
+  state without tearing down the sandbox. ``ManifestEnvironment`` cycles the
+  framework-started services and restores the baseline captured during
+  ``provision`` for stateful manifests.
 """
 
 from __future__ import annotations

--- a/tests/environment/test_manifest_env.py
+++ b/tests/environment/test_manifest_env.py
@@ -251,7 +251,77 @@ async def test_snapshot_restore_on_stateless_env_raise_clear_error():
         await env.restore(StateSnapshot(id="x"))
 
 
-async def test_reset_not_implemented():
+async def test_reset_before_provision_is_a_clear_error():
+    """Reset has no baseline before provision — fail loudly instead of silently
+    doing nothing. Guards the fix for #383: reset() used to ``raise
+    NotImplementedError`` unconditionally, masking real lifecycle bugs."""
     env = ManifestEnvironment(CLAWS, sandbox=FakeSandbox())
-    with pytest.raises(NotImplementedError):
+    with pytest.raises(RuntimeError, match="provision"):
         await env.reset()
+
+
+async def test_reset_restarts_framework_started_services_for_stateless_env():
+    """A stateless framework-started manifest has no baseline to restore, but
+    reset must still cycle the services so the next episode starts from a
+    clean process state. Guards the fix for #383."""
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CLAWS, sandbox=sandbox)
+    await env.provision(ctx=None)
+    sandbox.exec_calls.clear()
+    await env.reset()
+    pkills = [c for c in sandbox.exec_calls if "pkill" in c]
+    restarts = [c for c in sandbox.exec_calls if "serve" in c and c.rstrip().endswith("&")]
+    assert len(pkills) == 2, "reset must stop every framework-started service"
+    assert len(restarts) == 2, "reset must restart every framework-started service"
+    # No restore — there is no [environment.state] table, so no snapshot
+    # directory should be copied back over the live state files.
+    assert not any("/tmp/benchflow-snapshots/" in c for c in sandbox.exec_calls)
+
+
+async def test_reset_restores_baseline_state_for_stateful_env():
+    """A stateful manifest captures a baseline during provision; reset must
+    copy the baseline files back over the live paths so the next episode sees
+    the seed data, not whatever the previous agent left behind. Guards the
+    fix for #383."""
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CLAWS_STATEFUL, sandbox=sandbox)
+    await env.provision(ctx=None)
+    # Baseline backup runs during provision, before reset is called.
+    provision_backups = [c for c in sandbox.exec_calls if ".backup" in c]
+    assert provision_backups, "provision must capture a baseline for stateful manifests"
+    sandbox.exec_calls.clear()
+    await env.reset()
+    restore_cmds = [c for c in sandbox.exec_calls if "/tmp/benchflow-snapshots/" in c]
+    assert restore_cmds, "reset must copy the baseline state files back"
+    assert "/data/gmail.db" in restore_cmds[0]
+    # And restart the service we previously started.
+    assert any("serve" in c and c.rstrip().endswith("&") for c in sandbox.exec_calls)
+
+
+async def test_reset_on_owns_lifecycle_env_does_not_touch_services():
+    """When the image entrypoint owns the lifecycle, the framework never
+    started the services and cannot restart them. Reset on a stateless
+    owns_lifecycle manifest is therefore a no-op against the sandbox.
+    Guards the fix for #383."""
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CHI, sandbox=sandbox)
+    await env.provision(ctx=None)
+    sandbox.exec_calls.clear()
+    await env.reset()
+    assert sandbox.exec_calls == []
+
+
+async def test_reset_is_idempotent_across_multiple_calls():
+    """Reset can be called repeatedly between episodes — each call must
+    re-stop and re-start the framework-started services without drifting
+    state. Guards the fix for #383."""
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CLAWS, sandbox=sandbox)
+    await env.provision(ctx=None)
+    await env.reset()
+    sandbox.exec_calls.clear()
+    await env.reset()
+    pkills = [c for c in sandbox.exec_calls if "pkill" in c]
+    restarts = [c for c in sandbox.exec_calls if "serve" in c]
+    assert len(pkills) == 2
+    assert len(restarts) == 2


### PR DESCRIPTION
Closes #383. `reset()` stops framework-started services, restores baseline snapshot (when `[environment.state]` is declared), and restarts services. Raises before `provision()`. `owns_lifecycle=true` manifests without state get a no-op. 5 focused tests replace the prior `test_reset_not_implemented` tautology.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches episode lifecycle and SQLite restore ordering (stop services before copy); behavior is well-covered by tests but incorrect reset could leave dirty state between rollouts.
> 
> **Overview**
> Implements **`ManifestEnvironment.reset()`** (#383) so environments can be reused for another episode without tearing down the sandbox—separate from **`restore`**, which targets an arbitrary snapshot.
> 
> **Stateful manifests** (`[environment.state]`): **`provision`** now captures a per-task **baseline** via shared **`_capture_baseline()`** (also used by **`snapshot`**). **`reset`** stops framework-started services, restores that baseline, then restarts the same services. **`reset`** before **`provision`** raises **`RuntimeError`**.
> 
> **Stateless, framework-started** manifests: **`reset`** only cycles services (pkill + restart), with no SQLite copy. **`owns_lifecycle = true`**: no service stop/restart in the sandbox (no-op when the framework never started processes).
> 
> Docs and the Environment protocol describe **`reset`** as implemented; five tests replace the old **`NotImplementedError`** check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0b47c93319c2c634e4aee714d397f8d78fed132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->