### PR TITLE
Fix v0.5 diagnostics, transport, and verifier reporting

### DIFF
--- a/src/benchflow/_utils/diagnostics.py
+++ b/src/benchflow/_utils/diagnostics.py
@@ -1,0 +1,309 @@
+"""Shared structured diagnostic helpers for rollout result surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from benchflow._utils.scoring import (
+    IDLE_TIMEOUT,
+    INFRA_ERROR,
+    INSTALL_FAILED,
+    PIPE_CLOSED,
+    SANDBOX_SETUP,
+    TIMED_OUT,
+    VERIFIER_DEP_INSTALL,
+    VERIFIER_TIMEOUT,
+    classify_error,
+    classify_verifier_error,
+)
+
+RESULT_DIAGNOSTIC_FIELDS = (
+    "idle_timeout_info",
+    "sandbox_startup_info",
+    "transport_error_info",
+    "verifier_timeout_info",
+)
+
+INFRA_ERROR_CATEGORIES = {
+    INSTALL_FAILED,
+    TIMED_OUT,
+    IDLE_TIMEOUT,
+    PIPE_CLOSED,
+    SANDBOX_SETUP,
+    INFRA_ERROR,
+}
+
+VERIFIER_DIAGNOSTIC_CATEGORIES = {
+    VERIFIER_DEP_INSTALL,
+    VERIFIER_TIMEOUT,
+}
+
+
+def serialize_flat_diagnostics(
+    *,
+    error: str | None,
+    verifier_error: str | None,
+    idle_timeout_info: dict | None = None,
+    sandbox_startup_info: dict | None = None,
+    transport_error_info: dict | None = None,
+    verifier_timeout_info: dict | None = None,
+) -> dict[str, Any]:
+    """Return the legacy flat diagnostic fields for result.json."""
+    return {
+        "error_category": classify_error(error),
+        "verifier_error_category": classify_verifier_error(verifier_error),
+        "idle_timeout_info": idle_timeout_info,
+        "sandbox_startup_info": sandbox_startup_info,
+        "transport_error_info": transport_error_info,
+        "verifier_timeout_info": verifier_timeout_info,
+    }
+
+
+def diagnostic_category_counts(
+    results: Iterable[Mapping[str, Any]],
+) -> tuple[dict[str, int], dict[str, int]]:
+    """Count agent and verifier diagnostic categories across result payloads."""
+    error_category_counts: dict[str, int] = {}
+    verifier_error_category_counts: dict[str, int] = {}
+    for result in results:
+        category = classify_error(result.get("error"))
+        if category:
+            error_category_counts[category] = (
+                error_category_counts.get(category, 0) + 1
+            )
+        verifier_category = classify_verifier_error(result.get("verifier_error"))
+        if verifier_category:
+            verifier_error_category_counts[verifier_category] = (
+                verifier_error_category_counts.get(verifier_category, 0) + 1
+            )
+    return error_category_counts, verifier_error_category_counts
+
+
+@dataclass(frozen=True)
+class SummaryWarningSpec:
+    source: Literal["agent", "verifier"]
+    category: str
+    template: str
+
+
+SUMMARY_WARNING_SPECS = (
+    SummaryWarningSpec(
+        source="agent",
+        category=IDLE_TIMEOUT,
+        template=(
+            "{count} tasks ({pct:.0f}%) hit idle timeout — "
+            "check idle_timeout_info in result.json for diagnostics"
+        ),
+    ),
+    SummaryWarningSpec(
+        source="agent",
+        category=SANDBOX_SETUP,
+        template=(
+            "{count} tasks ({pct:.0f}%) failed during sandbox startup — "
+            "check sandbox_startup_info in result.json for diagnostics"
+        ),
+    ),
+    SummaryWarningSpec(
+        source="agent",
+        category=PIPE_CLOSED,
+        template=(
+            "{count} tasks ({pct:.0f}%) lost transport (pipe closed / rc=255) — "
+            "check transport_error_info in result.json for diagnostics"
+        ),
+    ),
+    SummaryWarningSpec(
+        source="verifier",
+        category=VERIFIER_DEP_INSTALL,
+        template=(
+            "{count} tasks ({pct:.0f}%) failed during verifier dependency install — "
+            "check verifier_error_category in result.json and fix the task's index policy"
+        ),
+    ),
+    SummaryWarningSpec(
+        source="verifier",
+        category=VERIFIER_TIMEOUT,
+        template=(
+            "{count} tasks ({pct:.0f}%) had verifier timeouts — "
+            "check verifier_timeout_info in result.json for budget/elapsed details"
+        ),
+    ),
+)
+
+
+def summary_diagnostic_warnings(
+    *,
+    total: int,
+    error_category_counts: Mapping[str, int],
+    verifier_error_category_counts: Mapping[str, int],
+) -> list[str]:
+    """Render job-level warning messages from diagnostic category counts."""
+    messages: list[str] = []
+    for spec in SUMMARY_WARNING_SPECS:
+        counts = (
+            verifier_error_category_counts
+            if spec.source == "verifier"
+            else error_category_counts
+        )
+        count = counts.get(spec.category, 0)
+        if count:
+            pct = count / total * 100 if total else 0
+            messages.append(spec.template.format(count=count, pct=pct))
+    return messages
+
+
+def agent_infra_category(result: Mapping[str, Any]) -> str | None:
+    """Return the invalidating agent-side infra category for a result."""
+    error = result.get("error")
+    category = classify_error(str(error)) if error else None
+    if category in INFRA_ERROR_CATEGORIES:
+        return category
+    return None
+
+
+def verifier_diagnostic_category(result: Mapping[str, Any]) -> str | None:
+    """Return the invalidating verifier-side diagnostic category for a result."""
+    verifier_error = result.get("verifier_error")
+    category = classify_verifier_error(verifier_error) if verifier_error else None
+    if category in VERIFIER_DIAGNOSTIC_CATEGORIES:
+        return category
+    return None
+
+
+def _task_name(result: Mapping[str, Any]) -> str:
+    return str(result.get("task_name", "?"))
+
+
+def _info(result: Mapping[str, Any], field: str) -> Mapping[str, Any] | None:
+    value = result.get(field)
+    return value if isinstance(value, Mapping) else None
+
+
+def _idle_timeout_issue(task: str, result: Mapping[str, Any]) -> str:
+    info = _info(result, "idle_timeout_info")
+    if not info:
+        return f"{task}: {result.get('error')}"
+    return (
+        f"{task}: idle timeout after {info.get('idle_duration_sec', '?')}s idle "
+        f"({info.get('n_tool_calls', '?')} tool calls, "
+        f"{info.get('wall_clock_elapsed_sec', '?')}s wall)"
+    )
+
+
+def _sandbox_startup_issue(task: str, result: Mapping[str, Any]) -> str:
+    info = _info(result, "sandbox_startup_info")
+    if not info:
+        return f"{task}: {result.get('error')}"
+    return (
+        f"{task}: sandbox startup failed (sandbox_id={info.get('sandbox_id', '?')}, "
+        f"state={info.get('sandbox_state', '?')}, attempts={info.get('attempts', '?')}, "
+        f"build_timeout_sec={info.get('build_timeout_sec', '?')})"
+    )
+
+
+def _transport_issue(task: str, result: Mapping[str, Any]) -> str:
+    info = _info(result, "transport_error_info")
+    if not info:
+        return f"{task}: {result.get('error')}"
+    return (
+        f"{task}: transport closed (rc={info.get('process_exit_code', '?')}, "
+        f"diagnosis={info.get('transport_diagnosis', '?')}, "
+        f"sandbox_reachable={info.get('sandbox_reachable', '?')})"
+    )
+
+
+_AGENT_ISSUE_RENDERERS = {
+    IDLE_TIMEOUT: _idle_timeout_issue,
+    SANDBOX_SETUP: _sandbox_startup_issue,
+    PIPE_CLOSED: _transport_issue,
+}
+
+_AGENT_INVALIDATION_TEMPLATES = {
+    IDLE_TIMEOUT: (
+        "INVALIDATED: {count} task(s) hit idle timeout and should be rerun: {tasks}"
+    ),
+    SANDBOX_SETUP: (
+        "INVALIDATED: {count} task(s) failed during sandbox startup and should "
+        "be rerun: {tasks}"
+    ),
+    PIPE_CLOSED: (
+        "INVALIDATED: {count} task(s) lost ACP transport (pipe closed / rc=255) "
+        "and should be rerun: {tasks}"
+    ),
+}
+
+
+def format_agent_infra_issue(result: Mapping[str, Any], category: str) -> str:
+    """Render the checker issue line for an agent-side infra diagnostic."""
+    renderer = _AGENT_ISSUE_RENDERERS.get(category)
+    if renderer is None:
+        return f"{_task_name(result)}: {result.get('error')}"
+    return renderer(_task_name(result), result)
+
+
+def format_agent_invalidation_messages(
+    tasks_by_category: Mapping[str, list[str]],
+) -> list[str]:
+    return _format_invalidation_messages(tasks_by_category, _AGENT_INVALIDATION_TEMPLATES)
+
+
+def _verifier_dep_install_issue(task: str, result: Mapping[str, Any]) -> str:
+    return (
+        f"{task}: verifier dependency install failed — "
+        f"measurement invalid (verifier never reached tests)"
+    )
+
+
+def _verifier_timeout_issue(task: str, result: Mapping[str, Any]) -> str:
+    info = _info(result, "verifier_timeout_info")
+    budget = info.get("timeout_budget_sec", "?") if info else "?"
+    elapsed = info.get("elapsed_sec", "?") if info else "?"
+    return (
+        f"{task}: verifier timed out (budget={budget}s, elapsed={elapsed}s) — "
+        f"measurement invalid (verifier never produced reward)"
+    )
+
+
+_VERIFIER_ISSUE_RENDERERS = {
+    VERIFIER_DEP_INSTALL: _verifier_dep_install_issue,
+    VERIFIER_TIMEOUT: _verifier_timeout_issue,
+}
+
+_VERIFIER_INVALIDATION_TEMPLATES = {
+    VERIFIER_DEP_INSTALL: (
+        "INVALIDATED: {count} task(s) failed during verifier dependency install "
+        "and should be rerun after fixing the index policy: {tasks}"
+    ),
+    VERIFIER_TIMEOUT: (
+        "INVALIDATED: {count} task(s) had verifier timeouts — increase timeout_sec "
+        "or reduce verifier cost: {tasks}"
+    ),
+}
+
+
+def format_verifier_diagnostic_issue(result: Mapping[str, Any], category: str) -> str:
+    renderer = _VERIFIER_ISSUE_RENDERERS[category]
+    return renderer(_task_name(result), result)
+
+
+def format_verifier_invalidation_messages(
+    tasks_by_category: Mapping[str, list[str]],
+) -> list[str]:
+    return _format_invalidation_messages(
+        tasks_by_category, _VERIFIER_INVALIDATION_TEMPLATES
+    )
+
+
+def _format_invalidation_messages(
+    tasks_by_category: Mapping[str, list[str]],
+    templates: Mapping[str, str],
+) -> list[str]:
+    messages: list[str] = []
+    for category, template in templates.items():
+        tasks = tasks_by_category.get(category)
+        if tasks:
+            messages.append(
+                template.format(count=len(tasks), tasks=", ".join(tasks))
+            )
+    return messages

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -24,6 +24,10 @@ from typing import Any
 
 import yaml
 
+from benchflow._utils.diagnostics import (
+    diagnostic_category_counts,
+    summary_diagnostic_warnings,
+)
 from benchflow._utils.evaluation_results import (
     rollout_result_payload,
     usage_summary,
@@ -42,8 +46,6 @@ from benchflow._utils.scoring import (
     INFRA_ERROR,
     INSTALL_FAILED,
     PIPE_CLOSED,
-    SANDBOX_SETUP,
-    VERIFIER_DEP_INSTALL,
     VERIFIER_INFRA,
     VERIFIER_TIMEOUT,
     classify_error,
@@ -1186,18 +1188,9 @@ class Evaluation:
             f"{job_result.verifier_errored} != {job_result.total}"
         )
 
-        # Count error categories across all results for summary diagnostics.
-        error_category_counts: dict[str, int] = {}
-        verifier_error_category_counts: dict[str, int] = {}
-        for r in all_results.values():
-            cat = classify_error(r.get("error"))
-            if cat:
-                error_category_counts[cat] = error_category_counts.get(cat, 0) + 1
-            vcat = classify_verifier_error(r.get("verifier_error"))
-            if vcat:
-                verifier_error_category_counts[vcat] = (
-                    verifier_error_category_counts.get(vcat, 0) + 1
-                )
+        error_category_counts, verifier_error_category_counts = (
+            diagnostic_category_counts(all_results.values())
+        )
 
         # Save summary
         summary = {
@@ -1255,45 +1248,13 @@ class Evaluation:
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Job-level trainer artifact aggregation failed: %s", e)
 
+        for message in summary_diagnostic_warnings(
+            total=job_result.total,
+            error_category_counts=error_category_counts,
+            verifier_error_category_counts=verifier_error_category_counts,
+        ):
+            logger.warning(message)
         idle_count = error_category_counts.get(IDLE_TIMEOUT, 0)
-        if idle_count > 0:
-            pct = idle_count / job_result.total * 100
-            logger.warning(
-                f"{idle_count} tasks ({pct:.0f}%) hit idle timeout — "
-                f"check idle_timeout_info in result.json for diagnostics"
-            )
-
-        sandbox_count = error_category_counts.get(SANDBOX_SETUP, 0)
-        if sandbox_count > 0:
-            pct = sandbox_count / job_result.total * 100
-            logger.warning(
-                f"{sandbox_count} tasks ({pct:.0f}%) failed during sandbox startup — "
-                f"check sandbox_startup_info in result.json for diagnostics"
-            )
-
-        pipe_count = error_category_counts.get(PIPE_CLOSED, 0)
-        if pipe_count > 0:
-            pct = pipe_count / job_result.total * 100
-            logger.warning(
-                f"{pipe_count} tasks ({pct:.0f}%) lost transport (pipe closed / rc=255) — "
-                f"check transport_error_info in result.json for diagnostics"
-            )
-        dep_install_count = verifier_error_category_counts.get(VERIFIER_DEP_INSTALL, 0)
-        if dep_install_count > 0:
-            pct = dep_install_count / job_result.total * 100
-            logger.warning(
-                f"{dep_install_count} tasks ({pct:.0f}%) failed during verifier "
-                f"dependency install — check verifier_error_category in result.json "
-                f"and fix the task's index policy"
-            )
-
-        verifier_timeout_count = verifier_error_category_counts.get(VERIFIER_TIMEOUT, 0)
-        if verifier_timeout_count > 0:
-            pct = verifier_timeout_count / job_result.total * 100
-            logger.warning(
-                f"{verifier_timeout_count} tasks ({pct:.0f}%) had verifier timeouts — "
-                f"check verifier_timeout_info in result.json for budget/elapsed details"
-            )
         if audit_counts["verifier_errored"] > 0:
             pct = audit_counts["verifier_errored"] / job_result.total * 100
             logger.warning(

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -51,7 +51,7 @@ from typing import Any
 
 from benchflow._types import Role, Scene, Turn
 from benchflow._utils.config import normalize_agent_name, normalize_sandbox_user
-from benchflow._utils.scoring import classify_error, classify_verifier_error
+from benchflow._utils.diagnostics import serialize_flat_diagnostics
 from benchflow.acp.client import ACPClient, ACPError
 from benchflow.acp.runtime import connect_acp, execute_prompts
 from benchflow.agents.credentials import (
@@ -451,6 +451,10 @@ def _parse_transport_error(e: ConnectionError) -> dict:
     """
     import re as _re
 
