### PR TITLE
Fix Codex ACP Azure GPT-5.5 routing

### DIFF
--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -299,6 +299,7 @@ class ACPClient:
         )
         session_id = result.get("sessionId", "default")
         self._session = ACPSession(session_id)
+        self._session.model_state = result.get("models")
         if self._initialize_result:
             self._session.agent_info = self._initialize_result.agent_info
             self._session.agent_capabilities = (
@@ -314,6 +315,7 @@ class ACPClient:
         result = await self._send_request("session/load", params)
         loaded_id = result.get("sessionId", session_id)
         self._session = ACPSession(loaded_id)
+        self._session.model_state = result.get("models")
         if self._initialize_result:
             self._session.agent_info = self._initialize_result.agent_info
             self._session.agent_capabilities = (

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -64,6 +64,56 @@ _MODELSDEV_PROVIDER_HEURISTICS: list[tuple[str, str]] = [
 ]
 
 
+def _codex_model_name(model_id: str) -> str:
+    """Return the bare model name from a Codex ACP ``model[effort]`` ID."""
+    return model_id.split("[", 1)[0]
+
+
+def _codex_reasoning_effort(model_id: str) -> str:
+    """Return the reasoning effort suffix from a Codex ACP model ID."""
+    if "[" not in model_id or not model_id.endswith("]"):
+        return ""
+    return model_id.rsplit("[", 1)[1][:-1]
+
+
+def _codex_session_model_id(model: str, session: object | None) -> str:
+    """Map a bare Codex model to the exact ACP modelId returned by session/new.
+
+    ``@agentclientprotocol/codex-acp`` validates ``session/set_model`` against
+    model IDs shaped as ``model[reasoning-effort]``. BenchFlow's public model
+    IDs stay effort-free, so use the session's advertised model state to choose
+    the concrete Codex ACP ID.
+    """
+    state = getattr(session, "model_state", None)
+    if not isinstance(state, dict):
+        return model
+
+    requested_name = _codex_model_name(model)
+    current_model = state.get("currentModelId")
+    if isinstance(current_model, str) and _codex_model_name(current_model) == requested_name:
+        return current_model
+
+    available = state.get("availableModels")
+    if not isinstance(available, list):
+        return model
+    candidates = [
+        entry.get("modelId")
+        for entry in available
+        if isinstance(entry, dict)
+        and isinstance(entry.get("modelId"), str)
+        and _codex_model_name(entry["modelId"]) == requested_name
+    ]
+    if not candidates:
+        return model
+
+    preferred_efforts = ("medium", "high", "low", "minimal", "none")
+    for effort in preferred_efforts:
+        for candidate in candidates:
+            if _codex_reasoning_effort(candidate) == effort:
+                return candidate
+    return candidates[0]
+
+
 def _format_acp_model(model: str, agent: str) -> str:
     """Format a model ID for ACP session/set_model based on agent requirements.
 
@@ -102,6 +152,18 @@ def _format_acp_model(model: str, agent: str) -> str:
         "Cannot infer models.dev provider for %r — defaulting to anthropic/", bare
     )
     return f"anthropic/{bare}"
+
+
+def _select_acp_model_id(
+    model: str,
+    agent: str,
+    session: object | None,
+) -> str:
+    """Return the concrete modelId to send through ACP session/set_model."""
+    formatted = _format_acp_model(model, agent)
+    if agent == "codex-acp":
+        return _codex_session_model_id(formatted, session)
+    return formatted
 
 
 def _should_skip_acp_set_model(
@@ -266,7 +328,7 @@ async def connect_acp(
 
     if model and not _should_skip_acp_set_model(agent, model, agent_env):
         acp_model_input = _resolve_acp_model_input(agent, model, agent_env)
-        acp_model_id = _format_acp_model(acp_model_input, agent)
+        acp_model_id = _select_acp_model_id(acp_model_input, agent, session)
         try:
             await asyncio.wait_for(acp_client.set_model(acp_model_id), timeout=60)
             logger.info(f"Model set to: {acp_model_id} (from {acp_model_input})")

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -60,6 +60,7 @@ class ACPSession:
         self.session_id = session_id
         self.agent_info: AgentInfo | None = None
         self.agent_capabilities: AgentCapabilities | None = None
+        self.model_state: dict | None = None
         self.message_chunks: list[str] = []
         self.thought_chunks: list[str] = []
         self.tool_calls: list[ToolCallRecord] = []

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -42,6 +42,9 @@ _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
 _AZURE_RESOURCE_ENV = "AZURE_RESOURCE"
 _AZURE_ENDPOINT_ENV = "AZURE_API_ENDPOINT"
 _AZURE_HOST_SUFFIXES = (".openai.azure.com", ".services.ai.azure.com")
+_CODEX_CONFIG_ENV = "CODEX_CONFIG"
+_CODEX_MODEL_PROVIDER_ENV = "MODEL_PROVIDER"
+_CODEX_PROVIDER_ID_PREFIX = "benchflow-"
 
 
 def _derive_azure_resource(agent_env: dict[str, str]) -> None:
@@ -438,6 +441,64 @@ def _shares_auth_context(required_key: str | None, candidate_key: str | None) ->
     )
 
 
+def _codex_provider_id(agent_env: dict[str, str]) -> str:
+    provider_name = agent_env.get("BENCHFLOW_PROVIDER_NAME", "openai-compatible")
+    safe_name = "".join(
+        char if char.isalnum() or char in {"-", "_"} else "-"
+        for char in provider_name.lower()
+    ).strip("-")
+    return f"{_CODEX_PROVIDER_ID_PREFIX}{safe_name or 'provider'}"
+
+
+def _load_codex_config(agent_env: dict[str, str]) -> dict:
+    raw_config = agent_env.get(_CODEX_CONFIG_ENV)
+    if not raw_config:
+        return {}
+    try:
+        config = json.loads(raw_config)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{_CODEX_CONFIG_ENV} must be valid JSON") from exc
+    if not isinstance(config, dict):
+        raise ValueError(f"{_CODEX_CONFIG_ENV} must decode to a JSON object")
+    return config
+
+
+def _configure_codex_custom_provider(
+    agent: str,
+    model: str | None,
+    agent_env: dict[str, str],
+) -> None:
+    """Expose BenchFlow provider routing through Codex's native config model."""
+    if agent != "codex-acp" or not model:
+        return
+
+    base_url = agent_env.get("BENCHFLOW_PROVIDER_BASE_URL") or agent_env.get(
+        "OPENAI_BASE_URL"
+    )
+    provider_model = agent_env.get("BENCHFLOW_PROVIDER_MODEL")
+    if not base_url or not provider_model:
+        return
+
+    provider_id = _codex_provider_id(agent_env)
+    config = _load_codex_config(agent_env)
+    providers = config.get("model_providers")
+    providers = {} if not isinstance(providers, dict) else dict(providers)
+
+    providers[provider_id] = {
+        "name": agent_env.get("BENCHFLOW_PROVIDER_NAME", "BenchFlow provider"),
+        "base_url": base_url,
+        "env_key": "OPENAI_API_KEY",
+        "wire_api": "responses",
+        "supports_websockets": False,
+    }
+    config["model_providers"] = providers
+    config["model_provider"] = provider_id
+    config["model"] = provider_model
+
+    agent_env[_CODEX_MODEL_PROVIDER_ENV] = provider_id
+    agent_env[_CODEX_CONFIG_ENV] = json.dumps(config, separators=(",", ":"))
+
+
 def resolve_agent_env(
     agent: str,
     model: str | None,
@@ -534,6 +595,7 @@ def resolve_agent_env(
                     "Pass it explicitly (for example via --agent-env/agent_env) "
                     "or define it in .env."
                 )
+        _configure_codex_custom_provider(agent, model, agent_env)
     else:
         # No model specified — still check subscription auth for required env vars
         if agent_cfg:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -738,6 +738,43 @@ class TestConnectAcpModelSelection:
         mock_acp.set_model.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_codex_uses_session_advertised_model_id(self, tmp_path):
+        """Guards commit 81ff286 against codex-acp rejecting bare set_model IDs."""
+        from benchflow.acp.runtime import connect_acp
+
+        mock_acp = self._make_mocks()
+        mock_acp.session_new.return_value.model_state = {
+            "availableModels": [
+                {"modelId": "gpt-5.5[low]"},
+                {"modelId": "gpt-5.5[medium]"},
+                {"modelId": "gpt-5.5[high]"},
+            ],
+            "currentModelId": "gpt-5[medium]",
+        }
+        mock_env = AsyncMock()
+        with (
+            patch(
+                "benchflow.acp.runtime.DockerProcess.from_sandbox_env",
+                return_value=MagicMock(),
+            ),
+            patch("benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="codex-acp",
+                agent_launch="codex-acp",
+                agent_env={},
+                sandbox_user=None,
+                model="azure-foundry-openai/gpt-5.5",
+                rollout_dir=tmp_path,
+                environment="docker",
+                agent_cwd="/app",
+            )
+
+        mock_acp.set_model.assert_awaited_once_with("gpt-5.5[medium]")
+
+    @pytest.mark.asyncio
     async def test_claude_bedrock_sets_model_from_provider_mapping(self, tmp_path):
         from benchflow.acp.runtime import connect_acp
 

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -5,6 +5,7 @@ check_subscription_auth, and the no-model subscription auth path in
 resolve_agent_env.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -638,6 +639,18 @@ class TestResolveAgentEnvAzureFoundry:
             result["OPENAI_BASE_URL"]
             == "https://example-resource.openai.azure.com/openai/v1"
         )
+        assert result["MODEL_PROVIDER"] == "benchflow-azure-foundry-openai"
+        codex_config = json.loads(result["CODEX_CONFIG"])
+        assert codex_config["model"] == "gpt-5.5"
+        assert codex_config["model_provider"] == "benchflow-azure-foundry-openai"
+        provider = codex_config["model_providers"]["benchflow-azure-foundry-openai"]
+        assert provider == {
+            "name": "azure-foundry-openai",
+            "base_url": "https://example-resource.openai.azure.com/openai/v1",
+            "env_key": "OPENAI_API_KEY",
+            "wire_api": "responses",
+            "supports_websockets": False,
+        }
 
     def test_claude_uses_same_azure_key_on_anthropic_surface(self, monkeypatch):
         monkeypatch.setenv("AZURE_API_KEY", "az-test")


### PR DESCRIPTION
## Summary
- Capture ACP session model state so Codex ACP can receive the exact advertised model ID, e.g. `gpt-5.5[medium]`, instead of a bare `gpt-5.5` that `@agentclientprotocol/codex-acp` rejects.
- Register BenchFlow custom OpenAI-compatible providers in Codex's native `CODEX_CONFIG`, including Azure Foundry OpenAI, so Codex routes requests to the provider base URL instead of `api.openai.com`.
- Add regression coverage for both the Codex ACP model ID formatting and Azure Foundry Codex env/config resolution.

## Verification
- `uv run python -m pytest tests/test_acp.py tests/test_resolve_env_helpers.py tests/test_agent_registry.py tests/test_internet_policy.py -q`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/`
- Live SkillsBench run: `codex-acp` + `azure-foundry-openai/gpt-5.5` on `weighted-gdp-calc` now reaches `end_turn`, makes 10 tool calls, runs verifier, and records `errors=0`. The remaining reward=0 is a task-answer verifier failure, not an ACP/provider runtime error.

## Notes
The original unhealthy run failed before the task started with `Failed to set model 'gpt-5.5' via ACP`. After the model-ID fix, the next blocker was Codex routing the Azure key to `api.openai.com`; the Codex native provider config fixes that routing.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/560" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->