### PR TITLE
fix: RolloutConfig coerces str path inputs to Path (#368.2, ENG-166)

### DIFF
--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -833,6 +833,15 @@ class RolloutConfig:
     def __post_init__(self) -> None:
         from benchflow._utils.config import normalize_agent_idle_timeout
 
+        if not isinstance(self.task_path, Path):
+            self.task_path = Path(self.task_path)
+        if self.context_root is not None and not isinstance(self.context_root, Path):
+            self.context_root = Path(self.context_root)
+        if self.skills_dir is not None and not isinstance(self.skills_dir, Path):
+            self.skills_dir = Path(self.skills_dir)
+        if not isinstance(self.jobs_dir, Path):
+            self.jobs_dir = Path(self.jobs_dir)
+
         self.agent = normalize_agent_name(self.agent)
         self.sandbox_user = normalize_sandbox_user(self.sandbox_user)
         self.agent_idle_timeout = normalize_agent_idle_timeout(self.agent_idle_timeout)

--- a/tests/test_rollout_config_path_coercion.py
+++ b/tests/test_rollout_config_path_coercion.py
@@ -1,0 +1,76 @@
+"""RolloutConfig coerces string path inputs to :class:`pathlib.Path`.
+
+Regression for #368.2 (ENG-166): passing ``task_path='tasks/foo'`` used to
+leave ``self.task_path`` as ``str``, then downstream callers that access
+``task_path.name`` raised ``AttributeError: 'str' object has no attribute
+'name'``. ``RolloutConfig.__post_init__`` now normalises ``task_path``,
+``context_root``, ``skills_dir``, and ``jobs_dir`` to ``Path``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchflow.rollout import RolloutConfig, Scene
+
+
+def test_rollout_config_coerces_task_path_string() -> None:
+    cfg = RolloutConfig(
+        task_path="tasks/foo",
+        scenes=[Scene.single(agent="claude-agent-acp")],
+    )
+
+    assert isinstance(cfg.task_path, Path)
+    assert cfg.task_path == Path("tasks/foo")
+    # The downstream attribute that originally crashed must now resolve.
+    assert cfg.task_path.name == "foo"
+
+
+def test_rollout_config_coerces_optional_paths() -> None:
+    cfg = RolloutConfig(
+        task_path="tasks/foo",
+        scenes=[Scene.single(agent="claude-agent-acp")],
+        context_root="ctx/root",
+        skills_dir="skills",
+        jobs_dir="custom-jobs",
+    )
+
+    assert isinstance(cfg.context_root, Path)
+    assert cfg.context_root == Path("ctx/root")
+    assert isinstance(cfg.skills_dir, Path)
+    assert cfg.skills_dir == Path("skills")
+    assert isinstance(cfg.jobs_dir, Path)
+    assert cfg.jobs_dir == Path("custom-jobs")
+
+
+def test_rollout_config_keeps_path_when_already_path() -> None:
+    task_path = Path("tasks/foo")
+    context_root = Path("ctx/root")
+    skills_dir = Path("skills")
+    jobs_dir = Path("custom-jobs")
+
+    cfg = RolloutConfig(
+        task_path=task_path,
+        scenes=[Scene.single(agent="claude-agent-acp")],
+        context_root=context_root,
+        skills_dir=skills_dir,
+        jobs_dir=jobs_dir,
+    )
+
+    # No double-wrapping: the stored value is the same Path instance the
+    # caller supplied, not ``Path(Path(...))``.
+    assert cfg.task_path is task_path
+    assert cfg.context_root is context_root
+    assert cfg.skills_dir is skills_dir
+    assert cfg.jobs_dir is jobs_dir
+
+
+def test_rollout_config_context_root_none_stays_none() -> None:
+    """Optional fields that default to ``None`` are left untouched."""
+    cfg = RolloutConfig(
+        task_path="tasks/foo",
+        scenes=[Scene.single(agent="claude-agent-acp")],
+    )
+
+    assert cfg.context_root is None
+    assert cfg.skills_dir is None

--- a/tests/test_self_gen_cli.py
+++ b/tests/test_self_gen_cli.py
@@ -56,6 +56,7 @@ def test_eval_create_single_task_self_gen_passes_trial_config(tmp_path: Path):
 
     cfg = captured["config"]
     assert cfg.skill_mode == "self-gen"
-    assert cfg.skills_dir == str(provided_skills)
+    # RolloutConfig.__post_init__ coerces str path inputs to Path (ENG-166).
+    assert cfg.skills_dir == provided_skills
     assert cfg.skill_creator_dir == str(skill_creator)
     assert cfg.self_gen_no_internet is True


### PR DESCRIPTION
Follow-up to PR #452. PR-#368's commit message claimed the string `task_path` AttributeError was "already fixed upstream in 81a63a3 (ENG-166)" but that commit lives on `cursor/user-audit-benchflow-0d54` and is NOT in v0.5-integration. Reproducing `RolloutConfig(task_path='tasks/foo', scenes=[...])` still threw AttributeError.

This PR cherry-picks the 9-line `__post_init__` coercion (covers `task_path`, `context_root`, `skills_dir`, `jobs_dir`). 4 new tests + 1921 regression pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small dataclass normalization in __post_init__ with focused tests; no auth, security, or rollout execution logic changes beyond type consistency.
> 
> **Overview**
> **`RolloutConfig.__post_init__`** now normalizes **`task_path`**, **`context_root`**, **`skills_dir`**, and **`jobs_dir`** from `str` to **`pathlib.Path`**, fixing **`AttributeError`** when callers pass string paths (e.g. `task_path='tasks/foo'`) and code uses **`.name`**. Existing **`Path`** instances are left as-is (no double-wrap); optional **`None`** values stay **`None`**.
> 
> Adds regression tests in **`tests/test_rollout_config_path_coercion.py`** (ENG-166 / #368.2) and updates **`test_self_gen_cli`** to expect **`skills_dir`** as **`Path`** after coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7292e3b12984d6824aa6e43aa8f6149167fac059. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->