### PR TITLE
Support OpenHands Bedrock runs on Daytona

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -129,6 +129,10 @@ def _normalize_openhands_model(model: str) -> str:
     if model.startswith("google/gemini"):
         return f"gemini/{model.split('/', 1)[1]}"
     stripped = strip_provider_prefix(model)
+    if model.startswith("aws-bedrock/") and stripped.startswith(
+        ("anthropic.", "us.anthropic.", "global.anthropic.")
+    ):
+        return f"anthropic/{stripped}"
     lower = model.lower()
     if is_vertex_model(model) and "gemini" in lower:
         return f"vertex_ai/{stripped}"

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -77,6 +77,26 @@ def _install_python_script(container_path: str, source: str) -> str:
     )
 
 
+def _apt_install(*packages: str) -> str:
+    """POSIX shell snippet for apt installs with transient mirror recovery."""
+    package_args = " ".join(shlex.quote(package) for package in packages)
+    return (
+        "( attempt=1; "
+        'while [ "$attempt" -le 3 ]; do '
+        "rm -rf /var/lib/apt/lists/*; "
+        "apt-get clean; "
+        "if apt-get -o Acquire::Retries=3 update -qq && "
+        f"apt-get -o Acquire::Retries=3 install -y -qq {package_args}; then "
+        "exit 0; "
+        "fi; "
+        'case "$attempt" in 1) sleep 2; attempt=2 ;; '
+        "2) sleep 4; attempt=3 ;; "
+        "*) sleep 6; attempt=4 ;; esac; "
+        "done; "
+        "exit 1 )"
+    )
+
+
 # Isolated Node.js bootstrap for JavaScript-based ACP agents.
 #
 # Keep this out of system prefixes. Task images may need their own Node/npm
