### PR TITLE
fix: persist Daytona sandbox IDs for audit and cleanup

### DIFF
--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -805,7 +805,16 @@ def _persist_sandbox_info(env: Any, rollout_dir: Path | None) -> None:
     """Write sandbox.json with provider-side sandbox ID immediately after creation.
 
     This ensures the sandbox ID is persisted even if the run is interrupted
-    before result.json is written.
+    before result.json is written. Daytona also calls this at the moment its
+    sandbox is created (inside ``start()``), not only after ``start()`` returns
+    — closing the in-``start()`` interrupt window for DinD's long daemon-wait
+    (#554/#563).
+
+    The ``sandbox.json`` write is best-effort: a failure to write it (disk full,
+    read-only dir) must not abort an otherwise-healthy run, so it is wrapped and
+    logged rather than raised. The id-capture itself is load-bearing and lives in
+    the caller (``Rollout.start``); this helper only does the best-effort file
+    write.
     """
     sandbox_id = getattr(env, "sandbox_id", None)
     if not isinstance(sandbox_id, str) or not rollout_dir:
@@ -816,7 +825,11 @@ def _persist_sandbox_info(env: Any, rollout_dir: Path | None) -> None:
         "provider": provider,
         "created_at": str(datetime.now()),
     }
-    (rollout_dir / "sandbox.json").write_text(json.dumps(info, indent=2))
+    try:
+        (rollout_dir / "sandbox.json").write_text(json.dumps(info, indent=2))
+    except Exception as e:  # best-effort: never fail start() over an audit file
+        logger.warning(f"Failed to persist sandbox.json for {sandbox_id}: {e}")
+        return
     logger.info(f"Sandbox {sandbox_id} ({provider})")
 
 

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -2703,6 +2703,8 @@ class Rollout:
                 runtime_skills_dir=self._config.skills_dir,
                 declared_sandbox_skills_dir=None,
             ),
