### PR TITLE
fix: classify provider auth failures as non-retryable

### DIFF
--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -10,7 +10,18 @@ ACP_ERROR = "acp_error"
 IDLE_TIMEOUT = "idle_timeout"
 INFRA_ERROR = "infra_failure"
 SANDBOX_SETUP = "sandbox_setup"
+PROVIDER_AUTH = "provider_auth"
 TIMED_OUT = "timeout"
+
+_PROVIDER_AUTH_MARKERS = (
+    "PERMISSION_DENIED",
+    "leaked",
+    "Failed to authenticate",
+    "Invalid bearer token",
+    "Invalid API key",
+    "was rejected as invalid",
+    "Unauthorized",
+)
 
 # Verifier error category constants
 VERIFIER_FAILED = "verifier_failure"
@@ -41,7 +52,9 @@ def classify_error(error: str | None) -> str | None:
         return INSTALL_FAILED
     if "closed stdout" in lower:
         return PIPE_CLOSED
-    if "ACP error" in error:
+    if "ACP error" in error or "was rejected as invalid" in error:
+        if any(m in error for m in _PROVIDER_AUTH_MARKERS):
+            return PROVIDER_AUTH
         return ACP_ERROR
     if "sandbox startup" in lower or "sandbox creation" in lower:
         return SANDBOX_SETUP

--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -13,14 +13,21 @@ SANDBOX_SETUP = "sandbox_setup"
 PROVIDER_AUTH = "provider_auth"
 TIMED_OUT = "timeout"
 
+# Matched case-insensitively against the error string. Covers the
+# human-authored markers plus the sanitized "provider auth failed (HTTP 401)"
+# marker injected at the rollout/provider boundary (#546/#564), where the real
+# 401/403 is visible only in the proxy trajectory, not the top-level ACP error.
 _PROVIDER_AUTH_MARKERS = (
-    "PERMISSION_DENIED",
+    "permission_denied",
     "leaked",
-    "Failed to authenticate",
-    "Invalid bearer token",
-    "Invalid API key",
+    "failed to authenticate",
+    "invalid bearer token",
+    "invalid api key",
     "was rejected as invalid",
-    "Unauthorized",
+    "unauthorized",
+    "provider auth failed",
+    "http 401",
+    "http 403",
 )
 
 # Verifier error category constants
@@ -53,7 +60,7 @@ def classify_error(error: str | None) -> str | None:
     if "closed stdout" in lower:
         return PIPE_CLOSED
     if "ACP error" in error or "was rejected as invalid" in error:
-        if any(m in error for m in _PROVIDER_AUTH_MARKERS):
+        if any(m in lower for m in _PROVIDER_AUTH_MARKERS):
             return PROVIDER_AUTH
         return ACP_ERROR
     if "sandbox startup" in lower or "sandbox creation" in lower:

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -24,20 +24,11 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
 def _retry_config(raw: dict[str, Any]) -> RetryConfig:
-    retry = raw.get("retry") or {}
-    return RetryConfig(
-        max_retries=int(retry.get("max_retries", 2)),
-        retry_on_install=bool(retry.get("retry_on_install", True)),
-        retry_on_pipe=bool(retry.get("retry_on_pipe", True)),
-        retry_on_acp=bool(retry.get("retry_on_acp", True)),
-        retry_on_idle_timeout=bool(retry.get("retry_on_idle_timeout", True)),
-        retry_on_infra=bool(retry.get("retry_on_infra", True)),
-        retry_on_verifier_infra=bool(retry.get("retry_on_verifier_infra", True)),
-        wait_multiplier=float(retry.get("wait_multiplier", 2.0)),
-        min_wait_sec=float(retry.get("min_wait_sec", 1.0)),
-        max_wait_sec=float(retry.get("max_wait_sec", 30.0)),
-        exclude_categories=set(retry.get("exclude_categories", ["timeout"])),
-    )
+    # Centralized parsing: omitted fields fall back to RetryConfig's own
+    # defaults (which exclude provider_auth), not hard-coded literals, so a
+    # partial worker payload can't silently revert to retrying auth failures
+    # (#564 finding 2).
+    return RetryConfig.from_mapping(raw.get("retry"))
 
 
 def _environment_manifest(raw: dict[str, Any]):

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -47,6 +47,7 @@ from benchflow._utils.scoring import (
     INFRA_ERROR,
     INSTALL_FAILED,
     PIPE_CLOSED,
+    PROVIDER_AUTH,
     VERIFIER_DEP_INSTALL,
     VERIFIER_INFRA,
     VERIFIER_TIMEOUT,
@@ -119,7 +120,9 @@ class RetryConfig:
     wait_multiplier: float = 2.0
     min_wait_sec: float = 1.0
     max_wait_sec: float = 30.0
-    exclude_categories: set[str] = field(default_factory=lambda: {"timeout"})
+    exclude_categories: set[str] = field(
+        default_factory=lambda: {"timeout", PROVIDER_AUTH}
+    )
 
     def should_retry(
         self,

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -124,6 +124,39 @@ class RetryConfig:
         default_factory=lambda: {"timeout", PROVIDER_AUTH}
     )
 
+    @classmethod
+    def from_mapping(cls, raw: dict | None) -> RetryConfig:
+        """Build from a serialized ``retry`` payload (e.g. a worker config).
+
+        Any omitted field falls back to this dataclass's own default — never a
+        hard-coded literal — so a partial/older payload that drops, say,
+        ``exclude_categories`` still excludes ``provider_auth`` (#564 finding 2).
+        """
+        raw = raw or {}
+        defaults = cls()
+        exclude = raw.get("exclude_categories")
+        return cls(
+            max_retries=int(raw.get("max_retries", defaults.max_retries)),
+            retry_on_install=bool(
+                raw.get("retry_on_install", defaults.retry_on_install)
+            ),
+            retry_on_pipe=bool(raw.get("retry_on_pipe", defaults.retry_on_pipe)),
+            retry_on_acp=bool(raw.get("retry_on_acp", defaults.retry_on_acp)),
+            retry_on_idle_timeout=bool(
+                raw.get("retry_on_idle_timeout", defaults.retry_on_idle_timeout)
+            ),
+            retry_on_infra=bool(raw.get("retry_on_infra", defaults.retry_on_infra)),
+            retry_on_verifier_infra=bool(
+                raw.get("retry_on_verifier_infra", defaults.retry_on_verifier_infra)
+            ),
+            wait_multiplier=float(raw.get("wait_multiplier", defaults.wait_multiplier)),
+            min_wait_sec=float(raw.get("min_wait_sec", defaults.min_wait_sec)),
+            max_wait_sec=float(raw.get("max_wait_sec", defaults.max_wait_sec)),
+            exclude_categories=(
+                set(exclude) if exclude is not None else defaults.exclude_categories
+            ),
+        )
+
     def should_retry(
         self,
         error: str | None,

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime
 from typing import Any
 
@@ -11,6 +12,33 @@ from benchflow.trajectories.types import (
     LLMRequest,
     LLMResponse,
     Trajectory,
+)
+
+_PROVIDER_AUTH_STATUS_CODES = (401, 403)
+_STATUS_KEYS = {
+    "httpstatus",
+    "httpstatuscode",
+    "status",
+    "statuscode",
+    "status_code",
+    "http_status",
+    "http_status_code",
+    "response_code",
+    "response_status",
+    "response_status_code",
+}
+_PROVIDER_AUTH_STATUS_RE = re.compile(r"\b(401|403)\b")
+_PROVIDER_AUTH_HINT_RE = re.compile(
+    r"\b("
+    r"auth(?:entication|orization)?|"
+    r"unauthori[sz]ed|"
+    r"permission_denied|"
+    r"forbidden|"
+    r"bearer|"
+    r"api[-_ ]?key|"
+    r"credentials?"
+    r")\b",
+    re.IGNORECASE,
 )
 
 
@@ -204,6 +232,74 @@ def _record_response_body(record: dict[str, Any]) -> dict[str, Any]:
     return body
 
 
+def _coerce_auth_status(value: Any) -> int | None:
+    if isinstance(value, int) and value in _PROVIDER_AUTH_STATUS_CODES:
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            status = int(stripped)
+            if status in _PROVIDER_AUTH_STATUS_CODES:
+                return status
+    return None
+
+
+def _explicit_auth_status(value: Any) -> int | None:
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).lower() in _STATUS_KEYS:
+                status = _coerce_auth_status(nested)
+                if status is not None:
+                    return status
+        for nested in value.values():
+            status = _explicit_auth_status(nested)
+            if status is not None:
+                return status
+    elif isinstance(value, list | tuple):
+        for nested in value:
+            status = _explicit_auth_status(nested)
+            if status is not None:
+                return status
+    return None
+
+
+def _flatten_failure_text(value: Any) -> str:
+    if isinstance(value, dict):
+        return " ".join(
+            part
+            for item in value.items()
+            if str(item[0]).lower() not in {"stack", "stacktrace", "traceback"}
+            for part in (str(item[0]), _flatten_failure_text(item[1]))
+            if part
+        )
+    if isinstance(value, list | tuple):
+        return " ".join(_flatten_failure_text(item) for item in value)
+    if value is None:
+        return ""
+    return str(value)
+
+
+def _provider_auth_status_from_failure_record(record: dict[str, Any]) -> int | None:
+    """Return a sanitized provider auth status from a LiteLLM failure record."""
+    if record.get("event") != "failure":
+        return None
+    failure_payload = {
+        "error": record.get("error"),
+        "response": record.get("response"),
+    }
+    status = _explicit_auth_status(failure_payload)
+    if status is not None:
+        return status
+
+    text = _flatten_failure_text(failure_payload)
+    if not _PROVIDER_AUTH_HINT_RE.search(text):
+        return None
+    match = _PROVIDER_AUTH_STATUS_RE.search(text)
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
 def trajectory_from_litellm_callback_log(
     text: str,
     *,
@@ -227,7 +323,10 @@ def trajectory_from_litellm_callback_log(
         request_body = request.get("body")
         request_body = request_body if isinstance(request_body, dict) else {}
         response_body = _record_response_body(record)
-        status = 200 if record.get("event") == "success" else 500
+        if record.get("event") == "success":
+            status = 200
+        else:
+            status = _provider_auth_status_from_failure_record(record) or 500
         trajectory.exchanges.append(
             LLMExchange(
                 request=LLMRequest(

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -2052,6 +2052,13 @@ class Rollout:
             # the runtime reference below, and is read later by ACP-error
             # classification — for Daytona the trajectory is empty until here
             # (#546/#564).
+            #
+            # Coverage gap: only `self._usage_runtime` is scanned here. Bedrock
+            # auth failures flow through `self._provider_runtime`, whose server
+            # (BedrockProxyServer) exposes no `.trajectory`/`.exchanges`, so a
+            # fallback scan of it would always return None — useless, so it's
+            # not implemented. The direct-AWS-Bedrock case (remote sandbox,
+            # runtime=None) bypasses both proxies entirely and is out of scope.
             self._provider_auth_status_cached = _provider_auth_status_from_runtime(
                 usage_runtime
             )
@@ -2199,6 +2206,14 @@ class Rollout:
             # error lives in the usage-proxy trajectory, which Daytona's
             # SandboxUsageProxy only imports on stop() (#546/#564).
             pending_acp_error = e
+            # Set a provisional error so cleanup()'s
+            # _enforce_required_usage_tracking guard early-returns instead of
+            # logging a misleading "no provider token usage was captured"
+            # message — the agent failed with an ACP error, not a usage gap.
+            # The post-cleanup block below still unconditionally refines
+            # self._error to the provider_auth marker, so this is only a
+            # placeholder during cleanup.
+            self._error = str(e)
             logger.error(str(e))
         except Exception as e:
             self._error = str(e)
@@ -2612,7 +2627,11 @@ class Rollout:
             diag.sandbox_probe_traceback = traceback.format_exc()[-2000:]
 
     def _classify_acp_error(self, e: AgentProtocolError) -> str:
-        if "Invalid API key" in e.message:
+        # The base AgentProtocolError only annotates `message: str` without
+        # assigning it, so a base instance has no `.message` (AttributeError
+        # risk); ACPError subclasses do set it. Fall back to str(e) defensively.
+        message = getattr(e, "message", str(e))
+        if "Invalid API key" in message:
             from benchflow.agents.env import check_subscription_auth
             from benchflow.agents.registry import infer_env_key_for_model
 

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -2585,7 +2585,31 @@ class Rollout:
                     f"Subscription auth credentials exist — unset the env var "
                     f"to use them: env -u {key} <command>"
                 )
+        # A real invalid-key failure often surfaces only as a generic
+        # "ACP error -32603: Internal error" at this layer — the provider's
+        # actual 401/403 is visible only in the proxy-captured trajectory
+        # (#546/#564). Surface a sanitized auth marker (status code only — never
+        # the response body or headers) so RetryConfig.should_retry classifies
+        # it as provider_auth and fails fast instead of burning retries.
+        auth_status = self._provider_auth_status()
+        if auth_status is not None:
+            return f"{e} | provider auth failed (HTTP {auth_status})"
         return str(e)
+
+    def _provider_auth_status(self) -> int | None:
+        """Return a provider 401/403 status from the proxy trajectory, if any.
+
+        Only the integer status code is read — never the response body or
+        headers — so no credential material can leak into ``result.error``.
+        """
+        server = getattr(getattr(self, "_usage_runtime", None), "server", None)
+        trajectory = getattr(server, "trajectory", None)
+        exchanges = getattr(trajectory, "exchanges", None) or []
+        for exchange in reversed(exchanges):
+            status = getattr(getattr(exchange, "response", None), "status_code", None)
+            if status in (401, 403):
+                return status
+        return None
 
     def _write_llm_trajectory(self, usage_runtime: Any) -> None:
         """Persist captured provider HTTP exchanges as JSONL."""

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -2649,7 +2649,6 @@ class Rollout:
         ``result.error`` (#546/#564).
         """
         return self._provider_auth_status_cached
-        return None
 
     def _write_llm_trajectory(self, usage_runtime: Any) -> None:
         """Persist captured provider HTTP exchanges as JSONL."""

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -108,6 +108,24 @@ _DISALLOW_WEB_TOOLS_ENV = "BENCHFLOW_DISALLOW_WEB_TOOLS"
 GENERATED_SKILLS_ROOT = "/app/generated-skills"
 
 
+def _provider_auth_status_from_runtime(runtime: Any) -> int | None:
+    """Return a provider 401/403 status from a usage runtime's trajectory.
+
+    Scans the captured provider HTTP exchanges for an auth-failure status.
+    Only the integer status code is read — never response bodies or headers —
+    so no credential material can leak into ``result.error`` (#546/#564).
+    Returns ``None`` when there is no runtime, no trajectory, or no 401/403.
+    """
+    server = getattr(runtime, "server", None)
+    trajectory = getattr(server, "trajectory", None)
+    exchanges = getattr(trajectory, "exchanges", None) or []
+    for exchange in reversed(exchanges):
+        status = getattr(getattr(exchange, "response", None), "status_code", None)
+        if status in (401, 403):
+            return status
+    return None
+
+
 def _task_disallows_internet(task: Any) -> bool:
     """Return True when task.toml requests no internet for the agent task."""
     env_config = getattr(getattr(task, "config", None), "environment", None)
@@ -1140,6 +1158,11 @@ class Rollout:
         self._task_skill_policy: TaskSkillPolicy | None = None
         self._usage_runtime: Any = None
         self._usage_metrics: dict[str, Any] = self._planes.extract_usage(None)
+        # Provider 401/403 status snapshotted during cleanup, after the usage
+        # proxy imports its captures (Daytona's SandboxUsageProxy only fills
+        # trajectory on stop()). Read by _provider_auth_status() so ACP-error
+        # classification can fail fast on auth failures (#546/#564).
+        self._provider_auth_status_cached: int | None = None
 
         # Populated by install_agent()
         self._agent_cfg: Any = None
@@ -2024,6 +2047,14 @@ class Rollout:
             except Exception as e:
                 logger.warning(f"Usage telemetry runtime stop failed: {e}")
                 self._usage_metrics = self._planes.extract_usage(None)
+            # Snapshot any provider 401/403 now that captures are imported
+            # (stop() populated the trajectory). This must happen before we drop
+            # the runtime reference below, and is read later by ACP-error
+            # classification — for Daytona the trajectory is empty until here
+            # (#546/#564).
+            self._provider_auth_status_cached = _provider_auth_status_from_runtime(
+                usage_runtime
+            )
             try:
                 self._write_llm_trajectory(usage_runtime)
             except Exception as e:
@@ -2078,6 +2109,7 @@ class Rollout:
         """
         cfg = self._config
         agent_timed_out = False
+        pending_acp_error: AgentProtocolError | None = None
         if cfg.skill_mode == SKILL_MODE_SELF_GEN:
             raise ValueError(
                 "self-gen requires the runtime orchestrator. Use bf.run(), "
@@ -2162,13 +2194,23 @@ class Rollout:
             self._diagnostics.set(e.diagnostic)
             logger.error(self._error)
         except AgentProtocolError as e:
-            self._error = self._classify_acp_error(e)
-            logger.error(self._error)
+            # Defer classification until after cleanup(): the provider 401/403
+            # that distinguishes provider_auth from a generic retryable ACP
+            # error lives in the usage-proxy trajectory, which Daytona's
+            # SandboxUsageProxy only imports on stop() (#546/#564).
+            pending_acp_error = e
+            logger.error(str(e))
         except Exception as e:
             self._error = str(e)
             logger.error("Run failed", exc_info=True)
         finally:
             await self.cleanup()
+
+        # cleanup() has now imported usage-proxy captures and snapshotted any
+        # provider auth status, so classification can see the real 401/403.
+        if pending_acp_error is not None:
+            self._error = self._classify_acp_error(pending_acp_error)
+            logger.error(self._error)
 
         if self._rollout_dir is None:
             return RolloutResult(
@@ -2597,18 +2639,16 @@ class Rollout:
         return str(e)
 
     def _provider_auth_status(self) -> int | None:
-        """Return a provider 401/403 status from the proxy trajectory, if any.
+        """Return the provider 401/403 status snapshotted during cleanup.
 
-        Only the integer status code is read — never the response body or
-        headers — so no credential material can leak into ``result.error``.
+        The snapshot is taken in :meth:`cleanup` after the usage proxy imports
+        its captures, so this is valid for both the host proxy (trajectory
+        filled as requests complete) and Daytona's SandboxUsageProxy (filled
+        only on ``stop()``). Only the integer status code is ever read — never
+        response bodies or headers — so no credential material reaches
+        ``result.error`` (#546/#564).
         """
-        server = getattr(getattr(self, "_usage_runtime", None), "server", None)
-        trajectory = getattr(server, "trajectory", None)
-        exchanges = getattr(trajectory, "exchanges", None) or []
-        for exchange in reversed(exchanges):
-            status = getattr(getattr(exchange, "response", None), "status_code", None)
-            if status in (401, 403):
-                return status
+        return self._provider_auth_status_cached
         return None
 
     def _write_llm_trajectory(self, usage_runtime: Any) -> None:

--- a/tests/test_eval_worker_retry.py
+++ b/tests/test_eval_worker_retry.py
@@ -1,0 +1,57 @@
+"""Guards PR #564 finding 2: worker retry-config parsing must not silently
+revert to retrying provider_auth failures when a payload omits
+``exclude_categories``.
+
+The worker reconstructs ``RetryConfig`` from a serialized payload. Centralizing
+that in ``RetryConfig.from_mapping`` means omitted fields fall back to the
+dataclass defaults (which exclude ``provider_auth``), not a hard-coded literal.
+"""
+
+from benchflow.eval_worker import _evaluation_config, _retry_config
+from benchflow.evaluation import RetryConfig
+
+_PROVIDER_AUTH_ERROR = (
+    "ACP error -32603: Internal error: Failed to authenticate. "
+    "API Error: 401 Invalid bearer token"
+)
+
+
+def test_from_mapping_omitted_exclude_keeps_provider_auth():
+    """A payload with no exclude_categories must still exclude provider_auth."""
+    cfg = RetryConfig.from_mapping({"max_retries": 3})
+    assert not cfg.should_retry(_PROVIDER_AUTH_ERROR)
+    assert cfg.max_retries == 3  # other fields still parsed
+
+
+def test_from_mapping_none_uses_defaults():
+    cfg = RetryConfig.from_mapping(None)
+    assert not cfg.should_retry(_PROVIDER_AUTH_ERROR)
+
+
+def test_from_mapping_explicit_exclude_respected():
+    """An explicit exclude_categories is honored verbatim (not merged with
+    defaults)."""
+    cfg = RetryConfig.from_mapping({"exclude_categories": ["timeout"]})
+    assert cfg.exclude_categories == {"timeout"}
+    # acp_error is retryable; provider_auth never is (no retry branch for it),
+    # so dropping it from excludes still doesn't make auth failures retry.
+    assert cfg.should_retry("ACP error -32000: connection refused")
+    assert not cfg.should_retry(_PROVIDER_AUTH_ERROR)
+
+
+def test_worker_retry_config_omitting_exclude_does_not_retry_provider_auth():
+    """Worker payload without retry.exclude_categories must not retry auth."""
+    cfg = _retry_config({"retry": {"max_retries": 2}})
+    assert not cfg.should_retry(_PROVIDER_AUTH_ERROR)
+
+
+def test_worker_retry_config_no_retry_key_at_all():
+    cfg = _retry_config({})
+    assert not cfg.should_retry(_PROVIDER_AUTH_ERROR)
+
+
+def test_evaluation_config_retry_excludes_provider_auth_by_default():
+    """End-to-end: a worker config payload with no retry block yields an
+    EvaluationConfig whose retry refuses to retry provider_auth (#564)."""
+    eval_cfg = _evaluation_config({"tasks_dir": "/tmp/tasks", "agent": "oracle"})
+    assert not eval_cfg.retry.should_retry(_PROVIDER_AUTH_ERROR)

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -42,10 +42,21 @@ class TestRetryConfig:
         )
 
     def test_should_not_retry_provider_auth_claude_401(self):
+        """Guards the fix from PR #564 for issue #546: Claude 401 auth failures
+        must not be retried — they waste Daytona sandbox quota."""
         cfg = RetryConfig()
         assert not cfg.should_retry(
             "ACP error -32603: Internal error: Failed to authenticate. "
             "API Error: 401 Invalid bearer token"
+        )
+
+    def test_should_not_retry_sanitized_proxy_auth_marker(self):
+        """Guards PR #564: the sanitized "provider auth failed (HTTP 401)"
+        marker injected from the proxy trajectory must fail fast, even when the
+        top-level ACP error is only a generic internal error."""
+        cfg = RetryConfig()
+        assert not cfg.should_retry(
+            "ACP error -32603: Internal error | provider auth failed (HTTP 401)"
         )
 
     def test_should_not_retry_timeout(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -38,7 +38,7 @@ class TestRetryConfig:
         should not be retried — they waste Daytona sandbox quota."""
         cfg = RetryConfig()
         assert not cfg.should_retry(
-            'ACP error 403: PERMISSION_DENIED: Your API key was reported as leaked.'
+            "ACP error 403: PERMISSION_DENIED: Your API key was reported as leaked."
         )
 
     def test_should_not_retry_provider_auth_claude_401(self):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -31,7 +31,22 @@ class TestRetryConfig:
 
     def test_should_retry_acp_error(self):
         cfg = RetryConfig()
-        assert cfg.should_retry("ACP error -32000: Authentication required")
+        assert cfg.should_retry("ACP error -32000: connection refused")
+
+    def test_should_not_retry_provider_auth_gemini_403(self):
+        """Guards the fix from PR #564 for issue #546: provider auth failures
+        should not be retried — they waste Daytona sandbox quota."""
+        cfg = RetryConfig()
+        assert not cfg.should_retry(
+            'ACP error 403: PERMISSION_DENIED: Your API key was reported as leaked.'
+        )
+
+    def test_should_not_retry_provider_auth_claude_401(self):
+        cfg = RetryConfig()
+        assert not cfg.should_retry(
+            "ACP error -32603: Internal error: Failed to authenticate. "
+            "API Error: 401 Invalid bearer token"
+        )
 
     def test_should_not_retry_timeout(self):
         cfg = RetryConfig()

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -1,0 +1,55 @@
+"""Tests for provider-auth detection at the rollout boundary (PR #564 / #546).
+
+The real failure mode: an invalid provider key surfaces at the ACP layer only
+as a generic "ACP error -32603: Internal error"; the actual 401/403 is visible
+only in the proxy-captured trajectory. ``Rollout._provider_auth_status`` reads
+that status (status code only — never body/headers) so a sanitized auth marker
+can be appended to ``result.error`` and the retry classifier can fail fast.
+"""
+
+from types import SimpleNamespace
+
+from benchflow.rollout import Rollout
+
+
+def _rollout_with_statuses(statuses):
+    """Build a bare Rollout whose proxy trajectory has the given response statuses."""
+    exchanges = [
+        SimpleNamespace(response=SimpleNamespace(status_code=s)) for s in statuses
+    ]
+    trajectory = SimpleNamespace(exchanges=exchanges)
+    server = SimpleNamespace(trajectory=trajectory)
+    rollout = Rollout.__new__(Rollout)
+    rollout._usage_runtime = SimpleNamespace(server=server)
+    return rollout
+
+
+def test_detects_401_in_trajectory():
+    """Guards PR #564: a provider 401 in the proxy trajectory is surfaced."""
+    assert _rollout_with_statuses([200, 401])._provider_auth_status() == 401
+
+
+def test_detects_403_in_trajectory():
+    """Guards PR #564: a provider 403 in the proxy trajectory is surfaced."""
+    assert _rollout_with_statuses([403])._provider_auth_status() == 403
+
+
+def test_returns_last_auth_status():
+    """The most recent auth failure wins (trajectory scanned newest-first)."""
+    assert _rollout_with_statuses([401, 200, 403])._provider_auth_status() == 403
+
+
+def test_no_auth_status_when_all_ok():
+    """Guards PR #564: a healthy trajectory must not be flagged as auth failure."""
+    assert _rollout_with_statuses([200, 200, 500])._provider_auth_status() is None
+
+
+def test_missing_usage_runtime_is_safe():
+    """No proxy runtime (e.g. oracle runs) must not raise — returns None."""
+    rollout = Rollout.__new__(Rollout)
+    rollout._usage_runtime = None
+    assert rollout._provider_auth_status() is None
+
+
+def test_empty_trajectory_is_safe():
+    assert _rollout_with_statuses([])._provider_auth_status() is None

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -14,6 +14,9 @@ snapshot taken once captures are imported.
 """
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
 
 from benchflow.rollout import _provider_auth_status_from_runtime
 
@@ -83,3 +86,145 @@ def test_snapshot_after_late_capture_import():
     proxy.stop()
     # After import (what cleanup() now does before snapshotting): 401 visible.
     assert _provider_auth_status_from_runtime(proxy) == 401
+
+
+# ── Rollout-level run()/cleanup() ordering (PR #564 deeper review) ──
+
+
+def _auth_rollout(tmp_path, *, usage_source="unavailable"):
+    """Build a minimal real Rollout whose usage proxy carries a 401 but reports
+    no provider token usage — the exact shape of a provider-auth failure under
+    ``usage_tracking.mode == "required"`` (PR #564 / issue #546).
+
+    The FakeServer's proxy trajectory holds a single 401 exchange, so
+    cleanup()'s ``_provider_auth_status_from_runtime`` snapshot returns 401,
+    while ``extract_usage`` yields ``usage_source`` (default ``"unavailable"``)
+    so the required-usage enforcement path is reachable.
+    """
+    from benchflow.providers.runtime import ProviderRuntime
+    from benchflow.rollout import Rollout, RolloutConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    class FakeServer:
+        trajectory = SimpleNamespace(
+            exchanges=[SimpleNamespace(response=SimpleNamespace(status_code=401))]
+        )
+
+        async def stop(self):
+            return None
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = RolloutConfig(
+        task_path=tmp_path / "task",
+        usage_tracking=UsageTrackingConfig(mode="required"),
+    )
+    rollout._error = None
+    rollout._trajectory = []
+    rollout._acp_client = None
+    rollout._agent_launch = ""
+    rollout._env = SimpleNamespace(stop=AsyncMock())
+    rollout._environment = None
+    rollout._provider_runtime = None
+    rollout._provider_auth_status_cached = None
+    rollout._usage_runtime = ProviderRuntime(
+        kind="usage-proxy",
+        agent_base_url="http://host.docker.internal:32124",
+        backend_model="gpt-5.5",
+        server=FakeServer(),
+    )
+    rollout._planes = SimpleNamespace(
+        stop_provider_runtime=lambda runtime: runtime.server.stop(),
+        extract_usage=lambda runtime: {"usage_source": usage_source},
+    )
+    rollout._rollout_dir = tmp_path
+    return rollout
+
+
+def test_classify_acp_error_handles_base_error_without_message(tmp_path):
+    """Guards PR #564 / issue #546: a base ``AgentProtocolError`` (which only
+    annotates ``message: str`` and never assigns it) must not AttributeError in
+    ``_classify_acp_error``; the sanitized ``provider auth failed (HTTP 401)``
+    marker is still appended when a 401 snapshot is present.
+
+    FAILS if FIX 2 is reverted to reading ``e.message`` directly.
+    """
+    from benchflow.agents.errors import AgentProtocolError
+
+    rollout = _auth_rollout(tmp_path)
+    rollout._provider_auth_status_cached = 401
+
+    err = AgentProtocolError("ACP error -32603: Internal error")
+    assert not hasattr(err, "message")
+
+    classified = rollout._classify_acp_error(err)
+    assert classified == (
+        "ACP error -32603: Internal error | provider auth failed (HTTP 401)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_auth_failure_sets_provisional_error_before_cleanup(
+    tmp_path, monkeypatch
+):
+    """KEY guarding test for FIX 1 (PR #564 / issue #546).
+
+    Drives the real ``Rollout.run()`` ordering: install_agent raises an ACPError,
+    cleanup() runs ``_enforce_required_usage_tracking`` (usage mode required, no
+    provider usage captured), then the post-cleanup block refines self._error to
+    the provider_auth marker.
+
+    A spy wraps the real ``_classify_acp_error`` and records ``self._error`` at
+    the seam — after cleanup's enforcement, before refinement. With FIX 1 the
+    recorded value is the provisional ACP-error string (enforcement skipped);
+    without it the recorded value becomes the spurious "Token usage tracking is
+    required..." message, so this test FAILS if FIX 1 is reverted.
+    """
+    from benchflow.acp.client import ACPError
+
+    rollout = _auth_rollout(tmp_path, usage_source="unavailable")
+    # Lightweight RolloutResult path (no trial dir / _build_result needed).
+    rollout._rollout_dir = None
+
+    monkeypatch.setattr(rollout, "setup", AsyncMock())
+    monkeypatch.setattr(rollout, "start", AsyncMock())
+    monkeypatch.setattr(
+        rollout,
+        "install_agent",
+        AsyncMock(side_effect=ACPError(-32603, "Internal error")),
+    )
+
+    recorded = {}
+    real_classify = rollout._classify_acp_error
+
+    def spy_classify(e):
+        recorded["error_at_seam"] = rollout._error
+        return real_classify(e)
+
+    monkeypatch.setattr(rollout, "_classify_acp_error", spy_classify)
+
+    result = await rollout.run()
+
+    # Enforcement was skipped because run() set a provisional self._error — the
+    # seam value is the ACP-error string, NOT the spurious usage message.
+    assert recorded["error_at_seam"] == "ACP error -32603: Internal error"
+    assert result.error == (
+        "ACP error -32603: Internal error | provider auth failed (HTTP 401)"
+    )
+    assert rollout._provider_auth_status_cached == 401
+
+
+def test_enforcement_still_fires_when_no_error_and_usage_missing(tmp_path):
+    """Negative control for FIX 1 (PR #564 / issue #546): on a clean run with no
+    ACP error and no captured provider usage, the legitimate required-usage
+    enforcement message must STILL fire — the provisional-error guard only
+    suppresses it when an error is already set.
+    """
+    rollout = _auth_rollout(tmp_path, usage_source="unavailable")
+    rollout._usage_metrics = {"usage_source": "unavailable"}
+    rollout._error = None
+
+    rollout._enforce_required_usage_tracking()
+
+    assert rollout._error == (
+        "Token usage tracking is required, but no provider token usage was captured."
+    )

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -137,9 +137,9 @@ def test_litellm_non_auth_failure_import_remains_generic_500():
     )
 
     assert trajectory.exchanges[0].response.status_code == 500
-    assert _provider_auth_status_from_runtime(
-        _runtime_with_trajectory(trajectory)
-    ) is None
+    assert (
+        _provider_auth_status_from_runtime(_runtime_with_trajectory(trajectory)) is None
+    )
 
 
 def test_snapshot_after_late_capture_import():

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -13,11 +13,13 @@ the ACP error. Classification now happens after cleanup, reading a status
 snapshot taken once captures are imported.
 """
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 
+from benchflow.providers.litellm_logging import trajectory_from_litellm_callback_log
 from benchflow.rollout import _provider_auth_status_from_runtime
 
 
@@ -26,6 +28,10 @@ def _runtime_with_statuses(statuses):
         SimpleNamespace(response=SimpleNamespace(status_code=s)) for s in statuses
     ]
     trajectory = SimpleNamespace(exchanges=exchanges)
+    return SimpleNamespace(server=SimpleNamespace(trajectory=trajectory))
+
+
+def _runtime_with_trajectory(trajectory):
     return SimpleNamespace(server=SimpleNamespace(trajectory=trajectory))
 
 
@@ -62,6 +68,78 @@ def test_missing_runtime_is_safe():
 
 def test_empty_trajectory_is_safe():
     assert _provider_auth_status_from_runtime(_runtime_with_statuses([])) is None
+
+
+def test_litellm_auth_failure_import_drives_sanitized_provider_marker(tmp_path):
+    """Guards PR #564: LiteLLM callback auth failures that only expose ``401
+    Invalid bearer token`` inside the failure payload must still surface as
+    provider_auth without leaking the payload into ``result.error``."""
+    from benchflow.agents.errors import AgentProtocolError
+
+    record = {
+        "event": "failure",
+        "request_model": "benchflow-claude",
+        "provider_model": "anthropic/claude-opus-4-8",
+        "request": {"method": "POST", "path": "/v1/messages", "body": {}},
+        "response": {},
+        "error": {
+            "type": "AuthenticationError",
+            "message": (
+                "litellm.AuthenticationError: AnthropicException - "
+                "API Error: 401 Invalid bearer token"
+            ),
+        },
+        "start_time": "2026-06-04T10:00:00",
+        "end_time": "2026-06-04T10:00:00",
+    }
+
+    trajectory = trajectory_from_litellm_callback_log(
+        json.dumps(record),
+        session_id="session",
+        agent_name="openhands",
+    )
+    status = _provider_auth_status_from_runtime(_runtime_with_trajectory(trajectory))
+
+    assert trajectory.exchanges[0].response.status_code == 401
+    assert status == 401
+
+    rollout = _auth_rollout(tmp_path)
+    rollout._provider_auth_status_cached = status
+
+    classified = rollout._classify_acp_error(
+        AgentProtocolError("ACP error -32603: Internal error")
+    )
+
+    assert classified == (
+        "ACP error -32603: Internal error | provider auth failed (HTTP 401)"
+    )
+    assert "Invalid bearer token" not in classified
+
+
+def test_litellm_non_auth_failure_import_remains_generic_500():
+    """Guards PR #564: non-auth LiteLLM failures stay 500/None."""
+    record = {
+        "event": "failure",
+        "request_model": "benchflow-gpt",
+        "request": {"method": "POST", "path": "/v1/chat/completions", "body": {}},
+        "error": {
+            "type": "APIConnectionError",
+            "message": "upstream connection reset while reading response",
+        },
+        "start_time": "2026-06-04T10:00:00",
+        "end_time": "2026-06-04T10:00:00",
+    }
+
+    trajectory = trajectory_from_litellm_callback_log(
+        json.dumps(record),
+        session_id="session",
+        agent_name="codex-acp",
+    )
+
+    assert trajectory.exchanges[0].response.status_code == 500
+    assert _provider_auth_status_from_runtime(
+        _runtime_with_trajectory(trajectory)
+    ) is None
 
 
 def test_snapshot_after_late_capture_import():

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -2,54 +2,84 @@
 
 The real failure mode: an invalid provider key surfaces at the ACP layer only
 as a generic "ACP error -32603: Internal error"; the actual 401/403 is visible
-only in the proxy-captured trajectory. ``Rollout._provider_auth_status`` reads
-that status (status code only — never body/headers) so a sanitized auth marker
-can be appended to ``result.error`` and the retry classifier can fail fast.
+only in the proxy-captured trajectory. The rollout snapshots that status (code
+only — never body/headers) after the usage proxy imports its captures, so a
+sanitized marker can be appended to ``result.error`` and the retry classifier
+can fail fast.
+
+PR #564 review finding 1: Daytona's SandboxUsageProxy only fills its trajectory
+on ``stop()``, which runs during ``cleanup()`` — *after* the old code classified
+the ACP error. Classification now happens after cleanup, reading a status
+snapshot taken once captures are imported.
 """
 
 from types import SimpleNamespace
 
-from benchflow.rollout import Rollout
+from benchflow.rollout import _provider_auth_status_from_runtime
 
 
-def _rollout_with_statuses(statuses):
-    """Build a bare Rollout whose proxy trajectory has the given response statuses."""
+def _runtime_with_statuses(statuses):
     exchanges = [
         SimpleNamespace(response=SimpleNamespace(status_code=s)) for s in statuses
     ]
     trajectory = SimpleNamespace(exchanges=exchanges)
-    server = SimpleNamespace(trajectory=trajectory)
-    rollout = Rollout.__new__(Rollout)
-    rollout._usage_runtime = SimpleNamespace(server=server)
-    return rollout
+    return SimpleNamespace(server=SimpleNamespace(trajectory=trajectory))
 
 
 def test_detects_401_in_trajectory():
     """Guards PR #564: a provider 401 in the proxy trajectory is surfaced."""
-    assert _rollout_with_statuses([200, 401])._provider_auth_status() == 401
+    assert _provider_auth_status_from_runtime(_runtime_with_statuses([200, 401])) == 401
 
 
 def test_detects_403_in_trajectory():
     """Guards PR #564: a provider 403 in the proxy trajectory is surfaced."""
-    assert _rollout_with_statuses([403])._provider_auth_status() == 403
+    assert _provider_auth_status_from_runtime(_runtime_with_statuses([403])) == 403
 
 
 def test_returns_last_auth_status():
     """The most recent auth failure wins (trajectory scanned newest-first)."""
-    assert _rollout_with_statuses([401, 200, 403])._provider_auth_status() == 403
+    assert (
+        _provider_auth_status_from_runtime(_runtime_with_statuses([401, 200, 403]))
+        == 403
+    )
 
 
 def test_no_auth_status_when_all_ok():
     """Guards PR #564: a healthy trajectory must not be flagged as auth failure."""
-    assert _rollout_with_statuses([200, 200, 500])._provider_auth_status() is None
+    assert (
+        _provider_auth_status_from_runtime(_runtime_with_statuses([200, 200, 500]))
+        is None
+    )
 
 
-def test_missing_usage_runtime_is_safe():
+def test_missing_runtime_is_safe():
     """No proxy runtime (e.g. oracle runs) must not raise — returns None."""
-    rollout = Rollout.__new__(Rollout)
-    rollout._usage_runtime = None
-    assert rollout._provider_auth_status() is None
+    assert _provider_auth_status_from_runtime(None) is None
 
 
 def test_empty_trajectory_is_safe():
-    assert _rollout_with_statuses([])._provider_auth_status() is None
+    assert _provider_auth_status_from_runtime(_runtime_with_statuses([])) is None
+
+
+def test_snapshot_after_late_capture_import():
+    """Guards PR #564 finding 1: a proxy that only populates its trajectory on
+    stop() (Daytona's SandboxUsageProxy) must still yield the 401 once captures
+    are imported — the snapshot is read after, not before, import."""
+
+    class LateProxy:
+        """server.trajectory is empty until stop() imports captures."""
+
+        def __init__(self):
+            self.server = SimpleNamespace(trajectory=SimpleNamespace(exchanges=[]))
+
+        def stop(self):
+            self.server.trajectory.exchanges = [
+                SimpleNamespace(response=SimpleNamespace(status_code=401))
+            ]
+
+    proxy = LateProxy()
+    # Before import: nothing visible (this is exactly the old-code bug).
+    assert _provider_auth_status_from_runtime(proxy) is None
+    proxy.stop()
+    # After import (what cleanup() now does before snapshotting): 401 visible.
+    assert _provider_auth_status_from_runtime(proxy) == 401

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -105,7 +105,25 @@ class TestClassifyError:
         )
 
     def test_provider_auth_invalid_api_key(self):
+        """Guards the fix from PR #564 for issue #546: invalid-API-key errors
+        classify as provider_auth, not acp_error."""
         assert classify_error("ACP error -32001: Invalid API key") == "provider_auth"
+
+    def test_provider_auth_lowercase_and_status_forms(self):
+        """Guards PR #564: reviewer-reported auth shapes the original top-level
+        string match missed must classify as provider_auth, not acp_error."""
+        for err in (
+            "ACP error 401: unauthorized",
+            "ACP error -32001: invalid api key",
+            "ACP error -32603: failed to authenticate",
+            "ACP error -32603: Internal error | provider auth failed (HTTP 401)",
+        ):
+            assert classify_error(err) == "provider_auth", err
+
+    def test_generic_acp_internal_error_still_retryable(self):
+        """Guards PR #564: a bare ACP internal error with no auth signal stays
+        acp_error — only a real surfaced 401/403 should flip it to provider_auth."""
+        assert classify_error("ACP error -32603: Internal error") == "acp_error"
 
     def test_provider_auth_rejected_as_invalid(self):
         """The message from _classify_acp_error when subscription auth exists."""

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -83,6 +83,45 @@ class TestClassifyError:
     def test_other(self):
         assert classify_error("something unexpected") == "other"
 
+    def test_provider_auth_gemini_403(self):
+        """Guards the fix from PR #564 for issue #546: Gemini PERMISSION_DENIED
+        should be classified as provider_auth, not acp_error."""
+        assert (
+            classify_error(
+                'ACP error 403: PERMISSION_DENIED: Your API key was reported as leaked.'
+            )
+            == "provider_auth"
+        )
+
+    def test_provider_auth_claude_401(self):
+        """Guards the fix from PR #564 for issue #546: Claude 401 auth failure
+        should be classified as provider_auth."""
+        assert (
+            classify_error(
+                "ACP error -32603: Internal error: Failed to authenticate. "
+                "API Error: 401 Invalid bearer token"
+            )
+            == "provider_auth"
+        )
+
+    def test_provider_auth_invalid_api_key(self):
+        assert classify_error("ACP error -32001: Invalid API key") == "provider_auth"
+
+    def test_provider_auth_rejected_as_invalid(self):
+        """The message from _classify_acp_error when subscription auth exists."""
+        assert (
+            classify_error(
+                "GEMINI_API_KEY was rejected as invalid. "
+                "Subscription auth credentials exist — unset the env var "
+                "to use them: env -u GEMINI_API_KEY <command>"
+            )
+            == "provider_auth"
+        )
+
+    def test_acp_error_non_auth_still_retryable(self):
+        """Generic ACP errors without auth markers should stay acp_error."""
+        assert classify_error("ACP error -32000: connection refused") == "acp_error"
+
     def test_install_broad_match_not_used(self):
         """'install' alone should NOT match — only 'install failed'."""
         assert classify_error("installing dependencies") == "other"

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -88,7 +88,7 @@ class TestClassifyError:
         should be classified as provider_auth, not acp_error."""
         assert (
             classify_error(
-                'ACP error 403: PERMISSION_DENIED: Your API key was reported as leaked.'
+                "ACP error 403: PERMISSION_DENIED: Your API key was reported as leaked."
             )
             == "provider_auth"
         )


### PR DESCRIPTION
## Summary

- Provider auth errors (Gemini 403 `PERMISSION_DENIED`, Claude 401 `Failed to authenticate`, leaked/invalid API keys) were classified as generic `acp_error` and retried up to 3 times, each spinning up a fresh Daytona sandbox.
- Added `PROVIDER_AUTH` error category in `scoring.py` with auth-specific markers (`PERMISSION_DENIED`, `Invalid API key`, `Failed to authenticate`, `Invalid bearer token`, `leaked`, `Unauthorized`, `was rejected as invalid`).
- `classify_error()` now detects these markers within ACP errors and returns `provider_auth` instead of `acp_error`.
- `RetryConfig.exclude_categories` defaults to `{"timeout", "provider_auth"}`, so auth failures fail fast on the first attempt.

Closes #546

## Test plan

- [x] `test_provider_auth_gemini_403` — Gemini 403 PERMISSION_DENIED classified as provider_auth
- [x] `test_provider_auth_claude_401` — Claude 401 invalid bearer token classified as provider_auth
- [x] `test_provider_auth_invalid_api_key` — generic invalid API key classified as provider_auth
- [x] `test_provider_auth_rejected_as_invalid` — BenchFlow's own subscription auth message classified as provider_auth
- [x] `test_acp_error_non_auth_still_retryable` — generic ACP errors remain retryable
- [x] `test_should_not_retry_provider_auth_gemini_403` — RetryConfig rejects Gemini auth
- [x] `test_should_not_retry_provider_auth_claude_401` — RetryConfig rejects Claude auth
- [x] Full test suite passes (1373 passed, 9 pre-existing failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/564" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->