### PR TITLE
fix: aggregate tool-call and phase-timing metrics in summary.json (#501)

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -10,6 +10,17 @@ from benchflow._utils.reward_events import (
 )
 from benchflow.models import RolloutResult
 
+# Phase keys produced by Rollout (see rollout.py — environment_setup,
+# agent_setup, agent_execution, verifier, total). Kept here so summary
+# aggregation stays in lockstep with the rollout writer.
+_TIMING_PHASES: tuple[str, ...] = (
+    "environment_setup",
+    "agent_setup",
+    "agent_execution",
+    "verifier",
+    "total",
+)
+
 
 def agent_result_from_rollout(result: RolloutResult) -> dict[str, Any]:
     """Return the serialized agent_result block for an in-memory rollout result."""
@@ -92,3 +103,58 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
         ),
         "telemetry_coverage": (len(covered) / len(completed) if completed else 0.0),
     }
+
+
+def _round_secs(value: float) -> float:
+    """Round a duration in seconds to the same precision rollout.py uses."""
+    return round(float(value), 1)
+
+
+def tool_call_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate per-rollout ``n_tool_calls`` across every result in the job.
+
+    Unlike ``usage_summary``, this counts EVERY rollout — including errored
+    and verifier-errored ones — because tool-call cost is paid regardless of
+    whether verification succeeded. Reviewers asking "how many tool calls did
+    this job consume?" want the literal sum, not a success-filtered one.
+    """
+    counts = [int(r.get("n_tool_calls") or 0) for r in results.values()]
+    total = sum(counts)
+    return {
+        "total_tool_calls": total,
+        "avg_tool_calls_per_task": (total / len(counts)) if counts else 0.0,
+        "max_tool_calls_per_task": max(counts) if counts else 0,
+    }
+
+
+def phase_timing_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate per-phase wall-clock timing across every rollout.
+
+    Sums and averages cover any rollout that recorded a ``timing`` block, so
+    reviewers can answer "how much time went to agent vs verifier?" without
+    inspecting each ``result.json``. Phase keys follow ``rollout.py``:
+    ``environment_setup``, ``agent_setup``, ``agent_execution``, ``verifier``,
+    ``total``. The ``timing_coverage`` ratio surfaces when phase data is
+    incomplete (e.g. mocked test runs that don't persist ``timing``).
+    """
+    timings: list[dict[str, float]] = []
+    for r in results.values():
+        t = r.get("timing")
+        if isinstance(t, dict) and t:
+            timings.append(t)
+
+    out: dict[str, Any] = {
+        "timing_coverage": (len(timings) / len(results)) if results else 0.0,
+    }
+    for phase in _TIMING_PHASES:
+        values = [
+            float(t[phase]) for t in timings if isinstance(t.get(phase), (int, float))
+        ]
+        # Phases with no data get a 0.0 sum + null avg/max so downstream
+        # readers can distinguish "ran but cost nothing" from "no data".
+        out[f"{phase}_time_sec"] = _round_secs(sum(values)) if values else 0.0
+        out[f"avg_{phase}_time_sec"] = (
+            _round_secs(sum(values) / len(values)) if values else None
+        )
+        out[f"max_{phase}_time_sec"] = _round_secs(max(values)) if values else None
+    return out

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -25,7 +25,9 @@ from typing import Any
 import yaml
 
 from benchflow._utils.evaluation_results import (
+    phase_timing_summary,
     rollout_result_payload,
+    tool_call_summary,
     usage_summary,
 )
 from benchflow._utils.learner_memory import (
@@ -681,6 +683,37 @@ class Evaluation:
             return str(candidate) if candidate.is_dir() else None
         return skills_dir
 
+    def _enrich_payload_with_persisted_timing(
+        self, payload: dict, result: RolloutResult
+    ) -> None:
+        """Copy ``timing`` from the rollout's on-disk result.json into payload.
+
+        ``RolloutResult`` does not carry phase timing, but the rollout writer
+        (``rollout.py``) persists it under ``rollout_dir/result.json``. Reading
+        it back lets ``phase_timing_summary`` aggregate phase totals for fresh
+        runs (issue #501). Best-effort: legacy SDK paths that mock the writer
+        — or any case where no rollout_name is set — silently leave timing
+        absent rather than crash summary generation.
+        """
+        if "timing" in payload:
+            return
+        rollout_name = getattr(result, "rollout_name", "") or ""
+        if not rollout_name:
+            return
+        rfile = (
+            self._jobs_dir / self._job_name / rollout_name / "result.json"
+        )
+        if not rfile.exists():
+            return
+        try:
+            persisted = json.loads(rfile.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.debug("Could not read persisted timing from %s: %s", rfile, e)
+            return
+        timing = persisted.get("timing")
+        if isinstance(timing, dict):
+            payload["timing"] = timing
+
     async def _run_single_task(
         self, task_dir: Path, cfg: EvaluationConfig
     ) -> RolloutResult:
@@ -1149,12 +1182,18 @@ class Evaluation:
         for task, data in completed.items():
             all_results[task] = data
         for name, result in pairs:
-            all_results[name] = rollout_result_payload(
+            payload = rollout_result_payload(
                 result,
                 source_provenance=cfg.source_provenance,
                 tasks_dir=self._tasks_dir,
                 task_name=name,
             )
+            # ``rollout_result_payload`` is RolloutResult-driven and so cannot
+            # see ``timing`` (it lives only in the persisted result.json).
+            # Pull it from disk so phase-timing aggregates cover fresh pairs
+            # the same way they cover resumed tasks (issue #501).
+            self._enrich_payload_with_persisted_timing(payload, result)
+            all_results[name] = payload
 
         # EvaluationResult is the score/invariant view. summary.json is the
         # audit view consumed by result checkers, so verifier evidence remains
@@ -1225,6 +1264,8 @@ class Evaluation:
             "memory": memory,
             "memory_scores": memory_scores,
             **usage_summary(all_results),
+            **tool_call_summary(all_results),
+            **phase_timing_summary(all_results),
             **summary_source_fields(cfg.source_provenance, all_results),
         }
         # Surface continual-learning provenance — generation, curve — so a

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -603,3 +603,119 @@ class TestJobRunOrchestration:
         assert summary["total_cost_usd"] == 0.003
         assert summary["avg_cost_per_trial_usd"] == 0.0015
         assert summary["telemetry_coverage"] == 2 / 3
+
+    @pytest.mark.asyncio
+    async def test_summary_json_aggregates_tool_calls_and_phase_timing(
+        self, tmp_path
+    ):
+        """Issue #501: summary.json must aggregate per-rollout n_tool_calls and
+        timing so reviewers don't have to inspect each result.json by hand.
+
+        We seed the resume path with three pre-written result.json files that
+        carry known n_tool_calls and timing blocks, then assert the aggregates
+        match by hand-computation. Using the resume path keeps the test free
+        of the rollout writer machinery while still exercising the exact
+        ``all_results`` shape that drives ``phase_timing_summary``.
+        """
+        job = self._make_job(tmp_path, n_tasks=3, concurrency=1)
+        job_dir = job._jobs_dir / job._job_name
+        job_dir.mkdir(parents=True, exist_ok=True)
+
+        seeded = [
+            {
+                "task_name": "task-0",
+                "n_tool_calls": 4,
+                "timing": {
+                    "environment_setup": 1.0,
+                    "agent_setup": 2.0,
+                    "agent_execution": 10.0,
+                    "verifier": 3.0,
+                    "total": 16.0,
+                },
+            },
+            {
+                "task_name": "task-1",
+                "n_tool_calls": 6,
+                "timing": {
+                    "environment_setup": 1.5,
+                    "agent_setup": 2.5,
+                    "agent_execution": 20.0,
+                    "verifier": 5.0,
+                    "total": 29.0,
+                },
+            },
+            {
+                "task_name": "task-2",
+                "n_tool_calls": 2,
+                "timing": {
+                    "environment_setup": 0.5,
+                    "agent_setup": 1.0,
+                    "agent_execution": 4.0,
+                    "verifier": 1.0,
+                    "total": 6.5,
+                },
+            },
+        ]
+        for entry in seeded:
+            rdir = job_dir / entry["task_name"]
+            rdir.mkdir(parents=True, exist_ok=True)
+            (rdir / "result.json").write_text(
+                json.dumps({**entry, "rewards": {"reward": 1.0}}, indent=2)
+            )
+
+        await job.run()
+
+        summary = json.loads((job_dir / "summary.json").read_text())
+        # Tool-call aggregates — counts every rollout regardless of outcome.
+        assert summary["total_tool_calls"] == 12
+        assert summary["avg_tool_calls_per_task"] == pytest.approx(4.0)
+        assert summary["max_tool_calls_per_task"] == 6
+        # Phase totals (sums) — hand-computed from the seeded timing blocks.
+        assert summary["environment_setup_time_sec"] == 3.0
+        assert summary["agent_setup_time_sec"] == 5.5
+        assert summary["agent_execution_time_sec"] == 34.0
+        assert summary["verifier_time_sec"] == 9.0
+        assert summary["total_time_sec"] == 51.5
+        # Averages and maxes round-trip with rollout.py's 0.1s precision.
+        assert summary["avg_verifier_time_sec"] == pytest.approx(3.0)
+        assert summary["max_verifier_time_sec"] == 5.0
+        assert summary["max_agent_execution_time_sec"] == 20.0
+        # Coverage is 1.0 — every rollout reported a timing block.
+        assert summary["timing_coverage"] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_summary_json_phase_timing_handles_missing_blocks(
+        self, tmp_path
+    ):
+        """Mocked rollouts (no timing in RunResult, no rollout_name) must not
+        crash phase_timing_summary — they just lower timing_coverage to 0.0
+        while tool-call aggregation still works.
+        """
+        job = self._make_job(tmp_path, n_tasks=2, concurrency=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(
+            side_effect=[
+                RunResult(
+                    task_name="task-0",
+                    rewards={"reward": 1.0},
+                    n_tool_calls=7,
+                ),
+                RunResult(
+                    task_name="task-1",
+                    rewards={"reward": 1.0},
+                    n_tool_calls=3,
+                ),
+            ]
+        )
+
+        await job.run()
+
+        summary = json.loads((job._jobs_dir / "summary.json").read_text())
+        assert summary["total_tool_calls"] == 10
+        assert summary["max_tool_calls_per_task"] == 7
+        assert summary["timing_coverage"] == 0.0
+        # No data → sums collapse to 0.0 and avg/max are null (distinguishable
+        # from "ran but cost nothing").
+        assert summary["agent_execution_time_sec"] == 0.0
+        assert summary["avg_agent_execution_time_sec"] is None
+        assert summary["max_agent_execution_time_sec"] is None


### PR DESCRIPTION
Fixes #501.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Reporting-only changes to summary aggregation with best-effort disk reads; no change to rollout execution or scoring.
> 
> **Overview**
> **Job-level `summary.json` now rolls up tool usage and phase wall-clock time** so reviewers can see total agent cost and where time went without opening every `result.json` (#501).
> 
> New helpers **`tool_call_summary`** and **`phase_timing_summary`** in `evaluation_results.py` compute totals, averages, and maxes across all rollouts. Tool-call counts include **failed and errored** tasks (unlike token usage, which stays success-filtered). Phase timing follows the same keys as `rollout.py` (`environment_setup`, `agent_setup`, `agent_execution`, `verifier`, `total`), with **`timing_coverage`** when some rollouts lack timing data.
> 
> **`Evaluation.run`** merges those fields into the summary and, for freshly finished rollouts, **best-effort loads `timing` from on-disk `result.json`** via `_enrich_payload_with_persisted_timing`, because `RolloutResult` does not carry phase timing in memory.
> 
> Tests cover seeded resume results with timing blocks and mocked runs with missing timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27f8ed7ae3f428ca22c8150e0e6f7f4801d45e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->