### PR TITLE
fix: wire ACPSessionAdapter into rollout runtime (#382 follow-up)

### DIFF
--- a/benchmarks/followup-bench/runner.py
+++ b/benchmarks/followup-bench/runner.py
@@ -81,7 +81,7 @@ async def _role_runner(env, role: SceneRole, prompt: str) -> None:
     agent_env = {}
     agent_launch = AGENT_LAUNCH.get(agent_name, agent_name)
 
-    client, session, _ = await connect_acp(
+    client, session, _adapter, _ = await connect_acp(
         env=env,
         agent=agent_name,
         agent_launch=agent_launch,

--- a/experiments/reviewer_ablation.py
+++ b/experiments/reviewer_ablation.py
@@ -156,7 +156,7 @@ async def _run_acp(
     agent_env = resolve_agent_env(AGENT, MODEL, None)
     agent_env.pop("_BENCHFLOW_SUBSCRIPTION_AUTH", None)
     t0 = time.time()
-    acp_client, session, _ = await connect_acp(
+    acp_client, session, _adapter, _ = await connect_acp(
         env=env,
         agent=AGENT,
         agent_launch=launch_cmd,

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from benchflow.acp.client import ACPClient
 from benchflow.acp.container_transport import ContainerTransport
+from benchflow.agents.protocol import ACPSessionAdapter
 from benchflow.agents.providers import find_provider, strip_provider_prefix
 from benchflow.agents.registry import AGENTS
 from benchflow.sandbox.lockdown import build_priv_drop_cmd
@@ -169,8 +170,17 @@ async def connect_acp(
     rollout_dir: Path,
     environment: str,
     agent_cwd: str,
-) -> tuple[ACPClient, object, str]:
-    """Create ACP transport, connect, init session, set model. Return (client, session, agent_name).
+) -> tuple[ACPClient, object, ACPSessionAdapter, str]:
+    """Create ACP transport, connect, init session, set model.
+
+    Returns ``(client, session, session_adapter, agent_name)``. ``session`` is
+    the raw :class:`~benchflow.acp.session.ACPSession` (still passed to
+    ``execute_prompts`` for trajectory capture and the idle watchdog).
+    ``session_adapter`` is the :class:`ACPSessionAdapter` bound to ``client``;
+    registering an ``on_ask_user`` handler on it is the only way a handler
+    reaches the live ``session/request_permission`` path on the wire. Without
+    instantiating the adapter here, every handler the kernel registers stayed
+    dormant and the auto-approve policy ran unconditionally (#382 follow-up).
 
     Retries with exponential backoff on ConnectionError (Daytona SSH storms).
     """
@@ -269,7 +279,8 @@ async def connect_acp(
             f"Skipping ACP set_model for {agent} — launch/env config owns model selection"
         )
 
-    return acp_client, session, agent_name
+    session_adapter = ACPSessionAdapter(acp_client)
+    return acp_client, session, session_adapter, agent_name
 
 
 async def execute_prompts(

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -950,6 +950,22 @@ class Rollout:
         # Populated by connect()
         self._acp_client: ACPClient | None = None
         self._session: Any = None
+        # ``_session_adapter`` carries the Agent-plane :class:`Session` contract
+        # over the live ACP client (architecture.md, "The four contracts").
+        # The kernel registers ``on_ask_user`` handlers through it so the live
+        # ``session/request_permission`` path runs the handler instead of the
+        # auto-approve fallback (#382 follow-up — instantiating the adapter
+        # here is what makes the wire path honour the contract).
+        self._session_adapter: Any = None
+        # Sticky ``on_ask_user`` handler. Stored on the rollout (not the
+        # adapter) because connect()/_reconnect_for_role() rebuild the adapter
+        # each time we attach a new agent process; the handler the caller
+        # registered before the first connect must follow across reconnects.
+        # The "ever set" flag distinguishes "never registered" (default
+        # auto-approve policy) from "explicitly cleared" (caller passed
+        # ``None`` to roll back to auto-approve).
+        self._ask_user_handler: Any = None
+        self._ask_user_handler_set: bool = False
         self._agent_name: str = ""
         self._active_role: Role | None = None
 
@@ -1281,7 +1297,12 @@ class Rollout:
             environment=cfg.environment,
             session_id=getattr(self, "_rollout_name", "") or "",
         )
-        self._acp_client, self._session, self._agent_name = await connect_acp(
+        (
+            self._acp_client,
+            self._session,
+            self._session_adapter,
+            self._agent_name,
+        ) = await connect_acp(
             env=self._env,
             agent=cfg.primary_agent,
             agent_launch=self._agent_launch,
@@ -1292,6 +1313,7 @@ class Rollout:
             environment=cfg.environment,
             agent_cwd=self._agent_cwd,
         )
+        self._reapply_ask_user_handler()
 
         if "agent_setup" not in self._timing:
             self._timing["agent_setup"] = (datetime.now() - t0).total_seconds()
@@ -1308,6 +1330,7 @@ class Rollout:
                 logger.warning(f"ACP client close failed: {e}")
             self._acp_client = None
             self._session = None
+            self._session_adapter = None
         # Kill any lingering agent processes to prevent context bleed between scenes
         if self._env and self._agent_launch.strip():
             agent_cmd = self._agent_launch.split()[0].split("/")[-1]
@@ -1317,6 +1340,48 @@ class Rollout:
         self._session_tool_count = 0
         self._session_traj_count = 0
         self._phase = "installed"
+
+    def on_ask_user(self, handler: Any) -> None:
+        """Register the agent-initiated ``session/request_permission`` handler.
+
+        Forwards to :meth:`ACPSessionAdapter.on_ask_user` on the live adapter
+        so the handler runs on the wire path; before #382's follow-up the
+        adapter was never instantiated in production and the auto-approve
+        policy ran unconditionally. The handler is sticky — stored on the
+        rollout so reconnects (e.g. ``_reconnect_for_role``) re-register it
+        on the freshly bound adapter via :meth:`_reapply_ask_user_handler`.
+
+        Pass ``None`` to clear; the client's most-permissive auto-approve
+        policy takes over (preserves the benchmark-mode default).
+        """
+        self._ask_user_handler = handler
+        self._ask_user_handler_set = True
+        self._reapply_ask_user_handler()
+
+    def _reapply_ask_user_handler(self) -> None:
+        """Re-bind any registered ``on_ask_user`` handler to the live adapter.
+
+        ``getattr`` defaults guard ``Rollout`` instances built via
+        ``__new__`` in tests that pre-date the on_ask_user field — they
+        skip ``__init__`` and only set the attributes their scenarios use.
+        """
+        adapter = getattr(self, "_session_adapter", None)
+        if adapter is None:
+            return
+        # No-op when the caller never touched on_ask_user — leaves the
+        # default auto-approve path alone and avoids redundant client calls
+        # from the connect()/_reconnect_for_role() hot paths.
+        if not getattr(self, "_ask_user_handler_set", False):
+            return
+        handler = getattr(self, "_ask_user_handler", None)
+        if handler is None:
+            # Explicit clear — drop the bridge closure on the client so
+            # the default most-permissive policy takes over.
+            client = getattr(self, "_acp_client", None)
+            if client is not None:
+                client.on_ask_user(None)
+            return
+        adapter.on_ask_user(handler)
 
     def _capture_partial_acp_trajectory(self) -> None:
         if self._trajectory or not self._acp_client or not self._acp_client.session:
@@ -2118,7 +2183,12 @@ class Rollout:
 
         self._agent_launch = agent_launch
 
-        self._acp_client, self._session, self._agent_name = await connect_acp(
+        (
+            self._acp_client,
+            self._session,
+            self._session_adapter,
+            self._agent_name,
+        ) = await connect_acp(
             env=self._env,
             agent=role.agent,
             agent_launch=agent_launch,
@@ -2129,6 +2199,7 @@ class Rollout:
             environment=cfg.environment,
             agent_cwd=self._agent_cwd,
         )
+        self._reapply_ask_user_handler()
         self._active_role = role
 
         if "agent_setup" not in self._timing:

--- a/tests/conformance/proof_multi_agent.py
+++ b/tests/conformance/proof_multi_agent.py
@@ -77,7 +77,7 @@ async def role_runner(env, role: SceneRole, prompt: str) -> None:
     rollout_dir = Path(f"/tmp/multi-agent-proof/{role.name}")
     rollout_dir.mkdir(parents=True, exist_ok=True)
     launch_cmd = AGENT_LAUNCH.get(role.agent, role.agent)
-    acp_client, session, _agent_name = await connect_acp(
+    acp_client, session, _adapter, _agent_name = await connect_acp(
         env=env,
         agent=role.agent,
         agent_launch=launch_cmd,

--- a/tests/test_connect_as_env.py
+++ b/tests/test_connect_as_env.py
@@ -63,7 +63,7 @@ class TestConnectAsEnvMerge:
             patch("benchflow.rollout.resolve_agent_env", side_effect=fake_resolve),
             patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as mock_conn,
         ):
-            mock_conn.return_value = (AsyncMock(), AsyncMock(), "agent")
+            mock_conn.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "agent")
             role = _mock_trial._config.scenes[0].roles[0]
             await _mock_trial.connect_as(role)
 
@@ -89,7 +89,7 @@ class TestConnectAsEnvMerge:
             patch("benchflow.rollout.resolve_agent_env", side_effect=fake_resolve),
             patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as mock_conn,
         ):
-            mock_conn.return_value = (AsyncMock(), AsyncMock(), "agent")
+            mock_conn.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "agent")
             role = _mock_trial._config.scenes[0].roles[0]
             await _mock_trial.connect_as(role)
 
@@ -115,7 +115,7 @@ class TestConnectAsEnvMerge:
             patch("benchflow.rollout.resolve_agent_env", side_effect=fake_resolve),
             patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as mock_conn,
         ):
-            mock_conn.return_value = (AsyncMock(), AsyncMock(), "agent")
+            mock_conn.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "agent")
             role = _mock_trial._config.scenes[0].roles[0]
             await _mock_trial.connect_as(role)
 
@@ -136,7 +136,7 @@ class TestConnectAsEnvMerge:
             patch("benchflow.rollout.resolve_agent_env", side_effect=fake_resolve),
             patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as mock_conn,
         ):
-            mock_conn.return_value = (AsyncMock(), AsyncMock(), "agent")
+            mock_conn.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "agent")
             role = _mock_trial._config.scenes[0].roles[0]
             await _mock_trial.connect_as(role)
 
@@ -174,7 +174,7 @@ class TestConnectAsEnvMerge:
             patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as mock_conn,
         ):
             mock_bedrock.return_value = ({"ANTHROPIC_API_KEY": "from-config"}, None)
-            mock_conn.return_value = (AsyncMock(), AsyncMock(), "agent")
+            mock_conn.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "agent")
 
             await _mock_trial.connect_as(role)
 

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -151,7 +151,7 @@ async def test_connect_as_applies_web_policy_to_role_env(tmp_path):
         patch("benchflow.rollout.resolve_agent_env", side_effect=fake_resolve),
         patch("benchflow.rollout.connect_acp") as connect_acp,
     ):
-        connect_acp.return_value = (MagicMock(), MagicMock(), "agent")
+        connect_acp.return_value = (MagicMock(), MagicMock(), MagicMock(), "agent")
         await trial.connect_as(cfg.scenes[0].roles[0])
 
     assert captured["env"]["BENCHFLOW_PROVIDER_BASE_URL"] == "http://localhost:8080/v1"
@@ -229,7 +229,7 @@ async def test_connect_as_applies_hard_web_policy_to_role_agent(tmp_path):
         ) as apply_policy,
         patch("benchflow.rollout.connect_acp", new=AsyncMock()) as connect_acp,
     ):
-        connect_acp.return_value = (MagicMock(), MagicMock(), "agent")
+        connect_acp.return_value = (MagicMock(), MagicMock(), MagicMock(), "agent")
         await trial.connect_as(role)
 
     apply_policy.assert_awaited_once()

--- a/tests/test_rollout_on_ask_user_wiring.py
+++ b/tests/test_rollout_on_ask_user_wiring.py
@@ -1,0 +1,299 @@
+"""Guards #382 follow-up: ACPSessionAdapter must reach the live runtime.
+
+PR #382 made ``ACPSessionAdapter.on_ask_user`` forward into the ACP client,
+but never instantiated the adapter inside ``rollout.py`` / ``connect_acp``.
+The correctness reviewer found that ``connect_acp`` returned the raw
+``ACPSession`` (no adapter) — so the kernel had nowhere to register a
+handler against the live wire path. Every rollout therefore kept running
+the unconditional auto-approve policy that pre-#382 callers shipped.
+
+These tests pin two boundaries:
+
+* ``connect_acp`` constructs and returns an :class:`ACPSessionAdapter`
+  bound to the live :class:`ACPClient`. The :class:`Rollout` stores it as
+  ``_session_adapter`` and exposes :meth:`Rollout.on_ask_user`.
+* A handler registered through that path actually fires when an agent
+  emits ``session/request_permission`` during a real prompt round-trip
+  (driven through the existing mock-ACP-agent stdio fixture so the wire
+  is real, not a stub).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from benchflow.acp.client import ACPClient
+from benchflow.acp.transport import StdioTransport
+from benchflow.acp.types import StopReason
+from benchflow.agents.protocol import ACPSessionAdapter, AskUserRequest
+from benchflow.rollout import Rollout
+
+# Re-uses the existing mock agent that emits ``session/request_permission``
+# mid-prompt — the same one ``test_acp.py`` drives for the interleaved
+# notification + request scenario.
+MOCK_AGENT_INTERLEAVED = str(
+    Path(__file__).parent / "fixtures" / "mock_acp_agent_interleaved.py"
+)
+
+
+def _bare_rollout() -> Rollout:
+    """Build a ``Rollout`` instance without going through ``__init__``.
+
+    The real ``__init__`` requires a sandbox config and resolves agent
+    launchers — none of which the on_ask_user wiring touches. ``__new__``
+    plus the handful of fields the wiring reads keeps the test focused.
+    """
+    rollout = Rollout.__new__(Rollout)
+    rollout._acp_client = None
+    rollout._session = None
+    rollout._session_adapter = None
+    rollout._ask_user_handler = None
+    rollout._ask_user_handler_set = False
+    return rollout
+
+
+@pytest.mark.asyncio
+async def test_rollout_on_ask_user_forwards_to_live_adapter() -> None:
+    """Registering through ``Rollout.on_ask_user`` reaches the client."""
+    rollout = _bare_rollout()
+
+    # Stand-in client + adapter — what ``connect_acp`` would produce.
+    client = ACPClient.__new__(ACPClient)
+    client._transport = MagicMock()
+    client._ask_user_handler = None
+    rollout._acp_client = client
+    rollout._session_adapter = ACPSessionAdapter(client)
+
+    received: list[AskUserRequest] = []
+
+    async def handler(request: AskUserRequest) -> str:
+        received.append(request)
+        return "deny"
+
+    rollout.on_ask_user(handler)
+
+    # The bridge installed by ACPSessionAdapter is now on the client.
+    assert client._ask_user_handler is not None
+
+    # Drive a permission request through the bridge.
+    bridge = client._ask_user_handler
+    option_id = await bridge(
+        {
+            "sessionId": "s1",
+            "options": [
+                {"optionId": "allow_once", "kind": "allow_once"},
+                {"optionId": "deny", "kind": "reject"},
+            ],
+            "toolCall": {"title": "rm -rf /etc"},
+        }
+    )
+
+    assert option_id == "deny"
+    assert len(received) == 1
+    assert received[0].options == ["allow_once", "deny"]
+    assert received[0].prompt == "rm -rf /etc"
+
+
+@pytest.mark.asyncio
+async def test_rollout_on_ask_user_handler_persists_across_reconnect() -> None:
+    """A handler registered before the first connect must survive reconnects.
+
+    The kernel rebuilds the adapter every time it attaches an agent process
+    (``connect()`` / ``_reconnect_for_role()``). Without a sticky handler
+    on the rollout, the registered policy would silently revert to
+    auto-approve after the first scene boundary.
+    """
+    rollout = _bare_rollout()
+
+    async def handler(_request: AskUserRequest) -> str:
+        return "allow_once"
+
+    # Register before any adapter exists — handler is stored on the rollout.
+    rollout.on_ask_user(handler)
+    assert rollout._ask_user_handler is handler
+
+    # First "connect" — adapter is built and the handler is reapplied.
+    client_a = ACPClient.__new__(ACPClient)
+    client_a._transport = MagicMock()
+    client_a._ask_user_handler = None
+    rollout._acp_client = client_a
+    rollout._session_adapter = ACPSessionAdapter(client_a)
+    rollout._reapply_ask_user_handler()
+    assert client_a._ask_user_handler is not None
+
+    # Second "connect" (reconnect for new role) — fresh client + adapter,
+    # the same handler must rebind without the caller doing anything.
+    client_b = ACPClient.__new__(ACPClient)
+    client_b._transport = MagicMock()
+    client_b._ask_user_handler = None
+    rollout._acp_client = client_b
+    rollout._session_adapter = ACPSessionAdapter(client_b)
+    rollout._reapply_ask_user_handler()
+    assert client_b._ask_user_handler is not None
+
+
+@pytest.mark.asyncio
+async def test_reapply_is_noop_when_handler_never_registered() -> None:
+    """The connect() hot path must not touch the client when no handler is set.
+
+    Without this, reconnect() would synchronously call ``client.on_ask_user(None)``
+    on every attach — harmless for real clients but it broke test mocks (the
+    benchmark-mode default already wins on the client side, no clearing
+    needed).
+    """
+    rollout = _bare_rollout()
+    client = MagicMock()
+    adapter = MagicMock()
+    rollout._acp_client = client
+    rollout._session_adapter = adapter
+
+    rollout._reapply_ask_user_handler()
+
+    client.on_ask_user.assert_not_called()
+    adapter.on_ask_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_rollout_on_ask_user_none_clears_client_handler() -> None:
+    """Passing ``None`` to ``on_ask_user`` restores the auto-approve policy."""
+    rollout = _bare_rollout()
+    client = ACPClient.__new__(ACPClient)
+    client._transport = MagicMock()
+    client._ask_user_handler = None
+    rollout._acp_client = client
+    rollout._session_adapter = ACPSessionAdapter(client)
+
+    async def handler(_request: AskUserRequest) -> str:
+        return "deny"
+
+    rollout.on_ask_user(handler)
+    assert client._ask_user_handler is not None
+
+    rollout.on_ask_user(None)
+    assert client._ask_user_handler is None
+
+
+@pytest.mark.asyncio
+async def test_connect_acp_returns_session_adapter_bound_to_client(tmp_path) -> None:
+    """``connect_acp`` hands back an adapter wrapping the live ACPClient.
+
+    Without this, every kernel/SDK caller hitting ``Rollout.on_ask_user``
+    would still bypass the wire path — exactly the gap PR #382's reviewer
+    flagged.
+    """
+    from benchflow.acp.runtime import connect_acp
+
+    # Mock the transport-level dependencies — we only need to verify the
+    # return shape and that the adapter forwards into the returned client.
+    mock_session = MagicMock()
+    mock_session.session_id = "s1"
+    mock_init = MagicMock()
+    mock_init.agent_info = None
+
+    mock_acp = AsyncMock(spec=ACPClient)
+    mock_acp.connect = AsyncMock()
+    mock_acp.initialize = AsyncMock(return_value=mock_init)
+    mock_acp.session_new = AsyncMock(return_value=mock_session)
+    mock_acp.set_model = AsyncMock()
+    mock_acp.close = AsyncMock()
+
+    captured: dict[str, Any] = {}
+
+    def _capture_handler(handler: Any) -> None:
+        captured["handler"] = handler
+
+    mock_acp.on_ask_user = MagicMock(side_effect=_capture_handler)
+
+    from unittest.mock import patch
+
+    mock_env = AsyncMock()
+    with (
+        patch(
+            "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "benchflow.acp.runtime.ContainerTransport",
+            return_value=MagicMock(),
+        ),
+        patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+    ):
+        result = await connect_acp(
+            env=mock_env,
+            agent="test-agent",
+            agent_launch="test-agent",
+            agent_env={},
+            sandbox_user=None,
+            model=None,
+            rollout_dir=tmp_path,
+            environment="docker",
+            agent_cwd="/app",
+        )
+
+    # The new fourth tuple element is the adapter — wired to the live client.
+    assert len(result) == 4
+    client, session, adapter, agent_name = result
+    assert client is mock_acp
+    assert session is mock_session
+    assert isinstance(adapter, ACPSessionAdapter)
+    assert agent_name == "test-agent"
+
+    # Registering a handler through the adapter must reach the client.
+    async def handler(_req: AskUserRequest) -> str:
+        return "allow_once"
+
+    adapter.on_ask_user(handler)
+    assert "handler" in captured
+    assert captured["handler"] is not None
+
+
+@pytest.mark.asyncio
+async def test_handler_fires_on_full_rollout_prompt_roundtrip() -> None:
+    """Drives a real prompt through the mock ACP agent fixture end-to-end.
+
+    The mock subprocess emits ``session/update`` → ``session/request_permission``
+    → ``session/update`` → final ``session/prompt`` response, exactly the
+    sequence a real ACP agent would produce when asking for tool approval
+    mid-turn. Wiring is what PR #382's follow-up adds: ``connect_acp``
+    style construction of the adapter, then ``Rollout.on_ask_user``
+    registration. A handler is registered through that path, and we assert
+    it fires *during* the prompt — not via an out-of-band stub.
+    """
+    client = ACPClient(StdioTransport(sys.executable, [MOCK_AGENT_INTERLEAVED]))
+    received: list[AskUserRequest] = []
+
+    async def handler(request: AskUserRequest) -> str:
+        received.append(request)
+        # The handler's return value drives the optionId sent back on the
+        # wire — this is the contract pre-fix was silently bypassing.
+        return "allow_once"
+
+    try:
+        await client.connect()
+        await client.initialize()
+        await client.session_new()
+
+        # Production wiring — construct the adapter the way connect_acp now
+        # does, then register through the Rollout-facing path.
+        adapter = ACPSessionAdapter(client)
+        rollout = _bare_rollout()
+        rollout._acp_client = client
+        rollout._session_adapter = adapter
+        rollout.on_ask_user(handler)
+
+        # Driving prompt() makes the mock agent emit the permission request
+        # mid-turn; the client must dispatch it through our handler before
+        # returning the final stop reason.
+        result = await client.prompt("Go!")
+        assert StopReason(result.stop_reason) == StopReason.END_TURN
+    finally:
+        await client.close()
+
+    # The handler ran exactly once with the agent-emitted options.
+    assert len(received) == 1
+    assert received[0].options == ["allow_once"]

--- a/tests/test_trial_bedrock_proxy.py
+++ b/tests/test_trial_bedrock_proxy.py
@@ -51,7 +51,7 @@ async def test_trial_connect_starts_bedrock_runtime_before_connect_acp(tmp_path)
         ),
         patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as connect_acp,
     ):
-        connect_acp.return_value = (AsyncMock(), AsyncMock(), "codex-acp")
+        connect_acp.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "codex-acp")
         await trial.connect()
 
     ensure_runtime.assert_awaited_once()
@@ -126,7 +126,7 @@ async def test_trial_connect_as_starts_bedrock_runtime_for_role(tmp_path):
         patch("benchflow.rollout.apply_web_tool_policy", new=AsyncMock()),
         patch("benchflow.rollout.connect_acp", new_callable=AsyncMock) as connect_acp,
     ):
-        connect_acp.return_value = (AsyncMock(), AsyncMock(), "claude-agent-acp")
+        connect_acp.return_value = (AsyncMock(), AsyncMock(), AsyncMock(), "claude-agent-acp")
         await trial.connect_as(role)
 
     ensure_runtime.assert_awaited_once()

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -635,7 +635,7 @@ async def test_rollout_connect_wires_usage_proxy_before_acp(tmp_path, monkeypatc
         assert kwargs["agent_env"]["OPENAI_BASE_URL"] == (
             "http://host.docker.internal:32124"
         )
-        return (AsyncMock(), AsyncMock(), "codex-acp")
+        return (AsyncMock(), AsyncMock(), AsyncMock(), "codex-acp")
 
     monkeypatch.setattr("benchflow.rollout.ensure_bedrock_proxy_runtime", fake_bedrock)
     monkeypatch.setattr("benchflow.rollout.ensure_usage_proxy_runtime", fake_usage)

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -767,7 +767,7 @@ class TestScrapedTrajectoryTrust:
                     patch(
                         "benchflow.rollout.connect_acp",
                         new_callable=AsyncMock,
-                        return_value=(mock_acp, mock_session, "test-agent"),
+                        return_value=(mock_acp, mock_session, MagicMock(), "test-agent"),
                     ),
                     patch(
                         "benchflow.rollout.execute_prompts",
@@ -832,7 +832,7 @@ class TestScrapedTrajectoryTrust:
                 patch(
                     "benchflow.rollout.connect_acp",
                     new_callable=AsyncMock,
-                    return_value=(mock_acp, mock_session, "test-agent"),
+                    return_value=(mock_acp, mock_session, MagicMock(), "test-agent"),
                 ),
                 patch(
                     "benchflow.rollout.execute_prompts",


### PR DESCRIPTION
Stacks on PR #439 (#382 fix). The correctness reviewer found that PR-#382's handler-registration was structurally wired at the adapter level but never used in the kernel — `rollout.py:1284,2121` called `connect_acp()` and never constructed an ACPSessionAdapter. So production rollouts still got auto-approve unconditionally.

Picked Option 2 (cleaner of the reviewer's suggestions): `connect_acp` now returns a 4-tuple `(ACPClient, ACPSession, ACPSessionAdapter, agent_name)`. Kernel uses the adapter; raw ACPSession still emitted for `execute_prompts` / trajectory capture.

New public `Rollout.on_ask_user(handler)` — stores sticky, re-applies across reconnects via `_reapply_ask_user_handler`. 6 new tests including a real e2e roundtrip using `mock_acp_agent_interleaved.py` subprocess fixture (the mock emits session/request_permission mid-turn; handler registered via Rollout.on_ask_user fires on the wire). 1931 regression pass.

Updates ~8 callers of connect_acp throughout tests/experiments/benchmarks for the new tuple shape.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live tool-permission handling on the ACP wire path; behavior shifts from unconditional auto-approve to honoring registered handlers, with solid tests but real security/policy impact for callers that set handlers.
> 
> **Overview**
> Fixes the **#382 follow-up**: handler registration existed on `ACPSessionAdapter` but production never constructed that adapter, so every rollout kept **auto-approving** `session/request_permission` regardless of kernel policy.
> 
> **`connect_acp`** now returns a **4-tuple** `(client, session, session_adapter, agent_name)` and builds `ACPSessionAdapter` bound to the live `ACPClient`. The raw session is unchanged for `execute_prompts` / trajectory capture.
> 
> **`Rollout`** stores `_session_adapter`, adds **`on_ask_user(handler)`** (sticky across reconnects via `_reapply_ask_user_handler` after `connect()` / `connect_as()`), and supports clearing with `None` to restore default auto-approve. Benchmarks, experiments, conformance proofs, and mocks are updated for the new return shape.
> 
> New regression tests cover adapter return value, forwarding to the client, reconnect persistence, no-op when never registered, and an end-to-end prompt round-trip with a mock agent emitting permission requests mid-turn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18aed7f436889cf57e6f0e3611b891a5e6faeec3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->