### PR TITLE
style: apply ruff format to v0.5-integration

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -122,9 +122,7 @@ def skill_invocation_summary(results: dict[str, dict]) -> dict[str, Any]:
     total = sum(result_skill_invocations(result) for result in results.values())
     return {
         "total_skill_invocations": total,
-        "avg_skill_invocations": (
-            round(total / len(results), 1) if results else 0.0
-        ),
+        "avg_skill_invocations": (round(total / len(results), 1) if results else 0.0),
     }
 
 

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -70,9 +70,9 @@ class Diagnostic:
         dataclass; this lets it reuse the dataclass's formatting rules
         without having to reconstruct the instance.
         """
-        return cls(**{k: v for k, v in info.items() if k in cls._init_fields()}).format_issue(
-            task_name
-        )
+        return cls(
+            **{k: v for k, v in info.items() if k in cls._init_fields()}
+        ).format_issue(task_name)
 
     @classmethod
     def _init_fields(cls) -> set[str]:
@@ -161,9 +161,7 @@ class TransportClosedDiagnostic(Diagnostic):
 
     def format_issue(self, task_name: str) -> str:
         rc = self.process_exit_code if self.process_exit_code is not None else "?"
-        reachable = (
-            "?" if self.sandbox_reachable is None else self.sandbox_reachable
-        )
+        reachable = "?" if self.sandbox_reachable is None else self.sandbox_reachable
         return (
             f"{task_name}: transport closed (rc={rc}, "
             f"diagnosis={self.transport_diagnosis}, sandbox_reachable={reachable})"
@@ -326,7 +324,9 @@ class RolloutDiagnostics:
         to ``None`` so the result schema stays stable.
         """
         return {
-            d.field: self._events[d.field].to_dict() if d.field in self._events else None
+            d.field: self._events[d.field].to_dict()
+            if d.field in self._events
+            else None
             for d in DIAGNOSTIC_REGISTRY
         }
 

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -53,8 +53,9 @@ class EnvironmentSnapshotError(RuntimeError):
     evidence as if they were real.
     """
 
-    def __init__(self, message: str, *, command: str, exit_code: int,
-                 stdout: str, stderr: str) -> None:
+    def __init__(
+        self, message: str, *, command: str, exit_code: int, stdout: str, stderr: str
+    ) -> None:
         super().__init__(message)
         self.command = command
         self.exit_code = exit_code

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -717,9 +717,7 @@ class Evaluation:
         rollout_name = getattr(result, "rollout_name", "") or ""
         if not rollout_name:
             return
-        rfile = (
-            self._jobs_dir / self._job_name / rollout_name / "result.json"
-        )
+        rfile = self._jobs_dir / self._job_name / rollout_name / "result.json"
         if not rfile.exists():
             return
         try:

--- a/src/benchflow/sandbox/protocol.py
+++ b/src/benchflow/sandbox/protocol.py
@@ -79,6 +79,7 @@ class SandboxStartupError(RuntimeError):
             raw_message=str(message)[:500],
         )
 
+
 SandboxStartupFailure = SandboxStartupError
 
 

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -700,7 +700,9 @@ def _reconstruct_gemini_response(events: list[dict[str, Any]]) -> dict[str, Any]
                         parts_list.append({})
                     target = parts_list[part_idx]
                     if "text" in part:
-                        target["text"] = target.get("text", "") + (part.get("text") or "")
+                        target["text"] = target.get("text", "") + (
+                            part.get("text") or ""
+                        )
                     # Function calls / inline data / other part shapes —
                     # carry the most recent value verbatim. Gemini sends
                     # these whole rather than as deltas.

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -571,7 +571,9 @@ def check_agent(agent_dir: Path) -> dict:
     from benchflow.diagnostics import DIAGNOSTIC_REGISTRY, format_issue_for_field
 
     _CATEGORY_TO_DIAGNOSTIC = {
-        d.category: d for d in DIAGNOSTIC_REGISTRY if d.category and d.channel == "error"
+        d.category: d
+        for d in DIAGNOSTIC_REGISTRY
+        if d.category and d.channel == "error"
     }
     _INVALIDATION_DESCRIPTIONS = {
         "idle_timeout": ("hit idle timeout", ""),

--- a/tests/integration/check_skillsbench_harbor_parity.py
+++ b/tests/integration/check_skillsbench_harbor_parity.py
@@ -282,9 +282,7 @@ def _baseline_pin_issues(root: Path, expected_ref: str) -> list[str]:
         ]
     actual = pin_path.read_text().strip()
     if actual != expected_ref:
-        return [
-            f"harbor: {PIN_FILE} has {actual}, expected pinned ref {expected_ref}"
-        ]
+        return [f"harbor: {PIN_FILE} has {actual}, expected pinned ref {expected_ref}"]
     return []
 
 
@@ -298,7 +296,9 @@ def _by_task(results: list[NormalizedResult]) -> dict[str, list[NormalizedResult
 def _distribution(results: list[NormalizedResult]) -> dict[str, Any]:
     total = len(results)
     counts = Counter(result.outcome for result in results)
-    rewards = [result.reward if result.reward is not None else 0.0 for result in results]
+    rewards = [
+        result.reward if result.reward is not None else 0.0 for result in results
+    ]
     mean_reward = sum(rewards) / total if total else 0.0
     return {
         "total": total,
@@ -360,8 +360,7 @@ def compare_result_sets(
             for result in [*benchflow_task_results, *harbor_task_results]:
                 if result.trajectory is None:
                     issues.append(
-                        f"{result.source}: {task}: missing trajectory for "
-                        f"{result.path}"
+                        f"{result.source}: {task}: missing trajectory for {result.path}"
                     )
 
         harbor_outcomes = {result.outcome for result in harbor_task_results}
@@ -488,8 +487,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"Harbor baseline root: {harbor_root}")
     print(f"Harbor baseline ref: {args.harbor_baseline_ref}")
     print(
-        "Tasks: "
-        f"{', '.join(sorted(effective_tasks)) if effective_tasks else '(none)'}"
+        f"Tasks: {', '.join(sorted(effective_tasks)) if effective_tasks else '(none)'}"
     )
 
     if benchflow.results:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -959,7 +959,9 @@ class TestTransportErrorDiagnostics:
                 return b"Connection to sandbox lost"
 
         class _LP(LiveProcess):
-            async def start(self, command, env=None, cwd=None) -> None:  # pragma: no cover - unused
+            async def start(
+                self, command, env=None, cwd=None
+            ) -> None:  # pragma: no cover - unused
                 pass
 
         lp = _LP()
@@ -992,7 +994,9 @@ class TestTransportErrorDiagnostics:
                 return b""
 
         class _LP(LiveProcess):
-            async def start(self, command, env=None, cwd=None) -> None:  # pragma: no cover - unused
+            async def start(
+                self, command, env=None, cwd=None
+            ) -> None:  # pragma: no cover - unused
                 pass
 
         lp = _LP()
@@ -1012,7 +1016,9 @@ class TestTransportErrorDiagnostics:
             TransportClosedError,
         )
 
-        err = TransportClosedError("test", TransportClosedDiagnostic(raw_message="test"))
+        err = TransportClosedError(
+            "test", TransportClosedDiagnostic(raw_message="test")
+        )
         assert isinstance(err, ConnectionError)
         assert err.diagnostic.transport_diagnosis == "unknown"
 
@@ -1180,9 +1186,7 @@ class TestDiagnosticRegistry:
                 "sandbox_reachable": False,
             },
         )
-        assert (
-            "task-2: transport closed (rc=255, diagnosis=process_exited" in line
-        )
+        assert "task-2: transport closed (rc=255, diagnosis=process_exited" in line
 
     def test_sandbox_startup_error_diagnostic_view_is_consistent(self) -> None:
         """``SandboxStartupError.diagnostic.to_dict()`` reflects the same

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -42,8 +42,7 @@ class TestEnvMappingField:
     def test_gemini_has_mapping(self):
         cfg = AGENTS["gemini"]
         assert (
-            cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"]
-            == "GOOGLE_GEMINI_BASE_URL"
+            cfg.env_mapping["BENCHFLOW_PROVIDER_BASE_URL"] == "GOOGLE_GEMINI_BASE_URL"
         )
         # #342: map BENCHFLOW_PROVIDER_API_KEY to the CLI-native var. The
         # bidirectional mirror in auto_inherit_env handles GOOGLE_API_KEY

