### PR TITLE
fix: wire RuntimeConfig fields + add --environment-manifest to eval create (#378 #398)

### DIFF
--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -159,15 +159,25 @@ reaches them on `localhost`. During a rollout:
    is healthy.
 3. `Rollout.cleanup()` tears the environment down.
 
-Run a task against an environment manifest. `--environment-manifest` currently
-lives on the legacy `bench run` command (hidden in `--help` but still
-callable); porting it to `bench eval create` is tracked separately.
+Run a task against an environment manifest. `--environment-manifest` is
+available on both the legacy `bench run` command (single task) and on
+`bench eval create` (batch / Job API) so manifest-backed evaluations can
+be driven through the same Job pipeline used for regular benchmark sweeps.
 
 ```bash
+# single task
 bench run benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
+
+# batch / Job API
+bench eval create --tasks-dir benchmarks/clawsbench/tasks \
+  --environment-manifest benchmarks/clawsbench/environment.toml \
+  --agent claude-agent-acp --model claude-haiku-4-5
 ```
+
+YAML configs may declare the same seam with ``environment_manifest:
+<path>`` at the top level so the batch run is reproducible from disk.
 
 `--environment-manifest` is distinct from `--sandbox`: the sandbox is *where*
 it runs (the Sandbox plane); the environment manifest is *the world* (the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -81,6 +81,7 @@ bench eval create \
 | `--agent` | `claude-agent-acp` | Agent name |
 | `--model` | Agent default | Model ID |
 | `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |
+| `--environment-manifest` | — | Path to an Environment-plane manifest (`environment.toml`); applied to every rollout in the batch |
 | `--concurrency` | `4` | Max concurrent tasks (batch mode only) |
 | `--agent-idle-timeout` | (built-in default) | Abort ACP prompts after this many idle seconds; `0` disables idle detection |
 | `--jobs-dir` | `jobs` | Output directory |

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -309,10 +309,12 @@ bench eval create \
 A **stateful** benchmark — one with mock services, databases, or accounts the
 agent acts on — declares its world in an `environment.toml` manifest and runs
 on the [Environment plane](./environment-plane.md). The `--environment-manifest`
-flag currently lives on the legacy `bench run` command (hidden in `--help` but
-still callable); porting it to `bench eval create` is tracked separately.
+flag is available on both the single-task `bench run` command and on
+`bench eval create` (batch / Job API), so manifest-backed evaluations can be
+driven through the same pipeline as regular benchmark sweeps.
 
 ```bash
+# single task
 bench run benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
@@ -320,7 +322,15 @@ bench run benchmarks/clawsbench/tasks/<task> \
 bench run benchmarks/chi-bench/tasks/<task> \
   --environment-manifest benchmarks/chi-bench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
+
+# batch via the Job API
+bench eval create --tasks-dir benchmarks/clawsbench/tasks \
+  --environment-manifest benchmarks/clawsbench/environment.toml \
+  --agent claude-agent-acp --model claude-haiku-4-5
 ```
+
+YAML configs may declare the same seam with ``environment_manifest:
+<path>`` at the top level so the batch run is reproducible from disk.
 
 `--environment-manifest` is distinct from `--sandbox`: the sandbox is *where*
 the rollout runs; the environment manifest is *the world* the agent acts in.

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1048,6 +1048,18 @@ def eval_create(
         str | None,
         typer.Option("--sandbox", help="Sandbox: docker, daytona, or modal"),
     ] = None,
+    environment_manifest: Annotated[
+        Path | None,
+        typer.Option(
+            "--environment-manifest",
+            help=(
+                "Path to an Environment-plane manifest (environment.toml). "
+                "Applied to every rollout in the batch so the manifest-declared "
+                "stateful environment is provisioned, gated on readiness, and "
+                "torn down — same seam as `bench run --environment-manifest`."
+            ),
+        ),
+    ] = None,
     concurrency: Annotated[
         int | None,
         typer.Option("--concurrency", help="Max concurrent tasks"),
@@ -1161,6 +1173,22 @@ def eval_create(
         raise typer.Exit(1) from None
     output_jobs_dir = jobs_dir or "jobs"
 
+    # Resolve the optional Environment-plane manifest once and reuse across
+    # every source branch (config / source_repo / tasks_dir / source_env).
+    # Bench eval create's batch surface mirrors `bench run` so manifest-backed
+    # rollouts can be driven through the Job pipeline (#398).
+    eval_env_manifest = None
+    if environment_manifest is not None:
+        from benchflow.environment.manifest import load_manifest
+
+        try:
+            eval_env_manifest = load_manifest(environment_manifest)
+        except (OSError, ValueError) as exc:
+            console.print(
+                f"[red]Could not load --environment-manifest {environment_manifest}: {exc}[/red]"
+            )
+            raise typer.Exit(1) from None
+
     if config_file:
         j = Evaluation.from_yaml(config_file)
         if agent is not None:
@@ -1185,6 +1213,11 @@ def eval_create(
             j._config.include_tasks = include_tasks
         if exclude_tasks:
             j._config.exclude_tasks = exclude_tasks
+        # CLI --environment-manifest wins over whatever the YAML carried
+        # so an operator can override a baseline manifest without editing
+        # the config file.
+        if eval_env_manifest is not None:
+            j._config.environment_manifest = eval_env_manifest
         try:
             result = asyncio.run(j.run())
         except EmptyTaskSelectionError as e:
@@ -1217,6 +1250,11 @@ def eval_create(
         if eval_agent != DEFAULT_AGENT:
             console.print(
                 f"[dim]source-env records --agent {eval_agent!r}, but executes the model endpoint through Verifiers.[/dim]"
+            )
+        if eval_env_manifest is not None:
+            console.print(
+                "[yellow]--environment-manifest is for benchflow Environment-plane rollouts; "
+                "the hosted Verifiers environment owns its own provisioning. Ignoring.[/yellow]"
             )
 
         try:
@@ -1284,6 +1322,7 @@ def eval_create(
                 source_provenance=resolved.provenance,
                 include_tasks=include_tasks,
                 exclude_tasks=exclude_tasks,
+                environment_manifest=eval_env_manifest,
             ),
         )
         try:
@@ -1323,6 +1362,7 @@ def eval_create(
                 self_gen_no_internet=self_gen_no_internet,
                 include_tasks=include_tasks,
                 exclude_tasks=exclude_tasks,
+                environment_manifest=eval_env_manifest,
             ),
         )
         try:

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -54,6 +54,7 @@ from benchflow._utils.scoring import (
     pass_rate_excl_errors,
 )
 from benchflow._utils.source_provenance import summary_source_fields
+from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.learner_store import LearnerState, LearnerStore
 from benchflow.models import RolloutResult
 from benchflow.trajectories.tree import RolloutNode
@@ -204,6 +205,12 @@ class EvaluationConfig:
     self_gen_no_internet: bool = False
     job_mode: str = DEFAULT_JOB_MODE
     source_provenance: dict[str, Any] | None = None
+    # Environment-plane manifest applied to every rollout in the batch.
+    # When set, each task's RolloutConfig.environment_manifest is populated
+    # so the Environment plane (manifest-declared stateful environment,
+    # readiness gating, teardown) is exercised — closing the gap between
+    # single-rollout SDK.run() and the batch Evaluation/Job API (#398).
+    environment_manifest: EnvironmentManifest | None = None
 
     def __post_init__(self):
         from benchflow._utils.config import (
@@ -467,6 +474,15 @@ class Evaluation:
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
         agent_name = raw.get("agent", DEFAULT_AGENT)
+        # Optional environment-plane manifest path. Keeps YAML and CLI in
+        # sync so manifest-backed evaluations can be driven from either
+        # (#398).
+        env_manifest_raw = raw.get("environment_manifest")
+        env_manifest: EnvironmentManifest | None = None
+        if env_manifest_raw is not None:
+            from benchflow.environment.manifest import load_manifest
+
+            env_manifest = load_manifest(env_manifest_raw)
         config = EvaluationConfig(
             agent=agent_name,
             model=effective_model(agent_name, raw.get("model")),
@@ -493,6 +509,7 @@ class Evaluation:
             self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
             job_mode=raw.get("job_mode", DEFAULT_JOB_MODE),
             source_provenance=source_provenance,
+            environment_manifest=env_manifest,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -697,6 +714,7 @@ class Evaluation:
             jobs_dir=str(self._jobs_dir),
             concurrency=cfg.concurrency,
             environment=cfg.environment,
+            environment_manifest=cfg.environment_manifest,
             skills_dir=skills_dir,
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -909,6 +909,12 @@ class RolloutConfig:
     # (e.g. gemini-cli not responding). None disables idle detection and
     # falls back to the agent's wall-clock timeout (task.toml [agent]).
     agent_idle_timeout: int | None = 600
+    # Hard wall-clock budget for the agent prompt, in seconds. When set,
+    # overrides the per-task default (``task.toml [agent] timeout_sec``).
+    # ``None`` keeps the task's own default — this is the seam through which
+    # ``Runtime(RuntimeConfig(timeout=...))`` enforces a caller-supplied
+    # budget without editing every task.toml (#378).
+    timeout: int | None = None
 
     # User-driven progressive-disclosure loop
     user: BaseUser | None = None
@@ -1280,7 +1286,13 @@ class Rollout:
                 preserve_agent_network=self._disallow_web_tools,
                 environment_manifest=cfg.environment_manifest,
             )
-        self._timeout = int(self._task.config.agent.timeout_sec or 0)
+        # Caller-supplied wall-clock budget (e.g. RuntimeConfig.timeout)
+        # wins over the task's own default. Without this override there is
+        # no way to tighten/loosen the agent budget per run — see #378.
+        if cfg.timeout is not None:
+            self._timeout = int(cfg.timeout)
+        else:
+            self._timeout = int(self._task.config.agent.timeout_sec or 0)
 
         _write_config(
             self._rollout_dir,

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -344,6 +344,8 @@ class Runtime:
             sandbox_locked_paths=config.sandbox_locked_paths,
             sandbox_setup_timeout=config.sandbox_setup_timeout,
             jobs_dir=config.jobs_dir,
+            rollout_name=config.rollout_name,
+            timeout=config.timeout,
             context_root=config.context_root,
             pre_agent_hooks=config.pre_agent_hooks,
             agent=self.agent.name,
@@ -366,6 +368,11 @@ class Runtime:
         run_result = await rollout.run()
 
         reward = (run_result.rewards or {}).get("reward")
+        # The Rollout owns the on-disk artifact directory; lift it into the
+        # RuntimeResult so callers can locate result.json / trajectory/ etc.
+        # without scanning jobs_dir. Required because RuntimeResult's
+        # docstring promises an artifact-oriented surface (#378).
+        rollout_dir = getattr(rollout, "_rollout_dir", None)
         return RuntimeResult(
             task_name=run_result.task_name,
             rollout_name=run_result.rollout_name,
@@ -375,6 +382,7 @@ class Runtime:
             error=run_result.error,
             verifier_error=run_result.verifier_error,
             trajectory=run_result.trajectory,
+            rollout_dir=rollout_dir,
             started_at=run_result.started_at,
             finished_at=run_result.finished_at,
         )

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -62,6 +62,7 @@ def test_eval_create_help_lists_all_documented_flags() -> None:
         "--agent",
         "--model",
         "--sandbox",
+        "--environment-manifest",
         "--concurrency",
         "--agent-idle-timeout",
         "--jobs-dir",
@@ -81,12 +82,12 @@ def test_eval_create_help_lists_all_documented_flags() -> None:
         )
 
 
-def test_eval_create_does_not_accept_environment_manifest() -> None:
-    """Doc fix: `--environment-manifest` is on legacy `bench run`, not `bench
-    eval create`. Confirm the supported public command does NOT advertise it,
-    so we don't silently re-add it without updating the docs."""
+def test_eval_create_accepts_environment_manifest() -> None:
+    """`bench eval create --environment-manifest` is the batch seam for
+    Environment-plane rollouts — same flag as `bench run` (#398). Guard
+    against silent removal so the docs and CLI stay in sync."""
     out = _help(["eval", "create"])
-    assert "--environment-manifest" not in out
+    assert "--environment-manifest" in out
 
 
 def test_documented_subcommands_exist() -> None:

--- a/tests/test_evaluation_environment_manifest.py
+++ b/tests/test_evaluation_environment_manifest.py
@@ -1,0 +1,214 @@
+"""Regression tests for #398 — Evaluation/Job must accept environment manifests.
+
+Before the fix the batch ``Evaluation`` API could not run manifest-backed
+rollouts:
+
+* ``EvaluationConfig`` had no ``environment_manifest`` field;
+* ``Evaluation._run_single_task`` built ``RolloutConfig.from_legacy`` without
+  one, so the manifest seam disappeared at the Job layer;
+* ``bench eval create`` exposed no ``--environment-manifest`` option even
+  though ``bench run`` did.
+
+These tests assert the full path: dataclass → CLI flag → YAML loader →
+``RolloutConfig.environment_manifest``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+from benchflow.environment.manifest import EnvironmentManifest
+from benchflow.evaluation import Evaluation, EvaluationConfig
+
+_MANIFEST_TOML = """\
+[environment]
+name = "test-env-398"
+image = "example/test:latest"
+"""
+
+_MANIFEST = EnvironmentManifest.model_validate_toml(_MANIFEST_TOML)
+
+
+def _write_task(task_dir: Path) -> None:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "task.toml").write_text('version = "1.0"\n')
+
+
+# ---------------------------------------------------------------------------
+# EvaluationConfig dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_evaluation_config_has_environment_manifest_field() -> None:
+    """The batch config must carry the manifest the runtime can consume."""
+    cfg = EvaluationConfig(environment_manifest=_MANIFEST)
+    assert cfg.environment_manifest is _MANIFEST
+
+
+def test_evaluation_config_environment_manifest_defaults_to_none() -> None:
+    """Default keeps batch behaviour for benchmarks that do not need a manifest."""
+    cfg = EvaluationConfig()
+    assert cfg.environment_manifest is None
+
+
+# ---------------------------------------------------------------------------
+# Evaluation._run_single_task threads the manifest into RolloutConfig
+# ---------------------------------------------------------------------------
+
+
+async def test_run_single_task_passes_manifest_to_rollout_config(
+    tmp_path: Path,
+) -> None:
+    """The manifest must reach RolloutConfig.environment_manifest (#398).
+
+    The manifest seam is what allows ``Rollout.setup()`` to provision the
+    environment-plane container. If the Job layer drops it on the floor,
+    the env plane is never exercised — exactly the gap #398 describes.
+    """
+    task_dir = tmp_path / "pass-json"
+    _write_task(task_dir)
+    cfg = EvaluationConfig(environment_manifest=_MANIFEST)
+    job = Evaluation(tasks_dir=task_dir, jobs_dir=tmp_path / "jobs", config=cfg)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_create(cls_cfg: Any) -> Any:  # type: ignore[no-untyped-def]
+        captured["manifest"] = cls_cfg.environment_manifest
+
+        async def fake_run() -> Any:
+            from benchflow.models import RolloutResult
+
+            return RolloutResult(
+                task_name=task_dir.name,
+                rollout_name="rt",
+                rewards={"reward": 1.0},
+                trajectory=[],
+                agent="",
+                agent_name="",
+                model="",
+                n_tool_calls=0,
+                n_prompts=0,
+                error=None,
+                verifier_error=None,
+                partial_trajectory=False,
+                trajectory_source=None,
+                started_at=None,
+                finished_at=None,
+            )
+
+        return SimpleNamespace(run=fake_run)
+
+    with patch("benchflow.rollout.Rollout.create", new=fake_create):
+        await job._run_single_task(task_dir, cfg)
+
+    assert captured["manifest"] is _MANIFEST
+
+
+# ---------------------------------------------------------------------------
+# bench eval create --environment-manifest
+# ---------------------------------------------------------------------------
+
+
+def test_cli_eval_create_flag_loads_manifest_into_evaluation_config(
+    tmp_path: Path,
+) -> None:
+    """`--environment-manifest <path>` lands on EvaluationConfig (#398)."""
+    task_dir = tmp_path / "pass-json"
+    _write_task(task_dir)
+    manifest_path = tmp_path / "environment.toml"
+    manifest_path.write_text(_MANIFEST_TOML)
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run(self: Evaluation) -> Any:
+        captured["manifest"] = self._config.environment_manifest
+        return SimpleNamespace(
+            passed=1, total=1, score=1.0, errored=0, verifier_errored=0
+        )
+
+    with patch.object(Evaluation, "run", new=fake_run):
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--tasks-dir",
+                str(task_dir),
+                "--environment-manifest",
+                str(manifest_path),
+                "--agent",
+                "oracle",
+                "--jobs-dir",
+                str(tmp_path / "jobs"),
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    assert isinstance(captured["manifest"], EnvironmentManifest)
+    assert captured["manifest"].name == "test-env-398"
+    assert captured["manifest"].image == "example/test:latest"
+
+
+def test_cli_eval_create_missing_manifest_path_exits_nonzero(
+    tmp_path: Path,
+) -> None:
+    """A bogus manifest path must fail loud, not silently disable the seam."""
+    task_dir = tmp_path / "pass-json"
+    _write_task(task_dir)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--tasks-dir",
+            str(task_dir),
+            "--environment-manifest",
+            str(tmp_path / "does-not-exist.toml"),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# YAML config — environment_manifest support
+# ---------------------------------------------------------------------------
+
+
+def test_yaml_loader_parses_environment_manifest(tmp_path: Path) -> None:
+    """Native YAML must accept ``environment_manifest: <path>`` (#398).
+
+    Matters because a release-scale evaluation is usually checked into
+    Git as YAML; if the manifest seam works on the CLI but not in YAML
+    the audit trail diverges.
+    """
+    task_dir = tmp_path / "pass-json"
+    _write_task(task_dir)
+    manifest_path = tmp_path / "environment.toml"
+    manifest_path.write_text(_MANIFEST_TOML)
+
+    yaml_path = tmp_path / "eval.yaml"
+    yaml_path.write_text(
+        "tasks_dir: "
+        + str(task_dir)
+        + "\njobs_dir: "
+        + str(tmp_path / "jobs")
+        + "\nagent: oracle\nenvironment_manifest: "
+        + str(manifest_path)
+        + "\n"
+    )
+
+    job = Evaluation.from_yaml(yaml_path)
+    assert isinstance(job._config.environment_manifest, EnvironmentManifest)
+    assert job._config.environment_manifest.name == "test-env-398"

--- a/tests/test_runtime_config_wired.py
+++ b/tests/test_runtime_config_wired.py
@@ -1,0 +1,209 @@
+"""Regression tests for #378 — RuntimeConfig fields must flow through.
+
+The public ``Runtime`` / ``bf.run(Agent, Environment, RuntimeConfig)`` API
+advertises an artifact-oriented ``RuntimeResult`` with ``rollout_dir``, and
+``RuntimeConfig`` exposes ``rollout_name`` and ``timeout`` knobs. Before the
+fix:
+
+* ``RuntimeResult.rollout_dir`` was always ``None`` — callers had to scan
+  ``jobs_dir/`` to find the artifacts.
+* ``RuntimeConfig.rollout_name`` was silently dropped — the rollout was
+  always named ``<task>__<uuid>``.
+* ``RuntimeConfig.timeout`` was silently dropped — only ``task.toml``'s
+  ``[agent] timeout_sec`` reached the rollout.
+
+These tests fail without the wiring fix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.rollout import Rollout, RolloutConfig
+from benchflow.runtime import Agent, Environment, Runtime, RuntimeConfig
+
+TASK_PATH = Path(__file__).parent / "examples" / "hello-world-task"
+
+
+class _FakeInner:
+    """Stand-in sandbox: records lifecycle without doing real work."""
+
+    def __init__(self) -> None:
+        self.started = 0
+        self.stopped = 0
+
+    async def start(self, *a: Any, **kw: Any) -> None:
+        self.started += 1
+
+    async def stop(self, *a: Any, **kw: Any) -> None:
+        self.stopped += 1
+
+    async def exec(self, cmd: str, **_: Any) -> Any:
+        return type("R", (), {"stdout": "", "stderr": "", "returncode": 0})()
+
+    async def upload_file(self, *a: Any, **kw: Any) -> None: ...
+
+    async def upload_dir(self, *a: Any, **kw: Any) -> None: ...
+
+
+def _stub_run_result(rollout_name: str = "rt") -> Any:
+    """Build a minimal RolloutResult so the runtime layer can finish."""
+    from benchflow.models import RolloutResult
+
+    return RolloutResult(
+        task_name=TASK_PATH.name,
+        rollout_name=rollout_name,
+        rewards={"reward": 1.0},
+        trajectory=[],
+        agent="",
+        agent_name="",
+        model="",
+        n_tool_calls=0,
+        n_prompts=0,
+        error=None,
+        verifier_error=None,
+        partial_trajectory=False,
+        trajectory_source=None,
+        started_at=None,
+        finished_at=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# RuntimeResult.rollout_dir
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runtime_result_rollout_dir_set_from_rollout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RuntimeResult.rollout_dir must point at Rollout._rollout_dir (#378)."""
+    inner = _FakeInner()
+    env = Environment(inner=inner, task_path=TASK_PATH, sandbox="docker")
+    agent = Agent(name="claude-agent-acp", model="claude-haiku-4-5-20251001")
+
+    fake_dir = Path("/tmp/fake-rollout-dir-for-test-378")
+
+    async def fake_run(self: Rollout) -> Any:
+        # Simulate what Rollout.setup() would have written.
+        self._rollout_dir = fake_dir
+        return _stub_run_result()
+
+    monkeypatch.setattr(Rollout, "run", fake_run)
+
+    result = await Runtime(env, agent, RuntimeConfig()).execute()
+
+    assert result.rollout_dir == fake_dir, (
+        "RuntimeResult.rollout_dir was not lifted from the Rollout — callers "
+        "still cannot find result.json without scanning jobs_dir (#378)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# RuntimeConfig.rollout_name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_runtime_config_rollout_name_threaded_into_rollout_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """RuntimeConfig.rollout_name must populate RolloutConfig.rollout_name (#378).
+
+    Before the fix the runtime built RolloutConfig without ``rollout_name``
+    so the user's explicit ``"explicit-runtime-rollout"`` was silently
+    replaced by ``<task>__<uuid>``.
+    """
+    inner = _FakeInner()
+    env = Environment(inner=inner, task_path=TASK_PATH, sandbox="docker")
+    agent = Agent(name="claude-agent-acp", model="claude-haiku-4-5-20251001")
+
+    captured: dict[str, Any] = {}
+    real_create = Rollout.create
+
+    @classmethod
+    async def fake_create(cls, cfg: RolloutConfig) -> Rollout:  # type: ignore[misc]
+        captured["rollout_name"] = cfg.rollout_name
+        captured["timeout"] = cfg.timeout
+        return await real_create(cfg)
+
+    async def fake_run(self: Rollout) -> Any:
+        return _stub_run_result()
+
+    monkeypatch.setattr(Rollout, "create", fake_create)
+    monkeypatch.setattr(Rollout, "run", fake_run)
+
+    await Runtime(
+        env,
+        agent,
+        RuntimeConfig(rollout_name="explicit-runtime-rollout", timeout=123),
+    ).execute()
+
+    assert captured["rollout_name"] == "explicit-runtime-rollout"
+    assert captured["timeout"] == 123
+
+
+# ---------------------------------------------------------------------------
+# RolloutConfig.timeout overrides task default
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_config_timeout_field_defaults_to_none() -> None:
+    """Default keeps the per-task budget — only an explicit override wins."""
+    cfg = RolloutConfig(task_path=TASK_PATH)
+    assert cfg.timeout is None
+
+
+@pytest.mark.asyncio
+async def test_rollout_config_timeout_overrides_task_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rollout.setup must honour cfg.timeout instead of task.config.agent.timeout_sec.
+
+    This is the seam by which ``RuntimeConfig.timeout`` actually shortens
+    or extends the agent's wall-clock budget. Without it the field is
+    accepted but does nothing (#378).
+    """
+    cfg = RolloutConfig(task_path=TASK_PATH, environment="docker", timeout=42)
+    rollout = Rollout(cfg)
+    rollout.use_prebuilt_env(_FakeInner())
+
+    monkeypatch.setattr(
+        "benchflow.rollout._create_environment",
+        lambda *a, **kw: _FakeInner(),
+    )
+
+    await rollout.setup()
+
+    assert rollout._timeout == 42, (
+        "RolloutConfig.timeout did not override the task default — "
+        "RuntimeConfig.timeout cannot bind the agent budget (#378)."
+    )
+
+
+@pytest.mark.asyncio
+async def test_rollout_config_timeout_none_keeps_task_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Negative side: omitting timeout still falls back to the task value."""
+    cfg = RolloutConfig(task_path=TASK_PATH, environment="docker")  # timeout=None
+    rollout = Rollout(cfg)
+    rollout.use_prebuilt_env(_FakeInner())
+
+    monkeypatch.setattr(
+        "benchflow.rollout._create_environment",
+        lambda *a, **kw: _FakeInner(),
+    )
+
+    await rollout.setup()
+
+    # The hello-world-task fixture's task.toml owns this number; we only
+    # assert that the rollout picked it up rather than zero/None.
+    from benchflow.task import Task
+
+    expected = int(Task(TASK_PATH).config.agent.timeout_sec or 0)
+    assert rollout._timeout == expected


### PR DESCRIPTION
Fixes #378, #398.

## #378 — RuntimeConfig fields silently dropped
`RuntimeConfig.rollout_name`, `RuntimeConfig.timeout`, and `RuntimeResult.rollout_dir` are advertised on the public `Runtime` / `bf.run(Agent, Environment, RuntimeConfig)` API but never reached the rollout layer.

- `RolloutConfig.timeout` (new, optional): overrides the per-task `task.toml [agent] timeout_sec` so callers can shorten/extend the agent budget without editing every task.
- `Runtime.execute()` now threads `RuntimeConfig.rollout_name` and `RuntimeConfig.timeout` into `RolloutConfig`.
- `RuntimeResult.rollout_dir` is populated from the underlying `Rollout._rollout_dir` after execute, so callers can locate `result.json` / `trajectory/` / etc. without scanning `jobs_dir`.

## #398 — Evaluation/Job API could not run manifest-backed rollouts
The manifest seam existed on `SDK.run()` and `RolloutConfig` but disappeared at the batch layer.

- `EvaluationConfig.environment_manifest` field added.
- `Evaluation._run_single_task` threads it into `RolloutConfig`.
- `bench eval create` accepts `--environment-manifest <path>` (CLI value wins over a YAML-supplied manifest when both are present).
- Native YAML loader accepts `environment_manifest: <path>` at the top level.
- Docs (`docs/environment-plane.md`, `docs/running-benchmarks.md`, `docs/reference/cli.md`) updated; the cli-docs-drift guard now asserts the flag is present (it was previously asserting the gap explicitly).

## Regression coverage
- `tests/test_runtime_config_wired.py` — `rollout_dir` set on result, `rollout_name`/`timeout` threaded through to `RolloutConfig`, `RolloutConfig.timeout` override honoured by `Rollout.setup()`, default-`None` path still falls back to the task value.
- `tests/test_evaluation_environment_manifest.py` — config field + default, end-to-end CLI flow with a mocked `Rollout`, YAML loader path, and missing-path error.

## Test/lint
- `uv run python -m pytest tests/` — 2350 passed, 2 skipped.
- `uv run ruff check .` — clean.
- `uv run ty check src/` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout timeout naming, batch provisioning via manifests, and eval CLI behavior; well-covered by tests but touches core rollout and job paths.
> 
> **Overview**
> Two public API gaps are closed so advertised knobs actually reach rollouts.
> 
> **Runtime (#378):** `Runtime.execute()` now passes `RuntimeConfig.rollout_name` and `RuntimeConfig.timeout` into `RolloutConfig`, and sets `RuntimeResult.rollout_dir` from the rollout’s artifact directory. `RolloutConfig.timeout` optionally overrides per-task `timeout_sec` during setup.
> 
> **Batch eval / Environment plane (#398):** `EvaluationConfig.environment_manifest` is threaded from YAML (`environment_manifest:`), `bench eval create --environment-manifest`, and into each batch `RolloutConfig`—matching `bench run`. CLI manifest overrides YAML when both are set; hosted `--source-env` runs warn and ignore the flag.
> 
> Docs and the CLI drift test are updated to document and guard `--environment-manifest` on `eval create`. New regression tests cover both fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a170bad3094e19c9b05e345c453cacf812dd522c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->