### PR TITLE
fix: route Gemini CLI usage telemetry through proxy (#375)

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -409,7 +409,7 @@ AGENTS: dict[str, AgentConfig] = {
         # a multi-endpoint option. Set this when a Gemini-compatible provider
         # with multiple endpoints (e.g. OpenRouter) is added.
         env_mapping={
-            "BENCHFLOW_PROVIDER_BASE_URL": "GEMINI_API_BASE_URL",
+            "BENCHFLOW_PROVIDER_BASE_URL": "GOOGLE_GEMINI_BASE_URL",
             # Map to the CLI-native var; auto_inherit_env mirrors it to
             # GOOGLE_API_KEY for compatibility with users who set that alias.
             "BENCHFLOW_PROVIDER_API_KEY": "GEMINI_API_KEY",

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -188,6 +188,7 @@ def _agent_base_url_envs(agent: str) -> list[str]:
             "ANTHROPIC_BASE_URL",
             "ANTHROPIC_BEDROCK_BASE_URL",
             "OPENAI_BASE_URL",
+            "GOOGLE_GEMINI_BASE_URL",
             "GEMINI_API_BASE_URL",
             "LLM_BASE_URL",
         ]

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -145,7 +145,7 @@ class TrajectoryProxy:
                     body=body,
                 )
 
-                is_streaming = body.get("stream", False)
+                is_streaming = body.get("stream", False) or _is_sse_request_path(path)
 
                 start_time = time.monotonic()
                 target_url = f"{self._target}{path}"
@@ -220,10 +220,18 @@ class TrajectoryProxy:
         duration_ms = (time.monotonic() - start_time) * 1000
 
         resp_body: dict[str, Any] = {}
-        try:
-            resp_body = resp.json()
-        except (json.JSONDecodeError, ValueError):
-            resp_body = {"raw": resp.text[:_RAW_RESP_TRUNCATE]}
+        content_type = resp.headers.get("content-type", "").lower()
+        if "text/event-stream" in content_type:
+            try:
+                resp_body = _reconstruct_sse_response(resp.content)
+            except Exception as e:
+                logger.warning(f"SSE response reconstruction failed: {e}")
+                resp_body = {"raw": resp.text[:_RAW_RESP_TRUNCATE]}
+        else:
+            try:
+                resp_body = resp.json()
+            except (json.JSONDecodeError, ValueError):
+                resp_body = {"raw": resp.text[:_RAW_RESP_TRUNCATE]}
 
         self._record_exchange(
             req, resp.status_code, dict(resp.headers), resp_body, duration_ms
@@ -418,6 +426,19 @@ def _is_openai_generation_path(path: str) -> bool:
     return request_path.endswith("/responses") or request_path.endswith(
         "/chat/completions"
     )
+
+
+def _is_sse_request_path(path: str) -> bool:
+    """Return True for provider endpoints that stream SSE without a body flag."""
+    request_path = path.split("?", 1)[0].rstrip("/")
+    return request_path.endswith(":streamGenerateContent") or "alt=sse" in path
+
+
+def _reconstruct_sse_response(body_bytes: bytes) -> dict[str, Any]:
+    events, sse_buffer = _parse_sse_events_buffer(body_bytes.decode(errors="replace"))
+    if sse_buffer.strip():
+        events.extend(_parse_sse_events(sse_buffer.encode()))
+    return _reconstruct_response(events)
 
 
 def _decode_request_body(body_bytes: bytes, content_encoding: str) -> bytes:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -41,7 +41,10 @@ class TestEnvMappingField:
 
     def test_gemini_has_mapping(self):
         cfg = AGENTS["gemini"]
-        assert cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"] == "GEMINI_API_BASE_URL"
+        assert (
+            cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"]
+            == "GOOGLE_GEMINI_BASE_URL"
+        )
         # #342: map BENCHFLOW_PROVIDER_API_KEY to the CLI-native var. The
         # bidirectional mirror in auto_inherit_env handles GOOGLE_API_KEY
         # callers transparently.

--- a/tests/test_atif_trajectory.py
+++ b/tests/test_atif_trajectory.py
@@ -574,6 +574,85 @@ class TestTrajectoryProxy:
             await stream_server.wait_closed()
 
     @pytest.mark.asyncio
+    async def test_proxy_reconstructs_gemini_sse_without_stream_flag(self) -> None:
+        """Guards the follow-up to PR #483: Gemini CLI's real
+        streamGenerateContent request uses ``alt=sse`` without a JSON
+        ``stream`` flag, so SSE detection must not depend on request body
+        shape alone (#375)."""
+
+        async def gemini_handler(
+            reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+        ) -> None:
+            await reader.readline()
+            headers = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"\r\n", b"\n", b""):
+                    break
+                k, _, v = line.decode().partition(":")
+                headers[k.strip().lower()] = v.strip()
+            cl = int(headers.get("content-length", "0"))
+            if cl > 0:
+                await reader.readexactly(cl)
+
+            frame = {
+                "candidates": [
+                    {
+                        "content": {
+                            "role": "model",
+                            "parts": [{"text": "done"}],
+                        },
+                        "finishReason": "STOP",
+                        "index": 0,
+                    }
+                ],
+                "modelVersion": "gemini-2.5-flash",
+                "usageMetadata": {
+                    "promptTokenCount": 7,
+                    "candidatesTokenCount": 1,
+                    "totalTokenCount": 8,
+                },
+            }
+            body = f"data: {json.dumps(frame)}\r\n\r\n".encode()
+            writer.write(
+                b"HTTP/1.1 200 OK\r\n"
+                b"content-type: text/event-stream\r\n"
+                + f"content-length: {len(body)}\r\n\r\n".encode()
+                + body
+            )
+            await writer.drain()
+            writer.close()
+
+        stream_server = await asyncio.start_server(gemini_handler, "127.0.0.1", 0)
+        stream_port = stream_server.sockets[0].getsockname()[1]
+
+        proxy = TrajectoryProxy(
+            target=f"http://127.0.0.1:{stream_port}",
+            session_id="gemini-sse-no-stream-flag",
+            agent_name="gemini",
+        )
+        await proxy.start()
+
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    f"{proxy.base_url}/v1beta/models/"
+                    "gemini-2.5-flash:streamGenerateContent?alt=sse",
+                    json={"contents": []},
+                )
+                assert resp.status_code == 200
+
+            body = proxy.trajectory.exchanges[0].response.body
+            assert "raw" not in body
+            assert "_raw_events" not in body
+            assert body["usageMetadata"]["totalTokenCount"] == 8
+            assert proxy.trajectory.total_provider_tokens == 8
+        finally:
+            await proxy.stop()
+            stream_server.close()
+            await stream_server.wait_closed()
+
+    @pytest.mark.asyncio
     async def test_extract_usage_populates_gemini_telemetry_after_stream(self) -> None:
         """Regression for #375 — assert the full pipeline: a Gemini streaming
         response goes through the proxy and ``extract_usage`` returns

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -11,6 +11,7 @@ from benchflow.providers.runtime import (
     ProviderRuntime,
     _bedrock_frontend_model,
     ensure_bedrock_proxy_runtime,
+    ensure_usage_proxy_runtime,
     needs_provider_runtime,
     stop_provider_runtime,
 )
@@ -297,3 +298,60 @@ class TestBedrockProxyRemoteSandbox:
 
         with pytest.raises(AssertionError):
             _bedrock_proxy_command(environment="daytona")
+
+
+class TestUsageProxyRuntime:
+    @pytest.mark.asyncio
+    async def test_gemini_proxy_uses_cli_base_url_env(self, monkeypatch):
+        """Guards the follow-up to PR #483: Gemini CLI 0.42.0 reads
+        GOOGLE_GEMINI_BASE_URL, not GEMINI_API_BASE_URL (#375)."""
+
+        monkeypatch.setattr(
+            provider_runtime_mod, "_docker_host_address", lambda: "host.docker.internal"
+        )
+
+        class FakeProxy:
+            def __init__(
+                self,
+                *,
+                target,
+                session_id,
+                agent_name,
+                host,
+                port,
+                prompt_cache_retention=None,
+            ):
+                self.target = target
+                self.session_id = session_id
+                self.agent_name = agent_name
+                self.host = host
+                self.port = 43210
+                self.prompt_cache_retention = prompt_cache_retention
+
+            async def start(self):
+                return None
+
+            async def stop(self):
+                return None
+
+        monkeypatch.setattr(provider_runtime_mod, "TrajectoryProxy", FakeProxy)
+
+        updated, runtime = await ensure_usage_proxy_runtime(
+            agent="gemini",
+            agent_env={"GEMINI_API_KEY": "test-key"},
+            model="gemini-2.5-flash",
+            runtime=None,
+            environment="docker",
+        )
+
+        assert runtime is not None
+        assert runtime.server.target == "https://generativelanguage.googleapis.com"
+        assert (
+            updated["BENCHFLOW_PROVIDER_BASE_URL"]
+            == "http://host.docker.internal:43210"
+        )
+        assert (
+            updated["GOOGLE_GEMINI_BASE_URL"]
+            == "http://host.docker.internal:43210"
+        )
+        assert "GEMINI_API_BASE_URL" not in updated


### PR DESCRIPTION
Fixes #375.

## Summary

PR #483 taught the trajectory proxy how to reconstruct Gemini SSE chunks, but a real Gemini Docker eval still captured zero provider exchanges. The missing piece is that Gemini CLI 0.42.0 reads `GOOGLE_GEMINI_BASE_URL`, not `GEMINI_API_BASE_URL`, and its `streamGenerateContent?alt=sse` requests do not include a JSON `stream: true` flag.

This PR keeps the fix in the runtime/provider telemetry layer:

- maps BenchFlow's provider base URL to `GOOGLE_GEMINI_BASE_URL` for the `gemini` agent;
- recognizes `GOOGLE_GEMINI_BASE_URL` as a provider base URL env var;
- detects SSE by Gemini's `:streamGenerateContent?alt=sse` path instead of relying only on a body flag;
- reconstructs text/event-stream responses even if they arrive through the regular response path; and
- adds focused regressions for the env mapping and no-`stream` Gemini SSE shape.

## Verification

Clean worktree at commit `757422a`:

```bash
uv sync --extra dev --extra sandbox-daytona --locked
uv run python -m pytest \
  tests/test_agent_registry.py \
  tests/test_provider_runtime.py \
  tests/test_runtime_config_wired.py \
  tests/test_evaluation_environment_manifest.py \
  tests/test_cli_docs_drift.py \
  tests/test_atif_trajectory.py::TestTrajectoryProxy::test_proxy_reconstructs_gemini_streaming_usage \
  tests/test_atif_trajectory.py::TestTrajectoryProxy::test_proxy_reconstructs_gemini_sse_without_stream_flag \
  tests/test_atif_trajectory.py::TestTrajectoryProxy::test_extract_usage_populates_gemini_telemetry_after_stream \
  -q
# 49 passed, 6 warnings

uv run ruff check src/benchflow/agents/registry.py src/benchflow/providers/runtime.py src/benchflow/trajectories/proxy.py tests/test_agent_registry.py tests/test_provider_runtime.py tests/test_atif_trajectory.py
# All checks passed

uv run ty check src/benchflow/agents/registry.py src/benchflow/providers/runtime.py src/benchflow/trajectories/proxy.py
# All checks passed
```

Real Gemini Docker eval with local env keys:

```bash
uv run bench eval create \
  --tasks-dir tests/examples/hello-world-task \
  --agent gemini \
  --model gemini-2.5-flash \
  --sandbox docker \
  --jobs-dir /tmp/benchflow-gemini-telemetry-issue375-fixed2 \
  --agent-idle-timeout 180
```

Observed telemetry artifact:

```text
Proxy stopped. Captured 2 exchanges.
trajectory/llm_trajectory.jsonl exists, 2 lines
usage_source=provider_response
n_input_tokens=20199
n_output_tokens=63
n_cache_read_tokens=9806
total_tokens=20391
cost_usd=0.00695265
```

Note: the sample hello-world Gemini run still scored `reward=0.0` because Gemini CLI failed its write tool with `Cannot enable privileged approval modes in an untrusted folder`; that is separate from #375. The provider telemetry was captured and persisted.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->