### PR TITLE
fix: surface test-stdout.txt in verifier exception for dep_install classification (#540)

### DIFF
--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -18,6 +18,16 @@ VERIFIER_INFRA = "verifier_infra"
 VERIFIER_TIMEOUT = "verifier_timeout"
 VERIFIER_DEP_INSTALL = "verifier_dep_install"
 
+# Canonical dependency-install markers shared by verifier stdout scanning and
+# verifier-error classification. Keep these lower-case; the helper below
+# performs case-insensitive matching.
+VERIFIER_DEP_INSTALL_MARKERS: tuple[str, ...] = (
+    "dependency install failed",
+    "no solution found",
+    "could not find a version",
+    "resolution impossible",
+)
+
 ScoreOutcome = Literal["passed", "failed", "errored", "verifier_errored"]
 ResultOutcome = Literal["passed", "failed", "errored", "verifier_errored", "unscored"]
 
@@ -77,7 +87,7 @@ def classify_verifier_error(verifier_error: str | None) -> str | None:
         return None
     lower = verifier_error.lower()
     if "verifier crashed" in verifier_error:
-        if _looks_like_verifier_dep_install_error(lower):
+        if contains_verifier_dep_install_marker(lower):
             return VERIFIER_DEP_INSTALL
         if _looks_like_verifier_infra_error(lower):
             return VERIFIER_INFRA
@@ -87,15 +97,15 @@ def classify_verifier_error(verifier_error: str | None) -> str | None:
     return "verifier_other"
 
 
-def _looks_like_verifier_dep_install_error(error: str) -> bool:
+def contains_verifier_dep_install_marker(text: str) -> bool:
     """Detect verifier dependency installation failures (ENG-151)."""
-    markers = (
-        "dependency install failed",
-        "no solution found",
-        "could not find a version",
-        "resolution impossible",
-    )
-    return any(marker in error for marker in markers)
+    lower = text.lower()
+    return any(marker in lower for marker in VERIFIER_DEP_INSTALL_MARKERS)
+
+
+def _looks_like_verifier_dep_install_error(error: str) -> bool:
+    """Backward-compatible internal alias for dep-install marker matching."""
+    return contains_verifier_dep_install_marker(error)
 
 
 def _looks_like_verifier_infra_error(error: str) -> bool:

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -13,8 +13,10 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import shlex
 import shutil
+from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -62,14 +64,57 @@ class RubricNotFoundError(Exception):
 
 _TAIL_LINES = 30
 
+# Secret patterns redacted from verifier stdout before it is surfaced in an
+# exception message (and from there into ``verifier_error`` / summaries /
+# dashboards). ``test-stdout.txt`` is untrusted subprocess output that can
+# contain env dumps, install URLs, or tokens — see PR #572 review. Mirrors the
+# trajectory redaction set (#537); kept local so this module has no dependency
+# on the trajectories package.
+_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"(sk-ant-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
+    (re.compile(r"(sk-proj-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
+    (re.compile(r"(sk-[a-zA-Z0-9]{10})[a-zA-Z0-9]+"), r"\1***REDACTED***"),
+    (re.compile(r"(AIzaSy[A-Za-z0-9_-]{4})[A-Za-z0-9_-]{20,}"), r"\1***REDACTED***"),
+    (
+        re.compile(r"((?:AKIA|ASIA)[A-Z0-9]{4})[A-Z0-9]{12}(?![A-Z0-9])"),
+        r"\1***REDACTED***",
+    ),
+    (re.compile(r"(dtn_[A-Za-z0-9_]{4})[A-Za-z0-9_]{16,}"), r"\1***REDACTED***"),
+    (
+        re.compile(r'("authorization"\s*:\s*"Bearer\s+)[^"]+(")', re.IGNORECASE),
+        r"\1***REDACTED***\2",
+    ),
+    (
+        re.compile(r"(Bearer\s+)[A-Za-z0-9._-]{12,}", re.IGNORECASE),
+        r"\1***REDACTED***",
+    ),
+    (
+        re.compile(r"((?:x-api-key|api-key)\s*[:=]\s*)\S+", re.IGNORECASE),
+        r"\1***REDACTED***",
+    ),
+)
+
+
+def _redact_secrets(text: str) -> str:
+    """Strip well-known credential patterns from untrusted subprocess output."""
+    for pattern, replacement in _SECRET_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
 
 def _tail_file(path: Path, n: int = _TAIL_LINES) -> str:
-    """Return the last *n* lines of *path*, or empty string if unreadable."""
+    """Return the last *n* lines of *path*, redacted, or "" if unreadable.
+
+    Streams the file with a bounded ``deque`` so a large ``test-stdout.txt``
+    is never fully materialized. Output is redacted because it is untrusted
+    subprocess output surfaced into ``verifier_error`` (PR #572 review).
+    """
     try:
-        lines = path.read_text(errors="replace").splitlines()
-        return "\n".join(lines[-n:])
+        with path.open(errors="replace") as f:
+            lines = deque(f, maxlen=n)
     except OSError:
         return ""
+    return _redact_secrets("".join(lines).rstrip("\n"))
 
 
 class Verifier:

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 import shlex
 import shutil
 from collections import deque
@@ -64,57 +63,48 @@ class RubricNotFoundError(Exception):
 
 _TAIL_LINES = 30
 
-# Secret patterns redacted from verifier stdout before it is surfaced in an
-# exception message (and from there into ``verifier_error`` / summaries /
-# dashboards). ``test-stdout.txt`` is untrusted subprocess output that can
-# contain env dumps, install URLs, or tokens — see PR #572 review. Mirrors the
-# trajectory redaction set (#537); kept local so this module has no dependency
-# on the trajectories package.
-_SECRET_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
-    (re.compile(r"(sk-ant-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
-    (re.compile(r"(sk-proj-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
-    (re.compile(r"(sk-[a-zA-Z0-9]{10})[a-zA-Z0-9]+"), r"\1***REDACTED***"),
-    (re.compile(r"(AIzaSy[A-Za-z0-9_-]{4})[A-Za-z0-9_-]{20,}"), r"\1***REDACTED***"),
-    (
-        re.compile(r"((?:AKIA|ASIA)[A-Z0-9]{4})[A-Z0-9]{12}(?![A-Z0-9])"),
-        r"\1***REDACTED***",
-    ),
-    (re.compile(r"(dtn_[A-Za-z0-9_]{4})[A-Za-z0-9_]{16,}"), r"\1***REDACTED***"),
-    (
-        re.compile(r'("authorization"\s*:\s*"Bearer\s+)[^"]+(")', re.IGNORECASE),
-        r"\1***REDACTED***\2",
-    ),
-    (
-        re.compile(r"(Bearer\s+)[A-Za-z0-9._-]{12,}", re.IGNORECASE),
-        r"\1***REDACTED***",
-    ),
-    (
-        re.compile(r"((?:x-api-key|api-key)\s*[:=]\s*)\S+", re.IGNORECASE),
-        r"\1***REDACTED***",
-    ),
+# Lines that mark a dependency-install failure in ``test-stdout.txt`` (the uv/
+# pip resolver output). When one is present we surface a FIXED, secret-free
+# diagnostic — never the raw stdout — so ``classify_verifier_error`` can return
+# ``VERIFIER_DEP_INSTALL`` without persisting untrusted subprocess output (env
+# dumps, install URLs, tokens) into ``verifier_error`` / summaries / dashboards
+# (PR #572 review). The raw stdout stays in the verifier log artifact, not in
+# result metadata. These must stay in sync with
+# ``scoring._looks_like_verifier_dep_install_error``.
+_DEP_INSTALL_MARKERS: tuple[str, ...] = (
+    "no solution found",
+    "could not find a version",
+    "resolution impossible",
+    "dependency install failed",
 )
 
+# The safe, fixed diagnostic surfaced into ``verifier_error`` on a detected
+# dep-install failure. Contains a marker the classifier recognises; carries no
+# stdout content. Points operators at the (private) log artifact for detail.
+_DEP_INSTALL_DIAGNOSTIC = (
+    "dependency install failed (see verifier/test-stdout.txt in the run "
+    "artifacts for resolver output)"
+)
 
-def _redact_secrets(text: str) -> str:
-    """Strip well-known credential patterns from untrusted subprocess output."""
-    for pattern, replacement in _SECRET_PATTERNS:
-        text = pattern.sub(replacement, text)
-    return text
+# Bytes of stdout scanned for markers. Streaming-bounded so a verifier emitting
+# a single huge line can't bloat memory; we never persist any of it.
+_SCAN_MAX_BYTES = 64 * 1024
 
 
-def _tail_file(path: Path, n: int = _TAIL_LINES) -> str:
-    """Return the last *n* lines of *path*, redacted, or "" if unreadable.
+def _has_dep_install_failure(path: Path) -> bool:
+    """True if *path* (test-stdout.txt) shows a dependency-install failure.
 
-    Streams the file with a bounded ``deque`` so a large ``test-stdout.txt``
-    is never fully materialized. Output is redacted because it is untrusted
-    subprocess output surfaced into ``verifier_error`` (PR #572 review).
+    Only the boolean verdict leaves this function — the scanned text is never
+    returned or persisted, so no secret-bearing stdout can reach result
+    metadata (PR #572). Reads at most ``_SCAN_MAX_BYTES`` from the file tail.
     """
     try:
         with path.open(errors="replace") as f:
-            lines = deque(f, maxlen=n)
+            chunk = deque(f, maxlen=_TAIL_LINES)
     except OSError:
-        return ""
-    return _redact_secrets("".join(lines).rstrip("\n"))
+        return False
+    text = "".join(chunk)[-_SCAN_MAX_BYTES:].lower()
+    return any(marker in text for marker in _DEP_INSTALL_MARKERS)
 
 
 class Verifier:
@@ -346,7 +336,6 @@ class Verifier:
         elif self._rollout_paths.reward_json_path.exists():
             rewards = self._parse_reward_json()
         else:
-            stdout_tail = _tail_file(self._rollout_paths.test_stdout_path)
             if test_return_code != 0:
                 msg = (
                     f"verifier exited with rc={test_return_code}; no reward file "
@@ -358,8 +347,13 @@ class Verifier:
                     f"No reward file found at {self._rollout_paths.reward_text_path} or "
                     f"{self._rollout_paths.reward_json_path}"
                 )
-            if stdout_tail:
-                msg += f"\n--- test-stdout.txt (last {_TAIL_LINES} lines) ---\n{stdout_tail}"
+            # Surface ONLY a fixed, secret-free dep-install diagnostic (never
+            # the raw stdout tail) so classify_verifier_error can return
+            # VERIFIER_DEP_INSTALL without leaking untrusted subprocess output
+            # into result metadata (#572). Raw resolver output remains in the
+            # downloaded verifier/test-stdout.txt artifact.
+            if _has_dep_install_failure(self._rollout_paths.test_stdout_path):
+                msg += f"\n{_DEP_INSTALL_DIAGNOSTIC}"
             raise RewardFileNotFoundError(msg)
 
         return VerifierResult(rewards=rewards)

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -314,7 +314,7 @@ class Verifier:
                     f"{self._rollout_paths.reward_json_path}"
                 )
             if stdout_tail:
-                msg += f"\n--- test-stdout.txt (last 30 lines) ---\n{stdout_tail}"
+                msg += f"\n--- test-stdout.txt (last {_TAIL_LINES} lines) ---\n{stdout_tail}"
             raise RewardFileNotFoundError(msg)
 
         return VerifierResult(rewards=rewards)

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -60,6 +60,18 @@ class RubricNotFoundError(Exception):
     """Raised when an llm-judge verifier cannot locate its rubric file."""
 
 
+_TAIL_LINES = 30
+
+
+def _tail_file(path: Path, n: int = _TAIL_LINES) -> str:
+    """Return the last *n* lines of *path*, or empty string if unreadable."""
+    try:
+        lines = path.read_text(errors="replace").splitlines()
+        return "\n".join(lines[-n:])
+    except OSError:
+        return ""
+
+
 class Verifier:
     """Runs the task's verifier and parses rewards.
 
@@ -289,16 +301,21 @@ class Verifier:
         elif self._rollout_paths.reward_json_path.exists():
             rewards = self._parse_reward_json()
         else:
+            stdout_tail = _tail_file(self._rollout_paths.test_stdout_path)
             if test_return_code != 0:
-                raise RewardFileNotFoundError(
+                msg = (
                     f"verifier exited with rc={test_return_code}; no reward file "
                     f"found at {self._rollout_paths.reward_text_path} or "
                     f"{self._rollout_paths.reward_json_path}"
                 )
-            raise RewardFileNotFoundError(
-                f"No reward file found at {self._rollout_paths.reward_text_path} or "
-                f"{self._rollout_paths.reward_json_path}"
-            )
+            else:
+                msg = (
+                    f"No reward file found at {self._rollout_paths.reward_text_path} or "
+                    f"{self._rollout_paths.reward_json_path}"
+                )
+            if stdout_tail:
+                msg += f"\n--- test-stdout.txt (last 30 lines) ---\n{stdout_tail}"
+            raise RewardFileNotFoundError(msg)
 
         return VerifierResult(rewards=rewards)
 

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -20,6 +20,10 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from benchflow._utils.scoring import (
+    VERIFIER_DEP_INSTALL_MARKERS,
+    contains_verifier_dep_install_marker,
+)
 from benchflow.rewards.validation import is_valid_reward_number, validate_reward_map
 from benchflow.sandbox.lockdown import _exec_return_code, clear_verifier_output_dir
 from benchflow.task.env import resolve_env_vars
@@ -60,21 +64,6 @@ class RubricNotFoundError(Exception):
     """Raised when an llm-judge verifier cannot locate its rubric file."""
 
 
-# Lines that mark a dependency-install failure in ``test-stdout.txt`` (the uv/
-# pip resolver output). When one is present we surface a FIXED, secret-free
-# diagnostic — never the raw stdout — so ``classify_verifier_error`` can return
-# ``VERIFIER_DEP_INSTALL`` without persisting untrusted subprocess output (env
-# dumps, install URLs, tokens) into ``verifier_error`` / summaries / dashboards
-# (PR #572 review). The raw stdout stays in the verifier log artifact, not in
-# result metadata. These must stay in sync with
-# ``scoring._looks_like_verifier_dep_install_error``.
-_DEP_INSTALL_MARKERS: tuple[str, ...] = (
-    "no solution found",
-    "could not find a version",
-    "resolution impossible",
-    "dependency install failed",
-)
-
 # The safe, fixed diagnostic surfaced into ``verifier_error`` on a detected
 # dep-install failure. Contains a marker the classifier recognises; carries no
 # stdout content. Points operators at the (private) log artifact for detail.
@@ -108,7 +97,7 @@ def _has_dep_install_failure(path: Path) -> bool:
     """
     # Longest marker minus one byte: enough overlap to catch a marker split
     # across two reads without rescanning whole chunks.
-    overlap = max(len(m) for m in _DEP_INSTALL_MARKERS) - 1
+    overlap = max(len(m) for m in VERIFIER_DEP_INSTALL_MARKERS) - 1
     try:
         with path.open(errors="replace") as f:
             carry = ""
@@ -116,8 +105,8 @@ def _has_dep_install_failure(path: Path) -> bool:
                 chunk = f.read(_SCAN_CHUNK_BYTES)
                 if not chunk:
                     return False
-                window = (carry + chunk).lower()
-                if any(marker in window for marker in _DEP_INSTALL_MARKERS):
+                window = carry + chunk
+                if contains_verifier_dep_install_marker(window):
                     return True
                 # Keep the tail of this chunk so a boundary-spanning marker is
                 # found on the next read; bound it to the overlap size.

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -15,7 +15,6 @@ import json
 import logging
 import shlex
 import shutil
-from collections import deque
 from pathlib import Path
 from typing import Any
 
@@ -61,8 +60,6 @@ class RubricNotFoundError(Exception):
     """Raised when an llm-judge verifier cannot locate its rubric file."""
 
 
-_TAIL_LINES = 30
-
 # Lines that mark a dependency-install failure in ``test-stdout.txt`` (the uv/
 # pip resolver output). When one is present we surface a FIXED, secret-free
 # diagnostic — never the raw stdout — so ``classify_verifier_error`` can return
@@ -86,9 +83,12 @@ _DEP_INSTALL_DIAGNOSTIC = (
     "artifacts for resolver output)"
 )
 
-# Bytes of stdout scanned for markers. Streaming-bounded so a verifier emitting
-# a single huge line can't bloat memory; we never persist any of it.
-_SCAN_MAX_BYTES = 64 * 1024
+# Size of each fixed chunk streamed off disk while scanning for markers. The
+# whole file is scanned (dep-install runs at the START of test.sh, so the marker
+# can be buried under arbitrarily many trailing lines — see PR #572), but only
+# one bounded chunk is ever held in memory at a time, so a verifier emitting a
+# single huge line can't bloat memory. We never persist any of the scanned text.
+_SCAN_CHUNK_BYTES = 64 * 1024
 
 
 def _has_dep_install_failure(path: Path) -> bool:
@@ -96,15 +96,34 @@ def _has_dep_install_failure(path: Path) -> bool:
 
     Only the boolean verdict leaves this function — the scanned text is never
     returned or persisted, so no secret-bearing stdout can reach result
-    metadata (PR #572). Reads at most ``_SCAN_MAX_BYTES`` from the file tail.
+    metadata (PR #572).
+
+    The ENTIRE file is scanned from the start in fixed ``_SCAN_CHUNK_BYTES``
+    chunks (with a small overlap so a marker straddling a chunk boundary is
+    still caught), short-circuiting on the first marker. uv/pip install runs at
+    the START of ``test.sh``, so its failure marker may be followed by many
+    lines of trailing output (fallback attempts, cleanup, partial tests); a
+    tail-only scan would silently drop it (PR #572). Memory stays bounded — at
+    most one chunk plus the overlap is held at a time, regardless of file size.
     """
+    # Longest marker minus one byte: enough overlap to catch a marker split
+    # across two reads without rescanning whole chunks.
+    overlap = max(len(m) for m in _DEP_INSTALL_MARKERS) - 1
     try:
         with path.open(errors="replace") as f:
-            chunk = deque(f, maxlen=_TAIL_LINES)
+            carry = ""
+            while True:
+                chunk = f.read(_SCAN_CHUNK_BYTES)
+                if not chunk:
+                    return False
+                window = (carry + chunk).lower()
+                if any(marker in window for marker in _DEP_INSTALL_MARKERS):
+                    return True
+                # Keep the tail of this chunk so a boundary-spanning marker is
+                # found on the next read; bound it to the overlap size.
+                carry = chunk[-overlap:] if overlap else ""
     except OSError:
         return False
-    text = "".join(chunk)[-_SCAN_MAX_BYTES:].lower()
-    return any(marker in text for marker in _DEP_INSTALL_MARKERS)
 
 
 class Verifier:
@@ -348,7 +367,7 @@ class Verifier:
                     f"{self._rollout_paths.reward_json_path}"
                 )
             # Surface ONLY a fixed, secret-free dep-install diagnostic (never
-            # the raw stdout tail) so classify_verifier_error can return
+            # any scanned stdout) so classify_verifier_error can return
             # VERIFIER_DEP_INSTALL without leaking untrusted subprocess output
             # into result metadata (#572). Raw resolver output remains in the
             # downloaded verifier/test-stdout.txt artifact.

--- a/tests/test_verifier_output.py
+++ b/tests/test_verifier_output.py
@@ -18,8 +18,10 @@ import pytest
 
 from benchflow._utils.scoring import (
     VERIFIER_DEP_INSTALL,
+    VERIFIER_DEP_INSTALL_MARKERS,
     VERIFIER_FAILED,
     classify_verifier_error,
+    contains_verifier_dep_install_marker,
 )
 from benchflow.task.verifier import (
     _DEP_INSTALL_DIAGNOSTIC,
@@ -45,8 +47,22 @@ def test_fixed_diagnostic_classifies_as_dep_install():
 def test_diagnostic_carries_no_stdout():
     """PR #572: the fixed diagnostic must not contain raw resolver output —
     only a marker the classifier needs and a pointer to the log artifact."""
-    assert "dependency install failed" in _DEP_INSTALL_DIAGNOSTIC
+    assert contains_verifier_dep_install_marker(_DEP_INSTALL_DIAGNOSTIC)
     assert "test-stdout.txt" in _DEP_INSTALL_DIAGNOSTIC
+
+
+def test_canonical_markers_drive_classifier_and_stdout_scan(tmp_path):
+    """Guards PR #572 against marker drift between verifier stdout scanning and
+    verifier-error classification."""
+    p = tmp_path / "test-stdout.txt"
+    for marker in VERIFIER_DEP_INSTALL_MARKERS:
+        assert (
+            classify_verifier_error(f"verifier crashed: {marker}")
+            == VERIFIER_DEP_INSTALL
+        )
+
+        p.write_text(f"running setup...\n{marker.upper()}\n")
+        assert _has_dep_install_failure(p) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_verifier_output.py
+++ b/tests/test_verifier_output.py
@@ -1,0 +1,160 @@
+"""Tests for verifier dependency-install classification and stdout surfacing.
+
+Covers the ENG-151 / PR #540 path where a missing reward file surfaces a
+redacted tail of ``test-stdout.txt`` through ``RewardFileNotFoundError`` so
+``classify_verifier_error`` can detect dependency-install failures, plus the
+PR #572 review fix that redacts secrets from that untrusted subprocess output
+before it lands in ``verifier_error`` / summaries / dashboards.
+"""
+
+import pytest
+
+from benchflow._utils.scoring import (
+    VERIFIER_DEP_INSTALL,
+    VERIFIER_FAILED,
+    classify_verifier_error,
+)
+from benchflow.task.verifier import _redact_secrets, _tail_file
+
+# ---------------------------------------------------------------------------
+# dep_install classification (PR #540) — markers reach the classifier only
+# because verifier.py tails test-stdout.txt into the exception message.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        (
+            "verifier crashed: verifier exited with rc=1; no reward file found\n"
+            "--- test-stdout.txt (last 30 lines) ---\n"
+            "x No solution found when resolving tool dependencies: torch==2.1.2+cpu",
+            VERIFIER_DEP_INSTALL,
+        ),
+        (
+            "verifier crashed: verifier exited with rc=1\n"
+            "Could not find a version that satisfies the requirement foo==9.9.9",
+            VERIFIER_DEP_INSTALL,
+        ),
+        (
+            "verifier crashed: verifier exited with rc=1\nERROR: dependency install failed",
+            VERIFIER_DEP_INSTALL,
+        ),
+        (
+            "verifier crashed: verifier exited with rc=1\nresolution impossible for bar",
+            VERIFIER_DEP_INSTALL,
+        ),
+    ],
+)
+def test_classify_dep_install_from_stdout_tail(input_str, expected):
+    """PR #540: dep-install markers in the surfaced stdout tail classify."""
+    assert classify_verifier_error(input_str) == expected
+
+
+def test_dep_install_takes_precedence_over_generic_crash():
+    """PR #540: dep_install wins over verifier_failure when both markers present."""
+    msg = (
+        "verifier crashed: verifier exited with rc=1; no reward file found\n"
+        "--- test-stdout.txt (last 30 lines) ---\n"
+        "x No solution found when resolving tool dependencies: torch==2.1.2+cpu"
+    )
+    assert classify_verifier_error(msg) == VERIFIER_DEP_INSTALL
+
+
+# ---------------------------------------------------------------------------
+# _tail_file: bounded streaming read + secret redaction (PR #572 review)
+# ---------------------------------------------------------------------------
+
+
+class TestTailFile:
+    def test_returns_redacted_tail(self, tmp_path):
+        """PR #540: tail surfaces the dep-install marker for the classifier."""
+        stdout = tmp_path / "test-stdout.txt"
+        stdout.write_text(
+            "Installing dependencies...\n"
+            "x No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"
+        )
+        assert "no solution found" in _tail_file(stdout).lower()
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _tail_file(tmp_path / "nope.txt") == ""
+
+    def test_only_keeps_last_n_lines(self, tmp_path):
+        stdout = tmp_path / "test-stdout.txt"
+        stdout.write_text("".join(f"line{i}\n" for i in range(100)))
+        tail = _tail_file(stdout, n=5)
+        assert tail.splitlines() == [f"line{i}" for i in range(95, 100)]
+
+    def test_redacts_secrets_in_tail(self, tmp_path):
+        """PR #572: untrusted stdout (env dumps, tokens) must be redacted.
+
+        An obviously-fake key is used as the fixture (never a real one).
+        """
+        stdout = tmp_path / "test-stdout.txt"
+        stdout.write_text(
+            "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
+            "Authorization: Bearer fake-token-aaaaaaaaaaaaaaaa\n"
+        )
+        tail = _tail_file(stdout)
+        assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in tail
+        assert "fake-token-aaaaaaaaaaaaaaaa" not in tail
+        assert "***REDACTED***" in tail
+
+
+class TestRedactSecrets:
+    """PR #572: redaction patterns mirror the trajectory set (#537).
+
+    All fixtures use obviously-fake credential values, never real ones.
+    """
+
+    @pytest.mark.parametrize(
+        "raw,leaked",
+        [
+            ("key=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx", "FORTESTSONLYxxxxxxxxxxxxxxx"),
+            ("key=sk-ant-api03-FAKEFAKEFAKEdeadbeefcafe1234", "deadbeefcafe1234"),
+            ("key=AKIAFAKEFAKEFAKE1234", "FAKEFAKE1234"),
+            ("key=dtn_FAKEFAKEFAKEFAKEFAKE12345678", "FAKEFAKE12345678"),
+            ("x-api-key: abc123secretvalue456", "abc123secretvalue456"),
+        ],
+    )
+    def test_redacts_pattern(self, raw, leaked):
+        out = _redact_secrets(raw)
+        assert leaked not in out
+        assert "***REDACTED***" in out
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "region=ASIAPACIFIC",  # English word, not an AWS key
+            "queue=task-sk-us-east-1-foo-bar",  # slug containing sk-
+            "label=dtn_v2_0",  # short identifier
+            "just normal verifier output, nothing secret here",
+        ],
+    )
+    def test_preserves_non_secret(self, raw):
+        assert _redact_secrets(raw) == raw
+
+    def test_classifier_still_fires_after_redaction(self, tmp_path):
+        """Redaction must not eat the dep-install marker the classifier needs."""
+        stdout = tmp_path / "test-stdout.txt"
+        stdout.write_text(
+            "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
+            "x No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"
+        )
+        verifier_error = (
+            "verifier crashed: verifier exited with rc=1\n"
+            f"--- test-stdout.txt (last 30 lines) ---\n{_tail_file(stdout)}"
+        )
+        assert classify_verifier_error(verifier_error) == VERIFIER_DEP_INSTALL
+        assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in verifier_error
+
+
+def test_no_dep_markers_stays_verifier_failure(tmp_path):
+    """PR #540: without dep-install markers the classifier returns verifier_failure."""
+    stdout = tmp_path / "test-stdout.txt"
+    stdout.write_text("some random test output\nassertion failed\n")
+    verifier_error = (
+        "verifier crashed: verifier exited with rc=1\n"
+        f"--- test-stdout.txt (last 30 lines) ---\n{_tail_file(stdout)}"
+    )
+    assert classify_verifier_error(verifier_error) == VERIFIER_FAILED

--- a/tests/test_verifier_output.py
+++ b/tests/test_verifier_output.py
@@ -85,6 +85,30 @@ class TestHasDepInstallFailure:
         p.write_text("x" * (256 * 1024) + " no solution found\n")
         assert _has_dep_install_failure(p) is True
 
+    def test_early_marker_with_long_trailing_output(self, tmp_path):
+        """PR #572 / issue #540: dep-install runs at the START of test.sh, so a
+        resolver-failure marker on an EARLY line can be followed by far more than
+        the old 30-line tail window. Scanning the whole file must still detect
+        it (a tail-only scan silently misclassified it as a generic failure)."""
+        p = tmp_path / "test-stdout.txt"
+        early = "Resolving dependencies...\nx No solution found resolving torch\n"
+        trailing = "".join(f"falling back / cleanup line {i}\n" for i in range(500))
+        p.write_text(early + trailing)
+        assert _has_dep_install_failure(p) is True
+
+    def test_marker_spanning_chunk_boundary(self, tmp_path):
+        """PR #572: a marker straddling a fixed-chunk read boundary must still be
+        caught (the chunked scan carries a small overlap across reads)."""
+        from benchflow.task.verifier import _SCAN_CHUNK_BYTES
+
+        p = tmp_path / "test-stdout.txt"
+        marker = "no solution found"
+        # Place the marker so it begins a few bytes before a chunk boundary and
+        # ends after it, then bury it under lots of trailing output.
+        prefix = "a" * (_SCAN_CHUNK_BYTES - 5)
+        p.write_text(prefix + marker + "\n" + "trailing\n" * 1000)
+        assert _has_dep_install_failure(p) is True
+
 
 # ---------------------------------------------------------------------------
 # Production wiring: _verify_test_script raises a redacted, classifiable error

--- a/tests/test_verifier_output.py
+++ b/tests/test_verifier_output.py
@@ -1,11 +1,18 @@
-"""Tests for verifier dependency-install classification and stdout surfacing.
+"""Tests for verifier dependency-install classification (PR #540 / #572).
 
-Covers the ENG-151 / PR #540 path where a missing reward file surfaces a
-redacted tail of ``test-stdout.txt`` through ``RewardFileNotFoundError`` so
-``classify_verifier_error`` can detect dependency-install failures, plus the
-PR #572 review fix that redacts secrets from that untrusted subprocess output
-before it lands in ``verifier_error`` / summaries / dashboards.
+PR #540 made dep-install failures classifiable: a missing reward file whose
+``test-stdout.txt`` shows a resolver failure surfaces a diagnostic through
+``RewardFileNotFoundError`` so ``classify_verifier_error`` returns
+``VERIFIER_DEP_INSTALL``.
+
+PR #572 review hardened this: the raw stdout is NEVER persisted into
+``verifier_error`` (it can carry env dumps / tokens / credentialed install
+URLs). Instead the verifier scans stdout for dep-install markers and, on a
+hit, appends only a FIXED secret-free diagnostic. The raw resolver output
+stays in the downloaded ``verifier/test-stdout.txt`` artifact.
 """
+
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -14,150 +21,154 @@ from benchflow._utils.scoring import (
     VERIFIER_FAILED,
     classify_verifier_error,
 )
-from benchflow.task.verifier import _redact_secrets, _tail_file
-
-# ---------------------------------------------------------------------------
-# dep_install classification (PR #540) — markers reach the classifier only
-# because verifier.py tails test-stdout.txt into the exception message.
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    "input_str,expected",
-    [
-        (
-            "verifier crashed: verifier exited with rc=1; no reward file found\n"
-            "--- test-stdout.txt (last 30 lines) ---\n"
-            "x No solution found when resolving tool dependencies: torch==2.1.2+cpu",
-            VERIFIER_DEP_INSTALL,
-        ),
-        (
-            "verifier crashed: verifier exited with rc=1\n"
-            "Could not find a version that satisfies the requirement foo==9.9.9",
-            VERIFIER_DEP_INSTALL,
-        ),
-        (
-            "verifier crashed: verifier exited with rc=1\nERROR: dependency install failed",
-            VERIFIER_DEP_INSTALL,
-        ),
-        (
-            "verifier crashed: verifier exited with rc=1\nresolution impossible for bar",
-            VERIFIER_DEP_INSTALL,
-        ),
-    ],
+from benchflow.task.verifier import (
+    _DEP_INSTALL_DIAGNOSTIC,
+    RewardFileNotFoundError,
+    Verifier,
+    _has_dep_install_failure,
 )
-def test_classify_dep_install_from_stdout_tail(input_str, expected):
-    """PR #540: dep-install markers in the surfaced stdout tail classify."""
-    assert classify_verifier_error(input_str) == expected
-
-
-def test_dep_install_takes_precedence_over_generic_crash():
-    """PR #540: dep_install wins over verifier_failure when both markers present."""
-    msg = (
-        "verifier crashed: verifier exited with rc=1; no reward file found\n"
-        "--- test-stdout.txt (last 30 lines) ---\n"
-        "x No solution found when resolving tool dependencies: torch==2.1.2+cpu"
-    )
-    assert classify_verifier_error(msg) == VERIFIER_DEP_INSTALL
-
 
 # ---------------------------------------------------------------------------
-# _tail_file: bounded streaming read + secret redaction (PR #572 review)
+# Classifier recognises the fixed diagnostic (PR #540 / #572)
 # ---------------------------------------------------------------------------
 
 
-class TestTailFile:
-    def test_returns_redacted_tail(self, tmp_path):
-        """PR #540: tail surfaces the dep-install marker for the classifier."""
-        stdout = tmp_path / "test-stdout.txt"
-        stdout.write_text(
-            "Installing dependencies...\n"
-            "x No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"
-        )
-        assert "no solution found" in _tail_file(stdout).lower()
-
-    def test_missing_file_returns_empty(self, tmp_path):
-        assert _tail_file(tmp_path / "nope.txt") == ""
-
-    def test_only_keeps_last_n_lines(self, tmp_path):
-        stdout = tmp_path / "test-stdout.txt"
-        stdout.write_text("".join(f"line{i}\n" for i in range(100)))
-        tail = _tail_file(stdout, n=5)
-        assert tail.splitlines() == [f"line{i}" for i in range(95, 100)]
-
-    def test_redacts_secrets_in_tail(self, tmp_path):
-        """PR #572: untrusted stdout (env dumps, tokens) must be redacted.
-
-        An obviously-fake key is used as the fixture (never a real one).
-        """
-        stdout = tmp_path / "test-stdout.txt"
-        stdout.write_text(
-            "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
-            "Authorization: Bearer fake-token-aaaaaaaaaaaaaaaa\n"
-        )
-        tail = _tail_file(stdout)
-        assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in tail
-        assert "fake-token-aaaaaaaaaaaaaaaa" not in tail
-        assert "***REDACTED***" in tail
-
-
-class TestRedactSecrets:
-    """PR #572: redaction patterns mirror the trajectory set (#537).
-
-    All fixtures use obviously-fake credential values, never real ones.
-    """
-
-    @pytest.mark.parametrize(
-        "raw,leaked",
-        [
-            (
-                "key=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx",
-                "FORTESTSONLYxxxxxxxxxxxxxxx",
-            ),
-            ("key=sk-ant-api03-FAKEFAKEFAKEdeadbeefcafe1234", "deadbeefcafe1234"),
-            ("key=AKIAFAKEFAKEFAKE1234", "FAKEFAKE1234"),
-            ("key=dtn_FAKEFAKEFAKEFAKEFAKE12345678", "FAKEFAKE12345678"),
-            ("x-api-key: abc123secretvalue456", "abc123secretvalue456"),
-        ],
-    )
-    def test_redacts_pattern(self, raw, leaked):
-        out = _redact_secrets(raw)
-        assert leaked not in out
-        assert "***REDACTED***" in out
-
-    @pytest.mark.parametrize(
-        "raw",
-        [
-            "region=ASIAPACIFIC",  # English word, not an AWS key
-            "queue=task-sk-us-east-1-foo-bar",  # slug containing sk-
-            "label=dtn_v2_0",  # short identifier
-            "just normal verifier output, nothing secret here",
-        ],
-    )
-    def test_preserves_non_secret(self, raw):
-        assert _redact_secrets(raw) == raw
-
-    def test_classifier_still_fires_after_redaction(self, tmp_path):
-        """Redaction must not eat the dep-install marker the classifier needs."""
-        stdout = tmp_path / "test-stdout.txt"
-        stdout.write_text(
-            "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
-            "x No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"
-        )
-        verifier_error = (
-            "verifier crashed: verifier exited with rc=1\n"
-            f"--- test-stdout.txt (last 30 lines) ---\n{_tail_file(stdout)}"
-        )
-        assert classify_verifier_error(verifier_error) == VERIFIER_DEP_INSTALL
-        assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in verifier_error
-
-
-def test_no_dep_markers_stays_verifier_failure(tmp_path):
-    """PR #540: without dep-install markers the classifier returns verifier_failure."""
-    stdout = tmp_path / "test-stdout.txt"
-    stdout.write_text("some random test output\nassertion failed\n")
+def test_fixed_diagnostic_classifies_as_dep_install():
+    """PR #572: the fixed diagnostic the verifier appends must classify as
+    dep_install once rollout wraps it with 'verifier crashed:'."""
     verifier_error = (
-        "verifier crashed: verifier exited with rc=1\n"
-        f"--- test-stdout.txt (last 30 lines) ---\n{_tail_file(stdout)}"
+        f"verifier crashed: ...no reward file...\n{_DEP_INSTALL_DIAGNOSTIC}"
     )
-    assert classify_verifier_error(verifier_error) == VERIFIER_FAILED
+    assert classify_verifier_error(verifier_error) == VERIFIER_DEP_INSTALL
+
+
+def test_diagnostic_carries_no_stdout():
+    """PR #572: the fixed diagnostic must not contain raw resolver output —
+    only a marker the classifier needs and a pointer to the log artifact."""
+    assert "dependency install failed" in _DEP_INSTALL_DIAGNOSTIC
+    assert "test-stdout.txt" in _DEP_INSTALL_DIAGNOSTIC
+
+
+# ---------------------------------------------------------------------------
+# _has_dep_install_failure: boolean verdict only, never returns stdout
+# ---------------------------------------------------------------------------
+
+
+class TestHasDepInstallFailure:
+    @pytest.mark.parametrize(
+        "stdout",
+        [
+            "Installing...\nx No solution found when resolving torch==2.1.2+cpu\n",
+            "Could not find a version that satisfies the requirement foo==9.9\n",
+            "ERROR: dependency install failed\n",
+            "resolution impossible for package bar\n",
+            "NO SOLUTION FOUND\n",  # case-insensitive
+        ],
+    )
+    def test_detects_marker(self, tmp_path, stdout):
+        p = tmp_path / "test-stdout.txt"
+        p.write_text(stdout)
+        assert _has_dep_install_failure(p) is True
+
+    def test_no_marker_is_false(self, tmp_path):
+        p = tmp_path / "test-stdout.txt"
+        p.write_text("running tests...\nassertion failed: 2 != 3\n")
+        assert _has_dep_install_failure(p) is False
+
+    def test_missing_file_is_false(self, tmp_path):
+        assert _has_dep_install_failure(tmp_path / "nope.txt") is False
+
+    def test_single_huge_line_is_bounded(self, tmp_path):
+        """PR #572 finding 3: a single huge line must not blow up — we read a
+        bounded window and still detect the marker if present."""
+        p = tmp_path / "test-stdout.txt"
+        p.write_text("x" * (256 * 1024) + " no solution found\n")
+        assert _has_dep_install_failure(p) is True
+
+
+# ---------------------------------------------------------------------------
+# Production wiring: _verify_test_script raises a redacted, classifiable error
+# (PR #572 finding 2 — exercise the real verifier, not synthesized strings)
+# ---------------------------------------------------------------------------
+
+
+def _make_verifier(tmp_path, *, stdout_text):
+    """Build a Verifier over a fake mounted sandbox whose test.sh writes the
+    given stdout and produces NO reward file."""
+    verifier_dir = tmp_path / "verifier"
+    verifier_dir.mkdir(parents=True, exist_ok=True)
+
+    rollout_paths = MagicMock()
+    rollout_paths.verifier_dir = verifier_dir
+    rollout_paths.test_stdout_path = verifier_dir / "test-stdout.txt"
+    rollout_paths.reward_text_path = verifier_dir / "reward.txt"
+    rollout_paths.reward_json_path = verifier_dir / "reward.json"
+
+    task = MagicMock()
+    task.config.verifier.type = "test-script"
+    task.config.verifier.service = "main"
+    task.config.verifier.user = "root"
+    task.config.verifier.env = None
+    task.config.verifier.timeout_sec = 60
+    task.paths.tests_dir = tmp_path / "tests"
+    (tmp_path / "tests").mkdir(exist_ok=True)
+    task.paths.test_path = tmp_path / "tests" / "test.sh"
+
+    sandbox = MagicMock()
+    sandbox.is_mounted = True
+    sandbox.upload_dir = AsyncMock()
+
+    def _cmd(args, kwargs):
+        return args[0] if args else kwargs.get("command", "")
+
+    async def fake_exec(*args, **kwargs):
+        cmd = _cmd(args, kwargs)
+        # Setup commands (chmod/mkdir) succeed; the test.sh run writes stdout,
+        # produces no reward file, and exits nonzero.
+        if "chmod" in cmd or cmd.startswith("mkdir"):
+            return MagicMock(exit_code=0, returncode=0)
+        rollout_paths.test_stdout_path.write_text(stdout_text)
+        return MagicMock(exit_code=1, returncode=1)
+
+    sandbox.exec = AsyncMock(side_effect=fake_exec)
+    return Verifier(task=task, rollout_paths=rollout_paths, sandbox=sandbox)
+
+
+@pytest.mark.asyncio
+async def test_verify_test_script_surfaces_classifiable_dep_install(tmp_path):
+    """PR #572 finding 2: the REAL verifier path must raise an error that, once
+    wrapped as 'verifier crashed: {e}', classifies as VERIFIER_DEP_INSTALL."""
+    verifier = _make_verifier(
+        tmp_path,
+        stdout_text=(
+            "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
+            "PIP_INDEX_URL=https://user:p4ssw0rd@pypi.example/simple\n"
+            "x No solution found when resolving torch==2.1.2+cpu\n"
+        ),
+    )
+    with pytest.raises(RewardFileNotFoundError) as exc:
+        await verifier._verify_test_script()
+
+    msg = str(exc.value)
+    wrapped = f"verifier crashed: {msg}"  # how rollout.py builds verifier_error
+    assert classify_verifier_error(wrapped) == VERIFIER_DEP_INSTALL
+    # Finding 1: no raw stdout / secrets leaked into the surfaced error.
+    assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in msg
+    assert "p4ssw0rd" not in msg
+    assert "PIP_INDEX_URL" not in msg
+
+
+@pytest.mark.asyncio
+async def test_verify_test_script_non_dep_failure_is_not_dep_install(tmp_path):
+    """A missing reward file with no dep-install marker must NOT be misclassified
+    as dep_install (stays a generic verifier failure)."""
+    verifier = _make_verifier(
+        tmp_path,
+        stdout_text="running pytest...\n3 failed, 0 passed\nassertion error\n",
+    )
+    with pytest.raises(RewardFileNotFoundError) as exc:
+        await verifier._verify_test_script()
+
+    wrapped = f"verifier crashed: {exc.value}"
+    assert classify_verifier_error(wrapped) == VERIFIER_FAILED
+    assert _DEP_INSTALL_DIAGNOSTIC not in str(exc.value)

--- a/tests/test_verifier_output.py
+++ b/tests/test_verifier_output.py
@@ -110,7 +110,10 @@ class TestRedactSecrets:
     @pytest.mark.parametrize(
         "raw,leaked",
         [
-            ("key=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx", "FORTESTSONLYxxxxxxxxxxxxxxx"),
+            (
+                "key=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx",
+                "FORTESTSONLYxxxxxxxxxxxxxxx",
+            ),
             ("key=sk-ant-api03-FAKEFAKEFAKEdeadbeefcafe1234", "deadbeefcafe1234"),
             ("key=AKIAFAKEFAKEFAKE1234", "FAKEFAKE1234"),
             ("key=dtn_FAKEFAKEFAKEFAKEFAKE12345678", "FAKEFAKE12345678"),

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from benchflow._utils.scoring import (
+    VERIFIER_DEP_INSTALL,
     VERIFIER_FAILED,
     VERIFIER_INFRA,
     VERIFIER_TIMEOUT,
@@ -34,6 +35,28 @@ from benchflow.models import RunResult
         ),
         ("verifier timed out after 900s", VERIFIER_TIMEOUT),
         ("verifier did something weird", "verifier_other"),
+        # dep_install markers surfaced via test-stdout.txt tail
+        (
+            "verifier crashed: verifier exited with rc=1; no reward file found\n"
+            "--- test-stdout.txt (last 30 lines) ---\n"
+            "× No solution found when resolving tool dependencies: torch==2.1.2+cpu",  # noqa: RUF001
+            VERIFIER_DEP_INSTALL,
+        ),
+        (
+            "verifier crashed: verifier exited with rc=1\n"
+            "Could not find a version that satisfies the requirement foo==9.9.9",
+            VERIFIER_DEP_INSTALL,
+        ),
+        (
+            "verifier crashed: verifier exited with rc=1\n"
+            "ERROR: dependency install failed",
+            VERIFIER_DEP_INSTALL,
+        ),
+        (
+            "verifier crashed: verifier exited with rc=1\n"
+            "resolution impossible for package bar",
+            VERIFIER_DEP_INSTALL,
+        ),
     ],
 )
 def test_classify_verifier_error(input_str, expected):
@@ -47,6 +70,72 @@ def test_classify_verifier_error_substring_order():
     """
     msg = "verifier crashed: verifier timed out inside"
     assert classify_verifier_error(msg) == VERIFIER_FAILED
+
+
+def test_dep_install_takes_precedence_over_generic_crash():
+    """dep_install wins over verifier_failure when both markers are present."""
+    msg = (
+        "verifier crashed: verifier exited with rc=1; no reward file found\n"
+        "--- test-stdout.txt (last 30 lines) ---\n"
+        "× No solution found when resolving tool dependencies: torch==2.1.2+cpu"  # noqa: RUF001
+    )
+    assert classify_verifier_error(msg) == VERIFIER_DEP_INSTALL
+
+
+class TestRewardFileNotFoundSurfacesStdout:
+    """Verify that RewardFileNotFoundError includes test-stdout.txt tail,
+    so classify_verifier_error can detect dep-install markers end-to-end.
+    """
+
+    def test_exception_includes_stdout_tail(self, tmp_path):
+        from benchflow.task.verifier import _tail_file
+
+        stdout = tmp_path / "test-stdout.txt"
+        stdout.write_text(
+            "Installing dependencies...\n"
+            "× No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"  # noqa: RUF001
+        )
+        tail = _tail_file(stdout)
+        assert "no solution found" in tail.lower()
+
+    def test_exception_message_triggers_classifier(self, tmp_path):
+        """Simulate the exact exception message verifier.py now builds and
+        verify the classifier returns VERIFIER_DEP_INSTALL."""
+        stdout_content = (
+            "Collecting torch==2.1.2+cpu\n"
+            "× No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"  # noqa: RUF001
+        )
+        (tmp_path / "test-stdout.txt").write_text(stdout_content)
+
+        from benchflow.task.verifier import _tail_file
+
+        tail = _tail_file(tmp_path / "test-stdout.txt")
+        verifier_error = (
+            f"verifier crashed: verifier exited with rc=1; no reward file "
+            f"found at {tmp_path}/reward.txt or {tmp_path}/reward.json"
+            f"\n--- test-stdout.txt (last 30 lines) ---\n{tail}"
+        )
+        assert classify_verifier_error(verifier_error) == VERIFIER_DEP_INSTALL
+
+    def test_missing_stdout_produces_no_tail(self, tmp_path):
+        from benchflow.task.verifier import _tail_file
+
+        tail = _tail_file(tmp_path / "nonexistent.txt")
+        assert tail == ""
+
+    def test_no_dep_markers_stays_verifier_failure(self, tmp_path):
+        """Without dep-install markers the classifier should return verifier_failure."""
+        (tmp_path / "test-stdout.txt").write_text("some random test output\nfail\n")
+
+        from benchflow.task.verifier import _tail_file
+
+        tail = _tail_file(tmp_path / "test-stdout.txt")
+        verifier_error = (
+            f"verifier crashed: verifier exited with rc=1; no reward file "
+            f"found at {tmp_path}/reward.txt\n"
+            f"--- test-stdout.txt (last 30 lines) ---\n{tail}"
+        )
+        assert classify_verifier_error(verifier_error) == VERIFIER_FAILED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -9,7 +9,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from benchflow._utils.scoring import (
-    VERIFIER_DEP_INSTALL,
     VERIFIER_FAILED,
     VERIFIER_INFRA,
     VERIFIER_TIMEOUT,
@@ -35,28 +34,8 @@ from benchflow.models import RunResult
         ),
         ("verifier timed out after 900s", VERIFIER_TIMEOUT),
         ("verifier did something weird", "verifier_other"),
-        # dep_install markers surfaced via test-stdout.txt tail
-        (
-            "verifier crashed: verifier exited with rc=1; no reward file found\n"
-            "--- test-stdout.txt (last 30 lines) ---\n"
-            "× No solution found when resolving tool dependencies: torch==2.1.2+cpu",  # noqa: RUF001
-            VERIFIER_DEP_INSTALL,
-        ),
-        (
-            "verifier crashed: verifier exited with rc=1\n"
-            "Could not find a version that satisfies the requirement foo==9.9.9",
-            VERIFIER_DEP_INSTALL,
-        ),
-        (
-            "verifier crashed: verifier exited with rc=1\n"
-            "ERROR: dependency install failed",
-            VERIFIER_DEP_INSTALL,
-        ),
-        (
-            "verifier crashed: verifier exited with rc=1\n"
-            "resolution impossible for package bar",
-            VERIFIER_DEP_INSTALL,
-        ),
+        # dep_install classification + stdout surfacing live in
+        # tests/test_verifier_output.py (PR #540 / #572).
     ],
 )
 def test_classify_verifier_error(input_str, expected):
@@ -70,72 +49,6 @@ def test_classify_verifier_error_substring_order():
     """
     msg = "verifier crashed: verifier timed out inside"
     assert classify_verifier_error(msg) == VERIFIER_FAILED
-
-
-def test_dep_install_takes_precedence_over_generic_crash():
-    """dep_install wins over verifier_failure when both markers are present."""
-    msg = (
-        "verifier crashed: verifier exited with rc=1; no reward file found\n"
-        "--- test-stdout.txt (last 30 lines) ---\n"
-        "× No solution found when resolving tool dependencies: torch==2.1.2+cpu"  # noqa: RUF001
-    )
-    assert classify_verifier_error(msg) == VERIFIER_DEP_INSTALL
-
-
-class TestRewardFileNotFoundSurfacesStdout:
-    """Verify that RewardFileNotFoundError includes test-stdout.txt tail,
-    so classify_verifier_error can detect dep-install markers end-to-end.
-    """
-
-    def test_exception_includes_stdout_tail(self, tmp_path):
-        from benchflow.task.verifier import _tail_file
-
-        stdout = tmp_path / "test-stdout.txt"
-        stdout.write_text(
-            "Installing dependencies...\n"
-            "× No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"  # noqa: RUF001
-        )
-        tail = _tail_file(stdout)
-        assert "no solution found" in tail.lower()
-
-    def test_exception_message_triggers_classifier(self, tmp_path):
-        """Simulate the exact exception message verifier.py now builds and
-        verify the classifier returns VERIFIER_DEP_INSTALL."""
-        stdout_content = (
-            "Collecting torch==2.1.2+cpu\n"
-            "× No solution found when resolving tool dependencies: torch==2.1.2+cpu\n"  # noqa: RUF001
-        )
-        (tmp_path / "test-stdout.txt").write_text(stdout_content)
-
-        from benchflow.task.verifier import _tail_file
-
-        tail = _tail_file(tmp_path / "test-stdout.txt")
-        verifier_error = (
-            f"verifier crashed: verifier exited with rc=1; no reward file "
-            f"found at {tmp_path}/reward.txt or {tmp_path}/reward.json"
-            f"\n--- test-stdout.txt (last 30 lines) ---\n{tail}"
-        )
-        assert classify_verifier_error(verifier_error) == VERIFIER_DEP_INSTALL
-
-    def test_missing_stdout_produces_no_tail(self, tmp_path):
-        from benchflow.task.verifier import _tail_file
-
-        tail = _tail_file(tmp_path / "nonexistent.txt")
-        assert tail == ""
-
-    def test_no_dep_markers_stays_verifier_failure(self, tmp_path):
-        """Without dep-install markers the classifier should return verifier_failure."""
-        (tmp_path / "test-stdout.txt").write_text("some random test output\nfail\n")
-
-        from benchflow.task.verifier import _tail_file
-
-        tail = _tail_file(tmp_path / "test-stdout.txt")
-        verifier_error = (
-            f"verifier crashed: verifier exited with rc=1; no reward file "
-            f"found at {tmp_path}/reward.txt\n"
-            f"--- test-stdout.txt (last 30 lines) ---\n{tail}"
-        )
-        assert classify_verifier_error(verifier_error) == VERIFIER_FAILED
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Root cause:** `RewardFileNotFoundError` in `verifier.py` only included file paths in its message, never pip's actual error output. The `classify_verifier_error` function had `dep_install` markers (`"no solution found"`, etc.) but could never match them because they lived in `test-stdout.txt`, not the exception.
- **Fix:** When raising `RewardFileNotFoundError`, tail the last 30 lines of `test-stdout.txt` into the exception message. This lets `classify_verifier_error` see pip's output and correctly return `verifier_dep_install`.
- **No changes to `scoring.py`** — the classifier logic and markers were already correct (added in prior PRs); only the wiring was broken.

## Test plan

- [x] 4 new parametrized cases in `test_classify_verifier_error` covering all dep_install markers in exception messages
- [x] `test_dep_install_takes_precedence_over_generic_crash` — precedence test
- [x] `TestRewardFileNotFoundSurfacesStdout` — 4 end-to-end wiring tests: stdout tail present, classifier fires, missing file graceful, non-dep-install stays `verifier_failure`
- [x] All 96 verifier+scoring tests pass
- [x] ruff clean

Closes #540

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->