### PR TITLE
docs: task authoring

### DIFF
--- a/benchmarks/CONVERT.md
+++ b/benchmarks/CONVERT.md
@@ -1,6 +1,6 @@
 # Benchmark Conversion Guide
 
-How to convert a new benchmark into BenchFlow format.
+How to convert a new benchmark into Harbor-format tasks for BenchFlow.
 
 ## Overview
 
@@ -24,7 +24,7 @@ Clone the benchmark repo and study its structure:
 
 ### 2. Write the converter (`benchflow.py`)
 
-Create `benchmarks/<name>/benchflow.py` that maps the source format to BenchFlow task format.
+Create `benchmarks/<name>/benchflow.py` that maps the source format to Harbor-format task directories for BenchFlow.
 
 Each generated task directory must contain:
 ```

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -23,7 +23,7 @@ This guide covers how to run them — from a single task to a full evaluation sw
 | [SkillsBench](https://github.com/benchflow-ai/skillsbench) | 94+ | Unit tests | `benchmarks/skillsbench-*.yaml` |
 
 Each adapted benchmark includes:
-- **`benchflow.py`** — converter: raw benchmark → Harbor-format task directories for BenchFlow
+- **`benchflow.py`** — converter for the raw benchmark source
 - **`benchmark.yaml`** — metadata descriptor (task count, categories, verification method, parity results)
 - **`<name>-*.yaml`** — job configs for different agents/models
 - **`parity_test.py`** — parity validation suite

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -1,10 +1,13 @@
 # Running Adapted Benchmarks
 
-How to run benchmarks that have been converted to BenchFlow format.
+How to run benchmarks that have been converted into Harbor-format tasks for BenchFlow.
 
 BenchFlow ships with adapted benchmarks under `benchmarks/<name>/`. Each benchmark
 includes a converter, parity tests, metadata, and one or more YAML job configs.
 This guide covers how to run them — from a single task to a full evaluation sweep.
+
+> [!NOTE]
+> BenchFlow is providing first-party support for PrimeIntellect Verifiers and OpenReward Standard.
 
 > **Working inside the benchflow repo?** Use `uv run bench` instead of `bench`
 > to run the CLI from your local editable install.
@@ -20,7 +23,7 @@ This guide covers how to run them — from a single task to a full evaluation sw
 | [SkillsBench](https://github.com/benchflow-ai/skillsbench) | 94+ | Unit tests | `benchmarks/skillsbench-*.yaml` |
 
 Each adapted benchmark includes:
-- **`benchflow.py`** — converter: raw benchmark → BenchFlow task format
+- **`benchflow.py`** — converter: raw benchmark → Harbor-format task directories for BenchFlow
 - **`benchmark.yaml`** — metadata descriptor (task count, categories, verification method, parity results)
 - **`<name>-*.yaml`** — job configs for different agents/models
 - **`parity_test.py`** — parity validation suite
@@ -390,6 +393,6 @@ All fields from [CLI reference](./reference/cli.md#yaml-config-format) apply:
 ## Adding a new benchmark
 
 See the [Benchmark Conversion Guide](../benchmarks/CONVERT.md) for the 9-step
-process to convert a new benchmark into BenchFlow format. Harvey LAB
+process to convert a new benchmark into Harbor-format tasks for BenchFlow. Harvey LAB
 (`benchmarks/harvey-lab/`) and ProgramBench (`benchmarks/programbench/`) are
 reference implementations.

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -5,6 +5,11 @@ A BenchFlow task packages an instruction, a sandboxed environment, and a verifie
 
 ## Directory layout
 
+> [!NOTE]
+> BenchFlow will provide first-party support for Kaggle, Verifiers, and OpenReward Standard.
+
+You can create [Harbor-format tasks](https://www.harborframework.com/docs/tasks) in BenchFlow with a `task.toml` config file, separate `instruction.md`, sandbox assets under `environment/`, verifier files under `tests/`, and an optional `solution/` oracle.
+
 ```
 my-task/
 ├── task.toml              # timeouts, resources, metadata


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording and notes; no runtime, API, or verifier behavior changes.
> 
> **Overview**
> This PR **reframes BenchFlow task packaging as Harbor-format directories** instead of a generic “BenchFlow format,” and adds short **roadmap notes** for upcoming first-party integrations.
> 
> In **`docs/task-authoring.md`**, a note calls out planned support for **Kaggle**, **PrimeIntellect Verifiers**, and **OpenReward Standard**, and the layout section now explicitly points authors to **[Harbor-format tasks](https://www.harborframework.com/docs/tasks)** (`task.toml`, `instruction.md`, `environment/`, `tests/`, optional `solution/`).
> 
> **`docs/running-benchmarks.md`** and **`benchmarks/CONVERT.md`** use the same Harbor wording for converted benchmarks and converters, and **`running-benchmarks.md`** adds a note about **PrimeIntellect Verifiers** and **OpenReward Standard**. The **`benchflow.py`** bullet is shortened to describe it as a converter for the raw source rather than “raw → BenchFlow task format.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2350368e3a69bfe7af6649f9e7c0d4df7347541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->