### PR TITLE
fix: Terminal-Bench Dockerfile COPY + Gemini provider telemetry (#362 #375)

### DIFF
--- a/src/benchflow/adapters/terminal_bench.py
+++ b/src/benchflow/adapters/terminal_bench.py
@@ -25,6 +25,8 @@ running (architecture.md, capability #8).
 
 from __future__ import annotations
 
+import re
+import shlex
 from pathlib import Path
 from typing import Any
 
@@ -202,12 +204,148 @@ class TerminalBenchAdapter:
             if src.is_file():
                 _place(native, src)
 
+        # The Dockerfile's build context. Terminal-Bench Dockerfiles routinely
+        # COPY/ADD task-root files (requirements.txt, app/, etc.) into the
+        # image; the legacy adapter only carried the Dockerfile itself, so the
+        # converted task built against an empty context and failed at
+        # ``docker build`` time. Walk the Dockerfile's COPY/ADD instructions
+        # and place every referenced source into the environment/ subtree
+        # under its same relative path (so ``COPY requirements.txt /tmp``
+        # resolves against environment/requirements.txt, which is where the
+        # remapped Dockerfile lives). See issue #362.
+        dockerfile = root / "Dockerfile"
+        if dockerfile.is_file():
+            for src_rel in _dockerfile_context_sources(dockerfile):
+                src = root / src_rel
+                # Tolerate sources that don't exist on disk (URL ADDs, build
+                # args expanded at build time, stage-name --from=builder
+                # references already filtered upstream) — the adapter is a
+                # pure translator, not a Dockerfile validator.
+                if not src.exists():
+                    continue
+                if src.is_file():
+                    _place(f"environment/{src_rel}", src)
+                elif src.is_dir():
+                    for entry in sorted(p for p in src.rglob("*") if p.is_file()):
+                        _place(
+                            f"environment/{entry.relative_to(root).as_posix()}",
+                            entry,
+                        )
+
         # The tests/ subtree is already native — carry it verbatim, with the
         # same collision check so a native tests/test.sh can't silently
         # collide with a remapped root run-tests.sh.
         carry_native_subtrees(root, _place, subtrees=("tests",))
 
         return files
+
+
+# A Dockerfile instruction line — captures the verb and the rest. We only
+# care about COPY / ADD; comments and blank lines are filtered separately.
+_DOCKERFILE_INSTRUCTION = re.compile(r"^\s*(\w+)\s+(.*)$", re.IGNORECASE)
+# Stage references like ``--from=builder`` carry no real source path on the
+# build context; same for HTTP(S) URLs in ADD instructions.
+_URL_SOURCE = re.compile(r"^https?://", re.IGNORECASE)
+
+
+def _dockerfile_context_sources(dockerfile: Path) -> list[str]:
+    """Extract build-context source paths referenced by COPY/ADD instructions.
+
+    Returns a list of *task-root-relative* paths the Dockerfile expects to
+    find in its build context. Designed for the Terminal-Bench case, where
+    the Dockerfile sits at the task root and its build context is the task
+    root itself.
+
+    Implementation notes:
+
+    * Line continuations (``\\``) are joined before parsing so a multi-line
+      ``COPY`` carries all of its sources.
+    * Comments (``# ...``), blank lines, and ``--flag=value`` arguments are
+      skipped. ``--from=stage`` sources are skipped (they reference an
+      earlier build stage, not the build context).
+    * Shell-form (``COPY src dst``) and exec-form (``COPY ["src", "dst"]``)
+      are both handled.
+    * URL sources (``ADD https://...``) are skipped — they aren't part of
+      the build context.
+    * Sources with ``$VAR`` interpolation are skipped — we can't resolve
+      build args without executing the build.
+    * Absolute paths and ``..`` escapes are skipped — they don't address a
+      file inside the task directory.
+    """
+    sources: list[str] = []
+    try:
+        text = dockerfile.read_text(errors="replace")
+    except OSError:
+        return sources
+
+    # Join line continuations: a trailing ``\`` (optionally followed by
+    # whitespace) folds the next line into the current instruction.
+    joined = re.sub(r"\\\s*\n", " ", text)
+
+    for raw_line in joined.splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        match = _DOCKERFILE_INSTRUCTION.match(line)
+        if not match:
+            continue
+        verb = match.group(1).upper()
+        if verb not in ("COPY", "ADD"):
+            continue
+
+        rest = match.group(2).strip()
+        # Exec form: ["src1", "src2", "dst"] — parse as JSON-ish list.
+        if rest.startswith("["):
+            try:
+                import json as _json
+
+                parts = _json.loads(rest)
+                if not isinstance(parts, list):
+                    continue
+                tokens = [str(p) for p in parts]
+            except (ValueError, TypeError):
+                continue
+        else:
+            try:
+                tokens = shlex.split(rest, posix=True)
+            except ValueError:
+                continue
+
+        # Drop --flag=value arguments (--from=, --chown=, --chmod=, ...).
+        # A --from=<stage> source is *not* in the build context — skip the
+        # whole instruction in that case.
+        positional: list[str] = []
+        skip_instruction = False
+        for tok in tokens:
+            if tok.startswith("--"):
+                if tok.startswith("--from="):
+                    skip_instruction = True
+                continue
+            positional.append(tok)
+        if skip_instruction:
+            continue
+        # Need at least one source and one destination.
+        if len(positional) < 2:
+            continue
+
+        for src in positional[:-1]:
+            if _URL_SOURCE.match(src):
+                continue
+            if "$" in src or "{" in src:
+                # Build-arg / env interpolation — can't resolve statically.
+                continue
+            # Normalize and reject anything that doesn't address a file
+            # inside the build context (absolute paths, parent escapes).
+            normalized = src.lstrip("./")
+            if not normalized:
+                continue
+            if src.startswith("/") or normalized.startswith("../"):
+                continue
+            if any(part == ".." for part in normalized.split("/")):
+                continue
+            sources.append(normalized)
+
+    return sources
 
 
 def from_terminal_bench_task(task_dir: Path | str) -> InboundTask:

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -475,9 +475,24 @@ def _decompress_brotli(data: bytes) -> bytes:
 def _reconstruct_response(events: list[dict[str, Any]]) -> dict[str, Any]:
     """Reconstruct a complete API response from SSE events.
 
-    Works with both Anthropic (message_start/content_block_delta/message_delta)
-    and OpenAI (choices[].delta) streaming formats.
+    Works with Anthropic (message_start/content_block_delta/message_delta),
+    OpenAI (choices[].delta), and Gemini (candidates[] + usageMetadata)
+    streaming formats. The Gemini path matters for usage telemetry: every
+    Gemini SSE chunk carries an incremental ``usageMetadata`` block, and
+    losing it means Gemini Docker runs surface ``usage_source: unavailable``
+    despite the proxy capturing every byte (see issue #375).
     """
+    # Try Gemini format early — its events carry neither ``type`` nor
+    # ``choices`` and would otherwise fall through to the raw-events
+    # fallback, dropping ``usageMetadata`` on the floor.
+    if any(
+        ("candidates" in event and isinstance(event.get("candidates"), list))
+        or "usageMetadata" in event
+        or "modelVersion" in event
+        for event in events
+    ) and not any(event.get("type") or event.get("choices") for event in events):
+        return _reconstruct_gemini_response(events)
+
     # Try Anthropic format first
     message: dict[str, Any] = {}
     content_blocks: dict[int, dict[str, Any]] = {}
@@ -594,3 +609,102 @@ def _reconstruct_response(events: list[dict[str, Any]]) -> dict[str, Any]:
 
     # Fallback: return raw events
     return {"_raw_events": events}
+
+
+def _reconstruct_gemini_response(events: list[dict[str, Any]]) -> dict[str, Any]:
+    """Reconstruct a Gemini generateContent response from SSE chunks.
+
+    Each Gemini streaming chunk looks like::
+
+        {
+          "candidates": [{
+            "content": {"role": "model", "parts": [{"text": "..."}]},
+            "finishReason": "STOP",
+            "index": 0
+          }],
+          "modelVersion": "gemini-3.1-flash-lite-preview",
+          "usageMetadata": {
+            "promptTokenCount": 11,
+            "candidatesTokenCount": 4,
+            "totalTokenCount": 15
+          }
+        }
+
+    Incremental chunks carry partial text in ``candidates[0].content.parts[i].text``
+    that we concatenate; ``usageMetadata`` is cumulative per the Gemini API
+    contract, so the *last* chunk's value is the final total. We keep this
+    shape verbatim under ``usageMetadata`` (not ``usage``) so the existing
+    Trajectory accessors in ``trajectories.types`` find it.
+    """
+    # Aggregate text parts by (candidate_index, part_index). Tool/function
+    # call parts and inline data are passed through from the most recent
+    # chunk that supplied them (Gemini sends them whole, not as text deltas).
+    candidates: dict[int, dict[str, Any]] = {}
+    usage_metadata: dict[str, Any] = {}
+    model_version: str = ""
+    prompt_feedback: dict[str, Any] = {}
+
+    for event in events:
+        if isinstance(event.get("modelVersion"), str):
+            model_version = event["modelVersion"]
+        if isinstance(event.get("usageMetadata"), dict):
+            # Cumulative per Gemini's contract — overwrite so the last chunk
+            # wins. Falling back to .update() would be wrong if a key
+            # disappeared mid-stream, which Gemini doesn't promise.
+            usage_metadata = dict(event["usageMetadata"])
+        if isinstance(event.get("promptFeedback"), dict):
+            prompt_feedback = event["promptFeedback"]
+
+        for cand in event.get("candidates", []) or []:
+            if not isinstance(cand, dict):
+                continue
+            idx = cand.get("index", 0)
+            existing = candidates.setdefault(
+                idx,
+                {
+                    "content": {"role": "model", "parts": []},
+                    "index": idx,
+                },
+            )
+            content = cand.get("content")
+            if isinstance(content, dict):
+                role = content.get("role")
+                if isinstance(role, str):
+                    existing["content"]["role"] = role
+                for part_idx, part in enumerate(content.get("parts", []) or []):
+                    if not isinstance(part, dict):
+                        continue
+                    parts_list = existing["content"]["parts"]
+                    while len(parts_list) <= part_idx:
+                        parts_list.append({})
+                    target = parts_list[part_idx]
+                    if "text" in part:
+                        target["text"] = target.get("text", "") + (part.get("text") or "")
+                    # Function calls / inline data / other part shapes —
+                    # carry the most recent value verbatim. Gemini sends
+                    # these whole rather than as deltas.
+                    for key, value in part.items():
+                        if key == "text":
+                            continue
+                        target[key] = value
+            if "finishReason" in cand:
+                existing["finishReason"] = cand["finishReason"]
+            if "safetyRatings" in cand:
+                existing["safetyRatings"] = cand["safetyRatings"]
+            if "citationMetadata" in cand:
+                existing["citationMetadata"] = cand["citationMetadata"]
+
+    response: dict[str, Any] = {
+        "candidates": [candidates[i] for i in sorted(candidates)],
+    }
+    # The model field is consumed by _model_from_trajectory; mirror Gemini's
+    # ``modelVersion`` into the standard ``model`` slot so downstream pricing
+    # lookup works without a special case.
+    if model_version:
+        response["modelVersion"] = model_version
+        response["model"] = model_version
+    if usage_metadata:
+        response["usageMetadata"] = usage_metadata
+    if prompt_feedback:
+        response["promptFeedback"] = prompt_feedback
+    return response

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -74,6 +74,7 @@ class Trajectory(BaseModel):
         total = 0
         for ex in self.exchanges:
             usage = ex.response.body.get("usage", {})
+            usage_metadata = ex.response.body.get("usageMetadata", {})
             # OpenAI may return these keys with an explicit null value, so
             # `or {}` is required — `.get(key, {})` would still yield None.
             prompt_details = usage.get("prompt_tokens_details") or {}
@@ -82,6 +83,7 @@ class Trajectory(BaseModel):
                 usage.get("cache_read_input_tokens", 0)
                 or prompt_details.get("cached_tokens", 0)
                 or input_details.get("cached_tokens", 0)
+                or usage_metadata.get("cachedContentTokenCount", 0)
                 or 0
             )
         return total

--- a/tests/test_atif_trajectory.py
+++ b/tests/test_atif_trajectory.py
@@ -448,6 +448,221 @@ class TestTrajectoryProxy:
             stream_server.close()
             await stream_server.wait_closed()
 
+    @pytest.mark.asyncio
+    async def test_proxy_reconstructs_gemini_streaming_usage(self) -> None:
+        """Regression for #375: Gemini's SSE chunks carry ``usageMetadata`` per
+        chunk and no ``type`` / ``choices`` fields. Before this fix the proxy
+        fell through to a raw-events fallback, so token counts and the model
+        name were dropped — Docker Gemini runs reported ``usage_source:
+        unavailable`` despite the proxy capturing every chunk."""
+
+        async def gemini_handler(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            headers = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                k, _, v = line.decode().partition(":")
+                headers[k.strip().lower()] = v.strip()
+            cl = int(headers.get("content-length", "0"))
+            if cl > 0:
+                await reader.readexactly(cl)
+
+            # Gemini's streamGenerateContent?alt=sse chunks. usageMetadata is
+            # cumulative — the last chunk carries the final totals.
+            frames = [
+                {
+                    "candidates": [
+                        {
+                            "content": {
+                                "role": "model",
+                                "parts": [{"text": "Hello "}],
+                            },
+                            "index": 0,
+                        }
+                    ],
+                    "modelVersion": "gemini-3.1-flash-lite-preview",
+                    "usageMetadata": {
+                        "promptTokenCount": 11,
+                        "candidatesTokenCount": 1,
+                        "totalTokenCount": 12,
+                    },
+                },
+                {
+                    "candidates": [
+                        {
+                            "content": {
+                                "role": "model",
+                                "parts": [{"text": "world"}],
+                            },
+                            "finishReason": "STOP",
+                            "index": 0,
+                        }
+                    ],
+                    "modelVersion": "gemini-3.1-flash-lite-preview",
+                    "usageMetadata": {
+                        "promptTokenCount": 11,
+                        "candidatesTokenCount": 4,
+                        "totalTokenCount": 15,
+                    },
+                },
+            ]
+            body = b"".join(
+                f"data: {json.dumps(frame)}\n\n".encode() for frame in frames
+            )
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"content-type: text/event-stream\r\n"
+                + f"content-length: {len(body)}\r\n\r\n".encode()
+                + body
+            )
+            await writer.drain()
+            writer.close()
+
+        stream_server = await asyncio.start_server(gemini_handler, "127.0.0.1", 0)
+        stream_port = stream_server.sockets[0].getsockname()[1]
+
+        proxy = TrajectoryProxy(
+            target=f"http://127.0.0.1:{stream_port}",
+            session_id="gemini-stream-test",
+            agent_name="gemini",
+        )
+        await proxy.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{proxy.base_url}/v1beta/models/"
+                    "gemini-3.1-flash-lite-preview:streamGenerateContent?alt=sse",
+                    json={
+                        "contents": [
+                            {"role": "user", "parts": [{"text": "say hi"}]}
+                        ],
+                        "stream": True,
+                    },
+                )
+                assert resp.status_code == 200
+
+            traj = proxy.trajectory
+            assert len(traj.exchanges) == 1
+
+            # The captured response body must carry Gemini-shaped fields the
+            # downstream token/cost extractors expect — not the
+            # ``_raw_events`` fallback that drops usageMetadata.
+            body = traj.exchanges[0].response.body
+            assert "_raw_events" not in body, (
+                "Gemini SSE response fell through to raw-events fallback; "
+                "usageMetadata would be lost"
+            )
+            assert body.get("usageMetadata", {}).get("promptTokenCount") == 11
+            assert body.get("usageMetadata", {}).get("candidatesTokenCount") == 4
+            assert body.get("usageMetadata", {}).get("totalTokenCount") == 15
+            # Text parts are concatenated across chunks.
+            assert body["candidates"][0]["content"]["parts"][0]["text"] == "Hello world"
+
+            # End-to-end: the Trajectory accessors that feed extract_usage
+            # see the cumulative counts.
+            assert traj.total_input_tokens == 11
+            assert traj.total_output_tokens == 4
+            assert traj.total_provider_tokens == 15
+        finally:
+            await proxy.stop()
+            stream_server.close()
+            await stream_server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_extract_usage_populates_gemini_telemetry_after_stream(self) -> None:
+        """Regression for #375 — assert the full pipeline: a Gemini streaming
+        response goes through the proxy and ``extract_usage`` returns
+        populated token fields with ``usage_source=provider_response``
+        (not the ``unavailable`` defaults seen in the bug)."""
+        from benchflow.providers.runtime import ProviderRuntime, extract_usage
+
+        async def gemini_handler(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            headers = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                k, _, v = line.decode().partition(":")
+                headers[k.strip().lower()] = v.strip()
+            cl = int(headers.get("content-length", "0"))
+            if cl > 0:
+                await reader.readexactly(cl)
+
+            frame = {
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "model",
+                            "parts": [{"text": "done"}],
+                        },
+                        "finishReason": "STOP",
+                        "index": 0,
+                    }
+                ],
+                "modelVersion": "gemini-2.5-flash",
+                "usageMetadata": {
+                    "promptTokenCount": 100,
+                    "candidatesTokenCount": 50,
+                    "totalTokenCount": 150,
+                },
+            }
+            body = f"data: {json.dumps(frame)}\n\n".encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"content-type: text/event-stream\r\n"
+                + f"content-length: {len(body)}\r\n\r\n".encode()
+                + body
+            )
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_server(gemini_handler, "127.0.0.1", 0)
+        port = server.sockets[0].getsockname()[1]
+
+        proxy = TrajectoryProxy(
+            target=f"http://127.0.0.1:{port}",
+            session_id="gemini-extract-usage",
+            agent_name="gemini",
+        )
+        await proxy.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"{proxy.base_url}/v1beta/models/"
+                    "gemini-2.5-flash:streamGenerateContent?alt=sse",
+                    json={"contents": [], "stream": True},
+                )
+
+            runtime = ProviderRuntime(
+                kind="usage-proxy",
+                host="127.0.0.1",
+                port=proxy.port,
+                backend_model="gemini-2.5-flash",
+                server=proxy,
+            )
+            usage = extract_usage(runtime)
+        finally:
+            await proxy.stop()
+            server.close()
+            await server.wait_closed()
+
+        assert usage["usage_source"] == "provider_response"
+        assert usage["n_input_tokens"] == 100
+        assert usage["n_output_tokens"] == 50
+        assert usage["total_tokens"] == 150
+        # gemini-2.5-flash has a pricing entry, so cost must be populated.
+        assert usage["cost_usd"] is not None
+        assert usage["cost_usd"] > 0
+
 
 class TestOTelCollector:
     @pytest.mark.asyncio