--- a/tests/test_atif_trajectory.py
+++ b/tests/test_atif_trajectory.py
@@ -538,9 +538,7 @@ class TestTrajectoryProxy:
                     f"{proxy.base_url}/v1beta/models/"
                     "gemini-3.1-flash-lite-preview:streamGenerateContent?alt=sse",
                     json={
-                        "contents": [
-                            {"role": "user", "parts": [{"text": "say hi"}]}
-                        ],
+                        "contents": [{"role": "user", "parts": [{"text": "say hi"}]}],
                         "stream": True,
                     },
                 )

--- a/tests/test_inbound_adapters.py
+++ b/tests/test_inbound_adapters.py
@@ -300,8 +300,7 @@ class TestTerminalBenchAdapter:
         converted task fails because the build context is incomplete."""
         task_dir = _write_tb_task(tmp_path)
         (task_dir / "Dockerfile").write_text(
-            "FROM python:3.12-slim\n"
-            "COPY requirements.txt /tmp/requirements.txt\n"
+            "FROM python:3.12-slim\nCOPY requirements.txt /tmp/requirements.txt\n"
         )
         (task_dir / "requirements.txt").write_text("pytest\n")
 
@@ -316,9 +315,7 @@ class TestTerminalBenchAdapter:
         """A ``COPY app/ /app/`` must carry every file under app/ — directory
         sources expand to all their files relative to the task root."""
         task_dir = _write_tb_task(tmp_path)
-        (task_dir / "Dockerfile").write_text(
-            "FROM python:3.12-slim\nCOPY app/ /app/\n"
-        )
+        (task_dir / "Dockerfile").write_text("FROM python:3.12-slim\nCOPY app/ /app/\n")
         app_dir = task_dir / "app"
         app_dir.mkdir()
         (app_dir / "main.py").write_text("print('hi')\n")
@@ -377,8 +374,7 @@ class TestTerminalBenchAdapter:
         """``ADD https://...`` fetches over HTTP, no build-context file."""
         task_dir = _write_tb_task(tmp_path)
         (task_dir / "Dockerfile").write_text(
-            "FROM python:3.12-slim\n"
-            "ADD https://example.com/data.tgz /opt/data.tgz\n"
+            "FROM python:3.12-slim\nADD https://example.com/data.tgz /opt/data.tgz\n"
         )
 
         # Should not raise and should not try to resolve the URL as a file.

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -187,8 +187,7 @@ def test_check_results_accepts_skill_invocation_metrics(tmp_path: Path) -> None:
     traj_dir = run_dir / "trajectory"
     traj_dir.mkdir()
     (traj_dir / "acp_trajectory.jsonl").write_text(
-        json.dumps({"type": "tool_call", "kind": "skill", "title": "calculator"})
-        + "\n"
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "calculator"}) + "\n"
     )
     _write_config(run_dir)
     (agent_dir / "summary.json").write_text(
@@ -240,8 +239,7 @@ def test_check_results_flags_skill_invocation_mismatch(tmp_path: Path) -> None:
     traj_dir = run_dir / "trajectory"
     traj_dir.mkdir()
     (traj_dir / "acp_trajectory.jsonl").write_text(
-        json.dumps({"type": "tool_call", "kind": "skill", "title": "calculator"})
-        + "\n"
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "calculator"}) + "\n"
     )
     _write_config(run_dir)
     (agent_dir / "summary.json").write_text(

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -605,9 +605,7 @@ class TestJobRunOrchestration:
         assert summary["telemetry_coverage"] == 2 / 3
 
     @pytest.mark.asyncio
-    async def test_summary_json_aggregates_tool_calls_and_phase_timing(
-        self, tmp_path
-    ):
+    async def test_summary_json_aggregates_tool_calls_and_phase_timing(self, tmp_path):
         """Issue #501: summary.json must aggregate per-rollout n_tool_calls and
         timing so reviewers don't have to inspect each result.json by hand.
 
@@ -684,9 +682,7 @@ class TestJobRunOrchestration:
         assert summary["timing_coverage"] == 1.0
 
     @pytest.mark.asyncio
-    async def test_summary_json_phase_timing_handles_missing_blocks(
-        self, tmp_path
-    ):
+    async def test_summary_json_phase_timing_handles_missing_blocks(self, tmp_path):
         """Mocked rollouts (no timing in RunResult, no rollout_name) must not
         crash phase_timing_summary — they just lower timing_coverage to 0.0
         while tool-call aggregation still works.

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -350,8 +350,5 @@ class TestUsageProxyRuntime:
             updated["BENCHFLOW_PROVIDER_BASE_URL"]
             == "http://host.docker.internal:43210"
         )
