### PR TITLE
chore: set up Matt Pocock engineering skills config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,17 @@ uv run ruff check .
 - **Human review before `main`.** PRs only. No force-pushes to `main`. Self-approval doesn't count.
 - **Trunk-based:** branch off `main`, PR back to `main`. No long-lived release branches.
 - **Releases:** bump `pyproject.toml` to the stable version, tag `v<version>` on main, push tag (CI publishes to PyPI), then bump main to the next `.dev0`.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `benchflow-ai/benchflow`, driven via the `gh` CLI. See [`docs/agents/issue-tracker.md`](./docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Canonical vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). `wontfix` already exists in the repo; the other four are not yet created — run `gh label create` if/when you start using them. See [`docs/agents/triage-labels.md`](./docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` and `docs/adr/` live at the repo root (neither file exists yet; producer skills create them lazily). See [`docs/agents/domain.md`](./docs/agents/domain.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,38 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+This repo is single-context.
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,24 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+**Note:** `wontfix` already exists in this repo. The other four labels are not yet created. Run these to create them when you start using the triage workflow:
+
+```bash
+gh label create needs-triage --description "Maintainer needs to evaluate" --color "fbca04"
+gh label create needs-info --description "Waiting on reporter" --color "d876e3"
+gh label create ready-for-agent --description "Fully specified, AFK-ready" --color "0e8a16"
+gh label create ready-for-human --description "Needs human implementation" --color "5319e7"
+```
+
+Edit the right-hand column above if you later remap to existing or different label names.


### PR DESCRIPTION
Scaffolds the per-repo configuration the [Matt Pocock engineering skills](https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/SKILL.md) assume, so downstream skills (`to-issues`, `triage`, `diagnose`, `tdd`, `improve-codebase-architecture`, `zoom-out`) read this repo's context correctly.

## What's added

- **`AGENTS.md`** gains an `## Agent skills` section pointing at three short docs. `CLAUDE.md` is left as the existing one-line pointer to `AGENTS.md` — no duplicate created (per the skill's hard rule).
- **`docs/agents/issue-tracker.md`** — GitHub Issues via `gh` CLI (matches what we already do).
- **`docs/agents/triage-labels.md`** — canonical vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). `wontfix` already exists in this repo; the file records the `gh label create` commands for the other four so they can be added when triage actually starts.
- **`docs/agents/domain.md`** — confirms single-context layout (`CONTEXT.md` + `docs/adr/` at the repo root). Neither file exists yet; producer skills create them lazily.

## Decisions captured

| Decision | Choice |
|---|---|
| Issue tracker | GitHub Issues at `benchflow-ai/benchflow` |
| Triage label vocabulary | Canonical names verbatim |
| Domain docs layout | Single-context |

## Optional follow-up

Run these to create the four new triage labels (skipped here because that's an external write on the repo settings):

```bash
gh label create needs-triage --description "Maintainer needs to evaluate" --color "fbca04" --repo benchflow-ai/benchflow
gh label create needs-info --description "Waiting on reporter" --color "d876e3" --repo benchflow-ai/benchflow
gh label create ready-for-agent --description "Fully specified, AFK-ready" --color "0e8a16" --repo benchflow-ai/benchflow
gh label create ready-for-human --description "Needs human implementation" --color "5319e7" --repo benchflow-ai/benchflow
```

## Base branch note

Targeting `v0.5-integration` for consistency with the rest of this session's docs work; will flow into `main` when #344 lands. (`AGENTS.md`'s trunk-based rule says branch off `main` — happy to retarget if you'd rather land this independently of the v0.5 release.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no application code, auth, or data-path impact.
> 
> **Overview**
> Adds **per-repo agent configuration** so Matt Pocock engineering skills can resolve this repo’s issue tracker, triage vocabulary, and domain-doc layout.
> 
> **`AGENTS.md`** now has an **`## Agent skills`** section with pointers to three new docs under **`docs/agents/`**.
> 
> **`issue-tracker.md`** standardizes **GitHub Issues** on **`benchflow-ai/benchflow`** via **`gh`** (create/view/list/comment/label/close).
> 
> **`triage-labels.md`** maps canonical roles to label names (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) and documents **`gh label create`** for the four labels not yet in the repo.
> 
> **`domain.md`** records a **single-context** layout (`CONTEXT.md`, **`docs/adr/`** at repo root), instructs agents to read those when present, proceed silently if missing, use glossary terms, and flag ADR conflicts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ede2f8a557494b3bc9b808f2da5633ceb5706133. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->