### PR TITLE
Harden trace-to-task generated artifacts

### DIFF
--- a/src/benchflow/traces/task_gen.py
+++ b/src/benchflow/traces/task_gen.py
@@ -7,14 +7,18 @@ with a ``test.sh`` verifier derived from the trace outcome.
 
 from __future__ import annotations
 
+import base64
 import hashlib
+import json
 import logging
 import os
 import re
 import shlex
+import shutil
 import textwrap
+from dataclasses import dataclass
 from pathlib import Path
-from typing import cast
+from urllib.parse import urlparse
 
 from benchflow.traces.models import ParsedTrace
 
@@ -49,6 +53,49 @@ _TIMEOUT_BY_DIFFICULTY = {
     "hard": 1200,
     "expert": 1800,
 }
+
+_WHOLE_FILE_WRITE_TOOLS = {"Write", "write_to_file"}
+_AMBIGUOUS_EDIT_TOOLS = {"Edit", "MultiEdit", "edit_file"}
+_GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_GIT_COMMIT_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+
+
+@dataclass(frozen=True)
+class _FileExpectation:
+    """A generated verifier/oracle target extracted from a trace."""
+
+    path: str
+    expected_content: str | None
+
+    @property
+    def has_dynamic_path(self) -> bool:
+        return _has_dynamic_segments(self.path)
+
+    @property
+    def target(self) -> str:
+        return _globify_path(self.path) if self.has_dynamic_path else self.path
+
+    def verifier_payload(self, *, has_git: bool) -> dict[str, str]:
+        if self.expected_content is not None:
+            return {
+                "kind": "content",
+                "path": self.path,
+                "target": self.target,
+                "content_b64": base64.b64encode(self.expected_content.encode()).decode(
+                    "ascii"
+                ),
+            }
+        if has_git:
+            return {
+                "kind": "git_status",
+                "path": self.path,
+                "target": self.target,
+            }
+        return {
+            "kind": "manual",
+            "path": self.path,
+            "target": self.target,
+        }
 
 
 def _estimate_difficulty(trace: ParsedTrace) -> str:
