### PR TITLE
Remove deprecated bench run CLI command

### DIFF
--- a/.claude/dev-docs/0.3-plan.md
+++ b/.claude/dev-docs/0.3-plan.md
@@ -167,7 +167,7 @@ Anthropic-style `bench <resource> <verb>` at top level. Every macro emits fine t
 
 **Events emitted by macros:** `JobStarted`, `TrialDispatched`, `TrajectoryTurn`, `TrajectoryRound`, `TrajectoryStep`, `ProcessReward`, `EnvSnapshot`, `VerifierResult`. One stream, many consumers (publisher, metrics, replay, train loop).
 
-**Supersedes `docs/cli-redesign-proposal.md`.** The "unified `benchflow run`" auto-mode detection logic lands as the body of `bench job run`; drop the verb conflation. Old `benchflow {run, job, eval, skill-eval}` commands removed in one migration.
+**Supersedes `docs/cli-redesign-proposal.md`.** The unified-run auto-mode detection logic lands as the body of `bench job run`; drop the verb conflation. Old top-level `{run, job, eval, skill-eval}` commands were removed in one migration.
 
 ---
 

--- a/.claude/skills/benchflow/references/create-task.md
+++ b/.claude/skills/benchflow/references/create-task.md
@@ -143,7 +143,7 @@ fi
 
 ```bash
 # Run with benchflow
-benchflow run --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
+bench eval create --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
 
 # Or with SDK
 python -c "

--- a/.claude/skills/benchflow/references/review-and-test.md
+++ b/.claude/skills/benchflow/references/review-and-test.md
@@ -57,9 +57,9 @@ After fixes pass unit tests, run a real smoke test:
 source .env
 
 # Pick 5 diverse tasks (cross-env if available)
-benchflow run --tasks-dir benchflow-ai/skillsbench/task-1 --agent claude-agent-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
-benchflow run --tasks-dir benchflow-ai/skillsbench/task-2 --agent pi-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
-benchflow run --tasks-dir benchflow-ai/skillsbench/task-3 --agent openclaw --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
+bench eval create --tasks-dir benchflow-ai/skillsbench/task-1 --agent claude-agent-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
+bench eval create --tasks-dir benchflow-ai/skillsbench/task-2 --agent pi-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
+bench eval create --tasks-dir benchflow-ai/skillsbench/task-3 --agent openclaw --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
 ```
 
 Verify for each agent:

--- a/.claude/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/SKILL.md
+++ b/.claude/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/SKILL.md
@@ -29,11 +29,11 @@ Arguments passed: `$ARGUMENTS`
 4. Show recent job results if any exist in `jobs/`
 5. Point to next action based on state
 
-### `run <task-path>` — run a single task
+### `eval create --tasks-dir <task-path>` — run a task
 
 ```bash
 source .env
-benchflow run --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
+bench eval create --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
 ```
 
 Or via SDK:

--- a/.claude/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/references/create-task.md
+++ b/.claude/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/references/create-task.md
@@ -143,7 +143,7 @@ fi
 
 ```bash
 # Run with benchflow
-benchflow run --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
+bench eval create --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
 
 # Or with SDK
 python -c "

--- a/.claude/skills/benchflow/tasks/create-simple-task/environment/benchflow/SKILL.md
+++ b/.claude/skills/benchflow/tasks/create-simple-task/environment/benchflow/SKILL.md
@@ -29,11 +29,11 @@ Arguments passed: `$ARGUMENTS`
 4. Show recent job results if any exist in `jobs/`
 5. Point to next action based on state
 
-### `run <task-path>` — run a single task
+### `eval create --tasks-dir <task-path>` — run a task
 
 ```bash
 source .env
-benchflow run --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
+bench eval create --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
 ```
 
 Or via SDK:

--- a/.claude/skills/benchflow/tasks/create-simple-task/environment/benchflow/references/create-task.md
+++ b/.claude/skills/benchflow/tasks/create-simple-task/environment/benchflow/references/create-task.md
@@ -143,7 +143,7 @@ fi
 
 ```bash
 # Run with benchflow
-benchflow run --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
+bench eval create --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
 
 # Or with SDK
 python -c "

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -82,7 +82,7 @@ task/agent IDs. For each hit, verify it resolves in the current tree:
 - Function / class / decorator names (`register_agent`, `SDK`,
   `RunResult`, `detect_services_from_dockerfile`, …) → `Grep` in
   `src/benchflow/` and the `__init__.py` re-exports.