+    structured = getattr(e, "transport_error_info", None)
+    if isinstance(structured, dict):
+        return dict(structured)
+
     msg = str(e)
     info: dict[str, Any] = {"reason": "transport_closed", "raw_message": msg[:500]}
 
@@ -576,16 +580,16 @@ def _build_rollout_result(
                     "price_source": result.price_source,
                 },
                 "error": result.error,
-                "error_category": classify_error(result.error),
                 "verifier_error": result.verifier_error,
-                "verifier_error_category": classify_verifier_error(
-                    result.verifier_error
-                ),
                 "export_error": result.export_error,
-                "idle_timeout_info": idle_timeout_info,
-                "sandbox_startup_info": sandbox_startup_info,
-                "transport_error_info": transport_error_info,
-                "verifier_timeout_info": verifier_timeout_info,
+                **serialize_flat_diagnostics(
+                    error=result.error,
+                    verifier_error=result.verifier_error,
+                    idle_timeout_info=idle_timeout_info,
+                    sandbox_startup_info=sandbox_startup_info,
+                    transport_error_info=transport_error_info,
+                    verifier_timeout_info=verifier_timeout_info,
+                ),
                 "partial_trajectory": result.partial_trajectory,
                 "trajectory_source": result.trajectory_source,
                 "started_at": str(result.started_at),
