### PR TITLE
Fix flaky ACP idle-watchdog cancel-drain test

### DIFF
--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -471,9 +471,25 @@ class TestACPIdleWatchdog:
     async def test_idle_watchdog_returns_even_when_prompt_cancel_drain_stalls(
         self,
     ) -> None:
-        """Guards the 2026-05-22 Daytona/Gemini blocker fix against stuck cancel drain."""
-        from benchflow.acp.runtime import execute_prompts
+        """Guards the 2026-05-22 Daytona/Gemini blocker fix against stuck cancel drain.
 
+        When the idle watchdog fires it cancels the prompt task and drains it.
+        A non-cooperative agent — here one that swallows the cancellation and
+        blocks on an event that never arrives — must not be able to wedge the
+        watchdog: it bounds the drain and raises ``IdleTimeoutError`` anyway.
+
+        Determinism: this asserts the *behaviour* (idle error raised; the stuck
+        prompt task abandoned while still pending) rather than a wall-clock upper
+        bound, so it cannot be squeezed into a spurious failure when the full
+        suite loads the event loop. The outer ``wait_for`` is only a hang guard;
+        its timeout is deliberately loose (far above the real ~1.25s runtime), so
+        load can never trip it, while a regression to an unbounded drain hangs
+        past it and fails.
+        """
+        from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+
+        # release is never set while the watchdog runs, so the prompt task stays
+        # wedged in its cancellation handler — exactly the stuck-drain scenario.
         class StubbornPromptClient:
             def __init__(self) -> None:
                 self.release = asyncio.Event()
@@ -490,9 +506,12 @@ class TestACPIdleWatchdog:
         client = StubbornPromptClient()
         session = ACPSession("idle-session")
 
+        # Loose hang guard: ~4x the real runtime (1s idle detect + 0.25s bounded
+        # drain). Not a tight assertion — it only catches a true hang/regression.
+        hang_guard_sec = 5.0
+
         try:
-            started = asyncio.get_running_loop().time()
-            with pytest.raises(TimeoutError, match="Agent idle for 1s"):
+            with pytest.raises(IdleTimeoutError, match="Agent idle for 1s"):
                 await asyncio.wait_for(
                     execute_prompts(
                         client,  # type: ignore[arg-type]
@@ -501,10 +520,13 @@ class TestACPIdleWatchdog:
                         timeout=30,
                         idle_timeout=1,
                     ),
-                    timeout=1.8,
+                    timeout=hang_guard_sec,
                 )
-            elapsed = asyncio.get_running_loop().time() - started
-            assert elapsed < 1.35
+            # The watchdog returned while the stuck prompt task is still wedged on
+            # release.wait(): proves it bounded the drain instead of waiting for a
+            # cancellation that never completes. Load-independent — no clock math.
+            assert client.task is not None
+            assert not client.task.done()
         finally:
             client.release.set()
             if client.task is not None:


### PR DESCRIPTION
## Problem

`tests/test_acp.py::TestACPIdleWatchdog::test_idle_watchdog_returns_even_when_prompt_cancel_drain_stalls`
(added 2026-05-26 in 546aca5) is a flaky async-timing test. It passes in isolation and
in a standalone `test_acp.py` run, but **intermittently fails under the full serial suite**
(`uv run python -m pytest tests/`, ~2.6k tests). It produces spurious red CI on unrelated PRs.

## Root cause

The test asserted a **tight wall-clock upper bound** on a path whose real cost is ~1.25s:

- Idle detection sleeps one `poll_interval` = **1s** (`max(1, min(30, idle_timeout//4, max(1, timeout//4)))` = 1 for `idle_timeout=1`), then raises `IdleTimeoutError`.
- The `finally` cancel-drain then runs the **full 0.25s** `_PROMPT_CANCEL_DRAIN_TIMEOUT_SEC`, because the stubborn stub swallows the cancel and blocks on an event that never fires.

Total ≈ **1.25s**, asserted against `elapsed < 1.35` — only ~0.1s of slack. Under the loaded
event loop of the full suite, scheduling jitter on that real 1s sleep pushes `elapsed` over the
bound and the assertion fails. (The outer `wait_for(timeout=1.8)` was a second squeeze: if it
fired first, the bare `TimeoutError` would fail the `match=`.)

## Approach / changes

Assert the **behaviour**, not the clock — test-only change, no production code touched:

- **Drop** the `started` / `elapsed < 1.35` wall-clock assertion.
- **Assert** `pytest.raises(IdleTimeoutError, match="Agent idle for 1s")` (tightened from `TimeoutError` → the exact idle type, so it can't be satisfied by the hang guard's generic timeout).
- **Add** `assert not client.task.done()` after the raise: when the watchdog returns, the stuck prompt task is still wedged on `release.wait()`. This is a *more direct* proof of return-on-stall than the old timing bound — it shows the watchdog **bounded the drain** rather than awaiting a cancellation that never completes. It is load-independent (no clock math).
- **Keep** the outer `wait_for` purely as a hang guard, at a deliberately loose `5.0s` (~4× real runtime). Normal load can never trip it, but a regression to an *unbounded* drain hangs past it and still fails.

The return-on-stall guarantee is preserved and strengthened, not weakened.

## Results

- **Load-robustness proof:** with synthetic synchronous loop-stalls injected (emulating suite contention), `elapsed` reached **3.234s** — the old `elapsed < 1.35` *would have failed*, while the new assertions passed and the bounded-drain path fired (`ACP prompt task did not finish within 0.25s after cancellation`), still under the 5s guard.
- Target test: **5/5** in isolation.
- `tests/test_acp.py`: 67 passed, 1 skipped.
- Full suite (`uv run python -m pytest tests/`): **3/3 runs green** — 2667 passed, 49 skipped (~87–105s each).
- `ruff check` + `ruff format --check`: clean.
