### PR TITLE
fix: Sandbox.snapshot/restore on the contract used by kernel (#384)

### DIFF
--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -79,6 +79,8 @@ from benchflow.sandbox import (
     ImageConfig,
     ImageRef,
     Sandbox,
+    SandboxImage,
+    SandboxSnapshotNotSupported,
     build_service_hooks,
     detect_services_from_dockerfile,
     register_service,
@@ -88,7 +90,14 @@ from benchflow.sandbox import (
 from benchflow.sandbox import ExecResult as SandboxExecResult
 from benchflow.sandbox.protocol import ExecResult
 from benchflow.sandbox.setup import stage_dockerfile_deps
-from benchflow.sandbox.snapshot import list_snapshots, restore, snapshot
+from benchflow.sandbox.snapshot import (
+    list_snapshots,
+    list_workspace_snapshots,
+    restore,
+    snapshot,
+    workspace_restore,
+    workspace_snapshot,
+)
 from benchflow.sandbox.user import BaseUser, FunctionUser, PassthroughUser, RoundResult
 from benchflow.scenes import MailboxTransport, Message, MessageTransport, SceneRole
 from benchflow.scenes import Scene as SceneRuntime
@@ -127,6 +136,8 @@ __all__ = [
     # Sandbox protocol
     "Sandbox",
     "SandboxExecResult",
+    "SandboxImage",
+    "SandboxSnapshotNotSupported",
     "ImageBuilder",
     "ImageConfig",
     "ImageRef",
@@ -175,7 +186,11 @@ __all__ = [
     "Message",
     "MessageTransport",
     "MailboxTransport",
-    # Env snapshots
+    # Workspace snapshots (filesystem helper — NOT the Sandbox primitive, #384)
+    "workspace_snapshot",
+    "workspace_restore",
+    "list_workspace_snapshots",
+    # Backward-compatible aliases for the above (pre-#384 names)
     "snapshot",
     "restore",
     "list_snapshots",

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1410,6 +1410,8 @@ class Rollout:
         self,
         n: int,
         run_child: ChildRunner | None = None,
+        *,
+        require_sandbox_snapshot: bool = False,
     ) -> float:
         """Branch the rollout at the cursor into ``n`` child continuations.
 
@@ -1424,8 +1426,16 @@ class Rollout:
         default restores the env, connects a fresh agent, runs the continuation,
         and scores it. A caller that needs per-child prompts binds them into the
         ``run_child`` closure.
+
+        ``require_sandbox_snapshot`` gates the branch on the active Sandbox
+        implementing container-level snapshot/restore. When True, providers
+        without that capability (Modal, Daytona DinD) fail closed with a clear
+        diagnostic rather than running with a half-consistent checkpoint
+        (#384, Branch lifecycle in docs/architecture.md).
         """
-        return await _branch_engine(self, n, run_child)
+        return await _branch_engine(
+            self, n, run_child, require_sandbox_snapshot=require_sandbox_snapshot
+        )
 
     # ── Phase 4: VERIFY ──
 

--- a/src/benchflow/rollout_branch.py
+++ b/src/benchflow/rollout_branch.py
@@ -98,6 +98,8 @@ async def branch(
     rollout: Rollout,
     n: int,
     run_child: ChildRunner | None = None,
+    *,
+    require_sandbox_snapshot: bool = False,
 ) -> float:
     """Branch ``rollout`` at its cursor into ``n`` child continuations.
 
@@ -131,6 +133,26 @@ async def branch(
         )
     if n < 2:
         raise ValueError(f"a branch forks into >= 2 children, got n={n}")
+
+    # Fail closed when the run requires a three-layer checkpoint but the
+    # sandbox cannot snapshot the container layer (#384). The Branch
+    # lifecycle composes container ⊃ environment-state ⊃ agent-session;
+    # without the container layer, restoring only environment state can
+    # produce inconsistent state for runs that mutate process/service state
+    # the Environment manifest does not capture.
+    if require_sandbox_snapshot:
+        sandbox = getattr(rollout, "_env", None)
+        supports = getattr(sandbox, "supports_snapshot", False)
+        if not supports:
+            sandbox_name = type(sandbox).__name__ if sandbox else "<none>"
+            raise RuntimeError(
+                f"branch(require_sandbox_snapshot=True) cannot run: the active "
+                f"sandbox {sandbox_name!r} does not implement container-level "
+                "snapshot/restore. Use a provider whose Sandbox satisfies the "
+                "checkpoint contract (DockerSandbox or DaytonaSandbox in direct "
+                "mode), or drop require_sandbox_snapshot if Environment-state "
+                "checkpoint is sufficient for this run."
+            )
 
     parent = rollout._cursor
     runner = run_child if run_child is not None else make_default_runner(rollout)

--- a/src/benchflow/sandbox/__init__.py
+++ b/src/benchflow/sandbox/__init__.py
@@ -14,6 +14,8 @@ from benchflow.sandbox.protocol import (
     ImageConfig,
     ImageRef,
     Sandbox,
+    SandboxImage,
+    SandboxSnapshotNotSupported,
 )
 from benchflow.sandbox.services import (
     SERVICES,
@@ -29,6 +31,8 @@ __all__ = [
     "ImageConfig",
     "ImageRef",
     "Sandbox",
+    "SandboxImage",
+    "SandboxSnapshotNotSupported",
     "ServiceConfig",
     "SERVICES",
     "build_service_hooks",

--- a/src/benchflow/sandbox/_base.py
+++ b/src/benchflow/sandbox/_base.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from benchflow.sandbox.protocol import SandboxImage, SandboxSnapshotNotSupported
 from benchflow.task.config import SandboxConfig
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths
@@ -304,3 +305,46 @@ class BaseSandbox(ABC):
 
     async def attach(self) -> None:
         raise NotImplementedError("This environment does not support attaching.")
+
+    # ── Container-level snapshot/restore (Branch substrate) ──────────────
+    #
+    # Part of the Sandbox contract (``docs/architecture.md``): the Branch
+    # lifecycle composes container ⊃ environment-state ⊃ agent-session in
+    # that order. Backends that cannot snapshot the container (Modal, the
+    # Daytona DinD/compose strategy today) leave the defaults in place and
+    # raise :class:`SandboxSnapshotNotSupported`. ``Rollout.branch()`` gates
+    # on :attr:`supports_snapshot` and fails closed with a clear diagnostic
+    # rather than producing a half-consistent checkpoint (#384).
+
+    @property
+    def supports_snapshot(self) -> bool:
+        """Whether this backend implements container-level snapshot/restore.
+
+        Default ``False`` so new backends are safe-by-default — they must
+        opt-in by overriding both this property and ``snapshot``/``restore``.
+        """
+        return False
+
+    async def snapshot(self, name: str | None = None) -> SandboxImage:
+        """Capture the current container state as a re-usable image.
+
+        Default implementation raises :class:`SandboxSnapshotNotSupported`;
+        Docker and Daytona-direct override this with provider-native commit
+        and snapshot APIs respectively.
+        """
+        raise SandboxSnapshotNotSupported(
+            f"{type(self).__name__} does not support container-level snapshots. "
+            "Branch requires a provider whose Sandbox can checkpoint the "
+            "container layer; see docs/architecture.md, 'The hard part'."
+        )
+
+    async def restore(self, image: SandboxImage) -> None:
+        """Restore the container to a previously captured snapshot.
+
+        Default implementation raises :class:`SandboxSnapshotNotSupported`.
+        """
+        raise SandboxSnapshotNotSupported(
+            f"{type(self).__name__} does not support container-level restore. "
+            "Branch requires a provider whose Sandbox can checkpoint the "
+            "container layer; see docs/architecture.md, 'The hard part'."
+        )

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -33,6 +33,7 @@ from benchflow.sandbox._compose import (
     compose_mkdir_p_command,
     compose_parent_mkdir_p_command,
 )
+from benchflow.sandbox.protocol import SandboxImage, SandboxSnapshotNotSupported
 from benchflow.task.config import SandboxConfig
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
@@ -180,6 +181,11 @@ class DaytonaClientManager:
 class _DaytonaStrategy:
     """Base for Daytona implementation strategies."""
 
+    # Strategies declare whether they can satisfy container-level snapshots;
+    # the DaytonaSandbox wrapper forwards the question to its strategy so the
+    # capability tracks the active mode (direct vs. DinD/compose) — see #384.
+    supports_snapshot: bool = False
+
     def __init__(self, env: DaytonaSandbox) -> None:
         self._env = env
 
@@ -230,9 +236,25 @@ class _DaytonaStrategy:
     @abstractmethod
     async def attach(self) -> None: ...
 
+    async def snapshot(self, name: str | None = None) -> SandboxImage:
+        """Capture a provider-level snapshot. Default: not supported."""
+        raise SandboxSnapshotNotSupported(
+            f"{type(self).__name__} does not support container-level snapshots."
+        )
+
+    async def restore(self, image: SandboxImage) -> None:
+        """Restore from a provider-level snapshot. Default: not supported."""
+        raise SandboxSnapshotNotSupported(
+            f"{type(self).__name__} does not support container-level restore."
+        )
+
 
 class _DaytonaDirect(_DaytonaStrategy):
     """Direct sandbox strategy — single-container behavior."""
+
+    # Daytona ships a native sandbox-snapshot API on AsyncSandbox; the direct
+    # strategy uses it for the container layer of Branch (#384).
+    supports_snapshot: bool = True
 
     async def start(self, force_build: bool) -> None:
         env = self._env
@@ -424,6 +446,60 @@ class _DaytonaDirect(_DaytonaStrategy):
             "ssh",
             ["ssh", f"{ssh_access.token}@ssh.app.daytona.io"],
         )
+
+    async def snapshot(self, name: str | None = None) -> SandboxImage:
+        """Create a Daytona snapshot from the current sandbox state.
+
+        Wraps ``AsyncSandbox._experimental_create_snapshot``; the snapshot
+        name is the ``ref`` other Daytona sandboxes can be created from via
+        :class:`CreateSandboxFromSnapshotParams`.
+        """
+        env = self._env
+        if not env._sandbox:
+            raise SandboxSnapshotNotSupported(
+                "DaytonaSandbox.snapshot requires a started sandbox; call "
+                "start() before snapshot()."
+            )
+        snap_name = name or f"bf-snap-{env.environment_name}-{uuid4().hex[:12]}"
+        # Daytona names: lowercase, dash-separated, ascii — sanitize defensively.
+        snap_name = snap_name.lower().replace("_", "-")
+        await env._sandbox._experimental_create_snapshot(snap_name)
+        env.logger.info(f"Snapshot created: {snap_name}")
+        return SandboxImage(
+            provider="daytona",
+            ref=snap_name,
+            meta={"sandbox_id": getattr(env._sandbox, "id", "") or ""},
+        )
+
+    async def restore(self, image: SandboxImage) -> None:
+        """Replace the current Daytona sandbox with one from ``image``.
+
+        Daytona snapshots are immutable — restore is implemented by deleting
+        the current sandbox and creating a fresh one from the snapshot,
+        matching the provider's native semantics.
+        """
+        env = self._env
+        if image.provider != "daytona":
+            raise SandboxSnapshotNotSupported(
+                f"DaytonaSandbox.restore cannot consume a {image.provider!r} "
+                f"snapshot (got ref={image.ref!r}); snapshots are not portable "
+                "across providers."
+            )
+        if env._sandbox is not None:
+            try:
+                await env._sandbox.delete()
+            except Exception as e:
+                env.logger.warning(f"Failed to delete sandbox before restore: {e}")
+            env._sandbox = None
+
+        params = CreateSandboxFromSnapshotParams(
+            auto_delete_interval=env._auto_delete_interval,
+            auto_stop_interval=env._auto_stop_interval,
+            snapshot=image.ref,
+            network_block_all=env._network_block_all,
+        )
+        await env._create_sandbox(params=params)
+        env.logger.info(f"Snapshot restored: {image.ref}")
 
 
 class _DaytonaDinD(_DaytonaStrategy):
@@ -1334,3 +1410,15 @@ class DaytonaSandbox(BaseSandbox):
 
     async def attach(self) -> None:
         return await self._strategy.attach()
+
+    # ── Container snapshot/restore — delegates to active strategy (#384) ──
+
+    @property
+    def supports_snapshot(self) -> bool:
+        return self._strategy.supports_snapshot
+
+    async def snapshot(self, name: str | None = None) -> SandboxImage:
+        return await self._strategy.snapshot(name)
+
+    async def restore(self, image: SandboxImage) -> None:
+        return await self._strategy.restore(image)

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -34,6 +34,7 @@ from benchflow.sandbox._compose import (
     COMPOSE_NO_NETWORK_PATH,
     COMPOSE_PREBUILT_PATH,
 )
+from benchflow.sandbox.protocol import SandboxImage
 from benchflow.task.config import SandboxConfig
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
@@ -430,6 +431,144 @@ class DockerSandbox(BaseSandbox):
             ["cp", f"{service}:{source_dir}/.", str(target_dir)],
             check=True,
         )
+
+    # ── Container snapshot/restore (Branch substrate) ────────────────────
+    #
+    # ``docker commit`` captures the ``main`` container's filesystem into a
+    # local image; restore re-creates ``main`` from that image. Snapshots
+    # are container-level only — they include the filesystem the agent has
+    # mutated, but **not** mounted host volumes (rollout dir, verifier dir)
+    # and **not** sibling compose services. The Branch lifecycle composes
+    # this with the Environment-state snapshot (DB dump) that captures the
+    # mounted/sidecar state separately (#384).
+
+    @property
+    def supports_snapshot(self) -> bool:
+        return True
+
+    async def snapshot(self, name: str | None = None) -> SandboxImage:
+        """Commit the current ``main`` container into a re-usable image.
+
+        Uses ``docker commit`` so the snapshot lives in the local Docker
+        image store. Returns a :class:`SandboxImage` whose ``ref`` is the
+        committed image tag — pass it back to :meth:`restore` to roll the
+        ``main`` container back to this checkpoint.
+        """
+        from benchflow.sandbox.protocol import SandboxSnapshotNotSupported
+
+        container_id = await self._main_container_id()
+        if not container_id:
+            raise SandboxSnapshotNotSupported(
+                "DockerSandbox.snapshot requires the main container to be "
+                "running; call start() before snapshot()."
+            )
+        suffix = name or uuid.uuid4().hex[:12]
+        tag = _sanitize_docker_image_name(
+            f"bf-snap-{self.environment_name}-{suffix}"
+        )
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            "commit",
+            container_id,
+            tag,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        if proc.returncode != 0:
+            raise RuntimeError(
+                "docker commit failed: "
+                f"{(stderr_bytes or stdout_bytes or b'').decode(errors='replace')}"
+            )
+        digest = (stdout_bytes or b"").decode(errors="replace").strip()
+        self.logger.info(f"Snapshot created: {tag} ({digest})")
+        return SandboxImage(
+            provider="docker",
+            ref=tag,
+            meta={"container_id": container_id, "digest": digest},
+        )
+
+    async def restore(self, image: SandboxImage) -> None:
+        """Restore the ``main`` container from a previously committed image.
+
+        Stops and removes the current ``main`` container, then ``docker
+        run``s a replacement from ``image.ref``. Sibling compose services
+        are untouched — they keep running as before, matching the
+        documented container-only scope of the Sandbox layer.
+        """
+        from benchflow.sandbox.protocol import SandboxSnapshotNotSupported
+
+        if image.provider != "docker":
+            raise SandboxSnapshotNotSupported(
+                f"DockerSandbox.restore cannot consume a {image.provider!r} "
+                f"snapshot (got ref={image.ref!r}); snapshots are not portable "
+                "across providers."
+            )
+
+        container_id = await self._main_container_id()
+        if container_id:
+            await self._docker_cli(["stop", container_id])
+            await self._docker_cli(["rm", "-f", container_id])
+
+        project_name = _sanitize_docker_compose_project_name(self.session_id)
+        new_name = f"{project_name}-main-restored-{uuid.uuid4().hex[:8]}"
+
+        run_cmd = [
+            "run",
+            "--detach",
+            "--name",
+            new_name,
+            "--network",
+            f"{project_name}_default",
+            "--label",
+            f"com.docker.compose.project={project_name}",
+            "--label",
+            "com.docker.compose.service=main",
+            image.ref,
+            "sleep",
+            "infinity",
+        ]
+        result = await self._docker_cli(run_cmd, check=False)
+        if result.return_code != 0:
+            raise RuntimeError(
+                f"docker run from snapshot {image.ref!r} failed: "
+                f"{result.stderr or result.stdout}"
+            )
+        self.logger.info(f"Snapshot restored: {image.ref} -> {new_name}")
+
+    async def _main_container_id(self) -> str | None:
+        """Return the container id of the ``main`` compose service, or None."""
+        try:
+            result = await self._run_docker_compose_command(
+                ["ps", "-q", "main"], check=False
+            )
+        except RuntimeError:
+            return None
+        cid = (result.stdout or "").strip().splitlines()
+        return cid[0] if cid else None
+
+    async def _docker_cli(
+        self, args: list[str], check: bool = True
+    ) -> ExecResult:
+        """Run a raw ``docker`` CLI command — bypasses compose."""
+        proc = await asyncio.create_subprocess_exec(
+            "docker",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout_bytes, stderr_bytes = await proc.communicate()
+        result = ExecResult(
+            stdout=(stdout_bytes or b"").decode(errors="replace"),
+            stderr=(stderr_bytes or b"").decode(errors="replace"),
+            return_code=proc.returncode or 0,
+        )
+        if check and result.return_code != 0:
+            raise RuntimeError(
+                f"docker {' '.join(args)} failed: "
+                f"{result.stderr or result.stdout}"
+            )
+        return result
 
     async def services(self) -> list[str]:
         """List compose service names defined for this sandbox.

--- a/src/benchflow/sandbox/protocol.py
+++ b/src/benchflow/sandbox/protocol.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
@@ -10,6 +10,38 @@ class ExecResult:
     return_code: int
     stdout: str
     stderr: str
+
+
+@dataclass(frozen=True)
+class SandboxImage:
+    """A provider-opaque handle to a container-level checkpoint.
+
+    The Branch lifecycle (``docs/architecture.md``) composes three snapshot
+    layers — container, environment-state, agent-session — and this is the
+    container layer's unit of roll-back. Concrete providers carry whatever
+    they need to round-trip a snapshot inside ``provider``-scoped fields:
+
+    * Docker:  ``provider="docker"``, ``ref`` is the committed image tag.
+    * Daytona: ``provider="daytona"``, ``ref`` is the daytona snapshot name.
+
+    ``ref`` is opaque to the kernel — only the originating provider knows
+    how to ``restore`` from it. ``meta`` carries provider-specific extras
+    (image digest, parent container id, etc.) for diagnostics.
+    """
+
+    provider: str
+    ref: str
+    meta: dict[str, str] = field(default_factory=dict)
+
+
+class SandboxSnapshotNotSupported(NotImplementedError):
+    """Raised when a Sandbox backend cannot satisfy ``snapshot``/``restore``.
+
+    The Sandbox contract declares snapshot/restore, but not every backend can
+    implement them (Daytona DinD/compose, Modal). Callers — notably
+    ``Rollout.branch()`` — catch this to fail closed with a clear diagnostic
+    when the run requires container-level checkpointing.
+    """
 
 
 @runtime_checkable
@@ -24,6 +56,12 @@ class Sandbox(Protocol):
 
     BenchFlow provides the sandbox infrastructure; it does **not**
     orchestrate agent-internal loops or tool protocols (ENG-50).
+
+    Roll-back (``snapshot``/``restore``) is part of the contract — Branch
+    composes container, environment-state, and agent-session checkpoints in
+    that order (``docs/architecture.md``). Backends that cannot snapshot the
+    container raise :class:`SandboxSnapshotNotSupported`; callers gate on
+    :attr:`supports_snapshot` to fail closed before running.
     """
 
     async def exec(
@@ -42,6 +80,33 @@ class Sandbox(Protocol):
 
     async def start(self) -> None: ...
     async def stop(self, *, delete: bool = True) -> None: ...
+
+    # --- container-level roll-back (the substrate Branch runs on) ---
+    async def snapshot(self, name: str | None = None) -> SandboxImage:
+        """Capture the current container state as a re-usable image.
+
+        Raises :class:`SandboxSnapshotNotSupported` on backends without a
+        provider-level snapshot primitive. Branchable runs should gate on
+        :attr:`supports_snapshot` before calling.
+        """
+        ...
+
+    async def restore(self, image: SandboxImage) -> None:
+        """Restore the container to a previously captured snapshot.
+
+        Raises :class:`SandboxSnapshotNotSupported` on backends without a
+        provider-level snapshot primitive.
+        """
+        ...
+
+    @property
+    def supports_snapshot(self) -> bool:
+        """Whether this backend implements container-level snapshot/restore.
+
+        Capability gate for ``Rollout.branch()`` — see the Branch lifecycle
+        in ``docs/architecture.md``.
+        """
+        ...
 
     @property
     def host(self) -> str: ...

--- a/src/benchflow/sandbox/snapshot.py
+++ b/src/benchflow/sandbox/snapshot.py
@@ -1,15 +1,22 @@
-"""Sandbox snapshot/restore — filesystem-level checkpointing.
+"""Workspace snapshot/restore — filesystem-level helper, NOT the Sandbox primitive.
 
-Provides snapshot(name) -> ref and restore(ref) for any environment that
-supports env.exec().  Works on both Docker and Daytona sandboxes.
+Provides ``workspace_snapshot(name) -> ref`` and ``workspace_restore(ref)``
+for any environment that supports ``env.exec()``. Works on Docker and
+Daytona sandboxes.
 
-Implementation: tar the workspace directory into /tmp/.benchflow_snapshots/.
-In-place restore by clearing and untarring.  Sandbox-agnostic — no Docker
-daemon or Daytona snapshot API required.
+**Scope** (#384): this is a *workspace-only* tar/untar helper, not the
+container-level snapshot/restore the Branch lifecycle calls. It captures
+files under a single directory (default ``/app``); it does **not** snapshot
+the container filesystem, mounted volumes, process state, sibling compose
+services, or provider images.
 
-For 0.3+, Daytona's _experimental_create_snapshot can be swapped in as an
-optimization for branching rollouts (new sandbox from snapshot), but the
-filesystem approach covers the rewind use case and is provable now.
+Container-level snapshot/restore lives on the Sandbox contract itself —
+see :meth:`benchflow.sandbox.protocol.Sandbox.snapshot` and the
+``supports_snapshot`` capability gate. ``Rollout.branch`` composes those
+with Environment-state snapshots for full Branch semantics.
+
+The historical ``snapshot``/``restore``/``list_snapshots`` names are kept
+as backward-compatible aliases.
 """
 
 import logging
@@ -22,11 +29,12 @@ logger = logging.getLogger(__name__)
 _SNAP_DIR = "/tmp/.benchflow_snapshots"
 
 
-async def snapshot(env, name: str, workspace: str = "/app") -> str:
-    """Create a named snapshot of the workspace.
+async def workspace_snapshot(env, name: str, workspace: str = "/app") -> str:
+    """Create a named *workspace-only* snapshot — tar of ``workspace``.
 
-    Returns a reference string suitable for restore() and for recording
-    in trial metadata / rewards.jsonl.
+    Returns a reference string suitable for ``workspace_restore()`` and for
+    recording in trial metadata / rewards.jsonl. This does **not** capture
+    container state — use :meth:`Sandbox.snapshot` for that (#384).
     """
     if not _re.match(r"^[a-zA-Z0-9_-]+$", name):
         raise ValueError(
@@ -45,10 +53,12 @@ async def snapshot(env, name: str, workspace: str = "/app") -> str:
     return ref
 
 
-async def restore(env, ref: str, workspace: str = "/app") -> None:
-    """Restore workspace to a named snapshot.
+async def workspace_restore(env, ref: str, workspace: str = "/app") -> None:
+    """Restore ``workspace`` to a named workspace snapshot.
 
-    ref: the string returned by snapshot() — format is "fs:{name}:{path}".
+    ref: the string returned by ``workspace_snapshot()`` — format is
+    ``"fs:{name}:{path}"``. Does not restore container state — use
+    :meth:`Sandbox.restore` for that (#384).
     """
     parts = ref.split(":", 2)
     if len(parts) != 3 or parts[0] != "fs":
@@ -74,8 +84,8 @@ async def restore(env, ref: str, workspace: str = "/app") -> None:
     logger.info(f"Snapshot restored: {ref}")
 
 
-async def list_snapshots(env) -> list[str]:
-    """List available snapshot names."""
+async def list_workspace_snapshots(env) -> list[str]:
+    """List available *workspace* snapshot names."""
     result = await env.exec(f"ls {_SNAP_DIR}/*.tar.gz 2>/dev/null || true")
     if not (result.stdout or "").strip():
         return []
@@ -83,3 +93,15 @@ async def list_snapshots(env) -> list[str]:
         PurePosixPath(line.strip()).stem.removesuffix(".tar")
         for line in (result.stdout or "").strip().splitlines()
     ]
+
+
+# ── Backward-compatibility aliases ────────────────────────────────────────
+#
+# Pre-#384 these were ``snapshot`` / ``restore`` / ``list_snapshots`` and
+# exported as ``bf.snapshot`` etc. The names looked like the Sandbox lifecycle
+# primitive but only ever covered a single workspace directory. The renamed
+# functions above make the scope explicit; the old names stay as aliases so
+# external callers (proof scripts, downstream tasks) keep working.
+snapshot = workspace_snapshot
+restore = workspace_restore
+list_snapshots = list_workspace_snapshots

--- a/tests/test_sandbox_snapshot_contract.py
+++ b/tests/test_sandbox_snapshot_contract.py
@@ -1,0 +1,258 @@
+"""Sandbox snapshot/restore contract conformance (#384).
+
+Guards the fix from PR for issue #384 against a regression where
+``snapshot``/``restore`` were free functions over ``env.exec()`` rather
+than methods on the Sandbox contract the kernel uses.
+
+The contract surface (``docs/architecture.md``, "The four contracts"):
+
+* ``Sandbox.snapshot()`` / ``Sandbox.restore(image)`` are real methods.
+* ``Sandbox.supports_snapshot`` is the capability gate.
+* Providers that cannot snapshot the container layer raise
+  :class:`SandboxSnapshotNotSupported` from both methods.
+* ``Rollout.branch(require_sandbox_snapshot=True)`` fails closed on those
+  providers with a clear diagnostic.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from benchflow.sandbox.protocol import (
+    Sandbox,
+    SandboxImage,
+    SandboxSnapshotNotSupported,
+)
+
+# ── 1. Protocol surface ──────────────────────────────────────────────────
+
+
+class TestSandboxProtocolHasSnapshot:
+    """The Sandbox Protocol exposes snapshot/restore — the kernel can rely on it."""
+
+    def test_protocol_has_snapshot(self):
+        assert hasattr(Sandbox, "snapshot")
+
+    def test_protocol_has_restore(self):
+        assert hasattr(Sandbox, "restore")
+
+    def test_protocol_has_supports_snapshot(self):
+        assert hasattr(Sandbox, "supports_snapshot")
+
+    def test_sandbox_image_is_provider_scoped(self):
+        img = SandboxImage(
+            provider="docker", ref="bf-snap-foo", meta={"digest": "sha256:abc"}
+        )
+        assert img.provider == "docker"
+        assert img.ref == "bf-snap-foo"
+        assert img.meta == {"digest": "sha256:abc"}
+
+    def test_sandbox_image_is_frozen(self):
+        img = SandboxImage(provider="docker", ref="x")
+        with pytest.raises((AttributeError, TypeError)):
+            img.ref = "y"  # type: ignore[misc]
+
+
+# ── 2. Capability declarations on concrete backends ──────────────────────
+
+
+class TestDockerSnapshotCapability:
+    """DockerSandbox declares snapshot support — implemented via ``docker commit``."""
+
+    def test_docker_supports_snapshot(self):
+        from benchflow.sandbox.docker import DockerSandbox
+
+        # Class-level capability — true for every DockerSandbox instance.
+        assert DockerSandbox.supports_snapshot is not False  # property descriptor
+        # Build a minimal instance and probe the property.
+        # Avoid touching the real constructor: just call the property descriptor.
+        prop = DockerSandbox.__dict__["supports_snapshot"]
+        result = prop.fget(None)  # type: ignore[arg-type]
+        assert result is True
+
+    def test_docker_snapshot_is_async(self):
+        from benchflow.sandbox.docker import DockerSandbox
+
+        assert asyncio.iscoroutinefunction(DockerSandbox.snapshot)
+        assert asyncio.iscoroutinefunction(DockerSandbox.restore)
+
+
+_daytona_available = True
+try:
+    import daytona as _daytona_mod  # noqa: F401
+except ImportError:
+    _daytona_available = False
+
+
+@pytest.mark.skipif(not _daytona_available, reason="daytona not installed")
+class TestDaytonaSnapshotCapability:
+    """Daytona direct = supported (native API); DinD = unsupported."""
+
+    def test_daytona_direct_supports_snapshot(self):
+        from benchflow.sandbox.daytona import _DaytonaDirect
+
+        assert _DaytonaDirect.supports_snapshot is True
+
+    def test_daytona_dind_does_not_support_snapshot(self):
+        from benchflow.sandbox.daytona import _DaytonaDinD
+
+        # DinD/compose cannot satisfy provider-level snapshot today (#384).
+        assert _DaytonaDinD.supports_snapshot is False
+
+    def test_daytona_sandbox_snapshot_is_async(self):
+        from benchflow.sandbox.daytona import DaytonaSandbox
+
+        assert asyncio.iscoroutinefunction(DaytonaSandbox.snapshot)
+        assert asyncio.iscoroutinefunction(DaytonaSandbox.restore)
+
+
+_modal_available = True
+try:
+    import modal as _modal_mod  # noqa: F401
+except ImportError:
+    _modal_available = False
+
+
+@pytest.mark.skipif(not _modal_available, reason="modal not installed")
+class TestModalSnapshotCapability:
+    """Modal has no provider-level snapshot — declares unsupported."""
+
+    def test_modal_does_not_support_snapshot(self):
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        # ModalSandbox inherits the default (False) from BaseSandbox.
+        prop = ModalSandbox.__dict__.get(
+            "supports_snapshot"
+        ) or ModalSandbox.__mro__[1].__dict__.get("supports_snapshot")
+        result = prop.fget(None)  # type: ignore[arg-type, union-attr]
+        assert result is False
+
+
+# ── 3. Default fails closed with SandboxSnapshotNotSupported ─────────────
+
+
+class _UnsupportedSandbox:
+    """Bare object exercising BaseSandbox's default snapshot/restore."""
+
+    # Inherit the methods directly off BaseSandbox so the default path is
+    # what's under test — without dragging the whole __init__ in.
+    pass
+
+
+async def test_base_sandbox_default_snapshot_raises_unsupported():
+    """The default ``snapshot`` raises so naive new backends fail closed."""
+    from benchflow.sandbox._base import BaseSandbox
+
+    # Bind the unbound method to a sentinel object; the body never touches
+    # ``self`` state, only the type name in the error message.
+    class _Dummy:
+        __class__ = type("FakeSandbox", (), {})  # for the error message
+
+    with pytest.raises(SandboxSnapshotNotSupported, match="does not support"):
+        await BaseSandbox.snapshot(_Dummy())  # type: ignore[arg-type]
+
+
+async def test_base_sandbox_default_restore_raises_unsupported():
+    """The default ``restore`` raises so naive new backends fail closed."""
+    from benchflow.sandbox._base import BaseSandbox
+
+    class _Dummy:
+        pass
+
+    img = SandboxImage(provider="docker", ref="x")
+    with pytest.raises(SandboxSnapshotNotSupported, match="does not support"):
+        await BaseSandbox.restore(_Dummy(), img)  # type: ignore[arg-type]
+
+
+# ── 4. Branch fails closed on unsupported providers ──────────────────────
+
+
+class _FakeRolloutEnv:
+    """Minimal Environment for the Branch engine — records snapshot calls."""
+
+    async def snapshot(self):
+        from benchflow.environment.protocol import StateSnapshot
+
+        return StateSnapshot(id="snap-1", path="/tmp/x")
+
+    async def restore(self, snap):
+        pass
+
+
+class _FakeRollout:
+    """A stand-in just rich enough for the require_sandbox_snapshot gate."""
+
+    def __init__(self, sandbox_supports: bool):
+        from benchflow.trajectories.tree import RolloutTree
+
+        self._tree = RolloutTree()
+        self._cursor = self._tree.root
+        self._environment = _FakeRolloutEnv()
+
+        class _FakeSandbox:
+            supports_snapshot = sandbox_supports
+
+        self._env = _FakeSandbox()
+        self._trajectory: list = []
+        self._n_tool_calls = 0
+        self._phase = "ready"
+        self._rewards = None
+        self._trajectory_source = None
+        self._partial_trajectory = False
+        self._session_tool_count = 0
+        self._session_traj_count = 0
+
+    async def disconnect(self):
+        pass
+
+
+async def test_branch_fails_closed_when_sandbox_snapshot_required_but_unsupported():
+    """``require_sandbox_snapshot=True`` rejects providers without snapshot."""
+    from benchflow.rollout_branch import branch
+
+    rollout = _FakeRollout(sandbox_supports=False)
+    with pytest.raises(RuntimeError, match="container-level snapshot/restore"):
+        await branch(rollout, n=2, require_sandbox_snapshot=True)  # type: ignore[arg-type]
+
+
+async def test_branch_does_not_require_sandbox_snapshot_by_default():
+    """Backwards-compat: the existing Environment-only path is unchanged."""
+    from benchflow.rollout_branch import branch
+
+    rollout = _FakeRollout(sandbox_supports=False)
+
+    async def _runner(child):
+        return 0.5
+
+    # Without the flag, the engine continues — the env-only path still works.
+    # Children run via the injected runner so this exercises only the gate.
+    value = await branch(rollout, n=2, run_child=_runner)  # type: ignore[arg-type]
+    assert value == pytest.approx(0.5)
+
+
+# ── 5. Workspace helper is scope-renamed, alias preserved ─────────────────
+
+
+class TestWorkspaceHelperScoped:
+    """``benchflow.sandbox.snapshot`` is now explicitly workspace-only (#384)."""
+
+    def test_new_workspace_names_exported(self):
+        import benchflow
+
+        assert hasattr(benchflow, "workspace_snapshot")
+        assert hasattr(benchflow, "workspace_restore")
+        assert hasattr(benchflow, "list_workspace_snapshots")
+
+    def test_legacy_aliases_preserved(self):
+        import benchflow
+        from benchflow.sandbox.snapshot import (
+            workspace_restore,
+            workspace_snapshot,
+        )
+
+        # Pre-#384 names stay as aliases so the proof script and downstream
+        # callers keep working.
+        assert benchflow.snapshot is workspace_snapshot
+        assert benchflow.restore is workspace_restore


### PR DESCRIPTION
Closes #384.

Sandbox snapshot/restore now live on the `Sandbox` Protocol that kernel + `Rollout.branch` consume, not as free `bf.snapshot(env, ...)` helpers that only tar a workspace dir.

- `sandbox/protocol.py`: added `SandboxImage`, `SandboxSnapshotNotSupported`, `snapshot()`/`restore()`/`supports_snapshot` on Sandbox Protocol.
- `sandbox/_base.py`: `BaseSandbox` default: unsupported (fail-closed).
- `sandbox/docker.py`: implements via `docker commit` + `docker run`. `supports_snapshot = True`.
- `sandbox/daytona.py`: `_DaytonaDirect` uses Daytona's `_experimental_create_snapshot` + `CreateSandboxFromSnapshotParams`; `_DaytonaDinD` unsupported (compose-in-Daytona checkpointing unsolved). `DaytonaSandbox.supports_snapshot` forwards to strategy.
- `sandbox/modal_impl.py`: inherits unsupported.
- `rollout_branch.py` + `rollout.py`: `branch(require_sandbox_snapshot=True)` fails closed with clear diagnostic when sandbox lacks capability.
- `sandbox/snapshot.py`: renamed free helpers to `workspace_snapshot`/`workspace_restore`/`list_workspace_snapshots` with explicit workspace-only scope; legacy aliases kept.

17 new tests + 1934 regression pass.

**Deferred (architecturally hard)**: agent-session snapshot layer ("The hard part" per architecture.md); Daytona DinD container snapshots; Modal native snapshot; docker-compose multi-service volume capture (intentional scope per architecture's three-layer checkpoint model).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Sandbox contract and branching checkpoint semantics across providers; mitigated by safe defaults, provider-scoped images, and opt-in `require_sandbox_snapshot` gating.
> 
> **Overview**
> Moves **container-level** checkpointing onto the `Sandbox` protocol (`SandboxImage`, `snapshot`/`restore`, `supports_snapshot`) so Branch and the kernel can rely on one contract instead of workspace-only tar helpers.
> 
> **Docker** checkpoints the `main` container via `docker commit` and restore via `docker run` (filesystem in the image; not host mounts or sibling compose services). **Daytona direct** uses the provider snapshot API; **DinD/compose** and default backends stay unsupported and raise `SandboxSnapshotNotSupported`. **`Rollout.branch(require_sandbox_snapshot=True)`** fails closed with a clear error when the active sandbox cannot snapshot the container layer.
> 
> The old **`bf.snapshot` / `restore`** helpers are renamed to **`workspace_snapshot` / `workspace_restore`** (explicit workspace tar scope); legacy names remain as aliases. New contract tests cover protocol surface, capabilities, and the branch gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2180a6147feba6ff3c06b3a90d796f2d1dfdb31f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->