@@ -842,7 +846,7 @@ async def _verify_rollout(
         verifier_timeout_info = {
             "timeout_budget_sec": timeout_budget,
             "elapsed_sec": round(elapsed, 1),
-            "task_name": task.config.name,
+            "task_name": task.name,
         }
         rewards = None
         logger.error(verifier_error)
@@ -2560,7 +2564,11 @@ class Rollout:
                 self._transport_error_info["sandbox_probe_rc"] = rc
                 self._transport_error_info["sandbox_probe_stdout"] = stdout[:200]
         except Exception as probe_err:
+            logger.debug("sandbox health probe failed", exc_info=True)
             self._transport_error_info["sandbox_reachable"] = False
+            self._transport_error_info["sandbox_probe_error_type"] = type(
+                probe_err
+            ).__name__
             self._transport_error_info["sandbox_probe_error"] = str(probe_err)[:200]
 
     def _classify_acp_error(self, e: ACPError) -> str:

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -26,6 +26,32 @@ _BOOTSTRAP_DONE = "__BENCHFLOW_BOOTSTRAP_DONE__"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+class TransportClosedError(ConnectionError):
+    """ConnectionError carrying stable transport diagnostics for result.json."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        process_exit_code: int | None = None,
+        process_pid: int | None = None,
+        transport_diagnosis: str = "unknown",
+        stderr_snippet: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        info: dict[str, Any] = {
+            "reason": "transport_closed",
+            "raw_message": message[:500],
+            "process_exit_code": process_exit_code,
+            "transport_diagnosis": transport_diagnosis,
+        }
+        if process_pid is not None:
+            info["process_pid"] = process_pid
+        if stderr_snippet:
+            info["stderr_snippet"] = stderr_snippet[:500]
+        self.transport_error_info = info
+
+
 async def _cleanup_daytona_remote_env_file(
     sandbox: Any,
     remote_env_path: str,
@@ -140,7 +166,15 @@ class LiveProcess(ABC):
             msg = f"Process closed stdout (rc={rc}): {hint}"
             if stderr_text:
                 msg += f"\nstderr: {stderr_text[:_DIAG_TRUNCATE]}"
-            raise ConnectionError(msg)
+            raise TransportClosedError(
+                msg,
+                process_exit_code=rc,
+                process_pid=pid,
+                transport_diagnosis=(
+                    "remote_session_killed" if rc is None else "process_exited"
+                ),
+                stderr_snippet=stderr_text or None,
+            )
         return line
 
     async def writeline(self, data: str) -> None:
@@ -727,14 +761,23 @@ class DaytonaPtyProcess(LiveProcess):
 
     async def readline(self) -> bytes:
         if self._closed:
-            raise ConnectionError("PTY closed")
+            raise TransportClosedError(
+                "PTY closed",
+                transport_diagnosis="pty_error",
+            )
         try:
             line = await asyncio.wait_for(self._line_buffer.get(), timeout=900)
             return line
         except TimeoutError as e:
-            raise ConnectionError("PTY readline timeout (900s)") from e
+            raise TransportClosedError(
+                "PTY readline timeout (900s)",
+                transport_diagnosis="pty_error",
+            ) from e
         except Exception as e:
-            raise ConnectionError(f"PTY readline error: {e}") from e
+            raise TransportClosedError(
+                f"PTY readline error: {e}",
+                transport_diagnosis="pty_error",
+            ) from e
 
     async def writeline(self, data: str) -> None:
         if not self._pty or self._closed:

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -26,12 +26,16 @@ from pathlib import Path
 from typing import Any, cast
 
 from benchflow._utils.config import normalize_agent_idle_timeout
-from benchflow._utils.reward_events import memory_score_from_result
-from benchflow._utils.scoring import (
-    classify_error,
-    classify_verifier_error,
-    count_result_outcomes,
+from benchflow._utils.diagnostics import (
+    agent_infra_category,
+    format_agent_infra_issue,
+    format_agent_invalidation_messages,
+    format_verifier_diagnostic_issue,
+    format_verifier_invalidation_messages,
+    verifier_diagnostic_category,
 )
+from benchflow._utils.reward_events import memory_score_from_result
+from benchflow._utils.scoring import count_result_outcomes
 from benchflow._utils.source_provenance import source_issues, source_matches_parent
 
 EXPECTED: dict[str, Any] = {}
@@ -53,16 +57,6 @@ SUMMARY_REQUIRED = {
     "verifier_errored",
     "score",
 }
-INFRA_ERROR_CATEGORIES = {
-    "install_failure",
-    "timeout",
-    "idle_timeout",
-    "pipe_closed",
-    "sandbox_setup",
-    "infra_failure",
-}
-
-
 def load_results(agent_dir: Path) -> tuple[list[tuple[Path, dict]], list[str]]:
     """Load every result.json from an agent's jobs directory."""
     results: list[tuple[Path, dict]] = []
@@ -508,119 +502,32 @@ def check_agent(agent_dir: Path) -> dict:
 
     # Infrastructure errors
     infra_errors = []
-    idle_timeout_tasks: list[str] = []
-    sandbox_startup_tasks: list[str] = []
-    transport_error_tasks: list[str] = []
+    agent_invalidation_tasks: dict[str, list[str]] = {}
     for r in results:
-        err = r.get("error")
-        cat = classify_error(str(err)) if err else None
-        if cat and cat in INFRA_ERROR_CATEGORIES:
+        cat = agent_infra_category(r)
+        if cat:
             task = r.get("task_name", "?")
-            if cat == "idle_timeout":
-                info = r.get("idle_timeout_info")
-                if info:
-                    infra_errors.append(
-                        f"{task}: idle timeout after "
-                        f"{info.get('idle_duration_sec', '?')}s idle "
-                        f"({info.get('n_tool_calls', '?')} tool calls, "
-                        f"{info.get('wall_clock_elapsed_sec', '?')}s wall)"
-                    )
-                else:
-                    infra_errors.append(f"{task}: {err}")
-                idle_timeout_tasks.append(task)
-            elif cat == "sandbox_setup":
-                sinfo = r.get("sandbox_startup_info")
-                if sinfo:
-                    sid = sinfo.get("sandbox_id", "?")
-                    state = sinfo.get("sandbox_state", "?")
-                    attempts = sinfo.get("attempts", "?")
-                    build_to = sinfo.get("build_timeout_sec", "?")
-                    infra_errors.append(
-                        f"{task}: sandbox startup failed (sandbox_id={sid}, "
-                        f"state={state}, attempts={attempts}, "
-                        f"build_timeout_sec={build_to})"
-                    )
-                else:
-                    infra_errors.append(f"{task}: {err}")
-                sandbox_startup_tasks.append(task)
-            elif cat == "pipe_closed":
-                tinfo = r.get("transport_error_info")
-                if tinfo:
-                    rc = tinfo.get("process_exit_code", "?")
-                    diag = tinfo.get("transport_diagnosis", "?")
-                    reachable = tinfo.get("sandbox_reachable", "?")
-                    infra_errors.append(
-                        f"{task}: transport closed (rc={rc}, "
-                        f"diagnosis={diag}, sandbox_reachable={reachable})"
-                    )
-                else:
-                    infra_errors.append(f"{task}: {err}")
-                transport_error_tasks.append(task)
-            else:
-                infra_errors.append(f"{task}: {err}")
+            infra_errors.append(format_agent_infra_issue(r, cat))
+            agent_invalidation_tasks.setdefault(cat, []).append(str(task))
     if infra_errors:
         findings["issues"].extend(infra_errors)
         findings["ok"] = False
-    if idle_timeout_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(idle_timeout_tasks)} task(s) hit idle timeout "
-            f"and should be rerun: {', '.join(idle_timeout_tasks)}"
-        )
-    if sandbox_startup_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(sandbox_startup_tasks)} task(s) failed during "
-            f"sandbox startup and should be rerun: "
-            f"{', '.join(sandbox_startup_tasks)}"
-        )
-    if transport_error_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(transport_error_tasks)} task(s) lost ACP transport "
-            f"(pipe closed / rc=255) and should be rerun: "
-            f"{', '.join(transport_error_tasks)}"
-        )
+    findings["issues"].extend(
+        format_agent_invalidation_messages(agent_invalidation_tasks)
+    )
 
