### PR TITLE
Add --prompt to bench eval create

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -101,6 +101,7 @@ bench eval create \
 | `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |
 | `--usage-tracking` | `auto` | Token usage telemetry policy: `auto`, `required`, or `off` |
 | `--environment-manifest` | — | Path to an Environment-plane manifest (`environment.toml`); applied to every rollout in the batch |
+| `--prompt` | `instruction.md` | Prompt to send to the agent; repeatable for multi-prompt runs |
 | `--concurrency` | `4` | Max concurrent tasks (batch mode only) |
 | `--agent-idle-timeout` | (built-in default) | Abort ACP prompts after this many idle seconds; `0` disables idle detection |
 | `--jobs-dir` | `jobs` | Output directory |

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1098,6 +1098,10 @@ def eval_create(
             ),
         ),
     ] = None,
+    prompt: Annotated[
+        list[str] | None,
+        typer.Option("--prompt", help="Prompt(s) to send (default: instruction.md)"),
+    ] = None,
     concurrency: Annotated[
         int | None,
         typer.Option("--concurrency", help="Max concurrent tasks"),
@@ -1243,6 +1247,7 @@ def eval_create(
         _normalize_eval_agent_or_exit(agent) if agent is not None else DEFAULT_AGENT
     )
     eval_environment = environment or "docker"
+    eval_prompts = cast("list[str | None] | None", prompt)
     sandbox_user = normalize_sandbox_user(sandbox_user)
     eval_concurrency = concurrency if concurrency is not None else 4
     usage_tracking_overridden = usage_tracking is not None
@@ -1343,6 +1348,8 @@ def eval_create(
             j._config.concurrency = concurrency
         if build_concurrency is not None:
             j._config.build_concurrency = build_concurrency
+        if prompt is not None:
+            j._config.prompts = eval_prompts
         if agent_idle_timeout is not None:
             j._config.agent_idle_timeout = eval_agent_idle_timeout
         if usage_tracking_overridden:
@@ -1401,6 +1408,11 @@ def eval_create(
                 "[yellow]--usage-tracking is for BenchFlow ACP rollouts; "
                 "source-env runs own their provider calls. Ignoring.[/yellow]"
             )
+        if prompt is not None:
+            console.print(
+                "[yellow]--prompt is for BenchFlow ACP rollouts; "
+                "source-env runs own their prompts. Ignoring.[/yellow]"
+            )
 
         try:
             ref = HostedEnvRef.parse(source_env, version=source_env_version)
@@ -1456,6 +1468,7 @@ def eval_create(
                 environment=eval_environment,
                 concurrency=eval_concurrency,
                 build_concurrency=build_concurrency,
+                prompts=eval_prompts,
                 agent_idle_timeout=eval_agent_idle_timeout,
                 agent_env=parsed_env,
                 sandbox_user=sandbox_user,
@@ -1486,6 +1499,7 @@ def eval_create(
                 environment=eval_environment,
                 concurrency=eval_concurrency,
                 build_concurrency=build_concurrency,
+                prompts=eval_prompts,
                 agent_idle_timeout=eval_agent_idle_timeout,
                 agent_env=parsed_env,
                 sandbox_user=sandbox_user,

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -63,6 +63,7 @@ def test_eval_create_help_lists_all_documented_flags() -> None:
         "--model",
         "--sandbox",
         "--environment-manifest",
+        "--prompt",
         "--concurrency",
         "--agent-idle-timeout",
         "--jobs-dir",

--- a/tests/test_eval_source_provenance.py
+++ b/tests/test_eval_source_provenance.py
@@ -287,6 +287,41 @@ def test_eval_create_single_task_applies_concurrency_override(monkeypatch, tmp_p
     assert captured["concurrency"] == 64
 
 
+def test_eval_create_single_task_passes_cli_prompts(monkeypatch, tmp_path):
+    """Guards the bench run cleanup path so eval create keeps custom prompts."""
+    task_dir = tmp_path / "task-a"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text("[task]\n")
+    captured = {}
+
+    async def fake_eval_run(self):
+        captured["prompts"] = self._config.prompts
+        return SimpleNamespace(
+            passed=1, total=1, score=1.0, errored=0, verifier_errored=0
+        )
+
+    monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--tasks-dir",
+            str(task_dir),
+            "--agent",
+            "oracle",
+            "--prompt",
+            "first instruction",
+            "--prompt",
+            "second instruction",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["prompts"] == ["first instruction", "second instruction"]
+
+
 def test_eval_create_single_task_applies_agent_idle_timeout(monkeypatch, tmp_path):
     """Guards v0.5-integration@219906c against unbounded active-dev ACP hangs."""
     task_dir = tmp_path / "task-a"
@@ -350,6 +385,45 @@ def test_eval_create_config_allows_literal_jobs_dir_override(monkeypatch, tmp_pa
 
     assert result.exit_code == 0, result.stdout
     assert captured["jobs_dir"] == Path("jobs")
+
+
+def test_eval_create_config_prompt_overrides_yaml(monkeypatch, tmp_path):
+    """Guards bench eval create --prompt as an explicit CLI override."""
+    tasks_root = tmp_path / "tasks"
+    tasks_root.mkdir()
+    config = tmp_path / "eval.yaml"
+    config.write_text(
+        "\n".join(
+            [
+                f"tasks_dir: {tasks_root}",
+                "agent: oracle",
+                "prompts:",
+                "  - yaml instruction",
+            ]
+        )
+    )
+    captured = {}
+
+    async def fake_eval_run(self):
+        captured["prompts"] = self._config.prompts
+        return SimpleNamespace(passed=0, total=0, score=0.0, errored=0)
+
+    monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--config",
+            str(config),
+            "--prompt",
+            "cli instruction",
+        ],
+    )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["prompts"] == ["cli instruction"]
 
 
 def test_eval_create_config_applies_identity_overrides(monkeypatch, tmp_path):

--- a/tests/test_eval_source_provenance.py
+++ b/tests/test_eval_source_provenance.py
@@ -288,7 +288,7 @@ def test_eval_create_single_task_applies_concurrency_override(monkeypatch, tmp_p
 
 
 def test_eval_create_single_task_passes_cli_prompts(monkeypatch, tmp_path):
-    """Guards the bench run cleanup path so eval create keeps custom prompts."""
+    """Guards PR #608 so eval create keeps custom prompts after bench run cleanup."""
     task_dir = tmp_path / "task-a"
     task_dir.mkdir()
     (task_dir / "task.toml").write_text("[task]\n")
@@ -388,7 +388,7 @@ def test_eval_create_config_allows_literal_jobs_dir_override(monkeypatch, tmp_pa
 
 
 def test_eval_create_config_prompt_overrides_yaml(monkeypatch, tmp_path):
-    """Guards bench eval create --prompt as an explicit CLI override."""
+    """Guards PR #608 so bench eval create --prompt overrides YAML prompts."""
     tasks_root = tmp_path / "tasks"
     tasks_root.mkdir()
     config = tmp_path / "eval.yaml"


### PR DESCRIPTION
## Summary
- add a repeatable `--prompt` option to `bench eval create`
- thread CLI prompts through `EvaluationConfig.prompts` for `--tasks-dir`, `--source-repo`, and `--config` override paths
- document the new flag and cover help/docs drift plus prompt plumbing tests

## Validation
- `uv sync --extra dev --locked`
- `uv run python -m pytest tests/test_cli_docs_drift.py tests/test_eval_source_provenance.py -q`
- `uv run python -m pytest tests/test_cli_run.py -q`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/` (2655 passed, 49 skipped, 1 deselected)