### PR TITLE
feat: canonical VerifyResult on the live reward path (v0.5 Phase 1a)

### DIFF
--- a/src/benchflow/rewards/node.py
+++ b/src/benchflow/rewards/node.py
@@ -25,13 +25,108 @@ contract as native ``NodeScorer``-based ones.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Final, Protocol, runtime_checkable
+from typing import Any, Final, Protocol, cast, runtime_checkable
 
-from benchflow.rewards.events import RewardEvent, Space
+from benchflow.rewards.events import Granularity, RewardEvent, Space
 from benchflow.rewards.protocol import RewardFunc, VerifyResult
 from benchflow.trajectories.tree import RolloutNode
 
 _OUTPUT_SPACE: Final[Space] = "output"
+
+
+def verify_result_from_reward_map(
+    rewards: dict[str, Any] | None,
+    *,
+    error: str | None = None,
+) -> VerifyResult:
+    """Lift a validated verifier reward ``dict`` into a canonical ``VerifyResult``.
+
+    This is the **single** dict→``VerifyResult`` conversion point. The legacy
+    ``Verifier`` produces ``{"reward": float, "rubric": [...], ...scalars...}``;
+    Phase 1 lifts it here, during scoring, so the ``VerifyResult`` is the live
+    source of truth — not something re-derived at export time. Unlike a bare
+    lift, it produces the full ``events`` list — one ``terminal`` Output event
+    for the headline reward plus one ``process`` event per rubric item carrying
+    that item's ``(space, granularity)`` — so ``rewards.jsonl`` /
+    ``verifiers.jsonl`` tags are *sourced* from the result, not defaulted at the
+    writer.
+
+    Note the asymmetry the architecture mandates (``docs/architecture.md``,
+    "Evaluation"): the headline reward is the Output/terminal outcome; rubric
+    items default to ``(output, step)`` — process signals along the path.
+
+    A ``None`` map (verifier crashed/timed out) yields ``reward=0.0`` with
+    ``error`` populated, so a downstream ``reward_valid`` flag reads ``False``.
+    """
+    if rewards is None:
+        return VerifyResult(
+            reward=0.0,
+            items={},
+            events=[],
+            error=error or "no rewards",
+            space=_OUTPUT_SPACE,
+            granularity="terminal",
+        )
+
+    reward = rewards.get("reward")
+    headline = (
+        float(reward)
+        if isinstance(reward, (int, float)) and not isinstance(reward, bool)
+        else 0.0
+    )
+
+    items: dict[str, float] = {}
+    events: list[RewardEvent] = []
+
+    if reward is not None:
+        events.append(
+            RewardEvent(
+                type="terminal",
+                reward=headline,
+                source="verifier",
+                space=_OUTPUT_SPACE,
+                granularity="terminal",
+            )
+        )
+
+    for key, value in rewards.items():
+        if key in ("reward", "rubric", "space", "granularity"):
+            continue
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            items[str(key)] = float(value)
+
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            rubric_item = cast(dict[str, Any], item)
+            score = rubric_item.get("score")
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                continue
+            name = str(rubric_item.get("name") or f"rubric_{i}")
+            items[name] = float(score)
+            events.append(
+                RewardEvent(
+                    type="process",
+                    reward=float(score),
+                    source=name,
+                    step=i,
+                    space=cast(Space, rubric_item.get("space", "output")),
+                    granularity=cast(
+                        Granularity, rubric_item.get("granularity", "step")
+                    ),
+                )
+            )
+
+    return VerifyResult(
+        reward=headline,
+        items=items,
+        events=events,
+        error=error,
+        space=_OUTPUT_SPACE,
+        granularity="terminal",
+    )
 
 #: ``node.state`` key under which a rollout's on-disk directory is recorded.
 #: :class:`PathReward` reads this to bridge node-scoped scoring to the legacy

--- a/src/benchflow/rewards/node.py
+++ b/src/benchflow/rewards/node.py
@@ -34,6 +34,18 @@ from benchflow.trajectories.tree import RolloutNode
 _OUTPUT_SPACE: Final[Space] = "output"
 
 
