### PR TITLE
docs: clarify install and upgrade paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Document the public vs internal preview install/upgrade command matrix,
+  including `uv tool` exact pins, internal preview upgrades, and the
+  `--force` path for replacing stale entrypoint scripts.
+
 ## 0.5.2 — 2026-06-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,11 +26,28 @@ BenchFlow's current public release is `0.5.2`:
 pip install --upgrade benchflow
 ```
 
-For a `uv`-managed CLI install of the public release:
+For a `uv`-managed CLI install or upgrade of the public release:
 
 ```bash
-uv tool install --prerelease allow 'benchflow==0.5.2'
+uv tool install --prerelease allow --upgrade 'benchflow==0.5.2'
 ```
+
+Use the exact `benchflow==0.5.2` pin for the public CLI. The
+`--prerelease allow` flag is currently needed for BenchFlow's pinned LiteLLM
+release-candidate dependency; the exact BenchFlow pin keeps you off internal
+preview builds.
+
+Internal users who want the newest preview published from `main` should omit
+the exact public pin:
+
+```bash
+uv tool install --prerelease allow --upgrade benchflow
+```
+
+That installs the latest internal preview, such as `0.5.3.dev<N>`. If either
+command reports `Executables already exist: bench, benchflow`, the machine has
+old entrypoints from a previous install; rerun the same command with `--force`
+to let `uv` replace them.
 
 Requires Python 3.12+ and [uv](https://docs.astral.sh/uv/). Set `DAYTONA_API_KEY` for Daytona runs or configure Modal auth for Modal runs; export the relevant agent API key (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) or run `claude login` / `codex --login` for subscription auth. Provider-prefixed models may use provider-specific credentials; Azure Foundry models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,11 +14,22 @@ A 5-minute path from install to first eval.
 pip install --upgrade benchflow
 ```
 
-For a `uv`-managed CLI install of the current public release:
+For a `uv`-managed CLI install or upgrade of the current public release:
 
 ```bash
-uv tool install --prerelease allow 'benchflow==0.5.2'
+uv tool install --prerelease allow --upgrade 'benchflow==0.5.2'
 ```
+
+Use the exact public version pin for stable CLI installs. To follow the newest
+internal preview from `main`, run:
+
+```bash
+uv tool install --prerelease allow --upgrade benchflow
+```
+
+If `uv` reports `Executables already exist: bench, benchflow`, rerun the same
+command with `--force` to replace older non-`uv` entrypoints. See
+[Release channels](./release.md) for the full command matrix.
 
 This gives you the `benchflow` (alias `bench`) CLI plus the Python SDK. To install for editable development:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -14,36 +14,58 @@ Current release state:
 - After the public tag is cut, `main` should move to `0.5.3.dev0`, which
   publishes internal preview builds as `0.5.3.dev<N>` after CI passes.
 
-Regular users install public releases with:
+## Install and Upgrade Commands
+
+Use the public channel by default. Opt into internal preview only when you want
+the newest build from `main` before the next public tag.
+
+Public Python package users:
 
 ```bash
 pip install --upgrade benchflow
 ```
 
-For a `uv`-managed CLI install of the current public release:
+Public `uv`-managed CLI users:
 
 ```bash
-uv tool install --prerelease allow 'benchflow==0.5.2'
+uv tool install --prerelease allow --upgrade 'benchflow==0.5.2'
 ```
 
 The exact `benchflow==0.5.2` pin keeps `uv` on the public release while
 `--prerelease allow` permits the release-candidate LiteLLM dependency used by
 this package line.
 
-Internal users install the latest preview package with:
+Internal preview Python package users:
 
 ```bash
 pip install --pre --upgrade benchflow
 ```
 
-For the CLI, install or upgrade the preview tool with:
+Internal preview `uv`-managed CLI users:
 
 ```bash
 uv tool install --prerelease allow --upgrade benchflow
-uv tool upgrade --prerelease allow benchflow
 ```
 
-For downstream projects that use `uv`, lock the preview dependency with:
+The preview CLI command intentionally omits the exact public pin, so `uv`
+selects the latest `0.5.3.dev<N>` package. If a machine was previously
+installed with `pip install --user` or another non-`uv tool` method, the command
+can fail with `Executables already exist: bench, benchflow`. In that case,
+rerun the same command with `--force`:
+
+```bash
+uv tool install --prerelease allow --upgrade --force benchflow
+```
+
+For downstream projects that use `uv`, keep public dependencies pinned unless
+the project intentionally tracks preview builds:
+
+```bash
+uv add --prerelease allow 'benchflow==0.5.2'
+uv lock --upgrade-package benchflow --prerelease allow
+```
+
+To lock the latest internal preview instead:
 
 ```bash
 uv add --prerelease allow benchflow


### PR DESCRIPTION
## Summary

- document public stable vs internal preview install/upgrade commands in the README
- expand release-channel docs with the command matrix for pip, uv tool, and downstream uv-locked projects
- call out the `Executables already exist: bench, benchflow` case and the `--force` recovery path for stale non-uv entrypoints

## Validation

- `uv run python -m pytest tests/test_cli_docs_drift.py tests/test_release_version.py tests/test_workflow_action_pinning.py`
- `uv run ruff check src tests tools`
- `uv run ruff format --check src tests tools`
- `uv run ty check`