### PR TITLE
fix: unify reward plane on node-based contract (#397)

### DIFF
--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -46,12 +46,16 @@ from benchflow.evaluation import (
 from benchflow.metrics import BenchmarkMetrics, collect_metrics
 from benchflow.models import AgentInstallError, AgentTimeoutError, RolloutResult
 
-# Rewards protocol (v0.4 — composable Rubric + RewardFunc)
+# Rewards plane. Reward is the canonical node-based contract
+# (``score(node) -> VerifyResult``); RewardFunc is the legacy path-based shape
+# (``score(rollout_dir) -> float``) adapted into Reward via PathReward.
 from benchflow.rewards import (
     CodeExecRewardFunc,
     Criterion,
     JudgeConfig,
     LLMJudgeRewardFunc,
+    PathReward,
+    Reward,
     RewardEvent,
     RewardFunc,
     Rubric,
@@ -108,10 +112,12 @@ from benchflow.trajectories.types import Trajectory
 # may change without notice.
 __all__ = [
     "__version__",
-    # Rewards protocol (v0.4)
+    # Rewards plane
+    "Reward",
     "Rubric",
     "RewardFunc",
     "RewardEvent",
+    "PathReward",
     "VerifyResult",
     "TestRewardFunc",
     "LLMJudgeRewardFunc",

--- a/src/benchflow/rewards/__init__.py
+++ b/src/benchflow/rewards/__init__.py
@@ -9,7 +9,8 @@ from benchflow.rewards.builtins import (
 )
 from benchflow.rewards.events import RewardEvent
 from benchflow.rewards.memory_scorer import MEMORY_STATE_KEY, MemoryScorer
-from benchflow.rewards.protocol import RewardFunc, VerifyResult
+from benchflow.rewards.node import PATH_STATE_KEY, NodeScorer, PathReward, score_node
+from benchflow.rewards.protocol import Reward, RewardFunc, VerifyResult
 from benchflow.rewards.rubric import Rubric
 from benchflow.rewards.rubric_config import (
     Criterion,
@@ -23,12 +24,16 @@ from benchflow.rewards.rubric_config import (
 
 __all__ = [
     "MEMORY_STATE_KEY",
+    "PATH_STATE_KEY",
     "CodeExecRewardFunc",
     "Criterion",
     "JudgeConfig",
     "JudgeScoringError",
     "LLMJudgeRewardFunc",
     "MemoryScorer",
+    "NodeScorer",
+    "PathReward",
+    "Reward",
     "RewardEvent",
     "RewardFunc",
     "Rubric",
@@ -40,4 +45,5 @@ __all__ = [
     "load_rubric",
     "load_rubric_json",
     "load_rubric_toml",
+    "score_node",
 ]

--- a/src/benchflow/rewards/node.py
+++ b/src/benchflow/rewards/node.py
@@ -12,17 +12,31 @@ emits a ``RewardEvent`` tagged ``(space, granularity)``.
 The headline ``VerifyResult.reward`` is the outcome signal (the Output space —
 "did it finish the job?"); process-space events ride along for credit
 assignment up the tree.
+
+This module also provides :class:`PathReward` — the adapter that lifts a
+legacy path-based :class:`~benchflow.rewards.protocol.RewardFunc` (or a
+:class:`~benchflow.rewards.rubric.Rubric`) into the canonical
+:class:`~benchflow.rewards.protocol.Reward` contract. The adapter reads
+``rollout_dir`` from ``node.state[PATH_STATE_KEY]`` and returns a tagged
+``VerifyResult``, so existing path-based scorers compose under the same
+contract as native ``NodeScorer``-based ones.
 """
 
 from __future__ import annotations
 
-from typing import Protocol, runtime_checkable
+from pathlib import Path
+from typing import Final, Protocol, runtime_checkable
 
-from benchflow.rewards.events import RewardEvent
-from benchflow.rewards.protocol import VerifyResult
+from benchflow.rewards.events import RewardEvent, Space
+from benchflow.rewards.protocol import RewardFunc, VerifyResult
 from benchflow.trajectories.tree import RolloutNode
 
-_OUTPUT_SPACE = "output"
+_OUTPUT_SPACE: Final[Space] = "output"
+
+#: ``node.state`` key under which a rollout's on-disk directory is recorded.
+#: :class:`PathReward` reads this to bridge node-scoped scoring to the legacy
+#: ``score(rollout_dir: Path) -> float`` shape.
+PATH_STATE_KEY: Final = "rollout_dir"
 
 
 @runtime_checkable
@@ -79,3 +93,72 @@ async def score_node(node: RolloutNode, scorers: list[NodeScorer]) -> VerifyResu
         space=_OUTPUT_SPACE,
         granularity="terminal",
     )
+
+
+class PathReward:
+    """Adapter — lift a legacy path-based ``RewardFunc`` into ``Reward``.
+
+    ``PathReward`` makes any :class:`~benchflow.rewards.protocol.RewardFunc`
+    (including a :class:`~benchflow.rewards.rubric.Rubric` and built-ins like
+    ``TestRewardFunc`` / ``LLMJudgeRewardFunc``) satisfy the canonical
+    :class:`~benchflow.rewards.protocol.Reward` contract: ``score(node) ->
+    VerifyResult``. It reads the rollout's on-disk directory from
+    ``node.state[PATH_STATE_KEY]`` and lifts the path-based result into a
+    tagged ``VerifyResult``.
+
+    A wrapped function returning a bare ``float`` is promoted to a tagged
+    ``VerifyResult(reward=…, items={source: reward}, events=[terminal-event],
+    space="output", granularity="terminal")``. A wrapped function already
+    returning a ``VerifyResult`` (e.g. a ``Rubric``) is passed through, with
+    the headline reward recorded as the canonical outcome.
+
+    If ``node.state[PATH_STATE_KEY]`` is missing, the adapter records the
+    error on the returned ``VerifyResult`` (``reward=0.0``) rather than
+    raising — the canonical contract distinguishes "nobody scored" from
+    "scored 0.0" by populating ``error``.
+    """
+
+    def __init__(self, func: RewardFunc, source: str | None = None) -> None:
+        self._func = func
+        self.source = source or type(func).__name__
+
+    async def score(self, node: RolloutNode) -> VerifyResult:
+        rollout_dir = node.state.get(PATH_STATE_KEY)
+        if rollout_dir is None:
+            return VerifyResult(
+                reward=0.0,
+                error=(
+                    f"PathReward[{self.source}]: node.state["
+                    f"{PATH_STATE_KEY!r}] is missing — cannot adapt "
+                    "path-based RewardFunc"
+                ),
+                space=_OUTPUT_SPACE,
+                granularity="terminal",
+            )
+        result = await self._func.score(Path(rollout_dir))
+        if isinstance(result, VerifyResult):
+            # Already canonical — preserve the inner result, just pin the
+            # outer (space, granularity) tag for the headline.
+            return VerifyResult(
+                reward=result.reward,
+                items=result.items,
+                events=result.events,
+                error=result.error,
+                space=result.space,
+                granularity=result.granularity,
+            )
+        reward = float(result)
+        event = RewardEvent(
+            type="terminal",
+            reward=reward,
+            source=self.source,
+            space=_OUTPUT_SPACE,
+            granularity="terminal",
+        )
+        return VerifyResult(
+            reward=reward,
+            items={self.source: reward},
+            events=[event],
+            space=_OUTPUT_SPACE,
+            granularity="terminal",
+        )

--- a/src/benchflow/rewards/protocol.py
+++ b/src/benchflow/rewards/protocol.py
@@ -1,17 +1,61 @@
-"""Core reward protocol and result type."""
+"""Core reward protocols and result type.
+
+The Reward plane has **one canonical contract** — :class:`Reward`, matching the
+architecture's ``score(node) -> VerifyResult`` shape (``docs/architecture.md``
+§ "The four contracts"). A ``RolloutNode`` carries its tree context
+(``node.path``, ``node.subtree``, ``node.state``), so one method expresses both
+**outcome** reward (read the leaf) and **process** reward (walk the path).
+
+:class:`RewardFunc` is the **legacy path-based shape** kept for backward
+compatibility with existing benchmarks: ``score(rollout_dir: Path) -> float``.
+A ``RewardFunc`` is not a ``Reward`` by itself — it is adapted to the canonical
+contract via :class:`~benchflow.rewards.node.PathReward`, which reads
+``rollout_dir`` from ``node.state`` and lifts the float into a tagged
+:class:`VerifyResult`. New scorers should target :class:`Reward` directly.
+"""
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from benchflow.rewards.events import Granularity, RewardEvent, Space
+
+if TYPE_CHECKING:
+    from benchflow.trajectories.tree import RolloutNode
+
+
+@runtime_checkable
+class Reward(Protocol):
+    """The canonical Reward-plane contract — ``score(node) -> VerifyResult``.
+
+    Matches the architecture's Reward contract (``docs/architecture.md``
+    § "The four contracts"). One method expresses both outcome reward (read
+    the leaf node) and process reward (walk ``node.path``), since a
+    ``RolloutNode`` carries its tree/path/subtree context.
+
+    Implementations may be ad-hoc (one outcome scorer per task) or composed
+    (a :class:`~benchflow.rewards.node.PathReward` adapter around a legacy
+    :class:`RewardFunc`, a :class:`~benchflow.rewards.rubric.Rubric`, or an
+    aggregation of :class:`~benchflow.rewards.node.NodeScorer` dimensions via
+    :func:`~benchflow.rewards.node.score_node`).
+    """
+
+    async def score(self, node: RolloutNode) -> VerifyResult: ...
 
 
 @runtime_checkable
 class RewardFunc(Protocol):
-    """Single scoring dimension."""
+    """Legacy path-based scoring shape — ``score(rollout_dir) -> float``.
+
+    *Not* the canonical Reward contract — :class:`Reward` is. ``RewardFunc``
+    is the historical shape benchmarks ship today (``test.sh``-style
+    verifiers, ``LLMJudgeRewardFunc``, etc.); it is preserved verbatim so
+    existing benchmarks keep working. Wrap a ``RewardFunc`` in
+    :class:`~benchflow.rewards.node.PathReward` to expose it under the
+    canonical node-based contract.
+    """
 
     async def score(self, rollout_dir: Path) -> float: ...
 

--- a/tests/test_reward_unified_contract.py
+++ b/tests/test_reward_unified_contract.py
@@ -1,0 +1,175 @@
+"""Tests for the unified Reward contract — guards the fix from issue #397.
+
+Pins the Reward plane's single canonical contract: ``Reward.score(node) ->
+VerifyResult`` (``docs/architecture.md`` § "The four contracts"). Legacy
+path-based ``RewardFunc``s adapt into the canonical contract via
+``PathReward``, which reads ``rollout_dir`` from ``node.state[PATH_STATE_KEY]``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.rewards import (
+    PATH_STATE_KEY,
+    PathReward,
+    Reward,
+    RewardFunc,
+    Rubric,
+    TestRewardFunc,
+    VerifyResult,
+)
+from benchflow.rewards.events import RewardEvent
+from benchflow.trajectories.tree import RolloutNode
+
+
+class _ConstFunc:
+    """Path-based RewardFunc returning a constant — deterministic test fixture."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    async def score(self, rollout_dir: Path) -> float:
+        return self._value
+
+
+class _NativeNodeReward:
+    """A Reward implemented directly against the canonical node contract."""
+
+    async def score(self, node: RolloutNode) -> VerifyResult:
+        return VerifyResult(
+            reward=float(node.state.get("score", 0.0)),
+            space="output",
+            granularity="terminal",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Canonical contract
+# ---------------------------------------------------------------------------
+
+
+def test_reward_protocol_is_runtime_checkable_and_node_based() -> None:
+    """The canonical Reward Protocol accepts node-based scorers."""
+    assert isinstance(_NativeNodeReward(), Reward)
+
+
+def test_path_reward_satisfies_canonical_reward_contract() -> None:
+    """A PathReward-wrapped RewardFunc is a Reward — the two paths unify here."""
+    adapter = PathReward(_ConstFunc(0.7))
+    assert isinstance(adapter, Reward)
+
+
+async def test_legacy_reward_func_must_be_adapted_before_acting_as_reward(
+    tmp_path: Path,
+) -> None:
+    """A bare path-based ``RewardFunc`` is not usable as a ``Reward``.
+
+    ``Reward`` and ``RewardFunc`` are structurally similar (both expose a
+    ``score`` method) so ``isinstance`` cannot tell them apart at runtime —
+    that is why #397 surfaced in the first place. The real test is
+    behavioural: feeding a ``RolloutNode`` into a legacy ``RewardFunc`` fails
+    (no ``rollout_dir`` attr / not a ``Path``), and wrapping it in
+    ``PathReward`` is what makes it actually work under the canonical
+    contract. Pinning this stops a future refactor from collapsing the two
+    protocols and re-opening the issue.
+    """
+    bare = TestRewardFunc()
+    assert isinstance(bare, RewardFunc)  # has the legacy ``score`` method shape
+    node = RolloutNode(id="leaf", state={PATH_STATE_KEY: str(tmp_path)})
+
+    # Direct node-call fails — TestRewardFunc expects a Path-like rollout_dir.
+    with pytest.raises((AttributeError, TypeError)):
+        await bare.score(node)  # type: ignore[arg-type]
+
+    # Wrapped, it works and returns the canonical VerifyResult.
+    wrapped = PathReward(bare)
+    result = await wrapped.score(node)
+    assert isinstance(result, VerifyResult)
+
+
+# ---------------------------------------------------------------------------
+# PathReward adapter behaviour
+# ---------------------------------------------------------------------------
+
+
+async def test_path_reward_reads_rollout_dir_from_node_state(tmp_path: Path) -> None:
+    """The adapter bridges node-scoped scoring to path-based RewardFuncs."""
+    node = RolloutNode(id="leaf", state={PATH_STATE_KEY: str(tmp_path)})
+    adapter = PathReward(_ConstFunc(0.42), source="const")
+
+    result = await adapter.score(node)
+
+    assert isinstance(result, VerifyResult)
+    assert result.reward == 0.42
+    assert result.items == {"const": 0.42}
+    assert result.space == "output"
+    assert result.granularity == "terminal"
+    assert result.error is None
+    assert len(result.events) == 1
+    event = result.events[0]
+    assert event.source == "const"
+    assert event.reward == 0.42
+
+
+async def test_path_reward_missing_rollout_dir_records_error() -> None:
+    """A node with no rollout_dir scores 0.0 with error — never raises.
+
+    Distinguishes 'nobody scored' (error populated) from an honest 0.0 score,
+    matching ``score_node``'s contract.
+    """
+    node = RolloutNode(id="leaf")  # no state
+    adapter = PathReward(_ConstFunc(1.0), source="x")
+
+    result = await adapter.score(node)
+
+    assert result.reward == 0.0
+    assert result.error is not None
+    assert "rollout_dir" in result.error
+
+
+async def test_path_reward_passes_through_verify_result(tmp_path: Path) -> None:
+    """A Rubric returns ``VerifyResult``; the adapter must not double-wrap it."""
+    rubric = Rubric(reward_funcs=[_ConstFunc(0.5), _ConstFunc(1.0)])
+    node = RolloutNode(id="leaf", state={PATH_STATE_KEY: str(tmp_path)})
+
+    result = await PathReward(rubric, source="rubric").score(node)
+
+    assert isinstance(result, VerifyResult)
+    # Rubric's weighted mean with equal weights — 0.75, threaded through.
+    assert result.reward == pytest.approx(0.75)
+    # Underlying per-function items are preserved (not collapsed to {"rubric"}).
+    assert "_ConstFunc" in result.items or "_ConstFunc_0" in result.items
+
+
+async def test_path_reward_default_source_is_inner_class_name(
+    tmp_path: Path,
+) -> None:
+    """Without an explicit source, the adapter uses the wrapped class name."""
+    node = RolloutNode(id="leaf", state={PATH_STATE_KEY: str(tmp_path)})
+
+    result = await PathReward(_ConstFunc(0.9)).score(node)
+
+    assert "_ConstFunc" in result.items
+
+
+async def test_path_reward_promotes_float_to_tagged_terminal_event(
+    tmp_path: Path,
+) -> None:
+    """A bare float becomes a terminal Output-space ``RewardEvent``.
+
+    The architecture mandates every reward record be tagged ``(space,
+    granularity)`` — the adapter is the seam that puts that tag onto legacy
+    path-based scorers' raw floats.
+    """
+    node = RolloutNode(id="leaf", state={PATH_STATE_KEY: str(tmp_path)})
+
+    result = await PathReward(_ConstFunc(0.6), source="t").score(node)
+
+    assert len(result.events) == 1
+    event: RewardEvent = result.events[0]
+    assert event.type == "terminal"
+    assert event.space == "output"
+    assert event.granularity == "terminal"


### PR DESCRIPTION
Closes #397.

Reward plane had competing contracts: architecture's node-based `score(node) -> VerifyResult` vs production's path-based `RewardFunc.score(rollout_dir: Path) -> float`. Picked node-based as canonical (per architecture.md). Added `Reward` Protocol + `PathReward` adapter that lifts any legacy `RewardFunc` (or `Rubric`) into the canonical contract. Bare floats get promoted to a tagged terminal Output-space `RewardEvent`; `VerifyResult` passes through unchanged.

`RewardFunc` kept for back-compat (docstring marks it non-canonical). 8 new tests pinning the contract + 1916 regression pass.

**Out of scope (follow-up needed)**: wiring the rollout verifier (`_verify_rollout` / `Verifier.verify`) to the canonical `Reward` contract end-to-end — that's ~500 lines touching rollout.py + task/verifier.py + artifact emitters. Related work in #385, #391, #396 covers the downstream tag/JSONL pieces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and adapter layer with preserved legacy `RewardFunc` behavior; no rollout verifier integration in this diff.
> 
> **Overview**
> Unifies the rewards plane on a **single canonical contract**: `Reward` with `score(node) -> VerifyResult`, aligned with architecture docs. **`RewardFunc`** (`score(rollout_dir) -> float`) stays for backward compatibility but is documented as legacy.
> 
> Adds **`PathReward`** to adapt any path-based scorer (including **`Rubric`** and built-ins) into the node contract via `node.state[PATH_STATE_KEY]` (`"rollout_dir"`). Bare floats become tagged terminal **output** `RewardEvent`s; existing **`VerifyResult`** from rubrics pass through without double-wrapping. Missing `rollout_dir` yields `reward=0.0` with **`error`** set instead of raising.
> 
> Exports **`Reward`**, **`PathReward`**, and **`PATH_STATE_KEY`** from the public API. New tests lock in protocol behavior and adapter semantics (#397). Rollout/verifier wiring to **`Reward`** end-to-end is explicitly **not** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 353f4cb45925d9b64f3717e0364a56da3b436c39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->