### PR TITLE
Preserve OpenHands Azure API version

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -547,6 +547,8 @@ AGENTS: dict[str, AgentConfig] = {
             '"$LLM_MODEL" "$LLM_API_KEY"; '
             'if [ -n "$LLM_BASE_URL" ]; then '
             'printf \',"base_url":"%s"\' "$LLM_BASE_URL"; fi; '
+            'if [ -n "$LLM_API_VERSION" ]; then '
+            'printf \',"api_version":"%s"\' "$LLM_API_VERSION"; fi; '
             "printf '}}'; } > ~/.openhands/agent_settings.json && "
             "openhands acp --always-approve --override-with-envs"
         ),

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -88,6 +88,13 @@ class TestOpenHandsConfig:
         cfg = AGENTS["openhands"]
         assert cfg.supports_acp_set_model is False
 
+    def test_openhands_launch_cmd_writes_optional_azure_api_version(self):
+        """Guards the fix from branch bry/openhands-azure-api-version against dropping Azure API version config."""
+        cfg = AGENTS["openhands"]
+        assert 'if [ -n "$LLM_API_VERSION" ]' in cfg.launch_cmd
+        assert ',"api_version":"%s"' in cfg.launch_cmd
+        assert '"$LLM_API_VERSION"' in cfg.launch_cmd
+
     def test_harvey_lab_installs_python_deps_in_venv(self):
         """Guards the v0.5 stress failure where pip hit PEP 668 in Ubuntu."""
         cfg = AGENTS["harvey-lab-harness"]

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -89,7 +89,7 @@ class TestOpenHandsConfig:
         assert cfg.supports_acp_set_model is False
 
     def test_openhands_launch_cmd_writes_optional_azure_api_version(self):
-        """Guards the fix from branch bry/openhands-azure-api-version against dropping Azure API version config."""
+        """Guards the fix from PR #559 against dropping Azure API version config."""
         cfg = AGENTS["openhands"]
         assert 'if [ -n "$LLM_API_VERSION" ]' in cfg.launch_cmd
         assert ',"api_version":"%s"' in cfg.launch_cmd


### PR DESCRIPTION
## Summary
- write optional `LLM_API_VERSION` into OpenHands `agent_settings.json` as `llm.api_version`
- keep existing model/api_key/base_url behavior unchanged
- add regression coverage for the launcher config

## Why
OpenHands SDK supports `llm.api_version`, and Azure gpt-5.x deployments require newer preview API versions. Without persisting this field, BenchFlow launches OpenHands with its SDK default Azure API version and gpt-5.x runs fail before producing healthy ACP trajectories.

## Validation
- `uv run python -m pytest tests/test_agent_registry.py tests/test_resolve_env_helpers.py -q`
- `uv run ruff check src/benchflow/agents/registry.py tests/test_agent_registry.py`
- `uv run ty check src/`
- `uv run python -m pytest tests/ -q` (2407 passed, 11 skipped, 1 deselected)
- `uv run ruff check .`
- real smoke: OpenHands + Daytona + Azure `vllm/azure/gpt-5.5` with `LLM_API_VERSION=2025-04-01-preview` produced non-partial ACP trajectory and passed `tests/integration/check_results.py`

This PR was created by an AI agent on behalf of the user.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/559" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->