### PR TITLE
Add worker-sharded eval runner

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1077,6 +1077,31 @@ def eval_create(
         int | None,
         typer.Option("--concurrency", help="Max concurrent tasks"),
     ] = None,
+    worker_concurrency: Annotated[
+        int | None,
+        typer.Option(
+            "--worker-concurrency",
+            help=(
+                "Run batch eval through isolated worker subprocesses, each with "
+                "at most this many concurrent tasks; --concurrency remains the "
+                "aggregate target."
+            ),
+        ),
+    ] = None,
+    worker_retries: Annotated[
+        int,
+        typer.Option(
+            "--worker-retries",
+            help="Retry a crashed worker shard this many times, resuming its jobs_dir.",
+        ),
+    ] = 1,
+    worker_start_stagger_sec: Annotated[
+        float,
+        typer.Option(
+            "--worker-start-stagger-sec",
+            help="Seconds to stagger worker starts to avoid Daytona connection storms.",
+        ),
+    ] = 1.0,
     agent_idle_timeout: Annotated[
         str | None,
         typer.Option(
@@ -1167,6 +1192,17 @@ def eval_create(
             "[red]Choose only one source: --config, --tasks-dir, --source-repo, or --source-env[/red]"
         )
         raise typer.Exit(1)
+    if worker_concurrency is not None and not (tasks_dir or source_repo):
+        console.print(
+            "[red]--worker-concurrency is supported for --tasks-dir and --source-repo batch runs[/red]"
+        )
+        raise typer.Exit(1)
+    if worker_retries < 0:
+        console.print("[red]--worker-retries must be >= 0[/red]")
+        raise typer.Exit(1)
+    if worker_start_stagger_sec < 0:
+        console.print("[red]--worker-start-stagger-sec must be >= 0[/red]")
+        raise typer.Exit(1)
     eval_agent = (
         _normalize_eval_agent_or_exit(agent) if agent is not None else DEFAULT_AGENT
     )
@@ -1201,6 +1237,50 @@ def eval_create(
                 f"[red]Could not load --environment-manifest {environment_manifest}: {exc}[/red]"
             )
             raise typer.Exit(1) from None
+
+    def _run_batch_eval(
+        resolved_tasks_dir: Path,
+        eval_config: EvaluationConfig,
+    ):
+        try:
+            if worker_concurrency is None:
+                result = asyncio.run(
+                    Evaluation(
+                        tasks_dir=str(resolved_tasks_dir),
+                        jobs_dir=output_jobs_dir,
+                        config=eval_config,
+                    ).run()
+                )
+            else:
+                from benchflow.eval_sharding import (
+                    ShardWorkerError,
+                    run_sharded_evaluation,
+                )
+
+                result = asyncio.run(
+                    run_sharded_evaluation(
+                        tasks_dir=resolved_tasks_dir,
+                        jobs_dir=Path(output_jobs_dir),
+                        config=eval_config,
+                        worker_concurrency=worker_concurrency,
+                        worker_retries=worker_retries,
+                        worker_start_stagger_sec=worker_start_stagger_sec,
+                        environment_manifest_path=environment_manifest,
+                    )
+                )
+        except EmptyTaskSelectionError as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1) from None
+        except (ValueError, ShardWorkerError) as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1) from None
+
+        console.print(
+            f"\n[bold]Score: {result.passed}/{result.total} "
+            f"({result.score:.1%})[/bold], errors={result.errored}"
+        )
+        _exit_if_evaluation_had_errors(result)
+        return result
 
     if config_file:
         j = Evaluation.from_yaml(config_file)
@@ -1316,10 +1396,9 @@ def eval_create(
         )
         resolved_tasks_dir = resolved.path
         eff_model = effective_model(eval_agent, model)
