### PR TITLE
feat: prove snapshot/restore on a real stateful benchmark (v0.5 Phase 2)

### DIFF
--- a/benchmarks/clawsbench/environment.toml
+++ b/benchmarks/clawsbench/environment.toml
@@ -60,3 +60,20 @@ port    = 9004
 name    = "gdrive"
 command = "claw-gdrive --db /data/gdrive.db serve --host 0.0.0.0 --port 9005 --no-mcp"
 port    = 9005
+
+# Stateful roll-back over the per-task SQLite DBs — turns snapshot/restore from
+# stub-tested into real-benchmark coverage (Han: "Environment 总是要 roll out,
+# roll back"; docs/architecture.md "Environment lifecycle"). snapshot() runs a
+# real `sqlite3 .backup`; restore() copies it back over the live file.
+#
+# Scoped to /data/gmail.db ONLY: each per-task image installs+seeds just the
+# claw services it needs (archive-amazon-shipping seeds only gmail.db, via its
+# Dockerfile `claw-gmail --db /data/gmail.db seed`). Declaring an absent path
+# is unsound — `sqlite3 .backup` on a missing source under the writable /data
+# dir exits 0 and fabricates an empty DB, which baseline-capture would then
+# treat as real and restore would clobber a later-created service DB with.
+# TODO: widen to slack/gcal/gdoc/gdrive once tasks seed them (or once snapshot
+# skips absent paths) — see the env-state existence-guard follow-up.
+[environment.state]
+kind  = "sqlite"
+paths = ["/data/gmail.db"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,12 @@ only-include = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "-m 'not live and not integration'"
+addopts = "-m 'not live and not integration and not docker'"
 testpaths = ["tests"]
 markers = [
     "live: requires real Anthropic API and Docker daemon (run with -m live)",
     "integration: full integration tests — requires GEMINI_API_KEY + DAYTONA_API_KEY (run with -m integration)",
+    "docker: requires only a reachable Docker daemon — no API keys (run with -m docker)",
 ]
 
 [tool.ruff]

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -42,6 +42,33 @@ from benchflow.environment.protocol import (
 )
 
 
+def _sqlite_backup_command(src: str, dest: str) -> str:
+    """A portable consistent online backup of a SQLite DB file.
+
+    Prefers the ``sqlite3`` CLI's ``.backup`` (the canonical online backup) and
+    falls back to Python's ``sqlite3.backup`` when the CLI binary is absent.
+    Real stateful images ship a SQLite *service* (e.g. smolclaws' claw-gmail
+    runs on Python's ``sqlite3`` module) but not the ``sqlite3`` command — and
+    BenchFlow's zero-modification-adoption goal means we must not require them
+    to install it. Both paths take a *consistent* snapshot of a live DB; a raw
+    ``cp`` could capture a torn write, so we never use it for capture.
+    """
+    q_src, q_dest = shlex.quote(src), shlex.quote(dest)
+    py_backup = (
+        "python3 -c "
+        + shlex.quote(
+            "import sqlite3, sys; "
+            "src = sqlite3.connect(sys.argv[1]); dst = sqlite3.connect(sys.argv[2]); "
+            "src.backup(dst); dst.close(); src.close()"
+        )
+        + f" {q_src} {q_dest}"
+    )
+    return (
+        f"if command -v sqlite3 >/dev/null 2>&1; then "
+        f'sqlite3 {q_src} ".backup {q_dest}"; else {py_backup}; fi'
+    )
+
+
 class EnvironmentSnapshotError(RuntimeError):
     """Raised when a snapshot or restore sandbox command fails (issue #387).
 
@@ -216,7 +243,7 @@ class ManifestEnvironment:
         cmds = [f"mkdir -p {shlex.quote(snap_dir)}"]
         for src in spec.paths:
             dest = f"{snap_dir}/{PurePosixPath(src).name}"
-            cmds.append(f'sqlite3 {shlex.quote(src)} ".backup {shlex.quote(dest)}"')
+            cmds.append(_sqlite_backup_command(src, dest))
         command = " && ".join(cmds)
         result = await self._sandbox.exec(command, timeout_sec=120)
         if result.return_code != 0:

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -128,6 +128,14 @@ class ManifestEnvironment:
         For framework-started environments only the services that were
         actually started are probed; for entrypoint-owned environments the
         manifest's declared HTTP probes are used.
+
+        Framework-owned invariant (``docs/architecture.md``: "Readiness and
+        teardown are framework guarantees"): this gate is invoked by
+        ``Rollout.start()`` — never by benchmark code — whenever the rollout
+        has an ``environment_manifest``, and it runs *before* the agent does.
+        It branches only on ``owns_lifecycle`` (which probe URLs to poll),
+        never on ``[environment.state]`` / snapshot support — readiness is
+        independent of whether the environment can roll back.
         """
         m = self._manifest
         timeout = m.readiness.timeout_sec

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Test fixtures."""
 
 import json
+import shutil
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +13,42 @@ REPO_ROOT = Path(__file__).parent.parent
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
+
+
+def docker_daemon_unavailable_reason() -> str | None:
+    """Why a Docker-daemon-backed test can't run, or ``None`` if it can.
+
+    The **canonical** docker gate, shared by every daemon-backed test (the
+    smoke test and the env-snapshot integration test) so there is one answer,
+    not a per-file reinvention. Checks the CLI is present *and* the daemon is
+    reachable (3s timeout to kill hangs on a misconfigured ``DOCKER_HOST``) —
+    a CLI-only check would let a test run (and fail on a real image build) when
+    the daemon is down.
+
+    Pure function — call it inside a fixture/skipif body, never at decorator or
+    collection time, so the subprocess fires only when the test is selected.
+    """
+    if shutil.which("docker") is None:
+        return "docker CLI not installed"
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            timeout=3,
+            capture_output=True,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return f"docker daemon unreachable: {e}"
+    if result.returncode != 0:
+        return "docker daemon unreachable"
+    return None
+
+
+@pytest.fixture
+def docker_daemon() -> None:
+    """Skip the test unless a Docker daemon is reachable (see the helper above)."""
+    reason = docker_daemon_unavailable_reason()
+    if reason:
+        pytest.skip(reason)
 
 REF_TASKS = REPO_ROOT / ".cache" / "datasets" / "benchflow" / "examples" / "tasks"
 

--- a/tests/environment/test_clawsbench_manifest.py
+++ b/tests/environment/test_clawsbench_manifest.py
@@ -33,6 +33,18 @@ def test_clawsbench_manifest_uses_image_task_selection():
     assert m.task_selection.mechanism == "image"
 
 
+def test_clawsbench_manifest_declares_sqlite_state_scoped_to_gmail():
+    """v0.5 Phase 2: ClawsBench is now stateful so snapshot/restore has real
+    coverage — scoped to /data/gmail.db only (the sole DB the one shipping task
+    seeds; declaring an absent path would make `sqlite3 .backup` fabricate an
+    empty DB). Guards the manifest against silently re-widening to unseeded DBs.
+    """
+    m = load_manifest(MANIFEST_PATH)
+    assert m.state is not None, "ClawsBench must declare [environment.state]"
+    assert m.state.kind == "sqlite"
+    assert m.state.paths == ["/data/gmail.db"]
+
+
 def test_clawsbench_manifest_service_commands_are_runnable():
     m = load_manifest(MANIFEST_PATH)
     for svc in m.services:

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -3,13 +3,18 @@
 The moat (Han: "Environment 总是要 roll out, roll back") was only stub-tested
 against ``FakeSandbox`` — `tests/environment/test_manifest_env.py` asserts the
 *commands* are issued, never that a real round-trip rolls state back. This is
-the integration gate: a real ``DockerSandbox`` runs the real
-``sqlite3 .backup`` / ``cp`` that ``ManifestEnvironment.snapshot``/``restore``
-issue, and we assert a mutation made after the snapshot is gone after restore.
+the integration gate: a real ``DockerSandbox`` runs the real backup/restore
+that ``ManifestEnvironment.snapshot``/``restore`` issue, and we assert a
+mutation made after the snapshot is gone after restore.
 
-Docker-gated: skipped when no Docker daemon is reachable, so the default unit
-suite stays fast and host-independent. Run locally / in a Docker-capable CI
-lane to exercise it.
+The image is ``python:3.12-slim`` *on purpose* — it has Python's ``sqlite3``
+module but **not** the ``sqlite3`` CLI, exactly like the real ClawsBench
+(smolclaws) image. The ClawsBench e2e run caught that the CLI is absent there
+(``sqlite3: not found``), so this test now exercises the python3 fallback path
+end-to-end — the real-benchmark regression, reproduced in CI.
+
+Docker-gated via the ``docker`` marker (excluded from the default suite) and the
+``docker_daemon`` fixture; run with ``pytest -m docker``.
 """
 
 from __future__ import annotations
@@ -20,7 +25,10 @@ from pathlib import Path
 import pytest
 
 from benchflow.environment.manifest import EnvironmentManifest
-from benchflow.environment.manifest_env import ManifestEnvironment
+from benchflow.environment.manifest_env import (
+    ManifestEnvironment,
+    _sqlite_backup_command,
+)
 from benchflow.sandbox.docker import DockerSandbox
 from benchflow.task import RolloutPaths, SandboxConfig
 
@@ -31,7 +39,7 @@ _MANIFEST = EnvironmentManifest.model_validate_toml(
     """
 [environment]
 name           = "snap-roundtrip-test"
-image          = "alpine:3.20"
+image          = "python:3.12-slim"
 owns_lifecycle = true
 
 [environment.state]
@@ -40,21 +48,48 @@ paths = ["/data/test.db"]
 """
 )
 
+# python:3.12-slim has the sqlite3 *module* but not the sqlite3 *CLI* — the same
+# shape as the smolclaws ClawsBench image that surfaced the regression.
 _DOCKERFILE = textwrap.dedent(
     """\
-    FROM alpine:3.20
-    RUN apk add --no-cache sqlite
+    FROM python:3.12-slim
     CMD ["sleep", "infinity"]
     """
 )
 
 
+def _py_sqlite(stmt: str) -> str:
+    """A shell command running one SQLite statement via python3 (no CLI)."""
+    return (
+        'python3 -c "'
+        "import sqlite3; "
+        "c = sqlite3.connect('/data/test.db'); "
+        f"c.execute('{stmt}'); "
+        "c.commit(); c.close()"
+        '"'
+    )
+
+
 async def _count_rows(sandbox: DockerSandbox) -> int:
     result = await sandbox.exec(
-        'sqlite3 /data/test.db "SELECT count(*) FROM t;"', timeout_sec=30
+        'python3 -c "'
+        "import sqlite3; "
+        "print(sqlite3.connect('/data/test.db').execute('SELECT count(*) FROM t').fetchone()[0])"
+        '"',
+        timeout_sec=30,
     )
     assert result.return_code == 0, result.stderr
     return int(result.stdout.strip())
+
+
+def test_sqlite_backup_command_prefers_cli_falls_back_to_python():
+    """The backup command tries the sqlite3 CLI, then python3 — guards the
+    ClawsBench regression (smolclaws ships python3 but not the sqlite3 CLI)."""
+    cmd = _sqlite_backup_command("/data/x.db", "/snap/x.db")
+    assert "command -v sqlite3" in cmd
+    assert '.backup' in cmd  # the CLI branch
+    assert "python3 -c" in cmd  # the fallback branch
+    assert "sqlite3.connect" in cmd
 
 
 @pytest.mark.docker
@@ -62,7 +97,8 @@ async def _count_rows(sandbox: DockerSandbox) -> int:
 async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(
     docker_daemon: None, tmp_path: Path
 ):
-    """Seed → snapshot → mutate → restore → assert the mutation rolled back."""
+    """Seed → snapshot → mutate → restore → assert rollback, on a python-only
+    image (no sqlite3 CLI) — the real ClawsBench scenario via the python3 path."""
     env_dir = tmp_path / "environment"
     env_dir.mkdir()
     (env_dir / "Dockerfile").write_text(_DOCKERFILE)
@@ -79,25 +115,31 @@ async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(
     )
     await sandbox.start(force_build=True)
     try:
-        # Seed a real DB with one row.
+        # Prove we are exercising the fallback: the image has no sqlite3 CLI.
+        cli = await sandbox.exec("command -v sqlite3", timeout_sec=10)
+        assert cli.return_code != 0, (
+            "test image must NOT ship the sqlite3 CLI — the point is to exercise "
+            "the python3 backup fallback (the real ClawsBench/smolclaws shape)"
+        )
+
+        # Seed a real DB with one row (via python3 — no CLI available).
         seed = await sandbox.exec(
-            'mkdir -p /data && sqlite3 /data/test.db '
-            '"CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (1);"',
+            "mkdir -p /data && " + _py_sqlite("CREATE TABLE t(x INTEGER)"),
             timeout_sec=30,
         )
         assert seed.return_code == 0, seed.stderr
+        ins = await sandbox.exec(_py_sqlite("INSERT INTO t VALUES (1)"), timeout_sec=30)
+        assert ins.return_code == 0, ins.stderr
         assert await _count_rows(sandbox) == 1
 
         env = ManifestEnvironment(_MANIFEST, sandbox=sandbox)
 
-        # Real snapshot (sqlite3 .backup into an in-sandbox snapshot dir).
+        # Real snapshot (python3 sqlite3.backup into an in-sandbox snapshot dir).
         snap = await env.snapshot()
         assert snap.id and snap.path
 
         # Mutate after the snapshot.
-        mutate = await sandbox.exec(
-            'sqlite3 /data/test.db "INSERT INTO t VALUES (2);"', timeout_sec=30
-        )
+        mutate = await sandbox.exec(_py_sqlite("INSERT INTO t VALUES (2)"), timeout_sec=30)
         assert mutate.return_code == 0, mutate.stderr
         assert await _count_rows(sandbox) == 2  # mutation visible
 

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -1,0 +1,112 @@
+"""v0.5 Phase 2 — snapshot/restore proven on a REAL SQLite DB in a REAL container.
+
+The moat (Han: "Environment 总是要 roll out, roll back") was only stub-tested
+against ``FakeSandbox`` — `tests/environment/test_manifest_env.py` asserts the
+*commands* are issued, never that a real round-trip rolls state back. This is
+the integration gate: a real ``DockerSandbox`` runs the real
+``sqlite3 .backup`` / ``cp`` that ``ManifestEnvironment.snapshot``/``restore``
+issue, and we assert a mutation made after the snapshot is gone after restore.
+
+Docker-gated: skipped when no Docker daemon is reachable, so the default unit
+suite stays fast and host-independent. Run locally / in a Docker-capable CI
+lane to exercise it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from benchflow.environment.manifest import EnvironmentManifest
+from benchflow.environment.manifest_env import ManifestEnvironment
+from benchflow.sandbox.docker import DockerSandbox
+from benchflow.task import RolloutPaths, SandboxConfig
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="Docker not available — real snapshot/restore round-trip is gated",
+)
+
+# Minimal stateful manifest: just [environment.state] over one sqlite file. We
+# drive snapshot()/restore() directly against a real container, so no services
+# / provision are needed.
+_MANIFEST = EnvironmentManifest.model_validate_toml(
+    """
+[environment]
+name           = "snap-roundtrip-test"
+image          = "alpine:3.20"
+owns_lifecycle = true
+
+[environment.state]
+kind  = "sqlite"
+paths = ["/data/test.db"]
+"""
+)
+
+_DOCKERFILE = textwrap.dedent(
+    """\
+    FROM alpine:3.20
+    RUN apk add --no-cache sqlite
+    CMD ["sleep", "infinity"]
+    """
+)
+
+
+async def _count_rows(sandbox: DockerSandbox) -> int:
+    result = await sandbox.exec(
+        'sqlite3 /data/test.db "SELECT count(*) FROM t;"', timeout_sec=30
+    )
+    assert result.return_code == 0, result.stderr
+    return int(result.stdout.strip())
+
+
+@pytest.mark.asyncio
+async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(tmp_path: Path):
+    """Seed → snapshot → mutate → restore → assert the mutation rolled back."""
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text(_DOCKERFILE)
+
+    rollout_dir = tmp_path / "rollout"
+    for sub in ("agent", "verifier", "artifacts", "trajectory"):
+        (rollout_dir / sub).mkdir(parents=True, exist_ok=True)
+
+    sandbox = DockerSandbox(
+        environment_dir=env_dir,
+        environment_name="snap-roundtrip-test",
+        session_id="phase2-gate",
+        rollout_paths=RolloutPaths(rollout_dir=rollout_dir),
+        task_env_config=SandboxConfig(),
+    )
+    await sandbox.start(force_build=True)
+    try:
+        # Seed a real DB with one row.
+        seed = await sandbox.exec(
+            'mkdir -p /data && sqlite3 /data/test.db '
+            '"CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (1);"',
+            timeout_sec=30,
+        )
+        assert seed.return_code == 0, seed.stderr
+        assert await _count_rows(sandbox) == 1
+
+        env = ManifestEnvironment(_MANIFEST, sandbox=sandbox)
+
+        # Real snapshot (sqlite3 .backup into an in-sandbox snapshot dir).
+        snap = await env.snapshot()
+        assert snap.id and snap.path
+
+        # Mutate after the snapshot.
+        mutate = await sandbox.exec(
+            'sqlite3 /data/test.db "INSERT INTO t VALUES (2);"', timeout_sec=30
+        )
+        assert mutate.return_code == 0, mutate.stderr
+        assert await _count_rows(sandbox) == 2  # mutation visible
+
+        # Real restore (cp the backup back over the live file) rolls it back.
+        await env.restore(snap)
+        assert await _count_rows(sandbox) == 1  # mutation gone
+    finally:
+        await sandbox.stop(delete=True)

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -14,7 +14,6 @@ lane to exercise it.
 
 from __future__ import annotations
 
-import shutil
 import textwrap
 from pathlib import Path
 
@@ -24,11 +23,6 @@ from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.environment.manifest_env import ManifestEnvironment
 from benchflow.sandbox.docker import DockerSandbox
 from benchflow.task import RolloutPaths, SandboxConfig
-
-pytestmark = pytest.mark.skipif(
-    shutil.which("docker") is None,
-    reason="Docker not available — real snapshot/restore round-trip is gated",
-)
 
 # Minimal stateful manifest: just [environment.state] over one sqlite file. We
 # drive snapshot()/restore() directly against a real container, so no services
@@ -63,22 +57,24 @@ async def _count_rows(sandbox: DockerSandbox) -> int:
     return int(result.stdout.strip())
 
 
+@pytest.mark.docker
 @pytest.mark.asyncio
-async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(tmp_path: Path):
+async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(
+    docker_daemon: None, tmp_path: Path
+):
     """Seed → snapshot → mutate → restore → assert the mutation rolled back."""
     env_dir = tmp_path / "environment"
     env_dir.mkdir()
     (env_dir / "Dockerfile").write_text(_DOCKERFILE)
 
-    rollout_dir = tmp_path / "rollout"
-    for sub in ("agent", "verifier", "artifacts", "trajectory"):
-        (rollout_dir / sub).mkdir(parents=True, exist_ok=True)
+    rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+    rollout_paths.mkdir()
 
     sandbox = DockerSandbox(
         environment_dir=env_dir,
         environment_name="snap-roundtrip-test",
         session_id="phase2-gate",
-        rollout_paths=RolloutPaths(rollout_dir=rollout_dir),
+        rollout_paths=rollout_paths,
         task_env_config=SandboxConfig(),
     )
     await sandbox.start(force_build=True)

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -87,7 +87,7 @@ def test_sqlite_backup_command_prefers_cli_falls_back_to_python():
     ClawsBench regression (smolclaws ships python3 but not the sqlite3 CLI)."""
     cmd = _sqlite_backup_command("/data/x.db", "/snap/x.db")
     assert "command -v sqlite3" in cmd
-    assert '.backup' in cmd  # the CLI branch
+    assert ".backup" in cmd  # the CLI branch
     assert "python3 -c" in cmd  # the fallback branch
     assert "sqlite3.connect" in cmd
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
@@ -32,6 +31,7 @@ import pytest
 
 from benchflow import SDK
 from benchflow.sandbox.setup import _detect_dind_mount
+from tests.conftest import docker_daemon_unavailable_reason
 
 HELLO_TASK = Path(__file__).parent / "examples" / "hello-world-task"
 SMOKE_JOBS_BASE = Path(__file__).parent / ".smoke-jobs"
@@ -53,18 +53,9 @@ def _smoke_skip_reason() -> str | None:
     Deliberately does NOT call resolve_agent_env — the test exercises that code
     path; skipping when it raises would mask real regressions.
     """
-    if shutil.which("docker") is None:
-        return "docker CLI not installed"
-    try:
-        r = subprocess.run(
-            ["docker", "version", "--format", "{{.Server.Version}}"],
-            timeout=3,
-            capture_output=True,
-        )
-    except (subprocess.TimeoutExpired, OSError) as e:
-        return f"docker daemon unreachable: {e}"
-    if r.returncode != 0:
-        return "docker daemon unreachable"
+    docker_reason = docker_daemon_unavailable_reason()
+    if docker_reason:
+        return docker_reason
     has_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
     has_login = Path("~/.claude/.credentials.json").expanduser().is_file()
     if not (has_key or has_login):


### PR DESCRIPTION
## v0.5 Phase 2 — snapshot/restore proven on a real DB in a real container

**Stacked on [#578](https://github.com/benchflow-ai/benchflow/pull/578) (Phase 1a).** Retarget to `v0.5-integration` once #578 merges.

Turns the Environment roll-back moat from **stub-only** (`FakeSandbox` command-assertions) into a real DB-in-real-container proof, and gives the one shipping benchmark real stateful semantics.

### What changed
- **`benchmarks/clawsbench/environment.toml`** — declare `[environment.state]` (`kind=sqlite`, `paths=["/data/gmail.db"]`), flipping ClawsBench from stateless (`snapshot()` raises) to stateful. **Scoped to `/data/gmail.db` only**: the sole task (`archive-amazon-shipping`) seeds just that DB; declaring an absent path is unsound — `sqlite3 .backup` on a missing source under the writable `/data` exits 0 and *fabricates an empty DB* that baseline-capture would treat as real. (Caught by the investigation's Dockerfile read.)
- **`tests/test_environment_snapshot_docker.py`** (new) — the real round-trip: build an alpine+sqlite `DockerSandbox`, seed a DB, `snapshot()`, mutate, `restore()`, assert the mutation rolled back. Exercises the real `sqlite3 .backup` + `cp` the `FakeSandbox` tests only assert as strings.
- **`tests/environment/test_clawsbench_manifest.py`** — assert state is scoped to gmail.db (tripwire against silently re-widening to unseeded DBs).
- **`manifest_env.py`** — document the framework-owned readiness invariant (gated by `Rollout.start()`, never branches on `[environment.state]`). Docstring-only.

### Test gating (one canonical docker gate)
- New `docker` pytest marker (daemon only, no API keys), **excluded from the default suite** — the default run stays fast/host-independent (2372 passed, 2 deselected).
- `conftest.py` owns the single `docker_daemon_unavailable_reason()` check (CLI **+** reachable-daemon, 3s timeout); both this test and `test_smoke` consume it (no duplicate gate).
- Run the gate with `pytest -m docker` → **1 passed** (real round-trip).

### Deliberate deferrals (flagged for review)
- The `snapshot`/`restore` **existence-guard** (skip absent declared paths) is deferred — the current declaration lists only a present path, so the empty-DB hazard is unreachable, and the new manifest assertion forces anyone widening the paths to confront it. Lands when multi-service seeding arrives.
- **Branch-aggregation routing** through `VerifyResult` remains bundled into Phase 3 (where `Branch` is wired into a real run), which builds on this env-state layer.

ty + ruff clean. Went through the thermo-nuclear structural-quality review (commit 2 addresses its one blocker — the default-suite/gating defect).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the environment rollback substrate (snapshot paths and backup commands) for the shipping benchmark; risk is mitigated by narrow gmail.db scope, explicit empty-DB hazard docs, and a real-container integration test.
> 
> **Overview**
> ClawsBench is now **stateful**: `environment.toml` adds `[environment.state]` with SQLite rollback scoped to **`/data/gmail.db` only** (the DB the shipping task actually seeds), so snapshot/restore is exercised on a real benchmark instead of staying stateless.
> 
> **`ManifestEnvironment`** snapshot capture no longer assumes the `sqlite3` CLI: backup uses **`sqlite3 .backup` when available**, otherwise **`python3` + `sqlite3.backup`**, matching smolclaws images that have the module but not the binary. Readiness docs clarify that gating is framework-owned and independent of state rollback.
> 
> **Testing / CI**: a new **`docker`** pytest marker (excluded from default `addopts`) plus shared **`docker_daemon_unavailable_reason()`** / **`docker_daemon`** fixture in `conftest` (smoke reuses it). **`test_environment_snapshot_docker.py`** runs seed → snapshot → mutate → restore in a real container on `python:3.12-slim` (no CLI). A manifest test locks ClawsBench state to gmail-only paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed65c7ecf02d53e55fb096d0b3822ce6fcbbb20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->