### PR TITLE
Add bench --version flag

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,10 @@
 # CLI reference
 BenchFlow uses a resource-verb pattern: `bench <resource> <verb>`.
 
+```bash
+bench --version
+```
+
 ---
 
 ## bench agent

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from benchflow import __version__
 from benchflow._dotenv import load_dotenv_env
 from benchflow._utils.config import (
     DEFAULT_AGENT_IDLE_TIMEOUT_SEC,
@@ -36,6 +37,27 @@ app = typer.Typer(
     help="ACP-native agent benchmarking framework.",
     no_args_is_help=True,
 )
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"benchflow {__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _cli_main(
+    version: Annotated[
+        bool | None,
+        typer.Option(
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show the version and exit.",
+        ),
+    ] = None,
+) -> None:
+    """ACP-native agent benchmarking framework."""
 
 
 _PROVIDER_AUTH_MESSAGE = (

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -8,6 +8,14 @@ from benchflow.cli.main import app
 from benchflow.models import RunResult
 
 
+def test_benchflow_version_flag() -> None:
+    from benchflow import __version__
+
+    result = CliRunner().invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip() == f"benchflow {__version__}"
+
+
 def test_benchflow_run_exits_nonzero_when_verifier_errors(tmp_path, monkeypatch):
     """Guards the v0.5 reward-output regression at the CLI boundary."""
     task_dir = tmp_path / "task"


### PR DESCRIPTION
## Summary
- Adds a top-level `--version` flag to the `bench` / `benchflow` CLI
- Prints `benchflow <version>` and exits (e.g. `benchflow 0.5.0.dev0`)
- Documents the flag in `docs/reference/cli.md` and adds a CLI regression test

## Motivation
Users currently have no CLI-native way to check which BenchFlow version is installed. This is especially confusing when multiple installs exist (uv tool, project venv, editable dev installs).

## Test plan
- [x] `uv run pytest tests/test_cli_run.py::test_benchflow_version_flag -q`
- [x] `uv run pytest tests/test_cli_docs_drift.py::test_top_level_help_lists_public_groups -q`
- [ ] `bench --version` after install


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, read-only CLI UX change with no auth, data, or execution-path impact beyond printing the package version.
> 
> **Overview**
> Adds a top-level **`--version`** flag to the BenchFlow CLI so users can see which package is installed without digging into the environment.
> 
> Invoking `bench --version` (or `benchflow --version`) prints **`benchflow <version>`** from `benchflow.__version__` and exits immediately via an eager Typer callback on the root app. The CLI reference documents the flag, and **`test_benchflow_version_flag`** locks in exit code 0 and the exact output string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a77d2ea6b3a19d20a50a7423840c6774600d044. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->