### PR TITLE
Fix OpenHands skill invocation counting

### DIFF
--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -3,6 +3,8 @@
 import logging
 from datetime import datetime
 
+from benchflow.trajectories.metrics import content_contains_skill_invocation_tool
+
 from .types import (
     AgentCapabilities,
     AgentInfo,
@@ -11,6 +13,19 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _canonical_tool_kind(kind: object, title: object = "") -> str:
+    raw_kind = kind if isinstance(kind, str) and kind else "other"
+    normalized_kind = raw_kind.strip().lower().replace("-", "_")
+    normalized_title = (
+        title.strip().lower().replace("-", "_") if isinstance(title, str) else ""
+    )
+    if normalized_kind in {"skill", "invoke_skill", "activate_skill"}:
+        return "skill"
+    if normalized_title in {"invoke_skill", "activate_skill"}:
+        return "skill"
+    return raw_kind
 
 
 class ToolCallRecord:
@@ -105,7 +120,9 @@ class ACPSession:
             record = ToolCallRecord(
                 tool_call_id=update.get("toolCallId", ""),
                 title=update.get("title", ""),
-                kind=update.get("kind", "other"),
+                kind=_canonical_tool_kind(
+                    update.get("kind", "other"), update.get("title", "")
+                ),
             )
             self.tool_calls.append(record)
             self._tool_call_map[record.tool_call_id] = record
@@ -119,7 +136,9 @@ class ACPSession:
                 record = ToolCallRecord(
                     tool_call_id=tc_id,
                     title=update.get("title", ""),
-                    kind=update.get("kind", "tool"),
+                    kind=_canonical_tool_kind(
+                        update.get("kind", "tool"), update.get("title", "")
+                    ),
                 )
                 self.tool_calls.append(record)
                 self._tool_call_map[tc_id] = record
@@ -129,7 +148,10 @@ class ACPSession:
             except ValueError:
                 logger.warning(f"Unknown tool call status: {update.get('status')}")
                 status = ToolCallStatus.IN_PROGRESS
-            record.update_status(status, update.get("content"))
+            content = update.get("content")
+            record.update_status(status, content)
+            if content_contains_skill_invocation_tool(content):
+                record.kind = "skill"
 
         elif update_type == "agent_message_chunk":
             content = update.get("content", {})

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from benchflow.trajectories.metrics import content_contains_skill_invocation_tool
+from benchflow.trajectories.metrics import is_skill_invocation_event
 
 from .types import (
     AgentCapabilities,
@@ -15,15 +15,25 @@ from .types import (
 logger = logging.getLogger(__name__)
 
 
+def _is_skill_tool_call(
+    kind: object, title: object = "", content: object = None
+) -> bool:
+    """Classify a live ACP tool call via the shared trajectory classifier.
+
+    Builds a synthetic trajectory event so live capture and historical rescans
+    apply one identical definition of "skill invocation". Crucially, the tool's
+    own ``kind`` gates content sniffing, so a ``read`` / ``execute`` / ``search``
+    tool whose output quotes a legacy ``invoke_skill`` envelope is not
+    reclassified as a skill.
+    """
+    return is_skill_invocation_event(
+        {"type": "tool_call", "kind": kind, "title": title, "content": content}
+    )
+
+
 def _canonical_tool_kind(kind: object, title: object = "") -> str:
     raw_kind = kind if isinstance(kind, str) and kind else "other"
-    normalized_kind = raw_kind.strip().lower().replace("-", "_")
-    normalized_title = (
-        title.strip().lower().replace("-", "_") if isinstance(title, str) else ""
-    )
-    if normalized_kind in {"skill", "invoke_skill", "activate_skill"}:
-        return "skill"
-    if normalized_title in {"invoke_skill", "activate_skill"}:
+    if _is_skill_tool_call(kind, title):
         return "skill"
     return raw_kind
 
@@ -150,7 +160,13 @@ class ACPSession:
                 status = ToolCallStatus.IN_PROGRESS
             content = update.get("content")
             record.update_status(status, content)
-            if content_contains_skill_invocation_tool(content):
+            # Canonicalize legacy OpenHands invoke_skill calls using the same
+            # classifier the rescan path uses. Only upgrade to "skill"; never
+            # downgrade, and never reclassify a tool that already has a real
+            # ACP kind (its output may merely quote a skill envelope).
+            if record.kind != "skill" and _is_skill_tool_call(
+                record.kind, record.title, record.content
+            ):
                 record.kind = "skill"
 
         elif update_type == "agent_message_chunk":

--- a/src/benchflow/trajectories/metrics.py
+++ b/src/benchflow/trajectories/metrics.py
@@ -7,7 +7,21 @@ from collections.abc import Mapping
 from typing import Any
 
 _SKILL_TOOL_NAMES = frozenset({"invoke_skill", "activate_skill", "skill"})
-_SKILL_TOOL_LINE_RE = re.compile(r"(?im)^\s*Tool:\s*(invoke_skill|activate_skill)\s*$")
+
+# OpenHands legacy ACP artifacts render an invoke-skill *result* as a text block
+# that begins with the tool header (``Tool: invoke_skill``) and carries a
+# ``[skill: <name>]`` result marker. Anchoring the header to the start of the
+# block (``\A``) is the structural signal that the tool itself was invoke_skill
+# — not that some other tool's output merely quoted such text mid-stream.
+_SKILL_RESULT_HEADER_RE = re.compile(
+    r"\A\s*Tool:\s*(?:invoke_skill|activate_skill)\b", re.IGNORECASE
+)
+_SKILL_RESULT_MARKER = "[skill:"
+
+# Only these unclassified tool kinds are eligible for content sniffing. Any tool
+# carrying a real ACP kind (read, edit, execute, search, fetch, ...) is trusted
+# as-is and never reinterpreted from its output text.
+_CONTENT_SNIFFABLE_KINDS = frozenset({"", "other", "tool"})
 
 
 def _normalized_tool_name(value: Any) -> str:
@@ -16,15 +30,31 @@ def _normalized_tool_name(value: Any) -> str:
     return value.strip().lower().replace("-", "_")
 
 
-def _iter_text_fragments(value: Any):
-    if isinstance(value, str):
-        yield value
-    elif isinstance(value, Mapping):
-        for child in value.values():
-            yield from _iter_text_fragments(child)
-    elif isinstance(value, list | tuple):
-        for child in value:
-            yield from _iter_text_fragments(child)
+def _tool_result_texts(content: Any):
+    """Yield the text of structured ACP tool-call *result* blocks.
+
+    ACP serializes tool-call content as a list of blocks. The OpenHands legacy
+    invoke-skill envelope is a ``content`` block wrapping a text ``ContentBlock``
+    (``{"type": "content", "content": {"type": "text", "text": ...}}``); some
+    shims inline the text block directly. Only those structured tool-result
+    texts are inspected — nested metadata (locations, diffs, raw inputs) is
+    deliberately ignored so an ordinary tool's payload cannot impersonate a
+    skill result by burying marker text in an unrelated field.
+    """
+    if not isinstance(content, list):
+        return
+    for block in content:
+        if not isinstance(block, Mapping):
+            continue
+        body = block.get("content")
+        if isinstance(body, Mapping) and body.get("type") == "text":
+            text = body.get("text")
+            if isinstance(text, str):
+                yield text
+        elif block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                yield text
 
 
 def _event_tool_name(event: Mapping[str, Any]) -> str:
@@ -49,20 +79,36 @@ def _event_tool_name(event: Mapping[str, Any]) -> str:
 
 
 def content_contains_skill_invocation_tool(content: Any) -> bool:
-    """Return whether structured tool-call content is an invoke-skill result."""
-    text = "\n".join(_iter_text_fragments(content))
-    if not text:
-        return False
-    return bool(_SKILL_TOOL_LINE_RE.search(text)) and "[skill:" in text.lower()
+    """Return whether tool-call content is an OpenHands invoke-skill result.
+
+    Requires the structured legacy envelope: a tool-result text block that
+    *begins* with the ``Tool: invoke_skill`` / ``Tool: activate_skill`` header
+    and carries a ``[skill: ...]`` marker. The anchored header is what
+    distinguishes a genuine invoke-skill tool result from ordinary output that
+    merely quotes such text. This is intentionally narrow; it is the only
+    text-derived path and is paired with the no-skill experiment-health
+    invariant in the result checker as a backstop.
+    """
+    for text in _tool_result_texts(content):
+        if _SKILL_RESULT_HEADER_RE.match(text) and _SKILL_RESULT_MARKER in text.lower():
+            return True
+    return False
 
 
 def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
     """Return whether an ACP trajectory event represents a skill invocation.
 
-    ``kind == "skill"`` is the canonical representation. Older OpenHands ACP
-    artifacts emitted ``invoke_skill`` calls as ``kind == "other"`` with the
-    structured tool result in ``content``; keep recognizing that shape so
-    existing uploaded trajectories can be rescanned accurately.
+    This is the single source of truth for "is this tool call a skill
+    invocation", shared by historical trajectory rescans and live ACP capture
+    (:mod:`benchflow.acp.session`).
+
+    ``kind == "skill"`` is the canonical representation. Identity signals (tool
+    kind, tool name, or title naming ``invoke_skill`` / ``activate_skill``) are
+    trusted outright. Older OpenHands ACP artifacts emitted ``invoke_skill``
+    calls as ``kind == "other"`` with the structured tool result in ``content``;
+    that shape is recognized only when the tool kind is unclassified, so an
+    ordinary ``read`` / ``execute`` / ``search`` tool whose output happens to
+    quote the marker is never reclassified.
     """
     if event.get("type") != "tool_call":
         return False
@@ -78,7 +124,7 @@ def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
     if title in {"invoke_skill", "activate_skill"}:
         return True
 
-    if kind and kind not in {"other", "tool"}:
+    if kind not in _CONTENT_SNIFFABLE_KINDS:
         return False
 
     return content_contains_skill_invocation_tool(event.get("content"))

--- a/src/benchflow/trajectories/metrics.py
+++ b/src/benchflow/trajectories/metrics.py
@@ -2,24 +2,101 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from typing import Any
+
+_SKILL_TOOL_NAMES = frozenset({"invoke_skill", "activate_skill", "skill"})
+_SKILL_TOOL_LINE_RE = re.compile(r"(?im)^\s*Tool:\s*(invoke_skill|activate_skill)\s*$")
+
+
+def _normalized_tool_name(value: Any) -> str:
+    if not isinstance(value, str):
+        return ""
+    return value.strip().lower().replace("-", "_")
+
+
+def _iter_text_fragments(value: Any):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        for child in value.values():
+            yield from _iter_text_fragments(child)
+    elif isinstance(value, list | tuple):
+        for child in value:
+            yield from _iter_text_fragments(child)
+
+
+def _event_tool_name(event: Mapping[str, Any]) -> str:
+    for key in ("tool_name", "toolName", "name", "function_name", "functionName"):
+        name = _normalized_tool_name(event.get(key))
+        if name:
+            return name
+
+    tool = event.get("tool")
+    if isinstance(tool, Mapping):
+        name = _normalized_tool_name(tool.get("name"))
+        if name:
+            return name
+
+    function = event.get("function")
+    if isinstance(function, Mapping):
+        name = _normalized_tool_name(function.get("name"))
+        if name:
+            return name
+
+    return ""
+
+
+def content_contains_skill_invocation_tool(content: Any) -> bool:
+    """Return whether structured tool-call content is an invoke-skill result."""
+    text = "\n".join(_iter_text_fragments(content))
+    if not text:
+        return False
+    return bool(_SKILL_TOOL_LINE_RE.search(text)) and "[skill:" in text.lower()
+
+
+def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
+    """Return whether an ACP trajectory event represents a skill invocation.
+
+    ``kind == "skill"`` is the canonical representation. Older OpenHands ACP
+    artifacts emitted ``invoke_skill`` calls as ``kind == "other"`` with the
+    structured tool result in ``content``; keep recognizing that shape so
+    existing uploaded trajectories can be rescanned accurately.
+    """
+    if event.get("type") != "tool_call":
+        return False
+
+    kind = _normalized_tool_name(event.get("kind"))
+    if kind in _SKILL_TOOL_NAMES:
+        return True
+
+    if _event_tool_name(event) in _SKILL_TOOL_NAMES:
+        return True
+
+    title = _normalized_tool_name(event.get("title"))
+    if title in {"invoke_skill", "activate_skill"}:
+        return True
+
+    if kind and kind not in {"other", "tool"}:
+        return False
+
+    return content_contains_skill_invocation_tool(event.get("content"))
 
 
 def count_skill_invocations(trajectory: list[dict[str, Any]]) -> int:
     """Count ACP skill invocations from structured tool-call events.
 
-    BenchFlow records ACP tool calls as dict events with ``type`` and ``kind``.
-    A skill invocation is only counted when the event is explicitly a
-    ``tool_call`` whose structured ``kind`` is ``"skill"``. Display text such as
-    titles, messages, or tool names is intentionally ignored.
+    BenchFlow records ACP tool calls as dict events. A canonical skill
+    invocation has ``type == "tool_call"`` and ``kind == "skill"``. Some legacy
+    harness artifacts have structured invoke-skill evidence in tool-call
+    content instead, so the counter accepts those shapes while still ignoring
+    ordinary agent messages and display text outside tool-call events.
     """
     return sum(
         1
         for event in trajectory
-        if isinstance(event, dict)
-        and event.get("type") == "tool_call"
-        and event.get("kind") == "skill"
+        if isinstance(event, Mapping) and is_skill_invocation_event(event)
     )
 
 

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -233,6 +233,53 @@ def _load_config(result_file: Path) -> tuple[Path, dict | None, str | None]:
         return config_path, None, "config.json: invalid JSON"
 
 
+# Skill modes that make skills available to the agent (canonical ``skill_mode``
+# field). Only an explicit no-skill sentinel means no skills; any other mode
+# (with-skill, self-gen, or a future/unknown mode) is treated as provisioned so
+# the no-skill invariant never false-flags a legitimate with-skill trial.
+_NO_SKILL_MODES = frozenset({"no-skill", "no-skills", "none", "without-skill"})
+
+
+def _config_provisions_skills(config: dict[str, Any] | None) -> bool:
+    """Return whether a rollout config made any skills available to the agent.
+
+    A "no-skill" trial has no single-agent ``skills_dir``, no task-bundled
+    skills, no scene/role ``skills_dir``, and no skill-providing ``skill_mode``.
+    Any of those present means skills were provisioned. Used to enforce the
+    experiment-health invariant that no-skill trials must not record skill
+    invocations.
+
+    Handles both the current config schema (``skills_dir`` /
+    ``include_task_skills``) and the canonical ``skill_mode`` field
+    (``no-skill`` / ``with-skill`` / ``self-gen``) so the invariant stays
+    correct as skill provisioning is recorded by mode.
+    """
+    if not isinstance(config, dict):
+        return False
+    if config.get("skills_dir"):
+        return True
+    if config.get("include_task_skills"):
+        return True
+    skill_mode = config.get("skill_mode")
+    if isinstance(skill_mode, str):
+        normalized = skill_mode.strip().lower().replace("_", "-")
+        if normalized and normalized not in _NO_SKILL_MODES:
+            return True
+    scenes = config.get("scenes")
+    if isinstance(scenes, list):
+        for scene in scenes:
+            if not isinstance(scene, dict):
+                continue
+            if scene.get("skills_dir"):
+                return True
+            roles = scene.get("roles")
+            if isinstance(roles, list):
+                for role in roles:
+                    if isinstance(role, dict) and role.get("skills_dir"):
+                        return True
+    return False
+
+
 def _source_hash_truth_issues(source: object, label: str) -> list[str]:
     if not isinstance(source, dict):
         return []
@@ -434,6 +481,10 @@ def check_agent(agent_dir: Path) -> dict:
         skill_count = r.get("n_skill_invocations")
         agent_result = r.get("agent_result") or {}
         agent_skill_count = agent_result.get("n_skill_invocations")
+        trajectory = _load_acp_trajectory(result_file)
+        trajectory_skill_count = (
+            count_skill_invocations(trajectory) if trajectory is not None else None
+        )
         if skill_count is not None:
             issue = _nonnegative_int_issue(
                 skill_count, f"{r.get('task_name', '?')}: n_skill_invocations"
@@ -447,15 +498,21 @@ def check_agent(agent_dir: Path) -> dict:
                     "does not match result.json n_skill_invocations"
                 )
                 findings["ok"] = False
-            trajectory = _load_acp_trajectory(result_file)
-            if trajectory is not None:
-                expected_skill_count = count_skill_invocations(trajectory)
-                if skill_count != expected_skill_count:
-                    findings["issues"].append(
-                        f"{r.get('task_name', '?')}: n_skill_invocations={skill_count} "
-                        f"but trajectory implies {expected_skill_count}"
-                    )
-                    findings["ok"] = False
+            if (
+                trajectory_skill_count is not None
+                and skill_count != trajectory_skill_count
+            ):
+                findings["issues"].append(
+                    f"{r.get('task_name', '?')}: n_skill_invocations={skill_count} "
+                    f"but trajectory implies {trajectory_skill_count}"
+                )
+                findings["ok"] = False
+        # Effective count for the no-skill invariant: prefer the recorded value,
+        # fall back to the trajectory so artifacts that omit the field are still
+        # held to the invariant.
+        effective_skill_count = (
+            skill_count if skill_count is not None else trajectory_skill_count
+        )
         if agent_skill_count is not None:
             issue = _nonnegative_int_issue(
                 agent_skill_count,
@@ -484,6 +541,24 @@ def check_agent(agent_dir: Path) -> dict:
             findings["ok"] = False
         else:
             assert config is not None
+            # Experiment-health invariant: a trial that provisioned no skills
+            # must not record skill invocations. A positive count here is a
+            # detector false-positive, agent-native skill leakage, or an
+            # experiment-fidelity failure — quarantine it for human review.
+            if (
+                isinstance(effective_skill_count, int)
+                and not isinstance(effective_skill_count, bool)
+                and effective_skill_count > 0
+                and not _config_provisions_skills(config)
+            ):
+                findings["issues"].append(
+                    f"{r.get('task_name', '?')}: n_skill_invocations="
+                    f"{effective_skill_count} but config provisions no skills "
+                    "(no-skill trial must not invoke skills — quarantine: detector "
+                    "false-positive, agent-native skill leakage, or experiment "
+                    "fidelity failure)"
+                )
+                findings["ok"] = False
             expected_model = _expected(agent, "model")
             expected_environment = _expected(agent, "environment")
             expected_concurrency = _expected(agent, "concurrency")

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -212,6 +212,36 @@ class TestACPSession:
         )
         assert session.tool_calls[0].status == ToolCallStatus.COMPLETED
 
+    def test_handle_openhands_invoke_skill_update_marks_kind_skill(self):
+        """Guards issue #507: OpenHands invoke_skill ACP calls are canonicalized."""
+        session = ACPSession("test-session")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "Load PDF skill for processing",
+                "kind": "other",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "content": [
+                    {
+                        "content": {
+                            "type": "text",
+                            "text": "Tool: invoke_skill\nResult:\n[skill: pdf]",
+                        },
+                        "type": "content",
+                    }
+                ],
+            }
+        )
+
+        assert session.tool_calls[0].kind == "skill"
+
     def test_handle_invalid_tool_call_status(self):
         """Invalid status should fall back to IN_PROGRESS, not crash."""
         session = ACPSession("test-session")

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -242,6 +242,68 @@ class TestACPSession:
 
         assert session.tool_calls[0].kind == "skill"
 
+    def test_handle_tool_output_quoting_skill_marker_keeps_kind(self):
+        """Guards #507: a real tool whose output quotes an invoke_skill
+        envelope is not reclassified as a skill (live-capture false positive)."""
+        session = ACPSession("test-session")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "cat prior_trajectory.txt",
+                "kind": "execute",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "content": [
+                    {
+                        "content": {
+                            "type": "text",
+                            "text": "Tool: invoke_skill\nResult:\n[skill: pdf]",
+                        },
+                        "type": "content",
+                    }
+                ],
+            }
+        )
+
+        assert session.tool_calls[0].kind == "execute"
+
+    def test_handle_other_kind_mid_output_skill_marker_keeps_kind(self):
+        """Guards #507: an unclassified tool whose output merely mentions the
+        marker mid-stream (not as the result header) stays unclassified."""
+        session = ACPSession("test-session")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_1",
+                "title": "grep -n invoke_skill logs/",
+                "kind": "other",
+            }
+        )
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call_update",
+                "toolCallId": "tc_1",
+                "status": "completed",
+                "content": [
+                    {
+                        "content": {
+                            "type": "text",
+                            "text": "logs/run.txt:42:Tool: invoke_skill\n[skill: pdf]",
+                        },
+                        "type": "content",
+                    }
+                ],
+            }
+        )
+
+        assert session.tool_calls[0].kind == "other"
+
     def test_handle_invalid_tool_call_status(self):
         """Invalid status should fall back to IN_PROGRESS, not crash."""
         session = ACPSession("test-session")

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -272,6 +272,80 @@ def test_check_results_flags_skill_invocation_mismatch(tmp_path: Path) -> None:
     )
 
 