-- CLI commands (`benchflow run`, `benchflow ls`, `benchflow view`, …) →
+- CLI commands (`bench eval create`, `bench eval list`, `bench skills list`, …) →
   check the Typer app in `src/benchflow/cli/`.
 - Task IDs referenced in examples → check `examples/` and
   `fixtures/`.

--- a/benchmarks/chi-bench/README.md
+++ b/benchmarks/chi-bench/README.md
@@ -37,8 +37,8 @@ framework's readiness gate probes the same `:8023/health` endpoint.
 ## Run it
 
 ```bash
-bench run benchmarks/chi-bench/tasks/<task> \
-  --environment benchmarks/chi-bench/environment.toml \
+bench eval create --tasks-dir benchmarks/chi-bench/tasks/<task> \
+  --environment-manifest benchmarks/chi-bench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 ```
 

--- a/benchmarks/clawsbench/README.md
+++ b/benchmarks/clawsbench/README.md
@@ -21,8 +21,8 @@ for the hard-coded `SERVICES` dict in `benchflow/sandbox/services.py`.
 ## Run it
 
 ```bash
-bench run benchmarks/clawsbench/tasks/<task> \
-  --environment benchmarks/clawsbench/environment.toml \
+bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \
+  --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 ```
 

--- a/benchmarks/clawsbench/tasks/archive-amazon-shipping/README.md
+++ b/benchmarks/clawsbench/tasks/archive-amazon-shipping/README.md
@@ -25,7 +25,7 @@ build-time message id is baked in.
 ## Run it
 
 ```bash
-bench run benchmarks/clawsbench/tasks/archive-amazon-shipping \
+bench eval create --tasks-dir benchmarks/clawsbench/tasks/archive-amazon-shipping \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent gemini --model gemini-3.1-flash-lite-preview \
   --sandbox daytona

--- a/benchmarks/followup-bench/runner.py
+++ b/benchmarks/followup-bench/runner.py
@@ -1,4 +1,4 @@
-"""Followup-bench runner — Scene-based two-agent code review benchmark.
+"""Followup-bench orchestrator — Scene-based two-agent code review benchmark.
 
 Uses the Scene runtime to orchestrate coder + reviewer in a SHARED sandbox:
   1. Coder agent attempts the task (in shared /app/)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -94,7 +94,7 @@ A User is a `BaseUser` subclass (or `FunctionUser` wrapping a function) with two
 - `setup(instruction, solution)` — once, before round 0
 - `run(round, instruction, round_result) → str | None` — per round; return `None` to stop the loop
 
-Between rounds, benchflow runs `soft_verify()` (verifier without the destructive parts of full hardening), gives the user the round's `RoundResult` (trajectory, rewards, verifier output, tool count), and lets the user decide round N+1's prompt.
+Between rounds, BenchFlow executes `soft_verify()` (verifier without the destructive parts of full hardening), gives the user the round's `RoundResult` (trajectory, rewards, verifier output, tool count), and lets the user decide round N+1's prompt.
 
 Use `BaseUser` when the loop logic is rule-based (compress instruction → show test failures as hints → stop on pass). See [`progressive-disclosure.md`](./progressive-disclosure.md) for the full guide.
 

--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -159,18 +159,17 @@ reaches them on `localhost`. During a rollout:
    is healthy.
 3. `Rollout.cleanup()` tears the environment down.
 
-Run a task against an environment manifest. `--environment-manifest` is
-available on both the legacy `bench run` command (single task) and on
-`bench eval create` (batch / Job API) so manifest-backed evaluations can
-be driven through the same Job pipeline used for regular benchmark sweeps.
+Run one task or a task directory against an environment manifest with
+`bench eval create --tasks-dir ...`. `--environment-manifest` applies the
+Environment-plane manifest to every rollout in the Job pipeline.
 
 ```bash
-# single task
-bench run benchmarks/clawsbench/tasks/<task> \
+# one task
+bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 
-# batch / Job API
+# task directory
 bench eval create --tasks-dir benchmarks/clawsbench/tasks \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -113,7 +113,7 @@ Multi-scene / multi-role configs are not compatible with `User` — the loop ass
 
 ## Soft-verify and full-verify: two different verifiers
 
