### PR TITLE
Add Daytona usage tracking proxy support

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -42,6 +42,9 @@ bench eval create \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
   --sandbox daytona \
+  --usage-tracking required \
+  --usage-proxy-url https://your-tunnel.example.com \
+  --usage-proxy-port 18081 \
   --concurrency 64 \
   --sandbox-setup-timeout 300
 
@@ -84,6 +87,10 @@ bench eval create \
 | `--agent` | `claude-agent-acp` | Agent name |
 | `--model` | Agent default | Model ID |
 | `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |
+| `--usage-tracking` | `auto` | Token usage telemetry policy: `auto`, `required`, or `off` |
+| `--usage-proxy-url` | — | Externally reachable usage-proxy base URL for remote sandboxes such as Daytona |
+| `--usage-proxy-bind-host` | auto | Local interface for the usage proxy; external proxy mode defaults to `127.0.0.1` |
+| `--usage-proxy-port` | random | Fixed local port for externally tunneled usage tracking |
 | `--environment-manifest` | — | Path to an Environment-plane manifest (`environment.toml`); applied to every rollout in the batch |
 | `--concurrency` | `4` | Max concurrent tasks (batch mode only) |
 | `--agent-idle-timeout` | (built-in default) | Abort ACP prompts after this many idle seconds; `0` disables idle detection |
@@ -102,6 +109,12 @@ When mounting skills, the recommended docs default is
 `--agent-env BENCHFLOW_SKILL_NUDGE=name`. See
 [Architecture: skill loading](../architecture.md#skill-loading) for how
 `--skills-dir` is registered with each agent and how the nudge modes differ.
+
+For official Daytona batch runs that must report provider token/cost telemetry,
+use `--usage-tracking required` with a tunnel or ingress URL pointing at the
+fixed `--usage-proxy-port`. Without an external URL, Daytona runs continue in
+`auto` mode and record `usage_source=unavailable` because the remote sandbox
+cannot reach a host-bound proxy.
 
 `--source-env` is for external hosted environment hubs. The first supported
 runner is PrimeIntellect / Verifiers: BenchFlow preserves the hosted identity

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,7 +35,17 @@ accepts a single task directory.
 # From YAML config
 bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
-# From remote repo
+# From remote repo (fast Daytona batch; token usage may be unavailable)
+bench eval create \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks \
+  --agent gemini \
+  --model gemini-3.1-flash-lite-preview \
+  --sandbox daytona \
+  --concurrency 64 \
+  --sandbox-setup-timeout 300
+
+# From remote repo with required token usage telemetry through an external tunnel
 bench eval create \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks \
@@ -114,9 +124,11 @@ For official Daytona batch runs that must report provider token/cost telemetry,
 use `--usage-tracking required` with a tunnel or ingress URL pointing at the
 fixed `--usage-proxy-port`. The fixed-port tunnel mode supports one rollout per
 BenchFlow process; use `--concurrency 1`, or run multiple jobs with separate
-ports/tunnels. Without an external URL, Daytona runs continue in `auto` mode
-and record `usage_source=unavailable` because the remote sandbox cannot reach a
-host-bound proxy.
+ports/tunnels. This limit applies only to metered external-tunnel mode; Daytona
+batch runs that do not require usage telemetry can still use higher concurrency.
+Without an external URL, Daytona runs continue in `auto` mode and record
+`usage_source=unavailable` because the remote sandbox cannot reach a host-bound
+proxy.
 
 `--source-env` is for external hosted environment hubs. The first supported
 runner is PrimeIntellect / Verifiers: BenchFlow preserves the hosted identity

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -45,7 +45,7 @@ bench eval create \
   --usage-tracking required \
   --usage-proxy-url https://your-tunnel.example.com \
   --usage-proxy-port 18081 \
-  --concurrency 64 \
+  --concurrency 1 \
   --sandbox-setup-timeout 300
 
 # From local directory
@@ -112,9 +112,11 @@ When mounting skills, the recommended docs default is
 
 For official Daytona batch runs that must report provider token/cost telemetry,
 use `--usage-tracking required` with a tunnel or ingress URL pointing at the
-fixed `--usage-proxy-port`. Without an external URL, Daytona runs continue in
-`auto` mode and record `usage_source=unavailable` because the remote sandbox
-cannot reach a host-bound proxy.
+fixed `--usage-proxy-port`. The fixed-port tunnel mode supports one rollout per
+BenchFlow process; use `--concurrency 1`, or run multiple jobs with separate
+ports/tunnels. Without an external URL, Daytona runs continue in `auto` mode
+and record `usage_source=unavailable` because the remote sandbox cannot reach a
+host-bound proxy.
 
 `--source-env` is for external hosted environment hubs. The first supported
 runner is PrimeIntellect / Verifiers: BenchFlow preserves the hosted identity

--- a/docs/v05-e2e-testing-guide.md
+++ b/docs/v05-e2e-testing-guide.md
@@ -25,15 +25,15 @@ All commands below assume you are in the repo root.
 > The examples below use `weighted-gdp-calc` (fast, ~5 tool calls) as the
 > default lightweight task. Swap in any task name from `$TASKS/`.
 
-> **Usage telemetry caveat (Daytona / Modal):** For remote sandboxes
-> (`--sandbox daytona`, `--sandbox modal`) the agent runs on a remote host
-> that cannot reach the host-side usage proxy, so token/cost telemetry is
-> intentionally unavailable. You will see a log line that begins with
-> `Skipping host-side usage telemetry proxy:` and the resulting
-> `result.json` will report `agent_result.usage_source == "unavailable"`
-> with `null` token/cost fields. This is not an infra failure — confirm by
-> checking `summary.json.telemetry_coverage`. Local sandboxes (e.g.
-> `--sandbox docker`) do populate usage telemetry.
+> **Usage telemetry caveat (Daytona / Modal):** Remote sandboxes run the agent
+> on a host that cannot reach BenchFlow's host-bound usage proxy. Default
+> `--usage-tracking auto` therefore records `agent_result.usage_source ==
+> "unavailable"` unless you configure an external tunnel/ingress with
+> `--usage-proxy-url` and `--usage-proxy-port`. Official batch runs that need
+> token/cost telemetry should use `--usage-tracking required` so the run fails
+> before the agent starts if the external endpoint is missing or unhealthy.
+> Local sandboxes (e.g. `--sandbox docker`) populate usage telemetry without a
+> tunnel.
 
 ---
 
@@ -512,5 +512,4 @@ types, categories) that the §4–§7 live recipes only partially cover.
   via the source-side `TransportClosedDiagnostic` emission, but there is
   no live recipe for them. Add one via a fake transport fixture if you
   need true end-to-end coverage.
-
 

--- a/docs/v05-e2e-testing-guide.md
+++ b/docs/v05-e2e-testing-guide.md
@@ -31,9 +31,10 @@ All commands below assume you are in the repo root.
 > "unavailable"` unless you configure an external tunnel/ingress with
 > `--usage-proxy-url` and `--usage-proxy-port`. Official batch runs that need
 > token/cost telemetry should use `--usage-tracking required` so the run fails
-> before the agent starts if the external endpoint is missing or unhealthy.
-> Local sandboxes (e.g. `--sandbox docker`) populate usage telemetry without a
-> tunnel.
+> before the agent starts if the external endpoint is missing or unhealthy. The
+> fixed-port tunnel mode supports one rollout per BenchFlow process; use
+> `--concurrency 1`, or run multiple jobs with separate ports/tunnels. Local
+> sandboxes (e.g. `--sandbox docker`) populate usage telemetry without a tunnel.
 
 ---
 
@@ -512,4 +513,3 @@ types, categories) that the §4–§7 live recipes only partially cover.
   via the source-side `TransportClosedDiagnostic` emission, but there is
   no live recipe for them. Add one via a fake transport fixture if you
   need true end-to-end coverage.
-

--- a/docs/v05-e2e-testing-guide.md
+++ b/docs/v05-e2e-testing-guide.md
@@ -33,7 +33,9 @@ All commands below assume you are in the repo root.
 > token/cost telemetry should use `--usage-tracking required` so the run fails
 > before the agent starts if the external endpoint is missing or unhealthy. The
 > fixed-port tunnel mode supports one rollout per BenchFlow process; use
-> `--concurrency 1`, or run multiple jobs with separate ports/tunnels. Local
+> `--concurrency 1`, or run multiple jobs with separate ports/tunnels. This
+> constraint is specific to metered external-tunnel mode; Daytona batches that do
+> not require usage telemetry can still run with higher concurrency. Local
 > sandboxes (e.g. `--sandbox docker`) populate usage telemetry without a tunnel.
 
 ---

--- a/src/benchflow/_utils/yaml_loader.py
+++ b/src/benchflow/_utils/yaml_loader.py
@@ -45,6 +45,7 @@ import yaml
 
 from benchflow._types import Role, Scene, Turn
 from benchflow.rollout import RolloutConfig
+from benchflow.usage_tracking import UsageTrackingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +128,7 @@ def rollout_config_from_dict(
         skill_mode=raw.get("skill_mode", "default"),
         skill_creator_dir=raw.get("skill_creator_dir"),
         self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
+        usage_tracking=UsageTrackingConfig.from_mapping(raw),
     )
 
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1248,7 +1248,7 @@ def eval_create(
         )
     )
     try:
