### PR TITLE
Bump main to 0.5.1.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.5.0"
+version = "0.5.1.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.5.0"
+version = "0.5.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- bump main back to the next development version after publishing 0.5.0
- restore the internal preview channel so future main pushes publish 0.5.1.devN builds

## Validation
- uv lock --check
- uv run --extra dev python -m pytest tests/test_release_version.py tests/test_workflow_action_pinning.py
- uv run ruff check src tests tools
- uv run ruff format --check src tests tools
- uv build --no-sources && uv run --with twine --no-project twine check dist/*
- TEST_RUN_NUMBER=999 uv run --with packaging --no-project python tools/release_version.py internal-preview

## Release flow validation
After this PR merges, the existing internal preview workflow should publish benchflow==0.5.1.dev<test-run-number> to PyPI from the tested main commit.