-            sandbox_id=self._sandbox_id,
+            # getattr guard: cleanup/export paths build a Rollout skeleton via
+            # __new__ (no __init__), so _sandbox_id may be unset there (#563).
+            sandbox_id=getattr(self, "_sandbox_id", None),
             **self._usage_metrics,
         )

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -521,6 +521,7 @@ def _build_rollout_result(
     source_provenance: dict[str, Any] | None = None,
     diagnostics: RolloutDiagnostics | None = None,
     skill_policy: TaskSkillPolicy | None = None,
+    sandbox_id: str | None = None,
 ) -> RolloutResult:
     """Build RolloutResult and write result.json, timing.json, prompts.json, trajectory.
 
@@ -640,6 +641,7 @@ def _build_rollout_result(
                     if source_provenance is not None
                     else {}
                 ),
+                "sandbox_id": sandbox_id,
             },
             indent=2,
         )
@@ -783,6 +785,25 @@ async def _start_env_and_upload(
         await env.upload_file(task_path / "instruction.md", "/instruction.md")
     if (task_path / "solution").is_dir():
         await env.upload_dir(task_path / "solution", "/solution")
+
+
+def _persist_sandbox_info(env: Any, rollout_dir: Path | None) -> None:
+    """Write sandbox.json with provider-side sandbox ID immediately after creation.
+
+    This ensures the sandbox ID is persisted even if the run is interrupted
+    before result.json is written.
+    """
+    sandbox_id = getattr(env, "sandbox_id", None)
+    if not isinstance(sandbox_id, str) or not rollout_dir:
+        return
+    provider = type(env).__name__
+    info = {
+        "sandbox_id": sandbox_id,
+        "provider": provider,
+        "created_at": str(datetime.now()),
+    }
+    (rollout_dir / "sandbox.json").write_text(json.dumps(info, indent=2))
+    logger.info(f"Sandbox {sandbox_id} ({provider})")
 
 
 async def _run_oracle(
@@ -1141,6 +1162,9 @@ class Rollout:
         self._usage_runtime: Any = None
         self._usage_metrics: dict[str, Any] = self._planes.extract_usage(None)
 
+        # Populated by start()
+        self._sandbox_id: str | None = None
+
         # Populated by install_agent()
         self._agent_cfg: Any = None
         self._agent_cwd: str = "/app"
@@ -1427,6 +1451,10 @@ class Rollout:
             self._timing,
             skip_start=self._env_externally_owned,
         )
+
+        sid = getattr(self._env, "sandbox_id", None)
+        self._sandbox_id = sid if isinstance(sid, str) else None
+        _persist_sandbox_info(self._env, self._rollout_dir)
 
         for hook in self._config.pre_agent_hooks or []:
             await hook(self._env)
@@ -2654,5 +2682,6 @@ class Rollout:
                 runtime_skills_dir=self._config.skills_dir,
                 declared_sandbox_skills_dir=None,
             ),
+            sandbox_id=self._sandbox_id,
             **self._usage_metrics,
         )

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -77,6 +77,7 @@ from benchflow.models import RolloutResult, TrajectorySource
 from benchflow.rewards.validation import validate_reward_map
 from benchflow.rollout_branch import ChildRunner
 from benchflow.rollout_branch import branch as _branch_engine
+from benchflow.sandbox.metadata import persist_sandbox_info
 from benchflow.scenes import (
     compile_scenes_to_steps,
     scene_step_prompt,
@@ -801,38 +802,6 @@ async def _start_env_and_upload(
         await env.upload_dir(task_path / "solution", "/solution")
 
 
-def _persist_sandbox_info(env: Any, rollout_dir: Path | None) -> None:
-    """Write sandbox.json with provider-side sandbox ID immediately after creation.
-
-    This ensures the sandbox ID is persisted even if the run is interrupted
-    before result.json is written. Daytona also calls this at the moment its
-    sandbox is created (inside ``start()``), not only after ``start()`` returns
-    — closing the in-``start()`` interrupt window for DinD's long daemon-wait
-    (#554/#563).
-
-    The ``sandbox.json`` write is best-effort: a failure to write it (disk full,
-    read-only dir) must not abort an otherwise-healthy run, so it is wrapped and
-    logged rather than raised. The id-capture itself is load-bearing and lives in
-    the caller (``Rollout.start``); this helper only does the best-effort file
-    write.
-    """
-    sandbox_id = getattr(env, "sandbox_id", None)
-    if not isinstance(sandbox_id, str) or not rollout_dir:
-        return
-    provider = type(env).__name__
-    info = {
-        "sandbox_id": sandbox_id,
-        "provider": provider,
-        "created_at": str(datetime.now()),
-    }
-    try:
-        (rollout_dir / "sandbox.json").write_text(json.dumps(info, indent=2))
-    except Exception as e:  # best-effort: never fail start() over an audit file
-        logger.warning(f"Failed to persist sandbox.json for {sandbox_id}: {e}")
-        return
-    logger.info(f"Sandbox {sandbox_id} ({provider})")
-
-
 async def _run_oracle(
     env: Any, task_path: Path, timeout: int, sandbox_user: str | None = None
 ) -> tuple[list[dict], str]:
@@ -1480,7 +1449,7 @@ class Rollout:
             # sandbox.json to audit or clean up.
             sid = getattr(self._env, "sandbox_id", None)
             self._sandbox_id = sid if isinstance(sid, str) else None
-            _persist_sandbox_info(self._env, self._rollout_dir)
+            persist_sandbox_info(self._env, self._rollout_dir)
 
         await _start_env_and_upload(
             self._env,
@@ -2677,6 +2646,13 @@ class Rollout:
             usage_source=usage_source,
         )
 
+    def _current_sandbox_id(self) -> str | None:
+        sandbox_id = getattr(self, "_sandbox_id", None)
+        if isinstance(sandbox_id, str):
+            return sandbox_id
+        env_sandbox_id = getattr(getattr(self, "_env", None), "sandbox_id", None)
+        return env_sandbox_id if isinstance(env_sandbox_id, str) else None
+
     def _build_result(self) -> RolloutResult:
         rollout_dir = self._require_rollout_dir()
         # For Scene/multi-turn rollouts, each execute() call records the
@@ -2716,8 +2692,6 @@ class Rollout:
                 runtime_skills_dir=self._config.skills_dir,
                 declared_sandbox_skills_dir=None,
             ),
-            # getattr guard: cleanup/export paths build a Rollout skeleton via
-            # __new__ (no __init__), so _sandbox_id may be unset there (#563).
-            sandbox_id=getattr(self, "_sandbox_id", None),
+            sandbox_id=self._current_sandbox_id(),
             **self._usage_metrics,
         )

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -45,6 +45,7 @@ import os
 import re
 import shlex
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
@@ -764,7 +765,12 @@ def _resolve_prompts(
 
 
 async def _start_env_and_upload(
-    env: Any, task_path: Path, timing: dict, *, skip_start: bool = False
+    env: Any,
+    task_path: Path,
+    timing: dict,
+    *,
+    skip_start: bool = False,
+    on_started: Callable[[], None] | None = None,
 ) -> None:
     """Start environment and upload task files.
 
@@ -772,6 +778,12 @@ async def _start_env_and_upload(
     by the caller (Runtime with a live Environment, #388) — we still
     upload task files but must not re-run ``start()`` since most sandbox
     backends (e.g. daytona) are not idempotent.
+
+    ``on_started`` runs once the sandbox exists but *before* any upload
+    (#554/#563). Persisting the sandbox id here — not after upload —
+    closes the failure window where an upload error or interrupt after
+    Daytona creation would otherwise leave no ``sandbox.json`` to audit
+    or clean up.
     """
     if skip_start:
         logger.info(f"Reusing caller-owned environment: {task_path.name}")
@@ -781,6 +793,8 @@ async def _start_env_and_upload(
         t0 = datetime.now()
         await env.start(force_build=False)
         timing["environment_setup"] = (datetime.now() - t0).total_seconds()
+    if on_started is not None:
+        on_started()
     if (task_path / "instruction.md").exists():
         await env.upload_file(task_path / "instruction.md", "/instruction.md")
     if (task_path / "solution").is_dir():
@@ -1445,16 +1459,23 @@ class Rollout:
 
     async def start(self) -> None:
         """Start the environment and upload task files."""
+
+        def _capture_and_persist_sandbox() -> None:
+            # Persist the sandbox id the moment the sandbox exists, before any
+            # upload that could fail or be interrupted (#554/#563). Otherwise a
+            # mid-upload failure leaves a live Daytona sandbox with no
+            # sandbox.json to audit or clean up.
+            sid = getattr(self._env, "sandbox_id", None)
+            self._sandbox_id = sid if isinstance(sid, str) else None
+            _persist_sandbox_info(self._env, self._rollout_dir)
+
         await _start_env_and_upload(
             self._env,
             self._config.task_path,
             self._timing,
             skip_start=self._env_externally_owned,
+            on_started=_capture_and_persist_sandbox,
         )
-
-        sid = getattr(self._env, "sandbox_id", None)
-        self._sandbox_id = sid if isinstance(sid, str) else None
-        _persist_sandbox_info(self._env, self._rollout_dir)
 
         for hook in self._config.pre_agent_hooks or []:
             await hook(self._env)

--- a/src/benchflow/sandbox/_base.py
+++ b/src/benchflow/sandbox/_base.py
@@ -167,6 +167,16 @@ class BaseSandbox(ABC):
             merged.update(env)
         return merged or None
 
+    @property
+    def sandbox_id(self) -> str | None:
+        """Provider-side identifier for this sandbox instance.
+
+        Backends that allocate a remote resource (Daytona, Modal) override
+        this to return the provider's ID once the sandbox has been created.
+        Used for post-mortem cleanup and audit.
+        """
+        return None
+
     @abstractmethod
     def _validate_definition(self) -> None: ...
 

--- a/src/benchflow/sandbox/_base.py
+++ b/src/benchflow/sandbox/_base.py
@@ -171,9 +171,11 @@ class BaseSandbox(ABC):
     def sandbox_id(self) -> str | None:
         """Provider-side identifier for this sandbox instance.
 
-        Backends that allocate a remote resource (Daytona, Modal) override
-        this to return the provider's ID once the sandbox has been created.
-        Used for post-mortem cleanup and audit.
+        Backends that allocate a remote resource override this to return the
+        provider's ID once the sandbox has been created. Today only Daytona
+        does (Modal does not expose one); Docker and process backends have no
+        provider-side id and keep this ``None``. Used for post-mortem cleanup
+        and audit.
         """
         return None
 

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -1183,6 +1183,10 @@ class DaytonaSandbox(BaseSandbox):
         return self._compose_mode
 
     @property
+    def sandbox_id(self) -> str | None:
+        return self._sandbox.id if self._sandbox else None
+
+    @property
     def is_mounted(self) -> bool:
         return False
 

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -63,6 +63,7 @@ from benchflow.sandbox._compose import (
     compose_mkdir_p_command,
     compose_parent_mkdir_p_command,
 )
+from benchflow.sandbox.metadata import persist_sandbox_info
 from benchflow.sandbox.protocol import (
     SandboxImage,
     SandboxSnapshotNotSupported,
@@ -1227,12 +1228,7 @@ class DaytonaSandbox(BaseSandbox):
         """
         if self.rollout_paths is None:
             return
-        # Lazy import: ``benchflow.rollout`` is a high-level module; importing it
-        # at call time (not module import) keeps the sandbox layer free of a
-        # rollout dependency and avoids any import-time cycle.
-        from benchflow.rollout import _persist_sandbox_info
-
-        _persist_sandbox_info(self, self.rollout_paths.rollout_dir)
+        persist_sandbox_info(self, self.rollout_paths.rollout_dir)
 
     @retry(
         stop=stop_after_attempt(3),

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -1208,6 +1208,32 @@ class DaytonaSandbox(BaseSandbox):
 
     # ── Shared helpers used by both strategies ──────────────────────────
 
+    def _on_sandbox_created(self) -> None:
+        """Persist sandbox.json the instant the Daytona sandbox id is known.
+
+        Called from ``_create_sandbox`` the moment ``self._sandbox`` is assigned
+        — before ``start()`` does its remaining (and, for DinD, long) work:
+        launching dockerd, polling ``_wait_for_docker_daemon`` for tens of
+        seconds, mkdir/chmod, compose build/up. If the run is interrupted
+        (CancelledError/SIGINT/timeout) anywhere in that stretch, the Daytona
+        sandbox already exists server-side; persisting here means there is still
+        a ``sandbox.json`` to audit and clean up (#554/#563).
+
+        Best-effort and self-contained: a missing ``rollout_paths`` (e.g. a
+        snapshot/branch sandbox built outside a rollout dir) is a no-op, and the
+        underlying write swallows-and-logs its own failures. The rollout-layer
+        ``on_started`` callback still runs after ``start()`` returns as an
+        idempotent fallback.
+        """
+        if self.rollout_paths is None:
+            return
+        # Lazy import: ``benchflow.rollout`` is a high-level module; importing it
+        # at call time (not module import) keeps the sandbox layer free of a
+        # rollout dependency and avoids any import-time cycle.
+        from benchflow.rollout import _persist_sandbox_info
+
+        _persist_sandbox_info(self, self.rollout_paths.rollout_dir)
+
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
@@ -1246,6 +1272,10 @@ class DaytonaSandbox(BaseSandbox):
             self._sandbox = await asyncio.wait_for(
                 asyncio.shield(create_task), timeout=hard_timeout
             )
+            # Persist the id the moment the sandbox exists — before start()'s
+            # remaining (DinD: long) work — so an interrupt mid-start() still
+            # leaves a sandbox.json to audit/clean up (#554/#563).
+            self._on_sandbox_created()
         except TimeoutError:
             self.logger.error(
                 f"Sandbox creation timed out after {hard_timeout}s "
@@ -1256,6 +1286,9 @@ class DaytonaSandbox(BaseSandbox):
         except asyncio.CancelledError:
             try:
                 self._sandbox = await asyncio.wait_for(create_task, timeout=30)
+                # Sandbox came back even though we were cancelled — persist its
+                # id before re-raising so it is not orphaned (#554/#563).
+                self._on_sandbox_created()
             except (TimeoutError, asyncio.CancelledError, Exception):
                 create_task.cancel()
             raise

--- a/src/benchflow/sandbox/metadata.py
+++ b/src/benchflow/sandbox/metadata.py
@@ -1,0 +1,34 @@
+"""Sandbox metadata artifact helpers."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def persist_sandbox_info(env: Any, rollout_dir: Path | None) -> None:
+    """Write sandbox.json with provider-side sandbox ID immediately after creation.
+
+    The write is best-effort: failures to write this audit file must not abort
+    an otherwise-healthy sandbox startup.
+    """
+    sandbox_id = getattr(env, "sandbox_id", None)
+    if not isinstance(sandbox_id, str) or not rollout_dir:
+        return
+    provider = type(env).__name__
+    info = {
+        "sandbox_id": sandbox_id,
+        "provider": provider,
+        "created_at": str(datetime.now()),
+    }
+    try:
+        (rollout_dir / "sandbox.json").write_text(json.dumps(info, indent=2))
+    except Exception as e:  # best-effort: never fail start() over an audit file
+        logger.warning(f"Failed to persist sandbox.json for {sandbox_id}: {e}")
+        return
+    logger.info(f"Sandbox {sandbox_id} ({provider})")

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -348,3 +348,62 @@ def test_result_json_sandbox_id_null_for_docker(tmp_path: Path) -> None:
 
     data = json.loads((tmp_path / "result.json").read_text())
     assert data["sandbox_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_on_started_persists_before_upload(tmp_path: Path) -> None:
+    """Guards the fix from PR #563 for issue #554: the on_started callback must
+    fire after the sandbox starts but before any upload, so a sandbox id is
+    persisted even when an upload later fails."""
+    order: list[str] = []
+
+    class RecordingEnv(FakeUploadEnv):
+        async def start(self, force_build: bool) -> None:
+            await super().start(force_build)
+            order.append("start")
+
+        async def upload_file(self, source: Path | str, target: str) -> None:
+            order.append("upload_file")
+            await super().upload_file(source, target)
+
+    task = tmp_path / "task"
+    task.mkdir()
+    (task / "instruction.md").write_text("solve\n")
+    env = RecordingEnv()
+
+    await _start_env_and_upload(
+        env, task, {}, on_started=lambda: order.append("on_started")
+    )
+
+    assert order == ["start", "on_started", "upload_file"]
+
+
+@pytest.mark.asyncio
+async def test_sandbox_json_survives_upload_failure(tmp_path: Path) -> None:
+    """Guards the fix from PR #563 for issue #554: a sandbox.json must exist
+    even when an upload fails after the sandbox was created — otherwise an
+    interrupted run leaks a live Daytona sandbox with no audit/cleanup record."""
+    rollout_dir = tmp_path / "rollout"
+    rollout_dir.mkdir()
+    task = tmp_path / "task"
+    task.mkdir()
+    (task / "instruction.md").write_text("solve\n")
+
+    class FailingUploadEnv(FakeUploadEnv):
+        sandbox_id = "sb-failwindow"
+
+        async def upload_file(self, source: Path | str, target: str) -> None:
+            raise RuntimeError("upload boom")
+
+    env = FailingUploadEnv()
+
+    with pytest.raises(RuntimeError, match="upload boom"):
+        await _start_env_and_upload(
+            env,
+            task,
+            {},
+            on_started=lambda: _persist_sandbox_info(env, rollout_dir),
+        )
+
+    info = json.loads((rollout_dir / "sandbox.json").read_text())
+    assert info["sandbox_id"] == "sb-failwindow"

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -1,4 +1,4 @@
-"""Tests for rollout startup uploads."""
+"""Tests for rollout startup uploads and sandbox info persistence."""
 
 import json
 from pathlib import Path
@@ -13,6 +13,8 @@ from benchflow.rollout import (
     Rollout,
     RolloutConfig,
     Scene,
+    _build_rollout_result,
+    _persist_sandbox_info,
     _publish_trajectory_for_verifier,
     _start_env_and_upload,
 )
@@ -256,3 +258,93 @@ async def test_rollout_setup_records_self_gen_artifact_mode(
     assert config["skill_source"] == "self_generated"
     assert config["include_task_skills"] is False
     assert config["effective_skills_dir"] is None
+
+
+def test_persist_sandbox_info_writes_sandbox_json(tmp_path: Path) -> None:
+    """Guards the fix from PR #563 for issue #554: Daytona sandbox IDs must
+    be persisted immediately after creation so interrupted runs can be
+    audited and cleaned up."""
+
+    class FakeDaytonaSandbox:
+        sandbox_id = "sb-abc123"
+
+    _persist_sandbox_info(FakeDaytonaSandbox(), tmp_path)
+
+    info = json.loads((tmp_path / "sandbox.json").read_text())
+    assert info["sandbox_id"] == "sb-abc123"
+    assert info["provider"] == "FakeDaytonaSandbox"
+    assert "created_at" in info
+
+
+def test_persist_sandbox_info_skips_when_no_sandbox_id(tmp_path: Path) -> None:
+    """No sandbox.json for backends without a provider-side ID (e.g. Docker)."""
+
+    class FakeDockerSandbox:
+        sandbox_id = None
+
+    _persist_sandbox_info(FakeDockerSandbox(), tmp_path)
+    assert not (tmp_path / "sandbox.json").exists()
+
+
+def test_persist_sandbox_info_skips_when_no_rollout_dir() -> None:
+    """No crash when rollout_dir is None (shouldn't happen but be safe)."""
+
+    class FakeSandbox:
+        sandbox_id = "sb-xyz"
+
+    _persist_sandbox_info(FakeSandbox(), None)
+
+
+def test_result_json_includes_sandbox_id(tmp_path: Path) -> None:
+    """Guards the fix from PR #563 for issue #554: result.json should include
+    the sandbox_id for completed runs so post-mortem cleanup can reconcile
+    Daytona sandboxes against rollout artifacts."""
+    from datetime import datetime
+
+    _build_rollout_result(
+        tmp_path,
+        task_name="my-task",
+        rollout_name="my-rollout",
+        agent="oracle",
+        agent_name="oracle",
+        model="",
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards={"score": 1.0},
+        started_at=datetime(2026, 5, 25, 12, 0),
+        timing={},
+        sandbox_id="sb-daytona-123",
+    )
+
+    data = json.loads((tmp_path / "result.json").read_text())
+    assert data["sandbox_id"] == "sb-daytona-123"
+
+
+def test_result_json_sandbox_id_null_for_docker(tmp_path: Path) -> None:
+    """Docker runs have no provider-side sandbox ID."""
+    from datetime import datetime
+
+    _build_rollout_result(
+        tmp_path,
+        task_name="my-task",
+        rollout_name="my-rollout",
+        agent="oracle",
+        agent_name="oracle",
+        model="",
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards={"score": 1.0},
+        started_at=datetime(2026, 5, 25, 12, 0),
+        timing={},
+    )
+
+    data = json.loads((tmp_path / "result.json").read_text())
+    assert data["sandbox_id"] is None

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from benchflow.diagnostics import RolloutDiagnostics
 from benchflow.rollout import (
     SKILL_MODE_NO_SKILL,
     SKILL_MODE_SELF_GEN,
@@ -15,10 +16,10 @@ from benchflow.rollout import (
     RolloutConfig,
     Scene,
     _build_rollout_result,
-    _persist_sandbox_info,
     _publish_trajectory_for_verifier,
     _start_env_and_upload,
 )
+from benchflow.sandbox.metadata import persist_sandbox_info
 
 
 class FakeUploadEnv:
@@ -269,7 +270,7 @@ def test_persist_sandbox_info_writes_sandbox_json(tmp_path: Path) -> None:
     class FakeDaytonaSandbox:
         sandbox_id = "sb-abc123"
 
-    _persist_sandbox_info(FakeDaytonaSandbox(), tmp_path)
+    persist_sandbox_info(FakeDaytonaSandbox(), tmp_path)
 
     info = json.loads((tmp_path / "sandbox.json").read_text())
     assert info["sandbox_id"] == "sb-abc123"
@@ -283,7 +284,7 @@ def test_persist_sandbox_info_skips_when_no_sandbox_id(tmp_path: Path) -> None:
     class FakeDockerSandbox:
         sandbox_id = None
 
-    _persist_sandbox_info(FakeDockerSandbox(), tmp_path)
+    persist_sandbox_info(FakeDockerSandbox(), tmp_path)
     assert not (tmp_path / "sandbox.json").exists()
 
 
@@ -293,7 +294,7 @@ def test_persist_sandbox_info_skips_when_no_rollout_dir() -> None:
     class FakeSandbox:
         sandbox_id = "sb-xyz"
 
-    _persist_sandbox_info(FakeSandbox(), None)
+    persist_sandbox_info(FakeSandbox(), None)
 
 
 def test_result_json_includes_sandbox_id(tmp_path: Path) -> None:
@@ -323,6 +324,68 @@ def test_result_json_includes_sandbox_id(tmp_path: Path) -> None:
 
     data = json.loads((tmp_path / "result.json").read_text())
     assert data["sandbox_id"] == "sb-daytona-123"
+
+
+@pytest.mark.asyncio
+async def test_rollout_result_falls_back_to_env_sandbox_id_after_start_failure(
+    tmp_path: Path,
+) -> None:
+    """Guards the fix from PR #563 for issue #554: if Daytona creates the
+    provider sandbox and then fails later in start(), result.json still records
+    env.sandbox_id even though the rollout on_started callback never ran."""
+    from datetime import datetime
+
+    rollout_dir = tmp_path / "rollout"
+    rollout_dir.mkdir()
+    task = tmp_path / "task"
+    task.mkdir()
+
+    class CreatedThenFailingEnv(FakeUploadEnv):
+        sandbox_id = "sb-post-create-fail"
+
+        async def start(self, force_build: bool) -> None:
+            persist_sandbox_info(self, rollout_dir)
+            raise RuntimeError("post-create startup failed")
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = RolloutConfig(
+        task_path=task,
+        scenes=[Scene.single(agent="oracle")],
+        jobs_dir=tmp_path / "jobs",
+    )
+    rollout._rollout_dir = rollout_dir
+    rollout._started_at = datetime(2026, 5, 25, 12, 0)
+    rollout._rollout_name = "my-rollout"
+    rollout._agent_name = "oracle"
+    rollout._env = CreatedThenFailingEnv()
+    rollout._env_externally_owned = False
+    rollout._timing = {}
+    rollout._executed_prompts = []
+    rollout._resolved_prompts = []
+    rollout._n_tool_calls = 0
+    rollout._error = "post-create startup failed"
+    rollout._verifier_error = None
+    rollout._export_error = None
+    rollout._trajectory = []
+    rollout._partial_trajectory = False
+    rollout._trajectory_source = None
+    rollout._rewards = None
+    rollout._evolved_skills = None
+    rollout._diagnostics = RolloutDiagnostics()
+    rollout._usage_metrics = {}
+    rollout._task_skill_policy = None
+    rollout._sandbox_id = None
+
+    with pytest.raises(RuntimeError, match="post-create startup failed"):
+        await rollout.start()
+
+    assert rollout._sandbox_id is None
+    rollout._build_result()
+
+    sandbox_info = json.loads((rollout_dir / "sandbox.json").read_text())
+    result = json.loads((rollout_dir / "result.json").read_text())
+    assert sandbox_info["sandbox_id"] == "sb-post-create-fail"
+    assert result["sandbox_id"] == "sb-post-create-fail"
 
 
 def test_result_json_sandbox_id_null_for_docker(tmp_path: Path) -> None:
@@ -403,7 +466,7 @@ async def test_sandbox_json_survives_upload_failure(tmp_path: Path) -> None:
             env,
             task,
             {},
-            on_started=lambda: _persist_sandbox_info(env, rollout_dir),
+            on_started=lambda: persist_sandbox_info(env, rollout_dir),
         )
 
     info = json.loads((rollout_dir / "sandbox.json").read_text())
@@ -421,7 +484,7 @@ async def test_sandbox_json_survives_interrupt_inside_start(tmp_path: Path) -> N
     stretch would leave a live server-side sandbox with no ``sandbox.json``.
 
     Daytona now persists the id the instant ``self._sandbox`` is assigned
-    (``_create_sandbox`` calls ``_persist_sandbox_info`` before the daemon-wait).
+    (``_create_sandbox`` calls ``persist_sandbox_info`` before the daemon-wait).
     This models that: a fake env whose ``start()`` persists the id and then is
     cancelled before returning must still leave a ``sandbox.json`` behind."""
     rollout_dir = tmp_path / "rollout"
@@ -437,7 +500,7 @@ async def test_sandbox_json_survives_interrupt_inside_start(tmp_path: Path) -> N
             # Provider create returned: the sandbox id is now known. Persist it
             # immediately (this is what DaytonaSandbox._create_sandbox does on
             # assignment, before the DinD daemon-wait) ...
-            _persist_sandbox_info(self, rollout_dir)
+            persist_sandbox_info(self, rollout_dir)
             # ... then get cancelled during the long daemon-wait, before start()
             # could return and before on_started would have fired.
             raise asyncio.CancelledError
@@ -500,7 +563,7 @@ async def test_create_sandbox_persists_sandbox_json_normal_path(tmp_path: Path) 
     ``DaytonaSandbox._create_sandbox`` must persist ``sandbox.json`` the instant
     ``self._sandbox`` is assigned — via ``_on_sandbox_created`` — not only after
     ``start()`` returns. Unlike ``test_sandbox_json_survives_interrupt_inside_start``
-    (which hand-calls ``_persist_sandbox_info`` from a fake ``start()``), this
+    (which hand-calls ``persist_sandbox_info`` from a fake ``start()``), this
     drives the production ``_create_sandbox``/``_on_sandbox_created`` wiring, so
     deleting the ``_on_sandbox_created()`` call in ``daytona.py`` fails it."""
     rollout_dir = tmp_path / "rollout"

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -1,5 +1,6 @@
 """Tests for rollout startup uploads and sandbox info persistence."""
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -407,3 +408,163 @@ async def test_sandbox_json_survives_upload_failure(tmp_path: Path) -> None:
 
     info = json.loads((rollout_dir / "sandbox.json").read_text())
     assert info["sandbox_id"] == "sb-failwindow"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_json_survives_interrupt_inside_start(tmp_path: Path) -> None:
+    """Guards the fix from PR #563 for issue #554: the in-``start()`` interrupt
+    window. A Daytona sandbox id becomes available mid-``start()`` (right after
+    the provider create call), but ``start()`` then does substantial work — DinD
+    launches dockerd and polls for the daemon for tens of seconds — before it
+    returns. The rollout-layer ``on_started`` callback only fires after
+    ``start()`` returns, so an interrupt (CancelledError/SIGINT/timeout) in that
+    stretch would leave a live server-side sandbox with no ``sandbox.json``.
+
+    Daytona now persists the id the instant ``self._sandbox`` is assigned
+    (``_create_sandbox`` calls ``_persist_sandbox_info`` before the daemon-wait).
+    This models that: a fake env whose ``start()`` persists the id and then is
+    cancelled before returning must still leave a ``sandbox.json`` behind."""
+    rollout_dir = tmp_path / "rollout"
+    rollout_dir.mkdir()
+    task = tmp_path / "task"
+    task.mkdir()
+    (task / "instruction.md").write_text("solve\n")
+
+    class InterruptedInStartEnv(FakeUploadEnv):
+        sandbox_id = "sb-instart"
+
+        async def start(self, force_build: bool) -> None:
+            # Provider create returned: the sandbox id is now known. Persist it
+            # immediately (this is what DaytonaSandbox._create_sandbox does on
+            # assignment, before the DinD daemon-wait) ...
+            _persist_sandbox_info(self, rollout_dir)
+            # ... then get cancelled during the long daemon-wait, before start()
+            # could return and before on_started would have fired.
+            raise asyncio.CancelledError
+
+    env = InterruptedInStartEnv()
+
+    captured: list[str] = []
+
+    with pytest.raises(asyncio.CancelledError):
+        await _start_env_and_upload(
+            env,
+            task,
+            {},
+            on_started=lambda: captured.append("on_started"),
+        )
+
+    # on_started never ran (start() never returned) — proving the window is real.
+    assert captured == []
+    # ... yet sandbox.json is present, written from inside start().
+    info = json.loads((rollout_dir / "sandbox.json").read_text())
+    assert info["sandbox_id"] == "sb-instart"
+
+
+def _make_daytona_sandbox(rollout_dir: Path, create_impl):
+    """Build a bare ``DaytonaSandbox`` wired for ``_create_sandbox`` (#554/#563).
+
+    ``__init__`` materializes the daytona SDK and picks a strategy, neither of
+    which ``_create_sandbox``/``_on_sandbox_created`` need. We construct via
+    ``__new__`` and set only the attributes those two methods touch:
+    ``_client_manager`` (whose ``get_client()`` returns a fake daytona whose
+    ``create()`` runs ``create_impl``), ``task_env_config`` (for
+    ``build_timeout_sec``), ``rollout_paths`` (a real ``RolloutPaths`` at
+    ``rollout_dir``), a no-op ``logger`` and ``_sandbox=None``.
+    """
+    from benchflow.sandbox.daytona import DaytonaSandbox
+    from benchflow.task import RolloutPaths
+
+    env = DaytonaSandbox.__new__(DaytonaSandbox)
+
+    class _FakeDaytona:
+        async def create(self, params, timeout):
+            return await create_impl(params, timeout)
+
+    class _FakeClientManager:
+        async def get_client(self):
+            return _FakeDaytona()
+
+    env._client_manager = _FakeClientManager()
+    env._sandbox = None
+    env.task_env_config = MagicMock(build_timeout_sec=10)
+    env.rollout_paths = RolloutPaths(rollout_dir)
+    env.logger = MagicMock()
+    return env
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_persists_sandbox_json_normal_path(tmp_path: Path) -> None:
+    """Guards the fix from PR #563 for issue #554 at the real call site: the
+    normal ``asyncio.wait_for`` success branch of
+    ``DaytonaSandbox._create_sandbox`` must persist ``sandbox.json`` the instant
+    ``self._sandbox`` is assigned — via ``_on_sandbox_created`` — not only after
+    ``start()`` returns. Unlike ``test_sandbox_json_survives_interrupt_inside_start``
+    (which hand-calls ``_persist_sandbox_info`` from a fake ``start()``), this
+    drives the production ``_create_sandbox``/``_on_sandbox_created`` wiring, so
+    deleting the ``_on_sandbox_created()`` call in ``daytona.py`` fails it."""
+    rollout_dir = tmp_path / "rollout"
+    rollout_dir.mkdir()
+
+    class _FakeCreatedSandbox:
+        id = "sb-normal-123"
+
+    async def create_impl(params, timeout):
+        return _FakeCreatedSandbox()
+
+    env = _make_daytona_sandbox(rollout_dir, create_impl)
+
+    await env._create_sandbox(params=MagicMock())
+
+    assert env.sandbox_id == "sb-normal-123"
+    info = json.loads((rollout_dir / "sandbox.json").read_text())
+    assert info["sandbox_id"] == "sb-normal-123"
+    assert info["provider"] == "DaytonaSandbox"
+
+
+@pytest.mark.asyncio
+async def test_create_sandbox_persists_sandbox_json_on_cancelled_recovery(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Guards the fix from PR #563 for issue #554 on the
+    ``except asyncio.CancelledError`` recovery branch of
+    ``DaytonaSandbox._create_sandbox``. If the shielded first wait is cancelled
+    but the underlying ``create()`` task still yields a sandbox, the recovery
+    block awaits it, persists ``sandbox.json`` via ``_on_sandbox_created``, then
+    re-raises — so the live server-side sandbox is never orphaned without an
+    audit file. We make the first ``asyncio.wait_for`` raise ``CancelledError``
+    and let the second await the (completed) create task."""
+    import asyncio as _asyncio
+
+    rollout_dir = tmp_path / "rollout"
+    rollout_dir.mkdir()
+
+    class _FakeCreatedSandbox:
+        id = "sb-cancelled-456"
+
+    async def create_impl(params, timeout):
+        return _FakeCreatedSandbox()
+
+    env = _make_daytona_sandbox(rollout_dir, create_impl)
+
+    real_wait_for = _asyncio.wait_for
+    calls = {"n": 0}
+
+    async def fake_wait_for(awaitable, timeout):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # First (shielded) wait is interrupted — but the create task keeps
+            # running and completes, exactly as in a mid-create SIGINT/cancel.
+            raise asyncio.CancelledError
+        return await real_wait_for(awaitable, timeout)
+
+    monkeypatch.setattr("benchflow.sandbox.daytona.asyncio.wait_for", fake_wait_for)
+
+    with pytest.raises(asyncio.CancelledError):
+        await env._create_sandbox(params=MagicMock())
+
+    assert calls["n"] == 2  # both the shielded wait and the recovery wait ran
+    assert env.sandbox_id == "sb-cancelled-456"
+    info = json.loads((rollout_dir / "sandbox.json").read_text())
+    assert info["sandbox_id"] == "sb-cancelled-456"
+    assert info["provider"] == "DaytonaSandbox"


### PR DESCRIPTION
## Summary

- Daytona runs now write `sandbox.json` immediately after sandbox creation, ensuring the provider-side sandbox ID survives process interruptions.
- `result.json` also includes `sandbox_id` for completed runs, linking rollout artifacts to provider-side resources.
- Adds a `sandbox_id` property to `BaseSandbox` (returns `None` by default), overridden in `DaytonaSandbox` to return `self._sandbox.id`.
- Uses `isinstance(sandbox_id, str)` checks to safely handle mocked environments in tests.

Closes #554

## Test plan

- [x] `test_persist_sandbox_info_writes_sandbox_json` — verifies sandbox.json is written with correct ID and provider
- [x] `test_persist_sandbox_info_skips_when_no_sandbox_id` — Docker backends produce no sandbox.json
- [x] `test_persist_sandbox_info_skips_when_no_rollout_dir` — no crash on None rollout_dir
- [x] `test_result_json_includes_sandbox_id` — sandbox_id appears in result.json
- [x] `test_result_json_sandbox_id_null_for_docker` — sandbox_id is null when not provided
- [x] Full test suite passes (1371 passed, 9 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/563" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->