+def test_check_results_flags_openhands_legacy_skill_invocation_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Guards issue #507: OpenHands invoke_skill artifacts are rescannable."""
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-05-24__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "openhands",
+                "model": "test-model",
+                "rewards": {"reward": 0.0},
+                "error": None,
+                "verifier_error": None,
+                "n_skill_invocations": 0,
+                "agent_result": {"n_skill_invocations": 0},
+                "source": _source(),
+            }
+        )
+    )
+    traj_dir = run_dir / "trajectory"
+    traj_dir.mkdir()
+    (traj_dir / "acp_trajectory.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "tool_call",
+                "kind": "other",
+                "title": "Load PDF skill for processing",
+                "content": [
+                    {
+                        "content": {
+                            "type": "text",
+                            "text": "Tool: invoke_skill\nResult:\n[skill: pdf]",
+                        },
+                        "type": "content",
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
+    _write_config(run_dir)
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "agent": "openhands",
+                "model": "test-model",
+                "environment": "daytona",
+                "concurrency": 64,
+                "agent_idle_timeout_sec": 600,
+                "total": 1,
+                "passed": 0,
+                "failed": 1,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "0.0%",
+                "total_skill_invocations": 0,
+                "avg_skill_invocations": 0.0,
+                "source": _source(),
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is False
+    assert any(
+        "n_skill_invocations=0 but trajectory implies 1" in issue
+        for issue in findings["issues"]
+    )
+
+
 def test_check_results_requires_source_provenance(tmp_path: Path) -> None:
     """Guards v0.5-integration@cb8759e against unaudited source artifacts."""
     agent_dir = tmp_path / "agentA"

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -151,6 +151,9 @@ def _write_config(
     agent: str = "agentA",
     model: str = "test-model",
     idle_timeout: object = 600,
+    skills_dir: object = "/tmp/skills",
+    include_task_skills: bool = False,
+    skill_mode: object = None,
 ) -> None:
     config = {
         "task_path": "/tmp/tasks/task-a",
@@ -159,8 +162,12 @@ def _write_config(
         "environment": "daytona",
         "concurrency": 64,
         "agent_idle_timeout_sec": idle_timeout,
+        "skills_dir": skills_dir,
+        "include_task_skills": include_task_skills,
         "source": source or _source(),
     }
+    if skill_mode is not None:
+        config["skill_mode"] = skill_mode
     (path / "config.json").write_text(json.dumps(config))
 
 
@@ -343,6 +350,165 @@ def test_check_results_flags_openhands_legacy_skill_invocation_mismatch(
     assert any(
         "n_skill_invocations=0 but trajectory implies 1" in issue
         for issue in findings["issues"]
+    )
+
+
+def _write_skill_summary(agent_dir: Path, *, agent: str, total: int) -> None:
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "agent": agent,
+                "model": "test-model",
+                "environment": "daytona",
+                "concurrency": 64,
+                "agent_idle_timeout_sec": 600,
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "100.0%",
+                "total_skill_invocations": total,
+                "avg_skill_invocations": float(total),
+                "source": _source(),
+            }
+        )
+    )
+
+
+def test_check_results_flags_no_skill_trial_with_skill_invocation(
+    tmp_path: Path,
+) -> None:
+    """Guards #507: a trial provisioning no skills must not invoke skills."""
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-05-24__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "model": "test-model",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "n_skill_invocations": 1,
+                "agent_result": {"n_skill_invocations": 1},
+                "source": _source(),
+            }
+        )
+    )
+    traj_dir = run_dir / "trajectory"
+    traj_dir.mkdir()
+    (traj_dir / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "pdf"}) + "\n"
+    )
+    # No-skill trial: no skills_dir, no task-bundled skills.
+    _write_config(run_dir, skills_dir=None, include_task_skills=False)
+    _write_skill_summary(agent_dir, agent="agentA", total=1)
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is False
+    assert any("config provisions no skills" in issue for issue in findings["issues"])
+
+
+def test_check_results_allows_skill_invocation_when_skills_provisioned(
+    tmp_path: Path,
+) -> None:
+    """Guards #507: the no-skill invariant must not flag with-skill trials."""
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-05-24__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "model": "test-model",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "n_skill_invocations": 1,
+                "agent_result": {"n_skill_invocations": 1},
+                "source": _source(),
+            }
+        )
+    )
+    traj_dir = run_dir / "trajectory"
+    traj_dir.mkdir()
+    (traj_dir / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "pdf"}) + "\n"
+    )
+    # With-skill trial: task-bundled skills were mounted.
+    _write_config(run_dir, skills_dir=None, include_task_skills=True)
+    _write_skill_summary(agent_dir, agent="agentA", total=1)
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is True
+    assert not any(
+        "config provisions no skills" in issue for issue in findings["issues"]
+    )
+
+
+def _write_skill_trial(
+    tmp_path: Path, *, skill_mode: str, n_skill_invocations: int = 1
+) -> Path:
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-05-24__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "model": "test-model",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "n_skill_invocations": n_skill_invocations,
+                "agent_result": {"n_skill_invocations": n_skill_invocations},
+                "source": _source(),
+            }
+        )
+    )
+    traj_dir = run_dir / "trajectory"
+    traj_dir.mkdir()
+    traj = "".join(
+        json.dumps({"type": "tool_call", "kind": "skill", "title": "pdf"}) + "\n"
+        for _ in range(n_skill_invocations)
+    )
+    (traj_dir / "acp_trajectory.jsonl").write_text(traj)
+    # Canonical skill_mode field with no legacy skills_dir/include_task_skills.
+    _write_config(
+        run_dir, skills_dir=None, include_task_skills=False, skill_mode=skill_mode
+    )
+    _write_skill_summary(agent_dir, agent="agentA", total=n_skill_invocations)
+    return agent_dir
+
+
+def test_check_results_skill_mode_no_skill_flags_invocation(tmp_path: Path) -> None:
+    """Guards #507: skill_mode=no-skill is a no-skill trial; invocations flag."""
+    agent_dir = _write_skill_trial(tmp_path, skill_mode="no-skill")
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is False
+    assert any("config provisions no skills" in issue for issue in findings["issues"])
+
+
+def test_check_results_skill_mode_with_skill_allows_invocation(
+    tmp_path: Path,
+) -> None:
+    """Guards #507: skill_mode=with-skill provisions skills; no false flag."""
+    agent_dir = _write_skill_trial(tmp_path, skill_mode="with-skill")
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is True
+    assert not any(
+        "config provisions no skills" in issue for issue in findings["issues"]
     )
 
 

