### PR TITLE
Fix ruff format drift on two test files (unblock CI on all open PRs)

### DIFF
--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -342,7 +342,9 @@ class TestVerifierDirWipe:
             capture_output=True,
             text=True,
         ).stdout.strip()
-        assert decide == "skip", f"workspace {workspace} should be skipped, got {decide}"
+        assert decide == "skip", (
+            f"workspace {workspace} should be skipped, got {decide}"
+        )
 
     @pytest.mark.asyncio
     async def test_reclaim_still_clears_caches_outside_the_workspace(self):

--- a/tests/test_usage_proxy_gemini_rewrite.py
+++ b/tests/test_usage_proxy_gemini_rewrite.py
@@ -26,14 +26,29 @@ from benchflow.providers.sandbox_usage_proxy import _NODE_PROXY_SOURCE
 # (litellm-emitted incoming path, expected normalized upstream path)
 _GEMINI_REWRITE_CASES = [
     # prompt-cache probe: bogus per-model action -> Google's real top-level collection
-    ("/models/gemini-3.5-flash:cachedContents?key=secret", "/v1beta/cachedContents?key=secret"),
+    (
+        "/models/gemini-3.5-flash:cachedContents?key=secret",
+        "/v1beta/cachedContents?key=secret",
+    ),
     # main completion call: missing /v1beta restored
-    ("/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
-    ("/models/gemini-3.5-flash:streamGenerateContent?alt=sse", "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse"),
-    ("/models/gemini-3.5-flash:countTokens", "/v1beta/models/gemini-3.5-flash:countTokens"),
+    (
+        "/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
+    (
+        "/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+        "/v1beta/models/gemini-3.5-flash:streamGenerateContent?alt=sse",
+    ),
+    (
+        "/models/gemini-3.5-flash:countTokens",
+        "/v1beta/models/gemini-3.5-flash:countTokens",
+    ),
     # already-correct paths are left untouched (idempotent)
     ("/v1beta/cachedContents", "/v1beta/cachedContents"),
-    ("/v1beta/models/gemini-3.5-flash:generateContent", "/v1beta/models/gemini-3.5-flash:generateContent"),
+    (
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+        "/v1beta/models/gemini-3.5-flash:generateContent",
+    ),
     ("/v1/models/x:generateContent", "/v1/models/x:generateContent"),
 ]
 


### PR DESCRIPTION
## Problem

The required `test` CI check runs `uv run ruff format --check src tests` over the whole tree, and it is currently **red on `main`**:

```
Would reformat: tests/test_sandbox_hardening.py
Would reformat: tests/test_usage_proxy_gemini_rewrite.py
2 files would be reformatted, 335 files already formatted
```

Because the check scans the entire tree (not just the PR diff), **every open PR inherits this red check**, blocking merges across the board.

## Root cause

Both files landed format-drifted on `main` — last touched by the PR #598 ENOSPC work (`e1ade53` / `08630a3`), which didn't run `ruff format` before merge.

## Fix

`uv run ruff format` on the two files. **Reformat-only** (long-tuple line wrapping in test parametrize tables); no logic change.

## Test

```
uv run ruff format --check src tests  ->  337 files already formatted
uv run pytest tests/test_sandbox_hardening.py tests/test_usage_proxy_gemini_rewrite.py  ->  88 passed
```

Note: PR #605 also carries these same two reformatted files (it hit the same red check). Whichever merges first resolves it; this PR isolates the fix so it can land independently and unblock the other open PRs immediately.
