### PR TITLE
fix: sequential-shared continual learning persists across resume (#394)

### DIFF
--- a/src/benchflow/_utils/learner_memory.py
+++ b/src/benchflow/_utils/learner_memory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,8 @@ from benchflow.models import RolloutResult
 from benchflow.rewards.memory_scorer import MEMORY_STATE_KEY, MemoryScorer
 from benchflow.task.config import TaskConfig
 from benchflow.trajectories.tree import RolloutNode
+
+logger = logging.getLogger(__name__)
 
 
 def expected_skills_for_task(task_dir: Path) -> list[str] | None:
@@ -112,3 +115,39 @@ def _last_reward_jsonl_ts(text: str) -> str | None:
             if isinstance(ts, str):
                 return ts
     return None
+
+
+def patch_learner_generation_artifact(
+    result_path: Path,
+    *,
+    inherited_from: int,
+    produced: int | None,
+    committed: bool | None,
+) -> None:
+    """Stamp continual-learning generation metadata onto a result artifact.
+
+    Records which store generation the rollout inherited from and (if it
+    committed) which generation it produced. ``committed`` is ``None`` for an
+    unscored rollout, ``True`` for an accepted commit, ``False`` when
+    :meth:`LearnerStore.commit_or_revert` rejected a regression.
+
+    Additive — readers that do not know about the ``learner_generation`` block
+    just skip it. Guards issue #394: a resumed run can audit per-rollout
+    which generation it consumed and produced.
+    """
+    if not result_path.is_file():
+        return
+    try:
+        data = json.loads(result_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug(f"Could not stamp generation metadata on {result_path}: {e}")
+        return
+    data["learner_generation"] = {
+        "inherited_from": inherited_from,
+        "produced": produced,
+        "committed": committed,
+    }
+    try:
+        result_path.write_text(json.dumps(data, indent=2))
+    except OSError as e:
+        logger.debug(f"Could not stamp generation metadata on {result_path}: {e}")

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -33,6 +33,7 @@ from benchflow._utils.learner_memory import (
     evolved_skills_for_result,
     expected_skills_for_task,
     memory_delta_from_skills,
+    patch_learner_generation_artifact,
 )
 from benchflow._utils.reward_events import memory_summary
 from benchflow._utils.scoring import (
@@ -292,8 +293,16 @@ class Evaluation:
         # The persistent learner store for sequential-shared (continual
         # learning) jobs — the one owner. parallel-independent jobs leave it
         # None.
+        #
+        # On resume, the store is restored from the per-job JSON snapshot so
+        # rollout N+1 still inherits the (memory + skills) state earlier
+        # rollouts evolved. Without this restore an interrupted continual-
+        # learning job would silently mix old result rows with a fresh empty
+        # store (issue #394).
         self.learner_store: LearnerStore | None = (
-            LearnerStore() if self._config.job_mode == "sequential-shared" else None
+            self._load_or_init_learner_store()
+            if self._config.job_mode == "sequential-shared"
+            else None
         )
         # Per-rollout continual-learning skill dirs, set by
         # _run_sequential_shared before each _run_task call and consumed by
@@ -303,6 +312,42 @@ class Evaluation:
         # One RolloutNode per sequential-shared rollout, each carrying that
         # rollout's memory_delta — the Memory-space scorer's input.
         self.learner_nodes: list[RolloutNode] = []
+
+    def _learner_store_path(self) -> Path:
+        """Where the persisted LearnerStore snapshot lives for this job."""
+        return self._jobs_dir / self._job_name / "learner_store.json"
+
+    def _load_or_init_learner_store(self) -> LearnerStore:
+        """Restore the per-job LearnerStore snapshot, or start fresh.
+
+        A corrupt snapshot is a hard failure rather than a silent reset: a
+        resumed continual-learning job that secretly started from an empty
+        store is exactly the bug this guards (issue #394).
+        """
+        snapshot = self._learner_store_path()
+        if not snapshot.is_file():
+            return LearnerStore()
+        try:
+            store = LearnerStore.load(snapshot)
+        except (ValueError, OSError, json.JSONDecodeError) as e:
+            raise RuntimeError(
+                f"Could not load persisted LearnerStore from {snapshot}: {e}. "
+                f"Delete the file or use a fresh jobs_dir to start a new run."
+            ) from e
+        logger.info(
+            f"Resumed LearnerStore from {snapshot} at generation "
+            f"{store.generation} ({len(store.history) - 1} prior rollouts)"
+        )
+        return store
+
+    def _save_learner_store(self) -> None:
+        """Persist the current LearnerStore so the next process can resume it."""
+        if self.learner_store is None:
+            return
+        try:
+            self.learner_store.save(self._learner_store_path())
+        except OSError as e:
+            logger.warning(f"Could not persist LearnerStore: {e}")
 
     @classmethod
     def from_yaml(cls, path: str | Path, **kwargs) -> Evaluation:
@@ -787,6 +832,7 @@ class Evaluation:
                 # 1. READ — materialize the store's current skills so the
                 # rollout starts from the evolved set.
                 before_state = store.current()
+                before_generation = store.generation
                 skills_dir = work_root / f"rollout-{i}-skills"
                 export_dir = work_root / f"rollout-{i}-evolved"
                 materialize_skills(before_state, skills_dir)
@@ -814,7 +860,7 @@ class Evaluation:
                 pairs.append((td.name, result))
 
                 await self._commit_learner_generation(
-                    store, td, result, before_state, export_dir
+                    store, td, result, before_state, before_generation, export_dir
                 )
         return pairs
 
@@ -824,6 +870,7 @@ class Evaluation:
         td: Path,
         result: RunResult,
         before_state: LearnerState,
+        before_generation: int,
         export_dir: Path,
     ) -> None:
         """Capture a rollout's evolved skills and commit the next generation.
@@ -832,6 +879,10 @@ class Evaluation:
         offers the captured (memory + skills) state to the store: an
         improvement stamps a new generation, a regression is reverted. An
         errored rollout (no reward) leaves the store untouched.
+
+        Persists the store and stamps generation metadata onto the result
+        artifact (which inherited from / which it produced) so a resumed job
+        can audit the learning curve across processes — see issue #394.
         """
         # 2/3. CAPTURE — the skills the agent generated/evolved. Prefer the
         # result's own field (the real Rollout populates it); fall back to
@@ -866,20 +917,39 @@ class Evaluation:
 
         # 4. COMMIT — offer the evolved (memory + skills) state to the store.
         reward = result.rewards.get("reward") if result.rewards else None
-        if reward is None:
-            return
-        # Commit the normalized `after_skills` (str-valued) — not the raw
-        # `evolved_skills` — so the committed store state is byte-identical
-        # to the `memory_delta` recorded above.
-        next_state = LearnerState(
-            memory=before_state.memory,
-            skills=after_skills,
-        )
-        kept = store.commit_or_revert(next_state, metric=float(reward))
-        if not kept:
-            logger.info(
-                f"Learner store: {td.name} regressed (reward={reward}) — "
-                f"reverted, staying at generation {store.generation}"
+        committed_generation: int | None = None
+        kept: bool | None = None
+        if reward is not None:
+            # Commit the normalized `after_skills` (str-valued) — not the raw
+            # `evolved_skills` — so the committed store state is byte-identical
+            # to the `memory_delta` recorded above.
+            next_state = LearnerState(
+                memory=before_state.memory,
+                skills=after_skills,
+            )
+            kept = store.commit_or_revert(next_state, metric=float(reward))
+            if kept:
+                committed_generation = store.generation
+            else:
+                logger.info(
+                    f"Learner store: {td.name} regressed (reward={reward}) — "
+                    f"reverted, staying at generation {store.generation}"
+                )
+
+        # Persist the store after every rollout so an interrupted job can
+        # resume from the last committed generation (#394). We save even when
+        # the rollout did not commit (errored or reverted) so the snapshot's
+        # pointer matches the live store.
+        self._save_learner_store()
+
+        # Stamp generation metadata on the result artifact so a resumed run
+        # can audit which rollout inherited which store generation.
+        if result_path is not None:
+            patch_learner_generation_artifact(
+                result_path,
+                inherited_from=before_generation,
+                produced=committed_generation,
+                committed=kept,
             )
 
     def _learner_node(self, td: Path) -> RolloutNode:
@@ -901,16 +971,29 @@ class Evaluation:
         completed = self._get_completed_tasks()
         remaining = [d for d in task_dirs if d.name not in completed]
 
-        # A resumed sequential-shared job cannot continue the learning curve:
-        # the LearnerStore is process-local, so completed rollouts' evolved
-        # skills are gone and the curve restarts at generation 0.
+        # A resumed sequential-shared job rebuilds the LearnerStore from the
+        # per-job snapshot under ``<job>/learner_store.json``. If that file
+        # is missing while completed rollouts exist, the run cannot honestly
+        # continue the learning curve — the older rollouts' evolved skills
+        # are lost. Fail closed (#394) rather than silently mix old result
+        # rows with a fresh empty store.
         if completed and self._config.job_mode == "sequential-shared":
-            logger.warning(
-                f"Resuming a continual-learning (sequential-shared) job with "
-                f"{len(completed)} task(s) already done: the LearnerStore is "
-                f"not persisted across processes, so the learning curve "
-                f"restarts at generation 0 and earlier rollouts' evolved "
-                f"skills are lost. Use a fresh jobs_dir for a clean run."
+            snapshot = self._learner_store_path()
+            if not snapshot.is_file():
+                raise RuntimeError(
+                    f"Cannot resume sequential-shared job: "
+                    f"{len(completed)} completed task(s) but no persisted "
+                    f"LearnerStore at {snapshot}. The learning curve would "
+                    f"restart at generation 0 and earlier rollouts' evolved "
+                    f"skills are lost. Use a fresh jobs_dir for a clean run, "
+                    f"or restore the snapshot from a backup."
+                )
+            assert self.learner_store is not None
+            logger.info(
+                f"Resuming sequential-shared job at generation "
+                f"{self.learner_store.generation} "
+                f"({len(completed)} completed task(s), "
+                f"{len(remaining)} remaining)"
             )
 
         # Warn if resuming with different config than completed tasks
@@ -1037,6 +1120,16 @@ class Evaluation:
             **usage_summary(all_results),
             **summary_source_fields(cfg.source_provenance, all_results),
         }
+        # Surface continual-learning provenance — generation, curve — so a
+        # resumed run can be audited end-to-end (#394).
+        if cfg.job_mode == "sequential-shared" and self.learner_store is not None:
+            summary["learner_store"] = {
+                "generation": self.learner_store.generation,
+                "learning_curve": self.learner_store.learning_curve(),
+                "snapshot_path": str(
+                    self._learner_store_path().relative_to(self._jobs_dir)
+                ),
+            }
         # Write summary into the job directory so each run is self-contained.
         job_dir = self._jobs_dir / self._job_name
         job_dir.mkdir(parents=True, exist_ok=True)

--- a/src/benchflow/learner_store.py
+++ b/src/benchflow/learner_store.py
@@ -30,7 +30,9 @@ versions state.
 from __future__ import annotations
 
 import copy
+import json
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 
 __all__ = ["LearnerState", "LearnerStore"]
@@ -193,3 +195,86 @@ class LearnerStore:
             return False
         self.commit(state, metric=metric)
         return True
+
+    # --- persistence ---
+    #
+    # The store is otherwise pure data, but a continual-learning Job survives
+    # process death only if it can be reloaded from disk on resume. These
+    # helpers serialize the full history (every generation, in number order)
+    # plus the live pointer and the next-number counter, so a reloaded store
+    # is byte-identical to the in-memory one. The Job orchestrator
+    # (``evaluation.py``) writes the file under the job directory and reads
+    # it back on resume; the store itself just knows the shape.
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializable snapshot of the entire store — every generation."""
+        return {
+            "version": 1,
+            "generation": self._generation,
+            "next_number": self._next_number,
+            "history": [
+                {
+                    "number": gen.number,
+                    "metric": gen.metric,
+                    "memory": copy.deepcopy(gen.state.memory),
+                    "skills": copy.deepcopy(gen.state.skills),
+                }
+                for gen in (self.history[n] for n in sorted(self.history))
+            ],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> LearnerStore:
+        """Rebuild a store from a :meth:`to_dict` snapshot."""
+        version = data.get("version", 1)
+        if version != 1:
+            raise ValueError(
+                f"unsupported learner_store snapshot version {version!r} — "
+                f"expected 1"
+            )
+        store = cls()
+        store.history = {
+            int(entry["number"]): Generation(
+                number=int(entry["number"]),
+                state=LearnerState(
+                    memory=copy.deepcopy(entry.get("memory") or {}),
+                    skills=copy.deepcopy(entry.get("skills") or {}),
+                ),
+                metric=entry.get("metric"),
+            )
+            for entry in data.get("history") or []
+        }
+        if 0 not in store.history:
+            # Generation 0 is the empty starting state; a snapshot that drops
+            # it would corrupt :meth:`_revert` and :meth:`learning_curve`.
+            store.history[0] = Generation(number=0, state=LearnerState())
+        store._generation = int(data.get("generation", 0))
+        # next_number defaults to one past the highest known number, so a
+        # store with no explicit counter still stamps unique generations.
+        store._next_number = int(
+            data.get("next_number", max(store.history) + 1)
+        )
+        if store._generation not in store.history:
+            raise ValueError(
+                f"learner_store snapshot pointer generation={store._generation} "
+                f"missing from history {sorted(store.history)}"
+            )
+        return store
+
+    def save(self, path: Path | str) -> None:
+        """Atomically write a JSON snapshot to ``path``.
+
+        Atomic via write-then-rename so a crash mid-save leaves the previous
+        snapshot intact — a half-written file would silently corrupt the
+        learning curve on the next resume.
+        """
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(json.dumps(self.to_dict(), indent=2))
+        tmp.replace(path)
+
+    @classmethod
+    def load(cls, path: Path | str) -> LearnerStore:
+        """Load a snapshot from ``path``."""
+        return cls.from_dict(json.loads(Path(path).read_text()))

--- a/tests/test_job_sequential_shared_resume.py
+++ b/tests/test_job_sequential_shared_resume.py
@@ -1,0 +1,314 @@
+"""Resume tests for the ``sequential-shared`` Job mode — guards issue #394.
+
+A continual-learning Job persists its :class:`LearnerStore` under the job
+directory and restores it on resume, so rollout N+1 inherits the (memory +
+skills) state earlier rollouts evolved. A resume with completed rollouts but
+no snapshot must fail closed — silently mixing old result rows with a fresh
+empty store would invalidate the learning curve without a hard failure.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
+from benchflow.learner_store import LearnerState
+from benchflow.models import RunResult
+
+
+def _make_job(tmp_path, n_tasks: int, *, jobs_dir=None, job_name=None):
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir(exist_ok=True)
+    for i in range(n_tasks):
+        td = tasks_dir / f"task-{i}"
+        td.mkdir(exist_ok=True)
+        (td / "task.toml").write_text(
+            'version = "1.0"\n[verifier]\ntimeout_sec = 60\n'
+            "[agent]\ntimeout_sec = 60\n[environment]\n"
+        )
+    cfg = EvaluationConfig(
+        concurrency=1,
+        retry=RetryConfig(max_retries=0),
+        job_mode="sequential-shared",
+    )
+    return Evaluation(
+        tasks_dir=tasks_dir,
+        jobs_dir=jobs_dir or tmp_path / "jobs",
+        config=cfg,
+        job_name=job_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_sequential_shared_persists_learner_store_to_disk(tmp_path):
+    """Every commit/revert must write the LearnerStore snapshot under the
+    job directory — a resume needs it to continue the learning curve (#394)."""
+    job = _make_job(tmp_path, n_tasks=2)
+    rewards = iter([0.5, 0.9])
+
+    async def fake_run(*args, **kwargs):
+        return RunResult(
+            task_name=args[0].name,
+            rewards={"reward": next(rewards)},
+            evolved_skills={"k": "v"},
+        )
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    await job.run()
+
+    snapshot = job._jobs_dir / job._job_name / "learner_store.json"
+    assert snapshot.is_file(), "learner_store.json must be persisted under job dir"
+    data = json.loads(snapshot.read_text())
+    assert data["generation"] == 2
+    assert [g["metric"] for g in data["history"] if g["number"] != 0] == [0.5, 0.9]
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_learner_store_from_disk(tmp_path):
+    """A second Evaluation pointed at the same job dir must load the
+    persisted store, not start from generation 0 (the bug #394 reports)."""
+    jobs_dir = tmp_path / "jobs"
+    job_name = "rollout-job"
+
+    # First run: 1 task, stamps generation 1.
+    job1 = _make_job(tmp_path, n_tasks=2, jobs_dir=jobs_dir, job_name=job_name)
+    # Pretend task-0 already completed by writing a result.json *and* the
+    # learner_store snapshot directly — that is the resume-from-crash shape.
+    job1.learner_store.commit(  # type: ignore[union-attr]
+        LearnerState(skills={"seed": "from-rollout-0"}), metric=0.8
+    )
+    job1._save_learner_store()
+
+    rollout_dir = jobs_dir / job_name / "task-0__abc"
+    rollout_dir.mkdir(parents=True)
+    (rollout_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-0",
+                "rollout_name": "task-0__abc",
+                "rewards": {"reward": 0.8},
+                "timing": {},
+            }
+        )
+    )
+
+    # Second run resumes: __init__ must load the persisted store.
+    job2 = _make_job(tmp_path, n_tasks=2, jobs_dir=jobs_dir, job_name=job_name)
+    assert job2.learner_store is not None
+    assert job2.learner_store.generation == 1, (
+        "resumed store must inherit prior generation, not restart at 0"
+    )
+    assert job2.learner_store.current().skills == {"seed": "from-rollout-0"}
+
+    # The remaining task sees the inherited skills as `before_state.skills`.
+    seen_before: list[dict] = []
+
+    async def fake_run(*args, **kwargs):
+        from benchflow.learner_skills import capture_skills
+
+        seen_before.append(capture_skills(job2._learner_skills_dir))
+        return RunResult(
+            task_name=args[0].name,
+            rewards={"reward": 1.0},
+            evolved_skills={"seed": "from-rollout-0", "fresh": "rollout-1"},
+        )
+
+    job2._run_task = fake_run  # type: ignore[method-assign]
+    await job2.run()
+
+    assert seen_before == [{"seed": "from-rollout-0"}], (
+        "the remaining rollout must inherit the persisted skill set"
+    )
+    assert job2.learner_store.generation == 2
+    assert job2.learner_store.learning_curve() == [0.8, 1.0]
+
+
+@pytest.mark.asyncio
+async def test_resume_without_snapshot_but_completed_tasks_fails_closed(tmp_path):
+    """The bug #394 reports: completed rollouts exist but the LearnerStore
+    snapshot is missing. Must fail closed rather than silently aggregate old
+    result rows with a fresh empty store."""
+    jobs_dir = tmp_path / "jobs"
+    job_name = "broken-resume"
+
+    # Simulate an old job: result.json exists but no learner_store.json.
+    rollout_dir = jobs_dir / job_name / "task-0__abc"
+    rollout_dir.mkdir(parents=True)
+    (rollout_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-0",
+                "rollout_name": "task-0__abc",
+                "rewards": {"reward": 0.5},
+                "timing": {},
+            }
+        )
+    )
+
+    job = _make_job(tmp_path, n_tasks=2, jobs_dir=jobs_dir, job_name=job_name)
+
+    async def should_never_run(*args, **kwargs):
+        raise AssertionError("a corrupt-resume job must abort before running tasks")
+
+    job._run_task = should_never_run  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="no persisted LearnerStore"):
+        await job.run()
+
+
+@pytest.mark.asyncio
+async def test_fresh_job_with_no_completed_tasks_does_not_fail(tmp_path):
+    """A fresh sequential-shared job (no completed rollouts) must still run
+    even though no snapshot exists — that is the normal first-run case."""
+    job = _make_job(tmp_path, n_tasks=2)
+
+    async def fake_run(*args, **kwargs):
+        return RunResult(task_name=args[0].name, rewards={"reward": 1.0})
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    result = await job.run()
+    assert result.total == 2
+    assert job.learner_store.generation == 2
+
+
+@pytest.mark.asyncio
+async def test_summary_includes_learner_store_provenance(tmp_path):
+    """summary.json must record the final generation and learning curve so a
+    resumed run can be audited end-to-end (the third bullet in #394)."""
+    job = _make_job(tmp_path, n_tasks=2)
+    rewards = iter([0.4, 0.9])
+
+    async def fake_run(*args, **kwargs):
+        return RunResult(
+            task_name=args[0].name,
+            rewards={"reward": next(rewards)},
+        )
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    await job.run()
+
+    summary = json.loads((job._jobs_dir / "summary.json").read_text())
+    assert "learner_store" in summary
+    assert summary["learner_store"]["generation"] == 2
+    assert summary["learner_store"]["learning_curve"] == [0.4, 0.9]
+    # The path is recorded so the auditor knows where the snapshot lives.
+    assert summary["learner_store"]["snapshot_path"].endswith("learner_store.json")
+
+
+@pytest.mark.asyncio
+async def test_result_artifact_records_generation_provenance(tmp_path):
+    """Each rollout's result.json gets a learner_generation block — which
+    generation it inherited from and which it produced — so a resume can be
+    audited per-rollout (the third bullet in #394)."""
+    job = _make_job(tmp_path, n_tasks=2)
+    rewards = iter([0.4, 0.9])
+
+    async def fake_run(*args, **kwargs):
+        rollout_name = f"{args[0].name}__abc"
+        rollout_dir = job._jobs_dir / job._job_name / rollout_name
+        rollout_dir.mkdir(parents=True, exist_ok=True)
+        (rollout_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": args[0].name,
+                    "rollout_name": rollout_name,
+                    "rewards": {"reward": next(rewards)},
+                    "timing": {},
+                }
+            )
+        )
+        return RunResult(
+            task_name=args[0].name,
+            rollout_name=rollout_name,
+            rewards={"reward": 0.4 if args[0].name == "task-0" else 0.9},
+        )
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    await job.run()
+
+    artifact_0 = json.loads(
+        (job._jobs_dir / job._job_name / "task-0__abc" / "result.json").read_text()
+    )
+    artifact_1 = json.loads(
+        (job._jobs_dir / job._job_name / "task-1__abc" / "result.json").read_text()
+    )
+
+    # Rollout 0 inherited from gen 0 (empty store) and produced gen 1.
+    assert artifact_0["learner_generation"] == {
+        "inherited_from": 0,
+        "produced": 1,
+        "committed": True,
+    }
+    # Rollout 1 inherited from gen 1 and produced gen 2.
+    assert artifact_1["learner_generation"] == {
+        "inherited_from": 1,
+        "produced": 2,
+        "committed": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_regressed_rollout_records_committed_false(tmp_path):
+    """A reverted (regressed) rollout records ``committed=False`` and no
+    produced generation so the audit trail does not lie about the curve."""
+    job = _make_job(tmp_path, n_tasks=2)
+    rewards = iter([0.9, 0.2])  # second regresses
+
+    async def fake_run(*args, **kwargs):
+        rollout_name = f"{args[0].name}__abc"
+        rollout_dir = job._jobs_dir / job._job_name / rollout_name
+        rollout_dir.mkdir(parents=True, exist_ok=True)
+        reward = next(rewards)
+        (rollout_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": args[0].name,
+                    "rollout_name": rollout_name,
+                    "rewards": {"reward": reward},
+                    "timing": {},
+                }
+            )
+        )
+        return RunResult(
+            task_name=args[0].name,
+            rollout_name=rollout_name,
+            rewards={"reward": reward},
+        )
+
+    job._run_task = fake_run  # type: ignore[method-assign]
+    await job.run()
+
+    regressed = json.loads(
+        (job._jobs_dir / job._job_name / "task-1__abc" / "result.json").read_text()
+    )
+    assert regressed["learner_generation"] == {
+        "inherited_from": 1,
+        "produced": None,
+        "committed": False,
+    }
+
+
+def test_corrupt_snapshot_fails_closed_at_init(tmp_path):
+    """A corrupt learner_store.json must raise at ``__init__`` time — silently
+    starting fresh would reintroduce the bug #394."""
+    jobs_dir = tmp_path / "jobs"
+    job_name = "with-bad-snap"
+    (jobs_dir / job_name).mkdir(parents=True)
+    (jobs_dir / job_name / "learner_store.json").write_text("{not valid json")
+
+    with pytest.raises(RuntimeError, match="Could not load persisted LearnerStore"):
+        _make_job(tmp_path, n_tasks=1, jobs_dir=jobs_dir, job_name=job_name)
+
+
+def test_parallel_independent_does_not_persist_learner_store(tmp_path):
+    """parallel-independent jobs have no LearnerStore — there is nothing to
+    persist, and no snapshot should appear under the job dir."""
+    cfg = EvaluationConfig(job_mode="parallel-independent")
+    job = Evaluation(
+        tasks_dir=tmp_path / "t",
+        jobs_dir=tmp_path / "jobs",
+        config=cfg,
+    )
+    assert job.learner_store is None

