### PR TITLE
Add openai + us-openai provider routing

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -50,6 +50,7 @@ _CLAUDE_OAUTH_TOKEN_ENV = "CLAUDE_OAUTH_TOKEN"
 _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
 )
+_CANONICAL_OPENAI_URL = "https://api.openai.com/v1"
 _GENERIC_PROVIDER_OVERRIDE_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "BENCHFLOW_PROVIDER_API_KEY"}
 )
@@ -246,7 +247,14 @@ def _is_codex_native_openai_context(
     model: str | None,
     required_key: str | None,
 ) -> bool:
-    """True when Codex can use its own OpenAI auth mechanisms directly."""
+    """True when Codex can use its own OpenAI auth mechanisms directly.
+
+    Native auth covers bare model IDs (``gpt-*``) and the first-party
+    ``openai/`` provider prefix pointing at ``api.openai.com``. Custom or
+    proxy providers (``vllm/``, ``us-openai/``, etc.) must supply
+    ``OPENAI_API_KEY`` explicitly — subscription/access-token auth does not
+    apply to them.
+    """
     if agent != "codex-acp" or required_key != "OPENAI_API_KEY":
         return False
     if model is None:
@@ -254,12 +262,25 @@ def _is_codex_native_openai_context(
 
     from benchflow.agents.providers import find_provider
 
-    return find_provider(model) is None
+    result = find_provider(model)
+    if result is None:
+        return True
+    name, cfg = result
+    return name == "openai" and cfg.base_url == _CANONICAL_OPENAI_URL
 
 
 def _has_custom_openai_endpoint(agent_env: dict[str, str]) -> bool:
-    """True when Codex is being pointed at an OpenAI-compatible non-OpenAI URL."""
-    return any(agent_env.get(key) for key in _CUSTOM_OPENAI_ENDPOINT_KEYS)
+    """True when Codex is being pointed at an OpenAI-compatible non-OpenAI URL.
+
+    The first-party ``openai/`` provider populates these keys with the
+    canonical ``api.openai.com`` URL — that is the native endpoint, not a
+    custom proxy, so it must not disqualify subscription/access-token auth.
+    """
+    for key in _CUSTOM_OPENAI_ENDPOINT_KEYS:
+        value = agent_env.get(key)
+        if value and value.rstrip("/") != _CANONICAL_OPENAI_URL:
+            return True
+    return False
 
 
 def _can_use_codex_subscription_auth(

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -155,6 +155,18 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_env="AZURE_API_KEY",
         url_params={"resource": "AZURE_RESOURCE"},
     ),
+    # ── OpenAI first-party API ──
+    "openai": ProviderConfig(
+        name="openai",
+        base_url="https://api.openai.com/v1",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="OPENAI_API_KEY",
+        endpoints={
+            "openai-completions": "https://api.openai.com/v1",
+            "openai-responses": "https://api.openai.com/v1",
+        },
+    ),
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(
         name="vllm",

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -167,6 +167,19 @@ PROVIDERS: dict[str, ProviderConfig] = {
             "openai-responses": "https://api.openai.com/v1",
         },
     ),
+    # OpenAI US data-residency endpoint. Same key, regional URL.
+    "us-openai": ProviderConfig(
+        name="us-openai",
+        base_url="https://us.api.openai.com/v1",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="OPENAI_API_KEY",
+        endpoints={
+            "openai-completions": "https://us.api.openai.com/v1",
+            "openai-responses": "https://us.api.openai.com/v1",
+        },
+    ),
+    # TODO: add eu-openai (https://eu.api.openai.com/v1) when needed.
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(
         name="vllm",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -41,6 +41,16 @@ class TestFindProvider:
         assert name == "aws-bedrock"
         assert cfg.auth_type == "aws"
 
+    def test_openai_prefix(self):
+        """Guards the PR #158 follow-up fix for openai/... provider routing."""
+        name, cfg = find_provider("openai/gpt-5.4-mini")
+
+        assert name == "openai"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "OPENAI_API_KEY"
+        assert resolve_auth_env("openai/gpt-5.4-mini") == "OPENAI_API_KEY"
+        assert strip_provider_prefix("openai/gpt-5.4-mini") == "gpt-5.4-mini"
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [
@@ -106,6 +116,20 @@ class TestResolveBaseUrl:
             auth_env="ZAI_API_KEY",
         )
         assert resolve_base_url(p, {}) == "https://api.z.ai/api/paas/v4"
+
+    def test_openai_endpoints(self):
+        """Guards the PR #158 follow-up fix for first-party OpenAI endpoints."""
+        p = PROVIDERS["openai"]
+
+        assert resolve_base_url(p, {}) == "https://api.openai.com/v1"
+        assert (
+            resolve_base_url(p, {}, protocol="openai-completions")
+            == "https://api.openai.com/v1"
+        )
+        assert (
+            resolve_base_url(p, {}, protocol="openai-responses")
+            == "https://api.openai.com/v1"
+        )
 
     def test_project_id_expansion(self):
         p = ProviderConfig(

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -51,6 +51,15 @@ class TestFindProvider:
         assert resolve_auth_env("openai/gpt-5.4-mini") == "OPENAI_API_KEY"
         assert strip_provider_prefix("openai/gpt-5.4-mini") == "gpt-5.4-mini"
 
+    def test_us_openai_prefix(self):
+        name, cfg = find_provider("us-openai/gpt-5.4-mini")
+
+        assert name == "us-openai"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "OPENAI_API_KEY"
+        assert resolve_auth_env("us-openai/gpt-5.4-mini") == "OPENAI_API_KEY"
+        assert strip_provider_prefix("us-openai/gpt-5.4-mini") == "gpt-5.4-mini"
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [
@@ -129,6 +138,19 @@ class TestResolveBaseUrl:
         assert (
             resolve_base_url(p, {}, protocol="openai-responses")
             == "https://api.openai.com/v1"
+        )
+
+    def test_us_openai_endpoints(self):
+        p = PROVIDERS["us-openai"]
+
+        assert resolve_base_url(p, {}) == "https://us.api.openai.com/v1"
+        assert (
+            resolve_base_url(p, {}, protocol="openai-completions")
+            == "https://us.api.openai.com/v1"
+        )
+        assert (
+            resolve_base_url(p, {}, protocol="openai-responses")
+            == "https://us.api.openai.com/v1"
         )
 
     def test_project_id_expansion(self):

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -966,3 +966,104 @@ class TestResolveAgentEnvHostProviderEndpoint:
 
         assert result["BENCHFLOW_PROVIDER_API_KEY"] == "zk-test"
         assert result["OPENAI_API_KEY"] == "zk-test"
+
+
+class TestResolveAgentEnvCodexOpenAIPrefix:
+    """Registering the first-party ``openai`` provider must not regress Codex auth.
+
+    Codex-acp historically accepts four auth modes against api.openai.com:
+    OPENAI_API_KEY / CODEX_API_KEY (alias) / CODEX_ACCESS_TOKEN /
+    host ``~/.codex/auth.json`` subscription auth. The first three are also
+    valid for bare ``gpt-*`` model IDs. After registering ``openai`` as a
+    provider, ``find_provider("openai/...")`` returns a match and the native-
+    OpenAI gate must still treat the canonical endpoint as native — otherwise
+    the alias/access-token/subscription paths silently break for users who
+    switch from ``gpt-5.4-mini`` to ``openai/gpt-5.4-mini``.
+
+    Custom proxies (``vllm/``, ``us-openai/``, etc.) must keep requiring an
+    explicit OPENAI_API_KEY — subscription/access-token auth does not apply.
+    """
+
+    def _patch_expanduser(self, monkeypatch, tmp_path):
+        orig = Path.expanduser
+
+        def fake(self):
+            s = str(self)
+            if s.startswith("~"):
+                return tmp_path / s[2:]
+            return orig(self)
+
+        monkeypatch.setattr(Path, "expanduser", fake)
+
+    @pytest.fixture(autouse=True)
+    def _clean_env(self, monkeypatch):
+        for k in (
+            "OPENAI_API_KEY",
+            "CODEX_API_KEY",
+            "CODEX_ACCESS_TOKEN",
+            "CODEX_AUTH_JSON",
+            "ANTHROPIC_API_KEY",
+        ):
+            monkeypatch.delenv(k, raising=False)
+
+    def test_codex_api_key_alias_works_for_openai_prefix(self, monkeypatch, tmp_path):
+        self._patch_expanduser(monkeypatch, tmp_path)
+        result = resolve_agent_env(
+            "codex-acp",
+            "openai/gpt-5.4-mini",
+            {"CODEX_API_KEY": "codex-key"},
+        )
+        assert result["CODEX_API_KEY"] == "codex-key"
+        assert result["OPENAI_API_KEY"] == "codex-key"
+
+    def test_codex_access_token_works_for_openai_prefix(self, monkeypatch, tmp_path):
+        self._patch_expanduser(monkeypatch, tmp_path)
+        result = resolve_agent_env(
+            "codex-acp",
+            "openai/gpt-5.4-mini",
+            {"CODEX_ACCESS_TOKEN": "access-token"},
+        )
+        assert result["CODEX_ACCESS_TOKEN"] == "access-token"
+
+    def test_codex_auth_json_works_for_openai_prefix(self, monkeypatch, tmp_path):
+        self._patch_expanduser(monkeypatch, tmp_path)
+        result = resolve_agent_env(
+            "codex-acp",
+            "openai/gpt-5.4-mini",
+            {"CODEX_AUTH_JSON": '{"tokens": {}}'},
+        )
+        assert result["CODEX_AUTH_JSON"] == '{"tokens": {}}'
+
+    def test_codex_host_subscription_auth_works_for_openai_prefix(
+        self, monkeypatch, tmp_path
+    ):
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("{}")
+        self._patch_expanduser(monkeypatch, tmp_path)
+
+        result = resolve_agent_env("codex-acp", "openai/gpt-5.4-mini", {})
+
+        assert result["_BENCHFLOW_SUBSCRIPTION_AUTH"] == "1"
+
+    def test_us_openai_prefix_still_requires_explicit_key(
+        self, monkeypatch, tmp_path
+    ):
+        """Regional endpoint is not the canonical api.openai.com — host auth must not apply."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("{}")
+        self._patch_expanduser(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            resolve_agent_env("codex-acp", "us-openai/gpt-5.4-mini", {})
+
+    def test_vllm_prefix_still_requires_explicit_key(self, monkeypatch, tmp_path):
+        """Custom OpenAI-compatible endpoints keep rejecting subscription auth."""
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        (codex_dir / "auth.json").write_text("{}")
+        self._patch_expanduser(monkeypatch, tmp_path)
+
+        with pytest.raises(ValueError, match="OPENAI_API_KEY"):
+            resolve_agent_env("codex-acp", "vllm/Qwen-test", {})

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -282,6 +282,32 @@ class TestResolveProviderEnv:
         assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
         assert env["OPENAI_BASE_URL"] == "https://api.z.ai/api/paas/v4"
 
+    def test_openai_provider_sets_pi_openai_completions_env(self):
+        """Guards PR #158 follow-up: pi-acp must not fallback to Anthropic for openai/...."""
+        env = {"OPENAI_API_KEY": "sk-test"}
+
+        resolve_provider_env(env, "openai/gpt-5.4-mini", "pi-acp")
+
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "openai"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "gpt-5.4-mini"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-completions"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.openai.com/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-test"
+
+    def test_openai_provider_sets_codex_responses_env(self):
+        """Guards PR #158 follow-up: codex-acp must use Responses for openai/... models."""
+        env = {"OPENAI_API_KEY": "sk-test"}
+
+        resolve_provider_env(env, "openai/gpt-5.4-mini", "codex-acp")
+
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "openai"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "gpt-5.4-mini"
+        assert env["BENCHFLOW_PROVIDER_PROTOCOL"] == "openai-responses"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.openai.com/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-test"
+        assert env["OPENAI_BASE_URL"] == "https://api.openai.com/v1"
+        assert env["OPENAI_API_KEY"] == "sk-test"
+
     def test_azure_foundry_openai_maps_to_codex_env(self):
         env = {
             "AZURE_API_KEY": "az-test",

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -1046,9 +1046,7 @@ class TestResolveAgentEnvCodexOpenAIPrefix:
 
         assert result["_BENCHFLOW_SUBSCRIPTION_AUTH"] == "1"
 
-    def test_us_openai_prefix_still_requires_explicit_key(
-        self, monkeypatch, tmp_path
-    ):
+    def test_us_openai_prefix_still_requires_explicit_key(self, monkeypatch, tmp_path):
         """Regional endpoint is not the canonical api.openai.com — host auth must not apply."""
         codex_dir = tmp_path / ".codex"
         codex_dir.mkdir()


### PR DESCRIPTION
## Summary
- Register first-party `openai` provider so `model: openai/<id>` routes correctly (was silently falling back to unauthenticated Anthropic).
- Add `us-openai` provider for the US data-residency endpoint (`https://us.api.openai.com/v1`), reusing `OPENAI_API_KEY`.
- Expose both `openai-completions` and `openai-responses` endpoint variants on each.
- TODO comment left in the registry for `eu-openai` when needed.

## Root cause
`openai/<model>` looked provider-prefixed, but `openai` was not in `PROVIDERS`. BenchFlow skipped `BENCHFLOW_PROVIDER_*` injection, and pi-acp (and any launcher mirroring its conditional) fell through to the Anthropic env path — producing zero-tool-call trials with no error surfaced.

## What changes for users
- `model: openai/gpt-5.4-mini` — routes to `api.openai.com` with `OPENAI_API_KEY`.
- `model: us-openai/gpt-5.4-mini` — routes to `us.api.openai.com` with the same key.

## Validation
- `uv run pytest tests/test_providers.py tests/test_resolve_env_helpers.py tests/test_pi_acp_launcher.py tests/test_registry_invariants.py tests/test_agent_registry.py -q`
- `uv run ruff check src/benchflow/agents/providers.py tests/test_providers.py tests/test_resolve_env_helpers.py`
- `uv run ty check src/benchflow/agents/providers.py src/benchflow/agents/env.py`
- Verified end-to-end against fork's `local` branch.

## Test plan
- [ ] CI passes
- [ ] Reviewer confirms provider registry placement / naming