### PR TITLE
Fix usage tracking policy fallbacks

### DIFF
--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -892,6 +892,36 @@ def _apply_litellm_agent_env(
     return updated
 
 
+async def _skip_litellm_runtime(
+    agent_env: dict[str, str],
+    runtime: Any | None,
+    *,
+    reason: str | None = None,
+) -> tuple[dict[str, str], Any | None]:
+    if runtime is not None:
+        await stop_litellm_runtime(runtime)
+    if reason:
+        logger.info("Skipping LiteLLM proxy: %s", reason)
+    return agent_env, None
+
+
+async def _fallback_or_raise_for_unavailable_litellm(
+    *,
+    usage_cfg: UsageTrackingConfig,
+    agent_env: dict[str, str],
+    runtime: Any | None,
+    required_error: str,
+    fallback_reason: str,
+) -> tuple[dict[str, str], Any | None]:
+    if usage_cfg.mode == "required":
+        raise RuntimeError(required_error)
+    return await _skip_litellm_runtime(
+        agent_env,
+        runtime,
+        reason=fallback_reason,
+    )
+
+
 async def ensure_litellm_runtime(
     *,
     agent: str,
@@ -904,28 +934,56 @@ async def ensure_litellm_runtime(
     sandbox: Any | None = None,
 ) -> tuple[dict[str, str], Any | None]:
     """Start/reuse LiteLLM and rewrite the agent env to talk to it."""
+    usage_cfg = UsageTrackingConfig.coerce(usage_tracking).with_env_defaults()
+    if usage_cfg.mode == "off":
+        return await _skip_litellm_runtime(
+            agent_env,
+            runtime,
+            reason="usage_tracking=off leaves provider traffic untouched",
+        )
+
     if not needs_litellm_runtime(agent, model):
+        if usage_cfg.mode == "required" and agent != "oracle":
+            raise RuntimeError(
+                "Token usage tracking is required, but agent "
+                f"{agent!r} cannot be routed through LiteLLM."
+            )
         if runtime is not None:
-            await stop_litellm_runtime(runtime)
+            return await _skip_litellm_runtime(agent_env, runtime)
         return agent_env, None
     assert model is not None
 
-    usage_cfg = UsageTrackingConfig.coerce(usage_tracking).with_env_defaults()
-    route = resolve_litellm_route(model, agent_env)
+    try:
+        route = resolve_litellm_route(model, agent_env)
+    except ValueError as exc:
+        return await _fallback_or_raise_for_unavailable_litellm(
+            usage_cfg=usage_cfg,
+            agent_env=agent_env,
+            runtime=runtime,
+            required_error=(
+                "Token usage tracking is required, but LiteLLM cannot resolve "
+                f"model {model!r}: {exc}"
+            ),
+            fallback_reason=(
+                f"usage_tracking=auto could not resolve model {model!r}: {exc}"
+            ),
+        )
     missing = _missing_required_env(route, agent_env)
     if missing:
-        if (
-            agent_env.get("_BENCHFLOW_SUBSCRIPTION_AUTH")
-            and usage_cfg.mode != "required"
-        ):
-            logger.info(
-                "Skipping LiteLLM for subscription-auth-only run; missing provider keys: %s",
-                ", ".join(missing),
-            )
-            return agent_env, None
-        raise RuntimeError(
-            f"LiteLLM route for model {model!r} requires {', '.join(missing)}. "
+        missing_text = ", ".join(missing)
+        required_error = (
+            f"LiteLLM route for model {model!r} requires {missing_text}. "
             "Pass provider credentials via --agent-env/agent_env or define them in .env."
+        )
+        return await _fallback_or_raise_for_unavailable_litellm(
+            usage_cfg=usage_cfg,
+            agent_env=agent_env,
+            runtime=runtime,
+            required_error=required_error,
+            fallback_reason=(
+                f"usage_tracking=auto could not start LiteLLM for model {model!r}; "
+                f"missing provider credentials: {missing_text}"
+            ),
         )
 
     master_key = (
@@ -950,25 +1008,39 @@ async def ensure_litellm_runtime(
                 )
         await stop_litellm_runtime(runtime)
 
-    if environment in {"daytona", "modal"}:
-        if sandbox is None:
-            raise RuntimeError("sandbox-local LiteLLM requires a sandbox handle")
-        server = await _start_sandbox_litellm(
-            sandbox=sandbox,
-            route=route,
-            master_key=master_key,
+    try:
+        if environment in {"daytona", "modal"}:
+            if sandbox is None:
+                raise RuntimeError("sandbox-local LiteLLM requires a sandbox handle")
+            server = await _start_sandbox_litellm(
+                sandbox=sandbox,
+                route=route,
+                master_key=master_key,
+                agent_env=agent_env,
+                session_id=session_id,
+                agent_name=agent,
+            )
+        else:
+            server = await _start_host_litellm(
+                route=route,
+                master_key=master_key,
+                agent_env=agent_env,
+                environment=environment,
+                session_id=session_id,
+                agent_name=agent,
+            )
+    except Exception as exc:
+        return await _fallback_or_raise_for_unavailable_litellm(
+            usage_cfg=usage_cfg,
             agent_env=agent_env,
-            session_id=session_id,
-            agent_name=agent,
-        )
-    else:
-        server = await _start_host_litellm(
-            route=route,
-            master_key=master_key,
-            agent_env=agent_env,
-            environment=environment,
-            session_id=session_id,
-            agent_name=agent,
+            runtime=None,
+            required_error=(
+                "Token usage tracking is required, but LiteLLM failed to start "
+                f"for model {model!r}: {exc}"
+            ),
+            fallback_reason=(
+                f"usage_tracking=auto could not start LiteLLM for model {model!r}: {exc}"
+            ),
         )
 
     from benchflow.providers.runtime import ProviderRuntime

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -6,7 +6,11 @@ import pytest
 
 from benchflow.providers import litellm_runtime as runtime_mod
 from benchflow.providers.litellm_config import LITELLM_MODEL_ALIAS_ENV
-from benchflow.providers.runtime import ensure_litellm_runtime, stop_provider_runtime
+from benchflow.providers.runtime import (
+    ProviderRuntime,
+    ensure_litellm_runtime,
+    stop_provider_runtime,
+)
 
 
 class FakeLiteLLMServer:
@@ -155,6 +159,135 @@ async def test_required_usage_fails_when_litellm_lacks_provider_key():
             agent="codex-acp",
             agent_env={},
             model="openai/gpt-4.1-mini",
+            runtime=None,
+            environment="docker",
+            usage_tracking="required",
+        )
+
+
+@pytest.mark.asyncio
+async def test_usage_tracking_off_leaves_provider_env_untouched(monkeypatch):
+    """Guards the follow-up to PR #613: off must not proxy provider traffic."""
+
+    async def fail_start(**_kwargs):
+        raise AssertionError("LiteLLM should not start when usage tracking is off")
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+    env = {"OPENAI_API_KEY": "sk-openai"}
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="codex-acp",
+        agent_env=env,
+        model="openai/gpt-4.1-mini",
+        runtime=None,
+        environment="docker",
+        usage_tracking="off",
+    )
+
+    assert updated == env
+    assert provider_runtime is None
+
+
+@pytest.mark.asyncio
+async def test_usage_tracking_off_stops_existing_litellm_runtime():
+    """Guards the follow-up to PR #613: off must clear stale LiteLLM routing."""
+
+    server = FakeLiteLLMServer("http://127.0.0.1:4000", route=None)
+    existing = ProviderRuntime(
+        kind="litellm",
+        agent_base_url=server.base_url,
+        server=server,
+        config_key="old",
+    )
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="codex-acp",
+        agent_env={"OPENAI_API_KEY": "sk-openai"},
+        model="openai/gpt-4.1-mini",
+        runtime=existing,
+        environment="docker",
+        usage_tracking="off",
+    )
+
+    assert updated == {"OPENAI_API_KEY": "sk-openai"}
+    assert provider_runtime is None
+    assert server.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_auto_usage_falls_back_when_litellm_lacks_provider_key(monkeypatch):
+    """Guards the follow-up to PR #613: auto should not fail just to track usage."""
+
+    async def fail_start(**_kwargs):
+        raise AssertionError("LiteLLM should not start without provider credentials")
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="codex-acp",
+        agent_env={},
+        model="openai/gpt-4.1-mini",
+        runtime=None,
+        environment="docker",
+        usage_tracking="auto",
+    )
+
+    assert updated == {}
+    assert provider_runtime is None
+
+
+@pytest.mark.asyncio
+async def test_auto_usage_falls_back_when_litellm_start_fails(monkeypatch):
+    """Guards the follow-up to PR #613: auto should survive proxy startup errors."""
+
+    async def fail_start(**_kwargs):
+        raise RuntimeError("proxy unavailable")
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+    env = {"OPENAI_API_KEY": "sk-openai"}
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="codex-acp",
+        agent_env=env,
+        model="openai/gpt-4.1-mini",
+        runtime=None,
+        environment="docker",
+        usage_tracking="auto",
+    )
+
+    assert updated == env
+    assert provider_runtime is None
+
+
+@pytest.mark.asyncio
+async def test_required_usage_propagates_litellm_start_failure(monkeypatch):
+    """Guards the follow-up to PR #613: required must still fail closed."""
+
+    async def fail_start(**_kwargs):
+        raise RuntimeError("proxy unavailable")
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+
+    with pytest.raises(RuntimeError, match="Token usage tracking is required"):
+        await ensure_litellm_runtime(
+            agent="codex-acp",
+            agent_env={"OPENAI_API_KEY": "sk-openai"},
+            model="openai/gpt-4.1-mini",
+            runtime=None,
+            environment="docker",
+            usage_tracking="required",
+        )
+
+
+@pytest.mark.asyncio
+async def test_required_usage_fails_for_native_agent_without_litellm_route():
+    """Guards the follow-up to PR #613: required cannot silently go unavailable."""
+
+    with pytest.raises(RuntimeError, match="cannot be routed through LiteLLM"):
+        await ensure_litellm_runtime(
+            agent="gemini",
+            agent_env={"GEMINI_API_KEY": "gemini-key"},
+            model="gemini-2.5-flash",
             runtime=None,
             environment="docker",
             usage_tracking="required",


### PR DESCRIPTION
## Problem

PR #613 moved BenchFlow provider traffic behind the LiteLLM runtime, but the `usage_tracking` policy was not enforced at the runtime boundary:

- `usage_tracking=off` still started/reused LiteLLM and rewrote the agent's provider env, so the documented "leave provider traffic untouched" contract was false.
- default/`auto` behaved too much like `required`: missing provider keys or LiteLLM startup failures could fail the run instead of falling back to direct provider traffic.
- `required` did not have an explicit guard for agents that cannot be routed through LiteLLM, which could let required telemetry degrade into unavailable telemetry later in the rollout.

That made the policy ambiguous: official experiments should require usage metadata, but recovery/debug/native-provider runs still need an honest escape hatch.

## Approach

This PR makes `ensure_litellm_runtime()` the single policy boundary for `auto|required|off`:

- `off` now returns the original `agent_env`, does not start LiteLLM, and stops any stale LiteLLM runtime from a prior call.
- `auto` still attempts LiteLLM first, but falls back to direct provider traffic when route resolution, credential availability, or LiteLLM startup makes telemetry unavailable.
- `required` remains fail-closed for missing credentials, LiteLLM startup failures, and native agents that cannot be proxied through LiteLLM.

The implementation keeps the branching contained in two small helpers instead of scattering mode checks through the host/sandbox startup paths.

## Evidence This Is Fixed

### Targeted regression coverage

New tests prove each policy edge directly:

- `test_usage_tracking_off_leaves_provider_env_untouched`: `off` does not start LiteLLM and preserves raw provider env.
- `test_usage_tracking_off_stops_existing_litellm_runtime`: `off` clears a stale proxy runtime instead of reusing it.
- `test_auto_usage_falls_back_when_litellm_lacks_provider_key`: `auto` does not fail just because LiteLLM lacks provider credentials.
- `test_auto_usage_falls_back_when_litellm_start_fails`: `auto` survives proxy startup failures.
- `test_required_usage_propagates_litellm_start_failure`: `required` still fails closed.
- `test_required_usage_fails_for_native_agent_without_litellm_route`: required telemetry cannot silently become unavailable for a native non-proxied agent.

Existing tests still cover the Daytona sandbox-local required path, normal LiteLLM env rewrites, runtime reuse, and oracle bypass behavior.

### Real VM Docker E2E

Ran a real Docker rollout on the `daytona-orchestrator` VM against this PR branch:

```bash
bench eval create \
  --tasks-dir /home/bingran_you/skillsbench/tasks \
  --include citation-check \
  --agent openhands \
  --model gemini-3.5-flash \
  --sandbox docker \
  --concurrency 1 \
  --usage-tracking required \
  --agent-idle-timeout none \
  --agent-env LLM_CACHING_PROMPT=false \
  --jobs-dir /home/bingran_you/runs/pr620-gemini-docker-required-191608
```

Result artifact: `/home/bingran_you/runs/pr620-gemini-docker-required-191608/summary.json`

- `total=1`, `passed=1`, `failed=0`, `errored=0`, score `100.0%`.
- Task reward: `citation-check` had `rewards.reward=1.0` with `error=null` and `verifier_error=null`.
- Required usage tracking was actually enabled: `usage_tracking.status=enabled`, `endpoint_kind=host`, `usage_source=provider_response`.
- Telemetry was complete: `telemetry_coverage=1.0`, `total_tokens=738311`, `total_cost_usd=0.4191984`, `price_source=litellm`.
- `trajectory/llm_trajectory.jsonl` had 23 LiteLLM exchanges, all 23 with provider usage, through `/v1/chat/completions` for `gemini-3.5-flash`.

This E2E exercises the real Docker host-LiteLLM startup path inside the new try-wrapper, not just mocked unit tests. Because the rollout used `--usage-tracking required`, it also proves the happy path does not accidentally fall back to direct provider traffic when LiteLLM is healthy.

A prior Daytona attempt is intentionally excluded from the evidence: that run failed during sandbox creation because the VM checkout was missing the `sandbox-daytona` extra (`ModuleNotFoundError: No module named 'daytona'`), before reaching this PR's runtime code.

## Verification

Local:

- `uv run python -m pytest tests/`  
  `2613 passed, 49 skipped, 1 deselected, 348 warnings in 109.78s`
- `uv run ty check src/`  
  `All checks passed!`
- `uv run ruff check .`  
  `All checks passed!`

GitHub checks:

- `test`: passed
- `pip-audit`: passed
- `Mintlify Deployment`: skipped