### PR TITLE
Prepare 0.5.0 public release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.5.0.dev0"
+version = "0.5.0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.5.0.dev0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- bump benchflow from 0.5.0.dev0 to 0.5.0 for the first public release under the new release workflow
- sync uv.lock package metadata

## Validation
- uv lock --check
- uv run --extra dev python -m pytest tests/test_release_version.py tests/test_workflow_action_pinning.py
- uv run ruff check src tests tools
- uv run ruff format --check src tests tools
- uv build --no-sources && uv run --with twine --no-project twine check dist/*
- uv run python tools/release_version.py public-release --tag v0.5.0

## Release note
After this PR is merged, tag the merge commit as v0.5.0. The public release workflow requires the PyPI Trusted Publisher for workflow public-release.yml with environment pypi-public to exist before publish can succeed.