### PR TITLE
Support native ACP usage for subscription auth

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -17,6 +17,7 @@ from benchflow.trajectories.metrics import (
     count_skill_invocations,
     result_skill_invocations,
 )
+from benchflow.usage_tracking import is_trusted_usage_source
 
 # Phase keys produced by Rollout (see rollout.py — environment_setup,
 # agent_setup, agent_execution, verifier, total). Kept here so summary
@@ -35,7 +36,7 @@ def agent_result_from_rollout(result: RolloutResult) -> dict[str, Any]:
     n_skill_invocations = result.n_skill_invocations or count_skill_invocations(
         result.trajectory
     )
-    return {
+    agent_result = {
         "n_tool_calls": result.n_tool_calls,
         "n_skill_invocations": n_skill_invocations,
         "n_prompts": result.n_prompts,
@@ -48,6 +49,9 @@ def agent_result_from_rollout(result: RolloutResult) -> dict[str, Any]:
         "usage_source": result.usage_source,
         "price_source": result.price_source,
     }
+    if getattr(result, "usage_details", None) is not None:
+        agent_result["usage_details"] = result.usage_details
+    return agent_result
 
 
 def rollout_result_payload(
@@ -105,7 +109,7 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
     covered = [
         r
         for r in completed
-        if (r.get("agent_result") or {}).get("usage_source") == "provider_response"
+        if is_trusted_usage_source((r.get("agent_result") or {}).get("usage_source"))
     ]
 
     def total(field: str) -> int:

--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -380,6 +380,7 @@ class ACPClient:
         # vendored ``StopReason`` enum so consumers keep ``.value`` / member
         # comparisons working.
         self._session.stop_reason = StopReason(prompt_result.stop_reason)
+        self._session.record_prompt_usage(getattr(prompt_result, "usage", None))
         return prompt_result
 
     async def cancel(self) -> None:

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -3,6 +3,7 @@
 import logging
 from collections.abc import Callable
 from datetime import datetime
+from typing import Any
 
 from benchflow.trajectories.metrics import is_skill_invocation_event
 
@@ -14,6 +15,81 @@ from .types import (
 )
 
 logger = logging.getLogger(__name__)
+
+ACPUsageSnapshot = dict[str, int | None]
+
+_ACP_USAGE_FIELDS: tuple[str, ...] = (
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cached_read_tokens",
+    "cached_write_tokens",
+    "thought_tokens",
+)
+
+
+def _coerce_usage_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float | str | bytes | bytearray):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    try:
+        return int(str(value))
+    except ValueError:
+        return None
+
+
+def _usage_mapping(usage: object) -> dict[str, Any]:
+    if isinstance(usage, dict):
+        return {str(key): value for key, value in usage.items()}
+    dump = getattr(usage, "model_dump", None)
+    if callable(dump):
+        data = dump(by_alias=False, exclude_none=True)
+        if isinstance(data, dict):
+            alias_data = dump(by_alias=True, exclude_none=True)
+            if isinstance(alias_data, dict):
+                data = {**alias_data, **data}
+            return data
+    return {
+        field: getattr(usage, field)
+        for field in _ACP_USAGE_FIELDS
+        if hasattr(usage, field)
+    }
+
+
+def normalize_acp_usage(usage: object | None) -> ACPUsageSnapshot | None:
+    """Normalize SDK ACP usage into BenchFlow's snake_case token counters."""
+    if usage is None:
+        return None
+    raw = _usage_mapping(usage)
+    if not raw:
+        return None
+    aliases = {
+        "input_tokens": ("input_tokens", "inputTokens"),
+        "output_tokens": ("output_tokens", "outputTokens"),
+        "total_tokens": ("total_tokens", "totalTokens"),
+        "cached_read_tokens": ("cached_read_tokens", "cachedReadTokens"),
+        "cached_write_tokens": ("cached_write_tokens", "cachedWriteTokens"),
+        "thought_tokens": ("thought_tokens", "thoughtTokens"),
+    }
+    snapshot: ACPUsageSnapshot = {}
+    for field, names in aliases.items():
+        value = None
+        for name in names:
+            if name in raw:
+                value = raw[name]
+                break
+        snapshot[field] = _coerce_usage_int(value)
+    if all(value is None for value in snapshot.values()):
+        return None
+    return snapshot
 
 
 def _is_skill_tool_call(
@@ -93,6 +169,7 @@ class ACPSession:
         self.tool_calls: list[ToolCallRecord] = []
         self._tool_call_map: dict[str, ToolCallRecord] = {}
         self.stop_reason: StopReason | None = None
+        self.usage_snapshots: list[ACPUsageSnapshot] = []
         self.created_at = datetime.now()
         self.events: list[dict] = []
         self._pending_text: list[dict] = []
@@ -123,6 +200,20 @@ class ACPSession:
         """Flush pending agent text after a prompt completes."""
         self._flush_agent_text()
         self._notify_change()
+
+    def record_prompt_usage(self, usage: object | None) -> None:
+        """Record cumulative ACP token usage returned by session/prompt."""
+        snapshot = normalize_acp_usage(usage)
+        if snapshot is None:
+            return
+        self.usage_snapshots.append(snapshot)
+        self._notify_change()
+
+    def latest_usage_totals(self) -> ACPUsageSnapshot | None:
+        """Return the latest cumulative ACP usage snapshot, if any."""
+        if not self.usage_snapshots:
+            return None
+        return dict(self.usage_snapshots[-1])
 
     def _flush_agent_text(self) -> None:
         """Flush pending text events, merging consecutive same-type chunks."""

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -47,8 +47,17 @@ _CODEX_ACCESS_TOKEN_ENV = "CODEX_ACCESS_TOKEN"
 _CODEX_AUTH_JSON_ENV = "CODEX_AUTH_JSON"
 _CLAUDE_CODE_OAUTH_TOKEN_ENV = "CLAUDE_CODE_OAUTH_TOKEN"
 _CLAUDE_OAUTH_TOKEN_ENV = "CLAUDE_OAUTH_TOKEN"
+_SUBSCRIPTION_AUTH_MARKER = "_BENCHFLOW_SUBSCRIPTION_AUTH"
 _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
+)
+_NATIVE_ACP_USAGE_AGENTS = frozenset({"codex-acp", "claude-agent-acp"})
+_LITELLM_RUNTIME_MARKER_KEYS = frozenset(
+    {
+        "BENCHFLOW_LITELLM_MASTER_KEY",
+        "BENCHFLOW_LITELLM_MODEL_ALIAS",
+        "BENCHFLOW_LITELLM_MODEL_VIA_ENV",
+    }
 )
 _CANONICAL_OPENAI_URL = "https://api.openai.com/v1"
 _GENERIC_PROVIDER_OVERRIDE_KEYS = frozenset(
@@ -368,6 +377,64 @@ def _has_codex_auth_json_auth(
     ) and bool(agent_env.get(_CODEX_AUTH_JSON_ENV))
 
 
+def agent_supports_native_acp_usage(agent: str) -> bool:
+    """Return True when native ACP PromptResponse.usage is trusted for the agent."""
+    return agent in _NATIVE_ACP_USAGE_AGENTS
+
+
+def uses_native_subscription_auth(
+    agent: str,
+    model: str | None,
+    agent_env: dict[str, str],
+) -> bool:
+    """Return True when an agent should use CLI/subscription auth directly.
+
+    This is the Harbor-style split point: API-key runs can be routed through
+    LiteLLM, while subscription-auth runs stay on the native Codex/Claude ACP
+    path and report usage from the agent protocol response.
+    """
+    if agent_env.get("BENCHFLOW_PROVIDER_NAME") == "litellm" or any(
+        agent_env.get(key) for key in _LITELLM_RUNTIME_MARKER_KEYS
+    ):
+        return False
+
+    if agent == "codex-acp":
+        if agent_env.get("OPENAI_API_KEY"):
+            return False
+        required_key = "OPENAI_API_KEY"
+        if not _can_use_codex_subscription_auth(
+            agent,
+            model,
+            required_key,
+            agent_env,
+        ):
+            return False
+        return (
+            bool(agent_env.get(_CODEX_ACCESS_TOKEN_ENV))
+            or bool(agent_env.get(_CODEX_AUTH_JSON_ENV))
+            or agent_env.get(_SUBSCRIPTION_AUTH_MARKER) == "1"
+            or check_subscription_auth(agent, required_key)
+        )
+
+    if agent == "claude-agent-acp":
+        if agent_env.get("ANTHROPIC_API_KEY"):
+            return False
+        if model is not None:
+            from benchflow.agents.registry import infer_env_key_for_model
+
+            if infer_env_key_for_model(model) != "ANTHROPIC_API_KEY":
+                return False
+        return (
+            bool(agent_env.get(_CLAUDE_CODE_OAUTH_TOKEN_ENV))
+            or bool(agent_env.get(_CLAUDE_OAUTH_TOKEN_ENV))
+            or bool(agent_env.get("ANTHROPIC_AUTH_TOKEN"))
+            or agent_env.get(_SUBSCRIPTION_AUTH_MARKER) == "1"
+            or check_subscription_auth(agent, "ANTHROPIC_API_KEY")
+        )
+
+    return False
+
+
 def inject_vertex_credentials(agent_env: dict[str, str], model: str) -> None:
     """Inject ADC credentials and defaults for Vertex AI models."""
     from benchflow.agents.registry import is_vertex_model
@@ -668,7 +735,7 @@ def resolve_agent_env(
                 required_key,
                 agent_env,
             ) and check_subscription_auth(agent, required_key):
-                agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
+                agent_env[_SUBSCRIPTION_AUTH_MARKER] = "1"
                 logger.info(
                     "Using host subscription auth (no %s set)",
                     required_key,
@@ -701,7 +768,7 @@ def resolve_agent_env(
                     and _can_use_subscription_auth(agent, model, req_key, agent_env)
                     and check_subscription_auth(agent, req_key)
                 ):
-                    agent_env["_BENCHFLOW_SUBSCRIPTION_AUTH"] = "1"
+                    agent_env[_SUBSCRIPTION_AUTH_MARKER] = "1"
                     logger.info(
                         "Using host subscription auth (no %s set)",
                         req_key,

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -51,7 +51,6 @@ _SUBSCRIPTION_AUTH_MARKER = "_BENCHFLOW_SUBSCRIPTION_AUTH"
 _CUSTOM_OPENAI_ENDPOINT_KEYS = frozenset(
     {"BENCHFLOW_PROVIDER_BASE_URL", "OPENAI_BASE_URL"}
 )
-_NATIVE_ACP_USAGE_AGENTS = frozenset({"codex-acp", "claude-agent-acp"})
 _LITELLM_RUNTIME_MARKER_KEYS = frozenset(
     {
         "BENCHFLOW_LITELLM_MASTER_KEY",
@@ -375,11 +374,6 @@ def _has_codex_auth_json_auth(
         required_key,
         agent_env,
     ) and bool(agent_env.get(_CODEX_AUTH_JSON_ENV))
-
-
-def agent_supports_native_acp_usage(agent: str) -> bool:
-    """Return True when native ACP PromptResponse.usage is trusted for the agent."""
-    return agent in _NATIVE_ACP_USAGE_AGENTS
 
 
 def uses_native_subscription_auth(

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -21,6 +21,7 @@ from benchflow._utils.scoring import (
     pass_rate_excl_errors,
 )
 from benchflow.trajectories.metrics import result_skill_invocations
+from benchflow.usage_tracking import is_trusted_usage_source
 
 logger = logging.getLogger(__name__)
 
@@ -199,7 +200,7 @@ class BenchmarkMetrics:
         return [
             t
             for t in self.tasks
-            if t.completed and t.usage_source == "provider_response"
+            if t.completed and is_trusted_usage_source(t.usage_source)
         ]
 
     @property

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -87,9 +87,10 @@ class RolloutResult:
         total_tokens: Sum of input, output, cache-read, and cache-creation tokens,
                       or None when provider telemetry was unavailable.
         cost_usd:     Provider cost estimate in USD, or None when unavailable.
-        usage_source: Provider telemetry source. One of "provider_response" or
-                      "unavailable".
+        usage_source: Token telemetry source. One of "provider_response",
+                      "agent_native_acp", or "unavailable".
         price_source: Pricing table version used for cost_usd, or None.
+        usage_details: Optional source-specific telemetry details.
         error:        Error description string, or None on success.
         error_category: Stable category for ``error``, or None on success.
         verifier_error: Verifier error description, or None if verifier succeeded
@@ -139,6 +140,7 @@ class RolloutResult:
         cost_usd: float | None = None,
         usage_source: str = "unavailable",
         price_source: str | None = None,
+        usage_details: dict[str, Any] | None = None,
         error: str | None = None,
         error_category: str | None = None,
         verifier_error: str | None = None,
@@ -170,6 +172,7 @@ class RolloutResult:
         self.cost_usd = cost_usd
         self.usage_source = usage_source
         self.price_source = price_source
+        self.usage_details = usage_details
         self.error = error
         self.error_category = error_category
         self.verifier_error = verifier_error

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -13,6 +13,7 @@ from benchflow.trajectories.types import (
     LLMResponse,
     Trajectory,
 )
+from benchflow.usage_tracking import usage_unavailable
 
 _PROVIDER_AUTH_STATUS_CODES = (401, 403)
 _STATUS_KEYS = {
@@ -351,19 +352,6 @@ def trajectory_from_litellm_callback_log(
     if saw_cost:
         trajectory.metadata["cost_usd"] = round(total_cost, 10)
     return trajectory
-
-
-def usage_unavailable() -> dict[str, Any]:
-    return {
-        "n_input_tokens": 0,
-        "n_output_tokens": 0,
-        "n_cache_read_tokens": 0,
-        "n_cache_creation_tokens": 0,
-        "total_tokens": 0,
-        "cost_usd": None,
-        "usage_source": "unavailable",
-        "price_source": None,
-    }
 
 
 def extract_usage_from_trajectory(

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -25,10 +25,7 @@ import httpx
 import yaml
 
 from benchflow.agents.codex_config import apply_codex_provider_config
-from benchflow.agents.env import (
-    agent_supports_native_acp_usage,
-    uses_native_subscription_auth,
-)
+from benchflow.agents.env import uses_native_subscription_auth
 from benchflow.agents.registry import AGENTS
 from benchflow.providers.litellm_config import (
     LITELLM_MASTER_KEY_ENV,
@@ -42,10 +39,9 @@ from benchflow.providers.litellm_logging import (
     callback_module_source,
     extract_usage_from_trajectory,
     trajectory_from_litellm_callback_log,
-    usage_unavailable,
 )
 from benchflow.trajectories.types import Trajectory
-from benchflow.usage_tracking import UsageTrackingConfig
+from benchflow.usage_tracking import UsageTrackingConfig, usage_unavailable
 
 logger = logging.getLogger(__name__)
 
@@ -966,19 +962,10 @@ async def ensure_litellm_runtime(
         )
 
     if uses_native_subscription_auth(agent, model, agent_env):
-        if usage_cfg.mode == "required" and not agent_supports_native_acp_usage(agent):
-            raise RuntimeError(
-                "Token usage tracking is required, but agent "
-                f"{agent!r} cannot report native ACP usage."
-            )
         return await _skip_litellm_runtime(
             agent_env,
             runtime,
-            reason=(
-                "native subscription auth will use agent ACP usage telemetry"
-                if agent_supports_native_acp_usage(agent)
-                else "native subscription auth bypasses LiteLLM"
-            ),
+            reason="native subscription auth will use agent ACP usage telemetry",
         )
 
     if not needs_litellm_runtime(agent, model):

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -25,6 +25,10 @@ import httpx
 import yaml
 
 from benchflow.agents.codex_config import apply_codex_provider_config
+from benchflow.agents.env import (
+    agent_supports_native_acp_usage,
+    uses_native_subscription_auth,
+)
 from benchflow.agents.registry import AGENTS
 from benchflow.providers.litellm_config import (
     LITELLM_MASTER_KEY_ENV,
@@ -959,6 +963,22 @@ async def ensure_litellm_runtime(
             agent_env,
             runtime,
             reason="usage_tracking=off leaves provider traffic untouched",
+        )
+
+    if uses_native_subscription_auth(agent, model, agent_env):
+        if usage_cfg.mode == "required" and not agent_supports_native_acp_usage(agent):
+            raise RuntimeError(
+                "Token usage tracking is required, but agent "
+                f"{agent!r} cannot report native ACP usage."
+            )
+        return await _skip_litellm_runtime(
+            agent_env,
+            runtime,
+            reason=(
+                "native subscription auth will use agent ACP usage telemetry"
+                if agent_supports_native_acp_usage(agent)
+                else "native subscription auth bypasses LiteLLM"
+            ),
         )
 
     if not needs_litellm_runtime(agent, model):

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -179,7 +179,9 @@ def _native_acp_usage_delta(
         "thought_tokens",
     ):
         current_value = _as_nonnegative_int(current.get(usage_field))
-        previous_value = _as_nonnegative_int(previous.get(usage_field)) if previous else 0
+        previous_value = (
+            _as_nonnegative_int(previous.get(usage_field)) if previous else 0
+        )
         delta[usage_field] = max(current_value - previous_value, 0)
 
     current_total = current.get("total_tokens")
@@ -1958,7 +1960,10 @@ class Rollout:
         metrics = dict(
             getattr(self, "_native_usage_metrics", _zero_native_acp_usage_metrics())
         )
-        for snapshot_field, result_field in _NATIVE_ACP_USAGE_SNAPSHOT_TO_RESULT.items():
+        for (
+            snapshot_field,
+            result_field,
+        ) in _NATIVE_ACP_USAGE_SNAPSHOT_TO_RESULT.items():
             if result_field == "total_tokens":
                 continue
             metrics[result_field] = _as_nonnegative_int(metrics.get(result_field)) + (
@@ -2248,11 +2253,15 @@ class Rollout:
 
     def _finalize_usage_metrics(self) -> None:
         """Prefer LiteLLM usage, otherwise use trusted native ACP usage."""
-        current_metrics = getattr(self, "_usage_metrics", {"usage_source": "unavailable"})
+        current_metrics = getattr(
+            self, "_usage_metrics", {"usage_source": "unavailable"}
+        )
         if current_metrics.get("usage_source") == USAGE_SOURCE_PROVIDER_RESPONSE:
             return
         native_metrics = getattr(self, "_native_usage_metrics", None)
-        if isinstance(native_metrics, dict) and is_token_usage_available(native_metrics):
+        if isinstance(native_metrics, dict) and is_token_usage_available(
+            native_metrics
+        ):
             self._usage_metrics = native_metrics
 
     def _enforce_required_usage_tracking(self) -> None:

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -103,7 +103,12 @@ from benchflow.trajectories._capture import (
 from benchflow.trajectories.metrics import count_skill_invocations
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
 from benchflow.trajectories.types import redact_acp_trajectory_jsonl
-from benchflow.usage_tracking import UsageTrackingConfig
+from benchflow.usage_tracking import (
+    USAGE_SOURCE_AGENT_NATIVE_ACP,
+    USAGE_SOURCE_PROVIDER_RESPONSE,
+    UsageTrackingConfig,
+    is_token_usage_available,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +132,90 @@ def _provider_auth_status_from_runtime(runtime: Any) -> int | None:
         if status in (401, 403):
             return status
     return None
+
+
+_NATIVE_ACP_USAGE_RESULT_FIELDS = (
+    "n_input_tokens",
+    "n_output_tokens",
+    "n_cache_read_tokens",
+    "n_cache_creation_tokens",
+    "total_tokens",
+)
+_NATIVE_ACP_USAGE_SNAPSHOT_TO_RESULT = {
+    "input_tokens": "n_input_tokens",
+    "output_tokens": "n_output_tokens",
+    "cached_read_tokens": "n_cache_read_tokens",
+    "cached_write_tokens": "n_cache_creation_tokens",
+    "total_tokens": "total_tokens",
+}
+
+
+def _zero_native_acp_usage_metrics() -> dict[str, Any]:
+    return {
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+        "n_cache_read_tokens": 0,
+        "n_cache_creation_tokens": 0,
+        "total_tokens": 0,
+        "cost_usd": None,
+        "usage_source": "unavailable",
+        "price_source": None,
+        "usage_details": {"thought_tokens": 0},
+    }
+
+
+def _as_nonnegative_int(value: object) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, float | str | bytes | bytearray):
+        try:
+            return max(int(value), 0)
+        except ValueError:
+            return 0
+    try:
+        return max(int(str(value)), 0)
+    except ValueError:
+        return 0
+
+
+def _native_acp_usage_delta(
+    previous: dict[str, int | None] | None,
+    current: dict[str, int | None],
+) -> dict[str, int]:
+    delta: dict[str, int] = {}
+    for usage_field in (
+        "input_tokens",
+        "output_tokens",
+        "cached_read_tokens",
+        "cached_write_tokens",
+        "thought_tokens",
+    ):
+        current_value = _as_nonnegative_int(current.get(usage_field))
+        previous_value = _as_nonnegative_int(previous.get(usage_field)) if previous else 0
+        delta[usage_field] = max(current_value - previous_value, 0)
+
+    current_total = current.get("total_tokens")
+    if current_total is not None:
+        current_value = _as_nonnegative_int(current_total)
+        previous_value = (
+            _as_nonnegative_int(previous.get("total_tokens"))
+            if previous and previous.get("total_tokens") is not None
+            else 0
+        )
+        delta["total_tokens"] = max(current_value - previous_value, 0)
+    else:
+        delta["total_tokens"] = (
+            delta["input_tokens"]
+            + delta["output_tokens"]
+            + delta["cached_read_tokens"]
+            + delta["cached_write_tokens"]
+            + delta["thought_tokens"]
+        )
+    return delta
 
 
 def _task_disallows_internet(task: Any) -> bool:
@@ -537,6 +626,7 @@ def _build_rollout_result(
     cost_usd: float | None = None,
     usage_source: str = "unavailable",
     price_source: str | None = None,
+    usage_details: dict[str, Any] | None = None,
     usage_tracking: dict[str, Any] | None = None,
     evolved_skills: dict[str, str] | None = None,
     source_provenance: dict[str, Any] | None = None,
@@ -588,6 +678,7 @@ def _build_rollout_result(
         cost_usd=cost_usd,
         usage_source=usage_source,
         price_source=price_source,
+        usage_details=usage_details,
         error=error,
         error_category=error_category,
         verifier_error=verifier_error,
@@ -615,6 +706,8 @@ def _build_rollout_result(
         "usage_source": result.usage_source,
         "price_source": result.price_source,
     }
+    if result.usage_details is not None:
+        agent_result["usage_details"] = result.usage_details
     final_metrics = final_metrics_from_agent_result(agent_result)
     trajectory_summary = trajectory_summary_from_events(
         trajectory,
@@ -1178,6 +1271,8 @@ class Rollout:
         self._task_skill_policy: TaskSkillPolicy | None = None
         self._usage_runtime: Any = None
         self._usage_metrics: dict[str, Any] = self._planes.extract_usage(None)
+        self._native_usage_metrics: dict[str, Any] = _zero_native_acp_usage_metrics()
+        self._native_usage_checkpoint: dict[str, int | None] | None = None
         # Provider 401/403 status snapshotted during cleanup, after the usage
         # proxy imports its captures (Daytona's SandboxUsageProxy only fills
         # trajectory on stop()). Read by _provider_auth_status() so ACP-error
@@ -1649,6 +1744,7 @@ class Rollout:
             agent_cwd=self._agent_cwd,
             reasoning_effort=cfg.primary_reasoning_effort,
         )
+        self._native_usage_checkpoint = None
         self._reapply_ask_user_handler()
         self._attach_trajectory_writer(rollout_dir)
 
@@ -1827,6 +1923,7 @@ class Rollout:
         self._n_tool_calls += new_tools
         self._executed_prompts.extend(effective_prompts)
         self._trajectory_source = "acp"
+        self._collect_native_acp_usage()
 
         # Grow the tree at Step-level granularity — one Step per ACP event
         # (tool_call, agent_message, agent_thought, user_message). A single
@@ -1858,6 +1955,43 @@ class Rollout:
 
         self._phase = "executed"
         return trajectory, n_tool_calls
+
+    def _collect_native_acp_usage(self) -> None:
+        """Accumulate ACP PromptResponse.usage deltas for native subscription runs."""
+        session = getattr(self, "_session", None)
+        latest_fn = getattr(session, "latest_usage_totals", None)
+        if not callable(latest_fn):
+            return
+        latest = latest_fn()
+        if not latest:
+            return
+        previous = getattr(self, "_native_usage_checkpoint", None)
+        delta = _native_acp_usage_delta(previous, latest)
+        self._native_usage_checkpoint = dict(latest)
+        if not any(delta.values()):
+            return
+
+        metrics = dict(
+            getattr(self, "_native_usage_metrics", _zero_native_acp_usage_metrics())
+        )
+        for snapshot_field, result_field in _NATIVE_ACP_USAGE_SNAPSHOT_TO_RESULT.items():
+            if result_field == "total_tokens":
+                continue
+            metrics[result_field] = _as_nonnegative_int(metrics.get(result_field)) + (
+                delta.get(snapshot_field) or 0
+            )
+        metrics["total_tokens"] = _as_nonnegative_int(metrics.get("total_tokens")) + (
+            delta.get("total_tokens") or 0
+        )
+        details = dict(metrics.get("usage_details") or {})
+        details["thought_tokens"] = _as_nonnegative_int(
+            details.get("thought_tokens")
+        ) + (delta.get("thought_tokens") or 0)
+        metrics["usage_details"] = details
+        metrics["usage_source"] = USAGE_SOURCE_AGENT_NATIVE_ACP
+        metrics["cost_usd"] = None
+        metrics["price_source"] = None
+        self._native_usage_metrics = metrics
 
     def _build_step_batch(self, new_events: list[dict], new_tools: int) -> list[Step]:
         """Build one Step per ACP event from the events appended this execute.
@@ -2102,7 +2236,9 @@ class Rollout:
                 logger.warning(f"LLM trajectory write failed: {e}")
             finally:
                 self._usage_runtime = None
-            self._enforce_required_usage_tracking()
+
+        self._finalize_usage_metrics()
+        self._enforce_required_usage_tracking()
 
         if self._environment is not None:
             with contextlib.suppress(Exception):
@@ -2126,11 +2262,20 @@ class Rollout:
 
         self._phase = "cleaned"
 
+    def _finalize_usage_metrics(self) -> None:
+        """Prefer LiteLLM usage, otherwise use trusted native ACP usage."""
+        current_metrics = getattr(self, "_usage_metrics", {"usage_source": "unavailable"})
+        if current_metrics.get("usage_source") == USAGE_SOURCE_PROVIDER_RESPONSE:
+            return
+        native_metrics = getattr(self, "_native_usage_metrics", None)
+        if isinstance(native_metrics, dict) and is_token_usage_available(native_metrics):
+            self._usage_metrics = native_metrics
+
     def _enforce_required_usage_tracking(self) -> None:
         usage_cfg = self._config.usage_tracking.with_env_defaults()
         if usage_cfg.mode != "required" or self._config.primary_agent == "oracle":
             return
-        if self._usage_metrics.get("usage_source") == "provider_response":
+        if is_token_usage_available(getattr(self, "_usage_metrics", None)):
             return
         if self._error is not None:
             return
@@ -2721,7 +2866,7 @@ class Rollout:
         usage_source = str(self._usage_metrics.get("usage_source", "unavailable"))
         if usage_cfg.mode == "off":
             status = "off"
-        elif usage_source == "provider_response":
+        elif is_token_usage_available(self._usage_metrics):
             status = "enabled"
         else:
             status = "unavailable"

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -108,6 +108,7 @@ from benchflow.usage_tracking import (
     USAGE_SOURCE_PROVIDER_RESPONSE,
     UsageTrackingConfig,
     is_token_usage_available,
+    usage_unavailable,
 )
 
 logger = logging.getLogger(__name__)
@@ -134,13 +135,6 @@ def _provider_auth_status_from_runtime(runtime: Any) -> int | None:
     return None
 
 
-_NATIVE_ACP_USAGE_RESULT_FIELDS = (
-    "n_input_tokens",
-    "n_output_tokens",
-    "n_cache_read_tokens",
-    "n_cache_creation_tokens",
-    "total_tokens",
-)
 _NATIVE_ACP_USAGE_SNAPSHOT_TO_RESULT = {
     "input_tokens": "n_input_tokens",
     "output_tokens": "n_output_tokens",
@@ -151,17 +145,7 @@ _NATIVE_ACP_USAGE_SNAPSHOT_TO_RESULT = {
 
 
 def _zero_native_acp_usage_metrics() -> dict[str, Any]:
-    return {
-        "n_input_tokens": 0,
-        "n_output_tokens": 0,
-        "n_cache_read_tokens": 0,
-        "n_cache_creation_tokens": 0,
-        "total_tokens": 0,
-        "cost_usd": None,
-        "usage_source": "unavailable",
-        "price_source": None,
-        "usage_details": {"thought_tokens": 0},
-    }
+    return {**usage_unavailable(), "usage_details": {"thought_tokens": 0}}
 
 
 def _as_nonnegative_int(value: object) -> int:

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -55,6 +55,20 @@ def is_token_usage_available(metrics: dict[str, Any] | None) -> bool:
     return is_trusted_usage_source(metrics.get("usage_source"))
 
 
+def usage_unavailable() -> dict[str, Any]:
+    """Return the canonical empty token-usage metrics payload."""
+    return {
+        "n_input_tokens": 0,
+        "n_output_tokens": 0,
+        "n_cache_read_tokens": 0,
+        "n_cache_creation_tokens": 0,
+        "total_tokens": 0,
+        "cost_usd": None,
+        "usage_source": USAGE_SOURCE_UNAVAILABLE,
+        "price_source": None,
+    }
+
+
 @dataclass(frozen=True, init=False)
 class UsageTrackingConfig:
     """User-facing token/cost telemetry policy.

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -7,8 +7,15 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 UsageTrackingMode = Literal["auto", "required", "off"]
+UsageSource = Literal["provider_response", "agent_native_acp", "unavailable"]
 
 USAGE_TRACKING_ENV = "BENCHFLOW_USAGE_TRACKING"
+USAGE_SOURCE_PROVIDER_RESPONSE = "provider_response"
+USAGE_SOURCE_AGENT_NATIVE_ACP = "agent_native_acp"
+USAGE_SOURCE_UNAVAILABLE = "unavailable"
+TRUSTED_USAGE_SOURCES: frozenset[str] = frozenset(
+    {USAGE_SOURCE_PROVIDER_RESPONSE, USAGE_SOURCE_AGENT_NATIVE_ACP}
+)
 
 _MODES: set[str] = {"auto", "required", "off"}
 _LEGACY_USAGE_PROXY_KEYS: frozenset[str] = frozenset(
@@ -36,13 +43,25 @@ def _optional_mode(value: Any) -> UsageTrackingMode | None:
     return normalize_usage_tracking_mode(str(value))
 
 
+def is_trusted_usage_source(value: object) -> bool:
+    """Return True for usage telemetry sources that satisfy required tracking."""
+    return str(value) in TRUSTED_USAGE_SOURCES
+
+
+def is_token_usage_available(metrics: dict[str, Any] | None) -> bool:
+    """Return True when a usage metrics payload has trusted token telemetry."""
+    if not metrics:
+        return False
+    return is_trusted_usage_source(metrics.get("usage_source"))
+
+
 @dataclass(frozen=True, init=False)
 class UsageTrackingConfig:
     """User-facing token/cost telemetry policy.
 
     ``mode`` is the operator contract:
-    - ``auto`` records usage when the LiteLLM gateway can be started.
-    - ``required`` fails before the agent runs when telemetry cannot be wired.
+    - ``auto`` records usage when LiteLLM or native ACP telemetry can be used.
+    - ``required`` fails when no trusted token telemetry can be captured.
     - ``off`` leaves provider traffic untouched.
     """
 
@@ -119,6 +138,8 @@ class UsageTrackingConfig:
         endpoint_kind = "sandbox" if environment == "daytona" else "host"
         if self.mode == "off":
             endpoint_kind = "none"
+        elif usage_source == USAGE_SOURCE_AGENT_NATIVE_ACP:
+            endpoint_kind = "agent_native"
         return {
             "requested": self.mode,
             "status": status,

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -166,6 +166,52 @@ async def test_required_usage_fails_when_litellm_lacks_provider_key():
 
 
 @pytest.mark.asyncio
+async def test_required_usage_skips_litellm_for_codex_subscription(monkeypatch):
+    """Guards PR #613 follow-up: Codex subscription usage comes from ACP."""
+
+    async def fail_start(**_kwargs):
+        raise AssertionError("LiteLLM should not start for Codex subscription auth")
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+    env = {"CODEX_AUTH_JSON": '{"tokens": {"access_token": "access-token"}}'}
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="codex-acp",
+        agent_env=env,
+        model="openai/gpt-4.1-mini",
+        runtime=None,
+        environment="docker",
+        usage_tracking="required",
+    )
+
+    assert updated == env
+    assert provider_runtime is None
+
+
+@pytest.mark.asyncio
+async def test_required_usage_skips_litellm_for_claude_subscription(monkeypatch):
+    """Guards PR #613 follow-up: Claude Code subscription usage comes from ACP."""
+
+    async def fail_start(**_kwargs):
+        raise AssertionError("LiteLLM should not start for Claude subscription auth")
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+    env = {"CLAUDE_CODE_OAUTH_TOKEN": "oauth-token"}
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="claude-agent-acp",
+        agent_env=env,
+        model="claude-sonnet-4-6",
+        runtime=None,
+        environment="docker",
+        usage_tracking="required",
+    )
+
+    assert updated == env
+    assert provider_runtime is None
+
+
+@pytest.mark.asyncio
 async def test_usage_tracking_off_leaves_provider_env_untouched(monkeypatch):
     """Guards the follow-up to PR #613: off must not proxy provider traffic."""
 

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_acp_client_records_prompt_response_usage():
+    """Guards PR #613 follow-up: native ACP usage is captured from prompt results."""
+    from benchflow.acp.client import ACPClient
+    from benchflow.acp.session import ACPSession
+
+    session = ACPSession("session-1")
+    client = ACPClient.__new__(ACPClient)
+    client._session = session
+
+    async def fake_send_request(method, params):
+        assert method == "session/prompt"
+        assert params["sessionId"] == "session-1"
+        return {
+            "stopReason": "end_turn",
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 4,
+                "totalTokens": 16,
+                "cachedReadTokens": 2,
+                "cachedWriteTokens": 1,
+                "thoughtTokens": 1,
+            },
+        }
+
+    client._send_request = fake_send_request
+
+    result = await client.prompt("solve")
+
+    assert result.stop_reason == "end_turn"
+    assert session.latest_usage_totals() == {
+        "input_tokens": 10,
+        "output_tokens": 4,
+        "total_tokens": 16,
+        "cached_read_tokens": 2,
+        "cached_write_tokens": 1,
+        "thought_tokens": 1,
+    }
+
+
+def test_rollout_native_acp_usage_uses_cumulative_deltas():
+    """Guards PR #613 follow-up: ACP cumulative usage is not double-counted."""
+    from benchflow.acp.session import ACPSession
+    from benchflow.rollout import Rollout
+
+    session = ACPSession("session-1")
+    rollout = Rollout.__new__(Rollout)
+    rollout._session = session
+    rollout._native_usage_checkpoint = None
+
+    session.record_prompt_usage(
+        SimpleNamespace(
+            input_tokens=10,
+            output_tokens=4,
+            total_tokens=16,
+            cached_read_tokens=2,
+            cached_write_tokens=1,
+            thought_tokens=1,
+        )
+    )
+    rollout._collect_native_acp_usage()
+    session.record_prompt_usage(
+        SimpleNamespace(
+            input_tokens=13,
+            output_tokens=9,
+            total_tokens=27,
+            cached_read_tokens=3,
+            cached_write_tokens=1,
+            thought_tokens=3,
+        )
+    )
+    rollout._collect_native_acp_usage()
+
+    assert rollout._native_usage_metrics == {
+        "n_input_tokens": 13,
+        "n_output_tokens": 9,
+        "n_cache_read_tokens": 3,
+        "n_cache_creation_tokens": 1,
+        "total_tokens": 27,
+        "cost_usd": None,
+        "usage_source": "agent_native_acp",
+        "price_source": None,
+        "usage_details": {"thought_tokens": 3},
+    }
+
+
+def test_rollout_provider_usage_wins_over_native_acp_usage():
+    """Guards PR #613 follow-up: LiteLLM provider telemetry remains authoritative."""
+    from benchflow.rollout import Rollout
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._usage_metrics = {
+        "n_input_tokens": 100,
+        "n_output_tokens": 20,
+        "n_cache_read_tokens": 0,
+        "n_cache_creation_tokens": 0,
+        "total_tokens": 120,
+        "cost_usd": 0.01,
+        "usage_source": "provider_response",
+        "price_source": "litellm",
+    }
+    rollout._native_usage_metrics = {
+        "n_input_tokens": 10,
+        "n_output_tokens": 5,
+        "n_cache_read_tokens": 0,
+        "n_cache_creation_tokens": 0,
+        "total_tokens": 15,
+        "cost_usd": None,
+        "usage_source": "agent_native_acp",
+        "price_source": None,
+        "usage_details": {"thought_tokens": 0},
+    }
+
+    rollout._finalize_usage_metrics()
+
+    assert rollout._usage_metrics["usage_source"] == "provider_response"
+    assert rollout._usage_metrics["total_tokens"] == 120
+
+
+def test_required_usage_accepts_native_acp_usage(tmp_path):
+    """Guards PR #613 follow-up: required tracking accepts native ACP telemetry."""
+    from benchflow.rollout import Rollout, RolloutConfig
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = RolloutConfig(
+        task_path=tmp_path / "task",
+        usage_tracking=UsageTrackingConfig(mode="required"),
+    )
+    rollout._error = None
+    rollout._usage_metrics = {"usage_source": "unavailable"}
+    rollout._native_usage_metrics = {
+        "n_input_tokens": 10,
+        "n_output_tokens": 5,
+        "n_cache_read_tokens": 0,
+        "n_cache_creation_tokens": 0,
+        "total_tokens": 15,
+        "cost_usd": None,
+        "usage_source": "agent_native_acp",
+        "price_source": None,
+        "usage_details": {"thought_tokens": 0},
+    }
+
+    rollout._finalize_usage_metrics()
+    rollout._enforce_required_usage_tracking()
+
+    assert rollout._error is None
+    assert rollout._usage_metrics["usage_source"] == "agent_native_acp"
+
+
+def test_native_acp_usage_result_json_and_metadata(tmp_path):
+    """Guards PR #613 follow-up: result.json exposes native ACP usage metadata."""
+    from benchflow.rollout import _build_rollout_result
+    from benchflow.usage_tracking import UsageTrackingConfig
+
+    _build_rollout_result(
+        tmp_path,
+        task_name="usage-task",
+        rollout_name="usage-rollout",
+        agent="codex-acp",
+        agent_name="Codex",
+        model="gpt-4o",
+        n_tool_calls=0,
+        prompts=["solve"],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards={"reward": 1.0},
+        started_at=datetime(2026, 6, 4, 12, 0),
+        timing={},
+        n_input_tokens=10,
+        n_output_tokens=5,
+        n_cache_read_tokens=2,
+        n_cache_creation_tokens=1,
+        total_tokens=20,
+        usage_source="agent_native_acp",
+        usage_details={"thought_tokens": 2},
+        usage_tracking=UsageTrackingConfig(mode="required").to_result_metadata(
+            environment="docker",
+            status="enabled",
+            usage_source="agent_native_acp",
+        ),
+    )
+
+    data = json.loads((tmp_path / "result.json").read_text())
+
+    assert data["agent_result"]["usage_source"] == "agent_native_acp"
+    assert data["agent_result"]["usage_details"] == {"thought_tokens": 2}
+    assert data["usage_tracking"]["endpoint_kind"] == "agent_native"
+
+
+def test_usage_summary_includes_native_acp_usage():
+    """Guards PR #613 follow-up: native ACP usage counts as telemetry coverage."""
+    from benchflow._utils.evaluation_results import usage_summary
+
+    summary = usage_summary(
+        {
+            "provider": {
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "agent_result": {
+                    "usage_source": "provider_response",
+                    "n_input_tokens": 10,
+                    "n_output_tokens": 5,
+                    "n_cache_read_tokens": 0,
+                    "n_cache_creation_tokens": 0,
+                    "total_tokens": 15,
+                    "cost_usd": 0.01,
+                },
+            },
+            "native": {
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "agent_result": {
+                    "usage_source": "agent_native_acp",
+                    "n_input_tokens": 20,
+                    "n_output_tokens": 7,
+                    "n_cache_read_tokens": 1,
+                    "n_cache_creation_tokens": 2,
+                    "total_tokens": 30,
+                    "cost_usd": None,
+                },
+            },
+        }
+    )
+
+    assert summary["total_input_tokens"] == 30
+    assert summary["total_output_tokens"] == 12
+    assert summary["total_tokens"] == 45
+    assert summary["total_cost_usd"] == 0.01
+    assert summary["telemetry_coverage"] == 1.0

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -208,6 +208,42 @@ class TestResolveAgentEnvSubscription:
         assert "OPENAI_API_KEY" not in result
         assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
 
+    def test_codex_auth_json_marks_native_subscription_usage_path(self):
+        """Guards PR #613 follow-up: Codex subscription runs bypass LiteLLM."""
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        assert uses_native_subscription_auth(
+            "codex-acp",
+            "gpt-4o",
+            {"CODEX_AUTH_JSON": '{"tokens": {"access_token": "access-token"}}'},
+        )
+
+    def test_codex_api_key_prefers_litellm_usage_path(self):
+        """Guards PR #613 follow-up: API-key Codex runs stay on LiteLLM."""
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        assert not uses_native_subscription_auth(
+            "codex-acp",
+            "gpt-4o",
+            {
+                "CODEX_AUTH_JSON": '{"tokens": {"access_token": "access-token"}}',
+                "OPENAI_API_KEY": "sk-openai",
+            },
+        )
+
+    def test_codex_custom_base_url_not_native_subscription_usage_path(self):
+        """Guards PR #613 follow-up: subscription auth is not proxy auth."""
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        assert not uses_native_subscription_auth(
+            "codex-acp",
+            "gpt-4o",
+            {
+                "CODEX_AUTH_JSON": '{"tokens": {"access_token": "access-token"}}',
+                "OPENAI_BASE_URL": "http://localhost:8765/v1",
+            },
+        )
+
     def test_codex_access_token_auth(self, monkeypatch, tmp_path):
         """Guards PR #296: Blocks-style Codex auth via CODEX_ACCESS_TOKEN."""
         for k in ("CODEX_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
@@ -223,6 +259,43 @@ class TestResolveAgentEnvSubscription:
         assert result["CODEX_ACCESS_TOKEN"] == "access-token"
         assert "OPENAI_API_KEY" not in result
         assert "_BENCHFLOW_SUBSCRIPTION_AUTH" not in result
+
+    def test_claude_oauth_marks_native_subscription_usage_path(self):
+        """Guards PR #613 follow-up: Claude Code OAuth bypasses LiteLLM."""
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        assert uses_native_subscription_auth(
+            "claude-agent-acp",
+            "claude-haiku-4-5-20251001",
+            {"CLAUDE_CODE_OAUTH_TOKEN": "oauth-token"},
+        )
+
+    def test_claude_api_key_prefers_litellm_usage_path(self):
+        """Guards PR #613 follow-up: Claude API-key runs stay on LiteLLM."""
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        assert not uses_native_subscription_auth(
+            "claude-agent-acp",
+            "claude-haiku-4-5-20251001",
+            {
+                "CLAUDE_CODE_OAUTH_TOKEN": "oauth-token",
+                "ANTHROPIC_API_KEY": "sk-ant",
+            },
+        )
+
+    def test_claude_litellm_auth_token_is_not_subscription_usage_path(self):
+        """Guards PR #613 follow-up: LiteLLM rewrites must not look like OAuth."""
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        assert not uses_native_subscription_auth(
+            "claude-agent-acp",
+            "claude-haiku-4-5-20251001",
+            {
+                "ANTHROPIC_AUTH_TOKEN": "sk-benchflow-master",
+                "BENCHFLOW_PROVIDER_NAME": "litellm",
+                "BENCHFLOW_LITELLM_MODEL_VIA_ENV": "1",
+            },
+        )
 
     def test_codex_api_key_auth_alias(self, monkeypatch, tmp_path):
         """Guards PR #296: CODEX_API_KEY works for native Codex auth."""


### PR DESCRIPTION
## What problem this PR solves

BenchFlow used to treat Codex/Claude Code runs with a model as LiteLLM-routable before the ACP agent started. That is correct for API-key/provider-key runs, but wrong for subscription login runs.

Concrete failure mode:
- `codex-acp` with `CODEX_AUTH_JSON`, `CODEX_ACCESS_TOKEN`, or host `~/.codex/auth.json` but no `OPENAI_API_KEY` can run natively, while LiteLLM preflight fails because the OpenAI route requires `OPENAI_API_KEY`.
- `claude-agent-acp` with Claude Code OAuth/subscription auth but no real `ANTHROPIC_API_KEY` can run natively, while LiteLLM preflight wants provider credentials.
- These subscription credentials are native CLI/OAuth credentials, not provider API keys, so forcing them through LiteLLM breaks the run before BenchFlow can collect a result.

The goal is to keep token usage tracking and time tracking healthy without pretending subscription credentials are provider API keys.

## Solution

This PR implements a Harbor-style split between two telemetry/auth paths:

1. **API-key/provider-key path remains LiteLLM-based.**
   - If the run has real provider credentials, BenchFlow still starts LiteLLM.
   - LiteLLM usage remains `usage_source="provider_response"`.
   - LiteLLM remains authoritative for cost and pricing metadata.

2. **Codex/Claude Code subscription path stays native ACP.**
   - BenchFlow detects native subscription auth before LiteLLM route resolution.
   - For supported native subscription agents, `ensure_litellm_runtime()` skips LiteLLM instead of failing on missing provider API keys.
   - BenchFlow captures token usage from ACP `PromptResponse.usage` and records it as `usage_source="agent_native_acp"`.

3. **Required usage tracking accepts trusted native telemetry.**
   - `usage_tracking=required` now accepts either `provider_response` or `agent_native_acp`.
   - If a native subscription run does not return ACP usage, required tracking still fails.

4. **Time tracking stays independent.**
   - This PR does not change the `Rollout.execute()` wall-clock timing path.
   - Native usage is read after prompt completion and does not wrap, replace, or alter `agent_execution` timing.

## Main changes

- `usage_tracking.py`
  - Adds explicit trusted usage sources: `provider_response`, `agent_native_acp`, `unavailable`.
  - Adds helper checks for trusted token telemetry and canonical unavailable usage metrics.
  - Adds `endpoint_kind="agent_native"` for native ACP usage metadata.

- `agents/env.py`
  - Adds `uses_native_subscription_auth()` as the single native-subscription split point.
  - Codex native subscription is allowed only for native OpenAI context, without `OPENAI_API_KEY`, and without custom OpenAI-compatible base URLs.
  - Claude native subscription is allowed only for Claude-family models, without `ANTHROPIC_API_KEY`.
  - LiteLLM rewritten env is explicitly excluded so LiteLLM bridge vars are not mistaken for native subscription auth.

- `providers/litellm_runtime.py`
  - Adds an early native-subscription skip before route resolution and provider-key validation.
  - Preserves existing LiteLLM behavior for API-key/provider-key runs.

- `acp/client.py` and `acp/session.py`
  - Captures ACP `PromptResponse.usage` after each prompt.
  - Normalizes SDK snake_case and camelCase usage fields.
  - Stores session-level usage snapshots.

- `rollout.py`
  - Converts cumulative ACP usage snapshots into per-execute deltas to avoid double-counting multi-turn sessions.
  - Merges usage with this precedence: `provider_response` first, then `agent_native_acp`, then `unavailable`.
  - Keeps cost as `None` for native subscription usage because there is no provider pricing response.
  - Includes native `thought_tokens` under `usage_details` without changing the established `AgentResult` token fields.

- `models.py`, `_utils/evaluation_results.py`, and `metrics.py`
  - Exposes optional `usage_details`.
  - Counts `agent_native_acp` as healthy telemetry in summaries and benchmark metrics.

## Why each change is necessary

| Change | Why it is necessary | Why it is not redundant |
| --- | --- | --- |
| Trusted usage source constants/helpers | `required` gating, result metadata, summaries, and metrics all need the same definition of healthy telemetry. | Without this, the repo keeps string-comparing only `provider_response`, so native tokens would be captured but still reported as unavailable. |
| Native subscription detection in `agents/env.py` | Auth semantics already live there, including Codex native OpenAI checks and custom-base-url rejection. | Duplicating those rules inside LiteLLM runtime would drift from existing env validation and risk accepting subscription auth for proxy providers. |
| Early skip in `ensure_litellm_runtime()` | The failure happens before ACP starts, during LiteLLM route/key validation. | Capturing ACP usage later cannot help if LiteLLM aborts first. The skip is the actual unblocker. |
| ACP usage capture in client/session | Native subscription runs do not go through LiteLLM, so ACP response usage is the available trusted token source. | Existing LiteLLM extraction cannot see native CLI traffic. Without this, subscription runs remain usage-unavailable. |
| Cumulative snapshot delta in Rollout | ACP `Usage` is session cumulative. Multi-turn sessions would otherwise double-count previous prompts. | A simple sum of snapshots is wrong; a checkpoint is required for correctness. |
| Provider-response priority | API-key runs can expose both native-ish agent metadata and LiteLLM telemetry. | LiteLLM has provider response usage and cost, so it must stay authoritative to avoid double-counting and preserve pricing. |
| `usage_details.thought_tokens` | ACP includes thought tokens, but existing result fields do not have a dedicated thought-token slot. | Dropping it would lose data; adding it as details avoids breaking the established result schema. |
| Summary/metrics updates | Healthy native subscription runs should count toward telemetry coverage. | Otherwise the rollout result says tokens exist, but aggregate reporting still says telemetry is missing. |
| Tests for subscription skip and native usage | This guards the exact regression: subscription auth should not require provider API keys. | Existing LiteLLM tests only covered API-key/proxy behavior, not native subscription telemetry. |

## Evidence

Unit/static coverage after rebasing onto latest `origin/main`:

```bash
uv run python -m pytest tests/test_subscription_auth.py tests/test_litellm_runtime.py tests/test_native_acp_usage.py tests/test_usage_required.py tests/test_provider_auth_detection.py tests/test_usage_litellm.py tests/test_scene_result_aggregation.py -q
# 83 passed

uv run ruff check .
# All checks passed

uv run ty check src/
# All checks passed

uv run python -m pytest tests/
# 2751 passed, 49 skipped, 1 deselected
```

Real VM E2E on `daytona-orchestrator`, Docker sandbox, `usage_tracking=required`, provider keys explicitly unset:

```bash
# Codex subscription, native host ~/.codex/auth.json, no OPENAI_API_KEY/OPENAI_BASE_URL
uv run bench eval create \
  --tasks-dir /home/bingran_you/skillsbench/tasks \
  --include jax-computing-basics \
  --agent codex-acp \
  --model gpt-5.5 \
  --sandbox docker \
  --usage-tracking required \
  --agent-idle-timeout none \
  --jobs-dir /home/bingran_you/pr627-real-runs/codex-hostauth-20260604T222121Z/jobs

# Claude Code subscription, CLAUDE_OAUTH_TOKEN, no ANTHROPIC_API_KEY
uv run bench eval create \
  --tasks-dir /home/bingran_you/skillsbench/tasks \
  --include jax-computing-basics \
  --agent claude-agent-acp \
  --model claude-haiku-4-5-20251001 \
  --sandbox docker \
  --usage-tracking required \
  --agent-idle-timeout none \
  --jobs-dir /home/bingran_you/pr627-real-runs/claude-20260604T222531Z/jobs
```

Codex result evidence:
- Log shows `Using host subscription auth (no OPENAI_API_KEY set)`.
- Log shows `Skipping LiteLLM proxy: native subscription auth will use agent ACP usage telemetry`.
- Verifier passed `jax-computing-basics`: `Rewards: {'reward': 1.0}`, `errors=0`.
- `agent_result.usage_source="agent_native_acp"`.
- Tokens: input `347`, output `169`, cache read `17792`, cache creation `0`, total `18308`.
- `usage_tracking={"requested":"required","status":"enabled","endpoint_kind":"agent_native","usage_source":"agent_native_acp"}`.
- Timing present: `agent_execution=92.1s`, `total=157.6s`.
- No `llm_trajectory.jsonl` was produced, proving LiteLLM was not the source of usage.


Fresh inline Codex auth proof after re-login:
- Generated a sanitized temp `.env` from fresh local `~/.codex/auth.json` with only `CODEX_AUTH_JSON`; no provider keys.
- Command used `BENCHFLOW_DOTENV_PATH=/home/bingran_you/pr627-fresh-codex.env` and explicitly unset `OPENAI_API_KEY`, `OPENAI_BASE_URL`, `CODEX_ACCESS_TOKEN`, and `CODEX_API_KEY`.
- Log shows `Agent credential file written: /home/agent/.codex/auth.json`, proving the inline `CODEX_AUTH_JSON` path was used rather than VM host auth upload.
- Verifier passed `jax-computing-basics`: `Rewards: {'reward': 1.0}`, `errors=0`.
- `agent_result.usage_source="agent_native_acp"`.
- Tokens: input `11103`, output `183`, cache read `6528`, cache creation `0`, total `17814`, `usage_details.thought_tokens=24`.
- `usage_tracking={"requested":"required","status":"enabled","endpoint_kind":"agent_native","usage_source":"agent_native_acp"}`.
- Timing present: `agent_execution=171.9s`, `total=272.0s`.
- No `llm_trajectory.jsonl` was produced.
- Temp remote secret file `/home/bingran_you/pr627-fresh-codex.env` was removed after the run.

Claude Code result evidence:
- Log shows `Skipping LiteLLM proxy: native subscription auth will use agent ACP usage telemetry`.
- Agent completed the real task and verifier ran with `errors=0` (`reward=0.0` is a valid model/task failure, not an auth/runtime failure).
- `agent_result.usage_source="agent_native_acp"`.
- Tokens: input `98`, output `5501`, cache read `421292`, cache creation `6977`, total `433868`.
- `usage_tracking={"requested":"required","status":"enabled","endpoint_kind":"agent_native","usage_source":"agent_native_acp"}`.
- Timing present: `agent_execution=53.4s`, `total=138.5s`.
- No `llm_trajectory.jsonl` was produced, proving LiteLLM was not the source of usage.

Auth hygiene notes from E2E:
- The original copied `.env` `CODEX_AUTH_JSON` was stale: Codex returned `Your access token could not be refreshed because your refresh token was already used`.
- After re-login, a fresh inline `CODEX_AUTH_JSON` generated from local `~/.codex/auth.json` passed the same real task end-to-end, so both supported Codex subscription shapes are covered: host auth file and inline auth JSON.
- Temporary copied secret files on the VM were removed after the runs.

## Explicit non-goals

- No Gemini subscription usage changes in this PR.
- No native subscription cost estimation; `cost_usd` stays `None` without provider pricing response.
- No change to LiteLLM routing for API-key/provider-key runs.
- No change to the agent execution wall-clock timing path.
