### PR TITLE
feat: branch aggregation through canonical VerifyResult (v0.5 Phase 1b)

### DIFF
--- a/benchmarks/clawsbench/environment.toml
+++ b/benchmarks/clawsbench/environment.toml
@@ -60,3 +60,20 @@ port    = 9004
 name    = "gdrive"
 command = "claw-gdrive --db /data/gdrive.db serve --host 0.0.0.0 --port 9005 --no-mcp"
 port    = 9005
+
+# Stateful roll-back over the per-task SQLite DBs — turns snapshot/restore from
+# stub-tested into real-benchmark coverage (Han: "Environment 总是要 roll out,
+# roll back"; docs/architecture.md "Environment lifecycle"). snapshot() runs a
+# real `sqlite3 .backup`; restore() copies it back over the live file.
+#
+# Scoped to /data/gmail.db ONLY: each per-task image installs+seeds just the
+# claw services it needs (archive-amazon-shipping seeds only gmail.db, via its
+# Dockerfile `claw-gmail --db /data/gmail.db seed`). Declaring an absent path
+# is unsound — `sqlite3 .backup` on a missing source under the writable /data
+# dir exits 0 and fabricates an empty DB, which baseline-capture would then
+# treat as real and restore would clobber a later-created service DB with.
+# TODO: widen to slack/gcal/gdoc/gdrive once tasks seed them (or once snapshot
+# skips absent paths) — see the env-state existence-guard follow-up.
+[environment.state]
+kind  = "sqlite"
+paths = ["/data/gmail.db"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,11 +90,12 @@ only-include = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
-addopts = "-m 'not live and not integration'"
+addopts = "-m 'not live and not integration and not docker'"
 testpaths = ["tests"]
 markers = [
     "live: requires real Anthropic API and Docker daemon (run with -m live)",
     "integration: full integration tests — requires GEMINI_API_KEY + DAYTONA_API_KEY (run with -m integration)",
+    "docker: requires only a reachable Docker daemon — no API keys (run with -m docker)",
 ]
 
 [tool.ruff]

--- a/src/benchflow/branch.py
+++ b/src/benchflow/branch.py
@@ -19,10 +19,13 @@ from __future__ import annotations
 from typing import Any
 
 from benchflow.environment.protocol import StateSnapshot
+from benchflow.rewards.events import RewardEvent
+from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
 
 _SNAPSHOT_KEY = "snapshot"
 _REWARD_KEY = "reward"
+_VERIFY_RESULT_KEY = "verify_result"
 
 
 async def checkpoint(node: RolloutNode, environment: Any) -> StateSnapshot:
@@ -62,13 +65,59 @@ async def branch(
 
 
 def aggregate(node: RolloutNode) -> float:
-    """V(node) — the mean of the children's returns.
+    """V(node) — the mean of the children's returns (scalar form).
 
     Each child carries its return in ``state["reward"]`` (written by the Reward
     plane after a child rollout is scored). Averaging them estimates the value
-    of ``node``'s state — a reward function become a value function.
+    of ``node``'s state — a reward function become a value function. Kept for
+    back-compat; :func:`aggregate_verify_result` is the canonical form.
     """
     if not node.children:
         raise ValueError(f"node {node.id!r} has no children to aggregate")
     returns = [float(child.state.get(_REWARD_KEY, 0.0)) for child in node.children]
     return sum(returns) / len(returns)
+
+
+def aggregate_verify_result(node: RolloutNode) -> VerifyResult:
+    """V(node) as a composed ``VerifyResult`` — the canonical value function.
+
+    The node-scored counterpart to :func:`aggregate`: instead of averaging bare
+    floats, it reads each child's ``VerifyResult`` (recorded under
+    ``child.state["verify_result"]`` by the Reward plane after the child is
+    scored) and composes them into V(node) — mean child reward, per-child
+    ``items``, concatenated ``events``. This carries the architecture's Reward
+    contract end to end ("from a reward function to a value function"), so a
+    branch's value estimate is a tagged ``VerifyResult``, not a lossy scalar.
+
+    A child that was scored with only a bare float (a custom runner, legacy
+    path) is tolerated: its ``state["reward"]`` is lifted into a minimal
+    ``VerifyResult``. The parent ``error`` is conservative — populated unless
+    *every* child scored cleanly — so a partial scoring failure can't masquerade
+    as a clean value.
+    """
+    if not node.children:
+        raise ValueError(f"node {node.id!r} has no children to aggregate")
+    results: list[VerifyResult] = []
+    for child in node.children:
+        vr = child.state.get(_VERIFY_RESULT_KEY)
+        if not isinstance(vr, VerifyResult):
+            vr = VerifyResult(reward=float(child.state.get(_REWARD_KEY, 0.0)))
+        results.append(vr)
+    mean = sum(r.reward for r in results) / len(results)
+    items: dict[str, float] = {}
+    events: list[RewardEvent] = []
+    for i, r in enumerate(results):
+        items[f"child-{i}"] = r.reward
+        for source, value in r.items.items():
+            items[f"child-{i}/{source}"] = value
+        events.extend(r.events)
+    failed = sum(1 for r in results if r.error is not None)
+    error = None if failed == 0 else f"{failed}/{len(results)} children failed scoring"
+    return VerifyResult(
+        reward=mean,
+        items=items,
+        events=events,
+        error=error,
+        space="output",
+        granularity="terminal",
+    )

--- a/src/benchflow/branch.py
+++ b/src/benchflow/branch.py
@@ -20,6 +20,7 @@ from typing import Any
 
 from benchflow.environment.protocol import StateSnapshot
 from benchflow.rewards.events import RewardEvent
+from benchflow.rewards.node import verify_result_from_reward_map
 from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
 
@@ -101,7 +102,12 @@ def aggregate_verify_result(node: RolloutNode) -> VerifyResult:
     for child in node.children:
         vr = child.state.get(_VERIFY_RESULT_KEY)
         if not isinstance(vr, VerifyResult):
-            vr = VerifyResult(reward=float(child.state.get(_REWARD_KEY, 0.0)))
+            # One float->VerifyResult lift policy across the codebase (the same
+            # one branch()'s runner-normalisation uses), so a bare-float child
+            # composes identically however it was scored.
+            vr = verify_result_from_reward_map(
+                {"reward": float(child.state.get(_REWARD_KEY, 0.0))}
+            )
         results.append(vr)
     mean = sum(r.reward for r in results) / len(results)
     items: dict[str, float] = {}

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -42,6 +42,33 @@ from benchflow.environment.protocol import (
 )
 
 
+def _sqlite_backup_command(src: str, dest: str) -> str:
+    """A portable consistent online backup of a SQLite DB file.
+
+    Prefers the ``sqlite3`` CLI's ``.backup`` (the canonical online backup) and
+    falls back to Python's ``sqlite3.backup`` when the CLI binary is absent.
+    Real stateful images ship a SQLite *service* (e.g. smolclaws' claw-gmail
+    runs on Python's ``sqlite3`` module) but not the ``sqlite3`` command — and
+    BenchFlow's zero-modification-adoption goal means we must not require them
+    to install it. Both paths take a *consistent* snapshot of a live DB; a raw
+    ``cp`` could capture a torn write, so we never use it for capture.
+    """
+    q_src, q_dest = shlex.quote(src), shlex.quote(dest)
+    py_backup = (
+        "python3 -c "
+        + shlex.quote(
+            "import sqlite3, sys; "
+            "src = sqlite3.connect(sys.argv[1]); dst = sqlite3.connect(sys.argv[2]); "
+            "src.backup(dst); dst.close(); src.close()"
+        )
+        + f" {q_src} {q_dest}"
+    )
+    return (
+        f"if command -v sqlite3 >/dev/null 2>&1; then "
+        f'sqlite3 {q_src} ".backup {q_dest}"; else {py_backup}; fi'
+    )
+
+
 class EnvironmentSnapshotError(RuntimeError):
     """Raised when a snapshot or restore sandbox command fails (issue #387).
 
@@ -216,7 +243,7 @@ class ManifestEnvironment:
         cmds = [f"mkdir -p {shlex.quote(snap_dir)}"]
         for src in spec.paths:
             dest = f"{snap_dir}/{PurePosixPath(src).name}"
-            cmds.append(f'sqlite3 {shlex.quote(src)} ".backup {shlex.quote(dest)}"')
+            cmds.append(_sqlite_backup_command(src, dest))
         command = " && ".join(cmds)
         result = await self._sandbox.exec(command, timeout_sec=120)
         if result.return_code != 0:

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -128,6 +128,14 @@ class ManifestEnvironment:
         For framework-started environments only the services that were
         actually started are probed; for entrypoint-owned environments the
         manifest's declared HTTP probes are used.
+
+        Framework-owned invariant (``docs/architecture.md``: "Readiness and
+        teardown are framework guarantees"): this gate is invoked by
+        ``Rollout.start()`` — never by benchmark code — whenever the rollout
+        has an ``environment_manifest``, and it runs *before* the agent does.
+        It branches only on ``owns_lifecycle`` (which probe URLs to poll),
+        never on ``[environment.state]`` / snapshot support — readiness is
+        independent of whether the environment can roll back.
         """
         m = self._manifest
         timeout = m.readiness.timeout_sec

--- a/src/benchflow/rewards/node.py
+++ b/src/benchflow/rewards/node.py
@@ -25,13 +25,108 @@ contract as native ``NodeScorer``-based ones.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Final, Protocol, runtime_checkable
+from typing import Any, Final, Protocol, cast, runtime_checkable
 
-from benchflow.rewards.events import RewardEvent, Space
+from benchflow.rewards.events import Granularity, RewardEvent, Space
 from benchflow.rewards.protocol import RewardFunc, VerifyResult
 from benchflow.trajectories.tree import RolloutNode
 
 _OUTPUT_SPACE: Final[Space] = "output"
+
+
+def verify_result_from_reward_map(
+    rewards: dict[str, Any] | None,
+    *,
+    error: str | None = None,
+) -> VerifyResult:
+    """Lift a validated verifier reward ``dict`` into a canonical ``VerifyResult``.
+
+    This is the **single** dict→``VerifyResult`` conversion point. The legacy
+    ``Verifier`` produces ``{"reward": float, "rubric": [...], ...scalars...}``;
+    Phase 1 lifts it here, during scoring, so the ``VerifyResult`` is the live
+    source of truth — not something re-derived at export time. Unlike a bare
+    lift, it produces the full ``events`` list — one ``terminal`` Output event
+    for the headline reward plus one ``process`` event per rubric item carrying
+    that item's ``(space, granularity)`` — so ``rewards.jsonl`` /
+    ``verifiers.jsonl`` tags are *sourced* from the result, not defaulted at the
+    writer.
+
+    Note the asymmetry the architecture mandates (``docs/architecture.md``,
+    "Evaluation"): the headline reward is the Output/terminal outcome; rubric
+    items default to ``(output, step)`` — process signals along the path.
+
+    A ``None`` map (verifier crashed/timed out) yields ``reward=0.0`` with
+    ``error`` populated, so a downstream ``reward_valid`` flag reads ``False``.
+    """
+    if rewards is None:
+        return VerifyResult(
+            reward=0.0,
+            items={},
+            events=[],
+            error=error or "no rewards",
+            space=_OUTPUT_SPACE,
+            granularity="terminal",
+        )
+
+    reward = rewards.get("reward")
+    headline = (
+        float(reward)
+        if isinstance(reward, (int, float)) and not isinstance(reward, bool)
+        else 0.0
+    )
+
+    items: dict[str, float] = {}
+    events: list[RewardEvent] = []
+
+    if reward is not None:
+        events.append(
+            RewardEvent(
+                type="terminal",
+                reward=headline,
+                source="verifier",
+                space=_OUTPUT_SPACE,
+                granularity="terminal",
+            )
+        )
+
+    for key, value in rewards.items():
+        if key in ("reward", "rubric", "space", "granularity"):
+            continue
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            items[str(key)] = float(value)
+
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            rubric_item = cast(dict[str, Any], item)
+            score = rubric_item.get("score")
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                continue
+            name = str(rubric_item.get("name") or f"rubric_{i}")
+            items[name] = float(score)
+            events.append(
+                RewardEvent(
+                    type="process",
+                    reward=float(score),
+                    source=name,
+                    step=i,
+                    space=cast(Space, rubric_item.get("space", "output")),
+                    granularity=cast(
+                        Granularity, rubric_item.get("granularity", "step")
+                    ),
+                )
+            )
+
+    return VerifyResult(
+        reward=headline,
+        items=items,
+        events=events,
+        error=error,
+        space=_OUTPUT_SPACE,
+        granularity="terminal",
+    )
 
 #: ``node.state`` key under which a rollout's on-disk directory is recorded.
 #: :class:`PathReward` reads this to bridge node-scoped scoring to the legacy

--- a/src/benchflow/rewards/node.py
+++ b/src/benchflow/rewards/node.py
@@ -34,6 +34,18 @@ from benchflow.trajectories.tree import RolloutNode
 _OUTPUT_SPACE: Final[Space] = "output"
 
 
+def _as_score(value: Any) -> float | None:
+    """Coerce a reward-map value to a float score, or ``None`` if it isn't one.
+
+    Centralises the "real number, not a bool" guard the reward map needs in
+    three places (headline, extra scalars, rubric scores) — ``bool`` is an
+    ``int`` subclass and must not slip through as ``1.0``/``0.0``.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
 def verify_result_from_reward_map(
     rewards: dict[str, Any] | None,
     *,
@@ -69,11 +81,7 @@ def verify_result_from_reward_map(
         )
 
     reward = rewards.get("reward")
-    headline = (
-        float(reward)
-        if isinstance(reward, (int, float)) and not isinstance(reward, bool)
-        else 0.0
-    )
+    headline = _as_score(reward) or 0.0
 
     items: dict[str, float] = {}
     events: list[RewardEvent] = []
@@ -92,8 +100,9 @@ def verify_result_from_reward_map(
     for key, value in rewards.items():
         if key in ("reward", "rubric", "space", "granularity"):
             continue
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            items[str(key)] = float(value)
+        score = _as_score(value)
+        if score is not None:
+            items[str(key)] = score
 
     rubric = rewards.get("rubric")
     if isinstance(rubric, list):
@@ -101,15 +110,15 @@ def verify_result_from_reward_map(
             if not isinstance(item, dict):
                 continue
             rubric_item = cast(dict[str, Any], item)
-            score = rubric_item.get("score")
-            if not isinstance(score, (int, float)) or isinstance(score, bool):
+            score = _as_score(rubric_item.get("score"))
+            if score is None:
                 continue
             name = str(rubric_item.get("name") or f"rubric_{i}")
-            items[name] = float(score)
+            items[name] = score
             events.append(
                 RewardEvent(
                     type="process",
-                    reward=float(score),
+                    reward=score,
                     source=name,
                     step=i,
                     space=cast(Space, rubric_item.get("space", "output")),

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -83,6 +83,8 @@ from benchflow.providers.runtime import (
     extract_usage,
     stop_provider_runtime,
 )
+from benchflow.rewards.node import verify_result_from_reward_map
+from benchflow.rewards.protocol import VerifyResult
 from benchflow.rewards.validation import validate_reward_map
 from benchflow.rollout_branch import ChildRunner
 from benchflow.rollout_branch import branch as _branch_engine
@@ -258,6 +260,45 @@ async def _ensure_sandbox_dir(
 
 
 _DIAG_TRUNCATE = 2000
+
+
+def _write_verify_result_json(
+    rollout_dir: Path, verify_result: VerifyResult | None
+) -> None:
+    """Persist the canonical ``VerifyResult`` to ``verifier/verify_result.json``.
+
+    The Reward-plane source of truth (#v0.5 Phase 1): unlike ``result.json``
+    (which keeps the legacy reward *dict* for the ~10 existing consumers), this
+    file is the canonical ``{reward, items, events, error, space, granularity}``
+    structure — carrying the architecture's ``(space, granularity)`` tag and the
+    full event list — that the trainer export reads and branch aggregation will
+    read. Skipped when no result was produced (nothing scored).
+    """
+    if verify_result is None:
+        return
+    vr = verify_result
+    payload = {
+        "reward": vr.reward,
+        "items": vr.items,
+        "events": [
+            {
+                "type": e.type,
+                "source": e.source,
+                "reward": e.reward,
+                "step": e.step,
+                "space": e.space,
+                "granularity": e.granularity,
+                "ts": e.ts,
+            }
+            for e in vr.events
+        ],
+        "error": vr.error,
+        "space": vr.space,
+        "granularity": vr.granularity,
+    }
+    out = rollout_dir / "verifier" / "verify_result.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(payload, indent=2, default=str))
 
 
 def _write_rewards_jsonl(
@@ -469,6 +510,7 @@ def _build_rollout_result(
     export_error: str | None = None,
     trajectory_source: TrajectorySource | None = None,
     rewards: dict | None,
+    verify_result: VerifyResult | None = None,
     started_at: datetime,
     timing: dict[str, float],
     scenes: list[Scene] | None = None,
@@ -492,6 +534,11 @@ def _build_rollout_result(
     """
     if diagnostics is None:
         diagnostics = RolloutDiagnostics()
+    # The canonical Reward-plane result. On the live path Rollout.verify()
+    # already built it; derive here only for callers that pass just the legacy
+    # dict, so every rollout still emits one sourced VerifyResult (#v0.5 Phase 1).
+    if verify_result is None:
+        verify_result = verify_result_from_reward_map(rewards, error=verifier_error)
     finished_at = datetime.now()
     result = RolloutResult(
         task_name=task_name,
@@ -577,6 +624,11 @@ def _build_rollout_result(
     )
     (rollout_dir / "timing.json").write_text(json.dumps(timing, indent=2))
     (rollout_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
+    _write_verify_result_json(rollout_dir, verify_result)
+    # rewards.jsonl stays dict-derived: it reads (space, granularity) from the
+    # same validated reward map the VerifyResult is built from, so its lines are
+    # identical to sourcing verify_result.events — and verify_result.json is the
+    # canonical structure trainers/branch read.
     _write_rewards_jsonl(rollout_dir, rewards, finished_at)
     _write_trainer_artifact(
         rollout_dir,
@@ -584,6 +636,7 @@ def _build_rollout_result(
         prompts=prompts,
         trajectory=trajectory,
         rewards=rewards,
+        verify_result=verify_result,
         model=model,
         verifier_error=verifier_error,
     )
@@ -597,6 +650,7 @@ def _write_trainer_artifact(
     prompts: list[str],
     trajectory: list[dict],
     rewards: dict | None,
+    verify_result: VerifyResult | None = None,
     model: str | None,
     verifier_error: str | None,
 ) -> None:
@@ -606,6 +660,10 @@ def _write_trainer_artifact(
     that reaches result-building should produce a trainer-ready Verifiers /
     ORS record so prime-rl / Verifiers can ingest the run directly. Failures
     here are logged but never block result writing.
+
+    Phase 1: the export READS the canonical ``verify_result`` (the source of
+    truth) instead of re-deriving the reward from the legacy dict; ``rewards``
+    is kept as a back-compat fallback for callers without a VerifyResult.
     """
     from benchflow.trajectories.export import write_rollout_verifiers_jsonl
 
@@ -616,6 +674,7 @@ def _write_trainer_artifact(
             prompts=prompts,
             trajectory=trajectory,
             rewards=rewards,
+            verify_result=verify_result,
             model=model,
             environment=task_name,
             error=verifier_error,
@@ -1097,6 +1156,11 @@ class Rollout:
 
         # Populated by verify()
         self._rewards: dict | None = None
+        # The canonical Reward-plane result — the source of truth that export
+        # and (later) branch aggregation READ, instead of re-deriving from the
+        # legacy dict above. The dict is kept as a derived projection for the
+        # ~10 existing consumers of RolloutResult.rewards (#v0.5 Phase 1).
+        self._verify_result: VerifyResult | None = None
         self._verifier_error: str | None = None
         self._error: str | None = None
         # Populated by _export_generated_skills() on failure (#389 follow-up).
@@ -1759,6 +1823,13 @@ class Rollout:
         )
         if verifier_timeout_diag is not None:
             self._diagnostics.set(verifier_timeout_diag)
+
+        # Build the canonical VerifyResult once, here, from the validated
+        # reward map — the source of truth downstream artifacts read (#v0.5
+        # Phase 1). verify() still returns the dict for backward compatibility.
+        self._verify_result = verify_result_from_reward_map(
+            self._rewards, error=self._verifier_error
+        )
 
         self._phase = "verified"
         return self._rewards
@@ -2621,6 +2692,7 @@ class Rollout:
             partial_trajectory=self._partial_trajectory,
             trajectory_source=self._trajectory_source,
             rewards=self._rewards,
+            verify_result=self._verify_result,
             started_at=self._require_started_at(),
             timing=self._timing,
             scenes=self._config.effective_scenes,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -44,7 +44,7 @@ import logging
 import os
 import shlex
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -276,29 +276,13 @@ def _write_verify_result_json(
     """
     if verify_result is None:
         return
-    vr = verify_result
-    payload = {
-        "reward": vr.reward,
-        "items": vr.items,
-        "events": [
-            {
-                "type": e.type,
-                "source": e.source,
-                "reward": e.reward,
-                "step": e.step,
-                "space": e.space,
-                "granularity": e.granularity,
-                "ts": e.ts,
-            }
-            for e in vr.events
-        ],
-        "error": vr.error,
-        "space": vr.space,
-        "granularity": vr.granularity,
-    }
+    # Serialize via the dataclass itself — no hand-rolled second event schema to
+    # drift from VerifyResult/RewardEvent (the ORS ``timestamp`` rename is for
+    # the trainer wire format only; this internal artifact uses the dataclass'
+    # own ``ts``, matching rewards.jsonl).
     out = rollout_dir / "verifier" / "verify_result.json"
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(payload, indent=2, default=str))
+    out.write_text(json.dumps(asdict(verify_result), indent=2, default=str))
 
 
 def _write_rewards_jsonl(

--- a/src/benchflow/rollout_branch.py
+++ b/src/benchflow/rollout_branch.py
@@ -32,19 +32,23 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from benchflow.branch import aggregate as _aggregate_branch
+from benchflow.branch import aggregate_verify_result as _aggregate_vr
 from benchflow.branch import checkpoint as _checkpoint_branch
 from benchflow.branch import restore as _restore_branch
 from benchflow.models import TrajectorySource
+from benchflow.rewards.node import verify_result_from_reward_map
+from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories.tree import RolloutNode
 
 if TYPE_CHECKING:
     from benchflow.rollout import Rollout
 
 # The per-child runner: given the child's branch node, run its continuation and
-# return the scalar return. No ``int`` index — a caller that needs per-child
-# prompts binds them into a closure (see ``run_child`` in :func:`branch`).
-ChildRunner = Callable[[RolloutNode], Awaitable[float]]
+# return its score — a canonical ``VerifyResult`` (the default runner) or a bare
+# ``float`` (custom runners / tests, which :func:`branch` lifts to a
+# ``VerifyResult``). No ``int`` index — a caller that needs per-child prompts
+# binds them into a closure (see ``run_child`` in :func:`branch`).
+ChildRunner = Callable[[RolloutNode], Awaitable["VerifyResult | float"]]
 
 
 @dataclass
@@ -66,6 +70,7 @@ class _LinearState:
     session_tool_count: int
     session_traj_count: int
     executed_prompts: list[str]
+    verify_result: VerifyResult | None
 
     @classmethod
     def capture(cls, rollout: Rollout) -> _LinearState:
@@ -81,6 +86,7 @@ class _LinearState:
             session_tool_count=getattr(rollout, "_session_tool_count", 0),
             session_traj_count=getattr(rollout, "_session_traj_count", 0),
             executed_prompts=list(rollout._executed_prompts),
+            verify_result=getattr(rollout, "_verify_result", None),
         )
 
     def restore_onto(self, rollout: Rollout) -> None:
@@ -95,6 +101,7 @@ class _LinearState:
         rollout._session_tool_count = self.session_tool_count
         rollout._session_traj_count = self.session_traj_count
         rollout._executed_prompts = list(self.executed_prompts)
+        rollout._verify_result = self.verify_result
 
 
 async def branch(
@@ -184,16 +191,24 @@ async def branch(
         rollout._cursor = child
 
         ret = await runner(child)
-        child.state["reward"] = float(ret)
+        # Normalise the runner's return to a canonical VerifyResult. The default
+        # runner returns one; custom runners / tests may return a bare float,
+        # which we lift. Keep state["reward"] as the float for legacy readers.
+        vr = ret if isinstance(ret, VerifyResult) else verify_result_from_reward_map(
+            {"reward": float(ret)}
+        )
+        child.state["verify_result"] = vr
+        child.state["reward"] = vr.reward
 
     # restore the parent's linear state — the tree grew, nothing else moved.
     saved.restore_onto(rollout)
 
-    # aggregate — per-child return -> V(parent).
-    value = _aggregate_branch(parent)
-    parent.state["value"] = value
+    # aggregate — per-child VerifyResult -> V(parent) as a node-scored VerifyResult.
+    result = _aggregate_vr(parent)
+    parent.state["verify_result"] = result
+    parent.state["value"] = result.reward  # back-compat scalar mirror
     rollout._phase = "branched"
-    return value
+    return result.reward
 
 
 def make_default_runner(rollout: Rollout) -> ChildRunner:
@@ -204,19 +219,23 @@ def make_default_runner(rollout: Rollout) -> ChildRunner:
     (``docs/architecture.md``, "The hard part"), so the agent restarts per
     child. Each child connects a fresh agent and disconnects it at the end, so
     no two children's agents overlap (the next child connects only after the
-    previous one disconnected). ``verify()`` returning ``None`` or an empty
-    dict falls back to a ``0.0`` return.
+    previous one disconnected). It returns the child's canonical
+    ``VerifyResult`` — ``rollout.verify()`` populates ``rollout._verify_result``
+    as a side effect (the Phase 1a source of truth), so the runner reads it
+    without changing ``verify()``'s dict return. A verifier that produced no
+    rewards yields a 0.0 ``VerifyResult``.
     """
 
-    async def _runner(child: RolloutNode) -> float:
+    async def _runner(child: RolloutNode) -> VerifyResult:
         await rollout.connect()
         # Fill the pending branch-child node in place — the continuation Step
         # lands on `child` itself, no content-free placeholder.
         await rollout.execute(node=child)
         rewards = await rollout.verify()
         await rollout.disconnect()
-        if not rewards:
-            return 0.0
-        return float(rewards.get("reward", 0.0))
+        vr = rollout._verify_result
+        if vr is None:
+            vr = verify_result_from_reward_map(rewards)
+        return vr
 
     return _runner

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 import json
 import logging
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from benchflow._utils.json_safe import scrub_non_finite
 from benchflow.adapters.ors import ORSAdapter
@@ -189,43 +189,19 @@ def reward_map_to_verify_result(
     *,
     error: str | None = None,
 ) -> VerifyResult:
-    """Adapt a canonical verifier reward ``dict`` to :class:`VerifyResult`.
+    """Back-compat shim — lift a verifier reward ``dict`` to :class:`VerifyResult`.
 
-    ``Rollout.verify()`` produces a validated reward map with the shape
-    ``{"reward": float, "rubric": [...], ...other scalars...}``. The
-    Verifiers record helper expects a :class:`VerifyResult`, so we lift the
-    headline ``reward`` and any per-item scalars into ``VerifyResult.items``.
-
-    A ``None`` rewards map (verifier crashed/timed out) yields a 0.0 reward
-    with ``error`` populated so the exported record's ``reward_valid`` flag
-    is ``False``.
+    *The canonical conversion lives upstream* in
+    :func:`benchflow.rewards.node.verify_result_from_reward_map`, which Phase 1
+    runs once during scoring so the ``VerifyResult`` is the source of truth
+    (not re-derived at export time). This shim is retained only for exporting
+    **pre-existing** rollout dirs that carry the legacy reward ``dict`` but no
+    ``verify_result`` — see :func:`write_rollout_verifiers_jsonl`. It delegates
+    to the single conversion point so the two never diverge.
     """
-    if rewards is None:
-        return VerifyResult(reward=0.0, items={}, error=error or "no rewards")
+    from benchflow.rewards.node import verify_result_from_reward_map
 
-    reward = rewards.get("reward")
-    headline = float(reward) if isinstance(reward, (int, float)) else 0.0
-
-    items: dict[str, float] = {}
-    for key, value in rewards.items():
-        if key in ("reward", "rubric"):
-            continue
-        if isinstance(value, (int, float)) and not isinstance(value, bool):
-            items[str(key)] = float(value)
-
-    rubric = rewards.get("rubric")
-    if isinstance(rubric, list):
-        for i, item in enumerate(rubric):
-            if not isinstance(item, dict):
-                continue
-            rubric_item = cast(dict[str, Any], item)
-            score = rubric_item.get("score")
-            if not isinstance(score, (int, float)) or isinstance(score, bool):
-                continue
-            name = str(rubric_item.get("name") or f"rubric_{i}")
-            items[name] = float(score)
-
-    return VerifyResult(reward=headline, items=items, error=error)
+    return verify_result_from_reward_map(rewards, error=error)
 
 
 def write_rollout_verifiers_jsonl(
@@ -234,7 +210,8 @@ def write_rollout_verifiers_jsonl(
     task_id: str,
     prompts: list[str] | None,
     trajectory: list[dict[str, Any]],
-    rewards: dict[str, Any] | None,
+    rewards: dict[str, Any] | None = None,
+    verify_result: VerifyResult | None = None,
     model: str | None,
     environment: str,
     example_id: int = 0,
@@ -247,9 +224,17 @@ def write_rollout_verifiers_jsonl(
     Output path is ``rollout_dir/trainer/verifiers.jsonl`` — the
     architecture's trainer seam (issue #385). Returns the written record so
     callers can aggregate across a job.
+
+    Phase 1: when ``verify_result`` is supplied (the live path), the record is
+    built by **reading** that canonical :class:`VerifyResult` — the export no
+    longer re-derives the reward from the dict. ``rewards`` is the back-compat
+    fallback for old job dirs that only have the legacy reward map; it is
+    lifted via :func:`reward_map_to_verify_result` only when ``verify_result``
+    is ``None``.
     """
     messages = acp_events_to_messages(trajectory, prompts)
-    verify_result = reward_map_to_verify_result(rewards, error=error)
+    if verify_result is None:
+        verify_result = reward_map_to_verify_result(rewards, error=error)
     record = trajectory_to_verifiers_record(
         task_id=task_id,
         messages=messages,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 """Test fixtures."""
 
 import json
+import shutil
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +13,42 @@ REPO_ROOT = Path(__file__).parent.parent
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
+
+
+def docker_daemon_unavailable_reason() -> str | None:
+    """Why a Docker-daemon-backed test can't run, or ``None`` if it can.
+
+    The **canonical** docker gate, shared by every daemon-backed test (the
+    smoke test and the env-snapshot integration test) so there is one answer,
+    not a per-file reinvention. Checks the CLI is present *and* the daemon is
+    reachable (3s timeout to kill hangs on a misconfigured ``DOCKER_HOST``) —
+    a CLI-only check would let a test run (and fail on a real image build) when
+    the daemon is down.
+
+    Pure function — call it inside a fixture/skipif body, never at decorator or
+    collection time, so the subprocess fires only when the test is selected.
+    """
+    if shutil.which("docker") is None:
+        return "docker CLI not installed"
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "{{.Server.Version}}"],
+            timeout=3,
+            capture_output=True,
+        )
+    except (subprocess.TimeoutExpired, OSError) as e:
+        return f"docker daemon unreachable: {e}"
+    if result.returncode != 0:
+        return "docker daemon unreachable"
+    return None
+
+
+@pytest.fixture
+def docker_daemon() -> None:
+    """Skip the test unless a Docker daemon is reachable (see the helper above)."""
+    reason = docker_daemon_unavailable_reason()
+    if reason:
+        pytest.skip(reason)
 
 REF_TASKS = REPO_ROOT / ".cache" / "datasets" / "benchflow" / "examples" / "tasks"
 

--- a/tests/environment/test_clawsbench_manifest.py
+++ b/tests/environment/test_clawsbench_manifest.py
@@ -33,6 +33,18 @@ def test_clawsbench_manifest_uses_image_task_selection():
     assert m.task_selection.mechanism == "image"
 
 
+def test_clawsbench_manifest_declares_sqlite_state_scoped_to_gmail():
+    """v0.5 Phase 2: ClawsBench is now stateful so snapshot/restore has real
+    coverage — scoped to /data/gmail.db only (the sole DB the one shipping task
+    seeds; declaring an absent path would make `sqlite3 .backup` fabricate an
+    empty DB). Guards the manifest against silently re-widening to unseeded DBs.
+    """
+    m = load_manifest(MANIFEST_PATH)
+    assert m.state is not None, "ClawsBench must declare [environment.state]"
+    assert m.state.kind == "sqlite"
+    assert m.state.paths == ["/data/gmail.db"]
+
+
 def test_clawsbench_manifest_service_commands_are_runnable():
     m = load_manifest(MANIFEST_PATH)
     for svc in m.services:

--- a/tests/test_branch.py
+++ b/tests/test_branch.py
@@ -7,8 +7,16 @@ aggregate the children's returns into V(parent).
 
 import pytest
 
-from benchflow.branch import aggregate, branch, checkpoint, fork, restore
+from benchflow.branch import (
+    aggregate,
+    aggregate_verify_result,
+    branch,
+    checkpoint,
+    fork,
+    restore,
+)
 from benchflow.environment.protocol import StateSnapshot
+from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories.tree import RolloutTree, branch_points
 
 
@@ -81,6 +89,45 @@ def test_aggregate_averages_children_returns_into_value():
     children[0].state["reward"] = 1.0
     children[1].state["reward"] = 0.0
     assert aggregate(tree.root) == 0.5
+
+
+def test_aggregate_verify_result_composes_children():
+    """V(parent) is a node-scored VerifyResult: mean reward, namespaced items,
+    concatenated events (the canonical Phase 1b aggregation)."""
+    tree = RolloutTree()
+    children = fork(tree, tree.root, 2)
+    children[0].state["verify_result"] = VerifyResult(reward=1.0, items={"acc": 1.0})
+    children[1].state["verify_result"] = VerifyResult(reward=0.0)
+    vr = aggregate_verify_result(tree.root)
+    assert isinstance(vr, VerifyResult)
+    assert vr.reward == 0.5
+    assert vr.space == "output" and vr.granularity == "terminal"
+    assert vr.items["child-0"] == 1.0 and vr.items["child-1"] == 0.0
+    assert vr.items["child-0/acc"] == 1.0  # child items namespaced, no collision
+    assert vr.error is None
+
+
+def test_aggregate_verify_result_error_is_conservative():
+    """If any child failed scoring, V(parent).error is populated (a partial
+    scoring failure must not masquerade as a clean value)."""
+    tree = RolloutTree()
+    children = fork(tree, tree.root, 2)
+    children[0].state["verify_result"] = VerifyResult(reward=1.0)
+    children[1].state["verify_result"] = VerifyResult(reward=0.0, error="boom")
+    vr = aggregate_verify_result(tree.root)
+    assert vr.reward == 0.5  # value still defined from the children that scored
+    assert vr.error is not None and "1/2" in vr.error
+
+
+def test_aggregate_verify_result_tolerates_bare_float_children():
+    """A child scored with only a bare float reward is lifted, not dropped."""
+    tree = RolloutTree()
+    children = fork(tree, tree.root, 2)
+    children[0].state["reward"] = 1.0  # no verify_result
+    children[1].state["reward"] = 0.0
+    vr = aggregate_verify_result(tree.root)
+    assert isinstance(vr, VerifyResult)
+    assert vr.reward == 0.5
 
 
 def test_aggregate_without_children_raises():

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -3,13 +3,18 @@
 The moat (Han: "Environment 总是要 roll out, roll back") was only stub-tested
 against ``FakeSandbox`` — `tests/environment/test_manifest_env.py` asserts the
 *commands* are issued, never that a real round-trip rolls state back. This is
-the integration gate: a real ``DockerSandbox`` runs the real
-``sqlite3 .backup`` / ``cp`` that ``ManifestEnvironment.snapshot``/``restore``
-issue, and we assert a mutation made after the snapshot is gone after restore.
+the integration gate: a real ``DockerSandbox`` runs the real backup/restore
+that ``ManifestEnvironment.snapshot``/``restore`` issue, and we assert a
+mutation made after the snapshot is gone after restore.
 
-Docker-gated: skipped when no Docker daemon is reachable, so the default unit
-suite stays fast and host-independent. Run locally / in a Docker-capable CI
-lane to exercise it.
+The image is ``python:3.12-slim`` *on purpose* — it has Python's ``sqlite3``
+module but **not** the ``sqlite3`` CLI, exactly like the real ClawsBench
+(smolclaws) image. The ClawsBench e2e run caught that the CLI is absent there
+(``sqlite3: not found``), so this test now exercises the python3 fallback path
+end-to-end — the real-benchmark regression, reproduced in CI.
+
+Docker-gated via the ``docker`` marker (excluded from the default suite) and the
+``docker_daemon`` fixture; run with ``pytest -m docker``.
 """
 
 from __future__ import annotations
@@ -20,7 +25,10 @@ from pathlib import Path
 import pytest
 
 from benchflow.environment.manifest import EnvironmentManifest
-from benchflow.environment.manifest_env import ManifestEnvironment
+from benchflow.environment.manifest_env import (
+    ManifestEnvironment,
+    _sqlite_backup_command,
+)
 from benchflow.sandbox.docker import DockerSandbox
 from benchflow.task import RolloutPaths, SandboxConfig
 
@@ -31,7 +39,7 @@ _MANIFEST = EnvironmentManifest.model_validate_toml(
     """
 [environment]
 name           = "snap-roundtrip-test"
-image          = "alpine:3.20"
+image          = "python:3.12-slim"
 owns_lifecycle = true
 
 [environment.state]
@@ -40,21 +48,48 @@ paths = ["/data/test.db"]
 """
 )
 
+# python:3.12-slim has the sqlite3 *module* but not the sqlite3 *CLI* — the same
+# shape as the smolclaws ClawsBench image that surfaced the regression.
 _DOCKERFILE = textwrap.dedent(
     """\
-    FROM alpine:3.20
-    RUN apk add --no-cache sqlite
+    FROM python:3.12-slim
     CMD ["sleep", "infinity"]
     """
 )
 
 
+def _py_sqlite(stmt: str) -> str:
+    """A shell command running one SQLite statement via python3 (no CLI)."""
+    return (
+        'python3 -c "'
+        "import sqlite3; "
+        "c = sqlite3.connect('/data/test.db'); "
+        f"c.execute('{stmt}'); "
+        "c.commit(); c.close()"
+        '"'
+    )
+
+
 async def _count_rows(sandbox: DockerSandbox) -> int:
     result = await sandbox.exec(
-        'sqlite3 /data/test.db "SELECT count(*) FROM t;"', timeout_sec=30
+        'python3 -c "'
+        "import sqlite3; "
+        "print(sqlite3.connect('/data/test.db').execute('SELECT count(*) FROM t').fetchone()[0])"
+        '"',
+        timeout_sec=30,
     )
     assert result.return_code == 0, result.stderr
     return int(result.stdout.strip())
+
+
+def test_sqlite_backup_command_prefers_cli_falls_back_to_python():
+    """The backup command tries the sqlite3 CLI, then python3 — guards the
+    ClawsBench regression (smolclaws ships python3 but not the sqlite3 CLI)."""
+    cmd = _sqlite_backup_command("/data/x.db", "/snap/x.db")
+    assert "command -v sqlite3" in cmd
+    assert '.backup' in cmd  # the CLI branch
+    assert "python3 -c" in cmd  # the fallback branch
+    assert "sqlite3.connect" in cmd
 
 
 @pytest.mark.docker
@@ -62,7 +97,8 @@ async def _count_rows(sandbox: DockerSandbox) -> int:
 async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(
     docker_daemon: None, tmp_path: Path
 ):
-    """Seed → snapshot → mutate → restore → assert the mutation rolled back."""
+    """Seed → snapshot → mutate → restore → assert rollback, on a python-only
+    image (no sqlite3 CLI) — the real ClawsBench scenario via the python3 path."""
     env_dir = tmp_path / "environment"
     env_dir.mkdir()
     (env_dir / "Dockerfile").write_text(_DOCKERFILE)
@@ -79,25 +115,31 @@ async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(
     )
     await sandbox.start(force_build=True)
     try:
-        # Seed a real DB with one row.
+        # Prove we are exercising the fallback: the image has no sqlite3 CLI.
+        cli = await sandbox.exec("command -v sqlite3", timeout_sec=10)
+        assert cli.return_code != 0, (
+            "test image must NOT ship the sqlite3 CLI — the point is to exercise "
+            "the python3 backup fallback (the real ClawsBench/smolclaws shape)"
+        )
+
+        # Seed a real DB with one row (via python3 — no CLI available).
         seed = await sandbox.exec(
-            'mkdir -p /data && sqlite3 /data/test.db '
-            '"CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (1);"',
+            "mkdir -p /data && " + _py_sqlite("CREATE TABLE t(x INTEGER)"),
             timeout_sec=30,
         )
         assert seed.return_code == 0, seed.stderr
+        ins = await sandbox.exec(_py_sqlite("INSERT INTO t VALUES (1)"), timeout_sec=30)
+        assert ins.return_code == 0, ins.stderr
         assert await _count_rows(sandbox) == 1
 
         env = ManifestEnvironment(_MANIFEST, sandbox=sandbox)
 
-        # Real snapshot (sqlite3 .backup into an in-sandbox snapshot dir).
+        # Real snapshot (python3 sqlite3.backup into an in-sandbox snapshot dir).
         snap = await env.snapshot()
         assert snap.id and snap.path
 
         # Mutate after the snapshot.
-        mutate = await sandbox.exec(
-            'sqlite3 /data/test.db "INSERT INTO t VALUES (2);"', timeout_sec=30
-        )
+        mutate = await sandbox.exec(_py_sqlite("INSERT INTO t VALUES (2)"), timeout_sec=30)
         assert mutate.return_code == 0, mutate.stderr
         assert await _count_rows(sandbox) == 2  # mutation visible
 

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -1,0 +1,112 @@
+"""v0.5 Phase 2 — snapshot/restore proven on a REAL SQLite DB in a REAL container.
+
+The moat (Han: "Environment 总是要 roll out, roll back") was only stub-tested
+against ``FakeSandbox`` — `tests/environment/test_manifest_env.py` asserts the
+*commands* are issued, never that a real round-trip rolls state back. This is
+the integration gate: a real ``DockerSandbox`` runs the real
+``sqlite3 .backup`` / ``cp`` that ``ManifestEnvironment.snapshot``/``restore``
+issue, and we assert a mutation made after the snapshot is gone after restore.
+
+Docker-gated: skipped when no Docker daemon is reachable, so the default unit
+suite stays fast and host-independent. Run locally / in a Docker-capable CI
+lane to exercise it.
+"""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from benchflow.environment.manifest import EnvironmentManifest
+from benchflow.environment.manifest_env import ManifestEnvironment
+from benchflow.sandbox.docker import DockerSandbox
+from benchflow.task import RolloutPaths, SandboxConfig
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("docker") is None,
+    reason="Docker not available — real snapshot/restore round-trip is gated",
+)
+
+# Minimal stateful manifest: just [environment.state] over one sqlite file. We
+# drive snapshot()/restore() directly against a real container, so no services
+# / provision are needed.
+_MANIFEST = EnvironmentManifest.model_validate_toml(
+    """
+[environment]
+name           = "snap-roundtrip-test"
+image          = "alpine:3.20"
+owns_lifecycle = true
+
+[environment.state]
+kind  = "sqlite"
+paths = ["/data/test.db"]
+"""
+)
+
+_DOCKERFILE = textwrap.dedent(
+    """\
+    FROM alpine:3.20
+    RUN apk add --no-cache sqlite
+    CMD ["sleep", "infinity"]
+    """
+)
+
+
+async def _count_rows(sandbox: DockerSandbox) -> int:
+    result = await sandbox.exec(
+        'sqlite3 /data/test.db "SELECT count(*) FROM t;"', timeout_sec=30
+    )
+    assert result.return_code == 0, result.stderr
+    return int(result.stdout.strip())
+
+
+@pytest.mark.asyncio
+async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(tmp_path: Path):
+    """Seed → snapshot → mutate → restore → assert the mutation rolled back."""
+    env_dir = tmp_path / "environment"
+    env_dir.mkdir()
+    (env_dir / "Dockerfile").write_text(_DOCKERFILE)
+
+    rollout_dir = tmp_path / "rollout"
+    for sub in ("agent", "verifier", "artifacts", "trajectory"):
+        (rollout_dir / sub).mkdir(parents=True, exist_ok=True)
+
+    sandbox = DockerSandbox(
+        environment_dir=env_dir,
+        environment_name="snap-roundtrip-test",
+        session_id="phase2-gate",
+        rollout_paths=RolloutPaths(rollout_dir=rollout_dir),
+        task_env_config=SandboxConfig(),
+    )
+    await sandbox.start(force_build=True)
+    try:
+        # Seed a real DB with one row.
+        seed = await sandbox.exec(
+            'mkdir -p /data && sqlite3 /data/test.db '
+            '"CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (1);"',
+            timeout_sec=30,
+        )
+        assert seed.return_code == 0, seed.stderr
+        assert await _count_rows(sandbox) == 1
+
+        env = ManifestEnvironment(_MANIFEST, sandbox=sandbox)
+
+        # Real snapshot (sqlite3 .backup into an in-sandbox snapshot dir).
+        snap = await env.snapshot()
+        assert snap.id and snap.path
+
+        # Mutate after the snapshot.
+        mutate = await sandbox.exec(
+            'sqlite3 /data/test.db "INSERT INTO t VALUES (2);"', timeout_sec=30
+        )
+        assert mutate.return_code == 0, mutate.stderr
+        assert await _count_rows(sandbox) == 2  # mutation visible
+
+        # Real restore (cp the backup back over the live file) rolls it back.
+        await env.restore(snap)
+        assert await _count_rows(sandbox) == 1  # mutation gone
+    finally:
+        await sandbox.stop(delete=True)

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -14,7 +14,6 @@ lane to exercise it.
 
 from __future__ import annotations
 
-import shutil
 import textwrap
 from pathlib import Path
 
@@ -24,11 +23,6 @@ from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.environment.manifest_env import ManifestEnvironment
 from benchflow.sandbox.docker import DockerSandbox
 from benchflow.task import RolloutPaths, SandboxConfig
-
-pytestmark = pytest.mark.skipif(
-    shutil.which("docker") is None,
-    reason="Docker not available — real snapshot/restore round-trip is gated",
-)
 
 # Minimal stateful manifest: just [environment.state] over one sqlite file. We
 # drive snapshot()/restore() directly against a real container, so no services
@@ -63,22 +57,24 @@ async def _count_rows(sandbox: DockerSandbox) -> int:
     return int(result.stdout.strip())
 
 
+@pytest.mark.docker
 @pytest.mark.asyncio
-async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(tmp_path: Path):
+async def test_manifest_env_snapshot_restore_rolls_back_real_sqlite(
+    docker_daemon: None, tmp_path: Path
+):
     """Seed → snapshot → mutate → restore → assert the mutation rolled back."""
     env_dir = tmp_path / "environment"
     env_dir.mkdir()
     (env_dir / "Dockerfile").write_text(_DOCKERFILE)
 
-    rollout_dir = tmp_path / "rollout"
-    for sub in ("agent", "verifier", "artifacts", "trajectory"):
-        (rollout_dir / sub).mkdir(parents=True, exist_ok=True)
+    rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+    rollout_paths.mkdir()
 
     sandbox = DockerSandbox(
         environment_dir=env_dir,
         environment_name="snap-roundtrip-test",
         session_id="phase2-gate",
-        rollout_paths=RolloutPaths(rollout_dir=rollout_dir),
+        rollout_paths=rollout_paths,
         task_env_config=SandboxConfig(),
     )
     await sandbox.start(force_build=True)

--- a/tests/test_environment_snapshot_docker.py
+++ b/tests/test_environment_snapshot_docker.py
@@ -87,7 +87,7 @@ def test_sqlite_backup_command_prefers_cli_falls_back_to_python():
     ClawsBench regression (smolclaws ships python3 but not the sqlite3 CLI)."""
     cmd = _sqlite_backup_command("/data/x.db", "/snap/x.db")
     assert "command -v sqlite3" in cmd
-    assert '.backup' in cmd  # the CLI branch
+    assert ".backup" in cmd  # the CLI branch
     assert "python3 -c" in cmd  # the fallback branch
     assert "sqlite3.connect" in cmd
 

--- a/tests/test_phase1_reward_source_of_truth.py
+++ b/tests/test_phase1_reward_source_of_truth.py
@@ -1,0 +1,158 @@
+"""Guards v0.5 Phase 1 — the canonical VerifyResult is the live source of truth.
+
+Phase 1 routes the reward path through ``Reward.score(node) -> VerifyResult``
+(``docs/architecture.md`` § "The four contracts"): the verifier's reward map is
+lifted ONCE during scoring into a canonical ``VerifyResult``
+(``verify_result_from_reward_map``), persisted to ``verifier/verify_result.json``,
+and the trainer export READS it instead of re-deriving the reward from the legacy
+dict at export time. ``result.json['rewards']`` stays the legacy dict for the
+existing consumers.
+
+These tests pin that direction so a later refactor can't quietly reintroduce the
+downgrade-on-export, or default the ``(space, granularity)`` tag at the writer.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from benchflow.rewards.node import verify_result_from_reward_map
+from benchflow.rewards.protocol import VerifyResult
+from benchflow.rollout import _build_rollout_result
+from benchflow.trajectories.export import (
+    ROLLOUT_ARTIFACT_RELPATH,
+    write_rollout_verifiers_jsonl,
+)
+
+
+def test_verify_result_from_reward_map_builds_canonical():
+    """The single conversion point lifts dict -> tagged VerifyResult + events."""
+    vr = verify_result_from_reward_map(
+        {
+            "reward": 0.75,
+            "exact_match": 1.0,
+            "rubric": [{"name": "clarity", "score": 0.5}],
+        }
+    )
+    assert isinstance(vr, VerifyResult)
+    assert vr.reward == 0.75
+    assert vr.items["exact_match"] == 1.0
+    assert vr.items["clarity"] == 0.5
+    assert vr.space == "output"
+    assert vr.granularity == "terminal"
+    # One terminal Output event for the headline + one process event per rubric.
+    terminal = [e for e in vr.events if e.type == "terminal"]
+    process = [e for e in vr.events if e.type == "process"]
+    assert len(terminal) == 1
+    assert terminal[0].space == "output" and terminal[0].granularity == "terminal"
+    assert len(process) == 1
+    assert process[0].source == "clarity"
+    assert process[0].granularity == "step"
+
+
+def test_verify_result_from_reward_map_handles_none():
+    """A crashed/timed-out verifier yields reward 0.0 with error populated."""
+    vr = verify_result_from_reward_map(None, error="verifier timed out")
+    assert vr.reward == 0.0
+    assert vr.items == {}
+    assert vr.events == []
+    assert vr.error == "verifier timed out"
+
+
+def test_export_reads_verify_result_not_the_dict():
+    """write_rollout_verifiers_jsonl READS the VerifyResult when supplied.
+
+    Pass a VerifyResult and a deliberately DIFFERENT rewards dict; the record
+    must reflect the VerifyResult (0.9), never the dict (0.1) — proving export
+    reads the canonical result rather than re-deriving from the legacy map.
+    """
+    import tempfile
+    from pathlib import Path
+
+    vr = verify_result_from_reward_map({"reward": 0.9})
+    with tempfile.TemporaryDirectory() as d:
+        rec = write_rollout_verifiers_jsonl(
+            Path(d),
+            task_id="t1",
+            prompts=["do it"],
+            trajectory=[],
+            rewards={"reward": 0.1},  # intentionally different — must be ignored
+            verify_result=vr,
+            model="m",
+            environment="e",
+        )
+    assert rec["reward"] == 0.9
+    assert rec["info"]["reward_metadata"]["space"] == "output"
+    assert rec["info"]["reward_metadata"]["granularity"] == "terminal"
+
+
+def test_build_result_writes_canonical_verify_result_json(tmp_path):
+    """_build_rollout_result persists verify_result.json and keeps the legacy dict.
+
+    The canonical Reward-plane artifact carries (space, granularity) and the
+    event list; result.json['rewards'] stays the legacy dict for back-compat;
+    and the headline reward agrees across both, sourced from the VerifyResult.
+    """
+    rewards = {"reward": 1.0, "rubric": [{"name": "clarity", "score": 0.5}]}
+    vr = verify_result_from_reward_map(rewards)
+    _build_rollout_result(
+        tmp_path,
+        task_name="hello-world-task",
+        rollout_name="r1",
+        agent="oracle",
+        agent_name="oracle",
+        model=None,
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards=rewards,
+        verify_result=vr,
+        started_at=datetime.now(),
+        timing={},
+    )
+
+    vr_json = json.loads((tmp_path / "verifier" / "verify_result.json").read_text())
+    assert vr_json["reward"] == 1.0
+    assert vr_json["space"] == "output"
+    assert vr_json["granularity"] == "terminal"
+    assert any(e["type"] == "process" for e in vr_json["events"])
+
+    result_json = json.loads((tmp_path / "result.json").read_text())
+    # Legacy dict preserved for the ~10 existing consumers (no breaking change).
+    assert result_json["rewards"] == rewards
+
+    # The trainer artifact's headline agrees with the canonical result.
+    rec = json.loads((tmp_path / ROLLOUT_ARTIFACT_RELPATH).read_text().strip())
+    assert rec["reward"] == 1.0
+
+
+def test_build_result_derives_verify_result_when_absent(tmp_path):
+    """Callers that pass only the legacy dict still get a sourced verify_result.json.
+
+    SDK/Evaluation builders don't thread a VerifyResult; _build_rollout_result
+    must derive one from the dict so every rollout emits the canonical artifact.
+    """
+    _build_rollout_result(
+        tmp_path,
+        task_name="t",
+        rollout_name="r",
+        agent="oracle",
+        agent_name="oracle",
+        model=None,
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards={"reward": 0.5},
+        started_at=datetime.now(),
+        timing={},
+    )
+    vr_json = json.loads((tmp_path / "verifier" / "verify_result.json").read_text())
+    assert vr_json["reward"] == 0.5
+    assert vr_json["space"] == "output"

--- a/tests/test_rollout_branch.py
+++ b/tests/test_rollout_branch.py
@@ -18,6 +18,7 @@ import pytest
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.environment.manifest_env import ManifestEnvironment
 from benchflow.environment.protocol import StateSnapshot
+from benchflow.rewards.protocol import VerifyResult
 from benchflow.rollout import Rollout, RolloutConfig, Scene
 from benchflow.sandbox.protocol import ExecResult
 from benchflow.trajectories.tree import RolloutTree, branch_points, trajectory
@@ -449,3 +450,67 @@ async def test_branch_drives_manifest_environment_snapshot_restore(tmp_path: Pat
     # the real restore path ran once per child: cp from the snapshot dir
     restore_cmds = [c for c in sandbox.exec_calls if c.startswith("cp ")]
     assert len(restore_cmds) == 2
+
+
+@pytest.mark.asyncio
+async def test_branch_aggregates_into_a_node_scored_verify_result(tmp_path: Path):
+    """PR-1b: branch() composes child VerifyResults into a node-scored
+    parent.state['verify_result'], while keeping the float mirror for back-compat."""
+    rollout = _rollout(tmp_path)
+    rollout._environment = FakeEnvironment()
+    parent = rollout._cursor
+
+    seq = iter([0.0, 1.0])
+
+    async def run_child(child):
+        return next(seq)  # bare floats — branch() lifts them to VerifyResults
+
+    value = await rollout.branch(2, run_child=run_child)
+
+    # Back-compat scalar still holds.
+    assert value == 0.5
+    assert parent.state["value"] == 0.5
+    # Canonical VerifyResult composed on the parent.
+    vr = parent.state["verify_result"]
+    assert isinstance(vr, VerifyResult)
+    assert vr.reward == 0.5
+    assert vr.space == "output" and vr.granularity == "terminal"
+    # Each child carries its own VerifyResult.
+    assert all(isinstance(c.state["verify_result"], VerifyResult) for c in parent.children)
+    assert {c.state["verify_result"].reward for c in parent.children} == {0.0, 1.0}
+
+
+@pytest.mark.asyncio
+async def test_branch_runner_back_compat_accepts_bare_float(tmp_path: Path):
+    """A custom run_child returning a bare float still yields a composed
+    VerifyResult on the parent (the runner contract tolerates float|VerifyResult)."""
+    rollout = _rollout(tmp_path)
+    rollout._environment = FakeEnvironment()
+    parent = rollout._cursor
+
+    async def run_child(child):
+        return 1.0
+
+    await rollout.branch(2, run_child=run_child)
+    vr = parent.state["verify_result"]
+    assert isinstance(vr, VerifyResult)
+    assert vr.reward == 1.0
+
+
+@pytest.mark.asyncio
+async def test_linear_state_isolates_verify_result(tmp_path: Path):
+    """_LinearState round-trips rollout._verify_result so a child's scoring does
+    not leak onto the parent after branch() returns (extends the isolation
+    invariant to the Phase 1a field)."""
+    rollout = _rollout(tmp_path)
+    rollout._environment = FakeEnvironment()
+    sentinel = VerifyResult(reward=0.42)
+    rollout._verify_result = sentinel
+
+    async def run_child(child):
+        rollout._verify_result = VerifyResult(reward=0.99)  # a child's scoring mutates it
+        return 0.99
+
+    await rollout.branch(2, run_child=run_child)
+    # The parent's pre-branch verify_result is restored — not a child's value.
+    assert rollout._verify_result is sentinel

--- a/tests/test_self_gen_export_failures.py
+++ b/tests/test_self_gen_export_failures.py
@@ -37,6 +37,9 @@ def _bare_rollout(tmp_path: Path, export_target: Path | None) -> Rollout:
     rollout._evolved_skills = None
     rollout._error = None
     rollout._export_error = None
+    # Mirror __init__: _build_result() reads the canonical VerifyResult (#v0.5
+    # Phase 1); a __new__-constructed skeleton must set it like the real ctor.
+    rollout._verify_result = None
     # Stub the bits cleanup() touches but we don't care about for this test.
     rollout.disconnect = AsyncMock()
     rollout._capture_partial_acp_trajectory = lambda: None

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import os
 import shutil
-import subprocess
 import uuid
 from collections.abc import Iterator
 from pathlib import Path
@@ -32,6 +31,7 @@ import pytest
 
 from benchflow import SDK
 from benchflow.sandbox.setup import _detect_dind_mount
+from tests.conftest import docker_daemon_unavailable_reason
 
 HELLO_TASK = Path(__file__).parent / "examples" / "hello-world-task"
 SMOKE_JOBS_BASE = Path(__file__).parent / ".smoke-jobs"
@@ -53,18 +53,9 @@ def _smoke_skip_reason() -> str | None:
     Deliberately does NOT call resolve_agent_env — the test exercises that code
     path; skipping when it raises would mask real regressions.
     """
-    if shutil.which("docker") is None:
-        return "docker CLI not installed"
-    try:
-        r = subprocess.run(
-            ["docker", "version", "--format", "{{.Server.Version}}"],
-            timeout=3,
-            capture_output=True,
-        )
-    except (subprocess.TimeoutExpired, OSError) as e:
-        return f"docker daemon unreachable: {e}"
-    if r.returncode != 0:
-        return "docker daemon unreachable"
+    docker_reason = docker_daemon_unavailable_reason()
+    if docker_reason:
+        return docker_reason
     has_key = bool(os.environ.get("ANTHROPIC_API_KEY"))
     has_login = Path("~/.claude/.credentials.json").expanduser().is_file()
     if not (has_key or has_login):


### PR DESCRIPTION
## v0.5 Phase 1b — branch aggregation speaks the canonical VerifyResult

**Stacked on [#580](https://github.com/benchflow-ai/benchflow/pull/580) (Phase 2).** First of three Phase 3 PRs (this · container-snapshot layer · ask_user trigger). Retarget up the stack as each merges.

The deferred half of Phase 1a: branch value aggregation used a lossy `float`; it now composes the canonical `VerifyResult` that Phase 1a put on the live reward path (`Rollout._verify_result`). This is the substrate the container-layer + trigger PRs build on.

### What changed
- **`branch.py`** — new **pure** primitive `aggregate_verify_result(node) -> VerifyResult`: composes child `VerifyResult`s into V(node) — mean reward, per-child items namespaced `child-{i}/{source}` (no key collisions), concatenated events, and a **conservative error** (populated unless *every* child scored clean, so a partial scoring failure can't masquerade as a clean value). The float `aggregate()` stays for back-compat.
- **`rollout_branch.py`** — `make_default_runner` returns the child's `VerifyResult` (read from `rollout._verify_result`, which `verify()` populates as a side effect — no change to `verify()`'s dict return). `branch()` normalises any runner return (`VerifyResult` or bare `float`) and records `child.state['verify_result']`, keeping the float `child.state['reward']` mirror; V(parent) is composed into `parent.state['verify_result']`, keeping the `parent.state['value']` float mirror; `branch()` still returns the float. `_LinearState` isolation extended to round-trip `_verify_result` so a child's scoring can't leak onto the parent.

### Behavior-preserving
All **21 existing branch tests pass unchanged** (the float mirrors keep `value == 0.5`, `child.state['reward'] == [0.0, 1.0]` etc. true). **+6 new tests** guard the `VerifyResult` aggregation, the bare-float back-compat path, and the `_verify_result` isolation. ty + ruff clean; full suite **2379 passed**.

### Scope
Container-snapshot layer (the 3-layer checkpoint) and the `ask_user` branch trigger are the **two follow-on Phase 3 PRs**, gated by a real branch run on the stateful clawsbench/sqlite env. This PR is the foundation. Going through the thermo-nuclear review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes credit-assignment and rollout isolation around scoring metadata; behavior is intended to be backward-compatible via float mirrors but affects how branch values and errors are represented.
> 
> **Overview**
> Branch value aggregation now composes full **`VerifyResult`** objects instead of only averaging scalar returns, while keeping float mirrors (`state["value"]`, `state["reward"]`, and `branch()`’s return) for backward compatibility.
> 
> **`aggregate_verify_result`** in `branch.py` is the canonical V(parent): mean child reward, per-child items under `child-{i}/…`, merged events, and a conservative parent `error` when any child failed scoring; bare-float children are lifted via `verify_result_from_reward_map`. **`rollout_branch`** records `verify_result` on each child and parent, lets `ChildRunner` return `VerifyResult | float`, has the default runner read `rollout._verify_result` after `verify()`, and extends **`_LinearState`** so `_verify_result` does not leak from child sub-rollouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6868edc748deba52feca3aa6ac5312164ba05d9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->