### PR TITLE
fix: add Mintlify docs config

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://mintlify.com/docs.json",
+  "theme": "mint",
+  "name": "BenchFlow",
+  "colors": {
+    "primary": "#111827"
+  },
+  "navigation": {
+    "groups": [
+      {
+        "group": "Start here",
+        "pages": [
+          "docs/getting-started",
+          "docs/concepts"
+        ]
+      },
+      {
+        "group": "Guides",
+        "pages": [
+          "docs/running-benchmarks",
+          "docs/task-authoring",
+          "docs/use-cases",
+          "docs/progressive-disclosure",
+          "docs/skill-eval",
+          "docs/llm-judge",
+          "docs/sandbox-hardening"
+        ]
+      },
+      {
+        "group": "Reference",
+        "pages": [
+          "docs/reference/cli",
+          "docs/reference/python-api",
+          "docs/integration-tests"
+        ]
+      }
+    ]
+  }
+}

--- a/docs/sandbox-hardening.md
+++ b/docs/sandbox-hardening.md
@@ -75,7 +75,7 @@ Known residual risk:
 
 ## Related
 
-- [`labs/benchjack-sandbox-hardening/README.md`](../labs/benchjack-sandbox-hardening/README.md) — full BenchJack pattern catalog and repro instructions.
-- [`labs/reward-hack-matrix/README.md`](../labs/reward-hack-matrix/README.md) — methodology, exploit taxonomy, sweep results.
+- [`labs/benchjack-sandbox-hardening/README.md`](https://github.com/benchflow-ai/benchflow/tree/main/labs/benchjack-sandbox-hardening) — full BenchJack pattern catalog and repro instructions.
+- [`labs/reward-hack-matrix/README.md`](https://github.com/benchflow-ai/benchflow/tree/main/labs/reward-hack-matrix) — methodology, exploit taxonomy, sweep results.
 - [`progressive-disclosure.md`](./progressive-disclosure.md) — soft-verify (the relaxed hardening used between rounds in multi-round trials).
 - [`task-authoring.md`](./task-authoring.md) — the `task.toml` schema including `[verifier.hardening]` opt-outs.


### PR DESCRIPTION
## Summary
- add the required root `docs.json` so Mintlify can discover the docs site config
- include a small navigation over existing docs pages
- convert two lab README links to GitHub URLs so Mintlify link validation does not treat them as broken in-doc routes

## Why
The `main` branch check for PR #422 failed in the external `Mintlify Deployment` check with `Unable to find docs.json or mint.json`. This PR fixes that missing config without changing runtime code.

## Validation
- `jq . docs.json`
- navigation page existence check via `jq -r '.navigation.groups[].pages[]' docs.json`
- `npx -p node@20 -p mint@latest mint broken-links`
- `npx -p node@20 -p mint@latest mint validate`
- `uv sync --extra dev --locked`
- `uv run python -m pytest tests/`
- `uv run ty check src/`
- `uv run ruff check .`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->