### PR TITLE
docs: add experiment guidance to AGENTS.md; ignore .claude/handoffs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ tests/.smoke-jobs/
 context/
 tutorials/
 .playwright-mcp/
+/.claude/handoffs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,10 @@ uv run ruff check .
 - **Human review before `main`.** PRs only. No force-pushes to `main`. Self-approval doesn't count.
 - **Trunk-based:** branch off `main`, PR back to `main`. No long-lived release branches.
 - **Releases:** bump `pyproject.toml` to the stable version, tag `v<version>` on main, push tag (CI publishes to PyPI), then bump main to the next `.dev0`.
+
+## Experiment guidance (when using benchflow to run batch tasks experiments)
+
+- When running tasks experiments on Daytona, keep in mind that Daytona supports up to 100 parallel VMs.
+- When running tasks experiments by default use the highest inference level for all the model calls (For example, xhigh for GPT5.5, or MAX for Opus4.8).
+- When running tasks experiments, for each API key that available to you, verify 1. whether the key is still working by sending basic LLM calls; 2. ask the user how many parallel tasks can each key support / figure it out by yourself. Thus you can use highest available concurrency when running experiments.
+- Use Huggingface as the ground truth of tasks traj database. The target is making sure number_of_tasks * 2 (with/without skills) * number_of_trials (usually 3 / 5) for each model + each harness is complete. Each traj on Huggingface must be "healthy" - "healthy" means 1. the trial has complete traj information (agent pass / fail / timeout the task); 2. the trial has complete meta information (for example: token usage; timing; etc.). For each traj, we should use subagents to audit 1. whether the fail / timeout is due to agent capability instead of task config or env setting; 2. there is no reward hacking behavior; 3. in "no-skill" trials the agents do not have access to any skill files or accessed any skill files in traj.


### PR DESCRIPTION
## What

- **AGENTS.md**: add an "Experiment guidance" section documenting conventions for running batch task experiments — Daytona parallelism cap (100 VMs), defaulting to the highest inference level, per-API-key verification + concurrency discovery, and HuggingFace as the ground-truth trajectory database with per-trajectory health/audit expectations.
- **.gitignore**: ignore `/.claude/handoffs`.

## Why

Captures the experiment-running playbook in the repo's agent instructions so it's consistently applied. (CLAUDE.md points to AGENTS.md, so this is the effective "CLAUDE.md" change.)

Docs-only + gitignore; no code paths touched.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->