-    # Verifier dependency install failures (ENG-151)
-    dep_install_tasks: list[str] = []
+    # Invalidating verifier diagnostics (ENG-151 / ENG-152)
+    verifier_invalidation_tasks: dict[str, list[str]] = {}
     for r in results:
-        verifier_err = r.get("verifier_error")
-        vcat = classify_verifier_error(verifier_err) if verifier_err else None
-        if vcat == "verifier_dep_install":
+        vcat = verifier_diagnostic_category(r)
+        if vcat:
             task = r.get("task_name", "?")
-            dep_install_tasks.append(task)
-            findings["issues"].append(
-                f"{task}: verifier dependency install failed — "
-                f"measurement invalid (verifier never reached tests)"
-            )
+            verifier_invalidation_tasks.setdefault(vcat, []).append(str(task))
+            findings["issues"].append(format_verifier_diagnostic_issue(r, vcat))
             findings["ok"] = False
-    if dep_install_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(dep_install_tasks)} task(s) failed during "
-            f"verifier dependency install and should be rerun after "
-            f"fixing the index policy: {', '.join(dep_install_tasks)}"
-        )
-
-    # Verifier timeout failures (ENG-152)
-    verifier_timeout_tasks: list[str] = []
-    for r in results:
-        verifier_err = r.get("verifier_error")
-        vcat = classify_verifier_error(verifier_err) if verifier_err else None
-        if vcat == "verifier_timeout":
-            task = r.get("task_name", "?")
-            vti = r.get("verifier_timeout_info")
-            budget = vti.get("timeout_budget_sec", "?") if vti else "?"
-            elapsed = vti.get("elapsed_sec", "?") if vti else "?"
-            verifier_timeout_tasks.append(task)
-            findings["issues"].append(
-                f"{task}: verifier timed out (budget={budget}s, elapsed={elapsed}s) — "
-                f"measurement invalid (verifier never produced reward)"
-            )
-            findings["ok"] = False
-    if verifier_timeout_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(verifier_timeout_tasks)} task(s) had verifier "
-            f"timeouts — increase timeout_sec or reduce verifier cost: "
-            f"{', '.join(verifier_timeout_tasks)}"
-        )
+    findings["issues"].extend(
+        format_verifier_invalidation_messages(verifier_invalidation_tasks)
+    )
 
     # Summary.json — bench eval create writes it at the agent_dir root
     summary_path = agent_dir / "summary.json"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -980,7 +980,7 @@ class TestTransportErrorDiagnostics:
         assert info["reason"] == "transport_closed"
 
     def test_typed_transport_error_survives_message_wording_change(self) -> None:
-        """Guards the fix from PR TBD against #504: transport diagnostics must
+        """Guards the fix from PR #509 against #504: transport diagnostics must
         not depend on parsing human-readable process error text."""
         from benchflow.rollout import _parse_transport_error
         from benchflow.sandbox.process import TransportClosedError
@@ -1005,7 +1005,7 @@ class TestTransportErrorDiagnostics:
     async def test_probe_sandbox_health_logs_traceback_and_error_type(
         self, caplog
     ) -> None:
-        """Guards the fix from PR TBD against #502: sandbox health probe
+        """Guards the fix from PR #509 against #502: sandbox health probe
         failures keep traceback logs and a structured exception type."""
         from benchflow.rollout import Rollout
 
@@ -1240,7 +1240,7 @@ class TestVerifierTimeoutDiagnostics:
     async def test_verify_rollout_timeout_uses_task_name(
         self, tmp_path: Path, monkeypatch
     ) -> None:
-        """Guards the fix from PR TBD against #495: verifier timeout handling
+        """Guards the fix from PR #509 against #495: verifier timeout handling
         reads Task.name instead of the absent TaskConfig.name field."""
         from benchflow.rollout import _verify_rollout
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1,8 +1,10 @@
 """Tests for ACP client ↔ mock agent — Step 10."""
 
 import asyncio
+import logging
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -977,6 +979,64 @@ class TestTransportErrorDiagnostics:
         assert info["transport_diagnosis"] == "unknown"
         assert info["reason"] == "transport_closed"
 
+    def test_typed_transport_error_survives_message_wording_change(self) -> None:
+        """Guards the fix from PR TBD against #504: transport diagnostics must
+        not depend on parsing human-readable process error text."""
+        from benchflow.rollout import _parse_transport_error
+        from benchflow.sandbox.process import TransportClosedError
+
+        err = TransportClosedError(
+            "Process stdout ended: local process used different text for exit code 255",
+            process_exit_code=255,
+            process_pid=12345,
+            transport_diagnosis="process_exited",
+            stderr_snippet="Connection to sandbox lost",
+        )
+
+        info = _parse_transport_error(err)
+
+        assert info["reason"] == "transport_closed"
+        assert info["process_exit_code"] == 255
+        assert info["process_pid"] == 12345
+        assert info["transport_diagnosis"] == "process_exited"
+        assert info["stderr_snippet"] == "Connection to sandbox lost"
+
+    @pytest.mark.asyncio
+    async def test_probe_sandbox_health_logs_traceback_and_error_type(
+        self, caplog
+    ) -> None:
+        """Guards the fix from PR TBD against #502: sandbox health probe
+        failures keep traceback logs and a structured exception type."""
+        from benchflow.rollout import Rollout
+
+        class ExplodingEnv:
+            async def exec(self, *args, **kwargs):
+                raise RuntimeError("probe backend exploded")
+
+        rollout = Rollout.__new__(Rollout)
+        rollout._transport_error_info = {"reason": "transport_closed"}
+        rollout._env = ExplodingEnv()
+
+        with caplog.at_level(logging.DEBUG, logger="benchflow.rollout"):
+            await rollout._probe_sandbox_health()
+
+        assert rollout._transport_error_info["sandbox_reachable"] is False
+        assert (
+            rollout._transport_error_info["sandbox_probe_error_type"] == "RuntimeError"
+        )
+        assert (
+            rollout._transport_error_info["sandbox_probe_error"]
+            == "probe backend exploded"
+        )
+        probe_logs = [
+            record
+            for record in caplog.records
+            if record.name == "benchflow.rollout"
+            and record.getMessage() == "sandbox health probe failed"
+        ]
+        assert probe_logs
+        assert probe_logs[0].exc_info
+
     def test_transport_error_info_in_result_json(self, tmp_path) -> None:
         """Guards ENG-148: transport_error_info is written to result.json."""
         from benchflow.rollout import _build_rollout_result
@@ -1175,6 +1235,47 @@ class TestVerifierTimeoutDiagnostics:
             classify_verifier_error("verifier crashed: dependency install failed")
             != VERIFIER_TIMEOUT
         )
+
+    @pytest.mark.asyncio
+    async def test_verify_rollout_timeout_uses_task_name(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Guards the fix from PR TBD against #495: verifier timeout handling
+        reads Task.name instead of the absent TaskConfig.name field."""
+        from benchflow.rollout import _verify_rollout
+
+        async def fake_harden_before_verify(*args, **kwargs):
+            return None
+
+        class SlowVerifier:
+            def __init__(self, **kwargs):
+                pass
+
+            async def verify(self):
+                await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            "benchflow.sandbox.lockdown.harden_before_verify",
+            fake_harden_before_verify,
+        )
+        monkeypatch.setattr("benchflow.task.Verifier", SlowVerifier)
+        task = SimpleNamespace(
+            name="quantum-numerical-simulation",
+            config=SimpleNamespace(verifier=SimpleNamespace(timeout_sec=0.001)),
+        )
+        rollout_paths = SimpleNamespace(verifier_dir=tmp_path / "verifier")
+        timing = {}
+
+        rewards, verifier_error, verifier_timeout_info = await _verify_rollout(
+            object(), task, rollout_paths, timing
+        )
+
+        assert rewards is None
+        assert verifier_error == "verifier timed out after 0.001s"
+        assert verifier_timeout_info is not None
+        assert verifier_timeout_info["task_name"] == "quantum-numerical-simulation"
+        assert verifier_timeout_info["timeout_budget_sec"] == 0.001
+        assert "verifier" in timing
 
     def test_verifier_timeout_info_in_result_json(self, tmp_path: Path) -> None:
         """Guards ENG-152: result.json includes verifier_timeout_info when

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -14,7 +14,7 @@ from benchflow._utils.diagnostics import (
 
 
 def test_flat_result_diagnostics_are_serialized_from_one_helper() -> None:
-    """Guards the fix from PR TBD against #503: result.json diagnostic fields
+    """Guards the fix from PR #509 against #503: result.json diagnostic fields
     are serialized through the shared flat diagnostic contract."""
     transport_info = {"reason": "transport_closed"}
     verifier_timeout_info = {"timeout_budget_sec": 60, "elapsed_sec": 60.1}
