### PR TITLE
Add SkillsBench Harbor parity checker

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -140,6 +140,45 @@ inventory under `dogfood/2026-05-19-release-gate/hosted-envs/` by default.
 OpenReward and PrimeIntellect remain hub-metadata checks until account/credited
 hosted eval support is available; Harbor has a public registry inventory path.
 
+SkillsBench-vs-Harbor parity is an offline checker over existing artifacts. It
+does not clone `benchflow-ai/skillsbench-trajectories` during the release run
+because that baseline repository is large. Supply a local checkout or extracted
+artifact root pinned to `2d86fe82f6a06f7c7b3a22a3ae90d554d0e9655c`:
+
+```bash
+uv run python tests/integration/run_suite.py --lane skillsbench-harbor-parity \
+  --execute-skillsbench-harbor-parity \
+  --skillsbench-harbor-benchflow-root jobs/integration-<run-id>/<agent> \
+  --skillsbench-harbor-baseline-root /path/to/skillsbench-trajectories/shenghan/gemini-cli/gemini3flash/noskills \
+  --skillsbench-harbor-task jax-computing-basics \
+  --skillsbench-harbor-task python-scala-translation \
+  --skillsbench-harbor-task jpg-ocr-stat \
+  --skillsbench-harbor-task grid-dispatch-operator \
+  --skillsbench-harbor-task threejs-to-obj \
+  --skillsbench-harbor-task data-to-d3 \
+  --skillsbench-harbor-task lake-warming-attribution \
+  --skillsbench-harbor-task weighted-gdp-calc \
+  --skillsbench-harbor-task shock-analysis-supply
+```
+
+The checker normalizes the expected schema differences explicitly: Harbor
+rewards come from `verifier_result.rewards.reward` and ATIF trajectories from
+`agent/trajectory.json`, while BenchFlow rewards come from `rewards.reward` and
+ACP trajectories from `trajectory/acp_trajectory.jsonl`. It fails on missing
+tasks, malformed artifacts, missing trajectories, unseen task outcomes, per-task
+reward movement outside the Harbor observed range, and aggregate
+outcome/reward-rate drift over the configured thresholds.
+
+To refresh the Harbor pin, fetch the baseline repository, inspect the candidate
+run root, run the parity checker against known BenchFlow evidence, and update
+`tests/integration/suites/release.yaml` plus the command above only after the
+new baseline is accepted:
+
+```bash
+git -C /path/to/skillsbench-trajectories fetch origin main
+git -C /path/to/skillsbench-trajectories rev-parse origin/main
+```
+
 Use `--fail-on-todo` whenever a dry-run plan is being used as release evidence. Despite the name, this gate fails on unresolved TODOs and explicit `blocked_by` entries. The `near-term`, `release-gated-cli`, `hosted-envs`, and `full-release` profiles are expected to pass the gate today. The `backlog` profile is expected to fail this gate until the future Firecracker/Kubernetes security DinD lane is resolved; that failure tracks planned coverage, not a current release blocker.
 
 ### Run Tracking and Profiles

