### PR TITLE
Add MAI-Thinking-1 verifier-hardening checklist to experiment-review skill

### DIFF
--- a/.claude/skills/benchflow-experiment-review/SKILL.md
+++ b/.claude/skills/benchflow-experiment-review/SKILL.md
@@ -117,9 +117,14 @@ shape and sandbox behavior.
 6. Verify skill loading. With-skill runs must show the harness-specific native
    skill metadata or prompt injection pattern; no-skill runs must not expose
    skill files or descriptions.
-7. Verify verifier isolation. The verifier starts only after agent exit or
-   timeout, cannot leak solution data into the agent phase, and records score
-   provenance against the completed trajectory.
+7. Verify verifier isolation and environment hardening. The verifier starts
+   only after agent exit or timeout, cannot leak solution data into the agent
+   phase, and records score provenance against the completed trajectory. Confirm
+   the anti-reward-hacking invariants in
+   `references/verifier-hardening-checklist.md`: network off by default (proxied
+   and allowlisted when needed), git history scrubbed past the base commit, no
+   answer/hidden-test/scorer files in agent-readable paths, empty patch fails
+   while golden patch passes, and agent test edits are reset before grading.
 8. Scale only after the canary passes. Increase concurrency gradually and keep
    each VM below the Docker/container pressure that makes the daemon unstable.
 
@@ -184,6 +189,9 @@ Verifier leakage or reward hacking:
 - When the trajectory looks suspicious, load
   `references/reward-hacking-patterns.md` and classify the evidence against the
   solution-contamination, grader-gaming, and alignment-risk patterns there.
+- To remediate and prevent recurrence, apply
+  `references/verifier-hardening-checklist.md`, which maps each pattern to the
+  environment/grader fix that closes it at the source.
 
 Skill loading mismatch:
 

--- a/.claude/skills/benchflow-experiment-review/references/reward-hacking-patterns.md
+++ b/.claude/skills/benchflow-experiment-review/references/reward-hacking-patterns.md
@@ -114,3 +114,14 @@ For every suspected reward hack, report:
 
 If evidence is suspicious but not conclusive, keep the trial out of published
 healthy data until a clean rerun or manual review resolves the ambiguity.
+
+## Prevention
+
+Detection above is necessary but not sufficient. For the environment- and
+grader-side fixes that close each pattern at the source, load
+`references/verifier-hardening-checklist.md`. Those invariants come from
+Microsoft AI's MAI-Thinking-1 report, which confirmed the A-online, A-git, and
+B-tampering patterns via LLM-monitor plus human review of RL rollouts. Note its
+caveat: monkey-patching the test framework and overriding equality (`__eq__`)
+are not fully closed by test-reset or hidden tests, so keep the B monkey-patch
+and operator-overload checks active even on a hardened environment.