--- a/tests/test_inbound_adapters.py
+++ b/tests/test_inbound_adapters.py
@@ -293,6 +293,98 @@ class TestTerminalBenchAdapter:
         result = TerminalBenchAdapter.from_task_dir(task_dir)
         assert result.files["tests/test.sh"] == task_dir / "run-tests.sh"
 
+    def test_dockerfile_copy_sources_carried_into_context(self, tmp_path: Path) -> None:
+        """Regression for #362: ``COPY requirements.txt /tmp/`` in the
+        Dockerfile must pull ``requirements.txt`` into the converted
+        environment/ build context — otherwise ``docker build`` of the
+        converted task fails because the build context is incomplete."""
+        task_dir = _write_tb_task(tmp_path)
+        (task_dir / "Dockerfile").write_text(
+            "FROM python:3.12-slim\n"
+            "COPY requirements.txt /tmp/requirements.txt\n"
+        )
+        (task_dir / "requirements.txt").write_text("pytest\n")
+
+        result = TerminalBenchAdapter.from_task_dir(task_dir)
+
+        assert "environment/requirements.txt" in result.files
+        assert result.files["environment/requirements.txt"] == (
+            task_dir / "requirements.txt"
+        )
+
+    def test_dockerfile_copy_directory_carried(self, tmp_path: Path) -> None:
+        """A ``COPY app/ /app/`` must carry every file under app/ — directory
+        sources expand to all their files relative to the task root."""
+        task_dir = _write_tb_task(tmp_path)
+        (task_dir / "Dockerfile").write_text(
+            "FROM python:3.12-slim\nCOPY app/ /app/\n"
+        )
+        app_dir = task_dir / "app"
+        app_dir.mkdir()
+        (app_dir / "main.py").write_text("print('hi')\n")
+        (app_dir / "utils.py").write_text("def x(): return 1\n")
+
+        result = TerminalBenchAdapter.from_task_dir(task_dir)
+
+        assert "environment/app/main.py" in result.files
+        assert "environment/app/utils.py" in result.files
+
+    def test_dockerfile_copy_multiline_continuation(self, tmp_path: Path) -> None:
+        """Line-continuation COPY (``\\``-joined) carries every source."""
+        task_dir = _write_tb_task(tmp_path)
+        (task_dir / "Dockerfile").write_text(
+            "FROM python:3.12-slim\n"
+            "COPY requirements.txt \\\n"
+            "     setup.py \\\n"
+            "     /opt/\n"
+        )
+        (task_dir / "requirements.txt").write_text("pytest\n")
+        (task_dir / "setup.py").write_text("from setuptools import setup\n")
+
+        result = TerminalBenchAdapter.from_task_dir(task_dir)
+
+        assert "environment/requirements.txt" in result.files
+        assert "environment/setup.py" in result.files
+
+    def test_dockerfile_copy_from_stage_skipped(self, tmp_path: Path) -> None:
+        """``COPY --from=builder`` references an earlier build stage, not a
+        build-context file — the adapter must not try to locate it on disk."""
+        task_dir = _write_tb_task(tmp_path)
+        (task_dir / "Dockerfile").write_text(
+            "FROM python:3.12-slim AS builder\n"
+            "FROM python:3.12-slim\n"
+            "COPY --from=builder /opt/app /opt/app\n"
+        )
+
+        # Must not raise; /opt/app does not exist on the task root.
+        result = TerminalBenchAdapter.from_task_dir(task_dir)
+        # No environment/opt entries were synthesized for the stage source.
+        assert not any(k.startswith("environment/opt/") for k in result.files)
+
+    def test_dockerfile_copy_missing_source_tolerated(self, tmp_path: Path) -> None:
+        """A COPY source that doesn't exist on disk (e.g. expanded build arg
+        in the original benchmark) is silently skipped — the adapter is a
+        pure translator, not a Dockerfile validator."""
+        task_dir = _write_tb_task(tmp_path)
+        (task_dir / "Dockerfile").write_text(
+            "FROM python:3.12-slim\nCOPY missing.txt /tmp/\n"
+        )
+
+        result = TerminalBenchAdapter.from_task_dir(task_dir)
+        assert "environment/missing.txt" not in result.files
+
+    def test_dockerfile_add_url_source_skipped(self, tmp_path: Path) -> None:
+        """``ADD https://...`` fetches over HTTP, no build-context file."""
+        task_dir = _write_tb_task(tmp_path)
+        (task_dir / "Dockerfile").write_text(
+            "FROM python:3.12-slim\n"
+            "ADD https://example.com/data.tgz /opt/data.tgz\n"
+        )
+
+        # Should not raise and should not try to resolve the URL as a file.
+        result = TerminalBenchAdapter.from_task_dir(task_dir)
+        assert not any(k.startswith("environment/https") for k in result.files)
+
 
 # ---------------------------------------------------------------------------
 # detect_adapter — format dispatch