--- a/tests/test_skill_invocation_artifacts.py
+++ b/tests/test_skill_invocation_artifacts.py
@@ -12,8 +12,8 @@ from benchflow.rollout import _build_rollout_result
 from benchflow.trajectories.metrics import count_skill_invocations
 
 
-def test_skill_invocation_count_uses_structured_kind_only() -> None:
-    """Guards issue #507: skill counts must not come from display-text matching."""
+def test_skill_invocation_count_uses_structured_tool_calls_only() -> None:
+    """Guards issue #507: skill counts must not come from agent display text."""
     trajectory = [
         {
             "type": "tool_call",
@@ -25,6 +25,55 @@ def test_skill_invocation_count_uses_structured_kind_only() -> None:
     ]
 
     assert count_skill_invocations(trajectory) == 1
+
+
+def test_skill_invocation_count_accepts_openhands_invoke_skill_content() -> None:
+    """Guards issue #507: OpenHands invoke_skill ACP calls count as skills."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": "Load PDF skill for processing",
+            "status": "completed",
+            "content": [
+                {
+                    "content": {
+                        "type": "text",
+                        "text": "Tool: invoke_skill\nResult:\n[skill: pdf]\n# PDF Guide",
+                    },
+                    "type": "content",
+                }
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 1
+
+
+def test_skill_invocation_count_ignores_non_skill_tool_output_mentions() -> None:
+    """Guards issue #507: ordinary tool output is not a skill invocation."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "bash",
+            "title": "cat log.txt",
+            "content": [
+                {
+                    "content": {
+                        "type": "text",
+                        "text": "Tool: invoke_skill\nResult:\n[skill: pdf]",
+                    },
+                    "type": "content",
+                }
+            ],
+        },
+        {
+            "type": "agent_message",
+            "text": "Tool: invoke_skill\nResult:\n[skill: marker]",
+        },
+    ]
+
+    assert count_skill_invocations(trajectory) == 0
 
 
 def test_build_rollout_result_writes_skill_invocation_metric(tmp_path) -> None:

