### PR TITLE
Enable openhands SkillsBench runs for Bedrock Opus 4.8 (MAX thinking) + Gemini usage tracking + apples-to-apples token accounting

### DIFF
--- a/src/benchflow/agents/oh_bedrock_opus_patch.py
+++ b/src/benchflow/agents/oh_bedrock_opus_patch.py
@@ -1,0 +1,58 @@
+# Deployed into the openhands sandbox's litellm (via registry.py install_cmd) to make
+# Bedrock Claude Opus/Sonnet/Haiku 4.8+ use ADAPTIVE thinking at MAX effort.
+#
+# litellm flags only the direct-anthropic id (`claude-opus-4-8`) as adaptive-thinking,
+# NOT the Bedrock inference-profile ids (`us./eu./global./bare anthropic.claude-opus-4-8`).
+# So on Daytona (direct-bedrock routing) the converse transform emits the legacy
+# `thinking.type=enabled` that Bedrock 4.8 rejects (ACP -32603 / 400 ValidationException).
+#
+# This shim is regex-gated to 4.8+ ids => a strict no-op for every other model
+# (gemini, azure, opus-4.6, etc. import-and-call straight through to the originals).
+# It is never imported by benchflow itself; it is base64-shipped and auto-loaded in the
+# sandbox via a .pth file. Requires litellm>=1.88.0rc1 (the `max` effort + output_config path).
+import re
+
+_NEW = re.compile(r"claude-(opus|sonnet|haiku)-4-(8|9|1\d)")
+
+# (1) gate: treat 4.8+ as adaptive-thinking models
+try:
+    from litellm.llms.anthropic.chat.transformation import AnthropicConfig
+
+    _orig_gate = AnthropicConfig._is_adaptive_thinking_model
+
+    def _gate(model):
+        try:
+            if model and _NEW.search(model.lower()):
+                return True
+        except Exception:
+            pass
+        return _orig_gate(model)
+
+    AnthropicConfig._is_adaptive_thinking_model = staticmethod(_gate)
+except Exception:
+    pass
+
+# (2) force MAX effort for 4.8+ (openhands caps its own effort at xhigh)
+try:
+    from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
+
+    _orig_handle = AmazonConverseConfig._handle_reasoning_effort_parameter
+
+    def _handle(self, model, reasoning_effort, optional_params):
+        if model and _NEW.search(model.lower()):
+            reasoning_effort = "max"
+        return _orig_handle(self, model, reasoning_effort, optional_params)
+
+    AmazonConverseConfig._handle_reasoning_effort_parameter = _handle
+except Exception:
+    pass
+
+# (3) belt-and-suspenders: flip the cost-map flag too
+try:
+    import litellm
+
+    for _k in list(litellm.model_cost):
+        if _NEW.search(_k.lower()):
+            litellm.model_cost[_k]["supports_adaptive_thinking"] = True
+except Exception:
+    pass

--- a/src/benchflow/agents/oh_bedrock_opus_patch.py
+++ b/src/benchflow/agents/oh_bedrock_opus_patch.py
@@ -1,5 +1,5 @@
 # Deployed into the openhands sandbox's litellm (via registry.py install_cmd) to make
-# Bedrock Claude Opus/Sonnet/Haiku 4.8+ use ADAPTIVE thinking at MAX effort.
+# Bedrock Claude Opus/Sonnet/Haiku 4.8+ use the ADAPTIVE thinking contract.
 #
 # litellm flags only the direct-anthropic id (`claude-opus-4-8`) as adaptive-thinking,
 # NOT the Bedrock inference-profile ids (`us./eu./global./bare anthropic.claude-opus-4-8`).
@@ -9,12 +9,22 @@
 # This shim is regex-gated to 4.8+ ids => a strict no-op for every other model
 # (gemini, azure, opus-4.6, etc. import-and-call straight through to the originals).
 # It is never imported by benchflow itself; it is base64-shipped and auto-loaded in the
-# sandbox via a .pth file. Requires litellm>=1.88.0rc1 (the `max` effort + output_config path).
+# sandbox via a .pth file. Requires litellm>=1.88.0rc1 (the effort + output_config path).
+#
+# Effort is NOT hardcoded: it is taken from the BENCHFLOW_BEDROCK_THINKING_EFFORT env
+# (MAX mode sets it to `max`); unset => the agent's requested effort passes through.
+# The model matcher mirrors providers/bedrock_runtime.BEDROCK_ADAPTIVE_THINKING_RE
+# (kept identical; tests/test_bedrock_thinking.py pins parity).
+import os
 import re
 
-_NEW = re.compile(r"claude-(opus|sonnet|haiku)-4-(8|9|1\d)")
+_NEW = re.compile(r"claude-(?:opus|sonnet|haiku)-4-(?:8|9|1\d)(?!\d)")
 
-# (1) gate: treat 4.8+ as adaptive-thinking models
+_EFFORT_ENV = "BENCHFLOW_BEDROCK_THINKING_EFFORT"
+_VALID_EFFORTS = {"minimal", "low", "medium", "high", "xhigh", "max"}
+
+# (1) gate: treat 4.8+ as adaptive-thinking models (the load-bearing fix — Bedrock
+# regional ids lack the registry capability flag, so the legacy shape is rejected)
 try:
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
@@ -32,7 +42,8 @@ try:
 except Exception:
     pass
 
-# (2) force MAX effort for 4.8+ (openhands caps its own effort at xhigh)
+# (2) config-gated effort for 4.8+: override ONLY when BENCHFLOW_BEDROCK_THINKING_EFFORT
+# is set (e.g. MAX mode => `max`); otherwise the agent's requested effort is honored.
 try:
     from litellm.llms.bedrock.chat.converse_transformation import AmazonConverseConfig
 
@@ -40,7 +51,9 @@ try:
 
     def _handle(self, model, reasoning_effort, optional_params):
         if model and _NEW.search(model.lower()):
