### PR TITLE
Bump main to 0.5.2.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.5.1"
+version = "0.5.2.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.5.1"
+version = "0.5.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- return main to the next internal preview development version after publishing 0.5.1
- update uv.lock to match pyproject.toml

## Validation
- uv lock --check
- TEST_RUN_NUMBER=999 uv run --with packaging --no-project python tools/release_version.py internal-preview
- uv run --extra dev python -m pytest tests/test_release_version.py tests/test_workflow_action_pinning.py