--- a/tests/test_skill_invocation_artifacts.py
+++ b/tests/test_skill_invocation_artifacts.py
@@ -76,6 +76,60 @@ def test_skill_invocation_count_ignores_non_skill_tool_output_mentions() -> None
     assert count_skill_invocations(trajectory) == 0
 
 
+def test_skill_invocation_count_ignores_mid_output_skill_marker() -> None:
+    """Guards #507: an unclassified tool whose output merely mentions the
+    invoke_skill marker mid-stream is not counted; only a result whose text
+    *begins* with the tool header is a legacy skill invocation."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": "grep invoke_skill logs/",
+            "content": [
+                {
+                    "content": {
+                        "type": "text",
+                        "text": "logs/run.txt:42:Tool: invoke_skill\n[skill: pdf]",
+                    },
+                    "type": "content",
+                }
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 0
+
+
+def test_skill_invocation_count_ignores_marker_in_nested_metadata() -> None:
+    """Guards #507: marker text buried in non-text tool-call metadata (diffs,
+    locations, raw inputs) is ignored — only structured text result blocks
+    are inspected."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": "edit notes.md",
+            "content": [
+                {
+                    "type": "diff",
+                    "path": "notes.md",
+                    "oldText": "",
+                    "newText": "Tool: invoke_skill\nResult:\n[skill: pdf]",
+                },
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": "Applied edit to notes.md",
+                    },
+                },
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 0
+
+
 def test_build_rollout_result_writes_skill_invocation_metric(tmp_path) -> None:
     """Guards issue #507: result.json exposes structured skill invocation counts."""
     trajectory = [


### PR DESCRIPTION
## Summary
- recognize legacy OpenHands ACP `invoke_skill` / `activate_skill` tool-call result envelopes when counting skill invocations
- canonicalize live ACP capture through the same classifier so genuine invoke-skill records are stored as `kind=skill`
- keep ordinary read/execute/search output from being reclassified just because it quotes `[skill: ...]` text
- quarantine no-skill trials that nevertheless record positive skill invocation counts

## Scope of the metric
`n_skill_invocations` is intentionally the count of ACP skill-invocation tool calls. It is **not** a broader "skill usage" metric. A current OpenHands run may use skill files by directly reading `~/.agents/skills/.../SKILL.md`; that behavior remains `read` tool usage and is not counted here unless OpenHands emits the ACP `invoke_skill` envelope.

## Verification
- `uv sync --extra dev --locked`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/` -> `2564 passed, 49 skipped, 1 deselected`

## Real OpenHands validation
- On the GCP `daytona-orchestrator` VM, verified the live Gemini key with a raw provider call (`200`).
- Ran PR head `53f94ff` with Docker sandbox + real OpenHands + `gemini-3.5-flash` on a forced skill-invocation task.
- The task passed (`reward=1.0`), produced 3 tool calls, and recorded `n_skill_invocations=1` in both `result.json` and `agent_result`.
- The captured ACP trajectory contains a real skill event stored as `kind="skill"` with content beginning `Tool: invoke_skill` and `[skill: token-writer]`.
- Also reran PR #597's classifier over existing real OpenHands legacy trajectories on the VM: previously stored counts were `0`, while the fixed counter implies `1` for representative `citation-check` and `3d-scan-calc` with-skill runs.
- Ran a current real `citation-check` with-skill OpenHands run as a sanity check. It passed and used skill files via normal `read` tools, but emitted no `invoke_skill` event, so `n_skill_invocations=0`; this confirms the metric is scoped to invocation events rather than generic skill-file reads.

## Data rescan
- Rescanned latest HF PR4 refs/pr/4 at `4fbc7cf6d19880a2d47a0557b4c0e9e738f5d30d`.
- Parsed 4034/4034 ACP trajectories successfully.
- Existing stored `n_skill_invocations` were all 0; fixed counter finds 115 trials with skill invocations, 127 total invocations.