### PR DESCRIPTION
Fixes #362, #375.

## #362 — Terminal-Bench adapter drops Dockerfile COPY files
The adapter only carried the Dockerfile plus a fixed root allowlist, so any task whose Dockerfile referenced ancillary files via `COPY` / `ADD` (`requirements.txt`, `app/`, etc.) produced an incomplete `environment/` subtree that later failed at `docker build` time with a missing-file error.

`TerminalBenchAdapter` now parses the Dockerfile and walks its `COPY` / `ADD` instructions:
- Shell form (`COPY src dst`) and exec form (`COPY ["src", "dst"]`)
- Line continuations (`\\`-joined multi-line instructions)
- `--from=<stage>` references are skipped (they don't address the build context)
- URL sources (`ADD https://...`) are skipped
- `$VAR` interpolation and `..` / absolute-path sources are skipped
- Missing sources on disk are tolerated (the adapter is a pure translator, not a Dockerfile validator)

Every resolvable source is pulled into `environment/<relpath>` so the converted task's build context matches what the original Dockerfile expects.

## #375 — Gemini Docker evals complete without provider usage telemetry
`TrajectoryProxy._reconstruct_response` only understood Anthropic (`message_start` / `content_block_delta` / `message_delta`) and OpenAI (`choices[].delta`) SSE shapes. Gemini's `streamGenerateContent?alt=sse` chunks carry `candidates[]` + cumulative `usageMetadata` and no `type` / `choices` keys, so they fell through to the `{"_raw_events": ...}` fallback. Downstream the `Trajectory` accessors couldn't find `usageMetadata` and `extract_usage` returned the `usage_source: unavailable` defaults — even though the proxy captured every byte.

This PR:
- Adds `_reconstruct_gemini_response` to aggregate text parts across chunks and surface the cumulative `usageMetadata` / `modelVersion` on the captured response body (mirroring `modelVersion` into the standard `model` slot so pricing lookup works without a special case).
- Picks up Gemini's `cachedContentTokenCount` in `Trajectory.total_cache_read_tokens` so cache telemetry survives end-to-end alongside the existing Anthropic/OpenAI shapes.

## Regression tests
- `tests/test_inbound_adapters.py`: `COPY requirements.txt`, directory `COPY app/`, multiline `COPY` continuation, `COPY --from=stage` skip, missing-source tolerated, `ADD https://` URL skip.
- `tests/test_atif_trajectory.py`: end-to-end Gemini SSE stream through the proxy populates `usageMetadata`; full pipeline via `extract_usage` returns `usage_source=provider_response` with populated token counts and a real cost estimate.

## Verification
- `uv run python -m pytest tests/` — 2347 passed, 2 skipped, 1 deselected
- `uv run ruff check .` — clean
- `uv run ty check src/` — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are localized to inbound task file mapping, SSE response reconstruction, and token accessors, with broad regression tests and no auth or persistence changes.
> 
> **Overview**
> Fixes two conversion/telemetry gaps: **Terminal-Bench** tasks with root `Dockerfile` `COPY`/`ADD` dependencies, and **Gemini** streaming responses in the trajectory proxy.
> 
> **Terminal-Bench (#362):** `TerminalBenchAdapter` now parses the root `Dockerfile` and copies every resolvable build-context path into `environment/<relpath>` (files and directory trees), so converted tasks don’t fail `docker build` with only the Dockerfile remapped. Parsing covers shell/exec form, line continuations, and skips `--from=` stages, URLs, interpolated paths, and missing files.
> 
> **Gemini (#375):** `TrajectoryProxy` detects Gemini SSE (`candidates`, `usageMetadata`) and rebuilds a full response via `_reconstruct_gemini_response` (merged text, last cumulative `usageMetadata`, `modelVersion` → `model`) instead of `_raw_events`. `Trajectory.total_cache_read_tokens` also reads Gemini `cachedContentTokenCount`.
> 
> Regression tests cover Dockerfile context cases and end-to-end Gemini proxy → `extract_usage` with `usage_source=provider_response`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4c580b3ddee22e9fa16a96d868314f5afc6a7de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->