@@ -502,8 +522,7 @@ AGENTS: dict[str, AgentConfig] = {
             'export PATH="$HOME/.local/bin:$PATH" && '
             "( command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 || "
             "  if command -v apt-get >/dev/null 2>&1; then "
-            "    apt-get update -qq && "
-            "    apt-get install -y -qq curl ca-certificates git >/dev/null 2>&1; "
+            f"    {_apt_install('curl', 'ca-certificates', 'git')}; "
             "  elif command -v dnf >/dev/null 2>&1; then "
             "    dnf -y install curl ca-certificates git >/dev/null 2>&1; "
             "  elif command -v apk >/dev/null 2>&1; then "
@@ -525,6 +544,7 @@ AGENTS: dict[str, AgentConfig] = {
             '    export PATH="$HOME/.local/bin:$PATH"; '
             "  fi && "
             "uv tool install --force --refresh "
+            "--with 'boto3>=1.40' "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12 && "
             "  uv tool list | grep -q '^openhands\\b' ) && "

--- a/src/benchflow/providers/bedrock_proxy.py
+++ b/src/benchflow/providers/bedrock_proxy.py
@@ -53,10 +53,24 @@ def _sse_json_bytes(payload: bytes) -> bytes:
 
 
 _STREAM_END = object()
+_BEDROCK_RUNTIME_MAX_ATTEMPTS = 4
+_BEDROCK_RUNTIME_RETRY_DELAYS_SEC = (1, 2, 4)
 
 
 def _next_stream_event(iterator: Any) -> Any:
     return next(iterator, _STREAM_END)
+
+
+def _is_retriable_bedrock_runtime_error(exc: Exception) -> bool:
+    """Return true for transient Bedrock transport failures before a response."""
+    name = exc.__class__.__name__
+    module = exc.__class__.__module__
+    return name in {
+        "ConnectionClosedError",
+        "ConnectTimeoutError",
+        "EndpointConnectionError",
+        "ReadTimeoutError",
+    } or (name == "NameResolutionError" and module.startswith("urllib3."))
 
 
 def _match_bedrock_model_path(path: str, suffix: str) -> str | None:
@@ -147,6 +161,29 @@ class BedrockProxyServer:
         client = self._client
         assert client is not None
         return client
+
+    async def _call_bedrock_runtime(self, operation: str, **payload: Any) -> Any:
+        method = getattr(self._require_client(), operation)
+        for attempt in range(1, _BEDROCK_RUNTIME_MAX_ATTEMPTS + 1):
+            try:
+                return await asyncio.to_thread(method, **payload)
+            except Exception as exc:
+                if (
+                    attempt >= _BEDROCK_RUNTIME_MAX_ATTEMPTS
+                    or not _is_retriable_bedrock_runtime_error(exc)
+                ):
+                    raise
+                delay = _BEDROCK_RUNTIME_RETRY_DELAYS_SEC[attempt - 1]
+                logger.warning(
+                    "Bedrock runtime %s failed on attempt %s/%s; retrying in %ss: %s",
+                    operation,
+                    attempt,
+                    _BEDROCK_RUNTIME_MAX_ATTEMPTS,
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+        raise AssertionError("unreachable Bedrock runtime retry state")
 
     async def start(self) -> None:
         if self._client is None:
@@ -258,11 +295,10 @@ class BedrockProxyServer:
         body: dict[str, Any],
         writer: asyncio.StreamWriter,
     ) -> None:
-        client = self._require_client()
         model = self._backend_model or body["model"]
         payload = anthropic_request_to_bedrock_converse({**body, "model": model})
         if body.get("stream"):
-            response = await asyncio.to_thread(client.converse_stream, **payload)
+            response = await self._call_bedrock_runtime("converse_stream", **payload)
             writer.write(
                 b"HTTP/1.1 200 OK\r\n"
                 b"content-type: text/event-stream\r\n"
@@ -284,7 +320,7 @@ class BedrockProxyServer:
             await writer.drain()
             return
 
-        response = await asyncio.to_thread(client.converse, **payload)
+        response = await self._call_bedrock_runtime("converse", **payload)
         normalized = bedrock_response_to_anthropic(response, model=body["model"])
         writer.write(_json_http_response(200, normalized))
         await writer.drain()
@@ -294,11 +330,10 @@ class BedrockProxyServer:
         body: dict[str, Any],
         writer: asyncio.StreamWriter,
     ) -> None:
-        client = self._require_client()
         model = self._backend_model or body["model"]
         payload = openai_responses_request_to_bedrock_converse({**body, "model": model})
         if body.get("stream"):
-            response = await asyncio.to_thread(client.converse_stream, **payload)
+            response = await self._call_bedrock_runtime("converse_stream", **payload)
             writer.write(
                 b"HTTP/1.1 200 OK\r\n"
                 b"content-type: text/event-stream\r\n"
@@ -322,7 +357,7 @@ class BedrockProxyServer:
             await writer.drain()
             return
 
-        response = await asyncio.to_thread(client.converse, **payload)
+        response = await self._call_bedrock_runtime("converse", **payload)
         normalized = bedrock_response_to_openai_response(
             response,
             model=body["model"],

--- a/src/benchflow/providers/bedrock_runtime.py
+++ b/src/benchflow/providers/bedrock_runtime.py
@@ -12,12 +12,15 @@ claude-agent-acp: text, tool calling, and basic inference config.
 
 from __future__ import annotations
 
+import base64
 import json
 import time
 from typing import Any
 
 BEDROCK_RUNTIME_SERVICE = "bedrock-runtime"
 BEDROCK_OPTIONAL_DEPENDENCY_HINT = "uv sync --extra bedrock"
+BEDROCK_CONNECT_TIMEOUT_SEC = 10
+BEDROCK_READ_TIMEOUT_SEC = 300
 
 
 def resolve_bedrock_region(env: dict[str, str]) -> str:
@@ -57,9 +60,19 @@ def build_bedrock_client(
                 "Bedrock support requires the optional 'bedrock' dependency group. "
                 f"Install it with: {BEDROCK_OPTIONAL_DEPENDENCY_HINT}"
             ) from exc
+    try:
+        from botocore.config import Config
+    except ImportError:  # pragma: no cover - botocore ships with boto3
+        config = None
+    else:
+        config = Config(
+            connect_timeout=BEDROCK_CONNECT_TIMEOUT_SEC,
+            read_timeout=BEDROCK_READ_TIMEOUT_SEC,
+        )
     return boto3_module.client(
         service_name=BEDROCK_RUNTIME_SERVICE,
         region_name=normalized["AWS_REGION"],
+        config=config,
     )
 
 
@@ -76,7 +89,33 @@ def _anthropic_system_to_bedrock(system: Any) -> list[dict[str, str]]:
     return blocks
 
 
-def _tool_result_content_blocks(content: Any) -> list[dict[str, str]]:
+_IMAGE_MEDIA_TYPE_TO_BEDROCK_FORMAT = {
+    "image/gif": "gif",
+    "image/jpeg": "jpeg",
+    "image/png": "png",
+    "image/webp": "webp",
+}
+
+
+def _anthropic_image_block_to_bedrock(block: dict[str, Any]) -> dict[str, Any]:
+    source = block.get("source") or {}
+    if source.get("type") != "base64":
+        raise ValueError(f"Unsupported Anthropic image source: {source!r}")
+    image_format = _IMAGE_MEDIA_TYPE_TO_BEDROCK_FORMAT.get(source.get("media_type"))
+    if not image_format:
+        raise ValueError(f"Unsupported Anthropic image media type: {source!r}")
+    data = source.get("data")
+    if not isinstance(data, str):
+        raise ValueError(f"Unsupported Anthropic image data: {source!r}")
+    return {
+        "image": {
+            "format": image_format,
+            "source": {"bytes": base64.b64decode(data, validate=True)},
+        }
+    }
+
+
+def _tool_result_content_blocks(content: Any) -> list[dict[str, Any]]:
     if content is None:
         return []
     if isinstance(content, str):
@@ -86,7 +125,11 @@ def _tool_result_content_blocks(content: Any) -> list[dict[str, str]]:
         if isinstance(block, str):
             blocks.append({"text": block})
             continue
-        if block.get("type") != "text":
+        block_type = block.get("type")
+        if block_type == "image":
+            blocks.append(_anthropic_image_block_to_bedrock(block))
+            continue
+        if block_type != "text":
             raise ValueError(f"Unsupported tool_result content block: {block!r}")
         blocks.append({"text": block["text"]})
     return blocks
@@ -100,6 +143,8 @@ def _anthropic_content_to_bedrock(content: Any) -> list[dict[str, Any]]:
         block_type = block.get("type")
         if block_type == "text":
             blocks.append({"text": block["text"]})
+        elif block_type == "image":
+            blocks.append(_anthropic_image_block_to_bedrock(block))
         elif block_type == "tool_use":
             blocks.append(
                 {
@@ -163,16 +208,35 @@ def _responses_content_to_bedrock(role: str, content: Any) -> list[dict[str, Any
     return blocks
 
 
+_MODELS_WITHOUT_BEDROCK_SAMPLING_PARAMS = {"anthropic.claude-opus-4-7"}
+
+
+def _bedrock_model_key(model: str | None) -> str:
+    """Return the foundation model key from a Bedrock model/profile id."""
+    if not model:
+        return ""
+    key = model.rsplit("/", 1)[-1].lower()
+    for prefix in ("us.", "global."):
+        if key.startswith(prefix):
+            return key[len(prefix) :]
+    return key
+
+
+def _supports_bedrock_sampling_params(model: str | None) -> bool:
+    return _bedrock_model_key(model) not in _MODELS_WITHOUT_BEDROCK_SAMPLING_PARAMS
+
+
 def _inference_config_from_request(
     body: dict[str, Any], *, max_tokens_key: str
 ) -> dict[str, Any]:
     config: dict[str, Any] = {}
     if body.get(max_tokens_key) is not None:
         config["maxTokens"] = body[max_tokens_key]
-    if body.get("temperature") is not None:
-        config["temperature"] = body["temperature"]
-    if body.get("top_p") is not None:
-        config["topP"] = body["top_p"]
+    if _supports_bedrock_sampling_params(body.get("model")):
+        if body.get("temperature") is not None:
+            config["temperature"] = body["temperature"]
+        if body.get("top_p") is not None:
+            config["topP"] = body["top_p"]
     stop = body.get("stop_sequences")
     if stop is None:
         stop = body.get("stop")

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 from benchflow.agents.providers import find_provider, strip_provider_prefix
 from benchflow.agents.registry import AGENTS
@@ -18,6 +20,7 @@ BEDROCK_PROXY_BIND_HOST = "0.0.0.0"
 BEDROCK_PROXY_LOCAL_HOST = "127.0.0.1"
 USAGE_PROXY_BIND_HOST = "0.0.0.0"
 PROMPT_CACHE_RETENTION_ENV = "BENCHFLOW_PROVIDER_PROMPT_CACHE_RETENTION"
+DISABLE_USAGE_PROXY_ENV = "BENCHFLOW_DISABLE_USAGE_PROXY"
 _PROMPT_CACHE_RETENTION_VALUES = {"in_memory", "24h"}
 
 
@@ -38,7 +41,7 @@ class ProviderRuntime:
 
 
 def needs_provider_runtime(model: str | None) -> bool:
-    """True when the model must be routed through a local helper runtime."""
+    """True when the model needs Bedrock-specific runtime handling."""
     if not model:
         return False
     result = find_provider(model)
@@ -81,6 +84,51 @@ def _apply_agent_provider_mapping(
 def _bedrock_frontend_model(*, agent: str, backend_model: str) -> str:
     """Return the model name the upstream agent should see."""
     return backend_model
+
+
+def _direct_bedrock_frontend_model(*, agent: str, backend_model: str) -> str:
+    """Return the Bedrock-native model name for agents that can call AWS directly."""
+    if agent == "openhands":
+        return f"bedrock/{backend_model}"
+    raise ValueError(f"Agent {agent!r} does not support direct Bedrock routing")
+
+
+def _agent_supports_direct_bedrock(agent: str) -> bool:
+    return agent == "openhands"
+
+
+def _apply_direct_bedrock_agent_mapping(
+    agent_env: dict[str, str],
+    *,
+    agent: str,
+    backend_model: str,
+    environment: str,
+) -> dict[str, str]:
+    """Wire agent env vars for direct AWS Bedrock access without a host proxy."""
+    if not _agent_supports_direct_bedrock(agent):
+        raise RuntimeError(
+            f"Bedrock-routed models are not supported on the "
+            f"'{environment}' sandbox for agent {agent!r}: the host-side "
+            "Bedrock proxy is unreachable from that remote sandbox, and this "
+            "agent does not support direct Bedrock routing. "
+            "Use an agent with direct Bedrock support, run with '--sandbox docker', "
+            "or select a non-Bedrock model."
+        )
+
+    updated = dict(agent_env)
+    updated["BENCHFLOW_PROVIDER_MODEL"] = backend_model
+    updated.pop("BENCHFLOW_PROVIDER_BASE_URL", None)
+    for env_name in _agent_base_url_envs(agent):
+        updated.pop(env_name, None)
+
+    if agent == "openhands":
+        updated["LLM_MODEL"] = _direct_bedrock_frontend_model(
+            agent=agent,
+            backend_model=backend_model,
+        )
+        if updated.get("AWS_BEARER_TOKEN_BEDROCK"):
+            updated["LLM_API_KEY"] = updated["AWS_BEARER_TOKEN_BEDROCK"]
+    return updated
 
 
 def _docker_host_address() -> str:
@@ -163,6 +211,29 @@ def _bedrock_proxy_command(
     return BEDROCK_PROXY_LOCAL_HOST
 
 
+def _host_side_proxy_target_url(target: str, *, environment: str) -> str:
+    """Return the upstream URL a host-side proxy should dial.
+
+    The URL injected into an agent container may use Docker's host alias
+    (``host.docker.internal`` or the Linux bridge gateway). That address is for
+    the container. A proxy process running on the host should reach another
+    host-bound BenchFlow proxy through loopback instead.
+    """
+    if not host_proxy_reachable_from_agent(environment):
+        return target
+    parsed = urlsplit(target)
+    if not parsed.hostname:
+        return target
+    if parsed.hostname != _bedrock_proxy_command(environment=environment):
+        return target
+    netloc = BEDROCK_PROXY_LOCAL_HOST
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunsplit(
+        (parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment)
+    )
+
+
 def _usage_unavailable() -> dict[str, Any]:
     return {
         "n_input_tokens": None,
@@ -174,6 +245,10 @@ def _usage_unavailable() -> dict[str, Any]:
         "usage_source": "unavailable",
         "price_source": None,
     }
+
+
+def _env_flag_enabled(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _agent_base_url_envs(agent: str) -> list[str]:
@@ -309,6 +384,16 @@ async def ensure_usage_proxy_runtime(
     """
     if agent == "oracle":
         return agent_env, runtime
+    if _env_flag_enabled(os.environ.get(DISABLE_USAGE_PROXY_ENV)):
+        if runtime is not None:
+            await stop_provider_runtime(runtime)
+        logger.info(
+            "Skipping host-side usage telemetry proxy: %s is enabled. "
+            "The agent will call the provider directly and usage telemetry "
+            "will be unavailable for this run.",
+            DISABLE_USAGE_PROXY_ENV,
+        )
+        return agent_env, None
     if not host_proxy_reachable_from_agent(environment):
         if runtime is not None:
             await stop_provider_runtime(runtime)
@@ -323,7 +408,10 @@ async def ensure_usage_proxy_runtime(
     target = _resolve_usage_proxy_target(agent, agent_env, model)
     if not target:
         return agent_env, runtime
-    target = target.rstrip("/")
+    target = _host_side_proxy_target_url(
+        target.rstrip("/"),
+        environment=environment,
+    )
 
     # A multi-role scene can switch providers between connect_as() calls. The
     # running proxy forwards to a fixed upstream, so reusing it would route the
@@ -418,16 +506,12 @@ async def ensure_bedrock_proxy_runtime(
     runtime: ProviderRuntime | None,
     environment: str,
 ) -> tuple[dict[str, str], ProviderRuntime | None]:
-    """Start the host-side Bedrock proxy if needed and wire env vars to it.
+    """Wire Bedrock-routed models through the best reachable path.
 
-    Unlike the usage telemetry proxy (pure telemetry — safe to skip when the
-    agent cannot reach the host), the Bedrock proxy is *load-bearing*: it
-    translates Anthropic/OpenAI requests into AWS Bedrock Converse calls and
-    signs them with host AWS credentials. There is no direct path for the
-    agent to reach Bedrock without it. So on a remote sandbox where the host
-    proxy is unreachable, the run cannot succeed — we fail fast here with an
-    actionable error instead of injecting an unreachable ``127.0.0.1`` base
-    URL that would surface as an opaque mid-run ``ECONNREFUSED``.
+    Same-host agents use BenchFlow's host-side Bedrock proxy, which translates
+    OpenAI/Anthropic-shaped requests into Bedrock Converse. Remote sandboxes
+    cannot reach that host-bound proxy, so agents with native Bedrock support
+    are configured to call AWS directly instead.
     """
     if not needs_provider_runtime(model):
         return agent_env, runtime
@@ -436,13 +520,21 @@ async def ensure_bedrock_proxy_runtime(
     if not host_proxy_reachable_from_agent(environment):
         if runtime is not None:
             await stop_provider_runtime(runtime)
-        raise RuntimeError(
-            f"Bedrock-routed models are not supported on the "
-            f"'{environment}' sandbox: the host-side Bedrock proxy that "
-            f"translates and signs requests to AWS Bedrock binds to the "
-            f"host machine and is unreachable from the agent, which runs "
-            f"on a separate remote host. Re-run with '--sandbox docker', "
-            f"or select a model that is not routed through AWS Bedrock."
+        logger.info(
+            "Skipping host-side Bedrock proxy: the '%s' sandbox runs the "
+            "agent on a remote host unreachable from the host proxy; wiring "
+            "%s for direct AWS Bedrock access.",
+            environment or "unknown",
+            agent,
+        )
+        return (
+            _apply_direct_bedrock_agent_mapping(
+                agent_env,
+                agent=agent,
+                backend_model=strip_provider_prefix(model),
+                environment=environment,
+            ),
+            None,
         )
 
     if runtime is None:

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -41,6 +41,16 @@ from benchflow.task.paths import RolloutPaths, SandboxPaths
 
 logger = logging.getLogger("benchflow")
 
+_DOCKER_BUILD_RETRY_DELAYS_SEC = (2.0, 5.0)
+_DOCKER_BUILD_RETRYABLE_ERRORS = (
+    re.compile(r"at least one invalid signature was encountered", re.IGNORECASE),
+    re.compile(r"the repository '.+' is not signed", re.IGNORECASE),
+    re.compile(r"no space left on device", re.IGNORECASE),
+    re.compile(r"readtimeouterror", re.IGNORECASE),
+    re.compile(r"read timed out", re.IGNORECASE),
+    re.compile(r"connection (?:timed out|reset by peer)", re.IGNORECASE),
+)
+
 
 def _sanitize_docker_image_name(name: str) -> str:
     name = name.lower()
@@ -56,6 +66,10 @@ def _sanitize_docker_compose_project_name(name: str) -> str:
         name = "0" + name
     name = re.sub(r"[^a-z0-9_-]", "-", name)
     return name
+
+
+def _is_retryable_docker_build_error(message: str) -> bool:
+    return any(pattern.search(message) for pattern in _DOCKER_BUILD_RETRYABLE_ERRORS)
 
 
 class DockerSandboxEnvVars(BaseModel):
@@ -311,6 +325,30 @@ class DockerSandbox(BaseSandbox):
 
         return result
 
+    async def _run_docker_compose_build(self) -> None:
+        max_attempts = len(_DOCKER_BUILD_RETRY_DELAYS_SEC) + 1
+        for attempt in range(1, max_attempts + 1):
+            try:
+                await self._run_docker_compose_command(["build"])
+                return
+            except RuntimeError as exc:
+                if attempt == max_attempts or not _is_retryable_docker_build_error(
+                    str(exc)
+                ):
+                    raise
+
+                delay = _DOCKER_BUILD_RETRY_DELAYS_SEC[attempt - 1]
+                self.logger.warning(
+                    "Retrying Docker build for %s after transient failure "
+                    "(attempt %s/%s, retrying in %.1fs): %s",
+                    self.environment_name,
+                    attempt,
+                    max_attempts,
+                    delay,
+                    exc,
+                )
+                await asyncio.sleep(delay)
+
     async def start(self, force_build: bool) -> None:
         if self._mounts_json:
             self._mounts_compose_path = self._write_mounts_compose_file()
@@ -322,7 +360,7 @@ class DockerSandbox(BaseSandbox):
                 self.environment_name, asyncio.Lock()
             )
             async with lock:
-                await self._run_docker_compose_command(["build"])
+                await self._run_docker_compose_build()
 
         with contextlib.suppress(RuntimeError):
             await self._run_docker_compose_command(["down", "--remove-orphans"])

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -66,6 +66,21 @@ class TestEnvMappingField:
 
         assert env["LLM_MODEL"] == "glm-5"
 
+    def test_openhands_bedrock_anthropic_model_uses_litellm_provider_prefix(self):
+        """Guards v0.5-integration@e55219d against OpenHands receiving a bare Bedrock profile id."""
+        env = {
+            "AWS_BEARER_TOKEN_BEDROCK": "bedrock-token",
+            "AWS_REGION": "us-west-2",
+        }
+
+        resolve_provider_env(
+            agent="openhands",
+            model="aws-bedrock/us.anthropic.claude-opus-4-7",
+            agent_env=env,
+        )
+
+        assert env["LLM_MODEL"] == "anthropic/us.anthropic.claude-opus-4-7"
+
 
 class TestOpenHandsConfig:
     def test_openhands_uses_agentskills_paths(self):
@@ -75,14 +90,35 @@ class TestOpenHandsConfig:
 
     def test_openhands_install_cmd_forces_github_main(self):
         cfg = AGENTS["openhands"]
-        assert "apt-get install -y -qq curl ca-certificates git" in cfg.install_cmd
+        assert (
+            "apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates git"
+            in cfg.install_cmd
+        )
+        assert "--with 'boto3>=1.40'" in cfg.install_cmd
         assert (
             "uv tool install --force --refresh "
+            "--with 'boto3>=1.40' "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12" in cfg.install_cmd
         )
         assert "command -v git" in cfg.install_cmd
         assert "install.openhands.dev/install.sh" not in cfg.install_cmd
+
+    def test_openhands_apt_bootstrap_retries_transient_mirror_failures(self):
+        """Guards the local fix on v0.5-integration@e55219d against Ubuntu mirror signature flakiness."""
+        cfg = AGENTS["openhands"]
+
+        assert "rm -rf /var/lib/apt/lists/*" in cfg.install_cmd
+        assert "apt-get clean" in cfg.install_cmd
+        assert "Acquire::Retries=3" in cfg.install_cmd
+        assert 'while [ "$attempt" -le 3 ]' in cfg.install_cmd
+        assert 'case "$attempt"' in cfg.install_cmd
+
+    def test_openhands_installs_boto3_for_bedrock_provider(self):
+        """Guards v0.5-integration@e55219d against OpenHands Bedrock runs missing boto3."""
+        cfg = AGENTS["openhands"]
+
+        assert "--with 'boto3>=1.40'" in cfg.install_cmd
 
     def test_openhands_skips_acp_set_model(self):
         cfg = AGENTS["openhands"]

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -522,6 +522,7 @@ async def test_install_agent_writes_command_stdout_and_stderr_on_failure(
     assert log_text.startswith("$ ")
     assert (
         "uv tool install --force --refresh "
+        "--with 'boto3>=1.40' "
         "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
         "openhands --python 3.12" in log_text
     )

--- a/tests/test_bedrock_proxy.py
+++ b/tests/test_bedrock_proxy.py
@@ -9,6 +9,7 @@ from io import BytesIO
 import httpx
 import pytest
 
+import benchflow.providers.bedrock_proxy as bedrock_proxy
 from benchflow.providers.bedrock_proxy import BedrockProxyServer
 
 
@@ -146,6 +147,21 @@ class FakeUnsupportedCountTokensBedrockClient(FakeBedrockClient):
         )
 
 
+class EndpointConnectionError(Exception):
+    pass
+
+
+class FakeFlakyBedrockClient(FakeBedrockClient):
+    def __init__(self) -> None:
+        self.converse_calls = 0
+
+    def converse(self, **kwargs):
+        self.converse_calls += 1
+        if self.converse_calls == 1:
+            raise EndpointConnectionError("temporary dns failure")
+        return super().converse(**kwargs)
+
+
 class FakeBedrockHTTPClient:
     async def post(self, url, *, content, headers):
         assert headers["authorization"] == "Bearer bedrock-token"
@@ -254,6 +270,44 @@ async def test_bedrock_proxy_responses_route():
             body = resp.json()
             assert body["output_text"] == "hello from codex"
             assert body["usage"]["total_tokens"] == 11
+    finally:
+        task.cancel()
+        await server.stop()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.asyncio
+async def test_bedrock_proxy_retries_transient_runtime_transport_errors(monkeypatch):
+    """Guards v0.5-integration@e55219d against transient Bedrock DNS failures invalidating trials."""
+    monkeypatch.setattr(bedrock_proxy, "_BEDROCK_RUNTIME_RETRY_DELAYS_SEC", (0, 0, 0))
+    fake_client = FakeFlakyBedrockClient()
+    server = BedrockProxyServer(
+        host="127.0.0.1",
+        port=0,
+        client=fake_client,
+        backend_model="anthropic.claude-haiku-4-5-20251001-v1:0",
+        frontend_model="anthropic.claude-haiku-4-5-20251001-v1:0",
+    )
+    await server.start()
+    task = asyncio.create_task(server.serve_forever())
+    try:
+        async with httpx.AsyncClient(
+            base_url=f"http://127.0.0.1:{server.port}"
+        ) as client:
+            resp = await client.post(
+                "/v1/messages",
+                json={
+                    "model": "anthropic.claude-haiku-4-5-20251001-v1:0",
+                    "messages": [
+                        {"role": "user", "content": [{"type": "text", "text": "hi"}]}
+                    ],
+                    "max_tokens": 32,
+                },
+            )
+            assert resp.status_code == 200
+            assert resp.json()["content"][0]["text"] == "hello from claude"
+            assert fake_client.converse_calls == 2
     finally:
         task.cancel()
         await server.stop()

--- a/tests/test_bedrock_runtime.py
+++ b/tests/test_bedrock_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import sys
 
@@ -54,6 +55,7 @@ class TestBedrockRuntimeEnv:
             )
 
     def test_build_bedrock_client_with_injected_boto3_module(self):
+        """Guards v0.5-integration@e55219d against Bedrock read-timeout proxy exits."""
         calls = {}
 
         class FakeBoto3:
@@ -69,10 +71,10 @@ class TestBedrockRuntimeEnv:
             boto3_module=FakeBoto3(),
         )
         assert client == {"ok": True}
-        assert calls == {
-            "service_name": "bedrock-runtime",
-            "region_name": "us-east-1",
-        }
+        assert calls["service_name"] == "bedrock-runtime"
+        assert calls["region_name"] == "us-east-1"
+        assert calls["config"].connect_timeout == 10
+        assert calls["config"].read_timeout == 300
 
 
 class TestAnthropicTranslation:
@@ -137,6 +139,92 @@ class TestAnthropicTranslation:
         }
         assert payload["toolConfig"]["toolChoice"] == {
             "tool": {"name": "lookup_weather"}
+        }
+
+    def test_opus47_request_omits_deprecated_sampling_params(self):
+        """Guards v0.5-integration@e55219d against Bedrock Opus4.7 sampling-param 400s."""
+        body = {
+            "model": "us.anthropic.claude-opus-4-7",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 256,
+            "temperature": 0.2,
+            "top_p": 0.9,
+            "stop_sequences": ["DONE"],
+        }
+
+        payload = anthropic_request_to_bedrock_converse(body)
+
+        assert payload["inferenceConfig"] == {
+            "maxTokens": 256,
+            "stopSequences": ["DONE"],
+        }
+
+    def test_tool_result_image_blocks_translate_to_bedrock_images(self):
+        """Guards v0.5-integration@e55219d against OpenHands image tool-result proxy crashes."""
+        image_bytes = b"fake jpeg bytes"
+        body = {
+            "model": "us.anthropic.claude-opus-4-7",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_1",
+                            "content": [
+                                {"type": "text", "text": "Screenshot attached."},
+                                {
+                                    "type": "image",
+                                    "source": {
+                                        "type": "base64",
+                                        "media_type": "image/jpeg",
+                                        "data": base64.b64encode(image_bytes).decode(),
+                                    },
+                                },
+                            ],
+                        }
+                    ],
+                },
+            ],
+            "max_tokens": 256,
+        }
+
+        payload = anthropic_request_to_bedrock_converse(body)
+
+        content = payload["messages"][0]["content"][0]["toolResult"]["content"]
+        assert content[0] == {"text": "Screenshot attached."}
+        assert content[1] == {
+            "image": {"format": "jpeg", "source": {"bytes": image_bytes}}
+        }
+
+    def test_user_image_blocks_translate_to_bedrock_images(self):
+        """Guards v0.5-integration@e55219d against Anthropic image-message proxy crashes."""
+        image_bytes = b"fake png bytes"
+        body = {
+            "model": "us.anthropic.claude-opus-4-7",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "What is shown?"},
+                        {
+                            "type": "image",
+                            "source": {
+                                "type": "base64",
+                                "media_type": "image/png",
+                                "data": base64.b64encode(image_bytes).decode(),
+                            },
+                        },
+                    ],
+                },
+            ],
+            "max_tokens": 256,
+        }
+
+        payload = anthropic_request_to_bedrock_converse(body)
+
+        assert payload["messages"][0]["content"][1] == {
+            "image": {"format": "png", "source": {"bytes": image_bytes}}
         }
 
     def test_bedrock_response_to_anthropic(self):
@@ -228,6 +316,20 @@ class TestOpenAIResponsesTranslation:
         )
         assert payload["inferenceConfig"]["maxTokens"] == 128
         assert payload["toolConfig"]["toolChoice"] == {"auto": {}}
+
+    def test_opus47_responses_request_omits_deprecated_sampling_params(self):
+        """Guards v0.5-integration@e55219d against Bedrock Opus4.7 sampling-param 400s."""
+        body = {
+            "model": "global.anthropic.claude-opus-4-7",
+            "input": "Hello",
+            "max_output_tokens": 128,
+            "temperature": 0.1,
+            "top_p": 0.95,
+        }
+
+        payload = openai_responses_request_to_bedrock_converse(body)
+
+        assert payload["inferenceConfig"] == {"maxTokens": 128}
 
     def test_bedrock_response_to_openai_response(self):
         response = {

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -157,6 +157,111 @@ class TestDockerExecEnvSecrecy:
         for arg in cmd:
             assert "sk-leak" not in arg
 
+    @pytest.mark.asyncio
+    async def test_docker_build_retries_transient_apt_signature_errors(
+        self, monkeypatch
+    ):
+        """Guards v0.5-integration@e55219d against apt signature noise."""
+        from benchflow.sandbox import docker as docker_module
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.docker import DockerSandbox
+
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox.environment_name = "apt-flake"
+        sandbox.logger = docker_module.logger
+
+        calls: list[list[str]] = []
+        sleeps: list[float] = []
+
+        async def fake_run(command):
+            calls.append(command)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Docker compose command failed. Stdout: "
+                    "At least one invalid signature was encountered. "
+                    "The repository 'http://ports.ubuntu.com noble InRelease' "
+                    "is not signed."
+                )
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        monkeypatch.setattr(sandbox, "_run_docker_compose_command", fake_run)
+        monkeypatch.setattr(docker_module.asyncio, "sleep", fake_sleep)
+
+        await sandbox._run_docker_compose_build()
+
+        assert calls == [["build"], ["build"]]
+        assert sleeps == [2.0]
+
+    @pytest.mark.asyncio
+    async def test_docker_build_retries_transient_pip_read_timeouts(
+        self, monkeypatch
+    ):
+        """Guards v0.5-integration@e55219d against pip download noise."""
+        from benchflow.sandbox import docker as docker_module
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.docker import DockerSandbox
+
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox.environment_name = "pip-flake"
+        sandbox.logger = docker_module.logger
+
+        calls: list[list[str]] = []
+        sleeps: list[float] = []
+
+        async def fake_run(command):
+            calls.append(command)
+            if len(calls) == 1:
+                raise RuntimeError(
+                    "Docker compose command failed. Stdout: "
+                    "pip._vendor.urllib3.exceptions.ReadTimeoutError: "
+                    "HTTPSConnectionPool(host='files.pythonhosted.org', "
+                    "port=443): Read timed out."
+                )
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        monkeypatch.setattr(sandbox, "_run_docker_compose_command", fake_run)
+        monkeypatch.setattr(docker_module.asyncio, "sleep", fake_sleep)
+
+        await sandbox._run_docker_compose_build()
+
+        assert calls == [["build"], ["build"]]
+        assert sleeps == [2.0]
+
+    @pytest.mark.asyncio
+    async def test_docker_build_does_not_retry_non_transient_errors(self, monkeypatch):
+        """Guards v0.5-integration@e55219d against broad retry masking."""
+        from benchflow.sandbox import docker as docker_module
+        from benchflow.sandbox.docker import DockerSandbox
+
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox.environment_name = "real-build-bug"
+        sandbox.logger = docker_module.logger
+
+        calls: list[list[str]] = []
+        sleeps: list[float] = []
+
+        async def fake_run(command):
+            calls.append(command)
+            raise RuntimeError("Docker compose command failed. Stdout: syntax error")
+
+        async def fake_sleep(delay):
+            sleeps.append(delay)
+
+        monkeypatch.setattr(sandbox, "_run_docker_compose_command", fake_run)
+        monkeypatch.setattr(docker_module.asyncio, "sleep", fake_sleep)
+
+        with pytest.raises(RuntimeError, match="syntax error"):
+            await sandbox._run_docker_compose_build()
+
+        assert calls == [["build"]]
+        assert sleeps == []
+
     def test_umask_scoped_to_env_file_write(self):
         """Guards bug I from PR #323: `umask 077` must not leak into the command.
 

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -349,6 +349,85 @@ async def test_start_proxy_rewrites_env(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_usage_proxy_dials_loopback_for_host_bound_provider_proxy(monkeypatch):
+    """Guards v0.5-integration@e55219d against host-side proxy chains dialing Docker aliases."""
+    from benchflow.providers import runtime as provider_runtime_mod
+    from benchflow.providers.runtime import ensure_usage_proxy_runtime
+
+    monkeypatch.setattr(
+        provider_runtime_mod, "_docker_host_address", lambda: "host.docker.internal"
+    )
+
+    class FakeTrajectoryProxy:
+        def __init__(
+            self,
+            target,
+            session_id="",
+            agent_name="",
+            host="127.0.0.1",
+            port=0,
+            prompt_cache_retention=None,
+        ):
+            self.target = target
+            self.host = host
+            self.port = 32124
+            self.trajectory = Trajectory(session_id=session_id, agent_name=agent_name)
+
+        async def start(self):
+            return None
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(provider_runtime_mod, "TrajectoryProxy", FakeTrajectoryProxy)
+
+    updated, runtime = await ensure_usage_proxy_runtime(
+        agent="openhands",
+        agent_env={
+            "BENCHFLOW_PROVIDER_BASE_URL": "http://host.docker.internal:32123",
+            "LLM_BASE_URL": "http://host.docker.internal:32123",
+        },
+        model="aws-bedrock/anthropic.claude-opus-4-7",
+        runtime=None,
+        environment="docker",
+        session_id="rollout-1",
+    )
+
+    assert runtime is not None
+    assert runtime.server.target == "http://127.0.0.1:32123"
+    assert updated["LLM_BASE_URL"] == "http://host.docker.internal:32124"
+
+
+@pytest.mark.asyncio
+async def test_usage_proxy_can_be_disabled_for_operator_recovery(monkeypatch):
+    """Guards v0.5-integration@e55219d recovery runs when telemetry proxying blocks rollouts."""
+    from benchflow.providers import runtime as provider_runtime_mod
+    from benchflow.providers.runtime import ensure_usage_proxy_runtime
+
+    def _fail_start(*_args, **_kwargs):
+        raise AssertionError("TrajectoryProxy must not start when disabled")
+
+    monkeypatch.setenv("BENCHFLOW_DISABLE_USAGE_PROXY", "1")
+    monkeypatch.setattr(provider_runtime_mod, "TrajectoryProxy", _fail_start)
+
+    env = {
+        "BENCHFLOW_PROVIDER_BASE_URL": "http://host.docker.internal:32123",
+        "LLM_BASE_URL": "http://host.docker.internal:32123",
+    }
+    updated, runtime = await ensure_usage_proxy_runtime(
+        agent="openhands",
+        agent_env=env,
+        model="aws-bedrock/us.anthropic.claude-opus-4-7",
+        runtime=None,
+        environment="docker",
+        session_id="rollout-1",
+    )
+
+    assert runtime is None
+    assert updated == env
+
+
+@pytest.mark.asyncio
 async def test_start_proxy_uses_openai_v1_default_for_codex(monkeypatch):
     from benchflow.providers import runtime as provider_runtime_mod
     from benchflow.providers.runtime import ensure_usage_proxy_runtime
@@ -541,6 +620,57 @@ async def test_daytona_runtime_retired_when_environment_unreachable(monkeypatch)
     assert runtime is None
     assert stopped == [True]
     assert updated["ANTHROPIC_BASE_URL"] == "https://api.anthropic.com"
+
+
+@pytest.mark.asyncio
+async def test_daytona_openhands_bedrock_uses_direct_agent_mapping(monkeypatch):
+    """Guards v0.5-integration@e55219d against rejecting remote OpenHands Bedrock runs."""
+    from benchflow.providers import runtime as provider_runtime_mod
+    from benchflow.providers.runtime import ensure_bedrock_proxy_runtime
+
+    def _fail_start(*_args, **_kwargs):
+        raise AssertionError("BedrockProxyServer must not start for daytona")
+
+    monkeypatch.setattr(provider_runtime_mod, "BedrockProxyServer", _fail_start)
+
+    env = {
+        "AWS_BEARER_TOKEN_BEDROCK": "bedrock-token",
+        "AWS_REGION": "us-west-2",
+        "BENCHFLOW_PROVIDER_BASE_URL": "",
+        "BENCHFLOW_PROVIDER_API_KEY": "bedrock-proxy",
+        "LLM_BASE_URL": "",
+        "LLM_API_KEY": "bedrock-proxy",
+        "LLM_MODEL": "anthropic/us.anthropic.claude-opus-4-7",
+    }
+    updated, runtime = await ensure_bedrock_proxy_runtime(
+        agent="openhands",
+        agent_env=env,
+        model="aws-bedrock/us.anthropic.claude-opus-4-7",
+        runtime=None,
+        environment="daytona",
+    )
+
+    assert runtime is None
+    assert "BENCHFLOW_PROVIDER_BASE_URL" not in updated
+    assert "LLM_BASE_URL" not in updated
+    assert updated["LLM_MODEL"] == "bedrock/us.anthropic.claude-opus-4-7"
+    assert updated["LLM_API_KEY"] == "bedrock-token"
+    assert updated["AWS_BEARER_TOKEN_BEDROCK"] == "bedrock-token"
+
+
+@pytest.mark.asyncio
+async def test_daytona_bedrock_rejects_agents_without_direct_support():
+    """Guards v0.5-integration@e55219d against silently wiring unreachable Bedrock proxy URLs."""
+    from benchflow.providers.runtime import ensure_bedrock_proxy_runtime
+
+    with pytest.raises(RuntimeError, match="direct Bedrock support"):
+        await ensure_bedrock_proxy_runtime(
+            agent="codex-acp",
+            agent_env={"AWS_BEARER_TOKEN_BEDROCK": "bedrock-token"},
+            model="aws-bedrock/us.anthropic.claude-opus-4-7",
+            runtime=None,
+            environment="daytona",
+        )
 
 
 def test_host_proxy_reachable_only_for_local_environments():


### PR DESCRIPTION
## Summary
- allow OpenHands on remote sandboxes to call AWS Bedrock directly instead of failing on unreachable host proxy
- keep unsupported agents failing with actionable remote-sandbox errors
- harden OpenHands/Bedrock rollout blockers found during SkillsBench runs: OpenHands install deps, Bedrock Opus 4.7 request translation, transient Bedrock/Docker retry handling

## Verification
- Daytona smoke: OpenHands + aws-bedrock/us.anthropic.claude-opus-4-7 on 3d-scan-calc completed 1/1 pass with no provider/rate-limit errors
- uv run python -m pytest tests/test_agent_registry.py tests/test_usage_proxy.py tests/test_bedrock_runtime.py tests/test_bedrock_proxy.py tests/test_sandbox.py
- uv run ruff check src/benchflow/agents/env.py src/benchflow/agents/registry.py src/benchflow/providers/bedrock_proxy.py src/benchflow/providers/bedrock_runtime.py src/benchflow/providers/runtime.py src/benchflow/sandbox/docker.py tests/test_agent_registry.py tests/test_agent_setup.py tests/test_bedrock_proxy.py tests/test_bedrock_runtime.py tests/test_sandbox.py tests/test_usage_proxy.py
- uv run ty check src/
- uv run python -m pytest tests/
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/565" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->