--- a/tests/integration/check_skillsbench_harbor_parity.py
+++ b/tests/integration/check_skillsbench_harbor_parity.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Compare BenchFlow SkillsBench results against a pinned Harbor baseline.
+
+The Harbor baseline is intentionally supplied as a local path. The public
+``benchflow-ai/skillsbench-trajectories`` repository is large, so this checker
+does not clone or refresh it as a side effect of a release evidence run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from benchflow._utils.scoring import classify_result
+
+DEFAULT_HARBOR_BASELINE_REF = "2d86fe82f6a06f7c7b3a22a3ae90d554d0e9655c"
+PIN_FILE = ".benchflow-harbor-baseline-ref"
+BENCHFLOW_REQUIRED = {"task_name", "rewards", "error", "verifier_error"}
+HARBOR_REQUIRED = {"task_name", "config", "agent_info", "verifier_result"}
+OUTCOMES = ("passed", "failed", "errored", "verifier_errored")
+
+
+@dataclass(frozen=True)
+class NormalizedTrajectory:
+    path: Path
+    format: str
+    steps: int
+    tool_calls: int
+
+
+@dataclass(frozen=True)
+class NormalizedResult:
+    source: str
+    path: Path
+    task_name: str
+    reward: float | None
+    outcome: str
+    agent: str | None
+    model: str | None
+    environment: str | None
+    trajectory: NormalizedTrajectory | None
+
+
+@dataclass(frozen=True)
+class ResultSet:
+    source: str
+    results: list[NormalizedResult]
+    issues: list[str]
+
+
+def _load_json(path: Path) -> Any:
+    with open(path) as f:
+        return json.load(f)
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _string(value: Any) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _jsonl_records(path: Path) -> list[Any]:
+    records = []
+    with open(path) as f:
+        for line in f:
+            if line.strip():
+                records.append(json.loads(line))
+    return records
+
+
+def _trajectory_candidates(result_path: Path) -> list[Path]:
+    parent = result_path.parent
+    candidates = [
+        parent / "trajectory" / "acp_trajectory.jsonl",
+        parent / "agent" / "trajectory.json",
+        parent / "trajectory.json",
+    ]
+    agent_dir = parent / "agent"
+    if agent_dir.exists():
+        candidates.extend(sorted(agent_dir.glob("*.trajectory.json")))
+    return candidates
+
+
+def _load_trajectory(result_path: Path) -> NormalizedTrajectory | None:
+    path = next(
+        (
+            candidate
+            for candidate in _trajectory_candidates(result_path)
+            if candidate.exists()
+        ),
+        None,
+    )
+    if path is None:
+        return None
+
+    if path.suffix == ".jsonl":
+        records = _jsonl_records(path)
+        tool_calls = sum(
+            1
+            for record in records
+            if isinstance(record, dict) and record.get("type") == "tool_call"
+        )
+        return NormalizedTrajectory(path, "acp-jsonl", len(records), tool_calls)
+
+    data = _load_json(path)
+    if not isinstance(data, dict):
+        raise ValueError(f"trajectory JSON is not an object: {path}")
+    steps = data.get("steps")
+    if not isinstance(steps, list):
+        raise ValueError(f"trajectory JSON has no steps list: {path}")
+    tool_calls = 0
+    for step in steps:
+        if isinstance(step, dict) and isinstance(step.get("tool_calls"), list):
+            tool_calls += len(step["tool_calls"])
+    schema = _string(data.get("schema_version")) or "json"
+    return NormalizedTrajectory(path, schema, len(steps), tool_calls)
+
+
+def _find_result_files(root: Path) -> list[Path]:
+    return sorted(path for path in root.rglob("result.json") if path.is_file())
+
+
+def _task_name_from_path(path: Path) -> str:
+    return path.parent.name.rsplit("__", 1)[0]
+
+
+def _path_may_match_task(path: Path, tasks: set[str]) -> bool:
+    path_task = _task_name_from_path(path)
+    return any(task == path_task or task.startswith(path_task) for task in tasks)
+
+
+def _normalize_benchflow_result(path: Path, data: dict[str, Any]) -> NormalizedResult:
+    missing = BENCHFLOW_REQUIRED - set(data)
+    if missing:
+        raise ValueError(f"missing BenchFlow field(s): {sorted(missing)}")
+    task_name = _string(data.get("task_name"))
+    if task_name is None:
+        raise ValueError("BenchFlow task_name must be a non-empty string")
+    rewards = data.get("rewards")
+    reward = _number(rewards.get("reward")) if isinstance(rewards, dict) else None
+    error = _string(data.get("error"))
+    verifier_error = _string(data.get("verifier_error"))
+    return NormalizedResult(
+        source="benchflow",
+        path=path,
+        task_name=task_name,
+        reward=reward,
+        outcome=classify_result(
+            reward=reward,
+            error=error,
+            verifier_error=verifier_error,
+        ),
+        agent=_string(data.get("agent")),
+        model=_string(data.get("model")),
+        environment=None,
+        trajectory=_load_trajectory(path),
+    )
+
+
+def _harbor_agent_name(agent_info: Any, config_agent: Any) -> str | None:
+    if isinstance(agent_info, dict):
+        return _string(agent_info.get("name"))
+    if isinstance(config_agent, dict):
+        return _string(config_agent.get("name"))
+    return None
+
+
+def _harbor_model_name(agent_info: Any, config_agent: Any) -> str | None:
+    model_info = agent_info.get("model_info") if isinstance(agent_info, dict) else None
+    if isinstance(model_info, dict):
+        return _string(model_info.get("name"))
+    if isinstance(config_agent, dict):
+        return _string(config_agent.get("model_name"))
+    return None
+
+
+def _normalize_harbor_result(path: Path, data: dict[str, Any]) -> NormalizedResult:
+    missing = HARBOR_REQUIRED - set(data)
+    if missing:
+        raise ValueError(f"missing Harbor field(s): {sorted(missing)}")
+    task_name = _string(data.get("task_name"))
+    if task_name is None:
+        raise ValueError("Harbor task_name must be a non-empty string")
+
+    verifier_result = data.get("verifier_result")
+    rewards = (
+        verifier_result.get("rewards") if isinstance(verifier_result, dict) else None
+    )
+    reward = _number(rewards.get("reward")) if isinstance(rewards, dict) else None
+    exception_info = data.get("exception_info")
+    error = json.dumps(exception_info, sort_keys=True) if exception_info else None
+
+    agent_info = data.get("agent_info")
+    config = data.get("config")
+    config_agent = config.get("agent") if isinstance(config, dict) else None
+    config_env = config.get("environment") if isinstance(config, dict) else None
+
+    return NormalizedResult(
+        source="harbor",
+        path=path,
+        task_name=task_name,
+        reward=reward,
+        outcome=classify_result(
+            reward=reward,
+            error=error,
+            verifier_error=None,
+        ),
+        agent=_harbor_agent_name(agent_info, config_agent),
+        model=_harbor_model_name(agent_info, config_agent),
+        environment=(
+            _string(config_env.get("type")) if isinstance(config_env, dict) else None
+        ),
+        trajectory=_load_trajectory(path),
+    )
+
+
+def load_result_set(root: Path, *, source: str, tasks: set[str] | None) -> ResultSet:
+    normalizer = (
+        _normalize_benchflow_result
+        if source == "benchflow"
+        else _normalize_harbor_result
+    )
+    results: list[NormalizedResult] = []
+    issues: list[str] = []
+    for path in _find_result_files(root):
+        if tasks is not None and not _path_may_match_task(path, tasks):
+            continue
+        try:
+            data = _load_json(path)
+            if not isinstance(data, dict):
+                raise ValueError("result.json is not a JSON object")
+            result = normalizer(path, data)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            issues.append(f"{source}: {path}: {exc}")
+            continue
+        if tasks is None or result.task_name in tasks:
+            results.append(result)
+    if not results:
+        issues.append(f"{source}: no matching result.json files under {root}")
+    return ResultSet(source, results, issues)
+
+
+def _git_head(root: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        return None
+    return completed.stdout.strip()
+
+
+def _baseline_pin_issues(root: Path, expected_ref: str) -> list[str]:
+    if not expected_ref:
+        return []
+    head = _git_head(root)
+    if head is not None:
+        if head != expected_ref:
+            return [
+                "harbor: baseline git HEAD "
+                f"{head} does not match pinned ref {expected_ref}"
+            ]
+        return []
+
+    pin_path = root / PIN_FILE
+    if not pin_path.exists():
+        return [
+            "harbor: baseline root is not a git checkout and has no "
+            f"{PIN_FILE} pin file"
+        ]
+    actual = pin_path.read_text().strip()
+    if actual != expected_ref:
+        return [
+            f"harbor: {PIN_FILE} has {actual}, expected pinned ref {expected_ref}"
+        ]
+    return []
+
+
+def _by_task(results: list[NormalizedResult]) -> dict[str, list[NormalizedResult]]:
+    grouped: dict[str, list[NormalizedResult]] = {}
+    for result in results:
+        grouped.setdefault(result.task_name, []).append(result)
+    return grouped
+
+
+def _distribution(results: list[NormalizedResult]) -> dict[str, Any]:
+    total = len(results)
+    counts = Counter(result.outcome for result in results)
+    rewards = [result.reward if result.reward is not None else 0.0 for result in results]
+    mean_reward = sum(rewards) / total if total else 0.0
+    return {
+        "total": total,
+        "counts": {outcome: counts.get(outcome, 0) for outcome in OUTCOMES},
+        "rates": {
+            outcome: counts.get(outcome, 0) / total if total else 0.0
+            for outcome in OUTCOMES
+        },
+        "mean_reward": mean_reward,
+    }
+
+
+def _format_distribution(label: str, distribution: dict[str, Any]) -> str:
+    counts = distribution["counts"]
+    return (
+        f"{label}: total={distribution['total']} "
+        f"passed={counts['passed']} failed={counts['failed']} "
+        f"errored={counts['errored']} "
+        f"verifier_errored={counts['verifier_errored']} "
+        f"mean_reward={distribution['mean_reward']:.3f}"
+    )
+
+
+def compare_result_sets(
+    benchflow: ResultSet,
+    harbor: ResultSet,
+    *,
+    tasks: set[str] | None,
+    require_trajectories: bool,
+    max_outcome_rate_delta: float,
+    max_mean_reward_delta: float,
+    max_task_reward_delta: float,
+) -> list[str]:
+    issues = [*benchflow.issues, *harbor.issues]
+    benchflow_by_task = _by_task(benchflow.results)
+    harbor_by_task = _by_task(harbor.results)
+    selected_tasks = sorted(tasks or benchflow_by_task)
+
+    for task in selected_tasks:
+        if task not in benchflow_by_task:
+            issues.append(f"benchflow: missing task result for {task}")
+        if task not in harbor_by_task:
+            issues.append(f"harbor: missing baseline result for {task}")
+
+    comparable_tasks = [
+        task
+        for task in selected_tasks
+        if task in benchflow_by_task and task in harbor_by_task
+    ]
+    if not comparable_tasks:
+        issues.append("no overlapping SkillsBench tasks to compare")
+        return issues
+
+    for task in comparable_tasks:
+        benchflow_task_results = benchflow_by_task[task]
+        harbor_task_results = harbor_by_task[task]
+
+        if require_trajectories:
+            for result in [*benchflow_task_results, *harbor_task_results]:
+                if result.trajectory is None:
+                    issues.append(
+                        f"{result.source}: {task}: missing trajectory for "
+                        f"{result.path}"
+                    )
+
+        harbor_outcomes = {result.outcome for result in harbor_task_results}
+        for result in benchflow_task_results:
+            if result.outcome not in harbor_outcomes:
+                issues.append(
+                    f"benchflow: {task}: outcome {result.outcome!r} is not present "
+                    f"in Harbor baseline outcomes {sorted(harbor_outcomes)}"
+                )
+
+        harbor_rewards = [
+            result.reward for result in harbor_task_results if result.reward is not None
+        ]
+        if harbor_rewards:
+            lower = min(harbor_rewards) - max_task_reward_delta
+            upper = max(harbor_rewards) + max_task_reward_delta
+            for result in benchflow_task_results:
+                if result.reward is not None and not lower <= result.reward <= upper:
+                    issues.append(
+                        f"benchflow: {task}: reward {result.reward:g} outside "
+                        f"Harbor baseline range {min(harbor_rewards):g}..{max(harbor_rewards):g}"
+                    )
+
+    benchflow_compared = [
+        result for task in comparable_tasks for result in benchflow_by_task[task]
+    ]
+    harbor_compared = [
+        result for task in comparable_tasks for result in harbor_by_task[task]
+    ]
+    benchflow_distribution = _distribution(benchflow_compared)
+    harbor_distribution = _distribution(harbor_compared)
+
+    for outcome in OUTCOMES:
+        delta = abs(
+            benchflow_distribution["rates"][outcome]
+            - harbor_distribution["rates"][outcome]
+        )
+        if delta > max_outcome_rate_delta:
+            issues.append(
+                f"outcome rate drift for {outcome}: {delta:.3f} "
+                f"> {max_outcome_rate_delta:.3f}"
+            )
+
+    mean_delta = abs(
+        benchflow_distribution["mean_reward"] - harbor_distribution["mean_reward"]
+    )
+    if mean_delta > max_mean_reward_delta:
+        issues.append(
+            f"mean reward drift: {mean_delta:.3f} > {max_mean_reward_delta:.3f}"
+        )
+
+    return issues
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Check SkillsBench result parity against a pinned Harbor baseline."
+    )
+    parser.add_argument("--benchflow-root", type=Path, required=True)
+    parser.add_argument("--harbor-baseline-root", type=Path, required=True)
+    parser.add_argument(
+        "--harbor-baseline-ref",
+        default=DEFAULT_HARBOR_BASELINE_REF,
+        help="Pinned benchflow-ai/skillsbench-trajectories ref.",
+    )
+    parser.add_argument(
+        "--task",
+        action="append",
+        default=[],
+        help="SkillsBench task name to compare. May be repeated.",
+    )
+    parser.add_argument(
+        "--no-require-trajectories",
+        action="store_true",
+        help="Do not require trajectory artifacts for compared results.",
+    )
+    parser.add_argument(
+        "--max-outcome-rate-delta",
+        type=float,
+        default=0.25,
+        help="Allowed absolute delta per normalized outcome rate.",
+    )
+    parser.add_argument(
+        "--max-mean-reward-delta",
+        type=float,
+        default=0.25,
+        help="Allowed absolute delta in mean reward over compared rows.",
+    )
+    parser.add_argument(
+        "--max-task-reward-delta",
+        type=float,
+        default=0.0,
+        help="Allowed per-task reward movement outside Harbor observed range.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    tasks = set(args.task) if args.task else None
+    benchflow_root = args.benchflow_root.resolve()
+    harbor_root = args.harbor_baseline_root.resolve()
+
+    pin_issues = _baseline_pin_issues(harbor_root, args.harbor_baseline_ref)
+    benchflow = load_result_set(benchflow_root, source="benchflow", tasks=tasks)
+    effective_tasks = tasks or {result.task_name for result in benchflow.results}
+    harbor = load_result_set(harbor_root, source="harbor", tasks=effective_tasks)
+    issues = [
+        *pin_issues,
+        *compare_result_sets(
+            benchflow,
+            harbor,
+            tasks=effective_tasks,
+            require_trajectories=not args.no_require_trajectories,
+            max_outcome_rate_delta=args.max_outcome_rate_delta,
+            max_mean_reward_delta=args.max_mean_reward_delta,
+            max_task_reward_delta=args.max_task_reward_delta,
+        ),
+    ]
+
+    print("SkillsBench Harbor parity")
+    print("-" * 80)
+    print(f"BenchFlow root: {benchflow_root}")
+    print(f"Harbor baseline root: {harbor_root}")
+    print(f"Harbor baseline ref: {args.harbor_baseline_ref}")
+    print(
+        "Tasks: "
+        f"{', '.join(sorted(effective_tasks)) if effective_tasks else '(none)'}"
+    )
+
+    if benchflow.results:
+        print(_format_distribution("BenchFlow", _distribution(benchflow.results)))
+    if harbor.results:
+        print(_format_distribution("Harbor", _distribution(harbor.results)))
+
+    if issues:
+        print("FAIL")
+        for issue in issues:
+            print(f"- {issue}")
+        return 1
+
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/run_suite.py
+++ b/tests/integration/run_suite.py
@@ -408,6 +408,14 @@ def _render_value(value: Any) -> str:
             if evidence_dir:
                 parts.append(f"evidence={evidence_dir}")
             return "; ".join(parts)
+        if value.get("kind") == "harbor_skillsbench_baseline":
+            repo = value.get("repo")
+            ref = value.get("ref")
+            path = value.get("path")
+            return f"harbor-skillsbench:{repo}/{path}@{ref}"
+        if value.get("kind") == "benchflow_results":
+            path = value.get("path")
+            return f"benchflow-results:{path}"
         if "env_uid" in value:
             hub_url = value.get("hub_url")
             suffix = f" [{hub_url}]" if hub_url else ""
@@ -470,6 +478,17 @@ def _run_hosted_env_evidence_checker(argv: list[str]) -> int:
         from tests.integration.check_hosted_env_evidence import main as evidence_main
     except ModuleNotFoundError:
         from check_hosted_env_evidence import main as evidence_main
+
+    return evidence_main(argv)
+
+
+def _run_skillsbench_harbor_parity_checker(argv: list[str]) -> int:
+    try:
+        from tests.integration.check_skillsbench_harbor_parity import (
+            main as evidence_main,
+        )
+    except ModuleNotFoundError:
+        from check_skillsbench_harbor_parity import main as evidence_main
 
     return evidence_main(argv)
 
@@ -556,6 +575,51 @@ def run_hosted_env_evidence(
     return _run_hosted_env_evidence_checker(checker_args)
 
 
+def run_skillsbench_harbor_parity(
+    lanes: list[Mapping[str, Any]], args: argparse.Namespace
+) -> int:
+    """Run SkillsBench-vs-Harbor parity validation."""
+    lane_ids = [lane["id"] for lane in lanes]
+    unsupported = [
+        lane_id for lane_id in lane_ids if lane_id != "skillsbench-harbor-parity"
+    ]
+    if unsupported:
+        raise SuiteError(
+            "--execute-skillsbench-harbor-parity only supports "
+            "skillsbench-harbor-parity; unsupported selected lane(s): "
+            f"{', '.join(unsupported)}"
+        )
+    if "skillsbench-harbor-parity" not in lane_ids:
+        raise SuiteError(
+            "--execute-skillsbench-harbor-parity requires lane "
+            "skillsbench-harbor-parity"
+        )
+    if args.skillsbench_harbor_benchflow_root is None:
+        raise SuiteError("--skillsbench-harbor-benchflow-root is required")
+    if args.skillsbench_harbor_baseline_root is None:
+        raise SuiteError("--skillsbench-harbor-baseline-root is required")
+
+    checker_args = [
+        "--benchflow-root",
+        str(args.skillsbench_harbor_benchflow_root),
+        "--harbor-baseline-root",
+        str(args.skillsbench_harbor_baseline_root),
+        "--harbor-baseline-ref",
+        args.skillsbench_harbor_baseline_ref,
+        "--max-outcome-rate-delta",
+        str(args.skillsbench_harbor_max_outcome_rate_delta),
+        "--max-mean-reward-delta",
+        str(args.skillsbench_harbor_max_mean_reward_delta),
+        "--max-task-reward-delta",
+        str(args.skillsbench_harbor_max_task_reward_delta),
+    ]
+    for task in args.skillsbench_harbor_task or []:
+        checker_args.extend(["--task", task])
+    if args.skillsbench_harbor_no_require_trajectories:
+        checker_args.append("--no-require-trajectories")
+    return _run_skillsbench_harbor_parity_checker(checker_args)
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Plan BenchFlow integration suite lanes from a manifest."
@@ -615,6 +679,11 @@ def build_parser() -> argparse.ArgumentParser:
         help="Execute hosted-env compatibility-board evidence validation.",
     )
     parser.add_argument(
+        "--execute-skillsbench-harbor-parity",
+        action="store_true",
+        help="Execute SkillsBench-vs-Harbor parity validation.",
+    )
+    parser.add_argument(
         "--adapter-evidence-repo-root",
         type=Path,
         default=Path.cwd(),
@@ -669,6 +738,50 @@ def build_parser() -> argparse.ArgumentParser:
         default=2,
         help="Number of Harbor registry task refs to inventory.",
     )
+    parser.add_argument(
+        "--skillsbench-harbor-benchflow-root",
+        type=Path,
+        help="BenchFlow result root to compare against the Harbor baseline.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-baseline-root",
+        type=Path,
+        help="Local pinned benchflow-ai/skillsbench-trajectories baseline root.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-baseline-ref",
+        default="2d86fe82f6a06f7c7b3a22a3ae90d554d0e9655c",
+        help="Pinned skillsbench-trajectories ref expected at the baseline root.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-task",
+        action="append",
+        default=[],
+        help="SkillsBench task to compare. May be repeated.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-no-require-trajectories",
+        action="store_true",
+        help="Do not require trajectory artifacts during Harbor parity.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-max-outcome-rate-delta",
+        type=float,
+        default=0.25,
+        help="Allowed outcome-rate drift for SkillsBench-vs-Harbor parity.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-max-mean-reward-delta",
+        type=float,
+        default=0.25,
+        help="Allowed mean-reward drift for SkillsBench-vs-Harbor parity.",
+    )
+    parser.add_argument(
+        "--skillsbench-harbor-max-task-reward-delta",
+        type=float,
+        default=0.0,
+        help="Allowed per-task reward movement outside Harbor observed range.",
+    )
     return parser
 
 
@@ -692,6 +805,7 @@ def main(argv: list[str] | None = None) -> int:
             args.execute_adapter_evidence,
             args.execute_trace_evidence,
             args.execute_hosted_env_evidence,
+            args.execute_skillsbench_harbor_parity,
         ]
         if args.dry_run and any(execution_modes):
             parser.error("use either --dry-run or an execution mode, not both")
