### PR TITLE
Add Harbor-style usage metadata

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -4,6 +4,10 @@ from pathlib import Path
 from typing import Any
 
 from benchflow._utils.benchmark_repos import task_source_provenance
+from benchflow._utils.result_metadata import (
+    final_metrics_from_rollout,
+    trajectory_summary_from_events,
+)
 from benchflow._utils.reward_events import (
     memory_score_from_events,
     reward_event_to_dict,
@@ -73,6 +77,12 @@ def rollout_result_payload(
         "n_tool_calls": result.n_tool_calls,
         "n_skill_invocations": n_skill_invocations,
         "agent_result": agent_result_from_rollout(result),
+        "final_metrics": final_metrics_from_rollout(result),
+        "trajectory_summary": trajectory_summary_from_events(
+            result.trajectory,
+            partial_trajectory=result.partial_trajectory,
+            trajectory_source=result.trajectory_source,
+        ),
         **(
             {"reward_events": [reward_event_to_dict(event) for event in reward_events]}
             if reward_events
@@ -116,6 +126,37 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
             round(total_cost / len(covered), 10) if covered else None
         ),
         "telemetry_coverage": (len(covered) / len(completed) if completed else 0.0),
+    }
+
+
+def trajectory_step_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate Harbor-style trajectory step counts for summary.json."""
+    summaries: list[dict[str, Any]] = []
+    for result in results.values():
+        summary = result.get("trajectory_summary")
+        if isinstance(summary, dict):
+            summaries.append(summary)
+    step_counts = [int(s.get("steps") or 0) for s in summaries]
+    tool_step_counts = [int(s.get("tool_call_steps") or 0) for s in summaries]
+    total_steps = sum(step_counts)
+    total_tool_steps = sum(tool_step_counts)
+
+    return {
+        "total_trajectory_steps": total_steps,
+        "avg_trajectory_steps_per_task": (
+            total_steps / len(step_counts) if step_counts else 0.0
+        ),
+        "max_trajectory_steps_per_task": max(step_counts) if step_counts else 0,
+        "total_trajectory_tool_call_steps": total_tool_steps,
+        "avg_trajectory_tool_call_steps_per_task": (
+            total_tool_steps / len(tool_step_counts) if tool_step_counts else 0.0
+        ),
+        "max_trajectory_tool_call_steps_per_task": (
+            max(tool_step_counts) if tool_step_counts else 0
+        ),
+        "trajectory_summary_coverage": (
+            len(summaries) / len(results) if results else 0.0
+        ),
     }
 
 

--- a/src/benchflow/_utils/result_metadata.py
+++ b/src/benchflow/_utils/result_metadata.py
@@ -1,0 +1,75 @@
+"""Shared result metadata derived from usage telemetry and ACP trajectories."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+
+def final_metrics_from_agent_result(
+    agent_result: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return Harbor-compatible final token/cost metrics.
+
+    Harbor's OpenHands runner exposes these four fields under
+    ``trajectory.json.final_metrics``. BenchFlow keeps richer provenance in
+    ``agent_result``; this helper adds the familiar Harbor shape without
+    dropping BenchFlow-specific telemetry such as cache-creation tokens and
+    source labels.
+    """
+    return {
+        "total_prompt_tokens": agent_result.get("n_input_tokens"),
+        "total_completion_tokens": agent_result.get("n_output_tokens"),
+        "total_cached_tokens": agent_result.get("n_cache_read_tokens"),
+        "total_cost_usd": agent_result.get("cost_usd"),
+    }
+
+
+def final_metrics_from_rollout(result: Any) -> dict[str, Any]:
+    """Build Harbor-compatible final metrics from a RolloutResult-like object."""
+    return final_metrics_from_agent_result(
+        {
+            "n_input_tokens": getattr(result, "n_input_tokens", None),
+            "n_output_tokens": getattr(result, "n_output_tokens", None),
+            "n_cache_read_tokens": getattr(result, "n_cache_read_tokens", None),
+            "cost_usd": getattr(result, "cost_usd", None),
+        }
+    )
+
+
+def trajectory_summary_from_events(
+    trajectory: Sequence[Mapping[str, Any]] | None,
+    *,
+    partial_trajectory: bool,
+    trajectory_source: str | None,
+) -> dict[str, Any]:
+    """Summarize ACP trajectory steps using the same counts Harbor reports."""
+    event_type_counts: dict[str, int] = {}
+    tool_call_status_counts: dict[str, int] = {}
+
+    for event in trajectory or ():
+        event_type = str(event.get("type") or "unknown")
+        event_type_counts[event_type] = event_type_counts.get(event_type, 0) + 1
+        if event_type == "tool_call":
+            status = str(event.get("status") or "unknown")
+            tool_call_status_counts[status] = tool_call_status_counts.get(status, 0) + 1
+
+    steps = sum(event_type_counts.values())
+    tool_call_steps = event_type_counts.get("tool_call", 0)
+    known_non_tool_steps = sum(
+        event_type_counts.get(event_type, 0)
+        for event_type in ("user_message", "agent_message", "agent_thought")
+    )
+
+    return {
+        "steps": steps,
+        "tool_call_steps": tool_call_steps,
+        "user_message_steps": event_type_counts.get("user_message", 0),
+        "agent_message_steps": event_type_counts.get("agent_message", 0),
+        "agent_thought_steps": event_type_counts.get("agent_thought", 0),
+        "other_steps": steps - tool_call_steps - known_non_tool_steps,
+        "event_type_counts": event_type_counts,
+        "tool_call_status_counts": tool_call_status_counts,
+        "partial_trajectory": partial_trajectory,
+        "trajectory_source": trajectory_source,
+    }

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -52,7 +52,12 @@ _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
 )
 _CANONICAL_OPENAI_URL = "https://api.openai.com/v1"
 _GENERIC_PROVIDER_OVERRIDE_KEYS = frozenset(
-    {"BENCHFLOW_PROVIDER_BASE_URL", "BENCHFLOW_PROVIDER_API_KEY"}
+    {
+        "BENCHFLOW_PROVIDER_BASE_URL",
+        "BENCHFLOW_PROVIDER_API_KEY",
+        "LLM_BASE_URL",
+        "LLM_API_KEY",
+    }
 )
 _AZURE_RESOURCE_ENV = "AZURE_RESOURCE"
 _AZURE_ENDPOINT_ENV = "AZURE_API_ENDPOINT"
@@ -543,18 +548,21 @@ def _drop_inherited_generic_provider_overrides(
         return
 
     from benchflow.agents.providers import find_provider
+    from benchflow.agents.registry import infer_env_key_for_model
 
     provider = find_provider(model)
     if provider is None:
-        return
-    _, provider_cfg = provider
-    # Providers with an empty base URL (for example vllm/) are explicitly
-    # user-supplied endpoints, so inherited BENCHFLOW_PROVIDER_* is the normal
-    # configuration path. Providers with a registered URL/auth env should not be
-    # shadowed by a global generic proxy from .env unless the caller explicitly
-    # passed that override for this run.
-    if not provider_cfg.base_url:
-        return
+        if infer_env_key_for_model(model) is None:
+            return
+    else:
+        _, provider_cfg = provider
+        # Providers with an empty base URL (for example vllm/) are explicitly
+        # user-supplied endpoints, so inherited BENCHFLOW_PROVIDER_* is the normal
+        # configuration path. Providers with a registered URL/auth env should not be
+        # shadowed by a global generic proxy from .env unless the caller explicitly
+        # passed that override for this run.
+        if not provider_cfg.base_url:
+            return
     for key in _GENERIC_PROVIDER_OVERRIDE_KEYS - explicit_agent_env_keys:
         agent_env.pop(key, None)
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -30,6 +30,7 @@ from benchflow._utils.evaluation_results import (
     rollout_result_payload,
     skill_invocation_summary,
     tool_call_summary,
+    trajectory_step_summary,
     usage_summary,
 )
 from benchflow._utils.learner_memory import (
@@ -1353,6 +1354,7 @@ class Evaluation:
             **skill_invocation_summary(all_results),
             **usage_summary(all_results),
             **tool_call_summary(all_results),
+            **trajectory_step_summary(all_results),
             **phase_timing_summary(all_results),
             **summary_source_fields(cfg.source_provenance, all_results),
         }

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -28,6 +28,10 @@ from pathlib import Path
 from typing import Any, cast
 from uuid import uuid4
 
+from benchflow._utils.result_metadata import (
+    final_metrics_from_agent_result,
+    trajectory_summary_from_events,
+)
 from benchflow.diagnostics import RolloutDiagnostics
 
 logger = logging.getLogger(__name__)
@@ -462,6 +466,18 @@ def _write_run_artifacts(
         runner=config.runner,
         env_args=config.env_args,
     )
+    agent_result = {
+        "n_tool_calls": result.total_tool_calls or 0,
+        "n_prompts": len(prompts),
+        "n_input_tokens": None,
+        "n_output_tokens": None,
+        "n_cache_read_tokens": None,
+        "n_cache_creation_tokens": None,
+        "total_tokens": None,
+        "cost_usd": None,
+        "usage_source": "unavailable",
+        "price_source": None,
+    }
 
     (result.run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
         "\n".join(json.dumps(e, default=str) for e in trajectory)
@@ -477,18 +493,13 @@ def _write_run_artifacts(
         "model": result.normalized_model or result.model or None,
         "n_tool_calls": result.total_tool_calls or 0,
         "n_prompts": len(prompts),
-        "agent_result": {
-            "n_tool_calls": result.total_tool_calls or 0,
-            "n_prompts": len(prompts),
-            "n_input_tokens": None,
-            "n_output_tokens": None,
-            "n_cache_read_tokens": None,
-            "n_cache_creation_tokens": None,
-            "total_tokens": None,
-            "cost_usd": None,
-            "usage_source": "unavailable",
-            "price_source": None,
-        },
+        "agent_result": agent_result,
+        "final_metrics": final_metrics_from_agent_result(agent_result),
+        "trajectory_summary": trajectory_summary_from_events(
+            trajectory,
+            partial_trajectory=False,
+            trajectory_source="hosted_env" if trajectory else None,
+        ),
         "error": result.error
         if result.returncode != 0 or not result.verifiers_error
         else None,

--- a/src/benchflow/providers/usage_proxy_runtime.py
+++ b/src/benchflow/providers/usage_proxy_runtime.py
@@ -247,11 +247,21 @@ def validate_usage_proxy_preconditions(
 def _pricing_for_model(model: str | None) -> PricingEntry | None:
     if not model:
         return None
-    bare = strip_provider_prefix(model).lower()
+    bare = _pricing_model_key(model)
     for prefix, pricing in PRICING_USD_PER_MTOK.items():
         if bare.startswith(prefix):
             return pricing
     return None
+
+
+def _pricing_model_key(model: str) -> str:
+    """Normalize provider-specific model IDs to pricing-table prefixes."""
+    bare = strip_provider_prefix(model).lower()
+    bare = bare.removeprefix("models/")
+    marker = "anthropic."
+    if marker in bare:
+        bare = bare.split(marker, 1)[1]
+    return bare
 
 
 def _estimate_cost_usd(
@@ -288,11 +298,13 @@ def _model_from_trajectory(runtime: ProviderRuntime) -> str | None:
     trajectory = getattr(runtime.server, "trajectory", None)
     if trajectory:
         for exchange in trajectory.exchanges:
-            response_model = exchange.response.body.get("model")
-            if response_model:
+            response_model = exchange.response.body.get(
+                "model"
+            ) or exchange.response.body.get("modelVersion")
+            if isinstance(response_model, str) and response_model:
                 return response_model
             request_model = exchange.request.body.get("model")
-            if request_model:
+            if isinstance(request_model, str) and request_model:
                 return request_model
     return runtime.backend_model
 

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -52,6 +52,10 @@ from typing import Any
 
 from benchflow._types import Role, Scene, Turn
 from benchflow._utils.config import normalize_agent_name, normalize_sandbox_user
+from benchflow._utils.result_metadata import (
+    final_metrics_from_agent_result,
+    trajectory_summary_from_events,
+)
 from benchflow._utils.scoring import classify_error, classify_verifier_error
 from benchflow.contracts import (
     AgentProtocolError,
@@ -545,6 +549,25 @@ def _build_rollout_result(
     )
     timing["total"] = (finished_at - started_at).total_seconds()
     timing = {k: round(v, 1) for k, v in timing.items()}
+    agent_result = {
+        "n_tool_calls": result.n_tool_calls,
+        "n_skill_invocations": result.n_skill_invocations,
+        "n_prompts": result.n_prompts,
+        "n_input_tokens": result.n_input_tokens,
+        "n_output_tokens": result.n_output_tokens,
+        "n_cache_read_tokens": result.n_cache_read_tokens,
+        "n_cache_creation_tokens": result.n_cache_creation_tokens,
+        "total_tokens": result.total_tokens,
+        "cost_usd": result.cost_usd,
+        "usage_source": result.usage_source,
+        "price_source": result.price_source,
+    }
+    final_metrics = final_metrics_from_agent_result(agent_result)
+    trajectory_summary = trajectory_summary_from_events(
+        trajectory,
+        partial_trajectory=partial_trajectory,
+        trajectory_source=trajectory_source,
+    )
     traj_dir = rollout_dir / "trajectory"
     traj_dir.mkdir(parents=True, exist_ok=True)
     (traj_dir / "acp_trajectory.jsonl").write_text(
@@ -563,19 +586,9 @@ def _build_rollout_result(
                 "n_tool_calls": result.n_tool_calls,
                 "n_skill_invocations": result.n_skill_invocations,
                 "n_prompts": result.n_prompts,
-                "agent_result": {
-                    "n_tool_calls": result.n_tool_calls,
-                    "n_skill_invocations": result.n_skill_invocations,
-                    "n_prompts": result.n_prompts,
-                    "n_input_tokens": result.n_input_tokens,
-                    "n_output_tokens": result.n_output_tokens,
-                    "n_cache_read_tokens": result.n_cache_read_tokens,
-                    "n_cache_creation_tokens": result.n_cache_creation_tokens,
-                    "total_tokens": result.total_tokens,
-                    "cost_usd": result.cost_usd,
-                    "usage_source": result.usage_source,
-                    "price_source": result.price_source,
-                },
+                "agent_result": agent_result,
+                "final_metrics": final_metrics,
+                "trajectory_summary": trajectory_summary,
                 "usage_tracking": usage_tracking,
                 "error": result.error,
                 "error_category": result.error_category,

--- a/src/benchflow/trajectories/pricing.py
+++ b/src/benchflow/trajectories/pricing.py
@@ -41,6 +41,15 @@ PRICING_USD_PER_MTOK: dict[str, PricingEntry] = {
         retrieved_at="2026-05-18",
         source_hash="e7518460f64c8b3f9f2bb816fdb7c060c500d20d7f5da88b9dbfde5e08e8338e",
     ),
+    "claude-opus-4-8": PricingEntry(
+        input=5.0,
+        output=25.0,
+        cache_read=0.5,
+        cache_creation=6.25,
+        source_url="https://www.anthropic.com/pricing",
+        retrieved_at="2026-06-03",
+        source_hash="3aef8590157ce26a14d9bab6d8c82a030dc80af341507655a3d63e93b66ab05e",
+    ),
     "gpt-4.1-mini": PricingEntry(
         input=0.4,
         output=1.6,
@@ -49,6 +58,15 @@ PRICING_USD_PER_MTOK: dict[str, PricingEntry] = {
         source_url="https://openai.com/api/pricing/",
         retrieved_at="2026-05-18",
         source_hash="081d1608413e6a8984cf85721f637cf300c1511903aac34d28da8b821598a33d",
+    ),
+    "gemini-3.5-flash": PricingEntry(
+        input=1.5,
+        output=9.0,
+        cache_read=0.15,
+        cache_creation=1.5,
+        source_url="https://ai.google.dev/gemini-api/docs/pricing",
+        retrieved_at="2026-06-03",
+        source_hash="1d557a83661069a226161cac2ca50e8f462b66feb07d1f87e30f54728726edc1",
     ),
     "gemini-2.5-flash": PricingEntry(
         input=0.3,

--- a/tests/test_hosted_env_rollout_contract.py
+++ b/tests/test_hosted_env_rollout_contract.py
@@ -81,6 +81,8 @@ def test_hosted_env_writes_contract_result_json(tmp_path, monkeypatch):
         "n_tool_calls",
         "n_prompts",
         "agent_result",
+        "final_metrics",
+        "trajectory_summary",
         "error",
         "verifier_error",
         "partial_trajectory",
@@ -104,6 +106,14 @@ def test_hosted_env_writes_contract_result_json(tmp_path, monkeypatch):
         "price_source",
     ):
         assert key in agent_result, f"missing agent_result key: {key}"
+    assert set(payload["final_metrics"]) == {
+        "total_prompt_tokens",
+        "total_completion_tokens",
+        "total_cached_tokens",
+        "total_cost_usd",
+    }
+    assert payload["trajectory_summary"]["steps"] >= 0
+    assert payload["trajectory_summary"]["tool_call_steps"] >= 0
 
 
 def test_hosted_env_writes_rewards_jsonl(tmp_path, monkeypatch):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -649,6 +649,7 @@ class TestJobRunOrchestration:
             {
                 "task_name": "task-0",
                 "n_tool_calls": 4,
+                "trajectory_summary": {"steps": 9, "tool_call_steps": 4},
                 "timing": {
                     "environment_setup": 1.0,
                     "agent_setup": 2.0,
@@ -660,6 +661,7 @@ class TestJobRunOrchestration:
             {
                 "task_name": "task-1",
                 "n_tool_calls": 6,
+                "trajectory_summary": {"steps": 13, "tool_call_steps": 6},
                 "timing": {
                     "environment_setup": 1.5,
                     "agent_setup": 2.5,
@@ -671,6 +673,7 @@ class TestJobRunOrchestration:
             {
                 "task_name": "task-2",
                 "n_tool_calls": 2,
+                "trajectory_summary": {"steps": 5, "tool_call_steps": 2},
                 "timing": {
                     "environment_setup": 0.5,
                     "agent_setup": 1.0,
@@ -694,6 +697,15 @@ class TestJobRunOrchestration:
         assert summary["total_tool_calls"] == 12
         assert summary["avg_tool_calls_per_task"] == pytest.approx(4.0)
         assert summary["max_tool_calls_per_task"] == 6
+        # Harbor-style trajectory aggregates track every ACP event and the
+        # subset of events that carried tool calls.
+        assert summary["total_trajectory_steps"] == 27
+        assert summary["avg_trajectory_steps_per_task"] == pytest.approx(9.0)
+        assert summary["max_trajectory_steps_per_task"] == 13
+        assert summary["total_trajectory_tool_call_steps"] == 12
+        assert summary["avg_trajectory_tool_call_steps_per_task"] == pytest.approx(4.0)
+        assert summary["max_trajectory_tool_call_steps_per_task"] == 6
+        assert summary["trajectory_summary_coverage"] == 1.0
         # Phase totals (sums) — hand-computed from the seeded timing blocks.
         assert summary["environment_setup_time_sec"] == 3.0
         assert summary["agent_setup_time_sec"] == 5.5

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -819,6 +819,10 @@ class TestResolveAgentEnvHostProviderEndpoint:
         for k in (
             "BENCHFLOW_PROVIDER_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY",
+            "GEMINI_API_KEY",
+            "GOOGLE_API_KEY",
+            "LLM_API_KEY",
+            "LLM_BASE_URL",
             "OPENAI_API_KEY",
             "OPENAI_BASE_URL",
             "ZAI_API_KEY",
@@ -873,6 +877,26 @@ class TestResolveAgentEnvHostProviderEndpoint:
         assert result["BENCHFLOW_PROVIDER_API_KEY"] == "sk-kimi"
         assert result["LLM_BASE_URL"] == "https://api.moonshot.ai/v1"
         assert result["LLM_API_KEY"] == "sk-kimi"
+
+    def test_inherited_provider_proxy_does_not_shadow_bare_gemini_model(
+        self, monkeypatch
+    ):
+        """Guards this PR: a global LiteLLM proxy must not hijack Gemini direct runs."""
+        monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+        monkeypatch.setenv(
+            "BENCHFLOW_PROVIDER_BASE_URL", "https://llm-proxy.example.test"
+        )
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_API_KEY", "sk-proxy")
+        monkeypatch.setenv("LLM_BASE_URL", "https://llm-proxy.example.test")
+        monkeypatch.setenv("LLM_API_KEY", "sk-proxy")
+
+        result = resolve_agent_env("openhands", "gemini-3.5-flash", {})
+
+        assert "BENCHFLOW_PROVIDER_BASE_URL" not in result
+        assert "LLM_BASE_URL" not in result
+        assert result["BENCHFLOW_PROVIDER_API_KEY"] == "test-gemini-key"
+        assert result["LLM_API_KEY"] == "test-gemini-key"
+        assert result["LLM_MODEL"] == "gemini/gemini-3.5-flash"
 
     def test_explicit_provider_base_url_can_override_registered_provider(self):
         """An explicit --agent-env generic endpoint remains a valid override."""

--- a/tests/test_usage_proxy.py
+++ b/tests/test_usage_proxy.py
@@ -62,6 +62,24 @@ def test_result_json_contains_unavailable_usage_defaults(tmp_path):
         "usage_source": "unavailable",
         "price_source": None,
     }
+    assert data["final_metrics"] == {
+        "total_prompt_tokens": None,
+        "total_completion_tokens": None,
+        "total_cached_tokens": None,
+        "total_cost_usd": None,
+    }
+    assert data["trajectory_summary"] == {
+        "steps": 0,
+        "tool_call_steps": 0,
+        "user_message_steps": 0,
+        "agent_message_steps": 0,
+        "agent_thought_steps": 0,
+        "other_steps": 0,
+        "event_type_counts": {},
+        "tool_call_status_counts": {},
+        "partial_trajectory": False,
+        "trajectory_source": None,
+    }
 
 
 def test_usage_source_never_absent(tmp_path):
@@ -98,6 +116,61 @@ def test_result_json_contains_provider_usage_when_supplied(tmp_path):
     assert data["agent_result"]["cost_usd"] == 0.0012
     assert data["agent_result"]["usage_source"] == "provider_response"
     assert data["agent_result"]["price_source"] == "pricing_table_2026-05"
+    assert data["final_metrics"] == {
+        "total_prompt_tokens": 100,
+        "total_completion_tokens": 20,
+        "total_cached_tokens": 7,
+        "total_cost_usd": 0.0012,
+    }
+
+
+def test_result_json_includes_harbor_style_trajectory_summary(tmp_path):
+    _build_result(
+        tmp_path,
+        trajectory=[
+            {"type": "user_message", "text": "solve"},
+            {"type": "agent_thought", "text": "thinking"},
+            {
+                "type": "tool_call",
+                "tool_call_id": "tc_1",
+                "kind": "bash",
+                "title": "ls",
+                "status": "completed",
+                "content": "",
+            },
+            {"type": "agent_message", "text": "done"},
+            {
+                "type": "tool_call",
+                "tool_call_id": "tc_2",
+                "kind": "bash",
+                "title": "false",
+                "status": "failed",
+                "content": "",
+            },
+            {"type": "tool_result", "text": "legacy"},
+        ],
+        partial_trajectory=True,
+        trajectory_source="partial_acp",
+    )
+
+    summary = _result_json(tmp_path)["trajectory_summary"]
+
+    assert summary["steps"] == 6
+    assert summary["tool_call_steps"] == 2
+    assert summary["user_message_steps"] == 1
+    assert summary["agent_message_steps"] == 1
+    assert summary["agent_thought_steps"] == 1
+    assert summary["other_steps"] == 1
+    assert summary["event_type_counts"] == {
+        "user_message": 1,
+        "agent_thought": 1,
+        "tool_call": 2,
+        "agent_message": 1,
+        "tool_result": 1,
+    }
+    assert summary["tool_call_status_counts"] == {"completed": 1, "failed": 1}
+    assert summary["partial_trajectory"] is True
+    assert summary["trajectory_source"] == "partial_acp"
 
 
 def test_telemetry_not_silently_dropped(tmp_path):
@@ -319,6 +392,76 @@ def test_extract_usage_with_gemini_exchanges():
     assert usage["n_cache_creation_tokens"] == 0
     assert usage["total_tokens"] == 15
     assert usage["usage_source"] == "provider_response"
+
+
+def test_extract_usage_estimates_cost_for_gemini_3_5_flash():
+    from benchflow.providers.runtime import ProviderRuntime, extract_usage
+
+    traj = Trajectory(session_id="s1", agent_name="agent")
+    traj.exchanges.append(
+        LLMExchange(
+            request=LLMRequest(body={"contents": []}),
+            response=LLMResponse(
+                body={
+                    "modelVersion": "models/gemini-3.5-flash",
+                    "usageMetadata": {
+                        "promptTokenCount": 2_380_559,
+                        "candidatesTokenCount": 40_363,
+                        "cachedContentTokenCount": 2_069_040,
+                    },
+                }
+            ),
+        )
+    )
+    runtime = ProviderRuntime(
+        kind="usage-proxy",
+        agent_base_url="http://host.docker.internal:12345",
+        backend_model="gemini-3.5-flash",
+        server=_ProxyLike(traj),
+    )
+
+    usage = extract_usage(runtime)
+
+    assert usage["n_input_tokens"] == 2_380_559
+    assert usage["n_output_tokens"] == 40_363
+    assert usage["n_cache_read_tokens"] == 2_069_040
+    assert usage["cost_usd"] == 1.1409015
+    assert str(usage["price_source"]).startswith(
+        "https://ai.google.dev/gemini-api/docs/pricing@"
+    )
+
+
+def test_extract_usage_estimates_cost_for_bedrock_opus_4_8():
+    from benchflow.providers.runtime import ProviderRuntime, extract_usage
+
+    runtime = ProviderRuntime(
+        kind="usage-proxy",
+        agent_base_url="http://host.docker.internal:12345",
+        backend_model="aws-bedrock/us.anthropic.claude-opus-4-8",
+        server=_ProxyLike(
+            _trajectory(
+                {
+                    "model": "us.anthropic.claude-opus-4-8",
+                    "usage": {
+                        "input_tokens": 10_000,
+                        "output_tokens": 1_000,
+                        "cache_read_input_tokens": 2_000,
+                        "cache_creation_input_tokens": 500,
+                    },
+                },
+                model="aws-bedrock/us.anthropic.claude-opus-4-8",
+            )
+        ),
+    )
+
+    usage = extract_usage(runtime)
+
+    assert usage["n_input_tokens"] == 12_500
+    assert usage["n_output_tokens"] == 1_000
+    assert usage["n_cache_read_tokens"] == 2_000
+    assert usage["n_cache_creation_tokens"] == 500
+    assert usage["cost_usd"] == 0.079125
+    assert str(usage["price_source"]).startswith("https://www.anthropic.com/pricing@")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add top-level `final_metrics` and `trajectory_summary` metadata to rollout/result payloads, including hosted-env results and evaluation summaries
- add pricing support and model normalization for Bedrock Opus 4.8 and Gemini 3.5 Flash usage extraction
- prevent inherited generic LLM proxy env from hijacking direct bare Gemini/OpenHands runs

## Validation
- `uv run python -m pytest tests/` -> 2672 passed, 12 skipped, 1 deselected
- `uv run ty check src/` -> passed
- `uv run ruff check .` -> passed
- VM targeted tests on `daytona-orchestrator` -> passed

## Real Daytona E2E
Task: SkillsBench `3d-scan-calc`, agent: OpenHands, sandbox: Daytona on VM.

- Bedrock Opus 4.8 MAX no-skill: PASS, reward 1.0, cost $0.911053, steps/tool calls 22/11
- Bedrock Opus 4.8 MAX with-skill: PASS, reward 1.0, cost $0.5664205, steps/tool calls 22/11
- Gemini 3.5 Flash no-skill: PASS, reward 1.0, patched extractor recalculates cost $0.74064255 from trajectory, steps/tool calls 41/19
- Gemini 3.5 Flash with-skill: PASS, reward 1.0, cost $0.39306525, steps/tool calls 45/21

Run roots on VM:
- `/home/bingran_you/benchflow-e2e-b6d6-daytona-four-20260603032843`
- `/home/bingran_you/benchflow-e2e-b6d6-daytona-gemini-costfix-direct-20260603040631`
- `/home/bingran_you/benchflow-e2e-b6d6-daytona-gemini-cost-final-20260603041211`
