### PR TITLE
fix: dashboard refuses to publish stale release evidence (#366)

### DIFF
--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -18,6 +18,12 @@ Usage::
     LINEAR_API_KEY=... python dashboard/generate.py  # mirror roadmap from Linear
     python dashboard/generate.py --run-tests         # re-run tests, then mirror
     python dashboard/generate.py --allow-missing-linear  # local UI dev only
+    python dashboard/generate.py --allow-stale-evidence  # local UI dev only
+
+Production generation also refuses to publish when the junit test evidence is
+missing or older than the release surface (the project version in
+``pyproject.toml`` or the HEAD commit) — so the dashboard never ships a stale
+or empty test-evidence summary as if it were release-fresh.
 """
 
 from __future__ import annotations
@@ -260,7 +266,11 @@ def collect_tests() -> dict:
             "summary": {"passed": 0, "failed": 0, "skipped": 0, "total": 0},
             "suites": [],
             "failures": [],
+            "modified_at": None,
         }
+    modified_at = datetime.fromtimestamp(JUNIT.stat().st_mtime).strftime(
+        "%Y-%m-%d %H:%M:%S"
+    )
     root = ET.parse(JUNIT).getroot()
     suites: dict[str, dict] = {}
     failures: list[dict] = []
@@ -301,6 +311,7 @@ def collect_tests() -> dict:
         },
         "suites": suite_list,
         "failures": failures,
+        "modified_at": modified_at,
     }
 
 
@@ -1322,6 +1333,106 @@ def collect_repo_status() -> dict:
     }
 
 
+PYPROJECT_TOML = ROOT / "pyproject.toml"
+_VERSION_RE = re.compile(r'^\s*version\s*=\s*"([^"]+)"', re.MULTILINE)
+
+
+def _project_version() -> str | None:
+    """Read ``version = "..."`` from the project ``pyproject.toml``."""
+    try:
+        text = PYPROJECT_TOML.read_text()
+    except OSError:
+        return None
+    match = _VERSION_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _git_iso_time(args: list[str]) -> str | None:
+    """Return an ISO-8601 commit time from a git command, or None on failure."""
+    try:
+        return _git([*args, "--format=%cI"]) or None
+    except Exception:
+        return None
+
+
+def _parse_iso(stamp: str | None) -> datetime | None:
+    if not stamp:
+        return None
+    with contextlib.suppress(ValueError):
+        return datetime.fromisoformat(stamp.replace("Z", "+00:00"))
+    return None
+
+
+def _parse_local(stamp: str | None) -> datetime | None:
+    if not stamp:
+        return None
+    with contextlib.suppress(ValueError):
+        return datetime.strptime(stamp, "%Y-%m-%d %H:%M:%S")
+    return None
+
+
+def collect_release_evidence(tests: dict) -> dict:
+    """Decide whether the bundled test evidence is fresh for the current release.
+
+    The dashboard is published as a release-evidence surface; if the test
+    evidence is missing or older than what the working copy claims to ship,
+    refuse to publish (unless the operator explicitly opts into stale data).
+
+    Freshness is checked against two signals on the release surface:
+
+    * ``pyproject.toml`` — the file that carries the project ``version``.
+      A version bump without re-running the suite makes the bundled evidence
+      stale by definition.
+    * The HEAD commit time — any code change since the last suite run makes
+      the evidence stale relative to the code it is supposed to attest to.
+
+    Returns a record with the freshness verdict, the stale reasons, and the
+    timestamps used so the dashboard UI (and tests) can surface them.
+    """
+    junit_local = _parse_local(tests.get("modified_at"))
+    junit_available = bool(tests.get("available"))
+
+    version = _project_version()
+    pyproject_at: datetime | None = None
+    if PYPROJECT_TOML.is_file():
+        with contextlib.suppress(OSError):
+            pyproject_at = datetime.fromtimestamp(PYPROJECT_TOML.stat().st_mtime)
+    head_at = _parse_iso(_git_iso_time(["log", "-1", "HEAD"]))
+
+    reasons: list[str] = []
+    if not junit_available or junit_local is None:
+        reasons.append("junit.xml missing — no test evidence has been recorded")
+    else:
+        if pyproject_at is not None and junit_local < pyproject_at.replace(
+            microsecond=0
+        ):
+            reasons.append(
+                f"junit.xml ({tests.get('modified_at')}) is older than "
+                f"pyproject.toml version={version!r}"
+            )
+        if head_at is not None:
+            head_local = head_at.astimezone().replace(tzinfo=None, microsecond=0)
+            if junit_local < head_local:
+                reasons.append(
+                    f"junit.xml ({tests.get('modified_at')}) is older than "
+                    f"HEAD commit ({head_local.strftime('%Y-%m-%d %H:%M:%S')})"
+                )
+
+    def _fmt(dt: datetime | None) -> str | None:
+        return dt.strftime("%Y-%m-%d %H:%M:%S") if dt else None
+
+    return {
+        "version": version,
+        "junit_modified_at": tests.get("modified_at"),
+        "pyproject_modified_at": _fmt(pyproject_at),
+        "head_committed_at": _fmt(
+            head_at.astimezone().replace(tzinfo=None) if head_at else None
+        ),
+        "stale_reasons": reasons,
+        "fresh": not reasons,
+    }
+
+
 def build_data() -> dict:
     tests = collect_tests()
     jobs = collect_jobs()
@@ -1329,6 +1440,7 @@ def build_data() -> dict:
     roadmap = collect_roadmap()
     architecture = collect_architecture()
     repo = collect_repo_status()
+    release_evidence = collect_release_evidence(tests)
 
     done = sum(1 for c in CONCEPT_MAP["capabilities"] if c["status"] == "shipped")
     all_issues = _roadmap_issues(roadmap)
@@ -1348,6 +1460,7 @@ def build_data() -> dict:
             "advisories_open": sum(
                 1 for a in ADVISORIES["items"] if a["status"] == "open"
             ),
+            "release_evidence_fresh": release_evidence["fresh"],
         },
         "concept_map": CONCEPT_MAP,
         "architecture": architecture,
@@ -1357,6 +1470,7 @@ def build_data() -> dict:
         "jobs": jobs,
         "experiments": experiments,
         "advisories": ADVISORIES,
+        "release_evidence": release_evidence,
     }
 
 
@@ -1375,6 +1489,23 @@ def main() -> int:
         print(f"error: Roadmap must mirror live Linear: {error}", file=sys.stderr)
         print(
             "hint: set LINEAR_API_KEY or pass --allow-missing-linear for local UI dev",
+            file=sys.stderr,
+        )
+        return 1
+    evidence = data["release_evidence"]
+    if not evidence["fresh"] and "--allow-stale-evidence" not in sys.argv:
+        print(
+            "error: dashboard refuses to publish stale release evidence:",
+            file=sys.stderr,
+        )
+        for reason in evidence["stale_reasons"]:
+            print(f"  - {reason}", file=sys.stderr)
+        print(
+            "hint: run `python dashboard/generate.py --run-tests` to refresh,",
+            file=sys.stderr,
+        )
+        print(
+            "      or pass --allow-stale-evidence for local UI dev only",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_dashboard_release_evidence.py
+++ b/tests/test_dashboard_release_evidence.py
@@ -1,0 +1,299 @@
+"""Tests for the dashboard release-evidence freshness gate (#366).
+
+The dashboard is a release-evidence surface, so it must refuse to publish
+stale or missing test evidence by default — and must surface the freshness
+verdict in ``data.json`` so the UI can warn on it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from dashboard import generate
+
+
+def _write_junit(path: Path, *, passed: int = 1) -> None:
+    """Minimal valid junit.xml with ``passed`` passing testcases."""
+    cases = "\n".join(
+        f'    <testcase classname="suite_a" name="t{i}" time="0.01"/>'
+        for i in range(passed)
+    )
+    path.write_text(
+        '<?xml version="1.0" encoding="utf-8"?>\n'
+        f'<testsuite name="dashboard" tests="{passed}" failures="0" errors="0" '
+        'skipped="0">\n'
+        f"{cases}\n"
+        "</testsuite>\n"
+    )
+
+
+def _stamp(path: Path, when: datetime) -> None:
+    ts = when.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def _make_repo(tmp_path: Path, *, version: str = "0.5.0.dev0") -> Path:
+    """Build a minimal repo layout mirroring what generate.py reads."""
+    repo = tmp_path / "repo"
+    dash = repo / "dashboard"
+    dash.mkdir(parents=True)
+    pyproject = repo / "pyproject.toml"
+    pyproject.write_text(f'[project]\nname = "x"\nversion = "{version}"\n')
+    subprocess.run(
+        ["git", "init", "-q"], cwd=repo, check=True, stdout=subprocess.DEVNULL
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "t@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "T"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "."], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", "init"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    return repo
+
+
+def _retarget_generate(monkeypatch, repo: Path) -> None:
+    dash = repo / "dashboard"
+    monkeypatch.setattr(generate, "ROOT", repo)
+    monkeypatch.setattr(generate, "DASH", dash)
+    monkeypatch.setattr(generate, "JUNIT", dash / "junit.xml")
+    monkeypatch.setattr(generate, "OUT", dash / "data.json")
+    monkeypatch.setattr(generate, "PYPROJECT_TOML", repo / "pyproject.toml")
+    monkeypatch.setattr(generate, "ARCHITECTURE_MD", dash / "architecture.md")
+    # The fake repo has no roadmap helper or experiments/labs trees; stub the
+    # collectors so the freshness gate is what we are actually exercising.
+    monkeypatch.setattr(
+        generate,
+        "collect_roadmap",
+        lambda: {"source": {"kind": "linear-live"}, "milestones": []},
+    )
+    monkeypatch.setattr(generate, "collect_experiments", lambda: [])
+    monkeypatch.setattr(generate, "collect_jobs", lambda: _empty_jobs(dash))
+
+
+def _empty_jobs(dash: Path) -> dict:
+    return {
+        "groups": [],
+        "total_tasks": 0,
+        "total_runs": 0,
+        "archived_tasks": 0,
+        "archived_runs": 0,
+        "source": {
+            "path": str(dash / "jobs"),
+            "label": "jobs",
+            "configured": False,
+            "remembered": False,
+            "available": False,
+            "latest_modified_at": None,
+        },
+    }
+
+
+def test_collect_tests_embeds_junit_modified_at(tmp_path: Path, monkeypatch):
+    """Tests payload carries junit.xml's mtime so freshness can be checked."""
+    repo = _make_repo(tmp_path)
+    junit = repo / "dashboard" / "junit.xml"
+    _write_junit(junit)
+    when = datetime(2026, 5, 22, 12, 0, 0)
+    _stamp(junit, when)
+    _retarget_generate(monkeypatch, repo)
+
+    tests = generate.collect_tests()
+
+    assert tests["available"] is True
+    assert tests["modified_at"] == "2026-05-22 12:00:00"
+    assert tests["summary"] == {"passed": 1, "failed": 0, "skipped": 0, "total": 1}
+
+
+def test_collect_tests_marks_missing_junit_without_modified_at(
+    tmp_path: Path, monkeypatch
+):
+    """Missing junit.xml stays an explicit unavailable state with no mtime."""
+    repo = _make_repo(tmp_path)
+    _retarget_generate(monkeypatch, repo)
+
+    tests = generate.collect_tests()
+
+    assert tests["available"] is False
+    assert tests["modified_at"] is None
+
+
+def test_release_evidence_flags_missing_junit_as_stale(tmp_path: Path, monkeypatch):
+    """Missing test evidence is the strongest stale signal."""
+    repo = _make_repo(tmp_path)
+    _retarget_generate(monkeypatch, repo)
+
+    evidence = generate.collect_release_evidence(generate.collect_tests())
+
+    assert evidence["fresh"] is False
+    assert evidence["junit_modified_at"] is None
+    assert any("junit.xml missing" in r for r in evidence["stale_reasons"])
+
+
+def test_release_evidence_flags_junit_older_than_pyproject(
+    tmp_path: Path, monkeypatch
+):
+    """A version bump after the last suite run leaves the evidence stale."""
+    repo = _make_repo(tmp_path)
+    junit = repo / "dashboard" / "junit.xml"
+    _write_junit(junit)
+    _stamp(junit, datetime(2026, 5, 20, 12, 0, 0))
+    _stamp(repo / "pyproject.toml", datetime(2026, 5, 22, 12, 0, 0))
+    _retarget_generate(monkeypatch, repo)
+
+    evidence = generate.collect_release_evidence(generate.collect_tests())
+
+    assert evidence["fresh"] is False
+    assert any("pyproject.toml" in r for r in evidence["stale_reasons"])
+    assert evidence["version"] == "0.5.0.dev0"
+
+
+def test_release_evidence_flags_junit_older_than_head_commit(
+    tmp_path: Path, monkeypatch
+):
+    """Code changes since the last suite run leave the evidence stale."""
+    repo = _make_repo(tmp_path)
+    junit = repo / "dashboard" / "junit.xml"
+    _write_junit(junit)
+    # Pin junit and pyproject well before the HEAD commit time so only the
+    # commit-vs-junit comparison fails.
+    long_ago = datetime.now() - timedelta(days=365)
+    _stamp(junit, long_ago)
+    _stamp(repo / "pyproject.toml", long_ago)
+    _retarget_generate(monkeypatch, repo)
+
+    evidence = generate.collect_release_evidence(generate.collect_tests())
+
+    assert evidence["fresh"] is False
+    assert any("HEAD commit" in r for r in evidence["stale_reasons"])
+
+
+def test_release_evidence_is_fresh_when_junit_newer_than_release_surface(
+    tmp_path: Path, monkeypatch
+):
+    """Junit newer than both pyproject and HEAD passes the gate."""
+    repo = _make_repo(tmp_path)
+    junit = repo / "dashboard" / "junit.xml"
+    _write_junit(junit)
+    future = datetime.now() + timedelta(hours=1)
+    _stamp(junit, future)
+    _retarget_generate(monkeypatch, repo)
+
+    evidence = generate.collect_release_evidence(generate.collect_tests())
+
+    assert evidence["fresh"] is True
+    assert evidence["stale_reasons"] == []
+    assert evidence["junit_modified_at"] is not None
+    assert evidence["pyproject_modified_at"] is not None
+    assert evidence["head_committed_at"] is not None
+
+
+def test_main_refuses_to_publish_when_evidence_is_stale(tmp_path: Path, monkeypatch):
+    """``main()`` exits non-zero and does not write data.json when stale."""
+    repo = _make_repo(tmp_path)
+    _retarget_generate(monkeypatch, repo)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate.py", "--allow-missing-linear"],
+    )
+    # No junit.xml — evidence is stale.
+
+    rc = generate.main()
+
+    assert rc == 1
+    assert not (repo / "dashboard" / "data.json").exists()
+
+
+def test_main_publishes_with_allow_stale_evidence_for_local_dev(
+    tmp_path: Path, monkeypatch
+):
+    """``--allow-stale-evidence`` is the documented escape hatch for local UI dev."""
+    repo = _make_repo(tmp_path)
+    _retarget_generate(monkeypatch, repo)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "generate.py",
+            "--allow-missing-linear",
+            "--allow-stale-evidence",
+        ],
+    )
+
+    rc = generate.main()
+
+    assert rc == 0
+    data = json.loads((repo / "dashboard" / "data.json").read_text())
+    assert data["release_evidence"]["fresh"] is False
+    assert data["summary"]["release_evidence_fresh"] is False
+
+
+def test_main_publishes_when_evidence_is_fresh(tmp_path: Path, monkeypatch):
+    """Happy path — fresh junit lets ``main()`` write data.json normally."""
+    repo = _make_repo(tmp_path)
+    junit = repo / "dashboard" / "junit.xml"
+    _write_junit(junit)
+    _stamp(junit, datetime.now() + timedelta(hours=1))
+    _retarget_generate(monkeypatch, repo)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["generate.py", "--allow-missing-linear"],
+    )
+
+    rc = generate.main()
+
+    assert rc == 0
+    data = json.loads((repo / "dashboard" / "data.json").read_text())
+    assert data["release_evidence"]["fresh"] is True
+    assert data["summary"]["release_evidence_fresh"] is True
+
+
+def test_release_evidence_handles_missing_pyproject(tmp_path: Path, monkeypatch):
+    """A repo with no pyproject.toml falls back to the HEAD signal only."""
+    repo = _make_repo(tmp_path)
+    junit = repo / "dashboard" / "junit.xml"
+    _write_junit(junit)
+    _stamp(junit, datetime.now() + timedelta(hours=1))
+    pyproject = repo / "pyproject.toml"
+    pyproject.unlink()
+    _retarget_generate(monkeypatch, repo)
+
+    evidence = generate.collect_release_evidence(generate.collect_tests())
+
+    assert evidence["version"] is None
+    assert evidence["pyproject_modified_at"] is None
+    # No pyproject signal, junit newer than HEAD ⇒ fresh.
+    assert evidence["fresh"] is True
+
+
+@pytest.mark.parametrize(
+    "version_line",
+    [
+        'version = "0.5.0.dev0"',
+        'version  =  "1.2.3"',
+        '\tversion = "9.9.9rc1"',
+    ],
+)
+def test_project_version_parses_common_pyproject_formats(
+    tmp_path: Path, monkeypatch, version_line: str
+):
+    """The version regex tolerates whitespace variants seen in real configs."""
+    repo = _make_repo(tmp_path)
+    (repo / "pyproject.toml").write_text(f"[project]\nname = \"x\"\n{version_line}\n")
+    _retarget_generate(monkeypatch, repo)
+
+    expected = version_line.split('"')[1]
+    assert generate._project_version() == expected

