### PR TITLE
fix: upload absolute str skills_dir host dirs in scene skill activation

### DIFF
--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -2128,19 +2128,24 @@ class Rollout:
 
         scene_name = str(step.data.get("scene") or "scene")
         role = scene_step_role(step)
-        source_value = skills_dir
-        source = str(source_value)
+        source = str(skills_dir)
         local_source = Path(source).expanduser()
-        if isinstance(source_value, os.PathLike) and local_source.is_dir():
+        # Upload whenever skills_dir resolves to a real directory on the
+        # orchestrator host, regardless of whether it arrived as a str or a
+        # PathLike. The SkillsBench entrypoint passes an absolute *str* host
+        # path (EvaluationConfig.skills_dir is typed str), so gating the upload
+        # on isinstance(..., os.PathLike) silently skipped it: the path then
+        # fell through to the "already inside the sandbox" branch below and
+        # _link_skill_paths produced a dangling symlink, so deployed task skills
+        # never reached the agent. An absolute path that does NOT exist on the
+        # host is a sandbox path produced by an earlier scene and is linked
+        # as-is.
+        if local_source.is_dir():
             remote_source = f"/skills/{_safe_skill_name(scene_name)}"
             await _ensure_sandbox_dir(self._env, Path(remote_source).parent)
             await self._env.upload_dir(local_source, remote_source)
         elif source.startswith("/"):
             remote_source = source
-        elif local_source.is_dir():
-            remote_source = f"/skills/{_safe_skill_name(scene_name)}"
-            await _ensure_sandbox_dir(self._env, Path(remote_source).parent)
-            await self._env.upload_dir(local_source, remote_source)
         else:
             raise FileNotFoundError(f"Scene skills_dir not found: {skills_dir}")
 

--- a/tests/test_scene_outbox_trial.py
+++ b/tests/test_scene_outbox_trial.py
@@ -359,3 +359,39 @@ async def test_scene_skills_prefers_remote_string_path_over_matching_host_path(
 
     assert trial._env._uploads == []
     assert not any(cmd.startswith("mkdir -p /skills") for cmd in trial._env._exec_log)
+
+
+async def test_scene_skills_upload_absolute_str_host_dir(tmp_path: Path) -> None:
+    """An absolute *str* skills_dir that exists on the host is uploaded.
+
+    Regression test guarding the OpenHands with-skills delivery fix: a prior
+    change gated the scene-skill upload on ``isinstance(skills_dir, os.PathLike)``,
+    but the SkillsBench entrypoint passes an absolute *str* host path
+    (``EvaluationConfig.skills_dir`` is typed ``str``). The gate skipped the
+    upload, the path fell through to the in-sandbox branch, and
+    ``_link_skill_paths`` produced a dangling symlink -- so deployed task skills
+    never reached the agent's available-skills catalog and the with-skills arm
+    became a no-op. Uploading must key on the directory existing on the host,
+    not on the argument's type.
+    """
+    skills_root = tmp_path / "environment" / "skills"
+    (skills_root / "mesh-analysis").mkdir(parents=True)
+    (skills_root / "mesh-analysis" / "SKILL.md").write_text(
+        "---\nname: mesh-analysis\ndescription: analyze meshes\n---\n# Mesh\n"
+    )
+    scene = Scene(
+        name="solve",
+        roles=[Role("solver", "claude-agent-acp", "haiku")],
+        turns=[Turn("solver")],
+        skills_dir=str(skills_root),  # absolute STR host path, as production passes
+    )
+    trial = _make_trial(scene)
+    trial._agent_cwd = "/app"
+
+    await trial._activate_step_skills(compile_scenes_to_steps([scene])[0])
+
+    assert trial._env._uploads == [(skills_root, "/skills/solve")]
+    assert any(
+        "ln -sfn /skills/solve /home/agent/.claude/skills" in cmd
+        for cmd in trial._env._exec_log
+    )


### PR DESCRIPTION
## Summary
`Rollout._activate_step_skills` skips uploading scene skills when `skills_dir` is an absolute **str** host path, so deployed SkillsBench task skills never reach the agent — the with-skills arm silently becomes a no-op.

## Root cause
`src/benchflow/rollout.py::_activate_step_skills` gated the upload on the argument **type**:
```python
if isinstance(source_value, os.PathLike) and local_source.is_dir():
    ...upload...
elif source.startswith("/"):
    remote_source = source            # treated as already-in-sandbox, NO upload
elif local_source.is_dir():           # unreachable for absolute paths
    ...upload...
```
The SkillsBench entrypoint always passes an absolute **str** host path (`EvaluationConfig.skills_dir` is typed `str`; the YAML loaders and `_resolve_skills_dir` all `str(...)`). So `isinstance(str, os.PathLike)` is `False`, the host path falls into the `startswith("/")` "already in the sandbox" branch (no upload), and `_link_skill_paths` then `rm -rf`s the discovery dir and `ln -sfn`s it to a host path that does not exist inside the container → **dangling symlink** → the task skill is never discovered.

OpenHands' built-in/public skills load independently, so the catalog still shows those — the deployed **task** skill is the only thing missing.

## Evidence (raw leaderboard trajectories)
- OpenHands with-skills skill delta: **PR2 +13.1pp, PR3 +11.1pp → PR4 −1.1pp**.
- PR4 raw with-skills trajectories: task skill **absent** from `<available_skills>` (only the 42 generic built-ins; byte-identical to the no-skills catalog); `invoke_skill` called **0/10**. PR2/PR3: task skill is the first `<skill>` entry; `invoke_skill` 7/14.
- Bisected to the commit that introduced the `isinstance(..., os.PathLike)` gate.

## Fix
Key the upload on the directory existing on the **host** (the pre-regression behaviour) rather than the argument's type:
```python
if local_source.is_dir():            # real host dir -> upload (str or PathLike)
    ...upload...
elif source.startswith("/"):         # absolute path not on host -> sandbox path from an earlier scene
    remote_source = source
else:
    raise FileNotFoundError(...)
```

## Note on prior intent (please sanity-check)
The gate was meant to treat absolute **str** `skills_dir` values as in-sandbox paths produced by an earlier scene (self-gen flow). That intent is preserved: such sandbox paths (e.g. `/app/generated-skills`) don't exist on the orchestrator host, so `local_source.is_dir()` is `False` and they're still linked as-is with no upload. The only behaviour change is that an absolute str path that **does** exist as a host directory is now uploaded — exactly the SkillsBench case. Existing self-gen tests still pass.

## Test plan
- New regression test `test_scene_skills_upload_absolute_str_host_dir`: an absolute **str** host `skills_dir` is uploaded to `/skills/<scene>` and linked into the agent discovery path.
- `tests/test_scene_outbox_trial.py` — 12/12 pass (incl. existing self-gen tests).
- `tests/test_scene.py tests/test_rollout_config_path_coercion.py tests/test_rollout_branch.py tests/test_agent_setup.py` — 49/49 pass.
- `ruff check` / `ruff format --check` / `ty check` clean.

---
Draft for maintainer review. Root cause + evidence derived from raw HF leaderboard trajectories (PR2/PR3/PR4) and a git bisect of the skill-deploy path.
