### PR TITLE
Fix no-skills task skill isolation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,12 +115,16 @@ A Rollout is checkpointable because three snapshot layers compose — container 
 
 ### Skill loading
 
-BenchFlow treats mounted skills as agent-native memory, not prompt text. A
-`--skills-dir` value, or a task-local `environment/skills` directory, is copied
-into the sandbox and registered through the selected agent's registry
-`skill_paths`. For Claude Code via `claude-agent-acp`, that means the skill packs
-land under the Claude Code skill root (for example `$HOME/.claude/skills`) and
-are discovered by Claude Code's native skill mechanism.
+BenchFlow treats mounted skills as agent-native memory, not prompt text. Skills
+are deployed only when the run explicitly asks for them with `--skills-dir` (or
+with-task-skills orchestration such as skill eval). A task-local
+`environment/skills` directory is not uploaded for a no-skills run; use
+`--skills-dir auto` or pass that directory explicitly when those task-local
+skills are meant to be agent-visible. Mounted skills are registered through the
+selected agent's registry `skill_paths`. For Claude Code via `claude-agent-acp`,
+that means the skill packs land under the Claude Code skill root (for example
+`$HOME/.claude/skills`) and are discovered by Claude Code's native skill
+mechanism.
 
 Claude Code reads each skill's frontmatter name and description for native
 discovery. The full `SKILL.md` body and bundled resources are loaded by the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -107,7 +107,7 @@ bench eval create \
 | `--jobs-dir` | `jobs` | Output directory |
 | `--sandbox-user` | `agent` | Sandbox user (null for root) |
 | `--sandbox-setup-timeout` | `120` | Timeout in seconds for sandbox user setup |
-| `--skills-dir` | — | Skills directory to deploy into each task sandbox |
+| `--skills-dir` | — | Skills directory to deploy into each task sandbox; use `auto` for each task's `environment/skills` |
 | `--skill-mode` | `default` | Skill mode: `default` or `self-gen` |
 | `--skill-creator-dir` | — | Path to a `skill-creator` directory (or a skills root containing it); used when `--skill-mode self-gen` |
 | `--self-gen-no-internet` | `false` | Disable web tools for the self-generated skill run |

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -136,10 +136,11 @@ will error instead of measuring skill lift.
 ### Existing task-embedded skills
 
 Skills embedded under a benchmark task, such as
-`tasks/<task>/environment/skills/<skill>/SKILL.md`, are task assets. To evaluate
-one directly with `bench skills eval`, add a sibling `evals/evals.json` inside
-that skill directory or copy the skill into a standalone skill directory with
-the same `evals/` contract.
+`tasks/<task>/environment/skills/<skill>/SKILL.md`, are task-local skill packs.
+They are not exposed to ordinary no-skills runs by default. To evaluate one
+directly with `bench skills eval`, add a sibling `evals/evals.json` inside that
+skill directory or copy the skill into a standalone skill directory with the
+same `evals/` contract.
 
 The repo includes a real standalone example at
 [`skills/citation-management/`](../skills/citation-management/), adapted

--- a/src/benchflow/_utils/yaml_loader.py
+++ b/src/benchflow/_utils/yaml_loader.py
@@ -125,6 +125,7 @@ def rollout_config_from_dict(
         model=raw.get("model"),
         agent_env=raw.get("agent_env"),
         skills_dir=raw.get("skills_dir"),
+        include_task_skills=bool(raw.get("include_task_skills", False)),
         skill_mode=raw.get("skill_mode", "default"),
         skill_creator_dir=raw.get("skill_creator_dir"),
         self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),

--- a/src/benchflow/agents/install.py
+++ b/src/benchflow/agents/install.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from benchflow.agents.registry import AGENT_INSTALLERS, AGENTS, AgentConfig
 from benchflow.models import AgentInstallError
+from benchflow.skill_policy import validate_container_mount_path
 
 if TYPE_CHECKING:
     from benchflow.task import Task