-        assert (
-            updated["GOOGLE_GEMINI_BASE_URL"]
-            == "http://host.docker.internal:43210"
-        )
+        assert updated["GOOGLE_GEMINI_BASE_URL"] == "http://host.docker.internal:43210"
         assert "GEMINI_API_BASE_URL" not in updated

--- a/tests/test_skill_eval_sweep.py
+++ b/tests/test_skill_eval_sweep.py
@@ -41,8 +41,7 @@ def _make_skill(
         f"---\nname: {name}\ndescription: d\n---\n# {name}\n"
     )
     payload: dict = {
-        "cases": cases
-        or [{"id": "case-001", "question": "q", "ground_truth": "a"}],
+        "cases": cases or [{"id": "case-001", "question": "q", "ground_truth": "a"}],
     }
     if skill_name_field is not None:
         payload["skill_name"] = skill_name_field
@@ -443,9 +442,7 @@ class TestGepaNonFiniteHandling:
         text = (out / "summary.json").read_text()
         assert "NaN" not in text and "Infinity" not in text
         # Strict-parseable.
-        json.loads(
-            text, parse_constant=lambda c: pytest.fail(f"non-finite token: {c}")
-        )
+        json.loads(text, parse_constant=lambda c: pytest.fail(f"non-finite token: {c}"))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_skillsbench_harbor_parity.py
+++ b/tests/test_skillsbench_harbor_parity.py
@@ -73,7 +73,8 @@ def _write_benchflow_result(root: Path, task: str, reward: float, rollout: str) 
     trajectory = rollout_dir / "trajectory" / "acp_trajectory.jsonl"
     trajectory.parent.mkdir(parents=True, exist_ok=True)
     trajectory.write_text(
-        json.dumps({"type": "user_message", "text": "solve"}) + "\n"
+        json.dumps({"type": "user_message", "text": "solve"})
+        + "\n"
         + json.dumps({"type": "assistant_message", "text": "done"})
         + "\n"
     )

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -612,7 +612,9 @@ def test_infer_task_source_provenance_for_cached_benchmark_repo(tmp_path, monkey
         "GIT_COMMITTER_NAME": "BenchFlow Test",
         "GIT_COMMITTER_EMAIL": "test@example.com",
     }