--- a/tests/test_learner_store_persistence.py
+++ b/tests/test_learner_store_persistence.py
@@ -1,0 +1,138 @@
+"""Persistence tests for the LearnerStore — guards issue #394.
+
+A continual-learning (``sequential-shared``) Job must survive process death:
+the LearnerStore is the agent's accumulating memory and skills, and a resumed
+job that silently starts from an empty store would mix old result rows with
+new ones whose learning curve never inherited the earlier rollouts' work.
+
+These tests pin the serialization round-trip and the atomic-save invariant
+the orchestrator depends on.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchflow.learner_store import LearnerState, LearnerStore
+
+
+def test_to_dict_round_trips_through_from_dict():
+    """A snapshot must rebuild a byte-identical store — same generation, same
+    history, same next-number counter."""
+    store = LearnerStore()
+    store.commit(LearnerState(memory={"a": 1}, skills={"s1": "v1"}), metric=0.5)
+    store.commit(LearnerState(memory={"a": 2}, skills={"s1": "v2"}), metric=0.8)
+
+    restored = LearnerStore.from_dict(store.to_dict())
+
+    assert restored.generation == store.generation
+    assert restored.learning_curve() == store.learning_curve()
+    assert restored.current().memory == {"a": 2}
+    assert restored.current().skills == {"s1": "v2"}
+    # next_number must survive so a revert + commit on the restored store
+    # never reuses a number from a dropped generation.
+    assert restored._next_number == store._next_number
+
+
+def test_save_and_load_through_disk(tmp_path):
+    """``LearnerStore.save`` then ``LearnerStore.load`` must rebuild the same
+    history end-to-end — the orchestrator depends on this for resume (#394)."""
+    store = LearnerStore()
+    store.commit(LearnerState(skills={"k": "v"}), metric=1.0)
+    snapshot = tmp_path / "snap" / "learner_store.json"
+
+    store.save(snapshot)
+    assert snapshot.is_file(), "save must create the parent directory"
+
+    loaded = LearnerStore.load(snapshot)
+    assert loaded.generation == 1
+    assert loaded.learning_curve() == [1.0]
+    assert loaded.current().skills == {"k": "v"}
+
+
+def test_save_is_atomic_under_crash(tmp_path, monkeypatch):
+    """A crash mid-save must leave the previous snapshot intact — a partial
+    JSON file would silently corrupt the next resume."""
+    snapshot = tmp_path / "learner_store.json"
+
+    good = LearnerStore()
+    good.commit(LearnerState(skills={"keep": "me"}), metric=0.9)
+    good.save(snapshot)
+    original = snapshot.read_text()
+
+    # Simulate a crash *after* the temp file is written but *before* the
+    # rename completes — the live snapshot must still be the prior one.
+    from pathlib import Path
+
+    real_replace = Path.replace
+
+    def boom(self, target):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "replace", boom)
+
+    later = LearnerStore()
+    later.commit(LearnerState(skills={"newer": "skill"}), metric=0.95)
+    with pytest.raises(OSError):
+        later.save(snapshot)
+
+    # Restore real behavior for the assert read.
+    monkeypatch.setattr(Path, "replace", real_replace)
+    assert snapshot.read_text() == original, (
+        "atomic-save invariant broken: a failed save corrupted the snapshot"
+    )
+
+
+def test_from_dict_rejects_unknown_version():
+    """An unknown snapshot version must hard-fail rather than silently load
+    a partial or future format."""
+    with pytest.raises(ValueError, match="version"):
+        LearnerStore.from_dict({"version": 999, "history": []})
+
+
+def test_from_dict_rejects_dangling_pointer():
+    """A snapshot whose ``generation`` pointer is not in ``history`` is
+    structurally corrupt — fail closed so the next rollout does not silently
+    inherit from generation 0."""
+    bad = {
+        "version": 1,
+        "generation": 5,
+        "next_number": 6,
+        "history": [
+            {"number": 0, "metric": None, "memory": {}, "skills": {}},
+        ],
+    }
+    with pytest.raises(ValueError, match="generation"):
+        LearnerStore.from_dict(bad)
+
+
+def test_from_dict_restores_generation_zero_when_missing():
+    """Generation 0 is the empty starting state — its absence in a snapshot
+    must not break revert/learning_curve callers."""
+    restored = LearnerStore.from_dict(
+        {
+            "version": 1,
+            "generation": 0,
+            "next_number": 1,
+            "history": [],
+        }
+    )
+    assert restored.generation == 0
+    assert 0 in restored.history
+
+
+def test_snapshot_is_pretty_json(tmp_path):
+    """The on-disk snapshot is human-auditable JSON — readers may diff it
+    across resumes to verify which generations rolled forward."""
+    store = LearnerStore()
+    store.commit(LearnerState(skills={"a": "b"}), metric=1.0)
+    snap = tmp_path / "s.json"
+    store.save(snap)
+
+    data = json.loads(snap.read_text())
+    assert data["version"] == 1
+    assert "history" in data
+    # Indented (non-minified) so it diffs cleanly.
+    assert "\n" in snap.read_text()


