### PR TITLE
Fix artifact provenance, YAML filters, and summary exports

### DIFF
--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -17,6 +17,7 @@ Usage::
 
     LINEAR_API_KEY=... python dashboard/generate.py  # mirror roadmap from Linear
     python dashboard/generate.py --run-tests         # re-run tests, then mirror
+    python dashboard/generate.py --sanitize-credential-names  # review export
     python dashboard/generate.py --allow-missing-linear  # local UI dev only
     python dashboard/generate.py --allow-stale-evidence  # local UI dev only
 
@@ -63,6 +64,10 @@ OUT = DASH / "data.json"
 ARCHITECTURE_MD = DASH / "architecture.md"
 TS_RE = re.compile(r"^\d{4}-\d{2}-\d{2}__\d{2}-\d{2}-\d{2}$")
 JOBS_ROOT_ENV = "BENCHFLOW_DASHBOARD_JOBS_ROOT"
+_CREDENTIAL_ENV_NAME_RE = re.compile(
+    r"\b[A-Z][A-Z0-9_]*(?:API_KEY|ACCESS_TOKEN|AUTH_TOKEN|OAUTH_TOKEN|SECRET|CREDENTIALS?)\b"
+)
+_CREDENTIAL_ENV_PLACEHOLDER = "[credential-env-var]"
 _ROADMAP_MODULE: ModuleType | None = None
 _SCORING_MODULE: ModuleType | None = None
 _REWARD_EVENTS_MODULE: ModuleType | None = None
@@ -77,6 +82,26 @@ def _load_local_module(module_name: str, path: Path) -> ModuleType:
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
+
+
+def _sanitize_credential_names(value):
+    if isinstance(value, str):
+        return _CREDENTIAL_ENV_NAME_RE.sub(_CREDENTIAL_ENV_PLACEHOLDER, value)
+    if isinstance(value, list):
+        return [_sanitize_credential_names(item) for item in value]
+    if isinstance(value, dict):
+        sanitized = {}
+        for key, item in value.items():
+            sanitized_key = _sanitize_credential_names(key)
+            if isinstance(sanitized_key, str):
+                base = sanitized_key
+                suffix = 2
+                while sanitized_key in sanitized:
+                    sanitized_key = f"{base}_{suffix}"
+                    suffix += 1
+            sanitized[sanitized_key] = _sanitize_credential_names(item)
+        return sanitized
+    return value
 
 
 def _load_roadmap_module() -> ModuleType:
@@ -1511,7 +1536,7 @@ def collect_release_evidence(tests: dict) -> dict:
     }
 
 
-def build_data() -> dict:
+def build_data(*, sanitize_credential_names: bool = False) -> dict:
     tests = collect_tests()
     jobs = collect_jobs()
     experiments = collect_experiments()
@@ -1522,7 +1547,7 @@ def build_data() -> dict:
 
     done = sum(1 for c in CONCEPT_MAP["capabilities"] if c["status"] == "shipped")
     all_issues = _roadmap_issues(roadmap)
