### PR TITLE
Expose skill invocation counts in rollout artifacts

### DIFF
--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -408,10 +408,17 @@ The `result.json` contains:
 ```json
 {
   "rewards": {"reward": 0.48},
+  "n_tool_calls": 12,
+  "n_skill_invocations": 2,
   "passed": true,
   "verifier_output": "..."
 }
 ```
+
+`n_skill_invocations` is derived from structured ACP trajectory events: BenchFlow
+counts only `tool_call` events whose `kind` is `skill`. Job `summary.json`
+also includes `total_skill_invocations` and `avg_skill_invocations` across the
+rollouts in the run.
 
 List evaluations:
 ```bash

--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -9,12 +9,20 @@ from benchflow._utils.reward_events import (
     reward_event_to_dict,
 )
 from benchflow.models import RolloutResult
+from benchflow.trajectories.metrics import (
+    count_skill_invocations,
+    result_skill_invocations,
+)
 
 
 def agent_result_from_rollout(result: RolloutResult) -> dict[str, Any]:
     """Return the serialized agent_result block for an in-memory rollout result."""
+    n_skill_invocations = result.n_skill_invocations or count_skill_invocations(
+        result.trajectory
+    )
     return {
         "n_tool_calls": result.n_tool_calls,
+        "n_skill_invocations": n_skill_invocations,
         "n_prompts": result.n_prompts,
         "n_input_tokens": result.n_input_tokens,
         "n_output_tokens": result.n_output_tokens,
@@ -40,6 +48,9 @@ def rollout_result_payload(
     task_source = result.source_provenance or task_source_provenance(
         source_provenance, tasks_dir / task_name
     )
+    n_skill_invocations = result.n_skill_invocations or count_skill_invocations(
+        result.trajectory
+    )
     return {
         "task_name": result.task_name,
         "rewards": result.rewards,
@@ -47,6 +58,7 @@ def rollout_result_payload(
         "verifier_error": result.verifier_error,
         "export_error": result.export_error,
         "n_tool_calls": result.n_tool_calls,
+        "n_skill_invocations": n_skill_invocations,
         "agent_result": agent_result_from_rollout(result),
         **(
             {"reward_events": [reward_event_to_dict(event) for event in reward_events]}
@@ -91,4 +103,15 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
             round(total_cost / len(covered), 10) if covered else None
         ),
         "telemetry_coverage": (len(covered) / len(completed) if completed else 0.0),
+    }
+
+
+def skill_invocation_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate structured skill invocation counts for summary.json."""
+    total = sum(result_skill_invocations(result) for result in results.values())
+    return {
+        "total_skill_invocations": total,
+        "avg_skill_invocations": (
+            round(total / len(results), 1) if results else 0.0
+        ),
     }

--- a/src/benchflow/acp/types.py
+++ b/src/benchflow/acp/types.py
@@ -78,6 +78,7 @@ class ToolKind(StrEnum):
     BROWSER = "browser"
     READ = "read"
     WRITE = "write"
+    SKILL = "skill"
 
 
 class ToolCallStatus(StrEnum):

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -26,6 +26,7 @@ import yaml
 
 from benchflow._utils.evaluation_results import (
     rollout_result_payload,
+    skill_invocation_summary,
     usage_summary,
 )
 from benchflow._utils.learner_memory import (
@@ -1224,6 +1225,7 @@ class Evaluation:
             ),
             "memory": memory,
             "memory_scores": memory_scores,
+            **skill_invocation_summary(all_results),
             **usage_summary(all_results),
             **summary_source_fields(cfg.source_provenance, all_results),
         }

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -20,6 +20,7 @@ from benchflow._utils.scoring import (
     pass_rate,
     pass_rate_excl_errors,
 )
+from benchflow.trajectories.metrics import result_skill_invocations
 
 logger = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class TaskMetrics:
     task_name: str
     reward: float | None = None
     n_tool_calls: int = 0
+    n_skill_invocations: int = 0
     n_prompts: int = 0
     error: str | None = None
     verifier_error: str | None = None
@@ -160,6 +162,16 @@ class BenchmarkMetrics:
         )
 
     @property
+    def avg_skill_invocations(self) -> float:
+        """Average structured skill invocations per completed task."""
+        completed = [t for t in self.tasks if t.completed]
+        return (
+            sum(t.n_skill_invocations for t in completed) / len(completed)
+            if completed
+            else 0.0
+        )
+
+    @property
     def avg_duration(self) -> float:
         """Average duration per completed task (seconds)."""
         completed = [t for t in self.tasks if t.completed and t.duration_sec > 0]
@@ -282,6 +294,7 @@ class BenchmarkMetrics:
             "score": f"{self.score:.1%}",
             "score_excl_errors": f"{self.score_excl_errors:.1%}",
             "avg_tool_calls": round(self.avg_tool_calls, 1),
+            "avg_skill_invocations": round(self.avg_skill_invocations, 1),
             "avg_duration_sec": round(self.avg_duration, 1),
             "total_input_tokens": self.total_input_tokens,
             "total_output_tokens": self.total_output_tokens,
@@ -366,6 +379,7 @@ def collect_metrics(
                 task_name=task_name,
                 reward=reward,
                 n_tool_calls=r.get("n_tool_calls", 0),
+                n_skill_invocations=result_skill_invocations(r),
                 n_prompts=r.get("n_prompts", 0),
                 error=r.get("error"),
                 verifier_error=r.get("verifier_error"),

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -72,6 +72,9 @@ class RolloutResult:
         agent_name:   Name reported by the agent via ACP initialize handshake.
         model:        Model ID used (e.g. "google/gemini-3.1-flash-lite-preview").
         n_tool_calls: Total tool calls observed during the session.
+        n_skill_invocations: Total skill tool calls observed in structured ACP
+                      trajectory events. Counts only ``tool_call`` events whose
+                      structured ``kind`` is ``"skill"``.
         n_prompts:    Number of user prompts sent to the agent.
         n_input_tokens: Cumulative provider prompt/input tokens, or None when
                       provider telemetry was unavailable.
@@ -124,6 +127,7 @@ class RolloutResult:
         agent_name: str = "",
         model: str | None = None,
         n_tool_calls: int = 0,
+        n_skill_invocations: int = 0,
         n_prompts: int = 0,
         n_input_tokens: int | None = None,
         n_output_tokens: int | None = None,
@@ -152,6 +156,7 @@ class RolloutResult:
         self.agent_name = agent_name
         self.model = model
         self.n_tool_calls = n_tool_calls
+        self.n_skill_invocations = n_skill_invocations
         self.n_prompts = n_prompts
         self.n_input_tokens = n_input_tokens
         self.n_output_tokens = n_output_tokens

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -96,6 +96,7 @@ from benchflow.trajectories._capture import (
     _capture_session_trajectory,
     _scrape_agent_trajectory,
 )
+from benchflow.trajectories.metrics import count_skill_invocations
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
 
 logger = logging.getLogger(__name__)
@@ -516,6 +517,7 @@ def _build_rollout_result(
 ) -> RolloutResult:
     """Build RolloutResult and write result.json, timing.json, prompts.json, trajectory."""
     finished_at = datetime.now()
+    n_skill_invocations = count_skill_invocations(trajectory)
     result = RolloutResult(
         task_name=task_name,
         rollout_name=rollout_name,
@@ -525,6 +527,7 @@ def _build_rollout_result(
         agent_name=agent_name,
         model=model,
         n_tool_calls=n_tool_calls,
+        n_skill_invocations=n_skill_invocations,
         n_prompts=len(prompts),
         n_input_tokens=n_input_tokens,
         n_output_tokens=n_output_tokens,
@@ -562,9 +565,11 @@ def _build_rollout_result(
                 "agent_name": result.agent_name,
                 "model": result.model,
                 "n_tool_calls": result.n_tool_calls,
+                "n_skill_invocations": result.n_skill_invocations,
                 "n_prompts": result.n_prompts,
                 "agent_result": {
                     "n_tool_calls": result.n_tool_calls,
+                    "n_skill_invocations": result.n_skill_invocations,
                     "n_prompts": result.n_prompts,
                     "n_input_tokens": result.n_input_tokens,
                     "n_output_tokens": result.n_output_tokens,

--- a/src/benchflow/trajectories/metrics.py
+++ b/src/benchflow/trajectories/metrics.py
@@ -1,0 +1,38 @@
+"""Metrics derived from structured trajectory events."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def count_skill_invocations(trajectory: list[dict[str, Any]]) -> int:
+    """Count ACP skill invocations from structured tool-call events.
+
+    BenchFlow records ACP tool calls as dict events with ``type`` and ``kind``.
+    A skill invocation is only counted when the event is explicitly a
+    ``tool_call`` whose structured ``kind`` is ``"skill"``. Display text such as
+    titles, messages, or tool names is intentionally ignored.
+    """
+    return sum(
+        1
+        for event in trajectory
+        if isinstance(event, dict)
+        and event.get("type") == "tool_call"
+        and event.get("kind") == "skill"
+    )
+
+
+def result_skill_invocations(result: Mapping[str, Any]) -> int:
+    """Return a result artifact's skill invocation count.
+
+    New artifacts expose ``n_skill_invocations`` at the top level and inside
+    ``agent_result``. Older artifacts may have neither; they are treated as
+    zero so aggregate readers remain backward compatible.
+    """
+    value = result.get("n_skill_invocations")
+    if value is None:
+        agent_result = result.get("agent_result")
+        if isinstance(agent_result, Mapping):
+            value = agent_result.get("n_skill_invocations")
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -33,6 +33,10 @@ from benchflow._utils.scoring import (
     count_result_outcomes,
 )
 from benchflow._utils.source_provenance import source_issues, source_matches_parent
+from benchflow.trajectories.metrics import (
+    count_skill_invocations,
+    result_skill_invocations,
+)
 
 EXPECTED: dict[str, Any] = {}
 EXPECTED_FIELDS = {
@@ -177,6 +181,28 @@ def _expected_label(value: Any) -> str:
     if value is _MISSING:
         return "<missing>"
     return "null" if value is None else repr(value)
+
+
+def _nonnegative_int_issue(value: Any, label: str) -> str | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return f"{label} must be a non-negative integer"
+    return None
+
+
+def _load_acp_trajectory(path: Path) -> list[dict[str, Any]] | None:
+    trajectory_path = path.parent / "trajectory" / "acp_trajectory.jsonl"
+    if not trajectory_path.exists():
+        return None
+    trajectory: list[dict[str, Any]] = []
+    try:
+        for line in trajectory_path.read_text().splitlines():
+            if line.strip():
+                event = json.loads(line)
+                if isinstance(event, dict):
+                    trajectory.append(event)
+    except (json.JSONDecodeError, OSError):
+        return None
+    return trajectory
 
 
 def _latest_results_by_task(result_entries: list[tuple[Path, dict]]) -> list[dict]:
@@ -405,6 +431,39 @@ def check_agent(agent_dir: Path) -> dict:
         if missing:
             findings["issues"].append(f"{r.get('task_name', '?')}: missing {missing}")
             findings["ok"] = False
+        skill_count = r.get("n_skill_invocations")
+        agent_result = r.get("agent_result") or {}
+        agent_skill_count = agent_result.get("n_skill_invocations")
+        if skill_count is not None:
+            issue = _nonnegative_int_issue(
+                skill_count, f"{r.get('task_name', '?')}: n_skill_invocations"
+            )
+            if issue:
+                findings["issues"].append(issue)
+                findings["ok"] = False
+            if agent_skill_count is not None and agent_skill_count != skill_count:
+                findings["issues"].append(
+                    f"{r.get('task_name', '?')}: agent_result.n_skill_invocations "
+                    "does not match result.json n_skill_invocations"
+                )
+                findings["ok"] = False
+            trajectory = _load_acp_trajectory(result_file)
+            if trajectory is not None:
+                expected_skill_count = count_skill_invocations(trajectory)
+                if skill_count != expected_skill_count:
+                    findings["issues"].append(
+                        f"{r.get('task_name', '?')}: n_skill_invocations={skill_count} "
+                        f"but trajectory implies {expected_skill_count}"
+                    )
+                    findings["ok"] = False
+        if agent_skill_count is not None:
+            issue = _nonnegative_int_issue(
+                agent_skill_count,
+                f"{r.get('task_name', '?')}: agent_result.n_skill_invocations",
+            )
+            if issue:
+                findings["issues"].append(issue)
+                findings["ok"] = False
         found_source_issues = source_issues(
             r.get("source"),
             f"{r.get('task_name', '?')}: result.json",
@@ -739,6 +798,18 @@ def check_agent(agent_dir: Path) -> dict:
                             f"summary source does not cover {r.get('task_name', '?')}"
                         )
                         findings["ok"] = False
+            for field in ("total_skill_invocations", "avg_skill_invocations"):
+                if field in summary:
+                    value = summary[field]
+                    if (
+                        isinstance(value, bool)
+                        or not isinstance(value, int | float)
+                        or value < 0
+                    ):
+                        findings["issues"].append(
+                            f"summary.json {field} must be a non-negative number"
+                        )
+                        findings["ok"] = False
             findings["summary"] = summary
         except json.JSONDecodeError:
             findings["issues"].append("summary.json: invalid JSON")
@@ -773,6 +844,23 @@ def check_agent(agent_dir: Path) -> dict:
                 findings["issues"].append(
                     f"summary.json memory_score={summary['memory_score']} "
                     f"but results imply {implied}"
+                )
+                findings["ok"] = False
+        if "total_skill_invocations" in summary:
+            implied = sum(result_skill_invocations(result) for result in latest_results)
+            if summary["total_skill_invocations"] != implied:
+                findings["issues"].append(
+                    "summary.json total_skill_invocations="
+                    f"{summary['total_skill_invocations']} but results imply {implied}"
+                )
+                findings["ok"] = False
+        if "avg_skill_invocations" in summary:
+            total = sum(result_skill_invocations(result) for result in latest_results)
+            implied = round(total / len(latest_results), 1) if latest_results else 0.0
+            if abs(float(summary["avg_skill_invocations"]) - implied) > 1e-9:
+                findings["issues"].append(
+                    "summary.json avg_skill_invocations="
+                    f"{summary['avg_skill_invocations']} but results imply {implied}"
                 )
                 findings["ok"] = False
 

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -164,6 +164,116 @@ def _write_config(
     (path / "config.json").write_text(json.dumps(config))
 
 
+def test_check_results_accepts_skill_invocation_metrics(tmp_path: Path) -> None:
+    """Guards issue #507: result checker accepts valid structured skill counts."""
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-05-24__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "model": "test-model",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "n_skill_invocations": 1,
+                "agent_result": {"n_skill_invocations": 1},
+                "source": _source(),
+            }
+        )
+    )
+    traj_dir = run_dir / "trajectory"
+    traj_dir.mkdir()
+    (traj_dir / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "calculator"})
+        + "\n"
+    )
+    _write_config(run_dir)
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "agent": "agentA",
+                "model": "test-model",
+                "environment": "daytona",
+                "concurrency": 64,
+                "agent_idle_timeout_sec": 600,
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "100.0%",
+                "total_skill_invocations": 1,
+                "avg_skill_invocations": 1.0,
+                "source": _source(),
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is True
+
+
+def test_check_results_flags_skill_invocation_mismatch(tmp_path: Path) -> None:
+    """Guards issue #507: result checker compares skill counts to ACP trajectory."""
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-05-24__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "model": "test-model",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "n_skill_invocations": 0,
+                "agent_result": {"n_skill_invocations": 0},
+                "source": _source(),
+            }
+        )
+    )
+    traj_dir = run_dir / "trajectory"
+    traj_dir.mkdir()
+    (traj_dir / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "calculator"})
+        + "\n"
+    )
+    _write_config(run_dir)
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "agent": "agentA",
+                "model": "test-model",
+                "environment": "daytona",
+                "concurrency": 64,
+                "agent_idle_timeout_sec": 600,
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "100.0%",
+                "total_skill_invocations": 0,
+                "avg_skill_invocations": 0.0,
+                "source": _source(),
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is False
+    assert any(
+        "n_skill_invocations=0 but trajectory implies 1" in issue
+        for issue in findings["issues"]
+    )
+
+
 def test_check_results_requires_source_provenance(tmp_path: Path) -> None:
     """Guards v0.5-integration@cb8759e against unaudited source artifacts."""
     agent_dir = tmp_path / "agentA"

--- a/tests/test_skill_invocation_artifacts.py
+++ b/tests/test_skill_invocation_artifacts.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from benchflow._utils.evaluation_results import (
+    rollout_result_payload,
+    skill_invocation_summary,
+)
+from benchflow.models import RolloutResult
+from benchflow.rollout import _build_rollout_result
+from benchflow.trajectories.metrics import count_skill_invocations
+
+
+def test_skill_invocation_count_uses_structured_kind_only() -> None:
+    """Guards issue #507: skill counts must not come from display-text matching."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "bash",
+            "title": "Use the data-cleaning skill",
+        },
+        {"type": "agent_message", "text": "Invoking Skill(data-cleaning)"},
+        {"type": "tool_call", "kind": "skill", "title": "data-cleaning"},
+    ]
+
+    assert count_skill_invocations(trajectory) == 1
+
+
+def test_build_rollout_result_writes_skill_invocation_metric(tmp_path) -> None:
+    """Guards issue #507: result.json exposes structured skill invocation counts."""
+    trajectory = [
+        {"type": "user_message", "text": "solve"},
+        {"type": "tool_call", "kind": "skill", "title": "calculator"},
+        {"type": "tool_call", "kind": "bash", "title": "python solve.py"},
+    ]
+
+    result = _build_rollout_result(
+        tmp_path,
+        task_name="task-a",
+        rollout_name="task-a__abc123",
+        agent="agentA",
+        agent_name="agentA",
+        model="test-model",
+        n_tool_calls=2,
+        prompts=["solve"],
+        error=None,
+        verifier_error=None,
+        trajectory=trajectory,
+        partial_trajectory=False,
+        rewards={"reward": 1.0},
+        started_at=datetime.now(),
+        timing={"agent": 1.0},
+    )
+
+    payload = json.loads((tmp_path / "result.json").read_text())
+    assert result.n_skill_invocations == 1
+    assert payload["n_skill_invocations"] == 1
+    assert payload["agent_result"]["n_skill_invocations"] == 1
+
+
+def test_evaluation_payload_and_summary_include_skill_invocations(tmp_path) -> None:
+    """Guards issue #507: evaluation artifacts aggregate the canonical metric."""
+    result = RolloutResult(
+        task_name="task-a",
+        rewards={"reward": 1.0},
+        trajectory=[
+            {"type": "tool_call", "kind": "skill", "title": "calculator"},
+            {"type": "tool_call", "kind": "skill", "title": "spreadsheet"},
+            {"type": "tool_call", "kind": "bash", "title": "pytest"},
+        ],
+        n_tool_calls=3,
+    )
+
+    payload = rollout_result_payload(
+        result,
+        source_provenance=None,
+        tasks_dir=tmp_path,
+        task_name="task-a",
+    )
+    summary = skill_invocation_summary({"task-a": payload})
+
+    assert payload["n_skill_invocations"] == 2
+    assert payload["agent_result"]["n_skill_invocations"] == 2
+    assert summary == {"total_skill_invocations": 2, "avg_skill_invocations": 2.0}

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -50,6 +50,7 @@ def test_result_json_contains_unavailable_usage_defaults(tmp_path):
     assert result.usage_source == "unavailable"
     assert data["agent_result"] == {
         "n_tool_calls": 3,
+        "n_skill_invocations": 0,
         "n_prompts": 1,
         "n_input_tokens": None,
         "n_output_tokens": None,


### PR DESCRIPTION
## Summary

- Add canonical structured trajectory helpers for skill invocation metrics.
- Persist `n_skill_invocations` in `result.json` and nested `agent_result`.
- Aggregate `total_skill_invocations` and `avg_skill_invocations` into `summary.json` and metrics summaries.
- Teach the integration result checker to validate optional skill invocation fields against ACP trajectory JSONL when present.
- Document the user-facing artifact fields.

The count is derived only from structured ACP events: `tool_call` events whose `kind` is exactly `skill`. It intentionally does not parse titles, messages, or other display text.

Closes #507.

## Validation

- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/test_skill_invocation_artifacts.py tests/test_integration_check_results.py tests/test_metrics.py tests/test_usage_proxy.py tests/test_acp.py tests/test_capture_trajectory.py`
- `uv run python -m pytest tests/` -> 2394 passed, 2 skipped, 1 deselected
- Local ACP smoke with a stdio mock agent emitting one `kind: "skill"` tool call and one `kind: "bash"` tool call -> `{"artifact_n_skill_invocations": 1, "n_skill_invocations": 1, "n_tool_calls": 2}`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->