### PR TITLE
feat: contracts package + provider registries (v0.5 Phase 0 kernel seam)

### DIFF
--- a/src/benchflow/contracts/__init__.py
+++ b/src/benchflow/contracts/__init__.py
@@ -1,0 +1,97 @@
+"""The kernel's contract surface — BenchFlow's four planes, in one place.
+
+Design principle 1 (``docs/architecture.md``): *the kernel depends only on
+contracts.* This package is that single import point. The kernel (Rollout
+lifecycle, reward, trajectory) types itself against the ``Protocol`` classes
+re-exported here; concrete providers (``DockerSandbox``, ``ManifestEnvironment``,
+the ACP session adapter, ``RewardFunc``s) live in their plane packages and join
+the kernel through the per-plane registries — never by being imported into the
+kernel directly.
+
+The four planes map onto Han's ``E = {T, H, V, S, C}``:
+
+* ``Sandbox``                 — where it runs (the substrate).
+* ``Agent`` / ``Session``     — who acts (Han's H, the harness).
+* ``Environment``             — the world (Han's S, the stateful state machine).
+* ``Reward`` / ``RewardFunc`` — how it's scored (Han's V, the verifier).
+
+This module re-exports **only Protocols and the small dataclasses that cross
+the kernel↔plane seam**. It imports no concrete provider, so importing
+``benchflow.contracts`` can never pull a sandbox/agent/reward backend into the
+kernel. Keep it that way.
+
+Note on the ``Agent`` / ``Environment`` names: ``benchflow.contracts.Agent`` and
+``benchflow.contracts.Environment`` are the *Protocols*. The top-level
+``benchflow.Agent`` / ``benchflow.Environment`` are the ``runtime`` module's
+convenience *config* dataclasses (a different thing). Import the contract from
+here when you mean the plane Protocol.
+"""
+
+from __future__ import annotations
+
+# ── Agent plane (Han's H) ──────────────────────────────────────────────────
+from benchflow.agents.protocol import (
+    Agent,
+    AgentCapabilities,
+    AskUserHandler,
+    AskUserRequest,
+    Session,
+    StopReason,
+)
+
+# ── Environment plane (Han's S) ────────────────────────────────────────────
+from benchflow.environment.protocol import (
+    EnvHandle,
+    Environment,
+    EnvState,
+    ReadinessProbe,
+    StateSnapshot,
+)
+
+# ── Reward plane (Han's V) ─────────────────────────────────────────────────
+from benchflow.rewards.protocol import (
+    Reward,
+    RewardFunc,
+    VerifyResult,
+)
+
+# ── Sandbox plane (the substrate) ──────────────────────────────────────────
+from benchflow.sandbox.protocol import (
+    ExecResult,
+    ImageBuilder,
+    ImageConfig,
+    ImageRef,
+    Sandbox,
+    SandboxImage,
+    SandboxSnapshotNotSupported,
+    SandboxStartupError,
+)
+
+__all__ = [
+    # Sandbox plane
+    "Sandbox",
+    "ExecResult",
+    "SandboxImage",
+    "SandboxSnapshotNotSupported",
+    "SandboxStartupError",
+    "ImageBuilder",
+    "ImageConfig",
+    "ImageRef",
+    # Agent plane
+    "Agent",
+    "Session",
+    "AgentCapabilities",
+    "AskUserHandler",
+    "AskUserRequest",
+    "StopReason",
+    # Environment plane
+    "Environment",
+    "EnvHandle",
+    "ReadinessProbe",
+    "EnvState",
+    "StateSnapshot",
+    # Reward plane
+    "Reward",
+    "RewardFunc",
+    "VerifyResult",
+]

