### PR TITLE
feat: scaffold Monitor mode API/CLI (#386)

### DIFF
--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -45,6 +45,12 @@ from benchflow.evaluation import (
 )
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RolloutResult
+from benchflow.monitor import (
+    Monitor,
+    MonitorConfig,
+    MonitorNotImplementedError,
+    MonitorResult,
+)
 
 # Rewards protocol (v0.4 — composable Rubric + RewardFunc)
 from benchflow.rewards import (
@@ -157,6 +163,11 @@ __all__ = [
     "AgentInstallError",
     "AgentTimeoutError",
     "RolloutResult",
+    # Monitor mode — scaffolded API surface (#386)
+    "Monitor",
+    "MonitorConfig",
+    "MonitorResult",
+    "MonitorNotImplementedError",
     # Runtime
     "Agent",
     "Environment",

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1589,5 +1589,88 @@ def environment_cleanup(
     _cleanup_daytona_sandboxes(dry_run=dry_run, max_age_minutes=max_age_minutes)
 
 
+monitor_app = typer.Typer(
+    help=(
+        "Monitor mode — score a rollout in production (#386). "
+        "API surface scaffold; runtime not yet implemented."
+    ),
+)
+app.add_typer(monitor_app, name="monitor")
+
+
+def _monitor_not_implemented() -> None:
+    """Emit the canonical not-implemented message and exit non-zero.
+
+    Centralised so every ``bench monitor`` subcommand fails closed with the
+    same wording and exit code, matching the issue's "fail closed with a
+    clear not-implemented status" requirement.
+    """
+    from benchflow.monitor import not_implemented_message
+
+    console.print("[yellow]Monitor mode not implemented yet.[/yellow]")
+    console.print(not_implemented_message())
+    # Exit code 2 (not 1) — distinguishes "feature absent" from "feature
+    # ran and failed", so CI dashboards do not conflate the two.
+    raise typer.Exit(2)
+
+
+@monitor_app.command("run")
+def monitor_run(
+    source: Annotated[
+        str,
+        typer.Argument(
+            help="Source trajectory (persisted rollout dir, file, or URI)."
+        ),
+    ],
+    rubric: Annotated[
+        Path | None,
+        typer.Option("--rubric", help="Rubric/verifier definition to score against."),
+    ] = None,
+    jobs_dir: Annotated[
+        str,
+        typer.Option("--jobs-dir", help="Output root for monitor artifacts."),
+    ] = "jobs/monitor",
+    run_name: Annotated[
+        str | None,
+        typer.Option("--run-name", help="Human-readable id for this monitor run."),
+    ] = None,
+) -> None:
+    """Score one trajectory under monitor semantics. **Not yet implemented (#386).**"""
+    del source, rubric, jobs_dir, run_name  # accepted for API stability
+    _monitor_not_implemented()
+
+
+@monitor_app.command("replay")
+def monitor_replay(
+    trajectory_path: Annotated[
+        Path,
+        typer.Argument(help="Path to a persisted rollout/trajectory to re-score."),
+    ],
+    jobs_dir: Annotated[
+        str,
+        typer.Option("--jobs-dir", help="Output root for monitor artifacts."),
+    ] = "jobs/monitor",
+) -> None:
+    """Re-score a persisted rollout under monitor semantics. **Not yet implemented (#386).**"""
+    del trajectory_path, jobs_dir  # accepted for API stability
+    _monitor_not_implemented()
+
+
+@monitor_app.command("watch")
+def monitor_watch(
+    source: Annotated[
+        str,
+        typer.Argument(help="Live event source (webhook, polling endpoint, queue)."),
+    ],
+    jobs_dir: Annotated[
+        str,
+        typer.Option("--jobs-dir", help="Output root for monitor artifacts."),
+    ] = "jobs/monitor",
+) -> None:
+    """Stream-score live production events. **Not yet implemented (#386).**"""
+    del source, jobs_dir  # accepted for API stability
+    _monitor_not_implemented()
+
+
 if __name__ == "__main__":
     app()

--- a/src/benchflow/monitor.py
+++ b/src/benchflow/monitor.py
@@ -1,0 +1,209 @@
+"""Monitor mode — score a rollout in production.
+
+Architecture (``docs/architecture.md``) names three first-class modes on the
+single ``scored rollout`` engine:
+
+- **Eval**    — score it and stop.
+- **Train**   — score it and hand the trajectory to a trainer.
+- **Monitor** — score it in production.
+
+Eval and Train have runtime code paths; Monitor does not yet. This module is
+the **API surface stub** for #386 so callers, the CLI, and downstream tooling
+have a stable import target while the runtime is built out. Every entry point
+raises :class:`NotImplementedError` with a pointer to the next step.
+
+Why a stub now (versus deleting Monitor from the architecture doc):
+    The reward plane, trajectory schema, and ``RewardEvent`` tagging
+    (``space``/``granularity``) were designed so that Eval, Train, and Monitor
+    share one signal pipeline. Deferring the API forever risks Eval and Train
+    drifting into shapes that the future Monitor cannot adopt without a
+    breaking change. The stubs let us *fail closed* with a clear message
+    today and grow the real implementation behind the same surface.
+
+Next steps (tracked under #386):
+    1. Input source: persisted-rollout replay vs. live trace ingestion
+       (webhook/polling) — pick one for the MVP.
+    2. Output schema: how :class:`MonitorResult` differs from
+       :class:`benchflow.runtime.RuntimeResult` (alert metadata, incident
+       tags), or whether it just reuses the existing trajectory record with
+       a ``mode="monitor"`` discriminator.
+    3. Failure taxonomy: production incident vs. verifier error vs. infra
+       error — these must be distinguishable at the dashboard level.
+    4. Artifact path: ``jobs/monitor/<run>/`` parallel to ``jobs/eval/`` so
+       monitor evidence does not pollute release-eval evidence.
+    5. CLI wiring: ``bench monitor run``, ``bench monitor replay``,
+       ``bench monitor watch`` — exact verbs land with the MVP.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "MonitorConfig",
+    "MonitorResult",
+    "Monitor",
+    "MonitorNotImplementedError",
+    "not_implemented_message",
+]
+
+
+class MonitorNotImplementedError(NotImplementedError):
+    """Raised by Monitor stubs until the runtime lands (#386).
+
+    A dedicated subclass so callers and tests can distinguish "this whole
+    mode isn't built yet" from incidental NotImplementedErrors elsewhere.
+    """
+
+
+_NOT_IMPLEMENTED_MSG = (
+    "Monitor mode is not yet implemented — only the API surface is scaffolded. "
+    "Track progress on https://github.com/benchflow-ai/benchflow/issues/386 ; "
+    "see docstring on benchflow.monitor for the planned next steps."
+)
+
+
+def not_implemented_message() -> str:
+    """Canonical not-implemented message for Monitor mode.
+
+    Exported so the CLI (and other surfaces) emit consistent wording
+    without reaching into module-private constants.
+    """
+    return _NOT_IMPLEMENTED_MSG
+
+
+@dataclass
+class MonitorConfig:
+    """Configuration for a monitor run.
+
+    Mirrors the shape of :class:`benchflow.rollout.RolloutConfig` so that
+    Eval/Train/Monitor share one mental model: a scored rollout with a
+    pluggable source. Fields are intentionally minimal until #386's MVP
+    pins the input source contract.
+
+    Attributes:
+        source:
+            Where the monitored trajectory comes from. Until the runtime
+            lands this is opaque — planned values are a path to a
+            persisted rollout directory (replay mode) or a URI for live
+            ingestion (watch mode).
+        rubric_path:
+            Optional path to a rubric/verifier definition to score the
+            trajectory against. ``None`` means "use the same verifier the
+            trajectory was originally produced with."
+        jobs_dir:
+            Output root for monitor artifacts. Defaults to
+            ``jobs/monitor`` so monitor evidence is separable from eval
+            release evidence (see ``docs/architecture.md`` §Lifecycles).
+        run_name:
+            Optional human-readable name for the monitor run; defaults
+            to a timestamped id.
+        metadata:
+            Free-form tags (incident id, deployment id, region…) carried
+            into :class:`MonitorResult` for downstream alerting.
+    """
+
+    source: str | Path
+    rubric_path: str | Path | None = None
+    jobs_dir: str | Path = "jobs/monitor"
+    run_name: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class MonitorResult:
+    """Result of a monitor run.
+
+    Shape mirrors :class:`benchflow.runtime.RuntimeResult` deliberately so
+    that the reward/trajectory contract is identical across Eval, Train,
+    and Monitor (the architecture's "eval = monitoring = reward" promise).
+
+    Attributes:
+        run_name:        Stable id for the monitor run.
+        source:          Origin of the scored trajectory (as supplied in
+                         :class:`MonitorConfig`).
+        rewards:         Same shape as ``RolloutResult.rewards`` — a
+                         dict keyed by reward name, plus the canonical
+                         ``"reward"`` key for the terminal scalar.
+        trajectory:      Full trajectory under the monitor lens. Same
+                         schema as eval/train trajectories.
+        error:           Infra/transport failure (could not score).
+        verifier_error:  Verifier crashed while scoring (failure of the
+                         monitor itself, *not* of the production trace).
+        alert:           True iff this run should page a human — distinct
+                         from ``passed`` so production incidents do not
+                         look like eval regressions on dashboards.
+        artifact_dir:    Where artifacts are written under ``jobs_dir``.
+        metadata:        Echoed from :class:`MonitorConfig`.
+        started_at/finished_at: Run window for the monitor itself, not
+                         for the underlying production event.
+    """
+
+    run_name: str
+    source: str
+    rewards: dict[str, Any] | None = None
+    trajectory: list[dict] = field(default_factory=list)
+    error: str | None = None
+    verifier_error: str | None = None
+    alert: bool = False
+    artifact_dir: Path | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+
+
+class Monitor:
+    """Score a rollout in production (Mode 3 of the architecture).
+
+    API surface only — all methods raise :class:`MonitorNotImplementedError`
+    pointing at #386. The shape is fixed so callers and the CLI can import
+    against it today without committing to runtime details.
+
+    Usage (target — not yet functional)::
+
+        from benchflow.monitor import Monitor, MonitorConfig
+
+        config = MonitorConfig(source="jobs/prod-trace/abc123")
+        monitor = Monitor(config)
+        result = await monitor.run()       # -> MonitorResult
+        # or, for a live stream of production events:
+        async for result in monitor.watch():
+            ...
+    """
+
+    def __init__(self, config: MonitorConfig) -> None:
+        self.config = config
+
+    async def run(self) -> MonitorResult:
+        """Score a single persisted trajectory against the monitor rubric.
+
+        Not implemented — see :class:`Monitor` and :mod:`benchflow.monitor`.
+        """
+        logger.warning(_NOT_IMPLEMENTED_MSG)
+        raise MonitorNotImplementedError(_NOT_IMPLEMENTED_MSG)
+
+    async def replay(self, trajectory_path: str | Path) -> MonitorResult:
+        """Re-score a persisted rollout under monitor semantics.
+
+        Not implemented — see :class:`Monitor` and :mod:`benchflow.monitor`.
+        """
+        logger.warning(_NOT_IMPLEMENTED_MSG)
+        raise MonitorNotImplementedError(_NOT_IMPLEMENTED_MSG)
+
+    async def watch(self):  # type: ignore[no-untyped-def]
+        """Stream-score live production events.
+
+        Not implemented — see :class:`Monitor` and :mod:`benchflow.monitor`.
+
+        Will be an async iterator yielding :class:`MonitorResult` per event
+        once the input source contract is pinned (step 1 of the next steps
+        in :mod:`benchflow.monitor`).
+        """
+        logger.warning(_NOT_IMPLEMENTED_MSG)
+        raise MonitorNotImplementedError(_NOT_IMPLEMENTED_MSG)

--- a/tests/test_monitor_scaffold.py
+++ b/tests/test_monitor_scaffold.py
@@ -1,0 +1,133 @@
+"""Monitor mode API surface — scaffold guarantees for #386.
+
+These tests pin the *contract* of the Monitor scaffold (importable names,
+types on the public package, CLI subcommands present, fail-closed semantics).
+They are intentionally not behavioural — when the runtime lands, the
+behavioural tests will live in a separate module and these can be retained
+as a "the public API has not silently disappeared" guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from typer.testing import CliRunner
+
+import benchflow
+from benchflow.cli.main import app
+from benchflow.monitor import (
+    Monitor,
+    MonitorConfig,
+    MonitorNotImplementedError,
+    MonitorResult,
+    not_implemented_message,
+)
+
+
+def test_monitor_types_are_exported_from_package() -> None:
+    """Architecture names Monitor as a first-class mode — public package
+    must expose it alongside Eval/Train types."""
+    assert benchflow.Monitor is Monitor
+    assert benchflow.MonitorConfig is MonitorConfig
+    assert benchflow.MonitorResult is MonitorResult
+    assert benchflow.MonitorNotImplementedError is MonitorNotImplementedError
+    for name in (
+        "Monitor",
+        "MonitorConfig",
+        "MonitorResult",
+        "MonitorNotImplementedError",
+    ):
+        assert name in benchflow.__all__, f"{name} missing from benchflow.__all__"
+
+
+def test_monitor_not_implemented_error_is_subclass_of_notimplementederror() -> None:
+    """Callers may catch ``NotImplementedError`` generically; subclass
+    relationship keeps that contract."""
+    assert issubclass(MonitorNotImplementedError, NotImplementedError)
+
+
+def test_monitor_config_minimal_construction() -> None:
+    """Config must accept just a source — the only field whose absence
+    would make the call ambiguous."""
+    cfg = MonitorConfig(source="jobs/prod-trace/abc123")
+    assert str(cfg.source) == "jobs/prod-trace/abc123"
+    assert cfg.jobs_dir == "jobs/monitor"  # separable from eval evidence
+    assert cfg.rubric_path is None
+    assert cfg.metadata == {}
+
+
+def test_monitor_result_has_alert_distinct_from_passed() -> None:
+    """`alert` must exist as a distinct field — issue called out that
+    monitoring failures must not look like eval regressions on dashboards."""
+    result = MonitorResult(run_name="r1", source="x")
+    assert hasattr(result, "alert")
+    assert result.alert is False
+    # error and verifier_error remain the eval/train failure taxonomy
+    assert hasattr(result, "error")
+    assert hasattr(result, "verifier_error")
+
+
+def test_monitor_run_raises_not_implemented_with_issue_pointer() -> None:
+    """Every entry point must fail closed and point users to #386."""
+    cfg = MonitorConfig(source="anywhere")
+    monitor = Monitor(cfg)
+
+    with pytest.raises(MonitorNotImplementedError) as exc:
+        asyncio.run(monitor.run())
+    assert "386" in str(exc.value)
+
+
+def test_monitor_replay_and_watch_also_fail_closed() -> None:
+    """Replay and watch are part of the documented surface — same
+    fail-closed semantics so callers cannot accidentally believe a run
+    succeeded."""
+    cfg = MonitorConfig(source="anywhere")
+    monitor = Monitor(cfg)
+
+    with pytest.raises(MonitorNotImplementedError):
+        asyncio.run(monitor.replay("jobs/eval/old/task__abc"))
+    with pytest.raises(MonitorNotImplementedError):
+        asyncio.run(monitor.watch())
+
+
+def test_not_implemented_message_is_actionable() -> None:
+    """The message must point to an issue, name the mode, and be a single
+    string (used directly by the CLI)."""
+    msg = not_implemented_message()
+    assert isinstance(msg, str)
+    assert "Monitor" in msg
+    assert "386" in msg
+
+
+def test_cli_monitor_subcommand_exists() -> None:
+    """`bench monitor --help` must list run/replay/watch — the issue
+    asked for a monitor CLI even before the runtime exists."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["monitor", "--help"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    assert "run" in out
+    assert "replay" in out
+    assert "watch" in out
+
+
+def test_cli_monitor_run_fails_closed_with_exit_code_2() -> None:
+    """Exit code must be 2 (not 1) so dashboards can distinguish 'feature
+    absent' from 'feature ran and failed'."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["monitor", "run", "anywhere"])
+    assert result.exit_code == 2
+    assert "not implemented" in result.output.lower()
+    assert "386" in result.output
+
+
+def test_cli_monitor_replay_and_watch_also_exit_with_code_2() -> None:
+    runner = CliRunner()
+    for argv in (
+        ["monitor", "replay", "some/path"],
+        ["monitor", "watch", "queue://events"],
+    ):
+        result = runner.invoke(app, argv)
+        assert result.exit_code == 2, (argv, result.output)
+        assert "386" in result.output


### PR DESCRIPTION
Closes #386. Per playbook STOP rule (full runtime would exceed 500 lines), this lands a minimal API surface scaffold with documented next steps.

Adds `benchflow.monitor` module (`MonitorConfig`, `MonitorResult`, `Monitor.run/replay/watch`, `MonitorNotImplementedError`); `bench monitor run|replay|watch` CLI subcommands (exit code 2 to distinguish 'feature absent' from 'feature ran and failed'); re-exports from `benchflow` top-level. 10 new tests pinning the contract.

**Five next steps documented in module docstring**: input source, output schema, failure taxonomy, artifact path, CLI verb semantics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Stub-only surface with no scoring or production paths; changes are additive exports, CLI placeholders, and tests.
> 
> **Overview**
> Adds **Monitor** as a third architecture mode alongside Eval/Train: a new `benchflow.monitor` module with `MonitorConfig`, `MonitorResult` (including an **`alert`** field separate from eval-style pass/fail), `MonitorNotImplementedError`, and stub async methods `run` / `replay` / `watch` that **fail closed** with a message pointing at issue **#386**.
> 
> The top-level `benchflow` package re-exports those types. The CLI gains **`bench monitor run`**, **`replay`**, and **`watch`** with stable flags; each command prints the canonical not-implemented text and exits with code **2** so CI can tell “feature missing” from “run failed.”
> 
> Contract tests lock exports, config defaults (`jobs/monitor`), error subclassing, and CLI behavior. Runtime scoring is explicitly deferred; the module docstring lists five follow-up work items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1747723aba9338ba3ecced31e5272e375141e7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->