### PR TITLE
Fix CI formatting after skill mode changes

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -222,7 +222,9 @@ def job(
     ] = None,
     skill_mode: Annotated[
         str,
-        typer.Option("--skill-mode", help="Skill mode: no-skill, with-skill, or self-gen"),
+        typer.Option(
+            "--skill-mode", help="Skill mode: no-skill, with-skill, or self-gen"
+        ),
     ] = SKILL_MODE_NO_SKILL,
 ) -> None:
     """Run all tasks in a directory with concurrency and retries.
@@ -397,7 +399,9 @@ def eval(
     ] = "jobs",
     skill_mode: Annotated[
         str,
-        typer.Option("--skill-mode", help="Skill mode: no-skill, with-skill, or self-gen"),
+        typer.Option(
+            "--skill-mode", help="Skill mode: no-skill, with-skill, or self-gen"
+        ),
     ] = SKILL_MODE_NO_SKILL,
 ) -> None:
     """Evaluate a skill against multiple tasks.

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1024,14 +1024,18 @@ class RolloutConfig:
     ) -> RolloutConfig:
         """Construct from flat SDK.run()-style args."""
         mode = normalize_skill_mode(skill_mode)
-        scenes = [] if mode == SKILL_MODE_SELF_GEN else [
-            Scene.single(
-                agent=agent,
-                model=model,
-                reasoning_effort=reasoning_effort,
-                prompts=prompts,
-            )
-        ]
+        scenes = (
+            []
+            if mode == SKILL_MODE_SELF_GEN
+            else [
+                Scene.single(
+                    agent=agent,
+                    model=model,
+                    reasoning_effort=reasoning_effort,
+                    prompts=prompts,
+                )
+            ]
+        )
         return cls(
             task_path=task_path,
             scenes=scenes,

--- a/src/benchflow/skill_policy.py
+++ b/src/benchflow/skill_policy.py
@@ -31,6 +31,7 @@ SKILL_SOURCE_TASK_BUNDLED = "task_bundled"
 SKILL_SOURCE_CUSTOM_RUNTIME = "custom_runtime"
 SKILL_SOURCE_SELF_GENERATED = "self_generated"
 
+
 @dataclass(frozen=True)
 class TaskSkillPolicy:
     mode: str


### PR DESCRIPTION
## Summary
- Apply Ruff formatting to the files changed by #615
- Restore the CI format gate on main after the latest merged PRs

## Tests
- uv sync --extra dev --locked
- uv run ruff format --check src tests
- uv run ruff check .
- uv run ty check src/
- uv run python -m pytest tests/