### PR TITLE
fix(dashboard): unwrap PaginatedSandboxes in daytona_status panel

### DIFF
--- a/dashboard/daytona_status.py
+++ b/dashboard/daytona_status.py
@@ -83,7 +83,12 @@ def snapshot(api_key: str | None) -> dict:
     except Exception as e:
         return {**empty, "error": f"daytona support unavailable: {e}"}
     try:
-        items = list(build_sync_client((api_key or "").strip() or None).list())
+        # client.list() returns a PaginatedSandboxes; the real Sandbox objects are
+        # under .items. Iterating the paginator directly yields its internal fields
+        # (which is why count looked like 5 and every row was "?"). Fall back to the
+        # raw result for SDK versions that return a plain list.
+        paginated = build_sync_client((api_key or "").strip() or None).list()
+        items = list(getattr(paginated, "items", None) or paginated)
     except Exception as e:
         return {**empty, "error": f"Daytona list() failed: {e}"}
 


### PR DESCRIPTION
## Problem
The dashboard's **Daytona panel** showed a bogus sandbox count and **every per-sandbox row rendered `?`** for id/state/created/age/target (reported live: "5 active sandboxes" with all-`?` rows when there were actually ~98).

## Cause
`daytona_status.snapshot()` did `items = list(build_sync_client(...).list())`. But `client.list()` returns a **`PaginatedSandboxes`** object, not a list of `Sandbox` objects — the real objects live under `.items`. Iterating the paginator directly yields its *internal fields* (≈5 of them), so the count looked like 5 and `_row()` found no `id`/`state`/`created_at` on those field objects → all `?`.

## Fix
Unwrap `.items` (one-line change), with a fallback to the raw result for SDK versions that return a plain list:
```python
paginated = build_sync_client((api_key or "").strip() or None).list()
items = list(getattr(paginated, "items", None) or paginated)
```

## Verification
Restarted the dashboard with this fix → panel now returns `count=98`, `by_state={STARTED:95, DESTROYING:3}` with real ids/states/ages/targets, matching the SDK's `list().items` and the daytona CLI. No other behavior changed (`_row`/`_age`/sorting untouched). 6-line diff.
