### PR TITLE
Allow external usage proxy concurrency

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -55,7 +55,7 @@ bench eval create \
   --usage-tracking required \
   --usage-proxy-url https://your-tunnel.example.com \
   --usage-proxy-port 18081 \
-  --concurrency 1 \
+  --concurrency 64 \
   --sandbox-setup-timeout 300
 
 # From local directory
@@ -122,11 +122,10 @@ When mounting skills, the recommended docs default is
 
 For official Daytona batch runs that must report provider token/cost telemetry,
 use `--usage-tracking required` with a tunnel or ingress URL pointing at the
-fixed `--usage-proxy-port`. The fixed-port tunnel mode supports one rollout per
-BenchFlow process; use `--concurrency 1`, or run multiple jobs with separate
-ports/tunnels. This limit applies only to metered external-tunnel mode; Daytona
-batch runs that do not require usage telemetry can still use higher concurrency.
-Without an external URL, Daytona runs continue in `auto` mode and record
+fixed `--usage-proxy-port`. A single BenchFlow process can multiplex concurrent
+rollouts over that fixed port using per-rollout path prefixes. Sharded worker
+processes still need separate ports/tunnels because each process owns its own
+listener. Without an external URL, Daytona runs continue in `auto` mode and record
 `usage_source=unavailable` because the remote sandbox cannot reach a host-bound
 proxy.
 

--- a/docs/v05-e2e-testing-guide.md
+++ b/docs/v05-e2e-testing-guide.md
@@ -32,10 +32,9 @@ All commands below assume you are in the repo root.
 > `--usage-proxy-url` and `--usage-proxy-port`. Official batch runs that need
 > token/cost telemetry should use `--usage-tracking required` so the run fails
 > before the agent starts if the external endpoint is missing or unhealthy. The
-> fixed-port tunnel mode supports one rollout per BenchFlow process; use
-> `--concurrency 1`, or run multiple jobs with separate ports/tunnels. This
-> constraint is specific to metered external-tunnel mode; Daytona batches that do
-> not require usage telemetry can still run with higher concurrency. Local
+> fixed-port tunnel mode supports concurrent rollouts in one BenchFlow process
+> by assigning each rollout a secret path prefix. Sharded worker processes still
+> need separate ports/tunnels because each process owns its own listener. Local
 > sandboxes (e.g. `--sandbox docker`) populate usage telemetry without a tunnel.
 
 ---

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import secrets
@@ -46,6 +47,79 @@ class ProviderRuntime:
     @property
     def base_url(self) -> str:
         return self.agent_base_url
+
+
+@dataclass
+class _ExternalUsageProxyRoute:
+    """Per-rollout route registered on a shared external usage proxy listener."""
+
+    proxy: TrajectoryProxy
+    path_prefix: str
+    target: str
+    trajectory: Any
+    pool_key: tuple[str, int]
+    stopped: bool = False
+
+    @property
+    def port(self) -> int:
+        return self.proxy.port
+
+    async def stop(self) -> None:
+        lock = _external_usage_proxy_lock(self.pool_key)
+        async with lock:
+            if self.stopped:
+                return
+            self.proxy.unregister_route(self.path_prefix)
+            self.stopped = True
+            if not self.proxy.has_routes:
+                await self.proxy.stop()
+                _EXTERNAL_USAGE_PROXIES.pop(self.pool_key, None)
+
+
+_EXTERNAL_USAGE_PROXIES: dict[tuple[str, int], TrajectoryProxy] = {}
+_EXTERNAL_USAGE_PROXY_LOCKS: dict[tuple[str, int], asyncio.Lock] = {}
+
+
+def _external_usage_proxy_lock(pool_key: tuple[str, int]) -> asyncio.Lock:
+    lock = _EXTERNAL_USAGE_PROXY_LOCKS.get(pool_key)
+    if lock is None:
+        lock = asyncio.Lock()
+        _EXTERNAL_USAGE_PROXY_LOCKS[pool_key] = lock
+    return lock
+
+
+async def _register_external_usage_proxy_route(
+    *,
+    target: str,
+    session_id: str,
+    agent: str,
+    bind_host: str,
+    bind_port: int,
+    prompt_cache_retention: str | None,
+    path_prefix: str,
+) -> _ExternalUsageProxyRoute:
+    pool_key = (bind_host, bind_port)
+    lock = _external_usage_proxy_lock(pool_key)
+    async with lock:
+        proxy = _EXTERNAL_USAGE_PROXIES.get(pool_key)
+        if proxy is None:
+            proxy = TrajectoryProxy(target=None, host=bind_host, port=bind_port)
+            await proxy.start()
+            _EXTERNAL_USAGE_PROXIES[pool_key] = proxy
+        trajectory = proxy.register_route(
+            target=target,
+            session_id=session_id,
+            agent_name=agent,
+            prompt_cache_retention=prompt_cache_retention,
+            path_prefix=path_prefix,
+        )
+    return _ExternalUsageProxyRoute(
+        proxy=proxy,
+        path_prefix=path_prefix,
+        target=target,
+        trajectory=trajectory,
+        pool_key=pool_key,
+    )
 
 
 def needs_provider_runtime(model: str | None) -> bool:
