### PR TITLE
Harden usage tracking follow-up edges

### DIFF
--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -56,6 +56,7 @@ _PATCH_MODULE = "benchflow_litellm_bedrock_patch"
 # GenerateContent format), so they talk to their provider directly and report
 # usage_source='unavailable'. ``oracle`` has no model at all.
 _NATIVE_PROTOCOL_AGENTS = frozenset({"oracle", "gemini"})
+_SANDBOX_LOCAL_ENVIRONMENTS = frozenset({"daytona", "modal"})
 
 
 @dataclass(frozen=True)
@@ -948,10 +949,11 @@ async def ensure_litellm_runtime(
                 "Token usage tracking is required, but agent "
                 f"{agent!r} cannot be routed through LiteLLM."
             )
-        if runtime is not None:
-            return await _skip_litellm_runtime(agent_env, runtime)
-        return agent_env, None
+        return await _skip_litellm_runtime(agent_env, runtime)
     assert model is not None
+
+    if environment in _SANDBOX_LOCAL_ENVIRONMENTS and sandbox is None:
+        raise RuntimeError("sandbox-local LiteLLM requires a sandbox handle")
 
     try:
         route = resolve_litellm_route(model, agent_env)
@@ -1009,9 +1011,7 @@ async def ensure_litellm_runtime(
         await stop_litellm_runtime(runtime)
 
     try:
-        if environment in {"daytona", "modal"}:
-            if sandbox is None:
-                raise RuntimeError("sandbox-local LiteLLM requires a sandbox handle")
+        if environment in _SANDBOX_LOCAL_ENVIRONMENTS:
             server = await _start_sandbox_litellm(
                 sandbox=sandbox,
                 route=route,

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -237,6 +237,33 @@ async def test_auto_usage_falls_back_when_litellm_lacks_provider_key(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_auto_usage_falls_back_when_route_resolution_fails(monkeypatch):
+    """Guards the follow-up to PR #620: auto falls back on route failures."""
+
+    def fail_route(*_args, **_kwargs):
+        raise ValueError("missing AZURE_RESOURCE")
+
+    async def fail_start(**_kwargs):
+        raise AssertionError("LiteLLM should not start without a resolved route")
+
+    monkeypatch.setattr(runtime_mod, "resolve_litellm_route", fail_route)
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+    env = {"AZURE_API_KEY": "azure-key"}
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="codex-acp",
+        agent_env=env,
+        model="azure-foundry-openai/gpt-4.1-mini",
+        runtime=None,
+        environment="docker",
+        usage_tracking="auto",
+    )
+
+    assert updated == env
+    assert provider_runtime is None
+
+
+@pytest.mark.asyncio
 async def test_auto_usage_falls_back_when_litellm_start_fails(monkeypatch):
     """Guards the follow-up to PR #613: auto should survive proxy startup errors."""
 
@@ -257,6 +284,48 @@ async def test_auto_usage_falls_back_when_litellm_start_fails(monkeypatch):
 
     assert updated == env
     assert provider_runtime is None
+
+
+@pytest.mark.asyncio
+async def test_auto_usage_requires_sandbox_handle_for_sandbox_local_litellm():
+    """Guards the follow-up to PR #620: auto must not hide wiring bugs."""
+
+    with pytest.raises(RuntimeError, match="sandbox-local LiteLLM"):
+        await ensure_litellm_runtime(
+            agent="openhands",
+            agent_env={"OPENAI_API_KEY": "sk-openai"},
+            model="openai/gpt-4.1-mini",
+            runtime=None,
+            environment="daytona",
+            usage_tracking="auto",
+            sandbox=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_auto_usage_checks_sandbox_handle_before_route_fallback(monkeypatch):
+    """Guards the follow-up to PR #620: sandbox wiring wins over route fallback."""
+
+    route_calls = []
+
+    def fail_route(*_args, **_kwargs):
+        route_calls.append(True)
+        raise ValueError("missing AZURE_RESOURCE")
+
+    monkeypatch.setattr(runtime_mod, "resolve_litellm_route", fail_route)
+
+    with pytest.raises(RuntimeError, match="sandbox-local LiteLLM"):
+        await ensure_litellm_runtime(
+            agent="openhands",
+            agent_env={},
+            model="azure-foundry-openai/gpt-4.1-mini",
+            runtime=None,
+            environment="daytona",
+            usage_tracking="auto",
+            sandbox=None,
+        )
+
+    assert route_calls == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

PR #620 fixed the main `usage_tracking` policy bug, but follow-up review found two edges worth tightening before this area settles:

- The sandbox-local LiteLLM invariant (`daytona`/`modal` require a sandbox handle) must be a fail-fast internal wiring check, not something `usage_tracking=auto` can ever downgrade into telemetry-unavailable fallback.
- The `resolve_litellm_route()` `ValueError` fallback path was part of the design but needed direct regression coverage.

There was also one tiny redundant branch around `_skip_litellm_runtime()` and one repeated sandbox-environment literal.

## Approach

- Move the sandbox-handle invariant before route resolution, credential checks, runtime reuse, and LiteLLM startup. This makes missing sandbox wiring win even in double-fault cases where route resolution or provider credentials are also broken.
- Add regression coverage that route-resolution failures still fall back in `auto` for host/Docker mode.
- Add regression coverage that sandbox-local `auto` raises before route resolution when the sandbox handle is missing.
- Collapse the redundant `runtime is not None` branch by always going through `_skip_litellm_runtime()`.
- Replace duplicated `{daytona, modal}` literals with `_SANDBOX_LOCAL_ENVIRONMENTS`.

## Evidence

Targeted tests added/kept:

- `test_auto_usage_falls_back_when_route_resolution_fails`
- `test_auto_usage_requires_sandbox_handle_for_sandbox_local_litellm`
- `test_auto_usage_checks_sandbox_handle_before_route_fallback`

Verification run locally:

- `uv run python -m pytest tests/test_litellm_runtime.py tests/test_usage_tracking.py`
  - `28 passed`
- `uv run python -m pytest tests/`
  - `2709 passed, 49 skipped, 1 deselected, 348 warnings in 114.39s`
- `uv run ty check src/`
- `uv run ruff check .`
- `uv run ruff format --check src/benchflow/providers/litellm_runtime.py tests/test_litellm_runtime.py`