@@ -729,10 +843,14 @@ def main(argv: list[str] | None = None) -> int:
         if args.execute_hosted_env_evidence:
             return run_hosted_env_evidence(lanes, args)
 
+        if args.execute_skillsbench_harbor_parity:
+            return run_skillsbench_harbor_parity(lanes, args)
+
         parser.error(
             "execution is not implemented yet; pass --dry-run or "
             "--execute-adapter-evidence, --execute-trace-evidence, or "
-            "--execute-hosted-env-evidence"
+            "--execute-hosted-env-evidence, or "
+            "--execute-skillsbench-harbor-parity"
         )
     except SuiteError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/tests/integration/suites/release.yaml
+++ b/tests/integration/suites/release.yaml
@@ -67,6 +67,7 @@ execution_profiles:
     lanes:
       - shared-sandbox-smoke
       - skillsbench-agent-matrix
+      - skillsbench-harbor-parity
       - adapter-release-set
       - hosted-env-compatibility-board
       - terminal-bench-smoke
@@ -385,6 +386,32 @@ lanes:
       - Every credentialed agent produces valid result.json files.
       - "No infrastructure errors: agent install, timeout, pipe closed, or sandbox setup."
       - summary.json contains total, passed, failed, errored, and score.
+
+  - id: skillsbench-harbor-parity
+    release_blocker: true
+    purpose: Compare BenchFlow SkillsBench outputs against a pinned Harbor trajectory/result baseline.
+    evidence_command: uv run python tests/integration/run_suite.py --lane skillsbench-harbor-parity --execute-skillsbench-harbor-parity --skillsbench-harbor-benchflow-root <benchflow-jobs-root> --skillsbench-harbor-baseline-root <local-skillsbench-trajectories-checkout>
+    sources:
+      - kind: harbor_skillsbench_baseline
+        repo: benchflow-ai/skillsbench-trajectories
+        path: shenghan/gemini-cli/gemini3flash/noskills
+        ref: 2d86fe82f6a06f7c7b3a22a3ae90d554d0e9655c
+        schema_notes:
+          - Harbor stores rewards under verifier_result.rewards.reward.
+          - Harbor stores agent trajectories as ATIF JSON under agent/trajectory.json.
+      - kind: benchflow_results
+        path: jobs/integration-<run-id>/<agent>
+        schema_notes:
+          - BenchFlow stores rewards under rewards.reward.
+          - BenchFlow stores ACP trajectories as trajectory/acp_trajectory.jsonl.
+    matrix:
+      task_sets:
+        - skillsbench_release_subset
+    acceptance:
+      - Harbor baseline root is pinned to the recorded skillsbench-trajectories SHA.
+      - Expected schema differences are normalized explicitly before comparison.
+      - Compared tasks have result.json and trajectory artifacts on both sides.
+      - Outcome-rate, mean-reward, and per-task reward drift remain within the configured parity thresholds.
 
   - id: adapter-release-set
     release_blocker: true