@@ -591,18 +665,26 @@ async def ensure_usage_proxy_runtime(
         path_prefix = (
             _usage_proxy_path_prefix() if usage_cfg.uses_external_proxy else ""
         )
-        proxy_kwargs: dict[str, Any] = {
-            "target": target,
-            "session_id": session_id,
-            "agent_name": agent,
-            "host": bind_host,
-            "port": bind_port,
-            "prompt_cache_retention": prompt_cache_retention,
-        }
-        if path_prefix:
-            proxy_kwargs["path_prefix"] = path_prefix
-        server = TrajectoryProxy(**proxy_kwargs)
-        await server.start()
+        if usage_cfg.uses_external_proxy:
+            server = await _register_external_usage_proxy_route(
+                target=target,
+                session_id=session_id,
+                agent=agent,
+                bind_host=bind_host,
+                bind_port=bind_port,
+                prompt_cache_retention=prompt_cache_retention,
+                path_prefix=path_prefix,
+            )
+        else:
+            server = TrajectoryProxy(
+                target=target,
+                session_id=session_id,
+                agent_name=agent,
+                host=bind_host,
+                port=bind_port,
+                prompt_cache_retention=prompt_cache_retention,
+            )
+            await server.start()
         agent_base_url = _agent_usage_proxy_base_url(
             environment=environment,
             port=server.port,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -457,6 +457,7 @@ def _build_rollout_result(
     trajectory: list[dict],
     partial_trajectory: bool,
     export_error: str | None = None,
+    cleanup_error: str | None = None,
     trajectory_source: TrajectorySource | None = None,
     rewards: dict | None,
     started_at: datetime,
@@ -563,6 +564,7 @@ def _build_rollout_result(
                 "verifier_error": result.verifier_error,
                 "verifier_error_category": result.verifier_error_category,
                 "export_error": result.export_error,
+                "cleanup_error": cleanup_error,
                 **diagnostics.to_result_fields(),
                 "partial_trajectory": result.partial_trajectory,
                 "trajectory_source": result.trajectory_source,
@@ -1099,6 +1101,7 @@ class Rollout:
         # an export-time infra failure ("connection lost") as the agent's own
         # infra_failure category in dashboards.
         self._export_error: str | None = None
+        self._cleanup_error: str | None = None
         # Single bag for the four parallel diagnostic fields the old code
         # carried as separate attrs (issue #503). Each callsite that used
         # to assign to one of those slots now calls ``self._diagnostics.set(...)``
@@ -1899,6 +1902,7 @@ class Rollout:
                 try:
                     await self._env.stop(delete=True)
                 except Exception as e:
+                    self._cleanup_error = str(e)
                     logger.warning(f"Cleanup failed: {e}")
 
         if hasattr(self, "_task_tmp") and self._task_tmp:
@@ -2478,6 +2482,7 @@ class Rollout:
             error=self._error,
             verifier_error=self._verifier_error,
             export_error=self._export_error,
+            cleanup_error=self._cleanup_error,
             trajectory=self._trajectory,
             partial_trajectory=self._partial_trajectory,
             trajectory_source=self._trajectory_source,

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -11,6 +11,7 @@ import json
 import logging
 import time
 import zlib
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
@@ -26,6 +27,13 @@ _RAW_REQ_TRUNCATE = 10000  # max chars for non-JSON request body capture
 _PROMPT_CACHE_RETENTION_VALUES = {"in_memory", "24h"}
 
 
+@dataclass
+class _ProxyRoute:
+    target: str
+    trajectory: Trajectory
+    prompt_cache_retention: str | None = None
+
+
 class TrajectoryProxy:
     """HTTP proxy that forwards LLM API requests and captures exchanges.
 
@@ -36,7 +44,7 @@ class TrajectoryProxy:
 
     def __init__(
         self,
-        target: str = "https://api.anthropic.com",
+        target: str | None = "https://api.anthropic.com",
         session_id: str = "",
         agent_name: str = "",
         host: str = "127.0.0.1",
@@ -44,25 +52,20 @@ class TrajectoryProxy:
         prompt_cache_retention: str | None = None,
         path_prefix: str = "",
     ):
-        if (
-            prompt_cache_retention is not None
-            and prompt_cache_retention not in _PROMPT_CACHE_RETENTION_VALUES
-        ):
-            raise ValueError(
-                "prompt_cache_retention must be one of: "
-                f"{', '.join(sorted(_PROMPT_CACHE_RETENTION_VALUES))}"
-            )
-        self._target = target.rstrip("/")
         self._host = host
         self._port = port
-        self._prompt_cache_retention = prompt_cache_retention
-        self._path_prefix = _normalize_path_prefix(path_prefix)
-        self._trajectory = Trajectory(
-            session_id=session_id,
-            agent_name=agent_name,
-        )
+        self._default_path_prefix = _normalize_path_prefix(path_prefix)
+        self._routes: dict[str, _ProxyRoute] = {}
         self._server: asyncio.Server | None = None
         self._client: httpx.AsyncClient | None = None
+        if target is not None:
+            self.register_route(
+                target=target,
+                session_id=session_id,
+                agent_name=agent_name,
+                prompt_cache_retention=prompt_cache_retention,
+                path_prefix=path_prefix,
+            )
 
     @property
     def port(self) -> int:
@@ -75,11 +78,58 @@ class TrajectoryProxy:
     @property
     def target(self) -> str:
         """Upstream URL this proxy forwards to (normalized, no trailing slash)."""
-        return self._target
+        route = self._routes.get(self._default_path_prefix)
+        if route is None:
+            raise RuntimeError("default proxy route is not registered")
+        return route.target
 
     @property
     def trajectory(self) -> Trajectory:
-        return self._trajectory
+        route = self._routes.get(self._default_path_prefix)
+        if route is None:
+            raise RuntimeError("default proxy route is not registered")
+        return route.trajectory
+
+    @property
+    def has_routes(self) -> bool:
+        return bool(self._routes)
+
+    def register_route(
+        self,
+        *,
+        target: str,
+        session_id: str = "",
+        agent_name: str = "",
+        prompt_cache_retention: str | None = None,
+        path_prefix: str = "",
+    ) -> Trajectory:
+        if (
+            prompt_cache_retention is not None
+            and prompt_cache_retention not in _PROMPT_CACHE_RETENTION_VALUES
+        ):
+            raise ValueError(
+                "prompt_cache_retention must be one of: "
+                f"{', '.join(sorted(_PROMPT_CACHE_RETENTION_VALUES))}"
+            )
+        normalized_prefix = _normalize_path_prefix(path_prefix)
+        if normalized_prefix in self._routes:
+            raise ValueError(f"proxy route already registered: {normalized_prefix!r}")
+        trajectory = Trajectory(
+            session_id=session_id,
+            agent_name=agent_name,
+        )
+        self._routes[normalized_prefix] = _ProxyRoute(
+            target=target.rstrip("/"),
+            trajectory=trajectory,
+            prompt_cache_retention=prompt_cache_retention,
+        )
+        return trajectory
+
+    def unregister_route(self, path_prefix: str) -> None:
+        normalized_prefix = _normalize_path_prefix(path_prefix)
+        route = self._routes.pop(normalized_prefix, None)
+        if route is not None:
+            route.trajectory.finished_at = datetime.now()
 
     async def start(self) -> None:
         logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -89,18 +139,20 @@ class TrajectoryProxy:
         )
         sock = self._server.sockets[0]
         self._port = sock.getsockname()[1]
-        logger.info(f"Trajectory proxy listening on {self.base_url} → {self._target}")
+        logger.info("Trajectory proxy listening on %s", self.base_url)
 
     async def stop(self) -> None:
-        self._trajectory.finished_at = datetime.now()
+        finished_at = datetime.now()
+        captured = 0
+        for route in self._routes.values():
+            route.trajectory.finished_at = finished_at
+            captured += len(route.trajectory.exchanges)
         if self._server:
             self._server.close()
             await self._server.wait_closed()
         if self._client:
             await self._client.aclose()
-        logger.info(
-            f"Proxy stopped. Captured {len(self._trajectory.exchanges)} exchanges."
-        )
+        logger.info("Proxy stopped. Captured %s exchanges.", captured)
 
     async def _handle_connection(
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
@@ -133,7 +185,7 @@ class TrajectoryProxy:
                     body_bytes = await reader.readexactly(content_length)
 
                 try:
-                    path = _strip_path_prefix(path, self._path_prefix)
+                    route, path = self._route_for_path(path)
                 except ValueError:
                     await _write_json_response(
                         writer,
@@ -158,7 +210,7 @@ class TrajectoryProxy:
                     body_bytes=body_bytes,
                     headers=headers,
                     path=path,
-                    prompt_cache_retention=self._prompt_cache_retention,
+                    prompt_cache_retention=route.prompt_cache_retention,
                 )
 
                 req = LLMRequest(
@@ -171,7 +223,7 @@ class TrajectoryProxy:
                 is_streaming = body.get("stream", False) or _is_sse_request_path(path)
 
                 start_time = time.monotonic()
-                target_url = f"{self._target}{path}"
+                target_url = f"{route.target}{path}"
                 forward_headers = {
                     k: v
                     for k, v in headers.items()
@@ -181,6 +233,7 @@ class TrajectoryProxy:
                 try:
                     if is_streaming:
                         await self._handle_streaming(
+                            route,
                             req,
                             method,
                             target_url,
@@ -191,6 +244,7 @@ class TrajectoryProxy:
                         )
                     else:
                         await self._handle_regular(
+                            route,
                             req,
                             method,
                             target_url,
@@ -220,8 +274,25 @@ class TrajectoryProxy:
             except Exception:
                 logger.debug("Writer close failed during connection teardown")
 
+    def _route_for_path(self, path: str) -> tuple[_ProxyRoute, str]:
+        matches: list[tuple[str, _ProxyRoute]] = []
+        parsed = urlsplit(path)
+        request_path = parsed.path or "/"
+        for path_prefix, route in self._routes.items():
+            if (
+                not path_prefix
+                or request_path == path_prefix
+                or request_path.startswith(f"{path_prefix}/")
+            ):
+                matches.append((path_prefix, route))
+        if not matches:
+            raise ValueError("request path does not match any proxy route")
+        path_prefix, route = max(matches, key=lambda item: len(item[0]))
+        return route, _strip_path_prefix(path, path_prefix)
+
     async def _handle_regular(
         self,
+        route: _ProxyRoute,
         req: LLMRequest,
         method: str,
         url: str,
@@ -257,7 +328,7 @@ class TrajectoryProxy:
                 resp_body = {"raw": resp.text[:_RAW_RESP_TRUNCATE]}
 
         self._record_exchange(
-            req, resp.status_code, dict(resp.headers), resp_body, duration_ms
+            route, req, resp.status_code, dict(resp.headers), resp_body, duration_ms
         )
 
         resp_bytes = resp.content
@@ -272,6 +343,7 @@ class TrajectoryProxy:
 
     async def _handle_streaming(
         self,
+        route: _ProxyRoute,
         req: LLMRequest,
         method: str,
         url: str,
@@ -337,11 +409,12 @@ class TrajectoryProxy:
             logger.warning(f"SSE response reconstruction failed: {e}")
             resp_body = {}
         self._record_exchange(
-            req, resp.status_code, dict(resp.headers), resp_body, duration_ms
+            route, req, resp.status_code, dict(resp.headers), resp_body, duration_ms
         )
 
     def _record_exchange(
         self,
+        route: _ProxyRoute,
         req: LLMRequest,
         status_code: int,
         headers: dict,
@@ -354,7 +427,7 @@ class TrajectoryProxy:
             body=body,
         )
         exchange = LLMExchange(request=req, response=llm_resp, duration_ms=duration_ms)
-        self._trajectory.exchanges.append(exchange)
+        route.trajectory.exchanges.append(exchange)
         logger.debug(
             f"Captured: {req.method} {req.path} → {status_code} "
             f"({duration_ms:.0f}ms, stream={req.body.get('stream', False)})"

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -137,16 +137,12 @@ class UsageTrackingConfig:
         )
 
     def validate_parallelism(self, *, concurrency: int, worker_count: int = 1) -> None:
-        if (
-            self.mode != "off"
-            and self.uses_external_proxy
-            and max(concurrency, worker_count) > 1
-        ):
+        if self.mode != "off" and self.uses_external_proxy and worker_count > 1:
             raise ValueError(
-                "External usage proxy tracking currently supports only one "
-                "rollout per fixed local proxy port. Use --concurrency 1 and "
-                "one worker, or run separate jobs with separate "
-                f"{USAGE_PROXY_PORT_ENV} values/tunnels."
+                "External usage proxy tracking supports concurrent rollouts "
+                "within one BenchFlow process, but sharded workers cannot share "
+                "one fixed local proxy port. Use one worker, or run separate "
+                f"jobs with separate {USAGE_PROXY_PORT_ENV} values/tunnels."
             )
 
     @classmethod

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1,7 +1,9 @@
 """Tests for ACP client ↔ mock agent — Step 10."""
 
 import asyncio
+import json
 import sys
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -950,6 +952,32 @@ class TestSandboxStartupDiagnostics:
         rj = __import__("json").loads((tmp_path / "result.json").read_text())
         assert rj["sandbox_startup_info"] is None
         assert result.rewards == {"reward": 1.0}
+
+    def test_cleanup_error_in_result_json(self, tmp_path: Path) -> None:
+        """Guards PR #569's cleanup telemetry so failed teardown cannot be
+        mistaken for a healthy reusable experiment slot."""
+        from benchflow.rollout import _build_rollout_result
+
+        _build_rollout_result(
+            tmp_path,
+            task_name="test-task",
+            rollout_name="run-1",
+            agent="oracle",
+            agent_name="oracle",
+            model=None,
+            n_tool_calls=0,
+            prompts=["solve"],
+            error=None,
+            verifier_error=None,
+            cleanup_error="sandbox delete failed",
+            trajectory=[],
+            partial_trajectory=False,
+            rewards={"reward": 1.0},
+            started_at=datetime.now(),
+            timing={"agent": 0.0},
+        )
+        rj = json.loads((tmp_path / "result.json").read_text())
+        assert rj["cleanup_error"] == "sandbox delete failed"
 
     def test_create_sandbox_retry_count_is_three(self) -> None:
         """Guards ENG-147: _create_sandbox retries 3 times, not 2.

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -2,9 +2,37 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import socket
+
+import httpx
 import pytest
 
 from benchflow.trajectories.types import Trajectory
+
+
+def _unused_local_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+async def _read_http_request(
+    reader: asyncio.StreamReader,
+) -> tuple[str, str, bytes]:
+    request_line = (await reader.readline()).decode()
+    method, path, _version = request_line.strip().split(" ", 2)
+    headers: dict[str, str] = {}
+    while True:
+        line = await reader.readline()
+        if line in (b"\r\n", b"\n", b""):
+            break
+        key, _, value = line.decode().partition(":")
+        headers[key.lower().strip()] = value.strip()
+    content_length = int(headers.get("content-length", "0"))
+    body = await reader.readexactly(content_length) if content_length else b""
+    return method, path, body
 
 
 @pytest.mark.asyncio
@@ -32,13 +60,16 @@ async def test_daytona_required_usage_tracking_requires_external_endpoint():
 async def test_daytona_external_usage_proxy_advertises_tunnel_url(monkeypatch):
     """Guards PR #568: remote tracking must not inject local-only addresses."""
     from benchflow.providers import runtime as provider_runtime_mod
-    from benchflow.providers.runtime import ensure_usage_proxy_runtime
+    from benchflow.providers.runtime import (
+        ensure_usage_proxy_runtime,
+        stop_provider_runtime,
+    )
     from benchflow.usage_tracking import UsageTrackingConfig
 
     class FakeTrajectoryProxy:
         def __init__(
             self,
-            target,
+            target=None,
             session_id="",
             agent_name="",
             host="127.0.0.1",
@@ -54,6 +85,7 @@ async def test_daytona_external_usage_proxy_advertises_tunnel_url(monkeypatch):
             self.prompt_cache_retention = prompt_cache_retention
             self.path_prefix = path_prefix
             self.trajectory = Trajectory(session_id=session_id, agent_name=agent_name)
+            self.routes = {}
             self.started = False
 
         async def start(self):
@@ -61,6 +93,31 @@ async def test_daytona_external_usage_proxy_advertises_tunnel_url(monkeypatch):
 
         async def stop(self):
             return None
+
+        @property
+        def has_routes(self):
+            return bool(self.routes)
+
+        def register_route(
+            self,
+            *,
+            target,
+            session_id="",
+            agent_name="",
+            prompt_cache_retention=None,
+            path_prefix="",
+        ):
+            self.target = target
+            self.session_id = session_id
+            self.agent_name = agent_name
+            self.prompt_cache_retention = prompt_cache_retention
+            self.path_prefix = path_prefix
+            self.trajectory = Trajectory(session_id=session_id, agent_name=agent_name)
+            self.routes[path_prefix] = self.trajectory
+            return self.trajectory
+
+        def unregister_route(self, path_prefix):
+            self.routes.pop(path_prefix, None)
 
     async def reachable(_url):
         return True
@@ -88,13 +145,130 @@ async def test_daytona_external_usage_proxy_advertises_tunnel_url(monkeypatch):
     )
 
     assert runtime is not None
-    assert runtime.server.started is True
-    assert runtime.server.host == "127.0.0.1"
+    assert runtime.server.proxy.started is True
+    assert runtime.server.proxy.host == "127.0.0.1"
     assert runtime.server.port == 18081
     assert runtime.server.path_prefix.startswith("/__benchflow/")
     assert runtime.base_url.startswith("https://usage-proxy.example.test/__benchflow/")
     assert updated["LLM_BASE_URL"] == runtime.base_url
     assert updated["BENCHFLOW_PROVIDER_BASE_URL"] == runtime.base_url
+    await stop_provider_runtime(runtime)
+
+
+@pytest.mark.asyncio
+async def test_external_usage_proxy_multiplexes_concurrent_rollouts_on_one_port():
+    """Guards PR #568 follow-up: fixed-port Daytona tracking multiplexes rollouts."""
+    from benchflow.providers.runtime import (
+        ensure_usage_proxy_runtime,
+        stop_provider_runtime,
+    )
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    upstream_requests: list[tuple[str, str, bytes]] = []
+
+    async def upstream_handler(
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        method, path, body = await _read_http_request(reader)
+        upstream_requests.append((method, path, body))
+        response_body = json.dumps(
+            {
+                "id": f"chatcmpl-{len(upstream_requests)}",
+                "model": "gpt-4.1-mini",
+                "usage": {
+                    "prompt_tokens": 3,
+                    "completion_tokens": 5,
+                    "total_tokens": 8,
+                },
+            },
+            separators=(",", ":"),
+        ).encode()
+        writer.write(
+            b"HTTP/1.1 200 OK\r\n"
+            b"content-type: application/json\r\n"
+            + f"content-length: {len(response_body)}\r\n\r\n".encode()
+            + response_body
+        )
+        await writer.drain()
+        writer.close()
+        await writer.wait_closed()
+
+    upstream = await asyncio.start_server(upstream_handler, "127.0.0.1", 0)
+    upstream_port = upstream.sockets[0].getsockname()[1]
+    proxy_port = _unused_local_port()
+    usage_tracking = UsageTrackingConfig(
+        mode="required",
+        advertised_base_url=f"http://127.0.0.1:{proxy_port}",
+        port=proxy_port,
+    )
+    runtime1 = None
+    runtime2 = None
+
+    try:
+        _env1, runtime1 = await ensure_usage_proxy_runtime(
+            agent="openhands",
+            agent_env={
+                "LLM_BASE_URL": f"http://127.0.0.1:{upstream_port}",
+                "LLM_API_KEY": "sk-test",
+            },
+            model="gpt-4.1-mini",
+            runtime=None,
+            environment="daytona",
+            session_id="rollout-1",
+            usage_tracking=usage_tracking,
+        )
+        _env2, runtime2 = await ensure_usage_proxy_runtime(
+            agent="openhands",
+            agent_env={
+                "LLM_BASE_URL": f"http://127.0.0.1:{upstream_port}",
+                "LLM_API_KEY": "sk-test",
+            },
+            model="gpt-4.1-mini",
+            runtime=None,
+            environment="daytona",
+            session_id="rollout-2",
+            usage_tracking=usage_tracking,
+        )
+
+        assert runtime1 is not None
+        assert runtime2 is not None
+        assert runtime1.base_url != runtime2.base_url
+        assert runtime1.server.proxy is runtime2.server.proxy
+
+        async with httpx.AsyncClient() as client:
+            response1, response2 = await asyncio.gather(
+                client.post(
+                    f"{runtime1.base_url}/chat/completions",
+                    json={"model": "gpt-4.1-mini", "messages": []},
+                ),
+                client.post(
+                    f"{runtime2.base_url}/chat/completions",
+                    json={"model": "gpt-4.1-mini", "messages": []},
+                ),
+            )
+            assert response1.status_code == 200
+            assert response2.status_code == 200
+            assert len(runtime1.server.trajectory.exchanges) == 1
+            assert len(runtime2.server.trajectory.exchanges) == 1
+
+            await stop_provider_runtime(runtime1)
+            runtime1 = None
+
+            health = await client.get(f"{runtime2.base_url}/__benchflow_health")
+            assert health.status_code == 200
+
+        assert [request[1] for request in upstream_requests] == [
+            "/chat/completions",
+            "/chat/completions",
+        ]
+    finally:
+        if runtime1 is not None:
+            await stop_provider_runtime(runtime1)
+        if runtime2 is not None:
+            await stop_provider_runtime(runtime2)
+        upstream.close()
+        await upstream.wait_closed()
 
 
 def test_evaluation_yaml_loads_required_usage_tracking(tmp_path):
@@ -170,8 +344,8 @@ def test_evaluation_preflight_rejects_external_proxy_port_zero(tmp_path):
         evaluation._preflight_usage_tracking()
 
 
-def test_evaluation_preflight_rejects_external_proxy_concurrency(tmp_path):
-    """Guards PR #568: one fixed external proxy port cannot host concurrency."""
+def test_evaluation_preflight_allows_external_proxy_concurrency(tmp_path):
+    """Guards PR #568 follow-up: one fixed external proxy port hosts concurrent rollouts."""
     from benchflow.evaluation import Evaluation, EvaluationConfig
     from benchflow.usage_tracking import UsageTrackingConfig
 
@@ -179,7 +353,7 @@ def test_evaluation_preflight_rejects_external_proxy_concurrency(tmp_path):
         tasks_dir=tmp_path,
         jobs_dir=tmp_path / "jobs",
         config=EvaluationConfig(
-            concurrency=2,
+            concurrency=94,
             environment="daytona",
             usage_tracking=UsageTrackingConfig(
                 mode="required",
@@ -189,8 +363,7 @@ def test_evaluation_preflight_rejects_external_proxy_concurrency(tmp_path):
         ),
     )
 
-    with pytest.raises(ValueError, match="supports only one rollout"):
-        evaluation._preflight_usage_tracking()
+    evaluation._preflight_usage_tracking()
 
 
 def test_explicit_auto_usage_tracking_beats_env_default(monkeypatch):
@@ -293,7 +466,7 @@ def test_external_usage_tracking_rejects_multiple_shard_workers():
         port=18081,
     )
 
-    with pytest.raises(ValueError, match="supports only one rollout"):
+    with pytest.raises(ValueError, match="sharded workers cannot share"):
         config.validate_parallelism(concurrency=1, worker_count=2)
 
 


### PR DESCRIPTION
## Summary
- multiplex external usage-proxy routes over one fixed local listener using secret path prefixes
- allow high concurrency for external usage tracking in a single BenchFlow process while still rejecting multi-worker fixed-port sharing
- persist rollout cleanup failures into `result.json` so downstream experiment health gates cannot treat failed teardown as a reusable healthy slot
- update docs and add regression coverage for concurrent Daytona-style external proxy usage and cleanup telemetry

## Tests
- `uv run ruff check .`
- `uv run ty check src`
- `uv run python -m pytest tests/test_usage_tracking.py tests/test_trajectory_proxy_path_prefix.py tests/test_usage_proxy.py tests/test_acp.py::TestSandboxStartupDiagnostics -q`
- `uv run python -m pytest tests/ -q`

## Notes
- Follow-up to PR #568: fixed-port external usage tracking can now support concurrent rollouts in one process; sharded workers still need separate ports/tunnels.
- Kept as draft because the requested live Daytona E2E for `deepseek-v4-flash` is blocked by the current provider proxy model list: no healthy `deepseek-v4-flash` model ID is exposed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/569" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