@@ -349,140 +396,156 @@ def _build_task_toml(
 def _build_test_sh(trace: ParsedTrace) -> str:
     """Generate a test.sh verifier from the trace.
 
-    When git context is available (repo was cloned), checks that files
-    were **modified** relative to the base commit — not just that they
-    exist.  Otherwise falls back to file-existence checks.
+    Whole-file writes become exact content checks. Ambiguous edit-only traces
+    use git status when a base commit is available; otherwise the verifier
+    reports 0.0 and requires manual authoring instead of auto-passing a weak
+    existence check.
     Writes reward to /logs/verifier/reward.txt per BenchFlow contract.
     """
-    # Drop traversal/absolute paths so the verifier never asserts existence
-    # of files outside /app — see issue #376.
-    files = [
-        rel for f in trace.files_edited if (rel := _safe_relativize(f)) is not None
-    ]
-    if not files:
-        return (
-            "#!/bin/bash\n"
-            f"# Auto-generated verifier from trace {trace.trace_id}\n"
-            "# No file checks available — manual verification required.\n"
-            'echo "No file checks available for this trace-generated task."\n'
-            'echo "0.0" > /logs/verifier/reward.txt\n'
-        )
-
+    expectations = _file_expectations_from_trace(trace)
     has_git = bool(trace.git.repo and trace.git.commit_before)
+    payload = [
+        expectation.verifier_payload(has_git=has_git)
+        for expectation in expectations[:20]
+    ]
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
-    checks: list[str] = []
-    for f in files[:20]:
-        if _has_dynamic_segments(f):
-            pattern = _globify_path(f)
-            quoted_pattern = shlex.quote(pattern)
-            checks.append(f"if ! compgen -G {quoted_pattern} > /dev/null 2>&1; then")
-            checks.append(f'  echo "Missing (pattern): {quoted_pattern}"')
-            checks.append("  PASS=0")
-            checks.append("fi")
-        elif has_git:
-            quoted = shlex.quote(f)
-            checks.append(
-                f"if ! git diff --name-only HEAD {quoted} 2>/dev/null | grep -q .; then"
-            )
-            checks.append(f'  echo "Not modified: {quoted}"')
-            checks.append("  PASS=0")
-            checks.append("fi")
-        else:
-            quoted = shlex.quote(f)
-            checks.append(f"if [ ! -f {quoted} ]; then")
-            checks.append(f'  echo "Missing: {quoted}"')
-            checks.append("  PASS=0")
-            checks.append("fi")
-
-    checks_block = "\n".join(checks)
-
-    header = f"#!/bin/bash\n# Auto-generated verifier from trace {trace.trace_id}\n"
-    if has_git:
-        header += "# Checks that expected files were modified vs base commit.\n"
+    header = (
+        "#!/bin/bash\n"
+        f"# Auto-generated verifier from trace {_shell_comment_text(trace.trace_id)}\n"
+    )
+    if not payload:
+        header += "# No file checks available; manual verification required.\n"
+    elif has_git:
+        header += (
+            "# Checks exact content where known, otherwise git working-tree status.\n"
+        )
     else:
-        header += "# Checks that expected files were created/modified.\n"
+        header += (
+            "# Checks exact content where known; unverifiable edits fail closed.\n"
+        )
+    for expectation in expectations[:20]:
+        header += f"# Expected: {_shell_comment_text(expectation.target)}\n"
 
     return (
         f"{header}"
         "set -euo pipefail\n"
         "\n"
-        "PASS=1\n"
+        "python3 - <<'PY'\n"
+        "import base64\n"
+        "import glob\n"
+        "import json\n"
+        "import pathlib\n"
+        "import subprocess\n"
+        "import sys\n"
         "\n"
-        f"{checks_block}\n"
+        f"CHECKS = json.loads({payload_json!r})\n"
+        "REWARD = pathlib.Path('/logs/verifier/reward.txt')\n"
+        "REWARD.parent.mkdir(parents=True, exist_ok=True)\n"
         "\n"
-        'if [ "$PASS" = "1" ]; then\n'
-        '  echo "1.0" > /logs/verifier/reward.txt\n'
-        "else\n"
-        '  echo "0.0" > /logs/verifier/reward.txt\n'
-        "fi\n"
+        "def targets(check):\n"
+        "    target = check['target']\n"
+        "    if target != check['path']:\n"
+        "        return sorted(p for p in glob.glob(target) if pathlib.Path(p).is_file())\n"
+        "    return [target] if pathlib.Path(target).is_file() else []\n"
+        "\n"
+        "def git_changed(path):\n"
+        "    try:\n"
+        "        result = subprocess.run(\n"
+        "            ['git', 'status', '--porcelain', '--', path],\n"
+        "            check=False,\n"
+        "            text=True,\n"
+        "            stdout=subprocess.PIPE,\n"
+        "            stderr=subprocess.DEVNULL,\n"
+        "        )\n"
+        "    except OSError:\n"
+        "        return False\n"
+        "    return result.returncode == 0 and bool(result.stdout.strip())\n"
+        "\n"
+        "passed = True\n"
+        "if not CHECKS:\n"
+        "    print('No file checks available for this trace-generated task.')\n"
+        "    passed = False\n"
+        "\n"
+        "for check in CHECKS:\n"
+        "    kind = check['kind']\n"
+        "    matched = targets(check)\n"
+        "    if kind == 'content':\n"
+        "        expected = base64.b64decode(check['content_b64'])\n"
+        "        if not matched:\n"
+        "            print(f\"Missing: {check['target']}\")\n"
+        "            passed = False\n"
+        "            continue\n"
+        "        if not any(pathlib.Path(path).read_bytes() == expected for path in matched):\n"
+        "            print(f\"Content mismatch: {check['target']}\")\n"
+        "            passed = False\n"
+        "    elif kind == 'git_status':\n"
+        "        candidates = matched or [check['path']]\n"
+        "        if not any(git_changed(path) for path in candidates):\n"
+        "            print(f\"Not modified: {check['target']}\")\n"
+        "            passed = False\n"
+        "    else:\n"
+        "        print(f\"Manual verification required: {check['target']}\")\n"
+        "        passed = False\n"
+        "\n"
+        "REWARD.write_text('1.0\\n' if passed else '0.0\\n')\n"
+        "sys.exit(0)\n"
+        "PY\n"
     )
 
 
-def _tool_call_file_write(tc_input: dict[str, object]) -> tuple[str, str] | None:
-    """Extract a file path and best-effort final content from a write/edit call.
-
-    Drops the write entirely if the relativized path would escape the task
-    workspace (absolute or contains ``..``) — see issue #376.
-    """
+def _tool_call_path(tc_input: dict[str, object]) -> str | None:
     path = tc_input.get("file_path") or tc_input.get("path")
     if not isinstance(path, str) or not path:
         return None
+    return _safe_relativize(path)
 
-    safe = _safe_relativize(path)
-    if safe is None:
-        return None
 
-    content = tc_input.get("content")
-    if isinstance(content, str):
-        return safe, content
+def _whole_file_content(tc_input: dict[str, object]) -> str | None:
+    """Return final file content only for whole-file write tool inputs."""
+    for key in ("content", "text"):
+        value = tc_input.get(key)
+        if isinstance(value, str):
+            return value
+    return None
 
-    new_string = tc_input.get("new_string")
-    if isinstance(new_string, str):
-        return safe, new_string
 
-    text = tc_input.get("text")
-    if isinstance(text, str):
-        return safe, text
+def _file_expectations_from_trace(trace: ParsedTrace) -> list[_FileExpectation]:
+    """Return final per-path expectations without inventing edit content.
 
-    return safe, ""
+    ``Write``/``write_to_file`` carry whole-file content and can be replayed
+    exactly. ``Edit``/``MultiEdit`` carry replacement fragments, so they are
+    intentionally classified as content-unknown unless a later whole-file
+    write supersedes them.
+    """
+    by_path: dict[str, _FileExpectation] = {}
+
+    for step in trace.steps:
+        for tc in step.tool_calls:
+            if tc.name in _WHOLE_FILE_WRITE_TOOLS:
+                path = _tool_call_path(tc.input)
+                if path is None:
+                    continue
+                by_path[path] = _FileExpectation(
+                    path=path,
+                    expected_content=_whole_file_content(tc.input),
+                )
+            elif tc.name in _AMBIGUOUS_EDIT_TOOLS:
+                path = _tool_call_path(tc.input)
+                if path is None:
+                    continue
+                by_path[path] = _FileExpectation(path=path, expected_content=None)
+
+    return list(by_path.values())
 
 
 def _solution_writes_from_trace(trace: ParsedTrace) -> list[tuple[str, str]]:
     """Return deterministic file writes that can replay a trace as an oracle."""
-    writes_by_path: dict[str, str] = {}
-    write_tools = {"Write", "Edit", "write_to_file", "edit_file"}
-
-    for step in trace.steps:
-        for tc in step.tool_calls:
-            if tc.name in write_tools:
-                write = _tool_call_file_write(tc.input)
-                if write is not None:
-                    path, content = write
-                    writes_by_path[path] = content
-            elif tc.name == "MultiEdit":
-                path = tc.input.get("file_path") or tc.input.get("path")
-                edits = tc.input.get("edits")
-                if isinstance(path, str) and isinstance(edits, list):
-                    safe = _safe_relativize(path)
-                    if safe is None:
-                        continue
-                    parts = []
-                    for edit in edits:
-                        if isinstance(edit, dict):
-                            edit_input = cast("dict[str, object]", edit)
-                            new_string = edit_input.get("new_string")
-                            if isinstance(new_string, str):
-                                parts.append(new_string)
-                    writes_by_path[safe] = "\n".join(parts)
-
-    return list(writes_by_path.items())
-
-
-def _heredoc_marker(content: str) -> str:
-    marker = "BENCHFLOW_TRACE_CONTENT"
-    while marker in content:
-        marker += "_END"
-    return marker
+    return [
+        (expectation.path, expectation.expected_content)
+        for expectation in _file_expectations_from_trace(trace)
+        if expectation.expected_content is not None
+    ]
 
 
 def _build_solution_sh(trace: ParsedTrace) -> str:
@@ -490,7 +553,7 @@ def _build_solution_sh(trace: ParsedTrace) -> str:
     writes = _solution_writes_from_trace(trace)
     header = (
         "#!/bin/bash\n"
-        f"# Auto-generated oracle solution from trace {trace.trace_id}\n"
+        f"# Auto-generated oracle solution from trace {_shell_comment_text(trace.trace_id)}\n"
         "set -euo pipefail\n"
         "cd /app\n\n"
     )
@@ -500,20 +563,29 @@ def _build_solution_sh(trace: ParsedTrace) -> str:
             'echo "No replayable file writes were found for this trace." >&2\nexit 1\n'
         )
 