--- a/tests/test_dashboard_roadmap.py
+++ b/tests/test_dashboard_roadmap.py
@@ -767,6 +767,14 @@ def test_main_refuses_non_live_roadmap_without_local_dev_flag(
                 },
                 "milestones": [],
             },
+            "release_evidence": {
+                "version": "0.0.0",
+                "junit_modified_at": None,
+                "pyproject_modified_at": None,
+                "head_committed_at": None,
+                "stale_reasons": [],
+                "fresh": True,
+            },
         },
     )
     monkeypatch.setattr(sys, "argv", ["generate.py"])


### PR DESCRIPTION
Closes #366 (scoped to freshness gate, findings #1+#2; findings #3-5 already resolved or doc-copy). Added `collect_release_evidence(tests)` that compares `junit.xml` mtime against `pyproject.toml` and HEAD commit. `main()` refuses to publish (exit 1) when evidence is stale, unless `--allow-stale-evidence` is passed (mirrors existing `--allow-missing-linear` gate). 11 new tests + 80 dashboard sweep pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to dashboard generation and tests; no runtime product paths beyond failing closed when test evidence is outdated.
> 
> **Overview**
> Adds a **release-evidence freshness gate** to `dashboard/generate.py` so production runs do not write `data.json` when `junit.xml` is missing or older than the release surface.
> 
> `collect_tests()` now records **`modified_at`** from `junit.xml`’s mtime. New **`collect_release_evidence()`** compares that timestamp to **`pyproject.toml`** mtime (version surface) and **HEAD** commit time, returning `fresh`, `stale_reasons`, and related metadata. **`build_data()`** embeds `release_evidence` and **`summary.release_evidence_fresh`**. **`main()`** exits with an error when evidence is stale, unless **`--allow-stale-evidence`** is passed (parallel to `--allow-missing-linear` for local dev).
> 
> Adds **`tests/test_dashboard_release_evidence.py`** (11 tests) covering missing/aged junit, publish refusal, opt-out flag, and version parsing; **`test_dashboard_roadmap.py`** stubs include `release_evidence` in mocked `build_data`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9469105411f490559f23fb133f69be4217fb34a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->