--- a/src/benchflow/environment/registry.py
+++ b/src/benchflow/environment/registry.py
@@ -1,0 +1,61 @@
+"""Environment provider registry — how concrete worlds join the kernel.
+
+Design principle 2 (``docs/architecture.md``): the Environment plane is
+swappable + BYO. The kernel does not import ``ManifestEnvironment`` directly;
+it asks :func:`resolve_environment` for a :class:`benchflow.contracts.Environment`
+built from the rollout's manifest. ``ManifestEnvironment`` is the built-in
+default adapter that reads a declarative manifest; a third party registers an
+alternative world (a fixed sidecar fleet, a custom simulator host) with
+:func:`register_environment` and no kernel edit.
+
+Mirrors :mod:`benchflow.sandbox.registry` and the Agent plane's
+:mod:`benchflow.agents.registry`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from benchflow.contracts import Environment
+
+# A factory builds an Environment from its manifest, bound to a live sandbox.
+EnvironmentFactory = Callable[[Any, Any], "Environment"]
+
+_ENVIRONMENT_REGISTRY: dict[str, EnvironmentFactory] = {}
+
+# The manifest field that selects the provider; absent => the default below.
+DEFAULT_ENVIRONMENT_KIND = "manifest"
+
+
+def register_environment(kind: str, factory: EnvironmentFactory) -> None:
+    """Register an environment provider under ``kind`` (e.g. ``"manifest"``)."""
+    _ENVIRONMENT_REGISTRY[kind] = factory
+
+
+def available_environments() -> list[str]:
+    """Names of all registered environment providers, sorted."""
+    return sorted(_ENVIRONMENT_REGISTRY)
+
+
+def resolve_environment(kind: str, manifest: Any, *, sandbox: Any) -> Environment:
+    """Build an Environment by provider kind, raising for unknown kinds."""
+    try:
+        factory = _ENVIRONMENT_REGISTRY[kind]
+    except KeyError:
+        known = ", ".join(repr(n) for n in available_environments()) or "(none)"
+        raise ValueError(
+            f"Unknown environment provider {kind!r} (registered: {known})"
+        ) from None
+    return factory(manifest, sandbox)
+
+
+def _build_manifest_environment(manifest: Any, sandbox: Any) -> Environment:
+    # Lazy import: keep the concrete adapter out of the registry's import path.
+    from benchflow.environment.manifest_env import ManifestEnvironment
+
+    return ManifestEnvironment(manifest, sandbox=sandbox)
+
+
+register_environment(DEFAULT_ENVIRONMENT_KIND, _build_manifest_environment)

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -66,12 +66,16 @@ from benchflow.agents.install import (
     install_agent,
 )
 from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
+from benchflow.contracts import Environment, Sandbox
 from benchflow.diagnostics import (
     RolloutDiagnostics,
     VerifierTimeoutDiagnostic,
 )
 from benchflow.environment.manifest import EnvironmentManifest
-from benchflow.environment.manifest_env import ManifestEnvironment
+from benchflow.environment.registry import (
+    DEFAULT_ENVIRONMENT_KIND,
+    resolve_environment,
+)
 from benchflow.models import RolloutResult, TrajectorySource
 from benchflow.providers.runtime import (
     ensure_bedrock_proxy_runtime,
@@ -1026,12 +1030,12 @@ class Rollout:
         self._agent_env: dict[str, str] = {}
         self._resolved_prompts: list[str] = []
         self._agent_launch: str = ""
-        self._env: Any = None
+        self._env: Sandbox | None = None
         # When True, Rollout treats _env as caller-owned: setup() skips
         # creating a new sandbox and cleanup() skips stopping it. Set via
         # use_prebuilt_env() — see Runtime.execute() for the public path.
         self._env_externally_owned: bool = False
-        self._environment: ManifestEnvironment | None = None
+        self._environment: Environment | None = None
         self._timeout: int = 0
         self._timing: dict[str, float] = {}
         self._effective_locked: list[str] = []
@@ -1306,8 +1310,10 @@ class Rollout:
         # Environment plane: provision the manifest-declared stateful
         # environment and gate on its readiness before the agent runs.
         if self._config.environment_manifest is not None:
-            self._environment = ManifestEnvironment(
-                self._config.environment_manifest, sandbox=self._env
+            self._environment = resolve_environment(
+                DEFAULT_ENVIRONMENT_KIND,
+                self._config.environment_manifest,
+                sandbox=self._env,
             )
             await self._environment.provision(
                 ctx={"task_id": self._config.task_path.name}
@@ -1326,6 +1332,21 @@ class Rollout:
 
         self._phase = "started"
 
+    @property
+    def _sandbox(self) -> Sandbox:
+        """The active sandbox, narrowed non-None.
+
+        ``self._env`` is ``None`` only before ``setup()``/``start()`` build it.
+        The execute/verify/cleanup methods run strictly after that, so they
+        reach the sandbox through this accessor instead of repeating a None
+        guard at every call site — and it fails loudly if the invariant breaks.
+        """
+        if self._env is None:
+            raise RuntimeError(
+                "sandbox not started — setup() and start() must run first"
+            )
+        return self._env
+
     # ── Phase 3: INSTALL AGENT ──
 
     async def install_agent(self) -> None:
@@ -1338,7 +1359,7 @@ class Rollout:
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
 
-        cwd_result = await self._env.exec("pwd", timeout_sec=10)
+        cwd_result = await self._sandbox.exec("pwd", timeout_sec=10)
         agent_cwd = (cwd_result.stdout or "").strip() or "/app"
         self._agent_cwd = agent_cwd
 
@@ -1483,7 +1504,7 @@ class Rollout:
         if self._env and self._agent_launch.strip():
             agent_cmd = self._agent_launch.split()[0].split("/")[-1]
             with contextlib.suppress(Exception):
-                await self._env.exec(f"pkill -f '{agent_cmd}' || true", timeout_sec=10)
+                await self._sandbox.exec(f"pkill -f '{agent_cmd}' || true", timeout_sec=10)
         self._active_role = None
         self._session_tool_count = 0
         self._session_traj_count = 0
@@ -1807,7 +1828,7 @@ class Rollout:
             )
             rewards = _ensure_canonical_rewards(verifier_result.rewards)
             # Capture raw verifier output for the user
-            cat = await self._env.exec(
+            cat = await self._sandbox.exec(
                 "cat /logs/verifier/*.log 2>/dev/null || "
                 "cat /logs/verifier/output.txt 2>/dev/null || true",
                 timeout_sec=10,
@@ -1881,7 +1902,7 @@ class Rollout:
             # via Rollout.__new__() working.
             if not getattr(self, "_env_externally_owned", False):
                 try:
-                    await self._env.stop(delete=True)
+                    await self._sandbox.stop(delete=True)
                 except Exception as e:
                     logger.warning(f"Cleanup failed: {e}")
 
@@ -1916,7 +1937,7 @@ class Rollout:
                 # git safe.directory needed for SWE-bench tasks with sandbox_user
                 import shlex
 
-                await self._env.exec(
+                await self._sandbox.exec(
                     f"git config --global --add safe.directory "
                     f"{shlex.quote(self._agent_cwd)} 2>/dev/null || true",
                     user="root",
@@ -1943,7 +1964,7 @@ class Rollout:
                         logger.error(self._error)
                 finally:
                     if cfg.oracle_access:
-                        await self._env.exec(
+                        await self._sandbox.exec(
                             "mv /solution_oracle_backup /solution 2>/dev/null || true",
                             user="root",
                             timeout_sec=10,
@@ -2014,7 +2035,7 @@ class Rollout:
         last_err: Exception | None = None
         for attempt in range(3):
             try:
-                await self._env.download_dir(self._config.generated_skills_root, target)
+                await self._sandbox.download_dir(self._config.generated_skills_root, target)
                 break
             except Exception as e:
                 last_err = e
@@ -2047,13 +2068,13 @@ class Rollout:
         if isinstance(source_value, os.PathLike) and local_source.is_dir():
             remote_source = f"/skills/{_safe_skill_name(scene.name)}"
             await _ensure_sandbox_dir(self._env, Path(remote_source).parent)
-            await self._env.upload_dir(local_source, remote_source)
+            await self._sandbox.upload_dir(local_source, remote_source)
         elif source.startswith("/"):
             remote_source = source
         elif local_source.is_dir():
             remote_source = f"/skills/{_safe_skill_name(scene.name)}"
             await _ensure_sandbox_dir(self._env, Path(remote_source).parent)
-            await self._env.upload_dir(local_source, remote_source)
+            await self._sandbox.upload_dir(local_source, remote_source)
         else:
             raise FileNotFoundError(f"Scene skills_dir not found: {scene.skills_dir}")
 
@@ -2176,7 +2197,7 @@ class Rollout:
                 if cfg.sandbox_user:
                     user = shlex.quote(cfg.sandbox_user)
                     setup_cmd += f" && chown {user}:{user} {self._OUTBOX_DIR}"
-                await self._env.exec(setup_cmd, timeout_sec=10)
+                await self._sandbox.exec(setup_cmd, timeout_sec=10)
 
             inbox: dict[str, list[str]] = {r.name: [] for r in scene.roles}
             turn_counter = 0
@@ -2247,7 +2268,7 @@ class Rollout:
 
     async def _read_scene_outbox(self, sender: str) -> list[tuple[str, str]]:
         """Read and clear outbox files left by *sender*. Returns [(recipient, content), ...]."""
-        result = await self._env.exec(
+        result = await self._sandbox.exec(
             f"ls {self._OUTBOX_DIR}/*.json 2>/dev/null || true",
             timeout_sec=10,
         )
@@ -2257,7 +2278,7 @@ class Rollout:
         messages: list[tuple[str, str]] = []
         for fpath in files:
             quoted = shlex.quote(fpath)
-            cat = await self._env.exec(f"cat {quoted}", timeout_sec=10)
+            cat = await self._sandbox.exec(f"cat {quoted}", timeout_sec=10)
             try:
                 data = json.loads(cat.stdout or "{}")
                 recipient = data.get("to", "")
@@ -2269,7 +2290,7 @@ class Rollout:
                     )
             except json.JSONDecodeError:
                 logger.warning(f"[Scene] invalid JSON in outbox: {fpath}")
-            await self._env.exec(f"rm -f {quoted}", timeout_sec=10)
+            await self._sandbox.exec(f"rm -f {quoted}", timeout_sec=10)
         return messages
 
     async def _run_user_loop(self) -> None:
@@ -2305,7 +2326,7 @@ class Rollout:
         # Oracle access: read /solution before the agent runs, then remove it
         solution: str | None = None
         if cfg.oracle_access:
-            cat = await self._env.exec(
+            cat = await self._sandbox.exec(
                 "cat /solution/solve.sh 2>/dev/null || true",
                 user="root",
                 timeout_sec=10,
@@ -2317,7 +2338,7 @@ class Rollout:
         # Hide oracle files from agent — move rather than delete so the
         # final verify() can still access /solution if the verifier needs it.
         if cfg.oracle_access:
-            await self._env.exec(
+            await self._sandbox.exec(
                 "mv /solution /solution_oracle_backup 2>/dev/null || true",
                 user="root",
                 timeout_sec=10,
@@ -2364,7 +2385,7 @@ class Rollout:
             # next round. Temporarily restore /solution so the verifier can
             # access it, then re-hide before the next agent round.
             if cfg.oracle_access:
-                await self._env.exec(
+                await self._sandbox.exec(
                     "mv /solution_oracle_backup /solution 2>/dev/null || true",
                     user="root",
                     timeout_sec=10,
@@ -2373,7 +2394,7 @@ class Rollout:
                 rewards, verifier_output, verifier_error = await self.soft_verify()
             finally:
                 if cfg.oracle_access:
-                    await self._env.exec(
+                    await self._sandbox.exec(
                         "mv /solution /solution_oracle_backup 2>/dev/null || true",
                         user="root",
                         timeout_sec=10,

--- a/src/benchflow/sandbox/registry.py
+++ b/src/benchflow/sandbox/registry.py
@@ -1,0 +1,68 @@
+"""Sandbox provider registry — how concrete substrates join the kernel.
+
+Design principle 2 (``docs/architecture.md``): *four planes, each swappable,
+each managed + BYO.* The kernel never imports ``DockerSandbox`` /
+``DaytonaSandbox`` / a Modal class directly; it asks this registry to
+``resolve_sandbox(name, ctx)`` and gets back something that satisfies the
+:class:`benchflow.contracts.Sandbox` Protocol. Built-in providers register
+themselves (see :mod:`benchflow.sandbox.setup`); a third party adds a backend
+with :func:`register_sandbox` and no kernel edit.
+
+This mirrors the Agent plane's existing data-driven registry
+(:mod:`benchflow.agents.registry`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from benchflow.contracts import Sandbox
+
+
+@dataclass(frozen=True)
+class SandboxBuildContext:
+    """The resolved inputs every provider factory needs to build a sandbox.
+
+    The shared, provider-independent preamble (manifest image/env resolution,
+    network-policy adjustments) runs once before resolution and lands here;
+    each factory only does its own provider-specific construction.
+    """
+
+    environment_dir: Path
+    environment_name: str
+    session_id: str
+    rollout_paths: Any
+    task_env_config: Any
+    persistent_env: dict[str, str] | None
+
+
+# A factory takes the resolved context and returns a Sandbox-Protocol object.
+SandboxFactory = Callable[[SandboxBuildContext], "Sandbox"]
+
+_SANDBOX_REGISTRY: dict[str, SandboxFactory] = {}
+
+
+def register_sandbox(name: str, factory: SandboxFactory) -> None:
+    """Register a sandbox provider under ``name`` (e.g. ``"docker"``)."""
+    _SANDBOX_REGISTRY[name] = factory
+
+
+def available_sandboxes() -> list[str]:
+    """Names of all registered sandbox providers, sorted."""
+    return sorted(_SANDBOX_REGISTRY)
+
+
+def resolve_sandbox(name: str, ctx: SandboxBuildContext) -> Sandbox:
+    """Build a sandbox by provider name, raising for unknown names."""
+    try:
+        factory = _SANDBOX_REGISTRY[name]
+    except KeyError:
+        known = ", ".join(repr(n) for n in available_sandboxes()) or "(none)"
+        raise ValueError(
+            f"Unknown sandbox provider {name!r} (registered: {known})"
+        ) from None
+    return factory(ctx)

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -14,6 +14,11 @@ from typing import Any, NoReturn, cast
 
 from benchflow._paths import ignore_symlinks, is_safe_regular_file
 from benchflow.agents.registry import AGENTS
+from benchflow.sandbox.registry import (
+    SandboxBuildContext,
+    register_sandbox,
+    resolve_sandbox,
+)
 from benchflow.task import RolloutPaths, Task
 
 logger = logging.getLogger(__name__)
@@ -612,6 +617,88 @@ def _patch_docker_dind() -> None:
     _DIND_PATCH_APPLIED = True
 
 
+# ── Built-in sandbox provider factories ────────────────────────────────────
+# Each factory does only its own provider-specific construction; the shared,
+# provider-independent preamble runs once in ``_create_sandbox_environment``
+# and is handed in via the ``SandboxBuildContext``. Registered into the
+# provider registry at import time (bottom of module) so the kernel resolves
+# sandboxes by name (``contracts``/registry seam) rather than via this if/elif.
+
+
+def _build_docker_sandbox(ctx: SandboxBuildContext) -> Any:
+    from benchflow.sandbox.docker import DockerSandbox
+
+    return DockerSandbox(
+        environment_dir=ctx.environment_dir,
+        environment_name=ctx.environment_name,
+        session_id=ctx.session_id,
+        rollout_paths=ctx.rollout_paths,
+        task_env_config=ctx.task_env_config,
+        persistent_env=ctx.persistent_env,
+    )
+
+
+def _build_daytona_sandbox(ctx: SandboxBuildContext) -> Any:
+    try:
+        from benchflow.sandbox._sdk_ops import apply as _apply_daytona_patches
+        from benchflow.sandbox.daytona import DaytonaSandbox
+    except ModuleNotFoundError as exc:
+        _raise_missing_optional_sandbox_dependency("daytona", exc)
+
+    _apply_daytona_patches()
+
+    env_config = ctx.task_env_config
+    if env_config.cpus > _DAYTONA_MAX_CPUS:
+        logger.warning(
+            "Clamping cpus %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_CPUS)",
+            env_config.cpus,
+            _DAYTONA_MAX_CPUS,
+        )
+        env_config.cpus = _DAYTONA_MAX_CPUS
+    if env_config.memory_mb > _DAYTONA_MAX_MEMORY_MB:
+        logger.warning(
+            "Clamping memory_mb %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_MEMORY_MB)",
+            env_config.memory_mb,
+            _DAYTONA_MAX_MEMORY_MB,
+        )
+        env_config.memory_mb = _DAYTONA_MAX_MEMORY_MB
+    if env_config.storage_mb > _DAYTONA_MAX_STORAGE_MB:
+        logger.warning(
+            "Clamping storage_mb %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_STORAGE_MB)",
+            env_config.storage_mb,
+            _DAYTONA_MAX_STORAGE_MB,
+        )
+        env_config.storage_mb = _DAYTONA_MAX_STORAGE_MB
+
+    return DaytonaSandbox(
+        environment_dir=ctx.environment_dir,
+        environment_name=ctx.environment_name,
+        session_id=ctx.session_id,
+        rollout_paths=ctx.rollout_paths,
+        task_env_config=env_config,
+        auto_stop_interval_mins=1440,
+        auto_delete_interval_mins=1440,
+        persistent_env=ctx.persistent_env,
+    )
+
+
+def _build_modal_sandbox(ctx: SandboxBuildContext) -> Any:
+    try:
+        modal_environment_class = _create_benchflow_modal_environment_class()
+    except ModuleNotFoundError as exc:
+        _raise_missing_optional_sandbox_dependency("modal", exc)
+    modal_environment_class.preflight()
+
+    return modal_environment_class(
+        environment_dir=ctx.environment_dir,
+        environment_name=ctx.environment_name,
+        session_id=ctx.session_id,
+        rollout_paths=ctx.rollout_paths,
+        task_env_config=ctx.task_env_config,
+        persistent_env=ctx.persistent_env,
+    )
+
+
 def _create_sandbox_environment(
     sandbox_type: str,
     task: Task,
@@ -621,7 +708,11 @@ def _create_sandbox_environment(
     preserve_agent_network: bool = False,
     environment_manifest: Any = None,
 ) -> Any:
-    """Create a sandbox environment (Docker, Daytona, or Modal).
+    """Create a sandbox (Docker, Daytona, Modal, or any BYO provider).
+
+    Runs the shared, provider-independent preamble — network-policy
+    adjustment and manifest image/env resolution — then resolves the named
+    provider through :func:`benchflow.sandbox.registry.resolve_sandbox`.
 
     When ``environment_manifest`` is provided, its declared controls take
     effect at sandbox-construction time: the manifest's runnable ``image``
@@ -662,78 +753,21 @@ def _create_sandbox_environment(
             environment_manifest, task_id=task_path.name
         )
 
-    if sandbox_type == "docker":
-        from benchflow.sandbox.docker import DockerSandbox
+    ctx = SandboxBuildContext(
+        environment_dir=environment_dir,
+        environment_name=task_path.name,
+        session_id=rollout_name,
+        rollout_paths=rollout_paths,
+        task_env_config=env_config,
+        persistent_env=manifest_env or None,
+    )
+    return resolve_sandbox(sandbox_type, ctx)
 
-        return DockerSandbox(
-            environment_dir=environment_dir,
-            environment_name=task_path.name,
-            session_id=rollout_name,
-            rollout_paths=rollout_paths,
-            task_env_config=env_config,
-            persistent_env=manifest_env or None,
-        )
-    elif sandbox_type == "daytona":
-        try:
-            from benchflow.sandbox._sdk_ops import apply as _apply_daytona_patches
-            from benchflow.sandbox.daytona import DaytonaSandbox
-        except ModuleNotFoundError as exc:
-            _raise_missing_optional_sandbox_dependency("daytona", exc)
 
-        _apply_daytona_patches()
-
-        if env_config.cpus > _DAYTONA_MAX_CPUS:
-            logger.warning(
-                "Clamping cpus %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_CPUS)",
-                env_config.cpus,
-                _DAYTONA_MAX_CPUS,
-            )
-            env_config.cpus = _DAYTONA_MAX_CPUS
-        if env_config.memory_mb > _DAYTONA_MAX_MEMORY_MB:
-            logger.warning(
-                "Clamping memory_mb %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_MEMORY_MB)",
-                env_config.memory_mb,
-                _DAYTONA_MAX_MEMORY_MB,
-            )
-            env_config.memory_mb = _DAYTONA_MAX_MEMORY_MB
-        if env_config.storage_mb > _DAYTONA_MAX_STORAGE_MB:
-            logger.warning(
-                "Clamping storage_mb %d -> %d for Daytona (override with BENCHFLOW_DAYTONA_MAX_STORAGE_MB)",
-                env_config.storage_mb,
-                _DAYTONA_MAX_STORAGE_MB,
-            )
-            env_config.storage_mb = _DAYTONA_MAX_STORAGE_MB
-
-        return DaytonaSandbox(
-            environment_dir=environment_dir,
-            environment_name=task_path.name,
-            session_id=rollout_name,
-            rollout_paths=rollout_paths,
-            task_env_config=env_config,
-            auto_stop_interval_mins=1440,
-            auto_delete_interval_mins=1440,
-            persistent_env=manifest_env or None,
-        )
-    elif sandbox_type == "modal":
-        try:
-            modal_environment_class = _create_benchflow_modal_environment_class()
-        except ModuleNotFoundError as exc:
-            _raise_missing_optional_sandbox_dependency("modal", exc)
-        modal_environment_class.preflight()
-
-        return modal_environment_class(
-            environment_dir=environment_dir,
-            environment_name=task_path.name,
-            session_id=rollout_name,
-            rollout_paths=rollout_paths,
-            task_env_config=env_config,
-            persistent_env=manifest_env or None,
-        )
-    else:
-        raise ValueError(
-            f"Unknown sandbox_type: {sandbox_type!r} (use 'docker', 'daytona', or 'modal')"
-        )
-
+# Register the built-in providers so the kernel resolves them by name.
+register_sandbox("docker", _build_docker_sandbox)
+register_sandbox("daytona", _build_daytona_sandbox)
+register_sandbox("modal", _build_modal_sandbox)
 
 # Backward compatibility alias
 _create_environment = _create_sandbox_environment

--- a/tests/test_contracts_registry.py
+++ b/tests/test_contracts_registry.py
@@ -1,0 +1,109 @@
+"""Guards the v0.5 Phase 0 contracts/kernel seam.
+
+Phase 0 (docs/architecture.md design principle 1: "the kernel depends only on
+contracts") introduced:
+
+* ``benchflow.contracts`` — the single aggregation point for the four-plane
+  Protocols, so the kernel imports Protocols, never concrete providers.
+* ``benchflow.sandbox.registry`` / ``benchflow.environment.registry`` — the
+  data-driven provider registries the kernel resolves through, so a backend
+  joins by registration rather than a kernel ``if/elif`` edit.
+
+These tests pin that structure so a later refactor can't quietly collapse the
+contract surface or the registry seam back into the kernel.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_contracts_exposes_the_four_planes():
+    """The single import surface carries all four plane Protocols."""
+    import benchflow.contracts as c
+
+    # One Protocol (or pair) per plane — the kernel's whole type surface.
+    for name in ("Sandbox", "Agent", "Session", "Environment", "Reward"):
+        assert hasattr(c, name), f"contracts is missing {name!r}"
+        assert name in c.__all__
+
+    # The seam dataclasses that cross kernel<->plane must travel with them.
+    for name in ("ExecResult", "ReadinessProbe", "StateSnapshot", "VerifyResult"):
+        assert hasattr(c, name), f"contracts is missing {name!r}"
+
+
+def test_contracts_reexports_are_the_plane_protocols():
+    """contracts re-exports the canonical Protocols, not parallel copies."""
+    import benchflow.contracts as c
+    from benchflow.agents.protocol import Agent as AgentProto
+    from benchflow.environment.protocol import Environment as EnvProto
+    from benchflow.rewards.protocol import Reward as RewardProto
+    from benchflow.sandbox.protocol import Sandbox as SandboxProto
+
+    assert c.Sandbox is SandboxProto
+    assert c.Agent is AgentProto
+    assert c.Environment is EnvProto
+    assert c.Reward is RewardProto
+
+
+def test_sandbox_registry_has_builtin_providers():
+    """The three managed sandbox backends register themselves on import."""
+    from benchflow.sandbox.registry import available_sandboxes
+
+    assert {"docker", "daytona", "modal"} <= set(available_sandboxes())
+
+
+def test_sandbox_registry_resolves_and_rejects():
+    """resolve_sandbox dispatches by name and raises for unknown providers."""
+    from benchflow.sandbox import registry
+
+    sentinel = object()
+    registry.register_sandbox("byo-test", lambda ctx: sentinel)
+    ctx = registry.SandboxBuildContext(
+        environment_dir=None,  # type: ignore[arg-type]
+        environment_name="t",
+        session_id="s",
+        rollout_paths=None,
+        task_env_config=None,
+        persistent_env=None,
+    )
+    assert registry.resolve_sandbox("byo-test", ctx) is sentinel
+
+    with pytest.raises(ValueError, match="Unknown sandbox provider"):
+        registry.resolve_sandbox("does-not-exist", ctx)
+
+
+def test_environment_registry_has_manifest_default_and_rejects():
+    """The manifest provider is the registered default; unknown kinds raise."""
+    from benchflow.environment import registry
+
+    assert registry.DEFAULT_ENVIRONMENT_KIND in registry.available_environments()
+
+    sentinel = object()
+    registry.register_environment("byo-env-test", lambda m, sb: sentinel)
+    assert (
+        registry.resolve_environment("byo-env-test", object(), sandbox=object())
+        is sentinel
+    )
+
+    with pytest.raises(ValueError, match="Unknown environment provider"):
+        registry.resolve_environment("nope", object(), sandbox=object())
+
+
+def test_kernel_imports_contracts_not_concrete_planes():
+    """rollout.py types its plane handles against contracts, not concretes.
+
+    Guards the Phase 0 reseat: the kernel module must import the plane
+    Protocols from ``benchflow.contracts`` and must not re-introduce a direct
+    ``ManifestEnvironment`` import (it now resolves the environment via the
+    registry).
+    """
+    import inspect
+
+    import benchflow.rollout as rollout
+
+    src = inspect.getsource(rollout)
+    assert "from benchflow.contracts import" in src
+    assert "resolve_environment" in src
+    # The concrete environment adapter is no longer imported into the kernel.
+    assert "from benchflow.environment.manifest_env import" not in src


### PR DESCRIPTION
## v0.5 Phase 0 — the contracts/kernel seam

First phase of the v0.5 finish plan. Makes `docs/architecture.md` **design principle 1 — "the kernel depends only on contracts"** structurally true, **without changing behavior**.

### Why
The readiness assessment found the kernel coupled to ~25 concrete modules with the four-plane Protocols scattered across plane packages and no aggregation point — so every "swappable plane / BYO" claim was aspiration. This reseats that foundation.

### What changed
- **`benchflow/contracts/` (new)** — the single import surface for the four-plane Protocols (`Sandbox`, `Agent`/`Session`, `Environment`, `Reward`) + their seam dataclasses. Pure re-export; **no concrete provider deps**, so importing it can't pull a backend into the kernel.
- **`sandbox/registry.py` + `environment/registry.py` (new)** — data-driven provider registries mirroring `agents/registry.py`. The `docker/daytona/modal` if/elif in `_create_sandbox_environment` is refactored into **registered factory functions** (identical construction code); `manifest` is the registered default Environment provider. Backends now join by registration, not a kernel edit.
- **`rollout.py` (kernel)** — imports `Sandbox`/`Environment` from `contracts`, types `self._env`/`self._environment` against them, and builds the environment via `resolve_environment()`. The concrete `ManifestEnvironment` import is **gone from the kernel**. A narrowing `_sandbox` property keeps None-safety local (most of the diff is the mechanical `self._env.` → `self._sandbox.` reroute).

### Behavior preserved — gates
- ✅ CLI: `bench eval create --include hello-world-task --agent oracle --sandbox docker` → **1/1, reward 1.0**
- ✅ SDK: `bf.run(RolloutConfig(...))` → **reward 1.0**
- ✅ Structural: kernel imports Protocols from `contracts/` and resolves both planes through registries
- ✅ `ty` clean, `ruff` clean, full suite **2366 passed / 48 skipped**

### Guard
`tests/test_contracts_registry.py` pins the contract surface + registry seam (6 tests).

### Note
Clarifies a latent name collision: `benchflow.Agent`/`benchflow.Environment` are `runtime.py` *config* dataclasses, **not** the protocols — those now live unambiguously at `benchflow.contracts.Agent`/`Environment`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only seam with preserved rollout behavior, lazy provider imports, and new structural tests; no auth, data, or scoring logic changes.
> 
> **Overview**
> Introduces **v0.5 Phase 0**: the kernel is typed against a single **`benchflow.contracts`** surface (four-plane `Protocol`s and seam dataclasses only—no concrete backends) instead of scattering imports across plane packages.
> 
> **Sandbox** and **environment** planes now join via **`register_*` / `resolve_*` registries** (mirroring agents). Built-in Docker/Daytona/Modal construction moves from an `if/elif` in sandbox setup into registered factories; the manifest environment is the default registered provider with a lazy `ManifestEnvironment` import.
> 
> **`rollout.py`** drops direct `ManifestEnvironment` usage, resolves the environment through the registry, types `_env` / `_environment` as `Sandbox` / `Environment`, and routes post-start sandbox calls through a **`_sandbox`** accessor for clearer non-`None` handling.
> 
> **`tests/test_contracts_registry.py`** locks in the contract exports, registry dispatch, and kernel import boundaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092a292bb7ddf75e8a15c7be5bdf51962091abde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->