+def _as_score(value: Any) -> float | None:
+    """Coerce a reward-map value to a float score, or ``None`` if it isn't one.
+
+    Centralises the "real number, not a bool" guard the reward map needs in
+    three places (headline, extra scalars, rubric scores) — ``bool`` is an
+    ``int`` subclass and must not slip through as ``1.0``/``0.0``.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
 def verify_result_from_reward_map(
     rewards: dict[str, Any] | None,
     *,
@@ -69,11 +81,7 @@ def verify_result_from_reward_map(
         )
 
     reward = rewards.get("reward")
-    headline = (
-        float(reward)
-        if isinstance(reward, (int, float)) and not isinstance(reward, bool)
-        else 0.0
-    )
+    headline = _as_score(reward) or 0.0
 
     items: dict[str, float] = {}
     events: list[RewardEvent] = []
@@ -92,8 +100,9 @@ def verify_result_from_reward_map(
     for key, value in rewards.items():
         if key in ("reward", "rubric", "space", "granularity"):
             continue
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            items[str(key)] = float(value)
+        score = _as_score(value)
+        if score is not None:
+            items[str(key)] = score
 
     rubric = rewards.get("rubric")
     if isinstance(rubric, list):
@@ -101,15 +110,15 @@ def verify_result_from_reward_map(
             if not isinstance(item, dict):
                 continue
             rubric_item = cast(dict[str, Any], item)
-            score = rubric_item.get("score")
-            if not isinstance(score, (int, float)) or isinstance(score, bool):
+            score = _as_score(rubric_item.get("score"))
+            if score is None:
                 continue
             name = str(rubric_item.get("name") or f"rubric_{i}")
-            items[name] = float(score)
+            items[name] = score
             events.append(
                 RewardEvent(
                     type="process",
-                    reward=float(score),
+                    reward=score,
                     source=name,
                     step=i,
                     space=cast(Space, rubric_item.get("space", "output")),

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -83,6 +83,8 @@ from benchflow.providers.runtime import (
     extract_usage,
     stop_provider_runtime,
 )
+from benchflow.rewards.node import verify_result_from_reward_map
+from benchflow.rewards.protocol import VerifyResult
 from benchflow.rewards.validation import validate_reward_map
 from benchflow.rollout_branch import ChildRunner
 from benchflow.rollout_branch import branch as _branch_engine
@@ -258,6 +260,45 @@ async def _ensure_sandbox_dir(
 
 
 _DIAG_TRUNCATE = 2000
+
+
+def _write_verify_result_json(
+    rollout_dir: Path, verify_result: VerifyResult | None
+) -> None:
+    """Persist the canonical ``VerifyResult`` to ``verifier/verify_result.json``.
+
+    The Reward-plane source of truth (#v0.5 Phase 1): unlike ``result.json``
+    (which keeps the legacy reward *dict* for the ~10 existing consumers), this
+    file is the canonical ``{reward, items, events, error, space, granularity}``
+    structure — carrying the architecture's ``(space, granularity)`` tag and the
+    full event list — that the trainer export reads and branch aggregation will
+    read. Skipped when no result was produced (nothing scored).
+    """
+    if verify_result is None:
+        return
+    vr = verify_result
+    payload = {
+        "reward": vr.reward,
+        "items": vr.items,
+        "events": [
+            {
+                "type": e.type,
+                "source": e.source,
+                "reward": e.reward,
+                "step": e.step,
+                "space": e.space,
+                "granularity": e.granularity,
+                "ts": e.ts,
+            }
+            for e in vr.events
+        ],
+        "error": vr.error,
+        "space": vr.space,
+        "granularity": vr.granularity,
+    }
+    out = rollout_dir / "verifier" / "verify_result.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, default=str))
 
 
 def _write_rewards_jsonl(
@@ -469,6 +510,7 @@ def _build_rollout_result(
     export_error: str | None = None,
     trajectory_source: TrajectorySource | None = None,
     rewards: dict | None,
+    verify_result: VerifyResult | None = None,
     started_at: datetime,
     timing: dict[str, float],
     scenes: list[Scene] | None = None,
@@ -492,6 +534,11 @@ def _build_rollout_result(
     """
     if diagnostics is None:
         diagnostics = RolloutDiagnostics()
+    # The canonical Reward-plane result. On the live path Rollout.verify()
+    # already built it; derive here only for callers that pass just the legacy
+    # dict, so every rollout still emits one sourced VerifyResult (#v0.5 Phase 1).
+    if verify_result is None:
+        verify_result = verify_result_from_reward_map(rewards, error=verifier_error)
     finished_at = datetime.now()
     result = RolloutResult(
         task_name=task_name,
@@ -577,6 +624,11 @@ def _build_rollout_result(
     )
     (rollout_dir / "timing.json").write_text(json.dumps(timing, indent=2))
     (rollout_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
+    _write_verify_result_json(rollout_dir, verify_result)
+    # rewards.jsonl stays dict-derived: it reads (space, granularity) from the
+    # same validated reward map the VerifyResult is built from, so its lines are
+    # identical to sourcing verify_result.events — and verify_result.json is the
+    # canonical structure trainers/branch read.
     _write_rewards_jsonl(rollout_dir, rewards, finished_at)
     _write_trainer_artifact(
         rollout_dir,
@@ -584,6 +636,7 @@ def _build_rollout_result(
         prompts=prompts,
         trajectory=trajectory,
         rewards=rewards,
+        verify_result=verify_result,
         model=model,
         verifier_error=verifier_error,
     )
@@ -597,6 +650,7 @@ def _write_trainer_artifact(
     prompts: list[str],
     trajectory: list[dict],
     rewards: dict | None,
+    verify_result: VerifyResult | None = None,
     model: str | None,
     verifier_error: str | None,
 ) -> None:
@@ -606,6 +660,10 @@ def _write_trainer_artifact(
     that reaches result-building should produce a trainer-ready Verifiers /
     ORS record so prime-rl / Verifiers can ingest the run directly. Failures
     here are logged but never block result writing.
+
+    Phase 1: the export READS the canonical ``verify_result`` (the source of
+    truth) instead of re-deriving the reward from the legacy dict; ``rewards``
+    is kept as a back-compat fallback for callers without a VerifyResult.
     """
     from benchflow.trajectories.export import write_rollout_verifiers_jsonl
 
@@ -616,6 +674,7 @@ def _write_trainer_artifact(
             prompts=prompts,
             trajectory=trajectory,
             rewards=rewards,
+            verify_result=verify_result,
             model=model,
             environment=task_name,
             error=verifier_error,
@@ -1097,6 +1156,11 @@ class Rollout:
 
         # Populated by verify()
         self._rewards: dict | None = None
+        # The canonical Reward-plane result — the source of truth that export
+        # and (later) branch aggregation READ, instead of re-deriving from the
+        # legacy dict above. The dict is kept as a derived projection for the
+        # ~10 existing consumers of RolloutResult.rewards (#v0.5 Phase 1).
+        self._verify_result: VerifyResult | None = None
         self._verifier_error: str | None = None
         self._error: str | None = None
         # Populated by _export_generated_skills() on failure (#389 follow-up).
@@ -1759,6 +1823,13 @@ class Rollout:
         )
         if verifier_timeout_diag is not None:
             self._diagnostics.set(verifier_timeout_diag)
+
+        # Build the canonical VerifyResult once, here, from the validated
+        # reward map — the source of truth downstream artifacts read (#v0.5
+        # Phase 1). verify() still returns the dict for backward compatibility.
+        self._verify_result = verify_result_from_reward_map(
+            self._rewards, error=self._verifier_error
+        )
 
         self._phase = "verified"
         return self._rewards
@@ -2621,6 +2692,7 @@ class Rollout:
             partial_trajectory=self._partial_trajectory,
             trajectory_source=self._trajectory_source,
             rewards=self._rewards,
+            verify_result=self._verify_result,
             started_at=self._require_started_at(),
             timing=self._timing,
             scenes=self._config.effective_scenes,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -44,7 +44,7 @@ import logging
 import os
 import shlex
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -276,29 +276,13 @@ def _write_verify_result_json(
     """
     if verify_result is None:
         return
-    vr = verify_result
-    payload = {
-        "reward": vr.reward,
-        "items": vr.items,
-        "events": [
-            {
-                "type": e.type,
-                "source": e.source,
-                "reward": e.reward,
-                "step": e.step,
-                "space": e.space,
-                "granularity": e.granularity,
-                "ts": e.ts,
-            }
-            for e in vr.events
-        ],
-        "error": vr.error,
-        "space": vr.space,
-        "granularity": vr.granularity,
-    }
+    # Serialize via the dataclass itself — no hand-rolled second event schema to
+    # drift from VerifyResult/RewardEvent (the ORS ``timestamp`` rename is for
+    # the trainer wire format only; this internal artifact uses the dataclass'
+    # own ``ts``, matching rewards.jsonl).
     out = rollout_dir / "verifier" / "verify_result.json"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, indent=2, default=str))
+    out.write_text(json.dumps(asdict(verify_result), indent=2, default=str))
 
 
 def _write_rewards_jsonl(

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from benchflow._utils.json_safe import scrub_non_finite
 from benchflow.adapters.ors import ORSAdapter
@@ -189,43 +189,19 @@ def reward_map_to_verify_result(
     *,
     error: str | None = None,
 ) -> VerifyResult:
-    """Adapt a canonical verifier reward ``dict`` to :class:`VerifyResult`.
+    """Back-compat shim — lift a verifier reward ``dict`` to :class:`VerifyResult`.
 
-    ``Rollout.verify()`` produces a validated reward map with the shape
-    ``{"reward": float, "rubric": [...], ...other scalars...}``. The
-    Verifiers record helper expects a :class:`VerifyResult`, so we lift the
-    headline ``reward`` and any per-item scalars into ``VerifyResult.items``.
-
-    A ``None`` rewards map (verifier crashed/timed out) yields a 0.0 reward
-    with ``error`` populated so the exported record's ``reward_valid`` flag
-    is ``False``.
+    *The canonical conversion lives upstream* in
+    :func:`benchflow.rewards.node.verify_result_from_reward_map`, which Phase 1
+    runs once during scoring so the ``VerifyResult`` is the source of truth
+    (not re-derived at export time). This shim is retained only for exporting
+    **pre-existing** rollout dirs that carry the legacy reward ``dict`` but no
+    ``verify_result`` — see :func:`write_rollout_verifiers_jsonl`. It delegates
+    to the single conversion point so the two never diverge.
     """
-    if rewards is None:
-        return VerifyResult(reward=0.0, items={}, error=error or "no rewards")
+    from benchflow.rewards.node import verify_result_from_reward_map
 
-    reward = rewards.get("reward")
-    headline = float(reward) if isinstance(reward, (int, float)) else 0.0
-
-    items: dict[str, float] = {}
-    for key, value in rewards.items():
-        if key in ("reward", "rubric"):
-            continue
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            items[str(key)] = float(value)
-
-    rubric = rewards.get("rubric")
-    if isinstance(rubric, list):
-        for i, item in enumerate(rubric):
-            if not isinstance(item, dict):
-                continue
-            rubric_item = cast(dict[str, Any], item)
-            score = rubric_item.get("score")
-            if not isinstance(score, (int, float)) or isinstance(score, bool):
-                continue
-            name = str(rubric_item.get("name") or f"rubric_{i}")
-            items[name] = float(score)
-
-    return VerifyResult(reward=headline, items=items, error=error)
+    return verify_result_from_reward_map(rewards, error=error)
 
 
 def write_rollout_verifiers_jsonl(
@@ -234,7 +210,8 @@ def write_rollout_verifiers_jsonl(
     task_id: str,
     prompts: list[str] | None,
     trajectory: list[dict[str, Any]],
-    rewards: dict[str, Any] | None,
+    rewards: dict[str, Any] | None = None,
+    verify_result: VerifyResult | None = None,
     model: str | None,
     environment: str,
     example_id: int = 0,
@@ -247,9 +224,17 @@ def write_rollout_verifiers_jsonl(
     Output path is ``rollout_dir/trainer/verifiers.jsonl`` — the
     architecture's trainer seam (issue #385). Returns the written record so
     callers can aggregate across a job.
+
+    Phase 1: when ``verify_result`` is supplied (the live path), the record is
+    built by **reading** that canonical :class:`VerifyResult` — the export no
+    longer re-derives the reward from the dict. ``rewards`` is the back-compat
+    fallback for old job dirs that only have the legacy reward map; it is
+    lifted via :func:`reward_map_to_verify_result` only when ``verify_result``
+    is ``None``.
     """
     messages = acp_events_to_messages(trajectory, prompts)
-    verify_result = reward_map_to_verify_result(rewards, error=error)
+    if verify_result is None:
+        verify_result = reward_map_to_verify_result(rewards, error=error)
     record = trajectory_to_verifiers_record(
         task_id=task_id,
         messages=messages,

--- a/tests/test_phase1_reward_source_of_truth.py
+++ b/tests/test_phase1_reward_source_of_truth.py
@@ -1,0 +1,158 @@
+"""Guards v0.5 Phase 1 — the canonical VerifyResult is the live source of truth.
+
+Phase 1 routes the reward path through ``Reward.score(node) -> VerifyResult``
+(``docs/architecture.md`` § "The four contracts"): the verifier's reward map is
+lifted ONCE during scoring into a canonical ``VerifyResult``
+(``verify_result_from_reward_map``), persisted to ``verifier/verify_result.json``,
+and the trainer export READS it instead of re-deriving the reward from the legacy
+dict at export time. ``result.json['rewards']`` stays the legacy dict for the
+existing consumers.
+
+These tests pin that direction so a later refactor can't quietly reintroduce the
+downgrade-on-export, or default the ``(space, granularity)`` tag at the writer.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from benchflow.rewards.node import verify_result_from_reward_map
+from benchflow.rewards.protocol import VerifyResult
+from benchflow.rollout import _build_rollout_result
+from benchflow.trajectories.export import (
+    ROLLOUT_ARTIFACT_RELPATH,
+    write_rollout_verifiers_jsonl,
+)
+
+
+def test_verify_result_from_reward_map_builds_canonical():
+    """The single conversion point lifts dict -> tagged VerifyResult + events."""
+    vr = verify_result_from_reward_map(
+        {
+            "reward": 0.75,
+            "exact_match": 1.0,
+            "rubric": [{"name": "clarity", "score": 0.5}],
+        }
+    )
+    assert isinstance(vr, VerifyResult)
+    assert vr.reward == 0.75
+    assert vr.items["exact_match"] == 1.0
+    assert vr.items["clarity"] == 0.5
+    assert vr.space == "output"
+    assert vr.granularity == "terminal"
+    # One terminal Output event for the headline + one process event per rubric.
+    terminal = [e for e in vr.events if e.type == "terminal"]
+    process = [e for e in vr.events if e.type == "process"]
+    assert len(terminal) == 1
+    assert terminal[0].space == "output" and terminal[0].granularity == "terminal"
+    assert len(process) == 1
+    assert process[0].source == "clarity"
+    assert process[0].granularity == "step"
+
+
+def test_verify_result_from_reward_map_handles_none():
+    """A crashed/timed-out verifier yields reward 0.0 with error populated."""
+    vr = verify_result_from_reward_map(None, error="verifier timed out")
+    assert vr.reward == 0.0
+    assert vr.items == {}
+    assert vr.events == []
+    assert vr.error == "verifier timed out"
+
+
+def test_export_reads_verify_result_not_the_dict():
+    """write_rollout_verifiers_jsonl READS the VerifyResult when supplied.
+
+    Pass a VerifyResult and a deliberately DIFFERENT rewards dict; the record
+    must reflect the VerifyResult (0.9), never the dict (0.1) — proving export
+    reads the canonical result rather than re-deriving from the legacy map.
+    """
+    import tempfile
+    from pathlib import Path
+
+    vr = verify_result_from_reward_map({"reward": 0.9})
+    with tempfile.TemporaryDirectory() as d:
+        rec = write_rollout_verifiers_jsonl(
+            Path(d),
+            task_id="t1",
+            prompts=["do it"],
+            trajectory=[],
+            rewards={"reward": 0.1},  # intentionally different — must be ignored
+            verify_result=vr,
+            model="m",
+            environment="e",
+        )
+    assert rec["reward"] == 0.9
+    assert rec["info"]["reward_metadata"]["space"] == "output"
+    assert rec["info"]["reward_metadata"]["granularity"] == "terminal"
+
+
+def test_build_result_writes_canonical_verify_result_json(tmp_path):
+    """_build_rollout_result persists verify_result.json and keeps the legacy dict.
+
+    The canonical Reward-plane artifact carries (space, granularity) and the
+    event list; result.json['rewards'] stays the legacy dict for back-compat;
+    and the headline reward agrees across both, sourced from the VerifyResult.
+    """
+    rewards = {"reward": 1.0, "rubric": [{"name": "clarity", "score": 0.5}]}
+    vr = verify_result_from_reward_map(rewards)
+    _build_rollout_result(
+        tmp_path,
+        task_name="hello-world-task",
+        rollout_name="r1",
+        agent="oracle",
+        agent_name="oracle",
+        model=None,
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards=rewards,
+        verify_result=vr,
+        started_at=datetime.now(),
+        timing={},
+    )
+
+    vr_json = json.loads((tmp_path / "verifier" / "verify_result.json").read_text())
+    assert vr_json["reward"] == 1.0
+    assert vr_json["space"] == "output"
+    assert vr_json["granularity"] == "terminal"
+    assert any(e["type"] == "process" for e in vr_json["events"])
+
+    result_json = json.loads((tmp_path / "result.json").read_text())
+    # Legacy dict preserved for the ~10 existing consumers (no breaking change).
+    assert result_json["rewards"] == rewards
+
+    # The trainer artifact's headline agrees with the canonical result.
+    rec = json.loads((tmp_path / ROLLOUT_ARTIFACT_RELPATH).read_text().strip())
+    assert rec["reward"] == 1.0
+
+
+def test_build_result_derives_verify_result_when_absent(tmp_path):
+    """Callers that pass only the legacy dict still get a sourced verify_result.json.
+
+    SDK/Evaluation builders don't thread a VerifyResult; _build_rollout_result
+    must derive one from the dict so every rollout emits the canonical artifact.
+    """
+    _build_rollout_result(
+        tmp_path,
+        task_name="t",
+        rollout_name="r",
+        agent="oracle",
+        agent_name="oracle",
+        model=None,
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards={"reward": 0.5},
+        started_at=datetime.now(),
+        timing={},
+    )
+    vr_json = json.loads((tmp_path / "verifier" / "verify_result.json").read_text())
+    assert vr_json["reward"] == 0.5
+    assert vr_json["space"] == "output"

--- a/tests/test_self_gen_export_failures.py
+++ b/tests/test_self_gen_export_failures.py
@@ -37,6 +37,9 @@ def _bare_rollout(tmp_path: Path, export_target: Path | None) -> Rollout:
     rollout._evolved_skills = None
     rollout._error = None
     rollout._export_error = None
+    # Mirror __init__: _build_result() reads the canonical VerifyResult (#v0.5
+    # Phase 1); a __new__-constructed skeleton must set it like the real ctor.
+    rollout._verify_result = None
     # Stub the bits cleanup() touches but we don't care about for this test.
     rollout.disconnect = AsyncMock()
     rollout._capture_partial_acp_trajectory = lambda: None


### PR DESCRIPTION
## v0.5 Phase 1a — canonical reward on the live path

**Stacked on [#577](https://github.com/benchflow-ai/benchflow/pull/577) (Phase 0).** Base is the Phase 0 branch so this diff is Phase 1 only; retarget to `v0.5-integration` once #577 merges.

Fixes one of the three P0s from the readiness assessment: `Reward.score(node)→VerifyResult` was dormant on the live path — the default eval used the legacy `Verifier` dict and the export *downgraded* that dict into a `VerifyResult` at write time (the reverse of the target). This makes the canonical `VerifyResult` the **source of truth**, built once during scoring and **read** by the export.

### What changed
- **`rewards/node.py`** — new `verify_result_from_reward_map()`: the single dict→`VerifyResult` conversion point. Builds the full `events` list (one terminal Output event + one process event per rubric item with its `(space, granularity)`) so artifacts are *sourced*, not defaulted at the writer.
- **`rollout.py`** — `verify()` builds `self._verify_result` once; `_build_rollout_result` threads it, writes the canonical **`verifier/verify_result.json`**, and derives one for callers that pass only the legacy dict. `result.json['rewards']` stays the legacy dict (the ~10 existing consumers are untouched — retyping that field is the deferred Phase 2 cascade).
- **`trajectories/export.py`** — `write_rollout_verifiers_jsonl` now **reads** the supplied `VerifyResult`; `reward_map_to_verify_result` is demoted to a back-compat shim (for old job dirs) that delegates to the single conversion point.

### Decisions (please confirm)
- `verify_result.json` lives under `verifier/` (groups with reward.txt/reward.json).
- **Output** space is sourced now; **Memory** stays learner-only (no Environment/Agent producer for node memory deltas on the default path yet) — documented, not wired.
- **Branch aggregation routing** through `VerifyResult` is **deferred to bundle with Phase 3** (where `Branch` is wired into a real run). Routing it here would change the *type* asserted by passing branch tests (`value == 0.5` → `value.reward`), which doesn't belong in a reward-path PR. The default branch runner still reads the dict and works unchanged.
- `RolloutResult.rewards` stays a dict by design (Phase 2 cascade).

### Gate — real oracle run on hello-world-task
- `result.json` keeps `{'reward': 1.0}` (back-compat unbroken)
- new `verifier/verify_result.json` carries `(space=output, granularity=terminal)` + events
- `trainer/verifiers.jsonl` reward + tags **sourced from the VerifyResult** (`reward_valid: true`)
- all headline rewards byte-identical across the three artifacts
- ty + ruff clean; full suite **2371 passed / 48 skipped**

Guarded by `tests/test_phase1_reward_source_of_truth.py` (5 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the reward artifact pipeline and trainer export seam, but keeps the legacy rewards dict and adds regression tests; incorrect conversion would skew training metrics without breaking most eval consumers.
> 
> **Overview**
> **v0.5 Phase 1** makes the canonical **`VerifyResult`** the live reward source of truth instead of rebuilding it from the legacy verifier dict at trainer export time.
> 
> A new **`verify_result_from_reward_map`** in `rewards/node.py` is the **only** dict→`VerifyResult` conversion: headline reward, scalar/rubric **items**, and an **`events`** list (terminal output reward plus per-rubric process events with **`(space, granularity)`**). **`Rollout.verify()`** builds **`self._verify_result`** once from the validated map; **`_build_rollout_result`** writes **`verifier/verify_result.json`**, threads the result into **`trainer/verifiers.jsonl`**, and still keeps **`result.json['rewards']`** as the legacy dict for existing consumers. **`write_rollout_verifiers_jsonl`** prefers the passed-in **`VerifyResult`**; the export shim only lifts the dict when no canonical result exists (old rollout dirs).
> 
> Guard tests in **`tests/test_phase1_reward_source_of_truth.py`** lock export-on-read behavior and artifact consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26c7c604ead7de0abd4e83cff7b8ad2c3fdf1e81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->