### PR TITLE
fix: small bug sweep (#492 #494 #495 #500 #502)

### DIFF
--- a/dashboard/generate.py
+++ b/dashboard/generate.py
@@ -452,6 +452,55 @@ def _lang_for(p: Path) -> str:
     return _LANG.get(p.suffix.lower(), "text")
 
 
+# Credential-rule env var names that secret scanners flag on sight. We never
+# embed their *values* in data.json, but reviewer artifacts (agent configs,
+# rollout logs, etc.) frequently mention the variable *names*, which is
+# enough to trip naive scanners and create artifact-sharing noise (#494).
+# These are well-known agent credential rule names — not secrets, just the
+# names the rules look for.
+_CREDENTIAL_ENV_VAR_NAMES = frozenset(
+    {
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "AWS_BEARER_TOKEN_BEDROCK",
+        "AZURE_API_KEY",
+        "BENCHFLOW_PROVIDER_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CODEX_ACCESS_TOKEN",
+        "CODEX_API_KEY",
+        "DAYTONA_API_KEY",
+        "DEEPSEEK_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GENERATIVE_AI_API_KEY",
+        "GROQ_API_KEY",
+        "HUGGINGFACE_API_KEY",
+        "LINEAR_API_KEY",
+        "LLM_API_KEY",
+        "MODAL_TOKEN_ID",
+        "MODAL_TOKEN_SECRET",
+        "MORPH_API_KEY",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "TOGETHER_API_KEY",
+        "XAI_API_KEY",
+    }
+)
+_CREDENTIAL_ENV_VAR_PATTERN = re.compile(
+    r"\b(" + "|".join(sorted(re.escape(n) for n in _CREDENTIAL_ENV_VAR_NAMES)) + r")\b"
+)
+
+
+def _scrub_credential_env_names(text: str) -> str:
+    """Mask credential-rule env var *names* in embedded artifact content.
+
+    Replaces each occurrence with ``<CREDENTIAL_ENV>`` so artifact-sharing
+    pipelines do not flag the unredacted name. We do not touch values — none
+    are ever embedded in the first place.
+    """
+    return _CREDENTIAL_ENV_VAR_PATTERN.sub("<CREDENTIAL_ENV>", text)
+
+
 def _file_payload(p: Path) -> tuple[str | None, int, bool, str]:
     """Read a text file, capped. Returns (content, total_lines, truncated, lang).
 
@@ -480,6 +529,7 @@ def _file_payload(p: Path) -> tuple[str | None, int, bool, str]:
     if len(text) > _MAX_BYTES:
         text = text[:_MAX_BYTES]
         truncated = True
+    text = _scrub_credential_env_names(text)
     return text, total, truncated, lang
 
 

--- a/src/benchflow/_utils/benchmark_repos.py
+++ b/src/benchflow/_utils/benchmark_repos.py
@@ -414,6 +414,42 @@ def infer_task_source_provenance(task_path: Path) -> dict[str, Any] | None:
                 "file_hashes": task_file_hashes(task_resolved),
             }
 
+    # Non-snapshot resolve_source() cache layout:
+    # .cache/datasets/<org>/<repo>/<subpath...>. Attribute provenance to the
+    # cached benchmark repo's git remote/HEAD instead of falling through to
+    # the BenchFlow worktree (#492).
+    if cache_rel is not None and len(cache_rel.parts) >= 2:
+        org, repo_name, *rest = cache_rel.parts
+        if not repo_name.endswith("__snapshots") and not repo_name.startswith("_"):
+            cached_repo_root = cache_root / org / repo_name
+            if (cached_repo_root / ".git").exists():
+                resolved_sha = _git_stdout(cached_repo_root, "rev-parse", "HEAD")
+                if resolved_sha:
+                    source_path = "/".join(rest)
+                    rel_for_status = source_path or "."
+                    status = _git_stdout(
+                        cached_repo_root,
+                        "status",
+                        "--porcelain",
+                        "--",
+                        rel_for_status,
+                    )
+                    return {
+                        "type": "github",
+                        "repo": f"{org}/{repo_name}",
+                        "requested_ref": _git_stdout(
+                            cached_repo_root,
+                            "rev-parse",
+                            "--abbrev-ref",
+                            "HEAD",
+                        ),
+                        "resolved_sha": resolved_sha,
+                        "path": source_path,
+                        "local_path": str(task_resolved),
+                        "dirty": bool(status),
+                        "file_hashes": task_file_hashes(task_resolved),
+                    }
+
     repo_root = _repo_root()
     try:
         rel = task_resolved.relative_to(repo_root.resolve(strict=False))

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -557,6 +557,20 @@ class Evaluation:
         sandbox_locked_paths = raw.get("sandbox_locked_paths")
         sandbox_setup_timeout = raw.get("sandbox_setup_timeout", 120)
 
+        # Map legacy include/exclude task filters. Accept both singular and
+        # plural spellings ("include"/"includes", "exclude"/"excludes") so
+        # ported configs do not silently lose their filtering (#500).
+        include: set[str] = set()
+        for key in ("include", "includes", "include_tasks"):
+            values = raw.get(key)
+            if values:
+                include.update(values)
+        exclude: set[str] = set()
+        for key in ("exclude", "excludes", "exclude_tasks"):
+            values = raw.get(key)
+            if values:
+                exclude.update(values)
+
         config = EvaluationConfig(
             agent=agent_name,
             model=model,
@@ -571,6 +585,8 @@ class Evaluation:
             agent_idle_timeout=raw.get(
                 "agent_idle_timeout_sec", raw.get("agent_idle_timeout", 600)
             ),
+            include_tasks=include,
+            exclude_tasks=exclude,
             skill_mode=raw.get("skill_mode", "default"),
             skill_creator_dir=(
                 str(Path(raw["skill_creator_dir"]))

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -842,7 +842,7 @@ async def _verify_rollout(
         verifier_timeout_info = {
             "timeout_budget_sec": timeout_budget,
             "elapsed_sec": round(elapsed, 1),
-            "task_name": task.config.name,
+            "task_name": task.name,
         }
         rewards = None
         logger.error(verifier_error)
@@ -2560,8 +2560,17 @@ class Rollout:
                 self._transport_error_info["sandbox_probe_rc"] = rc
                 self._transport_error_info["sandbox_probe_stdout"] = stdout[:200]
         except Exception as probe_err:
+            import traceback
+
+            logger.exception("sandbox health probe failed")
             self._transport_error_info["sandbox_reachable"] = False
             self._transport_error_info["sandbox_probe_error"] = str(probe_err)[:200]
+            self._transport_error_info["sandbox_probe_error_type"] = type(
+                probe_err
+            ).__name__
+            self._transport_error_info["sandbox_probe_traceback"] = (
+                traceback.format_exc()[-2000:]
+            )
 
     def _classify_acp_error(self, e: ACPError) -> str:
         if "Invalid API key" in e.message:

--- a/tests/test_dashboard_credential_env_scrub.py
+++ b/tests/test_dashboard_credential_env_scrub.py
@@ -1,0 +1,115 @@
+"""Guards dashboard ``data.json`` from embedding credential-rule env var
+names verbatim in artifact content (#494).
+
+Secret scanners trip on names like ``GEMINI_API_KEY`` and ``DAYTONA_API_KEY``
+even when no value is present. We never ship values, but the names showed up
+in rollout artifact payloads (configs, logs, etc.), creating noise in
+artifact-sharing pipelines. Names must be masked to a stable placeholder.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dashboard import generate
+
+
+def _walk_strings(value: object):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, dict):
+        for v in value.values():
+            yield from _walk_strings(v)
+    elif isinstance(value, list):
+        for v in value:
+            yield from _walk_strings(v)
+
+
+def test_scrub_credential_env_names_masks_known_rule_names() -> None:
+    text = (
+        "Configured with GEMINI_API_KEY and DAYTONA_API_KEY from env.\n"
+        "GOOGLE_API_KEY mirror set.\n"
+    )
+    scrubbed = generate._scrub_credential_env_names(text)
+    assert "GEMINI_API_KEY" not in scrubbed
+    assert "DAYTONA_API_KEY" not in scrubbed
+    assert "GOOGLE_API_KEY" not in scrubbed
+    assert scrubbed.count("<CREDENTIAL_ENV>") == 3
+
+
+def test_scrub_credential_env_names_preserves_unrelated_text() -> None:
+    text = "MY_OTHER_VAR=hello and PUBLIC_FLAG=on"
+    assert generate._scrub_credential_env_names(text) == text
+
+
+def test_file_payload_scrubs_credential_env_names(tmp_path: Path) -> None:
+    """``_file_payload`` embeds artifact text into data.json; that text
+    must not carry credential-rule env var names verbatim."""
+    artifact = tmp_path / "agent_config.json"
+    artifact.write_text(
+        json.dumps(
+            {
+                "agent": "gemini",
+                "required_env": ["GEMINI_API_KEY", "DAYTONA_API_KEY"],
+                "note": "GOOGLE_API_KEY is a mirror of GEMINI_API_KEY",
+            }
+        )
+    )
+
+    content, _lines, _truncated, lang = generate._file_payload(artifact)
+
+    assert lang == "json"
+    assert content is not None
+    assert "GEMINI_API_KEY" not in content
+    assert "DAYTONA_API_KEY" not in content
+    assert "GOOGLE_API_KEY" not in content
+    assert "<CREDENTIAL_ENV>" in content
+
+
+def test_collect_jobs_payload_has_no_credential_env_names(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end: a rollout whose artifact files mention credential-rule env
+    var names produces a data.json payload with no such names anywhere."""
+    jobs_root = tmp_path / "jobs"
+    rollout = jobs_root / "2026-05-22__01-30-00" / "task-a__abc123"
+    (rollout / "verifier").mkdir(parents=True)
+    (rollout / "trajectory").mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "codex",
+                "rewards": {"reward": 1.0},
+                "timing": {},
+            }
+        )
+    )
+    (rollout / "config.json").write_text(
+        json.dumps(
+            {
+                "agent": "codex",
+                # Credential rule names appear in the config artifact — this
+                # is the #494 leak vector.
+                "agent_env": ["GEMINI_API_KEY", "DAYTONA_API_KEY"],
+                "comment": "GOOGLE_API_KEY auto-mirrored from GEMINI_API_KEY",
+            }
+        )
+    )
+    (rollout / "verifier" / "reward.txt").write_text("1.0\n")
+    (rollout / "trajectory" / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "step"}) + "\n"
+    )
+
+    monkeypatch.setenv(generate.JOBS_ROOT_ENV, str(jobs_root))
+    payload = generate.collect_jobs()
+
+    forbidden = ("GEMINI_API_KEY", "DAYTONA_API_KEY", "GOOGLE_API_KEY")
+    for s in _walk_strings(payload):
+        for name in forbidden:
+            assert name not in s, (
+                f"credential env var name {name!r} leaked into data.json: {s!r}"
+            )

--- a/tests/test_rollout_probe_sandbox_health.py
+++ b/tests/test_rollout_probe_sandbox_health.py
@@ -1,0 +1,91 @@
+"""Tests for Rollout._probe_sandbox_health diagnostics (#502)."""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from benchflow.rollout import Rollout
+
+
+class _ProbeHarness:
+    """Minimum surface so ``Rollout._probe_sandbox_health`` runs as an
+    instance method without spinning up a full rollout."""
+
+    _transport_error_info: dict | None
+    _env: object | None
+
+
+@pytest.mark.asyncio
+async def test_probe_sandbox_health_records_success_when_env_responds():
+    """Sanity: when the probe succeeds we record sandbox_reachable=True."""
+    harness = _ProbeHarness()
+    harness._transport_error_info = {}
+    harness._env = SimpleNamespace(
+        exec=AsyncMock(
+            return_value=SimpleNamespace(
+                stdout="__BENCHFLOW_HEALTH_OK__\n", return_code=0
+            )
+        )
+    )
+
+    await Rollout._probe_sandbox_health(harness)  # type: ignore[arg-type]
+
+    assert harness._transport_error_info["sandbox_reachable"] is True
+    assert harness._transport_error_info["sandbox_probe_rc"] == 0
+
+
+@pytest.mark.asyncio
+async def test_probe_sandbox_health_records_type_and_traceback_on_failure(caplog):
+    """Guards #502: when the probe itself raises, we must preserve
+
+    - a logger.exception() entry (with traceback),
+    - the exception type name in transport_error_info,
+    - and a truncated traceback string.
+    """
+
+    class _ProbeError(RuntimeError):
+        """Distinct type so we can assert the type name is recorded."""
+
+    async def _boom(*_a, **_kw):
+        raise _ProbeError("daytona session terminated unexpectedly")
+
+    harness = _ProbeHarness()
+    harness._transport_error_info = {}
+    harness._env = SimpleNamespace(exec=_boom)
+
+    with caplog.at_level(logging.ERROR, logger="benchflow.rollout"):
+        await Rollout._probe_sandbox_health(harness)  # type: ignore[arg-type]
+
+    info = harness._transport_error_info
+    assert info["sandbox_reachable"] is False
+    assert info["sandbox_probe_error"] == "daytona session terminated unexpectedly"
+    assert info["sandbox_probe_error_type"] == "_ProbeError"
+    # Traceback is captured (not just the message) so post-mortem keeps the
+    # original frame stack.
+    assert "_ProbeError" in info["sandbox_probe_traceback"]
+    assert "Traceback" in info["sandbox_probe_traceback"]
+
+    # logger.exception() emits a record with exc_info attached.
+    failure_records = [
+        rec
+        for rec in caplog.records
+        if rec.name == "benchflow.rollout" and rec.exc_info is not None
+    ]
+    assert failure_records, "expected logger.exception() to fire with exc_info"
+
+
+@pytest.mark.asyncio
+async def test_probe_sandbox_health_no_op_when_no_transport_error():
+    """If no transport error context has been captured, the probe is a no-op."""
+    harness = _ProbeHarness()
+    harness._transport_error_info = None
+    harness._env = SimpleNamespace(exec=AsyncMock())
+
+    await Rollout._probe_sandbox_health(harness)  # type: ignore[arg-type]
+
+    assert harness._transport_error_info is None
+    assert not harness._env.exec.called  # type: ignore[union-attr]

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -581,3 +581,72 @@ def test_source_dataclass_resolve(tmp_path, monkeypatch):
         == tmp_path / ".cache" / "datasets" / "benchflow-ai" / "benchmarks" / "tb2"
     )
     assert target.exists()
+
+
+def test_infer_task_source_provenance_for_cached_benchmark_repo(tmp_path, monkeypatch):
+    """Guards #492: tasks under ``.cache/datasets/<org>/<repo>/...`` must
+    attribute provenance to the cached benchmark repo (its remote/HEAD), not
+    to the BenchFlow worktree. Without this, ``check_results.py`` warns
+    ``source.resolved_sha does not match local_path git HEAD`` and friends
+    on legitimate local cached-benchmark runs.
+    """
+    import subprocess as sp
+
+    monkeypatch.chdir(tmp_path)
+    # Make the BenchFlow worktree marker live at tmp_path so ``_repo_root()``
+    # resolves here (matching the production layout under .cache/datasets).
+    (tmp_path / ".git").mkdir()
+
+    cache_root = tmp_path / ".cache" / "datasets" / "benchflow-ai" / "skillsbench"
+    tasks_dir = cache_root / "tasks"
+    task_dir = tasks_dir / "task-a"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text("[task]\n")
+    (task_dir / "instruction.md").write_text("Solve it.\n")
+
+    # Stand up a real git repo at the cache root so ``_git_stdout`` produces
+    # the expected HEAD/remote/status results.
+    env = {
+        "GIT_AUTHOR_NAME": "BenchFlow Test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "BenchFlow Test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    sp.run(["git", "init", "-b", "main"], cwd=cache_root, check=True, capture_output=True)
+    sp.run(
+        [
+            "git",
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/benchflow-ai/skillsbench.git",
+        ],
+        cwd=cache_root,
+        check=True,
+        capture_output=True,
+    )
+    sp.run(["git", "add", "."], cwd=cache_root, check=True, capture_output=True, env={**env})
+    sp.run(
+        ["git", "commit", "-m", "seed"],
+        cwd=cache_root,
+        check=True,
+        capture_output=True,
+        env={**env},
+    )
+    head = sp.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=cache_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    provenance = task_download.infer_task_source_provenance(task_dir)
+
+    assert provenance is not None
+    assert provenance["type"] == "github"
+    assert provenance["repo"] == "benchflow-ai/skillsbench"
+    assert provenance["resolved_sha"] == head
+    assert provenance["path"] == "tasks/task-a"
+    assert provenance["local_path"] == str(task_dir.resolve())
+    assert provenance["dirty"] is False

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -127,6 +127,59 @@ class TestSdkVerify:
         assert vti["timeout_budget_sec"] == 0.1
 
     @pytest.mark.asyncio
+    async def test_verifier_timeout_reads_task_name_not_config_name(self, tmp_path):
+        """Guards #495: timeout handler must read task.name, not task.config.name.
+
+        ``TaskConfig`` has no ``name`` field — the task name lives on ``Task``.
+        A real verifier timeout would otherwise crash with AttributeError
+        inside the ``except TimeoutError`` handler.
+        """
+        from benchflow.rollout import _verify_rollout
+        from benchflow.task.config import TaskConfig
+
+        # Build a real-shaped task: name lives on Task; TaskConfig has no name.
+        config = TaskConfig.model_validate(
+            {
+                "version": "1.0",
+                "metadata": {"author_name": "benchflow"},
+                "agent": {"timeout_sec": 30},
+                "verifier": {"timeout_sec": 0.1},
+                "environment": {"cpus": 1, "memory_mb": 1024},
+            }
+        )
+        assert not hasattr(config, "name")  # the bug condition
+
+        task = MagicMock()
+        task.name = "real-task-name"
+        task.config = config
+
+        env = MagicMock()
+        rollout_paths = MagicMock()
+        rollout_paths.verifier_dir = tmp_path / "verifier"
+
+        mock_v = MagicMock()
+        mock_v.verify = lambda: asyncio.sleep(10)
+
+        timing: dict = {}
+        with (
+            patch("benchflow.task.Verifier", return_value=mock_v),
+            patch(
+                "benchflow.sandbox.lockdown.harden_before_verify",
+                new_callable=AsyncMock,
+            ),
+        ):
+            rewards, verifier_error, vti = await _verify_rollout(
+                env, task, rollout_paths, timing
+            )
+
+        assert rewards is None
+        assert verifier_error is not None
+        assert "timed out" in verifier_error
+        assert vti is not None
+        assert vti["task_name"] == "real-task-name"
+        assert vti["timeout_budget_sec"] == 0.1
+
+    @pytest.mark.asyncio
     async def test_verifier_crash(self, verify_harness):
         sdk, env, task, tp = verify_harness
         mock_v = MagicMock()

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -455,3 +455,62 @@ sandbox_user: testuser
         assert job._config.agent_env == {}
         assert job._config.sandbox_user == "agent"
         assert job._config.sandbox_setup_timeout == 120
+
+
+def test_legacy_yaml_maps_include_exclude_filters(tmp_path):
+    """Guards #500: legacy YAML must not silently drop include/exclude filters."""
+    tasks = tmp_path / "tasks"
+    for name in ("alpha", "beta", "gamma"):
+        td = tasks / name
+        td.mkdir(parents=True)
+        (td / "task.toml").write_text('version = "1.0"')
+
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+agents:
+  - name: claude-agent-acp
+    model_name: anthropic/claude-haiku-4-5-20251001
+datasets:
+  - path: tasks
+include:
+  - alpha
+  - beta
+exclude:
+  - gamma
+"""
+    )
+
+    job = Evaluation.from_yaml(config)
+    cfg = job._config
+    assert cfg.include_tasks == {"alpha", "beta"}
+    assert cfg.exclude_tasks == {"gamma"}
+
+
+def test_legacy_yaml_accepts_plural_include_exclude(tmp_path):
+    """Plural spellings ('includes'/'excludes') must also map (#500)."""
+    tasks = tmp_path / "tasks"
+    for name in ("alpha", "beta"):
+        td = tasks / name
+        td.mkdir(parents=True)
+        (td / "task.toml").write_text('version = "1.0"')
+
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        """
+agents:
+  - name: claude-agent-acp
+    model_name: anthropic/claude-haiku-4-5-20251001
+datasets:
+  - path: tasks
+includes:
+  - alpha
+excludes:
+  - beta
+"""
+    )
+
+    job = Evaluation.from_yaml(config)
+    cfg = job._config
+    assert cfg.include_tasks == {"alpha"}
+    assert cfg.exclude_tasks == {"beta"}


### PR DESCRIPTION
Fixes #492, #494, #495, #500, #502.

## Per-issue changes

- **#492** `infer_task_source_provenance`: recognize the non-snapshot `resolve_source()` cache layout (`.cache/datasets/<org>/<repo>/...`) and attribute provenance to the cached benchmark repo's git remote/HEAD instead of falling through to the BenchFlow worktree. Stops `check_results.py` from emitting `source.repo`/`resolved_sha`/`path` mismatch warnings on legitimate local cached-benchmark runs.
- **#494** dashboard: scrub credential-rule env var *names* (`GEMINI_API_KEY`, `DAYTONA_API_KEY`, etc.) from embedded artifact content in `data.json` via `_file_payload`. Names get masked to `<CREDENTIAL_ENV>` so secret scanners stop flagging artifact-sharing pipelines. Values were never embedded; this only addresses the name-leak noise.
- **#495** verifier timeout handler in `_verify_rollout`: use `task.name` instead of `task.config.name`. `TaskConfig` has no `name` field, so the existing handler would crash with `AttributeError` on a real verifier timeout, losing the structured `verifier_timeout_info` diagnostic.
- **#500** `_from_legacy_yaml`: map `include` / `exclude` (and plural `includes` / `excludes`, plus the modern `include_tasks` / `exclude_tasks` spelling) into `JobConfig.include_tasks` / `exclude_tasks`. Previously silently dropped, so ported configs ran with no task filtering.
- **#502** `_probe_sandbox_health`: when the post-transport-death health probe itself raises, log via `logger.exception()` and record the exception type name + truncated traceback in `transport_error_info`. Previously stored only `str(probe_err)[:200]` with no log, making transport-failure post-mortems much harder.

## Regression tests

- `tests/test_yaml_config.py::test_legacy_yaml_maps_include_exclude_filters` and `::test_legacy_yaml_accepts_plural_include_exclude` (#500)
- `tests/test_verify.py::TestSdkVerify::test_verifier_timeout_reads_task_name_not_config_name` — uses a real `TaskConfig` so `config.name` access would AttributeError (#495)
- `tests/test_rollout_probe_sandbox_health.py` — asserts `logger.exception` fires and `transport_error_info` carries the exception type and traceback (#502)
- `tests/test_dashboard_credential_env_scrub.py` — unit + end-to-end via `collect_jobs()` (#494)
- `tests/test_task_download.py::test_infer_task_source_provenance_for_cached_benchmark_repo` — builds a real cached git repo under `.cache/datasets/` and asserts the inferred provenance matches the cached repo (#492)

## Quality bar

- `uv run pytest tests/` — 2400 passed, 2 skipped, 1 deselected
- `uv run ruff check .` — all checks passed
- `uv run --with ty ty check src/` — all checks passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized fixes to provenance inference, dashboard text scrubbing, legacy config parsing, and diagnostic fields; no auth, payment, or broad API contract changes.
> 
> **Overview**
> This PR bundles five small correctness and hygiene fixes, each with targeted regression tests.
> 
> **Dashboard (`data.json`)** — Embedded artifact text now masks well-known credential-rule env var *names* (e.g. `GEMINI_API_KEY`) to `<CREDENTIAL_ENV>` in `_file_payload`, so secret scanners stop flagging artifact-sharing pipelines when configs/logs mention names without values (#494).
> 
> **Task provenance** — `infer_task_source_provenance` recognizes tasks under `.cache/datasets/<org>/<repo>/...` (non-snapshot `resolve_source` layout) and attributes `repo` / `resolved_sha` / `path` to the cached benchmark git repo instead of the BenchFlow worktree, eliminating false `check_results.py` mismatch warnings on legitimate cached-benchmark runs (#492).
> 
> **Legacy YAML** — `_from_legacy_yaml` maps `include` / `exclude` and plural `includes` / `excludes` (plus `include_tasks` / `exclude_tasks`) into `EvaluationConfig.include_tasks` / `exclude_tasks`, which were previously ignored (#500).
> 
> **Verifier timeout** — The rollout verifier timeout path records `task_name` from `task.name` (not `task.config.name`, which does not exist), avoiding an `AttributeError` in the timeout handler on real timeouts (#495).
> 
> **Transport post-mortem** — After transport death, `_probe_sandbox_health` logs probe failures with `logger.exception` and stores exception type plus truncated traceback on the transport diagnostic (#502).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb9916ecbcc87694f77b69e82a84f930910afd59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->