@@ -37,7 +37,7 @@ def test_flat_result_diagnostics_are_serialized_from_one_helper() -> None:
 
 
 def test_diagnostic_registry_drives_summary_and_checker_rendering() -> None:
-    """Guards the fix from PR TBD against #503: summary warnings and result
+    """Guards the fix from PR #509 against #503: summary warnings and result
     checker diagnostics share one registry instead of parallel branches."""
     transport_result = {
         "task_name": "task-a",

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from benchflow._utils.diagnostics import (
+    agent_infra_category,
+    diagnostic_category_counts,
+    format_agent_infra_issue,
+    format_agent_invalidation_messages,
+    format_verifier_diagnostic_issue,
+    format_verifier_invalidation_messages,
+    serialize_flat_diagnostics,
+    summary_diagnostic_warnings,
+    verifier_diagnostic_category,
+)
+
+
+def test_flat_result_diagnostics_are_serialized_from_one_helper() -> None:
+    """Guards the fix from PR TBD against #503: result.json diagnostic fields
+    are serialized through the shared flat diagnostic contract."""
+    transport_info = {"reason": "transport_closed"}
+    verifier_timeout_info = {"timeout_budget_sec": 60, "elapsed_sec": 60.1}
+
+    payload = serialize_flat_diagnostics(
+        error="Process closed stdout (rc=255)",
+        verifier_error="verifier timed out after 60s",
+        transport_error_info=transport_info,
+        verifier_timeout_info=verifier_timeout_info,
+    )
+
+    assert payload == {
+        "error_category": "pipe_closed",
+        "verifier_error_category": "verifier_timeout",
+        "idle_timeout_info": None,
+        "sandbox_startup_info": None,
+        "transport_error_info": transport_info,
+        "verifier_timeout_info": verifier_timeout_info,
+    }
+
+
+def test_diagnostic_registry_drives_summary_and_checker_rendering() -> None:
+    """Guards the fix from PR TBD against #503: summary warnings and result
+    checker diagnostics share one registry instead of parallel branches."""
+    transport_result = {
+        "task_name": "task-a",
+        "error": "Process closed stdout (rc=255)",
+        "verifier_error": None,
+        "transport_error_info": {
+            "process_exit_code": 255,
+            "transport_diagnosis": "process_exited",
+            "sandbox_reachable": False,
+        },
+    }
+    verifier_timeout_result = {
+        "task_name": "task-b",
+        "error": None,
+        "verifier_error": "verifier timed out after 60s",
+        "verifier_timeout_info": {
+            "timeout_budget_sec": 60,
+            "elapsed_sec": 60.1,
+        },
+    }
+    error_counts, verifier_counts = diagnostic_category_counts(
+        [transport_result, verifier_timeout_result]
+    )
+
+    warnings = summary_diagnostic_warnings(
+        total=2,
+        error_category_counts=error_counts,
+        verifier_error_category_counts=verifier_counts,
+    )
+
+    assert warnings == [
+        "1 tasks (50%) lost transport (pipe closed / rc=255) — "
+        "check transport_error_info in result.json for diagnostics",
+        "1 tasks (50%) had verifier timeouts — "
+        "check verifier_timeout_info in result.json for budget/elapsed details",
+    ]
+    agent_category = agent_infra_category(transport_result)
+    verifier_category = verifier_diagnostic_category(verifier_timeout_result)
+    assert agent_category == "pipe_closed"
+    assert verifier_category == "verifier_timeout"
+    assert (
+        format_agent_infra_issue(transport_result, agent_category)
+        == "task-a: transport closed (rc=255, diagnosis=process_exited, "
+        "sandbox_reachable=False)"
+    )
+    assert (
+        format_verifier_diagnostic_issue(verifier_timeout_result, verifier_category)
+        == "task-b: verifier timed out (budget=60s, elapsed=60.1s) — "
+        "measurement invalid (verifier never produced reward)"
+    )
+    assert format_agent_invalidation_messages({"pipe_closed": ["task-a"]}) == [
+        "INVALIDATED: 1 task(s) lost ACP transport (pipe closed / rc=255) "
+        "and should be rerun: task-a"
+    ]
+    assert format_verifier_invalidation_messages({"verifier_timeout": ["task-b"]}) == [
+        "INVALIDATED: 1 task(s) had verifier timeouts — increase timeout_sec "
+        "or reduce verifier cost: task-b"
+    ]


### PR DESCRIPTION
## Summary

Addresses diagnostics/transport/verifier issues #495, #502, #503, and #504 for `v0.5-integration`.

- fixes verifier timeout handling to record `task.name` without crashing
- adds typed process transport diagnostics and keeps legacy parsing as a fallback
- logs sandbox health probe failures with traceback and stores exception type
- centralizes flat result diagnostics, summary warnings, and check-results rendering

## Validation

- `uv sync --extra dev --locked` passed; importing rollout requires the existing `sandbox-daytona` extra, so local validation also ran `uv sync --extra dev --extra sandbox-daytona --locked`
- `uv run python -m pytest tests/test_acp.py::TestTransportErrorDiagnostics tests/test_acp.py::TestVerifierTimeoutDiagnostics tests/test_diagnostics.py tests/test_integration_check_results.py::test_check_results_flags_transport_error_with_diagnostics tests/test_integration_check_results.py::test_check_results_flags_verifier_timeout tests/test_integration_check_results.py::test_check_results_flags_verifier_dep_install_failure` passed
- `uv run ruff check .` passed
- `uv run ty check src/` passed
- after rebasing onto current `origin/v0.5-integration`, `uv run python -m pytest tests/` passed: 2385 passed, 11 skipped, 1 deselected, 344 warnings

PR remains open for review.