### PR DESCRIPTION
Closes #394.

Three coordinated changes (all 3 issue bullets implemented):

1. **Persistence**: `LearnerStore.to_dict/from_dict/save/load` with atomic write-then-rename. Version-stamped (`version: 1`); rejects unknown versions and dangling generation pointers.

2. **Snapshot wiring in Evaluation**: `__init__` restores `learner_store.json` for sequential-shared jobs. `_commit_learner_generation` persists after every commit/revert. `run()` fails closed with RuntimeError if completed tasks exist but snapshot is missing.

3. **Audit metadata**: each `result.json` gets `learner_generation: {inherited_from, produced, committed}`. `summary.json` gains `learner_store` block with final generation + learning curve.

16 new tests pass + 70 learner-related regression. Files: +learner_store.py changes, +evaluation.py wiring, +learner_memory.py patch helper (kept evaluation.py under further bloat).

**Note**: `evaluation.py` 1112 → 1204 lines (already over 1000 cap pre-PR). Extraction helps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes continual-learning state and resume semantics; incorrect behavior would corrupt learning curves, but behavior is fail-closed on missing/corrupt snapshots and covered by new tests.
> 
> **Overview**
> **Sequential-shared** continual-learning jobs now **persist** the versioned `LearnerStore` to `<job>/learner_store.json` and **reload** it when `Evaluation` starts, so later rollouts inherit memory/skills after a process restart instead of silently resetting to generation 0 (#394).
> 
> After each rollout, the job **saves** the store (including failed/reverted commits) and stamps **`learner_generation`** on `result.json` (`inherited_from`, `produced`, `committed`). **`summary.json`** gains a **`learner_store`** block with final generation, learning curve, and snapshot path. **Resume** with completed tasks but **no** snapshot now **raises** `RuntimeError`; corrupt snapshots fail at init/load rather than resetting.
> 
> `LearnerStore` adds **`to_dict` / `from_dict` / `save` / `load`** (version 1, atomic write-then-rename). New tests cover round-trip, atomic save, resume, fail-closed paths, and audit metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 788d8683dcf5bdba5fae3f5ddfc1b929c7a89a00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->