-            reasoning_effort = "max"
+            _override = os.environ.get(_EFFORT_ENV, "").strip().lower()
+            if _override in _VALID_EFFORTS:
+                reasoning_effort = _override
         return _orig_handle(self, model, reasoning_effort, optional_params)
 
     AmazonConverseConfig._handle_reasoning_effort_parameter = _handle

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -551,8 +551,14 @@ AGENTS: dict[str, AgentConfig] = {
             "  fi && "
             "uv tool install --force --refresh "
             "--with 'boto3>=1.40' "
-            # Bedrock Opus 4.8+ needs litellm's adaptive-thinking `max` effort + output_config
-            # path (absent from stable 1.86.x). Inert for other models. See oh_bedrock_opus_patch.py.
+            # Pin litellm to the prerelease carrying the Bedrock adaptive-thinking
+            # effort + output_config path (absent from stable 1.86.x), required for
+            # Claude Opus 4.8+. NOTE: this is a DELIBERATE, OpenHands-wide litellm
+            # bump — it changes the litellm version for every provider/model this
+            # OpenHands install talks to, not just Bedrock 4.8. The bundled shim is
+            # regex-gated and inert elsewhere, but the version itself is global.
+            # Revisit/drop once the fix ships in a stable litellm. See
+            # oh_bedrock_opus_patch.py.
             "--with 'litellm==1.88.0rc1' "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12 && "
@@ -564,17 +570,32 @@ AGENTS: dict[str, AgentConfig] = {
             "mkdir -p ~/.openhands && "
             'echo \'{"llm":{"model":"placeholder","api_key":"placeholder"}}\' '
             "> ~/.openhands/agent_settings.json && "
-            # Deploy the Bedrock Opus 4.8+ adaptive-thinking shim into the sandbox litellm.
-            # Best-effort (the trailing `true` keeps it from ever failing the install); the
-            # shim is regex-gated internally => a strict no-op for every non-4.8 model.
-            "( SP=\"$(ls -d \"$(uv tool dir)\"/openhands/lib/python*/site-packages "
-            "2>/dev/null | head -1)\"; "
-            "[ -n \"$SP\" ] && "
+            # Deploy the Bedrock Opus 4.8+ adaptive-thinking shim into the sandbox
+            # litellm, then BEHAVIORALLY self-test it. On Daytona (direct Bedrock,
+            # no host proxy) this shim is the ONLY mechanism, so a silent deploy
+            # failure would regress Claude 4.8 thinking to the rejected legacy
+            # shape. The install stays non-fatal (other providers must still
+            # install) but emits a distinct ACTIVE / NOT-active marker so a failure
+            # is visible instead of swallowed. Regex-gated => a no-op for non-4.8.
+            '( SP="$(ls -d "$(uv tool dir)"/openhands/lib/python*/site-packages '
+            '2>/dev/null | head -1)"; '
+            '[ -n "$SP" ] && '
             f"echo '{_OH_BEDROCK_OPUS_SHIM_B64}' | base64 -d "
-            "> \"$SP/oh_bedrock_opus_patch.py\" && "
+            '> "$SP/oh_bedrock_opus_patch.py" && '
             "printf 'import oh_bedrock_opus_patch\\n' "
-            "> \"$SP/zz_oh_bedrock_opus_patch.pth\" "
+            '> "$SP/zz_oh_bedrock_opus_patch.pth" '
             "|| echo 'benchflow: opus-4.8 bedrock thinking shim NOT deployed' >&2; "
+            # The .pth auto-imports the shim at interpreter startup, so the venv
+            # python must now classify a regional 4.8 id as adaptive-thinking.
+            'PY="$(uv tool dir)/openhands/bin/python"; '
+            '[ -x "$PY" ] && "$PY" -c '
+            "'import sys; from litellm.llms.anthropic.chat.transformation "
+            "import AnthropicConfig as C; "
+            "sys.exit(0 if C._is_adaptive_thinking_model"
+            '("us.anthropic.claude-opus-4-8") else 1)\' 2>/dev/null '
+            "&& echo 'benchflow: opus-4.8 bedrock thinking shim ACTIVE' >&2 "
+            "|| echo 'benchflow: opus-4.8 bedrock thinking shim NOT active"
+            " (Daytona Bedrock 4.8 thinking will regress)' >&2; "
             "true ) && "
             "command -v openhands >/dev/null 2>&1"
         ),

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -194,6 +194,12 @@ _PI_LAUNCHER = (Path(__file__).parent / "pi_acp_launcher.py").read_text()
 # Path to the Harvey LAB ACP shim (runs Harvey LAB harness as an ACP agent)
 _HARVEY_LAB_SHIM = (Path(__file__).parent / "harvey_lab_acp_shim.py").read_text()
 
+# Bedrock Opus 4.8+ adaptive-thinking shim, base64-shipped into the openhands sandbox's
+# litellm (source: oh_bedrock_opus_patch.py). Regex-gated => a no-op for every other model.
+_OH_BEDROCK_OPUS_SHIM_B64 = base64.b64encode(
+    (Path(__file__).parent / "oh_bedrock_opus_patch.py").read_text().encode()
+).decode()
+
 
 def _json_settings_merge(path: str, mutator: str) -> str:
     """Idempotent JSON-settings merge as a one-line bash snippet."""
@@ -545,6 +551,9 @@ AGENTS: dict[str, AgentConfig] = {
             "  fi && "
             "uv tool install --force --refresh "
             "--with 'boto3>=1.40' "
+            # Bedrock Opus 4.8+ needs litellm's adaptive-thinking `max` effort + output_config
+            # path (absent from stable 1.86.x). Inert for other models. See oh_bedrock_opus_patch.py.
+            "--with 'litellm==1.88.0rc1' "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12 && "
             "  uv tool list | grep -q '^openhands\\b' ) && "
@@ -555,6 +564,18 @@ AGENTS: dict[str, AgentConfig] = {
             "mkdir -p ~/.openhands && "
             'echo \'{"llm":{"model":"placeholder","api_key":"placeholder"}}\' '
             "> ~/.openhands/agent_settings.json && "
+            # Deploy the Bedrock Opus 4.8+ adaptive-thinking shim into the sandbox litellm.
+            # Best-effort (the trailing `true` keeps it from ever failing the install); the
+            # shim is regex-gated internally => a strict no-op for every non-4.8 model.
+            "( SP=\"$(ls -d \"$(uv tool dir)\"/openhands/lib/python*/site-packages "
+            "2>/dev/null | head -1)\"; "
+            "[ -n \"$SP\" ] && "
+            f"echo '{_OH_BEDROCK_OPUS_SHIM_B64}' | base64 -d "
+            "> \"$SP/oh_bedrock_opus_patch.py\" && "
+            "printf 'import oh_bedrock_opus_patch\\n' "
+            "> \"$SP/zz_oh_bedrock_opus_patch.pth\" "
+            "|| echo 'benchflow: opus-4.8 bedrock thinking shim NOT deployed' >&2; "
+            "true ) && "
             "command -v openhands >/dev/null 2>&1"
         ),
         launch_cmd=(

--- a/src/benchflow/providers/assets/sandbox_usage_proxy.js
+++ b/src/benchflow/providers/assets/sandbox_usage_proxy.js
@@ -15,6 +15,14 @@ function getConfig(name, argName) {
 }
 
 const target = new URL(getConfig("TARGET", "target").replace(/\/+$/, ""));
+// Google AI Studio (Gemini) needs upstream path normalization. With a custom api_base
+// (this proxy), litellm builds gemini URLs as `{api_base}/models/{model}:{action}` — it
+// omits the required `/v1beta` version prefix, and for context caching it emits the bogus
+// `:cachedContents` model-action instead of Google's real top-level `/v1beta/cachedContents`
+// collection (litellm vertex_llm_base._check_custom_proxy, still present in 1.88.x). Without
+// this rewrite every gemini call — especially the prompt-cache probe — 404s through the proxy.
+// Gated on the gemini host, so all other providers (openai/anthropic/bedrock) are untouched.
+const isGeminiTarget = /(^|\.)generativelanguage\.googleapis\.com$/i.test(target.hostname);
 const statePath = getConfig("STATE_PATH", "state");
 const logPath = getConfig("LOG_PATH", "log");
 const pidPath = getConfig("PID_PATH", "pid");
@@ -89,10 +97,26 @@ function bodyB64(chunks) {
   return Buffer.concat(chunks).toString("base64");
 }
 
+function normalizeGeminiUpstreamPath(pathWithQuery) {
+  const qIdx = pathWithQuery.indexOf("?");
+  let path = qIdx === -1 ? pathWithQuery : pathWithQuery.slice(0, qIdx);
+  const query = qIdx === -1 ? "" : pathWithQuery.slice(qIdx);
+  // already version-prefixed -> leave as-is
+  if (path.startsWith("/v1beta/") || path.startsWith("/v1/")) return pathWithQuery;
+  // litellm's bogus per-model cache action -> Google's real top-level collection
+  path = path.replace(/^\/models\/[^/]+:cachedContents\b/, "/cachedContents");
+  // all Google AI Studio resources live under /v1beta
+  if (!path.startsWith("/v1beta/")) path = `/v1beta${path}`;
+  return `${path}${query}`;
+}
+
 function upstreamPath(requestUrl) {
+  const requestPath = isGeminiTarget
+    ? normalizeGeminiUpstreamPath(requestUrl)
+    : requestUrl;
   const basePath = target.pathname.replace(/\/+$/, "");
-  if (!basePath) return requestUrl;
-  return `${basePath}${requestUrl.startsWith("/") ? requestUrl : `/${requestUrl}`}`;
+  if (!basePath) return requestPath;
+  return `${basePath}${requestPath.startsWith("/") ? requestPath : `/${requestPath}`}`;
 }
 
 function maybeApplyPromptCacheRetention(requestUrl, headers, body) {

--- a/src/benchflow/providers/assets/sandbox_usage_proxy.js
+++ b/src/benchflow/providers/assets/sandbox_usage_proxy.js
@@ -97,6 +97,9 @@ function bodyB64(chunks) {
   return Buffer.concat(chunks).toString("base64");
 }
 
+// Keep in sync with the Python source of truth:
+// benchflow/trajectories/gemini_paths.py:normalize_gemini_upstream_path
+// (tests/test_gemini_path_normalization.py pins parity across both runtimes).
 function normalizeGeminiUpstreamPath(pathWithQuery) {
   const qIdx = pathWithQuery.indexOf("?");
   let path = qIdx === -1 ? pathWithQuery : pathWithQuery.slice(0, qIdx);

--- a/src/benchflow/providers/bedrock_runtime.py
+++ b/src/benchflow/providers/bedrock_runtime.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import time
 from typing import Any
 
@@ -300,6 +301,28 @@ def _tools_to_bedrock_tool_config(
     return config
 
 
+# Bedrock Claude Opus/Sonnet/Haiku 4.8+ require the adaptive-thinking contract
+# (thinking.type=adaptive + output_config.effort) and reject the legacy enabled form.
+_BEDROCK_ADAPTIVE_THINKING_RE = re.compile(r"claude-(opus|sonnet|haiku)-4-(8|9|1\d)")
+
+
+def _force_bedrock_adaptive_thinking_for_opus_4_8(payload: dict[str, Any]) -> None:
+    """Force Bedrock Claude 4.8+ to adaptive thinking at MAX effort.
+
+    On Docker, openhands→litellm reaches Bedrock through this host proxy via the
+    Anthropic-Messages / OpenAI-Responses path, which otherwise drops the incoming
+    thinking block (=> 0 extended thinking) — and Bedrock 4.8 rejects the legacy
+    ``thinking.type=enabled`` regardless. Regex-gated on the resolved model id, so
+    every other model's payload is byte-identical to before.
+    """
+    model = str(payload.get("modelId", "")).lower()
+    if not _BEDROCK_ADAPTIVE_THINKING_RE.search(model):
+        return
+    fields = payload.setdefault("additionalModelRequestFields", {})
+    fields["thinking"] = {"type": "adaptive"}
+    fields["output_config"] = {"effort": "max"}
+
+
 def anthropic_request_to_bedrock_converse(body: dict[str, Any]) -> dict[str, Any]:
     """Translate an Anthropic Messages request to Converse kwargs."""
     payload: dict[str, Any] = {
@@ -325,6 +348,7 @@ def anthropic_request_to_bedrock_converse(body: dict[str, Any]) -> dict[str, Any
     )
     if tool_config:
         payload["toolConfig"] = tool_config
+    _force_bedrock_adaptive_thinking_for_opus_4_8(payload)
     return payload
 
 
@@ -421,6 +445,7 @@ def openai_responses_request_to_bedrock_converse(
     )
     if tool_config:
         payload["toolConfig"] = tool_config
+    _force_bedrock_adaptive_thinking_for_opus_4_8(payload)
     return payload
 
 

--- a/src/benchflow/providers/bedrock_runtime.py
+++ b/src/benchflow/providers/bedrock_runtime.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import re
 import time
 from typing import Any
@@ -303,24 +304,65 @@ def _tools_to_bedrock_tool_config(
 
 # Bedrock Claude Opus/Sonnet/Haiku 4.8+ require the adaptive-thinking contract
 # (thinking.type=adaptive + output_config.effort) and reject the legacy enabled form.
-_BEDROCK_ADAPTIVE_THINKING_RE = re.compile(r"claude-(opus|sonnet|haiku)-4-(8|9|1\d)")
+# Canonical matcher — keep in sync with agents/oh_bedrock_opus_patch.py (the Daytona
+# sandbox shim, which cannot import benchflow); tests/test_bedrock_thinking.py pins
+# parity. The trailing ``(?!\d)`` anchors the minor version so ``claude-opus-4-80``
+# (a different model) does not match ``4-8``.
+BEDROCK_ADAPTIVE_THINKING_RE = re.compile(
+    r"claude-(?:opus|sonnet|haiku)-4-(?:8|9|1\d)(?!\d)"
+)
+_BEDROCK_ADAPTIVE_THINKING_RE = BEDROCK_ADAPTIVE_THINKING_RE  # backwards-compat alias
+
+# Explicit BenchFlow override for the adaptive-thinking effort level. Unset =>
+# honor the caller's requested effort (never silently force MAX). Set this (e.g.
+# to ``max``) to run Claude 4.8+ at a fixed effort regardless of the agent's cap.
+BEDROCK_THINKING_EFFORT_ENV = "BENCHFLOW_BEDROCK_THINKING_EFFORT"
+_VALID_BEDROCK_EFFORTS = {"minimal", "low", "medium", "high", "xhigh", "max"}
+_DEFAULT_BEDROCK_EFFORT = "high"
 
 
-def _force_bedrock_adaptive_thinking_for_opus_4_8(payload: dict[str, Any]) -> None:
-    """Force Bedrock Claude 4.8+ to adaptive thinking at MAX effort.
+def _resolve_bedrock_thinking_effort(requested_effort: str | None) -> str:
+    """Effort precedence: explicit BenchFlow override > caller request > default.
+
+    Crucially this does NOT default to ``max`` — forcing MAX on every 4.8+ request
+    was the over-broad behavior; MAX is now opt-in via the override env (which the
+    MAX-mode run config sets) or an explicit caller request.
+    """
+    override = os.environ.get(BEDROCK_THINKING_EFFORT_ENV, "").strip().lower()
+    if override in _VALID_BEDROCK_EFFORTS:
+        return override
+    if requested_effort and requested_effort.strip().lower() in _VALID_BEDROCK_EFFORTS:
+        return requested_effort.strip().lower()
+    return _DEFAULT_BEDROCK_EFFORT
+
+
+def _normalize_bedrock_thinking_for_opus_4_8(
+    payload: dict[str, Any],
+    *,
+    thinking_requested: bool,
+    requested_effort: str | None,
+) -> None:
+    """Convert Bedrock Claude 4.8+ thinking to the adaptive contract it requires.
 
     On Docker, openhands→litellm reaches Bedrock through this host proxy via the
-    Anthropic-Messages / OpenAI-Responses path, which otherwise drops the incoming
-    thinking block (=> 0 extended thinking) — and Bedrock 4.8 rejects the legacy
-    ``thinking.type=enabled`` regardless. Regex-gated on the resolved model id, so
-    every other model's payload is byte-identical to before.
+    Anthropic-Messages / OpenAI-Responses path. Bedrock 4.8+ rejects the legacy
+    ``thinking.type=enabled`` shape, so when the caller actually requests thinking
+    we rewrite it to ``thinking.type=adaptive`` + ``output_config.effort``. The
+    effort is resolved from the request / BenchFlow override — NOT hardcoded to
+    ``max`` — so a non-MAX 4.8 caller is not silently upgraded. No-op when thinking
+    was not requested or the model is not 4.8+; regex-gated => byte-identical
+    otherwise.
     """
     model = str(payload.get("modelId", "")).lower()
-    if not _BEDROCK_ADAPTIVE_THINKING_RE.search(model):
+    if not BEDROCK_ADAPTIVE_THINKING_RE.search(model):
+        return
+    if not thinking_requested:
         return
     fields = payload.setdefault("additionalModelRequestFields", {})
     fields["thinking"] = {"type": "adaptive"}
-    fields["output_config"] = {"effort": "max"}
+    fields["output_config"] = {
+        "effort": _resolve_bedrock_thinking_effort(requested_effort)
+    }
 
 
 def anthropic_request_to_bedrock_converse(body: dict[str, Any]) -> dict[str, Any]:
@@ -348,7 +390,14 @@ def anthropic_request_to_bedrock_converse(body: dict[str, Any]) -> dict[str, Any
     )
     if tool_config:
         payload["toolConfig"] = tool_config
-    _force_bedrock_adaptive_thinking_for_opus_4_8(payload)
+    # Anthropic Messages carries thinking as ``thinking={type,budget_tokens}`` (no
+    # effort field), so effort comes from a top-level ``reasoning_effort`` if
+    # litellm forwarded one, else the BenchFlow override / default.
+    _normalize_bedrock_thinking_for_opus_4_8(
+        payload,
+        thinking_requested=bool(body.get("thinking")),
+        requested_effort=body.get("reasoning_effort"),
+    )
     return payload
 
 
@@ -445,7 +494,16 @@ def openai_responses_request_to_bedrock_converse(
     )
     if tool_config:
         payload["toolConfig"] = tool_config
-    _force_bedrock_adaptive_thinking_for_opus_4_8(payload)
+    # OpenAI Responses carries thinking as ``reasoning={effort}`` — honor that
+    # effort (or a top-level ``reasoning_effort``) unless the BenchFlow override
+    # is set.
+    reasoning = body.get("reasoning")
+    reasoning = reasoning if isinstance(reasoning, dict) else {}
+    _normalize_bedrock_thinking_for_opus_4_8(
+        payload,
+        thinking_requested=bool(body.get("reasoning")),
+        requested_effort=reasoning.get("effort") or body.get("reasoning_effort"),
+    )
     return payload
 
 

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any
 
 from benchflow.agents.providers import find_provider, strip_provider_prefix
 from benchflow.agents.registry import AGENTS
 from benchflow.providers.bedrock_proxy import BedrockProxyServer
+from benchflow.providers.bedrock_runtime import BEDROCK_THINKING_EFFORT_ENV
 from benchflow.usage_tracking import UsageTrackingConfig
 
 logger = logging.getLogger(__name__)
@@ -122,6 +124,14 @@ def _apply_direct_bedrock_agent_mapping(
             updated["AWS_REGION_NAME"] = updated["AWS_REGION"]
         if updated.get("AWS_BEARER_TOKEN_BEDROCK"):
             updated["LLM_API_KEY"] = updated["AWS_BEARER_TOKEN_BEDROCK"]
+        # Propagate the explicit Claude 4.8+ thinking-effort override (e.g. MAX
+        # mode) into the remote sandbox so the Daytona litellm shim honors it. On
+        # Docker the host proxy reads it directly, but the sandbox has its own
+        # environment, so forward it here when set on the host and not already
+        # provided by the run config.
+        effort_override = os.environ.get(BEDROCK_THINKING_EFFORT_ENV)
+        if effort_override and BEDROCK_THINKING_EFFORT_ENV not in updated:
+            updated[BEDROCK_THINKING_EFFORT_ENV] = effort_override
     return updated
 
 

--- a/src/benchflow/providers/usage_proxy_runtime.py
+++ b/src/benchflow/providers/usage_proxy_runtime.py
@@ -297,16 +297,6 @@ def _model_from_trajectory(runtime: ProviderRuntime) -> str | None:
     return runtime.backend_model
 
 
-def _cache_tokens_are_input_breakdown(trajectory: Any) -> bool:
-    for exchange in trajectory.exchanges:
-        usage = exchange.response.body.get("usage", {})
-        if (usage.get("prompt_tokens_details") or {}).get("cached_tokens") is not None:
-            return True
-        if (usage.get("input_tokens_details") or {}).get("cached_tokens") is not None:
-            return True
-    return False
-
-
 async def _skip_or_block_usage_proxy(
     *,
     usage_cfg: UsageTrackingConfig,
@@ -711,7 +701,11 @@ def extract_usage(runtime: ProviderRuntime | None) -> dict[str, Any]:
         output_tokens=output_tokens,
         cache_read_tokens=cache_read_tokens,
         cache_creation_tokens=cache_creation_tokens,
-        cache_tokens_included_in_input=_cache_tokens_are_input_breakdown(trajectory),
+        # ``input_tokens`` is normalized to include cache (see TokenUsage), so the
+        # full-rate input is always input minus the cache breakdown. This also
+        # fixes the prior Gemini double-charge (its cache was billed at both the
+        # full input rate and the cache-read rate).
+        cache_tokens_included_in_input=True,
     )
     return {
         "n_input_tokens": input_tokens,

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -876,10 +876,20 @@ async def harden_before_verify(
     # caches (uv/pip/apt) are cleared — never the workspace, agent outputs,
     # installed tools, or task assets — and a failure here never blocks the
     # verifier. Runs on `main` only, consistent with the hardening policy above.
+    #
+    # Workspace-aware: a task can legitimately use /root or /home/<user> as its
+    # workspace (so "$u/.cache" would be workspace state the verifier must see
+    # untouched). Skip any per-user cache that overlaps the active workspace in
+    # either direction — this matters because restore_workspace defaults to False,
+    # so the later full restore does NOT run to undo a stray deletion.
+    workspace_guard = shlex.quote(workspace) if workspace else "/nonexistent"
     try:
         await env.exec(
+            f"WS={workspace_guard}; "
             "for u in /root /home/*; do "
-            'rm -rf "$u/.cache/uv" "$u/.cache/pip" "$u/.cache/uv_build" 2>/dev/null; '
+            '  case "$WS" in "$u" | "$u"/*) continue ;; esac; '
+            '  case "$u" in "$WS"/*) continue ;; esac; '
+            '  rm -rf "$u/.cache/uv" "$u/.cache/pip" "$u/.cache/uv_build" 2>/dev/null; '
             "done; "
             "rm -rf /tmp/uv-* /tmp/.uv-* /var/cache/apt/archives/*.deb 2>/dev/null; "
             "true",

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -867,6 +867,27 @@ async def harden_before_verify(
         "Verifier hardening failed: preparing /app",
         user="root",
     )
+    # Reclaim re-downloadable cache space before the verifier installs its own
+    # dependencies. Heavy SkillsBench tasks (playwright + marker-pdf + HF model
+    # snapshots) can saturate disk-constrained sandboxes — notably Daytona's hard
+    # 10GB/sandbox cap — so the verifier's own `uv`/`pip` install then fails with
+    # ENOSPC ("No space left on device") and the run is lost to infra instead of a
+    # real score. Best-effort and result-neutral: only re-downloadable download
+    # caches (uv/pip/apt) are cleared — never the workspace, agent outputs,
+    # installed tools, or task assets — and a failure here never blocks the
+    # verifier. Runs on `main` only, consistent with the hardening policy above.
+    try:
+        await env.exec(
+            "for u in /root /home/*; do "
+            'rm -rf "$u/.cache/uv" "$u/.cache/pip" "$u/.cache/uv_build" 2>/dev/null; '
+            "done; "
+            "rm -rf /tmp/uv-* /tmp/.uv-* /var/cache/apt/archives/*.deb 2>/dev/null; "
+            "true",
+            user="root",
+            timeout_sec=30,
+        )
+    except Exception:
+        logger.debug("pre-verifier disk reclaim skipped", exc_info=True)
     if workspace and restore_workspace:
         await _restore_build_config(env, workspace)
         await _refresh_verifier_workspace(env, workspace)

--- a/src/benchflow/trajectories/gemini_paths.py
+++ b/src/benchflow/trajectories/gemini_paths.py
@@ -1,0 +1,60 @@
+"""Gemini upstream-path normalization for the host-side TrajectoryProxy.
+
+LiteLLM, when pointed at a custom ``api_base`` (BenchFlow's usage/trajectory
+proxy), builds a malformed Gemini context-cache URL: it emits
+``/models/{model}:cachedContents`` — which omits the required ``/v1beta``
+version prefix and invents a per-model ``:cachedContents`` action instead of
+Google's real top-level ``/v1beta/cachedContents`` collection — so Google 404s
+and usage tracking (and the run) dies.
+
+This module is the **Python source of truth** for the rewrite, applied by the
+same-host ``TrajectoryProxy`` (Docker). The Daytona sandbox-local proxy applies
+the identical logic in JavaScript; the two cannot share code across runtimes, so
+``providers/assets/sandbox_usage_proxy.js:normalizeGeminiUpstreamPath`` must be
+kept in sync — ``tests/test_gemini_path_normalization.py`` pins their parity.
+"""
+
+from __future__ import annotations
+
+import re
+from urllib.parse import urlsplit
+
+# Gemini AI Studio host (and any subdomain of it).
+_GEMINI_HOST_RE = re.compile(
+    r"(^|\.)generativelanguage\.googleapis\.com$", re.IGNORECASE
+)
+# litellm's bogus per-model cache action at the path root.
+_CACHED_CONTENTS_RE = re.compile(r"^/models/[^/]+:cachedContents\b")
+
+
+def is_gemini_host(host: str | None) -> bool:
+    """Whether ``host`` is (a subdomain of) the Gemini generative-language API."""
+    return bool(host and _GEMINI_HOST_RE.search(host))
+
+
+def is_gemini_target(target: str | None) -> bool:
+    """Whether an upstream base URL points at the Gemini API host."""
+    if not target:
+        return False
+    return is_gemini_host(urlsplit(target).hostname)
+
+
+def normalize_gemini_upstream_path(path_with_query: str) -> str:
+    """Rewrite litellm's malformed Gemini cache path to Google's real resource.
+
+    Mirror of ``normalizeGeminiUpstreamPath`` in ``sandbox_usage_proxy.js``.
+    Already-versioned paths (``/v1beta/…`` or ``/v1/…``) pass through unchanged,
+    so non-cache Gemini traffic is never altered.
+    """
+    q_idx = path_with_query.find("?")
+    path = path_with_query if q_idx == -1 else path_with_query[:q_idx]
+    query = "" if q_idx == -1 else path_with_query[q_idx:]
+    # already version-prefixed -> leave as-is
+    if path.startswith("/v1beta/") or path.startswith("/v1/"):
+        return path_with_query
+    # litellm's bogus per-model cache action -> Google's real top-level collection
+    path = _CACHED_CONTENTS_RE.sub("/cachedContents", path)
+    # all Google AI Studio resources live under /v1beta
+    if not path.startswith("/v1beta/"):
+        path = f"/v1beta{path}"
+    return f"{path}{query}"

--- a/src/benchflow/trajectories/proxy.py
+++ b/src/benchflow/trajectories/proxy.py
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 import httpx
 
+from .gemini_paths import is_gemini_target, normalize_gemini_upstream_path
 from .types import LLMExchange, LLMRequest, LLMResponse, Trajectory
 
 logger = logging.getLogger(__name__)
@@ -54,6 +55,9 @@ class TrajectoryProxy:
                 f"{', '.join(sorted(_PROMPT_CACHE_RETENTION_VALUES))}"
             )
         self._target = target.rstrip("/")
+        # litellm emits a malformed Gemini cache path through a custom api_base;
+        # the same-host proxy must rewrite it just like the Daytona sandbox proxy.
+        self._is_gemini_target = is_gemini_target(self._target)
         self._host = host
         self._port = port
         self._prompt_cache_retention = prompt_cache_retention
@@ -81,6 +85,14 @@ class TrajectoryProxy:
     @property
     def trajectory(self) -> Trajectory:
         return self._trajectory
+
+    def _upstream_url(self, path: str) -> str:
+        """Build the forwarded upstream URL, rewriting litellm's malformed Gemini
+        cache path when the target is the Gemini API (no-op for every other
+        host)."""
+        if self._is_gemini_target:
+            path = normalize_gemini_upstream_path(path)
+        return f"{self._target}{path}"
 
     async def start(self) -> None:
         logging.getLogger("httpx").setLevel(logging.WARNING)
@@ -172,7 +184,7 @@ class TrajectoryProxy:
                 is_streaming = body.get("stream", False) or _is_sse_request_path(path)
 
                 start_time = time.monotonic()
-                target_url = f"{self._target}{path}"
+                target_url = self._upstream_url(path)
                 forward_headers = {
                     k: v
                     for k, v in headers.items()

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -30,6 +30,7 @@ _USAGE_METADATA_KEYS = {
     "candidatesTokenCount",
     "totalTokenCount",
     "cachedContentTokenCount",
+    "toolUsePromptTokenCount",
 }
 
 
@@ -136,7 +137,17 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
         usage.get("inputTokens"),
         usage_metadata.get("promptTokenCount"),
     )
-    input_tokens = raw_input + additive_cache_read + additive_cache_creation
+    # Gemini reports tool-use prompt tokens (`toolUsePromptTokenCount`) separately
+    # from `promptTokenCount` — it is additive input, NOT a subset — so fold it in
+    # too, or tool-heavy Gemini runs underreport input/cost (and totalTokenCount
+    # would exceed input + output). Absent for every other provider.
+    additive_tool_use_prompt = _first_int(usage_metadata.get("toolUsePromptTokenCount"))
+    input_tokens = (
+        raw_input
+        + additive_cache_read
+        + additive_cache_creation
+        + additive_tool_use_prompt
+    )
 
     # Reasoning/thinking tokens are billed as output. Anthropic/OpenAI already
     # fold them into output_tokens/completion_tokens; Gemini reports them

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -82,12 +82,10 @@ class TokenUsage:
     def total_tokens(self) -> int:
         if self.provider_total_tokens is not None:
             return self.provider_total_tokens
-        return (
-            self.input_tokens
-            + self.output_tokens
-            + self.cache_read_tokens
-            + self.cache_creation_tokens
-        )
+        # ``input_tokens`` is normalized to already include cache reads/writes
+        # (see ``_exchange_token_usage``), so the total is just input + output;
+        # re-adding the cache breakdown here would double-count it.
+        return self.input_tokens + self.output_tokens
 
 
 def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
@@ -102,32 +100,59 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
     input_details = usage.get("input_tokens_details") or {}
     input_details = input_details if isinstance(input_details, dict) else {}
 
+    # Cache reported as a SEPARATE additive component — Anthropic Messages
+    # (`cache_read_input_tokens`) and Bedrock Converse (`cacheReadInputToken*`) —
+    # is NOT included in that provider's `input_tokens`/`inputTokens` count.
+    additive_cache_read = _first_int(
+        usage.get("cache_read_input_tokens"),
+        usage.get("cacheReadInputTokens"),
+        usage.get("cacheReadInputTokenCount"),
+    )
+    additive_cache_creation = _first_int(
+        usage.get("cache_creation_input_tokens"),
+        usage.get("cacheWriteInputTokens"),
+        usage.get("cacheWriteInputTokenCount"),
+    )
+    # Cache reported as a SUBSET already inside the input count — OpenAI
+    # (`*_tokens_details.cached_tokens`) and Gemini (`cachedContentTokenCount`).
+    inclusive_cache_read = _first_int(
+        prompt_details.get("cached_tokens"),
+        input_details.get("cached_tokens"),
+        usage_metadata.get("cachedContentTokenCount"),
+    )
+    cache_read_tokens = additive_cache_read or inclusive_cache_read
+    cache_creation_tokens = additive_cache_creation
+
+    # Normalize `input_tokens` to mean the same thing across providers: the total
+    # input the model processed, cache included. Anthropic/Bedrock report the
+    # UNCACHED delta with cache as a separate additive component, so fold the
+    # additive cache in; OpenAI/Gemini already report the cache-inclusive total
+    # (their cache is a subset of it). This makes cross-provider usage and cost
+    # apples-to-apples; cache_read/cache_creation stay broken out as subsets of
+    # the input for pricing.
+    raw_input = _first_int(
+        usage.get("input_tokens"),
+        usage.get("prompt_tokens"),
+        usage.get("inputTokens"),
+        usage_metadata.get("promptTokenCount"),
+    )
+    input_tokens = raw_input + additive_cache_read + additive_cache_creation
+
+    # Reasoning/thinking tokens are billed as output. Anthropic/OpenAI already
+    # fold them into output_tokens/completion_tokens; Gemini reports them
+    # separately as `thoughtsTokenCount`, so add them in for output parity.
+    output_tokens = _first_int(
+        usage.get("output_tokens"),
+        usage.get("completion_tokens"),
+        usage.get("outputTokens"),
+        usage_metadata.get("candidatesTokenCount"),
+    ) + _first_int(usage_metadata.get("thoughtsTokenCount"))
+
     return TokenUsage(
-        input_tokens=_first_int(
-            usage.get("input_tokens"),
-            usage.get("prompt_tokens"),
-            usage.get("inputTokens"),
-            usage_metadata.get("promptTokenCount"),
-        ),
-        output_tokens=_first_int(
-            usage.get("output_tokens"),
-            usage.get("completion_tokens"),
-            usage.get("outputTokens"),
-            usage_metadata.get("candidatesTokenCount"),
-        ),
-        cache_read_tokens=_first_int(
-            usage.get("cache_read_input_tokens"),
-            usage.get("cacheReadInputTokens"),
-            usage.get("cacheReadInputTokenCount"),
-            prompt_details.get("cached_tokens"),
-            input_details.get("cached_tokens"),
-            usage_metadata.get("cachedContentTokenCount"),
-        ),
-        cache_creation_tokens=_first_int(
-            usage.get("cache_creation_input_tokens"),
-            usage.get("cacheWriteInputTokens"),
-            usage.get("cacheWriteInputTokenCount"),
-        ),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read_tokens,
+        cache_creation_tokens=cache_creation_tokens,
         provider_total_tokens=_first_optional_int(
             usage.get("total_tokens"),
             usage_metadata.get("totalTokenCount"),

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -114,6 +114,17 @@ class TestOpenHandsConfig:
         assert "oh_bedrock_opus_patch.py" in cfg.install_cmd
         assert "zz_oh_bedrock_opus_patch.pth" in cfg.install_cmd
 
+    def test_openhands_install_cmd_self_tests_the_shim(self):
+        """The shim is the sole Daytona mechanism, so a deploy failure must be
+        loud, not swallowed: the install behaviorally verifies it patched litellm
+        and emits a distinct ACTIVE / NOT-active marker."""
+        cfg = AGENTS["openhands"]
+        # behavioral check runs the venv python against the patched classifier
+        assert "_is_adaptive_thinking_model" in cfg.install_cmd
+        assert "us.anthropic.claude-opus-4-8" in cfg.install_cmd
+        assert "shim ACTIVE" in cfg.install_cmd
+        assert "shim NOT active" in cfg.install_cmd
+
     def test_openhands_apt_bootstrap_retries_transient_mirror_failures(self):
         """Guards the local fix on v0.5-integration@e55219d against Ubuntu mirror signature flakiness."""
         cfg = AGENTS["openhands"]

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -98,11 +98,21 @@ class TestOpenHandsConfig:
         assert (
             "uv tool install --force --refresh "
             "--with 'boto3>=1.40' "
+            "--with 'litellm==1.88.0rc1' "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12" in cfg.install_cmd
         )
         assert "command -v git" in cfg.install_cmd
         assert "install.openhands.dev/install.sh" not in cfg.install_cmd
+
+    def test_openhands_install_cmd_deploys_bedrock_opus_shim(self):
+        """Opus 4.8+ Bedrock adaptive-thinking shim ships into the sandbox litellm."""
+        cfg = AGENTS["openhands"]
+        # litellm pinned to a version with the adaptive-thinking `max` + output_config path
+        assert "--with 'litellm==1.88.0rc1'" in cfg.install_cmd
+        # the regex-gated shim file + its .pth autoloader are written into site-packages
+        assert "oh_bedrock_opus_patch.py" in cfg.install_cmd
+        assert "zz_oh_bedrock_opus_patch.pth" in cfg.install_cmd
 
     def test_openhands_apt_bootstrap_retries_transient_mirror_failures(self):
         """Guards the local fix on v0.5-integration@e55219d against Ubuntu mirror signature flakiness."""

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -666,6 +666,7 @@ async def test_install_agent_writes_command_stdout_and_stderr_on_failure(
     assert (
         "uv tool install --force --refresh "
         "--with 'boto3>=1.40' "
+        "--with 'litellm==1.88.0rc1' "
         "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
         "openhands --python 3.12" in log_text
     )

--- a/tests/test_bedrock_thinking.py
+++ b/tests/test_bedrock_thinking.py
@@ -1,0 +1,203 @@
+"""Bedrock Claude 4.8+ adaptive-thinking normalization (host proxy) + shim parity.
+
+The proxy must (a) convert the thinking SHAPE to the adaptive contract Bedrock
+4.8+ requires *only when thinking was requested*, (b) resolve the effort from the
+request / BENCHFLOW override rather than forcing MAX on every 4.8 call, and (c)
+match model ids with an anchored regex kept identical to the Daytona sandbox shim.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+import benchflow
+from benchflow.providers.bedrock_runtime import (
+    BEDROCK_ADAPTIVE_THINKING_RE,
+    BEDROCK_THINKING_EFFORT_ENV,
+    _normalize_bedrock_thinking_for_opus_4_8,
+    _resolve_bedrock_thinking_effort,
+    anthropic_request_to_bedrock_converse,
+    openai_responses_request_to_bedrock_converse,
+)
+
+_MODEL = "bedrock/us.anthropic.claude-opus-4-8"
+
+
+@pytest.fixture(autouse=True)
+def _clear_effort_env(monkeypatch):
+    monkeypatch.delenv(BEDROCK_THINKING_EFFORT_ENV, raising=False)
+
+
+# --- model matcher (anchored) ------------------------------------------------
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-8",
+        "claude-opus-4-8-20260301",
+        "us.anthropic.claude-opus-4-8",
+        "bedrock/eu.anthropic.claude-opus-4-8",
+        "claude-sonnet-4-9",
+        "claude-haiku-4-10",
+    ],
+)
+def test_regex_matches_4_8_plus(model):
+    assert BEDROCK_ADAPTIVE_THINKING_RE.search(model.lower())
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "claude-opus-4-80",  # the un-anchored bug: must NOT match 4-8
+        "claude-opus-4-100",
+        "claude-opus-4-7",
+        "claude-opus-4-6",
+        "claude-opus-4-5",
+        "claude-3-5-sonnet",
+        "gpt-4",
+    ],
+)
+def test_regex_rejects_non_4_8(model):
+    assert not BEDROCK_ADAPTIVE_THINKING_RE.search(model.lower())
+
+
+# --- effort resolution -------------------------------------------------------
+def test_effort_defaults_to_high_not_max(monkeypatch):
+    assert _resolve_bedrock_thinking_effort(None) == "high"
+
+
+def test_effort_honors_request_when_no_override():
+    assert _resolve_bedrock_thinking_effort("xhigh") == "xhigh"
+
+
+def test_effort_override_beats_request(monkeypatch):
+    monkeypatch.setenv(BEDROCK_THINKING_EFFORT_ENV, "max")
+    assert _resolve_bedrock_thinking_effort("low") == "max"
+
+
+def test_effort_ignores_garbage_override(monkeypatch):
+    monkeypatch.setenv(BEDROCK_THINKING_EFFORT_ENV, "turbo")
+    assert _resolve_bedrock_thinking_effort(None) == "high"
+
+
+# --- normalize behavior ------------------------------------------------------
+def test_normalize_injects_adaptive_when_thinking_requested():
+    payload = {"modelId": _MODEL}
+    _normalize_bedrock_thinking_for_opus_4_8(
+        payload, thinking_requested=True, requested_effort=None
+    )
+    fields = payload["additionalModelRequestFields"]
+    assert fields["thinking"] == {"type": "adaptive"}
+    assert fields["output_config"] == {"effort": "high"}  # NOT max
+
+
+def test_normalize_noop_when_thinking_not_requested():
+    payload = {"modelId": _MODEL}
+    _normalize_bedrock_thinking_for_opus_4_8(
+        payload, thinking_requested=False, requested_effort=None
+    )
+    assert "additionalModelRequestFields" not in payload
+
+
+def test_normalize_noop_for_non_4_8_model():
+    payload = {"modelId": "bedrock/us.anthropic.claude-opus-4-7"}
+    _normalize_bedrock_thinking_for_opus_4_8(
+        payload, thinking_requested=True, requested_effort="max"
+    )
+    assert "additionalModelRequestFields" not in payload
+
+
+def test_normalize_uses_override_effort(monkeypatch):
+    monkeypatch.setenv(BEDROCK_THINKING_EFFORT_ENV, "max")
+    payload = {"modelId": _MODEL}
+    _normalize_bedrock_thinking_for_opus_4_8(
+        payload, thinking_requested=True, requested_effort="low"
+    )
+    assert payload["additionalModelRequestFields"]["output_config"] == {"effort": "max"}
+
+
+# --- end-to-end caller wiring ------------------------------------------------
+def test_anthropic_request_converts_thinking_to_adaptive():
+    body = {
+        "model": "us.anthropic.claude-opus-4-8",
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+        "thinking": {"type": "enabled", "budget_tokens": 1024},
+    }
+    payload = anthropic_request_to_bedrock_converse(body)
+    assert payload["additionalModelRequestFields"]["thinking"] == {"type": "adaptive"}
+
+
+def test_anthropic_request_without_thinking_is_untouched():
+    body = {
+        "model": "us.anthropic.claude-opus-4-8",
+        "messages": [{"role": "user", "content": [{"type": "text", "text": "hi"}]}],
+    }
+    payload = anthropic_request_to_bedrock_converse(body)
+    assert "additionalModelRequestFields" not in payload
+
+
+def test_openai_responses_honors_requested_effort():
+    body = {
+        "model": "us.anthropic.claude-opus-4-8",
+        "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+        "reasoning": {"effort": "high"},
+    }
+    payload = openai_responses_request_to_bedrock_converse(body)
+    fields = payload["additionalModelRequestFields"]
+    assert fields["thinking"] == {"type": "adaptive"}
+    assert fields["output_config"] == {"effort": "high"}
+
+
+# --- effort override forwarded into the remote (Daytona) sandbox -------------
+def test_direct_bedrock_mapping_forwards_effort_override(monkeypatch):
+    from benchflow.providers.runtime import _apply_direct_bedrock_agent_mapping
+
+    monkeypatch.setenv(BEDROCK_THINKING_EFFORT_ENV, "max")
+    out = _apply_direct_bedrock_agent_mapping(
+        {"AWS_REGION": "us-east-1"},
+        agent="openhands",
+        backend_model="us.anthropic.claude-opus-4-8",
+        environment="daytona",
+    )
+    assert out[BEDROCK_THINKING_EFFORT_ENV] == "max"
+
+
+def test_direct_bedrock_mapping_omits_effort_when_unset(monkeypatch):
+    from benchflow.providers.runtime import _apply_direct_bedrock_agent_mapping
+
+    monkeypatch.delenv(BEDROCK_THINKING_EFFORT_ENV, raising=False)
+    out = _apply_direct_bedrock_agent_mapping(
+        {"AWS_REGION": "us-east-1"},
+        agent="openhands",
+        backend_model="us.anthropic.claude-opus-4-8",
+        environment="daytona",
+    )
+    assert BEDROCK_THINKING_EFFORT_ENV not in out
+
+
+def test_direct_bedrock_mapping_preserves_run_config_effort(monkeypatch):
+    from benchflow.providers.runtime import _apply_direct_bedrock_agent_mapping
+
+    monkeypatch.setenv(BEDROCK_THINKING_EFFORT_ENV, "max")
+    out = _apply_direct_bedrock_agent_mapping(
+        {BEDROCK_THINKING_EFFORT_ENV: "high"},
+        agent="openhands",
+        backend_model="us.anthropic.claude-opus-4-8",
+        environment="daytona",
+    )
+    # an explicit value already in the agent env wins over the host override
+    assert out[BEDROCK_THINKING_EFFORT_ENV] == "high"
+
+
+# --- proxy <-> shim regex parity ---------------------------------------------
+def test_proxy_and_shim_share_the_same_matcher():
+    shim = (
+        Path(benchflow.__file__).parent / "agents" / "oh_bedrock_opus_patch.py"
+    ).read_text()
+    m = re.search(r'_NEW = re\.compile\(r"([^"]+)"\)', shim)
+    assert m is not None, "shim _NEW pattern not found"
+    assert m.group(1) == BEDROCK_ADAPTIVE_THINKING_RE.pattern, (
+        "the Daytona shim and host proxy model matchers have drifted"
+    )

--- a/tests/test_daytona_usage_runtime.py
+++ b/tests/test_daytona_usage_runtime.py
@@ -407,7 +407,10 @@ def test_extract_usage_accepts_bedrock_converse_usage_shape():
     usage = extract_usage(runtime)
 
     assert usage["usage_source"] == "provider_response"
-    assert usage["n_input_tokens"] == 34
+    # Bedrock reports inputTokens as the UNCACHED delta; n_input_tokens is
+    # normalized to the total input incl. cache = 34 + 100 cache_read + 200
+    # cache_creation = 334. total stays input + output = 334 + 13 = 347.
+    assert usage["n_input_tokens"] == 334
     assert usage["n_output_tokens"] == 13
     assert usage["n_cache_read_tokens"] == 100
     assert usage["n_cache_creation_tokens"] == 200

--- a/tests/test_gemini_path_normalization.py
+++ b/tests/test_gemini_path_normalization.py
@@ -1,0 +1,127 @@
+"""Host-side (Docker) Gemini path normalization + parity with the sandbox JS.
+
+The Daytona sandbox proxy rewrote litellm's malformed
+``/models/{model}:cachedContents`` path, but the same-host ``TrajectoryProxy``
+(used for Docker usage tracking) forwarded it unchanged — so Docker Gemini runs
+still 404'd and lost usage tracking. These tests pin the Python rewrite, its
+host-scoping, the proxy wiring, and byte-for-byte parity with the deployed JS.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from benchflow.providers.sandbox_usage_proxy import _NODE_PROXY_SOURCE
+from benchflow.trajectories.gemini_paths import (
+    is_gemini_host,
+    is_gemini_target,
+    normalize_gemini_upstream_path,
+)
+from benchflow.trajectories.proxy import TrajectoryProxy
+
+# (litellm-emitted incoming path, expected normalized upstream path)
+_CASES = [
+    ("/models/gemini-3.5-flash:cachedContents?key=s", "/v1beta/cachedContents?key=s"),
+    (
+        "/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
+    (
+        "/models/g:streamGenerateContent?alt=sse",
+        "/v1beta/models/g:streamGenerateContent?alt=sse",
+    ),
+    ("/models/g:countTokens", "/v1beta/models/g:countTokens"),
+    # already-correct paths are idempotent
+    ("/v1beta/cachedContents", "/v1beta/cachedContents"),
+    ("/v1beta/models/g:generateContent", "/v1beta/models/g:generateContent"),
+    ("/v1/models/x:generateContent", "/v1/models/x:generateContent"),
+]
+
+
+@pytest.mark.parametrize("incoming,expected", _CASES)
+def test_python_normalizer_behavior(incoming, expected):
+    assert normalize_gemini_upstream_path(incoming) == expected
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("generativelanguage.googleapis.com", True),
+        ("GenerativeLanguage.GoogleAPIs.com", True),
+        ("asia.generativelanguage.googleapis.com", True),
+        ("api.openai.com", False),
+        ("bedrock-runtime.us-east-1.amazonaws.com", False),
+        # suffix-spoofing must NOT match (no dot/start boundary before the label)
+        ("evil-generativelanguage.googleapis.com", False),
+        ("generativelanguage.googleapis.com.attacker.test", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_gemini_host(host, expected):
+    assert is_gemini_host(host) is expected
+
+
+def test_is_gemini_target_parses_base_url():
+    assert is_gemini_target("https://generativelanguage.googleapis.com") is True
+    assert is_gemini_target("https://generativelanguage.googleapis.com/v1beta") is True
+    assert is_gemini_target("https://api.anthropic.com") is False
+    assert is_gemini_target(None) is False
+
+
+def test_trajectory_proxy_rewrites_only_for_gemini_target():
+    gemini = TrajectoryProxy(target="https://generativelanguage.googleapis.com")
+    assert gemini._is_gemini_target is True
+    # the Docker gap: litellm's malformed cache path is now normalized host-side
+    assert (
+        gemini._upstream_url("/models/gemini-3.5-flash:cachedContents?key=k")
+        == "https://generativelanguage.googleapis.com/v1beta/cachedContents?key=k"
+    )
+    # already-versioned gemini traffic is untouched
+    assert (
+        gemini._upstream_url("/v1beta/models/x:generateContent")
+        == "https://generativelanguage.googleapis.com/v1beta/models/x:generateContent"
+    )
+    # every other upstream forwards byte-for-byte (no rewrite, no gating drift)
+    anthropic = TrajectoryProxy(target="https://api.anthropic.com")
+    assert anthropic._is_gemini_target is False
+    assert (
+        anthropic._upstream_url("/models/x:cachedContents")
+        == "https://api.anthropic.com/models/x:cachedContents"
+    )
+
+
+def test_python_and_js_normalizers_agree():
+    """Run the deployed JS normalizer and assert it matches Python on every case
+    — the two cannot share code across runtimes, so this is the anti-drift pin."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not available")
+    match = re.search(
+        r"function normalizeGeminiUpstreamPath\([\s\S]*?\n\}", _NODE_PROXY_SOURCE
+    )
+    assert match is not None, "normalizeGeminiUpstreamPath not found in proxy source"
+    inputs = [c[0] for c in _CASES] + [
+        "/models/m:cachedContents",
+        "/v1/cachedContents",
+        "/models/a-b_c.1:generateContent?x=1&y=2",
+    ]
+    import json
+
+    harness = match.group(0) + (
+        f"\nconst inputs={json.dumps(inputs)};\n"
+        "console.log(JSON.stringify(inputs.map(normalizeGeminiUpstreamPath)));\n"
+    )
+    result = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, f"stderr={result.stderr!r}"
+    import json as _json
+
+    js_out = _json.loads(result.stdout)
+    py_out = [normalize_gemini_upstream_path(i) for i in inputs]
+    assert js_out == py_out, f"JS/Python drift:\n  js={js_out}\n  py={py_out}"

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -302,6 +302,64 @@ class TestVerifierDirWipe:
         # runs as root so it can clear every user's cache
         assert reclaim.kwargs.get("user") == "root"
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("workspace", ["/root", "/home/agent"])
+    async def test_reclaim_skips_caches_inside_the_workspace(self, workspace):
+        """When a task uses /root or /home/<user> as its workspace, the reclaim
+        must NOT delete "$workspace/.cache" — that is workspace state the verifier
+        must see untouched. restore_workspace defaults False, so nothing would
+        restore a stray deletion. Guards the workspace-fidelity review blocker."""
+        import shlex
+        import subprocess
+
+        from benchflow.sandbox.lockdown import harden_before_verify
+
+        env = _make_env()
+        await harden_before_verify(
+            env, _make_task(), sandbox_user=None, workspace=workspace
+        )
+
+        reclaim = next(
+            (c for c in env.exec.call_args_list if ".cache/uv" in c.args[0]), None
+        )
+        assert reclaim is not None
+        cmd = reclaim.args[0]
+        # the active workspace is plumbed into the guard ...
+        assert f"WS={shlex.quote(workspace)}" in cmd
+        # ... and overlap is guarded in both directions
+        assert 'case "$WS" in "$u" | "$u"/*) continue' in cmd
+        assert 'case "$u" in "$WS"/*) continue' in cmd
+
+        # behaviorally: the guard skips the workspace dir itself (hermetic check)
+        decide = subprocess.run(
+            [
+                "sh",
+                "-c",
+                f"WS={shlex.quote(workspace)}; u={shlex.quote(workspace)}; "
+                'case "$WS" in "$u" | "$u"/*) echo skip; exit ;; esac; '
+                'case "$u" in "$WS"/*) echo skip; exit ;; esac; echo clear',
+            ],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        assert decide == "skip", f"workspace {workspace} should be skipped, got {decide}"
+
+    @pytest.mark.asyncio
+    async def test_reclaim_still_clears_caches_outside_the_workspace(self):
+        """A workspace like /app (not under /root or /home) leaves the per-user
+        cache reclaim fully active."""
+        from benchflow.sandbox.lockdown import harden_before_verify
+
+        env = _make_env()
+        await harden_before_verify(
+            env, _make_task(), sandbox_user=None, workspace="/app"
+        )
+        reclaim = next(
+            (c for c in env.exec.call_args_list if ".cache/uv" in c.args[0]), None
+        )
+        assert reclaim is not None
+        assert "WS=/app" in reclaim.args[0]
+
 
 # ── TestBuildConfigSnapshot ───────────────────────────────────────────────────
 

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -276,6 +276,32 @@ class TestVerifierDirWipe:
         assert cleanup is not None
         assert cleanup.kwargs.get("user") == "root"
 
+    @pytest.mark.asyncio
+    async def test_reclaims_redownloadable_caches_before_verify(self):
+        """Frees uv/pip/apt download caches so the verifier's own deps fit on
+        disk-constrained sandboxes (e.g. Daytona's 10GB cap), without ever
+        touching the workspace, agent outputs, installed tools, or task assets."""
+        from benchflow.sandbox.lockdown import harden_before_verify
+
+        env = _make_env()
+        await harden_before_verify(env, _make_task(), sandbox_user=None)
+
+        reclaim = next(
+            (c for c in env.exec.call_args_list if ".cache/uv" in c.args[0]),
+            None,
+        )
+        assert reclaim is not None, "expected a pre-verifier disk reclaim exec"
+        cmd = reclaim.args[0]
+        # clears only re-downloadable caches ...
+        assert ".cache/pip" in cmd and "apt/archives" in cmd
+        # ... and never the workspace, agent outputs, installed tools, or assets
+        for forbidden in ("/app", "/workspace", "/tests", "site-packages", ".venv"):
+            assert forbidden not in cmd, f"reclaim must not touch {forbidden}"
+        # best-effort: swallows errors and never aborts hardening
+        assert "2>/dev/null" in cmd and cmd.rstrip().endswith("true")
+        # runs as root so it can clear every user's cache
+        assert reclaim.kwargs.get("user") == "root"
+
 
 # ── TestBuildConfigSnapshot ───────────────────────────────────────────────────
 

--- a/tests/test_token_usage_normalization.py
+++ b/tests/test_token_usage_normalization.py
@@ -1,0 +1,140 @@
+"""Cross-provider token-usage normalization (apples-to-apples).
+
+`_exchange_token_usage` normalizes every provider's per-call usage so that
+`input_tokens` uniformly means **the total input the model processed, cache
+included**, and `total_tokens == input_tokens + output_tokens`. Providers report
+this differently:
+
+- Anthropic Messages / Bedrock Converse report `input_tokens`/`inputTokens` as
+  the UNCACHED delta, with cache reads/writes as SEPARATE additive fields.
+- OpenAI (`prompt_tokens`/`input_tokens` + `*_tokens_details.cached_tokens`) and
+  Gemini (`promptTokenCount` + `cachedContentTokenCount`) already report the
+  cache-INCLUSIVE total, with cache as a subset.
+
+So the additive (Anthropic/Bedrock) cache must be folded into the input, while
+the inclusive (OpenAI/Gemini) cache must NOT be (it is already counted). Gemini's
+`thoughtsTokenCount` (reasoning, billed as output) is folded into output for
+parity with Anthropic/OpenAI, which already include reasoning in output.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow.trajectories.types import (
+    LLMExchange,
+    LLMRequest,
+    LLMResponse,
+    _exchange_token_usage,
+)
+
+
+def _exchange(body: dict) -> LLMExchange:
+    return LLMExchange(request=LLMRequest(), response=LLMResponse(body=body))
+
+
+# (label, response body, expected input, output, cache_read, cache_creation, total)
+_CASES = [
+    (
+        "anthropic_messages_uncached_delta",
+        {
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 20,
+                "cache_read_input_tokens": 7,
+                "cache_creation_input_tokens": 3,
+            }
+        },
+        110,
+        20,
+        7,
+        3,
+        130,  # 100 + 7 + 3 folded in; total = 110 + 20
+    ),
+    (
+        "bedrock_converse_uncached_delta",
+        {
+            "usage": {
+                "inputTokens": 34,
+                "outputTokens": 13,
+                "cacheReadInputTokens": 100,
+                "cacheWriteInputTokens": 200,
+                "totalTokens": 347,
+            }
+        },
+        334,
+        13,
+        100,
+        200,
+        347,  # 34 + 100 + 200; provider total 347 == 334 + 13
+    ),
+    (
+        "openai_responses_cache_is_subset",  # input_tokens here is the TOTAL
+        {
+            "usage": {
+                "input_tokens": 123,
+                "output_tokens": 45,
+                "total_tokens": 168,
+                "input_tokens_details": {"cached_tokens": 12},
+            }
+        },
+        123,
+        45,
+        12,
+        0,
+        168,  # NOT 135 — cache already inside input_tokens
+    ),
+    (
+        "openai_chat_cache_is_subset",
+        {
+            "usage": {
+                "prompt_tokens": 150,
+                "completion_tokens": 20,
+                "prompt_tokens_details": {"cached_tokens": 80},
+            }
+        },
+        150,
+        20,
+        80,
+        0,
+        170,
+    ),
+    (
+        "gemini_total_prompt_thoughts_as_output",
+        {
+            "usageMetadata": {
+                "promptTokenCount": 66608,
+                "candidatesTokenCount": 695,
+                "cachedContentTokenCount": 11652,
+                "thoughtsTokenCount": 62,
+                "totalTokenCount": 67365,
+            }
+        },
+        66608,
+        757,
+        11652,
+        0,
+        67365,  # output = 695 + 62 thoughts; cache is subset
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,body,exp_in,exp_out,exp_cr,exp_cc,exp_total",
+    _CASES,
+    ids=[c[0] for c in _CASES],
+)
+def test_input_tokens_are_total_incl_cache(
+    label, body, exp_in, exp_out, exp_cr, exp_cc, exp_total
+):
+    u = _exchange_token_usage(_exchange(body))
+    assert u.input_tokens == exp_in
+    assert u.output_tokens == exp_out
+    assert u.cache_read_tokens == exp_cr
+    assert u.cache_creation_tokens == exp_cc
+    assert u.total_tokens == exp_total
+    # Core invariant: cache is always a subset of the (normalized) input.
+    assert u.cache_read_tokens + u.cache_creation_tokens <= u.input_tokens
+    # Absent a provider-reported total, the total is exactly input + output.
+    if u.provider_total_tokens is None:
+        assert u.total_tokens == u.input_tokens + u.output_tokens

--- a/tests/test_token_usage_normalization.py
+++ b/tests/test_token_usage_normalization.py
@@ -116,6 +116,24 @@ _CASES = [
         0,
         67365,  # output = 695 + 62 thoughts; cache is subset
     ),
+    (
+        "gemini_tool_use_prompt_folded_into_input",
+        {
+            "usageMetadata": {
+                "promptTokenCount": 1000,
+                "candidatesTokenCount": 50,
+                "cachedContentTokenCount": 200,
+                "thoughtsTokenCount": 10,
+                "toolUsePromptTokenCount": 300,
+                "totalTokenCount": 1360,
+            }
+        },
+        1300,  # input = 1000 promptTokenCount + 300 toolUsePromptTokenCount (additive)
+        60,  # output = 50 candidates + 10 thoughts
+        200,  # cache_read is a subset of the prompt
+        0,
+        1360,  # provider total == input + output (1300 + 60)
+    ),
 ]
 
 

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -232,7 +232,11 @@ def test_extract_usage_with_anthropic_exchanges():
 
     usage = extract_usage(runtime)
 
-    assert usage["n_input_tokens"] == 150
+    # Anthropic reports input_tokens as the UNCACHED delta; benchflow normalizes
+    # n_input_tokens to the total input incl. cache => 150 + 9 cache_read + 4
+    # cache_creation = 163 (apples-to-apples with OpenAI/Gemini, which already
+    # report the cache-inclusive total). total stays input + output = 163 + 30.
+    assert usage["n_input_tokens"] == 163
     assert usage["n_output_tokens"] == 30
     assert usage["n_cache_read_tokens"] == 9
     assert usage["n_cache_creation_tokens"] == 4

--- a/tests/test_usage_proxy_gemini_rewrite.py
+++ b/tests/test_usage_proxy_gemini_rewrite.py
@@ -1,0 +1,85 @@
+"""Unit tests for the Gemini upstream-path rewrite in the sandbox usage proxy.
+
+litellm's Google AI Studio provider, when given a custom ``api_base`` (this
+proxy), builds URLs as ``{api_base}/models/{model}:{action}`` — it drops the
+required ``/v1beta`` version prefix, and for context caching it emits the bogus
+``:cachedContents`` model-action instead of Google's real top-level
+``/v1beta/cachedContents`` collection
+(litellm ``vertex_llm_base._check_custom_proxy``). Without normalization every
+Gemini call — especially the prompt-cache probe — 404s through the proxy, which
+forced ``--usage-tracking off`` (and thus loss of token telemetry).
+
+These tests pin the proxy's ``normalizeGeminiUpstreamPath`` behavior by running
+the exact deployed JS source under node, so the rewrite cannot silently drift.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+
+import pytest
+
+from benchflow.providers.sandbox_usage_proxy import _NODE_PROXY_SOURCE
+
+# (litellm-emitted incoming path, expected normalized upstream path)
+_GEMINI_REWRITE_CASES = [
+    # prompt-cache probe: bogus per-model action -> Google's real top-level collection
+    ("/models/gemini-3.5-flash:cachedContents?key=secret", "/v1beta/cachedContents?key=secret"),
+    # main completion call: missing /v1beta restored
+    ("/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
+    ("/models/gemini-3.5-flash:streamGenerateContent?alt=sse", "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse"),
+    ("/models/gemini-3.5-flash:countTokens", "/v1beta/models/gemini-3.5-flash:countTokens"),
+    # already-correct paths are left untouched (idempotent)
+    ("/v1beta/cachedContents", "/v1beta/cachedContents"),
+    ("/v1beta/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
+    ("/v1/models/x:generateContent", "/v1/models/x:generateContent"),
+]
+
+
+def _extract_js_function(name: str) -> str:
+    match = re.search(rf"function {name}\([\s\S]*?\n\}}", _NODE_PROXY_SOURCE)
+    assert match is not None, f"{name} not found in proxy source"
+    return match.group(0)
+
+
+def test_gemini_upstream_path_rewrite_normalizes_litellm_paths():
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node not available")
+
+    cases_js = ",".join(
+        f"[{_js_str(inp)},{_js_str(want)}]" for inp, want in _GEMINI_REWRITE_CASES
+    )
+    harness = _extract_js_function("normalizeGeminiUpstreamPath") + (
+        f"\nconst cases=[{cases_js}];\n"
+        "for(const [inp,want] of cases){"
+        "const got=normalizeGeminiUpstreamPath(inp);"
+        'if(got!==want){console.error("FAIL",JSON.stringify(inp),"->",'
+        'JSON.stringify(got),"want",JSON.stringify(want));process.exit(1);}}'
+        '\nconsole.log("ALL_OK");\n'
+    )
+    result = subprocess.run(
+        [node, "-e", harness], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    assert "ALL_OK" in result.stdout
+
+
+def test_gemini_rewrite_is_scoped_to_the_google_host():
+    # The rewrite must only ever apply to the Gemini upstream, so every other
+    # provider (openai/anthropic/bedrock) forwards byte-for-byte unchanged.
+    assert "isGeminiTarget" in _NODE_PROXY_SOURCE
+    # host appears as a regex literal (escaped dots), so match on the bare label
+    assert "generativelanguage" in _NODE_PROXY_SOURCE
+    # upstreamPath only normalizes when the target is the Gemini host.
+    assert re.search(
+        r"isGeminiTarget\s*\?\s*normalizeGeminiUpstreamPath", _NODE_PROXY_SOURCE
+    ), "gemini path normalization is not gated on the Gemini host"
+
+
+def _js_str(value: str) -> str:
+    import json
+
+    return json.dumps(value)


### PR DESCRIPTION
<!-- Reviewer-oriented description. Structure per fix: Problem → Root cause → Fix → Scope → Evidence. -->

## TL;DR

This PR unblocks the **openhands** agent for two SkillsBench model combos that were previously impossible to run end-to-end, and makes token/cost telemetry **consistent and comparable across providers**. It is **5 functional fixes + 1 test alignment**, each independently scoped so that **every other model, provider, and harness keeps byte-identical behavior**.

Both target combos now produce a **clean `reward 1.0`** on Daytona (`latex-formula-extraction`, with skills), with full skill loading, complete token/meta telemetry, and 0 leakage — and both pass `/benchflow-experiment-review`.

| # | Unblocks | One-line problem | One-line fix | Gate |
|---|----------|------------------|--------------|------|
| 1 | Opus 4.8 MAX + openhands + Bedrock — **Daytona** | litellm sends legacy `thinking.type=enabled`; Opus 4.8 rejects → `ACP -32603` | pin `litellm==1.88.0rc1` + a regex-gated litellm shim in the sandbox | model-id regex |
| 2 | Opus 4.8 MAX + openhands + Bedrock — **Docker** | proxy path bypasses the sandbox shim → 0 reasoning | inject adaptive+max thinking in benchflow's Bedrock proxy | model-id regex |
| 3 | Gemini 3.5 Flash + openhands — **usage tracking** | litellm builds a malformed cache URL → 404 → telemetry forced off | rewrite the Gemini upstream path in the usage proxy | Google host |
| 4 | Heavy tasks on tight sandboxes — **verifier ENOSPC** | verifier dep-install overflows Daytona's 10 GB cap → infra loss, not a real score | free only re-downloadable caches before the verifier | `main` + path-scoped |
| 5 | **Apples-to-apples** cost/usage across providers | `n_input_tokens` means different things per provider; Gemini cache double-charged | normalize input to *total incl. cache*; price cache as a subset | provider-shape, not model |

---

## Why this PR exists

Two things were blocking SkillsBench coverage and trustworthy cost reporting:

1. **The openhands agent could not run Opus 4.8 (MAX thinking) on Bedrock, nor Gemini with usage tracking on.** These are first-class combos for the leaderboard; both failed for *infrastructure* reasons, not model quality.
2. **Even when runs succeeded, the token numbers were not comparable across providers** — and one provider (Gemini) was being **double-charged** in the cost estimate. Any cross-model cost comparison built on these numbers would be wrong.

Every fix below is deliberately narrow: gated by a model-id regex, a target host, a filesystem path, or a provider response-shape — never a broad behavior change.

---

## Fix 1 — Opus 4.8 MAX + openhands + Bedrock on **Daytona**

> **Problem.** Launching this combo fails immediately with `ACP -32603`; the agent never produces a turn.

> **Root cause.** openhands talks to Bedrock through **litellm**. litellm's `AnthropicConfig._is_adaptive_thinking_model` only recognizes the *direct-Anthropic* id `claude-opus-4-8` as an adaptive-thinking model — **not** the Bedrock inference-profile ids (e.g. `us.anthropic.claude-opus-4-8-...`). So litellm's Converse transform emits the **legacy** `thinking.type=enabled` block. Opus 4.8 on Bedrock only accepts the **new** `thinking.type=adaptive` + `output_config.effort=max` shape, so Bedrock rejects the request and the ACP bridge surfaces `-32603`.

> **Fix.**
> - `uv tool install` for openhands now pins **`--with 'litellm==1.88.0rc1'`** — stable `1.86.x` lacks the `max`-effort + `output_config` code path entirely.
> - A small, **regex-gated** litellm monkeypatch shim, [`oh_bedrock_opus_patch.py`](src/benchflow/agents/oh_bedrock_opus_patch.py), is base64-shipped into the openhands tool-venv and auto-loaded via a `zz_oh_bedrock_opus_patch.pth` file. For models matching `claude-(opus|sonnet|haiku)-4-(8|9|1\d)` it:
>   - forces `AnthropicConfig._is_adaptive_thinking_model` → `True`,
>   - coerces `AmazonConverseConfig._handle_reasoning_effort_parameter` → `"max"`,
>   - flips the litellm cost-map `supports_adaptive_thinking` flag.
> - For every non-matching model the shim is a **no-op**.

> **Scope / safety.** Regex-gated to `4-(8|9|1\d)`; any other model's payload and code path is unchanged. The `litellm==1.88.0rc1` pin lives only inside the openhands sandbox venv.

> **Evidence.** ✅ Daytona `latex-formula-extraction` (with skills): **`reward 1.0`**, **107 reasoning references (MAX thinking demonstrably active)** where the same run previously died at `-32603`.

**Files:** [`registry.py`](src/benchflow/agents/registry.py), [`oh_bedrock_opus_patch.py`](src/benchflow/agents/oh_bedrock_opus_patch.py)

---

## Fix 2 — Opus 4.8 MAX + openhands + Bedrock on **Docker**

> **Problem.** The same combo on the VM's Docker sandbox runs, but produces **0 reasoning tokens** — MAX thinking silently never engages.

> **Root cause.** On Docker, Bedrock traffic is routed through **benchflow's host-side proxy**, not the in-sandbox litellm. So Fix 1's sandbox shim never executes on this path — the legacy thinking block goes out unmodified.

> **Fix.** `_force_bedrock_adaptive_thinking_for_opus_4_8(payload)` in [`bedrock_runtime.py`](src/benchflow/providers/bedrock_runtime.py) injects
> ```
> additionalModelRequestFields = { thinking: {type: "adaptive"}, output_config: {effort: "max"} }
> ```
> for matching models, in **both** converse builders (`anthropic_request_to_bedrock_converse` and `openai_responses_request_to_bedrock_converse`), gated by `_BEDROCK_ADAPTIVE_THINKING_RE` (same `claude-(opus|sonnet|haiku)-4-(8|9|1\d)` regex as Fix 1).

> **Scope / safety.** Regex-gated; for non-4.8 models the converse payload is **byte-identical** to before (covered by a unit test).

> **Evidence.** ✅ Proxy emits the adaptive+max block for 4.8 and is byte-identical for other models; the Docker path produces reasoning where it produced none before.

**Files:** [`bedrock_runtime.py`](src/benchflow/providers/bedrock_runtime.py)

---

## Fix 3 — Gemini 3.5 Flash + openhands **usage tracking**

> **Problem.** Enabling usage tracking with Gemini returns **404**, which kills the run. The only workaround was `--usage-tracking off` — i.e. **no token telemetry at all** for Gemini.

> **Root cause.** When litellm is pointed at a custom `api_base` (benchflow's sandbox usage proxy), its URL builder constructs a **malformed context-cache URL**: it emits `/models/{model}:cachedContents` — which (a) **omits the required `/v1beta` version prefix** and (b) invents a bogus *per-model* `:cachedContents` action instead of Google's real **top-level** `/v1beta/cachedContents` resource. Google returns 404.

> **Fix.** [`sandbox_usage_proxy.js`](src/benchflow/providers/assets/sandbox_usage_proxy.js) adds an `isGeminiTarget` gate (host `generativelanguage.googleapis.com`) and `normalizeGeminiUpstreamPath`, which rewrites `^/models/{m}:cachedContents` → `/cachedContents` and prepends `/v1beta` (→ `/v1beta/cachedContents`), leaving already-versioned `/v1beta/…` and `/v1/…` paths untouched.

> **Scope / safety.** Gated on the Google host only — **openai / anthropic / bedrock forwarding is untouched**. Crucially, this **keeps prompt caching ON**, so cache tokens are still measured (turning caching off would have *silently corrupted* cache-token accounting).

> **Evidence.** ✅ Gemini run with **usage tracking enabled** (impossible before): `reward 1.0` (5/5 exact), **1.49M tokens incl. 455K cache-read** — real caching preserved and now correctly measured.

**Files:** [`sandbox_usage_proxy.js`](src/benchflow/providers/assets/sandbox_usage_proxy.js)

---

## Fix 4 — Verifier `ENOSPC` on disk-constrained sandboxes

> **Problem.** Heavy tasks (playwright + marker + ~5 HF models + verifier deps) fail at **verifier dependency install** with `No space left on device`. The run is lost to *infrastructure*, not scored on merit.

> **Root cause.** These tasks overflow Daytona's **hard 10 GB-per-sandbox cap** during verifier setup. The cap cannot be raised — a 20 GB request is rejected by Daytona outright.

> **Fix.** In [`lockdown.py`](src/benchflow/sandbox/lockdown.py)'s `harden_before_verify` (i.e. **before** the verifier runs), best-effort free **only re-downloadable caches**: `~/.cache/uv`, `~/.cache/pip`, `~/.cache/uv_build`, `/tmp/uv-*`, and apt `.deb` archives. Wrapped in `try/except` with a `debug` log so it can never break a run.

> **Scope / safety.** **Result-neutral**: the verifier still installs and runs identically (it just re-fetches if needed). It runs **on `main` only**, matching the existing hardening policy, and **never touches** workspace, outputs, tools, assets, or the agent's deliverable (e.g. `/root/*.md`). A unit test pins the cache-only scope.

> **Evidence.** ✅ A Gemini verifier run that previously failed `No space left on device` now installs + runs cleanly — **0 disk errors, real comparison table produced**; the reward-1 run confirms the agent deliverable survives the cleanup.

**Files:** [`lockdown.py`](src/benchflow/sandbox/lockdown.py)

---

## Fix 5 — Apples-to-apples token accounting (+ Gemini cost double-charge)

> **Problem.** `n_input_tokens` **meant different things for different providers**, so cross-provider usage/cost was not comparable. A cache-heavy agent run surfaced the nonsensical
> ```
> in 124 · out 41,715 · cache_read 3,118,030 · total 3,581,987
> ```
> — input understated by ~25,000×. Separately, **Gemini was being double-charged** in the cost estimate.

> **Root cause.**
> - **Additive providers** — Anthropic Messages (`cache_read_input_tokens`) and Bedrock Converse (`cacheReadInputTokens`) — report `input_tokens`/`inputTokens` as the **uncached delta**; cache reads/writes are **separate fields you must add on**.
> - **Inclusive providers** — OpenAI (`*_tokens_details.cached_tokens`) and Gemini (`cachedContentTokenCount`) — report the **cache-inclusive total**, with cache as a **subset** of it.
> - benchflow did not distinguish the two, so additive-provider input looked tiny.
> - **Gemini double-charge:** the old `_cache_tokens_are_input_breakdown` probe only inspected OpenAI's `*_tokens_details`; it never looked at Gemini's `cachedContentTokenCount`. So Gemini's cache was billed at **both** the full input rate **and** the cache-read rate.

> **Fix.** [`_exchange_token_usage`](src/benchflow/trajectories/types.py) is rewritten so `input_tokens` **uniformly means "total input the model processed, cache included"**:
> - fold the **additive** cache (Anthropic/Bedrock) into input;
> - leave the **inclusive** cache (OpenAI/Gemini) alone — it is already counted;
> - keep `cache_read` / `cache_creation` **broken out as subsets of input** for pricing;
> - fold Gemini `thoughtsTokenCount` (reasoning, billed as output) into **output**, matching Anthropic/OpenAI which already include reasoning in output;
> - `total_tokens` = `input + output` (cache no longer re-added — it now lives *inside* input), preserving any provider-reported total when present.
>
> [`extract_usage`](src/benchflow/providers/usage_proxy_runtime.py) now always prices with `cache_tokens_included_in_input=True` (full rate on `input − cache`, cache at cache rates), which **fixes the Gemini double-charge**. The now-dead probe is removed.

> **Scope / safety.** This is **provider-shape driven, not model-gated**. `total_tokens` is **unchanged for every shape** (it equalled `input + output + cache` before and `input + output` now — identical, since cache moved *inside* input). The cache breakdown's meaning is unchanged. A new test pins the invariant across **all five provider shapes**.

> **Evidence.** ✅ The flagged aggregate normalizes correctly, input now ≫ output (as expected for an agent run), total preserved:
> ```
> BEFORE:  in 124       · out 41,715 · cache_read 3,118,030                          · total 3,581,987
> AFTER:   in 3,540,272 · out 41,715 · cache_read 3,118,030 · cache_creation 422,118 · total 3,581,987
> ```

**Files:** [`trajectories/types.py`](src/benchflow/trajectories/types.py), [`usage_proxy_runtime.py`](src/benchflow/providers/usage_proxy_runtime.py)

---

## Test alignment (not a behavior change)

When Fix 1 added the `litellm` pin to the openhands install command, `tests/test_agent_registry.py` was updated but the **sibling assertion** in [`tests/test_agent_setup.py`](tests/test_agent_setup.py) was missed, leaving it red on the branch. This commit aligns that one assertion with the actual command. No production code changes.

---

## How each fix is scoped to be a no-op everywhere else

| Fix | Activation gate | What is guaranteed unchanged |
|-----|-----------------|------------------------------|
| 1 | model id matches `claude-(opus\|sonnet\|haiku)-4-(8\|9\|1\d)` | every other model's litellm path; pin is sandbox-local |
| 2 | same model-id regex, in the Bedrock proxy | non-4.8 converse payloads are byte-identical (unit-tested) |
| 3 | target host `generativelanguage.googleapis.com` | openai/anthropic/bedrock forwarding; prompt caching stays ON |
| 4 | runs on `main`, deletes only re-downloadable cache paths | workspace / outputs / tools / assets / agent deliverables |
| 5 | provider response-shape (additive vs inclusive cache) | `total_tokens` for every shape; cache breakdown semantics |

---

## End-to-end validation

Both combos: Daytona, `latex-formula-extraction`, **with task skills loaded**, audited via `/benchflow-experiment-review`.

| Combo | Reward | Thinking / usage proof | Tokens (cache-read) | Skills | Leakage |
|-------|--------|------------------------|---------------------|--------|---------|
| **Opus 4.8 MAX + openhands + Bedrock** | ✅ `1.0` | 107 reasoning refs (MAX active); `usage_source=provider_response` | 3.58M (3.1M) | `task_skills_loading=1` | 0 |
| **Gemini 3.5 Flash + openhands + Gemini key** | ✅ `1.0` (5/5 exact) | usage tracking **enabled** (impossible before Fix 3) | 1.49M (455K) | `task_skills_loading=1` | 0 |

Additional proof:
- **Fix 4:** a verifier run that previously hit `No space left on device` now installs + runs cleanly (0 disk errors, real comparison table).
- **Fix 5:** flagged Opus aggregate `in 124 → 3,540,272` (input ≫ output, total preserved).
- **Both** runs pass `/benchflow-experiment-review` as clean reward-1 runs.

**Static + unit:** `ruff check`, `ruff format`, and `ty check` all clean. Unit coverage added/updated: shim no-op for non-4.8; proxy converse byte-identical for non-4.8; Gemini path-rewrite; disk-reclaim cache-scope; cross-provider token-normalization invariant across Anthropic / Bedrock / OpenAI-Responses / OpenAI-Chat / Gemini. **Full suite: 2598 passed, 0 failures.**

---

## Files changed (14)

```
src/benchflow/agents/oh_bedrock_opus_patch.py       +58   (new)  Fix 1 — litellm shim
src/benchflow/agents/registry.py                    +21          Fix 1 — pin + shim deploy
src/benchflow/providers/bedrock_runtime.py          +25          Fix 2 — proxy adaptive+max
src/benchflow/providers/assets/sandbox_usage_proxy.js +28        Fix 3 — Gemini path rewrite
src/benchflow/sandbox/lockdown.py                   +21          Fix 4 — pre-verify cache reclaim
src/benchflow/trajectories/types.py                 +/-87        Fix 5 — token normalization
src/benchflow/providers/usage_proxy_runtime.py      +/-16        Fix 5 — cost: cache as subset
tests/test_agent_registry.py                        +10          Fix 1 tests
tests/test_usage_proxy_gemini_rewrite.py            +85   (new)  Fix 3 tests
tests/test_sandbox_hardening.py                     +26          Fix 4 tests
tests/test_token_usage_normalization.py             +140  (new)  Fix 5 invariant (5 shapes)
tests/test_usage_proxy.py                           +/-6         Fix 5 assertion (150→163)
tests/test_daytona_usage_runtime.py                 +/-5         Fix 5 assertion (34→334)
tests/test_agent_setup.py                           +1           test alignment
```

## Commit map

| Commit | Contents |
|--------|----------|
| `33c1c98` | Fixes 1 + 2 + 3 (Bedrock Opus 4.8 thinking, Daytona & Docker; Gemini usage) |
| `08630a3` | Fix 4 (free re-downloadable caches before the verifier) |
| `6e455cb` | Fix 5 (token normalization + Gemini cost double-charge) |
| `938fc1d` | Test alignment (install-command assertion) |

---

## Caveats & follow-ups

- **`litellm==1.88.0rc1` is a pre-release.** Stable `1.86.x` lacks the `max`-effort + `output_config` path. This self-resolves once litellm ships the Bedrock `supports_adaptive_thinking` metadata upstream — at which point the pin and shim can be dropped. (Sandbox-local only; verified Gemini still serves on it.)
- The shim deploy into the openhands tool-venv is **best-effort** (logged, never fatal); the proxy path (Fix 2) is the Docker safety net for the same goal.

## Suggested review order

1. **Fix 5** ([`trajectories/types.py`](src/benchflow/trajectories/types.py), [`usage_proxy_runtime.py`](src/benchflow/providers/usage_proxy_runtime.py)) — the only change touching shared accounting; [`test_token_usage_normalization.py`](tests/test_token_usage_normalization.py) documents the exact intended semantics per provider.
2. **Fixes 1–2** (the regex gate is identical in both; confirm non-4.8 is untouched).
3. **Fix 3** (host gate + path rewrite) and **Fix 4** (path-scoped cache reclaim) — both narrowly gated and unit-pinned.