-        j = Evaluation(
-            tasks_dir=str(resolved_tasks_dir),
-            jobs_dir=output_jobs_dir,
-            config=EvaluationConfig(
+        _run_batch_eval(
+            resolved_tasks_dir,
+            EvaluationConfig(
                 agent=eval_agent,
                 model=eff_model,
                 environment=eval_environment,
@@ -1338,16 +1417,6 @@ def eval_create(
                 environment_manifest=eval_env_manifest,
             ),
         )
-        try:
-            result = asyncio.run(j.run())
-        except EmptyTaskSelectionError as e:
-            console.print(f"[red]{e}[/red]")
-            raise typer.Exit(1) from None
-        console.print(
-            f"\n[bold]Score: {result.passed}/{result.total} "
-            f"({result.score:.1%})[/bold], errors={result.errored}"
-        )
-        _exit_if_evaluation_had_errors(result)
     elif tasks_dir:
         resolved_tasks_dir = tasks_dir
         eff_model = effective_model(eval_agent, model)
@@ -1355,10 +1424,9 @@ def eval_create(
         # handles both layouts (Evaluation._get_task_dirs detects when
         # tasks_dir itself contains task.toml) and applies include/exclude
         # filters uniformly (#400, #401, #407).
-        j = Evaluation(
-            tasks_dir=str(resolved_tasks_dir),
-            jobs_dir=output_jobs_dir,
-            config=EvaluationConfig(
+        _run_batch_eval(
+            resolved_tasks_dir,
+            EvaluationConfig(
                 agent=eval_agent,
                 model=eff_model,
                 environment=eval_environment,
@@ -1378,16 +1446,6 @@ def eval_create(
                 environment_manifest=eval_env_manifest,
             ),
         )
-        try:
-            result = asyncio.run(j.run())
-        except EmptyTaskSelectionError as e:
-            console.print(f"[red]{e}[/red]")
-            raise typer.Exit(1) from None
-        console.print(
-            f"\n[bold]Score: {result.passed}/{result.total} "
-            f"({result.score:.1%})[/bold], errors={result.errored}"
-        )
-        _exit_if_evaluation_had_errors(result)
     else:
         console.print(
             "[red]Provide --config, --tasks-dir, --source-repo, or --source-env[/red]"

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -1,0 +1,346 @@
+"""Worker-sharded evaluation orchestration.
+
+This module keeps the high-concurrency control-plane policy out of
+``evaluation.py``. Each worker subprocess runs a normal Evaluation over a
+disjoint include set with a modest local concurrency; the parent owns only the
+durable shard plan, worker retries, and aggregate summary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from benchflow.evaluation import Evaluation, EvaluationConfig, EvaluationResult
+
+
+@dataclass(frozen=True)
+class EvalShard:
+    index: int
+    task_names: tuple[str, ...]
+    concurrency: int
+
+
+@dataclass(frozen=True)
+class EvalShardPlan:
+    total_concurrency: int
+    worker_concurrency: int
+    shards: tuple[EvalShard, ...]
+
+    @property
+    def worker_count(self) -> int:
+        return len(self.shards)
+
+
+class ShardWorkerError(RuntimeError):
+    """Raised when one or more worker subprocesses fail after retries."""
+
+
+def plan_eval_shards(
+    task_names: list[str],
+    *,
+    total_concurrency: int,
+    worker_concurrency: int,
+) -> EvalShardPlan:
+    """Split tasks across isolated workers without exceeding target concurrency."""
+    if total_concurrency < 1:
+        raise ValueError("total_concurrency must be >= 1")
+    if worker_concurrency < 1:
+        raise ValueError("worker_concurrency must be >= 1")
+    if not task_names:
+        return EvalShardPlan(total_concurrency, worker_concurrency, ())
+
+    worker_count = min(
+        len(task_names),
+        max(1, math.ceil(total_concurrency / worker_concurrency)),
+    )
+    remaining = total_concurrency
+    concurrencies: list[int] = []
+    for _ in range(worker_count):
+        concurrency = min(worker_concurrency, remaining)
+        concurrencies.append(max(1, concurrency))
+        remaining -= concurrency
+
+    buckets: list[list[str]] = [[] for _ in range(worker_count)]
+    for offset, task_name in enumerate(task_names):
+        buckets[offset % worker_count].append(task_name)
+
+    shards = tuple(
+        EvalShard(index=i, task_names=tuple(bucket), concurrency=concurrencies[i])
+        for i, bucket in enumerate(buckets)
+        if bucket
+    )
+    return EvalShardPlan(total_concurrency, worker_concurrency, shards)
+
+
+def _retry_payload(config: EvaluationConfig) -> dict[str, Any]:
+    retry = config.retry
+    return {
+        "max_retries": retry.max_retries,
+        "retry_on_install": retry.retry_on_install,
+        "retry_on_pipe": retry.retry_on_pipe,
+        "retry_on_acp": retry.retry_on_acp,
+        "retry_on_idle_timeout": retry.retry_on_idle_timeout,
+        "retry_on_infra": retry.retry_on_infra,
+        "retry_on_verifier_infra": retry.retry_on_verifier_infra,
+        "wait_multiplier": retry.wait_multiplier,
+        "min_wait_sec": retry.min_wait_sec,
+        "max_wait_sec": retry.max_wait_sec,
+        "exclude_categories": sorted(retry.exclude_categories),
+    }
+
+
+def _config_payload(
+    config: EvaluationConfig,
+    *,
+    shard: EvalShard,
+    environment_manifest_path: Path | None,
+) -> dict[str, Any]:
+    return {
+        "agent": config.agent,
+        "model": config.model,
+        "environment": config.environment,
+        "concurrency": shard.concurrency,
+        "prompts": config.prompts,
+        "agent_env": config.agent_env,
+        "retry": _retry_payload(config),
+        "skills_dir": config.skills_dir,
+        "sandbox_user": config.sandbox_user,
+        "sandbox_locked_paths": config.sandbox_locked_paths,
+        "sandbox_setup_timeout": config.sandbox_setup_timeout,
+        "agent_idle_timeout": config.agent_idle_timeout,
+        "context_root": config.context_root,
+        "exclude_tasks": sorted(config.exclude_tasks),
+        "include_tasks": sorted(shard.task_names),
+        "skill_mode": config.skill_mode,
+        "skill_creator_dir": config.skill_creator_dir,
+        "self_gen_no_internet": config.self_gen_no_internet,
+        "job_mode": config.job_mode,
+        "source_provenance": config.source_provenance,
+        "environment_manifest_path": (
+            str(environment_manifest_path) if environment_manifest_path else None
+        ),
+    }
+
+
+def _plan_payload(plan: EvalShardPlan) -> dict[str, Any]:
+    return {
+        "total_concurrency": plan.total_concurrency,
+        "worker_concurrency": plan.worker_concurrency,
+        "shards": [
+            {
+                "index": shard.index,
+                "concurrency": shard.concurrency,
+                "task_names": list(shard.task_names),
+            }
+            for shard in plan.shards
+        ],
+    }
+
+
+def _write_or_validate_plan(path: Path, plan: EvalShardPlan) -> None:
+    payload = _plan_payload(plan)
+    if path.exists():
+        existing = json.loads(path.read_text())
+        if existing != payload:
+            raise ValueError(
+                f"Existing shard plan at {path} differs from requested run. "
+                "Use a fresh --jobs-dir or the original sharding flags."
+            )
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+async def _stream_worker_log(
+    process: asyncio.subprocess.Process, log_path: Path
+) -> None:
+    assert process.stdout is not None
+    with log_path.open("ab") as log:
+        async for chunk in process.stdout:
+            log.write(chunk)
+            log.flush()
+
+
+async def _run_worker_once(payload_path: Path, log_path: Path) -> int:
+    env = os.environ.copy()
+    python_path = str(Path(__file__).resolve().parents[1])
+    env["PYTHONPATH"] = (
+        python_path
+        if not env.get("PYTHONPATH")
+        else f"{python_path}{os.pathsep}{env['PYTHONPATH']}"
+    )
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-m",
+        "benchflow.eval_worker",
+        str(payload_path),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+        env=env,
+    )
+    await _stream_worker_log(process, log_path)
+    return await process.wait()
+
+
+async def _run_worker_with_retries(
+    payload_path: Path,
+    log_path: Path,
+    *,
+    max_retries: int,
+) -> dict[str, Any]:
+    result_path = Path(json.loads(payload_path.read_text())["result_path"])
+    attempts = 0
+    last_returncode = 0
+    for attempt in range(max_retries + 1):
+        attempts = attempt + 1
+        with log_path.open("ab") as log:
+            log.write(
+                f"\n=== worker attempt {attempts} "
+                f"started {datetime.now(UTC).isoformat()} ===\n".encode()
+            )
+        last_returncode = await _run_worker_once(payload_path, log_path)
+        if last_returncode == 0 and result_path.exists():
+            result = json.loads(result_path.read_text())
+            result["attempts"] = attempts
+            result["returncode"] = last_returncode
+            result_path.write_text(json.dumps(result, indent=2))
+            return result
+        with log_path.open("ab") as log:
+            log.write(
+                f"=== worker attempt {attempts} failed rc={last_returncode} ===\n".encode()
+            )
+    raise ShardWorkerError(
+        f"{payload_path.parent.name} failed after {attempts} attempt(s), "
+        f"last return code {last_returncode}; see {log_path}"
+    )
+
+
+def _aggregate_result(
+    *,
+    jobs_dir: Path,
+    config: EvaluationConfig,
+    plan: EvalShardPlan,
+    shard_results: list[dict[str, Any]],
+    elapsed_sec: float,
+) -> EvaluationResult:
+    result = EvaluationResult(
+        job_name="worker-sharded",
+        config=config,
+        total=sum(int(r.get("total", 0)) for r in shard_results),
+        passed=sum(int(r.get("passed", 0)) for r in shard_results),
+        failed=sum(int(r.get("failed", 0)) for r in shard_results),
+        errored=sum(int(r.get("errored", 0)) for r in shard_results),
+        verifier_errored=sum(int(r.get("verifier_errored", 0)) for r in shard_results),
+        elapsed_sec=elapsed_sec,
+    )
+    summary = {
+        "job_name": result.job_name,
+        "total": result.total,
+        "passed": result.passed,
+        "failed": result.failed,
+        "errored": result.errored,
+        "verifier_errored": result.verifier_errored,
+        "score": result.score,
+        "score_excl_errors": result.score_excl_errors,
+        "elapsed_sec": result.elapsed_sec,
+        "concurrency": plan.total_concurrency,
+        "worker_concurrency": plan.worker_concurrency,
+        "worker_count": plan.worker_count,
+        "shards": shard_results,
+    }
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+    (jobs_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+    return result
+
+
+async def run_sharded_evaluation(
+    *,
+    tasks_dir: Path,
+    jobs_dir: Path,
+    config: EvaluationConfig,
+    worker_concurrency: int,
+    worker_retries: int,
+    worker_start_stagger_sec: float,
+    environment_manifest_path: Path | None = None,
+) -> EvaluationResult:
+    """Run a batch as isolated worker subprocesses and aggregate their summaries."""
+    discovery = Evaluation(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config)
+    task_dirs = discovery._get_task_dirs()
+    task_names = [task_dir.name for task_dir in task_dirs]
+    plan = plan_eval_shards(
+        task_names,
+        total_concurrency=config.concurrency,
+        worker_concurrency=worker_concurrency,
+    )
+    if not plan.shards:
+        from benchflow.evaluation import EmptyTaskSelectionError
+
+        raise EmptyTaskSelectionError(f"No tasks selected after filtering: {tasks_dir}")
+
+    root = jobs_dir / "worker-shards"
+    _write_or_validate_plan(root / "plan.json", plan)
+
+    worker_tasks = []
+    for shard in plan.shards:
+        shard_dir = root / f"shard-{shard.index:03d}"
+        shard_dir.mkdir(parents=True, exist_ok=True)
+        payload_path = shard_dir / "worker_payload.json"
+        result_path = shard_dir / "worker_result.json"
+        payload = {
+            "tasks_dir": str(tasks_dir),
+            "jobs_dir": str(shard_dir / "jobs"),
+            "result_path": str(result_path),
+            "config": _config_payload(
+                config,
+                shard=shard,
+                environment_manifest_path=environment_manifest_path,
+            ),
+        }
+        payload_path.write_text(json.dumps(payload, indent=2))
+        log_path = shard_dir / "worker.log"
+        worker_tasks.append((shard, payload_path, log_path))
+
+    async def run_one(offset: int, payload_path: Path, log_path: Path):
+        if worker_start_stagger_sec > 0:
+            await asyncio.sleep(offset * worker_start_stagger_sec)
+        return await _run_worker_with_retries(
+            payload_path,
+            log_path,
+            max_retries=worker_retries,
+        )
+
+    started = datetime.now(UTC)
+    results_or_errors = await asyncio.gather(
+        *[
+            run_one(offset, payload_path, log_path)
+            for offset, (_shard, payload_path, log_path) in enumerate(worker_tasks)
+        ],
+        return_exceptions=True,
+    )
+    errors = [err for err in results_or_errors if isinstance(err, BaseException)]
+    if errors:
+        failure_report = {
+            "failed_at": datetime.now(UTC).isoformat(),
+            "errors": [str(err) for err in errors],
+            "plan": _plan_payload(plan),
+        }
+        (root / "worker_failures.json").write_text(json.dumps(failure_report, indent=2))
+        raise ShardWorkerError("; ".join(str(err) for err in errors))
+
+    elapsed = (datetime.now(UTC) - started).total_seconds()
+    shard_results = [result for result in results_or_errors if isinstance(result, dict)]
+    return _aggregate_result(
+        jobs_dir=jobs_dir,
+        config=config,
+        plan=plan,
+        shard_results=shard_results,
+        elapsed_sec=elapsed,
+    )

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -1,0 +1,121 @@
+"""Subprocess worker for sharded evaluation runs.
+
+The public ``bench eval create`` command uses this module when the operator asks
+for worker-level isolation. A worker runs one normal :class:`Evaluation` over a
+small include set and exits zero when BenchFlow completed the shard, even if the
+benchmark tasks themselves failed. Non-zero exits are reserved for control-plane
+failures so the parent can retry or report the shard cleanly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+
+def _retry_config(raw: dict[str, Any]) -> RetryConfig:
+    retry = raw.get("retry") or {}
+    return RetryConfig(
+        max_retries=int(retry.get("max_retries", 2)),
+        retry_on_install=bool(retry.get("retry_on_install", True)),
+        retry_on_pipe=bool(retry.get("retry_on_pipe", True)),
+        retry_on_acp=bool(retry.get("retry_on_acp", True)),
+        retry_on_idle_timeout=bool(retry.get("retry_on_idle_timeout", True)),
+        retry_on_infra=bool(retry.get("retry_on_infra", True)),
+        retry_on_verifier_infra=bool(retry.get("retry_on_verifier_infra", True)),
+        wait_multiplier=float(retry.get("wait_multiplier", 2.0)),
+        min_wait_sec=float(retry.get("min_wait_sec", 1.0)),
+        max_wait_sec=float(retry.get("max_wait_sec", 30.0)),
+        exclude_categories=set(retry.get("exclude_categories", ["timeout"])),
+    )
+
+
+def _environment_manifest(raw: dict[str, Any]):
+    manifest_path = raw.get("environment_manifest_path")
+    if not manifest_path:
+        return None
+    from benchflow.environment.manifest import load_manifest
+
+    return load_manifest(Path(manifest_path))
+
+
+def _evaluation_config(raw: dict[str, Any]) -> EvaluationConfig:
+    return EvaluationConfig(
+        agent=raw.get("agent") or "claude-agent-acp",
+        model=raw.get("model"),
+        environment=raw.get("environment") or "docker",
+        concurrency=int(raw.get("concurrency") or 1),
+        prompts=raw.get("prompts"),
+        agent_env=dict(raw.get("agent_env") or {}),
+        retry=_retry_config(raw),
+        skills_dir=raw.get("skills_dir"),
+        sandbox_user=raw.get("sandbox_user", "agent"),
+        sandbox_locked_paths=raw.get("sandbox_locked_paths"),
+        sandbox_setup_timeout=int(raw.get("sandbox_setup_timeout") or 120),
+        agent_idle_timeout=raw.get("agent_idle_timeout"),
+        context_root=raw.get("context_root"),
+        exclude_tasks=set(raw.get("exclude_tasks") or []),
+        include_tasks=set(raw.get("include_tasks") or []),
+        skill_mode=raw.get("skill_mode") or "default",
+        skill_creator_dir=raw.get("skill_creator_dir"),
+        self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
+        job_mode=raw.get("job_mode") or "parallel-independent",
+        source_provenance=raw.get("source_provenance"),
+        environment_manifest=_environment_manifest(raw),
+    )
+
+
+def _result_payload(result) -> dict[str, Any]:
+    return {
+        "job_name": result.job_name,
+        "total": result.total,
+        "passed": result.passed,
+        "failed": result.failed,
+        "errored": result.errored,
+        "verifier_errored": result.verifier_errored,
+        "elapsed_sec": result.elapsed_sec,
+        "score": result.score,
+        "score_excl_errors": result.score_excl_errors,
+    }
+
+
+async def run_worker(payload_path: Path) -> dict[str, Any]:
+    payload = json.loads(payload_path.read_text())
+    config = _evaluation_config(payload["config"])
+    evaluation = Evaluation(
+        tasks_dir=payload["tasks_dir"],
+        jobs_dir=payload["jobs_dir"],
+        config=config,
+    )
+    result = await evaluation.run()
+    result_payload = _result_payload(result)
+    output_path = Path(payload["result_path"])
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(result_payload, indent=2))
+    return result_payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("Usage: python -m benchflow.eval_worker <payload.json>", file=sys.stderr)
+        return 2
+    try:
+        result = asyncio.run(run_worker(Path(args[0])))
+    except Exception as exc:
+        print(f"Worker failed: {exc}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised by subprocess runs
+    raise SystemExit(main())

--- a/tests/test_eval_sharding.py
+++ b/tests/test_eval_sharding.py
@@ -6,7 +6,7 @@ from benchflow.eval_sharding import plan_eval_shards
 
 
 def test_plan_eval_shards_caps_worker_concurrency() -> None:
-    """Guards bry/eval-worker-shards against one process owning all Daytona sessions."""
+    """Guards the fix from PR #567 against one process owning all Daytona sessions."""
     plan = plan_eval_shards(
         [f"task-{i}" for i in range(5)],
         total_concurrency=5,
@@ -19,7 +19,7 @@ def test_plan_eval_shards_caps_worker_concurrency() -> None:
 
 
 def test_plan_eval_shards_assigns_each_task_once() -> None:
-    """Guards bry/eval-worker-shards against duplicate or dropped shard tasks."""
+    """Guards the fix from PR #567 against duplicate or dropped shard tasks."""
     tasks = [f"task-{i}" for i in range(9)]
 
     plan = plan_eval_shards(tasks, total_concurrency=6, worker_concurrency=2)
@@ -30,7 +30,7 @@ def test_plan_eval_shards_assigns_each_task_once() -> None:
 
 
 def test_plan_eval_shards_rejects_invalid_concurrency() -> None:
-    """Guards bry/eval-worker-shards against silently creating unusable workers."""
+    """Guards the fix from PR #567 against silently creating unusable workers."""
     with pytest.raises(ValueError, match="total_concurrency"):
         plan_eval_shards(["task"], total_concurrency=0, worker_concurrency=1)
 

--- a/tests/test_eval_sharding.py
+++ b/tests/test_eval_sharding.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from benchflow.eval_sharding import plan_eval_shards
+
+
+def test_plan_eval_shards_caps_worker_concurrency() -> None:
+    """Guards bry/eval-worker-shards against one process owning all Daytona sessions."""
+    plan = plan_eval_shards(
+        [f"task-{i}" for i in range(5)],
+        total_concurrency=5,
+        worker_concurrency=2,
+    )
+
+    assert [shard.concurrency for shard in plan.shards] == [2, 2, 1]
+    assert sum(shard.concurrency for shard in plan.shards) == 5
+    assert max(shard.concurrency for shard in plan.shards) == 2
+
+
+def test_plan_eval_shards_assigns_each_task_once() -> None:
+    """Guards bry/eval-worker-shards against duplicate or dropped shard tasks."""
+    tasks = [f"task-{i}" for i in range(9)]
+
+    plan = plan_eval_shards(tasks, total_concurrency=6, worker_concurrency=2)
+
+    assigned = [task for shard in plan.shards for task in shard.task_names]
+    assert sorted(assigned) == sorted(tasks)
+    assert len(assigned) == len(set(assigned))
+
+
+def test_plan_eval_shards_rejects_invalid_concurrency() -> None:
+    """Guards bry/eval-worker-shards against silently creating unusable workers."""
+    with pytest.raises(ValueError, match="total_concurrency"):
+        plan_eval_shards(["task"], total_concurrency=0, worker_concurrency=1)
+
+    with pytest.raises(ValueError, match="worker_concurrency"):
+        plan_eval_shards(["task"], total_concurrency=1, worker_concurrency=0)


### PR DESCRIPTION
## Summary
- Add `--worker-concurrency`, `--worker-retries`, and `--worker-start-stagger-sec` for batch eval runs.
- Run high-concurrency evals through isolated worker subprocess shards, each using a small local task concurrency and a durable per-shard jobs directory.
- Aggregate worker summaries into the top-level `summary.json` while preserving normal task result directories and trajectory output.

## Why
A single BenchFlow/OpenHands/Daytona control process was unstable at higher concurrency, including observed `exit 143` failures at concurrency 4-6. Sharding isolates host-side ACP/SSH/PTY/Daytona control-plane load so the aggregate run can scale without one event loop owning every live session.

## Validation
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/` -> 2447 passed, 11 skipped, 1 deselected
- Real Daytona/OpenHands qwen3.6-plus with-skills smoke, aggregate concurrency 4 / worker concurrency 2: 4/4 result.json, worker errors 0
- Real Daytona/OpenHands qwen3.6-plus with-skills smoke, aggregate concurrency 8 / worker concurrency 2: 8/8 result.json, worker errors 0
- Real Daytona/OpenHands qwen3.6-plus with-skills smoke, aggregate concurrency 16 / worker concurrency 2: 16/16 result.json, 8/8 worker returncode 0, errors 0, verifier_errored 0

Created by Codex on behalf of Bingran You.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->