-    blocks: list[str] = [header]
-    for path, content in writes:
-        quoted_path = shlex.quote(path)
-        parent = str(Path(path).parent)
-        if parent and parent != ".":
-            blocks.append(f"mkdir -p {shlex.quote(parent)}\n")
-        marker = _heredoc_marker(content)
-        blocks.append(f"cat > {quoted_path} <<'{marker}'\n")
-        blocks.append(content)
-        if content and not content.endswith("\n"):
-            blocks.append("\n")
-        blocks.append(f"{marker}\n")
+    payload = [
+        {
+            "path": path,
+            "content_b64": base64.b64encode(content.encode()).decode("ascii"),
+        }
+        for path, content in writes
+    ]
+    payload_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
-    return "".join(blocks)
+    return (
+        header
+        + "python3 - <<'PY'\n"
+        + "import base64\n"
+        + "import json\n"
+        + "import pathlib\n"
+        + "\n"
+        + f"WRITES = json.loads({payload_json!r})\n"
+        + "for write in WRITES:\n"
+        + "    path = pathlib.Path(write['path'])\n"
+        + "    path.parent.mkdir(parents=True, exist_ok=True)\n"
+        + "    path.write_bytes(base64.b64decode(write['content_b64']))\n"
+        + "PY\n"
+    )
 
 
 def _build_dockerfile(trace: ParsedTrace | None = None) -> str:
@@ -521,6 +593,8 @@ def _build_dockerfile(trace: ParsedTrace | None = None) -> str:
 
     When the trace has git context (repo + commit), clones the repo at
     the specified commit so the agent has the actual codebase to work with.
+    The checkout must succeed; building against clone HEAD would make the
+    generated benchmark stale and misleading.
     """
     base = textwrap.dedent("""\
         FROM ubuntu:24.04
@@ -531,12 +605,15 @@ def _build_dockerfile(trace: ParsedTrace | None = None) -> str:
     """)
 
     if trace and trace.git.repo and trace.git.commit_before:
-        repo = trace.git.repo
-        commit = trace.git.commit_before
-        clone_url = _github_clone_url(repo)
+        clone_url = shlex.quote(_github_clone_url(trace.git.repo))
+        commit = _validate_git_commit(trace.git.commit_before)
+        quoted_commit = shlex.quote(commit)
         base += textwrap.dedent(f"""\
-            RUN git clone --depth 50 {clone_url} /app && \\
-                cd /app && git checkout {commit} || true
+            RUN git clone --no-checkout {clone_url} /app && \\
+                cd /app && \\
+                git fetch --depth 1 origin {quoted_commit} && \\
+                git checkout --detach {quoted_commit} && \\
+                case "$(git rev-parse --verify HEAD)" in {commit}*) ;; *) exit 1 ;; esac
 
             WORKDIR /app
         """)
@@ -547,15 +624,58 @@ def _build_dockerfile(trace: ParsedTrace | None = None) -> str:
 
 
 def _github_clone_url(repo: str) -> str:
-    """Return a clone URL for GitHub shorthand or full URLs."""
+    """Return a public HTTPS clone URL for GitHub shorthand or full URLs."""
     normalized = repo.strip()
     if normalized.endswith(".git"):
         normalized = normalized[:-4]
-    if normalized.startswith(("https://", "http://", "git@")):
-        return f"{normalized}.git"
+
+    if normalized.startswith("git@github.com:"):
+        return _github_https_url(normalized.removeprefix("git@github.com:"))
+
+    if normalized.startswith("ssh://git@github.com/"):
+        return _github_https_url(normalized.removeprefix("ssh://git@github.com/"))
+
+    if normalized.startswith(("https://", "http://")):
+        parsed = urlparse(normalized)
+        if parsed.netloc.lower() != "github.com":
+            raise ValueError(
+                "Trace git.repo must be a public GitHub HTTPS URL or owner/repo"
+            )
+        return _github_https_url(parsed.path.lstrip("/"))
+
+    if normalized.startswith("git@"):
+        raise ValueError("Trace git.repo SSH remotes are only supported for GitHub")
+
     if normalized.startswith("github.com/"):
-        return f"https://{normalized}.git"
+        return _github_https_url(normalized.removeprefix("github.com/"))
+
+    return _github_https_url(normalized)
+
+
+def _github_https_url(owner_repo: str) -> str:
+    normalized = owner_repo.strip().strip("/")
+    if normalized.endswith(".git"):
+        normalized = normalized[:-4]
+    if not _GITHUB_REPO_RE.fullmatch(normalized):
+        raise ValueError(
+            "Trace git.repo must identify a GitHub repository as owner/repo"
+        )
     return f"https://github.com/{normalized}.git"
+
+
+def _validate_git_commit(commit: str) -> str:
+    normalized = commit.strip()
+    if not _GIT_COMMIT_RE.fullmatch(normalized):
+        raise ValueError(
+            "Trace git.commit_before must be a 7-40 character hexadecimal commit"
+        )
+    return normalized.lower()
+
+
+def _shell_comment_text(value: str) -> str:
+    """Keep trace-controlled metadata inside a single shell comment line."""
+    clean = re.sub(r"[\r\n\t]+", " ", value)
+    return "".join(ch if 32 <= ord(ch) < 127 else "?" for ch in clean)
 
 
 def generate_task(
@@ -591,9 +711,9 @@ def generate_task(
         logger.info("Task %s already exists, skipping (use overwrite=True)", task_id)
         return task_dir
 
-    task_dir.mkdir(parents=True, exist_ok=True)
-
-    # Write task.toml
+    # Render every artifact before replacing an existing task directory. If
+    # trace metadata is unsafe (for example an unsupported git remote), fail
+    # without leaving a half-regenerated benchmark behind.
     effective_timeout = timeout_sec if timeout_sec > 0 else None
     task_name = f"trace-import/{task_id}"
     toml_content = _build_task_toml(
@@ -602,21 +722,32 @@ def generate_task(
         author=author,
         timeout_sec=effective_timeout,
     )
+    instruction = _build_instruction(trace)
+    dockerfile = _build_dockerfile(trace)
+    test_sh = _build_test_sh(trace)
+    solution_sh = _build_solution_sh(trace)
+
+    if task_dir.exists():
+        if task_dir.is_symlink() or task_dir.is_file():
+            task_dir.unlink()
+        else:
+            shutil.rmtree(task_dir)
+
+    task_dir.mkdir(parents=True, exist_ok=True)
+
     (task_dir / "task.toml").write_text(toml_content)
 
     # Write instruction.md
-    instruction = _build_instruction(trace)
     (task_dir / "instruction.md").write_text(instruction)
 
     # Write environment/Dockerfile
     env_dir = task_dir / "environment"
     env_dir.mkdir(exist_ok=True)
-    (env_dir / "Dockerfile").write_text(_build_dockerfile(trace))
+    (env_dir / "Dockerfile").write_text(dockerfile)
 
     # Write tests/test.sh
     tests_dir = task_dir / "tests"
     tests_dir.mkdir(exist_ok=True)
-    test_sh = _build_test_sh(trace)
     test_path = tests_dir / "test.sh"
     test_path.write_text(test_sh)
     test_path.chmod(0o755)
@@ -625,7 +756,7 @@ def generate_task(
     solution_dir = task_dir / "solution"
     solution_dir.mkdir(exist_ok=True)
     solution_path = solution_dir / "solve.sh"
-    solution_path.write_text(_build_solution_sh(trace))
+    solution_path.write_text(solution_sh)
     solution_path.chmod(0o755)
 
     logger.info(

--- a/tests/test_traces_task_gen.py
+++ b/tests/test_traces_task_gen.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -86,6 +87,17 @@ def no_prompt_trace() -> ParsedTrace:
     )
 
 
+def _run_generated_verifier(task_dir: Path, work_dir: Path, logs_dir: Path) -> str:
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    script = (
+        (task_dir / "tests" / "test.sh")
+        .read_text()
+        .replace("/logs/verifier", str(logs_dir))
+    )
+    subprocess.run(["bash"], input=script, text=True, cwd=work_dir, check=True)
+    return (logs_dir / "reward.txt").read_text().strip()
+
+
 # ---------------------------------------------------------------------------
 # Task generation tests
 # ---------------------------------------------------------------------------
@@ -147,6 +159,65 @@ class TestGenerateTask:
         assert "hello.txt" in content
         assert "/logs/verifier/reward.txt" in content
 
+    def test_content_verifier_rejects_wrong_content(
+        self, simple_trace: ParsedTrace, tmp_path: Path
+    ) -> None:
+        """Guards this PR's fix for #359: exact writes must verify content."""
+        task_dir = generate_task(simple_trace, tmp_path / "tasks")
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        (work_dir / "hello.txt").write_text("wrong\n")
+
+        reward = _run_generated_verifier(task_dir, work_dir, tmp_path / "logs-wrong")
+
+        assert reward == "0.0"
+
+    def test_content_verifier_accepts_exact_content(
+        self, simple_trace: ParsedTrace, tmp_path: Path
+    ) -> None:
+        """Guards this PR's fix for #359: exact writes still pass when correct."""
+        task_dir = generate_task(simple_trace, tmp_path / "tasks")
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        (work_dir / "hello.txt").write_text("Hello")
+
+        reward = _run_generated_verifier(task_dir, work_dir, tmp_path / "logs-ok")
+
+        assert reward == "1.0"
+
+    def test_edit_only_verifier_fails_closed_without_git(self, tmp_path: Path) -> None:
+        """Guards this PR's fix for #359: edit fragments must not auto-pass."""
+        trace = ParsedTrace(
+            trace_id="edit-only",
+            session_id="s",
+            steps=[
+                TraceStep(role="user", content="Update README"),
+                TraceStep(
+                    role="assistant",
+                    content="Edited.",
+                    tool_calls=[
+                        ToolCall(
+                            name="Edit",
+                            input={
+                                "file_path": "README.md",
+                                "old_string": "old",
+                                "new_string": "new fragment",
+                            },
+                        )
+                    ],
+                ),
+            ],
+            outcome="success",
+        )
+        task_dir = generate_task(trace, tmp_path / "tasks")
+        work_dir = tmp_path / "work"
+        work_dir.mkdir()
+        (work_dir / "README.md").write_text("new fragment\n")
+
+        reward = _run_generated_verifier(task_dir, work_dir, tmp_path / "logs")
+
+        assert reward == "0.0"
+
     def test_test_sh_is_executable(
         self, simple_trace: ParsedTrace, tmp_path: Path
     ) -> None:
@@ -168,12 +239,43 @@ class TestGenerateTask:
         assert solve_sh.exists()
         content = solve_sh.read_text()
         assert "Auto-generated oracle solution" in content
-        assert "cat > hello.txt" in content
-        assert "Hello" in content
+        assert '"path":"hello.txt"' in content
+        assert "path.write_bytes" in content
 
         import stat
 
         assert solve_sh.stat().st_mode & stat.S_IXUSR
+
+    def test_solution_sh_does_not_replay_edit_fragments(self, tmp_path: Path) -> None:
+        """Guards this PR's fix for #359: Edit.new_string is not final content."""
+        trace = ParsedTrace(
+            trace_id="edit-fragment",
+            session_id="s",
+            steps=[
+                TraceStep(role="user", content="Patch README"),
+                TraceStep(
+                    role="assistant",
+                    content="Patched.",
+                    tool_calls=[
+                        ToolCall(
+                            name="Edit",
+                            input={
+                                "file_path": "README.md",
+                                "old_string": "hello",
+                                "new_string": "world",
+                            },
+                        )
+                    ],
+                ),
+            ],
+            outcome="success",
+        )
+
+        task_dir = generate_task(trace, tmp_path)
+        solve_sh = (task_dir / "solution" / "solve.sh").read_text()
+
+        assert "No replayable file writes" in solve_sh
+        assert "path.write_bytes" not in solve_sh
 
     def test_dockerfile_generated(
         self, simple_trace: ParsedTrace, tmp_path: Path
@@ -212,6 +314,8 @@ class TestGenerateTask:
 
         assert "https://github.com/octocat/Hello-World.git" in dockerfile
         assert "https://github.com/https://github.com" not in dockerfile
+        assert "git fetch --depth 1 origin deadbeef" in dockerfile
+        assert "|| true" not in dockerfile
 
     def test_passes_bench_tasks_check(
         self, simple_trace: ParsedTrace, tmp_path: Path
@@ -238,8 +342,10 @@ class TestGenerateTask:
         assert test_sh.exists()
         content = test_sh.read_text()
         assert "/logs/verifier/reward.txt" in content
-        assert 'echo "0.0"' in content
-        assert 'echo "1.0"' not in content
+        work_dir = tmp_path / "work-no-files"
+        work_dir.mkdir()
+        reward = _run_generated_verifier(task_dir, work_dir, tmp_path / "logs")
+        assert reward == "0.0"
 
     def test_hard_difficulty(self, complex_trace: ParsedTrace, tmp_path: Path) -> None:
         task_dir = generate_task(complex_trace, tmp_path)
@@ -289,6 +395,86 @@ class TestGenerateTask:
         # Overwrite should regenerate
         task_dir = generate_task(simple_trace, tmp_path, overwrite=True)
         assert (task_dir / "task.toml").exists()
+
+    def test_overwrite_removes_stale_files(
+        self, simple_trace: ParsedTrace, tmp_path: Path
+    ) -> None:
+        """Guards this PR's fix for #359: overwrite replaces stale artifacts."""
+        task_dir = generate_task(simple_trace, tmp_path)
+        (task_dir / "tests" / "stale.sh").write_text("#!/bin/bash\n")
+        stale_asset = task_dir / "assets" / "old.txt"
+        stale_asset.parent.mkdir()
+        stale_asset.write_text("old")
+
+        regenerated = generate_task(simple_trace, tmp_path, overwrite=True)
+
+        assert regenerated == task_dir
+        assert not (task_dir / "tests" / "stale.sh").exists()
+        assert not stale_asset.exists()
+
+    def test_unsafe_git_commit_rejected_before_overwrite(
+        self, simple_trace: ParsedTrace, tmp_path: Path
+    ) -> None:
+        """Guards this PR's fix for #359: commit metadata is not shell code."""
+        task_dir = generate_task(simple_trace, tmp_path)
+        (task_dir / "marker.txt").write_text("keep")
+        simple_trace.git = GitContext(
+            repo="octocat/Hello-World",
+            commit_before="deadbeef; touch /tmp/pwned",
+        )
+
+        with pytest.raises(ValueError, match="commit_before"):
+            generate_task(simple_trace, tmp_path, overwrite=True)
+
+        assert (task_dir / "marker.txt").read_text() == "keep"
+
+    def test_git_status_verifier_accepts_untracked_new_file(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards this PR's fix for #359: new untracked files count as changed."""
+        trace = ParsedTrace(
+            trace_id="git-new-file",
+            session_id="s",
+            steps=[
+                TraceStep(role="user", content="Create new.txt"),
+                TraceStep(
+                    role="assistant",
+                    content="Created.",
+                    tool_calls=[ToolCall(name="Edit", input={"file_path": "new.txt"})],
+                ),
+            ],
+            git=GitContext(repo="octocat/Hello-World", commit_before="deadbeef"),
+            outcome="success",
+        )
+        task_dir = generate_task(trace, tmp_path / "tasks")
+        work_dir = tmp_path / "repo"
+        work_dir.mkdir()
+        subprocess.run(
+            ["git", "init"], cwd=work_dir, check=True, stdout=subprocess.PIPE
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "benchflow@example.com"],
+            cwd=work_dir,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "BenchFlow"],
+            cwd=work_dir,
+            check=True,
+        )
+        (work_dir / "README.md").write_text("base\n")
+        subprocess.run(["git", "add", "README.md"], cwd=work_dir, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "base"],
+            cwd=work_dir,
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        (work_dir / "new.txt").write_text("created\n")
+
+        reward = _run_generated_verifier(task_dir, work_dir, tmp_path / "logs")
+
+        assert reward == "1.0"
 
     def test_custom_author(self, simple_trace: ParsedTrace, tmp_path: Path) -> None:
         task_dir = generate_task(simple_trace, tmp_path, author="my-team")
@@ -453,9 +639,23 @@ class TestGithubCloneUrl:
             == "https://github.com/octocat/Hello-World.git"
         )
 
