### PR TITLE
experiments: SkillsBench max-effort fill + subagent-audit harness

### DIFF
--- a/experiments/skillsbench-fill/README.md
+++ b/experiments/skillsbench-fill/README.md
@@ -1,0 +1,83 @@
+# SkillsBench max-effort fill harness
+
+Tooling to run a large, **max-reasoning-effort** SkillsBench evaluation across
+multiple models × skill-modes × trials on Daytona (rolling, ≤100 parallel),
+review every trajectory for health, publish only healthy cells to the HuggingFace
+leaderboard, and monitor the whole pipeline live.
+
+Built for the Opus 4.8 / Gemini 3.5 Flash / MiniMax M3 fill →
+`benchflow/skillsbench-leaderboard` `refs/pr/5`, but the harness is
+model/task-agnostic. Pairs with the dashboard **Experiments** tab
+(`dashboard/experiments_status.py`).
+
+## Architecture
+
+One **ledger** keyed by `cell_id = <model>__<mode>__<task>__t<slot>`. Writers are
+decoupled (no shared-file locking at 100-wide): each stage drops a per-cell JSON;
+an aggregator merges them.
+
+```
+queued → running → completed → review_pass → published
+                            ↘ review_fail / quarantined → requeue
+```
+
+## Scripts
+
+| Script | Role |
+|---|---|
+| `reconcile.py` | List the HF PR tree, credit healthy cells, emit `state/queue.jsonl` (full grid minus what's done) |
+| `runner.py` | Rolling pooled driver — keeps N `run_cell.sh` in flight (Daytona; Docker fallback for heavy tasks). Flags: `--concurrency`, `--docker-concurrency`, `--only-models`, `--only-tasks`, `--skip-heavy` |
+| `run_cell.sh` | One cell = one `bench eval create` (one ephemeral sandbox). Per-model effort wiring + with/without skills. Writes `state/<cell>.json` |
+| `review_cell.py` | Mechanical health review of completed cells → `review/<cell>.json` (pass/fail/quarantine). Uses the `benchflow-experiment-review` skill's `extract_harness_skills.py` for skill posture |
+| `audit_evidence.py` | Per-cell evidence dump for the **subagent** `benchflow-experiment-review` audit (the authoritative gate — only agent-confirmed cells count) |
+| `publish.py` | Push a healthy cell's 5 canonical files + group `metadata.yaml` → HF PR ref; dedup by trial id; **scrubs secrets** + aborts if any survive |
+| `build_ledger.py` | Merge queue + state + review + published → `experiments_ledger.json` (drives the dashboard) |
+| `requeue_quarantine.py` | Reset infra-failed (quarantine) cells → re-run (gemini 429 / opus Bedrock transients) |
+| `requeue_nonpass.py` | Reset every non-pass cell (fail + quarantine) → re-run (e.g. after a task/skill fix) |
+| `trim_skill_fm.py` | Skill hygiene: trim bloated `SKILL.md` frontmatter that the OpenHands SDK silently drops (see skillsbench #914) |
+| `apply_audit.py` | Apply subagent-audit verdicts back onto the ledger / pull flagged cells |
+| **Autonomy (cron)** | |
+| `keep_runners.sh` | Supervisor: relaunch dead runners + requeue quarantine (every 5 min, flock-guarded) |
+| `reap_daytona.py` | Reaper: delete Daytona sandboxes older than ~90 min (every 30 min) |
+| `wave_once.sh` | One review → publish → ledger wave (every 5 min) |
+| `ledger_once.sh` | Rebuild the ledger (every 1 min) |
+| `fresh_start.sh` | Clean restart: apply task fixes, kill the run tree, requeue, relaunch runners |
+
+## Per-cell run recipe
+
+`bench eval create --tasks-dir <sb>/tasks --include <task> --concurrency 1 --agent
+openhands --sandbox daytona --usage-tracking required --agent-idle-timeout none`.
+Trial id = random hex (reconcile by counting distinct healthy cells per
+`(model,mode,task)` toward 3). **Do NOT pass `--reasoning-effort`** (it raises
+under openhands); effort is env-delivered via `--agent-env`:
+
+| Model | `--model` | effort wiring |
+|---|---|---|
+| Opus 4.8 | `aws-bedrock/us.anthropic.claude-opus-4-8` | `BENCHFLOW_BEDROCK_THINKING_EFFORT=max` + `AWS_REGION=us-west-2` |
+| Gemini 3.5 Flash | `gemini-3.5-flash` | `LLM_REASONING_EFFORT=high` (its ceiling); tokens not captured (native path) |
+| MiniMax M3 | `minimax/MiniMax-M3` | `LLM_REASONING_EFFORT=max` + `LLM_CACHING_PROMPT=false` |
+
+- **with-skills:** add `--skills-dir <sb>/tasks/<task>/environment/skills --skill-mode with-skill`. **without:** omit.
+
+## Health gate
+
+Healthy iff: `result.json` parseable, `error==null` (a normal idle/agent timeout is
+OK), `partial_trajectory==false`, `reward∈[0,1]`, `timing.total>0`, both `acp`+`llm`
+trajectories present; **skill posture** — with ⇒ `task_skills_loading==1`, without ⇒
+`==0`; meta (tokens+timing) present except Gemini tokens (native path). Infra
+failures (Daytona/Docker/ENOSPC/provider error) ⇒ quarantine+requeue, not fail.
+Reward 0/1 does NOT affect health.
+
+The **authoritative** gate is a subagent cluster running `benchflow-experiment-review`
+per cell (fed by `audit_evidence.py`); only agent-confirmed cells count.
+
+## Configuration
+
+Scripts read credentials from env files (`~/keys.env` / `~/.env`) at runtime —
+**no secrets are committed**. Adjust for your environment:
+- Keys: `ANTHROPIC_API_KEY` / `AWS_BEARER_TOKEN_BEDROCK`, `GEMINI_API_KEY`,
+  `MINIMAX_API_KEY` / `MINIMAX_BASE_URL`, `DAYTONA_API_KEY`, `HUGGING_FACE_TOKEN`.
+- Working dir defaults to `~/sb-fill/` on the run host; the `.env` path in
+  `publish.py`/`reconcile.py` and the jobs path in `read_*.py` may need adjusting.
+- **Env hygiene:** `unset OPENAI_* LLM_* LITELLM_* BENCHFLOW_PROVIDER_*` before
+  running (All-Hands proxy vars otherwise hijack model routing).

--- a/experiments/skillsbench-fill/apply_audit.py
+++ b/experiments/skillsbench-fill/apply_audit.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Apply the audit Workflow's AGENT verdicts as final (runs on the VM).
+
+The agent's per-cell conclusion overrides the mechanical (script) verdict. The audit
+Workflow's "flag" verdict is NOT uniform, so we compose three orthogonal primitives
+instead of a flat flag->delete:
+
+  delete_from_pr5 : remove these cell dirs from refs/pr/5 (CommitOperationDelete).
+  set_verdict     : {cell: "pass"|"fail"|"quarantine"} written into review/<cell>.json
+                    (verdict + health + note + optional task_skills_loading), overriding
+                    the mechanical verdict. pass=>publishable (cron republishes),
+                    fail/quarantine=>excluded.
+  requeue         : rm state/<cell>.json + published/<cell>.json so the runner re-runs it
+                    (use ONLY for transient/infra failures; do NOT requeue cells whose
+                    root cause -- open network egress, broken skill bundling -- is unfixed,
+                    or they just reproduce the problem).
+
+Then rebuild the ledger; the cron republishes the corrected set.
+
+Usage: apply_audit.py --verdicts agent_verdicts.json [--dry-run]
+  verdicts json:
+    {"delete_from_pr5": ["cell", ...],
+     "set_verdict": {"cell": {"verdict": "pass"|"fail"|"quarantine",
+                              "note": "...", "task_skills_loading": 1}, ...},
+     "requeue": ["cell", ...]}
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(os.path.dirname(os.path.abspath(__file__)))
+REPO = "benchflow/skillsbench-leaderboard"
+PR_REF = "refs/pr/5"
+
+
+def hf_token() -> str:
+    if os.environ.get("HUGGING_FACE_TOKEN"):
+        return os.environ["HUGGING_FACE_TOKEN"]
+    for p in (os.path.expanduser("~/keys.env"), os.path.expanduser("~/.env")):
+        try:
+            for line in open(p):
+                m = re.match(r'^\s*(?:export\s+)?HUGGING_FACE_TOKEN\s*=\s*["\']?([^"\'\s]+)', line)
+                if m:
+                    return m.group(1)
+        except FileNotFoundError:
+            continue
+    raise SystemExit("no HUGGING_FACE_TOKEN")
+
+
+def _published_path(cell: str):
+    p = ROOT / "published" / f"{cell}.json"
+    if p.exists():
+        try:
+            return json.load(open(p)).get("hf_path")
+        except Exception:
+            return None
+    return None
+
+
+def _set_verdict(cell: str, spec: dict, now: str):
+    rv = ROOT / "review" / f"{cell}.json"
+    d = {}
+    if rv.exists():
+        try:
+            d = json.load(open(rv))
+        except Exception:
+            d = {}
+    verdict = spec["verdict"]
+    health = "healthy" if verdict == "pass" else "unhealthy"
+    d.update(cell_id=cell, verdict=verdict, health=health, review_verdict=verdict,
+             agent_final=True, note=spec.get("note", ""), updated_at=now)
+    if "task_skills_loading" in spec:
+        d["task_skills_loading"] = spec["task_skills_loading"]
+        d["task_skills_loading_status"] = "agent_override"
+    json.dump(d, open(rv, "w"), indent=2)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--verdicts", required=True)
+    ap.add_argument("--dry-run", action="store_true")
+    a = ap.parse_args()
+    v = json.load(open(a.verdicts))
+    delete_from_pr5 = list(dict.fromkeys(v.get("delete_from_pr5", [])))
+    set_verdict = v.get("set_verdict", {})
+    requeue = list(dict.fromkeys(v.get("requeue", [])))
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    # 1) override verdicts
+    counts = {"pass": 0, "fail": 0, "quarantine": 0}
+    for cell, spec in set_verdict.items():
+        counts[spec["verdict"]] = counts.get(spec["verdict"], 0) + 1
+        if not a.dry_run:
+            _set_verdict(cell, spec, now)
+
+    # 2) resolve PR5 deletes
+    del_paths = []
+    for cell in delete_from_pr5:
+        hp = _published_path(cell)
+        if hp:
+            del_paths.append((cell, hp))
+        else:
+            print(f"  [warn] {cell} requested for PR5 delete but no published record (skip)")
+
+    # 3) requeue: fully reset the cell (state + published + review) so the runner re-runs
+    # it AND review_cell.py re-reviews the fresh result (it skips cells with a review file).
+    for cell in requeue:
+        if not a.dry_run:
+            (ROOT / "state" / f"{cell}.json").unlink(missing_ok=True)
+            (ROOT / "published" / f"{cell}.json").unlink(missing_ok=True)
+            (ROOT / "review" / f"{cell}.json").unlink(missing_ok=True)
+
+    print(f"set_verdict: {counts}  | delete_from_pr5: {len(del_paths)} resolved / {len(delete_from_pr5)} req"
+          f"  | requeue: {len(requeue)}")
+    for c, p in del_paths:
+        print(f"  DEL {p}   ({c})")
+    if a.dry_run:
+        print("DRY RUN — no review writes, no PR5 deletes, no requeue")
+        return 0
+
+    # remove published records for deleted cells too (so dashboard stops linking them)
+    for cell, _ in del_paths:
+        (ROOT / "published" / f"{cell}.json").unlink(missing_ok=True)
+
+    if del_paths:
+        os.environ.setdefault("HF_TOKEN", hf_token())
+        from huggingface_hub import CommitOperationDelete, HfApi
+        api = HfApi(token=os.environ["HF_TOKEN"])
+        ops = [CommitOperationDelete(path_in_repo=p, is_folder=True) for _, p in del_paths]
+        CH = 200
+        for i in range(0, len(ops), CH):
+            api.create_commit(repo_id=REPO, repo_type="dataset", revision=PR_REF, operations=ops[i:i + CH],
+                              commit_message=f"audit: remove {len(ops)} agent-flagged contaminated cells")
+            print(f"  deleted batch {i // CH + 1}: {len(ops[i:i+CH])} cells from {PR_REF}")
+    os.system(f"cd {ROOT} && python3 build_ledger.py --root . | tail -1")
+    print("[done] agent verdicts applied")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/skillsbench-fill/audit_evidence.py
+++ b/experiments/skillsbench-fill/audit_evidence.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Per-cell evidence for the subagent /benchflow-experiment-review audit.
+Given cell_ids, emit the exact facts each subagent needs to apply the checklist:
+result fields (error/partial/reward/timing), acp+llm trajectory presence, and the
+task_skills_loading posture (tsl) from the skill's own extract_harness_skills.py.
+Output: JSON list. The subagent JUDGES from this (pass iff all checklist items hold)."""
+import json, sys, os, subprocess, re, glob
+
+EX = os.path.expanduser("~/bf-pr607/.claude/skills/benchflow-experiment-review/scripts/extract_harness_skills.py")
+SB = os.path.expanduser("~/skillsbench/tasks")
+
+
+def extract_reward(r, rd):
+    """Canonical reward: result.json rewards.reward, then verifier/reward.txt,
+    then the terminal record in rewards.jsonl. Uses `is not None` throughout so a
+    legitimate reward of 0.0 (falsy) is never mistaken for a missing value."""
+    rw = r.get("rewards")
+    if isinstance(rw, dict) and rw.get("reward") is not None:
+        return rw.get("reward")
+    rt = os.path.join(rd, "verifier", "reward.txt")
+    if os.path.exists(rt):
+        try:
+            s = open(rt).read().strip()
+            if s:
+                return float(s)
+        except Exception:
+            pass
+    rl = os.path.join(rd, "rewards.jsonl")
+    if os.path.exists(rl):
+        try:
+            val = None
+            for line in open(rl):
+                line = line.strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                if rec.get("tag") == "reward" and rec.get("type") == "terminal" and rec.get("value") is not None:
+                    val = rec.get("value")  # keep the last terminal reward
+            if val is not None:
+                return val
+        except Exception:
+            pass
+    return None
+
+
+def extract_tokens(r):
+    """Canonical total tokens: result.json agent_result.total_tokens, falling back
+    to final_metrics prompt+completion. `is not None` so a true 0 isn't dropped."""
+    ar = r.get("agent_result")
+    if isinstance(ar, dict) and ar.get("total_tokens") is not None:
+        return ar.get("total_tokens")
+    fm = r.get("final_metrics")
+    if isinstance(fm, dict):
+        p, c = fm.get("total_prompt_tokens"), fm.get("total_completion_tokens")
+        if p is not None or c is not None:
+            return (p or 0) + (c or 0)
+    return None
+
+
+def rollout_of(cell):
+    sf = os.path.expanduser(f"~/sb-fill/state/{cell}.json")
+    if os.path.exists(sf):
+        try:
+            rd = (json.load(open(sf)) or {}).get("rollout_dir", "")
+            if rd and os.path.isdir(rd):
+                return rd
+        except Exception:
+            pass
+    # fallback: newest complete rollout under jobs/<cell>/
+    cands = [d for d in glob.glob(os.path.expanduser(f"~/sb-fill/jobs/{cell}/**/"), recursive=True)
+             if os.path.exists(os.path.join(d, "result.json"))]
+    return sorted(cands)[-1].rstrip("/") if cands else ""
+
+
+def evidence(cell):
+    m = re.match(r"(.+?)__(with|without)__(.+)__t(\d+)$", cell)
+    if not m:
+        return {"cell": cell, "artifacts": "unparseable_cell"}
+    model, mode, task, _ = m.groups()
+    ev = {"cell": cell, "model": model, "mode": mode, "task": task}
+    rd = rollout_of(cell)
+    ev["rollout_dir"] = rd
+    if not rd:
+        ev["artifacts"] = "missing"
+        return ev
+    rj = os.path.join(rd, "result.json")
+    if not os.path.exists(rj):
+        ev["artifacts"] = "no_result"
+        return ev
+    try:
+        r = json.load(open(rj))
+        ev["err"] = r.get("error")
+        ev["partial"] = r.get("partial_trajectory")
+        ev["reward"] = extract_reward(r, rd)
+        ev["timing_total"] = (r.get("timing") or {}).get("total")
+        ev["tokens"] = extract_tokens(r)
+    except Exception as e:
+        ev["artifacts"] = f"result_unreadable:{e}"
+        return ev
+    acp = os.path.join(rd, "trajectory", "acp_trajectory.jsonl")
+    llm = os.path.join(rd, "trajectory", "llm_trajectory.jsonl")
+    ev["acp_present"] = os.path.exists(acp) and os.path.getsize(acp) > 0
+    ev["llm_present"] = os.path.exists(llm) and os.path.getsize(llm) > 0
+    if ev["llm_present"] and os.path.exists(EX):
+        try:
+            o = subprocess.run(["python3", EX, llm, "--task-path", f"{SB}/{task}"],
+                               capture_output=True, text=True, timeout=90)
+            try:
+                tj = json.loads(o.stdout.strip())
+            except Exception:
+                mm = re.search(r'"task_skills_loading"\s*:\s*(\d+)', o.stdout)
+                tj = {"task_skills_loading": int(mm.group(1))} if mm else {}
+            ev["tsl"] = tj.get("task_skills_loading")
+            ev["tsl_status"] = tj.get("task_skills_loading_status")
+        except Exception as e:
+            ev["tsl_error"] = str(e)
+    return ev
+
+
+print(json.dumps([evidence(c) for c in sys.argv[1:]]))

--- a/experiments/skillsbench-fill/autoloops.sh
+++ b/experiments/skillsbench-fill/autoloops.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Autonomous review/publish/ledger loops for the SkillsBench fill — run ON the VM,
+# decoupled from any interactive session so the dashboard + PR5 keep advancing.
+#   ledger loop: rebuild experiments_ledger.json from state every 60s (live running/completed)
+#   wave loop:   mechanical review_cell.py + publish healthy cells to refs/pr/5 every ~10 min
+# Launch: setsid nohup bash autoloops.sh >/dev/null 2>&1 < /dev/null &
+set -u
+cd "$(dirname "$0")"
+VENVPY="$HOME/Experiment/benchflow/.venv/bin/python"
+mkdir -p logs
+
+( while true; do python3 build_ledger.py --root . >/dev/null 2>&1; sleep 60; done ) &
+LEDGER_PID=$!
+
+( while true; do
+    python3 review_cell.py >> logs/wave.log 2>&1
+    SHA="$(git -C "$HOME/skillsbench" rev-parse HEAD 2>/dev/null)"
+    "$VENVPY" publish.py --runs-root jobs --src-commit "$SHA" >> logs/wave.log 2>&1
+    echo "[wave $(date -u +%FT%TZ)] reviewed=$(ls review/*.json 2>/dev/null | wc -l) published=$(ls published/*.json 2>/dev/null | wc -l) completed=$(grep -l '\"status\": \"completed\"' state/*.json 2>/dev/null | wc -l)" >> logs/wave.log
+    sleep 600
+  done ) &
+WAVE_PID=$!
+
+echo "autoloops up: ledger=$LEDGER_PID wave=$WAVE_PID at $(date -u +%FT%TZ)" >> logs/wave.log
+wait

--- a/experiments/skillsbench-fill/build_ledger.py
+++ b/experiments/skillsbench-fill/build_ledger.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Merge the base grid + per-cell runner/review/publish state -> experiments_ledger.json.
+
+Reads (under --root):
+  grid.json            base 1638-cell grid from reconcile (immutable)
+  state/<cell>.json    runner state (run_cell.sh): running|completed|run_failed (+reward/timing/tokens)
+  review/<cell>.json   review verdict: {verdict: pass|fail|quarantine, health, task_skills_loading, note}
+  published/<cell>.json publish record: {hf_path}
+
+Writes experiments_ledger.json (atomic) for the dashboard. Status precedence:
+published > review_* > completed/run_failed/running > queued (later overlays win).
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+from collections import Counter
+from datetime import datetime, timezone
+from pathlib import Path
+
+RECONCILE_FILES = {"experiments_ledger.json", "queue.jsonl", "reconcile_report.json", "grid.json"}
+RUNNER_KEYS = ("status", "sandbox", "run_root", "rollout_dir", "reward", "error", "partial",
+               "timing_total_s", "tokens", "usage_source", "started_at", "updated_at", "enospc")
+
+
+def _load(p):
+    try:
+        return json.load(open(p))
+    except Exception:
+        return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=os.path.dirname(os.path.abspath(__file__)))
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+    root = Path(a.root)
+
+    base = _load(root / "grid.json") or _load(root / "state" / "experiments_ledger.json")
+    if not base:
+        raise SystemExit("no base grid (grid.json) — run reconcile.py first")
+    rows = {r["cell_id"]: dict(r) for r in base["rows"]}
+
+    # 1) runner state
+    for f in glob.glob(str(root / "state" / "*.json")):
+        if os.path.basename(f) in RECONCILE_FILES:
+            continue
+        st = _load(f)
+        if not st or st.get("cell_id") not in rows:
+            continue
+        r = rows[st["cell_id"]]
+        for k in RUNNER_KEYS:
+            if st.get(k) is not None:
+                r[k] = st[k]
+
+    # 2) review verdicts
+    for f in glob.glob(str(root / "review" / "*.json")):
+        rv = _load(f)
+        if not rv or rv.get("cell_id") not in rows:
+            continue
+        r = rows[rv["cell_id"]]
+        r["review_verdict"] = rv.get("verdict")
+        if rv.get("health") is not None:
+            r["health"] = rv["health"]
+        if rv.get("task_skills_loading") is not None:
+            r["task_skills_loading"] = rv["task_skills_loading"]
+        if rv.get("note"):
+            r["note"] = rv["note"]
+        # carry the measured metrics the review recorded (reward/tokens/timing/effort/loaded skills)
+        # so the dashboard's Reviewed panel shows them — a 'healthy' verdict implies these exist.
+        for k in ("reward", "tokens", "timing_total_s", "effort_ok", "loaded_task_skills", "usage_source"):
+            if rv.get(k) is not None:
+                r[k] = rv[k]
+        r["status"] = {"pass": "review_pass", "fail": "review_fail",
+                       "quarantine": "quarantined"}.get(rv.get("verdict"), r.get("status"))
+        if rv.get("updated_at"):
+            r["updated_at"] = rv["updated_at"]
+
+    # 3) publish records (terminal)
+    for f in glob.glob(str(root / "published" / "*.json")):
+        pb = _load(f)
+        if not pb or pb.get("cell_id") not in rows:
+            continue
+        r = rows[pb["cell_id"]]
+        r["status"] = "published"
+        r["hf_path"] = pb.get("hf_path")
+        if pb.get("updated_at"):
+            r["updated_at"] = pb["updated_at"]
+
+    out = {
+        "as_of": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "target": base.get("target", len(rows)),
+        "rows": list(rows.values()),
+    }
+    dest = a.out or str(root / "experiments_ledger.json")
+    tmp = dest + ".tmp"
+    json.dump(out, open(tmp, "w"), indent=2)
+    os.replace(tmp, dest)
+    print("ledger:", dict(Counter(r.get("status", "queued") for r in rows.values())), "->", dest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/skillsbench-fill/fresh_start.sh
+++ b/experiments/skillsbench-fill/fresh_start.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Fresh start: apply #914 skill fix to skillsbench, kill tree, requeue all non-pass,
+# relaunch the 3 light-only runners. Detached so the pkill storm can't drop SSH.
+{
+  echo "=== fresh start $(date -u +%H:%M:%SZ) ==="
+  echo "--- 1. apply #914 skill fix to skillsbench ---"
+  cd "$HOME/skillsbench" || exit 1
+  git fetch origin fix/skill-frontmatter-catalog-injection 2>&1 | tail -1
+  git checkout -f FETCH_HEAD 2>&1 | tail -2
+  echo "skillsbench HEAD: $(git log -1 --format='%h %s')"
+  echo "--- 2. kill tree ---"
+  pkill -9 -f '[r]unner.py'; pkill -9 -f '[r]un_cell'; pkill -9 -f 'bench [e]val'; pkill -9 -f '[o]penhands'
+  sleep 5; pkill -9 -f 'bench [e]val'; sleep 1
+  docker rm -f $(docker ps -aq) 2>/dev/null >/dev/null
+  echo "--- 3. requeue all non-pass ---"
+  cd "$HOME/sb-fill" && /usr/bin/python3 requeue_nonpass.py 2>&1 | tail -1
+  echo "--- 4. relaunch 3 light-only runners ---"
+  nohup /usr/bin/python3 runner.py --concurrency 60 --only-models minimax-m3       --skip-heavy --docker-concurrency 1 > logs/runner.minimax.log 2>&1 &
+  nohup /usr/bin/python3 runner.py --concurrency 15 --only-models opus-4.8          --skip-heavy --docker-concurrency 1 > logs/runner.opus.log 2>&1 &
+  nohup /usr/bin/python3 runner.py --concurrency 3  --only-models gemini-3.5-flash  --skip-heavy --docker-concurrency 1 > logs/runner.gemini.log 2>&1 &
+  sleep 14
+  echo "runners=$(pgrep -fc '[r]unner.py')"
+  grep -h '^work:' logs/runner.minimax.log logs/runner.opus.log logs/runner.gemini.log 2>/dev/null
+  echo "load=$(uptime | grep -oE 'average: [0-9.]*')"
+  echo "=== fresh start done $(date -u +%H:%M:%SZ) ==="
+} > /tmp/fresh.log 2>&1

--- a/experiments/skillsbench-fill/keep_runners.sh
+++ b/experiments/skillsbench-fill/keep_runners.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# VM-side supervisor: keep the 3 light-only runners alive (relaunch any that
+# died/finished its batch) and retry failed/gemini cells. Cron-driven so the
+# fill is autonomous without the laptop/session. flock-guarded by the crontab.
+cd "$HOME/sb-fill" || exit 0
+mkdir -p logs
+relaunch() {  # $1=model  $2=concurrency  $3=logname
+  pgrep -f "only-models $1" >/dev/null 2>&1 || \
+    nohup /usr/bin/python3 runner.py --concurrency "$2" --only-models "$1" --skip-heavy --docker-concurrency 1 >> "logs/runner.$3.log" 2>&1 &
+}
+relaunch minimax-m3      75 minimax
+relaunch opus-4.8        15 opus
+relaunch gemini-3.5-flash 3 gemini
+# retry: requeue quarantined cells (gemini 429 / opus Bedrock transient) so the
+# runners re-trickle them. Only resets quarantine cells; pass/published untouched.
+/usr/bin/python3 "$HOME/sb-fill/requeue_quarantine.py" >/dev/null 2>&1 || true
+echo "[keep $(date -u +%H:%M:%SZ)] runners=$(pgrep -fc '[r]unner.py') bench=$(pgrep -fc 'bench [e]val')"

--- a/experiments/skillsbench-fill/ledger_once.sh
+++ b/experiments/skillsbench-fill/ledger_once.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# One ledger rebuild (cron, every minute) — keeps running/completed live on the dashboard.
+export PATH="$HOME/.local/bin:/usr/bin:/bin:$PATH"
+cd "$HOME/sb-fill" || exit 0
+python3 build_ledger.py --root . >/dev/null 2>&1

--- a/experiments/skillsbench-fill/publish.py
+++ b/experiments/skillsbench-fill/publish.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Publish reviewed-healthy SkillsBench max-effort cells to HF refs/pr/5 (v1.1 layout).
+
+For each cell with review verdict 'pass' (review/<cell>.json) that has a local rollout
+dir (runs/<cell_id>/<task>__<tid>/), upload the 5 canonical files into:
+  submissions/skillsbench/v1.1/openhands-{with-skills|no-skills}__<slug>/<TS>-maxeffort/<task>__<tid>/
+- normalizes config.json.include_task_skills to match the mode (with->true)
+- generates timing.json from result.json.timing when the file is missing
+- (re)writes the group metadata.yaml
+- dedups vs PR5 by trial id; records published/<cell>.json
+
+Usage: publish.py [--dry-run] [--ts 2026-06-04__hhmm] [--src-commit <sha>]
+Read keys + paths default to this toolkit dir. Adapted from workspace/scripts/generic_push.py.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import io
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = "benchflow/skillsbench-leaderboard"
+REPO_TYPE = "dataset"
+PR_REF = "refs/pr/5"
+V11 = "submissions/skillsbench/v1.1"
+ROOT = Path(os.path.dirname(os.path.abspath(__file__)))
+ENV_PATH = os.path.expanduser("~/Downloads/GitHub/bingran-you/.env")
+CANON = ["config.json", "result.json", "timing.json",
+         "trajectory/acp_trajectory.jsonl", "trajectory/llm_trajectory.jsonl"]
+
+MODELS = {
+    "opus-4.8": {"slug": "aws-bedrock-us.anthropic.claude-opus-4-8", "model_name": "aws-bedrock/us.anthropic.claude-opus-4-8",
+                 "provider": "aws-bedrock", "display": "Claude Opus 4.8 (max thinking)", "org": "Anthropic"},
+    "gemini-3.5-flash": {"slug": "gemini-3.5-flash", "model_name": "gemini-3.5-flash",
+                 "provider": "google", "display": "Gemini 3.5 Flash (high)", "org": "Google"},
+    "minimax-m3": {"slug": "minimax-MiniMax-M3", "model_name": "minimax/MiniMax-M3",
+                 "provider": "minimax", "display": "MiniMax M3 (thinking/max)", "org": "MiniMax"},
+}
+HFMODE = {"with": "with-skills", "without": "no-skills"}
+
+# --- secret hygiene: nothing with a credential ever leaves for the public PR ---
+# benchflow already scrubs config/result/trajectories, but the publisher guarantees
+# it too: drop secret-named keys, redact secret-shaped values, and ABORT a cell if
+# any secret pattern survives in any file about to be uploaded.
+SECRET_NAME_RE = re.compile(r"(_API_KEY$|^API_KEY$|SECRET|TOKEN|BEARER|PASSWORD|CREDENTIAL|ACCESS_KEY)", re.I)
+SECRET_VAL_RE = re.compile(
+    r"(AQ\.[A-Za-z0-9._-]{8,}|AIza[A-Za-z0-9._-]{10,}|sk-api-[A-Za-z0-9_-]{8,}|sk-[A-Za-z0-9-]{16,}|"
+    r"ABSK[A-Za-z0-9+/=]{8,}|Bearer\s+[A-Za-z0-9._-]{12,}|gh[pousr]_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,})"
+)
+
+
+def _scrub(o):
+    if isinstance(o, dict):
+        return {k: ("[REDACTED]" if SECRET_NAME_RE.search(k) else _scrub(v)) for k, v in o.items()}
+    if isinstance(o, list):
+        return [_scrub(x) for x in o]
+    if isinstance(o, str):
+        return SECRET_VAL_RE.sub("[REDACTED]", o)
+    return o
+
+
+def safe_bytes(path, is_config=False, mode="without"):
+    """Return scrubbed bytes for upload; raise if any secret survives."""
+    raw = open(path, encoding="utf-8", errors="replace").read()
+    if str(path).endswith(".jsonl"):
+        text = SECRET_VAL_RE.sub("[REDACTED]", raw)
+    else:
+        obj = json.loads(raw)
+        if is_config:
+            obj["include_task_skills"] = (mode == "with")
+        text = json.dumps(_scrub(obj), indent=2)
+    if SECRET_VAL_RE.search(text):
+        raise ValueError(f"secret pattern survived scrub in {path}")
+    return text.encode()
+
+
+def hf_token() -> str:
+    if os.environ.get("HUGGING_FACE_TOKEN"):
+        return os.environ["HUGGING_FACE_TOKEN"]
+    for p in (ENV_PATH, os.path.expanduser("~/keys.env"), os.path.expanduser("~/.env")):
+        try:
+            for line in open(p):
+                m = re.match(r'^\s*(?:export\s+)?HUGGING_FACE_TOKEN\s*=\s*["\']?([^"\'\s]+)', line)
+                if m:
+                    return m.group(1)
+        except FileNotFoundError:
+            continue
+    raise SystemExit("no HUGGING_FACE_TOKEN (env, .env, or ~/keys.env)")
+
+
+def metadata_yaml(model_key: str, mode: str, src_commit: str) -> str:
+    m = MODELS[model_key]
+    skills = "true" if mode == "with" else "false"
+    origin = '"benchflow-ai/skillsbench task environment/skills"' if mode == "with" else "null"
+    return f"""agent_url: https://github.com/All-Hands-AI/OpenHands
+agent_display_name: "OpenHands ({HFMODE[mode]})"
+agent_org_display_name: "All Hands AI"
+agent_version: "openhands-sdk"
+
+skills_used: {skills}
+skills_dir_origin: {origin}
+
+models:
+  - model_name: {m["model_name"]}
+    model_provider: {m["provider"]}
+    model_display_name: "{m["display"]}"
+    model_org_display_name: "{m["org"]}"
+
+dataset:
+  name: skillsbench
+  version: v1.1
+  source_repo: benchflow-ai/skillsbench
+  source_commit: {src_commit}
+
+contact: bingran@benchflow.ai
+notes: |
+  OpenHands ({HFMODE[mode]}) + {m["display"]} at maximum reasoning effort, generated
+  2026-06 to fill the 91-task x 3-trial SkillsBench grid for this config. Every trial
+  passed benchflow-experiment-review (healthy ACP+LLM trajectory, parseable
+  config/result/timing, positive timing.total, no error, non-partial; with-skills
+  trials show task_skills_loading=1, no-skills show 0).
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--ts", default=datetime.now(timezone.utc).strftime("%Y-%m-%d__%H-%M-%S") + "-maxeffort")
+    ap.add_argument("--src-commit", default=os.environ.get("SB_SRC_COMMIT", "unknown"))
+    ap.add_argument("--runs-root", default=str(ROOT / "runs"),
+                    help="dir holding <cell>/<task>__<tid>/ rollouts (use 'jobs' when running on the VM)")
+    a = ap.parse_args()
+    runs_root = Path(a.runs_root)
+
+    os.environ.setdefault("HF_TOKEN", hf_token())
+    from huggingface_hub import HfApi, CommitOperationAdd
+    api = HfApi(token=os.environ["HF_TOKEN"])
+
+    # existing cells per group: {trial_id: cell_dir_path} for dedup AND path recovery, cached.
+    _exist_cache: dict = {}
+
+    def existing(group: str) -> dict:
+        if group not in _exist_cache:
+            ids: dict = {}
+            try:
+                for it in api.list_repo_tree(REPO, path_in_repo=f"{V11}/{group}", repo_type=REPO_TYPE, revision=PR_REF, recursive=True):
+                    if it.path.endswith("/result.json"):
+                        cell_dir = it.path.rsplit("/", 1)[0]
+                        leaf = cell_dir.split("/")[-1]
+                        if "__" in leaf:
+                            ids[leaf.rsplit("__", 1)[1]] = cell_dir
+            except Exception:
+                pass
+            _exist_cache[group] = ids
+        return _exist_cache[group]
+
+    review_files = glob.glob(str(ROOT / "review" / "*.json"))
+    ops = []
+    published = []
+    groups_seen = {}
+    skipped = 0
+    for rf in review_files:
+        rv = json.load(open(rf))
+        if rv.get("verdict") != "pass":
+            continue
+        cell = rv["cell_id"]
+        m = re.match(r"(?P<model>.+?)__(?P<mode>with|without)__(?P<task>.+)__t(?P<slot>\d+)$", cell)
+        if not m:
+            continue
+        model_key, mode, task = m["model"], m["mode"], m["task"]
+        # A cell can have several rollout dirs: failed creation attempts (result.json but
+        # no trajectory) plus the one successful run. Pick a COMPLETE rollout (result.json
+        # + llm_trajectory), not by sort position — else we grab an empty attempt and skip.
+        roll = [d for d in glob.glob(str(runs_root / cell / "**" / f"{task}__*"), recursive=True)
+                if Path(d).is_dir() and (Path(d) / "result.json").exists()
+                and (Path(d) / "trajectory" / "llm_trajectory.jsonl").exists()]
+        if not roll:
+            print(f"  [skip] no complete rollout (result.json+llm_trajectory) for {cell}")
+            continue
+        inner = Path(sorted(roll)[-1])
+        tid = inner.name.rsplit("__", 1)[1]
+        group = f"openhands-{HFMODE[mode]}__{MODELS[model_key]['slug']}"
+        exist = existing(group)
+        if tid in exist:
+            # already in PR5 (e.g. pushed earlier from another machine) — record its path
+            # so the dashboard shows the HF link; don't re-upload.
+            published.append({"cell_id": cell, "hf_path": exist[tid], "tid": tid, "already": True,
+                              "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")})
+            skipped += 1
+            continue
+        dest = f"{V11}/{group}/{a.ts}/{task}__{tid}"
+        rd = json.load(open(inner / "result.json"))
+        cell_ops = []
+        try:
+            for f in CANON:
+                src = inner / f
+                if src.exists():
+                    cell_ops.append(CommitOperationAdd(
+                        path_in_repo=f"{dest}/{f}",
+                        path_or_fileobj=io.BytesIO(safe_bytes(src, is_config=(f == "config.json"), mode=mode))))
+                elif f == "timing.json" and isinstance(rd.get("timing"), dict) and rd["timing"]:
+                    cell_ops.append(CommitOperationAdd(
+                        path_in_repo=f"{dest}/{f}",
+                        path_or_fileobj=io.BytesIO(json.dumps(_scrub(rd["timing"]), indent=2).encode())))
+                else:
+                    raise ValueError(f"missing canonical file {f}")
+        except ValueError as e:
+            print(f"  [skip] {cell}: {e}")
+            continue
+        ops.extend(cell_ops)
+        groups_seen.setdefault((model_key, mode), group)
+        published.append({"cell_id": cell, "hf_path": dest, "tid": tid,
+                          "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")})
+
+    # group metadata.yaml (once per group)
+    for (model_key, mode), group in groups_seen.items():
+        ops.append(CommitOperationAdd(path_in_repo=f"{V11}/{group}/metadata.yaml",
+                                      path_or_fileobj=io.BytesIO(metadata_yaml(model_key, mode, a.src_commit).encode())))
+
+    new = [p for p in published if not p.get("already")]
+    print(f"to publish: {len(new)} new + {len(published) - len(new)} already-in-PR5 recorded ({len(ops)} files); dedup {skipped}; groups={list(groups_seen.values())}")
+    if a.dry_run:
+        print("DRY RUN — nothing pushed")
+        return 0
+    # Always (re)write publish records so the dashboard links every cell that IS in PR5.
+    (ROOT / "published").mkdir(exist_ok=True)
+    for p in published:
+        json.dump(p, open(ROOT / "published" / f"{p['cell_id']}.json", "w"), indent=2)
+    if ops:
+        CH = 400
+        for i in range(0, len(ops), CH):
+            api.create_commit(repo_id=REPO, repo_type=REPO_TYPE, revision=PR_REF, operations=ops[i:i + CH],
+                              commit_message=f"max-effort fill: {len(new)} cells (batch {i // CH + 1})")
+            print(f"  committed batch {i // CH + 1}: {len(ops[i:i+CH])} files")
+    print(f"[done] {len(new)} uploaded, {len(published)} recorded -> {PR_REF}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/skillsbench-fill/read_meta.py
+++ b/experiments/skillsbench-fill/read_meta.py
@@ -1,0 +1,55 @@
+import json, glob, os
+cells = [
+ "opus-4.8__with__glm-lake-mendota__t3",
+ "opus-4.8__with__gravitational-wave-detection__t1",
+ "opus-4.8__with__gravitational-wave-detection__t3",
+ "opus-4.8__with__grid-dispatch-operator__t1",
+ "opus-4.8__with__grid-dispatch-operator__t2",
+ "opus-4.8__with__grid-dispatch-operator__t3",
+ "opus-4.8__with__hvac-control__t1",
+ "opus-4.8__with__hvac-control__t2",
+ "opus-4.8__with__hvac-control__t3",
+ "opus-4.8__with__invoice-fraud-detection__t1",
+ "opus-4.8__with__invoice-fraud-detection__t2",
+ "opus-4.8__with__invoice-fraud-detection__t3",
+]
+base="/home/bingran_you/sb-fill/jobs"
+def dig_tokens(obj):
+    # find any total_tokens / input+output tokens in nested dicts
+    found={}
+    def rec(o,path=""):
+        if isinstance(o,dict):
+            for k,v in o.items():
+                kl=k.lower()
+                if isinstance(v,(int,float)) and ("token" in kl):
+                    found[path+"/"+k]=v
+                rec(v,path+"/"+k)
+        elif isinstance(o,list):
+            for i,v in enumerate(o):
+                rec(v,path+f"[{i}]")
+    rec(obj)
+    return found
+out=[]
+for c in cells:
+    rj = glob.glob(os.path.join(base,c,"*","*","result.json"))
+    rec={"cell":c}
+    if not rj:
+        rec["err"]="no result.json"; out.append(rec); continue
+    r=json.load(open(rj[0]))
+    rec["error"]=r.get("error")
+    rec["error_category"]=r.get("error_category")
+    rec["partial_trajectory"]=r.get("partial_trajectory")
+    rec["trajectory_source"]=r.get("trajectory_source")
+    rec["model"]=r.get("model")
+    rec["skill_mode"]=r.get("skill_mode")
+    rec["include_task_skills"]=r.get("include_task_skills")
+    rec["n_tool_calls"]=r.get("n_tool_calls")
+    rec["usage_tracking"]=r.get("usage_tracking")
+    rec["rewards_field"]=r.get("rewards")
+    fm=r.get("final_metrics")
+    rec["final_metrics"]=fm
+    # token dig
+    toks=dig_tokens(r)
+    rec["token_fields"]=toks
+    out.append(rec)
+print(json.dumps(out,indent=1,default=str))

--- a/experiments/skillsbench-fill/read_rewards.py
+++ b/experiments/skillsbench-fill/read_rewards.py
@@ -1,0 +1,46 @@
+import json, glob, os, sys
+cells = [
+ "opus-4.8__with__glm-lake-mendota__t3",
+ "opus-4.8__with__gravitational-wave-detection__t1",
+ "opus-4.8__with__gravitational-wave-detection__t3",
+ "opus-4.8__with__grid-dispatch-operator__t1",
+ "opus-4.8__with__grid-dispatch-operator__t2",
+ "opus-4.8__with__grid-dispatch-operator__t3",
+ "opus-4.8__with__hvac-control__t1",
+ "opus-4.8__with__hvac-control__t2",
+ "opus-4.8__with__hvac-control__t3",
+ "opus-4.8__with__invoice-fraud-detection__t1",
+ "opus-4.8__with__invoice-fraud-detection__t2",
+ "opus-4.8__with__invoice-fraud-detection__t3",
+]
+base="/home/bingran_you/sb-fill/jobs"
+out=[]
+for c in cells:
+    rj = glob.glob(os.path.join(base,c,"*","*","result.json"))
+    rec={"cell":c}
+    if not rj:
+        rec["err"]="no result.json"; out.append(rec); continue
+    rdir=os.path.dirname(rj[0])
+    try:
+        r=json.load(open(rj[0]))
+        rec["result_reward"]=r.get("reward")
+        rec["result_keys"]=list(r.keys())
+    except Exception as e:
+        rec["result_err"]=str(e)
+    # rewards.jsonl
+    rl=os.path.join(rdir,"rewards.jsonl")
+    if os.path.exists(rl):
+        lines=[l for l in open(rl).read().splitlines() if l.strip()]
+        rec["rewards_jsonl"]=lines
+    # ctrf
+    ctrf=os.path.join(rdir,"verifier","ctrf.json")
+    if os.path.exists(ctrf):
+        try:
+            cc=json.load(open(ctrf))
+            summ=cc.get("results",{}).get("summary",{})
+            rec["ctrf_summary"]=summ
+        except Exception as e:
+            rec["ctrf_err"]=str(e)
+    # tokens: look in trajectory / agent
+    out.append(rec)
+print(json.dumps(out,indent=1))

--- a/experiments/skillsbench-fill/reap_daytona.py
+++ b/experiments/skillsbench-fill/reap_daytona.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""VM-side safety net: delete orphaned Daytona sandboxes (STARTED and older than
+90 min = no live run could still own it). Run via benchflow's venv from cron."""
+import os, re, datetime
+key = None
+for line in open(os.path.expanduser("~/keys.env")):
+    m = re.match(r'^\s*(?:export\s+)?DAYTONA_API_KEY\s*=\s*["\']?([^"\'\s]+)', line)
+    if m:
+        key = m.group(1)
+from benchflow.sandbox.daytona import build_sync_client
+c = build_sync_client(key)
+now = datetime.datetime.now(datetime.timezone.utc)
+deleted = 0
+# VM SDK's list() takes no page/limit kwargs; .items holds the Sandbox objects.
+r = c.list()
+items = list(getattr(r, "items", None) or r)
+if True:
+    for s in items:
+        if "STARTED" not in str(getattr(s, "state", "")):
+            continue
+        cr = getattr(s, "created_at", None) or getattr(s, "createdAt", None)
+        try:
+            if not isinstance(cr, datetime.datetime):
+                cr = datetime.datetime.fromisoformat(str(cr).replace("Z", "+00:00"))
+            if cr.tzinfo is None:
+                cr = cr.replace(tzinfo=datetime.timezone.utc)
+            age_min = (now - cr).total_seconds() / 60
+        except Exception:
+            continue
+        if age_min > 90:
+            try:
+                c.get(s.id).delete(); deleted += 1
+            except Exception:
+                pass
+print(f"[reap {now.strftime('%H:%M:%SZ')}] deleted {deleted} orphan sandboxes (>90min STARTED)")

--- a/experiments/skillsbench-fill/reconcile.py
+++ b/experiments/skillsbench-fill/reconcile.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Reconcile the SkillsBench max-effort fill target against HF PR5 (read-only).
+
+Target grid = 3 models x {with,without} x 91 tasks x 3 trials = 1638.
+
+An existing PR5 cell is CREDITED toward the target only if it is:
+  - healthy: error==None, partial_trajectory==False, reward in [0,1], timing.total>0,
+    (tokens>0 for models whose provider surfaces usage: opus, minimax)
+  - provably max-effort: the per-model effort env is present in config.json.agent_env
+    (opus: BENCHFLOW_BEDROCK_THINKING_EFFORT=max; gemini: LLM_REASONING_EFFORT=high;
+     minimax: LLM_REASONING_EFFORT=max)
+  - correct skill posture: include_task_skills matches the (with/without) mode
+
+Emits, under --out:
+  queue.jsonl            one row per (model,mode,task,trial_slot) still NEEDED
+  experiments_ledger.json full 1638-cell grid for the dashboard (credited slots ->
+                          published, needed -> queued)
+  reconcile_report.json  counts: credited, needed, and rejected-by-reason
+
+Does NOT modify PR5. Trial ids in PR5 are random hex, so credit counts DISTINCT
+healthy cells per (model,mode,task) toward 3 (not specific trial indices).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = "benchflow/skillsbench-leaderboard"
+PR_REF = "refs/pr/5"
+V11 = "submissions/skillsbench/v1.1"
+ENV_PATH = os.path.expanduser("~/Downloads/GitHub/bingran-you/.env")
+
+MODELS = {
+    "opus-4.8": {
+        "slug": "aws-bedrock-us.anthropic.claude-opus-4-8",
+        "model": "aws-bedrock/us.anthropic.claude-opus-4-8",
+        "effort_key": "BENCHFLOW_BEDROCK_THINKING_EFFORT", "effort_val": "max",
+        "needs_tokens": True,
+    },
+    "gemini-3.5-flash": {
+        "slug": "gemini-3.5-flash", "model": "gemini-3.5-flash",
+        "effort_key": "LLM_REASONING_EFFORT", "effort_val": "high",
+        "needs_tokens": False,  # native gemini path doesn't surface usage
+    },
+    "minimax-m3": {
+        "slug": "minimax-MiniMax-M3", "model": "minimax/MiniMax-M3",
+        "effort_key": "LLM_REASONING_EFFORT", "effort_val": "max",
+        "needs_tokens": True,
+    },
+}
+SLUG2MODEL = {m["slug"]: k for k, m in MODELS.items()}
+MODES = ("with", "without")
+N_TRIALS = 3
+
+
+def hf_token() -> str:
+    for line in open(ENV_PATH):
+        m = re.match(r'^\s*(?:export\s+)?HUGGING_FACE_TOKEN\s*=\s*["\']?([^"\'\s]+)', line)
+        if m:
+            return m.group(1)
+    raise SystemExit("HUGGING_FACE_TOKEN not found in " + ENV_PATH)
+
+
+def load_tasks(tasks_dir: str) -> list[str]:
+    p = Path(tasks_dir)
+    return sorted(d.name for d in p.iterdir() if d.is_dir() and (d / "task.toml").exists())
+
+
+def group_model_modehint(group: str):
+    """(model_key, mode_hint) from a v1.1 group dir name; mode_hint None if not encoded."""
+    if group.startswith("openhands-with-skills__"):
+        return SLUG2MODEL.get(group.split("__", 1)[1]), "with"
+    if group.startswith("openhands-no-skills__"):
+        return SLUG2MODEL.get(group.split("__", 1)[1]), "without"
+    if group.startswith("openhands__"):
+        return SLUG2MODEL.get(group.split("__", 1)[1]), None
+    return None, None
+
+
+def credit_gate(cfg: dict, res: dict, model_key: str, mode: str):
+    m = MODELS[model_key]
+    if res.get("error") is not None:
+        return False, "error"
+    if res.get("partial_trajectory"):
+        return False, "partial"
+    rew = (res.get("rewards") or {}).get("reward")
+    try:
+        if rew is None or not (0.0 <= float(rew) <= 1.0):
+            return False, "reward"
+    except (TypeError, ValueError):
+        return False, "reward"
+    tot = (res.get("timing") or {}).get("total")
+    if not tot or tot <= 0:
+        return False, "timing"
+    if m["needs_tokens"] and not ((res.get("agent_result") or {}).get("total_tokens") or 0) > 0:
+        return False, "tokens"
+    ae = cfg.get("agent_env", {}) or {}
+    if str(ae.get(m["effort_key"], "")).lower() != m["effort_val"]:
+        return False, "effort"
+    its = bool(cfg.get("include_task_skills"))
+    if (mode == "with") != its:
+        return False, "skillmode"
+    return True, "ok"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--tasks-dir", default=os.path.expanduser("~/Downloads/GitHub/BenchFlow.ai/skillsbench/tasks"))
+    ap.add_argument("--out", default=os.path.dirname(os.path.abspath(__file__)) + "/state")
+    args = ap.parse_args()
+
+    os.environ.setdefault("HF_TOKEN", hf_token())
+    from huggingface_hub import HfApi, hf_hub_download
+    api = HfApi(token=os.environ["HF_TOKEN"])
+
+    tasks = load_tasks(args.tasks_dir)
+    print(f"tasks: {len(tasks)} (from {args.tasks_dir})")
+    target = len(MODELS) * len(MODES) * len(tasks) * N_TRIALS
+    print(f"target grid: {len(MODELS)} models x {len(MODES)} modes x {len(tasks)} tasks x {N_TRIALS} trials = {target}")
+
+    # credited[(model,mode,task)] -> {trialid: {reward,tokens,timing,hf_path}}
+    credited: dict = defaultdict(dict)
+    rejected = defaultdict(lambda: defaultdict(int))  # model -> reason -> count
+    seen_cells = 0
+
+    for grp in api.list_repo_tree(REPO, repo_type="dataset", revision=PR_REF, path_in_repo=V11, recursive=False):
+        group = grp.path.split("/")[-1]
+        model_key, mode_hint = group_model_modehint(group)
+        if model_key is None:
+            continue
+        result_paths = [
+            k.path for k in api.list_repo_tree(REPO, repo_type="dataset", revision=PR_REF, path_in_repo=grp.path, recursive=True)
+            if k.path.endswith("/result.json")
+        ]
+        for rpath in result_paths:
+            seen_cells += 1
+            cell_dir = rpath.rsplit("/", 1)[0]
+            leaf = cell_dir.split("/")[-1]
+            if "__" not in leaf:
+                continue
+            task, tid = leaf.rsplit("__", 1)
+            if task not in tasks:
+                rejected[model_key]["task_not_in_grid"] += 1
+                continue
+            try:
+                res = json.load(open(hf_hub_download(REPO, rpath, repo_type="dataset", revision=PR_REF)))
+                cfg = json.load(open(hf_hub_download(REPO, cell_dir + "/config.json", repo_type="dataset", revision=PR_REF)))
+            except Exception:
+                rejected[model_key]["unreadable"] += 1
+                continue
+            mode = mode_hint or ("with" if cfg.get("include_task_skills") else "without")
+            ok, reason = credit_gate(cfg, res, model_key, mode)
+            if not ok:
+                rejected[model_key][reason] += 1
+                continue
+            credited[(model_key, mode, task)][tid] = {
+                "reward": (res.get("rewards") or {}).get("reward"),
+                "tokens": (res.get("agent_result") or {}).get("total_tokens"),
+                "timing_total_s": (res.get("timing") or {}).get("total"),
+                "hf_path": cell_dir,
+            }
+
+    # Build the full grid ledger + the queue of needed cells.
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    rows = []
+    queue = []
+    need_counts = defaultdict(int)
+    for model_key, mc in MODELS.items():
+        for mode in MODES:
+            for task in tasks:
+                creds = list(credited[(model_key, mode, task)].values())
+                for slot in range(1, N_TRIALS + 1):
+                    cid = f"{model_key}__{mode}__{task}__t{slot}"
+                    if slot <= len(creds):
+                        c = creds[slot - 1]
+                        rows.append({
+                            "cell_id": cid, "model": model_key, "model_slug": mc["slug"],
+                            "effort": mc["effort_val"], "skill_mode": mode, "task": task,
+                            "trial_slot": slot, "status": "published", "sandbox": "daytona",
+                            "reward": c["reward"], "health": "healthy", "review_verdict": "pass",
+                            "task_skills_loading": 1 if mode == "with" else 0,
+                            "tokens": {"total": c["tokens"]} if c["tokens"] else None,
+                            "timing_total_s": c["timing_total_s"], "hf_path": c["hf_path"],
+                            "note": "existing PR5 cell (pending deep re-review)", "updated_at": now,
+                        })
+                    else:
+                        need_counts[(model_key, mode)] += 1
+                        row = {
+                            "cell_id": cid, "model": model_key, "model_slug": mc["slug"],
+                            "effort": mc["effort_val"], "skill_mode": mode, "task": task,
+                            "trial_slot": slot, "status": "queued", "sandbox": "daytona",
+                            "updated_at": now,
+                        }
+                        rows.append(row)
+                        queue.append({k: row[k] for k in ("cell_id", "model", "skill_mode", "task", "trial_slot")})
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "queue.jsonl").write_text("".join(json.dumps(q) + "\n" for q in queue))
+    ledger = {"as_of": now, "target": target, "rows": rows}
+    (out / "experiments_ledger.json").write_text(json.dumps(ledger, indent=2))
+    report = {
+        "as_of": now, "target": target, "tasks": len(tasks),
+        "existing_cells_seen": seen_cells,
+        "credited_total": sum(len(v) for v in credited.values()),
+        "credited_by_model_mode": {f"{mk}/{md}": sum(len(credited[(mk, md, t)]) for t in tasks)
+                                   for mk in MODELS for md in MODES},
+        "needed_total": len(queue),
+        "needed_by_model_mode": {f"{mk}/{md}": need_counts[(mk, md)] for mk in MODELS for md in MODES},
+        "rejected_by_model_reason": {mk: dict(rejected[mk]) for mk in MODELS if rejected[mk]},
+    }
+    (out / "reconcile_report.json").write_text(json.dumps(report, indent=2))
+
+    print("\n=== reconcile report ===")
+    print(json.dumps(report, indent=2))
+    print(f"\nwrote {out}/queue.jsonl ({len(queue)} cells), experiments_ledger.json ({len(rows)} rows), reconcile_report.json")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/skillsbench-fill/requeue_nonpass.py
+++ b/experiments/skillsbench-fill/requeue_nonpass.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Fresh-start requeue: reset EVERY non-pass cell (fail + quarantine) to queued so
+the runners re-run them — after #914's skill fix is applied, the skill_posture fails
+should now pass; gemini 429 / opus Bedrock / infra get another attempt."""
+import json, glob, os
+REV = os.path.expanduser("~/sb-fill/review")
+ST = os.path.expanduser("~/sb-fill/state")
+SKIP = {"experiments_ledger.json", "queue.jsonl", "reconcile_report.json", "grid.json"}
+n = 0
+for f in glob.glob(REV + "/*.json"):
+    try:
+        rv = json.load(open(f))
+    except Exception:
+        continue
+    if rv.get("verdict") == "pass":
+        continue
+    cell = rv.get("cell_id") or os.path.basename(f)[:-5]
+    os.remove(f)
+    sf = os.path.join(ST, cell + ".json")
+    if os.path.exists(sf):
+        os.remove(sf)
+    n += 1
+r = 0
+for f in glob.glob(ST + "/*.json"):
+    if os.path.basename(f) in SKIP:
+        continue
+    try:
+        st = json.load(open(f))
+    except Exception:
+        continue
+    if st.get("status") == "running":
+        os.remove(f); r += 1
+print(f"requeued non-pass: {n} | reset orphaned running: {r}")

--- a/experiments/skillsbench-fill/requeue_quarantine.py
+++ b/experiments/skillsbench-fill/requeue_quarantine.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Requeue storm-damaged cells: delete state+review for every quarantine-verdict cell
+(and any orphaned running-state cell) so the runner re-runs them with DNS fixed."""
+import json, glob, os
+REV = os.path.expanduser("~/sb-fill/review")
+ST = os.path.expanduser("~/sb-fill/state")
+SKIP = {"queue.jsonl", "experiments_ledger.json", "grid.json", "reconcile_report.json"}
+
+q = 0
+for f in glob.glob(REV + "/*.json"):
+    try:
+        rv = json.load(open(f))
+    except Exception:
+        continue
+    if rv.get("verdict") != "quarantine":
+        continue
+    cell = rv.get("cell_id") or os.path.basename(f)[:-5]
+    os.remove(f)                                  # drop review verdict
+    sf = os.path.join(ST, cell + ".json")
+    if os.path.exists(sf):
+        os.remove(sf)                             # drop state -> runner re-runs
+    q += 1
+
+r = 0
+for f in glob.glob(ST + "/*.json"):
+    if os.path.basename(f) in SKIP:
+        continue
+    try:
+        st = json.load(open(f))
+    except Exception:
+        continue
+    if st.get("status") == "running":             # orphaned by reboot/kill
+        os.remove(f); r += 1
+print(f"requeued quarantine cells: {q} | reset orphaned running: {r}")

--- a/experiments/skillsbench-fill/review_cell.py
+++ b/experiments/skillsbench-fill/review_cell.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Mechanical bulk reviewer for the SkillsBench max-effort fill (runs on the VM).
+
+Automates the benchflow-experiment-review checklist per completed cell and writes
+review/<cell>.json with a verdict + evidence. Subagents then deep-audit every
+'fail' + a random sample for judgment (plausibility / reward-hacking).
+
+For each state/<cell>.json with status==completed and no review yet:
+  health      error is None, partial_trajectory False, reward in [0,1], timing.total>0
+  tokens      total_tokens>0 (required for opus/minimax; advisory for gemini)
+  trajectory  acp_trajectory.jsonl >100B and llm_trajectory.jsonl present
+  effort      opus: thinking/reasoning refs in llm_trajectory (max thinking fired)
+              gemini: agent_env LLM_REASONING_EFFORT==high ; minimax: ==max
+  skills      extract_harness_skills task_skills_loading == (1 if with else 0)
+verdict: pass iff all true; fail if a model-side criterion fails; quarantine if
+infra/artifacts missing (run_failed or unreadable).
+
+Usage: review_cell.py [--limit N] [--cell <id>]
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(os.path.dirname(os.path.abspath(__file__)))
+STATE, REVIEW = ROOT / "state", ROOT / "review"
+SB_TASKS = os.path.expanduser("~/skillsbench/tasks")
+EXTRACT = os.path.expanduser(
+    "~/Experiment/benchflow/.claude/skills/benchflow-experiment-review/scripts/extract_harness_skills.py"
+)
+RECONCILE_FILES = {"experiments_ledger.json", "queue.jsonl", "reconcile_report.json", "grid.json"}
+THINK_RE = re.compile(rb"thinking|reasoning_content|reasoningContent|redacted_thinking|signature", re.I)
+
+
+def _rollout(st: dict) -> Path | None:
+    rd = st.get("rollout_dir")
+    if rd and Path(rd).is_dir():
+        return Path(rd)
+    root = st.get("run_root")
+    if root:
+        hits = [d for d in glob.glob(f"{root}/**/{st['task']}__*", recursive=True) if Path(d).is_dir()]
+        if hits:
+            return Path(sorted(hits)[0])
+    return None
+
+
+def review(st: dict) -> dict:
+    cell, model, mode, task = st["cell_id"], st["model"], st["skill_mode"], st["task"]
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    out = {"cell_id": cell, "updated_at": now, "checklist": {}, "notes": ""}
+    if st.get("status") != "completed":
+        return {**out, "verdict": "quarantine", "health": "unhealthy",
+                "notes": f"status={st.get('status')} ({st.get('error')})"}
+    roll = _rollout(st)
+    if roll is None:
+        return {**out, "verdict": "quarantine", "health": "unhealthy", "notes": "no rollout dir"}
+    try:
+        res = json.load(open(roll / "result.json"))
+        cfg = json.load(open(roll / "config.json"))
+    except Exception as e:
+        return {**out, "verdict": "quarantine", "health": "unhealthy", "notes": f"unreadable: {e}"}
+
+    ar = res.get("agent_result") or {}
+    ae = cfg.get("agent_env", {}) or {}
+    acp, llm = roll / "trajectory/acp_trajectory.jsonl", roll / "trajectory/llm_trajectory.jsonl"
+    rew = (res.get("rewards") or {}).get("reward")
+    tot = (res.get("timing") or {}).get("total")
+    tokens = ar.get("total_tokens")
+
+    err = res.get("error")
+    # A genuine agent timeout with a complete trajectory + score is a HEALTHY
+    # normal_timeout (publishable per the review skill), NOT an infra failure.
+    is_timeout = bool(err) and "timed out" in str(err).lower()
+    out["outcome"] = "normal_timeout" if is_timeout else "completed"
+    c = out["checklist"]
+    c["error_ok"] = (err is None) or is_timeout
+    c["not_partial"] = (not res.get("partial_trajectory")) or is_timeout
+    try:
+        c["reward_valid"] = rew is not None and 0.0 <= float(rew) <= 1.0
+    except (TypeError, ValueError):
+        c["reward_valid"] = False
+    c["timing_ok"] = bool(tot and tot > 0)
+    c["acp_present"] = acp.is_file() and acp.stat().st_size > 100
+    c["llm_present"] = llm.is_file() and llm.stat().st_size > 50
+    c["tokens_ok"] = bool(tokens and tokens > 0) if model != "gemini-3.5-flash" else True
+
+    # effort provenance
+    if model == "opus-4.8":
+        think = 0
+        if llm.is_file():
+            with open(llm, "rb") as fh:
+                think = len(THINK_RE.findall(fh.read()))
+        c["effort_ok"] = think > 0 or str(ae.get("BENCHFLOW_BEDROCK_THINKING_EFFORT", "")).lower() == "max"
+        out["thinking_refs"] = think
+    elif model == "gemini-3.5-flash":
+        c["effort_ok"] = str(ae.get("LLM_REASONING_EFFORT", "")).lower() == "high"
+    else:  # minimax-m3
+        c["effort_ok"] = str(ae.get("LLM_REASONING_EFFORT", "")).lower() == "max"
+
+    # skill posture via extract_harness_skills
+    tsl, tsl_status = None, "unknown"
+    if llm.is_file():
+        try:
+            p = subprocess.run(["python3", EXTRACT, str(llm), "--task-path", f"{SB_TASKS}/{task}"],
+                               capture_output=True, text=True, timeout=120)
+            j = json.loads(p.stdout)
+            tsl, tsl_status = j.get("task_skills_loading"), j.get("task_skills_loading_status")
+        except Exception as e:
+            tsl_status = f"extract_error:{e}"
+    out["task_skills_loading"], out["task_skills_loading_status"] = tsl, tsl_status
+    c["skill_posture_ok"] = (tsl == (1 if mode == "with" else 0))
+
+    out["reward"] = rew
+    out["tokens"] = {"total": tokens} if tokens else None
+    out["timing_total_s"] = tot
+    out["usage_source"] = ar.get("usage_source")
+    healthy = all(c.values())
+    # infra/incomplete (missing trajectory, provider error, no reward) => quarantine+requeue,
+    # NOT a model fail. A model fail has a real trajectory+reward but flunks effort/skill/leakage.
+    infra = (err is not None and not is_timeout) or not c["acp_present"] or not c["llm_present"] or not c["reward_valid"]
+    if healthy:
+        out["health"], out["verdict"] = "healthy", "pass"
+    elif infra:
+        out["health"], out["verdict"] = "unhealthy", "quarantine"
+        out["notes"] = "infra/requeue: " + ",".join(k for k, v in c.items() if not v)
+    else:
+        out["health"], out["verdict"] = "unhealthy", "fail"
+        out["notes"] = "model-side: " + ",".join(k for k, v in c.items() if not v)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--cell", default="")
+    a = ap.parse_args()
+    REVIEW.mkdir(exist_ok=True)
+    done = {Path(f).stem for f in glob.glob(str(REVIEW / "*.json"))}
+    reviewed = passed = failed = quar = 0
+    for sf in sorted(glob.glob(str(STATE / "*.json"))):
+        if os.path.basename(sf) in RECONCILE_FILES:
+            continue
+        try:
+            st = json.load(open(sf))
+        except Exception:
+            continue
+        cell = st.get("cell_id")
+        if not cell or (a.cell and cell != a.cell) or cell in done:
+            continue
+        if st.get("status") != "completed":
+            continue
+        rv = review(st)
+        json.dump(rv, open(REVIEW / f"{cell}.json", "w"), indent=2)
+        reviewed += 1
+        passed += rv["verdict"] == "pass"
+        failed += rv["verdict"] == "fail"
+        quar += rv["verdict"] == "quarantine"
+        print(f"[{rv['verdict']:10s}] {cell} reward={rv.get('reward')} tsl={rv.get('task_skills_loading')} {rv.get('notes','')}")
+        if a.limit and reviewed >= a.limit:
+            break
+    print(f"\nreviewed {reviewed}: pass={passed} fail={failed} quarantine={quar}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/skillsbench-fill/run_cell.sh
+++ b/experiments/skillsbench-fill/run_cell.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Run ONE SkillsBench max-effort cell on the daytona-orchestrator VM.
+# Usage: run_cell.sh <model> <with|without> <task> <slot> <daytona|docker> <jobs_root> <state_dir>
+# Writes <state_dir>/<cell_id>.json (running -> completed|run_failed) with run_root + basic health.
+# Models: opus-4.8 | gemini-3.5-flash | minimax-m3  (effort: opus=max via bedrock shim, gemini=high, minimax=max)
+set -uo pipefail
+
+MODEL="${1:?model}" MODE="${2:?with|without}" TASK="${3:?task}" SLOT="${4:?slot}" SANDBOX="${5:?daytona|docker}"
+JOBS_ROOT="${6:?jobs_root}" STATE_DIR="${7:?state_dir}"
+CELL="${MODEL}__${MODE}__${TASK}__t${SLOT}"
+BENCH="$HOME/Experiment/benchflow"
+SB="$HOME/skillsbench"
+JOBS="$JOBS_ROOT/$CELL"
+mkdir -p "$JOBS" "$STATE_DIR"
+
+# --- env: load keys, strip All-Hands proxy hijack vars, fix per-provider keys ---
+set -a; source "$HOME/keys.env" 2>/dev/null || true; set +a
+unset OPENAI_API_KEY OPENAI_BASE_URL LLM_API_KEY LLM_BASE_URL \
+      BENCHFLOW_PROVIDER_API_KEY BENCHFLOW_PROVIDER_BASE_URL \
+      LITELLM_API_KEY LITELLM_BASE_URL 2>/dev/null || true
+export AWS_REGION=us-west-2 AWS_DEFAULT_REGION=us-west-2
+# latest-main: the host litellm runtime reads BENCHFLOW_BEDROCK_THINKING_EFFORT from the
+# host env (gated to bedrock opus 4.8; inert for gemini/minimax). Export it AND pass --agent-env.
+export BENCHFLOW_BEDROCK_THINKING_EFFORT=max
+[ -n "${GEMINI_API_KEY_2:-}" ] && export GEMINI_API_KEY="$GEMINI_API_KEY_2"
+
+# --- per-model flags (effort is env-delivered; --reasoning-effort is rejected by openhands) ---
+case "$MODEL" in
+  opus-4.8)
+    MODEL_ARGS=(--model aws-bedrock/us.anthropic.claude-opus-4-8
+                --agent-env BENCHFLOW_BEDROCK_THINKING_EFFORT=max --agent-env AWS_REGION=us-west-2);;
+  gemini-3.5-flash)
+    MODEL_ARGS=(--model gemini-3.5-flash --agent-env "GEMINI_API_KEY=${GEMINI_API_KEY:-}"
+                --agent-env LLM_REASONING_EFFORT=high --agent-env LITELLM_REASONING_EFFORT=high);;
+  minimax-m3)
+    MODEL_ARGS=(--model minimax/MiniMax-M3 --agent-env LLM_REASONING_EFFORT=max
+                --agent-env LITELLM_REASONING_EFFORT=max --agent-env LLM_CACHING_PROMPT=false);;
+  *) echo "unknown model $MODEL" >&2; exit 2;;
+esac
+# skill modes (current benchflow): with-skill | no-skill | self-gen. without => omit --skills-dir.
+if [ "$MODE" = "with" ]; then SKILL_ARGS=(--skills-dir "$SB/tasks/$TASK/environment/skills" --skill-mode with-skill); else SKILL_ARGS=(); fi
+
+# --- state: running ---
+python3 - "$STATE_DIR/$CELL.json" "$CELL" "$MODEL" "$MODE" "$TASK" "$SLOT" "$SANDBOX" "$JOBS" <<'PY'
+import json,sys,datetime
+p,cell,model,mode,task,slot,sb,jobs=sys.argv[1:9]
+now=datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+json.dump({"cell_id":cell,"model":model,"skill_mode":mode,"task":task,"trial_slot":int(slot),
+           "sandbox":sb,"status":"running","run_root":jobs,"started_at":now,"updated_at":now}, open(p,"w"), indent=2)
+PY
+
+# --- run the cell (one ephemeral sandbox) ---
+cd "$BENCH"
+"$BENCH/.venv/bin/bench" eval create \
+  --tasks-dir "$SB/tasks" --include "$TASK" --concurrency 1 \
+  --agent openhands --sandbox "$SANDBOX" \
+  "${MODEL_ARGS[@]}" "${SKILL_ARGS[@]}" \
+  --usage-tracking required --agent-idle-timeout none \
+  --jobs-dir "$JOBS" > "$JOBS/cell.log" 2>&1
+RC=$?
+
+# --- collect: parse result.json, detect ENOSPC for docker fallback signal ---
+python3 - "$STATE_DIR/$CELL.json" "$JOBS" "$RC" <<'PY'
+import json,sys,glob,os,datetime
+statef,jobs,rc=sys.argv[1],sys.argv[2],int(sys.argv[3])
+st=json.load(open(statef))
+res=None; rolldir=None
+for rj in sorted(glob.glob(os.path.join(jobs,"**","result.json"),recursive=True)):
+    rolldir=os.path.dirname(rj)
+    try: res=json.load(open(rj))
+    except Exception: res=None
+    break
+now=datetime.datetime.now(datetime.timezone.utc).isoformat(timespec="seconds")
+st["updated_at"]=now; st["rc"]=rc
+if res is not None:
+    ar=res.get("agent_result") or {}
+    st.update(status="completed", rollout_dir=rolldir,
+              reward=(res.get("rewards") or {}).get("reward"),
+              error=res.get("error"), partial=res.get("partial_trajectory"),
+              timing_total_s=(res.get("timing") or {}).get("total"),
+              tokens={"total":ar.get("total_tokens"),"input":ar.get("n_input_tokens"),"output":ar.get("n_output_tokens")},
+              usage_source=ar.get("usage_source"))
+else:
+    txt=""
+    try: txt=open(os.path.join(jobs,"cell.log"),errors="ignore").read()[-6000:]
+    except Exception: pass
+    st.update(status="run_failed", error="no result.json",
+              enospc=("No space left" in txt or "ENOSPC" in txt or "rc=2" in txt or "10240" in txt))
+json.dump(st,open(statef,"w"),indent=2)
+print(f"[{st['cell_id']}] {st['status']} reward={st.get('reward')} enospc={st.get('enospc',False)} rc={rc}")
+PY
+exit 0