-        eval_usage_tracking = UsageTrackingConfig.from_values(
+        eval_usage_tracking = UsageTrackingConfig(
             mode=usage_tracking,
             advertised_base_url=usage_proxy_url,
             bind_host=usage_proxy_bind_host,

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -21,6 +21,7 @@ from benchflow._utils.config import (
 from benchflow.agents.registry import parse_agent_spec
 from benchflow.cli.trace_import import register_tasks_generate
 from benchflow.evaluation import DEFAULT_AGENT, effective_model
+from benchflow.usage_tracking import UsageTrackingConfig
 
 # Show progress messages (logger.info) from benchflow internals by default.
 logging.basicConfig(
@@ -1061,6 +1062,34 @@ def eval_create(
         str | None,
         typer.Option("--sandbox", help="Sandbox: docker, daytona, or modal"),
     ] = None,
+    usage_tracking: Annotated[
+        str | None,
+        typer.Option(
+            "--usage-tracking",
+            help="Token usage tracking policy: auto, required, or off",
+        ),
+    ] = None,
+    usage_proxy_url: Annotated[
+        str | None,
+        typer.Option(
+            "--usage-proxy-url",
+            help="Externally reachable base URL for remote sandbox usage tracking",
+        ),
+    ] = None,
+    usage_proxy_bind_host: Annotated[
+        str | None,
+        typer.Option(
+            "--usage-proxy-bind-host",
+            help="Local interface for the usage proxy to bind",
+        ),
+    ] = None,
+    usage_proxy_port: Annotated[
+        int | None,
+        typer.Option(
+            "--usage-proxy-port",
+            help="Fixed local port for externally tunneled usage tracking",
+        ),
+    ] = None,
     environment_manifest: Annotated[
         Path | None,
         typer.Option(
@@ -1209,6 +1238,25 @@ def eval_create(
     eval_environment = environment or "docker"
     sandbox_user = normalize_sandbox_user(sandbox_user)
     eval_concurrency = concurrency if concurrency is not None else 4
+    usage_tracking_overridden = any(
+        value is not None
+        for value in (
+            usage_tracking,
+            usage_proxy_url,
+            usage_proxy_bind_host,
+            usage_proxy_port,
+        )
+    )
+    try:
+        eval_usage_tracking = UsageTrackingConfig.from_values(
+            mode=usage_tracking,
+            advertised_base_url=usage_proxy_url,
+            bind_host=usage_proxy_bind_host,
+            port=usage_proxy_port,
+        )
+    except (TypeError, ValueError) as exc:
+        console.print(f"[red]Invalid usage tracking config: {exc}[/red]")
+        raise typer.Exit(1) from None
     try:
         eval_agent_idle_timeout = normalize_agent_idle_timeout(
             agent_idle_timeout
@@ -1302,6 +1350,8 @@ def eval_create(
             j._config.concurrency = concurrency
         if agent_idle_timeout is not None:
             j._config.agent_idle_timeout = eval_agent_idle_timeout
+        if usage_tracking_overridden:
+            j._config.usage_tracking = eval_usage_tracking
         if include_tasks:
             j._config.include_tasks = include_tasks
         if exclude_tasks:
@@ -1348,6 +1398,11 @@ def eval_create(
             console.print(
                 "[yellow]--environment-manifest is for benchflow Environment-plane rollouts; "
                 "the hosted Verifiers environment owns its own provisioning. Ignoring.[/yellow]"
+            )
+        if usage_tracking_overridden:
+            console.print(
+                "[yellow]--usage-tracking is for BenchFlow ACP rollouts; "
+                "source-env runs own their provider calls. Ignoring.[/yellow]"
             )
 
         try:
@@ -1414,6 +1469,7 @@ def eval_create(
                 source_provenance=resolved.provenance,
                 include_tasks=include_tasks,
                 exclude_tasks=exclude_tasks,
+                usage_tracking=eval_usage_tracking,
                 environment_manifest=eval_env_manifest,
             ),
         )
@@ -1443,6 +1499,7 @@ def eval_create(
                 self_gen_no_internet=self_gen_no_internet,
                 include_tasks=include_tasks,
                 exclude_tasks=exclude_tasks,
+                usage_tracking=eval_usage_tracking,
                 environment_manifest=eval_env_manifest,
             ),
         )

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1351,7 +1351,9 @@ def eval_create(
         if agent_idle_timeout is not None:
             j._config.agent_idle_timeout = eval_agent_idle_timeout
         if usage_tracking_overridden:
-            j._config.usage_tracking = eval_usage_tracking
+            j._config.usage_tracking = j._config.usage_tracking.overlay(
+                eval_usage_tracking
+            )
         if include_tasks:
             j._config.include_tasks = include_tasks
         if exclude_tasks:
@@ -1363,7 +1365,7 @@ def eval_create(
             j._config.environment_manifest = eval_env_manifest
         try:
             result = asyncio.run(j.run())
-        except EmptyTaskSelectionError as e:
+        except (EmptyTaskSelectionError, ValueError) as e:
             console.print(f"[red]{e}[/red]")
             raise typer.Exit(1) from None
         console.print(

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -124,6 +124,14 @@ def _config_payload(
         "self_gen_no_internet": config.self_gen_no_internet,
         "job_mode": config.job_mode,
         "source_provenance": config.source_provenance,
+        "usage_tracking": {
+            "usage_tracking": config.usage_tracking.mode,
+            "usage_proxy": {
+                "advertised_base_url": config.usage_tracking.advertised_base_url,
+                "bind_host": config.usage_tracking.bind_host,
+                "port": config.usage_tracking.port,
+            },
+        },
         "environment_manifest_path": (
             str(environment_manifest_path) if environment_manifest_path else None
         ),

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -124,14 +124,7 @@ def _config_payload(
         "self_gen_no_internet": config.self_gen_no_internet,
         "job_mode": config.job_mode,
         "source_provenance": config.source_provenance,
-        "usage_tracking": {
-            "usage_tracking": config.usage_tracking.mode,
-            "usage_proxy": {
-                "advertised_base_url": config.usage_tracking.advertised_base_url,
-                "bind_host": config.usage_tracking.bind_host,
-                "port": config.usage_tracking.port,
-            },
-        },
+        "usage_tracking": config.usage_tracking.to_mapping(),
         "environment_manifest_path": (
             str(environment_manifest_path) if environment_manifest_path else None
         ),
@@ -287,6 +280,10 @@ async def run_sharded_evaluation(
         task_names,
         total_concurrency=config.concurrency,
         worker_concurrency=worker_concurrency,
+    )
+    config.usage_tracking.with_env_defaults().validate_parallelism(
+        concurrency=plan.total_concurrency,
+        worker_count=plan.worker_count,
     )
     if not plan.shards:
         from benchflow.evaluation import EmptyTaskSelectionError

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -103,7 +103,7 @@ def _config_payload(
     shard: EvalShard,
     environment_manifest_path: Path | None,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "agent": config.agent,
         "model": config.model,
         "environment": config.environment,
@@ -124,11 +124,12 @@ def _config_payload(
         "self_gen_no_internet": config.self_gen_no_internet,
         "job_mode": config.job_mode,
         "source_provenance": config.source_provenance,
-        "usage_tracking": config.usage_tracking.to_mapping(),
         "environment_manifest_path": (
             str(environment_manifest_path) if environment_manifest_path else None
         ),
     }
+    payload.update(config.usage_tracking.to_mapping())
+    return payload
 
 
 def _plan_payload(plan: EvalShardPlan) -> dict[str, Any]:

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -70,7 +70,7 @@ def _evaluation_config(raw: dict[str, Any]) -> EvaluationConfig:
         self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
         job_mode=raw.get("job_mode") or "parallel-independent",
         source_provenance=raw.get("source_provenance"),
-        usage_tracking=UsageTrackingConfig.coerce(raw.get("usage_tracking")),
+        usage_tracking=UsageTrackingConfig.from_mapping(raw),
         environment_manifest=_environment_manifest(raw),
     )
 

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
+from benchflow.usage_tracking import UsageTrackingConfig
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -69,6 +70,7 @@ def _evaluation_config(raw: dict[str, Any]) -> EvaluationConfig:
         self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
         job_mode=raw.get("job_mode") or "parallel-independent",
         source_provenance=raw.get("source_provenance"),
+        usage_tracking=UsageTrackingConfig.coerce(raw.get("usage_tracking")),
         environment_manifest=_environment_manifest(raw),
     )
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -892,6 +892,7 @@ class Evaluation:
 
         cfg = self._config
         usage = cfg.usage_tracking.with_env_defaults()
+        usage.validate_parallelism(concurrency=cfg.concurrency)
         if usage.mode == "off" or host_proxy_reachable_from_agent(cfg.environment):
             return
         if not usage.uses_external_proxy:

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -884,40 +884,25 @@ class Evaluation:
             self._on_result(td.name, result)
 
     def _preflight_usage_tracking(self) -> None:
-        from benchflow.providers.runtime import host_proxy_reachable_from_agent
-        from benchflow.usage_tracking import (
-            USAGE_PROXY_ADVERTISED_BASE_URL_ENV,
-            USAGE_PROXY_PORT_ENV,
-        )
+        from benchflow.providers.runtime import validate_usage_proxy_preconditions
 
         cfg = self._config
         usage = cfg.usage_tracking.with_env_defaults()
         usage.validate_parallelism(concurrency=cfg.concurrency)
-        if usage.mode == "off" or host_proxy_reachable_from_agent(cfg.environment):
+        failure = validate_usage_proxy_preconditions(
+            usage,
+            environment=cfg.environment,
+            model=cfg.model,
+        )
+        if failure is None:
             return
-        if not usage.uses_external_proxy:
-            message = (
-                f"Token usage tracking is {usage.mode} for sandbox={cfg.environment!r}, "
-                "but this sandbox runs on a remote host and no external usage "
-                f"proxy endpoint is configured. Set {USAGE_PROXY_ADVERTISED_BASE_URL_ENV} "
-                "or use --usage-proxy-url."
-            )
-            if usage.mode == "required":
-                raise RuntimeError(message)
-            logger.warning(
-                "%s Results will report usage_source='unavailable'.", message
-            )
-            return
-        if not usage.has_fixed_proxy_port:
-            message = (
-                "External usage proxy tracking needs a fixed positive local proxy port. "
-                f"Set {USAGE_PROXY_PORT_ENV} or use --usage-proxy-port."
-            )
-            if usage.mode == "required":
-                raise RuntimeError(message)
-            logger.warning(
-                "%s Results will report usage_source='unavailable'.", message
-            )
+        if usage.mode == "required":
+            raise RuntimeError(failure.required_message)
+        logger.log(
+            failure.log_level,
+            "%s Results will report usage_source='unavailable'.",
+            failure.skip_message,
+        )
 
     async def _run_parallel_independent(
         self, remaining: list[Path]

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -61,6 +61,7 @@ from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.learner_store import LearnerState, LearnerStore
 from benchflow.models import RolloutResult
 from benchflow.trajectories.tree import RolloutNode
+from benchflow.usage_tracking import UsageTrackingConfig
 
 # Backward-compat alias
 RunResult = RolloutResult
@@ -213,6 +214,7 @@ class EvaluationConfig:
     self_gen_no_internet: bool = False
     job_mode: str = DEFAULT_JOB_MODE
     source_provenance: dict[str, Any] | None = None
+    usage_tracking: UsageTrackingConfig = field(default_factory=UsageTrackingConfig)
     # Environment-plane manifest applied to every rollout in the batch.
     # When set, each task's RolloutConfig.environment_manifest is populated
     # so the Environment plane (manifest-declared stateful environment,
@@ -231,6 +233,7 @@ class EvaluationConfig:
         self.agent = normalize_agent_name(self.agent)
         self.sandbox_user = normalize_sandbox_user(self.sandbox_user)
         self.agent_idle_timeout = normalize_agent_idle_timeout(self.agent_idle_timeout)
+        self.usage_tracking = UsageTrackingConfig.coerce(self.usage_tracking)
         if self.job_mode not in JOB_MODES:
             raise ValueError(
                 f"unknown job_mode {self.job_mode!r} — "
@@ -517,6 +520,7 @@ class Evaluation:
             self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
             job_mode=raw.get("job_mode", DEFAULT_JOB_MODE),
             source_provenance=source_provenance,
+            usage_tracking=UsageTrackingConfig.from_mapping(raw),
             environment_manifest=env_manifest,
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
@@ -602,6 +606,7 @@ class Evaluation:
                 else None
             ),
             self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
+            usage_tracking=UsageTrackingConfig.from_mapping(raw),
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -779,6 +784,7 @@ class Evaluation:
             self_gen_no_internet=cfg.self_gen_no_internet,
             export_generated_skills_to=export_to,
             source_provenance=task_source_provenance(cfg.source_provenance, task_dir),
+            usage_tracking=cfg.usage_tracking,
         )
         if cfg.skill_mode == "self-gen":
             from benchflow.self_gen import run_self_gen
@@ -819,6 +825,7 @@ class Evaluation:
             skill_creator_dir=cfg.skill_creator_dir,
             self_gen_no_internet=cfg.self_gen_no_internet,
             source_provenance=task_source_provenance(cfg.source_provenance, task_dir),
+            usage_tracking=cfg.usage_tracking,
         )
 
     async def _run_task(self, task_dir: Path) -> RunResult:
@@ -875,6 +882,41 @@ class Evaluation:
         logger.info(f"[{status}] {td.name} (tools={result.n_tool_calls}){err}")
         if self._on_result:
             self._on_result(td.name, result)
+
+    def _preflight_usage_tracking(self) -> None:
+        from benchflow.providers.runtime import host_proxy_reachable_from_agent
+        from benchflow.usage_tracking import (
+            USAGE_PROXY_ADVERTISED_BASE_URL_ENV,
+            USAGE_PROXY_PORT_ENV,
+        )
+
+        cfg = self._config
+        usage = cfg.usage_tracking.with_env_defaults()
+        if usage.mode == "off" or host_proxy_reachable_from_agent(cfg.environment):
+            return
+        if not usage.uses_external_proxy:
+            message = (
+                f"Token usage tracking is {usage.mode} for sandbox={cfg.environment!r}, "
+                "but this sandbox runs on a remote host and no external usage "
+                f"proxy endpoint is configured. Set {USAGE_PROXY_ADVERTISED_BASE_URL_ENV} "
+                "or use --usage-proxy-url."
+            )
+            if usage.mode == "required":
+                raise RuntimeError(message)
+            logger.warning(
+                "%s Results will report usage_source='unavailable'.", message
+            )
+            return
+        if not usage.has_fixed_proxy_port:
+            message = (
+                "External usage proxy tracking needs a fixed positive local proxy port. "
+                f"Set {USAGE_PROXY_PORT_ENV} or use --usage-proxy-port."
+            )
+            if usage.mode == "required":
+                raise RuntimeError(message)
+            logger.warning(
+                "%s Results will report usage_source='unavailable'.", message
+            )
 
     async def _run_parallel_independent(
         self, remaining: list[Path]
@@ -1129,6 +1171,8 @@ class Evaluation:
             )
         completed = self._get_completed_tasks()
         remaining = [d for d in task_dirs if d.name not in completed]
+        if remaining:
+            self._preflight_usage_tracking()
 
         # A resumed sequential-shared job rebuilds the LearnerStore from the
         # per-job snapshot under ``<job>/learner_store.json``. If that file
@@ -1271,6 +1315,7 @@ class Evaluation:
             "environment": cfg.environment,
             "concurrency": cfg.concurrency,
             "agent_idle_timeout_sec": cfg.agent_idle_timeout,
+            "usage_tracking": cfg.usage_tracking.with_env_defaults().to_config_artifact(),
             "total": job_result.total,
             "passed": audit_counts["passed"],
             "failed": audit_counts["failed"],

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -4,21 +4,30 @@ from __future__ import annotations
 
 import logging
 import os
+import secrets
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
+
+import httpx
 
 from benchflow.agents.providers import find_provider, strip_provider_prefix
 from benchflow.agents.registry import AGENTS
 from benchflow.providers.bedrock_proxy import BedrockProxyServer
 from benchflow.trajectories.pricing import PRICING_USD_PER_MTOK, PricingEntry
 from benchflow.trajectories.proxy import TrajectoryProxy
+from benchflow.usage_tracking import (
+    DEFAULT_USAGE_PROXY_BIND_HOST,
+    USAGE_PROXY_ADVERTISED_BASE_URL_ENV,
+    USAGE_PROXY_PORT_ENV,
+    UsageTrackingConfig,
+)
 
 logger = logging.getLogger(__name__)
 
 BEDROCK_PROXY_BIND_HOST = "0.0.0.0"
 BEDROCK_PROXY_LOCAL_HOST = "127.0.0.1"
-USAGE_PROXY_BIND_HOST = "0.0.0.0"
+USAGE_PROXY_BIND_HOST = DEFAULT_USAGE_PROXY_BIND_HOST
 PROMPT_CACHE_RETENTION_ENV = "BENCHFLOW_PROVIDER_PROMPT_CACHE_RETENTION"
 DISABLE_USAGE_PROXY_ENV = "BENCHFLOW_DISABLE_USAGE_PROXY"
 _PROMPT_CACHE_RETENTION_VALUES = {"in_memory", "24h"}
@@ -34,9 +43,12 @@ class ProviderRuntime:
     backend_model: str | None = None
     frontend_model: str | None = None
     server: Any | None = None
+    agent_base_url: str | None = None
 
     @property
     def base_url(self) -> str:
+        if self.agent_base_url:
+            return self.agent_base_url
         return f"http://{self.host}:{self.port}"
 
 
@@ -302,6 +314,42 @@ def _resolve_usage_proxy_target(
     return _infer_default_provider_url(agent, model)
 
 
+def _external_usage_proxy_error(environment: str) -> str:
+    return (
+        f"Token usage tracking is required for sandbox={environment!r}, but "
+        "that sandbox runs the agent on a remote host and cannot reach a "
+        "host-bound usage proxy. Configure an external usage proxy endpoint "
+        f"with {USAGE_PROXY_ADVERTISED_BASE_URL_ENV} plus a fixed "
+        f"{USAGE_PROXY_PORT_ENV}, or rerun with --usage-tracking auto/off."
+    )
+
+
+def _usage_proxy_path_prefix() -> str:
+    return f"/__benchflow/{secrets.token_urlsafe(24)}"
+
+
+def _agent_usage_proxy_base_url(
+    *,
+    environment: str,
+    port: int,
+    usage_tracking: UsageTrackingConfig,
+    path_prefix: str,
+) -> str:
+    if usage_tracking.advertised_base_url:
+        return f"{usage_tracking.advertised_base_url}{path_prefix}"
+    return f"http://{_bedrock_proxy_command(environment=environment)}:{port}"
+
+
+async def _external_usage_proxy_reachable(base_url: str) -> bool:
+    health_url = f"{base_url.rstrip('/')}/__benchflow_health"
+    try:
+        async with httpx.AsyncClient(timeout=httpx.Timeout(5.0)) as client:
+            response = await client.get(health_url)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
 def _pricing_for_model(model: str | None) -> PricingEntry | None:
     if not model:
         return None
@@ -373,20 +421,26 @@ async def ensure_usage_proxy_runtime(
     runtime: ProviderRuntime | None,
     environment: str,
     session_id: str = "",
+    usage_tracking: UsageTrackingConfig | dict[str, Any] | str | None = None,
 ) -> tuple[dict[str, str], ProviderRuntime | None]:
     """Start the host-side usage proxy and wire env vars to it.
 
-    For remote cloud sandboxes (e.g. Daytona) the host proxy is unreachable
-    from the agent — it runs on a different machine and there is no reverse
-    tunnel back to the host. In that case the proxy is skipped: the agent
-    talks to the provider directly with its real key and host-side usage
-    telemetry reports ``usage_source: "unavailable"``.
+    Remote cloud sandboxes (e.g. Daytona) can only use this proxy when the
+    operator supplies an externally reachable URL. The local bind endpoint and
+    the URL advertised to the agent are deliberately separate: Docker sees the
+    host bridge address, while Daytona sees the tunnel/ingress URL.
     """
+    usage_cfg = UsageTrackingConfig.coerce(usage_tracking).with_env_defaults()
     if agent == "oracle":
         return agent_env, runtime
     if _env_flag_enabled(os.environ.get(DISABLE_USAGE_PROXY_ENV)):
         if runtime is not None:
             await stop_provider_runtime(runtime)
+        if usage_cfg.mode == "required":
+            raise RuntimeError(
+                f"Token usage tracking is required, but {DISABLE_USAGE_PROXY_ENV} "
+                "is enabled."
+            )
         logger.info(
             "Skipping host-side usage telemetry proxy: %s is enabled. "
             "The agent will call the provider directly and usage telemetry "
@@ -394,24 +448,70 @@ async def ensure_usage_proxy_runtime(
             DISABLE_USAGE_PROXY_ENV,
         )
         return agent_env, None
-    if not host_proxy_reachable_from_agent(environment):
+
+    if usage_cfg.mode == "off":
         if runtime is not None:
             await stop_provider_runtime(runtime)
+        logger.info("Skipping host-side usage telemetry proxy: usage_tracking=off.")
+        return agent_env, None
+
+    host_reachable = host_proxy_reachable_from_agent(environment)
+    if not host_reachable and not usage_cfg.uses_external_proxy:
+        if runtime is not None:
+            await stop_provider_runtime(runtime)
+        if usage_cfg.mode == "required":
+            raise RuntimeError(_external_usage_proxy_error(environment or "unknown"))
         logger.info(
             "Skipping host-side usage telemetry proxy: the '%s' sandbox runs "
-            "the agent on a remote host unreachable from the host proxy; the "
-            "agent will call the provider directly and usage telemetry will "
+            "the agent on a remote host unreachable from the host proxy and no "
+            "external usage proxy endpoint is configured; usage telemetry will "
             "be unavailable for this run.",
             environment or "unknown",
         )
         return agent_env, None
+
+    if usage_cfg.uses_external_proxy and not usage_cfg.has_fixed_proxy_port:
+        if runtime is not None:
+            await stop_provider_runtime(runtime)
+        message = (
+            "External usage proxy tracking requires a fixed positive local proxy port. "
+            f"Set {USAGE_PROXY_PORT_ENV} or pass --usage-proxy-port."
+        )
+        if usage_cfg.mode == "required":
+            raise RuntimeError(message)
+        logger.warning("%s Usage telemetry will be unavailable for this run.", message)
+        return agent_env, None
+
+    if (
+        needs_provider_runtime(model)
+        and not host_reachable
+        and usage_cfg.uses_external_proxy
+    ):
+        if runtime is not None:
+            await stop_provider_runtime(runtime)
+        message = (
+            "Remote Bedrock-direct runs cannot be metered by the generic usage "
+            "proxy because the agent calls AWS Bedrock natively instead of an "
+            "OpenAI/Anthropic-compatible HTTP endpoint. Use an OpenAI-compatible "
+            "provider proxy for this run, run with --sandbox docker, or leave "
+            "usage tracking as auto/off."
+        )
+        if usage_cfg.mode == "required":
+            raise RuntimeError(message)
+        logger.warning("%s Usage telemetry will be unavailable for this run.", message)
+        return agent_env, None
+
     target = _resolve_usage_proxy_target(agent, agent_env, model)
     if not target:
+        if usage_cfg.mode == "required":
+            raise RuntimeError(
+                "Token usage tracking is required, but BenchFlow could not "
+                "resolve a provider base URL for this agent/model."
+            )
         return agent_env, runtime
-    target = _host_side_proxy_target_url(
-        target.rstrip("/"),
-        environment=environment,
-    )
+    target = target.rstrip("/")
+    if host_reachable:
+        target = _host_side_proxy_target_url(target, environment=environment)
 
     # A multi-role scene can switch providers between connect_as() calls. The
     # running proxy forwards to a fixed upstream, so reusing it would route the
@@ -432,22 +532,59 @@ async def ensure_usage_proxy_runtime(
                 f"{', '.join(sorted(_PROMPT_CACHE_RETENTION_VALUES))}"
             )
         logger.info("Starting host-side usage telemetry proxy")
-        server = TrajectoryProxy(
-            target=target,
-            session_id=session_id,
-            agent_name=agent,
-            host=USAGE_PROXY_BIND_HOST,
-            port=0,
-            prompt_cache_retention=prompt_cache_retention,
+        bind_host = usage_cfg.bind_host
+        if bind_host is None:
+            bind_host = (
+                "127.0.0.1" if usage_cfg.uses_external_proxy else USAGE_PROXY_BIND_HOST
+            )
+        bind_port = usage_cfg.port if usage_cfg.port is not None else 0
+        path_prefix = (
+            _usage_proxy_path_prefix() if usage_cfg.uses_external_proxy else ""
         )
+        proxy_kwargs: dict[str, Any] = {
+            "target": target,
+            "session_id": session_id,
+            "agent_name": agent,
+            "host": bind_host,
+            "port": bind_port,
+            "prompt_cache_retention": prompt_cache_retention,
+        }
+        if path_prefix:
+            proxy_kwargs["path_prefix"] = path_prefix
+        server = TrajectoryProxy(**proxy_kwargs)
         await server.start()
+        agent_base_url = _agent_usage_proxy_base_url(
+            environment=environment,
+            port=server.port,
+            usage_tracking=usage_cfg,
+            path_prefix=path_prefix,
+        )
         runtime = ProviderRuntime(
             kind="usage-proxy",
-            host=_bedrock_proxy_command(environment=environment),
+            host=_bedrock_proxy_command(environment=environment)
+            if host_reachable
+            else bind_host,
             port=server.port,
             backend_model=strip_provider_prefix(model) if model else None,
             server=server,
+            agent_base_url=agent_base_url,
         )
+
+        if usage_cfg.uses_external_proxy:
+            reachable = await _external_usage_proxy_reachable(runtime.base_url)
+            if not reachable:
+                await stop_provider_runtime(runtime)
+                runtime = None
+                message = (
+                    "External usage proxy endpoint was configured but did not "
+                    f"respond to its health check: {usage_cfg.advertised_base_url}"
+                )
+                if usage_cfg.mode == "required":
+                    raise RuntimeError(message)
+                logger.warning(
+                    "%s. Usage telemetry will be unavailable for this run.", message
+                )
+                return agent_env, None
 
     updated = dict(agent_env)
     updated["BENCHFLOW_PROVIDER_BASE_URL"] = runtime.base_url

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -38,18 +38,14 @@ class ProviderRuntime:
     """State for a lazily-started provider-side helper process."""
 
     kind: str
-    host: str
-    port: int
+    agent_base_url: str
     backend_model: str | None = None
     frontend_model: str | None = None
     server: Any | None = None
-    agent_base_url: str | None = None
 
     @property
     def base_url(self) -> str:
-        if self.agent_base_url:
-            return self.agent_base_url
-        return f"http://{self.host}:{self.port}"
+        return self.agent_base_url
 
 
 def needs_provider_runtime(model: str | None) -> bool:
@@ -318,10 +314,20 @@ def _external_usage_proxy_error(environment: str) -> str:
     return (
         f"Token usage tracking is required for sandbox={environment!r}, but "
         "that sandbox runs the agent on a remote host and cannot reach a "
-        "host-bound usage proxy. Configure an external usage proxy endpoint "
-        f"with {USAGE_PROXY_ADVERTISED_BASE_URL_ENV} plus a fixed "
+        "host-bound usage proxy and no external usage proxy endpoint is "
+        "configured. Configure an external usage proxy endpoint with "
+        f"{USAGE_PROXY_ADVERTISED_BASE_URL_ENV} plus a fixed "
         f"{USAGE_PROXY_PORT_ENV}, or rerun with --usage-tracking auto/off."
     )
+
+
+@dataclass(frozen=True)
+class UsageProxyPreconditionFailure:
+    """Why the usage proxy cannot be wired for this rollout."""
+
+    required_message: str
+    skip_message: str
+    log_level: int = logging.WARNING
 
 
 def _usage_proxy_path_prefix() -> str:
@@ -340,13 +346,85 @@ def _agent_usage_proxy_base_url(
     return f"http://{_bedrock_proxy_command(environment=environment)}:{port}"
 
 
+def validate_usage_proxy_preconditions(
+    usage_cfg: UsageTrackingConfig,
+    *,
+    environment: str,
+    model: str | None,
+    disable_usage_proxy: bool | None = None,
+) -> UsageProxyPreconditionFailure | None:
+    """Return the first reason usage telemetry cannot be wired, if any."""
+    if usage_cfg.mode == "off":
+        return None
+
+    if disable_usage_proxy is None:
+        disable_usage_proxy = _env_flag_enabled(os.environ.get(DISABLE_USAGE_PROXY_ENV))
+    if disable_usage_proxy:
+        return UsageProxyPreconditionFailure(
+            required_message=(
+                f"Token usage tracking is required, but {DISABLE_USAGE_PROXY_ENV} "
+                "is enabled."
+            ),
+            skip_message=(
+                f"Skipping host-side usage telemetry proxy: {DISABLE_USAGE_PROXY_ENV} "
+                "is enabled."
+            ),
+            log_level=logging.INFO,
+        )
+
+    host_reachable = host_proxy_reachable_from_agent(environment)
+    if not host_reachable and not usage_cfg.uses_external_proxy:
+        return UsageProxyPreconditionFailure(
+            required_message=_external_usage_proxy_error(environment or "unknown"),
+            skip_message=(
+                "Skipping host-side usage telemetry proxy: the "
+                f"{environment or 'unknown'!r} sandbox runs the agent on a remote "
+                "host unreachable from the host proxy and no external usage proxy "
+                "endpoint is configured."
+            ),
+            log_level=logging.INFO,
+        )
+
+    if usage_cfg.uses_external_proxy and not usage_cfg.has_fixed_proxy_port:
+        message = (
+            "External usage proxy tracking requires a fixed positive local proxy port. "
+            f"Set {USAGE_PROXY_PORT_ENV} or pass --usage-proxy-port."
+        )
+        return UsageProxyPreconditionFailure(
+            required_message=message,
+            skip_message=message,
+            log_level=logging.WARNING,
+        )
+
+    if (
+        needs_provider_runtime(model)
+        and not host_reachable
+        and usage_cfg.uses_external_proxy
+    ):
+        message = (
+            "Remote Bedrock-direct runs cannot be metered by the generic usage "
+            "proxy because the agent calls AWS Bedrock natively instead of an "
+            "OpenAI/Anthropic-compatible HTTP endpoint. Use an OpenAI-compatible "
+            "provider proxy for this run, run with --sandbox docker, or leave "
+            "usage tracking as auto/off."
+        )
+        return UsageProxyPreconditionFailure(
+            required_message=message,
+            skip_message=message,
+            log_level=logging.WARNING,
+        )
+
+    return None
+
+
 async def _external_usage_proxy_reachable(base_url: str) -> bool:
     health_url = f"{base_url.rstrip('/')}/__benchflow_health"
     try:
         async with httpx.AsyncClient(timeout=httpx.Timeout(5.0)) as client:
             response = await client.get(health_url)
         return response.status_code == 200
-    except Exception:
+    except Exception as exc:
+        logger.debug("External usage proxy health check failed: %s", exc)
         return False
 
 
@@ -413,6 +491,25 @@ def _cache_tokens_are_input_breakdown(trajectory: Any) -> bool:
     return False
 
 
+async def _skip_or_block_usage_proxy(
+    *,
+    usage_cfg: UsageTrackingConfig,
+    failure: UsageProxyPreconditionFailure,
+    agent_env: dict[str, str],
+    runtime: ProviderRuntime | None,
+) -> tuple[dict[str, str], ProviderRuntime | None]:
+    if runtime is not None:
+        await stop_provider_runtime(runtime)
+    if usage_cfg.mode == "required":
+        raise RuntimeError(failure.required_message)
+    logger.log(
+        failure.log_level,
+        "%s Usage telemetry will be unavailable for this run.",
+        failure.skip_message,
+    )
+    return agent_env, None
+
+
 async def ensure_usage_proxy_runtime(
     *,
     agent: str,
@@ -433,21 +530,6 @@ async def ensure_usage_proxy_runtime(
     usage_cfg = UsageTrackingConfig.coerce(usage_tracking).with_env_defaults()
     if agent == "oracle":
         return agent_env, runtime
-    if _env_flag_enabled(os.environ.get(DISABLE_USAGE_PROXY_ENV)):
-        if runtime is not None:
-            await stop_provider_runtime(runtime)
-        if usage_cfg.mode == "required":
-            raise RuntimeError(
-                f"Token usage tracking is required, but {DISABLE_USAGE_PROXY_ENV} "
-                "is enabled."
-            )
-        logger.info(
-            "Skipping host-side usage telemetry proxy: %s is enabled. "
-            "The agent will call the provider directly and usage telemetry "
-            "will be unavailable for this run.",
-            DISABLE_USAGE_PROXY_ENV,
-        )
-        return agent_env, None
 
     if usage_cfg.mode == "off":
         if runtime is not None:
@@ -456,50 +538,18 @@ async def ensure_usage_proxy_runtime(
         return agent_env, None
 
     host_reachable = host_proxy_reachable_from_agent(environment)
-    if not host_reachable and not usage_cfg.uses_external_proxy:
-        if runtime is not None:
-            await stop_provider_runtime(runtime)
-        if usage_cfg.mode == "required":
-            raise RuntimeError(_external_usage_proxy_error(environment or "unknown"))
-        logger.info(
-            "Skipping host-side usage telemetry proxy: the '%s' sandbox runs "
-            "the agent on a remote host unreachable from the host proxy and no "
-            "external usage proxy endpoint is configured; usage telemetry will "
-            "be unavailable for this run.",
-            environment or "unknown",
+    failure = validate_usage_proxy_preconditions(
+        usage_cfg,
+        environment=environment,
+        model=model,
+    )
+    if failure is not None:
+        return await _skip_or_block_usage_proxy(
+            usage_cfg=usage_cfg,
+            failure=failure,
+            agent_env=agent_env,
+            runtime=runtime,
         )
-        return agent_env, None
-
-    if usage_cfg.uses_external_proxy and not usage_cfg.has_fixed_proxy_port:
-        if runtime is not None:
-            await stop_provider_runtime(runtime)
-        message = (
-            "External usage proxy tracking requires a fixed positive local proxy port. "
-            f"Set {USAGE_PROXY_PORT_ENV} or pass --usage-proxy-port."
-        )
-        if usage_cfg.mode == "required":
-            raise RuntimeError(message)
-        logger.warning("%s Usage telemetry will be unavailable for this run.", message)
-        return agent_env, None
-
-    if (
-        needs_provider_runtime(model)
-        and not host_reachable
-        and usage_cfg.uses_external_proxy
-    ):
-        if runtime is not None:
-            await stop_provider_runtime(runtime)
-        message = (
-            "Remote Bedrock-direct runs cannot be metered by the generic usage "
-            "proxy because the agent calls AWS Bedrock natively instead of an "
-            "OpenAI/Anthropic-compatible HTTP endpoint. Use an OpenAI-compatible "
-            "provider proxy for this run, run with --sandbox docker, or leave "
-            "usage tracking as auto/off."
-        )
-        if usage_cfg.mode == "required":
-            raise RuntimeError(message)
-        logger.warning("%s Usage telemetry will be unavailable for this run.", message)
-        return agent_env, None
 
     target = _resolve_usage_proxy_target(agent, agent_env, model)
     if not target:
@@ -561,13 +611,9 @@ async def ensure_usage_proxy_runtime(
         )
         runtime = ProviderRuntime(
             kind="usage-proxy",
-            host=_bedrock_proxy_command(environment=environment)
-            if host_reachable
-            else bind_host,
-            port=server.port,
+            agent_base_url=agent_base_url,
             backend_model=strip_provider_prefix(model) if model else None,
             server=server,
-            agent_base_url=agent_base_url,
         )
 
         if usage_cfg.uses_external_proxy:
@@ -691,8 +737,9 @@ async def ensure_bedrock_proxy_runtime(
         await server.start()
         runtime = ProviderRuntime(
             kind="aws-bedrock",
-            host=_bedrock_proxy_command(environment=environment),
-            port=server.port,
+            agent_base_url=(
+                f"http://{_bedrock_proxy_command(environment=environment)}:{server.port}"
+            ),
             backend_model=backend_model,
             frontend_model=frontend_model,
             server=server,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -79,6 +79,7 @@ from benchflow.trajectories._capture import (
 )
 from benchflow.trajectories.metrics import count_skill_invocations
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
+from benchflow.usage_tracking import UsageTrackingConfig
 
 logger = logging.getLogger(__name__)
 
@@ -366,6 +367,7 @@ def _write_config(
     timeout: int,
     started_at: datetime,
     agent_env: dict[str, str],
+    usage_tracking: UsageTrackingConfig | None = None,
     concurrency: int | None = None,
     agent_idle_timeout: int | None = None,
     scenes: list[Scene] | None = None,
@@ -390,6 +392,8 @@ def _write_config(
         "agent_env": recorded_env,
         "scenes": _scene_metadata(scenes or []),
     }
+    if usage_tracking is not None:
+        config_data["usage_tracking"] = usage_tracking.to_config_artifact()
     if source_provenance is not None:
         config_data["source"] = source_provenance
     (rollout_dir / "config.json").write_text(json.dumps(config_data, indent=2))
@@ -451,6 +455,7 @@ def _build_rollout_result(
     cost_usd: float | None = None,
     usage_source: str = "unavailable",
     price_source: str | None = None,
+    usage_tracking: dict[str, Any] | None = None,
     evolved_skills: dict[str, str] | None = None,
     source_provenance: dict[str, Any] | None = None,
     diagnostics: RolloutDiagnostics | None = None,
@@ -537,6 +542,7 @@ def _build_rollout_result(
                     "usage_source": result.usage_source,
                     "price_source": result.price_source,
                 },
+                "usage_tracking": usage_tracking,
                 "error": result.error,
                 "error_category": result.error_category,
                 "verifier_error": result.verifier_error,
@@ -869,6 +875,7 @@ class RolloutConfig:
     # ``Runtime(RuntimeConfig(timeout=...))`` enforces a caller-supplied
     # budget without editing every task.toml (#378).
     timeout: int | None = None
+    usage_tracking: UsageTrackingConfig = field(default_factory=UsageTrackingConfig)
 
     # User-driven progressive-disclosure loop
     user: BaseUser | None = None
@@ -906,6 +913,7 @@ class RolloutConfig:
         self.agent = normalize_agent_name(self.agent)
         self.sandbox_user = normalize_sandbox_user(self.sandbox_user)
         self.agent_idle_timeout = normalize_agent_idle_timeout(self.agent_idle_timeout)
+        self.usage_tracking = UsageTrackingConfig.coerce(self.usage_tracking)
         for scene in self.scenes:
             for role in scene.roles:
                 role.agent = normalize_agent_name(role.agent)
@@ -1264,6 +1272,7 @@ class Rollout:
             timeout=self._timeout,
             started_at=self._started_at,
             agent_env=self._agent_env,
+            usage_tracking=cfg.usage_tracking.with_env_defaults(),
             concurrency=cfg.concurrency,
             agent_idle_timeout=cfg.agent_idle_timeout,
             scenes=cfg.effective_scenes,
@@ -1439,6 +1448,7 @@ class Rollout:
             runtime=getattr(self, "_usage_runtime", None),
             environment=cfg.environment,
             session_id=getattr(self, "_rollout_name", "") or "",
+            usage_tracking=cfg.usage_tracking,
         )
         (
             self._acp_client,
@@ -2291,6 +2301,7 @@ class Rollout:
             runtime=getattr(self, "_usage_runtime", None),
             environment=cfg.environment,
             session_id=getattr(self, "_rollout_name", "") or "",
+            usage_tracking=cfg.usage_tracking,
         )
 
         role_agent_differs = role.agent != cfg.primary_agent
@@ -2416,6 +2427,21 @@ class Rollout:
             trajectory.to_jsonl(redact_keys=True)
         )
 
+    def _usage_tracking_metadata(self) -> dict[str, Any]:
+        usage_cfg = self._config.usage_tracking.with_env_defaults()
+        usage_source = str(self._usage_metrics.get("usage_source", "unavailable"))
+        if usage_cfg.mode == "off":
+            status = "off"
+        elif usage_source == "provider_response":
+            status = "enabled"
+        else:
+            status = "unavailable"
+        return usage_cfg.to_result_metadata(
+            environment=self._config.environment,
+            status=status,
+            usage_source=usage_source,
+        )
+
     def _build_result(self) -> RolloutResult:
         rollout_dir = self._require_rollout_dir()
         # For Scene/multi-turn rollouts, each execute() call records the
@@ -2447,5 +2473,6 @@ class Rollout:
             evolved_skills=self._evolved_skills,
             source_provenance=self._config.source_provenance,
             diagnostics=self._diagnostics,
+            usage_tracking=self._usage_tracking_metadata(),
             **self._usage_metrics,
         )

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -339,6 +339,7 @@ _SECRET_ENV_SUBSTRINGS: tuple[str, ...] = (
     "BEARER",
     "SESSION",
 )
+_SECRET_URL_PATH_MARKERS: tuple[str, ...] = ("/__benchflow/",)
 
 
 def _is_secret_env_key(name: str) -> bool:
@@ -350,6 +351,18 @@ def _is_secret_env_key(name: str) -> bool:
     """
     upper = name.upper()
     return any(s in upper for s in _SECRET_ENV_SUBSTRINGS)
+
+
+def _is_secret_env_value(name: str, value: str) -> bool:
+    """Return True if a normally public env value embeds a runtime secret."""
+    upper = name.upper()
+    if not upper.endswith("BASE_URL"):
+        return False
+    return any(marker in value for marker in _SECRET_URL_PATH_MARKERS)
+
+
+def _should_record_env_entry(name: str, value: str) -> bool:
+    return not _is_secret_env_key(name) and not _is_secret_env_value(name, value)
 
 
 def _write_config(
@@ -374,7 +387,9 @@ def _write_config(
     source_provenance: dict[str, Any] | None = None,
 ) -> None:
     """Write config.json to rollout_dir with secrets filtered out."""
-    recorded_env = {k: v for k, v in agent_env.items() if not _is_secret_env_key(k)}
+    recorded_env = {
+        k: v for k, v in agent_env.items() if _should_record_env_entry(k, v)
+    }
     config_data = {
         "task_path": str(task_path),
         "agent": agent,

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -207,6 +207,7 @@ class RuntimeConfig:
     context_root: str | Path | None = None
     pre_agent_hooks: list | None = None
     sandbox_locked_paths: list[str] | None = None
+    usage_tracking: Any = None
 
 
 @dataclass
@@ -355,6 +356,7 @@ class Runtime:
             model=self.agent.model,
             agent_env=self.agent.env,
             skills_dir=config.skills_dir,
+            usage_tracking=config.usage_tracking,
         )
 
         rollout = await Rollout.create(trial_config)
@@ -451,6 +453,7 @@ async def run(
             skills_dir=rc.skills_dir,
             agent=subject,
             model=model,
+            usage_tracking=rc.usage_tracking,
         )
         rollout = await Rollout.create(rollout_config)
         return await rollout.run()

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -178,6 +178,7 @@ class SDK:
         skill_creator_dir: str | Path | None = None,
         self_gen_no_internet: bool = False,
         source_provenance: dict[str, Any] | None = None,
+        usage_tracking: Any = None,
     ) -> RolloutResult:
         """Run a task — delegates to :func:`benchflow.run`."""
         from benchflow.rollout import RolloutConfig
@@ -206,5 +207,6 @@ class SDK:
             skill_creator_dir=skill_creator_dir,
             self_gen_no_internet=self_gen_no_internet,
             source_provenance=source_provenance,
+            usage_tracking=usage_tracking,
         )
         return await run(config)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -13,6 +13,7 @@ import time
 import zlib
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
@@ -41,6 +42,7 @@ class TrajectoryProxy:
         host: str = "127.0.0.1",
         port: int = 0,
         prompt_cache_retention: str | None = None,
+        path_prefix: str = "",
     ):
         if (
             prompt_cache_retention is not None
@@ -54,6 +56,7 @@ class TrajectoryProxy:
         self._host = host
         self._port = port
         self._prompt_cache_retention = prompt_cache_retention
+        self._path_prefix = _normalize_path_prefix(path_prefix)
         self._trajectory = Trajectory(
             session_id=session_id,
             agent_name=agent_name,
@@ -128,6 +131,25 @@ class TrajectoryProxy:
                 body_bytes = b""
                 if content_length > 0:
                     body_bytes = await reader.readexactly(content_length)
+
+                try:
+                    path = _strip_path_prefix(path, self._path_prefix)
+                except ValueError:
+                    await _write_json_response(
+                        writer,
+                        status_code=404,
+                        reason="Not Found",
+                        payload={"error": "not found"},
+                    )
+                    break
+                if _is_health_request(method, path):
+                    await _write_json_response(
+                        writer,
+                        status_code=200,
+                        reason="OK",
+                        payload={"status": "ok"},
+                    )
+                    break
 
                 body = _parse_request_body(body_bytes, headers)
                 body, body_bytes, headers = _apply_prompt_cache_retention(
@@ -394,6 +416,51 @@ def _parse_request_body(body_bytes: bytes, headers: dict[str, str]) -> dict[str,
     if isinstance(parsed, dict):
         return parsed
     return {"raw": parsed}
+
+
+def _normalize_path_prefix(path_prefix: str) -> str:
+    if not path_prefix:
+        return ""
+    if not path_prefix.startswith("/"):
+        raise ValueError("path_prefix must start with '/'")
+    return path_prefix.rstrip("/")
+
+
+def _strip_path_prefix(path: str, path_prefix: str) -> str:
+    if not path_prefix:
+        return path
+    parsed = urlsplit(path)
+    request_path = parsed.path or "/"
+    if request_path != path_prefix and not request_path.startswith(f"{path_prefix}/"):
+        raise ValueError("request path does not match proxy path prefix")
+    stripped_path = request_path[len(path_prefix) :] or "/"
+    return urlunsplit(("", "", stripped_path, parsed.query, parsed.fragment))
+
+
+def _is_health_request(method: str, path: str) -> bool:
+    if method.upper() != "GET":
+        return False
+    return (path.split("?", 1)[0].rstrip("/") or "/") in {
+        "/__benchflow_health",
+        "/health",
+    }
+
+
+async def _write_json_response(
+    writer: asyncio.StreamWriter,
+    *,
+    status_code: int,
+    reason: str,
+    payload: dict[str, Any],
+) -> None:
+    body = json.dumps(payload, separators=(",", ":")).encode()
+    writer.write(
+        f"HTTP/1.1 {status_code} {reason}\r\n".encode()
+        + b"content-type: application/json\r\n"
+        + f"content-length: {len(body)}\r\n\r\n".encode()
+        + body
+    )
+    await writer.drain()
 
 
 def _apply_prompt_cache_retention(

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -148,6 +148,7 @@ class TrajectoryProxy:
                         status_code=200,
                         reason="OK",
                         payload={"status": "ok"},
+                        include_body=method.upper() != "HEAD",
                     )
                     break
 
@@ -438,7 +439,7 @@ def _strip_path_prefix(path: str, path_prefix: str) -> str:
 
 
 def _is_health_request(method: str, path: str) -> bool:
-    if method.upper() != "GET":
+    if method.upper() not in {"GET", "HEAD"}:
         return False
     return (path.split("?", 1)[0].rstrip("/") or "/") in {
         "/__benchflow_health",
@@ -452,8 +453,9 @@ async def _write_json_response(
     status_code: int,
     reason: str,
     payload: dict[str, Any],
+    include_body: bool = True,
 ) -> None:
-    body = json.dumps(payload, separators=(",", ":")).encode()
+    body = json.dumps(payload, separators=(",", ":")).encode() if include_body else b""
     writer.write(
         f"HTTP/1.1 {status_code} {reason}\r\n".encode()
         + b"content-type: application/json\r\n"

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -121,6 +121,34 @@ class UsageTrackingConfig:
     def has_fixed_proxy_port(self) -> bool:
         return self.port is not None and self.port > 0
 
+    def overlay(self, override: UsageTrackingConfig) -> UsageTrackingConfig:
+        """Return this config with explicitly supplied override fields applied."""
+        return UsageTrackingConfig.from_values(
+            mode=override._mode if override.mode_is_explicit else self._mode,
+            advertised_base_url=(
+                override.advertised_base_url
+                if override.advertised_base_url is not None
+                else self.advertised_base_url
+            ),
+            bind_host=(
+                override.bind_host if override.bind_host is not None else self.bind_host
+            ),
+            port=override.port if override.port is not None else self.port,
+        )
+
+    def validate_parallelism(self, *, concurrency: int, worker_count: int = 1) -> None:
+        if (
+            self.mode != "off"
+            and self.uses_external_proxy
+            and max(concurrency, worker_count) > 1
+        ):
+            raise ValueError(
+                "External usage proxy tracking currently supports only one "
+                "rollout per fixed local proxy port. Use --concurrency 1 and "
+                "one worker, or run separate jobs with separate "
+                f"{USAGE_PROXY_PORT_ENV} values/tunnels."
+            )
+
     @classmethod
     def from_values(
         cls,
@@ -173,6 +201,22 @@ class UsageTrackingConfig:
         if isinstance(value, dict):
             return cls.from_mapping(value)
         raise TypeError(f"invalid usage_tracking config: {type(value).__name__}")
+
+    def to_mapping(self) -> dict[str, Any]:
+        proxy: dict[str, Any] = {}
+        if self.advertised_base_url is not None:
+            proxy["advertised_base_url"] = self.advertised_base_url
+        if self.bind_host is not None:
+            proxy["bind_host"] = self.bind_host
+        if self.port is not None:
+            proxy["port"] = self.port
+
+        payload: dict[str, Any] = {}
+        if self.mode_is_explicit:
+            payload["usage_tracking"] = self.mode
+        if proxy:
+            payload["usage_proxy"] = proxy
+        return payload
 
     def with_env_defaults(self) -> UsageTrackingConfig:
         env_mode = os.environ.get(USAGE_TRACKING_ENV)

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -1,0 +1,219 @@
+"""Configuration contract for provider token-usage telemetry."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Literal, cast
+from urllib.parse import urlsplit
+
+UsageTrackingMode = Literal["auto", "required", "off"]
+
+USAGE_TRACKING_ENV = "BENCHFLOW_USAGE_TRACKING"
+USAGE_PROXY_ADVERTISED_BASE_URL_ENV = "BENCHFLOW_USAGE_PROXY_ADVERTISED_BASE_URL"
+USAGE_PROXY_BIND_HOST_ENV = "BENCHFLOW_USAGE_PROXY_BIND_HOST"
+USAGE_PROXY_PORT_ENV = "BENCHFLOW_USAGE_PROXY_PORT"
+
+DEFAULT_USAGE_PROXY_BIND_HOST = "0.0.0.0"
+
+_MODES: set[str] = {"auto", "required", "off"}
+
+
+def normalize_usage_tracking_mode(value: str) -> UsageTrackingMode:
+    mode = value.strip().lower()
+    if mode not in _MODES:
+        expected = ", ".join(sorted(_MODES))
+        raise ValueError(f"usage_tracking must be one of: {expected}")
+    return cast(UsageTrackingMode, mode)
+
+
+def _optional_mode(value: Any) -> UsageTrackingMode | None:
+    if value is None:
+        return None
+    return normalize_usage_tracking_mode(str(value))
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _first_present(*values: Any) -> Any:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+def _optional_port(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    port = int(value)
+    if port < 0 or port > 65535:
+        raise ValueError("usage proxy port must be between 0 and 65535")
+    return port
+
+
+def normalize_advertised_base_url(value: str | None) -> str | None:
+    url = _optional_str(value)
+    if url is None:
+        return None
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(
+            "usage_proxy.advertised_base_url must be an absolute http(s) URL"
+        )
+    if parsed.query or parsed.fragment:
+        raise ValueError(
+            "usage_proxy.advertised_base_url must not include query or fragment"
+        )
+    if parsed.path not in {"", "/"}:
+        raise ValueError("usage_proxy.advertised_base_url must not include a path")
+    return url.rstrip("/")
+
+
+@dataclass(frozen=True, init=False)
+class UsageTrackingConfig:
+    """User-facing token/cost telemetry policy.
+
+    ``mode`` is the operator contract:
+    - ``auto`` records usage when the sandbox can reach a proxy.
+    - ``required`` fails before the agent runs when telemetry cannot be wired.
+    - ``off`` leaves provider traffic untouched.
+    """
+
+    _mode: UsageTrackingMode | None
+    advertised_base_url: str | None = None
+    bind_host: str | None = None
+    port: int | None = None
+
+    def __init__(
+        self,
+        mode: str | None = None,
+        advertised_base_url: str | None = None,
+        bind_host: str | None = None,
+        port: int | str | None = None,
+    ) -> None:
+        object.__setattr__(self, "_mode", _optional_mode(mode))
+        object.__setattr__(
+            self,
+            "advertised_base_url",
+            normalize_advertised_base_url(advertised_base_url),
+        )
+        object.__setattr__(self, "bind_host", _optional_str(bind_host))
+        object.__setattr__(self, "port", _optional_port(port))
+
+    @property
+    def mode(self) -> UsageTrackingMode:
+        return self._mode or "auto"
+
+    @property
+    def mode_is_explicit(self) -> bool:
+        return self._mode is not None
+
+    @property
+    def uses_external_proxy(self) -> bool:
+        return self.advertised_base_url is not None
+
+    @property
+    def has_fixed_proxy_port(self) -> bool:
+        return self.port is not None and self.port > 0
+
+    @classmethod
+    def from_values(
+        cls,
+        *,
+        mode: str | None = None,
+        advertised_base_url: str | None = None,
+        bind_host: str | None = None,
+        port: int | str | None = None,
+    ) -> UsageTrackingConfig:
+        return cls(
+            mode=mode,
+            advertised_base_url=advertised_base_url,
+            bind_host=bind_host,
+            port=port,
+        )
+
+    @classmethod
+    def from_mapping(cls, raw: dict[str, Any]) -> UsageTrackingConfig:
+        proxy = raw.get("usage_proxy")
+        if proxy is None:
+            proxy = {}
+        elif not isinstance(proxy, dict):
+            raise ValueError("usage_proxy must be a mapping")
+        return cls.from_values(
+            mode=raw.get("usage_tracking"),
+            advertised_base_url=(
+                _first_present(
+                    proxy.get("advertised_base_url"),
+                    raw.get("usage_proxy_advertised_base_url"),
+                    raw.get("usage_proxy_url"),
+                )
+            ),
+            bind_host=_first_present(
+                proxy.get("bind_host"),
+                raw.get("usage_proxy_bind_host"),
+            ),
+            port=_first_present(proxy.get("port"), raw.get("usage_proxy_port")),
+        )
+
+    @classmethod
+    def coerce(
+        cls, value: UsageTrackingConfig | dict[str, Any] | str | None
+    ) -> UsageTrackingConfig:
+        if value is None:
+            return cls()
+        if isinstance(value, UsageTrackingConfig):
+            return value
+        if isinstance(value, str):
+            return cls.from_values(mode=value)
+        if isinstance(value, dict):
+            return cls.from_mapping(value)
+        raise TypeError(f"invalid usage_tracking config: {type(value).__name__}")
+
+    def with_env_defaults(self) -> UsageTrackingConfig:
+        env_mode = os.environ.get(USAGE_TRACKING_ENV)
+        mode = self.mode
+        if env_mode and not self.mode_is_explicit:
+            mode = normalize_usage_tracking_mode(env_mode)
+
+        return UsageTrackingConfig.from_values(
+            mode=mode,
+            advertised_base_url=(
+                self.advertised_base_url
+                or os.environ.get(USAGE_PROXY_ADVERTISED_BASE_URL_ENV)
+            ),
+            bind_host=self.bind_host or os.environ.get(USAGE_PROXY_BIND_HOST_ENV),
+            port=(
+                self.port
+                if self.port is not None
+                else os.environ.get(USAGE_PROXY_PORT_ENV)
+            ),
+        )
+
+    def to_config_artifact(self) -> dict[str, Any]:
+        return {
+            "requested": self.mode,
+            "advertised_base_url_configured": self.uses_external_proxy,
+            "bind_host": self.bind_host,
+            "port": self.port,
+        }
+
+    def to_result_metadata(
+        self,
+        *,
+        environment: str,
+        status: str,
+        usage_source: str,
+    ) -> dict[str, Any]:
+        return {
+            "requested": self.mode,
+            "status": status,
+            "environment": environment,
+            "endpoint_kind": "external" if self.uses_external_proxy else "host",
+            "usage_source": usage_source,
+            "advertised_base_url_configured": self.uses_external_proxy,
+        }

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -123,7 +123,7 @@ class UsageTrackingConfig:
 
     def overlay(self, override: UsageTrackingConfig) -> UsageTrackingConfig:
         """Return this config with explicitly supplied override fields applied."""
-        return UsageTrackingConfig.from_values(
+        return UsageTrackingConfig(
             mode=override._mode if override.mode_is_explicit else self._mode,
             advertised_base_url=(
                 override.advertised_base_url
@@ -150,29 +150,13 @@ class UsageTrackingConfig:
             )
 
     @classmethod
-    def from_values(
-        cls,
-        *,
-        mode: str | None = None,
-        advertised_base_url: str | None = None,
-        bind_host: str | None = None,
-        port: int | str | None = None,
-    ) -> UsageTrackingConfig:
-        return cls(
-            mode=mode,
-            advertised_base_url=advertised_base_url,
-            bind_host=bind_host,
-            port=port,
-        )
-
-    @classmethod
     def from_mapping(cls, raw: dict[str, Any]) -> UsageTrackingConfig:
         proxy = raw.get("usage_proxy")
         if proxy is None:
             proxy = {}
         elif not isinstance(proxy, dict):
             raise ValueError("usage_proxy must be a mapping")
-        return cls.from_values(
+        return cls(
             mode=raw.get("usage_tracking"),
             advertised_base_url=(
                 _first_present(
@@ -197,7 +181,7 @@ class UsageTrackingConfig:
         if isinstance(value, UsageTrackingConfig):
             return value
         if isinstance(value, str):
-            return cls.from_values(mode=value)
+            return cls(mode=value)
         if isinstance(value, dict):
             return cls.from_mapping(value)
         raise TypeError(f"invalid usage_tracking config: {type(value).__name__}")
@@ -224,7 +208,7 @@ class UsageTrackingConfig:
         if env_mode and not self.mode_is_explicit:
             mode = normalize_usage_tracking_mode(env_mode)
 
-        return UsageTrackingConfig.from_values(
+        return UsageTrackingConfig(
             mode=mode,
             advertised_base_url=(
                 self.advertised_base_url

--- a/tests/test_atif_trajectory.py
+++ b/tests/test_atif_trajectory.py
@@ -721,8 +721,7 @@ class TestTrajectoryProxy:
 
             runtime = ProviderRuntime(
                 kind="usage-proxy",
-                host="127.0.0.1",
-                port=proxy.port,
+                agent_base_url=proxy.base_url,
                 backend_model="gemini-2.5-flash",
                 server=proxy,
             )

--- a/tests/test_config_redaction.py
+++ b/tests/test_config_redaction.py
@@ -116,3 +116,35 @@ def test_write_config_drops_secret_env_vars(tmp_path: Path) -> None:
     # Non-secret entries are preserved unchanged.
     assert recorded["NORMAL_VAR"] == "keep-me"
     assert recorded["PATH"] == "/usr/bin:/bin"
+
+
+def test_write_config_drops_usage_proxy_secret_base_urls(tmp_path: Path) -> None:
+    """Guards PR #568: external usage proxy path prefixes are bearer secrets."""
+    secret_base = "https://usage.example.test/__benchflow/secret-prefix"
+    agent_env = {
+        "BENCHFLOW_PROVIDER_BASE_URL": secret_base,
+        "OPENAI_BASE_URL": secret_base,
+        "NORMAL_VAR": "keep-me",
+    }
+
+    _write_config(
+        tmp_path,
+        task_path=tmp_path / "task",
+        agent="codex-acp",
+        model="gpt-4.1-mini",
+        environment="daytona",
+        skills_dir=None,
+        sandbox_user=None,
+        context_root=None,
+        timeout=300,
+        started_at=datetime(2026, 1, 1),
+        agent_env=agent_env,
+    )
+
+    raw = (tmp_path / "config.json").read_text()
+    recorded = json.loads(raw)["agent_env"]
+
+    assert "BENCHFLOW_PROVIDER_BASE_URL" not in recorded
+    assert "OPENAI_BASE_URL" not in recorded
+    assert "__benchflow/secret-prefix" not in raw
+    assert recorded["NORMAL_VAR"] == "keep-me"

--- a/tests/test_provider_runtime.py
+++ b/tests/test_provider_runtime.py
@@ -92,8 +92,7 @@ class TestBedrockProxyRuntime:
         )
 
         assert runtime is not None
-        assert runtime.host == "host.docker.internal"
-        assert runtime.port == 32123
+        assert runtime.base_url == "http://host.docker.internal:32123"
         assert runtime.backend_model == "openai.gpt-oss-20b-1:0"
         assert (
             updated["BENCHFLOW_PROVIDER_BASE_URL"]
@@ -200,7 +199,8 @@ class TestBedrockProxyRuntime:
     @pytest.mark.asyncio
     async def test_reuses_existing_runtime(self):
         runtime = ProviderRuntime(
-            kind="aws-bedrock", host="host.docker.internal", port=8099
+            kind="aws-bedrock",
+            agent_base_url="http://host.docker.internal:8099",
         )
         updated, returned = await ensure_bedrock_proxy_runtime(
             agent="codex-acp",
@@ -217,8 +217,7 @@ class TestBedrockProxyRuntime:
         server = AsyncMock()
         runtime = ProviderRuntime(
             kind="aws-bedrock",
-            host="host.docker.internal",
-            port=8099,
+            agent_base_url="http://host.docker.internal:8099",
             server=server,
         )
         await stop_provider_runtime(runtime)
@@ -279,8 +278,7 @@ class TestBedrockProxyRemoteSandbox:
         server = AsyncMock()
         runtime = ProviderRuntime(
             kind="aws-bedrock",
-            host="host.docker.internal",
-            port=8099,
+            agent_base_url="http://host.docker.internal:8099",
             server=server,
         )
         with pytest.raises(RuntimeError, match="not supported on the"):

--- a/tests/test_trajectory_proxy_path_prefix.py
+++ b/tests/test_trajectory_proxy_path_prefix.py
@@ -1,0 +1,116 @@
+"""Regression tests for external usage-proxy path-prefix routing."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from benchflow.trajectories.proxy import TrajectoryProxy
+
+
+async def _read_request(
+    reader: asyncio.StreamReader,
+) -> tuple[str, str, bytes]:
+    request_line = (await reader.readline()).decode()
+    method, path, _version = request_line.strip().split(" ", 2)
+    headers: dict[str, str] = {}
+    while True:
+        line = await reader.readline()
+        if line in (b"\r\n", b"\n", b""):
+            break
+        key, _, value = line.decode().partition(":")
+        headers[key.lower().strip()] = value.strip()
+    content_length = int(headers.get("content-length", "0"))
+    body = await reader.readexactly(content_length) if content_length else b""
+    return method, path, body
+
+
+@pytest.mark.asyncio
+async def test_path_prefix_gates_health_and_provider_requests():
+    """Guards PR #568: external tunnel traffic must match the secret path prefix."""
+    upstream_requests: list[tuple[str, str, bytes]] = []
+
+    async def upstream_handler(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        method, path, body = await _read_request(reader)
+        upstream_requests.append((method, path, body))
+        response_body = json.dumps(
+            {
+                "id": "msg_1",
+                "model": "gpt-4.1-mini",
+                "usage": {
+                    "input_tokens": 3,
+                    "output_tokens": 5,
+                    "total_tokens": 8,
+                },
+            },
+            separators=(",", ":"),
+        ).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"content-type: application/json\r\n"
+            + f"content-length: {len(response_body)}\r\n\r\n".encode()
+            + response_body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(upstream_handler, "127.0.0.1", 0)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+    proxy = TrajectoryProxy(
+        target=f"http://127.0.0.1:{upstream_port}",
+        session_id="path-prefix",
+        agent_name="openhands",
+        path_prefix="/__benchflow/abc123",
+    )
+    await proxy.start()
+
+    try:
+        async with httpx.AsyncClient() as client:
+            unprefixed_health = await client.get(f"{proxy.base_url}/__benchflow_health")
+            assert unprefixed_health.status_code == 404
+            assert upstream_requests == []
+
+            prefixed_head = await client.head(
+                f"{proxy.base_url}/__benchflow/abc123/__benchflow_health"
+            )
+            assert prefixed_head.status_code == 200
+            assert prefixed_head.content == b""
+            assert upstream_requests == []
+
+            prefixed_health = await client.get(
+                f"{proxy.base_url}/__benchflow/abc123/__benchflow_health"
+            )
+            assert prefixed_health.status_code == 200
+            assert prefixed_health.json() == {"status": "ok"}
+            assert upstream_requests == []
+
+            unprefixed_provider = await client.post(
+                f"{proxy.base_url}/v1/messages",
+                json={"model": "gpt-4.1-mini"},
+            )
+            assert unprefixed_provider.status_code == 404
+            assert upstream_requests == []
+
+            prefixed_provider = await client.post(
+                f"{proxy.base_url}/__benchflow/abc123/v1/messages?trace=1",
+                json={"model": "gpt-4.1-mini"},
+            )
+            assert prefixed_provider.status_code == 200
+
+        assert len(upstream_requests) == 1
+        method, path, body = upstream_requests[0]
+        assert method == "POST"
+        assert path == "/v1/messages?trace=1"
+        assert json.loads(body) == {"model": "gpt-4.1-mini"}
+        assert proxy.trajectory.exchanges[0].request.path == "/v1/messages?trace=1"
+    finally:
+        await proxy.stop()
+        upstream.close()
+        await upstream.wait_closed()

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -176,8 +176,7 @@ def test_extract_usage_with_anthropic_exchanges():
 
     runtime = ProviderRuntime(
         kind="usage-proxy",
-        host="host.docker.internal",
-        port=12345,
+        agent_base_url="http://host.docker.internal:12345",
         backend_model="claude-haiku-4-5-20251001",
         server=_ProxyLike(
             _trajectory(
@@ -220,8 +219,7 @@ def test_extract_usage_with_openai_exchanges():
 
     runtime = ProviderRuntime(
         kind="usage-proxy",
-        host="host.docker.internal",
-        port=12345,
+        agent_base_url="http://host.docker.internal:12345",
         backend_model="gpt-4.1-mini",
         server=_ProxyLike(
             _trajectory(
@@ -265,8 +263,7 @@ def test_extract_usage_with_gemini_exchanges():
 
     runtime = ProviderRuntime(
         kind="usage-proxy",
-        host="host.docker.internal",
-        port=12345,
+        agent_base_url="http://host.docker.internal:12345",
         backend_model="gemini-2.5-flash",
         server=_ProxyLike(
             _trajectory(
@@ -343,7 +340,7 @@ async def test_start_proxy_rewrites_env(monkeypatch):
     assert runtime is not None
     assert runtime.server.target == "https://api.anthropic.com"
     assert runtime.server.started is True
-    assert runtime.host == "host.docker.internal"
+    assert runtime.base_url == "http://host.docker.internal:32124"
     assert updated["BENCHFLOW_PROVIDER_BASE_URL"] == "http://host.docker.internal:32124"
     assert updated["ANTHROPIC_BASE_URL"] == "http://host.docker.internal:32124"
 
@@ -599,7 +596,9 @@ async def test_daytona_runtime_retired_when_environment_unreachable(monkeypatch)
             stopped.append(True)
 
     stale = ProviderRuntime(
-        kind="usage-proxy", host="127.0.0.1", port=999, server=_StaleServer()
+        kind="usage-proxy",
+        agent_base_url="http://127.0.0.1:999",
+        server=_StaleServer(),
     )
 
     monkeypatch.setattr(
@@ -691,8 +690,7 @@ def test_total_tokens_is_sum_of_parts():
 
     runtime = ProviderRuntime(
         kind="usage-proxy",
-        host="host.docker.internal",
-        port=12345,
+        agent_base_url="http://host.docker.internal:12345",
         backend_model="unknown-model",
         server=_ProxyLike(
             _trajectory(
@@ -810,8 +808,7 @@ async def test_rollout_cleanup_extracts_usage_and_writes_llm_trajectory(tmp_path
     rollout._environment = None
     rollout._usage_runtime = ProviderRuntime(
         kind="usage-proxy",
-        host="host.docker.internal",
-        port=32124,
+        agent_base_url="http://host.docker.internal:32124",
         backend_model="claude-haiku-4-5-20251001",
         server=server,
     )
@@ -860,8 +857,7 @@ def test_extract_usage_prefers_captured_model_over_backend_model():
     # backend_model is stale (haiku) but the exchange reports gpt-4.1-mini.
     runtime = ProviderRuntime(
         kind="usage-proxy",
-        host="host.docker.internal",
-        port=12345,
+        agent_base_url="http://host.docker.internal:12345",
         backend_model="claude-haiku-4-5-20251001",
         server=_ProxyLike(
             _trajectory(

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -1,0 +1,255 @@
+"""Tests for remote token usage tracking policy and config wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow.trajectories.types import Trajectory
+
+
+@pytest.mark.asyncio
+async def test_daytona_required_usage_tracking_requires_external_endpoint():
+    """Guards PR #568: required remote tracking must fail closed."""
+    from benchflow.providers.runtime import ensure_usage_proxy_runtime
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    with pytest.raises(RuntimeError, match="Token usage tracking is required"):
+        await ensure_usage_proxy_runtime(
+            agent="claude-agent-acp",
+            agent_env={
+                "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                "ANTHROPIC_API_KEY": "sk-real-key",
+            },
+            model="claude-haiku-4-5-20251001",
+            runtime=None,
+            environment="daytona",
+            session_id="rollout-1",
+            usage_tracking=UsageTrackingConfig(mode="required"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_daytona_external_usage_proxy_advertises_tunnel_url(monkeypatch):
+    """Guards PR #568: remote tracking must not inject local-only addresses."""
+    from benchflow.providers import runtime as provider_runtime_mod
+    from benchflow.providers.runtime import ensure_usage_proxy_runtime
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    class FakeTrajectoryProxy:
+        def __init__(
+            self,
+            target,
+            session_id="",
+            agent_name="",
+            host="127.0.0.1",
+            port=0,
+            prompt_cache_retention=None,
+            path_prefix="",
+        ):
+            self.target = target
+            self.session_id = session_id
+            self.agent_name = agent_name
+            self.host = host
+            self.port = port
+            self.prompt_cache_retention = prompt_cache_retention
+            self.path_prefix = path_prefix
+            self.trajectory = Trajectory(session_id=session_id, agent_name=agent_name)
+            self.started = False
+
+        async def start(self):
+            self.started = True
+
+        async def stop(self):
+            return None
+
+    async def reachable(_url):
+        return True
+
+    monkeypatch.setattr(provider_runtime_mod, "TrajectoryProxy", FakeTrajectoryProxy)
+    monkeypatch.setattr(
+        provider_runtime_mod, "_external_usage_proxy_reachable", reachable
+    )
+
+    updated, runtime = await ensure_usage_proxy_runtime(
+        agent="openhands",
+        agent_env={
+            "LLM_BASE_URL": "https://llm-proxy.example.test",
+            "LLM_API_KEY": "sk-real-key",
+        },
+        model="gpt-4.1-mini",
+        runtime=None,
+        environment="daytona",
+        session_id="rollout-1",
+        usage_tracking=UsageTrackingConfig(
+            mode="required",
+            advertised_base_url="https://usage-proxy.example.test",
+            port=18081,
+        ),
+    )
+
+    assert runtime is not None
+    assert runtime.server.started is True
+    assert runtime.server.host == "127.0.0.1"
+    assert runtime.server.port == 18081
+    assert runtime.server.path_prefix.startswith("/__benchflow/")
+    assert runtime.base_url.startswith("https://usage-proxy.example.test/__benchflow/")
+    assert updated["LLM_BASE_URL"] == runtime.base_url
+    assert updated["BENCHFLOW_PROVIDER_BASE_URL"] == runtime.base_url
+
+
+def test_evaluation_yaml_loads_required_usage_tracking(tmp_path):
+    """Guards PR #568: eval YAML should preserve required usage tracking."""
+    from benchflow.evaluation import Evaluation
+
+    tasks_dir = tmp_path / "tasks"
+    tasks_dir.mkdir()
+    config = tmp_path / "eval.yaml"
+    config.write_text(
+        "\n".join(
+            [
+                f"tasks_dir: {tasks_dir}",
+                "agent: openhands",
+                "model: gpt-4.1-mini",
+                "environment: daytona",
+                "usage_tracking: required",
+                "usage_proxy:",
+                "  advertised_base_url: https://usage-proxy.example.test",
+                "  port: 18081",
+            ]
+        )
+    )
+
+    evaluation = Evaluation.from_yaml(config)
+
+    assert evaluation._config.usage_tracking.mode == "required"
+    assert (
+        evaluation._config.usage_tracking.advertised_base_url
+        == "https://usage-proxy.example.test"
+    )
+    assert evaluation._config.usage_tracking.port == 18081
+
+
+def test_evaluation_preflight_fails_required_daytona_without_endpoint(tmp_path):
+    """Guards PR #568: required Daytona tracking fails before agent launch."""
+    from benchflow.evaluation import Evaluation, EvaluationConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    evaluation = Evaluation(
+        tasks_dir=tmp_path,
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(
+            environment="daytona",
+            usage_tracking=UsageTrackingConfig(mode="required"),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="no external usage proxy endpoint"):
+        evaluation._preflight_usage_tracking()
+
+
+def test_evaluation_preflight_rejects_external_proxy_port_zero(tmp_path):
+    """Guards PR #568: external proxy tracking needs a stable local port."""
+    from benchflow.evaluation import Evaluation, EvaluationConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    evaluation = Evaluation(
+        tasks_dir=tmp_path,
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(
+            environment="daytona",
+            usage_tracking=UsageTrackingConfig(
+                mode="required",
+                advertised_base_url="https://usage-proxy.example.test",
+                port=0,
+            ),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="fixed positive local proxy port"):
+        evaluation._preflight_usage_tracking()
+
+
+def test_explicit_auto_usage_tracking_beats_env_default(monkeypatch):
+    """Guards PR #568: explicit auto should override env-level required."""
+    from benchflow.usage_tracking import USAGE_TRACKING_ENV, UsageTrackingConfig
+
+    monkeypatch.setenv(USAGE_TRACKING_ENV, "required")
+
+    assert UsageTrackingConfig().with_env_defaults().mode == "required"
+    assert UsageTrackingConfig(mode="auto").with_env_defaults().mode == "auto"
+
+
+def test_usage_proxy_advertised_base_url_rejects_path():
+    """Guards PR #568: advertised proxy URLs must be root base URLs."""
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    with pytest.raises(ValueError, match="must not include a path"):
+        UsageTrackingConfig(
+            advertised_base_url="https://usage-proxy.example.test/benchflow"
+        )
+
+
+def test_usage_tracking_mapping_preserves_zero_port():
+    """Guards PR #568: config sharding must preserve explicit port=0."""
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    config = UsageTrackingConfig.from_mapping(
+        {
+            "usage_tracking": "required",
+            "usage_proxy": {
+                "advertised_base_url": "https://usage-proxy.example.test",
+                "port": 0,
+            },
+        }
+    )
+
+    assert config.port == 0
+    assert config.has_fixed_proxy_port is False
+
+
+@pytest.mark.asyncio
+async def test_completed_eval_resume_skips_usage_preflight(tmp_path, monkeypatch):
+    """Guards PR #568: completed resumes should not require a live usage proxy."""
+    from benchflow.evaluation import Evaluation, EvaluationConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    task_dir = tmp_path / "tasks" / "done-task"
+    task_dir.mkdir(parents=True)
+    evaluation = Evaluation(
+        tasks_dir=tmp_path / "tasks",
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(
+            environment="daytona",
+            usage_tracking=UsageTrackingConfig(mode="required"),
+        ),
+    )
+
+    def fail_preflight():
+        raise AssertionError("usage preflight should not run for completed jobs")
+
+    async def no_fresh_runs(remaining):
+        assert remaining == []
+        return []
+
+    monkeypatch.setattr(evaluation, "_preflight_usage_tracking", fail_preflight)
+    monkeypatch.setattr(evaluation, "_prune_docker", lambda: None)
+    monkeypatch.setattr(evaluation, "_get_task_dirs", lambda: [task_dir])
+    monkeypatch.setattr(
+        evaluation,
+        "_get_completed_tasks",
+        lambda: {
+            "done-task": {
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "n_tool_calls": 0,
+                "agent_result": {"usage_source": "unavailable"},
+            }
+        },
+    )
+    monkeypatch.setattr(evaluation, "_run_parallel_independent", no_fresh_runs)
+
+    result = await evaluation.run()
+
+    assert result.total == 1
+    assert result.passed == 1

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -156,6 +156,7 @@ def test_evaluation_preflight_rejects_external_proxy_port_zero(tmp_path):
         tasks_dir=tmp_path,
         jobs_dir=tmp_path / "jobs",
         config=EvaluationConfig(
+            concurrency=1,
             environment="daytona",
             usage_tracking=UsageTrackingConfig(
                 mode="required",
@@ -169,6 +170,29 @@ def test_evaluation_preflight_rejects_external_proxy_port_zero(tmp_path):
         evaluation._preflight_usage_tracking()
 
 
+def test_evaluation_preflight_rejects_external_proxy_concurrency(tmp_path):
+    """Guards PR #568: one fixed external proxy port cannot host concurrency."""
+    from benchflow.evaluation import Evaluation, EvaluationConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    evaluation = Evaluation(
+        tasks_dir=tmp_path,
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(
+            concurrency=2,
+            environment="daytona",
+            usage_tracking=UsageTrackingConfig(
+                mode="required",
+                advertised_base_url="https://usage-proxy.example.test",
+                port=18081,
+            ),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="supports only one rollout"):
+        evaluation._preflight_usage_tracking()
+
+
 def test_explicit_auto_usage_tracking_beats_env_default(monkeypatch):
     """Guards PR #568: explicit auto should override env-level required."""
     from benchflow.usage_tracking import USAGE_TRACKING_ENV, UsageTrackingConfig
@@ -177,6 +201,64 @@ def test_explicit_auto_usage_tracking_beats_env_default(monkeypatch):
 
     assert UsageTrackingConfig().with_env_defaults().mode == "required"
     assert UsageTrackingConfig(mode="auto").with_env_defaults().mode == "auto"
+
+
+def test_usage_tracking_shard_payload_preserves_implicit_env_mode(monkeypatch):
+    """Guards PR #568: sharded workers must still inherit env-level required."""
+    from benchflow.eval_sharding import EvalShard, _config_payload
+    from benchflow.eval_worker import _evaluation_config
+    from benchflow.evaluation import EvaluationConfig
+    from benchflow.usage_tracking import USAGE_TRACKING_ENV, UsageTrackingConfig
+
+    monkeypatch.setenv(USAGE_TRACKING_ENV, "required")
+    parent_config = EvaluationConfig(
+        environment="daytona",
+        usage_tracking=UsageTrackingConfig(),
+    )
+
+    payload = _config_payload(
+        parent_config,
+        shard=EvalShard(index=0, task_names=("task-a",), concurrency=1),
+        environment_manifest_path=None,
+    )
+    worker_config = _evaluation_config(payload)
+
+    assert "usage_tracking" not in payload["usage_tracking"]
+    assert worker_config.usage_tracking.mode_is_explicit is False
+    assert worker_config.usage_tracking.with_env_defaults().mode == "required"
+
+
+def test_usage_tracking_overlay_preserves_yaml_fields_for_partial_cli_override():
+    """Guards PR #568: partial CLI usage overrides must not erase YAML policy."""
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    yaml_config = UsageTrackingConfig(
+        mode="required",
+        advertised_base_url="https://old-proxy.example.test",
+        port=18081,
+    )
+    cli_override = UsageTrackingConfig(
+        advertised_base_url="https://new-proxy.example.test",
+    )
+
+    merged = yaml_config.overlay(cli_override)
+
+    assert merged.mode == "required"
+    assert merged.advertised_base_url == "https://new-proxy.example.test"
+    assert merged.port == 18081
+
+
+def test_external_usage_tracking_rejects_multiple_shard_workers():
+    """Guards PR #568: sharded workers cannot share one fixed proxy port."""
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    config = UsageTrackingConfig(
+        advertised_base_url="https://usage-proxy.example.test",
+        port=18081,
+    )
+
+    with pytest.raises(ValueError, match="supports only one rollout"):
+        config.validate_parallelism(concurrency=1, worker_count=2)
 
 
 def test_usage_proxy_advertised_base_url_rejects_path():

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -223,9 +223,45 @@ def test_usage_tracking_shard_payload_preserves_implicit_env_mode(monkeypatch):
     )
     worker_config = _evaluation_config(payload)
 
-    assert "usage_tracking" not in payload["usage_tracking"]
+    assert "usage_tracking" not in payload
     assert worker_config.usage_tracking.mode_is_explicit is False
     assert worker_config.usage_tracking.with_env_defaults().mode == "required"
+
+
+def test_usage_tracking_shard_payload_uses_flat_yaml_shape():
+    """Guards PR #568: worker payload must not nest usage_tracking twice."""
+    from benchflow.eval_sharding import EvalShard, _config_payload
+    from benchflow.eval_worker import _evaluation_config
+    from benchflow.evaluation import EvaluationConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    parent_config = EvaluationConfig(
+        environment="daytona",
+        usage_tracking=UsageTrackingConfig(
+            mode="required",
+            advertised_base_url="https://usage-proxy.example.test",
+            port=18081,
+        ),
+    )
+
+    payload = _config_payload(
+        parent_config,
+        shard=EvalShard(index=0, task_names=("task-a",), concurrency=1),
+        environment_manifest_path=None,
+    )
+    worker_config = _evaluation_config(payload)
+
+    assert payload["usage_tracking"] == "required"
+    assert payload["usage_proxy"] == {
+        "advertised_base_url": "https://usage-proxy.example.test",
+        "port": 18081,
+    }
+    assert worker_config.usage_tracking.mode == "required"
+    assert (
+        worker_config.usage_tracking.advertised_base_url
+        == "https://usage-proxy.example.test"
+    )
+    assert worker_config.usage_tracking.port == 18081
 
 
 def test_usage_tracking_overlay_preserves_yaml_fields_for_partial_cli_override():


### PR DESCRIPTION
## Motivation

Daytona runs currently cannot reliably report token usage because the OpenHands agent runs inside a remote sandbox and cannot reach BenchFlow's host-bound local usage proxy. That makes `agent_result.usage_source` fall back to `unavailable`, which blocks accurate SkillsBench result accounting for remote batch runs.

This PR adds an explicit, fail-closed path for official remote runs: operators can expose the local BenchFlow usage proxy through a tunnel or ingress URL and require usage tracking for the run. The default behavior stays compatible with existing runs.

## Changes

- Add a typed usage-tracking configuration layer:
  - `BENCHFLOW_USAGE_TRACKING=auto|required|off`
  - `BENCHFLOW_USAGE_PROXY_ADVERTISED_BASE_URL`
  - `BENCHFLOW_USAGE_PROXY_BIND_HOST`
  - `BENCHFLOW_USAGE_PROXY_PORT`
- Add CLI flags for `bench eval create`:
  - `--usage-tracking auto|required|off`
  - `--usage-proxy-url`
  - `--usage-proxy-bind-host`
  - `--usage-proxy-port`
- Thread the configuration through evaluation, sharding, workers, SDK rollout config, and runtime config.
- Teach provider runtimes to distinguish:
  - the local bind URL used by BenchFlow on the host
  - the advertised URL used by the remote sandbox agent
- Add external usage-proxy health checks before remote runs proceed.
- Add a secret per-run path prefix for externally advertised usage proxy URLs so remote access is scoped to the current run.
- Preserve the old `auto` behavior for Daytona/Modal when no external usage proxy is configured: usage telemetry is skipped instead of failing.
- Make `required` mode fail early if Daytona/Modal cannot access the usage proxy or if the proxy is disabled.
- Refuse remote direct Bedrock metering through the generic proxy because OpenHands direct Bedrock calls AWS natively rather than the OpenAI/Anthropic-compatible endpoint.
- Record sanitized usage-tracking metadata in result artifacts and summary artifacts.
- Document the Daytona tunnel/ingress workflow.

## Compatibility

Existing local runs and default remote runs continue to use `--usage-tracking auto`. That means users who do not opt in to the new required mode should not see behavior changes.

For official Daytona batch runs that must include token/cost telemetry, use:

```bash
bench eval create \
  --sandbox daytona \
  --usage-tracking required \
  --usage-proxy-url https://your-tunnel-or-ingress.example.com \
  --usage-proxy-port 18081 \
  ...
```

## Verification

- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/`
  - `2466 passed, 11 skipped, 1 deselected`
- Real Daytona SkillsBench e2e:
  - agent: `openhands`
  - model: `gpt-4.1-mini`
  - sandbox: `daytona`
  - task: `skillsbench/tasks/powerlifting-coef-calc`
  - usage mode: `--usage-tracking required`
  - result: run completed with no infrastructure or verifier error
  - captured usage:
    - `usage_source=provider_response`
    - `n_input_tokens=557655`
    - `n_output_tokens=37569`
    - `n_cache_read_tokens=507648`
    - `total_tokens=595224`
    - `cost_usd=0.130878`

The task reward was `0.0`, which was a model/task outcome; the Daytona run itself completed and produced the required token/cost telemetry.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->