+    def test_github_ssh_url_normalized_to_https(self) -> None:
+        """Guards this PR's fix for #359: public GitHub SSH remotes are clean."""
+        assert (
+            _github_clone_url("git@github.com:octocat/Hello-World.git")
+            == "https://github.com/octocat/Hello-World.git"
+        )
+
+    def test_non_github_ssh_url_rejected(self) -> None:
+        """Guards this PR's fix for #359: unsupported SSH remotes fail closed."""
+        with pytest.raises(ValueError, match="SSH"):
+            _github_clone_url("git@gitlab.com:octocat/Hello-World.git")
+
 
 class TestVerifierGlobPatterns:
-    def test_test_sh_uses_compgen_for_timestamp_paths(self, tmp_path: Path) -> None:
+    def test_test_sh_uses_glob_payload_for_timestamp_paths(
+        self, tmp_path: Path
+    ) -> None:
         trace = ParsedTrace(
             trace_id="ts-trace",
             session_id="s",
@@ -478,10 +678,11 @@ class TestVerifierGlobPatterns:
         )
         task_dir = generate_task(trace, tmp_path)
         test_sh = (task_dir / "tests" / "test.sh").read_text()
-        assert "compgen -G" in test_sh
         assert "*_create_invoices/up.sql" in test_sh
 
