### PR TITLE
ci: add separate prerelease and public release workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,77 @@
+name: prerelease
+
+# Internal prerelease track. Publishes a PEP 440 dev release to PyPI on every
+# green push to `main`, so teammates can `pip install --pre benchflow` to get
+# the latest merged code. This is intentionally separate from the public
+# release track (.github/workflows/release.yml): dev versions are ignored by a
+# plain `pip install`, so they never reach users who want a stable version.
+#
+# Triggered by the `test` workflow completing successfully, so only code that
+# already passed lint/type/tests gets published.
+#
+# Version: <base>.dev<run_number> (e.g. 0.5.0.dev42). The run number is
+# monotonic per workflow, giving each merge a strictly increasing dev version.
+#
+# Setup (one-time, by a maintainer): register a PyPI trusted publisher for the
+# `benchflow` project with owner `benchflow-ai`, repo `benchflow`, workflow
+# `prerelease.yml`, and environment `pypi-prerelease`. For a project that does
+# not exist on PyPI yet, add a "pending" trusted publisher instead.
+on:
+  workflow_run:
+    workflows: [test]
+    types: [completed]
+    branches: [main]
+
+# Least-privilege defaults — elevate per-job only when a step needs more.
+permissions:
+  contents: read
+
+jobs:
+  prerelease:
+    # Only publish code that passed `test` on a direct push to `main`.
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    environment: pypi-prerelease
+    permissions:
+      contents: read
+      id-token: write  # OIDC token for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Stamp dev version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
+        run: |
+          python3 - <<'PY'
+          import os, re, pathlib
+
+          run = os.environ["RUN_NUMBER"]
+          path = pathlib.Path("pyproject.toml")
+          text = path.read_text()
+          current = re.search(r'^version = "([^"]+)"', text, re.M).group(1)
+          base = re.match(r"\d+\.\d+\.\d+", current).group(0)
+          version = f"{base}.dev{run}"
+          path.write_text(
+              re.sub(r'^version = "[^"]+"', f'version = "{version}"', text, count=1, flags=re.M)
+          )
+          print(f"::notice::publishing prerelease {version}")
+          PY
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI (trusted publishing)
+        run: uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: release
+
+# Public release track. Publishes to PyPI and creates a GitHub Release when a
+# `v*` tag is pushed. This is intentionally separate from the internal
+# prerelease track (.github/workflows/prerelease.yml): only deliberate, tagged
+# versions reach users running a plain `pip install benchflow`.
+#
+# The tag must match the version in pyproject.toml. Cut a release by bumping
+# `pyproject.toml` on `main`, then pushing `vX.Y.Z`.
+#
+# Setup (one-time, by a maintainer): register a PyPI trusted publisher for the
+# `benchflow` project with owner `benchflow-ai`, repo `benchflow`, workflow
+# `release.yml`, and environment `pypi`. For a project that does not exist on
+# PyPI yet, add a "pending" trusted publisher instead.
+on:
+  push:
+    tags:
+      - "v*"
+
+# Least-privilege defaults — elevate per-job only when a step needs more.
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: write  # create the GitHub Release
+      id-token: write  # OIDC token for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Verify tag matches pyproject version
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
+          if [ "$tag" != "$version" ]; then
+            echo "::error::tag v$tag does not match pyproject version $version — bump pyproject.toml before tagging"
+            exit 1
+          fi
+          # PEP 440: a final release is digits-and-dots only; anything else is a prerelease.
+          if echo "$tag" | grep -Eq '^[0-9]+(\.[0-9]+)*$'; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+          echo "::notice::releasing $version"
+
+      - name: Build
+        run: uv build
+
+      - name: Publish to PyPI (trusted publishing)
+        run: uv publish
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
+        run: |
+          flags=(--title "$GITHUB_REF_NAME" --generate-notes --verify-tag)
+          [ "$PRERELEASE" = "true" ] && flags+=(--prerelease)
+          gh release create "$GITHUB_REF_NAME" dist/* "${flags[@]}"


### PR DESCRIPTION
## What

Adds two PyPI publishing tracks, kept **deliberately separate** so internal dev builds never reach users who just want a stable version.

| Track | Trigger | Version | Publishes to |
|---|---|---|---|
| **Internal / prerelease** (`prerelease.yml`) | Every green push to `main` (after the `test` workflow succeeds) | `<base>.dev<run_number>` e.g. `0.5.0.dev42` | PyPI — ignored by plain `pip install`, installed via `pip install --pre benchflow` |
| **Public** (`release.yml`) | Pushing a `vX.Y.Z` tag | The version in `pyproject.toml` (tag must match) | PyPI + GitHub Release |

### Why this satisfies "公开版和测试版分开"
- Both go to the same PyPI index, but on **separate version tracks**. PEP 440 dev releases (`.devN`) are skipped by a default `pip install`, so a user who wants stable gets the last tagged release; a teammate who wants the bleeding edge uses `--pre`.
- The public track only fires on a deliberate `vX.Y.Z` tag and refuses to run if the tag doesn't match `pyproject.toml`, so a release is always intentional.

## How
- **Trusted publishing (OIDC)** via `uv publish` — no PyPI tokens stored in the repo. Each job requests `id-token: write` only where needed.
- Reuses the **SHA-pinned** `actions/checkout` and `astral-sh/setup-uv` already used in `test.yml`.
- `prerelease.yml` triggers off `workflow_run` of the existing `test` workflow, gated to **successful `push` runs on `main`** — only tested code ships, and it checks out the exact tested SHA.
- The dev version is stamped at build time as `<base>.dev<github.run_number>` (monotonic per workflow, so each merge gets a strictly increasing version).
- `release.yml` auto-marks the GitHub Release as a prerelease for non-final tags (`rc`/`b`/`a`/`dev`).

## ⚠️ One-time maintainer setup before the first publish
PyPI trusted publishing must be registered (no secrets needed afterwards). On PyPI → project `benchflow` → *Publishing*, add **two** trusted publishers (owner `benchflow-ai`, repo `benchflow`):

| Workflow file | Environment |
|---|---|
| `prerelease.yml` | `pypi-prerelease` |
| `release.yml` | `pypi` |

Since `benchflow` isn't on PyPI yet, add these as **"pending" trusted publishers** instead. Optionally add reviewers/protection to the `pypi` GitHub environment to gate public releases.

## Notes / open questions
- This publishes a dev release to **real PyPI on every merge to main**, as requested. That's a lot of `.devN` versions over time — fine functionally (they're hidden from default installs), just noisy on the project's release history. If that's undesirable, the prerelease track can instead point at **TestPyPI** with a one-line index change.
- Public release flow is unchanged from the documented manual steps, just automated: bump `pyproject.toml` on `main` → push `vX.Y.Z`.

https://claude.ai/code/session_01CSzKprPoCQvAyd32oCWiVA

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSzKprPoCQvAyd32oCWiVA)_