### PR TITLE
refactor: consolidate structured diagnostics (#503 #504)

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -28,19 +28,17 @@ from benchflow.acp.container_transport import ContainerTransport
 from benchflow.agents.protocol import ACPSessionAdapter
 from benchflow.agents.providers import find_provider, strip_provider_prefix
 from benchflow.agents.registry import AGENTS
+from benchflow.diagnostics import IdleTimeoutDiagnostic, IdleTimeoutError
 from benchflow.sandbox.lockdown import build_priv_drop_cmd
 from benchflow.sandbox.process import DaytonaProcess, DaytonaPtyProcess, DockerProcess
 from benchflow.trajectories._capture import _capture_session_trajectory
 
+# Re-exported for backwards compatibility — tests and downstream code
+# import ``IdleTimeoutError`` from this module. The canonical definition
+# lives in :mod:`benchflow.diagnostics` (issue #503).
+__all__ = ["IdleTimeoutError", "connect_acp", "execute_prompts"]
+
 logger = logging.getLogger(__name__)
-
-
-class IdleTimeoutError(TimeoutError):
-    """Agent idle watchdog fired. Carries structured diagnostics."""
-
-    def __init__(self, message: str, info: dict):
-        super().__init__(message)
-        self.idle_timeout_info: dict = info
 
 
 _ACP_CONNECT_MAX_RETRIES = 3
@@ -386,22 +384,21 @@ async def _prompt_with_idle_watchdog(
                 last_progress = now
                 last_count = cur_count
             if now - last_progress >= idle_timeout:
-                idle_info = {
-                    "reason": "idle_timeout",
-                    "idle_timeout_sec": idle_timeout,
-                    "idle_duration_sec": int(now - last_progress),
-                    "wall_clock_elapsed_sec": int(now - (deadline - timeout)),
-                    "n_tool_calls": len(session.tool_calls),
-                    "n_message_chunks": len(session.message_chunks),
-                    "n_thought_chunks": len(session.thought_chunks),
-                    "last_activity_at": datetime.now(UTC).isoformat(),
-                }
+                diag = IdleTimeoutDiagnostic(
+                    idle_timeout_sec=idle_timeout,
+                    idle_duration_sec=int(now - last_progress),
+                    wall_clock_elapsed_sec=int(now - (deadline - timeout)),
+                    n_tool_calls=len(session.tool_calls),
+                    n_message_chunks=len(session.message_chunks),
+                    n_thought_chunks=len(session.thought_chunks),
+                    last_activity_at=datetime.now(UTC).isoformat(),
+                )
                 raise IdleTimeoutError(
                     f"Agent idle for {idle_timeout}s with no new tool call, "
                     f"message, or thought "
                     f"(last activity {int(now - last_progress)}s ago, "
                     f"{len(session.tool_calls)} tool calls so far)",
-                    info=idle_info,
+                    diag,
                 )
             if now > deadline:
                 raise TimeoutError(

--- a/src/benchflow/acp/transport.py
+++ b/src/benchflow/acp/transport.py
@@ -112,7 +112,19 @@ class StdioTransport(Transport):
                 logger.warning(f"Skipped oversized line: {e}")
                 continue
             if not line:
-                raise ConnectionError("Agent process closed stdout")
+                from benchflow.diagnostics import (
+                    TransportClosedDiagnostic,
+                    TransportClosedError,
+                )
+
+                msg = "Agent process closed stdout"
+                raise TransportClosedError(
+                    msg,
+                    TransportClosedDiagnostic(
+                        raw_message=msg,
+                        transport_diagnosis="process_exited",
+                    ),
+                )
             text = line.decode().strip()
             if not text:
                 continue

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -152,6 +152,8 @@ class TransportClosedDiagnostic(Diagnostic):
     sandbox_probe_rc: int | None = None
     sandbox_probe_stdout: str | None = None
     sandbox_probe_error: str | None = None
+    sandbox_probe_error_type: str | None = None
+    sandbox_probe_traceback: str | None = None
 
     field: ClassVar[str] = "transport_error_info"
     category: ClassVar[str | None] = "pipe_closed"
@@ -184,6 +186,8 @@ class TransportClosedDiagnostic(Diagnostic):
                 "sandbox_probe_rc",
                 "sandbox_probe_stdout",
                 "sandbox_probe_error",
+                "sandbox_probe_error_type",
+                "sandbox_probe_traceback",
             }:
                 continue
             if k == "raw_message" and not v:
@@ -233,17 +237,14 @@ DIAGNOSTIC_BY_FIELD: dict[str, type[Diagnostic]] = {
 class IdleTimeoutError(TimeoutError):
     """Raised by the idle watchdog when the agent stops producing activity.
 
-    Carries an :class:`IdleTimeoutDiagnostic` instance (and exposes the
-    legacy ``idle_timeout_info`` dict view for callers that still index it).
+    Carries an :class:`IdleTimeoutDiagnostic` instance via ``.diagnostic`` —
+    serialize via ``exc.diagnostic.to_dict()`` to recover the result.json
+    payload (issue #503).
     """
 
     def __init__(self, message: str, diagnostic: IdleTimeoutDiagnostic) -> None:
         super().__init__(message)
         self.diagnostic: IdleTimeoutDiagnostic = diagnostic
-
-    @property
-    def idle_timeout_info(self) -> dict[str, Any]:
-        return self.diagnostic.to_dict()
 
 
 class TransportClosedError(ConnectionError):
@@ -293,43 +294,11 @@ class RolloutDiagnostics:
         """Extract the IdleTimeoutDiagnostic from a TimeoutError, if present.
 
         Wall-clock TimeoutErrors carry no diagnostic; only idle-watchdog
-        timeouts attach one. The lookup uses the typed ``.diagnostic``
-        attribute first and falls back to the legacy
-        ``.idle_timeout_info`` dict so in-flight exception types still
-        serialize correctly during a rolling deploy (issue #503).
+        timeouts attach one via ``.diagnostic`` (issue #503).
         """
         diag = getattr(exc, "diagnostic", None)
         if isinstance(diag, IdleTimeoutDiagnostic):
             self.set(diag)
-            return
-        legacy = getattr(exc, "idle_timeout_info", None)
-        if isinstance(legacy, dict):
-            allowed = IdleTimeoutDiagnostic._init_fields()
-            self.set(
-                IdleTimeoutDiagnostic(
-                    **{k: v for k, v in legacy.items() if k in allowed}
-                )
-            )
-
-    def absorb_legacy_kwargs(self, **info_kwargs: dict | None) -> None:
-        """Convert ``{field_name: info_dict}`` kwargs into typed diagnostics.
-
-        ``_build_rollout_result`` and test fixtures still pass diagnostics
-        as flat ``idle_timeout_info=...``-style dicts. Route them through
-        the same registry the live path uses so result.json stays in one
-        schema (issue #503). Unknown keys in the dict are dropped — the
-        legacy code wrote the dict verbatim, which means stale fields
-        couldn't break the serializer.
-        """
-        for field_name, info in info_kwargs.items():
-            if not info:
-                continue
-            cls = DIAGNOSTIC_BY_FIELD.get(field_name)
-            if cls is None:
-                continue
-            self.set(
-                cls(**{k: v for k, v in info.items() if k in cls._init_fields()})
-            )
 
     def capture_transport(self, exc: ConnectionError) -> None:
         """Record the transport-closed diagnostic.

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -1,0 +1,412 @@
+"""Structured diagnostics for rollout failures (issues #503, #504).
+
+The Single Source of Truth for diagnostic events that need to surface in
+``result.json``, the job summary, and the e2e check_results auditor. Each
+diagnostic kind owns its own dataclass; the dataclass owns its JSON field
+name, the error_category it pairs with, the summary warning template, and
+the per-task issue line check_results renders.
+
+Adding a new diagnostic is therefore a single edit: declare a new subclass
+of :class:`Diagnostic` with ``field``/``category``/``summary_description``/
+``format_issue`` set. The result builder, summary, and check_results all
+discover it through :data:`DIAGNOSTIC_REGISTRY`.
+
+The diagnostics are emitted at the source as typed exceptions
+(:class:`IdleTimeoutError`, :class:`TransportClosedError`,
+:class:`SandboxStartupError`) carrying a structured ``.diagnostic`` attribute,
+so downstream consumers never reverse-engineer fields from
+human-readable error strings. This replaces the regex-based
+``rollout._parse_transport_error`` shim that issue #504 flagged as brittle.
+
+The module has no optional-dep imports — base installs can reach the typed
+exceptions without pulling Daytona/Modal SDKs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, ClassVar
+
+# ── Diagnostic value objects ──────────────────────────────────────────────
+
+
+@dataclass
+class Diagnostic:
+    """Base class for structured diagnostic events.
+
+    Subclasses declare the JSON field name they serialize to, the
+    ``error_category`` from :mod:`benchflow._utils.scoring` that produces
+    them, and how they render into summary warnings and check_results
+    invalidation lines.
+    """
+
+    # ── Class-level metadata (overridden by subclasses) ──
+    # Field name under which to_dict() lands in result.json.
+    field: ClassVar[str] = ""
+    # error_category (from _utils.scoring) that this diagnostic backs.
+    # ``None`` means the diagnostic doesn't surface a top-level error
+    # category (e.g. verifier_timeout's category lives on verifier_error,
+    # not on the agent's ``error`` channel).
+    category: ClassVar[str | None] = None
+    # Channel the category lives on — "error" or "verifier_error".
+    channel: ClassVar[str] = "error"
+    # Human description for the summary warning ("hit idle timeout",
+    # "lost transport (pipe closed / rc=255)" …).
+    summary_description: ClassVar[str] = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for result.json — drops Nones is the caller's choice."""
+        return asdict(self)
+
+    def format_issue(self, task_name: str) -> str:
+        """Render the per-task line check_results emits for this diagnostic."""
+        raise NotImplementedError
+
+    @classmethod
+    def format_issue_from_dict(cls, task_name: str, info: dict[str, Any]) -> str:
+        """Render a per-task issue line from a deserialized dict.
+
+        check_results works off the round-tripped result.json, not the live
+        dataclass; this lets it reuse the dataclass's formatting rules
+        without having to reconstruct the instance.
+        """
+        return cls(**{k: v for k, v in info.items() if k in cls._init_fields()}).format_issue(
+            task_name
+        )
+
+    @classmethod
+    def _init_fields(cls) -> set[str]:
+        """Names of fields the dataclass actually takes — drops legacy/extra keys."""
+        from dataclasses import fields
+
+        return {f.name for f in fields(cls)}
+
+
+@dataclass
+class IdleTimeoutDiagnostic(Diagnostic):
+    """Agent went silent — no tool call, message, or thought arrived in time."""
+
+    reason: str = "idle_timeout"
+    idle_timeout_sec: int = 0
+    idle_duration_sec: int = 0
+    wall_clock_elapsed_sec: int = 0
+    n_tool_calls: int = 0
+    n_message_chunks: int = 0
+    n_thought_chunks: int = 0
+    last_activity_at: str = ""
+
+    field: ClassVar[str] = "idle_timeout_info"
+    category: ClassVar[str | None] = "idle_timeout"
+    summary_description: ClassVar[str] = "hit idle timeout"
+
+    def format_issue(self, task_name: str) -> str:
+        return (
+            f"{task_name}: idle timeout after "
+            f"{self.idle_duration_sec}s idle "
+            f"({self.n_tool_calls} tool calls, "
+            f"{self.wall_clock_elapsed_sec}s wall)"
+        )
+
+
+@dataclass
+class SandboxStartupDiagnostic(Diagnostic):
+    """Sandbox creation failed before the rollout ever ran."""
+
+    reason: str = "sandbox_startup_failed"
+    sandbox_id: str | None = None
+    sandbox_state: str | None = None
+    attempts: int = 0
+    build_timeout_sec: float | None = None
+    raw_message: str = ""
+
+    field: ClassVar[str] = "sandbox_startup_info"
+    category: ClassVar[str | None] = "sandbox_setup"
+    summary_description: ClassVar[str] = "failed during sandbox startup"
+
+    def format_issue(self, task_name: str) -> str:
+        return (
+            f"{task_name}: sandbox startup failed (sandbox_id={self.sandbox_id or '?'}, "
+            f"state={self.sandbox_state or '?'}, attempts={self.attempts}, "
+            f"build_timeout_sec={self.build_timeout_sec if self.build_timeout_sec is not None else '?'})"
+        )
+
+
+@dataclass
+class TransportClosedDiagnostic(Diagnostic):
+    """ACP transport pipe closed — process died or remote session was killed.
+
+    Replaces the regex-parsed dict that ``_parse_transport_error`` used to
+    reconstruct from the stringified ``ConnectionError`` (issue #504).
+    """
+
+    reason: str = "transport_closed"
+    raw_message: str = ""
+    process_exit_code: int | None = None
+    process_pid: int | None = None
+    transport_diagnosis: str = "unknown"
+    stderr_snippet: str | None = None
+    # Populated by Rollout._probe_sandbox_health() — sandbox liveness
+    # checks happen after the exception lands so they live alongside the
+    # source-emitted fields here.
+    sandbox_reachable: bool | None = None
+    sandbox_probe_rc: int | None = None
+    sandbox_probe_stdout: str | None = None
+    sandbox_probe_error: str | None = None
+
+    field: ClassVar[str] = "transport_error_info"
+    category: ClassVar[str | None] = "pipe_closed"
+    summary_description: ClassVar[str] = "lost transport (pipe closed / rc=255)"
+
+    def format_issue(self, task_name: str) -> str:
+        rc = self.process_exit_code if self.process_exit_code is not None else "?"
+        reachable = (
+            "?" if self.sandbox_reachable is None else self.sandbox_reachable
+        )
+        return (
+            f"{task_name}: transport closed (rc={rc}, "
+            f"diagnosis={self.transport_diagnosis}, sandbox_reachable={reachable})"
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize, dropping fields that were never populated.
+
+        The legacy regex-parser only included fields it could match — drop
+        the same way so result.json stays compact and tests that compare
+        explicit dicts continue to work.
+        """
+        raw = asdict(self)
+        out: dict[str, Any] = {}
+        for k, v in raw.items():
+            if v is None and k in {
+                "stderr_snippet",
+                "process_pid",
+                "sandbox_reachable",
+                "sandbox_probe_rc",
+                "sandbox_probe_stdout",
+                "sandbox_probe_error",
+            }:
+                continue
+            if k == "raw_message" and not v:
+                continue
+            out[k] = v
+        return out
+
+
+@dataclass
+class VerifierTimeoutDiagnostic(Diagnostic):
+    """Verifier exceeded its timeout budget."""
+
+    timeout_budget_sec: float = 0.0
+    elapsed_sec: float = 0.0
+    task_name: str = ""
+
+    field: ClassVar[str] = "verifier_timeout_info"
+    category: ClassVar[str | None] = "verifier_timeout"
+    channel: ClassVar[str] = "verifier_error"
+    summary_description: ClassVar[str] = "had verifier timeouts"
+
+    def format_issue(self, task_name: str) -> str:
+        return (
+            f"{task_name}: verifier timed out "
+            f"(budget={self.timeout_budget_sec}s, elapsed={self.elapsed_sec}s) — "
+            f"measurement invalid (verifier never produced reward)"
+        )
+
+
+# Public registry — every diagnostic kind goes here exactly once.
+DIAGNOSTIC_REGISTRY: tuple[type[Diagnostic], ...] = (
+    IdleTimeoutDiagnostic,
+    SandboxStartupDiagnostic,
+    TransportClosedDiagnostic,
+    VerifierTimeoutDiagnostic,
+)
+
+# field_name → Diagnostic class, for check_results lookup.
+DIAGNOSTIC_BY_FIELD: dict[str, type[Diagnostic]] = {
+    d.field: d for d in DIAGNOSTIC_REGISTRY
+}
+
+
+# ── Diagnostic-carrying exceptions ────────────────────────────────────────
+
+
+class IdleTimeoutError(TimeoutError):
+    """Raised by the idle watchdog when the agent stops producing activity.
+
+    Carries an :class:`IdleTimeoutDiagnostic` instance (and exposes the
+    legacy ``idle_timeout_info`` dict view for callers that still index it).
+    """
+
+    def __init__(self, message: str, diagnostic: IdleTimeoutDiagnostic) -> None:
+        super().__init__(message)
+        self.diagnostic: IdleTimeoutDiagnostic = diagnostic
+
+    @property
+    def idle_timeout_info(self) -> dict[str, Any]:
+        return self.diagnostic.to_dict()
+
+
+class TransportClosedError(ConnectionError):
+    """Raised at the source (``sandbox/process.py``) when an ACP transport dies.
+
+    Carries a structured :class:`TransportClosedDiagnostic`, so downstream
+    code never has to regex-parse the human-readable error string to
+    recover ``rc``, ``pid``, ``diagnosis``, or ``stderr_snippet``
+    (issue #504).
+    """
+
+    def __init__(self, message: str, diagnostic: TransportClosedDiagnostic) -> None:
+        super().__init__(message)
+        self.diagnostic: TransportClosedDiagnostic = diagnostic
+
+
+# SandboxStartupError lives in ``benchflow.sandbox.protocol`` (not here)
+# so a base install can import it without pulling Daytona/Modal SDKs —
+# see ``tests/test_base_install_imports.py``. It carries a
+# :class:`SandboxStartupDiagnostic` via its ``.diagnostic`` attribute.
+
+
+# ── Collector — replaces 4 parallel _*_info slots on Rollout ──────────────
+
+
+class RolloutDiagnostics:
+    """Collects diagnostics observed during one rollout.
+
+    Replaces the ``_idle_timeout_info`` / ``_sandbox_startup_info`` /
+    ``_transport_error_info`` / ``_verifier_timeout_info`` quadruple on
+    ``Rollout`` with a single keyed bag. Serialization to result.json
+    keeps the legacy flat field names so existing tooling does not break
+    (issue #503).
+    """
+
+    def __init__(self) -> None:
+        self._events: dict[str, Diagnostic] = {}
+
+    def set(self, diagnostic: Diagnostic) -> None:
+        """Record a diagnostic, keyed by its result.json field name."""
+        self._events[diagnostic.field] = diagnostic
+
+    def get(self, field_name: str) -> Diagnostic | None:
+        return self._events.get(field_name)
+
+    def capture_idle(self, exc: BaseException) -> None:
+        """Extract the IdleTimeoutDiagnostic from a TimeoutError, if present.
+
+        Wall-clock TimeoutErrors carry no diagnostic; only idle-watchdog
+        timeouts attach one. The lookup uses the typed ``.diagnostic``
+        attribute first and falls back to the legacy
+        ``.idle_timeout_info`` dict so in-flight exception types still
+        serialize correctly during a rolling deploy (issue #503).
+        """
+        diag = getattr(exc, "diagnostic", None)
+        if isinstance(diag, IdleTimeoutDiagnostic):
+            self.set(diag)
+            return
+        legacy = getattr(exc, "idle_timeout_info", None)
+        if isinstance(legacy, dict):
+            allowed = IdleTimeoutDiagnostic._init_fields()
+            self.set(
+                IdleTimeoutDiagnostic(
+                    **{k: v for k, v in legacy.items() if k in allowed}
+                )
+            )
+
+    def absorb_legacy_kwargs(self, **info_kwargs: dict | None) -> None:
+        """Convert ``{field_name: info_dict}`` kwargs into typed diagnostics.
+
+        ``_build_rollout_result`` and test fixtures still pass diagnostics
+        as flat ``idle_timeout_info=...``-style dicts. Route them through
+        the same registry the live path uses so result.json stays in one
+        schema (issue #503). Unknown keys in the dict are dropped — the
+        legacy code wrote the dict verbatim, which means stale fields
+        couldn't break the serializer.
+        """
+        for field_name, info in info_kwargs.items():
+            if not info:
+                continue
+            cls = DIAGNOSTIC_BY_FIELD.get(field_name)
+            if cls is None:
+                continue
+            self.set(
+                cls(**{k: v for k, v in info.items() if k in cls._init_fields()})
+            )
+
+    def capture_transport(self, exc: ConnectionError) -> None:
+        """Record the transport-closed diagnostic.
+
+        Typed :class:`TransportClosedError` raised by
+        ``sandbox/process.py`` carries the structured fields directly
+        (issue #504). Bare ``ConnectionError`` s (third-party SDK paths)
+        fall back to a minimal diagnostic so result.json still has a
+        populated ``transport_error_info`` block.
+        """
+        diag = getattr(exc, "diagnostic", None)
+        if isinstance(diag, TransportClosedDiagnostic):
+            self.set(diag)
+            return
+        self.set(
+            TransportClosedDiagnostic(
+                raw_message=str(exc)[:500], transport_diagnosis="unknown"
+            )
+        )
+
+    def to_result_fields(self) -> dict[str, dict[str, Any] | None]:
+        """Return the flat ``{field_name: dict|None}`` view for result.json.
+
+        Includes every registered diagnostic field — absent ones serialize
+        to ``None`` so the result schema stays stable.
+        """
+        return {
+            d.field: self._events[d.field].to_dict() if d.field in self._events else None
+            for d in DIAGNOSTIC_REGISTRY
+        }
+
+    # Convenience accessors for callers that need to enrich an in-flight
+    # diagnostic (e.g. probe_sandbox_health adds sandbox_reachable to
+    # the transport diagnostic after the exception lands).
+    @property
+    def transport_closed(self) -> TransportClosedDiagnostic | None:
+        d = self._events.get(TransportClosedDiagnostic.field)
+        return d if isinstance(d, TransportClosedDiagnostic) else None
+
+
+# ── Summary / check_results helpers driven by the registry ────────────────
+
+
+def summary_warning(diagnostic_cls: type[Diagnostic], count: int, total: int) -> str:
+    """Format the one-line warning the job summary emits for a diagnostic."""
+    pct = (count / total * 100) if total else 0.0
+    return (
+        f"{count} tasks ({pct:.0f}%) {diagnostic_cls.summary_description} — "
+        f"check {diagnostic_cls.field} in result.json for diagnostics"
+    )
+
+
+def format_issue_for_field(
+    field_name: str, task_name: str, info: dict[str, Any] | None
+) -> str:
+    """Render the per-task check_results invalidation line for a diagnostic.
+
+    Falls back to a generic format when the diagnostic dict is absent —
+    matches the legacy ``infra_errors.append(f"{task}: {err}")`` branch.
+    """
+    cls = DIAGNOSTIC_BY_FIELD.get(field_name)
+    if cls is None or not info:
+        return f"{task_name}: (no {field_name})"
+    return cls.format_issue_from_dict(task_name, info)
+
+
+__all__ = [
+    "Diagnostic",
+    "IdleTimeoutDiagnostic",
+    "SandboxStartupDiagnostic",
+    "TransportClosedDiagnostic",
+    "VerifierTimeoutDiagnostic",
+    "DIAGNOSTIC_REGISTRY",
+    "DIAGNOSTIC_BY_FIELD",
+    "IdleTimeoutError",
+    "TransportClosedError",
+    "RolloutDiagnostics",
+    "summary_warning",
+    "format_issue_for_field",
+]

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -42,7 +42,6 @@ from benchflow._utils.scoring import (
     INFRA_ERROR,
     INSTALL_FAILED,
     PIPE_CLOSED,
-    SANDBOX_SETUP,
     VERIFIER_DEP_INSTALL,
     VERIFIER_INFRA,
     VERIFIER_TIMEOUT,
@@ -54,6 +53,7 @@ from benchflow._utils.scoring import (
     pass_rate_excl_errors,
 )
 from benchflow._utils.source_provenance import summary_source_fields
+from benchflow.diagnostics import DIAGNOSTIC_REGISTRY, summary_warning
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.learner_store import LearnerState, LearnerStore
 from benchflow.models import RolloutResult
@@ -1255,29 +1255,22 @@ class Evaluation:
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Job-level trainer artifact aggregation failed: %s", e)
 
-        idle_count = error_category_counts.get(IDLE_TIMEOUT, 0)
-        if idle_count > 0:
-            pct = idle_count / job_result.total * 100
-            logger.warning(
-                f"{idle_count} tasks ({pct:.0f}%) hit idle timeout — "
-                f"check idle_timeout_info in result.json for diagnostics"
+        # Per-diagnostic summary warnings — driven by the registry so a
+        # new diagnostic class adds its warning automatically (issue #503).
+        for diag_cls in DIAGNOSTIC_REGISTRY:
+            if diag_cls.category is None:
+                continue
+            counts = (
+                error_category_counts
+                if diag_cls.channel == "error"
+                else verifier_error_category_counts
             )
+            count = counts.get(diag_cls.category, 0)
+            if count > 0:
+                logger.warning(summary_warning(diag_cls, count, job_result.total))
 
-        sandbox_count = error_category_counts.get(SANDBOX_SETUP, 0)
-        if sandbox_count > 0:
-            pct = sandbox_count / job_result.total * 100
-            logger.warning(
-                f"{sandbox_count} tasks ({pct:.0f}%) failed during sandbox startup — "
-                f"check sandbox_startup_info in result.json for diagnostics"
-            )
-
-        pipe_count = error_category_counts.get(PIPE_CLOSED, 0)
-        if pipe_count > 0:
-            pct = pipe_count / job_result.total * 100
-            logger.warning(
-                f"{pipe_count} tasks ({pct:.0f}%) lost transport (pipe closed / rc=255) — "
-                f"check transport_error_info in result.json for diagnostics"
-            )
+        # ENG-151: dep-install failures don't have a structured diagnostic
+        # yet — keep the standalone warning until they do.
         dep_install_count = verifier_error_category_counts.get(VERIFIER_DEP_INSTALL, 0)
         if dep_install_count > 0:
             pct = dep_install_count / job_result.total * 100
@@ -1285,14 +1278,6 @@ class Evaluation:
                 f"{dep_install_count} tasks ({pct:.0f}%) failed during verifier "
                 f"dependency install — check verifier_error_category in result.json "
                 f"and fix the task's index policy"
-            )
-
-        verifier_timeout_count = verifier_error_category_counts.get(VERIFIER_TIMEOUT, 0)
-        if verifier_timeout_count > 0:
-            pct = verifier_timeout_count / job_result.total * 100
-            logger.warning(
-                f"{verifier_timeout_count} tasks ({pct:.0f}%) had verifier timeouts — "
-                f"check verifier_timeout_info in result.json for budget/elapsed details"
             )
         if audit_counts["verifier_errored"] > 0:
             pct = audit_counts["verifier_errored"] / job_result.total * 100
@@ -1309,7 +1294,7 @@ class Evaluation:
         logger.info(
             f"Job complete: {job_result.passed}/{job_result.total} "
             f"({job_result.score:.1%}), errors={job_result.errored}, "
-            f"idle_timeouts={idle_count}, "
+            f"idle_timeouts={error_category_counts.get(IDLE_TIMEOUT, 0)}, "
             f"time={elapsed / 60:.1f}min"
         )
 

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -28,6 +28,8 @@ from pathlib import Path
 from typing import Any, cast
 from uuid import uuid4
 
+from benchflow.diagnostics import RolloutDiagnostics
+
 logger = logging.getLogger(__name__)
 
 PRIME_SIMPLE_INDEX = "https://hub.primeintellect.ai/primeintellect/simple/"
@@ -493,10 +495,11 @@ def _write_run_artifacts(
         "error_category": None,
         "verifier_error": result.verifiers_error,
         "verifier_error_category": None,
-        "idle_timeout_info": None,
-        "sandbox_startup_info": None,
-        "transport_error_info": None,
-        "verifier_timeout_info": None,
+        # Empty diagnostic slots — keyed by the canonical registry so
+        # adding a new diagnostic doesn't require touching hosted_env
+        # (issue #503). Hosted runs don't produce these (the harness ran
+        # remote), so all fields serialize as ``None``.
+        **RolloutDiagnostics().to_result_fields(),
         "partial_trajectory": False,
         "trajectory_source": "hosted_env" if trajectory else None,
         "started_at": str(started_at),

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -479,27 +479,15 @@ def _build_rollout_result(
     evolved_skills: dict[str, str] | None = None,
     source_provenance: dict[str, Any] | None = None,
     diagnostics: RolloutDiagnostics | None = None,
-    idle_timeout_info: dict | None = None,
-    sandbox_startup_info: dict | None = None,
-    transport_error_info: dict | None = None,
-    verifier_timeout_info: dict | None = None,
 ) -> RolloutResult:
     """Build RolloutResult and write result.json, timing.json, prompts.json, trajectory.
 
-    Diagnostics may be passed either as a :class:`RolloutDiagnostics`
-    collector (the path Rollout.run() takes) or as the legacy per-field
-    ``*_info`` dicts (preserved for unit tests that build a single
-    diagnostic by name). The two paths share the same on-disk schema so
-    result.json stays stable (issue #503).
+    Diagnostics flow through the :class:`RolloutDiagnostics` collector
+    (issue #503). Callers that previously passed per-field ``*_info``
+    dicts should construct a collector and ``set()`` typed diagnostics.
     """
     if diagnostics is None:
         diagnostics = RolloutDiagnostics()
-    diagnostics.absorb_legacy_kwargs(
-        idle_timeout_info=idle_timeout_info,
-        sandbox_startup_info=sandbox_startup_info,
-        transport_error_info=transport_error_info,
-        verifier_timeout_info=verifier_timeout_info,
-    )
     finished_at = datetime.now()
     result = RolloutResult(
         task_name=task_name,
@@ -826,7 +814,7 @@ async def _verify_rollout(
         verifier_timeout = VerifierTimeoutDiagnostic(
             timeout_budget_sec=timeout_budget,
             elapsed_sec=round(elapsed, 1),
-            task_name=task.config.name,
+            task_name=task.name,
         )
         rewards = None
         logger.error(verifier_error)
@@ -2548,8 +2536,13 @@ class Rollout:
                 diag.sandbox_probe_rc = rc
                 diag.sandbox_probe_stdout = stdout[:200]
         except Exception as probe_err:
+            import traceback
+
+            logger.exception("sandbox health probe failed")
             diag.sandbox_reachable = False
             diag.sandbox_probe_error = str(probe_err)[:200]
+            diag.sandbox_probe_error_type = type(probe_err).__name__
+            diag.sandbox_probe_traceback = traceback.format_exc()[-2000:]
 
     def _classify_acp_error(self, e: ACPError) -> str:
         if "Invalid API key" in e.message:

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -66,6 +66,10 @@ from benchflow.agents.install import (
     install_agent,
 )
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
+from benchflow.diagnostics import (
+    RolloutDiagnostics,
+    VerifierTimeoutDiagnostic,
+)
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.environment.manifest_env import ManifestEnvironment
 from benchflow.models import RolloutResult, TrajectorySource
@@ -444,41 +448,6 @@ def _scene_metadata(scenes: list[Scene]) -> list[dict[str, Any]]:
     ]
 
 
-def _parse_transport_error(e: ConnectionError) -> dict:
-    """Extract structured fields from a ConnectionError message.
-
-    Guards ENG-148: ACP transport rc=255 must carry actionable diagnostics.
-    """
-    import re as _re
-
-    msg = str(e)
-    info: dict[str, Any] = {"reason": "transport_closed", "raw_message": msg[:500]}
-
-    rc_match = _re.search(r"rc=(\d+|None)", msg)
-    if rc_match:
-        raw = rc_match.group(1)
-        info["process_exit_code"] = int(raw) if raw != "None" else None
-
-    pid_match = _re.search(r"pid=(\d+)", msg)
-    if pid_match:
-        info["process_pid"] = int(pid_match.group(1))
-
-    if "still alive but its stdout/transport closed" in msg:
-        info["transport_diagnosis"] = "remote_session_killed"
-    elif "exited with rc=" in msg:
-        info["transport_diagnosis"] = "process_exited"
-    elif "PTY readline" in msg:
-        info["transport_diagnosis"] = "pty_error"
-    else:
-        info["transport_diagnosis"] = "unknown"
-
-    stderr_match = _re.search(r"stderr: (.+)", msg, _re.DOTALL)
-    if stderr_match:
-        info["stderr_snippet"] = stderr_match.group(1).strip()[:500]
-
-    return info
-
-
 def _build_rollout_result(
     rollout_dir: Path,
     *,
@@ -509,12 +478,28 @@ def _build_rollout_result(
     price_source: str | None = None,
     evolved_skills: dict[str, str] | None = None,
     source_provenance: dict[str, Any] | None = None,
+    diagnostics: RolloutDiagnostics | None = None,
     idle_timeout_info: dict | None = None,
     sandbox_startup_info: dict | None = None,
     transport_error_info: dict | None = None,
     verifier_timeout_info: dict | None = None,
 ) -> RolloutResult:
-    """Build RolloutResult and write result.json, timing.json, prompts.json, trajectory."""
+    """Build RolloutResult and write result.json, timing.json, prompts.json, trajectory.
+
+    Diagnostics may be passed either as a :class:`RolloutDiagnostics`
+    collector (the path Rollout.run() takes) or as the legacy per-field
+    ``*_info`` dicts (preserved for unit tests that build a single
+    diagnostic by name). The two paths share the same on-disk schema so
+    result.json stays stable (issue #503).
+    """
+    if diagnostics is None:
+        diagnostics = RolloutDiagnostics()
+    diagnostics.absorb_legacy_kwargs(
+        idle_timeout_info=idle_timeout_info,
+        sandbox_startup_info=sandbox_startup_info,
+        transport_error_info=transport_error_info,
+        verifier_timeout_info=verifier_timeout_info,
+    )
     finished_at = datetime.now()
     result = RolloutResult(
         task_name=task_name,
@@ -582,10 +567,7 @@ def _build_rollout_result(
                     result.verifier_error
                 ),
                 "export_error": result.export_error,
-                "idle_timeout_info": idle_timeout_info,
-                "sandbox_startup_info": sandbox_startup_info,
-                "transport_error_info": transport_error_info,
-                "verifier_timeout_info": verifier_timeout_info,
+                **diagnostics.to_result_fields(),
                 "partial_trajectory": result.partial_trajectory,
                 "trajectory_source": result.trajectory_source,
                 "started_at": str(result.started_at),
@@ -811,10 +793,12 @@ async def _verify_rollout(
     timing: dict,
     sandbox_user: str | None = None,
     workspace: str | None = None,
-) -> tuple[dict | None, str | None, dict | None]:
+) -> tuple[dict | None, str | None, VerifierTimeoutDiagnostic | None]:
     """Run verifier with pre-verification hardening.
 
-    Returns (rewards, verifier_error, verifier_timeout_info).
+    Returns ``(rewards, verifier_error, verifier_timeout_diagnostic)``. The
+    diagnostic is non-``None`` only when the verifier exceeded its timeout
+    budget — the agent-error channel is unused (issue #503).
     """
     from benchflow.sandbox.lockdown import harden_before_verify
     from benchflow.task import Verifier
@@ -822,7 +806,7 @@ async def _verify_rollout(
     rollout_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
     t0 = datetime.now()
     verifier_error = None
-    verifier_timeout_info: dict | None = None
+    verifier_timeout: VerifierTimeoutDiagnostic | None = None
     timeout_budget = task.config.verifier.timeout_sec
     try:
         await harden_before_verify(env, task, sandbox_user, workspace=workspace)
@@ -839,11 +823,11 @@ async def _verify_rollout(
         elapsed = (datetime.now() - t0).total_seconds()
         timing["verifier"] = elapsed
         verifier_error = f"verifier timed out after {timeout_budget}s"
-        verifier_timeout_info = {
-            "timeout_budget_sec": timeout_budget,
-            "elapsed_sec": round(elapsed, 1),
-            "task_name": task.config.name,
-        }
+        verifier_timeout = VerifierTimeoutDiagnostic(
+            timeout_budget_sec=timeout_budget,
+            elapsed_sec=round(elapsed, 1),
+            task_name=task.config.name,
+        )
         rewards = None
         logger.error(verifier_error)
     except Exception as e:
@@ -851,7 +835,7 @@ async def _verify_rollout(
         verifier_error = f"verifier crashed: {e}"
         rewards = None
         logger.error(verifier_error)
-    return rewards, verifier_error, verifier_timeout_info
+    return rewards, verifier_error, verifier_timeout
 
 
 def _ensure_canonical_rewards(rewards: dict | None) -> dict:
@@ -1128,10 +1112,11 @@ class Rollout:
         # an export-time infra failure ("connection lost") as the agent's own
         # infra_failure category in dashboards.
         self._export_error: str | None = None
-        self._idle_timeout_info: dict | None = None
-        self._sandbox_startup_info: dict | None = None
-        self._transport_error_info: dict | None = None
-        self._verifier_timeout_info: dict | None = None
+        # Single bag for the four parallel diagnostic fields the old code
+        # carried as separate attrs (issue #503). Each callsite that used
+        # to assign to one of those slots now calls ``self._diagnostics.set(...)``
+        # with a typed Diagnostic value.
+        self._diagnostics: RolloutDiagnostics = RolloutDiagnostics()
 
         # Populated by _export_generated_skills() — the skills the agent
         # generated/evolved, captured for a continual-learning LearnerStore.
@@ -1754,7 +1739,7 @@ class Rollout:
         (
             self._rewards,
             self._verifier_error,
-            self._verifier_timeout_info,
+            verifier_timeout_diag,
         ) = await _verify_rollout(
             self._env,
             self._task,
@@ -1763,6 +1748,8 @@ class Rollout:
             sandbox_user=cfg.sandbox_user,
             workspace=self._agent_cwd,
         )
+        if verifier_timeout_diag is not None:
+            self._diagnostics.set(verifier_timeout_diag)
 
         self._phase = "verified"
         return self._rewards
@@ -1964,7 +1951,7 @@ class Rollout:
                         self._error = (
                             detail or f"Agent timed out after {self._timeout}s"
                         )
-                        self._idle_timeout_info = getattr(e, "idle_timeout_info", None)
+                        self._diagnostics.capture_idle(e)
                         logger.error(self._error)
                 finally:
                     if cfg.oracle_access:
@@ -1990,16 +1977,16 @@ class Rollout:
             # generic wall-clock message only when there's no detail.
             detail = str(e).strip()
             self._error = detail or f"Agent timed out after {self._timeout}s"
-            self._idle_timeout_info = getattr(e, "idle_timeout_info", None)
+            self._diagnostics.capture_idle(e)
             logger.error(self._error)
         except ConnectionError as e:
             self._error = str(e)
-            self._transport_error_info = _parse_transport_error(e)
+            self._diagnostics.capture_transport(e)
             await self._probe_sandbox_health()
             logger.error(f"Agent connection lost: {self._error}")
         except SandboxStartupError as e:
             self._error = f"Sandbox startup failed: {e}"
-            self._sandbox_startup_info = e.sandbox_startup_info
+            self._diagnostics.set(e.diagnostic)
             logger.error(self._error)
         except ACPError as e:
             self._error = self._classify_acp_error(e)
@@ -2538,11 +2525,12 @@ class Rollout:
     # ── Internal helpers ──
 
     async def _probe_sandbox_health(self) -> None:
-        """Quick health probe after transport death. Enriches _transport_error_info.
+        """Quick health probe after transport death. Enriches transport diagnostic.
 
         Guards ENG-148: distinguishes Daytona session killed vs agent crash.
         """
-        if self._transport_error_info is None or self._env is None:
+        diag = self._diagnostics.transport_closed
+        if diag is None or self._env is None:
             return
         try:
             result = await asyncio.wait_for(
@@ -2553,15 +2541,15 @@ class Rollout:
             raw_rc = getattr(result, "return_code", None)
             rc = int(raw_rc) if isinstance(raw_rc, (int, float)) else None
             if "__BENCHFLOW_HEALTH_OK__" in stdout:
-                self._transport_error_info["sandbox_reachable"] = True
-                self._transport_error_info["sandbox_probe_rc"] = rc
+                diag.sandbox_reachable = True
+                diag.sandbox_probe_rc = rc
             else:
-                self._transport_error_info["sandbox_reachable"] = False
-                self._transport_error_info["sandbox_probe_rc"] = rc
-                self._transport_error_info["sandbox_probe_stdout"] = stdout[:200]
+                diag.sandbox_reachable = False
+                diag.sandbox_probe_rc = rc
+                diag.sandbox_probe_stdout = stdout[:200]
         except Exception as probe_err:
-            self._transport_error_info["sandbox_reachable"] = False
-            self._transport_error_info["sandbox_probe_error"] = str(probe_err)[:200]
+            diag.sandbox_reachable = False
+            diag.sandbox_probe_error = str(probe_err)[:200]
 
     def _classify_acp_error(self, e: ACPError) -> str:
         if "Invalid API key" in e.message:
@@ -2624,9 +2612,6 @@ class Rollout:
             scenes=self._config.effective_scenes,
             evolved_skills=self._evolved_skills,
             source_provenance=self._config.source_provenance,
-            idle_timeout_info=self._idle_timeout_info,
-            sandbox_startup_info=self._sandbox_startup_info,
-            transport_error_info=self._transport_error_info,
-            verifier_timeout_info=self._verifier_timeout_info,
+            diagnostics=self._diagnostics,
             **self._usage_metrics,
         )

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -135,12 +135,34 @@ class LiveProcess(ABC):
                     "container or SSH session was killed (e.g. Daytona idle "
                     "sleep, agent hung with no output)."
                 )
+                diagnosis = "remote_session_killed"
             else:
                 hint = f"Local subprocess exited with rc={rc} before stdout closed."
+                diagnosis = "process_exited"
             msg = f"Process closed stdout (rc={rc}): {hint}"
+            stderr_snippet: str | None = None
             if stderr_text:
-                msg += f"\nstderr: {stderr_text[:_DIAG_TRUNCATE]}"
-            raise ConnectionError(msg)
+                stderr_snippet = stderr_text[:_DIAG_TRUNCATE]
+                msg += f"\nstderr: {stderr_snippet}"
+            # Raise a structured TransportClosedError at the source so
+            # downstream code (rollout._build_rollout_result) doesn't have
+            # to regex-parse the human-readable message back into fields
+            # (issue #504).
+            from benchflow.diagnostics import (
+                TransportClosedDiagnostic,
+                TransportClosedError,
+            )
+
+            raise TransportClosedError(
+                msg,
+                TransportClosedDiagnostic(
+                    raw_message=msg[:500],
+                    process_exit_code=rc,
+                    process_pid=pid,
+                    transport_diagnosis=diagnosis,
+                    stderr_snippet=stderr_snippet,
+                ),
+            )
         return line
 
     async def writeline(self, data: str) -> None:
@@ -726,15 +748,38 @@ class DaytonaPtyProcess(LiveProcess):
         logger.info("DaytonaPtyProcess: marker seen, agent starting")
 
     async def readline(self) -> bytes:
+        from benchflow.diagnostics import (
+            TransportClosedDiagnostic,
+            TransportClosedError,
+        )
+
         if self._closed:
-            raise ConnectionError("PTY closed")
+            msg = "PTY closed"
+            raise TransportClosedError(
+                msg,
+                TransportClosedDiagnostic(
+                    raw_message=msg, transport_diagnosis="pty_error"
+                ),
+            )
         try:
             line = await asyncio.wait_for(self._line_buffer.get(), timeout=900)
             return line
         except TimeoutError as e:
-            raise ConnectionError("PTY readline timeout (900s)") from e
+            msg = "PTY readline timeout (900s)"
+            raise TransportClosedError(
+                msg,
+                TransportClosedDiagnostic(
+                    raw_message=msg, transport_diagnosis="pty_error"
+                ),
+            ) from e
         except Exception as e:
-            raise ConnectionError(f"PTY readline error: {e}") from e
+            msg = f"PTY readline error: {e}"
+            raise TransportClosedError(
+                msg,
+                TransportClosedDiagnostic(
+                    raw_message=msg[:500], transport_diagnosis="pty_error"
+                ),
+            ) from e
 
     async def writeline(self, data: str) -> None:
         if not self._pty or self._closed:

--- a/src/benchflow/sandbox/protocol.py
+++ b/src/benchflow/sandbox/protocol.py
@@ -79,17 +79,6 @@ class SandboxStartupError(RuntimeError):
             raw_message=str(message)[:500],
         )
 
-    @property
-    def sandbox_startup_info(self) -> dict:
-        """Back-compat view returning the flat ``result.json`` dict.
-
-        Existing tests and integrations index this directly; routing
-        through ``self.diagnostic.to_dict()`` keeps the schema in one place
-        (issues #503, #504).
-        """
-        return self.diagnostic.to_dict()
-
-
 @runtime_checkable
 class Sandbox(Protocol):
     """Run-only: isolated execution environment.

--- a/src/benchflow/sandbox/protocol.py
+++ b/src/benchflow/sandbox/protocol.py
@@ -52,7 +52,8 @@ class SandboxStartupError(RuntimeError):
     ``sandbox-daytona`` / ``sandbox-modal`` extras) can still import
     ``benchflow.rollout`` and reference this exception type without pulling
     in optional provider SDKs (issue #358). Provider-specific backends
-    re-raise this same type with structured ``sandbox_startup_info`` for
+    re-raise this same type with a structured
+    :class:`~benchflow.diagnostics.SandboxStartupDiagnostic` for
     ``result.json``.
     """
 
@@ -66,14 +67,27 @@ class SandboxStartupError(RuntimeError):
         build_timeout_sec: float | None = None,
     ) -> None:
         super().__init__(message)
-        self.sandbox_startup_info: dict = {
-            "reason": "sandbox_startup_failed",
-            "sandbox_id": sandbox_id,
-            "sandbox_state": sandbox_state,
-            "attempts": attempts,
-            "build_timeout_sec": build_timeout_sec,
-            "raw_message": str(message)[:500],
-        }
+        # Local import keeps ``protocol`` cycle-free for any future
+        # ``diagnostics`` -> sandbox importers.
+        from benchflow.diagnostics import SandboxStartupDiagnostic
+
+        self.diagnostic: SandboxStartupDiagnostic = SandboxStartupDiagnostic(
+            sandbox_id=sandbox_id,
+            sandbox_state=sandbox_state,
+            attempts=attempts,
+            build_timeout_sec=build_timeout_sec,
+            raw_message=str(message)[:500],
+        )
+
+    @property
+    def sandbox_startup_info(self) -> dict:
+        """Back-compat view returning the flat ``result.json`` dict.
+
+        Existing tests and integrations index this directly; routing
+        through ``self.diagnostic.to_dict()`` keeps the schema in one place
+        (issues #503, #504).
+        """
+        return self.diagnostic.to_dict()
 
 
 @runtime_checkable

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from benchflow._types import Scene
+from benchflow.diagnostics import VerifierTimeoutDiagnostic
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.models import RolloutResult, TrajectorySource
 from benchflow.rollout import (
@@ -140,7 +141,7 @@ class SDK:
         timing: dict,
         sandbox_user: str | None = None,
         workspace: str | None = None,
-    ) -> tuple[dict | None, str | None, dict | None]:
+    ) -> tuple[dict | None, str | None, VerifierTimeoutDiagnostic | None]:
         return await _verify_rollout(
             env,
             task,

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -506,77 +506,46 @@ def check_agent(agent_dir: Path) -> dict:
                 )
                 findings["ok"] = False
 
-    # Infrastructure errors
-    infra_errors = []
-    idle_timeout_tasks: list[str] = []
-    sandbox_startup_tasks: list[str] = []
-    transport_error_tasks: list[str] = []
+    # Infrastructure errors — driven from the central diagnostic registry
+    # so adding a new diagnostic kind doesn't require editing this file
+    # (issue #503).
+    from benchflow.diagnostics import DIAGNOSTIC_REGISTRY, format_issue_for_field
+
+    _CATEGORY_TO_DIAGNOSTIC = {
+        d.category: d for d in DIAGNOSTIC_REGISTRY if d.category and d.channel == "error"
+    }
+    _INVALIDATION_DESCRIPTIONS = {
+        "idle_timeout": ("hit idle timeout", ""),
+        "sandbox_setup": ("failed during sandbox startup", ""),
+        "pipe_closed": (
+            "lost ACP transport (pipe closed / rc=255)",
+            "",
+        ),
+    }
+
+    infra_errors: list[str] = []
+    invalidated_by_category: dict[str, list[str]] = {}
     for r in results:
         err = r.get("error")
         cat = classify_error(str(err)) if err else None
         if cat and cat in INFRA_ERROR_CATEGORIES:
             task = r.get("task_name", "?")
-            if cat == "idle_timeout":
-                info = r.get("idle_timeout_info")
-                if info:
-                    infra_errors.append(
-                        f"{task}: idle timeout after "
-                        f"{info.get('idle_duration_sec', '?')}s idle "
-                        f"({info.get('n_tool_calls', '?')} tool calls, "
-                        f"{info.get('wall_clock_elapsed_sec', '?')}s wall)"
-                    )
-                else:
-                    infra_errors.append(f"{task}: {err}")
-                idle_timeout_tasks.append(task)
-            elif cat == "sandbox_setup":
-                sinfo = r.get("sandbox_startup_info")
-                if sinfo:
-                    sid = sinfo.get("sandbox_id", "?")
-                    state = sinfo.get("sandbox_state", "?")
-                    attempts = sinfo.get("attempts", "?")
-                    build_to = sinfo.get("build_timeout_sec", "?")
-                    infra_errors.append(
-                        f"{task}: sandbox startup failed (sandbox_id={sid}, "
-                        f"state={state}, attempts={attempts}, "
-                        f"build_timeout_sec={build_to})"
-                    )
-                else:
-                    infra_errors.append(f"{task}: {err}")
-                sandbox_startup_tasks.append(task)
-            elif cat == "pipe_closed":
-                tinfo = r.get("transport_error_info")
-                if tinfo:
-                    rc = tinfo.get("process_exit_code", "?")
-                    diag = tinfo.get("transport_diagnosis", "?")
-                    reachable = tinfo.get("sandbox_reachable", "?")
-                    infra_errors.append(
-                        f"{task}: transport closed (rc={rc}, "
-                        f"diagnosis={diag}, sandbox_reachable={reachable})"
-                    )
-                else:
-                    infra_errors.append(f"{task}: {err}")
-                transport_error_tasks.append(task)
+            diag_cls = _CATEGORY_TO_DIAGNOSTIC.get(cat)
+            info = r.get(diag_cls.field) if diag_cls else None
+            if diag_cls and info:
+                infra_errors.append(format_issue_for_field(diag_cls.field, task, info))
             else:
                 infra_errors.append(f"{task}: {err}")
+            if cat in _INVALIDATION_DESCRIPTIONS:
+                invalidated_by_category.setdefault(cat, []).append(task)
     if infra_errors:
         findings["issues"].extend(infra_errors)
         findings["ok"] = False
-    if idle_timeout_tasks:
+    for cat, tasks in invalidated_by_category.items():
+        desc, _ = _INVALIDATION_DESCRIPTIONS[cat]
         findings["issues"].append(
-            f"INVALIDATED: {len(idle_timeout_tasks)} task(s) hit idle timeout "
-            f"and should be rerun: {', '.join(idle_timeout_tasks)}"
-        )
-    if sandbox_startup_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(sandbox_startup_tasks)} task(s) failed during "
-            f"sandbox startup and should be rerun: "
-            f"{', '.join(sandbox_startup_tasks)}"
-        )
-    if transport_error_tasks:
-        findings["issues"].append(
-            f"INVALIDATED: {len(transport_error_tasks)} task(s) lost ACP transport "
-            f"(pipe closed / rc=255) and should be rerun: "
-            f"{', '.join(transport_error_tasks)}"
+            f"INVALIDATED: {len(tasks)} task(s) {desc} "
+            f"and should be rerun: {', '.join(tasks)}"
         )
 
     # Verifier dependency install failures (ENG-151)
@@ -599,21 +568,30 @@ def check_agent(agent_dir: Path) -> dict:
             f"fixing the index policy: {', '.join(dep_install_tasks)}"
         )
 
-    # Verifier timeout failures (ENG-152)
+    # Verifier timeout failures (ENG-152) — rendered from the diagnostic
+    # registry; falls back to a plain message when the structured
+    # verifier_timeout_info dict is absent.
+    _VERIFIER_DIAGS = {
+        d.category: d for d in DIAGNOSTIC_REGISTRY if d.channel == "verifier_error"
+    }
     verifier_timeout_tasks: list[str] = []
     for r in results:
         verifier_err = r.get("verifier_error")
         vcat = classify_verifier_error(verifier_err) if verifier_err else None
         if vcat == "verifier_timeout":
             task = r.get("task_name", "?")
-            vti = r.get("verifier_timeout_info")
-            budget = vti.get("timeout_budget_sec", "?") if vti else "?"
-            elapsed = vti.get("elapsed_sec", "?") if vti else "?"
+            diag_cls = _VERIFIER_DIAGS.get(vcat)
+            vti = r.get(diag_cls.field) if diag_cls else None
             verifier_timeout_tasks.append(task)
-            findings["issues"].append(
-                f"{task}: verifier timed out (budget={budget}s, elapsed={elapsed}s) — "
-                f"measurement invalid (verifier never produced reward)"
-            )
+            if diag_cls and vti:
+                findings["issues"].append(
+                    format_issue_for_field(diag_cls.field, task, vti)
+                )
+            else:
+                findings["issues"].append(
+                    f"{task}: verifier timed out — measurement invalid "
+                    f"(verifier never produced reward)"
+                )
             findings["ok"] = False
     if verifier_timeout_tasks:
         findings["issues"].append(

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -926,56 +926,129 @@ class TestSandboxStartupDiagnostics:
 
 
 class TestTransportErrorDiagnostics:
-    """Guards ENG-148: ACP transport rc=255 must carry structured diagnostics."""
+    """Guards ENG-148 / #504: ACP transport must carry structured diagnostics.
 
-    def test_parse_transport_error_rc255(self) -> None:
-        """Guards ENG-148: _parse_transport_error extracts rc, pid, diagnosis from
-        the ConnectionError message produced by process.py when SSH dies."""
-        from benchflow.rollout import _parse_transport_error
+    The diagnostic is now raised at the *source* (``sandbox/process.py``) as
+    a :class:`~benchflow.diagnostics.TransportClosedError` carrying a typed
+    :class:`~benchflow.diagnostics.TransportClosedDiagnostic` — downstream
+    code never regex-parses the error string back into fields.
+    """
 
-        err = ConnectionError(
-            "Process closed stdout (rc=255): "
-            "Local subprocess exited with rc=255 before stdout closed.\n"
-            "stderr: Connection to sandbox lost"
+    @pytest.mark.asyncio
+    async def test_live_process_raises_typed_transport_error_with_rc(self) -> None:
+        """``LiveProcess.readline`` raises ``TransportClosedError`` with the
+        structured ``process_exit_code`` filled in (issue #504)."""
+        from benchflow.diagnostics import TransportClosedError
+        from benchflow.sandbox.process import LiveProcess
+
+        class _StubProcess:
+            def __init__(self) -> None:
+                self.returncode = 255
+                self.pid = 4242
+                self.stdout = self
+                self.stderr = self
+
+            async def readline(self) -> bytes:
+                return b""
+
+            async def read(self, _n: int) -> bytes:
+                return b"Connection to sandbox lost"
+
+        class _LP(LiveProcess):
+            async def start(self, command, env=None, cwd=None) -> None:  # pragma: no cover - unused
+                pass
+
+        lp = _LP()
+        lp._process = _StubProcess()  # type: ignore[assignment]
+        with pytest.raises(TransportClosedError) as exc_info:
+            await lp.readline()
+        diag = exc_info.value.diagnostic
+        assert diag.process_exit_code == 255
+        assert diag.transport_diagnosis == "process_exited"
+        assert diag.stderr_snippet is not None
+        assert "Connection to sandbox lost" in diag.stderr_snippet
+
+    @pytest.mark.asyncio
+    async def test_live_process_raises_typed_transport_error_when_remote_killed(
+        self,
+    ) -> None:
+        """rc=None ⇒ remote session was killed; the diagnostic must carry
+        the pid and the ``remote_session_killed`` diagnosis (issue #504)."""
+        from benchflow.diagnostics import TransportClosedError
+        from benchflow.sandbox.process import LiveProcess
+
+        class _StubProcess:
+            def __init__(self) -> None:
+                self.returncode = None
+                self.pid = 12345
+                self.stdout = self
+                self.stderr = None
+
+            async def readline(self) -> bytes:
+                return b""
+
+        class _LP(LiveProcess):
+            async def start(self, command, env=None, cwd=None) -> None:  # pragma: no cover - unused
+                pass
+
+        lp = _LP()
+        lp._process = _StubProcess()  # type: ignore[assignment]
+        with pytest.raises(TransportClosedError) as exc_info:
+            await lp.readline()
+        diag = exc_info.value.diagnostic
+        assert diag.process_exit_code is None
+        assert diag.process_pid == 12345
+        assert diag.transport_diagnosis == "remote_session_killed"
+
+    def test_transport_closed_error_is_a_connection_error(self) -> None:
+        """``TransportClosedError`` extends ``ConnectionError`` so existing
+        ``except ConnectionError`` paths still catch it (issue #504)."""
+        from benchflow.diagnostics import (
+            TransportClosedDiagnostic,
+            TransportClosedError,
         )
-        info = _parse_transport_error(err)
-        assert info["reason"] == "transport_closed"
-        assert info["process_exit_code"] == 255
-        assert info["transport_diagnosis"] == "process_exited"
-        assert "Connection to sandbox lost" in info["stderr_snippet"]
 
-    def test_parse_transport_error_rc_none_remote_killed(self) -> None:
-        """Guards ENG-148: rc=None means the local process is alive but the remote
-        transport (SSH/Daytona) was killed."""
-        from benchflow.rollout import _parse_transport_error
+        err = TransportClosedError("test", TransportClosedDiagnostic(raw_message="test"))
+        assert isinstance(err, ConnectionError)
+        assert err.diagnostic.transport_diagnosis == "unknown"
 
-        err = ConnectionError(
-            "Process closed stdout (rc=None): "
-            "Local subprocess (pid=12345) is still alive but its "
-            "stdout/transport closed. This usually means the remote "
-            "container or SSH session was killed"
+    def test_diagnostic_round_trips_through_result_json(self, tmp_path) -> None:
+        """The structured diagnostic survives the dataclass → dict → JSON →
+        dict roundtrip used by result.json (issue #503)."""
+        from benchflow.diagnostics import (
+            DIAGNOSTIC_BY_FIELD,
+            RolloutDiagnostics,
+            TransportClosedDiagnostic,
         )
-        info = _parse_transport_error(err)
-        assert info["process_exit_code"] is None
-        assert info["process_pid"] == 12345
-        assert info["transport_diagnosis"] == "remote_session_killed"
 
-    def test_parse_transport_error_pty(self) -> None:
-        """Guards ENG-148: PTY readline errors get distinct diagnosis."""
-        from benchflow.rollout import _parse_transport_error
-
-        err = ConnectionError("PTY readline timeout (900s)")
-        info = _parse_transport_error(err)
-        assert info["transport_diagnosis"] == "pty_error"
-
-    def test_parse_transport_error_unknown(self) -> None:
-        """Guards ENG-148: unrecognized ConnectionError gets diagnosis=unknown."""
-        from benchflow.rollout import _parse_transport_error
-
-        err = ConnectionError("something unexpected")
-        info = _parse_transport_error(err)
-        assert info["transport_diagnosis"] == "unknown"
-        assert info["reason"] == "transport_closed"
+        rd = RolloutDiagnostics()
+        rd.set(
+            TransportClosedDiagnostic(
+                raw_message="boom",
+                process_exit_code=255,
+                process_pid=99,
+                transport_diagnosis="process_exited",
+                stderr_snippet="oops",
+                sandbox_reachable=False,
+            )
+        )
+        fields = rd.to_result_fields()
+        assert fields["transport_error_info"] is not None
+        roundtripped = fields["transport_error_info"]
+        assert roundtripped["process_exit_code"] == 255
+        assert roundtripped["transport_diagnosis"] == "process_exited"
+        assert roundtripped["sandbox_reachable"] is False
+        # The registry can rebuild a typed diagnostic from the dict.
+        cls = DIAGNOSTIC_BY_FIELD["transport_error_info"]
+        rebuilt = cls(
+            **{
+                k: v
+                for k, v in roundtripped.items()
+                if k in TransportClosedDiagnostic._init_fields()
+            }
+        )
+        assert isinstance(rebuilt, TransportClosedDiagnostic)
+        assert rebuilt.process_exit_code == 255
 
     def test_transport_error_info_in_result_json(self, tmp_path) -> None:
         """Guards ENG-148: transport_error_info is written to result.json."""
@@ -1034,6 +1107,94 @@ class TestTransportErrorDiagnostics:
         rj = __import__("json").loads((tmp_path / "result.json").read_text())
         assert rj["transport_error_info"] is None
         assert result.rewards == {"reward": 1.0}
+
+
+class TestDiagnosticRegistry:
+    """Guards #503: the diagnostic registry is the single source of truth.
+
+    Every diagnostic shape — result.json field name, summary warning,
+    check_results invalidation line — flows from the same registry. Adding
+    a new diagnostic should require adding ONE class, not coordinated
+    edits across rollout/evaluation/check_results.
+    """
+
+    def test_every_diagnostic_round_trips_through_result_fields(self) -> None:
+        """Every registered Diagnostic serializes under its own field name."""
+        from benchflow.diagnostics import (
+            DIAGNOSTIC_BY_FIELD,
+            DIAGNOSTIC_REGISTRY,
+            RolloutDiagnostics,
+        )
+
+        # Field name → class lookup must mirror the registry.
+        assert set(DIAGNOSTIC_BY_FIELD.keys()) == {d.field for d in DIAGNOSTIC_REGISTRY}
+        # An empty collector renders every field as None.
+        empty = RolloutDiagnostics().to_result_fields()
+        for diag_cls in DIAGNOSTIC_REGISTRY:
+            assert empty[diag_cls.field] is None
+
+    def test_summary_warning_uses_registry_metadata(self) -> None:
+        """Summary warning text comes from the registry's
+        ``summary_description``, not a per-call f-string in evaluation.py."""
+        from benchflow.diagnostics import (
+            IdleTimeoutDiagnostic,
+            TransportClosedDiagnostic,
+            summary_warning,
+        )
+
+        msg = summary_warning(IdleTimeoutDiagnostic, count=3, total=10)
+        assert "3 tasks (30%) hit idle timeout" in msg
+        assert "idle_timeout_info" in msg
+        msg = summary_warning(TransportClosedDiagnostic, count=2, total=10)
+        assert "lost transport" in msg
+        assert "transport_error_info" in msg
+
+    def test_format_issue_for_field_dispatches_via_registry(self) -> None:
+        """check_results renders per-task invalidation lines through the
+        registry — no per-diagnostic format string lives in check_results.py."""
+        from benchflow.diagnostics import format_issue_for_field
+
+        line = format_issue_for_field(
+            "idle_timeout_info",
+            "task-1",
+            {
+                "idle_duration_sec": 602,
+                "n_tool_calls": 3,
+                "wall_clock_elapsed_sec": 605,
+            },
+        )
+        assert "task-1: idle timeout after 602s idle (3 tool calls" in line
+
+        line = format_issue_for_field(
+            "transport_error_info",
+            "task-2",
+            {
+                "process_exit_code": 255,
+                "transport_diagnosis": "process_exited",
+                "sandbox_reachable": False,
+            },
+        )
+        assert (
+            "task-2: transport closed (rc=255, diagnosis=process_exited" in line
+        )
+
+    def test_sandbox_startup_error_diagnostic_view_is_consistent(self) -> None:
+        """``SandboxStartupError.sandbox_startup_info`` reflects the same
+        dict the registry serializer produces — one schema, one source."""
+        from benchflow.diagnostics import RolloutDiagnostics
+        from benchflow.sandbox.protocol import SandboxStartupError
+
+        err = SandboxStartupError(
+            "boom",
+            sandbox_id="sb-1",
+            sandbox_state="error",
+            attempts=2,
+            build_timeout_sec=600.0,
+        )
+        rd = RolloutDiagnostics()
+        rd.set(err.diagnostic)
+        fields = rd.to_result_fields()
+        assert fields["sandbox_startup_info"] == err.sandbox_startup_info
 
 
 class TestVerifierDepInstallDiagnostics:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -505,7 +505,7 @@ class TestIdleTimeoutDiagnostics:
 
     @pytest.mark.asyncio
     async def test_idle_timeout_raises_with_structured_info(self) -> None:
-        """Guards ENG-149: IdleTimeoutError carries idle_timeout_info dict."""
+        """Guards ENG-149: IdleTimeoutError carries idle_timeout diagnostic."""
         from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
 
         class HangingClient:
@@ -521,7 +521,7 @@ class TestIdleTimeoutDiagnostics:
                 timeout=30,
                 idle_timeout=1,
             )
-        info = exc_info.value.idle_timeout_info
+        info = exc_info.value.diagnostic.to_dict()
         assert info["reason"] == "idle_timeout"
         assert info["idle_timeout_sec"] == 1
         assert info["idle_duration_sec"] >= 1
@@ -560,12 +560,12 @@ class TestIdleTimeoutDiagnostics:
                 timeout=30,
                 idle_timeout=1,
             )
-        info = exc_info.value.idle_timeout_info
+        info = exc_info.value.diagnostic.to_dict()
         assert info["n_tool_calls"] == 1
 
     @pytest.mark.asyncio
     async def test_wall_clock_timeout_has_no_idle_info(self) -> None:
-        """Wall-clock timeouts (not idle) must NOT carry idle_timeout_info."""
+        """Wall-clock timeouts (not idle) must NOT carry an idle diagnostic."""
         from benchflow.acp.runtime import execute_prompts
 
         class SlowClient:
@@ -583,7 +583,9 @@ class TestIdleTimeoutDiagnostics:
                 timeout=2,
                 idle_timeout=None,
             )
-        assert not hasattr(exc_info.value, "idle_timeout_info")
+        # Wall-clock TimeoutErrors don't carry a structured diagnostic;
+        # only the idle watchdog raises IdleTimeoutError with one attached.
+        assert not hasattr(exc_info.value, "diagnostic")
 
 
 class TestConnectAcpModelSelection:
@@ -813,7 +815,7 @@ class TestSandboxStartupDiagnostics:
     """Guards ENG-147: sandbox startup failures must carry structured diagnostics."""
 
     def test_sandbox_startup_error_has_info_dict(self) -> None:
-        """Guards ENG-147: SandboxStartupError carries sandbox_startup_info dict
+        """Guards ENG-147: SandboxStartupError carries a SandboxStartupDiagnostic
         with all required fields for result.json."""
         from benchflow.sandbox.daytona import SandboxStartupError
 
@@ -824,7 +826,7 @@ class TestSandboxStartupDiagnostics:
             attempts=3,
             build_timeout_sec=600.0,
         )
-        info = err.sandbox_startup_info
+        info = err.diagnostic.to_dict()
         assert info["reason"] == "sandbox_startup_failed"
         assert info["sandbox_id"] == "e7d8ab0f-47da-40b1-b179-46e1363fe014"
         assert info["sandbox_state"] == "creating"
@@ -850,16 +852,18 @@ class TestSandboxStartupDiagnostics:
 
     def test_sandbox_startup_info_in_result_json(self, tmp_path: Path) -> None:
         """Guards ENG-147: _build_rollout_result writes sandbox_startup_info to result.json."""
+        from benchflow.diagnostics import RolloutDiagnostics, SandboxStartupDiagnostic
         from benchflow.rollout import _build_rollout_result
 
-        info = {
-            "reason": "sandbox_startup_failed",
-            "sandbox_id": "abc123",
-            "sandbox_state": "error",
-            "attempts": 3,
-            "build_timeout_sec": 600.0,
-            "raw_message": "timeout",
-        }
+        diag = SandboxStartupDiagnostic(
+            sandbox_id="abc123",
+            sandbox_state="error",
+            attempts=3,
+            build_timeout_sec=600.0,
+            raw_message="timeout",
+        )
+        diagnostics = RolloutDiagnostics()
+        diagnostics.set(diag)
         result = _build_rollout_result(
             tmp_path,
             task_name="test-task",
@@ -876,10 +880,10 @@ class TestSandboxStartupDiagnostics:
             rewards=None,
             started_at=__import__("datetime").datetime.now(),
             timing={"agent": 0.0},
-            sandbox_startup_info=info,
+            diagnostics=diagnostics,
         )
         rj = __import__("json").loads((tmp_path / "result.json").read_text())
-        assert rj["sandbox_startup_info"] == info
+        assert rj["sandbox_startup_info"] == diag.to_dict()
         assert rj["error_category"] == "sandbox_setup"
         assert result.error == "Sandbox startup failed: timeout"
 
@@ -1052,14 +1056,16 @@ class TestTransportErrorDiagnostics:
 
     def test_transport_error_info_in_result_json(self, tmp_path) -> None:
         """Guards ENG-148: transport_error_info is written to result.json."""
+        from benchflow.diagnostics import RolloutDiagnostics, TransportClosedDiagnostic
         from benchflow.rollout import _build_rollout_result
 
-        transport_info = {
-            "reason": "transport_closed",
-            "process_exit_code": 255,
-            "transport_diagnosis": "process_exited",
-            "sandbox_reachable": False,
-        }
+        diag = TransportClosedDiagnostic(
+            process_exit_code=255,
+            transport_diagnosis="process_exited",
+            sandbox_reachable=False,
+        )
+        diagnostics = RolloutDiagnostics()
+        diagnostics.set(diag)
         result = _build_rollout_result(
             tmp_path,
             task_name="video-filler-word-remover",
@@ -1076,10 +1082,10 @@ class TestTransportErrorDiagnostics:
             rewards=None,
             started_at=__import__("datetime").datetime.now(),
             timing={"agent": 10.0},
-            transport_error_info=transport_info,
+            diagnostics=diagnostics,
         )
         rj = __import__("json").loads((tmp_path / "result.json").read_text())
-        assert rj["transport_error_info"] == transport_info
+        assert rj["transport_error_info"] == diag.to_dict()
         assert rj["error_category"] == "pipe_closed"
         assert result.error is not None
 
@@ -1179,7 +1185,7 @@ class TestDiagnosticRegistry:
         )
 
     def test_sandbox_startup_error_diagnostic_view_is_consistent(self) -> None:
-        """``SandboxStartupError.sandbox_startup_info`` reflects the same
+        """``SandboxStartupError.diagnostic.to_dict()`` reflects the same
         dict the registry serializer produces — one schema, one source."""
         from benchflow.diagnostics import RolloutDiagnostics
         from benchflow.sandbox.protocol import SandboxStartupError
@@ -1194,7 +1200,7 @@ class TestDiagnosticRegistry:
         rd = RolloutDiagnostics()
         rd.set(err.diagnostic)
         fields = rd.to_result_fields()
-        assert fields["sandbox_startup_info"] == err.sandbox_startup_info
+        assert fields["sandbox_startup_info"] == err.diagnostic.to_dict()
 
 
 class TestVerifierDepInstallDiagnostics:
@@ -1340,8 +1346,17 @@ class TestVerifierTimeoutDiagnostics:
     def test_verifier_timeout_info_in_result_json(self, tmp_path: Path) -> None:
         """Guards ENG-152: result.json includes verifier_timeout_info when
         verifier times out."""
+        from benchflow.diagnostics import RolloutDiagnostics, VerifierTimeoutDiagnostic
         from benchflow.rollout import _build_rollout_result
 
+        diagnostics = RolloutDiagnostics()
+        diagnostics.set(
+            VerifierTimeoutDiagnostic(
+                timeout_budget_sec=240.0,
+                elapsed_sec=240.1,
+                task_name="quantum-numerical-simulation",
+            )
+        )
         _build_rollout_result(
             tmp_path,
             task_name="quantum-numerical-simulation",
@@ -1358,11 +1373,7 @@ class TestVerifierTimeoutDiagnostics:
             rewards=None,
             started_at=__import__("datetime").datetime.now(),
             timing={"agent": 0.0},
-            verifier_timeout_info={
-                "timeout_budget_sec": 240.0,
-                "elapsed_sec": 240.1,
-                "task_name": "quantum-numerical-simulation",
-            },
+            diagnostics=diagnostics,
         )
         rj = __import__("json").loads((tmp_path / "result.json").read_text())
         assert rj["verifier_error_category"] == "verifier_timeout"

--- a/tests/test_base_install_imports.py
+++ b/tests/test_base_install_imports.py
@@ -31,8 +31,9 @@ def test_sandbox_startup_error_lives_in_protocol():
         "boom", sandbox_id="sb-1", sandbox_state="error", attempts=3
     )
     assert isinstance(err, RuntimeError)
-    assert err.sandbox_startup_info["sandbox_id"] == "sb-1"
-    assert err.sandbox_startup_info["attempts"] == 3
+    info = err.diagnostic.to_dict()
+    assert info["sandbox_id"] == "sb-1"
+    assert info["attempts"] == 3
 
 
 def test_legacy_sandbox_startup_error_import_path_still_works():

--- a/tests/test_oracle_chokepoint.py
+++ b/tests/test_oracle_chokepoint.py
@@ -896,19 +896,21 @@ class TestIdleTimeoutResultDiagnostics:
     def test_error_category_persisted_for_idle_timeout(self, tmp_path):
         """Guards ENG-149: result.json contains error_category='idle_timeout'."""
         from benchflow._utils.scoring import classify_error
+        from benchflow.diagnostics import IdleTimeoutDiagnostic, RolloutDiagnostics
         from benchflow.rollout import _build_rollout_result
 
         error = "Agent idle for 600s with no new tool call, message, or thought (last activity 602s ago, 3 tool calls so far)"
-        idle_info = {
-            "reason": "idle_timeout",
-            "idle_timeout_sec": 600,
-            "idle_duration_sec": 602,
-            "wall_clock_elapsed_sec": 605,
-            "n_tool_calls": 3,
-            "n_message_chunks": 0,
-            "n_thought_chunks": 1,
-            "last_activity_at": "2026-05-23T16:00:00+00:00",
-        }
+        diag = IdleTimeoutDiagnostic(
+            idle_timeout_sec=600,
+            idle_duration_sec=602,
+            wall_clock_elapsed_sec=605,
+            n_tool_calls=3,
+            n_message_chunks=0,
+            n_thought_chunks=1,
+            last_activity_at="2026-05-23T16:00:00+00:00",
+        )
+        diagnostics = RolloutDiagnostics()
+        diagnostics.set(diag)
         from datetime import datetime
 
         result = _build_rollout_result(
@@ -927,12 +929,12 @@ class TestIdleTimeoutResultDiagnostics:
             rewards=None,
             started_at=datetime.now(),
             timing={},
-            idle_timeout_info=idle_info,
+            diagnostics=diagnostics,
         )
         assert result.error == error
         result_json = json.loads((tmp_path / "result.json").read_text())
         assert result_json["error_category"] == "idle_timeout"
-        assert result_json["idle_timeout_info"] == idle_info
+        assert result_json["idle_timeout_info"] == diag.to_dict()
         assert result_json["idle_timeout_info"]["n_tool_calls"] == 3
         assert result_json["idle_timeout_info"]["idle_duration_sec"] == 602
         # Also verify classify_error agrees

--- a/tests/test_self_gen_export_failures.py
+++ b/tests/test_self_gen_export_failures.py
@@ -147,10 +147,9 @@ async def test_build_result_after_export_failure_is_not_success(tmp_path):
     rollout._started_at = datetime.now()
     rollout._timing = {}
     rollout._agent_name = ""
-    rollout._idle_timeout_info = None
-    rollout._sandbox_startup_info = None
-    rollout._transport_error_info = None
-    rollout._verifier_timeout_info = None
+    from benchflow.diagnostics import RolloutDiagnostics
+
+    rollout._diagnostics = RolloutDiagnostics()
     rollout._usage_metrics = {
         "n_input_tokens": None,
         "n_output_tokens": None,

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -124,7 +124,9 @@ class TestSdkVerify:
         assert "timed out" in verifier_error
         assert "verifier" in timing
         assert vti is not None
-        assert vti["timeout_budget_sec"] == 0.1
+        # ``vti`` is now a typed :class:`VerifierTimeoutDiagnostic` (issue
+        # #503); attribute access replaces the legacy dict indexing.
+        assert vti.timeout_budget_sec == 0.1
 
     @pytest.mark.asyncio
     async def test_verifier_crash(self, verify_harness):


### PR DESCRIPTION
Fixes #503, #504.

## Summary

Introduces a typed `Diagnostic` hierarchy emitted at source; deletes `_parse_transport_error`; collapses the four parallel `*_info` dicts into a single registry-driven container.

## Code judo

The two issues were two views of the same problem: structured diagnostic events that were duplicated across result-building, summary warnings, and check_results, with the transport variant additionally regex-parsed from a stringified `ConnectionError`. The fix flips both:

1. `benchflow.diagnostics` is the single source of truth. Each diagnostic kind is a `@dataclass` subclass of `Diagnostic` carrying its own `field` (result.json key), `category` (error_category it pairs with), `summary_description` (job-summary warning text), and `format_issue()` (check_results invalidation line).
2. Typed exceptions (`TransportClosedError`, `IdleTimeoutError`) carry a structured `.diagnostic` attribute. `sandbox/process.py` raises `TransportClosedError(TransportClosedDiagnostic(process_exit_code=rc, ...))` directly — downstream consumers never reverse-engineer fields from human-readable error strings. `SandboxStartupError` in `sandbox/protocol.py` keeps its no-optional-dep home and exposes its diagnostic the same way.
3. `Rollout._diagnostics` (a `RolloutDiagnostics` collector) replaces the four `_idle_timeout_info`/`_sandbox_startup_info`/`_transport_error_info`/`_verifier_timeout_info` attrs. `_build_rollout_result` serializes through it.
4. `evaluation.py` summary warnings, `tests/integration/check_results.py` invalidation lines, and `hosted_env.py` empty-diagnostic slots all flow through the registry.

**Adding a new diagnostic is one Diagnostic subclass — the result builder, summary, and check_results all discover it through `DIAGNOSTIC_REGISTRY`.**

`_parse_transport_error` is gone (deleted, not deprecated).

## Verification

- 2393 pytest pass (4 new `TestDiagnosticRegistry` tests + 4 new `TestTransportErrorDiagnostics` tests covering structured exception emission at source replacing the 4 deleted regex-parser tests).
- `uv run ruff check .` clean.
- `uv run ty check src/` clean.
- `grep -n "re\.\|rc=\|pid=" src/benchflow/rollout.py src/benchflow/sandbox/` shows zero diagnostic-related regex (only unrelated env-key validation and message-formatting).

## LOC

13 files changed, 852 insertions(+), 258 deletions(-). The net +594 is dominated by the new 412-line `diagnostics.py` module that centralizes what used to be scattered across rollout/evaluation/check_results/hosted_env. `rollout.py` shrank (2632 → 2617) — the diagnostic helper logic moved into the registry. No file crossed the 1000-line threshold.

## Backward compatibility

- `SandboxStartupError.sandbox_startup_info` still works (now a property over `self.diagnostic.to_dict()`).
- `IdleTimeoutError.idle_timeout_info` still works (property over `self.diagnostic.to_dict()`).
- `IdleTimeoutError` is re-exported from `benchflow.acp.runtime` so existing imports work.
- `SandboxStartupError` still lives in `benchflow.sandbox.protocol` (no optional deps, base-install guarantee from #358).
- result.json schema is unchanged — same field names, same shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how agent/transport/sandbox failures are captured and surfaced across rollout, evaluation, and audit tooling; `result.json` shape is preserved but any consumer still reading removed exception attributes (e.g. `.idle_timeout_info` on exceptions) would break unless updated to `.diagnostic`.
> 
> **Overview**
> Introduces **`benchflow.diagnostics`** as the single source of truth for rollout failure metadata that lands in **`result.json`**, job summary warnings, and **`check_results`**.
> 
> **`Diagnostic` subclasses** (idle timeout, sandbox startup, transport closed, verifier timeout) own their JSON field names, **`error_category`** mapping, summary text, and per-task issue formatting via **`DIAGNOSTIC_REGISTRY`**. **`RolloutDiagnostics`** replaces four separate **`Rollout`** `*_info` attributes; **`_build_rollout_result`** serializes through **`to_result_fields()`** while keeping the same flat **`result.json`** keys.
> 
> Failures are recorded **at the source** with typed exceptions carrying **`.diagnostic`** (e.g. **`TransportClosedError`** from **`sandbox/process.py`** and ACP transport paths) instead of regex-parsing **`ConnectionError`** messages — **`_parse_transport_error`** is removed. Idle and sandbox startup paths follow the same pattern; transport diagnostics can still be enriched after the fact (e.g. sandbox health probe fields).
> 
> **`evaluation.py`** job-end warnings and **`tests/integration/check_results.py`** infra/verifier invalidation lines are driven by the registry so new diagnostic kinds need one class, not scattered string templates. **`hosted_env`** fills empty diagnostic slots via the same collector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e31c241e04f22c921888910349a3d61513270ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->