-    return {
+    data = {
         "generated_at": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
         "summary": {
             "tests": tests["summary"],
@@ -1550,13 +1575,21 @@ def build_data() -> dict:
         "advisories": ADVISORIES,
         "release_evidence": release_evidence,
     }
+    if sanitize_credential_names:
+        return _sanitize_credential_names(data)
+    return data
 
 
 # --------------------------------------------------------------------------
 def main() -> int:
     if "--run-tests" in sys.argv:
         run_suite()
-    data = build_data()
+    sanitize_credential_names = "--sanitize-credential-names" in sys.argv
+    data = (
+        build_data(sanitize_credential_names=True)
+        if sanitize_credential_names
+        else build_data()
+    )
     if (
         data["roadmap"].get("source", {}).get("kind") != "linear-live"
         and "--allow-missing-linear" not in sys.argv
@@ -1592,6 +1625,8 @@ def main() -> int:
     jobs = data["jobs"]
     experiments = data["experiments"]
     print(f"wrote {OUT.relative_to(ROOT)}")
+    if sanitize_credential_names:
+        print("  review export: credential env-var names sanitized")
     print(
         f"  tests: {s['passed']}p/{s['failed']}f/{s['skipped']}s   "
         f"jobs: {jobs['total_tasks']} rollout rows in {len(jobs['groups'])} groups   "

--- a/src/benchflow/_utils/benchmark_repos.py
+++ b/src/benchflow/_utils/benchmark_repos.py
@@ -376,6 +376,13 @@ def _repo_slug_from_git_root(repo_root: Path) -> str | None:
     return None
 
 
+def _git_root_for_path(path: Path) -> Path | None:
+    root = _git_stdout(path, "rev-parse", "--show-toplevel")
+    if not root:
+        return None
+    return Path(root).resolve(strict=False)
+
+
 def infer_task_source_provenance(task_path: Path) -> dict[str, Any] | None:
     """Infer github source provenance for tasks under repo or dataset cache paths."""
     try:
@@ -413,6 +420,33 @@ def infer_task_source_provenance(task_path: Path) -> dict[str, Any] | None:
                 ),
                 "file_hashes": task_file_hashes(task_resolved),
             }
+
+    git_root = _git_root_for_path(task_resolved)
+    if git_root is not None:
+        repo_slug = _repo_slug_from_git_root(git_root)
+        resolved_sha = _git_stdout(git_root, "rev-parse", "HEAD")
+        if repo_slug and resolved_sha:
+            try:
+                rel = task_resolved.relative_to(git_root.resolve(strict=False))
+            except ValueError:
+                rel = None
+            if rel is not None:
+                branch = _git_stdout(git_root, "rev-parse", "--abbrev-ref", "HEAD")
+                requested_ref = branch if branch and branch != "HEAD" else None
+                return {
+                    "type": "github",
+                    "repo": repo_slug,
+                    "requested_ref": requested_ref,
+                    "resolved_sha": resolved_sha,
+                    "path": rel.as_posix(),
+                    "local_path": str(task_resolved),
+                    "dirty": bool(
+                        _git_stdout(
+                            git_root, "status", "--porcelain", "--", rel.as_posix()
+                        )
+                    ),
+                    "file_hashes": task_file_hashes(task_resolved),
+                }
 
     repo_root = _repo_root()
     try:

--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -47,6 +47,7 @@ def rollout_result_payload(
         "verifier_error": result.verifier_error,
         "export_error": result.export_error,
         "n_tool_calls": result.n_tool_calls,
+        "timing": result.timing,
         "agent_result": agent_result_from_rollout(result),
         **(
             {"reward_events": [reward_event_to_dict(event) for event in reward_events]}
@@ -91,4 +92,49 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
             round(total_cost / len(covered), 10) if covered else None
         ),
         "telemetry_coverage": (len(covered) / len(completed) if completed else 0.0),
+    }
+
+
+def _numeric(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    return 0.0
+
+
+def rollout_metrics_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate rollout-level tool-call and phase timing metrics."""
+    total_tasks = len(results)
+
+    def tool_calls(result: dict) -> int:
+        direct = result.get("n_tool_calls")
+        if isinstance(direct, int) and not isinstance(direct, bool):
+            return direct
+        nested = (result.get("agent_result") or {}).get("n_tool_calls")
+        return nested if isinstance(nested, int) and not isinstance(nested, bool) else 0
+
+    def timing_total(field: str) -> float:
+        return round(
+            sum(
+                _numeric((result.get("timing") or {}).get(field))
+                for result in results.values()
+            ),
+            1,
+        )
+
+    agent_setup = timing_total("agent_setup")
+    agent_execution = timing_total("agent_execution")
+    total_tool_calls = sum(tool_calls(result) for result in results.values())
+    return {
+        "total_tool_calls": total_tool_calls,
+        "avg_tool_calls_per_task": (
+            round(total_tool_calls / total_tasks, 2) if total_tasks else 0.0
+        ),
+        "environment_setup_time_sec": timing_total("environment_setup"),
+        "agent_setup_time_sec": agent_setup,
+        "agent_execution_time_sec": agent_execution,
+        "agent_time_sec": round(agent_setup + agent_execution, 1),
+        "verifier_time_sec": timing_total("verifier"),
+        "rollout_time_sec": timing_total("total"),
     }

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -25,6 +25,7 @@ from typing import Any
 import yaml
 
 from benchflow._utils.evaluation_results import (
+    rollout_metrics_summary,
     rollout_result_payload,
     usage_summary,
 )
@@ -70,6 +71,22 @@ logger = logging.getLogger(__name__)
 BENCHFLOW_OWNED_LABEL = "benchflow.owned=true"
 
 _SENTINEL: Any = object()  # default value for _sdk; tests replace with AsyncMock
+
+
+def _task_filter_set(raw: dict[str, Any], *keys: str) -> set[str]:
+    """Parse YAML task-filter fields from singular/plural spellings."""
+    filters: set[str] = set()
+    for key in keys:
+        value = raw.get(key)
+        if value is None:
+            continue
+        if isinstance(value, str):
+            filters.add(value)
+            continue
+        if not isinstance(value, (list, tuple, set)):
+            raise ValueError(f"YAML field {key!r} must be a string or list of strings")
+        filters.update(str(item) for item in value)
+    return filters
 
 
 class EmptyTaskSelectionError(ValueError):
@@ -467,8 +484,8 @@ class Evaluation:
         prompts = raw.get("prompts")
 
         agent_env_raw = raw.get("agent_env", {})
-        exclude = set(raw.get("exclude", []))
-        include = set(raw.get("include", []))
+        exclude = _task_filter_set(raw, "exclude", "excludes")
+        include = _task_filter_set(raw, "include", "includes")
         sandbox_user = raw.get("sandbox_user", "agent")
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
@@ -544,6 +561,8 @@ class Evaluation:
         # Orchestrator
         orch = raw.get("orchestrator", {})
         concurrency = orch.get("n_concurrent_trials", 4)
+        exclude = _task_filter_set(raw, "exclude", "excludes")
+        include = _task_filter_set(raw, "include", "includes")
 
         jobs_dir = Path(raw.get("jobs_dir", "jobs"))
         max_retries = (
@@ -571,6 +590,8 @@ class Evaluation:
             agent_idle_timeout=raw.get(
                 "agent_idle_timeout_sec", raw.get("agent_idle_timeout", 600)
             ),
+            exclude_tasks=exclude,
+            include_tasks=include,
             skill_mode=raw.get("skill_mode", "default"),
             skill_creator_dir=(
                 str(Path(raw["skill_creator_dir"]))
@@ -1225,6 +1246,7 @@ class Evaluation:
             "memory": memory,
             "memory_scores": memory_scores,
             **usage_summary(all_results),
+            **rollout_metrics_summary(all_results),
             **summary_source_fields(cfg.source_provenance, all_results),
         }
         # Surface continual-learning provenance — generation, curve — so a

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -110,6 +110,7 @@ class RolloutResult:
                       the data path that feeds the persistent LearnerStore
                       (capability 5).
         source_provenance: Source repository/ref/file-hash evidence for the task.
+        timing:       Phase timing metrics persisted in result.json.
         started_at:   Wall-clock start time.
         finished_at:  Wall-clock end time.
     """
@@ -141,6 +142,7 @@ class RolloutResult:
         reward_events: list[RewardEvent] | None = None,
         evolved_skills: dict[str, str] | None = None,
         source_provenance: dict[str, Any] | None = None,
+        timing: dict[str, float] | None = None,
         started_at: datetime | None = None,
         finished_at: datetime | None = None,
     ):
@@ -169,6 +171,7 @@ class RolloutResult:
         self.reward_events = reward_events
         self.evolved_skills = evolved_skills
         self.source_provenance = source_provenance
+        self.timing = timing or {}
         self.started_at = started_at
         self.finished_at = finished_at
 

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -516,6 +516,8 @@ def _build_rollout_result(
 ) -> RolloutResult:
     """Build RolloutResult and write result.json, timing.json, prompts.json, trajectory."""
     finished_at = datetime.now()
+    timing["total"] = (finished_at - started_at).total_seconds()
+    timing = {k: round(v, 1) for k, v in timing.items()}
     result = RolloutResult(
         task_name=task_name,
         rollout_name=rollout_name,
@@ -541,11 +543,10 @@ def _build_rollout_result(
         trajectory_source=trajectory_source,
         evolved_skills=evolved_skills,
         source_provenance=source_provenance,
+        timing=timing,
         started_at=started_at,
         finished_at=finished_at,
     )
-    timing["total"] = (finished_at - started_at).total_seconds()
-    timing = {k: round(v, 1) for k, v in timing.items()}
     traj_dir = rollout_dir / "trajectory"
     traj_dir.mkdir(parents=True, exist_ok=True)
     (traj_dir / "acp_trajectory.jsonl").write_text(

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -1415,7 +1415,7 @@ def _write_collectable_rollout(jobs_root: Path) -> Path:
 def test_dashboard_review_export_sanitizes_credential_env_var_names(
     tmp_path: Path, monkeypatch
 ):
-    """Guards the fix from PR #TBD against dashboard artifact noise from #494."""
+    """Guards the fix from PR #513 against dashboard artifact noise from #494."""
     jobs = tmp_path / "jobs"
     rollout = jobs / "2026-05-21__23-57-23" / "task__abc123"
     rollout.mkdir(parents=True)

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -1412,6 +1412,54 @@ def _write_collectable_rollout(jobs_root: Path) -> Path:
     return rollout
 
 
+def test_dashboard_review_export_sanitizes_credential_env_var_names(
+    tmp_path: Path, monkeypatch
+):
+    """Guards the fix from PR #TBD against dashboard artifact noise from #494."""
+    jobs = tmp_path / "jobs"
+    rollout = jobs / "2026-05-21__23-57-23" / "task__abc123"
+    rollout.mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task",
+                "rewards": {"reward": 1.0},
+                "timing": {},
+                "source": {
+                    "repo": "benchflow-ai/skillsbench",
+                    "path": "tasks/task",
+                },
+            }
+        )
+    )
+    (rollout / "config.json").write_text(
+        json.dumps(
+            {
+                "agent": "gemini",
+                "model": "gemini-test",
+                "environment": "daytona",
+                "requires_env": [
+                    "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY",
+                    "DAYTONA_API_KEY",
+                ],
+            }
+        )
+    )
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs))
+
+    raw = json.dumps(generate.collect_jobs())
+    sanitized = json.dumps(generate._sanitize_credential_names(json.loads(raw)))
+
+    assert "GEMINI_API_KEY" in raw
+    assert "GOOGLE_API_KEY" in raw
+    assert "DAYTONA_API_KEY" in raw
+    assert "GEMINI_API_KEY" not in sanitized
+    assert "GOOGLE_API_KEY" not in sanitized
+    assert "DAYTONA_API_KEY" not in sanitized
+    assert "[credential-env-var]" in sanitized
+
+
 def test_dashboard_jobs_root_ignores_stale_remembered_deep_result_json(
     tmp_path: Path, monkeypatch
 ):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -606,7 +606,7 @@ class TestJobRunOrchestration:
 
     @pytest.mark.asyncio
     async def test_summary_json_includes_tool_and_phase_aggregates(self, tmp_path):
