### PR TITLE
fix: recognize oracle as a known special agent (stop misleading log warning)

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -279,6 +279,14 @@ class AgentConfig:
     # Use for agents whose supported toggle is a launch/config override.
 
 
+# The oracle is a first-class *special* agent, not an ACP agent in ``AGENTS``:
+# it has its own rollout branch (``cfg.primary_agent == ORACLE_AGENT``) that
+# runs the task's ``solution/solve.sh`` instead of installing/connecting an
+# agent. It is deliberately absent from ``AGENTS`` (nothing to install), so
+# membership checks must use :func:`is_known_agent`, not ``name in AGENTS``.
+ORACLE_AGENT = "oracle"
+
+
 # Agent registry — all supported agents
 AGENTS: dict[str, AgentConfig] = {
     "claude-agent-acp": AgentConfig(
@@ -572,6 +580,17 @@ AGENTS: dict[str, AgentConfig] = {
 # Updated by register_agent() when new agents are added at runtime.
 AGENT_INSTALLERS: dict[str, str] = {name: a.install_cmd for name, a in AGENTS.items()}
 AGENT_LAUNCH: dict[str, str] = {name: a.launch_cmd for name, a in AGENTS.items()}
+
+
+def is_known_agent(name: str) -> bool:
+    """Whether ``name`` is a recognized agent — a registered ACP agent *or* the
+    oracle special mode.
+
+    Use this for "is this agent valid" checks instead of ``name in AGENTS``: the
+    oracle runs the task's reference solution and is intentionally not in
+    ``AGENTS``, so a bare membership test mis-flags it as unknown.
+    """
+    return name in AGENTS or name == ORACLE_AGENT
 
 
 def get_sandbox_home_dirs() -> set[str]:

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -220,7 +220,7 @@ class EvaluationConfig:
             normalize_agent_name,
             normalize_sandbox_user,
         )
-        from benchflow.agents.registry import AGENTS
+        from benchflow.agents.registry import AGENTS, is_known_agent
 
         self.agent = normalize_agent_name(self.agent)
         self.sandbox_user = normalize_sandbox_user(self.sandbox_user)
@@ -230,7 +230,9 @@ class EvaluationConfig:
                 f"unknown job_mode {self.job_mode!r} — "
                 f"expected one of {', '.join(JOB_MODES)}"
             )
-        if self.agent not in AGENTS:
+        # The oracle is a recognized special agent (it runs the task's reference
+        # solution), so it must not be reported as an unknown raw command.
+        if not is_known_agent(self.agent):
             available = ", ".join(sorted(AGENTS.keys()))
             logger.warning(
                 f"Unknown agent {self.agent!r} — not in registry. "

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -124,3 +124,39 @@ async def test_run_oracle_solution_env_resolves_host_vars(tmp_path, monkeypatch)
 
     solve_call = env.exec.call_args_list[0]
     assert solve_call.kwargs["env"]["TOKEN"] == "resolved_value"
+
+
+# ── oracle recognized as a special agent (log-clarity fix) ──────────────────
+
+
+def test_is_known_agent_recognizes_oracle():
+    from benchflow.agents.registry import is_known_agent
+
+    assert is_known_agent("oracle") is True
+    assert is_known_agent("claude-agent-acp") is True
+    assert is_known_agent("definitely-not-an-agent") is False
+
+
+def test_oracle_agent_does_not_log_unknown_agent_warning(caplog):
+    """Guards the log-clarity fix: oracle is a first-class special agent (it runs
+    solution/solve.sh), so EvaluationConfig must NOT warn 'Unknown agent ... use
+    as raw command' for it."""
+    import logging
+
+    from benchflow.evaluation import EvaluationConfig
+
+    with caplog.at_level(logging.WARNING):
+        EvaluationConfig(agent="oracle")
+    assert "Unknown agent" not in caplog.text
+
+
+def test_genuinely_unknown_agent_still_warns(caplog):
+    """The raw-command fallback warning still fires for a real unknown agent —
+    the fix must not silence the legitimate case."""
+    import logging
+
+    from benchflow.evaluation import EvaluationConfig
+
+    with caplog.at_level(logging.WARNING):
+        EvaluationConfig(agent="definitely-not-an-agent")
+    assert "Unknown agent" in caplog.text


### PR DESCRIPTION
## Stop the misleading "Unknown agent 'oracle'" log warning

`bench eval create --agent oracle ...` logged:

> Unknown agent 'oracle' — not in registry. Available: claude-agent-acp, … Will attempt to use as raw command.

…and then proceeded correctly into `Oracle mode: running solution/solve.sh`. Oracle is a **first-class special mode** (`cfg.primary_agent == "oracle"`, runs the task's `solution/solve.sh`), intentionally absent from `AGENTS` because there's nothing to install — so the membership test mis-flagged it as an unknown raw command. Purely cosmetic, but it made oracle runs look broken in logs (surfaced repeatedly during the v0.5 real-task oracle runs — clawsbench, nanofirm, terminal-bench-smoke).

### Fix
- **`agents/registry.py`** — add `ORACLE_AGENT` (one canonical home for the oracle name, which was a scattered string literal across ~8 sites) and `is_known_agent(name)` (recognized = registered ACP agent **or** oracle).
- **`evaluation.py`** — gate the warning on `not is_known_agent(...)` instead of `not in AGENTS`. Oracle no longer warns; genuinely-unknown agents still do (the raw-command fallback is preserved).
- **`tests/test_oracle.py`** — `is_known_agent` recognizes oracle; no "Unknown agent" warning for `agent="oracle"`; **and the warning still fires** for a real unknown agent (the fix doesn't silence the legit case).

### Verification
- Unit: 8 oracle tests pass (5 existing + 3 new); ty + ruff clean.
- E2E: a real `bench eval create --agent oracle --sandbox docker` run logs **no** "Unknown agent" line and scores 1/1.

No behavior change to oracle runs — log-clarity only. (Spun off from a v0.5 follow-up; targets `v0.5-integration`.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Log and validation messaging only; oracle rollout path and raw-command fallback for real unknown agents are unchanged.
> 
> **Overview**
> **Oracle** is documented and treated as a first-class special agent (runs `solution/solve.sh`, not in `AGENTS`). The registry adds `ORACLE_AGENT` and `is_known_agent()` so validity checks cover registered ACP agents **or** oracle.
> 
> `EvaluationConfig` now uses `is_known_agent` instead of `agent not in AGENTS`, so `agent="oracle"` no longer logs *Unknown agent … Will attempt to use as raw command* while runs still proceed as before. Genuinely unknown agents still get that warning.
> 
> Tests lock in `is_known_agent("oracle")`, no warning for oracle, and warnings still fire for bogus agent names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc40d1261b43c9104757151c79373f181d8749ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->