--- a/.claude/skills/benchflow-experiment-review/references/verifier-hardening-checklist.md
+++ b/.claude/skills/benchflow-experiment-review/references/verifier-hardening-checklist.md
@@ -1,0 +1,109 @@
+# Verifier Hardening Checklist
+
+Prevention-side companion to `reward-hacking-patterns.md`. That file is for
+*detection* (auditing a finished trajectory); this file is for *prevention*
+(closing the vector in the environment) when integration-testing a Benchflow
+code change or packaging a task.
+
+The invariants below are drawn from Microsoft AI's MAI-Thinking-1 technical
+report, "Building a Hill-Climbing Machine" (2026), which deployed an LLM monitor
+plus human review of RL rollouts and documented the concrete mitigations a
+frontier training stack uses. The report empirically confirmed three SWE
+reward-hacking types — internet answer search, local git-history search, and
+test tampering — and reported the fixes below. Each invariant names the
+`reward-hacking-patterns.md` pattern it closes. Section refs (e.g. MAI §3.3.1)
+point into that report; verify wording against the current paper before quoting.
+
+## Environment Isolation
+
+- Fresh sandbox per task, destroyed on completion, with no state carried between
+  tasks or trials. (MAI §3.3, Sandbox Execution Environment)
+- Network isolated by default. Only when a task genuinely needs it (e.g.,
+  package install) route egress through a caching proxy plus an explicit domain
+  allowlist — never open general egress. (MAI §3.3)
+  → closes A: online answer lookup.
+
+## Answer-Leakage Removal (category A)
+
+- Git "time-travel": scrub every commit, ref, branch, and tag *after* the task's
+  base commit, returning the repo to its original pre-fix state. Do not delete
+  git entirely — git is a legitimate skill and removing it breaks valid task
+  flows. (MAI §3.3.1; the SWE-bench #465 class of leak)
+  → closes A: git-history leakage.
+- No answer artifacts in agent-visible paths: reference solutions, expected
+  outputs, answer JSON, hidden tests, and scorer files live outside any path the
+  agent can read. (MAI §3.3.1)
+  → closes A: environment answer leakage.
+- Build-time leakage probe: confirm an empty/no-op patch FAILS the grader and
+  the golden patch PASSES, across multiple trials; drop environments with
+  non-deterministic tests. A passing empty patch means the reward is reachable
+  without solving — a leak or grader bug. (MAI §3.3.1)
+  → closes A: environment leakage + B: grader-bug exploitation.
+- Problem statement carries enough to solve but does not over-specify or embed
+  the answer. Score tasks on spec clarity, test quality, leakage risk, and
+  feasibility, and rewrite leaky or underspecified statements. (MAI §3.3.1)
+  → closes A: environment leakage; reduces B: test-input hardcoding pressure.
+
+## Grader Integrity (category B)
+
+- Reset all agent-modified test files before grading; the grade runs against the
+  original tests, not the agent's edits. (MAI §3.3.1, SWE-Bench protocol)
+  → closes B: test/verifier mutation, assertion suppression, skip/xfail abuse.
+- Hide test changes from the agent during the run and apply them only at grading
+  time (hidden tests). (MAI §3.3.1)
+  → closes B: test-input hardcoding.
+- Run the verifier as a separate process/container, started only after the agent
+  exits or times out, writing scores to a path the agent cannot touch. (MAI §3.3
+  grading lifecycle; matches this skill's verifier-isolation rule)
+  → closes B: direct result writing, exit-code manipulation.
+- Residual vectors the report flags as NOT closed by test-reset or hidden tests
+  alone: monkey-patching the test framework, and modifying equivalence behavior
+  (e.g., overriding `__eq__`). These must be caught by trajectory monitoring, so
+  keep the B: monkey-patch and operator-overload checks in
+  `reward-hacking-patterns.md` active even on an otherwise hardened environment.
+  (MAI §3.3.1)
+
+## Reward / Judge Design
+
+- Prefer verifiable rule-based rewards over LLM-judge rewards wherever the
+  constraint can be checked directly; verifiable rewards are reported as less
+  prone to reward hacking. (MAI §3.4.1)
+- For LLM judges, coarse rubrics (e.g., 0/1/2) are harder to game than granular
+  prompt-specific rubrics; add few-shot examples to the judge prompt to reduce
+  judge hacking. (MAI §3.5; Appendix Fig 25)
+  → reduces grader/judge gaming and sycophancy.
+- Penalize length via an acceptable per-context quantile range, not a flat
+  penalty, so the anti-verbosity reward cannot itself be hacked by collapsing
+  into an overly terse answer. (MAI §3.4.1)
+  → closes length-bias gaming.
+
+## Training-Loop Defense (only when runs feed model training)
+
+- Monitor rollouts with an LLM plus human review of flagged cases, and
+  continuously strengthen test-file detection/reset and anti-tampering
+  heuristics. (MAI §3.3.1)
+- When generating SFT/self-distillation data from runs, filter out traces that
+  exhibit reward hacking so the behavior is not reinforced into the next model.
+  (MAI §3.1.4)
+
+## Integration-Test Checklist
+
+When validating a Benchflow code change or task package, confirm:
+
+- [ ] Network off by default; any egress is proxied and allowlisted.
+- [ ] Sandbox is fresh per task and torn down after.
+- [ ] Repo git history scrubbed past the base commit (commits, refs, branches, tags).
+- [ ] No answer / reference / hidden-test / scorer files in agent-readable paths.
+- [ ] Empty patch fails and golden patch passes the grader, across multiple trials.
+- [ ] Agent test edits are reset before grading; hidden tests applied at grade time.
+- [ ] Verifier runs post-exit, isolated, scoring to an agent-unwritable path.
+- [ ] Trajectory monitoring still covers the monkey-patch / `__eq__` / exit-code
+      vectors the environment cannot fully block.
+
+## Source
+
+Microsoft AI, "MAI-Thinking-1: Building a Hill-Climbing Machine" (2026):
+§3.1.4 (self-distillation trace filtering), §3.3 (Sandbox Execution Environment),
+§3.3.1 (preventing reward hacking during SWE RL), §3.4.1 (verifiable vs judge
+rewards, length penalty), §3.5 (coarse style graders), Appendix Fig 25 (judge
+few-shot).


### PR DESCRIPTION
## What

Adds the prevention side of reward hacking to the `benchflow-experiment-review` skill. The skill already **detects** reward hacking (`references/reward-hacking-patterns.md` — A/B/C taxonomy, audit signals, and a `reward-hack` eval fixture); this PR adds **prevention**: environment- and grader-side fixes that close each pattern at the source.

## Source

All invariants are drawn from Microsoft AI's *MAI-Thinking-1: Building a Hill-Climbing Machine* (2026), which deployed an LLM monitor plus human review of RL rollouts and documented the concrete mitigations a frontier training stack uses (§3.1.4, §3.3, §3.3.1, §3.4.1, §3.5, App. Fig 25).

## Changes

- **New** `references/verifier-hardening-checklist.md` — environment isolation, git time-travel scrub, answer-leakage removal, grader integrity (test reset + hidden tests, post-exit verifier isolation), reward/judge design, and an integration-test checkbox list. Each invariant maps to the reward-hacking pattern it closes and cites the paper section.
- `SKILL.md` — Integration-Tests step 7 ("Verify verifier isolation" → "…and environment hardening") and the reward-hacking Failure Playbook now point to the checklist.
- `reward-hacking-patterns.md` — adds a `## Prevention` cross-link with the paper's empirical confirmation and the monkey-patch / `__eq__` residual-vector caveat.

## Notes

- Docs / skill-reference change only; no code touched. The 4 existing detection evals are unaffected.
- Design split: detection ref = audit a finished trajectory; hardening ref = prevent at env/grader build time.

## Not in this PR (possible follow-ups)

- `scripts/scan_reward_hacking.py` marker scanner (parity with `extract_harness_skills.py`).
- A-class / harder-B eval fixtures (current evals cover B test-mutation + direct-score-write only).