-        """Guards the fix from PR #TBD against summary metric omissions from #501."""
+        """Guards the fix from PR #513 against summary metric omissions from #501."""
         job = self._make_job(tmp_path, n_tasks=2, concurrency=1)
         job._sdk = AsyncMock()
         job._sdk.run = AsyncMock(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -603,3 +603,49 @@ class TestJobRunOrchestration:
         assert summary["total_cost_usd"] == 0.003
         assert summary["avg_cost_per_trial_usd"] == 0.0015
         assert summary["telemetry_coverage"] == 2 / 3
+
+    @pytest.mark.asyncio
+    async def test_summary_json_includes_tool_and_phase_aggregates(self, tmp_path):
+        """Guards the fix from PR #TBD against summary metric omissions from #501."""
+        job = self._make_job(tmp_path, n_tasks=2, concurrency=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(
+            side_effect=[
+                RunResult(
+                    task_name="task-0",
+                    rewards={"reward": 1.0},
+                    n_tool_calls=3,
+                    timing={
+                        "environment_setup": 1.0,
+                        "agent_setup": 0.5,
+                        "agent_execution": 4.0,
+                        "verifier": 2.0,
+                        "total": 7.5,
+                    },
+                ),
+                RunResult(
+                    task_name="task-1",
+                    rewards={"reward": 1.0},
+                    n_tool_calls=5,
+                    timing={
+                        "environment_setup": 0.5,
+                        "agent_setup": 1.0,
+                        "agent_execution": 2.0,
+                        "verifier": 1.5,
+                        "total": 5.0,
+                    },
+                ),
+            ]
+        )
+
+        await job.run()
+
+        summary = json.loads((job._jobs_dir / "summary.json").read_text())
+        assert summary["total_tool_calls"] == 8
+        assert summary["avg_tool_calls_per_task"] == 4.0
+        assert summary["environment_setup_time_sec"] == 1.5
+        assert summary["agent_setup_time_sec"] == 1.5
+        assert summary["agent_execution_time_sec"] == 6.0
+        assert summary["agent_time_sec"] == 7.5
+        assert summary["verifier_time_sec"] == 3.5
+        assert summary["rollout_time_sec"] == 12.5

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -325,7 +325,7 @@ def test_task_source_provenance_rejects_task_outside_source_root(tmp_path):
 
 
 def test_task_source_provenance_infers_cached_checkout_git_root(tmp_path, monkeypatch):
-    """Guards the fix from PR #TBD against cached task provenance drift from #492."""
+    """Guards the fix from PR #513 against cached task provenance drift from #492."""
     monkeypatch.chdir(tmp_path)
     repo = tmp_path / ".cache" / "datasets" / "benchflow-ai" / "skillsbench"
     task = repo / "tasks" / "sample-task"

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -1,6 +1,7 @@
 """Tests for benchmark task repository materialization."""
 
 import shutil
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -321,6 +322,56 @@ def test_task_source_provenance_rejects_task_outside_source_root(tmp_path):
 
     with pytest.raises(ValueError, match="outside source"):
         task_source_provenance(provenance, outside_task)
+
+
+def test_task_source_provenance_infers_cached_checkout_git_root(tmp_path, monkeypatch):
+    """Guards the fix from PR #TBD against cached task provenance drift from #492."""
+    monkeypatch.chdir(tmp_path)
+    repo = tmp_path / ".cache" / "datasets" / "benchflow-ai" / "skillsbench"
+    task = repo / "tasks" / "sample-task"
+    task.mkdir(parents=True)
+    (task / "task.toml").write_text("[task]\n")
+    (task / "instruction.md").write_text("Solve it.\n")
+
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=repo, check=True, stdout=subprocess.DEVNULL)
+    subprocess.run(
+        ["git", "checkout", "-b", "main"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@example.com"], cwd=repo, check=True
+    )
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=repo, check=True)
+    subprocess.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/benchflow-ai/skillsbench.git",
+        ],
+        cwd=repo,
+        check=True,
+    )
+    subprocess.run(["git", "add", "tasks"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "commit", "--no-gpg-sign", "-m", "init"],
+        cwd=repo,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
+
+    provenance = task_source_provenance(None, task)
+
+    assert provenance is not None
+    assert provenance["repo"] == "benchflow-ai/skillsbench"
+    assert provenance["requested_ref"] == "main"
+    assert provenance["path"] == "tasks/sample-task"
+    assert provenance["local_path"] == str(task)
+    assert set(provenance["file_hashes"]) == {"instruction.md", "task.toml"}
 
 
 def test_resolve_source_with_metadata_records_canonical_source_path(

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -279,7 +279,7 @@ datasets:
 
 
 def test_legacy_yaml_maps_include_exclude_filters(tmp_path, monkeypatch):
-    """Guards the fix from PR #TBD against legacy YAML filter drops from #500."""
+    """Guards the fix from PR #513 against legacy YAML filter drops from #500."""
     _make_tasks(tmp_path)
     monkeypatch.chdir(tmp_path)
     config = tmp_path / "config.yaml"

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -278,6 +278,30 @@ datasets:
     assert job._config.model == "vllm/Qwen/Qwen3.5-35B-A3B"
 
 
+def test_legacy_yaml_maps_include_exclude_filters(tmp_path, monkeypatch):
+    """Guards the fix from PR #TBD against legacy YAML filter drops from #500."""
+    _make_tasks(tmp_path)
+    monkeypatch.chdir(tmp_path)
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+include:
+  - task-a
+  - task-c
+excludes:
+  - task-c
+agents:
+  - name: oracle
+datasets:
+  - path: tasks
+""")
+
+    job = Evaluation.from_yaml(config)
+
+    assert job._config.include_tasks == {"task-a", "task-c"}
+    assert job._config.exclude_tasks == {"task-c"}
+    assert [task.name for task in job._get_task_dirs()] == ["task-a"]
+
+
 def test_from_legacy_yaml_defaults(tmp_path):
     """Test legacy YAML with minimal config.
 


### PR DESCRIPTION
## Summary
- infer source provenance from cached benchmark git checkouts used via --tasks-dir
- preserve legacy YAML include/exclude filters, including plural spellings
- add summary aggregate tool-call and phase-timing metrics
- add sanitized dashboard review export mode for credential env-var names

## Issues
Addresses #492, #494, #500, #501.

## Validation
- uv sync --extra dev --locked
- uv sync --extra dev --extra sandbox-daytona --locked (local validation extra because v0.5 imports Daytona during package import)
- uv run ruff check .
- uv run ty check src/
- uv run python -m pytest tests/
- provenance smoke: synthetic artifact checked by tests/integration/check_results.py against a real cached SkillsBench checkout
- dashboard smoke: generated --sanitize-credential-names data.json and verified credential env-var names were absent
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/513" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->