### PR TITLE
Fix native Gemini provider route isolation

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -24,6 +24,10 @@ from urllib.parse import urlparse
 
 from benchflow._dotenv import load_dotenv_env
 from benchflow.agents.codex_config import apply_codex_provider_config
+from benchflow.agents.provider_route import (
+    drop_inherited_cross_provider_overrides,
+    mark_explicit_provider_base_url_envs,
+)
 from benchflow.agents.registry import AGENTS
 
 logger = logging.getLogger(__name__)
@@ -51,9 +55,6 @@ _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
 )
 _CANONICAL_OPENAI_URL = "https://api.openai.com/v1"
-_GENERIC_PROVIDER_OVERRIDE_KEYS = frozenset(
-    {"BENCHFLOW_PROVIDER_BASE_URL", "BENCHFLOW_PROVIDER_API_KEY"}
-)
 _AZURE_RESOURCE_ENV = "AZURE_RESOURCE"
 _AZURE_ENDPOINT_ENV = "AZURE_API_ENDPOINT"
 _AZURE_HOST_SUFFIXES = (".openai.azure.com", ".services.ai.azure.com")
@@ -184,6 +185,8 @@ def auto_inherit_env(
         "OPENAI_BASE_URL",
         "GOOGLE_API_KEY",
         "GEMINI_API_KEY",
+        "GEMINI_API_BASE_URL",
+        "GOOGLE_GEMINI_BASE_URL",
         "GOOGLE_GENERATIVE_AI_API_KEY",
         "GOOGLE_CLOUD_PROJECT",
         "GOOGLE_CLOUD_LOCATION",
@@ -532,33 +535,6 @@ def _configure_codex_custom_provider(
     )
 
 
-def _drop_inherited_generic_provider_overrides(
-    agent_env: dict[str, str],
-    *,
-    model: str | None,
-    explicit_agent_env_keys: set[str],
-) -> None:
-    """Let registered providers use their own endpoint/key over host defaults."""
-    if not model:
-        return
-
-    from benchflow.agents.providers import find_provider
-
-    provider = find_provider(model)
-    if provider is None:
-        return
-    _, provider_cfg = provider
-    # Providers with an empty base URL (for example vllm/) are explicitly
-    # user-supplied endpoints, so inherited BENCHFLOW_PROVIDER_* is the normal
-    # configuration path. Providers with a registered URL/auth env should not be
-    # shadowed by a global generic proxy from .env unless the caller explicitly
-    # passed that override for this run.
-    if not provider_cfg.base_url:
-        return
-    for key in _GENERIC_PROVIDER_OVERRIDE_KEYS - explicit_agent_env_keys:
-        agent_env.pop(key, None)
-
-
 def resolve_agent_env(
     agent: str,
     model: str | None,
@@ -571,6 +547,7 @@ def resolve_agent_env(
     # Both sources use setdefault so explicit agent_env keys take priority.
     auto_inherit_env(agent_env, source_env=load_dotenv_env())
     auto_inherit_env(agent_env)
+    mark_explicit_provider_base_url_envs(agent_env, explicit_agent_env_keys)
     _normalize_codex_auth_env(agent, model, agent_env)
     pre_provider_env = dict(agent_env)
     agent_cfg = AGENTS.get(agent)
@@ -578,7 +555,7 @@ def resolve_agent_env(
     # API-key validation are skipped even if a caller forwards a model.
     if model and agent != "oracle":
         inject_vertex_credentials(agent_env, model)
-        _drop_inherited_generic_provider_overrides(
+        drop_inherited_cross_provider_overrides(
             agent_env,
             model=model,
             explicit_agent_env_keys=explicit_agent_env_keys,

--- a/src/benchflow/agents/provider_route.py
+++ b/src/benchflow/agents/provider_route.py
@@ -1,0 +1,144 @@
+"""Provider-route helpers shared by env resolution and usage proxy routing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from benchflow.agents.providers import find_provider, strip_provider_prefix
+
+GOOGLE_GEMINI_DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com"
+EXPLICIT_PROVIDER_BASE_URL_ENVS = "BENCHFLOW_EXPLICIT_PROVIDER_BASE_URL_ENVS"
+
+GENERIC_PROVIDER_BASE_URL_ENVS = (
+    "BENCHFLOW_PROVIDER_BASE_URL",
+    "LLM_BASE_URL",
+    "OPENAI_BASE_URL",
+    "LITELLM_BASE_URL",
+)
+GENERIC_PROVIDER_API_KEY_ENVS = (
+    "BENCHFLOW_PROVIDER_API_KEY",
+    "LLM_API_KEY",
+    "LITELLM_API_KEY",
+)
+GEMINI_BASE_URL_ENVS = ("GOOGLE_GEMINI_BASE_URL", "GEMINI_API_BASE_URL")
+
+
+@dataclass(frozen=True)
+class ProviderRoute:
+    """Routing contract for a model family before any proxy is installed."""
+
+    provider_name: str
+    default_base_url: str | None = None
+    base_url_envs: tuple[str, ...] = ()
+    allow_inherited_generic_base_url: bool = True
+
+
+def is_native_google_gemini_model(model: str | None) -> bool:
+    """True for direct Google AI Studio Gemini/Gemma models.
+
+    Registered providers (for example ``google-vertex/`` or ``litellm/``) own
+    their own routing contract and are intentionally excluded here.
+    """
+    if not model or find_provider(model) is not None:
+        return False
+    bare = strip_provider_prefix(model).lower()
+    return "gemini" in bare or "gemma" in bare
+
+
+def provider_route_for_model(model: str | None) -> ProviderRoute | None:
+    """Return the canonical route contract for model families that need one."""
+    if is_native_google_gemini_model(model):
+        return ProviderRoute(
+            provider_name="google-gemini",
+            default_base_url=GOOGLE_GEMINI_DEFAULT_BASE_URL,
+            base_url_envs=GEMINI_BASE_URL_ENVS,
+            allow_inherited_generic_base_url=False,
+        )
+    return None
+
+
+def mark_explicit_provider_base_url_envs(
+    agent_env: dict[str, str],
+    explicit_agent_env_keys: set[str],
+) -> None:
+    """Record explicit generic base-url overrides for later proxy routing.
+
+    After ``resolve_agent_env`` has merged .env and host defaults, the usage
+    proxy no longer knows which generic base URL came from a user's run-specific
+    override. This marker preserves that distinction without changing the
+    public agent-env API.
+    """
+    agent_env.pop(EXPLICIT_PROVIDER_BASE_URL_ENVS, None)
+    explicit = [
+        key for key in GENERIC_PROVIDER_BASE_URL_ENVS if key in explicit_agent_env_keys
+    ]
+    if explicit:
+        agent_env[EXPLICIT_PROVIDER_BASE_URL_ENVS] = ",".join(explicit)
+
+
+def drop_inherited_cross_provider_overrides(
+    agent_env: dict[str, str],
+    *,
+    model: str | None,
+    explicit_agent_env_keys: set[str],
+) -> None:
+    """Remove inherited generic provider env vars that do not belong to model.
+
+    Explicit ``agent_env`` values stay authoritative. Only broad defaults copied
+    from .env / host env are removed.
+    """
+    if not model:
+        return
+
+    provider = find_provider(model)
+    if provider is not None:
+        _, provider_cfg = provider
+        # Providers with an empty base URL (for example vllm/) are explicitly
+        # user-supplied endpoints, so inherited BENCHFLOW_PROVIDER_* is their
+        # normal configuration path.
+        if provider_cfg.base_url:
+            for key in {"BENCHFLOW_PROVIDER_BASE_URL", "BENCHFLOW_PROVIDER_API_KEY"}:
+                if key not in explicit_agent_env_keys:
+                    agent_env.pop(key, None)
+        return
+
+    route = provider_route_for_model(model)
+    if route is None or route.allow_inherited_generic_base_url:
+        return
+
+    inherited_generic_keys = (
+        set(GENERIC_PROVIDER_BASE_URL_ENVS) | set(GENERIC_PROVIDER_API_KEY_ENVS)
+    ) - explicit_agent_env_keys
+    for key in inherited_generic_keys:
+        agent_env.pop(key, None)
+
+
+def resolve_native_usage_proxy_target(
+    agent_env: dict[str, str],
+    model: str | None,
+) -> str | None:
+    """Resolve usage-proxy target for native provider families.
+
+    Returning ``None`` means callers should use their legacy/general routing
+    path. For native Gemini, generic inherited base URLs are deliberately
+    ignored; only explicit generic overrides, Gemini-specific base vars, or the
+    Google default can route the run.
+    """
+    route = provider_route_for_model(model)
+    if route is None:
+        return None
+
+    explicit_generic = tuple(
+        key
+        for key in agent_env.get(EXPLICIT_PROVIDER_BASE_URL_ENVS, "").split(",")
+        if key
+    )
+    for env_name in explicit_generic:
+        if env_name in GENERIC_PROVIDER_BASE_URL_ENVS and agent_env.get(env_name):
+            return agent_env[env_name]
+
+    for env_name in route.base_url_envs:
+        if agent_env.get(env_name):
+            return agent_env[env_name]
+
+    return route.default_base_url

--- a/src/benchflow/providers/usage_proxy_runtime.py
+++ b/src/benchflow/providers/usage_proxy_runtime.py
@@ -10,6 +10,7 @@ from typing import Any
 from urllib.parse import urlsplit, urlunsplit
 
 from benchflow.agents.codex_config import apply_codex_provider_config
+from benchflow.agents.provider_route import resolve_native_usage_proxy_target
 from benchflow.agents.providers import strip_provider_prefix
 from benchflow.agents.registry import AGENTS
 from benchflow.providers.runtime import (
@@ -116,6 +117,9 @@ def _resolve_usage_proxy_target(
     agent_env: dict[str, str],
     model: str | None,
 ) -> str | None:
+    native_target = resolve_native_usage_proxy_target(agent_env, model)
+    if native_target:
+        return native_target
     if agent_env.get("BENCHFLOW_PROVIDER_BASE_URL"):
         return agent_env["BENCHFLOW_PROVIDER_BASE_URL"]
     for env_name in _agent_base_url_envs(agent):

--- a/tests/test_provider_route_env_isolation.py
+++ b/tests/test_provider_route_env_isolation.py
@@ -1,0 +1,164 @@
+"""Regression tests for provider-route isolation after PR #598 review."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow.agents.env import resolve_agent_env
+from benchflow.agents.provider_route import EXPLICIT_PROVIDER_BASE_URL_ENVS
+from benchflow.providers.usage_proxy_runtime import _resolve_usage_proxy_target
+
+
+@pytest.fixture(autouse=True)
+def _clean_provider_env(monkeypatch, tmp_path):
+    """Keep tests independent from the developer machine's real provider env."""
+    for key in (
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "BENCHFLOW_PROVIDER_API_KEY",
+        "BENCHFLOW_EXPLICIT_PROVIDER_BASE_URL_ENVS",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "GOOGLE_GEMINI_BASE_URL",
+        "GEMINI_API_BASE_URL",
+        "LLM_API_KEY",
+        "LLM_BASE_URL",
+        "LITELLM_API_KEY",
+        "LITELLM_BASE_URL",
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    empty_dotenv = tmp_path / "empty.env"
+    empty_dotenv.write_text("")
+    monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(empty_dotenv))
+
+
+def test_openhands_gemini_drops_inherited_cross_provider_env(monkeypatch):
+    """Guards the PR #598 follow-up fix against shared .env route pollution."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "https://llm-proxy.example")
+    monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "sk-proxy")
+    monkeypatch.setenv("LLM_BASE_URL", "https://llm-proxy.example")
+    monkeypatch.setenv("LLM_API_KEY", "sk-proxy")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.example/v1")
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm-proxy.example")
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-litellm")
+
+    env = resolve_agent_env("openhands", "gemini-3.5-flash", {})
+
+    assert env["LLM_MODEL"] == "gemini/gemini-3.5-flash"
+    assert env["BENCHFLOW_PROVIDER_API_KEY"] == "gemini-key"
+    assert env["LLM_API_KEY"] == "gemini-key"
+    for key in (
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "LLM_BASE_URL",
+        "OPENAI_BASE_URL",
+        "LITELLM_BASE_URL",
+        "LITELLM_API_KEY",
+    ):
+        assert key not in env
+
+
+def test_gemini_usage_proxy_ignores_inherited_generic_base_urls():
+    """Guards the PR #598 follow-up fix for raw usage-proxy routing calls."""
+    target = _resolve_usage_proxy_target(
+        "openhands",
+        {
+            "BENCHFLOW_PROVIDER_BASE_URL": "https://llm-proxy.example",
+            "LLM_BASE_URL": "https://llm-proxy.example",
+            "OPENAI_BASE_URL": "https://openai-proxy.example/v1",
+        },
+        "gemini-3.5-flash",
+    )
+
+    assert target == "https://generativelanguage.googleapis.com"
+
+
+def test_stale_explicit_marker_does_not_promote_inherited_base_url(monkeypatch):
+    """Guards the PR #598 follow-up fix against forged explicit-route metadata."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.example/v1")
+
+    env = resolve_agent_env(
+        "openhands",
+        "gemini-3.5-flash",
+        {EXPLICIT_PROVIDER_BASE_URL_ENVS: "OPENAI_BASE_URL"},
+    )
+
+    assert EXPLICIT_PROVIDER_BASE_URL_ENVS not in env
+    assert "OPENAI_BASE_URL" not in env
+    assert (
+        _resolve_usage_proxy_target("openhands", env, "gemini-3.5-flash")
+        == "https://generativelanguage.googleapis.com"
+    )
+
+
+def test_gemini_usage_proxy_prefers_gemini_specific_base_url():
+    """Guards the PR #598 follow-up fix for Gemini-specific endpoint overrides."""
+    target = _resolve_usage_proxy_target(
+        "openhands",
+        {
+            "OPENAI_BASE_URL": "https://openai-proxy.example/v1",
+            "GOOGLE_GEMINI_BASE_URL": "https://generativelanguage.googleapis.com/v1beta",
+        },
+        "gemini-3.5-flash",
+    )
+
+    assert target == "https://generativelanguage.googleapis.com/v1beta"
+
+
+def test_gemini_specific_base_url_survives_env_resolution(monkeypatch):
+    """Guards the PR #598 follow-up fix for provider-specific Gemini routing."""
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv(
+        "GOOGLE_GEMINI_BASE_URL",
+        "https://generativelanguage.googleapis.com/v1beta",
+    )
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.example/v1")
+
+    env = resolve_agent_env("openhands", "gemini-3.5-flash", {})
+
+    assert "OPENAI_BASE_URL" not in env
+    assert (
+        _resolve_usage_proxy_target("openhands", env, "gemini-3.5-flash")
+        == "https://generativelanguage.googleapis.com/v1beta"
+    )
+
+
+def test_explicit_generic_base_url_still_overrides_gemini_route():
+    """Guards the PR #598 follow-up fix without breaking explicit proxy routing."""
+    env = resolve_agent_env(
+        "openhands",
+        "gemini-3.5-flash",
+        {
+            "GEMINI_API_KEY": "gemini-key",
+            "BENCHFLOW_PROVIDER_BASE_URL": "https://explicit-proxy.example",
+            "BENCHFLOW_PROVIDER_API_KEY": "sk-explicit",
+        },
+    )
+
+    assert env[EXPLICIT_PROVIDER_BASE_URL_ENVS] == "BENCHFLOW_PROVIDER_BASE_URL"
+    assert env["LLM_BASE_URL"] == "https://explicit-proxy.example"
+    assert env["LLM_API_KEY"] == "sk-explicit"
+    assert (
+        _resolve_usage_proxy_target("openhands", env, "gemini-3.5-flash")
+        == "https://explicit-proxy.example"
+    )
+
+
+def test_litellm_provider_prefix_keeps_litellm_route(monkeypatch):
+    """Guards the PR #598 follow-up fix from breaking intentional proxy providers."""
+    monkeypatch.setenv("LITELLM_BASE_URL", "https://litellm-proxy.example")
+    monkeypatch.setenv("LITELLM_API_KEY", "sk-litellm")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai-proxy.example/v1")
+
+    env = resolve_agent_env("openhands", "litellm/gemini-3.5-flash", {})
+
+    assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://litellm-proxy.example"
+    assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-litellm"
+    assert env["LLM_BASE_URL"] == "https://litellm-proxy.example"
+    assert env["LLM_API_KEY"] == "sk-litellm"
+    assert (
+        _resolve_usage_proxy_target("openhands", env, "litellm/gemini-3.5-flash")
+        == "https://litellm-proxy.example"
+    )

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -342,7 +342,9 @@ class TestVerifierDirWipe:
             capture_output=True,
             text=True,
         ).stdout.strip()
-        assert decide == "skip", f"workspace {workspace} should be skipped, got {decide}"
+        assert decide == "skip", (
+            f"workspace {workspace} should be skipped, got {decide}"
+        )
 
     @pytest.mark.asyncio
     async def test_reclaim_still_clears_caches_outside_the_workspace(self):

--- a/tests/test_usage_proxy_gemini_rewrite.py
+++ b/tests/test_usage_proxy_gemini_rewrite.py
@@ -26,14 +26,29 @@ from benchflow.providers.sandbox_usage_proxy import _NODE_PROXY_SOURCE
 # (litellm-emitted incoming path, expected normalized upstream path)
 _GEMINI_REWRITE_CASES = [
     # prompt-cache probe: bogus per-model action -> Google's real top-level collection
-    ("/models/gemini-3.5-flash:cachedContents?key=secret", "/v1beta/cachedContents?key=secret"),
+    (
+        "/models/gemini-3.5-flash:cachedContents?key=secret",
+        "/v1beta/cachedContents?key=secret",
+    ),
     # main completion call: missing /v1beta restored
-    ("/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
-    ("/models/gemini-3.5-flash:streamGenerateContent?alt=sse", "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse"),
-    ("/models/gemini-3.5-flash:countTokens", "/v1beta/models/gemini-3.5-flash:countTokens"),
+    (
+        "/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
+    (
+        "/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+        "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+    ),
+    (
+        "/models/gemini-3.5-flash:countTokens",
+        "/v1beta/models/gemini-3.5-flash:countTokens",
+    ),
     # already-correct paths are left untouched (idempotent)
     ("/v1beta/cachedContents", "/v1beta/cachedContents"),
-    ("/v1beta/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
+    (
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
     ("/v1/models/x:generateContent", "/v1/models/x:generateContent"),
 ]
 


### PR DESCRIPTION
## Summary
- Follow-up to PR #598: centralize provider-route cleanup in a shared provider_route helper used by env resolution and usage-proxy routing.
- For native Google Gemini/Gemma models, drop inherited cross-provider base URL/API-key env vars and route usage proxy traffic only to explicit per-run generic overrides, Gemini-specific base URLs, or Google's default endpoint.
- Preserve intentional registered-provider behavior for openai/, us-openai/, litellm/, vllm/, and explicit BENCHFLOW_PROVIDER_BASE_URL overrides.
- Add regression coverage for dirty shared .env routing, stale explicit-route markers, Gemini-specific endpoints, explicit proxy overrides, and litellm provider prefixes.

## Root Cause Addressed
Dirty shared .env values like OPENAI_BASE_URL, LLM_BASE_URL, and BENCHFLOW_PROVIDER_BASE_URL were inherited into native Gemini runs. The usage proxy then chose those broad agent-level routes before the Gemini default, sending Google models to an unrelated external proxy. The fix makes provider-family route ownership explicit and keeps inherited generic routes from crossing provider boundaries.

## Validation
- uv sync --extra dev --locked
- uv run ruff format --check src tests
- uv run ruff check .
- uv run ty check
- uv run python -m pytest tests/test_provider_route_env_isolation.py tests/test_resolve_env_helpers.py tests/test_providers.py tests/test_usage_proxy.py tests/test_no_cross_provider_fallback.py
- uv run python -m pytest tests/ (2638 passed, 49 skipped, 1 deselected)