--- a/tests/test_integration_run_suite.py
+++ b/tests/test_integration_run_suite.py
@@ -287,6 +287,7 @@ def test_full_release_dry_run_passes_current_release_gate(
     captured = capsys.readouterr()
     assert "Profile: full-release" in captured.out
     assert "shared-sandbox-smoke" in captured.out
+    assert "skillsbench-harbor-parity" in captured.out
     assert "hosted-env-compatibility-board" in captured.out
     assert "terminal-bench-smoke" in captured.out
     assert "trace-to-task-e2e" in captured.out

--- a/tests/test_skillsbench_harbor_parity.py
+++ b/tests/test_skillsbench_harbor_parity.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.integration.check_skillsbench_harbor_parity import (
+    DEFAULT_HARBOR_BASELINE_REF,
+    PIN_FILE,
+    main,
+)
+
+
+def _write_json(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _write_harbor_result(root: Path, task: str, reward: float, trial: str) -> None:
+    trial_dir = root / f"{task}__{trial}"
+    _write_json(
+        trial_dir / "result.json",
+        {
+            "task_name": task,
+            "trial_name": f"{task}__{trial}",
+            "config": {
+                "agent": {
+                    "name": "gemini-cli",
+                    "model_name": "google/gemini-3-flash-preview",
+                },
+                "environment": {"type": "docker"},
+            },
+            "agent_info": {
+                "name": "gemini-cli",
+                "model_info": {
+                    "name": "gemini-3-flash-preview",
+                    "provider": "google",
+                },
+            },
+            "verifier_result": {"rewards": {"reward": reward}},
+            "exception_info": None,
+        },
+    )
+    _write_json(
+        trial_dir / "agent" / "trajectory.json",
+        {
+            "schema_version": "ATIF-v1.2",
+            "steps": [
+                {"source": "user", "message": "solve"},
+                {
+                    "source": "agent",
+                    "message": "done",
+                    "tool_calls": [{"function_name": "run_shell_command"}],
+                },
+            ],
+        },
+    )
+
+
+def _write_benchflow_result(root: Path, task: str, reward: float, rollout: str) -> None:
+    rollout_dir = root / "2026-05-24__00-00-00" / f"{task}__{rollout}"
+    _write_json(
+        rollout_dir / "result.json",
+        {
+            "task_name": task,
+            "rollout_name": f"{task}__{rollout}",
+            "rewards": {"reward": reward},
+            "agent": "gemini",
+            "model": "gemini-3.1-flash-lite-preview",
+            "error": None,
+            "verifier_error": None,
+        },
+    )
+    trajectory = rollout_dir / "trajectory" / "acp_trajectory.jsonl"
+    trajectory.parent.mkdir(parents=True, exist_ok=True)
+    trajectory.write_text(
+        json.dumps({"type": "user_message", "text": "solve"}) + "\n"
+        + json.dumps({"type": "assistant_message", "text": "done"})
+        + "\n"
+    )
+
+
+def test_skillsbench_harbor_parity_normalizes_expected_schema_differences(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Guards issue #508 against comparing Harbor and BenchFlow artifacts literally."""
+    harbor = tmp_path / "harbor"
+    benchflow = tmp_path / "benchflow"
+    harbor.mkdir()
+    (harbor / PIN_FILE).write_text(DEFAULT_HARBOR_BASELINE_REF + "\n")
+
+    _write_harbor_result(harbor, "jax-computing-basics", 1.0, "harbor-a")
+    _write_harbor_result(harbor, "python-scala-translation", 0.0, "harbor-b")
+    _write_benchflow_result(benchflow, "jax-computing-basics", 1.0, "bf-a")
+    _write_benchflow_result(benchflow, "python-scala-translation", 0.0, "bf-b")
+
+    rc = main(
+        [
+            "--benchflow-root",
+            str(benchflow),
+            "--harbor-baseline-root",
+            str(harbor),
+            "--task",
+            "jax-computing-basics",
+            "--task",
+            "python-scala-translation",
+            "--max-outcome-rate-delta",
+            "0",
+            "--max-mean-reward-delta",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "PASS" in out
+    assert "BenchFlow: total=2 passed=1 failed=1" in out
+    assert "Harbor: total=2 passed=1 failed=1" in out
+
+
+def test_skillsbench_harbor_parity_fails_on_meaningful_reward_drift(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Guards issue #508 against accepting reward distribution drift."""
+    harbor = tmp_path / "harbor"
+    benchflow = tmp_path / "benchflow"
+    harbor.mkdir()
+    (harbor / PIN_FILE).write_text(DEFAULT_HARBOR_BASELINE_REF + "\n")
+
+    _write_harbor_result(harbor, "jax-computing-basics", 1.0, "harbor-a")
+    _write_benchflow_result(benchflow, "jax-computing-basics", 0.0, "bf-a")
+
+    rc = main(
+        [
+            "--benchflow-root",
+            str(benchflow),
+            "--harbor-baseline-root",
+            str(harbor),
+            "--task",
+            "jax-computing-basics",
+            "--max-outcome-rate-delta",
+            "0",
+            "--max-mean-reward-delta",
+            "0",
+        ]
+    )
+
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "FAIL" in out
+    assert "outcome 'failed' is not present" in out
+    assert "mean reward drift" in out
+
+
+def test_skillsbench_harbor_parity_requires_a_pinned_baseline(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    """Guards issue #508 against unpinned Harbor baseline evidence."""
+    harbor = tmp_path / "harbor"
+    benchflow = tmp_path / "benchflow"
+
+    _write_harbor_result(harbor, "jax-computing-basics", 1.0, "harbor-a")
+    _write_benchflow_result(benchflow, "jax-computing-basics", 1.0, "bf-a")
+
+    rc = main(
+        [
+            "--benchflow-root",
+            str(benchflow),
+            "--harbor-baseline-root",
+            str(harbor),
+            "--task",
+            "jax-computing-basics",
+        ]
+    )
+
+    assert rc == 1
+    assert f"no {PIN_FILE} pin file" in capsys.readouterr().out

--- a/tests/test_skillsbench_harbor_run_suite.py
+++ b/tests/test_skillsbench_harbor_run_suite.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tests.integration.run_suite import (
+    main,
+    run_skillsbench_harbor_parity,
+)
+
+SUITE_PATH = Path("tests/integration/suites/release.yaml")
+
+
+def test_skillsbench_harbor_parity_execution_invokes_checker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Guards issue #508 SkillsBench-vs-Harbor execution plumbing."""
+    captured = {}
+
+    def fake_checker(argv: list[str]) -> int:
+        captured["argv"] = argv
+        return 0
+
+    monkeypatch.setattr(
+        "tests.integration.run_suite._run_skillsbench_harbor_parity_checker",
+        fake_checker,
+    )
+
+    rc = main(
+        [
+            "--suite",
+            str(SUITE_PATH),
+            "--lane",
+            "skillsbench-harbor-parity",
+            "--execute-skillsbench-harbor-parity",
+            "--skillsbench-harbor-benchflow-root",
+            str(tmp_path / "benchflow"),
+            "--skillsbench-harbor-baseline-root",
+            str(tmp_path / "harbor"),
+            "--skillsbench-harbor-task",
+            "jax-computing-basics",
+            "--skillsbench-harbor-max-outcome-rate-delta",
+            "0",
+            "--skillsbench-harbor-max-mean-reward-delta",
+            "0",
+            "--skillsbench-harbor-max-task-reward-delta",
+            "0",
+        ]
+    )
+
+    assert rc == 0
+    assert captured["argv"] == [
+        "--benchflow-root",
+        str(tmp_path / "benchflow"),
+        "--harbor-baseline-root",
+        str(tmp_path / "harbor"),
+        "--harbor-baseline-ref",
+        "2d86fe82f6a06f7c7b3a22a3ae90d554d0e9655c",
+        "--max-outcome-rate-delta",
+        "0.0",
+        "--max-mean-reward-delta",
+        "0.0",
+        "--max-task-reward-delta",
+        "0.0",
+        "--task",
+        "jax-computing-basics",
+    ]
+
+
+def test_run_skillsbench_harbor_parity_rejects_empty_selection() -> None:
+    """Guards issue #508 SkillsBench-vs-Harbor execution rejects missing lane."""
+    args = SimpleNamespace(
+        skillsbench_harbor_benchflow_root=Path.cwd(),
+        skillsbench_harbor_baseline_root=Path.cwd(),
+        skillsbench_harbor_baseline_ref="2d86fe82f6a06f7c7b3a22a3ae90d554d0e9655c",
+        skillsbench_harbor_max_outcome_rate_delta=0.25,
+        skillsbench_harbor_max_mean_reward_delta=0.25,
+        skillsbench_harbor_max_task_reward_delta=0.0,
+        skillsbench_harbor_task=[],
+        skillsbench_harbor_no_require_trajectories=False,
+    )
+
+    with pytest.raises(ValueError, match="requires lane skillsbench-harbor-parity"):
+        run_skillsbench_harbor_parity([], args)


### PR DESCRIPTION
## Summary
- add an offline SkillsBench-vs-Harbor parity checker for pinned local skillsbench-trajectories baselines
- normalize BenchFlow and Harbor result/trajectory schema differences before comparing outcome and reward drift
- wire a dedicated run_suite.py lane and document baseline pin/refresh flow

## Validation
- uv run python -m pytest tests/test_skillsbench_harbor_parity.py tests/test_skillsbench_harbor_run_suite.py tests/test_integration_run_suite.py -q
- uv run ruff check .
- uv run ty check src/
- uv run python tests/integration/run_suite.py --lane skillsbench-harbor-parity --dry-run --fail-on-todo

Closes #508
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->