### PR TITLE
fix: _export_error sibling channel; gate _commit_learner_generation on success (#389 follow-up)

### DIFF
--- a/src/benchflow/_utils/learner_memory.py
+++ b/src/benchflow/_utils/learner_memory.py
@@ -29,7 +29,16 @@ def expected_skills_for_task(task_dir: Path) -> list[str] | None:
 def evolved_skills_for_result(
     result: RolloutResult, export_dir: Path
 ) -> dict[str, Any]:
-    """Return skills captured from a rollout, preferring the result payload."""
+    """Return skills captured from a rollout, preferring the result payload.
+
+    When the rollout's skill export failed (``result.export_error``), the
+    ``export_dir`` is half-written and re-reading it would re-introduce the
+    same partial state the rollout already signalled as unsafe. Return ``{}``
+    in that case so callers don't accidentally feed broken artifacts into
+    the LearnerStore (#389 follow-up).
+    """
+    if result.export_error is not None:
+        return {}
     if result.evolved_skills is not None:
         return dict(result.evolved_skills)
     return capture_skills(export_dir)

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -833,6 +833,17 @@ class Evaluation:
         improvement stamps a new generation, a regression is reverted. An
         errored rollout (no reward) leaves the store untouched.
         """
+        # Skip everything when the skill export itself failed (#389 follow-up).
+        # The export dir is half-written and ``result.evolved_skills`` is None,
+        # so committing would poison the LearnerStore with an empty/partial
+        # generation even though the verifier may have produced rewards.
+        if result.export_error is not None:
+            logger.warning(
+                f"Learner store: {td.name} skill export failed — "
+                f"skipping generation commit, staying at generation "
+                f"{store.generation}"
+            )
+            return
         # 2/3. CAPTURE — the skills the agent generated/evolved. Prefer the
         # result's own field (the real Rollout populates it); fall back to
         # reading the export dir directly.

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -85,6 +85,10 @@ class RolloutResult:
         error:        Error description string, or None on success.
         verifier_error: Verifier error description, or None if verifier succeeded
                       or was not reached. Separate from ``error`` (agent errors).
+        export_error: Skill-export error description, or None if export succeeded
+                      or was not configured. Separate from ``error`` (which would
+                      mis-classify export-time infra failures as agent failures)
+                      and ``verifier_error``. See #389 follow-up.
         partial_trajectory: True when the trajectory was salvaged from a timed-out
                       or crashed session and may be incomplete.
         trajectory_source: Provenance label for ``trajectory`` — one of
@@ -126,6 +130,7 @@ class RolloutResult:
         price_source: str | None = None,
         error: str | None = None,
         verifier_error: str | None = None,
+        export_error: str | None = None,
         partial_trajectory: bool = False,
         trajectory_source: TrajectorySource | None = None,
         reward_events: list[RewardEvent] | None = None,
@@ -153,6 +158,7 @@ class RolloutResult:
         self.price_source = price_source
         self.error = error
         self.verifier_error = verifier_error
+        self.export_error = export_error
         self.partial_trajectory = partial_trajectory
         self.trajectory_source = trajectory_source
         self.reward_events = reward_events
@@ -163,15 +169,24 @@ class RolloutResult:
 
     @property
     def success(self) -> bool:
-        """True when the trial completed without agent or verifier error.
+        """True when the trial completed without agent, verifier, or export error.
 
-        Agent errors (error) and verifier errors (verifier_error) both
-        indicate an incomplete trial. Rewards may still be zero on success.
+        Agent errors (error), verifier errors (verifier_error), and skill-export
+        errors (export_error) all indicate an incomplete trial. Rewards may
+        still be zero on success.
         """
-        return self.error is None and self.verifier_error is None
+        return (
+            self.error is None
+            and self.verifier_error is None
+            and self.export_error is None
+        )
 
     def __repr__(self) -> str:
-        status = "OK" if self.success else f"ERROR: {self.error or self.verifier_error}"
+        status = (
+            "OK"
+            if self.success
+            else f"ERROR: {self.error or self.verifier_error or self.export_error}"
+        )
         return (
             f"RolloutResult(task={self.task_name}, {status}, "
             f"rewards={self.rewards}, "

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -453,6 +453,7 @@ def _build_rollout_result(
     verifier_error: str | None,
     trajectory: list[dict],
     partial_trajectory: bool,
+    export_error: str | None = None,
     trajectory_source: TrajectorySource | None = None,
     rewards: dict | None,
     started_at: datetime,
@@ -495,6 +496,7 @@ def _build_rollout_result(
         price_source=price_source,
         error=error,
         verifier_error=verifier_error,
+        export_error=export_error,
         partial_trajectory=partial_trajectory,
         trajectory_source=trajectory_source,
         evolved_skills=evolved_skills,
@@ -539,6 +541,7 @@ def _build_rollout_result(
                 "verifier_error_category": classify_verifier_error(
                     result.verifier_error
                 ),
+                "export_error": result.export_error,
                 "idle_timeout_info": idle_timeout_info,
                 "sandbox_startup_info": sandbox_startup_info,
                 "transport_error_info": transport_error_info,
@@ -970,6 +973,11 @@ class Rollout:
         self._rewards: dict | None = None
         self._verifier_error: str | None = None
         self._error: str | None = None
+        # Populated by _export_generated_skills() on failure (#389 follow-up).
+        # Kept separate from self._error so classify_error() does not mis-tag
+        # an export-time infra failure ("connection lost") as the agent's own
+        # infra_failure category in dashboards.
+        self._export_error: str | None = None
         self._idle_timeout_info: dict | None = None
         self._sandbox_startup_info: dict | None = None
         self._transport_error_info: dict | None = None
@@ -1554,16 +1562,17 @@ class Rollout:
             try:
                 await self._export_generated_skills()
             except Exception as e:
-                # Surface export failure as a rollout error so it cannot be
-                # confused with a successful-but-empty skill update (ENG/PR #389).
-                # An export that was configured-but-failed must not collapse
-                # into the same observable state as "agent honestly produced no
-                # skills". Preserve any pre-existing agent/run error: skill
-                # export happens during cleanup, after the agent already ran.
+                # Surface export failure on a dedicated sibling channel
+                # (#389 follow-up). Routing it through self._error caused
+                # classify_error("Skill export failed: ... connection lost")
+                # to mis-tag the rollout as agent infra_failure, polluting
+                # the agent-error dashboards. Keep the agent/verifier error
+                # channels untouched: export runs during cleanup, after the
+                # agent already finished.
                 export_error = f"Skill export failed: {e}"
                 logger.error(export_error)
-                if self._error is None:
-                    self._error = export_error
+                if self._export_error is None:
+                    self._export_error = export_error
                 self._evolved_skills = None
 
         usage_runtime = getattr(self, "_usage_runtime", None)
@@ -2218,6 +2227,7 @@ class Rollout:
             prompts=self._resolved_prompts,
             error=self._error,
             verifier_error=self._verifier_error,
+            export_error=self._export_error,
             trajectory=self._trajectory,
             partial_trajectory=self._partial_trajectory,
             trajectory_source=self._trajectory_source,

--- a/tests/test_self_gen_export_error_channel.py
+++ b/tests/test_self_gen_export_error_channel.py
@@ -1,0 +1,202 @@
+"""Regression tests for #389 follow-up: export-error channel + commit gating.
+
+Two material issues found in PR-#389 review:
+
+1. Channel mix: routing a skill-export failure through ``Rollout._error`` runs
+   ``classify_error("Skill export failed: ... connection lost")`` through the
+   "looks_like_infra" heuristic and mis-tags the rollout as agent
+   ``infra_failure``. That contaminates agent-error dashboards with a
+   cleanup-phase event the agent never caused. Fix: dedicated
+   ``_export_error`` / ``RolloutResult.export_error`` sibling channel.
+
+2. Learner-store poisoning: ``_commit_learner_generation`` ran unconditionally
+   even when export failed but the verifier already produced rewards.
+   It would commit an empty/partial skill delta as the next generation. Fix:
+   short-circuit on ``result.export_error``, and have
+   ``evolved_skills_for_result`` return ``{}`` instead of re-reading the
+   half-written export dir.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow._utils.learner_memory import evolved_skills_for_result
+from benchflow._utils.scoring import classify_error
+from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
+from benchflow.models import RunResult
+
+# --- Issue 1: classify_error must not mis-tag export-time infra failures ---
+
+
+def test_classify_error_on_export_failure_message_would_say_infra():
+    """Document the bug PR-389 fix introduced if export rides ``error``.
+
+    The fix lifts the export message onto a sibling channel exactly because
+    ``classify_error`` cannot distinguish agent infra failures from
+    cleanup-phase export infra failures by string alone.
+    """
+    # A real-shape message PR-389 was routing through self._error.
+    msg = "Skill export failed: sandbox connection lost while pulling /app/skills"
+    # If this were on result.error, dashboards would group it with the
+    # agent's own infra crashes. That's the contamination #389 follow-up
+    # exists to prevent — the fix keeps result.error = None and puts the
+    # message on result.export_error instead.
+    assert classify_error(msg) == "infra_failure"
+
+
+def test_rollout_result_export_error_does_not_feed_classify_error():
+    """A RolloutResult with only export_error set looks clean to classify_error."""
+    r = RunResult(
+        task_name="t",
+        rewards={"reward": 1.0},
+        export_error="Skill export failed: sandbox connection lost",
+    )
+    # The agent error channel stays clean, so dashboards see no infra bump.
+    assert r.error is None
+    assert classify_error(r.error) is None
+    # But the run is not "success" — the export failure is observable.
+    assert r.success is False
+
+
+def test_rollout_result_success_requires_no_export_error():
+    """``RolloutResult.success`` must also gate on ``export_error``."""
+    ok = RunResult(task_name="t", rewards={"reward": 1.0})
+    assert ok.success is True
+
+    failed = RunResult(
+        task_name="t",
+        rewards={"reward": 1.0},
+        export_error="Skill export failed: download failed",
+    )
+    assert failed.success is False
+
+
+# --- Issue 2: evolved_skills_for_result must short-circuit on export_error ---
+
+
+def test_evolved_skills_for_result_returns_empty_when_export_failed(tmp_path: Path):
+    """Refuse to re-read the half-written export dir on a failed export.
+
+    Otherwise the next generation would commit whatever partial state the
+    sandbox managed to write before it died — exactly the poisoning the
+    export-error channel exists to prevent.
+    """
+    # Simulate a half-written export dir on disk (would normally be picked
+    # up by capture_skills if we fell through).
+    export_dir = tmp_path / "exports"
+    skill_dir = export_dir / "half-written"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: half-written\n---\n# WIP\n")
+
+    result = RunResult(
+        task_name="t",
+        rewards={"reward": 1.0},
+        evolved_skills=None,  # Rollout set this to None on export failure.
+        export_error="Skill export failed: download failed",
+    )
+
+    # Even with files on disk and rewards populated, we return {}.
+    assert evolved_skills_for_result(result, export_dir) == {}
+
+
+def test_evolved_skills_for_result_prefers_result_payload_when_no_error(
+    tmp_path: Path,
+):
+    """Happy path: still prefer the in-memory payload, ignore the disk fallback."""
+    result = RunResult(
+        task_name="t",
+        rewards={"reward": 1.0},
+        evolved_skills={"a": "# A\n"},
+    )
+    assert evolved_skills_for_result(result, tmp_path / "exports") == {"a": "# A\n"}
+
+
+# --- Issue 2: _commit_learner_generation must skip on export_error ---
+
+
+def _make_job(tmp_path: Path, n_tasks: int):
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    for i in range(n_tasks):
+        (tasks_dir / f"task-{i}").mkdir()
+        (tasks_dir / f"task-{i}" / "task.toml").write_text(
+            'version = "1.0"\n[verifier]\ntimeout_sec = 60\n'
+            "[agent]\ntimeout_sec = 60\n[environment]\n"
+        )
+    cfg = EvaluationConfig(
+        concurrency=1,
+        retry=RetryConfig(max_retries=0),
+        job_mode="sequential-shared",
+    )
+    return Evaluation(tasks_dir=tasks_dir, jobs_dir=tmp_path / "jobs", config=cfg)
+
+
+@pytest.mark.asyncio
+async def test_export_failure_with_rewards_does_not_commit_generation(
+    tmp_path: Path,
+):
+    """The exact poisoning scenario: verifier produced rewards, but export failed.
+
+    Pre-fix, ``_commit_learner_generation`` would happily stamp a new
+    generation with an empty/partial skill delta because ``result.rewards``
+    was populated. The fix gates the entire commit path on
+    ``result.export_error is None``.
+    """
+    job = _make_job(tmp_path, n_tasks=2)
+    results = iter(
+        [
+            # Rewards populated AND evolved_skills cleared by the rollout
+            # AND export_error set — the realistic failure shape.
+            RunResult(
+                task_name="task-0",
+                rewards={"reward": 1.0},
+                evolved_skills=None,
+                export_error="Skill export failed: connection lost",
+            ),
+            RunResult(
+                task_name="task-1",
+                rewards={"reward": 1.0},
+                evolved_skills={"good": "v1"},
+            ),
+        ]
+    )
+
+    async def fake_run(*args, **kwargs):
+        return next(results)
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    await job.run()
+
+    # Only the clean rollout stamped a generation; the export-failed one
+    # left the store untouched even though it had rewards.
+    assert job.learner_store.generation == 1
+    assert job.learner_store.current().skills == {"good": "v1"}
+
+
+@pytest.mark.asyncio
+async def test_export_failure_records_no_memory_node(tmp_path: Path):
+    """Skipping the commit also skips the Memory-space node attachment.
+
+    The Memory-space scorer reads ``memory_delta`` off the rollout's tree
+    node. A poisoned delta would still score as activity, so the entire
+    commit path — node attach included — must short-circuit.
+    """
+    job = _make_job(tmp_path, n_tasks=1)
+
+    async def fake_run(*args, **kwargs):
+        return RunResult(
+            task_name=args[0].name,
+            rewards={"reward": 1.0},
+            evolved_skills=None,
+            export_error="Skill export failed: connection lost",
+        )
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    await job.run()
+
+    assert job.learner_store.generation == 0
+    # No learner node attached for the export-failed rollout.
+    assert job.learner_nodes == []

--- a/tests/test_self_gen_export_failures.py
+++ b/tests/test_self_gen_export_failures.py
@@ -36,6 +36,7 @@ def _bare_rollout(tmp_path: Path, export_target: Path | None) -> Rollout:
     rollout._rollout_dir = tmp_path
     rollout._evolved_skills = None
     rollout._error = None
+    rollout._export_error = None
     # Stub the bits cleanup() touches but we don't care about for this test.
     rollout.disconnect = AsyncMock()
     rollout._capture_partial_acp_trajectory = lambda: None
@@ -43,8 +44,14 @@ def _bare_rollout(tmp_path: Path, export_target: Path | None) -> Rollout:
 
 
 @pytest.mark.asyncio
-async def test_cleanup_surfaces_export_failure_on_rollout_error(tmp_path):
-    """Export failures must set _error, not silently log-and-continue."""
+async def test_cleanup_surfaces_export_failure_on_dedicated_channel(tmp_path):
+    """Export failures must set _export_error, not _error.
+
+    Routing export failures through ``_error`` mis-classifies infra-shaped
+    messages like "connection lost" as agent ``infra_failure`` in
+    ``classify_error``, contaminating the agent-error dashboards. The
+    dedicated sibling channel keeps the two signals separable.
+    """
     rollout = _bare_rollout(tmp_path, export_target=tmp_path / "exports")
     rollout._export_generated_skills = AsyncMock(
         side_effect=RuntimeError("download failed")
@@ -52,10 +59,12 @@ async def test_cleanup_surfaces_export_failure_on_rollout_error(tmp_path):
 
     await rollout.cleanup()
 
-    # The export failure is now observable on the rollout — success is gone.
-    assert rollout._error is not None
-    assert "Skill export failed" in rollout._error
-    assert "download failed" in rollout._error
+    # Export failure surfaces on the dedicated channel only.
+    assert rollout._export_error is not None
+    assert "Skill export failed" in rollout._export_error
+    assert "download failed" in rollout._export_error
+    # The agent-error channel is untouched: the agent itself didn't fail.
+    assert rollout._error is None
     # And we did NOT collapse into a "honestly empty" skill update: the
     # evolved_skills field stays None, distinct from {} (no-op success).
     assert rollout._evolved_skills is None
@@ -63,7 +72,7 @@ async def test_cleanup_surfaces_export_failure_on_rollout_error(tmp_path):
 
 @pytest.mark.asyncio
 async def test_cleanup_export_failure_does_not_clobber_agent_error(tmp_path):
-    """Agent errors take priority — export failure must not overwrite them."""
+    """Agent errors and export errors live on separate channels."""
     rollout = _bare_rollout(tmp_path, export_target=tmp_path / "exports")
     rollout._error = "Agent timed out after 600s"
     rollout._export_generated_skills = AsyncMock(
@@ -72,14 +81,16 @@ async def test_cleanup_export_failure_does_not_clobber_agent_error(tmp_path):
 
     await rollout.cleanup()
 
-    # Pre-existing agent error wins: it ran first, it's the more useful signal.
+    # Both errors are preserved, on their own channels.
     assert rollout._error == "Agent timed out after 600s"
+    assert rollout._export_error is not None
+    assert "download failed" in rollout._export_error
     assert rollout._evolved_skills is None
 
 
 @pytest.mark.asyncio
-async def test_cleanup_no_export_configured_leaves_error_empty(tmp_path):
-    """When export is not configured, cleanup must not invent an error."""
+async def test_cleanup_no_export_configured_leaves_errors_empty(tmp_path):
+    """When export is not configured, cleanup must not invent any error."""
     rollout = _bare_rollout(tmp_path, export_target=None)
     # Sentinel: if _export_generated_skills is called at all, fail loudly.
     rollout._export_generated_skills = AsyncMock(
@@ -89,11 +100,12 @@ async def test_cleanup_no_export_configured_leaves_error_empty(tmp_path):
     await rollout.cleanup()
 
     assert rollout._error is None
+    assert rollout._export_error is None
     assert rollout._evolved_skills is None
 
 
 @pytest.mark.asyncio
-async def test_cleanup_successful_export_leaves_error_empty(tmp_path):
+async def test_cleanup_successful_export_leaves_errors_empty(tmp_path):
     """A successful export must not be confused with a failure."""
     rollout = _bare_rollout(tmp_path, export_target=tmp_path / "exports")
 
@@ -105,6 +117,7 @@ async def test_cleanup_successful_export_leaves_error_empty(tmp_path):
     await rollout.cleanup()
 
     assert rollout._error is None
+    assert rollout._export_error is None
     assert rollout._evolved_skills == {"skill-a": "# Skill A\n"}
 
 
@@ -113,7 +126,8 @@ async def test_build_result_after_export_failure_is_not_success(tmp_path):
     """The visible RolloutResult must reflect the export failure as not-success.
 
     The whole point of #389: empty-but-successful must be impossible to
-    confuse with failed-and-produced-empty in the downstream result.
+    confuse with failed-and-produced-empty in the downstream result. The
+    fixup adds: export_error must not bleed into the agent error channel.
     """
     rollout = _bare_rollout(tmp_path, export_target=tmp_path / "exports")
     rollout._export_generated_skills = AsyncMock(
@@ -151,6 +165,11 @@ async def test_build_result_after_export_failure_is_not_success(tmp_path):
     result = rollout._build_result()
 
     assert result.success is False
-    assert result.error is not None
-    assert "Skill export failed" in result.error
+    # The agent-error channel is empty — the agent itself didn't fail.
+    # Only the export channel carries the failure, so dashboards that
+    # group by ``error_category`` see no spurious infra_failure bump.
+    assert result.error is None
+    assert result.export_error is not None
+    assert "Skill export failed" in result.export_error
+    assert "sandbox lost connection" in result.export_error
     assert result.evolved_skills is None


### PR DESCRIPTION
Stacks on PR #451 (#389 fix). Addresses two BLOCKING review findings:

1. **Channel mix**: routing export failure through `self._error` causes `classify_error()` to mis-tag as agent `infra_failure`. Added `_export_error` sibling field on Rollout (precedent: `_verifier_error`); threaded through `_build_rollout_result` and `RolloutResult`. Extended `success` gate.
2. **Learner-store poisoning**: `_commit_learner_generation` ran unconditionally regardless of `result.success`. Now gates on `result.export_error is None`. `evolved_skills_for_result` also short-circuits when export_error is set so it doesn't fall back to `capture_skills(export_dir)` and re-read partial state.

12 tests pass (5 updated + 7 new pinning both review issues).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout success semantics and sequential-shared LearnerStore commits when export fails; behavior is well-tested but affects continual-learning and result classification paths.
> 
> **Overview**
> Follow-up to #389: skill-export failures are no longer folded into the agent **`error`** channel. **`RolloutResult.export_error`** (and **`Rollout._export_error`**) record cleanup-time export failures separately, so **`classify_error`** does not treat messages like “connection lost” as agent **`infra_failure`**. **`success`** now requires **`export_error`** to be unset, and **`result.json`** persists **`export_error`**.
> 
> **Sequential-shared** jobs skip **`_commit_learner_generation`** when export failed—even if the verifier returned rewards—so the **LearnerStore** is not advanced on empty or partial skill state. **`evolved_skills_for_result`** returns **`{}`** on **`export_error`** instead of re-reading a half-written export directory.
> 
> Regression tests cover the dedicated channel, success gating, evolved-skills short-circuit, and generation commit / memory-node behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7882a38d898bde46f9fe43523e5d13e4b2155a97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->