@@ -266,7 +267,7 @@ async def deploy_skills(
     task_skills_dir = (
         task.config.environment.skills_dir if include_task_skills else None
     )
-    target_skills_dir = skills_sandbox_dir or "/skills"
+    target_skills_dir = validate_container_mount_path(skills_sandbox_dir or "/skills")
     effective_skills = None if skills_sandbox_dir else task_skills_dir
 
     # Runtime upload (fallback if not baked into Dockerfile)

--- a/src/benchflow/agents/install.py
+++ b/src/benchflow/agents/install.py
@@ -260,32 +260,34 @@ async def deploy_skills(
     agent_cwd: str,
     task: "Task",
     include_task_skills: bool = False,
+    skills_sandbox_dir: str | None = None,
 ) -> None:
     """Deploy and distribute skills into sandbox."""
     task_skills_dir = (
         task.config.environment.skills_dir if include_task_skills else None
     )
-    effective_skills = task_skills_dir
+    target_skills_dir = skills_sandbox_dir or "/skills"
+    effective_skills = None if skills_sandbox_dir else task_skills_dir
 
     # Runtime upload (fallback if not baked into Dockerfile)
     if skills_dir:
         dockerfile = task_path / "environment" / "Dockerfile"
+        injected_copy = f"COPY _deps/skills {target_skills_dir.rstrip('/')}/"
         already_injected = (
-            dockerfile.exists()
-            and "COPY _deps/skills /skills/" in dockerfile.read_text()
+            dockerfile.exists() and injected_copy in dockerfile.read_text()
         )
         if not already_injected:
             skills_path = Path(skills_dir)
             if skills_path.is_dir():
                 logger.info(f"Deploying skills via runtime upload from {skills_path}")
-                await env.upload_dir(skills_path, "/skills")
-                logger.info("Skills deployed to /skills")
-                effective_skills = "/skills"
+                await env.upload_dir(skills_path, target_skills_dir)
+                logger.info("Skills deployed to %s", target_skills_dir)
+                effective_skills = target_skills_dir
             else:
                 logger.warning(f"Skills dir not found: {skills_path}")
         else:
             logger.info("Skills already injected via Dockerfile")
-            effective_skills = "/skills"
+            effective_skills = target_skills_dir
 
     # Distribute to agent-specific discovery paths
     if agent_cfg is not None:

--- a/src/benchflow/agents/install.py
+++ b/src/benchflow/agents/install.py
@@ -259,7 +259,7 @@ async def deploy_skills(
     sandbox_user: str | None,
     agent_cwd: str,
     task: "Task",
-    include_task_skills: bool = True,
+    include_task_skills: bool = False,
 ) -> None:
     """Deploy and distribute skills into sandbox."""
     task_skills_dir = (
@@ -286,13 +286,6 @@ async def deploy_skills(
         else:
             logger.info("Skills already injected via Dockerfile")
             effective_skills = "/skills"
-
-    # Auto-discover task-bundled skills already uploaded to /app/skills
-    # by _start_env_and_upload (from environment/skills/ in the task dir).
-    if not effective_skills and include_task_skills:
-        bundled = task_path / "environment" / "skills"
-        if bundled.is_dir():
-            effective_skills = "/app/skills"
 
     # Distribute to agent-specific discovery paths
     if agent_cfg is not None:

--- a/src/benchflow/contracts/planes.py
+++ b/src/benchflow/contracts/planes.py
@@ -35,7 +35,7 @@ class RolloutPlanes(Protocol):
 
     def stage_dockerfile_deps(self, task_path: Path, context_root: Path) -> None: ...
     def inject_skills_into_dockerfile(
-        self, task_path: Path, skills_dir: Path
+        self, task_path: Path, skills_dir: Path, *, sandbox_dir: str = "/skills"
     ) -> None: ...
 
     def create_environment(

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -112,6 +112,7 @@ def _config_payload(
         "agent_env": config.agent_env,
         "retry": _retry_payload(config),
         "skills_dir": config.skills_dir,
+        "include_task_skills": config.include_task_skills,
         "sandbox_user": config.sandbox_user,
         "sandbox_locked_paths": config.sandbox_locked_paths,
         "sandbox_setup_timeout": config.sandbox_setup_timeout,

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -58,6 +58,7 @@ def _evaluation_config(raw: dict[str, Any]) -> EvaluationConfig:
         agent_env=dict(raw.get("agent_env") or {}),
         retry=_retry_config(raw),
         skills_dir=raw.get("skills_dir"),
+        include_task_skills=bool(raw.get("include_task_skills", False)),
         sandbox_user=raw.get("sandbox_user", "agent"),
         sandbox_locked_paths=raw.get("sandbox_locked_paths"),
         sandbox_setup_timeout=int(raw.get("sandbox_setup_timeout") or 120),

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -211,6 +211,7 @@ class EvaluationConfig:
     agent_env: dict[str, str] = field(default_factory=dict)
     retry: RetryConfig = field(default_factory=RetryConfig)
     skills_dir: str | None = None
+    include_task_skills: bool = False
     sandbox_user: str | None = "agent"
     sandbox_locked_paths: list[str] | None = None
     sandbox_setup_timeout: int = 120
@@ -601,6 +602,7 @@ class Evaluation:
             agent_env=agent_env,
             retry=RetryConfig(max_retries=max(0, max_retries)),
             skills_dir=skills_dir,
+            include_task_skills=bool(raw.get("include_task_skills", False)),
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
@@ -793,6 +795,7 @@ class Evaluation:
             environment=cfg.environment,
             environment_manifest=cfg.environment_manifest,
             skills_dir=skills_dir,
+            include_task_skills=cfg.include_task_skills,
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -514,6 +514,7 @@ class Evaluation:
             agent_env=agent_env_raw,
             retry=RetryConfig(max_retries=raw.get("max_retries", 2)),
             skills_dir=str(Path(raw["skills_dir"])) if raw.get("skills_dir") else None,
+            include_task_skills=bool(raw.get("include_task_skills", False)),
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -727,10 +727,10 @@ class Evaluation:
 
     def _resolve_skills_dir(self, task_dir: Path, skills_dir: str | None) -> str | None:
         """Resolve skills_dir — 'auto' means per-task environment/skills/."""
-        if skills_dir == "auto":
-            candidate = task_dir / "environment" / "skills"
-            return str(candidate) if candidate.is_dir() else None
-        return skills_dir
+        from benchflow.skill_policy import resolve_runtime_skills_dir
+
+        resolved = resolve_runtime_skills_dir(task_dir, skills_dir)
+        return str(resolved) if resolved is not None else None
 
     def _enrich_payload_with_persisted_timing(
         self, payload: dict, result: RolloutResult

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -73,6 +73,7 @@ from benchflow.scenes import (
     scene_step_role,
     scene_step_skills_dir,
 )
+from benchflow.skill_policy import resolve_task_skill_policy, strip_task_bundled_skills
 from benchflow.trajectories._capture import (
     _capture_session_trajectory,
     _scrape_agent_trajectory,
@@ -385,6 +386,7 @@ def _write_config(
     agent_idle_timeout: int | None = None,
     scenes: list[Scene] | None = None,
     source_provenance: dict[str, Any] | None = None,
+    include_task_skills: bool = False,
 ) -> None:
     """Write config.json to rollout_dir with secrets filtered out."""
     recorded_env = {
@@ -396,6 +398,7 @@ def _write_config(
         "model": model,
         "environment": environment,
         "skills_dir": str(skills_dir) if skills_dir else None,
+        "include_task_skills": include_task_skills,
         "sandbox_user": sandbox_user,
         "sandbox_locked_paths": sandbox_locked_paths,
         "sandbox_setup_timeout": sandbox_setup_timeout,
@@ -632,6 +635,7 @@ def _resolve_prompts(
     task_path: Path,
     prompts: list[str | None] | None,
     skills_dir: str | Path | None = None,
+    task_skills_dir: str | Path | None = None,
     skill_nudge: str = "",
     agent: str | None = None,
     planes: RolloutPlanes | None = None,
@@ -650,7 +654,7 @@ def _resolve_prompts(
                 skill_display_path = agent_cfg.skill_paths[0].replace("$HOME", "~")
 
         skills = []
-        for src in [skills_dir, task_path / "environment" / "skills"]:
+        for src in [skills_dir, task_skills_dir]:
             if src and Path(src).is_dir():
                 for d in sorted(Path(src).iterdir()):
                     if d.is_dir() and (d / "SKILL.md").exists():
@@ -715,9 +719,6 @@ async def _start_env_and_upload(
         timing["environment_setup"] = (datetime.now() - t0).total_seconds()
     if (task_path / "instruction.md").exists():
         await env.upload_file(task_path / "instruction.md", "/instruction.md")
-    task_skills = task_path / "environment" / "skills"
-    if task_skills.is_dir():
-        await env.upload_dir(task_skills, "/app/skills")
     if (task_path / "solution").is_dir():
         await env.upload_dir(task_path / "solution", "/solution")
 
@@ -907,7 +908,7 @@ class RolloutConfig:
     skill_creator_dir: str | Path | None = None
     generated_skills_root: str = GENERATED_SKILLS_ROOT
     self_gen_no_internet: bool = False
-    include_task_skills: bool = True
+    include_task_skills: bool = False
     skip_verify: bool = False
     export_generated_skills_to: str | Path | None = None
     source_provenance: dict[str, Any] | None = None
@@ -1214,10 +1215,19 @@ class Rollout:
             ),
             disallow=self._disallow_web_tools,
         )
+        env_config = getattr(getattr(self._task, "config", None), "environment", None)
+        task_skill_policy = resolve_task_skill_policy(
+            task_path=cfg.task_path,
+            runtime_skills_dir=cfg.skills_dir,
+            declared_sandbox_skills_dir=getattr(env_config, "skills_dir", None),
+            include_task_skills=cfg.include_task_skills,
+        )
+        self._task_skill_policy = task_skill_policy
         self._resolved_prompts = _resolve_prompts(
             cfg.task_path,
             cfg.prompts,
             skills_dir=cfg.skills_dir,
+            task_skills_dir=task_skill_policy.prompt_bundled_dir,
             skill_nudge=_skill_nudge(cfg.agent_env),
             agent=cfg.primary_agent,
             planes=self._planes,
@@ -1231,7 +1241,7 @@ class Rollout:
         # (_inject_skills writes into environment/_deps/, stage_dockerfile
         # rewrites COPY paths — neither should modify the source tree)
         effective_task_path = cfg.task_path
-        if cfg.context_root or cfg.skills_dir:
+        if cfg.context_root or cfg.skills_dir or task_skill_policy.needs_task_copy:
             import shutil
             import tempfile
 
@@ -1239,6 +1249,8 @@ class Rollout:
             shutil.copytree(cfg.task_path, tmp / cfg.task_path.name, dirs_exist_ok=True)
             effective_task_path = tmp / cfg.task_path.name
             self._task_tmp = tmp
+            if task_skill_policy.strip_bundled_dir_from_copy:
+                strip_task_bundled_skills(effective_task_path)
 
         if cfg.context_root:
             self._planes.stage_dockerfile_deps(
@@ -1280,6 +1292,7 @@ class Rollout:
             model=cfg.primary_model,
             environment=cfg.environment,
             skills_dir=cfg.skills_dir,
+            include_task_skills=cfg.include_task_skills,
             sandbox_user=cfg.sandbox_user,
             context_root=cfg.context_root,
             sandbox_locked_paths=self._effective_locked,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -73,7 +73,12 @@ from benchflow.scenes import (
     scene_step_role,
     scene_step_skills_dir,
 )
-from benchflow.skill_policy import resolve_task_skill_policy, strip_task_bundled_skills
+from benchflow.skill_policy import (
+    resolve_runtime_skills_dir,
+    resolve_task_skill_policy,
+    strip_task_bundled_skills,
+    task_bundled_skills_dir,
+)
 from benchflow.trajectories._capture import (
     _capture_session_trajectory,
     _scrape_agent_trajectory,
@@ -921,8 +926,7 @@ class RolloutConfig:
             self.task_path = Path(self.task_path)
         if self.context_root is not None and not isinstance(self.context_root, Path):
             self.context_root = Path(self.context_root)
-        if self.skills_dir is not None and not isinstance(self.skills_dir, Path):
-            self.skills_dir = Path(self.skills_dir)
+        self.skills_dir = resolve_runtime_skills_dir(self.task_path, self.skills_dir)
         if not isinstance(self.jobs_dir, Path):
             self.jobs_dir = Path(self.jobs_dir)
 
@@ -1044,6 +1048,8 @@ class Rollout:
         self._timing: dict[str, float] = {}
         self._effective_locked: list[str] = []
         self._disallow_web_tools: bool = False
+        self._effective_skills_dir: Path | None = None
+        self._effective_skills_sandbox_dir: str | None = None
         self._usage_runtime: Any = None
         self._usage_metrics: dict[str, Any] = self._planes.extract_usage(None)
 
@@ -1226,8 +1232,7 @@ class Rollout:
         self._resolved_prompts = _resolve_prompts(
             cfg.task_path,
             cfg.prompts,
-            skills_dir=cfg.skills_dir,
-            task_skills_dir=task_skill_policy.prompt_bundled_dir,
+            skills_dir=task_skill_policy.prompt_dir,
             skill_nudge=_skill_nudge(cfg.agent_env),
             agent=cfg.primary_agent,
             planes=self._planes,
@@ -1241,7 +1246,7 @@ class Rollout:
         # (_inject_skills writes into environment/_deps/, stage_dockerfile
         # rewrites COPY paths — neither should modify the source tree)
         effective_task_path = cfg.task_path
-        if cfg.context_root or cfg.skills_dir or task_skill_policy.needs_task_copy:
+        if cfg.context_root or task_skill_policy.needs_task_copy:
             import shutil
             import tempfile
 
@@ -1256,12 +1261,23 @@ class Rollout:
             self._planes.stage_dockerfile_deps(
                 effective_task_path, Path(cfg.context_root)
             )
-        if cfg.skills_dir:
+        effective_skills_dir = task_skill_policy.host_dir
+        if (
+            effective_skills_dir is not None
+            and task_skill_policy.host_dir_is_bundled
+            and effective_task_path != cfg.task_path
+        ):
+            effective_skills_dir = task_bundled_skills_dir(effective_task_path)
+        if effective_skills_dir is not None:
             self._planes.inject_skills_into_dockerfile(
-                effective_task_path, Path(cfg.skills_dir)
+                effective_task_path,
+                effective_skills_dir,
+                sandbox_dir=task_skill_policy.sandbox_dir or "/skills",
             )
 
         self._effective_task_path = effective_task_path
+        self._effective_skills_dir = effective_skills_dir
+        self._effective_skills_sandbox_dir = task_skill_policy.sandbox_dir
 
         # Honour an externally-supplied sandbox (use_prebuilt_env, set by
         # Runtime.execute() when the caller passes a live Environment).
@@ -1379,12 +1395,13 @@ class Rollout:
             await self._planes.deploy_skills(
                 self._env,
                 getattr(self, "_effective_task_path", cfg.task_path),
-                cfg.skills_dir,
+                self._effective_skills_dir,
                 None,
                 cfg.sandbox_user,
                 self._agent_cwd,
                 self._task,
-                include_task_skills=cfg.include_task_skills,
+                include_task_skills=False,
+                skills_sandbox_dir=self._effective_skills_sandbox_dir,
             )
             if cfg.export_generated_skills_to:
                 await _ensure_sandbox_dir(
@@ -1433,12 +1450,13 @@ class Rollout:
         await self._planes.deploy_skills(
             self._env,
             getattr(self, "_effective_task_path", cfg.task_path),
-            cfg.skills_dir,
+            self._effective_skills_dir,
             self._agent_cfg,
             cfg.sandbox_user,
             self._agent_cwd,
             self._task,
-            include_task_skills=cfg.include_task_skills,
+            include_task_skills=False,
+            skills_sandbox_dir=self._effective_skills_sandbox_dir,
         )
         if cfg.export_generated_skills_to:
             await _ensure_sandbox_dir(

--- a/src/benchflow/rollout_planes.py
+++ b/src/benchflow/rollout_planes.py
@@ -84,8 +84,10 @@ class DefaultRolloutPlanes:
     def stage_dockerfile_deps(self, task_path: Path, context_root: Path) -> None:
         stage_dockerfile_deps(task_path, context_root)
 
-    def inject_skills_into_dockerfile(self, task_path: Path, skills_dir: Path) -> None:
-        _inject_skills_into_dockerfile(task_path, skills_dir)
+    def inject_skills_into_dockerfile(
+        self, task_path: Path, skills_dir: Path, *, sandbox_dir: str = "/skills"
+    ) -> None:
+        _inject_skills_into_dockerfile(task_path, skills_dir, sandbox_dir=sandbox_dir)
 
     def create_environment(
         self,

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -405,7 +405,7 @@ class DockerSandbox(BaseSandbox):
                 self._chown_to_host_user(str(SandboxPaths.logs_dir), recursive=True),
                 timeout=30,
             )
-        except (TimeoutError, asyncio.TimeoutError):
+        except TimeoutError:
             self.logger.warning("Chown logs directory timed out; continuing teardown.")
         except Exception as e:
             self.logger.warning(f"Failed to chown logs directory: {e}")

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -491,7 +491,13 @@ def _rewrite_copy_line(line: str, env_dir: Path, context_root: Path) -> str | No
     return None
 
 
-def _inject_skills_into_dockerfile(task_path: Path, skills_dir: Path) -> None:
+def _docker_copy_dir(path: str) -> str:
+    return path.rstrip("/") + "/"
+
+
+def _inject_skills_into_dockerfile(
+    task_path: Path, skills_dir: Path, *, sandbox_dir: str = "/skills"
+) -> None:
     """Inject skills into the task's Dockerfile (baked into image).
 
     Copies skills_dir into environment/_deps/skills/ and appends COPY + symlink
@@ -517,11 +523,11 @@ def _inject_skills_into_dockerfile(task_path: Path, skills_dir: Path) -> None:
     lines = [
         "",
         "# Skills directory (injected by benchflow --skills-dir)",
-        "COPY _deps/skills /skills/",
+        f"COPY _deps/skills {_docker_copy_dir(sandbox_dir)}",
     ]
     for agent_path in _get_agent_skill_paths():
         parent = str(Path(agent_path).parent)
-        lines.append(f"RUN mkdir -p {parent} && ln -sf /skills {agent_path}")
+        lines.append(f"RUN mkdir -p {parent} && ln -sf {sandbox_dir} {agent_path}")
 
     content = dockerfile_path.read_text()
     dockerfile_path.write_text(content + "\n".join(lines) + "\n")

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -14,6 +14,7 @@ from typing import Any, NoReturn, cast
 
 from benchflow._paths import ignore_symlinks, is_safe_regular_file
 from benchflow.agents.registry import AGENTS
+from benchflow.skill_policy import validate_container_mount_path
 from benchflow.task import RolloutPaths, Task
 
 logger = logging.getLogger(__name__)
@@ -505,6 +506,7 @@ def _inject_skills_into_dockerfile(
     skills are part of the image.
     """
     env_dir = task_path / "environment"
+    sandbox_dir = validate_container_mount_path(sandbox_dir)
     dockerfile_path = env_dir / "Dockerfile"
     if not dockerfile_path.exists() or not skills_dir.is_dir():
         return

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -66,6 +66,7 @@ class SDK:
         task_path: Path,
         prompts: list[str | None] | None,
         skills_dir: str | Path | None = None,
+        task_skills_dir: str | Path | None = None,
         skill_nudge: str = "",
         agent: str | None = None,
     ) -> list[str]:
@@ -73,6 +74,7 @@ class SDK:
             task_path,
             prompts,
             skills_dir=skills_dir,
+            task_skills_dir=task_skills_dir,
             skill_nudge=skill_nudge,
             agent=agent,
         )

--- a/src/benchflow/skill_eval/_core.py
+++ b/src/benchflow/skill_eval/_core.py
@@ -21,6 +21,7 @@ from typing import Any
 import tomli_w
 
 from benchflow._paths import assert_within, safe_path_segment
+from benchflow.skill_policy import validate_container_mount_path
 
 from .schema import DEFAULT_SKILL_MOUNT_DIR, validate_evals_json
 
@@ -33,20 +34,6 @@ JUDGE_API_ENV_KEYS = (
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
 )
-
-
-def _validate_container_path(value: object, field: str) -> str:
-    """Validate a simple absolute path inside the sandbox container."""
-    if not isinstance(value, str):
-        raise ValueError(f"{field} must be a string")
-    if (
-        not value.startswith("/")
-        or value == "/"
-        or value != value.strip()
-        or any(ch in value for ch in ('"', "\n", "\r", "\0"))
-    ):
-        raise ValueError(f"{field} must be an absolute container path like /skills")
-    return value.rstrip("/")
 
 
 # ---------------------------------------------------------------------------
@@ -87,7 +74,7 @@ class EvalDataset:
 
     @property
     def skill_mount_dir(self) -> str:
-        return _validate_container_path(
+        return validate_container_mount_path(
             self.defaults.get("skill_mount_dir", DEFAULT_SKILL_MOUNT_DIR),
             "defaults.skill_mount_dir",
         )

--- a/src/benchflow/skill_eval/_core.py
+++ b/src/benchflow/skill_eval/_core.py
@@ -637,6 +637,7 @@ class SkillEvaluator:
                 concurrency=concurrency,
                 retry=RetryConfig(max_retries=1),
                 agent_env=judge_env,
+                include_task_skills=with_skill,
             ),
         )
         await j.run()

--- a/src/benchflow/skill_policy.py
+++ b/src/benchflow/skill_policy.py
@@ -8,9 +8,12 @@ must be stripped so a no-skills run cannot pick them up through ``COPY .``.
 
 from __future__ import annotations
 
+import re
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+
+_CONTAINER_MOUNT_PATH_RE = re.compile(r"^/[A-Za-z0-9._/-]+$")
 
 
 @dataclass(frozen=True)
@@ -51,6 +54,22 @@ def resolve_runtime_skills_dir(
     return skills_dir if isinstance(skills_dir, Path) else Path(skills_dir)
 
 
+def validate_container_mount_path(value: object, field: str = "sandbox_dir") -> str:
+    """Validate a simple absolute POSIX path inside a sandbox container."""
+    if not isinstance(value, str):
+        raise ValueError(f"{field} must be a string")
+    if value != value.strip():
+        raise ValueError(f"{field} must be a simple absolute container path")
+
+    path = value.rstrip("/")
+    if path == "" or path == "/" or not _CONTAINER_MOUNT_PATH_RE.fullmatch(path):
+        raise ValueError(f"{field} must be a simple absolute container path")
+    parts = path.split("/")[1:]
+    if any(part in {"", ".", ".."} for part in parts):
+        raise ValueError(f"{field} must be a simple absolute container path")
+    return path
+
+
 def resolve_task_skill_policy(
     *,
     task_path: Path,
@@ -70,12 +89,15 @@ def resolve_task_skill_policy(
     if resolved_runtime is not None:
         enabled = True
         host_dir = resolved_runtime
-        sandbox_dir = "/skills"
+        sandbox_dir = validate_container_mount_path("/skills")
         strip_bundled = has_bundled and not _same_path(resolved_runtime, bundled)
     elif include_task_skills and has_bundled:
         enabled = True
         host_dir = bundled
-        sandbox_dir = declared_sandbox_skills_dir or "/skills"
+        sandbox_dir = validate_container_mount_path(
+            declared_sandbox_skills_dir or "/skills",
+            "environment.skills_dir",
+        )
         strip_bundled = False
 
     return TaskSkillPolicy(

--- a/src/benchflow/skill_policy.py
+++ b/src/benchflow/skill_policy.py
@@ -1,0 +1,71 @@
+"""Skill injection policy for rollout setup.
+
+Task-local ``environment/skills`` packs are agent capabilities, not ordinary
+environment assets. This module owns the small bit of policy needed to decide
+whether those packs are part of a rollout and whether the task build context
+must be stripped so a no-skills run cannot pick them up through ``COPY .``.
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class TaskSkillPolicy:
+    bundled_dir: Path
+    has_bundled_dir: bool
+    use_bundled_dir: bool
+
+    @property
+    def prompt_bundled_dir(self) -> Path | None:
+        return self.bundled_dir if self.use_bundled_dir else None
+
+    @property
+    def needs_task_copy(self) -> bool:
+        return self.has_bundled_dir
+
+    @property
+    def strip_bundled_dir_from_copy(self) -> bool:
+        return self.has_bundled_dir and not self.use_bundled_dir
+
+
+def task_bundled_skills_dir(task_path: Path) -> Path:
+    return task_path / "environment" / "skills"
+
+
+def resolve_task_skill_policy(
+    *,
+    task_path: Path,
+    runtime_skills_dir: str | Path | None,
+    declared_sandbox_skills_dir: str | None,
+    include_task_skills: bool,
+) -> TaskSkillPolicy:
+    bundled = task_bundled_skills_dir(task_path)
+    has_bundled = bundled.is_dir()
+    use_bundled = has_bundled and (
+        _same_path(runtime_skills_dir, bundled)
+        or (include_task_skills and bool(declared_sandbox_skills_dir))
+    )
+    return TaskSkillPolicy(
+        bundled_dir=bundled,
+        has_bundled_dir=has_bundled,
+        use_bundled_dir=use_bundled,
+    )
+
+
+def strip_task_bundled_skills(task_path: Path) -> None:
+    bundled = task_bundled_skills_dir(task_path)
+    if bundled.exists():
+        shutil.rmtree(bundled)
+
+
+def _same_path(a: str | Path | None, b: Path) -> bool:
+    if not a:
+        return False
+    try:
+        return Path(a).resolve() == b.resolve()
+    except OSError:
+        return False

--- a/src/benchflow/skill_policy.py
+++ b/src/benchflow/skill_policy.py
@@ -17,23 +17,38 @@ from pathlib import Path
 class TaskSkillPolicy:
     bundled_dir: Path
     has_bundled_dir: bool
-    use_bundled_dir: bool
+    enabled: bool
+    host_dir: Path | None
+    sandbox_dir: str | None
+    strip_bundled_dir_from_copy: bool
 
     @property
-    def prompt_bundled_dir(self) -> Path | None:
-        return self.bundled_dir if self.use_bundled_dir else None
+    def prompt_dir(self) -> Path | None:
+        return self.host_dir
 
     @property
     def needs_task_copy(self) -> bool:
-        return self.has_bundled_dir
+        return self.has_bundled_dir or self.host_dir is not None
 
     @property
-    def strip_bundled_dir_from_copy(self) -> bool:
-        return self.has_bundled_dir and not self.use_bundled_dir
+    def host_dir_is_bundled(self) -> bool:
+        return self.host_dir is not None and _same_path(self.host_dir, self.bundled_dir)
 
 
 def task_bundled_skills_dir(task_path: Path) -> Path:
     return task_path / "environment" / "skills"
+
+
+def resolve_runtime_skills_dir(
+    task_path: Path,
+    skills_dir: str | Path | None,
+) -> Path | None:
+    if skills_dir is None:
+        return None
+    if str(skills_dir) == "auto":
+        bundled = task_bundled_skills_dir(task_path)
+        return bundled if bundled.is_dir() else None
+    return skills_dir if isinstance(skills_dir, Path) else Path(skills_dir)
 
 
 def resolve_task_skill_policy(
@@ -45,14 +60,31 @@ def resolve_task_skill_policy(
 ) -> TaskSkillPolicy:
     bundled = task_bundled_skills_dir(task_path)
     has_bundled = bundled.is_dir()
-    use_bundled = has_bundled and (
-        _same_path(runtime_skills_dir, bundled)
-        or (include_task_skills and bool(declared_sandbox_skills_dir))
-    )
+    resolved_runtime = resolve_runtime_skills_dir(task_path, runtime_skills_dir)
+
+    enabled = False
+    host_dir: Path | None = None
+    sandbox_dir: str | None = None
+    strip_bundled = has_bundled
+
+    if resolved_runtime is not None:
+        enabled = True
+        host_dir = resolved_runtime
+        sandbox_dir = "/skills"
+        strip_bundled = has_bundled and not _same_path(resolved_runtime, bundled)
+    elif include_task_skills and has_bundled:
+        enabled = True
+        host_dir = bundled
+        sandbox_dir = declared_sandbox_skills_dir or "/skills"
+        strip_bundled = False
+
     return TaskSkillPolicy(
         bundled_dir=bundled,
         has_bundled_dir=has_bundled,
-        use_bundled_dir=use_bundled,
+        enabled=enabled,
+        host_dir=host_dir,
+        sandbox_dir=sandbox_dir,
+        strip_bundled_dir_from_copy=strip_bundled,
     )
 
 

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -122,6 +122,37 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_uses_policy_sandbox_dir(tmp_path):
+    """Guards PR #586 so task skills can mount outside the default /skills."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+    agent_cfg = AgentConfig(
+        name="test-agent",
+        install_cmd="true",
+        launch_cmd="true",
+        skill_paths=["$HOME/.agents/skills"],
+    )
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    await deploy_skills(
+        env=env,
+        task_path=tmp_path,
+        skills_dir=skills_dir,
+        agent_cfg=agent_cfg,
+        sandbox_user="agent",
+        agent_cwd="/workspace",
+        task=_make_task(None),
+        skills_sandbox_dir="/opt/benchflow/skill-eval",
+    )
+
+    env.upload_dir.assert_awaited_once_with(skills_dir, "/opt/benchflow/skill-eval")
+    link_cmd = env.exec.await_args.args[0]
+    assert "ln -sfn /opt/benchflow/skill-eval /home/agent/.agents/skills" in link_cmd
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_skips_runtime_upload_when_dockerfile_already_injected(
     tmp_path,
 ):
@@ -338,7 +369,7 @@ async def test_deploy_skills_agent_with_empty_skill_paths_does_not_use_oracle_pa
 
 @pytest.mark.asyncio
 async def test_deploy_skills_does_not_autodiscover_bundled_skills(tmp_path):
-    """Guards PR #860 against no-skills runs linking task bundles from /app."""
+    """Guards PR #586 against no-skills runs linking task bundles from /app."""
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
     env.upload_dir = AsyncMock()
@@ -364,7 +395,7 @@ async def test_deploy_skills_does_not_autodiscover_bundled_skills(tmp_path):
 
 @pytest.mark.asyncio
 async def test_deploy_skills_links_declared_task_skills_when_enabled(tmp_path):
-    """Guards PR #860 so with-task-skills mode still links declared mounts."""
+    """Guards PR #586 so with-task-skills mode still links declared mounts."""
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
     env.upload_dir = AsyncMock()
@@ -395,7 +426,7 @@ async def test_deploy_skills_links_declared_task_skills_when_enabled(tmp_path):
 async def test_deploy_skills_autodiscovery_skipped_when_include_task_skills_false(
     tmp_path,
 ):
-    """Guards PR #860 so include_task_skills=False never links task bundles."""
+    """Guards PR #586 so include_task_skills=False never links task bundles."""
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
     env.upload_dir = AsyncMock()

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -153,6 +153,28 @@ async def test_deploy_skills_uses_policy_sandbox_dir(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_rejects_unsafe_policy_sandbox_dir(tmp_path):
+    """Guards PR #586 so runtime skill upload cannot consume unsafe mount paths."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+
+    with pytest.raises(ValueError, match="simple absolute container path"):
+        await deploy_skills(
+            env=env,
+            task_path=tmp_path,
+            skills_dir=skills_dir,
+            agent_cfg=None,
+            sandbox_user=None,
+            agent_cwd="/app",
+            task=_make_task(None),
+            skills_sandbox_dir="/opt/skills; touch /tmp/PWNED",
+        )
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_skips_runtime_upload_when_dockerfile_already_injected(
     tmp_path,
 ):

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -42,6 +42,7 @@ async def test_deploy_skills_symlinks_agent_skill_paths_instead_of_copying(tmp_p
         sandbox_user="agent",
         agent_cwd="/app",
         task=_make_task("/opt/benchflow/skills"),
+        include_task_skills=True,
     )
 
     env.upload_dir.assert_not_called()
@@ -105,6 +106,7 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
         sandbox_user="agent",
         agent_cwd="/workspace",
         task=_make_task("/opt/benchflow/skills"),
+        include_task_skills=True,
     )
 
     env.upload_dir.assert_awaited_once_with(skills_dir, "/skills")
@@ -192,6 +194,7 @@ async def test_deploy_skills_chowns_full_dir_chain_for_pi_acp_layout(tmp_path):
         sandbox_user="agent",
         agent_cwd="/workspace",
         task=_make_task("/opt/benchflow/skills"),
+        include_task_skills=True,
     )
 
     cmd = env.exec.await_args.args[0]
@@ -229,6 +232,7 @@ async def test_deploy_skills_skips_chown_when_no_sandbox_user(tmp_path):
         sandbox_user=None,
         agent_cwd="/workspace",
         task=_make_task("/opt/benchflow/skills"),
+        include_task_skills=True,
     )
 
     cmd = env.exec.await_args.args[0]
@@ -256,6 +260,7 @@ async def test_deploy_skills_falls_back_when_local_skills_dir_is_missing(tmp_pat
         sandbox_user="agent",
         agent_cwd="/workspace",
         task=_make_task("/opt/benchflow/skills"),
+        include_task_skills=True,
     )
 
     env.upload_dir.assert_not_called()
@@ -332,13 +337,8 @@ async def test_deploy_skills_agent_with_empty_skill_paths_does_not_use_oracle_pa
 
 
 @pytest.mark.asyncio
-async def test_deploy_skills_oracle_autodiscovers_bundled_skills(tmp_path):
-    """Guards the fix from PR #558 for issue #557: oracle mode on Daytona
-    failed for tasks with bundled skills because deploy_skills never detected
-    the environment/skills/ directory that _start_env_and_upload already
-    uploaded to /app/skills.  Without auto-discovery, effective_skills stayed
-    None and the linking step was skipped, so /root/.claude/skills was never
-    populated."""
+async def test_deploy_skills_does_not_autodiscover_bundled_skills(tmp_path):
+    """Guards PR #860 against no-skills runs linking task bundles from /app."""
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
     env.upload_dir = AsyncMock()
@@ -359,17 +359,43 @@ async def test_deploy_skills_oracle_autodiscovers_bundled_skills(tmp_path):
     )
 
     env.upload_dir.assert_not_called()
+    env.exec.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_deploy_skills_links_declared_task_skills_when_enabled(tmp_path):
+    """Guards PR #860 so with-task-skills mode still links declared mounts."""
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_dir = AsyncMock()
+
+    task_path = tmp_path / "task"
+    bundled = task_path / "environment" / "skills" / "mesh-analysis" / "scripts"
+    bundled.mkdir(parents=True)
+    (bundled / "mesh_tool.py").write_text("class MeshAnalyzer: pass\n")
+
+    await deploy_skills(
+        env=env,
+        task_path=task_path,
+        skills_dir=None,
+        agent_cfg=None,
+        sandbox_user=None,
+        agent_cwd="/app",
+        task=_make_task("/skills"),
+        include_task_skills=True,
+    )
+
+    env.upload_dir.assert_not_called()
     env.exec.assert_awaited_once()
     link_cmd = env.exec.await_args.args[0]
-    assert "ln -sfn /app/skills /root/.claude/skills" in link_cmd
+    assert "ln -sfn /skills /root/.claude/skills" in link_cmd
 
 
 @pytest.mark.asyncio
 async def test_deploy_skills_autodiscovery_skipped_when_include_task_skills_false(
     tmp_path,
 ):
-    """Guards the fix from PR #558: auto-discovery must respect
-    include_task_skills=False so self-gen trials start without skills."""
+    """Guards PR #860 so include_task_skills=False never links task bundles."""
     env = MagicMock()
     env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
     env.upload_dir = AsyncMock()
@@ -415,6 +441,7 @@ async def test_deploy_skills_raises_when_skill_linking_fails(tmp_path):
             sandbox_user="agent",
             agent_cwd="/app",
             task=_make_task("/opt/benchflow/skills"),
+            include_task_skills=True,
         )
 
 

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -82,6 +82,18 @@ class TestInjectSkillsIntoDockerfile:
         assert "COPY _deps/skills /opt/benchflow/skill-eval/" in content
         assert "ln -sf /opt/benchflow/skill-eval" in content
 
+    def test_rejects_unsafe_sandbox_dir(self, tmp_path):
+        """Guards PR #586 against Dockerfile injection from sandbox_dir."""
+        task_path = _make_task(tmp_path)
+        skills_dir = _make_skills_dir(tmp_path)
+
+        with pytest.raises(ValueError, match="simple absolute container path"):
+            _inject_skills_into_dockerfile(
+                task_path,
+                skills_dir,
+                sandbox_dir="/opt/skills; touch /tmp/PWNED",
+            )
+
     def test_preserves_original_dockerfile_content(self, tmp_path):
         original = "FROM python:3.12\nRUN pip install flask\n"
         task_path = _make_task(tmp_path, original)

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -69,6 +69,19 @@ class TestInjectSkillsIntoDockerfile:
         assert "ln -sf /skills" in content
         assert "mkdir -p" in content
 
+    def test_injects_to_custom_sandbox_dir(self, tmp_path):
+        """Guards PR #586 so policy-chosen task skill mounts are baked correctly."""
+        task_path = _make_task(tmp_path)
+        skills_dir = _make_skills_dir(tmp_path)
+
+        _inject_skills_into_dockerfile(
+            task_path, skills_dir, sandbox_dir="/opt/benchflow/skill-eval"
+        )
+
+        content = (task_path / "environment" / "Dockerfile").read_text()
+        assert "COPY _deps/skills /opt/benchflow/skill-eval/" in content
+        assert "ln -sf /opt/benchflow/skill-eval" in content
+
     def test_preserves_original_dockerfile_content(self, tmp_path):
         original = "FROM python:3.12\nRUN pip install flask\n"
         task_path = _make_task(tmp_path, original)

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -75,7 +75,7 @@ def test_skill_nudge_falls_back_to_host_env(monkeypatch):
 
 
 def test_host_skill_nudge_does_not_read_task_skills_by_default(monkeypatch, tmp_path):
-    """Guards PR #860 against prompt-level no-skills leaks."""
+    """Guards PR #586 against prompt-level no-skills leaks."""
     from benchflow.sdk import SDK
 
     monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
@@ -102,7 +102,7 @@ def test_host_skill_nudge_does_not_read_task_skills_by_default(monkeypatch, tmp_
 def test_host_skill_nudge_reads_task_skills_when_explicitly_enabled(
     monkeypatch, tmp_path
 ):
-    """Guards PR #860 so with-task-skills mode still gets skill nudges."""
+    """Guards PR #586 so with-task-skills mode still gets skill nudges."""
     from benchflow.sdk import SDK
 
     monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -99,7 +99,9 @@ def test_host_skill_nudge_does_not_read_task_skills_by_default(monkeypatch, tmp_
     assert "Do not browse" not in prompts[0]
 
 
-def test_host_skill_nudge_reads_task_skills_when_explicitly_enabled(monkeypatch, tmp_path):
+def test_host_skill_nudge_reads_task_skills_when_explicitly_enabled(
+    monkeypatch, tmp_path
+):
     """Guards PR #860 so with-task-skills mode still gets skill nudges."""
     from benchflow.sdk import SDK
 

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -74,7 +74,8 @@ def test_skill_nudge_falls_back_to_host_env(monkeypatch):
     assert _skill_nudge({}) == "name"
 
 
-def test_host_skill_nudge_is_only_prompt_mutation(monkeypatch, tmp_path):
+def test_host_skill_nudge_does_not_read_task_skills_by_default(monkeypatch, tmp_path):
+    """Guards PR #860 against prompt-level no-skills leaks."""
     from benchflow.sdk import SDK
 
     monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
@@ -92,10 +93,35 @@ def test_host_skill_nudge_is_only_prompt_mutation(monkeypatch, tmp_path):
         agent="claude-agent-acp",
     )
 
-    assert prompts[0].startswith("Skills available at ~/.claude/skills: alpha.")
-    assert prompts[0].endswith("Do the thing.")
+    assert prompts == ["Do the thing."]
+    assert "alpha" not in prompts[0]
     assert "Internet access is disabled" not in prompts[0]
     assert "Do not browse" not in prompts[0]
+
+
+def test_host_skill_nudge_reads_task_skills_when_explicitly_enabled(monkeypatch, tmp_path):
+    """Guards PR #860 so with-task-skills mode still gets skill nudges."""
+    from benchflow.sdk import SDK
+
+    monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
+    (tmp_path / "instruction.md").write_text("Do the thing.")
+    task_skills = tmp_path / "environment" / "skills"
+    skill_dir = task_skills / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Alpha skill.\n---\n# Alpha\n"
+    )
+
+    prompts = SDK._resolve_prompts(
+        tmp_path,
+        prompts=None,
+        task_skills_dir=task_skills,
+        skill_nudge=_skill_nudge({}),
+        agent="claude-agent-acp",
+    )
+
+    assert prompts[0].startswith("Skills available at ~/.claude/skills: alpha.")
+    assert prompts[0].endswith("Do the thing.")
 
 
 def test_create_environment_preserves_agent_network_for_llm_runs(tmp_path):

--- a/tests/test_rollout_config_path_coercion.py
+++ b/tests/test_rollout_config_path_coercion.py
@@ -74,3 +74,19 @@ def test_rollout_config_context_root_none_stays_none() -> None:
 
     assert cfg.context_root is None
     assert cfg.skills_dir is None
+
+
+def test_rollout_config_resolves_skills_dir_auto(tmp_path: Path) -> None:
+    """Guards PR #586 so SDK.run and bench run share eval's skills auto mode."""
+    task = tmp_path / "task"
+    skills = task / "environment" / "skills" / "alpha"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("# Alpha\n")
+
+    cfg = RolloutConfig(
+        task_path=task,
+        scenes=[Scene.single(agent="claude-agent-acp")],
+        skills_dir="auto",
+    )
+
+    assert cfg.skills_dir == task / "environment" / "skills"

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -39,7 +39,9 @@ class FakeUploadEnv:
 
 
 @pytest.mark.asyncio
-async def test_start_env_does_not_upload_task_environment_skills(tmp_path: Path) -> None:
+async def test_start_env_does_not_upload_task_environment_skills(
+    tmp_path: Path,
+) -> None:
     """Guards PR #860 against the no-skills leak into /app/skills."""
     task = tmp_path / "task"
     (task / "environment" / "skills" / "jax-skills").mkdir(parents=True)

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -42,7 +42,7 @@ class FakeUploadEnv:
 async def test_start_env_does_not_upload_task_environment_skills(
     tmp_path: Path,
 ) -> None:
-    """Guards PR #860 against the no-skills leak into /app/skills."""
+    """Guards PR #586 against the no-skills leak into /app/skills."""
     task = tmp_path / "task"
     (task / "environment" / "skills" / "jax-skills").mkdir(parents=True)
     (task / "solution").mkdir(parents=True)
@@ -82,7 +82,7 @@ async def test_publish_trajectory_for_verifier_uploads_acp_jsonl() -> None:
 async def test_rollout_setup_strips_task_skills_from_no_skills_build_context(
     tmp_path: Path,
 ) -> None:
-    """Guards PR #860 against Dockerfile COPY . leaking task skills."""
+    """Guards PR #586 against Dockerfile COPY . leaking task skills."""
     task = tmp_path / "task"
     (task / "environment" / "skills" / "alpha").mkdir(parents=True)
     (task / "environment" / "skills" / "alpha" / "SKILL.md").write_text("# Alpha\n")
@@ -110,3 +110,44 @@ async def test_rollout_setup_strips_task_skills_from_no_skills_build_context(
     assert (task / "environment" / "skills" / "alpha" / "SKILL.md").exists()
     assert rollout._effective_task_path != task
     assert not (rollout._effective_task_path / "environment" / "skills").exists()
+
+
+@pytest.mark.asyncio
+async def test_rollout_setup_includes_task_skills_without_declared_mount(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #586 so include_task_skills=True enables task bundles."""
+    task = tmp_path / "task"
+    (task / "environment" / "skills" / "alpha").mkdir(parents=True)
+    (task / "environment" / "skills" / "alpha" / "SKILL.md").write_text("# Alpha\n")
+    (task / "environment" / "Dockerfile").write_text("FROM alpine:3.20\n")
+    (task / "instruction.md").write_text("solve\n")
+    (task / "task.toml").write_text('version = "1.0"\n')
+
+    env = MagicMock()
+    planes = MagicMock()
+    planes.resolve_locked_paths.return_value = []
+    planes.resolve_agent_env.return_value = {}
+    planes.agent_launch.return_value = "claude-agent-acp"
+    planes.create_environment.return_value = env
+
+    rollout = Rollout(
+        RolloutConfig.from_legacy(
+            task_path=task,
+            agent="claude-agent-acp",
+            jobs_dir=tmp_path / "jobs",
+            include_task_skills=True,
+            planes=planes,
+        )
+    )
+    await rollout.setup()
+
+    assert rollout._effective_task_path != task
+    assert (
+        rollout._effective_task_path / "environment" / "skills" / "alpha" / "SKILL.md"
+    ).exists()
+    planes.inject_skills_into_dockerfile.assert_called_once_with(
+        rollout._effective_task_path,
+        rollout._effective_task_path / "environment" / "skills",
+        sandbox_dir="/skills",
+    )

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -1,10 +1,16 @@
 """Tests for rollout startup uploads."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
-from benchflow.rollout import _publish_trajectory_for_verifier, _start_env_and_upload
+from benchflow.rollout import (
+    Rollout,
+    RolloutConfig,
+    _publish_trajectory_for_verifier,
+    _start_env_and_upload,
+)
 
 
 class FakeUploadEnv:
@@ -33,8 +39,8 @@ class FakeUploadEnv:
 
 
 @pytest.mark.asyncio
-async def test_start_env_uploads_task_environment_skills(tmp_path: Path) -> None:
-    """Guards ENG-88: remote oracle tasks can import bundled task skills."""
+async def test_start_env_does_not_upload_task_environment_skills(tmp_path: Path) -> None:
+    """Guards PR #860 against the no-skills leak into /app/skills."""
     task = tmp_path / "task"
     (task / "environment" / "skills" / "jax-skills").mkdir(parents=True)
     (task / "solution").mkdir(parents=True)
@@ -48,7 +54,7 @@ async def test_start_env_uploads_task_environment_skills(tmp_path: Path) -> None
     task_skills = task / "environment" / "skills"
     assert env.started is True
     assert (task / "instruction.md", "/instruction.md") in env.uploaded_files
-    assert (task_skills, "/app/skills") in env.uploaded_dirs
+    assert (task_skills, "/app/skills") not in env.uploaded_dirs
     assert (task / "solution", "/solution") in env.uploaded_dirs
     assert "environment_setup" in timing
 
@@ -68,3 +74,37 @@ async def test_publish_trajectory_for_verifier_uploads_acp_jsonl() -> None:
             "/logs/agent/acp_trajectory.jsonl",
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_rollout_setup_strips_task_skills_from_no_skills_build_context(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #860 against Dockerfile COPY . leaking task skills."""
+    task = tmp_path / "task"
+    (task / "environment" / "skills" / "alpha").mkdir(parents=True)
+    (task / "environment" / "skills" / "alpha" / "SKILL.md").write_text("# Alpha\n")
+    (task / "environment" / "Dockerfile").write_text("FROM alpine:3.20\nCOPY . /app\n")
+    (task / "instruction.md").write_text("solve\n")
+    (task / "task.toml").write_text('version = "1.0"\n')
+
+    env = MagicMock()
+    planes = MagicMock()
+    planes.resolve_locked_paths.return_value = []
+    planes.resolve_agent_env.return_value = {}
+    planes.agent_launch.return_value = "claude-agent-acp"
+    planes.create_environment.return_value = env
+
+    rollout = Rollout(
+        RolloutConfig.from_legacy(
+            task_path=task,
+            agent="claude-agent-acp",
+            jobs_dir=tmp_path / "jobs",
+            planes=planes,
+        )
+    )
+    await rollout.setup()
+
+    assert (task / "environment" / "skills" / "alpha" / "SKILL.md").exists()
+    assert rollout._effective_task_path != task
+    assert not (rollout._effective_task_path / "environment" / "skills").exists()

--- a/tests/test_skill_eval.py
+++ b/tests/test_skill_eval.py
@@ -214,10 +214,19 @@ class TestLoadEvalDataset:
 
         assert ds.skill_mount_dir == "/opt/benchflow/skill-eval"
 
-    def test_rejects_invalid_skill_mount_dir(self, skill_dir):
+    @pytest.mark.parametrize(
+        "mount_dir",
+        [
+            "relative/skills",
+            "/opt/skills; touch /tmp/PWNED",
+            "/opt/skills with spaces",
+            "/opt/../skills",
+        ],
+    )
+    def test_rejects_invalid_skill_mount_dir(self, skill_dir, mount_dir):
         evals_json = skill_dir / "evals" / "evals.json"
         data = json.loads(evals_json.read_text())
-        data["defaults"]["skill_mount_dir"] = "relative/skills"
+        data["defaults"]["skill_mount_dir"] = mount_dir
         evals_json.write_text(json.dumps(data))
 
         ds = load_eval_dataset(skill_dir)

--- a/tests/test_skill_policy.py
+++ b/tests/test_skill_policy.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from benchflow.skill_policy import resolve_task_skill_policy, strip_task_bundled_skills
+
+
+def _make_task_skills(task_path: Path) -> Path:
+    skills = task_path / "environment" / "skills" / "alpha"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("# Alpha\n")
+    return task_path / "environment" / "skills"
+
+
+def test_task_skills_are_stripped_from_no_skills_task_copy(tmp_path: Path) -> None:
+    """Guards PR #860 against Docker build-context leaks in no-skills runs."""
+    task = tmp_path / "task"
+    _make_task_skills(task)
+
+    policy = resolve_task_skill_policy(
+        task_path=task,
+        runtime_skills_dir=None,
+        declared_sandbox_skills_dir=None,
+        include_task_skills=False,
+    )
+
+    assert policy.prompt_bundled_dir is None
+    assert policy.needs_task_copy is True
+    assert policy.strip_bundled_dir_from_copy is True
+
+    strip_task_bundled_skills(task)
+    assert not (task / "environment" / "skills").exists()
+
+
+def test_explicit_task_skills_path_keeps_task_bundle(tmp_path: Path) -> None:
+    """Guards PR #860 so --skills-dir auto/task-path still enables task skills."""
+    task = tmp_path / "task"
+    skills_root = _make_task_skills(task)
+
+    policy = resolve_task_skill_policy(
+        task_path=task,
+        runtime_skills_dir=skills_root,
+        declared_sandbox_skills_dir=None,
+        include_task_skills=False,
+    )
+
+    assert policy.prompt_bundled_dir == skills_root
+    assert policy.strip_bundled_dir_from_copy is False
+
+
+def test_declared_task_skills_only_apply_when_included(tmp_path: Path) -> None:
+    """Guards PR #860 against task.toml skills overriding no-skills mode."""
+    task = tmp_path / "task"
+    skills_root = _make_task_skills(task)
+
+    disabled = resolve_task_skill_policy(
+        task_path=task,
+        runtime_skills_dir=None,
+        declared_sandbox_skills_dir="/skills",
+        include_task_skills=False,
+    )
+    enabled = resolve_task_skill_policy(
+        task_path=task,
+        runtime_skills_dir=None,
+        declared_sandbox_skills_dir="/skills",
+        include_task_skills=True,
+    )
+
+    assert disabled.prompt_bundled_dir is None
+    assert disabled.strip_bundled_dir_from_copy is True
+    assert enabled.prompt_bundled_dir == skills_root
+    assert enabled.strip_bundled_dir_from_copy is False

--- a/tests/test_skill_policy.py
+++ b/tests/test_skill_policy.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from benchflow.skill_policy import resolve_task_skill_policy, strip_task_bundled_skills
+from benchflow.skill_policy import (
+    resolve_runtime_skills_dir,
+    resolve_task_skill_policy,
+    strip_task_bundled_skills,
+)
 
 
 def _make_task_skills(task_path: Path) -> Path:
@@ -11,7 +15,7 @@ def _make_task_skills(task_path: Path) -> Path:
 
 
 def test_task_skills_are_stripped_from_no_skills_task_copy(tmp_path: Path) -> None:
-    """Guards PR #860 against Docker build-context leaks in no-skills runs."""
+    """Guards PR #586 against Docker build-context leaks in no-skills runs."""
     task = tmp_path / "task"
     _make_task_skills(task)
 
@@ -22,7 +26,10 @@ def test_task_skills_are_stripped_from_no_skills_task_copy(tmp_path: Path) -> No
         include_task_skills=False,
     )
 
-    assert policy.prompt_bundled_dir is None
+    assert policy.enabled is False
+    assert policy.host_dir is None
+    assert policy.sandbox_dir is None
+    assert policy.prompt_dir is None
     assert policy.needs_task_copy is True
     assert policy.strip_bundled_dir_from_copy is True
 
@@ -31,7 +38,7 @@ def test_task_skills_are_stripped_from_no_skills_task_copy(tmp_path: Path) -> No
 
 
 def test_explicit_task_skills_path_keeps_task_bundle(tmp_path: Path) -> None:
-    """Guards PR #860 so --skills-dir auto/task-path still enables task skills."""
+    """Guards PR #586 so --skills-dir auto/task-path still enables task skills."""
     task = tmp_path / "task"
     skills_root = _make_task_skills(task)
 
@@ -42,12 +49,15 @@ def test_explicit_task_skills_path_keeps_task_bundle(tmp_path: Path) -> None:
         include_task_skills=False,
     )
 
-    assert policy.prompt_bundled_dir == skills_root
+    assert policy.enabled is True
+    assert policy.host_dir == skills_root
+    assert policy.sandbox_dir == "/skills"
+    assert policy.prompt_dir == skills_root
     assert policy.strip_bundled_dir_from_copy is False
 
 
 def test_declared_task_skills_only_apply_when_included(tmp_path: Path) -> None:
-    """Guards PR #860 against task.toml skills overriding no-skills mode."""
+    """Guards PR #586 against task.toml skills overriding no-skills mode."""
     task = tmp_path / "task"
     skills_root = _make_task_skills(task)
 
@@ -64,7 +74,38 @@ def test_declared_task_skills_only_apply_when_included(tmp_path: Path) -> None:
         include_task_skills=True,
     )
 
-    assert disabled.prompt_bundled_dir is None
+    assert disabled.prompt_dir is None
+    assert disabled.sandbox_dir is None
     assert disabled.strip_bundled_dir_from_copy is True
-    assert enabled.prompt_bundled_dir == skills_root
+    assert enabled.enabled is True
+    assert enabled.host_dir == skills_root
+    assert enabled.sandbox_dir == "/skills"
+    assert enabled.prompt_dir == skills_root
     assert enabled.strip_bundled_dir_from_copy is False
+
+
+def test_include_task_skills_honors_declared_sandbox_path(tmp_path: Path) -> None:
+    """Guards PR #586 so task-local skills use the task-declared mount path."""
+    task = tmp_path / "task"
+    skills_root = _make_task_skills(task)
+
+    policy = resolve_task_skill_policy(
+        task_path=task,
+        runtime_skills_dir=None,
+        declared_sandbox_skills_dir="/opt/benchflow/skill-eval",
+        include_task_skills=True,
+    )
+
+    assert policy.enabled is True
+    assert policy.host_dir == skills_root
+    assert policy.sandbox_dir == "/opt/benchflow/skill-eval"
+    assert policy.strip_bundled_dir_from_copy is False
+
+
+def test_skills_dir_auto_resolves_at_rollout_boundary(tmp_path: Path) -> None:
+    """Guards PR #586 so direct RolloutConfig/SDK paths share --skills-dir auto."""
+    task = tmp_path / "task"
+    skills_root = _make_task_skills(task)
+
+    assert resolve_runtime_skills_dir(task, "auto") == skills_root
+    assert resolve_runtime_skills_dir(task, Path("auto")) == skills_root

--- a/tests/test_skill_policy.py
+++ b/tests/test_skill_policy.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 
+import pytest
+
 from benchflow.skill_policy import (
     resolve_runtime_skills_dir,
     resolve_task_skill_policy,
     strip_task_bundled_skills,
+    validate_container_mount_path,
 )
 
 
@@ -100,6 +103,50 @@ def test_include_task_skills_honors_declared_sandbox_path(tmp_path: Path) -> Non
     assert policy.host_dir == skills_root
     assert policy.sandbox_dir == "/opt/benchflow/skill-eval"
     assert policy.strip_bundled_dir_from_copy is False
+
+
+def test_include_task_skills_rejects_unsafe_sandbox_path(tmp_path: Path) -> None:
+    """Guards PR #586 against Dockerfile injection via task-declared skills_dir."""
+    task = tmp_path / "task"
+    _make_task_skills(task)
+
+    with pytest.raises(ValueError, match=r"environment\.skills_dir"):
+        resolve_task_skill_policy(
+            task_path=task,
+            runtime_skills_dir=None,
+            declared_sandbox_skills_dir="/opt/skills; touch /tmp/PWNED",
+            include_task_skills=True,
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/skills",
+        "/opt/benchflow/skill-eval",
+        "/a/b_c.d-1",
+    ],
+)
+def test_validate_container_mount_path_accepts_simple_absolute_paths(path: str) -> None:
+    """Guards PR #586 so valid sandbox skill mount paths still work."""
+    assert validate_container_mount_path(path) == path
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "relative/skills",
+        "/",
+        "/opt/skills with spaces",
+        "/opt/skills;touch",
+        "/opt/../skills",
+        "/opt//skills",
+    ],
+)
+def test_validate_container_mount_path_rejects_unsafe_paths(path: str) -> None:
+    """Guards PR #586 against shell metacharacters and ambiguous paths."""
+    with pytest.raises(ValueError, match="simple absolute container path"):
+        validate_container_mount_path(path)
 
 
 def test_skills_dir_auto_resolves_at_rollout_boundary(tmp_path: Path) -> None:

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -329,7 +329,7 @@ skills_dir: my-skills
 
 
 def test_native_yaml_with_include_task_skills(tmp_path):
-    """Guards PR #860 so native YAML can explicitly enable task skills."""
+    """Guards PR #586 so native YAML can explicitly enable task skills."""
     tasks = tmp_path / "tasks" / "task-a"
     tasks.mkdir(parents=True)
     (tasks / "task.toml").write_text('version = "1.0"')

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -73,6 +73,7 @@ def test_from_native_yaml(native_yaml):
     assert cfg.retry.max_retries == 1
     assert cfg.sandbox_setup_timeout == 45
     assert cfg.prompts == [None, "Review your solution."]
+    assert cfg.include_task_skills is False
     assert job._tasks_dir == Path("tasks")
     assert job._jobs_dir == Path("output")
 
@@ -325,6 +326,23 @@ skills_dir: my-skills
 
     job = Evaluation.from_yaml(config)
     assert job._config.skills_dir == "my-skills"
+
+
+def test_native_yaml_with_include_task_skills(tmp_path):
+    """Guards PR #860 so native YAML can explicitly enable task skills."""
+    tasks = tmp_path / "tasks" / "task-a"
+    tasks.mkdir(parents=True)
+    (tasks / "task.toml").write_text('version = "1.0"')
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+agent: claude-agent-acp
+include_task_skills: true
+""")
+
+    job = Evaluation.from_yaml(config)
+    assert job._config.include_task_skills is True
 
 
 def test_native_yaml_paths_are_cwd_relative(tmp_path):


### PR DESCRIPTION
## Summary
- stop uploading task-local `environment/skills` during sandbox startup
- centralize task-skill policy so no-skills runs strip task skill packs from Docker build context and prompt nudges
- require explicit task-skill inclusion for with-skill orchestration while preserving `--skills-dir auto` / explicit skills behavior

## Verification
- `uv sync --extra dev --locked`
- `uv run python -m pytest tests/` (2449 passed, 48 skipped, 1 deselected)
- `uv run ty check src/`
- `uv run ruff check .`
- Real Docker no-skills repro with `COPY . /app`: `find / -maxdepth 6 -name SKILL.md` returned empty
- Real Docker with explicit skills: `/skills/alpha/SKILL.md` present
- Real Gemini end-to-end task using host Gemini subscription auth: PASS, reward 1.0, verifier found no SKILL.md in agent-visible paths

Note: no `*_API_KEY` env var was present in this shell; the real-agent run used BenchFlow's existing Gemini subscription-auth path (`~/.gemini/oauth_creds.json`).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->