### PR TITLE
Add public and internal preview release workflows

### DIFF
--- a/.github/workflows/internal-preview-release.yml
+++ b/.github/workflows/internal-preview-release.yml
@@ -1,0 +1,123 @@
+name: internal-preview-release
+
+on:
+  workflow_run:
+    workflows: ["test"]
+    types: [completed]
+
+# PyPI Trusted Publishing uses OIDC, so no PyPI token is stored in GitHub.
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: internal-preview-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish internal preview to PyPI
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      }}
+    runs-on: ubuntu-latest
+    environment: pypi-internal-preview
+
+    steps:
+      - name: Check out tested commit
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Compute internal preview version
+        id: version
+        env:
+          TEST_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+        run: |
+          version="$(
+            uv run --with packaging --no-project python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          from packaging.version import Version
+
+          pyproject = tomllib.loads(Path("pyproject.toml").read_text())
+          current = Version(pyproject["project"]["version"])
+
+          if not current.is_devrelease:
+              if current.is_prerelease or current.local is not None:
+                  raise SystemExit(
+                      "Internal preview releases must be based on a plain .dev "
+                      f"version or a final public-release staging version, got {current}."
+                  )
+              print("SKIP_FINAL_VERSION")
+              raise SystemExit(0)
+          if current.pre is not None or current.local is not None:
+              raise SystemExit(
+                  "Internal preview releases must be based on a plain .dev "
+                  f"version, got {current}."
+              )
+
+          print(f"{current.base_version}.dev{os.environ['TEST_RUN_NUMBER']}")
+          PY
+          )"
+          if [ "$version" = "SKIP_FINAL_VERSION" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          uv version "$version" --frozen
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build distributions
+        if: steps.version.outputs.publish == 'true'
+        run: uv build --no-sources
+
+      - name: Check distributions
+        if: steps.version.outputs.publish == 'true'
+        run: uv run --with twine --no-project twine check dist/*
+
+      - name: Publish internal preview
+        if: steps.version.outputs.publish == 'true'
+        run: uv publish
+
+      - name: Summarize release
+        if: steps.version.outputs.publish == 'true'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Internal preview published
+
+          Published \`benchflow==${{ steps.version.outputs.version }}\` from tested commit:
+
+          \`${{ github.event.workflow_run.head_sha }}\`
+
+          Internal users can install it with:
+
+          \`\`\`bash
+          pip install --pre --upgrade benchflow
+          \`\`\`
+          EOF
+
+      - name: Summarize skipped final-version commit
+        if: steps.version.outputs.publish != 'true'
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Internal preview skipped
+
+          This commit uses a final public version in \`pyproject.toml\`.
+          It is handled by the tag-driven public release workflow instead of
+          the internal preview channel.
+          EOF

--- a/.github/workflows/internal-preview-release.yml
+++ b/.github/workflows/internal-preview-release.yml
@@ -10,10 +10,6 @@ permissions:
   contents: read
   id-token: write
 
-concurrency:
-  group: internal-preview-release
-  cancel-in-progress: false
-
 jobs:
   publish:
     name: Publish internal preview to PyPI

--- a/.github/workflows/internal-preview-release.yml
+++ b/.github/workflows/internal-preview-release.yml
@@ -40,43 +40,11 @@ jobs:
         id: version
         env:
           TEST_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
-        run: |
-          version="$(
-            uv run --with packaging --no-project python - <<'PY'
-          import os
-          import tomllib
-          from pathlib import Path
+        run: uv run --with packaging --no-project python tools/release_version.py internal-preview
 
-          from packaging.version import Version
-
-          pyproject = tomllib.loads(Path("pyproject.toml").read_text())
-          current = Version(pyproject["project"]["version"])
-
-          if not current.is_devrelease:
-              if current.is_prerelease or current.local is not None:
-                  raise SystemExit(
-                      "Internal preview releases must be based on a plain .dev "
-                      f"version or a final public-release staging version, got {current}."
-                  )
-              print("SKIP_FINAL_VERSION")
-              raise SystemExit(0)
-          if current.pre is not None or current.local is not None:
-              raise SystemExit(
-                  "Internal preview releases must be based on a plain .dev "
-                  f"version, got {current}."
-              )
-
-          print(f"{current.base_version}.dev{os.environ['TEST_RUN_NUMBER']}")
-          PY
-          )"
-          if [ "$version" = "SKIP_FINAL_VERSION" ]; then
-            echo "publish=false" >> "$GITHUB_OUTPUT"
-            echo "version=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          uv version "$version" --frozen
-          echo "publish=true" >> "$GITHUB_OUTPUT"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Apply internal preview version
+        if: steps.version.outputs.publish == 'true'
+        run: uv version "${{ steps.version.outputs.version }}" --frozen
 
       - name: Build distributions
         if: steps.version.outputs.publish == 'true'

--- a/.github/workflows/public-release.yml
+++ b/.github/workflows/public-release.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Check out tag
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
@@ -32,6 +34,15 @@ jobs:
 
       - name: Set up Python
         run: uv python install 3.12
+
+      - name: Verify tag is on main
+        run: |
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          tag_commit="$(git rev-parse HEAD)"
+          if ! git merge-base --is-ancestor "$tag_commit" refs/remotes/origin/main; then
+            echo "::error::Public release tag ${{ github.ref_name }} points to $tag_commit, which is not on origin/main."
+            exit 1
+          fi
 
       - name: Validate release tag
         id: version

--- a/.github/workflows/public-release.yml
+++ b/.github/workflows/public-release.yml
@@ -48,34 +48,7 @@ jobs:
         id: version
         env:
           TAG_NAME: ${{ github.ref_name }}
-        run: |
-          version="$(
-            uv run --with packaging --no-project python - <<'PY'
-          import os
-          import tomllib
-          from pathlib import Path
-
-          from packaging.version import Version
-
-          tag = os.environ["TAG_NAME"]
-          project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
-          version_text = project["version"]
-          version = Version(version_text)
-
-          if tag != f"v{version_text}":
-              raise SystemExit(
-                  f"Tag {tag!r} does not match pyproject.toml version "
-                  f"'v{version_text}'."
-              )
-          if version.is_prerelease or version.is_devrelease or version.local is not None:
-              raise SystemExit(
-                  f"Public releases must use a final PEP 440 version, got {version_text!r}."
-              )
-
-          print(version_text)
-          PY
-          )"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+        run: uv run --with packaging --no-project python tools/release_version.py public-release
 
       - name: Build distributions
         run: uv build --no-sources

--- a/.github/workflows/public-release.yml
+++ b/.github/workflows/public-release.yml
@@ -1,0 +1,99 @@
+name: public-release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+# PyPI Trusted Publishing uses OIDC, and GitHub Releases need contents: write.
+permissions:
+  contents: write
+  id-token: write
+
+concurrency:
+  group: public-release-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish public release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    environment: pypi-public
+
+    steps:
+      - name: Check out tag
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Validate release tag
+        id: version
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          version="$(
+            uv run --with packaging --no-project python - <<'PY'
+          import os
+          import tomllib
+          from pathlib import Path
+
+          from packaging.version import Version
+
+          tag = os.environ["TAG_NAME"]
+          project = tomllib.loads(Path("pyproject.toml").read_text())["project"]
+          version_text = project["version"]
+          version = Version(version_text)
+
+          if tag != f"v{version_text}":
+              raise SystemExit(
+                  f"Tag {tag!r} does not match pyproject.toml version "
+                  f"'v{version_text}'."
+              )
+          if version.is_prerelease or version.is_devrelease or version.local is not None:
+              raise SystemExit(
+                  f"Public releases must use a final PEP 440 version, got {version_text!r}."
+              )
+
+          print(version_text)
+          PY
+          )"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build distributions
+        run: uv build --no-sources
+
+      - name: Check distributions
+        run: uv run --with twine --no-project twine check dist/*
+
+      - name: Publish public release
+        run: uv publish
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ github.ref_name }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/* --clobber
+          else
+            gh release create "$tag" dist/* \
+              --title "benchflow ${{ steps.version.outputs.version }}" \
+              --generate-notes \
+              --verify-tag
+          fi
+
+      - name: Summarize release
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+          ## Public release published
+
+          Published \`benchflow==${{ steps.version.outputs.version }}\` to PyPI
+          and created GitHub release \`${{ github.ref_name }}\`.
+          EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
         run: uv sync --extra dev --extra sandbox-daytona --extra sandbox-modal --locked
 
       - name: Lint
-        run: uv run ruff check src tests
+        run: uv run ruff check src tests tools
 
       - name: Format check
-        run: uv run ruff format --check src tests
+        run: uv run ruff format --check src tests tools
 
       - name: Type check
         run: uv run ty check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ uv run ruff check .
 - **Regression tests must name the PR/commit they guard** in the docstring (e.g. `Guards the fix from PR #198 against the regression introduced by PR #193`).
 - **Human review before `main`.** PRs only. No force-pushes to `main`. Self-approval doesn't count.
 - **Trunk-based:** branch off `main`, PR back to `main`. No long-lived release branches.
-- **Releases:** bump `pyproject.toml` to the stable version, tag `v<version>` on main, push tag (CI publishes to PyPI), then bump main to the next `.dev0`.
+- **Releases:** current mechanics live in [`docs/release.md`](./docs/release.md). Merges to `main` publish internal preview `.devN` builds after CI passes; public releases require a reviewed stable-version PR, a matching `v<version>` tag on `main`, then a bump back to the next `.dev0`.
 
 ## Experiment guidance (when using benchflow to run batch tasks experiments)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/
 | Multi-round single-agent (progressive disclosure, oracle access) | [Progressive disclosure](./docs/progressive-disclosure.md) |
 | Skill evaluation (when the artifact is a skill, not a workspace) | [Skill eval](./docs/skill-eval.md) |
 | Understand the security model | [Sandbox hardening](./docs/sandbox-hardening.md) |
+| Use public vs internal preview SDK releases | [Release channels](./docs/release.md) |
 | CLI flags + commands | [CLI reference](./docs/reference/cli.md) |
 | Python API surface | [Python API reference](./docs/reference/python-api.md) |
 
@@ -99,7 +100,9 @@ Two runnable labs validate the security story:
 
 PRs welcome. Open against `main`. CI runs ruff + tests on every PR; please run `ruff check .` and `pytest tests/` locally first.
 
-For a release: bump `pyproject.toml` to the next stable version, tag `v<version>` on main, push the tag — CI publishes to PyPI. Then bump main to the next `.dev0`.
+Release channels are documented in [Release channels](./docs/release.md). In
+short: merges to `main` publish an internal preview after CI passes, while a
+matching `v<version>` tag publishes the public release.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,9 @@ bench eval create \
 
 Repos are cloned and cached locally under `.cache/datasets/` on first use.
 
-SkillsBench itself sources BenchFlow from GitHub `main` in its
-[`pyproject.toml`](https://github.com/benchflow-ai/skillsbench/blob/main/pyproject.toml).
-After a BenchFlow change lands, run `uv lock --upgrade-package benchflow` in
-SkillsBench when you need its lockfile to point at the newest BenchFlow commit.
+Downstream projects should depend on the public PyPI release by default. For
+internal validation before the next public release, install or lock the internal
+preview channel with prereleases enabled; see [Release channels](./docs/release.md).
 
 ## Featured
 

--- a/docs.json
+++ b/docs.json
@@ -31,6 +31,7 @@
         "pages": [
           "docs/reference/cli",
           "docs/reference/python-api",
+          "docs/release",
           "docs/integration-tests"
         ]
       }

--- a/docs/release-gate-2026-05-19.md
+++ b/docs/release-gate-2026-05-19.md
@@ -179,6 +179,10 @@ internal `0.4.0` refactor cut.
 
 Release sequence after merge approval:
 
+> Historical note: this dated gate predates the public/internal preview
+> publishing split. Current release-channel mechanics live in
+> [`docs/release.md`](./release.md).
+
 1. Merge PRs #279, #280, #283, #290, #291, and #292.
 2. Bump `pyproject.toml` on `main` to `1.0.0`.
 3. Tag `v1.0.0` on `main`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,10 +14,30 @@ Regular users install public releases with:
 pip install --upgrade benchflow
 ```
 
-Internal users install the latest preview with:
+For the CLI, install the public tool with:
+
+```bash
+uv tool install benchflow
+```
+
+Internal users install the latest preview package with:
 
 ```bash
 pip install --pre --upgrade benchflow
+```
+
+For the CLI, install or upgrade the preview tool with:
+
+```bash
+uv tool install --prerelease allow --upgrade benchflow
+uv tool upgrade --prerelease allow benchflow
+```
+
+For downstream projects that use `uv`, lock the preview dependency with:
+
+```bash
+uv add --prerelease allow benchflow
+uv lock --upgrade-package benchflow --prerelease allow
 ```
 
 ## Version Model

--- a/docs/release.md
+++ b/docs/release.md
@@ -60,7 +60,8 @@ Public release:
 2. Merge the release PR to `main`.
 3. Push a matching tag, for example `v0.5.1`.
 4. `.github/workflows/public-release.yml` validates the tag, publishes to PyPI,
-   and creates a GitHub Release.
+   and creates a GitHub Release. The workflow refuses tags whose commits are
+   not contained in `origin/main`.
 5. Bump `main` to the next `.dev0`, for example `0.5.2.dev0`.
 
 ## One-Time PyPI Setup

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,84 @@
+# Release Channels
+
+BenchFlow uses two PyPI release channels with the same package name:
+
+- **Public** releases are stable versions such as `0.5.0`. They are created by
+  pushing a matching `v<version>` tag.
+- **Internal preview** releases are development versions such as
+  `0.5.1.dev123`. They are created automatically after the `test` workflow
+  passes for a push to `main`.
+
+Regular users install public releases with:
+
+```bash
+pip install --upgrade benchflow
+```
+
+Internal users install the latest preview with:
+
+```bash
+pip install --pre --upgrade benchflow
+```
+
+## Version Model
+
+`pyproject.toml` on `main` should track the next public version as `.dev0`.
+For example, after publishing `0.5.0`, bump `main` to:
+
+```toml
+version = "0.5.1.dev0"
+```
+
+The internal preview workflow rewrites that version only inside the CI build,
+using the successful `test` workflow run number:
+
+```text
+0.5.1.dev0 in git -> 0.5.1.dev123 on PyPI
+```
+
+This keeps public and internal preview ordering correct: `0.5.1.dev123` is a
+preview of the future `0.5.1`, while `0.5.1` remains the public release users
+get by default.
+
+If `main` temporarily contains a final public version during the release flow,
+the internal preview workflow skips publishing and lets the tag-driven public
+workflow handle that commit.
+
+## Publishing Flow
+
+Internal preview:
+
+1. Merge a PR to `main`.
+2. `.github/workflows/test.yml` runs.
+3. `.github/workflows/internal-preview-release.yml` publishes to PyPI only if
+   the tested `main` commit passed.
+
+Public release:
+
+1. Update `pyproject.toml` from the next `.dev0` version to the final public
+   version, for example `0.5.1.dev0 -> 0.5.1`.
+2. Merge the release PR to `main`.
+3. Push a matching tag, for example `v0.5.1`.
+4. `.github/workflows/public-release.yml` validates the tag, publishes to PyPI,
+   and creates a GitHub Release.
+5. Bump `main` to the next `.dev0`, for example `0.5.2.dev0`.
+
+## One-Time PyPI Setup
+
+Configure PyPI Trusted Publishing for the `benchflow` project. No PyPI token is
+stored in GitHub.
+
+Create these PyPI trusted publishers:
+
+| Channel | Repository | Workflow filename | Environment |
+| --- | --- | --- | --- |
+| Internal preview | `benchflow-ai/benchflow` | `internal-preview-release.yml` | `pypi-internal-preview` |
+| Public | `benchflow-ai/benchflow` | `public-release.yml` | `pypi-public` |
+
+Create matching GitHub environments:
+
+- `pypi-internal-preview`: used for automatic preview publishing from `main`.
+- `pypi-public`: used for tag-driven public releases.
+
+The workflows build with `uv build --no-sources`, check distributions with
+`twine check`, and publish with `uv publish`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ python-version = "3.12"
 unresolved-import = "ignore"
 
 [tool.ty.src]
-include = ["src"]
+include = ["src", "tools"]
 # Modules that heavily use optional-dep types (daytona, modal, openai, boto3, …)
 # produce cascading type errors when those packages aren't installed.
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
+    "packaging>=24",
     "pre-commit>=3.7",
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24.0",

--- a/tests/test_release_version.py
+++ b/tests/test_release_version.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tools.release_version import (
+    InternalPreviewDecision,
+    ReleaseVersionError,
+    compute_internal_preview_version,
+    main,
+    validate_public_release_version,
+)
+
+
+@pytest.mark.parametrize(
+    ("version", "run_number", "expected"),
+    [
+        ("0.5.1.dev0", "123", "0.5.1.dev123"),
+        ("0.5.1.dev7", 124, "0.5.1.dev124"),
+        ("1.0.dev0", "00125", "1.0.dev125"),
+    ],
+)
+def test_internal_preview_computes_version(
+    version: str, run_number: str | int, expected: str
+) -> None:
+    """Guards PR #621 internal preview version policy."""
+    assert compute_internal_preview_version(
+        version,
+        run_number,
+    ) == InternalPreviewDecision(publish=True, version=expected)
+
+
+@pytest.mark.parametrize("version", ["0.5.1", "0.5.1.post1"])
+def test_internal_preview_skips_final_public_versions(version: str) -> None:
+    """Guards PR #621 release staging skip policy."""
+    assert compute_internal_preview_version(
+        version,
+        "123",
+    ) == InternalPreviewDecision(publish=False)
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "0.5.1a1",
+        "0.5.1b1",
+        "0.5.1rc1",
+        "0.5.1+local",
+        "0.5.1rc1.dev0",
+    ],
+)
+def test_internal_preview_rejects_ambiguous_versions(version: str) -> None:
+    """Guards PR #621 against publishing ambiguous preview bases."""
+    with pytest.raises(ReleaseVersionError, match="Internal preview releases"):
+        compute_internal_preview_version(version, "123")
+
+
+@pytest.mark.parametrize("run_number", ["0", "-1", "abc", "1.5"])
+def test_internal_preview_rejects_invalid_run_numbers(run_number: str) -> None:
+    """Guards PR #621 against malformed GitHub run numbers."""
+    with pytest.raises(ReleaseVersionError, match="positive integer"):
+        compute_internal_preview_version("0.5.1.dev0", run_number)
+
+
+@pytest.mark.parametrize("version", ["0.5.1", "0.5.1.post1"])
+def test_public_release_accepts_matching_final_versions(version: str) -> None:
+    """Guards PR #621 public release tag validation."""
+    assert validate_public_release_version(f"v{version}", version) == version
+
+
+@pytest.mark.parametrize("version", ["0.5.1.dev0", "0.5.1rc1", "0.5.1+local"])
+def test_public_release_rejects_non_final_versions(version: str) -> None:
+    """Guards PR #621 against non-final public release versions."""
+    with pytest.raises(ReleaseVersionError, match="final PEP 440"):
+        validate_public_release_version(f"v{version}", version)
+
+
+def test_public_release_rejects_tag_mismatch() -> None:
+    """Guards PR #621 against publishing mismatched release tags."""
+    with pytest.raises(ReleaseVersionError, match="does not match"):
+        validate_public_release_version("v0.5.2", "0.5.1")
+
+
+def test_internal_preview_cli_writes_github_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #621 GitHub output contract for internal preview releases."""
+    pyproject = tmp_path / "pyproject.toml"
+    output = tmp_path / "github-output"
+    pyproject.write_text('[project]\nversion = "0.5.1.dev0"\n')
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+    assert (
+        main(
+            [
+                "internal-preview",
+                "--pyproject",
+                str(pyproject),
+                "--run-number",
+                "321",
+            ]
+        )
+        == 0
+    )
+
+    assert output.read_text() == "publish=true\nversion=0.5.1.dev321\n"
+
+
+def test_public_release_cli_writes_github_outputs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #621 GitHub output contract for public releases."""
+    pyproject = tmp_path / "pyproject.toml"
+    output = tmp_path / "github-output"
+    pyproject.write_text('[project]\nversion = "0.5.1"\n')
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+
+    assert (
+        main(
+            [
+                "public-release",
+                "--pyproject",
+                str(pyproject),
+                "--tag",
+                "v0.5.1",
+            ]
+        )
+        == 0
+    )
+
+    assert output.read_text() == "version=0.5.1\n"

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Repository maintenance tools."""

--- a/tools/release_version.py
+++ b/tools/release_version.py
@@ -1,0 +1,192 @@
+"""Release version policy helpers for GitHub Actions workflows."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tomllib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from packaging.version import InvalidVersion, Version
+
+
+class ReleaseVersionError(ValueError):
+    """Raised when a release version does not match BenchFlow policy."""
+
+
+@dataclass(frozen=True)
+class InternalPreviewDecision:
+    """Internal preview publication decision."""
+
+    publish: bool
+    version: str = ""
+
+
+def read_project_version(pyproject_path: Path) -> str:
+    """Return the `[project].version` value from a pyproject file."""
+    try:
+        pyproject = tomllib.loads(pyproject_path.read_text())
+        version = pyproject["project"]["version"]
+    except (KeyError, tomllib.TOMLDecodeError) as exc:
+        raise ReleaseVersionError(
+            f"Could not read [project].version from {pyproject_path}."
+        ) from exc
+    if not isinstance(version, str) or not version:
+        raise ReleaseVersionError(
+            f"[project].version in {pyproject_path} must be a non-empty string."
+        )
+    return version
+
+
+def compute_internal_preview_version(
+    version_text: str, run_number: str | int
+) -> InternalPreviewDecision:
+    """Compute the internal preview version for a tested main workflow run."""
+    current = _parse_version(version_text)
+    normalized_run_number = _normalize_run_number(run_number)
+
+    if current.is_devrelease and current.pre is None and current.local is None:
+        return InternalPreviewDecision(
+            publish=True,
+            version=f"{current.base_version}.dev{normalized_run_number}",
+        )
+    if not current.is_prerelease and current.local is None:
+        return InternalPreviewDecision(publish=False)
+    raise ReleaseVersionError(
+        "Internal preview releases must be based on a plain .dev version "
+        f"or a final public-release staging version, got {current}."
+    )
+
+
+def validate_public_release_version(tag_name: str, version_text: str) -> str:
+    """Validate that a public release tag matches a final project version."""
+    version = _parse_version(version_text)
+
+    if tag_name != f"v{version_text}":
+        raise ReleaseVersionError(
+            f"Tag {tag_name!r} does not match pyproject.toml version 'v{version_text}'."
+        )
+    if version.is_prerelease or version.local is not None:
+        raise ReleaseVersionError(
+            f"Public releases must use a final PEP 440 version, got {version_text!r}."
+        )
+    return version_text
+
+
+def write_github_output(values: dict[str, str]) -> None:
+    """Write GitHub Actions outputs, or print key-value lines outside Actions."""
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path is None:
+        for key, value in values.items():
+            print(f"{key}={value}")
+        return
+
+    with Path(output_path).open("a", encoding="utf-8") as output_file:
+        for key, value in values.items():
+            output_file.write(f"{key}={value}\n")
+
+
+def _parse_version(version_text: str) -> Version:
+    try:
+        return Version(version_text)
+    except InvalidVersion as exc:
+        raise ReleaseVersionError(
+            f"Invalid PEP 440 version: {version_text!r}."
+        ) from exc
+
+
+def _normalize_run_number(run_number: str | int) -> str:
+    run_number_text = str(run_number)
+    if not run_number_text.isdecimal() or int(run_number_text) <= 0:
+        raise ReleaseVersionError(
+            f"GitHub workflow run number must be a positive integer, got {run_number!r}."
+        )
+    return str(int(run_number_text))
+
+
+def _cmd_internal_preview(args: argparse.Namespace) -> int:
+    run_number = args.run_number or os.environ.get("TEST_RUN_NUMBER")
+    if run_number is None:
+        raise ReleaseVersionError(
+            "TEST_RUN_NUMBER must be set or passed with --run-number."
+        )
+
+    decision = compute_internal_preview_version(
+        read_project_version(args.pyproject),
+        run_number,
+    )
+    write_github_output(
+        {
+            "publish": "true" if decision.publish else "false",
+            "version": decision.version,
+        }
+    )
+    return 0
+
+
+def _cmd_public_release(args: argparse.Namespace) -> int:
+    tag_name = args.tag or os.environ.get("TAG_NAME")
+    if tag_name is None:
+        raise ReleaseVersionError("TAG_NAME must be set or passed with --tag.")
+
+    version = validate_public_release_version(
+        tag_name,
+        read_project_version(args.pyproject),
+    )
+    write_github_output({"version": version})
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    internal_preview = subparsers.add_parser(
+        "internal-preview",
+        help="Compute the internal preview version for a main test workflow run.",
+    )
+    internal_preview.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml.",
+    )
+    internal_preview.add_argument(
+        "--run-number",
+        help="Successful test workflow run number. Defaults to TEST_RUN_NUMBER.",
+    )
+    internal_preview.set_defaults(func=_cmd_internal_preview)
+
+    public_release = subparsers.add_parser(
+        "public-release",
+        help="Validate a public release tag against pyproject.toml.",
+    )
+    public_release.add_argument(
+        "--pyproject",
+        type=Path,
+        default=Path("pyproject.toml"),
+        help="Path to pyproject.toml.",
+    )
+    public_release.add_argument(
+        "--tag",
+        help="Release tag name. Defaults to TAG_NAME.",
+    )
+    public_release.set_defaults(func=_cmd_public_release)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except ReleaseVersionError as exc:
+        parser.exit(1, f"{exc}\n")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -307,6 +307,7 @@ bedrock = [
     { name = "boto3" },
 ]
 dev = [
+    { name = "packaging" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -339,6 +340,7 @@ requires-dist = [
     { name = "litellm", extras = ["proxy"], specifier = "==1.88.0rc1" },
     { name = "modal", marker = "extra == 'sandbox-modal'", specifier = ">=0.73" },
     { name = "openai", marker = "extra == 'judge'", specifier = ">=1.40" },
+    { name = "packaging", marker = "extra == 'dev'", specifier = ">=24" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },


### PR DESCRIPTION
## Summary

Adds a two-channel SDK release model:

- **Internal preview**: after the existing `test` workflow succeeds for a push to `main`, publish `benchflow==<next-public>.dev<test-run-number>` to PyPI.
- **Public**: pushing a matching `v<version>` tag validates `pyproject.toml`, publishes the final version to PyPI, and creates/updates a GitHub Release.

Both workflows use PyPI Trusted Publishing/OIDC, so no PyPI token needs to live in GitHub secrets.

## Design Notes

- Internal preview is triggered via `workflow_run` from the existing `test` workflow, so it only publishes commits that passed the same CI gate used for PRs/main.
- The internal preview workflow checks out `github.event.workflow_run.head_sha`, not whatever `main` points at later.
- The `.devN` number comes from the successful `test` workflow run number, keeping package ordering monotonic with the tested run.
- If `main` temporarily contains a final public version during release staging, internal preview skips publishing and lets the tag-driven public workflow own that commit.
- Public release tags must exactly match `pyproject.toml` (`v0.5.0` -> `0.5.0`) and must be final PEP 440 versions.

## One-Time Maintainer Setup

Configure PyPI Trusted Publishing for the `benchflow` PyPI project:

| Channel | Repository | Workflow filename | Environment |
| --- | --- | --- | --- |
| Internal preview | `benchflow-ai/benchflow` | `internal-preview-release.yml` | `pypi-internal-preview` |
| Public | `benchflow-ai/benchflow` | `public-release.yml` | `pypi-public` |

Also create matching GitHub environments:

- `pypi-internal-preview`
- `pypi-public`

## Validation

- `python -m json.tool docs.json`
- Parsed all `.github/workflows/*.yml` with PyYAML
- `uv run --extra dev python -m pytest tests/test_workflow_action_pinning.py`
- `uv build --no-sources && uv run --with twine --no-project twine check dist/*`