-    def test_test_sh_uses_exact_check_for_static_paths(self, tmp_path: Path) -> None:
+    def test_test_sh_uses_content_verifier_for_static_paths(
+        self, tmp_path: Path
+    ) -> None:
         trace = ParsedTrace(
             trace_id="static-trace",
             session_id="s",
@@ -502,8 +703,8 @@ class TestVerifierGlobPatterns:
         )
         task_dir = generate_task(trace, tmp_path)
         test_sh = (task_dir / "tests" / "test.sh").read_text()
-        assert "[ ! -f" in test_sh
-        assert "compgen" not in test_sh
+        assert "src/main.py" in test_sh
+        assert "Content mismatch" in test_sh
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_traces_task_gen.py
+++ b/tests/test_traces_task_gen.py
@@ -162,7 +162,7 @@ class TestGenerateTask:
     def test_content_verifier_rejects_wrong_content(
         self, simple_trace: ParsedTrace, tmp_path: Path
     ) -> None:
-        """Guards this PR's fix for #359: exact writes must verify content."""
+        """Guards the fix from PR #488 for #359: exact writes must verify content."""
         task_dir = generate_task(simple_trace, tmp_path / "tasks")
         work_dir = tmp_path / "work"
         work_dir.mkdir()
@@ -175,7 +175,7 @@ class TestGenerateTask:
     def test_content_verifier_accepts_exact_content(
         self, simple_trace: ParsedTrace, tmp_path: Path
     ) -> None:
-        """Guards this PR's fix for #359: exact writes still pass when correct."""
+        """Guards the fix from PR #488 for #359: exact writes still pass when correct."""
         task_dir = generate_task(simple_trace, tmp_path / "tasks")
         work_dir = tmp_path / "work"
         work_dir.mkdir()