--- a/experiments/skillsbench-fill/runner.py
+++ b/experiments/skillsbench-fill/runner.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Rolling pooled driver for the SkillsBench max-effort fill (runs on the VM).
+
+Keeps --concurrency run_cell.sh processes in flight, drawn from state/queue.jsonl.
+- Known-heavy tasks start on docker (overflow Daytona's 10GB cap).
+- A daytona cell that fails with ENOSPC/infra error is retried on docker (once).
+- Restart-safe: skips cells already completed/review_pass/published.
+
+Usage:
+  runner.py --concurrency 18 --only-tasks citation-check,3d-scan-calc       # canary
+  runner.py --concurrency 50                                                # pooled scale (VM-safe)
+  runner.py --concurrency 18 --only-models opus-4.8 --only-tasks citation-check
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import threading
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(os.path.dirname(os.path.abspath(__file__)))
+JOBS = ROOT / "jobs"
+STATE = ROOT / "state"
+QUEUE = STATE / "queue.jsonl"
+
+# Cap concurrent LOCAL docker sandboxes (heavy tasks). Many simultaneous docker
+# setups (apt/pip) + GCP search-domain DNS amplification saturate systemd-resolved
+# and wedge the whole VM network. Bound it. Set in main() from --docker-concurrency.
+_DOCKER_SEM: threading.Semaphore | None = None
+
+# Tasks that overflow Daytona's hard 10GB image cap (storage_mb>10240 or heavy ML image).
+HEAVY = {
+    "latex-formula-extraction", "fix-druid-loophole-cve", "organize-messy-files",
+    "syzkaller-ppdev-syzlang", "video-tutorial-indexer", "video-filler-word-remover",
+    "debug-trl-grpo", "data-to-d3", "fix-visual-stability", "multilingual-video-dubbing",
+    "react-performance-debugging", "taxonomy-tree-merge",
+}
+DONE_STATES = {"completed", "review_pass", "published"}
+
+
+def cell_state(cell: str) -> dict:
+    f = STATE / f"{cell}.json"
+    if f.exists():
+        try:
+            return json.load(open(f)) or {}
+        except Exception:
+            return {}
+    return {}
+
+
+def should_skip(st: dict) -> bool:
+    """Skip cells already done, or actively running under another runner/orphan
+    (fresh < 45 min). Stale 'running' (crashed) falls through and is re-run."""
+    status = st.get("status")
+    if status in DONE_STATES:
+        return True
+    if status == "running":
+        try:
+            age = (datetime.now(timezone.utc) - datetime.fromisoformat(st.get("started_at", ""))).total_seconds()
+        except Exception:
+            age = 1e9
+        return age < 2700
+    return False
+
+
+def run_cell(model, mode, task, slot, sandbox):
+    cell = f"{model}__{mode}__{task}__t{slot}"
+    cmd = ["bash", str(ROOT / "run_cell.sh"), model, mode, task, str(slot), sandbox, str(JOBS), str(STATE)]
+    if sandbox == "docker" and _DOCKER_SEM is not None:
+        # hold the slot for the whole docker run so only N docker sandboxes exist at once
+        with _DOCKER_SEM:
+            subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    else:
+        subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        return cell, json.load(open(STATE / f"{cell}.json"))
+    except Exception:
+        return cell, {}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--concurrency", type=int, default=18)
+    ap.add_argument("--docker-concurrency", type=int, default=4,
+                    help="max concurrent LOCAL docker sandboxes (heavy tasks); guards VM DNS/network")
+    ap.add_argument("--skip-heavy", action="store_true",
+                    help="skip HEAVY-set tasks entirely (their docker builds fail on this VM); run only light->daytona cells")
+    ap.add_argument("--only-tasks", default="")
+    ap.add_argument("--only-models", default="")
+    ap.add_argument("--limit", type=int, default=0)
+    ap.add_argument("--max-retries", type=int, default=1)
+    a = ap.parse_args()
+    JOBS.mkdir(exist_ok=True)
+    STATE.mkdir(exist_ok=True)
+    global _DOCKER_SEM
+    _DOCKER_SEM = threading.Semaphore(max(1, a.docker_concurrency))
+
+    tasks_f = {t for t in a.only_tasks.split(",") if t}
+    models_f = {m for m in a.only_models.split(",") if m}
+    work = []
+    for line in open(QUEUE):
+        q = json.loads(line)
+        if tasks_f and q["task"] not in tasks_f:
+            continue
+        if models_f and q["model"] not in models_f:
+            continue
+        if a.skip_heavy and q["task"] in HEAVY:
+            continue
+        if should_skip(cell_state(q["cell_id"])):
+            continue
+        sandbox = "docker" if q["task"] in HEAVY else "daytona"
+        work.append((q["model"], q["skill_mode"], q["task"], q["trial_slot"], sandbox))
+    if a.limit:
+        work = work[:a.limit]
+    print(f"work: {len(work)} cells | concurrency={a.concurrency} | docker-concurrency={a.docker_concurrency} | heavy->docker", flush=True)
+
+    retries: dict[str, int] = {}
+    done = ok = 0
+    with ThreadPoolExecutor(max_workers=a.concurrency) as ex:
+        pending = {ex.submit(run_cell, *w): w for w in work}
+        while pending:
+            finished, _ = wait(list(pending), return_when=FIRST_COMPLETED)
+            for fut in finished:
+                model, mode, task, slot, sandbox = pending.pop(fut)
+                cell, st = fut.result()
+                done += 1
+                status = st.get("status")
+                if status == "completed":
+                    ok += 1
+                elif status == "run_failed":
+                    n = retries.get(cell, 0)
+                    if n < a.max_retries:
+                        retries[cell] = n + 1
+                        nb = "docker" if (sandbox == "daytona" and st.get("enospc")) else sandbox
+                        print(f"  retry {cell} on {nb} (was {sandbox}, enospc={st.get('enospc')})", flush=True)
+                        w2 = (model, mode, task, slot, nb)
+                        pending[ex.submit(run_cell, *w2)] = w2
+                print(f"[{done}] {cell} -> {status} (completed so far: {ok})", flush=True)
+    print(f"DONE: {ok} completed of {len(work)} initial cells", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/skillsbench-fill/status.sh
+++ b/experiments/skillsbench-fill/status.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# One-glance status of the SkillsBench fill. Run: bash ~/sb-fill/status.sh
+cd "$(dirname "$0")"
+python3 -c "
+import json,glob,collections,os
+ex={'experiments_ledger.json','queue.jsonl','reconcile_report.json','grid.json'}
+st=collections.Counter(); rm=collections.Counter(); rv=collections.Counter()
+for f in glob.glob('state/*.json'):
+    if os.path.basename(f) in ex: continue
+    try: d=json.load(open(f))
+    except: continue
+    st[d.get('status')]+=1
+    if d.get('status')=='running': rm[d.get('model')]+=1
+for f in glob.glob('review/*.json'):
+    try: rv[json.load(open(f)).get('verdict')]+=1
+    except: pass
+print('state    :', dict(st))
+print('running  :', dict(rm))
+print('review   :', dict(rv), '| published:', len(glob.glob('published/*.json')))
+"
+echo "runners  : $(ps -eo args | grep -c '[r]unner.py')   cron jobs: $(crontab -l 2>/dev/null | grep -c sb-fill)"
+echo "wave log : $(tail -1 logs/wave.log 2>/dev/null)"

--- a/experiments/skillsbench-fill/trim_skill_fm.py
+++ b/experiments/skillsbench-fill/trim_skill_fm.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Complete the #914 skill-catalog fix: trim bloated SKILL.md frontmatter to the
+canonical name+description so the OpenHands SDK stops silently dropping the skill.
+The SDK drops a SKILL.md whose frontmatter has type-mismatched/extra typed fields
+(compatibility, metadata, dependencies, examples, stats, ...). The skill BODY +
+scripts are untouched, so behavior is identical — only the catalog metadata shrinks.
+Surgical: only the tasks whose with-skill cells fail skill_posture."""
+import glob, os, re
+import yaml
+
+SB = os.path.expanduser("~/skillsbench/tasks")
+TASKS = ["dialogue-parser", "flink-query", "mario-coin-counting"]
+n = 0
+report = []
+for t in TASKS:
+    for sk in sorted(glob.glob(f"{SB}/{t}/environment/skills/*/SKILL.md")):
+        raw = open(sk, encoding="utf-8").read()
+        m = re.match(r"^---\s*\n(.*?)\n---\s*\n?(.*)$", raw, re.S)
+        if not m:
+            report.append(f"  no-frontmatter: {sk}"); continue
+        try:
+            fm = yaml.safe_load(m.group(1)) or {}
+        except Exception as e:
+            report.append(f"  yaml-error {sk}: {e}"); continue
+        body = m.group(2)
+        name, desc = fm.get("name"), fm.get("description")
+        if not name or not desc:
+            report.append(f"  missing name/desc: {sk}"); continue
+        before = len(fm)
+        if before <= 2:
+            report.append(f"  already-clean: {t}/{os.path.basename(os.path.dirname(sk))} ({before} fields)")
+            continue
+        new_fm = yaml.safe_dump({"name": name, "description": desc},
+                                default_flow_style=False, sort_keys=False, allow_unicode=True)
+        open(sk, "w", encoding="utf-8").write("---\n" + new_fm + "---\n" + body)
+        n += 1
+        report.append(f"  TRIMMED: {t}/{os.path.basename(os.path.dirname(sk))} ({before} -> 2 fields)")
+print("\n".join(report))
+print(f"\ntrimmed {n} SKILL.md to name+description")

--- a/experiments/skillsbench-fill/wave_once.sh
+++ b/experiments/skillsbench-fill/wave_once.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# One review->publish->ledger wave (cron, every 5 min, flock-guarded against overlap).
+export PATH="$HOME/.local/bin:/usr/bin:/bin:$PATH"
+cd "$HOME/sb-fill" || exit 0
+python3 review_cell.py
+"$HOME/Experiment/benchflow/.venv/bin/python" publish.py --runs-root jobs \
+    --src-commit "$(git -C "$HOME/skillsbench" rev-parse HEAD 2>/dev/null)"
+python3 build_ledger.py --root .
+echo "[wave $(date -u +%FT%TZ)] reviewed=$(ls review/*.json 2>/dev/null | wc -l) published=$(ls published/*.json 2>/dev/null | wc -l) completed=$(grep -l '"status": "completed"' state/*.json 2>/dev/null | wc -l)"


### PR DESCRIPTION
## What

The harness used to run the Opus 4.8 / Gemini 3.5 Flash / MiniMax M3 **max-effort** SkillsBench fill → HF `refs/pr/5`, plus the **subagent audit** that gates it. It previously lived in a personal repo + on the run VM; consolidating here (`experiments/skillsbench-fill/`) so future fills don't reinvent the wheel.

See [`README.md`](experiments/skillsbench-fill/README.md) for the architecture (ledger state machine, per-model effort wiring, health gate, autonomy crons) and the per-cell run recipe.

## Pairs with
- benchflow #637 — dashboard **Experiments** tab (live fill monitoring)
- skillsbench #914 — the task skill-frontmatter fix this harness surfaced (with-skill cells were silently dropping skills → `task_skills_loading=0`)

## Notes
- **No secrets committed** — scripts read keys from `~/keys.env` / `~/.env` at runtime (verified by scan).
- Some paths default to the run host (`~/sb-fill/`); see README → Configuration.
- The authoritative health gate is a **subagent cluster** running `benchflow-experiment-review` per cell (`audit_evidence.py` feeds it); only agent-confirmed cells count as published-healthy.