### PR TITLE
feat: OpenReward Track-2 driver (offline-testable)

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1257,24 +1257,11 @@ def eval_create(
                 "the hosted Verifiers environment owns its own provisioning. Ignoring.[/yellow]"
             )
 
-        # Provider routing guard (PR2): the slash form ``openreward/x`` has no
-        # ``provider:`` prefix, so ``HostedEnvRef.parse`` would read
-        # ``openreward`` as the *owner* and silently fall back to the default
-        # provider (primeintellect). A generic "owner is a provider name" guard
-        # can't fix this without breaking the legitimate ``primeintellect/...``
-        # owner form, so we special-case it here at dispatch and tell the user
-        # to use the explicit ``openreward:owner/name`` form. The legitimate
-        # ``primeintellect/owner/name`` form is untouched.
-        _src = source_env.strip()
-        if ":" not in _src and _src.split("/", 1)[0].lower() == "openreward":
-            console.print(
-                "[red]Ambiguous --source-env: 'openreward/...' parses "
-                "'openreward' as the owner, not the provider. Use the explicit "
-                "form 'openreward:owner/name' (e.g. "
-                "openreward:GeneralReasoning/KellyBench).[/red]"
-            )
-            raise typer.Exit(1)
-
+        # The slash-form provider mis-route guard ("openreward/x" parsing
+        # "openreward" as the owner) now lives in ``HostedEnvRef.parse`` so it
+        # covers every call site (env create/info/inspect + SDK); the parse
+        # below raises ``HostedEnvError`` with the hint, caught just like any
+        # other invalid reference.
         try:
             ref = HostedEnvRef.parse(source_env, version=source_env_version)
             run_result = run_hosted_env(

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1257,6 +1257,24 @@ def eval_create(
                 "the hosted Verifiers environment owns its own provisioning. Ignoring.[/yellow]"
             )
 
+        # Provider routing guard (PR2): the slash form ``openreward/x`` has no
+        # ``provider:`` prefix, so ``HostedEnvRef.parse`` would read
+        # ``openreward`` as the *owner* and silently fall back to the default
+        # provider (primeintellect). A generic "owner is a provider name" guard
+        # can't fix this without breaking the legitimate ``primeintellect/...``
+        # owner form, so we special-case it here at dispatch and tell the user
+        # to use the explicit ``openreward:owner/name`` form. The legitimate
+        # ``primeintellect/owner/name`` form is untouched.
+        _src = source_env.strip()
+        if ":" not in _src and _src.split("/", 1)[0].lower() == "openreward":
+            console.print(
+                "[red]Ambiguous --source-env: 'openreward/...' parses "
+                "'openreward' as the owner, not the provider. Use the explicit "
+                "form 'openreward:owner/name' (e.g. "
+                "openreward:GeneralReasoning/KellyBench).[/red]"
+            )
+            raise typer.Exit(1)
+
         try:
             ref = HostedEnvRef.parse(source_env, version=source_env_version)
             run_result = run_hosted_env(

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -235,7 +235,19 @@ def normalize_verifiers_model(model: str) -> str:
 
 
 def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
-    """Run a hosted environment using a controlled local Verifiers install."""
+    """Run a hosted environment.
+
+    PrimeIntellect runs locally via a controlled ``vf-eval`` install
+    (``runner='verifiers'``). OpenReward runs through the ``openreward`` client
+    session loop (lazy-imported so its dependency only loads on the openreward
+    path); the PrimeIntellect ``vf-eval``/version requirements below stay
+    PrimeIntellect-only.
+    """
+    if config.source_env.provider == "openreward":
+        from benchflow.openreward_env import run_hosted_env_openreward
+
+        return run_hosted_env_openreward(config)
+
     if config.runner != "verifiers":
         raise HostedEnvError(
             "Only runner='verifiers' is implemented. Use Prime CLI directly for "

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -73,13 +73,16 @@ class HostedEnvRef:
         - ``primeintellect:primeintellect/general-agent@0.1.1``  (provider:owner/name)
         - ``openreward:GeneralReasoning/KellyBench``             (provider:owner/name)
 
-        OpenReward **requires the explicit ``provider:`` prefix**: the slash form
-        ``openreward/KellyBench`` parses ``openreward`` as the *owner* and falls
-        back to the default provider (primeintellect). A generic "owner is a
-        provider name" guard can't fix this without breaking the legitimate
-        ``primeintellect/...`` owner form. TODO(PR2): route ``--source-env`` by
-        provider at the CLI/dispatch layer so the slash form can't silently
-        mis-route once the openreward runner is wired.
+        OpenReward (and any non-default provider) **requires the explicit
+        ``provider:`` prefix**: the slash form ``openreward/KellyBench`` would
+        otherwise parse ``openreward`` as the *owner* and fall back to the
+        default provider (primeintellect), silently mis-routing the env. We
+        can't auto-correct that without breaking the legitimate
+        ``primeintellect/owner/name`` owner form, so when the input has no
+        ``provider:`` prefix and its first slash-segment is a *known* provider
+        other than the default, we reject it with a hint to use
+        ``provider:owner/name``. This guard lives here (not in the CLI) so every
+        call site — ``env create``/``info``/``inspect`` and the SDK — is covered.
         """
         provider = default_provider
         value = raw.strip()
@@ -92,6 +95,21 @@ class HostedEnvRef:
                 raise HostedEnvError(f"Invalid hosted environment reference: {raw}")
             provider = prefix
             value = rest
+        else:
+            # No ``provider:`` prefix. If the first slash-segment names a known
+            # provider (other than the default, whose ``owner/name`` form is
+            # legitimate — e.g. ``primeintellect/owner/name``), the caller almost
+            # certainly meant it as the provider, not an owner. Reject with a
+            # hint rather than silently routing to the default provider.
+            head = value.split("/", 1)[0].lower()
+            if head != default_provider and head in _SUPPORTED_HOSTED_PROVIDERS:
+                raise HostedEnvError(
+                    f"Ambiguous hosted environment reference: {raw!r}. "
+                    f"{head!r} is a provider, not an owner — the slash form "
+                    f"parses it as the owner and falls back to "
+                    f"{default_provider!r}. Use the explicit form "
+                    f"{head}:owner/name (e.g. openreward:GeneralReasoning/KellyBench)."
+                )
 
         if "@" in value:
             value, embedded_version = value.rsplit("@", 1)
@@ -439,6 +457,122 @@ def _extract_verifiers_error(text: str) -> str | None:
     return None
 
 
+def build_hosted_result_payload(
+    result: HostedEnvRunResult,
+    config: HostedEnvRunConfig,
+    *,
+    rewards: dict[str, Any] | None,
+    prompts: list[str],
+    timing: dict[str, Any],
+    source_provenance: dict[str, Any],
+    started_at: datetime,
+    finished_at: datetime,
+    agent_name: str,
+    trajectory_source: str,
+    has_trajectory: bool,
+    error: str | None,
+    verifier_error: str | None,
+) -> dict[str, Any]:
+    """Build the canonical ``result.json`` payload for a hosted-env-style run.
+
+    Single owner of the ``result.json`` shape shared by the vf-eval path
+    (:func:`_write_run_artifacts`) and the OpenReward driver
+    (``benchflow.openreward_env``). The two paths differ only in a handful of
+    fields (``agent_name``, the ``error``/``verifier_error`` split, and the
+    ``trajectory_source`` lineage literal), which are passed in; everything else
+    — the ``agent_result`` token block, the ``RolloutDiagnostics`` slots, the
+    timing/source provenance — is produced identically so the schema never
+    drifts between the two drivers.
+    """
+    return {
+        "task_name": result.source_env.env_uid,
+        "rollout_name": result.run_dir.name,
+        "rewards": rewards,
+        "agent": config.agent or None,
+        "agent_name": agent_name,
+        "model": result.normalized_model or result.model or None,
+        "n_tool_calls": result.total_tool_calls or 0,
+        "n_prompts": len(prompts),
+        "agent_result": {
+            "n_tool_calls": result.total_tool_calls or 0,
+            "n_prompts": len(prompts),
+            "n_input_tokens": None,
+            "n_output_tokens": None,
+            "n_cache_read_tokens": None,
+            "n_cache_creation_tokens": None,
+            "total_tokens": None,
+            "cost_usd": None,
+            "usage_source": "unavailable",
+            "price_source": None,
+        },
+        "error": error,
+        "error_category": None,
+        "verifier_error": verifier_error,
+        "verifier_error_category": None,
+        # Empty diagnostic slots — keyed by the canonical registry so
+        # adding a new diagnostic doesn't require touching the hosted
+        # drivers (issue #503). Hosted/openreward runs don't produce these,
+        # so all fields serialize as ``None``.
+        **RolloutDiagnostics().to_result_fields(),
+        "partial_trajectory": False,
+        "trajectory_source": trajectory_source if has_trajectory else None,
+        "started_at": str(started_at),
+        "finished_at": str(finished_at),
+        "timing": timing,
+        "scenes": [],
+        "source": source_provenance,
+    }
+
+
+def build_hosted_config_payload(
+    result: HostedEnvRunResult,
+    config: HostedEnvRunConfig,
+    *,
+    source_provenance: dict[str, Any],
+    started_at: datetime,
+    environment: str,
+    runner: str,
+    extra_hosted_env: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the canonical ``config.json`` payload for a hosted-env-style run.
+
+    Shared by the vf-eval path and the OpenReward driver. ``environment`` and
+    ``runner`` are the per-driver literals; ``extra_hosted_env`` lets a driver
+    add fields to the ``hosted_env`` block (the OpenReward driver adds
+    ``split``/``index``).
+    """
+    return {
+        "task_path": None,
+        "agent": config.agent or None,
+        "model": result.normalized_model or result.model or None,
+        "environment": environment,
+        "skills_dir": None,
+        "sandbox_user": None,
+        "sandbox_locked_paths": None,
+        "sandbox_setup_timeout": None,
+        "context_root": None,
+        "timeout_sec": None,
+        "concurrency": config.concurrency,
+        "agent_idle_timeout_sec": None,
+        "started_at": str(started_at),
+        "agent_env": {},
+        "scenes": [],
+        "source": source_provenance,
+        "hosted_env": {
+            "provider": result.source_env.provider,
+            "env_uid": result.source_env.env_uid,
+            "runner": runner,
+            **(extra_hosted_env or {}),
+            "num_examples": config.num_examples,
+            "rollouts_per_example": config.rollouts_per_example,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "sampling_args": config.sampling_args,
+            "env_args": config.env_args,
+        },
+    }
+
+
 def _write_run_artifacts(
     result: HostedEnvRunResult,
     config: HostedEnvRunConfig,
@@ -493,8 +627,6 @@ def _write_run_artifacts(
     rewards = _build_rewards_dict(result, output_dir)
     prompts = _collect_prompts(output_dir, config)
     timing = {"total": round((finished_at - started_at).total_seconds(), 1)}
-    task_name = result.source_env.env_uid
-    rollout_name = result.run_dir.name
     source_provenance = _hosted_source_provenance(
         result.source_env,
         runner=config.runner,
@@ -506,79 +638,38 @@ def _write_run_artifacts(
         + ("\n" if trajectory else "")
     )
 
-    result_payload: dict[str, Any] = {
-        "task_name": task_name,
-        "rollout_name": rollout_name,
-        "rewards": rewards,
-        "agent": config.agent or None,
-        "agent_name": "verifiers",
-        "model": result.normalized_model or result.model or None,
-        "n_tool_calls": result.total_tool_calls or 0,
-        "n_prompts": len(prompts),
-        "agent_result": {
-            "n_tool_calls": result.total_tool_calls or 0,
-            "n_prompts": len(prompts),
-            "n_input_tokens": None,
-            "n_output_tokens": None,
-            "n_cache_read_tokens": None,
-            "n_cache_creation_tokens": None,
-            "total_tokens": None,
-            "cost_usd": None,
-            "usage_source": "unavailable",
-            "price_source": None,
-        },
-        "error": result.error
+    result_payload = build_hosted_result_payload(
+        result,
+        config,
+        rewards=rewards,
+        prompts=prompts,
+        timing=timing,
+        source_provenance=source_provenance,
+        started_at=started_at,
+        finished_at=finished_at,
+        agent_name="verifiers",
+        trajectory_source="hosted_env",
+        has_trajectory=bool(trajectory),
+        # vf-eval distinguishes a process crash (returncode != 0) from a
+        # verifier-level error: a clean run that reported a verifier error
+        # leaves ``error`` None and surfaces it under ``verifier_error``.
+        error=result.error
         if result.returncode != 0 or not result.verifiers_error
         else None,
-        "error_category": None,
-        "verifier_error": result.verifiers_error,
-        "verifier_error_category": None,
-        # Empty diagnostic slots — keyed by the canonical registry so
-        # adding a new diagnostic doesn't require touching hosted_env
-        # (issue #503). Hosted runs don't produce these (the harness ran
-        # remote), so all fields serialize as ``None``.
-        **RolloutDiagnostics().to_result_fields(),
-        "partial_trajectory": False,
-        "trajectory_source": "hosted_env" if trajectory else None,
-        "started_at": str(started_at),
-        "finished_at": str(finished_at),
-        "timing": timing,
-        "scenes": [],
-        "source": source_provenance,
-    }
+        verifier_error=result.verifiers_error,
+    )
     (result.run_dir / "result.json").write_text(json.dumps(result_payload, indent=2))
     (result.run_dir / "timing.json").write_text(json.dumps(timing, indent=2))
     (result.run_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
 
-    config_payload: dict[str, Any] = {
-        "task_path": None,
-        "agent": config.agent or None,
-        "model": result.normalized_model or result.model or None,
-        "environment": "hosted_env",
-        "skills_dir": None,
-        "sandbox_user": None,
-        "sandbox_locked_paths": None,
-        "sandbox_setup_timeout": None,
-        "context_root": None,
-        "timeout_sec": None,
-        "concurrency": config.concurrency,
-        "agent_idle_timeout_sec": None,
-        "started_at": str(started_at),
-        "agent_env": {},
-        "scenes": [],
-        "source": source_provenance,
-        "hosted_env": {
-            "provider": result.source_env.provider,
-            "env_uid": result.source_env.env_uid,
-            "runner": config.runner,
-            "num_examples": config.num_examples,
-            "rollouts_per_example": config.rollouts_per_example,
-            "max_tokens": config.max_tokens,
-            "temperature": config.temperature,
-            "sampling_args": config.sampling_args,
-            "env_args": config.env_args,
-        },
-    }
+    config_payload = build_hosted_config_payload(
+        result,
+        config,
+        source_provenance=source_provenance,
+        started_at=started_at,
+        environment="hosted_env",
+        runner=config.runner,
+    )
     (result.run_dir / "config.json").write_text(json.dumps(config_payload, indent=2))
 
     if rewards:

--- a/src/benchflow/openreward_env.py
+++ b/src/benchflow/openreward_env.py
@@ -1,0 +1,611 @@
+"""OpenReward / ORS hosted-environment driver (v0.5 Track-2).
+
+This is the OpenReward sibling of the PrimeIntellect ``vf-eval`` path in
+:mod:`benchflow.hosted_env`. Instead of shelling out to ``vf-eval`` against
+Prime's hub, it drives an OpenReward environment directly through the
+``openreward`` Python client's session loop:
+
+    c = openreward.OpenReward(api_key=...)
+    env = c.environments.get("<owner>/<name>")
+    task = env.get_task(split, index)
+    with env.session(task=task) as session:
+        session.get_prompt()
+        session.list_tools()
+        out = session.call_tool(name, input)   # -> ToolOutput
+        # loop until out.finished; final reward is out.reward
+
+The reward of the loop is ``ToolOutput.reward`` (NOT a ``RunResult`` /
+``ToolResult``). ``client.rollout.create(...)`` is telemetry-only and is **not**
+used here — it is not the env-interaction handle.
+
+The loop is driven by a :class:`Policy`. We ship a :class:`ScriptedPolicy`
+(schema-driven, no LLM) so the path is fully exercisable offline with a fake
+session; :class:`ModelPolicy` is left as a clearly-marked seam for a real LLM
+agent (PR3+).
+
+Artifacts: the final reward is lifted into a canonical ``VerifyResult`` via
+:func:`benchflow.rewards.node.verify_result_from_reward_map` (the single
+dict→VerifyResult conversion point — we do not duplicate ``adapters/ors.py``),
+and the BenchFlow rollout artifact contract is reconstructed by reusing the
+same writers the rest of the codebase uses: the legacy ``result.json`` /
+``rewards.jsonl`` / ``config.json`` / ``timing.json`` / ``prompts.json`` /
+``trajectory/acp_trajectory.jsonl`` shape from :mod:`benchflow.hosted_env`,
+plus the canonical ``verifier/verify_result.json`` and
+``trainer/verifiers.jsonl`` from :mod:`benchflow.rollout` /
+:mod:`benchflow.trajectories.export`. Lineage is stamped
+``trajectory_source="openreward"``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol
+from uuid import uuid4
+
+from benchflow.diagnostics import RolloutDiagnostics
+from benchflow.hosted_env import (
+    HostedEnvError,
+    HostedEnvRunConfig,
+    HostedEnvRunResult,
+    _hosted_source_provenance,
+    _write_hosted_rewards_jsonl,
+    normalize_verifiers_model,
+)
+
+if TYPE_CHECKING:
+    from benchflow.rewards.protocol import VerifyResult
+
+logger = logging.getLogger(__name__)
+
+OPENREWARD_API_KEY_ENV_VARS = ("OPENREWARD_API_KEY", "ORS_API_KEY")
+
+# Guard rail: a runaway env would otherwise loop forever if it never returns
+# ``finished``. Keep this small — the scripted policy makes one structured call
+# per tool, and real environments converge well under this.
+_DEFAULT_MAX_STEPS = 50
+
+
+class OpenRewardSession(Protocol):
+    """The slice of ``openreward.environments...Session`` the driver uses.
+
+    Declared structurally so the loop is testable with a fake session that
+    records ``call_tool`` and returns scripted ``ToolOutput``-shaped objects —
+    no network, no platform, no paid rollout.
+    """
+
+    def get_prompt(self) -> Any: ...
+    def list_tools(self, format: Any = ...) -> Any: ...
+    def call_tool(self, tool_name: str, input: Any = ...) -> Any: ...
+
+
+class Policy(Protocol):
+    """Chooses the next ``(tool_name, input)`` given the prompt and tools.
+
+    Returning ``None`` ends the loop early (the policy has nothing more to do);
+    otherwise the driver keeps calling tools until the environment reports
+    ``finished`` or the step budget is exhausted.
+    """
+
+    def act(
+        self,
+        prompt_text: str,
+        tools: list[Any],
+        last_output: Any | None,
+        step: int,
+    ) -> tuple[str, dict[str, Any]] | None: ...
+
+
+class ScriptedPolicy:
+    """Deterministic, schema-driven policy — no LLM in the loop.
+
+    Drives the environment by calling the available tools in order, sending an
+    empty input by default. When an answer/submit-style tool is present (a tool
+    whose name suggests it terminates the episode) it is preferred and called
+    with ``answer`` populated from ``answer`` (if supplied) so an offline run
+    can exercise the full terminate-on-``finished`` path. This is intentionally
+    minimal: it exists to drive the loop in tests and as a smoke policy, not to
+    solve tasks. A real agent plugs in via :class:`ModelPolicy`.
+    """
+
+    # Substrings that flag a tool as episode-terminating, in priority order.
+    _SUBMIT_HINTS = ("submit", "answer", "finish", "done", "respond")
+
+    def __init__(self, answer: str | None = None) -> None:
+        self._answer = answer
+
+    def _tool_name(self, tool: Any) -> str:
+        # ToolSpec is a dataclass with ``.name``; dicts use ``["name"]``.
+        if isinstance(tool, dict):
+            return str(tool.get("name", ""))
+        return str(getattr(tool, "name", ""))
+
+    def _build_input(self, tool: Any) -> dict[str, Any]:
+        name = self._tool_name(tool).lower()
+        if self._answer is not None and any(h in name for h in self._SUBMIT_HINTS):
+            return {"answer": self._answer}
+        return {}
+
+    def act(
+        self,
+        prompt_text: str,
+        tools: list[Any],
+        last_output: Any | None,
+        step: int,
+    ) -> tuple[str, dict[str, Any]] | None:
+        if not tools:
+            return None
+        # Prefer a submit/answer-style tool so the episode can terminate.
+        for tool in tools:
+            name = self._tool_name(tool)
+            if any(h in name.lower() for h in self._SUBMIT_HINTS):
+                return name, self._build_input(tool)
+        # Otherwise walk tools in order, one per step, then stop.
+        if step < len(tools):
+            tool = tools[step]
+            return self._tool_name(tool), self._build_input(tool)
+        return None
+
+
+class ModelPolicy:
+    """Seam for a real LLM-driven policy (PR3+).
+
+    Not implemented offline. A future change wires a BenchFlow agent / model
+    endpoint here: read ``prompt_text`` + ``tools`` (already provider-formatted
+    via ``session.list_tools(format=...)``), ask the model for a tool call, and
+    map its response to ``(tool_name, input)``. Kept as an explicit class so the
+    driver's policy seam is visible and the scripted path stays the only thing
+    shipped in PR2.
+    """
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+
+    def act(
+        self,
+        prompt_text: str,
+        tools: list[Any],
+        last_output: Any | None,
+        step: int,
+    ) -> tuple[str, dict[str, Any]] | None:
+        raise NotImplementedError(
+            "ModelPolicy is a seam for a real LLM agent and is not wired yet "
+            "(PR3+). Use ScriptedPolicy for offline runs."
+        )
+
+
+def _prompt_to_text(prompt: Any) -> str:
+    """Render an openreward prompt (list of TextBlock/ImageBlock) to text.
+
+    Best-effort: blocks expose ``.text`` (TextBlock) or are dict-shaped; images
+    and unknown blocks are summarised, never raised on.
+    """
+    if isinstance(prompt, str):
+        return prompt
+    if not isinstance(prompt, list):
+        return str(prompt)
+    parts: list[str] = []
+    for block in prompt:
+        text = getattr(block, "text", None)
+        if text is None and isinstance(block, dict):
+            text = block.get("text")
+        if isinstance(text, str) and text:
+            parts.append(text)
+        elif getattr(block, "type", None) == "image" or (
+            isinstance(block, dict) and block.get("type") == "image"
+        ):
+            parts.append("[image]")
+    return "\n".join(parts)
+
+
+def _tool_output_to_text(output: Any) -> str:
+    """Render a ToolOutput's blocks to a single text string (best-effort)."""
+    blocks = getattr(output, "blocks", None)
+    if blocks is None and isinstance(output, dict):
+        blocks = output.get("blocks")
+    if not isinstance(blocks, list):
+        return ""
+    return _prompt_to_text(blocks)
+
+
+def _read_attr(obj: Any, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def run_hosted_env_openreward(
+    config: HostedEnvRunConfig,
+    *,
+    policy: Policy | None = None,
+    split: str = "train",
+    index: int = 0,
+    session_factory: Any | None = None,
+    max_steps: int = _DEFAULT_MAX_STEPS,
+) -> HostedEnvRunResult:
+    """Run a single OpenReward environment task and write BenchFlow artifacts.
+
+    Drives the openreward session loop with *policy* (defaults to
+    :class:`ScriptedPolicy`), terminating when a ``ToolOutput`` reports
+    ``finished`` (or the step budget is hit). The final ``ToolOutput.reward``
+    is lifted to a canonical ``VerifyResult`` and the full rollout artifact
+    contract is written to ``run_dir``.
+
+    ``session_factory`` is the offline/test seam: when supplied it is called as
+    ``session_factory(config, split, index) -> context-manager yielding a
+    session`` instead of opening a real ``OpenReward`` client. Production leaves
+    it ``None`` and opens the client via :func:`_open_openreward_session`.
+
+    Namespace/owner is REQUIRED for openreward (a bare name 400s on the
+    platform) — raises :class:`HostedEnvError` before any session is opened.
+    """
+    ref = config.source_env
+    if ref.provider != "openreward":
+        raise HostedEnvError(
+            f"run_hosted_env_openreward called with provider {ref.provider!r}; "
+            "expected 'openreward'"
+        )
+    if ref.owner is None:
+        raise HostedEnvError(
+            "OpenReward requires an explicit owner/namespace "
+            "(e.g. openreward:GeneralReasoning/KellyBench). A bare environment "
+            "name is rejected by the platform."
+        )
+
+    policy = policy or ScriptedPolicy()
+    run_dir = _make_run_dir(config)
+    normalized_model = normalize_verifiers_model(config.model) if config.model else ""
+
+    started_at = datetime.now(UTC)
+    trajectory: list[dict[str, Any]] = []
+    prompts: list[str] = []
+    final_reward: float | None = None
+    n_tool_calls = 0
+    error: str | None = None
+
+    factory = session_factory or _open_openreward_session
+    try:
+        with factory(config, split, index) as session:
+            prompt = session.get_prompt()
+            prompt_text = _prompt_to_text(prompt)
+            if prompt_text:
+                prompts.append(prompt_text)
+                trajectory.append(
+                    {
+                        "type": "user_message",
+                        "ts": started_at.isoformat(),
+                        "content": prompt_text,
+                    }
+                )
+            tools = list(session.list_tools())
+
+            last_output: Any | None = None
+            for step in range(max_steps):
+                action = policy.act(prompt_text, tools, last_output, step)
+                if action is None:
+                    break
+                tool_name, tool_input = action
+                output = session.call_tool(tool_name, tool_input)
+                n_tool_calls += 1
+                last_output = output
+
+                ts = datetime.now(UTC).isoformat()
+                trajectory.append(
+                    {
+                        "type": "tool_call",
+                        "ts": ts,
+                        "title": tool_name,
+                        "kind": tool_name,
+                        "content": [{"type": "text", "text": json.dumps(tool_input)}],
+                    }
+                )
+                out_text = _tool_output_to_text(output)
+                if out_text:
+                    trajectory.append(
+                        {"type": "agent_message", "ts": ts, "content": out_text}
+                    )
+
+                reward = _read_attr(output, "reward")
+                if isinstance(reward, (int, float)) and not isinstance(reward, bool):
+                    final_reward = float(reward)
+                if _read_attr(output, "finished", False):
+                    break
+            else:
+                error = (
+                    f"environment did not report finished within {max_steps} steps"
+                )
+    except HostedEnvError:
+        raise
+    except Exception as e:  # surface any driver/client failure as run error
+        error = f"{type(e).__name__}: {e}"
+        logger.warning("openreward run failed: %s", error)
+
+    finished_at = datetime.now(UTC)
+
+    result = HostedEnvRunResult(
+        source_env=ref,
+        run_dir=run_dir,
+        command=["openreward", ref.env_id, f"split={split}", f"index={index}"],
+        returncode=0 if error is None else 1,
+        stdout="",
+        stderr=error or "",
+        model=config.model,
+        normalized_model=normalized_model,
+        reward=final_reward,
+        total_tool_calls=n_tool_calls,
+        verifiers_error=error,
+    )
+
+    _write_openreward_artifacts(
+        result,
+        config,
+        trajectory=trajectory,
+        prompts=prompts,
+        started_at=started_at,
+        finished_at=finished_at,
+        split=split,
+        index=index,
+        error=error,
+    )
+    return result
+
+
+def _make_run_dir(config: HostedEnvRunConfig) -> Path:
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d__%H-%M-%S-%f")
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", config.source_env.env_id)
+    jobs_dir = config.jobs_dir.expanduser().resolve()
+    run_id = f"{timestamp}__pid-{os.getpid()}__{uuid4().hex[:8]}"
+    run_dir = jobs_dir / "hosted-env" / f"{safe_name}__{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+    return run_dir
+
+
+def _open_openreward_session(
+    config: HostedEnvRunConfig,
+    split: str,
+    index: int,
+) -> Any:
+    """Open a real OpenReward session (production path; not used in tests).
+
+    Returns a context manager that yields a live session. The ``OpenReward``
+    client is created here and closed in the wrapper's ``__exit__`` (try/finally
+    via ``close()``), so the event-loop thread the sync client spins up is torn
+    down even on error.
+    """
+    return _OpenRewardSessionCtx(config, split, index)
+
+
+class _OpenRewardSessionCtx:
+    """Context manager: open client → get env → get task → open session.
+
+    Owns the ``OpenReward`` client lifecycle (``close()`` in ``__exit__``).
+    """
+
+    def __init__(self, config: HostedEnvRunConfig, split: str, index: int) -> None:
+        self._config = config
+        self._split = split
+        self._index = index
+        self._client: Any = None
+        self._session_cm: Any = None
+
+    def __enter__(self) -> Any:
+        import openreward
+
+        api_key = next(
+            (os.environ[k] for k in OPENREWARD_API_KEY_ENV_VARS if os.environ.get(k)),
+            None,
+        )
+        if not api_key:
+            raise HostedEnvError(
+                "OPENREWARD_API_KEY is required to run an openreward environment"
+            )
+        self._client = openreward.OpenReward(api_key=api_key)
+        try:
+            env = self._client.environments.get(self._config.source_env.env_id)
+            task = env.get_task(self._split, self._index)
+            self._session_cm = env.session(task=task)
+            return self._session_cm.__enter__()
+        except Exception:
+            self._close_client()
+            raise
+
+    def __exit__(self, *exc: Any) -> None:
+        try:
+            if self._session_cm is not None:
+                self._session_cm.__exit__(*exc)
+        finally:
+            self._close_client()
+
+    def _close_client(self) -> None:
+        client = self._client
+        self._client = None
+        if client is not None:
+            close = getattr(client, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception:  # best-effort teardown
+                    logger.debug("openreward client close() failed", exc_info=True)
+
+
+def _write_openreward_artifacts(
+    result: HostedEnvRunResult,
+    config: HostedEnvRunConfig,
+    *,
+    trajectory: list[dict[str, Any]],
+    prompts: list[str],
+    started_at: datetime,
+    finished_at: datetime,
+    split: str,
+    index: int,
+    error: str | None,
+) -> None:
+    """Write the BenchFlow rollout artifact contract for an openreward run.
+
+    Mirrors :func:`benchflow.hosted_env._write_run_artifacts` (legacy
+    ``result.json`` / ``rewards.jsonl`` / ``config.json`` / ``timing.json`` /
+    ``prompts.json`` / ``trajectory/acp_trajectory.jsonl``) and adds the
+    canonical Reward-plane artifacts (``verifier/verify_result.json``,
+    ``trainer/verifiers.jsonl``) by reusing the shared writers. Lineage is
+    stamped ``trajectory_source="openreward"``.
+    """
+    from benchflow.rewards.node import verify_result_from_reward_map
+
+    run_dir = result.run_dir
+    for sub in ("trajectory", "agent", "verifier", "artifacts"):
+        (run_dir / sub).mkdir(parents=True, exist_ok=True)
+
+    rewards = {"reward": float(result.reward)} if result.reward is not None else None
+    verify_result = verify_result_from_reward_map(rewards, error=error)
+
+    # trajectory/acp_trajectory.jsonl
+    (run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
+        "\n".join(json.dumps(e, default=str) for e in trajectory)
+        + ("\n" if trajectory else "")
+    )
+
+    if not prompts:
+        prompts = [f"<openreward:{result.source_env.env_uid} split={split} index={index}>"]
+
+    timing = {"total": round((finished_at - started_at).total_seconds(), 1)}
+    source_provenance = _hosted_source_provenance(
+        result.source_env,
+        runner="openreward",
+        env_args=config.env_args,
+    )
+    source_provenance["split"] = split
+    source_provenance["index"] = index
+
+    result_payload: dict[str, Any] = {
+        "task_name": result.source_env.env_uid,
+        "rollout_name": run_dir.name,
+        "rewards": rewards,
+        "agent": config.agent or None,
+        "agent_name": "openreward",
+        "model": result.normalized_model or result.model or None,
+        "n_tool_calls": result.total_tool_calls or 0,
+        "n_prompts": len(prompts),
+        "agent_result": {
+            "n_tool_calls": result.total_tool_calls or 0,
+            "n_prompts": len(prompts),
+            "n_input_tokens": None,
+            "n_output_tokens": None,
+            "n_cache_read_tokens": None,
+            "n_cache_creation_tokens": None,
+            "total_tokens": None,
+            "cost_usd": None,
+            "usage_source": "unavailable",
+            "price_source": None,
+        },
+        "error": result.error,
+        "error_category": None,
+        "verifier_error": None,
+        "verifier_error_category": None,
+        **RolloutDiagnostics().to_result_fields(),
+        "partial_trajectory": False,
+        "trajectory_source": "openreward" if trajectory else None,
+        "started_at": str(started_at),
+        "finished_at": str(finished_at),
+        "timing": timing,
+        "scenes": [],
+        "source": source_provenance,
+    }
+    (run_dir / "result.json").write_text(json.dumps(result_payload, indent=2))
+    (run_dir / "timing.json").write_text(json.dumps(timing, indent=2))
+    (run_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
+
+    config_payload: dict[str, Any] = {
+        "task_path": None,
+        "agent": config.agent or None,
+        "model": result.normalized_model or result.model or None,
+        "environment": "openreward",
+        "skills_dir": None,
+        "sandbox_user": None,
+        "sandbox_locked_paths": None,
+        "sandbox_setup_timeout": None,
+        "context_root": None,
+        "timeout_sec": None,
+        "concurrency": config.concurrency,
+        "agent_idle_timeout_sec": None,
+        "started_at": str(started_at),
+        "agent_env": {},
+        "scenes": [],
+        "source": source_provenance,
+        "hosted_env": {
+            "provider": result.source_env.provider,
+            "env_uid": result.source_env.env_uid,
+            "runner": "openreward",
+            "split": split,
+            "index": index,
+            "num_examples": config.num_examples,
+            "rollouts_per_example": config.rollouts_per_example,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "sampling_args": config.sampling_args,
+            "env_args": config.env_args,
+        },
+    }
+    (run_dir / "config.json").write_text(json.dumps(config_payload, indent=2))
+
+    if rewards:
+        _write_hosted_rewards_jsonl(run_dir, rewards, finished_at)
+
+    # Canonical Reward-plane artifacts — reuse the shared writers so the schema
+    # never drifts from native rollouts.
+    _write_verify_result_json(run_dir, verify_result)
+    _write_verifiers_jsonl(
+        run_dir,
+        task_id=result.source_env.env_uid,
+        prompts=prompts,
+        trajectory=trajectory,
+        verify_result=verify_result,
+        model=result.normalized_model or result.model or None,
+        is_completed=error is None,
+    )
+
+
+def _write_verify_result_json(
+    run_dir: Path, verify_result: VerifyResult | None
+) -> None:
+    """Persist the canonical VerifyResult to ``verifier/verify_result.json``.
+
+    Mirrors ``benchflow.rollout._write_verify_result_json`` (serialize the
+    dataclass via ``asdict``) without importing it — ``benchflow.rollout``
+    pulls heavy ACP/sandbox deps at import time, which this lightweight driver
+    must not drag in.
+    """
+    if verify_result is None:
+        return
+    out = run_dir / "verifier" / "verify_result.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(asdict(verify_result), indent=2, default=str))
+
+
+def _write_verifiers_jsonl(
+    run_dir: Path,
+    *,
+    task_id: str,
+    prompts: list[str],
+    trajectory: list[dict[str, Any]],
+    verify_result: VerifyResult,
+    model: str | None,
+    is_completed: bool,
+) -> None:
+    """Emit ``trainer/verifiers.jsonl`` via the shared trainer-export writer."""
+    from benchflow.trajectories.export import write_rollout_verifiers_jsonl
+
+    write_rollout_verifiers_jsonl(
+        run_dir,
+        task_id=task_id,
+        prompts=prompts,
+        trajectory=trajectory,
+        verify_result=verify_result,
+        model=model,
+        environment="openreward",
+        is_completed=is_completed,
+    )

--- a/src/benchflow/openreward_env.py
+++ b/src/benchflow/openreward_env.py
@@ -42,19 +42,19 @@ import json
 import logging
 import os
 import re
-from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 from uuid import uuid4
 
-from benchflow.diagnostics import RolloutDiagnostics
 from benchflow.hosted_env import (
     HostedEnvError,
     HostedEnvRunConfig,
     HostedEnvRunResult,
     _hosted_source_provenance,
     _write_hosted_rewards_jsonl,
+    build_hosted_config_payload,
+    build_hosted_result_payload,
     normalize_verifiers_model,
 )
 
@@ -433,6 +433,39 @@ class _OpenRewardSessionCtx:
                     logger.debug("openreward client close() failed", exc_info=True)
 
 
+def _build_verify_result(
+    rewards: dict[str, Any] | None, *, error: str | None
+) -> VerifyResult:
+    """Lift the run outcome to a canonical ``VerifyResult``.
+
+    Defers to the single dict→``VerifyResult`` conversion point
+    (:func:`benchflow.rewards.node.verify_result_from_reward_map`) for the
+    scored case and the genuine-failure case (a ``None`` map *with* an ``error``
+    is a crash — that function stamps the error and yields ``reward=0.0``).
+
+    The one case it handles directly is a **clean finish that produced no
+    reward**: ``rewards`` is ``None`` but ``error`` is ``None`` too. Routing that
+    through ``verify_result_from_reward_map`` would default ``error`` to the
+    sentinel ``"no rewards"``, conflating "unscored" with "verifier crashed"
+    (``result.json.error`` is ``None`` yet ``verify_result.json.error`` would be
+    truthy). Instead we emit an explicit unscored result — ``reward=0.0`` with
+    **no** error — so the two states stay distinguishable downstream.
+    """
+    from benchflow.rewards.node import verify_result_from_reward_map
+    from benchflow.rewards.protocol import VerifyResult
+
+    if rewards is None and error is None:
+        return VerifyResult(
+            reward=0.0,
+            items={},
+            events=[],
+            error=None,
+            space="output",
+            granularity="terminal",
+        )
+    return verify_result_from_reward_map(rewards, error=error)
+
+
 def _write_openreward_artifacts(
     result: HostedEnvRunResult,
     config: HostedEnvRunConfig,
@@ -454,14 +487,12 @@ def _write_openreward_artifacts(
     ``trainer/verifiers.jsonl``) by reusing the shared writers. Lineage is
     stamped ``trajectory_source="openreward"``.
     """
-    from benchflow.rewards.node import verify_result_from_reward_map
-
     run_dir = result.run_dir
     for sub in ("trajectory", "agent", "verifier", "artifacts"):
         (run_dir / sub).mkdir(parents=True, exist_ok=True)
 
     rewards = {"reward": float(result.reward)} if result.reward is not None else None
-    verify_result = verify_result_from_reward_map(rewards, error=error)
+    verify_result = _build_verify_result(rewards, error=error)
 
     # trajectory/acp_trajectory.jsonl
     (run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
@@ -481,75 +512,37 @@ def _write_openreward_artifacts(
     source_provenance["split"] = split
     source_provenance["index"] = index
 
-    result_payload: dict[str, Any] = {
-        "task_name": result.source_env.env_uid,
-        "rollout_name": run_dir.name,
-        "rewards": rewards,
-        "agent": config.agent or None,
-        "agent_name": "openreward",
-        "model": result.normalized_model or result.model or None,
-        "n_tool_calls": result.total_tool_calls or 0,
-        "n_prompts": len(prompts),
-        "agent_result": {
-            "n_tool_calls": result.total_tool_calls or 0,
-            "n_prompts": len(prompts),
-            "n_input_tokens": None,
-            "n_output_tokens": None,
-            "n_cache_read_tokens": None,
-            "n_cache_creation_tokens": None,
-            "total_tokens": None,
-            "cost_usd": None,
-            "usage_source": "unavailable",
-            "price_source": None,
-        },
-        "error": result.error,
-        "error_category": None,
-        "verifier_error": None,
-        "verifier_error_category": None,
-        **RolloutDiagnostics().to_result_fields(),
-        "partial_trajectory": False,
-        "trajectory_source": "openreward" if trajectory else None,
-        "started_at": str(started_at),
-        "finished_at": str(finished_at),
-        "timing": timing,
-        "scenes": [],
-        "source": source_provenance,
-    }
+    result_payload = build_hosted_result_payload(
+        result,
+        config,
+        rewards=rewards,
+        prompts=prompts,
+        timing=timing,
+        source_provenance=source_provenance,
+        started_at=started_at,
+        finished_at=finished_at,
+        agent_name="openreward",
+        trajectory_source="openreward",
+        has_trajectory=bool(trajectory),
+        # The driver already collapses any failure into ``result.error`` (see
+        # the loop's ``verifiers_error`` plumbing); there is no separate
+        # verifier-error channel, so this stays ``None``.
+        error=result.error,
+        verifier_error=None,
+    )
     (run_dir / "result.json").write_text(json.dumps(result_payload, indent=2))
     (run_dir / "timing.json").write_text(json.dumps(timing, indent=2))
     (run_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
 
-    config_payload: dict[str, Any] = {
-        "task_path": None,
-        "agent": config.agent or None,
-        "model": result.normalized_model or result.model or None,
-        "environment": "openreward",
-        "skills_dir": None,
-        "sandbox_user": None,
-        "sandbox_locked_paths": None,
-        "sandbox_setup_timeout": None,
-        "context_root": None,
-        "timeout_sec": None,
-        "concurrency": config.concurrency,
-        "agent_idle_timeout_sec": None,
-        "started_at": str(started_at),
-        "agent_env": {},
-        "scenes": [],
-        "source": source_provenance,
-        "hosted_env": {
-            "provider": result.source_env.provider,
-            "env_uid": result.source_env.env_uid,
-            "runner": "openreward",
-            "split": split,
-            "index": index,
-            "num_examples": config.num_examples,
-            "rollouts_per_example": config.rollouts_per_example,
-            "max_tokens": config.max_tokens,
-            "temperature": config.temperature,
-            "sampling_args": config.sampling_args,
-            "env_args": config.env_args,
-        },
-    }
+    config_payload = build_hosted_config_payload(
+        result,
+        config,
+        source_provenance=source_provenance,
+        started_at=started_at,
+        environment="openreward",
+        runner="openreward",
+        extra_hosted_env={"split": split, "index": index},
+    )
     (run_dir / "config.json").write_text(json.dumps(config_payload, indent=2))
 
     if rewards:
@@ -557,7 +550,9 @@ def _write_openreward_artifacts(
 
     # Canonical Reward-plane artifacts — reuse the shared writers so the schema
     # never drifts from native rollouts.
-    _write_verify_result_json(run_dir, verify_result)
+    from benchflow.trajectories.export import write_verify_result_json
+
+    write_verify_result_json(run_dir, verify_result)
     _write_verifiers_jsonl(
         run_dir,
         task_id=result.source_env.env_uid,
@@ -567,23 +562,6 @@ def _write_openreward_artifacts(
         model=result.normalized_model or result.model or None,
         is_completed=error is None,
     )
-
-
-def _write_verify_result_json(
-    run_dir: Path, verify_result: VerifyResult | None
-) -> None:
-    """Persist the canonical VerifyResult to ``verifier/verify_result.json``.
-
-    Mirrors ``benchflow.rollout._write_verify_result_json`` (serialize the
-    dataclass via ``asdict``) without importing it — ``benchflow.rollout``
-    pulls heavy ACP/sandbox deps at import time, which this lightweight driver
-    must not drag in.
-    """
-    if verify_result is None:
-        return
-    out = run_dir / "verifier" / "verify_result.json"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(asdict(verify_result), indent=2, default=str))
 
 
 def _write_verifiers_jsonl(

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -44,7 +44,7 @@ import logging
 import os
 import shlex
 import tempfile
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -106,6 +106,7 @@ from benchflow.trajectories._capture import (
     _capture_session_trajectory,
     _scrape_agent_trajectory,
 )
+from benchflow.trajectories.export import write_verify_result_json
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
 
 logger = logging.getLogger(__name__)
@@ -260,29 +261,6 @@ async def _ensure_sandbox_dir(
 
 
 _DIAG_TRUNCATE = 2000
-
-
-def _write_verify_result_json(
-    rollout_dir: Path, verify_result: VerifyResult | None
-) -> None:
-    """Persist the canonical ``VerifyResult`` to ``verifier/verify_result.json``.
-
-    The Reward-plane source of truth (#v0.5 Phase 1): unlike ``result.json``
-    (which keeps the legacy reward *dict* for the ~10 existing consumers), this
-    file is the canonical ``{reward, items, events, error, space, granularity}``
-    structure — carrying the architecture's ``(space, granularity)`` tag and the
-    full event list — that the trainer export reads and branch aggregation will
-    read. Skipped when no result was produced (nothing scored).
-    """
-    if verify_result is None:
-        return
-    # Serialize via the dataclass itself — no hand-rolled second event schema to
-    # drift from VerifyResult/RewardEvent (the ORS ``timestamp`` rename is for
-    # the trainer wire format only; this internal artifact uses the dataclass'
-    # own ``ts``, matching rewards.jsonl).
-    out = rollout_dir / "verifier" / "verify_result.json"
-    out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(json.dumps(asdict(verify_result), indent=2, default=str))
 
 
 def _write_rewards_jsonl(
@@ -608,7 +586,7 @@ def _build_rollout_result(
     )
     (rollout_dir / "timing.json").write_text(json.dumps(timing, indent=2))
     (rollout_dir / "prompts.json").write_text(json.dumps(prompts, indent=2))
-    _write_verify_result_json(rollout_dir, verify_result)
+    write_verify_result_json(rollout_dir, verify_result)
     # rewards.jsonl stays dict-derived: it reads (space, granularity) from the
     # same validated reward map the VerifyResult is built from, so its lines are
     # identical to sourcing verify_result.events — and verify_result.json is the

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +40,35 @@ logger = logging.getLogger(__name__)
 # Canonical artifact locations (see issue #385).
 ROLLOUT_ARTIFACT_RELPATH = "trainer/verifiers.jsonl"
 JOB_ARTIFACT_FILENAME = "verifiers.jsonl"
+
+
+def write_verify_result_json(
+    rollout_dir: Path, verify_result: VerifyResult | None
+) -> None:
+    """Persist the canonical ``VerifyResult`` to ``verifier/verify_result.json``.
+
+    The Reward-plane source of truth (#v0.5 Phase 1): unlike ``result.json``
+    (which keeps the legacy reward *dict* for the ~10 existing consumers), this
+    file is the canonical ``{reward, items, events, error, space, granularity}``
+    structure — carrying the architecture's ``(space, granularity)`` tag and the
+    full event list — that the trainer export reads and branch aggregation will
+    read. Skipped when no result was produced (nothing scored).
+
+    Canonical owner: ``benchflow.rollout`` and ``benchflow.openreward_env`` both
+    import this. It lives here (rather than in ``rollout``) so the lightweight
+    openreward driver can reuse it without dragging in ``rollout``'s heavy
+    ACP/sandbox import graph.
+
+    Serialize via the dataclass itself — no hand-rolled second event schema to
+    drift from ``VerifyResult``/``RewardEvent`` (the ORS ``timestamp`` rename is
+    for the trainer wire format only; this internal artifact uses the dataclass'
+    own ``ts``, matching ``rewards.jsonl``).
+    """
+    if verify_result is None:
+        return
+    out = rollout_dir / "verifier" / "verify_result.json"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(asdict(verify_result), indent=2, default=str))
 
 
 def _split_prompt_completion(

--- a/tests/test_hosted_env.py
+++ b/tests/test_hosted_env.py
@@ -298,11 +298,34 @@ def test_hosted_env_ref_rejects_unknown_provider():
         raise AssertionError("expected HostedEnvError")
 
 
+def test_hosted_env_ref_rejects_provider_slash_form():
+    """The provider mis-route guard lives in ``HostedEnvRef.parse`` so it covers
+    every call site (env create/show/inspect + SDK), not just ``eval create``.
+    'openreward/x' (no provider: prefix) would parse 'openreward' as the owner
+    and fall back to primeintellect; parse rejects it with the explicit-form
+    hint instead."""
+    try:
+        HostedEnvRef.parse("openreward/KellyBench")
+    except HostedEnvError as exc:
+        assert "openreward:owner/name" in str(exc)
+        assert "provider, not an owner" in str(exc)
+    else:
+        raise AssertionError("expected HostedEnvError")
+
+
+def test_hosted_env_ref_allows_primeintellect_owner_slash_form():
+    """The default-provider owner form (primeintellect/owner/name) is legitimate
+    and must NOT trip the guard — only non-default known providers do."""
+    ref = HostedEnvRef.parse("primeintellect/some-owner/general-agent")
+    assert ref.provider == "primeintellect"
+    assert ref.owner == "primeintellect"
+    assert ref.name == "some-owner/general-agent"
+
+
 def test_eval_create_rejects_openreward_slash_form(tmp_path, monkeypatch):
-    """PR2 routing guard: 'openreward/x' (no provider: prefix) would parse
-    'openreward' as the owner and mis-route to primeintellect. The CLI now
-    catches this at dispatch and points at the explicit 'openreward:owner/name'
-    form instead of silently running the wrong provider."""
+    """End-to-end: the parse-level routing guard surfaces through ``eval create``
+    — 'openreward/x' (no provider: prefix) exits non-zero with the explicit
+    'openreward:owner/name' hint instead of silently running primeintellect."""
 
     def fail_if_called(config):  # pragma: no cover - must not run
         raise AssertionError("run_hosted_env should not be called for slash form")

--- a/tests/test_hosted_env.py
+++ b/tests/test_hosted_env.py
@@ -296,3 +296,75 @@ def test_hosted_env_ref_rejects_unknown_provider():
         assert "openreward" in str(exc)  # supported set is surfaced
     else:
         raise AssertionError("expected HostedEnvError")
+
+
+def test_eval_create_rejects_openreward_slash_form(tmp_path, monkeypatch):
+    """PR2 routing guard: 'openreward/x' (no provider: prefix) would parse
+    'openreward' as the owner and mis-route to primeintellect. The CLI now
+    catches this at dispatch and points at the explicit 'openreward:owner/name'
+    form instead of silently running the wrong provider."""
+
+    def fail_if_called(config):  # pragma: no cover - must not run
+        raise AssertionError("run_hosted_env should not be called for slash form")
+
+    monkeypatch.setattr("benchflow.hosted_env.run_hosted_env", fail_if_called)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--source-env",
+            "openreward/KellyBench",
+            "--model",
+            "claude-haiku-4-5",
+            "--jobs-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "openreward:owner/name" in result.output
+
+
+def test_eval_create_openreward_colon_form_routes_to_runner(tmp_path, monkeypatch):
+    """The explicit 'openreward:owner/name' form routes to run_hosted_env with
+    the openreward provider preserved (it then dispatches to the openreward
+    driver internally)."""
+    seen: dict[str, object] = {}
+
+    def fake_run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
+        seen["config"] = config
+        return HostedEnvRunResult(
+            source_env=config.source_env,
+            run_dir=tmp_path / "run",
+            command=["openreward"],
+            returncode=0,
+            stdout="",
+            stderr="",
+            model=config.model,
+            normalized_model=normalize_verifiers_model(config.model),
+            reward=1.0,
+            total_tool_calls=1,
+        )
+
+    monkeypatch.setattr("benchflow.hosted_env.run_hosted_env", fake_run_hosted_env)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--source-env",
+            "openreward:GeneralReasoning/KellyBench",
+            "--model",
+            "claude-haiku-4-5",
+            "--jobs-dir",
+            str(tmp_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    config = seen["config"]
+    assert isinstance(config, HostedEnvRunConfig)
+    assert config.source_env.provider == "openreward"
+    assert config.source_env.owner == "GeneralReasoning"
+    assert config.source_env.name == "KellyBench"

--- a/tests/test_openreward_env.py
+++ b/tests/test_openreward_env.py
@@ -254,8 +254,11 @@ def test_max_steps_error_when_policy_keeps_acting(tmp_path):
 
 
 def test_no_reward_yields_reward_none_and_valid_artifacts(tmp_path):
-    # Env finishes but reports no reward -> result.reward None, verify_result
-    # falls back to reward 0.0 with an error (the "nobody scored" path).
+    # Env finishes cleanly but reports no reward ("unscored"): result.reward is
+    # None, and the VerifyResult is reward 0.0 with NO error. A clean,
+    # unscored finish must not be conflated with a verifier crash — both
+    # result.json.error and verify_result.json.error stay None so downstream
+    # readers can tell "nobody scored" apart from "the verifier blew up".
     session = FakeSession(
         tools=[FakeToolSpec(name="submit")],
         outputs=[FakeToolOutput(blocks=[FakeBlock("ok")], reward=None, finished=True)],
@@ -269,10 +272,11 @@ def test_no_reward_yields_reward_none_and_valid_artifacts(tmp_path):
     rd = result.run_dir
     result_json = json.loads((rd / "result.json").read_text())
     assert result_json["rewards"] is None
-    # verify_result still written, reward 0.0 + error populated.
+    assert result_json["error"] is None
+    # verify_result still written, reward 0.0, and NO phantom error.
     verify_result = json.loads((rd / "verifier" / "verify_result.json").read_text())
     assert verify_result["reward"] == 0.0
-    assert verify_result["error"]
+    assert verify_result["error"] is None
 
 
 def test_prompt_to_text_handles_blocks_and_images():

--- a/tests/test_openreward_env.py
+++ b/tests/test_openreward_env.py
@@ -1,0 +1,281 @@
+"""Offline driver tests for the OpenReward / ORS Track-2 runner.
+
+These exercise ``benchflow.openreward_env.run_hosted_env_openreward`` with a
+**fake session** that records ``call_tool`` and returns scripted
+``ToolOutput``-shaped objects — no network, no platform, no paid rollout. They
+run in the default suite (no marker): the real KellyBench live test is the
+separate, ``openreward``-marked PR3 gate.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.hosted_env import HostedEnvError, HostedEnvRef, HostedEnvRunConfig
+from benchflow.openreward_env import (
+    ScriptedPolicy,
+    _prompt_to_text,
+    run_hosted_env_openreward,
+)
+
+
+@dataclass
+class FakeBlock:
+    text: str
+    type: str = "text"
+
+
+@dataclass
+class FakeToolSpec:
+    name: str
+    description: str = ""
+    input_schema: dict | None = None
+
+
+@dataclass
+class FakeToolOutput:
+    blocks: list = field(default_factory=list)
+    reward: float | None = None
+    finished: bool = False
+    metadata: dict | None = None
+
+
+class FakeSession:
+    """Records call_tool and returns a scripted sequence of ToolOutputs.
+
+    ``outputs`` is consumed one per ``call_tool``; the last one repeats if the
+    loop calls more times than scripted.
+    """
+
+    def __init__(
+        self,
+        *,
+        tools: list[FakeToolSpec],
+        outputs: list[FakeToolOutput],
+        prompt: str = "Solve the task.",
+    ) -> None:
+        self._tools = tools
+        self._outputs = outputs
+        self._prompt = prompt
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def get_prompt(self) -> list[FakeBlock]:
+        return [FakeBlock(text=self._prompt)]
+
+    def list_tools(self, format: Any = None) -> list[FakeToolSpec]:
+        return list(self._tools)
+
+    def call_tool(
+        self, tool_name: str, input: dict[str, Any] | None = None
+    ) -> FakeToolOutput:
+        self.calls.append((tool_name, dict(input or {})))
+        idx = min(len(self.calls) - 1, len(self._outputs) - 1)
+        return self._outputs[idx]
+
+
+def _factory(session: FakeSession):
+    @contextmanager
+    def factory(config, split, index):
+        yield session
+
+    return factory
+
+
+def _config(tmp_path: Path) -> HostedEnvRunConfig:
+    return HostedEnvRunConfig(
+        source_env=HostedEnvRef.parse("openreward:GeneralReasoning/KellyBench"),
+        model="claude-haiku-4-5",
+        jobs_dir=tmp_path,
+    )
+
+
+def test_loop_drives_to_finished_and_maps_reward(tmp_path):
+    session = FakeSession(
+        tools=[FakeToolSpec(name="think"), FakeToolSpec(name="submit_answer")],
+        outputs=[FakeToolOutput(blocks=[FakeBlock("done")], reward=1.0, finished=True)],
+    )
+    result = run_hosted_env_openreward(
+        _config(tmp_path),
+        policy=ScriptedPolicy(answer="42"),
+        session_factory=_factory(session),
+    )
+
+    # The scripted policy preferred the submit/answer tool, populated `answer`,
+    # and the env reported finished on the first call -> reward maps through.
+    assert session.calls == [("submit_answer", {"answer": "42"})]
+    assert result.reward == 1.0
+    assert result.total_tool_calls == 1
+    assert result.error is None
+
+
+def test_loop_continues_until_finished(tmp_path):
+    # No submit-style tool -> scripted policy walks tools in order, one per
+    # step. The env only finishes on the second ToolOutput.
+    session = FakeSession(
+        tools=[FakeToolSpec(name="step_a"), FakeToolSpec(name="step_b")],
+        outputs=[
+            FakeToolOutput(blocks=[FakeBlock("partial")], reward=0.0, finished=False),
+            FakeToolOutput(blocks=[FakeBlock("done")], reward=0.5, finished=True),
+        ],
+    )
+    result = run_hosted_env_openreward(
+        _config(tmp_path),
+        policy=ScriptedPolicy(),
+        session_factory=_factory(session),
+    )
+    assert [c[0] for c in session.calls] == ["step_a", "step_b"]
+    assert result.reward == 0.5
+    assert result.total_tool_calls == 2
+    assert result.error is None
+
+
+def test_full_artifact_contract_written(tmp_path):
+    session = FakeSession(
+        tools=[FakeToolSpec(name="submit")],
+        outputs=[FakeToolOutput(blocks=[FakeBlock("ok")], reward=1.0, finished=True)],
+        prompt="What is the capital of France?",
+    )
+    result = run_hosted_env_openreward(
+        _config(tmp_path),
+        policy=ScriptedPolicy(answer="Paris"),
+        session_factory=_factory(session),
+    )
+    rd = result.run_dir
+
+    # result.json — legacy contract + openreward lineage stamp.
+    result_json = json.loads((rd / "result.json").read_text())
+    assert result_json["trajectory_source"] == "openreward"
+    assert result_json["rewards"] == {"reward": 1.0}
+    assert result_json["agent_name"] == "openreward"
+    assert result_json["source"]["provider"] == "openreward"
+    assert result_json["source"]["runner"] == "openreward"
+
+    # verifier/verify_result.json — canonical Reward-plane artifact.
+    verify_result = json.loads((rd / "verifier" / "verify_result.json").read_text())
+    assert verify_result["reward"] == 1.0
+    assert verify_result["space"] == "output"
+    assert verify_result["granularity"] == "terminal"
+    assert verify_result["error"] is None
+
+    # trainer/verifiers.jsonl — trainer seam, one record.
+    lines = (rd / "trainer" / "verifiers.jsonl").read_text().strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["reward"] == 1.0
+    assert record["info"]["environment"] == "openreward"
+    assert record["info"]["reward_valid"] is True
+
+    # Supporting contract files exist.
+    for rel in ("config.json", "timing.json", "prompts.json", "rewards.jsonl"):
+        assert (rd / rel).is_file(), rel
+    traj = (rd / "trajectory" / "acp_trajectory.jsonl").read_text().strip().splitlines()
+    # user prompt + tool_call + agent_message
+    types = [json.loads(line)["type"] for line in traj]
+    assert "user_message" in types
+    assert "tool_call" in types
+
+
+def test_missing_owner_raises_before_session(tmp_path):
+    # A bare openreward name (no owner) is rejected by the platform — the
+    # driver must raise before opening any session. We build the ref directly
+    # to bypass the parse layer.
+    ref = HostedEnvRef(provider="openreward", owner=None, name="KellyBench")
+    opened = {"called": False}
+
+    @contextmanager
+    def factory(config, split, index):
+        opened["called"] = True
+        yield FakeSession(tools=[], outputs=[])
+
+    config = HostedEnvRunConfig(source_env=ref, model="m", jobs_dir=tmp_path)
+    with pytest.raises(HostedEnvError, match="owner/namespace"):
+        run_hosted_env_openreward(config, session_factory=factory)
+    assert opened["called"] is False
+
+
+def test_wrong_provider_raises(tmp_path):
+    config = HostedEnvRunConfig(
+        source_env=HostedEnvRef.parse("primeintellect/general-agent", version="0.1.1"),
+        model="m",
+        jobs_dir=tmp_path,
+    )
+    with pytest.raises(HostedEnvError, match="expected 'openreward'"):
+        run_hosted_env_openreward(config)
+
+
+def test_scripted_policy_stops_cleanly_when_tools_exhausted(tmp_path):
+    # Env never reports finished, but the scripted policy walks each tool once
+    # and then returns None (nothing left to do). The loop ends cleanly with no
+    # error before the step budget is hit, and the last reward is surfaced.
+    session = FakeSession(
+        tools=[FakeToolSpec(name="loop_a"), FakeToolSpec(name="loop_b")],
+        outputs=[FakeToolOutput(blocks=[FakeBlock("x")], reward=0.0, finished=False)],
+    )
+    result = run_hosted_env_openreward(
+        _config(tmp_path),
+        policy=ScriptedPolicy(),
+        session_factory=_factory(session),
+        max_steps=10,
+    )
+    assert result.error is None
+    assert result.total_tool_calls == 2
+    assert result.reward == 0.0
+
+
+def test_max_steps_error_when_policy_keeps_acting(tmp_path):
+    # A policy that always acts + an env that never finishes -> step budget
+    # exhausted -> error recorded.
+    class AlwaysAct:
+        def act(self, prompt_text, tools, last_output, step):
+            return "loop", {}
+
+    session = FakeSession(
+        tools=[FakeToolSpec(name="loop")],
+        outputs=[FakeToolOutput(blocks=[FakeBlock("x")], reward=0.0, finished=False)],
+    )
+    result = run_hosted_env_openreward(
+        _config(tmp_path),
+        policy=AlwaysAct(),
+        session_factory=_factory(session),
+        max_steps=3,
+    )
+    assert result.total_tool_calls == 3
+    assert result.error is not None
+    assert "did not report finished" in result.error
+    # result.json carries the error and reward is the last observed value.
+    result_json = json.loads((result.run_dir / "result.json").read_text())
+    assert result_json["error"] is not None
+
+
+def test_no_reward_yields_reward_none_and_valid_artifacts(tmp_path):
+    # Env finishes but reports no reward -> result.reward None, verify_result
+    # falls back to reward 0.0 with an error (the "nobody scored" path).
+    session = FakeSession(
+        tools=[FakeToolSpec(name="submit")],
+        outputs=[FakeToolOutput(blocks=[FakeBlock("ok")], reward=None, finished=True)],
+    )
+    result = run_hosted_env_openreward(
+        _config(tmp_path),
+        policy=ScriptedPolicy(),
+        session_factory=_factory(session),
+    )
+    assert result.reward is None
+    rd = result.run_dir
+    result_json = json.loads((rd / "result.json").read_text())
+    assert result_json["rewards"] is None
+    # verify_result still written, reward 0.0 + error populated.
+    verify_result = json.loads((rd / "verifier" / "verify_result.json").read_text())
+    assert verify_result["reward"] == 0.0
+    assert verify_result["error"]
+
+
+def test_prompt_to_text_handles_blocks_and_images():
+    assert _prompt_to_text("plain") == "plain"
+    assert _prompt_to_text([FakeBlock("a"), FakeBlock("b")]) == "a\nb"
+    assert _prompt_to_text([{"type": "image", "data": "..."}]) == "[image]"


### PR DESCRIPTION
## What

PR2 of the 3-PR OpenReward plan. Adds the **OpenReward / ORS Track-2 driver** so `bench eval create --source-env openreward:<owner>/<env>` runs an OpenReward environment through the `openreward` Python client's session loop, parallel to the existing PrimeIntellect `vf-eval` path. (PR1 = provider recognition, already merged into `v0.5-integration`. PR3 = the live KellyBench gate, separate.)

- **`src/benchflow/openreward_env.py`** (new, ~530 lines): `run_hosted_env_openreward(config)` drives the session loop (`get_prompt` → `list_tools` → loop `call_tool` until `ToolOutput.finished`), with a schema-driven **`ScriptedPolicy`** (no LLM) and a clearly-marked **`ModelPolicy`** seam for a real agent later. Final reward (`ToolOutput.reward`) is lifted via `benchflow.rewards.node.verify_result_from_reward_map` (reused — no duplication of `adapters/ors.py`). The full BenchFlow artifact contract is reconstructed by reusing the existing `hosted_env` writers plus the canonical `verifier/verify_result.json` and `trainer/verifiers.jsonl` (via `write_rollout_verifiers_jsonl`); lineage stamped `trajectory_source="openreward"`. The `OpenReward` client is opened in a context manager and `close()`d in `finally`.
- **`src/benchflow/hosted_env.py`**: `run_hosted_env` branches `provider == "openreward"` → lazy-imports and calls the driver; the `vf-eval`/version requirements stay PrimeIntellect-only.
- **`src/benchflow/cli/main.py`**: routing guard for the slash form `openreward/x` (carried from the PR1 review). It would otherwise parse `openreward` as the *owner* and fall back to `primeintellect`; the CLI now raises a clear hint to use `openreward:owner/name`. The legitimate `primeintellect/owner/name` form is untouched.

## Why

OpenReward is a managed, session-based env platform; its drive shape (a `call_tool` loop that returns reward/finished on a `ToolOutput`) is fundamentally different from Prime's `vf-eval` subprocess. This wires the driver behind the same `HostedEnvRunResult` contract so dashboards/release checks treat openreward runs as first-class evidence.

## OpenReward API corrections confirmed (ground-truthed against the installed package)

- Drive surface is `openreward.api.environments.client` — `OpenReward(api_key=...).environments.get("<owner>/<name>")` → `env.get_task(split, index)` → `with env.session(task=task) as session:` → `session.get_prompt()` / `session.list_tools()` / loop `session.call_tool(name, input) -> ToolOutput`. Confirmed.
- Reward / termination live on **`ToolOutput`** (`reward: float|None`, `finished: bool`, `blocks`), **not** on a `RunResult`/`ToolResult`. Confirmed against `environments/types.py`.
- `client.rollout.create(...)` is **telemetry-only** — not the env-interaction handle. Not used.
- **Owner/namespace is required**: `EnvironmentsAPI.get` raises when a namespace is present without an api_key, and the deployment name is `namespace/name`. The driver raises a clear `HostedEnvError` if `owner is None` *before* opening any session.
- Sync wrappers `Environment` / `Session` exist and expose exactly the methods used; the client spins up a background event-loop thread, so the driver calls `close()` in teardown.

## Offline-test coverage (default suite, no marker, no network, no paid rollout)

`tests/test_openreward_env.py` drives the loop with a **fake session** (records `call_tool`, returns scripted `ToolOutput`):
- loop drives to `finished`; reward maps into a `VerifyResult`;
- multi-step loop continues until `finished`;
- full artifact contract written — `result.json` with `trajectory_source=openreward`, `verifier/verify_result.json` with reward/space/granularity, `trainer/verifiers.jsonl`, plus `config.json`/`timing.json`/`prompts.json`/`rewards.jsonl`/`acp_trajectory.jsonl`;
- missing-owner raises before any session opens; wrong-provider raises;
- step-budget exhaustion records an error; no-reward path yields `reward=None` with a valid (error-populated) `verify_result`.

`tests/test_hosted_env.py`: CLI slash-form `openreward/x` is rejected with the hint; explicit `openreward:owner/name` routes with provider preserved.

Gates: `ruff check .`, `ty check src/`, and `pytest tests/` all green (2397 passed, 48 skipped).

## Could NOT verify offline

- **The real session-loop shape against the live platform** — all tests use a fake session. The block/prompt/tool-output rendering and the exact `call_tool` input schema a real env expects are best-effort and only fully exercised by the **PR3 live KellyBench gate**.
- `_open_openreward_session` (the production client path) is not exercised by tests; its client lifecycle/teardown is structured but unverified end-to-end.
- The openreward env-page `hub_url` shape is still a TODO(PR3) display-only string.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New external-provider execution path (API keys, live client lifecycle) and shared artifact schema—mitigated by parse-time guards and extensive offline fake-session tests; production OpenReward path is not end-to-end tested here.
> 
> **Overview**
> Adds an **OpenReward hosted-environment driver** so `bench eval create --source-env openreward:owner/name` runs the OpenReward session loop (`get_prompt` → `list_tools` → `call_tool` until `finished`) instead of Prime’s `vf-eval` path. **`run_hosted_env`** lazy-dispatches on `provider == "openreward"`; Prime-only version/`vf-eval` checks stay on the Prime branch.
> 
> **`HostedEnvRef.parse`** now rejects ambiguous slash refs like `openreward/KellyBench` (would treat `openreward` as owner and default to Prime) with a hint to use `provider:owner/name`, for all call sites—not only the CLI.
> 
> Shared **`build_hosted_result_payload`** / **`build_hosted_config_payload`** keep `result.json` and `config.json` aligned between vf-eval and OpenReward; **`write_verify_result_json`** moves to **`benchflow.trajectories.export`** for reuse without importing rollout’s heavy graph.
> 
> The new driver ships a deterministic **`ScriptedPolicy`** (offline-testable) and a **`ModelPolicy`** stub for a future LLM agent; it writes the same rollout artifacts plus `verifier/verify_result.json` and `trainer/verifiers.jsonl`, with `trajectory_source="openreward"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41aa3cad61b17451c7fe7c67500668bc5654d3ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->