### PR TITLE
fix: align benchmark descriptors with current converter behavior (#369)

### DIFF
--- a/benchmarks/opaquetoolsbench/benchmark.yaml
+++ b/benchmarks/opaquetoolsbench/benchmark.yaml
@@ -27,13 +27,16 @@ tasks:
 # ── Conversion ───────────────────────────────────────────────────────
 # How raw benchmark data is converted to BenchFlow task format.
 conversion:
-  script: benchflow.py           # CLI: --output-dir, --limit, --overwrite, --task-ids
+  script: benchflow.py           # CLI: --opaquetoolsbench-dir, --output-dir, --limit, --overwrite, --task-ids
   source_format: "JSON config files in tool_configs/"
-  has_oracle_solutions: false
+  has_oracle_solutions: true
   oracle_notes: >
     Ground truth is provided as Python function-call strings
     (e.g. "calc_binomial_probability(n=20, k=5, p=0.6)"). The
-    agent must produce equivalent function call(s) as JSON.
+    converter emits solution/solve.sh per task — it parses the
+    ground-truth Python calls with ast and writes the equivalent
+    JSON function-call array to /app/output/response.json,
+    matching the agent's expected output format.
   docker_image_pinned: true      # python:3.13-slim pinned by digest
 
 # ── Verification ─────────────────────────────────────────────────────

--- a/benchmarks/programbench/benchflow.py
+++ b/benchmarks/programbench/benchflow.py
@@ -11,9 +11,11 @@ Requires a local checkout of the ProgramBench repo (or the installed
 
 from __future__ import annotations
 
+import argparse
 import json
 import logging
 import shutil
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from string import Template
@@ -553,3 +555,101 @@ def generate_all(
 
     logger.info("Generated %d tasks in %s", len(generated), output_dir)
     return generated
+
+
+# ── CLI ──────────────────────────────────────────────────────────────
+
+
+def _resolve_tasks_dir(explicit: Path | None) -> Path:
+    """Find the ProgramBench tasks directory."""
+    if explicit is not None:
+        # Accept either the repo root or the data/tasks dir directly.
+        candidate = explicit / "src" / "programbench" / "data" / "tasks"
+        if candidate.is_dir():
+            return candidate
+        if (explicit / "task.yaml").exists() or any(explicit.glob("*/task.yaml")):
+            return explicit
+        raise FileNotFoundError(f"No ProgramBench tasks found at {explicit}")
+
+    # Try the installed package.
+    try:
+        from programbench.constants import TASKS_DIR
+
+        if TASKS_DIR.is_dir():
+            return TASKS_DIR
+    except ImportError:
+        pass
+
+    # Try common local paths.
+    for path in [
+        Path.cwd() / "programbench",
+        Path.home() / "programbench",
+    ]:
+        candidate = path / "src" / "programbench" / "data" / "tasks"
+        if candidate.is_dir():
+            return candidate
+
+    print(
+        "ERROR: Cannot find ProgramBench tasks. Either:\n"
+        "  1. Install programbench: pip install programbench\n"
+        "  2. Pass --programbench-dir /path/to/programbench",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def main() -> None:
+    """CLI entry point — generate BenchFlow tasks from ProgramBench instances."""
+    parser = argparse.ArgumentParser(
+        description="Generate BenchFlow tasks from ProgramBench instances.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        required=True,
+        help="Directory to write generated task directories into.",
+    )
+    parser.add_argument(
+        "--programbench-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Path to ProgramBench repo or data/tasks directory. "
+            "If omitted, tries the installed programbench package."
+        ),
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None, help="Generate at most N tasks."
+    )
+    parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Overwrite existing task directories.",
+    )
+    parser.add_argument(
+        "--task-ids",
+        nargs="*",
+        default=None,
+        help="Only generate these instance IDs.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+
+    tasks_dir = _resolve_tasks_dir(args.programbench_dir)
+    generated = generate_all(
+        tasks_dir,
+        args.output_dir,
+        overwrite=args.overwrite,
+        limit=args.limit,
+        task_ids=args.task_ids,
+    )
+    print(f"Generated {len(generated)} tasks in {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/programbench/benchmark.yaml
+++ b/benchmarks/programbench/benchmark.yaml
@@ -26,7 +26,7 @@ tasks:
 # ── Conversion ───────────────────────────────────────────────────────
 # How raw benchmark data is converted to BenchFlow task format.
 conversion:
-  script: benchflow.py       # CLI: --output-dir, --limit, --overwrite, --task-ids
+  script: benchflow.py       # CLI: --output-dir, --programbench-dir, --limit, --overwrite, --task-ids
   generator: main.py         # python -m benchmarks.programbench.main --output-dir ...
   source_format: task.yaml + Docker images
   has_oracle_solutions: true

--- a/benchmarks/programbench/main.py
+++ b/benchmarks/programbench/main.py
@@ -1,5 +1,10 @@
 """CLI entry point for ProgramBench → BenchFlow task generation.
 
+Thin delegator to :func:`benchmarks.programbench.benchflow.main` so the
+documented ``python -m benchmarks.programbench.main`` invocation keeps
+working while ``benchmarks/programbench/benchflow.py`` is the single
+source of truth for the converter CLI.
+
 Usage::
 
     python -m benchmarks.programbench.main --output-dir benchmarks/programbench/tasks
@@ -9,99 +14,7 @@ Usage::
 
 from __future__ import annotations
 
-import argparse
-import logging
-import sys
-from pathlib import Path
-
-from benchmarks.programbench.benchflow import generate_all
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Generate BenchFlow tasks from ProgramBench instances.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=Path,
-        required=True,
-        help="Directory to write generated task directories into.",
-    )
-    parser.add_argument(
-        "--programbench-dir",
-        type=Path,
-        default=None,
-        help="Path to ProgramBench repo or data/tasks directory.  "
-        "If omitted, tries the installed programbench package.",
-    )
-    parser.add_argument(
-        "--limit", type=int, default=None, help="Generate at most N tasks."
-    )
-    parser.add_argument(
-        "--overwrite", action="store_true", help="Overwrite existing task directories."
-    )
-    parser.add_argument(
-        "--task-ids",
-        nargs="*",
-        default=None,
-        help="Only generate these instance IDs.",
-    )
-    parser.add_argument("-v", "--verbose", action="store_true")
-    args = parser.parse_args()
-
-    logging.basicConfig(
-        level=logging.DEBUG if args.verbose else logging.INFO,
-        format="%(asctime)s %(levelname)s %(message)s",
-    )
-
-    tasks_dir = _resolve_tasks_dir(args.programbench_dir)
-    generated = generate_all(
-        tasks_dir,
-        args.output_dir,
-        overwrite=args.overwrite,
-        limit=args.limit,
-        task_ids=args.task_ids,
-    )
-    print(f"Generated {len(generated)} tasks in {args.output_dir}")
-
-
-def _resolve_tasks_dir(explicit: Path | None) -> Path:
-    """Find the ProgramBench tasks directory."""
-    if explicit is not None:
-        # Accept either the repo root or the data/tasks dir directly
-        candidate = explicit / "src" / "programbench" / "data" / "tasks"
-        if candidate.is_dir():
-            return candidate
-        if (explicit / "task.yaml").exists() or any(explicit.glob("*/task.yaml")):
-            return explicit
-        raise FileNotFoundError(f"No ProgramBench tasks found at {explicit}")
-
-    # Try the installed package
-    try:
-        from programbench.constants import TASKS_DIR
-
-        if TASKS_DIR.is_dir():
-            return TASKS_DIR
-    except ImportError:
-        pass
-
-    # Try common local paths
-    for path in [
-        Path.cwd() / "programbench",
-        Path.home() / "programbench",
-    ]:
-        candidate = path / "src" / "programbench" / "data" / "tasks"
-        if candidate.is_dir():
-            return candidate
-
-    print(
-        "ERROR: Cannot find ProgramBench tasks. Either:\n"
-        "  1. Install programbench: pip install programbench\n"
-        "  2. Pass --programbench-dir /path/to/programbench",
-        file=sys.stderr,
-    )
-    sys.exit(1)
-
+from benchmarks.programbench.benchflow import main
 
 if __name__ == "__main__":
     main()

--- a/tests/test_adapter_scripts.py
+++ b/tests/test_adapter_scripts.py
@@ -3,6 +3,9 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+import yaml
+
 
 def test_harvey_lab_run_script_help_works():
     """Guards ENG-81: Harvey run script is invokable by path."""
@@ -111,3 +114,114 @@ def test_opaquetoolsbench_converter_emits_oracle_solution(tmp_path):
     solve_sh = output_dir / "executable-simple-0" / "solution" / "solve.sh"
     assert solve_sh.exists()
     assert "/app/output/response.json" in solve_sh.read_text()
+
+
+# ── Descriptor ↔ converter alignment (ENG-#369) ──────────────────────
+#
+# benchmark.yaml advertises capabilities (CLI flags, has_oracle_solutions).
+# These tests guard against drift between the descriptor and the actual
+# converter behavior.
+
+
+_BENCHMARKS_WITH_DESCRIPTOR_CLI = [
+    "programbench",
+    "opaquetoolsbench",
+    "harvey-lab",
+    "hilbench",
+    "continuallearningbench",
+]
+
+
+@pytest.mark.parametrize("benchmark", _BENCHMARKS_WITH_DESCRIPTOR_CLI)
+def test_benchflow_py_help_works(benchmark: str) -> None:
+    """benchmark.yaml's `conversion.script` must expose a usable --help.
+
+    Guards #369: ProgramBench's benchflow.py was an import-only module
+    while its descriptor advertised CLI flags.
+    """
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "benchmarks" / benchmark / "benchflow.py"
+    assert script.exists(), f"missing converter: {script}"
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"benchflow.py --help failed for {benchmark}: "
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    # An argparse help screen always prints "usage:".
+    assert "usage:" in result.stdout.lower(), (
+        f"benchflow.py --help did not print argparse usage for {benchmark}: "
+        f"stdout={result.stdout!r}"
+    )
+
+
+def test_opaquetoolsbench_descriptor_matches_oracle_emission(tmp_path: Path) -> None:
+    """benchmark.yaml's has_oracle_solutions must match converter output.
+
+    Guards #369: descriptor said False while the converter emits
+    solution/solve.sh.
+    """
+    repo = Path(__file__).resolve().parents[1]
+    descriptor = yaml.safe_load(
+        (repo / "benchmarks" / "opaquetoolsbench" / "benchmark.yaml").read_text()
+    )
+    advertised = descriptor["conversion"]["has_oracle_solutions"]
+
+    otb_dir = tmp_path / "OpaqueToolsBench"
+    configs_dir = otb_dir / "src" / "datasets" / "bfcl" / "tool_configs"
+    configs_dir.mkdir(parents=True)
+    (configs_dir / "executable_simple_base_config.json").write_text(
+        json.dumps(
+            {
+                "tests": [
+                    {
+                        "test_id": 0,
+                        "question": "Call the function.",
+                        "tools": [
+                            {
+                                "name": "f",
+                                "description": "",
+                                "parameters": {
+                                    "type": "object",
+                                    "properties": {},
+                                    "required": [],
+                                },
+                            }
+                        ],
+                        "ground_truth": ["f()"],
+                        "name_mapping": {},
+                        "execution_result_type": ["exact_match"],
+                    }
+                ]
+            }
+        )
+    )
+
+    output_dir = tmp_path / "tasks"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "benchmarks/opaquetoolsbench/benchflow.py",
+            "--opaquetoolsbench-dir",
+            str(otb_dir),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+    solve_sh = output_dir / "executable-simple-0" / "solution" / "solve.sh"
+    emits_oracle = solve_sh.exists()
+    assert emits_oracle == advertised, (
+        f"opaquetoolsbench descriptor says has_oracle_solutions={advertised} "
+        f"but converter emits oracle solve.sh={emits_oracle}"
+    )


### PR DESCRIPTION
Closes #369. (1) OpaqueToolsBench: `has_oracle_solutions: false → true`, rewritten oracle_notes, advertise `--opaquetoolsbench-dir`. (2) ProgramBench: implemented missing `main()` + argparse on `benchflow.py` so the documented CLI works; thin delegator on `main.py` keeps README invocation working. Parametrized `--help` test across all 5 benchmarks + descriptor-vs-converter consistency check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CLI wiring changes with new tests; no changes to verification logic or agent runtime behavior.
> 
> **Overview**
> Fixes **descriptor drift** for OpaqueToolsBench and ProgramBench so `benchmark.yaml` matches what the converters actually do.
> 
> **OpaqueToolsBench:** Sets `has_oracle_solutions` to **true** and updates `oracle_notes` to describe per-task `solution/solve.sh` (AST-parsed ground truth → JSON at `/app/output/response.json`). The conversion section now documents **`--opaquetoolsbench-dir`**.
> 
> **ProgramBench:** Moves the full argparse CLI (`main`, `_resolve_tasks_dir`, flags including `--programbench-dir`) into **`benchflow.py`**, which the descriptor already named as `conversion.script`. **`main.py`** only delegates to `benchflow.main` so `python -m benchmarks.programbench.main` keeps working.
> 
> **Tests:** Adds parametrized **`benchflow.py --help`** checks for five benchmarks and a test that OpaqueToolsBench’s advertised `has_oracle_solutions` matches whether the converter emits `solve.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6ee93470dff63355dd6736f045fa4606126487f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->