### PR TITLE
docs: document skill loading semantics

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,6 +115,25 @@ A Rollout is checkpointable because three snapshot layers compose — container 
 
 **Agent — who acts.** The agent under test (eval) or the policy under training — Han's harness, "not intelligent." Protocol: **ACP** (the official `agent-client-protocol`). BYO via `--agent-import-path`. The registry stores agent *declarations* as data, not install code in the kernel. A trainer-served policy endpoint (OpenAI-compatible, hot-swappable) is one agent provider type. The plane's real surface is the `Session` (below) — not just `connect`.
 
+### Skill loading
+
+BenchFlow treats mounted skills as agent-native memory, not prompt text. A
+`--skills-dir` value, or a task-local `environment/skills` directory, is copied
+into the sandbox and registered through the selected agent's registry
+`skill_paths`. For Claude Code via `claude-agent-acp`, that means the skill packs
+land under the Claude Code skill root (for example `$HOME/.claude/skills`) and
+are discovered by Claude Code's native skill mechanism.
+
+Claude Code reads each skill's frontmatter name and description for native
+discovery. The full `SKILL.md` body and bundled resources are loaded by the
+agent when it invokes or reads the skill; BenchFlow does not inline every
+mounted skill body into the task prompt by default.
+
+`BENCHFLOW_SKILL_NUDGE` is an optional prompt nudge layered on top of native
+discovery. Use `name` to tell the agent which skills are mounted, `description`
+to include each mounted skill's description, or `full` to include the full
+`SKILL.md` body. Omit the variable to keep BenchFlow's runtime default off.
+
 **Environment — the world (Han's S).** The stateful world the agent acts in. Owns the world's lifecycle: `provision / readiness / query / snapshot / restore / reset / teardown`. See "The Environment plane & the manifest."
 
 **Reward — how it's scored (Han's V).** `RewardFunc` / `Rubric` / verifier. `V: (task, completion, info) → [0,1]`, generalised to a graded, multi-space, multi-granularity signal over the trajectory tree. See "Evaluation."

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -33,8 +33,8 @@ bench eval create \
   --agent-env BENCHFLOW_SKILL_NUDGE=name
 ```
 
-Other nudge modes are `description` and `full`. Omit
-`--agent-env BENCHFLOW_SKILL_NUDGE=...` to leave BenchFlow's runtime default off.
+See [Architecture: skill loading](../architecture.md#skill-loading) for the
+skill loading semantics and available nudge modes.
 
 ## Demos
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,9 +113,9 @@ local directory, or `--config <config.yaml>` for a YAML config. Results land und
 `trajectory/acp_trajectory.jsonl` for the full agent trace.
 
 When you mount skills, use `BENCHFLOW_SKILL_NUDGE=name` as the default docs
-option. It tells the agent which skills are available and where to read them.
-For more context in the prompt, use `description` or `full`; omit the env var
-to keep BenchFlow's runtime default off.
+option. See [Architecture: skill loading](./architecture.md#skill-loading) for
+how mounted skills reach the agent and how `name`, `description`, and `full`
+differ.
 
 ## Run from Python
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -96,10 +96,9 @@ bench eval create \
 | `--exclude` | — | Skip these task names; repeatable (e.g. `--exclude quantum-numerical-simulation`) |
 
 When mounting skills, the recommended docs default is
-`--agent-env BENCHFLOW_SKILL_NUDGE=name`. It prepends a short hint telling the agent
-which skills are available and where to read them. More verbose modes are
-`description` and `full`. Omit the env var to leave BenchFlow's runtime default
-off.
+`--agent-env BENCHFLOW_SKILL_NUDGE=name`. See
+[Architecture: skill loading](../architecture.md#skill-loading) for how
+`--skills-dir` is registered with each agent and how the nudge modes differ.
 
 `--source-env` is for external hosted environment hubs. The first supported
 runner is PrimeIntellect / Verifiers: BenchFlow preserves the hosted identity

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -252,6 +252,10 @@ bench eval create \
   --agent-env BENCHFLOW_SKILL_NUDGE=name
 ```
 
+Task-local skills are mounted through the selected agent's native skill paths.
+See [Architecture: skill loading](./architecture.md#skill-loading) for the
+canonical loading semantics and nudge modes.
+
 `bench tasks generate` converts agent traces (Claude Code sessions, opentraces records, or HuggingFace datasets) into task directories with `task.toml`, `instruction.md`, and a file-existence `test.sh`. Use `--dry-run` to preview traces before generating. See [CLI reference](./reference/cli.md#bench-tasks-generate) for all flags.
 
 `bench tasks check` validates that `task.toml`, `instruction.md` (non-empty), `environment/Dockerfile`, and `tests/` (non-empty) all exist, and that `[agent].timeout_sec` is set. Exits with code 1 on failure (CI-friendly).


### PR DESCRIPTION
## Summary
- Add a canonical Architecture section for BenchFlow skill loading semantics.
- Explain that mounted skills are registered through agent registry skill_paths, with Claude Code / claude-agent-acp relying on native skill discovery and lazy body/resource loading.
- Link getting-started, CLI reference, task-authoring, and examples back to the canonical section instead of duplicating the semantics.

Fixes #506.

## Validation
- uv run python -m pytest tests/test_cli_docs_drift.py
- rg/link sanity for the new skill-loading anchor and references
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->