-    sp.run(["git", "init", "-b", "main"], cwd=cache_root, check=True, capture_output=True)
+    sp.run(
+        ["git", "init", "-b", "main"], cwd=cache_root, check=True, capture_output=True
+    )
     sp.run(
         [
             "git",
@@ -625,7 +627,13 @@ def test_infer_task_source_provenance_for_cached_benchmark_repo(tmp_path, monkey
         check=True,
         capture_output=True,
     )
-    sp.run(["git", "add", "."], cwd=cache_root, check=True, capture_output=True, env={**env})
+    sp.run(
+        ["git", "add", "."],
+        cwd=cache_root,
+        check=True,
+        capture_output=True,
+        env={**env},
+    )
     sp.run(
         ["git", "commit", "-m", "seed"],
         cwd=cache_root,

--- a/tests/test_workflow_action_pinning.py
+++ b/tests/test_workflow_action_pinning.py
@@ -47,7 +47,11 @@ def _iter_uses(node: object):
 
 def _iter_uses_lines(workflow: Path) -> list[str]:
     """Return raw `uses:` lines (preserving trailing comments) from *workflow*."""
-    return [line for line in workflow.read_text().splitlines() if re.search(r"^\s*-?\s*uses:", line)]
+    return [
+        line
+        for line in workflow.read_text().splitlines()
+        if re.search(r"^\s*-?\s*uses:", line)
+    ]
 
 
 def _workflow_files() -> list[Path]:


### PR DESCRIPTION
Fixes the `ruff format --check` failure on PR #344 (v0.5 → main merge). No behavior change.

Files reformatted by CI report:
- src/benchflow/_utils/evaluation_results.py
- src/benchflow/diagnostics.py
- src/benchflow/environment/manifest_env.py
- src/benchflow/evaluation.py
- src/benchflow/sandbox/protocol.py
- src/benchflow/trajectories/proxy.py
- tests/integration/check_results.py
- tests/integration/check_skillsbench_harbor_parity.py
- tests/test_acp.py
- tests/test_agent_registry.py
- tests/test_atif_trajectory.py
- tests/test_inbound_adapters.py
- tests/test_integration_check_results.py
- tests/test_job.py
- tests/test_provider_runtime.py
- tests/test_skill_eval_sweep.py
- tests/test_skillsbench_harbor_parity.py
- tests/test_task_download.py
- tests/test_workflow_action_pinning.py

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic formatting only; no functional changes intended beyond an unused startup error alias.
> 
> **Overview**
> Applies **Ruff formatter** output across **src/benchflow** and **tests** so `ruff format --check` passes on the v0.5-integration merge (PR #344). There is **no intended logic change**—only line breaks, wrapping, and whitespace.
> 
> Touched areas include evaluation summaries, diagnostics serialization, manifest env errors, evaluation timing enrichment, trajectory proxy Gemini text merging, integration checkers, and many unit/integration tests. The only notable non-whitespace addition is a **`SandboxStartupFailure = SandboxStartupError`** alias in `sandbox/protocol.py` for naming compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14db0b877bdd6654513912c7bed921f2146876e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->