-Between rounds, benchflow needs to score the agent's progress so the user can react. But the final, end-of-rollout verifier does destructive things (kills the agent, restores the workspace, chowns to root) that would prevent the next round from running. So benchflow runs **two** verifier passes:
+Between rounds, BenchFlow needs to score the agent's progress so the user can react. But the final, end-of-rollout verifier does destructive things (kills the agent, restores the workspace, chowns to root) that would prevent the next round from running. So BenchFlow executes **two** verifier passes:
 
 | | Soft-verify (between rounds) | Full-verify (end of rollout) |
 |---|---|---|

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -317,18 +317,18 @@ bench eval create \
 
 A **stateful** benchmark — one with mock services, databases, or accounts the
 agent acts on — declares its world in an `environment.toml` manifest and runs
-on the [Environment plane](./environment-plane.md). The `--environment-manifest`
-flag is available on both the single-task `bench run` command and on
-`bench eval create` (batch / Job API), so manifest-backed evaluations can be
-driven through the same pipeline as regular benchmark sweeps.
+on the [Environment plane](./environment-plane.md). Use
+`bench eval create --tasks-dir ...` for both single-task and batch
+manifest-backed evaluations; `--environment-manifest` applies the manifest to
+every rollout in the Job pipeline.
 
 ```bash
 # single task
-bench run benchmarks/clawsbench/tasks/<task> \
+bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 
-bench run benchmarks/chi-bench/tasks/<task> \
+bench eval create --tasks-dir benchmarks/chi-bench/tasks/<task> \
   --environment-manifest benchmarks/chi-bench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -95,17 +95,6 @@ def _apply_dotenv_to_process_env() -> None:
         os.environ.setdefault(key, value)
 
 
-def _exit_if_run_result_failed(run_result: object) -> None:
-    error = getattr(run_result, "error", None)
-    verifier_error = getattr(run_result, "verifier_error", None)
-    if error:
-        console.print(f"[red]Error:[/red] {error}")
-    if verifier_error:
-        console.print(f"[red]Verifier error:[/red] {verifier_error}")
-    if error or verifier_error:
-        raise typer.Exit(1)
-
-
 def _exit_if_evaluation_had_errors(result: object) -> None:
     errored = int(getattr(result, "errored", 0) or 0)
     verifier_errored = int(getattr(result, "verifier_errored", 0) or 0)
@@ -209,161 +198,6 @@ def _cleanup_daytona_sandboxes(dry_run: bool, max_age_minutes: int) -> None:
         console.print(
             f"\n[bold green]{total_deleted} sandboxes deleted[/bold green] ({total_skipped} skipped, younger than {max_age_minutes}m)"
         )
-
-
-@app.command(hidden=True, deprecated=True)
-def run(
-    task_dir: Annotated[
-        Path | None,
-        typer.Argument(help="Local task directory (must contain task.toml)"),
-    ] = None,
-    source_repo: Annotated[
-        str | None,
-        typer.Option(
-            "--source-repo",
-            help="Remote repo as org/repo (e.g. benchflow-ai/skillsbench)",
-        ),
-    ] = None,
-    source_path: Annotated[
-        str | None,
-        typer.Option(
-            "--source-path", help="Subpath within the repo (e.g. tasks/edit-pdf)"
-        ),
-    ] = None,
-    source_ref: Annotated[
-        str | None,
-        typer.Option("--source-ref", help="Branch or tag to clone (e.g. main)"),
-    ] = None,
-    agent: Annotated[
-        str,
-        typer.Option("--agent", help="Agent name from registry"),
-    ] = DEFAULT_AGENT,
-    model: Annotated[
-        str | None,
-        typer.Option("--model", help="Model to use"),
-    ] = None,
-    environment: Annotated[
-        str,
-        typer.Option("--sandbox", help="Sandbox: docker, daytona, or modal"),
-    ] = "docker",
-    environment_manifest: Annotated[
-        Path | None,
-        typer.Option(
-            "--environment-manifest",
-            help="Path to an Environment-plane manifest (environment.toml). "
-            "Runs the rollout against the declared stateful environment.",
-        ),
-    ] = None,
-    prompt: Annotated[
-        list[str] | None,
-        typer.Option("--prompt", help="Prompt(s) to send (default: instruction.md)"),
-    ] = None,
-    jobs_dir: Annotated[
-        str,
-        typer.Option("--jobs-dir", help="Output directory for results"),
-    ] = "jobs",
-    agent_env: Annotated[
-        list[str] | None,
-        typer.Option("--agent-env", help="Agent env var (KEY=VALUE)"),
-    ] = None,
-    skills_dir: Annotated[
-        Path | None,
-        typer.Option("--skills-dir", help="Skills directory to deploy into sandbox"),
-    ] = None,
-    skill_mode: Annotated[
-        str,
-        typer.Option(
-            "--skill-mode",
-            help="Skill mode: default or self-gen",
-        ),
-    ] = "default",
-    skill_creator_dir: Annotated[
-        Path | None,
-        typer.Option(
-            "--skill-creator-dir",
-            help="Path to skill-creator or a skills root containing it",
-        ),
-    ] = None,
-    self_gen_no_internet: Annotated[
-        bool,
-        typer.Option(
-            "--self-gen-no-internet",
-            help="Disable web tools for the self-generated run",
-        ),
-    ] = False,
-    sandbox_user: Annotated[
-        str | None,
-        typer.Option(
-            "--sandbox-user",
-            help="Run agent as non-root user (default: 'agent'). Pass 'none' for root.",
-        ),
-    ] = "agent",
-) -> None:
-    """Run a single task with an ACP agent.
-
-    Examples:
-        bench run --source-repo benchflow-ai/skillsbench --source-path tasks/edit-pdf
-        bench run tasks/edit-pdf --agent gemini --model gemini-3.1-flash-lite-preview
-    """
-    from benchflow.sdk import SDK
-
-    if source_repo:
-        from benchflow._utils.benchmark_repos import (
-            resolve_source_with_metadata,
-            task_source_provenance,
-        )
-
-        resolved = resolve_source_with_metadata(
-            source_repo, path=source_path, ref=source_ref
-        )
-        resolved_task_dir = resolved.path
-        source_provenance = task_source_provenance(
-            resolved.provenance, resolved_task_dir
-        )
-    elif task_dir:
-        resolved_task_dir = task_dir
-        source_provenance = None
-    else:
-        console.print("[red]Provide a task directory or --source-repo[/red]")
-        raise typer.Exit(1)
-
-    parsed_env = _parse_agent_env(agent_env)
-    agent = _normalize_eval_agent_or_exit(agent)
-    sandbox_user = normalize_sandbox_user(sandbox_user)
-
-    env_manifest = None
-    if environment_manifest is not None:
-        from benchflow.environment.manifest import load_manifest
-
-        env_manifest = load_manifest(environment_manifest)
-
-    sdk = SDK()
-    # CLI only ever passes plain strings; cast to widen for the SDK's
-    # `list[str | None] | None` API (None entries mean "use default").
-    result = asyncio.run(
-        sdk.run(
-            task_path=resolved_task_dir,
-            agent=agent,
-            model=model,
-            prompts=cast("list[str | None] | None", prompt),
-            agent_env=parsed_env,
-            jobs_dir=jobs_dir,
-            environment=environment,
-            environment_manifest=env_manifest,
-            skills_dir=str(skills_dir) if skills_dir else None,
-            sandbox_user=sandbox_user,
-            skill_mode=skill_mode,
-            skill_creator_dir=str(skill_creator_dir) if skill_creator_dir else None,
-            self_gen_no_internet=self_gen_no_internet,
-            source_provenance=source_provenance,
-        )
-    )
-
-    console.print(f"[green]Task:[/green] {result.task_name}")
-    console.print(f"[green]Agent:[/green] {result.agent_name}")
-    console.print(f"[green]Rewards:[/green] {result.rewards}")
-    console.print(f"[green]Tool calls:[/green] {result.n_tool_calls}")
-    _exit_if_run_result_failed(result)
 
 
 @app.command(hidden=True, deprecated=True)
@@ -1094,7 +928,7 @@ def eval_create(
                 "Path to an Environment-plane manifest (environment.toml). "
                 "Applied to every rollout in the batch so the manifest-declared "
                 "stateful environment is provisioned, gated on readiness, and "
-                "torn down — same seam as `bench run --environment-manifest`."
+                "torn down."
             ),
         ),
     ] = None,
@@ -1271,8 +1105,6 @@ def eval_create(
 
     # Resolve the optional Environment-plane manifest once and reuse across
     # every source branch (config / source_repo / tasks_dir / source_env).
-    # Bench eval create's batch surface mirrors `bench run` so manifest-backed
-    # rollouts can be driven through the Job pipeline (#398).
     eval_env_manifest = None
     if environment_manifest is not None:
         from benchflow.environment.manifest import load_manifest

--- a/tests/test_clawsbench_slice.py
+++ b/tests/test_clawsbench_slice.py
@@ -1,10 +1,10 @@
 """End-to-end vertical slice: ClawsBench manifest → scored trajectory →
-Verifiers/ORS export, plus the `bench run --environment-manifest` wiring.
+Verifiers/ORS export.
 
 The data-path test proves the thread with no Docker. A full live rollout is
 run manually:
 
-    bench run benchmarks/clawsbench/tasks/<task> \\
+    bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \\
       --environment-manifest benchmarks/clawsbench/environment.toml \\
       --agent claude-agent-acp --model claude-haiku-4-5
 """
@@ -12,9 +12,6 @@ run manually:
 import json
 from pathlib import Path
 
-from typer.testing import CliRunner
-
-from benchflow.cli.main import app
 from benchflow.environment.manifest import load_manifest
 from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories.export import (
@@ -53,13 +50,3 @@ def test_manifest_drives_a_scored_exportable_record(tmp_path):
     assert parsed["info"]["environment"] == "clawsbench"
     assert parsed["prompt"] and parsed["completion"]
     assert parsed["metrics"] == {"exact_match": 1.0}
-
-
-def test_cli_run_exposes_environment_manifest_flag():
-    """`bench run` advertises the --environment-manifest flag."""
-    import re
-
-    result = CliRunner().invoke(app, ["run", "--help"])
-    assert result.exit_code == 0
-    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
-    assert "--environment-manifest" in plain

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -30,7 +30,7 @@ def test_top_level_help_lists_public_groups() -> None:
     out = _help([])
     for group in ("eval", "skills", "tasks", "compat", "agent", "environment"):
         assert group in out, f"missing public group {group!r} in: {out}"
-    # Deprecated/hidden commands must not show up in the public help.
+    # Deprecated, hidden, and removed commands must not show up in public help.
     for hidden in ("run", "job", "agents", "metrics", "view", "eval-batch"):
         assert hidden not in out.split("Commands")[-1].split("─")[0], (
             f"hidden command {hidden!r} unexpectedly shown: {out}"
@@ -85,8 +85,8 @@ def test_eval_create_help_lists_all_documented_flags() -> None:
 
 def test_eval_create_accepts_environment_manifest() -> None:
     """`bench eval create --environment-manifest` is the batch seam for
-    Environment-plane rollouts — same flag as `bench run` (#398). Guard
-    against silent removal so the docs and CLI stay in sync."""
+    Environment-plane rollouts (#398). Guard against silent removal so the
+    docs and CLI stay in sync."""
     out = _help(["eval", "create"])
     assert "--environment-manifest" in out
 

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -5,7 +5,6 @@ import json
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
-from benchflow.models import RunResult
 
 
 def test_benchflow_version_flag() -> None:
@@ -16,27 +15,39 @@ def test_benchflow_version_flag() -> None:
     assert result.output.strip() == f"benchflow {__version__}"
 
 
-def test_benchflow_run_exits_nonzero_when_verifier_errors(tmp_path, monkeypatch):
-    """Guards the v0.5 reward-output regression at the CLI boundary."""
+def test_benchflow_run_command_is_removed():
+    """Guards the removal PR so the deprecated top-level run command stays gone."""
+    result = CliRunner().invoke(app, ["run", "--help"])
+
+    assert result.exit_code != 0
+    assert "No such command" in result.output
+
+
+def test_eval_create_exits_nonzero_when_verifier_errors(tmp_path, monkeypatch):
+    """Guards the v0.5 reward-output regression at the eval CLI boundary."""
     task_dir = tmp_path / "task"
     task_dir.mkdir()
     (task_dir / "task.toml").write_text('version = "1.0"\n[verifier]\n')
 
-    class FakeSDK:
-        async def run(self, **_kwargs):
-            return RunResult(
-                task_name="task",
-                agent_name="oracle",
-                rewards=None,
-                verifier_error="verifier crashed: No reward file found",
-            )
+    async def fake_eval_run(self):
+        from types import SimpleNamespace
 
-    monkeypatch.setattr("benchflow.sdk.SDK", FakeSDK)
+        return SimpleNamespace(
+            passed=0,
+            total=1,
+            score=0.0,
+            errored=0,
+            verifier_errored=1,
+        )
+
+    monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
 
     result = CliRunner().invoke(
         app,
         [
-            "run",
+            "eval",
+            "create",
+            "--tasks-dir",
             str(task_dir),
             "--agent",
             "oracle",
@@ -48,9 +59,7 @@ def test_benchflow_run_exits_nonzero_when_verifier_errors(tmp_path, monkeypatch)
     )
 
     assert result.exit_code == 1
-    assert "Rewards:" in result.output
-    assert "Verifier error:" in result.output
-    assert "No reward file found" in result.output
+    assert "Score: 0/1" in result.output
 
 
 def test_benchflow_metrics_pretty_prints_memory_score(tmp_path):

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -16,7 +16,7 @@ def test_benchflow_version_flag() -> None:
 
 
 def test_benchflow_run_command_is_removed():
-    """Guards the removal PR so the deprecated top-level run command stays gone."""
+    """Guards PR #610 so the deprecated top-level run command stays gone."""
     result = CliRunner().invoke(app, ["run", "--help"])
 
     assert result.exit_code != 0

--- a/tests/test_eval_source_provenance.py
+++ b/tests/test_eval_source_provenance.py
@@ -288,7 +288,7 @@ def test_eval_create_single_task_applies_concurrency_override(monkeypatch, tmp_p
 
 
 def test_eval_create_single_task_passes_cli_prompts(monkeypatch, tmp_path):
-    """Guards PR #608 so eval create keeps custom prompts after bench run cleanup."""
+    """Guards PR #608 so eval create keeps custom CLI prompts."""
     task_dir = tmp_path / "task-a"
     task_dir.mkdir()
     (task_dir / "task.toml").write_text("[task]\n")

--- a/tests/test_evaluation_environment_manifest.py
+++ b/tests/test_evaluation_environment_manifest.py
@@ -6,8 +6,7 @@ rollouts:
 * ``EvaluationConfig`` had no ``environment_manifest`` field;
 * ``Evaluation._run_single_task`` built ``RolloutConfig.from_legacy`` without
   one, so the manifest seam disappeared at the Job layer;
-* ``bench eval create`` exposed no ``--environment-manifest`` option even
-  though ``bench run`` did.
+* ``bench eval create`` exposed no ``--environment-manifest`` option.
 
 These tests assert the full path: dataclass → CLI flag → YAML loader →
 ``RolloutConfig.environment_manifest``.

--- a/tests/test_rollout_config_path_coercion.py
+++ b/tests/test_rollout_config_path_coercion.py
@@ -77,7 +77,7 @@ def test_rollout_config_context_root_none_stays_none() -> None:
 
 
 def test_rollout_config_resolves_skills_dir_auto(tmp_path: Path) -> None:
-    """Guards PR #586 so SDK.run and bench run share eval's skills auto mode."""
+    """Guards PR #586 so SDK.run and eval create share skills auto mode."""
     task = tmp_path / "task"
     skills = task / "environment" / "skills" / "alpha"
     skills.mkdir(parents=True)


### PR DESCRIPTION
## Summary
- remove the hidden deprecated top-level `bench run` command and its private failure helper
- migrate docs and benchmark READMEs to `bench eval create --tasks-dir ...`
- rewrite CLI coverage around `bench eval create` and add a guard that the removed command no longer resolves
- keep Python APIs such as `bf.run()`, `SDK.run()`, `Rollout.run()`, and `Evaluation.run()` intact

## Validation
- `uv run python -m pytest tests/test_cli_docs_drift.py tests/test_cli_misc.py tests/test_clawsbench_slice.py tests/test_eval_source_provenance.py tests/test_evaluation_environment_manifest.py tests/test_rollout_config_path_coercion.py -q`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/` (2655 passed, 49 skipped, 1 deselected)
- `rg -n 'bench run|benchflow run' src tests docs README.md benchmarks labs` (no matches)
- `uv run bench run --help` exits non-zero with `No such command 'run'`
- `uv run bench eval create --help` still shows `--prompt` and `--environment-manifest`