### PR TITLE
fix: hosted-env evaluations use rollout reward/trajectory engine (#419)

### DIFF
--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -5,11 +5,19 @@ as PrimeIntellect's Verifiers hub. These are not BenchFlow task directories and
 they do not use BenchFlow's Docker/Daytona sandbox runner directly. The adapter
 keeps their hosted identity intact and runs them through their native Verifiers
 execution surface.
+
+Hosted runs share the rollout artifact contract — ``result.json``,
+``rewards.jsonl``, ``trajectory/acp_trajectory.jsonl``, ``config.json``,
+``timing.json``, and ``prompts.json`` — so dashboards and release checks can
+treat them as first-class evidence (with ``source.type="hosted_env"`` and
+``trajectory_source="hosted_env"`` marking the lineage). Raw vf-eval evidence
+is preserved under the ``hosted_env/`` subdir for forensics.
 """
 
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -19,6 +27,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+
+logger = logging.getLogger(__name__)
 
 PRIME_SIMPLE_INDEX = "https://hub.primeintellect.ai/primeintellect/simple/"
 PRIME_HUB_ENV_URL = "https://app.primeintellect.ai/dashboard/environments"
@@ -261,6 +271,7 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         "--save-results",
         "--disable-tui",
     ]
+    started_at = datetime.now(UTC)
     proc = subprocess.run(
         command,
         cwd=run_dir,
@@ -269,6 +280,7 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         capture_output=True,
         check=False,
     )
+    finished_at = datetime.now(UTC)
     result = HostedEnvRunResult(
         source_env=config.source_env,
         run_dir=run_dir,
@@ -282,7 +294,14 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         total_tool_calls=_extract_int_metric(proc.stdout, "total_tool_calls"),
         verifiers_error=_extract_verifiers_error(proc.stdout + "\n" + proc.stderr),
     )
-    _write_run_artifacts(result, config, install_cmd)
+    _write_run_artifacts(
+        result,
+        config,
+        install_cmd,
+        output_dir=output_dir,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
     return result
 
 
@@ -384,10 +403,31 @@ def _write_run_artifacts(
     result: HostedEnvRunResult,
     config: HostedEnvRunConfig,
     install_cmd: list[str],
+    *,
+    output_dir: Path,
+    started_at: datetime,
+    finished_at: datetime,
 ) -> None:
-    (result.run_dir / "stdout.log").write_text(result.stdout)
-    (result.run_dir / "stderr.log").write_text(result.stderr)
-    payload = {
+    """Write rollout-contract artifacts plus hosted-env-specific evidence.
+
+    The contract files (``result.json``, ``rewards.jsonl``,
+    ``trajectory/acp_trajectory.jsonl``, ``config.json``, ``timing.json``,
+    ``prompts.json``) match the schema produced by
+    ``benchflow.rollout._build_rollout_result`` so downstream tools treat
+    hosted runs as equivalent to native rollouts. Raw vf-eval evidence
+    (stdout, stderr, hosted-env metadata) stays under ``hosted_env/``.
+    """
+    (result.run_dir / "trajectory").mkdir(parents=True, exist_ok=True)
+    (result.run_dir / "agent").mkdir(parents=True, exist_ok=True)
+    (result.run_dir / "verifier").mkdir(parents=True, exist_ok=True)
+    (result.run_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+    hosted_dir = result.run_dir / "hosted_env"
+    hosted_dir.mkdir(parents=True, exist_ok=True)
+
+    # Hosted-env-specific evidence (forensics, debugging).
+    (hosted_dir / "stdout.log").write_text(result.stdout)
+    (hosted_dir / "stderr.log").write_text(result.stderr)
+    hosted_payload = {
         "source_env": result.source_env.env_id,
         "source_env_version": result.source_env.version,
         "env_uid": result.source_env.env_uid,
@@ -404,5 +444,387 @@ def _write_run_artifacts(
         "error": result.error,
         "command": result.command,
         "install_command": install_cmd,
+        "output_dir": str(output_dir),
     }
-    (result.run_dir / "result.json").write_text(json.dumps(payload, indent=2))
+    (hosted_dir / "hosted_run.json").write_text(json.dumps(hosted_payload, indent=2))
+
+    # Rollout-contract artifacts.
+    trajectory = _reconstruct_trajectory(output_dir, started_at)
+    rewards = _build_rewards_dict(result, output_dir)
+    prompts = _collect_prompts(output_dir, config)
+    timing = {"total": round((finished_at - started_at).total_seconds(), 1)}
+    task_name = result.source_env.env_uid
+    rollout_name = result.run_dir.name
+    source_provenance = _hosted_source_provenance(
+        result.source_env,
+        runner=config.runner,
+        env_args=config.env_args,
+    )
+
+    (result.run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
+        "\n".join(json.dumps(e, default=str) for e in trajectory)
+        + ("\n" if trajectory else "")
+    )
+
+    result_payload: dict[str, Any] = {
+        "task_name": task_name,
+        "rollout_name": rollout_name,
+        "rewards": rewards,
+        "agent": config.agent or None,
+        "agent_name": "verifiers",
+        "model": result.normalized_model or result.model or None,
+        "n_tool_calls": result.total_tool_calls or 0,
+        "n_prompts": len(prompts),
+        "agent_result": {
+            "n_tool_calls": result.total_tool_calls or 0,
+            "n_prompts": len(prompts),
+            "n_input_tokens": None,
+            "n_output_tokens": None,
+            "n_cache_read_tokens": None,
+            "n_cache_creation_tokens": None,
+            "total_tokens": None,
+            "cost_usd": None,
+            "usage_source": "unavailable",
+            "price_source": None,
+        },
+        "error": result.error if result.returncode != 0 or not result.verifiers_error else None,
+        "error_category": None,
+        "verifier_error": result.verifiers_error,
+        "verifier_error_category": None,
+        "idle_timeout_info": None,
+        "sandbox_startup_info": None,
+        "transport_error_info": None,
+        "verifier_timeout_info": None,
+        "partial_trajectory": False,
+        "trajectory_source": "hosted_env" if trajectory else None,
+        "started_at": str(started_at),
+        "finished_at": str(finished_at),
+        "timing": timing,
+        "scenes": [],
+        "source": source_provenance,
+    }
+    (result.run_dir / "result.json").write_text(json.dumps(result_payload, indent=2))
+    (result.run_dir / "timing.json").write_text(json.dumps(timing, indent=2))
+    (result.run_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
+
+    config_payload: dict[str, Any] = {
+        "task_path": None,
+        "agent": config.agent or None,
+        "model": result.normalized_model or result.model or None,
+        "environment": "hosted_env",
+        "skills_dir": None,
+        "sandbox_user": None,
+        "sandbox_locked_paths": None,
+        "sandbox_setup_timeout": None,
+        "context_root": None,
+        "timeout_sec": None,
+        "concurrency": config.concurrency,
+        "agent_idle_timeout_sec": None,
+        "started_at": str(started_at),
+        "agent_env": {},
+        "scenes": [],
+        "source": source_provenance,
+        "hosted_env": {
+            "provider": result.source_env.provider,
+            "env_uid": result.source_env.env_uid,
+            "runner": config.runner,
+            "num_examples": config.num_examples,
+            "rollouts_per_example": config.rollouts_per_example,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "sampling_args": config.sampling_args,
+            "env_args": config.env_args,
+        },
+    }
+    (result.run_dir / "config.json").write_text(json.dumps(config_payload, indent=2))
+
+    if rewards:
+        _write_hosted_rewards_jsonl(result.run_dir, rewards, finished_at)
+
+
+def _hosted_source_provenance(
+    ref: HostedEnvRef,
+    *,
+    runner: str,
+    env_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Provenance block stamped on hosted-env artifacts.
+
+    Uses ``type="hosted_env"`` so audit tools can distinguish imported
+    evidence from native git-rooted rollouts (which use ``type="github"``).
+    """
+    return {
+        "type": "hosted_env",
+        "provider": ref.provider,
+        "env_id": ref.env_id,
+        "env_uid": ref.env_uid,
+        "version": ref.version,
+        "hub_url": ref.hub_url,
+        "runner": runner,
+        "env_args": env_args,
+    }
+
+
+def _reconstruct_trajectory(
+    output_dir: Path,
+    started_at: datetime,
+) -> list[dict[str, Any]]:
+    """Build an ACP-shaped trajectory from vf-eval's saved results.
+
+    vf-eval ``--save-results`` writes per-example completions to
+    ``output_dir/results.jsonl``. Each line typically carries a list of
+    chat messages and a reward. We map each row to a ``user_message`` +
+    ``agent_message`` pair so the trajectory is non-empty and consumers
+    can audit what the model saw. The reconstruction is best-effort:
+    unknown shapes are skipped rather than raising.
+    """
+    results_path = _find_results_jsonl(output_dir)
+    if results_path is None:
+        return []
+
+    trajectory: list[dict[str, Any]] = []
+    ts = started_at.isoformat()
+    try:
+        with results_path.open() as f:
+            for example_idx, raw_line in enumerate(f):
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug("skipping non-JSON vf-eval row: %r", line[:80])
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                trajectory.extend(_row_to_acp_events(row, example_idx, ts))
+    except OSError as e:
+        logger.debug("could not read %s: %s", results_path, e)
+        return []
+    return trajectory
+
+
+def _find_results_jsonl(output_dir: Path) -> Path | None:
+    """Locate the vf-eval ``results.jsonl`` artifact, if it exists."""
+    if not output_dir.exists():
+        return None
+    candidates = [output_dir / "results.jsonl", *output_dir.rglob("results.jsonl")]
+    for path in candidates:
+        if path.is_file():
+            return path
+    return None
+
+
+def _row_to_acp_events(
+    row: dict[str, Any],
+    example_idx: int,
+    ts: str,
+) -> list[dict[str, Any]]:
+    """Convert one vf-eval results row to ACP-style session events."""
+    events: list[dict[str, Any]] = []
+    prompt = row.get("prompt") or row.get("question") or row.get("input")
+    if isinstance(prompt, list):
+        for msg in prompt:
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                content = msg.get("content")
+                if isinstance(content, str) and content:
+                    events.append(
+                        {
+                            "type": "user_message",
+                            "ts": ts,
+                            "example_index": example_idx,
+                            "content": content,
+                        }
+                    )
+    elif isinstance(prompt, str) and prompt:
+        events.append(
+            {
+                "type": "user_message",
+                "ts": ts,
+                "example_index": example_idx,
+                "content": prompt,
+            }
+        )
+
+    completion = row.get("completion") or row.get("response") or row.get("output")
+    if isinstance(completion, list):
+        for msg in completion:
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                content = msg.get("content")
+                if isinstance(content, str) and content:
+                    events.append(
+                        {
+                            "type": "agent_message",
+                            "ts": ts,
+                            "example_index": example_idx,
+                            "content": content,
+                        }
+                    )
+    elif isinstance(completion, str) and completion:
+        events.append(
+            {
+                "type": "agent_message",
+                "ts": ts,
+                "example_index": example_idx,
+                "content": completion,
+            }
+        )
+
+    reward = row.get("reward")
+    if isinstance(reward, int | float):
+        events.append(
+            {
+                "type": "reward",
+                "ts": ts,
+                "example_index": example_idx,
+                "value": float(reward),
+                "source": "verifiers",
+            }
+        )
+    return events
+
+
+def _collect_prompts(output_dir: Path, config: HostedEnvRunConfig) -> list[str]:
+    """Collect unique user prompts observed in vf-eval results.
+
+    Falls back to a synthetic descriptor when results.jsonl is missing.
+    """
+    results_path = _find_results_jsonl(output_dir)
+    if results_path is None:
+        return [
+            f"<hosted_env:{config.source_env.env_uid} num_examples="
+            f"{config.num_examples}>"
+        ]
+    prompts: list[str] = []
+    seen: set[str] = set()
+    try:
+        with results_path.open() as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                raw_prompt = row.get("prompt") or row.get("question") or row.get("input")
+                text = _stringify_prompt(raw_prompt)
+                if text and text not in seen:
+                    seen.add(text)
+                    prompts.append(text)
+    except OSError:
+        pass
+    if not prompts:
+        prompts.append(
+            f"<hosted_env:{config.source_env.env_uid} num_examples="
+            f"{config.num_examples}>"
+        )
+    return prompts
+
+
+def _stringify_prompt(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for msg in value:
+            if isinstance(msg, dict) and msg.get("role") == "user":
+                content = msg.get("content")
+                if isinstance(content, str):
+                    parts.append(content)
+        return "\n".join(parts)
+    return ""
+
+
+def _build_rewards_dict(
+    result: HostedEnvRunResult,
+    output_dir: Path,
+) -> dict[str, Any] | None:
+    """Construct a rewards dict matching the native rollout shape.
+
+    Native rollouts store rewards as ``{"reward": float, "rubric": [...]}``.
+    Hosted runs report a single average reward from vf-eval's stdout
+    summary, optionally augmented by per-example rubric items reconstructed
+    from ``results.jsonl``.
+    """
+    if result.reward is None:
+        return None
+    rubric: list[dict[str, Any]] = []
+    results_path = _find_results_jsonl(output_dir)
+    if results_path is not None:
+        try:
+            with results_path.open() as f:
+                for example_idx, raw_line in enumerate(f):
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    reward = row.get("reward")
+                    if isinstance(reward, int | float):
+                        rubric.append(
+                            {
+                                "name": f"example_{example_idx}",
+                                "score": float(reward),
+                            }
+                        )
+        except OSError:
+            pass
+    payload: dict[str, Any] = {"reward": float(result.reward)}
+    if rubric:
+        payload["rubric"] = rubric
+    return payload
+
+
+def _write_hosted_rewards_jsonl(
+    rollout_dir: Path,
+    rewards: dict[str, Any],
+    finished_at: datetime,
+) -> None:
+    """Mirror ``rollout._write_rewards_jsonl`` for hosted-env rewards.
+
+    Kept in this module to avoid importing from ``benchflow.rollout`` (which
+    pulls heavy ACP/sandbox deps at import time).
+    """
+    events: list[dict[str, Any]] = []
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            events.append(
+                {
+                    "ts": finished_at.isoformat(),
+                    "type": "process",
+                    "source": "verifier_rubric",
+                    "value": item.get("score", 0.0),
+                    "tag": item.get("name", f"rubric_{i}"),
+                    "step_index": i,
+                    "meta": {
+                        k: v for k, v in item.items() if k not in ("score", "name")
+                    },
+                }
+            )
+    scalar = rewards.get("reward")
+    if scalar is not None:
+        non_event_keys = {"reward", "rubric"}
+        events.append(
+            {
+                "ts": finished_at.isoformat(),
+                "type": "terminal",
+                "source": "verifier",
+                "value": scalar,
+                "tag": "reward",
+                "step_index": None,
+                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
+            }
+        )
+    if events:
+        path = rollout_dir / "rewards.jsonl"
+        path.write_text("\n".join(json.dumps(e, default=str) for e in events) + "\n")

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -12,8 +12,13 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from benchflow.rewards.events import RewardEvent
 
-TrajectorySource = Literal["acp", "scraped", "partial_acp"]
-"""Provenance label for a captured trajectory. See RunResult.trajectory_source."""
+TrajectorySource = Literal["acp", "scraped", "partial_acp", "hosted_env"]
+"""Provenance label for a captured trajectory. See RunResult.trajectory_source.
+
+``"hosted_env"`` marks UNTRUSTED imported evidence produced by an external
+hub (e.g. PrimeIntellect Verifiers). The events are reconstructed from
+``vf-eval`` results, not captured over BenchFlow's ACP transport.
+"""
 
 
 class AgentInstallError(RuntimeError):

--- a/tests/test_hosted_env.py
+++ b/tests/test_hosted_env.py
@@ -115,9 +115,22 @@ def test_run_hosted_env_uses_controlled_verifiers_venv(tmp_path, monkeypatch):
     sampling_args = json.loads(calls[2][calls[2].index("--sampling-args") + 1])
     assert sampling_args == {}
 
+    # Hosted-env-specific evidence keeps its hub identity for forensics.
+    hosted = json.loads((result.run_dir / "hosted_env" / "hosted_run.json").read_text())
+    assert hosted["env_uid"] == "primeintellect:primeintellect/general-agent@0.1.1"
+    assert hosted["rewards"] == {"reward": 1.0}
+
+    # The contract result.json matches the native rollout schema so dashboards
+    # and release checks can treat hosted runs as first-class evidence.
     payload = json.loads((result.run_dir / "result.json").read_text())
-    assert payload["env_uid"] == "primeintellect:primeintellect/general-agent@0.1.1"
+    assert payload["task_name"] == "primeintellect:primeintellect/general-agent@0.1.1"
     assert payload["rewards"] == {"reward": 1.0}
+    assert payload["agent"] == "gemini"
+    assert payload["agent_name"] == "verifiers"
+    assert payload["source"]["type"] == "hosted_env"
+    assert payload["source"]["env_uid"] == (
+        "primeintellect:primeintellect/general-agent@0.1.1"
+    )
 
 
 def test_run_hosted_env_uses_unique_collision_safe_run_dirs(tmp_path, monkeypatch):

--- a/tests/test_hosted_env_rollout_contract.py
+++ b/tests/test_hosted_env_rollout_contract.py
@@ -1,0 +1,195 @@
+"""Hosted-env runs must produce the same artifact contract as native rollouts.
+
+Guards PR #419: hosted-env evaluations previously bypassed the rollout
+reward and trajectory engine and wrote a custom ``result.json``, so they
+could not be compared to native rollouts without a schema rewrite.
+
+Each test pins one slice of the contract that downstream tools (dashboards,
+release checks, ``rewards.jsonl`` consumers, trajectory readers) depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from benchflow.hosted_env import (
+    HostedEnvRef,
+    HostedEnvRunConfig,
+    run_hosted_env,
+)
+
+VF_EVAL_STDOUT = "reward: avg - 1.000\ntotal_tool_calls: avg - 2.000\n"
+
+
+def _patch_run(monkeypatch: pytest.MonkeyPatch, *, results_jsonl: str = "") -> Path:
+    """Patch shutil.which + subprocess.run; capture the output_dir vf-eval sees."""
+    captured: dict[str, Path] = {}
+
+    def fake_which(binary: str) -> str:
+        return f"/bin/{binary}"
+
+    def fake_run(cmd, **kwargs):
+        if str(cmd[0]).endswith("vf-eval"):
+            output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+            captured["output_dir"] = output_dir
+            if results_jsonl:
+                output_dir.mkdir(parents=True, exist_ok=True)
+                (output_dir / "results.jsonl").write_text(results_jsonl)
+            return SimpleNamespace(returncode=0, stdout=VF_EVAL_STDOUT, stderr="")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("benchflow.hosted_env.shutil.which", fake_which)
+    monkeypatch.setattr("benchflow.hosted_env.subprocess.run", fake_run)
+    return Path(captured.get("output_dir", Path()))
+
+
+def _run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results_jsonl: str = ""):
+    _patch_run(monkeypatch, results_jsonl=results_jsonl)
+    return run_hosted_env(
+        HostedEnvRunConfig(
+            source_env=HostedEnvRef.parse(
+                "primeintellect/general-agent", version="0.1.1"
+            ),
+            model="gemini-3.1-flash-lite-preview",
+            env_args={"task": "calendar_scheduling_t0"},
+            agent="gemini",
+            jobs_dir=tmp_path,
+            num_examples=2,
+        )
+    )
+
+
+def test_hosted_env_writes_contract_result_json(tmp_path, monkeypatch):
+    """result.json carries the rollout-contract field set, not a custom shape."""
+    result = _run(tmp_path, monkeypatch)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    # Required rollout-contract keys consumed by EvaluationResult /
+    # summary.json / dashboards. Missing any of these would silently
+    # downgrade hosted evidence to second-class status — the original bug.
+    for key in (
+        "task_name",
+        "rollout_name",
+        "rewards",
+        "agent",
+        "agent_name",
+        "model",
+        "n_tool_calls",
+        "n_prompts",
+        "agent_result",
+        "error",
+        "verifier_error",
+        "partial_trajectory",
+        "trajectory_source",
+        "started_at",
+        "finished_at",
+        "timing",
+        "source",
+    ):
+        assert key in payload, f"missing contract key: {key}"
+
+    agent_result = payload["agent_result"]
+    for key in (
+        "n_tool_calls",
+        "n_prompts",
+        "n_input_tokens",
+        "n_output_tokens",
+        "total_tokens",
+        "cost_usd",
+        "usage_source",
+        "price_source",
+    ):
+        assert key in agent_result, f"missing agent_result key: {key}"
+
+
+def test_hosted_env_writes_rewards_jsonl(tmp_path, monkeypatch):
+    """rewards.jsonl is required by the dense-reward / metrics pipeline."""
+    result = _run(tmp_path, monkeypatch)
+
+    rewards_path = result.run_dir / "rewards.jsonl"
+    assert rewards_path.exists(), "rewards.jsonl must be written"
+    events = [json.loads(line) for line in rewards_path.read_text().splitlines() if line]
+    # At least one terminal verifier reward event.
+    terminal = [e for e in events if e["type"] == "terminal" and e["tag"] == "reward"]
+    assert len(terminal) == 1
+    assert terminal[0]["value"] == 1.0
+    assert terminal[0]["source"] == "verifier"
+
+
+def test_hosted_env_writes_trajectory_dir(tmp_path, monkeypatch):
+    """trajectory/acp_trajectory.jsonl must exist (empty is fine, missing is not)."""
+    results_jsonl = (
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "schedule a meeting"}],
+                "completion": [{"role": "assistant", "content": "10am works"}],
+                "reward": 1.0,
+            }
+        )
+        + "\n"
+    )
+    result = _run(tmp_path, monkeypatch, results_jsonl=results_jsonl)
+
+    traj_path = result.run_dir / "trajectory" / "acp_trajectory.jsonl"
+    assert traj_path.exists()
+    events = [json.loads(line) for line in traj_path.read_text().splitlines() if line]
+    kinds = [e["type"] for e in events]
+    assert "user_message" in kinds
+    assert "agent_message" in kinds
+    assert "reward" in kinds
+
+
+def test_hosted_env_marks_trajectory_source_as_imported(tmp_path, monkeypatch):
+    """trajectory_source must signal the lineage so consumers can downweight."""
+    results_jsonl = (
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "hi"}],
+                "completion": [{"role": "assistant", "content": "hello"}],
+                "reward": 1.0,
+            }
+        )
+        + "\n"
+    )
+    result = _run(tmp_path, monkeypatch, results_jsonl=results_jsonl)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+    assert payload["trajectory_source"] == "hosted_env"
+
+
+def test_hosted_env_records_imported_source_provenance(tmp_path, monkeypatch):
+    """source provenance must declare ``type=hosted_env`` (not ``github``)."""
+    result = _run(tmp_path, monkeypatch)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    source = payload["source"]
+    assert source["type"] == "hosted_env"
+    assert source["provider"] == "primeintellect"
+    assert source["env_uid"] == "primeintellect:primeintellect/general-agent@0.1.1"
+    assert source["version"] == "0.1.1"
+
+
+def test_hosted_env_writes_config_and_timing_and_prompts(tmp_path, monkeypatch):
+    """The supporting trio (config.json, timing.json, prompts.json) is part of the contract."""
+    result = _run(tmp_path, monkeypatch)
+    assert (result.run_dir / "config.json").exists()
+    assert (result.run_dir / "timing.json").exists()
+    assert (result.run_dir / "prompts.json").exists()
+
+    config = json.loads((result.run_dir / "config.json").read_text())
+    assert config["environment"] == "hosted_env"
+    assert config["hosted_env"]["env_uid"] == (
+        "primeintellect:primeintellect/general-agent@0.1.1"
+    )
+
+
+def test_hosted_env_keeps_raw_evidence_for_forensics(tmp_path, monkeypatch):
+    """Raw vf-eval evidence moves to hosted_env/ so it does not clobber the contract."""
+    result = _run(tmp_path, monkeypatch)
+    hosted_dir = result.run_dir / "hosted_env"
+    assert (hosted_dir / "hosted_run.json").exists()
+    assert (hosted_dir / "stdout.log").exists()
+    assert (hosted_dir / "stderr.log").exists()


### PR DESCRIPTION
Closes #419. Hosted-env runs (`--source-env`, PrimeIntellect Verifiers) now write the full rollout artifact contract: `result.json` matching native schema, `rewards.jsonl` with terminal + per-example rubric events, reconstructed `trajectory/acp_trajectory.jsonl`, plus `config.json`/`timing.json`/`prompts.json`. Raw vf-eval evidence relocated to `hosted_env/` subdir for forensics. New `trajectory_source='hosted_env'` literal + `source.type='hosted_env'` lineage tag distinguishes imported evidence. 7 new contract tests + 9 existing.

**Deferred**: token/cost telemetry (vf-eval format unstable); multi-example splitting; routing through `Evaluation.run()` directly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evaluation evidence shape and provenance labels that dashboards and release checks consume; reconstruction from vf-eval is best-effort and may not match full ACP capture fidelity.
> 
> **Overview**
> **Hosted-env runs (`--source-env` / Prime Verifiers) now emit the same rollout artifact bundle as native BenchFlow rollouts**, instead of a bespoke `result.json` at the run root.
> 
> After `vf-eval`, `_write_run_artifacts` writes contract files—`result.json` (native-shaped fields), `rewards.jsonl`, `trajectory/acp_trajectory.jsonl`, `config.json`, `timing.json`, `prompts.json`—by reconstructing trajectory, prompts, and rubric rewards from `results.jsonl` when present. Raw hub output moves under `hosted_env/` (`stdout.log`, `stderr.log`, `hosted_run.json`). Lineage is explicit via `source.type="hosted_env"` and `trajectory_source="hosted_env"` (new `TrajectorySource` literal in `models.py`). Tests assert the contract and updated expectations on the legacy hosted run test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2375c9c268173d4bf76605e2c1b3007c4d5b3fe9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->