### PR TITLE
fix: extend trajectory JSONL redaction to cover Google, AWS, Daytona, and header patterns (#537)

### DIFF
--- a/docs/v05-e2e-testing-guide.md
+++ b/docs/v05-e2e-testing-guide.md
@@ -438,13 +438,15 @@ uv run python tests/integration/check_results.py "$JOB_DIR" \
 
 ## 14. Secret leak audit
 
-After any eval run, check that no API key **values** leaked into trajectories.
-Redaction (`Trajectory.to_jsonl(redact_keys=True)`, #537/#585) replaces secret
-*values* whole — prefix included — so grep for the live-key shapes, not the
-variable names (a bare `GEMINI_API_KEY=` with a redacted value is not a leak):
+After any eval run, check that no API key **values** leaked into trajectories
+or trainer JSONL artifacts. Redaction (`Trajectory.to_jsonl(redact_keys=True)`
+and Verifiers JSONL export, #537/#585) replaces secret *values* whole — prefix
+included — so grep for the live-key shapes, not the variable names (a bare
+`GEMINI_API_KEY=` with a redacted value is not a leak):
 
 ```bash
-grep -rn "AIzaSy[A-Za-z0-9_-]\{20,\}\|dtn_[A-Za-z0-9_]\{16,\}\|sk-ant-[a-zA-Z0-9_-]\{12,\}" /tmp/test-include/
+SECRET_SHAPES='AIzaSy[A-Za-z0-9_-]{20,}|dtn_[A-Za-z0-9_]{16,}|sk-ant-[A-Za-z0-9_-]{12,}|sk-proj-[A-Za-z0-9_-]{12,}|sk-[A-Za-z0-9]{12,}|(AKIA|ASIA)[A-Z0-9]{16}([^A-Z0-9]|$)|(authorization|x-api-key|x-goog-api-key|api-key|api_key)[[:space:]]*[:=][[:space:]]*"?[^"[:space:],}*]+'
+grep -rnE "$SECRET_SHAPES" /tmp/test-include/
 ```
 
 **Verify:** No matches. (Redacted placeholders read `***REDACTED***`; the

--- a/docs/v05-e2e-testing-guide.md
+++ b/docs/v05-e2e-testing-guide.md
@@ -438,13 +438,17 @@ uv run python tests/integration/check_results.py "$JOB_DIR" \
 
 ## 14. Secret leak audit
 
-After any eval run, check that no API keys leaked into trajectories:
+After any eval run, check that no API key **values** leaked into trajectories.
+Redaction (`Trajectory.to_jsonl(redact_keys=True)`, #537/#585) replaces secret
+*values* whole — prefix included — so grep for the live-key shapes, not the
+variable names (a bare `GEMINI_API_KEY=` with a redacted value is not a leak):
 
 ```bash
-grep -rn "AIzaSy\|dtn_\|GEMINI_API_KEY\|DAYTONA_API_KEY" /tmp/test-include/
+grep -rn "AIzaSy[A-Za-z0-9_-]\{20,\}\|dtn_[A-Za-z0-9_]\{16,\}\|sk-ant-[a-zA-Z0-9_-]\{12,\}" /tmp/test-include/
 ```
 
-**Verify:** No matches.
+**Verify:** No matches. (Redacted placeholders read `***REDACTED***`; the
+variable names themselves are not secrets and may appear.)
 
 ---
 

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -33,6 +33,7 @@ from benchflow._utils.result_metadata import (
     trajectory_summary_from_events,
 )
 from benchflow.diagnostics import RolloutDiagnostics
+from benchflow.trajectories.types import redact_acp_trajectory_jsonl
 
 logger = logging.getLogger(__name__)
 
@@ -480,8 +481,7 @@ def _write_run_artifacts(
     }
 
     (result.run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
-        "\n".join(json.dumps(e, default=str) for e in trajectory)
-        + ("\n" if trajectory else "")
+        redact_acp_trajectory_jsonl(trajectory) + ("\n" if trajectory else "")
     )
 
     result_payload: dict[str, Any] = {

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -100,6 +100,7 @@ from benchflow.trajectories._capture import (
 )
 from benchflow.trajectories.metrics import count_skill_invocations
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
+from benchflow.trajectories.types import redact_acp_trajectory_jsonl
 from benchflow.usage_tracking import UsageTrackingConfig
 
 logger = logging.getLogger(__name__)
@@ -604,6 +605,8 @@ def _build_rollout_result(
     # Final write — overwrites whatever the live streaming writer left
     # in place. Identical content in the normal ACP path, but this is
     # the only writer for oracle / scraped-fallback / no-session paths.
+    # Redaction is applied inside TrajectoryWriter so every write path
+    # (streaming + final) is scrubbed (#537/#585).
     TrajectoryWriter(traj_dir / "acp_trajectory.jsonl").write_final(trajectory)
     rollout_dir.mkdir(parents=True, exist_ok=True)
     (rollout_dir / "result.json").write_text(
@@ -834,7 +837,7 @@ async def _publish_trajectory_for_verifier(env, trajectory: list[dict]) -> None:
         return
     await env.exec("mkdir -p /logs/agent", user="root", timeout_sec=10)
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
-        f.write("\n".join(json.dumps(e, default=str) for e in trajectory))
+        f.write(redact_acp_trajectory_jsonl(trajectory))
         f.write("\n")
         tmp_path = f.name
     try:

--- a/src/benchflow/trajectories/_capture.py
+++ b/src/benchflow/trajectories/_capture.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from benchflow.acp.session import ACPSession
+from benchflow.trajectories.types import redact_acp_trajectory_jsonl
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +143,7 @@ class TrajectoryWriter:
         to the previous one — keeps a no-op chunk (an unchanged
         tool_call status poll) from churning the filesystem.
         """
-        payload = "\n".join(json.dumps(e, default=str) for e in events)
+        payload = redact_acp_trajectory_jsonl(events)
         if payload == self._last_payload:
             return
         self._tmp.write_text(payload)
@@ -157,7 +158,7 @@ class TrajectoryWriter:
         lands on disk even if the live streaming writer had already
         written the same content.
         """
-        payload = "\n".join(json.dumps(e, default=str) for e in trajectory)
+        payload = redact_acp_trajectory_jsonl(trajectory)
         self._tmp.write_text(payload)
         os.replace(self._tmp, self.path)
         self._last_payload = payload

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -33,6 +33,7 @@ from typing import Any, cast
 from benchflow._utils.json_safe import scrub_non_finite
 from benchflow.adapters.ors import ORSAdapter
 from benchflow.rewards.protocol import VerifyResult
+from benchflow.trajectories.types import redact_trajectory_text
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +93,16 @@ def trajectory_to_verifiers_record(
     }
 
 
+def _record_to_redacted_json_line(record: dict[str, Any]) -> str:
+    clean = scrub_non_finite(record)
+    raw = json.dumps(clean, default=str, allow_nan=False)
+    return redact_trajectory_text(raw)
+
+
+def _redact_verifiers_record(record: dict[str, Any]) -> dict[str, Any]:
+    return cast(dict[str, Any], json.loads(_record_to_redacted_json_line(record)))
+
+
 def export_trajectories_to_jsonl(
     records: list[dict[str, Any]], path: str | Path
 ) -> None:
@@ -107,8 +118,7 @@ def export_trajectories_to_jsonl(
     out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w") as f:
         for rec in records:
-            clean = scrub_non_finite(rec)
-            f.write(json.dumps(clean, default=str, allow_nan=False) + "\n")
+            f.write(_record_to_redacted_json_line(rec) + "\n")
 
 
 def _tool_call_to_content(event: dict[str, Any]) -> str:
@@ -261,8 +271,9 @@ def write_rollout_verifiers_jsonl(
         is_truncated=is_truncated,
     )
     out = Path(rollout_dir) / ROLLOUT_ARTIFACT_RELPATH
-    export_trajectories_to_jsonl([record], out)
-    return record
+    redacted_record = _redact_verifiers_record(record)
+    export_trajectories_to_jsonl([redacted_record], out)
+    return redacted_record
 
 
 def write_job_verifiers_jsonl(job_dir: str | Path) -> Path | None:
@@ -289,5 +300,5 @@ def write_job_verifiers_jsonl(job_dir: str | Path) -> Path | None:
                 continue
             if not text.endswith("\n"):
                 text = text + "\n"
-            fout.write(text)
+            fout.write(redact_trajectory_text(text))
     return out

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -1,5 +1,6 @@
 """Trajectory types — raw LLM API request/response pairs captured from providers."""
 
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -172,6 +173,51 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
     )
 
 
+_REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # Anthropic: sk-ant-api03-...
+    (re.compile(r"(sk-ant-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
+    # OpenAI project key: sk-proj-...  (must come before generic sk- since the
+    # generic pattern's narrow [a-zA-Z0-9] class can't span the hyphen)
+    (re.compile(r"(sk-proj-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
+    # OpenAI / generic sk- (alphanumeric only — widening to include `-` would
+    # match common slugs like `task-sk-us-east-1-...`)
+    (re.compile(r"(sk-[a-zA-Z0-9]{10})[a-zA-Z0-9]+"), r"\1***REDACTED***"),
+    # Google AI / Gemini: AIzaSy... (39 chars total, alphanumeric + `_-`)
+    (re.compile(r"(AIzaSy[A-Za-z0-9_-]{4})[A-Za-z0-9_-]{20,}"), r"\1***REDACTED***"),
+    # AWS access keys: AKIA...(16) / ASIA...(16) — exact 20-char keys; the
+    # length anchor prevents matching English words like "ASIAPACIFIC".
+    (
+        re.compile(r"((?:AKIA|ASIA)[A-Z0-9]{4})[A-Z0-9]{12}(?![A-Z0-9])"),
+        r"\1***REDACTED***",
+    ),
+    # Daytona SDK tokens: dtn_... — require ≥16 chars of suffix entropy to
+    # avoid matching short identifiers like `dtn_v2_0`.
+    (re.compile(r"(dtn_[A-Za-z0-9_]{4})[A-Za-z0-9_]{16,}"), r"\1***REDACTED***"),
+    # Authorization: Bearer <token>
+    (
+        re.compile(r'("authorization"\s*:\s*"Bearer\s+)[^"]+(")', re.IGNORECASE),
+        r"\1***REDACTED***\2",
+    ),
+    # x-api-key header
+    (
+        re.compile(r'("x-api-key"\s*:\s*")[^"]+(")', re.IGNORECASE),
+        r"\1***REDACTED***\2",
+    ),
+    # api-key header (Azure)
+    (
+        re.compile(r'("api-key"\s*:\s*")[^"]+(")', re.IGNORECASE),
+        r"\1***REDACTED***\2",
+    ),
+]
+
+
+def redact_trajectory_text(text: str) -> str:
+    """Apply all secret-redaction patterns to *text*."""
+    for pattern, replacement in _REDACTION_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
 class LLMRequest(BaseModel):
     """A single request to an LLM API, captured by the proxy."""
 
@@ -272,28 +318,12 @@ class Trajectory(BaseModel):
     def to_jsonl(self, *, redact_keys: bool = True) -> str:
         """Export as JSONL (one exchange per line)."""
         import json
-        import re
 
         lines = []
         for ex in self.exchanges:
             data = ex.model_dump(mode="json")
             raw = json.dumps(data, default=str)
             if redact_keys:
-                raw = re.sub(
-                    r"(sk-ant-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+",
-                    r"\1***REDACTED***",
-                    raw,
-                )
-                raw = re.sub(
-                    r"(sk-[a-zA-Z0-9]{10})[a-zA-Z0-9]+",
-                    r"\1***REDACTED***",
-                    raw,
-                )
-                raw = re.sub(
-                    r'("authorization"\s*:\s*"Bearer\s+)[^"]+(")',
-                    r"\1***REDACTED***\2",
-                    raw,
-                    flags=re.IGNORECASE,
-                )
+                raw = redact_trajectory_text(raw)
             lines.append(raw)
         return "\n".join(lines)

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -210,11 +210,14 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         ),
         r"\1***REDACTED***",
     ),
-    # Underscore form `api_key` needs a leading boundary so it does not match
-    # the tail of a longer name like `GEMINI_API_KEY`.
+    # Underscore form `api_key`. No leading boundary: namespaced env dumps like
+    # `GEMINI_API_KEY=secret` / `AZURE_OPENAI_API_KEY=...` and JSON keys such as
+    # `"openai_api_key"` must redact too (#585). The `\1` capture preserves the
+    # whole matched name+separator, so the key name (e.g. `GEMINI_API_KEY=`) is
+    # kept and only the value is dropped — no over-redaction of the name.
     (
         re.compile(
-            r'(?<![A-Za-z0-9_])("?api_key"?\s*[:=]\s*"?)[^"\s,}\\*]+',
+            r'("?api_key"?\s*[:=]\s*"?)[^"\s,}\\*]+',
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
@@ -256,6 +259,22 @@ def redact_trajectory_text(text: str) -> str:
     for pattern, replacement in _REDACTION_PATTERNS:
         text = pattern.sub(replacement, text)
     return text
+
+
+def redact_acp_trajectory_jsonl(trajectory: list[dict[str, Any]]) -> str:
+    """Serialize an ACP trajectory list to redacted JSONL.
+
+    Each event is JSON-encoded and then run through ``redact_trajectory_text``
+    so secrets the agent echoed into ``acp_trajectory.jsonl`` (env dumps, curl
+    -v output, header logs) are stripped before the file is written or uploaded
+    (#537/#585). Returns the joined lines without a trailing newline; callers
+    that need one (e.g. uploaded copies) append it themselves.
+    """
+    import json
+
+    return "\n".join(
+        redact_trajectory_text(json.dumps(event, default=str)) for event in trajectory
+    )
 
 
 class LLMRequest(BaseModel):

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -173,46 +173,86 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
     )
 
 
+# Token families are redacted *whole* — prefix included — so the v0.5
+# secret-leak audit (which greps for raw prefixes like ``AIzaSy``/``dtn_``)
+# sees no live-key shape (#537/#585). Keeping the prefix (``AIzaSy***``) would
+# still trip that grep, so the entire matched token becomes ``***REDACTED***``.
 _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # Anthropic: sk-ant-api03-...
-    (re.compile(r"(sk-ant-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
-    # OpenAI project key: sk-proj-...  (must come before generic sk- since the
-    # generic pattern's narrow [a-zA-Z0-9] class can't span the hyphen)
-    (re.compile(r"(sk-proj-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+"), r"\1***REDACTED***"),
+    (re.compile(r"sk-ant-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
+    # OpenAI project key: sk-proj-...  (before generic sk- so it wins)
+    (re.compile(r"sk-proj-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
     # OpenAI / generic sk- (alphanumeric only — widening to include `-` would
     # match common slugs like `task-sk-us-east-1-...`)
-    (re.compile(r"(sk-[a-zA-Z0-9]{10})[a-zA-Z0-9]+"), r"\1***REDACTED***"),
-    # Google AI / Gemini: AIzaSy... (39 chars total, alphanumeric + `_-`)
-    (re.compile(r"(AIzaSy[A-Za-z0-9_-]{4})[A-Za-z0-9_-]{20,}"), r"\1***REDACTED***"),
-    # AWS access keys: AKIA...(16) / ASIA...(16) — exact 20-char keys; the
-    # length anchor prevents matching English words like "ASIAPACIFIC".
+    (re.compile(r"sk-[a-zA-Z0-9]{12,}"), "***REDACTED***"),
+    # Google AI / Gemini: AIzaSy... (≥20 char suffix avoids matching `AIzaSy`
+    # alone). Prefix is redacted too so the audit grep for `AIzaSy` is clean.
+    (re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"), "***REDACTED***"),
+    # AWS access keys: AKIA/ASIA + exactly 16 chars; length anchor avoids
+    # matching English words like "ASIAPACIFIC".
+    (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])"), "***REDACTED***"),
+    # Daytona SDK tokens: dtn_... — ≥16 char suffix avoids short ids (`dtn_v2`).
+    (re.compile(r"dtn_[A-Za-z0-9_]{16,}"), "***REDACTED***"),
+    # Header / key-value secret carriers, in BOTH JSON and raw-text forms
+    # (agents print env, curl -v, request logs into trajectories — #585).
+    # Matches: `"x-api-key": "v"`, `x-api-key: v`, `api-key=v`,
+    # `authorization: <scheme> v`, etc. The name is kept; the value is dropped.
+    # Hyphenated header names (x-api-key / api-key / x-goog-api-key). No leading
+    # boundary needed — the hyphen makes them safe from matching inside
+    # underscore variable names. Value excludes backslash so a literal
+    # JSON-escaped `\n` after one secret can't swallow the next header, and
+    # excludes `*` so an already-redacted value isn't re-matched.
     (
-        re.compile(r"((?:AKIA|ASIA)[A-Z0-9]{4})[A-Z0-9]{12}(?![A-Z0-9])"),
+        re.compile(
+            r'((?:"?(?:x-api-key|x-goog-api-key|api-key)"?)\s*[:=]\s*"?)'
+            r'[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
         r"\1***REDACTED***",
     ),
-    # Daytona SDK tokens: dtn_... — require ≥16 chars of suffix entropy to
-    # avoid matching short identifiers like `dtn_v2_0`.
-    (re.compile(r"(dtn_[A-Za-z0-9_]{4})[A-Za-z0-9_]{16,}"), r"\1***REDACTED***"),
-    # Authorization: Bearer <token>
+    # Underscore form `api_key` needs a leading boundary so it does not match
+    # the tail of a longer name like `GEMINI_API_KEY`.
     (
-        re.compile(r'("authorization"\s*:\s*"Bearer\s+)[^"]+(")', re.IGNORECASE),
-        r"\1***REDACTED***\2",
+        re.compile(
+            r'(?<![A-Za-z0-9_])("?api_key"?\s*[:=]\s*"?)[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
     ),
-    # x-api-key header
+    # authorization header WITH a scheme (Bearer/Token/Basic/…): keep scheme.
     (
-        re.compile(r'("x-api-key"\s*:\s*")[^"]+(")', re.IGNORECASE),
-        r"\1***REDACTED***\2",
+        re.compile(
+            r"(?<![A-Za-z0-9_-])"
+            r'("?authorization"?\s*[:=]\s*"?(?:Bearer|Token|Basic|ApiKey)\s+)'
+            r'[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
     ),
-    # api-key header (Azure)
+    # authorization header with a bare value (no recognized scheme). The
+    # negative lookahead skips scheme-prefixed values already handled above,
+    # so `Bearer <tok>` isn't double-redacted into `***REDACTED*** ***...`.
     (
-        re.compile(r'("api-key"\s*:\s*")[^"]+(")', re.IGNORECASE),
-        r"\1***REDACTED***\2",
+        re.compile(
+            r"(?<![A-Za-z0-9_-])"
+            r'("?authorization"?\s*[:=]\s*"?)'
+            r"(?!(?:Bearer|Token|Basic|ApiKey)\b)"
+            r'[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
     ),
 ]
 
 
 def redact_trajectory_text(text: str) -> str:
-    """Apply all secret-redaction patterns to *text*."""
+    """Apply all secret-redaction patterns to *text*.
+
+    Token families (Anthropic/OpenAI/Google/AWS/Daytona) are redacted whole,
+    prefix included, so the secret-leak audit greps see no live-key shape.
+    Header/key-value carriers keep the field name but drop the value, in both
+    JSON (``"x-api-key": "v"``) and raw-text (``x-api-key: v``) forms.
+    """
     for pattern, replacement in _REDACTION_PATTERNS:
         text = pattern.sub(replacement, text)
     return text

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -14,6 +14,7 @@ architecture says they should.
 from __future__ import annotations
 
 import json
+import re
 from datetime import datetime
 
 from benchflow.rollout import _build_rollout_result
@@ -24,6 +25,9 @@ from benchflow.trajectories.export import (
     write_job_verifiers_jsonl,
     write_rollout_verifiers_jsonl,
 )
+
+_FAKE_GEMINI_KEY = "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"
+_FAKE_HEADER_SECRET = "plainSecretNoPrefix123"
 
 
 def _acp_trajectory() -> list[dict]:
@@ -41,6 +45,43 @@ def _acp_trajectory() -> list[dict]:
         },
         {"type": "agent_message", "text": "Archived 1 email."},
     ]
+
+
+def _secret_bearing_acp_trajectory() -> list[dict]:
+    """A trajectory with secrets in user, assistant, and tool-call content."""
+    return [
+        {
+            "type": "user_message",
+            "text": f"User pasted GEMINI_API_KEY={_FAKE_GEMINI_KEY}",
+        },
+        {
+            "type": "agent_message",
+            "text": f"Trying request with x-api-key: {_FAKE_HEADER_SECRET}",
+        },
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc-secret",
+            "kind": "bash",
+            "title": "curl service",
+            "status": "completed",
+            "content": [
+                {
+                    "text": (
+                        f"x-goog-api-key: {_FAKE_GEMINI_KEY}\n"
+                        f"api_key={_FAKE_HEADER_SECRET}"
+                    )
+                }
+            ],
+        },
+    ]
+
+
+def _assert_no_trainer_secret_leak(text: str) -> None:
+    assert "***REDACTED***" in text
+    assert _FAKE_GEMINI_KEY not in text
+    assert _FAKE_HEADER_SECRET not in text
+    residual = re.findall(r"AIzaSy[A-Za-z0-9_-]+", text)
+    assert residual == [], f"live Gemini key shapes survived: {residual}"
 
 
 # ── unit-level helpers ────────────────────────────────────────────────
@@ -151,6 +192,27 @@ def test_write_rollout_verifiers_jsonl_marks_invalid_when_no_rewards(tmp_path):
     assert parsed["info"]["reward_valid"] is False
 
 
+def test_write_rollout_verifiers_jsonl_redacts_trajectory_secrets(tmp_path):
+    """Guards the fix from PR #585 against trainer/verifiers.jsonl leaks."""
+    rollout_dir = tmp_path / "rollout-secret"
+    rollout_dir.mkdir()
+    record = write_rollout_verifiers_jsonl(
+        rollout_dir,
+        task_id="t-secret",
+        prompts=[f"Prompt includes {_FAKE_GEMINI_KEY}"],
+        trajectory=_secret_bearing_acp_trajectory(),
+        rewards={"reward": 1.0},
+        model="m",
+        environment="bench",
+    )
+
+    artifact = rollout_dir / ROLLOUT_ARTIFACT_RELPATH
+    text = artifact.read_text()
+    _assert_no_trainer_secret_leak(text)
+    _assert_no_trainer_secret_leak(json.dumps(record))
+    json.loads(text)
+
+
 # ── job-level aggregation ─────────────────────────────────────────────
 
 
@@ -182,6 +244,48 @@ def test_write_job_verifiers_jsonl_returns_none_when_no_rollouts(tmp_path):
     empty_job.mkdir()
     assert write_job_verifiers_jsonl(empty_job) is None
     assert not (empty_job / "verifiers.jsonl").exists()
+
+
+def test_write_job_verifiers_jsonl_redacts_aggregated_records(tmp_path):
+    """Guards the fix from PR #585 against job verifiers.jsonl leaks."""
+    job_dir = tmp_path / "job-secret"
+    rollout_dir = job_dir / "rollout-secret"
+    rollout_dir.mkdir(parents=True)
+    write_rollout_verifiers_jsonl(
+        rollout_dir,
+        task_id="t-secret",
+        prompts=[f"Prompt includes {_FAKE_GEMINI_KEY}"],
+        trajectory=_secret_bearing_acp_trajectory(),
+        rewards={"reward": 1.0},
+        model="m",
+        environment="bench",
+    )
+    # Simulate a legacy/raw per-rollout artifact so the job aggregation boundary
+    # proves it redacts too, instead of merely concatenating already-redacted
+    # rollout output.
+    raw_record = {
+        "example_id": 0,
+        "prompt": [{"role": "user", "content": f"Prompt includes {_FAKE_GEMINI_KEY}"}],
+        "completion": [
+            {
+                "role": "assistant",
+                "content": f"Trying request with x-api-key: {_FAKE_HEADER_SECRET}",
+            }
+        ],
+        "reward": 1.0,
+        "metrics": {},
+        "is_completed": True,
+        "is_truncated": False,
+        "info": {"task_id": "t-secret", "environment": "bench", "model": "m"},
+    }
+    (rollout_dir / ROLLOUT_ARTIFACT_RELPATH).write_text(json.dumps(raw_record) + "\n")
+
+    artifact = write_job_verifiers_jsonl(job_dir)
+    assert artifact == job_dir / "verifiers.jsonl"
+    text = artifact.read_text()
+    _assert_no_trainer_secret_leak(text)
+    assert len(text.splitlines()) == 1
+    json.loads(text)
 
 
 # ── end-to-end: _build_rollout_result wires the seam ─────────────────

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -1,0 +1,161 @@
+"""Tests for trajectory secret redaction patterns."""
+
+import pytest
+
+from benchflow.trajectories.types import redact_trajectory_text
+
+
+@pytest.mark.parametrize(
+    "label,raw,must_not_contain",
+    [
+        pytest.param(
+            "anthropic sk-ant-",
+            '{"key": "sk-ant-api03-abc123XYZ_defghijklmnopqrstuvwxyz0123456789"}',
+            "defghijklmnopqrstuvwxyz0123456789",
+            id="anthropic",
+        ),
+        pytest.param(
+            "openai sk-proj-",
+            '{"key": "sk-proj-abc123XYZ_defghijklmnopqrstuvwxyz0123456789"}',
+            "defghijklmnopqrstuvwxyz0123456789",
+            id="openai-proj",
+        ),
+        pytest.param(
+            "openai sk-",
+            '{"key": "sk-abc1234567defghijklmnopqrstuvwxyz"}',
+            "defghijklmnopqrstuvwxyz",
+            id="openai-generic",
+        ),
+        pytest.param(
+            "google AIzaSy",
+            '{"key": "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"}',
+            "FORTESTSONLYxxxxxxxxxxxxxxx",
+            id="google",
+        ),
+        pytest.param(
+            "aws AKIA",
+            '{"key": "AKIAIOSFODNN7EXAMPLE"}',
+            "IOSFODNN7EXAMPLE",
+            id="aws-akia",
+        ),
+        pytest.param(
+            "aws ASIA (STS)",
+            '{"key": "ASIAQWERTYUIOPASDFGH"}',
+            "QWERTYUIOPASDFGH",
+            id="aws-asia",
+        ),
+        pytest.param(
+            "daytona dtn_",
+            '{"key": "dtn_abcdefghijklmnop1234567890"}',
+            "ghijklmnop1234567890",
+            id="daytona",
+        ),
+        pytest.param(
+            "bearer header",
+            '{"authorization": "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.secret"}',
+            "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.secret",
+            id="bearer",
+        ),
+        pytest.param(
+            "x-api-key header",
+            '{"x-api-key": "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"}',
+            "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx",
+            id="x-api-key",
+        ),
+        pytest.param(
+            "api-key header (Azure)",
+            '{"api-key": "abc123secret456value"}',
+            "abc123secret456value",
+            id="api-key-azure",
+        ),
+    ],
+)
+def test_redacts_secret_pattern(label, raw, must_not_contain):
+    result = redact_trajectory_text(raw)
+    assert "***REDACTED***" in result, f"{label}: no redaction applied"
+    assert must_not_contain not in result, f"{label}: secret suffix survived"
+
+
+def test_preserves_non_secret_content():
+    raw = '{"role": "user", "content": "Write a Python script to process data"}'
+    assert redact_trajectory_text(raw) == raw
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # AWS prefix in English words / identifiers (issue: ASIA matched as substring)
+        '{"region": "ASIAPACIFIC"}',
+        '{"id": "ASIANEWS2024UPDATED"}',
+        # Hyphenated slugs containing "sk-" should not be flagged
+        '{"queue": "task-sk-us-east-1-foo-bar-baz"}',
+        '{"job": "workspace-sk-us-east-1-extra"}',
+        # Short Daytona-prefixed identifiers
+        '{"label": "dtn_v2_0"}',
+        '{"name": "dtn_test"}',
+        # Short Google-prefixed values that aren't keys
+        '{"name": "AIzaSy"}',
+    ],
+)
+def test_does_not_redact_non_secret_values(raw):
+    """Patterns must not corrupt legitimate identifiers that share a prefix."""
+    assert redact_trajectory_text(raw) == raw
+
+
+def test_redacts_multiple_patterns_in_one_string():
+    raw = (
+        '{"env": "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx '
+        'ANTHROPIC_API_KEY=sk-ant-api03-abc123XYZ_longSecretValueHere"}'
+    )
+    result = redact_trajectory_text(raw)
+    assert "FORTESTSONLYxxxxxxxxxxxxxxx" not in result
+    assert "longSecretValueHere" not in result
+    assert result.count("***REDACTED***") >= 2
+
+
+def test_to_jsonl_uses_redaction(tmp_path):
+    """End-to-end: Trajectory.to_jsonl applies redact_trajectory_text."""
+    from benchflow.trajectories.types import (
+        LLMExchange,
+        LLMRequest,
+        LLMResponse,
+        Trajectory,
+    )
+
+    trajectory = Trajectory(
+        session_id="test",
+        exchanges=[
+            LLMExchange(
+                request=LLMRequest(
+                    headers={"x-api-key": "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"},
+                ),
+                response=LLMResponse(),
+            ),
+        ],
+    )
+    jsonl = trajectory.to_jsonl(redact_keys=True)
+    assert "***REDACTED***" in jsonl
+    assert "FORTESTSONLYxxxxxxxxxxxxxxx" not in jsonl
+
+
+def test_to_jsonl_no_redaction_preserves_keys():
+    from benchflow.trajectories.types import (
+        LLMExchange,
+        LLMRequest,
+        LLMResponse,
+        Trajectory,
+    )
+
+    trajectory = Trajectory(
+        session_id="test",
+        exchanges=[
+            LLMExchange(
+                request=LLMRequest(
+                    headers={"x-api-key": "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"},
+                ),
+                response=LLMResponse(),
+            ),
+        ],
+    )
+    jsonl = trajectory.to_jsonl(redact_keys=False)
+    assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" in jsonl

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -1,8 +1,28 @@
-"""Tests for trajectory secret redaction patterns."""
+"""Tests for trajectory secret redaction patterns.
+
+Guards PR #585 (extends #537): redaction must cover raw-text header/kv forms
+(agents print env, curl -v, request logs into trajectories), and audit-sensitive
+token families (Google/Daytona/AWS) must be redacted whole — prefix included —
+so the v0.5 secret-leak audit grep sees no live-key shape.
+"""
 
 import pytest
 
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import (
+    LLMExchange,
+    LLMRequest,
+    LLMResponse,
+    Trajectory,
+    redact_trajectory_text,
+)
+
+
+def _jsonl_for_request_body(body: dict) -> str:
+    traj = Trajectory(
+        session_id="t",
+        exchanges=[LLMExchange(request=LLMRequest(body=body), response=LLMResponse())],
+    )
+    return traj.to_jsonl(redact_keys=True)
 
 
 @pytest.mark.parametrize(
@@ -159,3 +179,97 @@ def test_to_jsonl_no_redaction_preserves_keys():
     )
     jsonl = trajectory.to_jsonl(redact_keys=False)
     assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" in jsonl
+
+
+# ---------------------------------------------------------------------------
+# PR #585 finding 1: raw-text header / key-value forms (not only JSON keys)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,leaked",
+    [
+        ("x-api-key: abc123secret456value", "abc123secret456value"),
+        ("api-key=abc123secret456value", "abc123secret456value"),
+        ("api_key: abc123secret456value", "abc123secret456value"),
+        (
+            "x-goog-api-key: AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx",
+            "FORTESTSONLYxxxxxxxxxxxxxxx",
+        ),
+        ("authorization: Token abc123secret456value", "abc123secret456value"),
+        ("authorization: Basic dXNlcjpwYXNzd29yZGZ4eA==", "dXNlcjpwYXNz"),
+        ("Authorization: bare-token-value-aaaa", "bare-token-value-aaaa"),
+    ],
+)
+def test_redacts_raw_text_header_forms(raw, leaked):
+    """PR #585 finding 1: raw header/kv text (env dumps, curl -v) must redact,
+    not only JSON-shaped ``"x-api-key": "..."`` keys."""
+    result = redact_trajectory_text(raw)
+    assert "***REDACTED***" in result
+    assert leaked not in result
+
+
+def test_to_jsonl_redacts_raw_env_dump_in_message():
+    """PR #585: a shell env dump pasted into trajectory content must redact."""
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
+                    "DAYTONA_API_KEY=dtn_FAKEFAKEFAKEFAKEFAKE12345678\n"
+                    "x-api-key: abc123secret456value"
+                ),
+            }
+        ]
+    }
+    jsonl = _jsonl_for_request_body(body)
+    # The live-key *values* must be gone; variable names may remain.
+    assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in jsonl
+    assert "dtn_FAKEFAKEFAKEFAKEFAKE12345678" not in jsonl
+    assert "abc123secret456value" not in jsonl
+
+
+# ---------------------------------------------------------------------------
+# PR #585 finding 2: audit-sensitive tokens redacted whole (no live prefix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prefix_token,prefix",
+    [
+        ("AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx", "AIzaSy"),
+        ("dtn_FAKEFAKEFAKEFAKEFAKE12345678", "dtn_"),
+        ("AKIAIOSFODNN7EXAMPLE", "AKIA"),
+    ],
+)
+def test_audit_prefix_not_preserved(prefix_token, prefix):
+    """PR #585 finding 2: the v0.5 leak audit greps for raw prefixes like
+    ``AIzaSy``/``dtn_``; a kept prefix (``AIzaSy***``) would still trip it, so
+    the whole token — prefix included — must be redacted."""
+    out = redact_trajectory_text(f'{{"k": "{prefix_token}"}}')
+    assert prefix not in out
+    assert "***REDACTED***" in out
+
+
+def test_leak_audit_intent_passes_end_to_end():
+    """PR #585 finding 2: reproduce the §14 audit — a trajectory body with
+    GEMINI/DAYTONA env keys, written to JSONL, must leave no live-key shape
+    (the audit greps AIzaSy/dtn_ key *values*, not variable names)."""
+    import re
+
+    body = {
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "export GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
+                    "export DAYTONA_API_KEY=dtn_FAKEFAKEFAKEFAKEFAKE12345678"
+                ),
+            }
+        ]
+    }
+    jsonl = _jsonl_for_request_body(body)
+    # No live AIzaSy.../dtn_... token shape survives (bare prefixes excluded).
+    residual = [m for m in re.findall(r"AIzaSy[A-Za-z0-9_-]+|dtn_[A-Za-z0-9_]+", jsonl)]
+    assert residual == [], f"live key shapes survived: {residual}"

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -13,6 +13,7 @@ from benchflow.trajectories.types import (
     LLMRequest,
     LLMResponse,
     Trajectory,
+    redact_acp_trajectory_jsonl,
     redact_trajectory_text,
 )
 
@@ -273,3 +274,84 @@ def test_leak_audit_intent_passes_end_to_end():
     # No live AIzaSy.../dtn_... token shape survives (bare prefixes excluded).
     residual = [m for m in re.findall(r"AIzaSy[A-Za-z0-9_-]+|dtn_[A-Za-z0-9_]+", jsonl)]
     assert residual == [], f"live key shapes survived: {residual}"
+
+
+# ---------------------------------------------------------------------------
+# PR #585 bug 1: acp_trajectory.jsonl (the file the PR claims to protect) was
+# written with raw json.dumps and no redaction. rollout.py and hosted_env.py
+# now serialize ACP events through redact_acp_trajectory_jsonl.
+# ---------------------------------------------------------------------------
+
+
+def test_acp_trajectory_jsonl_redacts_event_content(tmp_path):
+    """PR #585 (issue #537): an ACP trajectory event whose content carries a
+    secret (an AIzaSy... live key plus a GEMINI_API_KEY=... env dump) must not
+    appear raw in the written ``acp_trajectory.jsonl`` file."""
+    import re
+
+    trajectory = [
+        {
+            "type": "agent_message",
+            "content": (
+                "Here is the environment:\n"
+                "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
+                "export DAYTONA_API_KEY=dtn_FAKEFAKEFAKEFAKEFAKE12345678"
+            ),
+        },
+        {"type": "tool_call", "command": "env | grep API"},
+    ]
+
+    traj_dir = tmp_path / "trajectory"
+    traj_dir.mkdir()
+    out = traj_dir / "acp_trajectory.jsonl"
+    out.write_text(redact_acp_trajectory_jsonl(trajectory))
+
+    written = out.read_text()
+    assert "***REDACTED***" in written
+    # The live-key *values* and any AIzaSy/dtn_ token shape must be gone.
+    assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in written
+    assert "dtn_FAKEFAKEFAKEFAKEFAKE12345678" not in written
+    residual = re.findall(r"AIzaSy[A-Za-z0-9_-]+|dtn_[A-Za-z0-9_]+", written)
+    assert residual == [], f"live key shapes survived: {residual}"
+    # Non-secret event structure is preserved (one line per event).
+    assert len(written.splitlines()) == 2
+    assert "env | grep API" in written
+
+
+# ---------------------------------------------------------------------------
+# PR #585 bug 2: namespaced *_API_KEY=value env vars were not redacted because
+# the underscore api_key rule had a (?<![A-Za-z0-9_]) lookbehind that the `_`
+# in GEMINI_API_KEY tripped. The lookbehind was removed; the \1 capture keeps
+# the key name so no over-redaction is introduced.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "raw,leaked,kept_name",
+    [
+        (
+            "GEMINI_API_KEY=plainSecretNoPrefix123",
+            "plainSecretNoPrefix123",
+            "GEMINI_API_KEY=",
+        ),
+        (
+            '{"openai_api_key": "plainSecretNoPrefix123"}',
+            "plainSecretNoPrefix123",
+            "openai_api_key",
+        ),
+        (
+            "AZURE_OPENAI_API_KEY=anotherPlainSecret456",
+            "anotherPlainSecret456",
+            "AZURE_OPENAI_API_KEY=",
+        ),
+    ],
+)
+def test_redacts_namespaced_api_key_env_vars(raw, leaked, kept_name):
+    """PR #585 (issue #537): namespaced ``*_API_KEY=value`` env dumps and
+    ``"*_api_key"`` JSON keys must redact their values even when the secret has
+    no recognizable token prefix; the key name is preserved by the \\1 capture."""
+    result = redact_trajectory_text(raw)
+    assert "***REDACTED***" in result
+    assert leaked not in result
+    # The key name itself must survive (over-redaction guard).
+    assert kept_name in result


### PR DESCRIPTION
## Summary

`Trajectory.to_jsonl` only redacted two secret patterns (`sk-ant-`, `Bearer`). Every other production credential pattern could leak into `acp_trajectory.jsonl` if it entered trajectory content (e.g. agent running `env` as a tool call).

Added redaction for:
- **Google AI / Gemini**: `AIzaSy*`
- **AWS access keys**: `AKIA*` / `ASIA*` (anchored to exact 20-char length to avoid matching `ASIAPACIFIC` etc.)
- **Daytona**: `dtn_*` (≥16 char suffix to avoid short identifiers)
- **OpenAI project keys**: `sk-proj-*`
- **HTTP headers**: `x-api-key`, `api-key` (Azure)

Extracted patterns into a compiled `_REDACTION_PATTERNS` list and a reusable `redact_trajectory_text()` function for downstream callers.

## Test plan

- [x] 10 parametrized tests covering each secret pattern
- [x] 7 parametrized false-positive guard tests (English words, hyphenated slugs, short identifiers)
- [x] End-to-end tests through `Trajectory.to_jsonl(redact_keys=True/False)`
- [x] 21/21 trajectory tests pass; ruff clean
- [x] Self-reviewed for regex correctness and false positives before submitting

Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->