### PR TITLE
Fix daytona sandbox cleanup/list for SDK >=0.18 iterator API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,10 @@ dev = [
     "ty>=0.0.1a1",
 ]
 sandbox-daytona = [
-    "daytona>=0.153.0",
+    # >=0.183: list() returns an auto-paginating Iterator[Sandbox] (the older
+    # paged list(page=, limit=) -> .items API was removed), and 0.176's broken
+    # top-level `Daytona` export is fixed.
+    "daytona>=0.183.0",
     "tenacity>=8.0",
 ]
 sandbox-modal = [

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -170,41 +170,36 @@ def _cleanup_daytona_sandboxes(dry_run: bool, max_age_minutes: int) -> None:
 
     d = _daytona_client_or_exit()
     now = datetime.now(UTC)
-    page = 1
     total_deleted = 0
     total_found = 0
     total_skipped = 0
 
-    while True:
-        result = d.list(page=page, limit=100)
-        if not result.items:
-            break
-        total_found += len(result.items)
-        for sb in result.items:
-            if not sb.created_at:
-                continue
-            created_at = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
-            age_minutes = (now - created_at).total_seconds() / 60
-            if age_minutes < max_age_minutes:
-                total_skipped += 1
-                if dry_run:
-                    console.print(
-                        f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [green](skip)[/green]"
-                    )
-                continue
+    # daytona SDK >=0.18 replaced the paged ``list(page=, limit=)`` API (which
+    # returned a page object with ``.items``) with ``list()`` -> an
+    # auto-paginating ``Iterator[Sandbox]``. Iterate it directly.
+    for sb in d.list():
+        total_found += 1
+        if not sb.created_at:
+            continue
+        created_at = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
+        age_minutes = (now - created_at).total_seconds() / 60
+        if age_minutes < max_age_minutes:
+            total_skipped += 1
             if dry_run:
                 console.print(
-                    f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [red](delete)[/red]"
+                    f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [green](skip)[/green]"
                 )
-            else:
-                try:
-                    d.delete(sb)
-                    total_deleted += 1
-                except Exception as e:
-                    console.print(f"  [yellow]Failed to delete {sb.id}: {e}[/yellow]")
-        if len(result.items) < 100:
-            break
-        page += 1
+            continue
+        if dry_run:
+            console.print(
+                f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [red](delete)[/red]"
+            )
+        else:
+            try:
+                d.delete(sb)
+                total_deleted += 1
+            except Exception as e:
+                console.print(f"  [yellow]Failed to delete {sb.id}: {e}[/yellow]")
 
     if dry_run:
         console.print(
@@ -1667,25 +1662,19 @@ def environment_list(
     table.add_column("Age")
     table.add_column("Target")
 
-    page = 1
     now = datetime.now(UTC)
     total = 0
-    while True:
-        result = d.list(page=page, limit=50)
-        if not result.items:
-            break
-        for sb in result.items:
-            total += 1
-            age = ""
-            if sb.created_at:
-                created = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
-                mins = (now - created).total_seconds() / 60
-                age = f"{mins:.0f}m"
-            target = getattr(sb, "target", "") or ""
-            table.add_row(sb.id[:12] + "…", str(sb.state), age, str(target)[:40])
-        if len(result.items) < 50:
-            break
-        page += 1
+    # daytona SDK >=0.18: ``list()`` yields an auto-paginating Iterator[Sandbox]
+    # (was a paged ``list(page=, limit=)`` -> page object with ``.items``).
+    for sb in d.list():
+        total += 1
+        age = ""
+        if sb.created_at:
+            created = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
+            mins = (now - created).total_seconds() / 60
+            age = f"{mins:.0f}m"
+        target = getattr(sb, "target", "") or ""
+        table.add_row(sb.id[:12] + "…", str(sb.state), age, str(target)[:40])
 
     console.print(table)
     console.print(f"\n[bold]{total} sandbox(es)[/bold]")

--- a/tests/test_cli_daytona.py
+++ b/tests/test_cli_daytona.py
@@ -16,9 +16,11 @@ def _install_fake_daytona(monkeypatch, sandboxes):
             self.deleted = []
             self.__class__.instances.append(self)
 
-        def list(self, page=None, limit=None, labels=None):
-            _ = (limit, labels)
-            return SimpleNamespace(items=sandboxes if page == 1 else [])
+        def list(self, query=None):
+            # Mirror daytona SDK >=0.18: list() returns an auto-paginating
+            # Iterator[Sandbox], not a page object with `.items`.
+            _ = query
+            return iter(sandboxes)
 
         def delete(self, sandbox, timeout=60):
             _ = timeout

--- a/tests/test_cli_daytona.py
+++ b/tests/test_cli_daytona.py
@@ -33,6 +33,8 @@ def _install_fake_daytona(monkeypatch, sandboxes):
 
 
 def test_environment_cleanup_dry_run_lists_old_daytona_sandboxes(monkeypatch):
+    """Guards PR #605: cleanup must iterate Daytona.list() (Iterator[Sandbox],
+    SDK >=0.18) instead of the removed paged ``.items`` page object."""
     sandboxes = [
         SimpleNamespace(
             id="old-sandbox",
@@ -53,6 +55,8 @@ def test_environment_cleanup_dry_run_lists_old_daytona_sandboxes(monkeypatch):
 
 
 def test_legacy_cleanup_delegates_to_daytona_cleanup(monkeypatch):
+    """Guards PR #605: `bench cleanup` deletes age-eligible sandboxes while
+    iterating Daytona.list()'s Iterator[Sandbox] (SDK >=0.18)."""
     sandboxes = [
         SimpleNamespace(
             id="old-sandbox",
@@ -70,6 +74,8 @@ def test_legacy_cleanup_delegates_to_daytona_cleanup(monkeypatch):
 
 
 def test_environment_list_uses_daytona_import_compat(monkeypatch):
+    """Guards PR #605 (iterating Daytona.list()'s Iterator[Sandbox], SDK >=0.18)
+    and the anyio import-compat shim for `bench environment list`."""
     import anyio
 
     monkeypatch.delattr(anyio, "AsyncContextManagerMixin", raising=False)

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -342,7 +342,9 @@ class TestVerifierDirWipe:
             capture_output=True,
             text=True,
         ).stdout.strip()
-        assert decide == "skip", f"workspace {workspace} should be skipped, got {decide}"
+        assert decide == "skip", (
+            f"workspace {workspace} should be skipped, got {decide}"
+        )
 
     @pytest.mark.asyncio
     async def test_reclaim_still_clears_caches_outside_the_workspace(self):

--- a/tests/test_usage_proxy_gemini_rewrite.py
+++ b/tests/test_usage_proxy_gemini_rewrite.py
@@ -26,14 +26,29 @@ from benchflow.providers.sandbox_usage_proxy import _NODE_PROXY_SOURCE
 # (litellm-emitted incoming path, expected normalized upstream path)
 _GEMINI_REWRITE_CASES = [
     # prompt-cache probe: bogus per-model action -> Google's real top-level collection
-    ("/models/gemini-3.5-flash:cachedContents?key=secret", "/v1beta/cachedContents?key=secret"),
+    (
+        "/models/gemini-3.5-flash:cachedContents?key=secret",
+        "/v1beta/cachedContents?key=secret",
+    ),
     # main completion call: missing /v1beta restored
-    ("/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
-    ("/models/gemini-3.5-flash:streamGenerateContent?alt=sse", "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse"),
-    ("/models/gemini-3.5-flash:countTokens", "/v1beta/models/gemini-3.5-flash:countTokens"),
+    (
+        "/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
+    (
+        "/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+        "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+    ),
+    (
+        "/models/gemini-3.5-flash:countTokens",
+        "/v1beta/models/gemini-3.5-flash:countTokens",
+    ),
     # already-correct paths are left untouched (idempotent)
     ("/v1beta/cachedContents", "/v1beta/cachedContents"),
-    ("/v1beta/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
+    (
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
     ("/v1/models/x:generateContent", "/v1/models/x:generateContent"),
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -252,7 +252,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
     { name = "anyio", specifier = ">=4.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40" },
-    { name = "daytona", marker = "extra == 'sandbox-daytona'", specifier = ">=0.153.0" },
+    { name = "daytona", marker = "extra == 'sandbox-daytona'", specifier = ">=0.183.0" },
     { name = "google-genai", marker = "extra == 'judge'", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "modal", marker = "extra == 'sandbox-modal'", specifier = ">=0.73" },
@@ -564,7 +564,7 @@ wheels = [
 
 [[package]]
 name = "daytona"
-version = "0.176.0"
+version = "0.183.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -588,14 +588,14 @@ dependencies = [
     { name = "urllib3" },
     { name = "wsproto" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/c7/72da9a8ea1c0092c1eeb2cf7b9c16fbdceeaa2fefadce3135bb4c45f8939/daytona-0.176.0.tar.gz", hash = "sha256:d26bccb20ad37c300c864226ed1c1deffffa335388c71581c509e8ae5e3cc910", size = 139522, upload-time = "2026-05-14T16:09:30.449Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/dd/3914a2ae3dc4ecf3fd861eff221f4222e48ba4e5530ff7e585d4c4aa7965/daytona-0.183.0.tar.gz", hash = "sha256:2f0020537712ae67693fd2341d3008d464ada06dcd8e89baa6183846271e2f76", size = 141636, upload-time = "2026-05-29T10:59:50.565Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/db/4c9af1b369c6d6555a5f4de8e1acf9bc316b34039cd6ac60fe25f0ff2bf1/daytona-0.176.0-py3-none-any.whl", hash = "sha256:34b917dfd6b224c13c5ce2c34515542fafbe1ca8be6e931535f103dcda0d2317", size = 169933, upload-time = "2026-05-14T16:09:28.597Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ae/b23f7e5381ca5d66f2be0f802ebef0110b5e21022946fa7b9d6e873ec6ad/daytona-0.183.0-py3-none-any.whl", hash = "sha256:89af1bcfc9b37c580329fcad01167bcfab786330e2d0ae74ad3fae8cb40397d2", size = 172192, upload-time = "2026-05-29T10:59:48.838Z" },
 ]
 
 [[package]]
 name = "daytona-api-client"
-version = "0.176.0"
+version = "0.183.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -603,14 +603,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/50/fe13cf7edfd6e8634085f921684e9294757437ee38e297deb5f9c6b99118/daytona_api_client-0.176.0.tar.gz", hash = "sha256:64648aead275ac137cd339b8c382faa9d47f6719d7b1f102772ce87c60d5ea8e", size = 148905, upload-time = "2026-05-14T16:08:29.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/40/a5090268e734f804489b8ca3dcdbd4de7c392b1b4d4b02a60c5d85c7198f/daytona_api_client-0.183.0.tar.gz", hash = "sha256:659fff84a6461d1f51986fb814bf6e3fbc51ac203e6502eb6ae6f26029d69814", size = 147714, upload-time = "2026-05-29T10:59:01.709Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/4e/8a7be3d23e9415d57590840df9c2ed0fc88fb30f0bfaf29d7c5532dd24e0/daytona_api_client-0.176.0-py3-none-any.whl", hash = "sha256:a076aee561a6901cd97bd89db435e8f9a44f37c4eecfbc5cea11fd2aedf808ca", size = 408234, upload-time = "2026-05-14T16:08:28.288Z" },
+    { url = "https://files.pythonhosted.org/packages/70/6a/8890e773ecf1cd9c1b70ddb0fda57e4941f5a8a44ced1c91574253797f63/daytona_api_client-0.183.0-py3-none-any.whl", hash = "sha256:c319ae3b4666ec15402cacb8ec3aaffbf55802c0dbc33f6826ef07afceae5085", size = 406274, upload-time = "2026-05-29T10:59:00.427Z" },
 ]
 
 [[package]]
 name = "daytona-api-client-async"
-version = "0.176.0"
+version = "0.183.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -619,14 +619,14 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/99/cb57706aa5c2df8a7705a0be14616dc173ba2981afeeac8ec9f9a23df724/daytona_api_client_async-0.176.0.tar.gz", hash = "sha256:e15929cab1dc449100e4e10ffed49532687b21555b2f8a069b76c9ce2df86b34", size = 149434, upload-time = "2026-05-14T16:08:39.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/aa/c9de46d48ee45228566a53bb699bc4bdab693dc8ce300516ce334bfec82f/daytona_api_client_async-0.183.0.tar.gz", hash = "sha256:4f5b397e375635fe3614c342cf34faa236d5a0918c53588d7059b5061d881407", size = 148190, upload-time = "2026-05-29T10:59:14.315Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/73/56/8eadd63b11c7630d0d03bf561f3e0560ca2806a0c7f3b4f05015a454fdcd/daytona_api_client_async-0.176.0-py3-none-any.whl", hash = "sha256:2b86a737d5066cbf3d39014459718aeb0ab5555f58d5705865fbd9fce32cc733", size = 411477, upload-time = "2026-05-14T16:08:37.741Z" },
+    { url = "https://files.pythonhosted.org/packages/71/db/dde2e2478faf010b048af24227e5ff8b4c635d8104ace26c66ed1f29dd49/daytona_api_client_async-0.183.0-py3-none-any.whl", hash = "sha256:8be2b0bac344893294a8ffd8df7a4703427ec48376f6948975aca85f09dba541", size = 409552, upload-time = "2026-05-29T10:59:12.964Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client"
-version = "0.176.0"
+version = "0.183.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -634,14 +634,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/23/f1/299ca63c3ba37721e7284ed03f979742381fa2807b8e136311d2d1b99e5f/daytona_toolbox_api_client-0.176.0.tar.gz", hash = "sha256:ba95750a357095c9f66d42dc243012df1e60a221e43faf6420f93c8d2983c27b", size = 77730, upload-time = "2026-05-14T16:08:55.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/ee/1c8b9785c4028a0932f655e131e44417380a1e3d6ff4eb58b4e10b9aac18/daytona_toolbox_api_client-0.183.0.tar.gz", hash = "sha256:7cf4eb8ab36ec488f436695822b0e4c06e82d12d8fb2fe28e3239151dd43c4b7", size = 77732, upload-time = "2026-05-29T10:58:40.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b0/a5/005b3cf54eac4e64d0f5cb7bac4321f2dfe7d7020d6169f309b7428df38e/daytona_toolbox_api_client-0.176.0-py3-none-any.whl", hash = "sha256:6272e1b3ef5e5a2b1abf3007581b1756ffa791a7f220768dc0caed1f94733e7b", size = 205628, upload-time = "2026-05-14T16:08:53.54Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3a/904bbf95eac89036775051410dbaf55414a73a1e6d074e1486ca29ee3dbb/daytona_toolbox_api_client-0.183.0-py3-none-any.whl", hash = "sha256:bc0c2fb986f50cad23791afa181c04f27d975b59301d7ce59ce519c1f518483c", size = 205626, upload-time = "2026-05-29T10:58:39.381Z" },
 ]
 
 [[package]]
 name = "daytona-toolbox-api-client-async"
-version = "0.176.0"
+version = "0.183.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -650,9 +650,9 @@ dependencies = [
     { name = "python-dateutil" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/e9/485564746d3da7e8a1e88a0d430d12d29f38e6c1d3dbc3ada94eca420e08/daytona_toolbox_api_client_async-0.176.0.tar.gz", hash = "sha256:fc7d8d71a1a145de47bbc44622b19a311f9e0af98dcd7bccf492f54c4899e0dd", size = 71353, upload-time = "2026-05-14T16:08:51.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/0f/85e2ad6511ae228e1c423944d6d90ba3ace2153685ba8aa3b4035c5ccc6f/daytona_toolbox_api_client_async-0.183.0.tar.gz", hash = "sha256:31984e9fc5c440efbb5d23426f187046fa419c075c42d8691b127304692c4e6b", size = 71347, upload-time = "2026-05-29T10:59:03.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/5f/59f81cdd0b75cca17dc07660c7b0563fe91173a3d59914ddc7dbc048ba35/daytona_toolbox_api_client_async-0.176.0-py3-none-any.whl", hash = "sha256:cecdbb8a578ccf7d120dbaa2923123a35ab85b1d1b8d632035397448e536c87a", size = 203905, upload-time = "2026-05-14T16:08:50.003Z" },
+    { url = "https://files.pythonhosted.org/packages/23/66/af01390a47ba626454fd2ba44766282ffb7174ecc60c1742ab4859bd074f/daytona_toolbox_api_client_async-0.183.0-py3-none-any.whl", hash = "sha256:54a25297cfaf68568d85cecfd5c07da2e7fd862c8ab445df97b76a360951f757", size = 203902, upload-time = "2026-05-29T10:59:02.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

`bench cleanup`, `bench environment cleanup`, and `bench environment list` all crash against daytona SDK >=0.18 (current resolved version is 0.183):

```
AttributeError: 'generator' object has no attribute 'items'
  at src/benchflow/cli/main.py  ->  if not result.items:
```

This means there is currently **no working way to reap leaked Daytona sandboxes from the CLI** — they keep running and cost money.

## Root cause

The daytona SDK replaced its sandbox-listing API:

| | old (<0.18) | new (>=0.18) |
|---|---|---|
| call | `d.list(page=N, limit=100)` | `d.list(query=None)` |
| return | page object with `.items` (list) | **auto-paginating `Iterator[Sandbox]`** |

Both call sites in `cli/main.py` still drove the old paged shape (`result.items`, `page += 1`, `len(result.items) < 100`), so the first `if not result.items` blows up on the generator.

Why CI didn't catch it: the test fake in `test_cli_daytona.py` also returned the **old** `SimpleNamespace(items=...)` shape, so the suite stayed green while the real CLI was broken — a fixture mirroring an obsolete API.

## Fix

- **`cli/main.py`** — iterate `d.list()` directly at both call sites (`_cleanup_daytona_sandboxes` + `environment list`); drop the manual paging. The SDK paginates internally via cursor. `Sandbox.id/.state/.created_at` and `d.delete(sb)` are unchanged.
- **`test_cli_daytona.py`** — fake `list()` now returns `Iterator[Sandbox]` (the real >=0.18 shape), so the suite would have caught this (and guards against a relapse).
- **`pyproject.toml` / `uv.lock`** — bump `sandbox-daytona` floor `0.153 -> 0.183`. The code now requires the iterator API, and this also moves off the broken `0.176` (its top-level `Daytona` export was missing → `bench` crashed on `from daytona import Daytona`).

## Test

```
uv run pytest tests/test_cli_daytona.py -q
3 passed
```
(daytona 0.183.0, click 8.3.1, typer 0.24.1). Verified live: `bench cleanup --dry-run` was 100% reproducing the AttributeError before this change.