@@ -186,7 +186,7 @@ class TestGenerateTask:
         assert reward == "1.0"
 
     def test_edit_only_verifier_fails_closed_without_git(self, tmp_path: Path) -> None:
-        """Guards this PR's fix for #359: edit fragments must not auto-pass."""
+        """Guards the fix from PR #488 for #359: edit fragments must not auto-pass."""
         trace = ParsedTrace(
             trace_id="edit-only",
             session_id="s",
@@ -247,7 +247,7 @@ class TestGenerateTask:
         assert solve_sh.stat().st_mode & stat.S_IXUSR
 
     def test_solution_sh_does_not_replay_edit_fragments(self, tmp_path: Path) -> None:
-        """Guards this PR's fix for #359: Edit.new_string is not final content."""
+        """Guards the fix from PR #488 for #359: Edit.new_string is not final content."""
         trace = ParsedTrace(
             trace_id="edit-fragment",
             session_id="s",
@@ -399,7 +399,7 @@ class TestGenerateTask:
     def test_overwrite_removes_stale_files(
         self, simple_trace: ParsedTrace, tmp_path: Path
     ) -> None:
-        """Guards this PR's fix for #359: overwrite replaces stale artifacts."""
+        """Guards the fix from PR #488 for #359: overwrite replaces stale artifacts."""
         task_dir = generate_task(simple_trace, tmp_path)
         (task_dir / "tests" / "stale.sh").write_text("#!/bin/bash\n")
         stale_asset = task_dir / "assets" / "old.txt"
@@ -415,7 +415,7 @@ class TestGenerateTask:
     def test_unsafe_git_commit_rejected_before_overwrite(
         self, simple_trace: ParsedTrace, tmp_path: Path
     ) -> None:
-        """Guards this PR's fix for #359: commit metadata is not shell code."""
+        """Guards the fix from PR #488 for #359: commit metadata is not shell code."""
         task_dir = generate_task(simple_trace, tmp_path)
         (task_dir / "marker.txt").write_text("keep")
         simple_trace.git = GitContext(
@@ -431,7 +431,7 @@ class TestGenerateTask:
     def test_git_status_verifier_accepts_untracked_new_file(
         self, tmp_path: Path
     ) -> None:
-        """Guards this PR's fix for #359: new untracked files count as changed."""
+        """Guards the fix from PR #488 for #359: new untracked files count as changed."""
         trace = ParsedTrace(
             trace_id="git-new-file",
             session_id="s",
@@ -640,14 +640,14 @@ class TestGithubCloneUrl:
         )
 
     def test_github_ssh_url_normalized_to_https(self) -> None:
-        """Guards this PR's fix for #359: public GitHub SSH remotes are clean."""
+        """Guards the fix from PR #488 for #359: public GitHub SSH remotes are clean."""
         assert (
             _github_clone_url("git@github.com:octocat/Hello-World.git")
             == "https://github.com/octocat/Hello-World.git"
         )
 
     def test_non_github_ssh_url_rejected(self) -> None:
-        """Guards this PR's fix for #359: unsupported SSH remotes fail closed."""
+        """Guards the fix from PR #488 for #359: unsupported SSH remotes fail closed."""
         with pytest.raises(ValueError, match="SSH"):
             _github_clone_url("git@gitlab.com:octocat/Hello-World.git")
 


### PR DESCRIPTION
## Summary

Fixes #359.

- derive verifier/oracle behavior from explicit per-file expectations instead of treating edit fragments as whole-file content
- verify known writes by exact content, use `git status --porcelain` for git-backed unknown edits, and fail closed for unverifiable edits
- normalize public GitHub SSH remotes to HTTPS, reject unsupported/unsafe git metadata, and make Docker checkout fail if the base commit cannot be fetched
- replace task directories on `overwrite=True` only after rendering artifacts successfully so stale files do not survive

## Verification

Ran in a clean worktree from `origin/v0.5-integration` with only this patch applied:

- `uv sync --extra dev --extra sandbox-daytona --locked`
- `uv run python -m pytest tests/test_traces_task_gen.py tests/test_trace_task_gen_traversal.py -q`
- `uv run python -m pytest tests/test_inbound_adapters.py::TestTerminalBenchAdapter::test_dockerfile_copy_sources_carried_into_context tests/test_inbound_adapters.py::TestTerminalBenchAdapter::test_dockerfile_copy_directory_carried -q`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/`
- original #359 wrong-content repro now writes reward `0.0`
- generated oracle solution followed by verifier writes reward `1.0`
- Terminal-Bench converted scratch Docker context builds with copied `requirements.txt`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/488" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->