### PR TITLE
fix: auto-discover task-bundled skills for oracle mode

### DIFF
--- a/src/benchflow/agents/install.py
+++ b/src/benchflow/agents/install.py
@@ -245,6 +245,13 @@ async def deploy_skills(
             logger.info("Skills already injected via Dockerfile")
             effective_skills = "/skills"
 
+    # Auto-discover task-bundled skills already uploaded to /app/skills
+    # by _start_env_and_upload (from environment/skills/ in the task dir).
+    if not effective_skills and include_task_skills:
+        bundled = task_path / "environment" / "skills"
+        if bundled.is_dir():
+            effective_skills = "/app/skills"
+
     # Distribute to agent-specific discovery paths
     if agent_cfg is not None:
         skill_paths = agent_cfg.skill_paths

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -332,6 +332,69 @@ async def test_deploy_skills_agent_with_empty_skill_paths_does_not_use_oracle_pa
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_oracle_autodiscovers_bundled_skills(tmp_path):
+    """Guards the fix from PR #558 for issue #557: oracle mode on Daytona
+    failed for tasks with bundled skills because deploy_skills never detected
+    the environment/skills/ directory that _start_env_and_upload already
+    uploaded to /app/skills.  Without auto-discovery, effective_skills stayed
+    None and the linking step was skipped, so /root/.claude/skills was never
+    populated."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+
+    task_path = tmp_path / "task"
+    bundled = task_path / "environment" / "skills" / "mesh-analysis" / "scripts"
+    bundled.mkdir(parents=True)
+    (bundled / "mesh_tool.py").write_text("class MeshAnalyzer: pass\n")
+
+    await deploy_skills(
+        env=env,
+        task_path=task_path,
+        skills_dir=None,
+        agent_cfg=None,
+        sandbox_user=None,
+        agent_cwd="/app",
+        task=_make_task(None),
+    )
+
+    env.upload_dir.assert_not_called()
+    env.exec.assert_awaited_once()
+    link_cmd = env.exec.await_args.args[0]
+    assert "ln -sfn /app/skills /root/.claude/skills" in link_cmd
+
+
+@pytest.mark.asyncio
+async def test_deploy_skills_autodiscovery_skipped_when_include_task_skills_false(
+    tmp_path,
+):
+    """Guards the fix from PR #558: auto-discovery must respect
+    include_task_skills=False so self-gen trials start without skills."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+
+    task_path = tmp_path / "task"
+    bundled = task_path / "environment" / "skills" / "some-skill"
+    bundled.mkdir(parents=True)
+    (bundled / "helper.py").write_text("pass\n")
+
+    await deploy_skills(
+        env=env,
+        task_path=task_path,
+        skills_dir=None,
+        agent_cfg=None,
+        sandbox_user=None,
+        agent_cwd="/app",
+        task=_make_task(None),
+        include_task_skills=False,
+    )
+
+    env.upload_dir.assert_not_called()
+    env.exec.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_raises_when_skill_linking_fails(tmp_path):
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=17, stdout="link failed"))


### PR DESCRIPTION
## Summary

- Oracle Daytona runs failed for tasks with bundled skills (`environment/skills/`) because `deploy_skills()` never detected them — `_start_env_and_upload` uploads them to `/app/skills` but `effective_skills` stayed `None`, so the symlink step to `/root/.claude/skills` was skipped.
- Added auto-discovery: when no explicit skills source is found, `deploy_skills()` checks for `task_path/environment/skills/` and links `/app/skills` to agent discovery paths.
- Added two regression tests guarding auto-discovery and `include_task_skills=False` behavior.

Closes #557

## Test plan

- [x] `test_deploy_skills_oracle_autodiscovers_bundled_skills` — oracle with bundled skills links `/app/skills` → `/root/.claude/skills`
- [x] `test_deploy_skills_autodiscovery_skipped_when_include_task_skills_false` — self-gen respects `include_task_skills=False`
- [x] Full test suite passes (1368 passed, 9 pre-existing failures unrelated)
- [x] `ty check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/562" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->