### PR TITLE
fix: _DaytonaDinD.exec uses env-file wrapper too (#412 follow-up)

### DIFF
--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -763,14 +763,22 @@ class _DaytonaDinD(_DaytonaStrategy):
         parts: list[str] = ["exec", "-T"]
         if cwd:
             parts.extend(["-w", cwd])
-        if env:
-            for k, v in env.items():
-                parts.extend(["-e", f"{k}={v}"])
         if user is not None:
             parts.extend(["-u", str(user)])
+        # Env vars are materialized inside the target container via a
+        # mode-0600 file and sourced, rather than passed as ``-e KEY=VALUE``
+        # flags. The flags would land in the DinD VM's process list (visible
+        # to ``ps`` and any Daytona session audit log) and leak verifier
+        # API keys / agent secrets on every multi-service task (#412
+        # follow-up). Matches the wrapping that ``DaytonaSandbox._sandbox_exec``
+        # already applies to the outer VM-side command.
+        if env:
+            command = _wrap_daytona_command_with_env_file(env, command)
         # Use POSIX ``sh`` rather than ``bash``: with multi-service support
         # (#248), ``service`` can target arbitrary task containers, and
-        # Alpine/distroless/minimal images often ship no ``/bin/bash``.
+        # Alpine/distroless/minimal images often ship no ``/bin/bash``. The
+        # wrapped command uses only POSIX constructs (``trap``, ``base64 -d``,
+        # ``set -a``/``. file``).
         parts.extend([service, "sh", "-c", command])
 
         return await self._compose_exec(parts, timeout_sec=timeout_sec)

--- a/tests/test_sandbox_exec_secret_handling.py
+++ b/tests/test_sandbox_exec_secret_handling.py
@@ -146,3 +146,80 @@ class TestDaytonaExecEnvSecrecy:
         # the regression marker is ``env KEY=`` adjacency at a word boundary.)
         assert "env OPENAI_API_KEY=" not in cmd
         assert "env AUTHORIZATION=" not in cmd
+
+    @pytest.mark.asyncio
+    async def test_daytona_dind_exec_no_secret_in_argv(self) -> None:
+        """``_DaytonaDinD.exec`` must not emit ``docker compose exec -e K=V ...``.
+
+        The DinD strategy is the multi-service compose path: ``exec`` runs
+        ``docker compose exec -T -e KEY=VALUE ... <service> sh -c <command>``
+        inside the DinD VM. Putting ``-e KEY=VALUE`` flags on the argv leaks
+        every verifier env var (LLM judge API keys, agent tokens) into the
+        DinD VM process list and any provider-side command audit log on every
+        multi-service task. Regression for the #412 follow-up.
+        """
+        pytest.importorskip("daytona")  # sandbox-daytona optional dependency
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+
+        await strategy.exec(
+            "run-verifier",
+            env={"OPENAI_API_KEY": "sk-dind-leak", "AUTHORIZATION": "Bearer dind"},
+            service="main",
+        )
+
+        sub = captured[0]
+        # No raw secret values anywhere in the compose argv.
+        joined = " ".join(sub)
+        assert "sk-dind-leak" not in joined
+        assert "Bearer dind" not in joined
+        # And no ``-e KEY=VALUE`` flags at all — those are exactly what
+        # would land in ``ps`` and Daytona audit logs.
+        assert "-e" not in sub
+        assert not any(
+            token.startswith("OPENAI_API_KEY=") or token.startswith("AUTHORIZATION=")
+            for token in sub
+        )
+        # The wrapped command is still routed to the target container via
+        # ``sh -c <wrapper>`` and the wrapper sources an env file inside it.
+        assert sub[-3] == "sh"
+        assert sub[-2] == "-c"
+        wrapped = sub[-1]
+        assert wrapped.startswith("trap 'rm -f ")
+        assert "base64 -d" in wrapped
+        assert wrapped.endswith("run-verifier")
+
+    @pytest.mark.asyncio
+    async def test_daytona_dind_exec_without_env_unchanged(self) -> None:
+        """No env -> no wrapping; the user command is passed through verbatim.
+
+        Guards against the wrapper being applied for empty/None env (which
+        would change behavior unnecessarily and complicate debugging).
+        """
+        pytest.importorskip("daytona")
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+        captured: list[list[str]] = []
+
+        async def fake_compose_exec(subcommand, timeout_sec=None):
+            captured.append(subcommand)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        strategy._compose_exec = fake_compose_exec  # type: ignore[method-assign]
+
+        await strategy.exec("echo hi", service="main")
+
+        sub = captured[0]
+        assert sub[-1] == "echo hi"
+        assert "-e" not in sub


### PR DESCRIPTION
Follow-up to PR #430 (#412 fix). The correctness reviewer found that PR-C closed only the Direct Daytona path — `_DaytonaDinD.exec` still emitted `docker compose exec -T -e KEY=VALUE` argv, leaking verifier env on every multi-service task with docker-compose.yaml.

This PR applies `_wrap_daytona_command_with_env_file` to the DinD exec path too. 2 new tests at the DinD layer + 58 sandbox regression pass.

Stacks on top of PR #430.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how verifier and agent secrets reach compose containers; incorrect wrapping could break multi-service runs or still leak credentials.
> 
> **Overview**
> **Multi-service Daytona (DinD) exec** no longer passes verifier/agent env through `docker compose exec -e KEY=VALUE`, which exposed secrets on the DinD VM process list and provider audit logs (#412 follow-up).
> 
> When `env` is set, `_DaytonaDinD.exec` now wraps the user command with `_wrap_daytona_command_with_env_file` (base64 → mode-0600 file → `set -a` / source → `trap` cleanup), matching `_sandbox_exec` on the direct path. Calls without `env` are unchanged.
> 
> Two async regression tests assert DinD compose argv has no `-e`, no raw secrets, and uses the POSIX wrapper only when env is present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a8bab2acb6360d77f56904f7b1fee77c952bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->