### PR TITLE
Task-standard runtime: package, gates, verifier, export, composition, user loops

### DIFF
--- a/docs/examples/task-standard/benchflow-wanted-features/README.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/README.md
@@ -9,7 +9,8 @@ Each package dogfoods a wanted BenchFlow feature. Partial runtime backing now
 exists on the task-standard branch (see the dogfood report follow-up section):
 
 - `runtime-capability-gate`: **mostly landed** — `TaskPackage` / `TaskRuntimeView`,
-  docker/daytona capability gates, `bench tasks check --sandbox`.
+  docker/daytona/modal capability gates, `bench tasks check --sandbox`; still
+  fails closed on `environment.healthcheck` by design.
 - `verifier-package-reward-contract`: **mostly landed** — `VerifierDocument`,
   JSON-first rewards, multi-metric maps, strategy routing (script, reward-kit,
   agent-judge); ORS/hybrid strategies still open.

--- a/docs/examples/task-standard/benchflow-wanted-features/README.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/README.md
@@ -8,15 +8,15 @@ parse as metadata today but are not fully executable runtime features yet.
 Each package dogfoods a wanted BenchFlow feature. Partial runtime backing now
 exists on the task-standard branch (see the dogfood report follow-up section):
 
-- `runtime-capability-gate`: **partial** — `TaskPackage` / `TaskRuntimeView`,
+- `runtime-capability-gate`: **mostly landed** — `TaskPackage` / `TaskRuntimeView`,
   docker/daytona capability gates, `bench tasks check --sandbox`.
-- `verifier-package-reward-contract`: **partial** — `VerifierDocument` parser,
-  `reward.json` precedence, `reward-details.json` copy-through; strategy
-  execution still open.
-- `compat-export-loss-reports`: **partial** — `bench tasks export` with typed
-  loss list; round-trip parity still open.
-- `prompt-user-semantics`: **authoring only** — prompt composition and
-  user/nudge runtime semantics not executable yet.
+- `verifier-package-reward-contract`: **mostly landed** — `VerifierDocument`,
+  JSON-first rewards, multi-metric maps, strategy routing (script only);
+  Reward Kit / agent-judge execution still open.
+- `compat-export-loss-reports`: **mostly landed** — `bench tasks export` with
+  `compatibility/export-report.json`; round-trip parity still open.
+- `prompt-user-semantics`: **partial** — append/replace composition on scene
+  turns; user/nudge loops fail-closed on docker/daytona until executable.
 
 See the dogfood report:
 [2026-06-05-task-standard-benchflow-dogfood.md](../../../reports/2026-06-05-task-standard-benchflow-dogfood.md).

--- a/docs/examples/task-standard/benchflow-wanted-features/README.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/README.md
@@ -15,8 +15,9 @@ exists on the task-standard branch (see the dogfood report follow-up section):
   Reward Kit / agent-judge execution still open.
 - `compat-export-loss-reports`: **mostly landed** — `bench tasks export` with
   `compatibility/export-report.json`; round-trip parity still open.
-- `prompt-user-semantics`: **partial** — append/replace composition on scene
-  turns; user/nudge loops fail-closed on docker/daytona until executable.
+- `prompt-user-semantics`: **mostly landed** — append/replace composition,
+  `DocumentSimulatedUser` + `compile_document_user_loop`, simulated-user
+  nudges via `nudge_budget`; multi-scene user-loop wiring still manual.
 
 See the dogfood report:
 [2026-06-05-task-standard-benchflow-dogfood.md](../../../reports/2026-06-05-task-standard-benchflow-dogfood.md).

--- a/docs/examples/task-standard/benchflow-wanted-features/README.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/README.md
@@ -14,10 +14,11 @@ exists on the task-standard branch (see the dogfood report follow-up section):
   JSON-first rewards, multi-metric maps, strategy routing (script only);
   Reward Kit / agent-judge execution still open.
 - `compat-export-loss-reports`: **mostly landed** — `bench tasks export` with
-  `compatibility/export-report.json`; round-trip parity still open.
+  `compatibility/export-report.json`; `bench tasks round-trip` validates
+  Harbor-compatible field parity (native-only concepts still reported as losses).
 - `prompt-user-semantics`: **mostly landed** — append/replace composition,
   `DocumentSimulatedUser` + `compile_document_user_loop`, simulated-user
-  nudges via `nudge_budget`; multi-scene user-loop wiring still manual.
+  nudges via `nudge_budget`, multi-scene user-loop auto-wiring on `user-loop` scenes.
 
 See the dogfood report:
 [2026-06-05-task-standard-benchflow-dogfood.md](../../../reports/2026-06-05-task-standard-benchflow-dogfood.md).

--- a/docs/examples/task-standard/benchflow-wanted-features/README.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/README.md
@@ -11,8 +11,8 @@ exists on the task-standard branch (see the dogfood report follow-up section):
 - `runtime-capability-gate`: **mostly landed** — `TaskPackage` / `TaskRuntimeView`,
   docker/daytona capability gates, `bench tasks check --sandbox`.
 - `verifier-package-reward-contract`: **mostly landed** — `VerifierDocument`,
-  JSON-first rewards, multi-metric maps, strategy routing (script only);
-  Reward Kit / agent-judge execution still open.
+  JSON-first rewards, multi-metric maps, strategy routing (script, reward-kit,
+  agent-judge); ORS/hybrid strategies still open.
 - `compat-export-loss-reports`: **mostly landed** — `bench tasks export` with
   `compatibility/export-report.json`; `bench tasks round-trip` validates
   Harbor-compatible field parity (native-only concepts still reported as losses).

--- a/docs/examples/task-standard/benchflow-wanted-features/README.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/README.md
@@ -5,17 +5,18 @@ want to do next. They are intentionally outside `docs/examples/task-md/**`
 because they use proposed `benchflow:` and `verifier/verifier.md` fields that
 parse as metadata today but are not fully executable runtime features yet.
 
-Each package is a task for a future implementation agent:
+Each package dogfoods a wanted BenchFlow feature. Partial runtime backing now
+exists on the task-standard branch (see the dogfood report follow-up section):
 
-- `runtime-capability-gate`: build `TaskPackage` / `TaskRuntimeView` and
-  fail-closed runtime capability validation.
-- `verifier-package-reward-contract`: add `VerifierDocument`,
-  `verifier/verifier.md`, Reward Kit preservation, and `reward.json`
-  precedence.
-- `compat-export-loss-reports`: add native-to-Harbor/Pier export and degraded
-  export reports.
-- `prompt-user-semantics`: implement prompt composition and document-declared
-  user/nudge runtime semantics.
+- `runtime-capability-gate`: **partial** — `TaskPackage` / `TaskRuntimeView`,
+  docker/daytona capability gates, `bench tasks check --sandbox`.
+- `verifier-package-reward-contract`: **partial** — `VerifierDocument` parser,
+  `reward.json` precedence, `reward-details.json` copy-through; strategy
+  execution still open.
+- `compat-export-loss-reports`: **partial** — `bench tasks export` with typed
+  loss list; round-trip parity still open.
+- `prompt-user-semantics`: **authoring only** — prompt composition and
+  user/nudge runtime semantics not executable yet.
 
 See the dogfood report:
 [2026-06-05-task-standard-benchflow-dogfood.md](../../../reports/2026-06-05-task-standard-benchflow-dogfood.md).

--- a/docs/examples/task-standard/benchflow-wanted-features/runtime-capability-gate/task.md
+++ b/docs/examples/task-standard/benchflow-wanted-features/runtime-capability-gate/task.md
@@ -24,6 +24,8 @@ environment:
   memory_mb: 8192
   storage_mb: 10240
   workdir: /repo
+  healthcheck:
+    command: "python -c 'print(1)'"
 agents:
   roles:
     architect:

--- a/docs/examples/task-standard/benchflow-wanted-features/verifier-package-reward-contract/verifier/rubrics/verifier.toml
+++ b/docs/examples/task-standard/benchflow-wanted-features/verifier-package-reward-contract/verifier/rubrics/verifier.toml
@@ -1,0 +1,21 @@
+# Structured rubric placeholder for verifier-package-reward-contract dogfood.
+
+[[criteria]]
+id = "verifier_document"
+weight = 0.30
+source = "deterministic"
+
+[[criteria]]
+id = "reward_contract"
+weight = 0.35
+source = "deterministic"
+
+[[criteria]]
+id = "judge_isolation"
+weight = 0.20
+source = "judge"
+
+[[criteria]]
+id = "compatibility"
+weight = 0.15
+source = "deterministic"

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -236,6 +236,23 @@ normalized instruction text, and content hashes for oracle (`solution/`),
 verifier (`tests/`), and `environment/` trees. Mismatches print as issues and
 exit with code 1.
 
+### bench tasks round-trip
+
+Export a native `task.md` package and validate Harbor/Pier round-trip parity in
+one step. Writes the split layout to `--output` (default
+`./<task-name>-round-trip`) plus `compatibility/export-report.json`, then checks
+config, instruction, and oracle/verifier/environment hashes against the source.
+
+```bash
+bench tasks round-trip tasks/my-task
+bench tasks round-trip tasks/my-task --target pier --output /tmp/my-task-rt
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target` | `harbor` | Export target layout (`harbor` or `pier`) |
+| `--output` | `./<task-name>-round-trip` | Directory for exported split layout |
+
 ### bench tasks migrate
 
 Convert a legacy task directory into the unified `task.md` format.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -185,7 +185,7 @@ bench tasks init my-legacy-task --format legacy
 
 Validate a task directory (`task.md` or legacy `task.toml` + `instruction.md`,
 Dockerfile, `verifier/` or legacy `tests/`). With `--sandbox`, also check that
-parsed task fields are supported on the chosen backend (`docker` or `daytona`).
+parsed task fields are supported on the chosen backend (`docker`, `daytona`, or `modal`).
 
 ```bash
 bench tasks check tasks/my-task
@@ -195,7 +195,7 @@ bench tasks check tasks/my-task --sandbox daytona
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--sandbox` | — | Also validate runtime support on `docker` or `daytona` |
+| `--sandbox` | — | Also validate runtime support on `docker`, `daytona`, or `modal` |
 
 ### bench tasks export
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -184,11 +184,35 @@ bench tasks init my-legacy-task --format legacy
 ### bench tasks check
 
 Validate a task directory (`task.md` or legacy `task.toml` + `instruction.md`,
-Dockerfile, `verifier/` or legacy `tests/`).
+Dockerfile, `verifier/` or legacy `tests/`). With `--sandbox`, also check that
+parsed task fields are supported on the chosen backend (`docker` or `daytona`).
 
 ```bash
 bench tasks check tasks/my-task
+bench tasks check tasks/my-task --sandbox docker
+bench tasks check tasks/my-task --sandbox daytona
 ```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--sandbox` | — | Also validate runtime support on `docker` or `daytona` |
+
+### bench tasks export
+
+Export a native `task.md` package to a Harbor or Pier split layout. Writes
+exported files and `compatibility/export-report.json` under `--output`
+(default: `./<task-name>-export`).
+
+```bash
+bench tasks export tasks/my-task
+bench tasks export tasks/my-task --target pier
+bench tasks export tasks/my-task --target harbor --output /tmp/my-task-harbor
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--target` | `harbor` | Export target layout: `harbor` or `pier` |
+| `--output` | `./<task-name>-export` | Directory to write exported files |
 
 ### bench tasks migrate
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -214,6 +214,28 @@ bench tasks export tasks/my-task --target harbor --output /tmp/my-task-harbor
 | `--target` | `harbor` | Export target layout: `harbor` or `pier` |
 | `--output` | `./<task-name>-export` | Directory to write exported files |
 
+### bench tasks import
+
+Import a Harbor or Pier split-layout package (`task.toml`, `instruction.md`,
+`solution/` or `tests/`). When the directory also contains a native `task.md`,
+the command reports whether the split layout matches that co-located document.
+Use `--native` to validate round-trip parity against a separate native package
+(for example, the source directory used with `bench tasks export`).
+
+```bash
+bench tasks import /tmp/my-task-export
+bench tasks import /tmp/my-task-export --native tasks/my-task
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--native` | — | Native `task.md` directory for export→import round-trip validation |
+
+Round-trip validation checks Harbor-compatible fields: canonical `TaskConfig`,
+normalized instruction text, and content hashes for oracle (`solution/`),
+verifier (`tests/`), and `environment/` trees. Mismatches print as issues and
+exit with code 1.
+
 ### bench tasks migrate
 
 Convert a legacy task directory into the unified `task.md` format.

--- a/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
+++ b/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
@@ -120,16 +120,28 @@ feature tasks read better when `oracle/` means reference behavior and
    prompt composition, user loops, and runtime support all need one selected
    view of the task package.
 
+## Implementation Follow-Up (2026-06-05, same branch)
+
+The wanted-feature dogfood packages now have partial runtime backing on
+`cursor/task-standard-runtime-gaps-e453`:
+
+| Wanted feature | Landed | Still open |
+|---|---|---|
+| `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload uses runtime view | Prompt composition, user/nudge compilation, source-hash provenance |
+| Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona` | Modal/K8s matrices, GPU/private-mount gates, narrow gates as features land |
+| `VerifierDocument` | `src/benchflow/task/verifier_document.py`, `check_task` + `Task()` validation | Strategy execution, Reward Kit runtime, agent-judge orchestration |
+| Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export` | Round-trip parity, on-disk `export-report.json`, Pier-specific losses |
+| Reward contract | JSON-first precedence, scalar agreement, `reward-details.json` copy-through | Multi-metric maps without top-level `reward`, aggregate policy |
+
+Regression guard: `tests/test_task_standard_dogfood.py` exercises all four
+wanted-feature packages through structural check, `Task()` load,
+`TaskRuntimeView`, export losses, and docker capability rejection for
+`runtime-capability-gate`.
+
 ## Decision
 
-The standard is useful for real BenchFlow work, but the dogfood pass also shows
-that `task.md` alone is not the product. The missing product surface is the
-runtime view plus verifier package parser:
-
-```text
-TaskPackage = task.md + verifier/verifier.md + oracle/ + environment/ + evidence
-TaskRuntimeView = selected executable interpretation for a specific backend
-```
-
-That should be the next implementation slice.
+The standard is useful for real BenchFlow work. The core missing product
+surface — runtime view plus verifier package parser — now exists in draft form.
+Remaining work is execution depth (strategies, prompt/user runtime, export
+round-trip), not another authoring-format spike.
 

--- a/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
+++ b/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
@@ -128,7 +128,7 @@ The wanted-feature dogfood packages now have partial runtime backing on
 | Wanted feature | Landed | Still open |
 |---|---|---|
 | `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload + runtime summary logging | Source-hash provenance, full prompt composition on base `/instruction.md` |
-| Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona\|modal` | K8s/podman matrices, GPU/private-mount gates, narrow gates as features land |
+| Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, docker/modal `environment.workdir`, healthcheck fail-closed; `bench tasks check --sandbox` | daytona workdir, K8s/podman matrices, GPU/private-mount gates |
 | `VerifierDocument` | `src/benchflow/task/verifier_document.py`, script/reward-kit/agent-judge routing in `Verifier` | ORS/hybrid strategies, full rubric-dimension orchestration |
 | Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export/import/round-trip` | Pier-specific losses; full foreign import preservation |
 | Reward contract | JSON-first precedence, multi-metric maps, `reward-details.json` in `result.json` | Reward Kit execution, aggregate policy from verifier metadata |

--- a/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
+++ b/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
@@ -127,12 +127,12 @@ The wanted-feature dogfood packages now have partial runtime backing on
 
 | Wanted feature | Landed | Still open |
 |---|---|---|
-| `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload uses runtime view | Prompt composition, user/nudge compilation, source-hash provenance |
+| `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload + runtime summary logging | Source-hash provenance, full prompt composition on base `/instruction.md` |
 | Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona` | Modal/K8s matrices, GPU/private-mount gates, narrow gates as features land |
 | `VerifierDocument` | `src/benchflow/task/verifier_document.py`, `check_task` + `Task()` validation | Strategy execution, Reward Kit runtime, agent-judge orchestration |
-| Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export/import` | Pier-specific losses; full foreign import preservation |
+| Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export/import/round-trip` | Pier-specific losses; full foreign import preservation |
 | Reward contract | JSON-first precedence, multi-metric maps, `reward-details.json` in `result.json` | Reward Kit execution, aggregate policy from verifier metadata |
-| Prompt/user semantics | `prompt_composition.py`, `user_loop.py`, `DocumentSimulatedUser` | Multi-scene user-loop auto-wiring, branchable nudges |
+| Prompt/user semantics | `prompt_composition.py`, `user_loop.py`, multi-scene `user-loop` auto-wiring | Branchable nudges, scene-level user-loop metadata |
 
 Regression guard: `tests/test_task_standard_dogfood.py` exercises all four
 wanted-feature packages through structural check, `Task()` load,
@@ -143,6 +143,6 @@ wanted-feature packages through structural check, `Task()` load,
 
 The standard is useful for real BenchFlow work. The core missing product
 surface — runtime view plus verifier package parser — now exists in draft form.
-Remaining work is execution depth (strategies, prompt/user runtime, export
-round-trip), not another authoring-format spike.
+Remaining work is execution depth (reward-kit/agent-judge strategies,
+branchable nudges, Modal/K8s capability matrices), not another authoring-format spike.
 

--- a/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
+++ b/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
@@ -130,8 +130,9 @@ The wanted-feature dogfood packages now have partial runtime backing on
 | `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload uses runtime view | Prompt composition, user/nudge compilation, source-hash provenance |
 | Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona` | Modal/K8s matrices, GPU/private-mount gates, narrow gates as features land |
 | `VerifierDocument` | `src/benchflow/task/verifier_document.py`, `check_task` + `Task()` validation | Strategy execution, Reward Kit runtime, agent-judge orchestration |
-| Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export` | Round-trip parity, on-disk `export-report.json`, Pier-specific losses |
-| Reward contract | JSON-first precedence, scalar agreement, `reward-details.json` copy-through | Multi-metric maps without top-level `reward`, aggregate policy |
+| Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export/import` | Pier-specific losses; full foreign import preservation |
+| Reward contract | JSON-first precedence, multi-metric maps, `reward-details.json` in `result.json` | Reward Kit execution, aggregate policy from verifier metadata |
+| Prompt/user semantics | `prompt_composition.py`, `user_loop.py`, `DocumentSimulatedUser` | Multi-scene user-loop auto-wiring, branchable nudges |
 
 Regression guard: `tests/test_task_standard_dogfood.py` exercises all four
 wanted-feature packages through structural check, `Task()` load,

--- a/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
+++ b/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
@@ -128,7 +128,7 @@ The wanted-feature dogfood packages now have partial runtime backing on
 | Wanted feature | Landed | Still open |
 |---|---|---|
 | `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload + runtime summary logging | Source-hash provenance, full prompt composition on base `/instruction.md` |
-| Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona` | Modal/K8s matrices, GPU/private-mount gates, narrow gates as features land |
+| Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona\|modal` | K8s/podman matrices, GPU/private-mount gates, narrow gates as features land |
 | `VerifierDocument` | `src/benchflow/task/verifier_document.py`, `check_task` + `Task()` validation | Strategy execution, Reward Kit runtime, agent-judge orchestration |
 | Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export/import/round-trip` | Pier-specific losses; full foreign import preservation |
 | Reward contract | JSON-first precedence, multi-metric maps, `reward-details.json` in `result.json` | Reward Kit execution, aggregate policy from verifier metadata |

--- a/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
+++ b/docs/reports/2026-06-05-task-standard-benchflow-dogfood.md
@@ -129,7 +129,7 @@ The wanted-feature dogfood packages now have partial runtime backing on
 |---|---|---|
 | `TaskPackage` / `TaskRuntimeView` | `src/benchflow/task/package.py`, rollout upload + runtime summary logging | Source-hash provenance, full prompt composition on base `/instruction.md` |
 | Runtime capability gates | `src/benchflow/task/runtime_capabilities.py`, wired in rollout + sandbox setup; `bench tasks check --sandbox docker\|daytona\|modal` | K8s/podman matrices, GPU/private-mount gates, narrow gates as features land |
-| `VerifierDocument` | `src/benchflow/task/verifier_document.py`, `check_task` + `Task()` validation | Strategy execution, Reward Kit runtime, agent-judge orchestration |
+| `VerifierDocument` | `src/benchflow/task/verifier_document.py`, script/reward-kit/agent-judge routing in `Verifier` | ORS/hybrid strategies, full rubric-dimension orchestration |
 | Export + loss reports | `src/benchflow/task/export.py`, `bench tasks export/import/round-trip` | Pier-specific losses; full foreign import preservation |
 | Reward contract | JSON-first precedence, multi-metric maps, `reward-details.json` in `result.json` | Reward Kit execution, aggregate policy from verifier metadata |
 | Prompt/user semantics | `prompt_composition.py`, `user_loop.py`, multi-scene `user-loop` auto-wiring | Branchable nudges, scene-level user-loop metadata |
@@ -143,6 +143,6 @@ wanted-feature packages through structural check, `Task()` load,
 
 The standard is useful for real BenchFlow work. The core missing product
 surface — runtime view plus verifier package parser — now exists in draft form.
-Remaining work is execution depth (reward-kit/agent-judge strategies,
-branchable nudges, Modal/K8s capability matrices), not another authoring-format spike.
+Remaining work is execution depth (ORS/hybrid verifier strategies,
+branchable nudges, K8s/podman capability matrices), not another authoring-format spike.
 

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -247,7 +247,7 @@ After the agent finishes, the BenchFlow runtime copies `verifier/` to
 copied to `/tests/` and run from there. The working directory is the
 Dockerfile's `WORKDIR` (typically `/app/` in the example Dockerfile below).
 
-**Your script must write a single float (0.0–1.0) to `/logs/verifier/reward.txt`.** The verifier should write a fresh `reward.txt` or `reward.json` and exit `0`. Current runtime treats a nonzero verifier exit with no fresh reward file as infrastructure failure; if a fresh reward file exists, BenchFlow accepts the reward.
+**Your script must write a reward artifact under `/logs/verifier/`.** Harbor-compatible tasks can write a single float (0.0–1.0) to `reward.txt`. When `reward.json` is present, BenchFlow treats it as authoritative and requires its scalar `reward` to agree with `reward.txt` if both files exist. The verifier should write fresh reward files and exit `0`. Current runtime treats a nonzero verifier exit with no fresh reward file as infrastructure failure; if a fresh reward file exists, BenchFlow accepts the reward.
 
 | Path | Contents |
 |---|---|

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -86,7 +86,9 @@ Frontmatter accepts the same modeled task config fields as Harbor-style
 `multi_step_reward_strategy`.
 Unknown config keys fail validation; arbitrary labels belong under `metadata`.
 BenchFlow-only document keys are `agents`, `scenes`, `user`, and the reserved
-extension namespace `benchflow`. Fields under `benchflow:` are parsed as raw
+extension namespace `benchflow`. A typed P3 subset (`prompt`, `nudges`,
+`compatibility`, `verifier`, `document_version`) is validated by
+`bench tasks check`; additional fields under `benchflow:` are parsed as raw
 document metadata today; the current runtime does not execute every proposed
 extension yet.
 

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -670,9 +670,11 @@ Current implementation status:
 | `task.md` prompt | yes | yes | keep |
 | native `verifier/` | yes | yes | keep |
 | native `oracle/` | yes | yes | keep |
-| `agents.roles` | yes | partial | move scene adoption into `TaskRuntimeView` |
-| `scenes` | yes | partial | define prompt composition and handoff policy |
-| `user` / `## user-persona` | yes | no | compile to a concrete simulated-user loop or mark metadata-only |
+| `agents.roles` | yes | partial | adopted via `TaskRuntimeView.to_rollout_scenes()` |
+| `scenes` | yes | partial | document scenes load into `RolloutConfig`; handoff policy still open |
+| `benchflow.prompt` composition | yes | partial | append/replace on scene turns; rollout default prompt still base-only |
+| `user` / `## user-persona` | yes | partial | `DocumentSimulatedUser` + `compile_document_user_loop`; multi-scene wiring manual |
+| `benchflow.nudges` | yes | partial | simulated-user mode with `nudge_budget`; branchable policy still open |
 | `benchflow:` | raw | no | typed document schema after v0.3 stabilizes |
 | Harbor `steps` | yes | no/partial | fail closed per sandbox until implemented |
 | root/step artifacts | yes | no/partial | implement collection or fail closed |
@@ -683,8 +685,8 @@ Current implementation status:
 | `reward.json` precedence | yes | yes | keep scalar agreement checks; multi-metric maps synthesize mean or honor JSON `aggregate_policy.field` |
 | `reward-details.json` preservation | yes | yes | copy through verifier rollout download; no parsing yet |
 | `TaskPackage` / `TaskRuntimeView` | yes | partial | entrypoint, dirs, scenes, alias collisions, `verifier_document`; prompt composition and sandbox gates still partial |
-| runtime capability gates (docker/daytona) | yes | partial | `validate_task_runtime_support` wired before sandbox creation; more backends and `bench tasks check --sandbox` pending |
-| Harbor/Pier export | yes | partial | native `task.md` export with loss reports; round-trip equivalence and alias parity pending |
+| runtime capability gates (docker/daytona) | yes | partial | `validate_task_runtime_support` + `bench tasks check --sandbox`; more backends pending |
+| Harbor/Pier export | yes | partial | `bench tasks export` + `compatibility/export-report.json`; `bench tasks import --native` round-trip |
 | native `/task.md` upload | yes | yes | keep `/instruction.md` compatibility contract |
 | alias dir collision checks | yes | partial | `bench tasks check` and `Task()` load fail closed; export parity pending |
 

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -685,7 +685,7 @@ Current implementation status:
 | `reward.json` precedence | yes | yes | keep scalar agreement checks; multi-metric maps synthesize mean or honor JSON `aggregate_policy.field` |
 | `reward-details.json` preservation | yes | yes | copy through verifier rollout download; no parsing yet |
 | `TaskPackage` / `TaskRuntimeView` | yes | partial | entrypoint, dirs, scenes, alias collisions, `verifier_document`; prompt composition and sandbox gates still partial |
-| runtime capability gates (docker/daytona) | yes | partial | `validate_task_runtime_support` + `bench tasks check --sandbox`; more backends pending |
+| runtime capability gates (docker/daytona/modal) | yes | partial | `validate_task_runtime_support` + `bench tasks check --sandbox`; K8s/podman pending |
 | Harbor/Pier export | yes | partial | `bench tasks export` + `compatibility/export-report.json`; `bench tasks round-trip` / `import --native` parity checks |
 | native `/task.md` upload | yes | yes | keep `/instruction.md` compatibility contract |
 | alias dir collision checks | yes | partial | `bench tasks check` and `Task()` load fail closed; export parity pending |
@@ -710,7 +710,7 @@ This module should answer:
 - whether mixed native/legacy definitions and alias directories are equivalent
   or collisions
 
-P1: Fail-closed capability checks (partial on docker/daytona).
+P1: Fail-closed capability checks (partial on docker/daytona/modal).
 
 Rollout, verifier, hardening, and adapters should stop parsing fields they do
 not execute without surfacing a validation result.

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -422,8 +422,10 @@ Target reward precedence:
   and task-specific payloads such as `metrics`, `regressions`, `participants`,
   `winner`, `raw`, and `debug`
 
-Current runtime does not yet fully match that target: `reward.txt` can take
-precedence over `reward.json`, and structured top-level JSON is limited.
+Current runtime still does not fully match that target: `reward.json` is now
+authoritative when present and scalar mismatches against `reward.txt` fail
+closed, but structured top-level JSON remains limited and multi-metric maps
+without a declared aggregate policy are not yet first-class.
 
 Validation evidence should include parser checks, legacy-vs-native migration
 parity, live rollout artifacts, negative-contract failures, and explicit
@@ -673,7 +675,9 @@ Current implementation status:
 | separate verifier env | yes | no/partial | materializer plus verifier runner support |
 | Windows / TPU | yes | no | fail closed |
 | healthcheck / workdir | yes | no/partial | materializer support |
-| `reward.json` precedence | yes | partial | prefer JSON when present and reject both-present mismatches |
+| `reward.json` precedence | yes | yes | keep scalar agreement checks; add multi-metric aggregate policy |
+| native `/task.md` upload | yes | yes | keep `/instruction.md` compatibility contract |
+| alias dir collision checks | yes | partial | `bench tasks check` and `Task()` load fail closed; export parity pending |
 
 Today `bench tasks check` is structural. A future sandbox-aware check, for
 example `bench tasks check --sandbox <backend>`, should validate this matrix. A

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -673,7 +673,7 @@ Current implementation status:
 | `agents.roles` | yes | partial | adopted via `TaskRuntimeView.to_rollout_scenes()` |
 | `scenes` | yes | partial | document scenes load into `RolloutConfig`; handoff policy still open |
 | `benchflow.prompt` composition | yes | partial | append/replace on scene turns; rollout default prompt still base-only |
-| `user` / `## user-persona` | yes | partial | `DocumentSimulatedUser` + `compile_document_user_loop`; multi-scene wiring manual |
+| `user` / `## user-persona` | yes | partial | `DocumentSimulatedUser` + `compile_document_user_loop`; multi-scene `user-loop` scenes auto-wire |
 | `benchflow.nudges` | yes | partial | simulated-user mode with `nudge_budget`; branchable policy still open |
 | `benchflow:` | raw | no | typed document schema after v0.3 stabilizes |
 | Harbor `steps` | yes | no/partial | fail closed per sandbox until implemented |
@@ -686,7 +686,7 @@ Current implementation status:
 | `reward-details.json` preservation | yes | yes | copy through verifier rollout download; no parsing yet |
 | `TaskPackage` / `TaskRuntimeView` | yes | partial | entrypoint, dirs, scenes, alias collisions, `verifier_document`; prompt composition and sandbox gates still partial |
 | runtime capability gates (docker/daytona) | yes | partial | `validate_task_runtime_support` + `bench tasks check --sandbox`; more backends pending |
-| Harbor/Pier export | yes | partial | `bench tasks export` + `compatibility/export-report.json`; `bench tasks import --native` round-trip |
+| Harbor/Pier export | yes | partial | `bench tasks export` + `compatibility/export-report.json`; `bench tasks round-trip` / `import --native` parity checks |
 | native `/task.md` upload | yes | yes | keep `/instruction.md` compatibility contract |
 | alias dir collision checks | yes | partial | `bench tasks check` and `Task()` load fail closed; export parity pending |
 

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -13,7 +13,7 @@ The standard is intentionally split into three views:
 | View | Purpose | Owner |
 |---|---|---|
 | Authoring document | What humans and generators write: one `task.md` plus sidecar dirs | `TaskDocument` |
-| Runtime task view | What rollout, verifier, hardening, provenance, and trajectories consume | future `TaskPackage` / `TaskRuntimeView` |
+| Runtime task view | What rollout, verifier, hardening, provenance, and trajectories consume | `TaskPackage` / `TaskRuntimeView` |
 | Foreign adapter view | What Harbor, Pier, Terminal-Bench, SWE-bench, Inspect, and hosted envs import/export | adapters |
 
 Do not treat these as the same interface. A good authoring document can include
@@ -416,7 +416,8 @@ Target reward precedence:
   match `float(reward.txt)` or validation should fail closed
 - if `reward.json` is a multi-metric map, verifier metadata must declare the
   aggregate policy used for scalar exports and training records
-- `reward-details.json` should be preserved when present
+- `reward-details.json` is preserved when present (copied through verifier
+  rollout download without parsing)
 - reward artifacts should preserve structured reserved keys such as `rubric`,
   `items`, `evidence`, `artifacts`, `metadata`, `reason`, `reasons`, `errors`,
   and task-specific payloads such as `metrics`, `regressions`, `participants`,
@@ -676,6 +677,10 @@ Current implementation status:
 | Windows / TPU | yes | no | fail closed |
 | healthcheck / workdir | yes | no/partial | materializer support |
 | `reward.json` precedence | yes | yes | keep scalar agreement checks; add multi-metric aggregate policy |
+| `reward-details.json` preservation | yes | yes | copy through verifier rollout download; no parsing yet |
+| `TaskPackage` / `TaskRuntimeView` | yes | partial | entrypoint, dirs, scenes, alias collisions, `verifier_document`; prompt composition and sandbox gates still partial |
+| runtime capability gates (docker/daytona) | yes | partial | `validate_task_runtime_support` wired before sandbox creation; more backends and `bench tasks check --sandbox` pending |
+| Harbor/Pier export | yes | partial | native `task.md` export with loss reports; round-trip equivalence and alias parity pending |
 | native `/task.md` upload | yes | yes | keep `/instruction.md` compatibility contract |
 | alias dir collision checks | yes | partial | `bench tasks check` and `Task()` load fail closed; export parity pending |
 
@@ -686,7 +691,7 @@ error.
 
 ## Architecture Slices
 
-P0: Add `TaskPackage` / `TaskRuntimeView`.
+P0: `TaskPackage` / `TaskRuntimeView` (partial).
 
 This module should answer:
 
@@ -699,7 +704,7 @@ This module should answer:
 - whether mixed native/legacy definitions and alias directories are equivalent
   or collisions
 
-P1: Add fail-closed capability checks.
+P1: Fail-closed capability checks (partial on docker/daytona).
 
 Rollout, verifier, hardening, and adapters should stop parsing fields they do
 not execute without surfacing a validation result.

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -425,8 +425,12 @@ Target reward precedence:
 
 Current runtime still does not fully match that target: `reward.json` is now
 authoritative when present and scalar mismatches against `reward.txt` fail
-closed, but structured top-level JSON remains limited and multi-metric maps
-without a declared aggregate policy are not yet first-class.
+closed. Multi-metric Harbor Reward Kit maps are accepted when every non-reserved
+top-level key is a numeric reward in `[0, 1]`; the runtime synthesizes a
+canonical `reward` as the unweighted mean of those metrics unless
+`aggregate_policy.field` is set in the JSON. Verifier-document
+`outputs.aggregate_policy` remains metadata for authors and is not yet wired
+into runtime synthesis beyond the JSON field.
 
 Validation evidence should include parser checks, legacy-vs-native migration
 parity, live rollout artifacts, negative-contract failures, and explicit
@@ -676,7 +680,7 @@ Current implementation status:
 | separate verifier env | yes | no/partial | materializer plus verifier runner support |
 | Windows / TPU | yes | no | fail closed |
 | healthcheck / workdir | yes | no/partial | materializer support |
-| `reward.json` precedence | yes | yes | keep scalar agreement checks; add multi-metric aggregate policy |
+| `reward.json` precedence | yes | yes | keep scalar agreement checks; multi-metric maps synthesize mean or honor JSON `aggregate_policy.field` |
 | `reward-details.json` preservation | yes | yes | copy through verifier rollout download; no parsing yet |
 | `TaskPackage` / `TaskRuntimeView` | yes | partial | entrypoint, dirs, scenes, alias collisions, `verifier_document`; prompt composition and sandbox gates still partial |
 | runtime capability gates (docker/daytona) | yes | partial | `validate_task_runtime_support` wired before sandbox creation; more backends and `bench tasks check --sandbox` pending |

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -675,7 +675,7 @@ Current implementation status:
 | `benchflow.prompt` composition | yes | partial | append/replace on scene turns; rollout default prompt still base-only |
 | `user` / `## user-persona` | yes | partial | `DocumentSimulatedUser` + `compile_document_user_loop`; multi-scene `user-loop` scenes auto-wire |
 | `benchflow.nudges` | yes | partial | simulated-user mode with `nudge_budget`; branchable policy still open |
-| `benchflow:` | raw | no | typed document schema after v0.3 stabilizes |
+| `benchflow:` | raw | partial | P3 typed subset (`prompt`, `nudges`, `compatibility`, `verifier`) via `validate_benchflow_metadata` |
 | Harbor `steps` | yes | no/partial | fail closed per sandbox until implemented |
 | root/step artifacts | yes | no/partial | implement collection or fail closed |
 | network allowlist | yes | no/partial | per-sandbox capability check |
@@ -683,7 +683,8 @@ Current implementation status:
 | Windows / TPU | yes | no | fail closed |
 | healthcheck / workdir | yes | no/partial | materializer support |
 | `reward.json` precedence | yes | yes | keep scalar agreement checks; multi-metric maps synthesize mean or honor JSON `aggregate_policy.field` |
-| `reward-details.json` preservation | yes | yes | copy through verifier rollout download; no parsing yet |
+| `reward-details.json` preservation | yes | yes | copy through verifier rollout download; agent-judge writes details on LLM runs |
+| `verifier/verifier.md` strategies | yes | partial | script + reward-kit (criteria → `test.sh`) + agent-judge (role + structured rubric → LLM judge); ORS/hybrid still open |
 | `TaskPackage` / `TaskRuntimeView` | yes | partial | entrypoint, dirs, scenes, alias collisions, `verifier_document`; prompt composition and sandbox gates still partial |
 | runtime capability gates (docker/daytona/modal) | yes | partial | `validate_task_runtime_support` + `bench tasks check --sandbox`; K8s/podman pending |
 | Harbor/Pier export | yes | partial | `bench tasks export` + `compatibility/export-report.json`; `bench tasks round-trip` / `import --native` parity checks |

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -681,7 +681,8 @@ Current implementation status:
 | network allowlist | yes | no/partial | per-sandbox capability check |
 | separate verifier env | yes | no/partial | materializer plus verifier runner support |
 | Windows / TPU | yes | no | fail closed |
-| healthcheck / workdir | yes | no/partial | materializer support |
+| healthcheck | yes | no/partial | fail closed until startup execution lands |
+| environment.workdir | yes | partial | docker + modal compose/exec defaults; daytona pending |
 | `reward.json` precedence | yes | yes | keep scalar agreement checks; multi-metric maps synthesize mean or honor JSON `aggregate_policy.field` |
 | `reward-details.json` preservation | yes | yes | copy through verifier rollout download; agent-judge writes details on LLM runs |
 | `verifier/verifier.md` strategies | yes | partial | script + reward-kit (criteria → `test.sh`) + agent-judge (role + structured rubric → LLM judge); ORS/hybrid still open |

--- a/src/benchflow/_utils/task_authoring.py
+++ b/src/benchflow/_utils/task_authoring.py
@@ -13,6 +13,7 @@ from benchflow.task.document import (
     TaskDocumentParseError,
     render_task_md_from_legacy,
 )
+from benchflow.task.aliases import alias_dir_collision_issues
 from benchflow.task.paths import TaskPaths
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ def check_task(task_dir: Path) -> list[str]:
         issues.append("Missing environment/Dockerfile")
 
     paths = TaskPaths(task_dir)
-    issues.extend(_check_alias_dir_collisions(paths))
+    issues.extend(alias_dir_collision_issues(paths))
 
     # Check verifier code. Native tasks use verifier/; tests/ remains the
     # legacy alias for existing Harbor-style task packages.
@@ -147,46 +148,6 @@ def _check_ctrf_path(test_sh: Path) -> list[str]:
             f"(expected '{_CTRF_STANDARD_PATH}')"
         ]
     return []
-
-
-def _normalized_tree_map(root: Path) -> dict[str, bytes]:
-    """Map relative POSIX paths to file bytes for every file under *root*."""
-    if not root.is_dir():
-        return {}
-    files: dict[str, bytes] = {}
-    for path in sorted(root.rglob("*")):
-        if path.is_file():
-            files[path.relative_to(root).as_posix()] = path.read_bytes()
-    return files
-
-
-def _check_alias_dir_collisions(paths: TaskPaths) -> list[str]:
-    """Fail closed when native and legacy alias trees disagree."""
-    issues: list[str] = []
-    pairs = (
-        (
-            paths.oracle_dir,
-            paths.legacy_solution_dir,
-            TaskPaths.NATIVE_ORACLE_DIRNAME,
-            TaskPaths.LEGACY_SOLUTION_DIRNAME,
-        ),
-        (
-            paths.verifier_source_dir,
-            paths.legacy_tests_dir,
-            TaskPaths.NATIVE_VERIFIER_DIRNAME,
-            TaskPaths.LEGACY_TESTS_DIRNAME,
-        ),
-    )
-    for native_dir, legacy_dir, native_name, legacy_name in pairs:
-        if not native_dir.is_dir() or not legacy_dir.is_dir():
-            continue
-        if _normalized_tree_map(native_dir) == _normalized_tree_map(legacy_dir):
-            continue
-        issues.append(
-            f"Alias collision: {native_name}/ and {legacy_name}/ both exist "
-            "but are not byte-identical"
-        )
-    return issues
 
 
 def _logical_dir_label(paths: TaskPaths, *, kind: Literal["verifier", "oracle"]) -> str:

--- a/src/benchflow/_utils/task_authoring.py
+++ b/src/benchflow/_utils/task_authoring.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Literal
 
 from benchflow.task.aliases import alias_dir_collision_issues
+from benchflow.task.benchflow_schema import validate_benchflow_metadata
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import (
     TaskDocument,
@@ -129,6 +130,7 @@ def check_task(task_dir: Path) -> list[str]:
     if task_document is not None:
         benchflow = task_document.benchflow
         if isinstance(benchflow, dict):
+            issues.extend(validate_benchflow_metadata(benchflow))
             benchflow_verifier = benchflow.get("verifier")
             if isinstance(benchflow_verifier, dict):
                 issues.extend(

--- a/src/benchflow/_utils/task_authoring.py
+++ b/src/benchflow/_utils/task_authoring.py
@@ -88,6 +88,7 @@ def check_task(task_dir: Path) -> list[str]:
         issues.append("Missing environment/Dockerfile")
 
     paths = TaskPaths(task_dir)
+    issues.extend(_check_alias_dir_collisions(paths))
 
     # Check verifier code. Native tasks use verifier/; tests/ remains the
     # legacy alias for existing Harbor-style task packages.
@@ -146,6 +147,46 @@ def _check_ctrf_path(test_sh: Path) -> list[str]:
             f"(expected '{_CTRF_STANDARD_PATH}')"
         ]
     return []
+
+
+def _normalized_tree_map(root: Path) -> dict[str, bytes]:
+    """Map relative POSIX paths to file bytes for every file under *root*."""
+    if not root.is_dir():
+        return {}
+    files: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            files[path.relative_to(root).as_posix()] = path.read_bytes()
+    return files
+
+
+def _check_alias_dir_collisions(paths: TaskPaths) -> list[str]:
+    """Fail closed when native and legacy alias trees disagree."""
+    issues: list[str] = []
+    pairs = (
+        (
+            paths.oracle_dir,
+            paths.legacy_solution_dir,
+            TaskPaths.NATIVE_ORACLE_DIRNAME,
+            TaskPaths.LEGACY_SOLUTION_DIRNAME,
+        ),
+        (
+            paths.verifier_source_dir,
+            paths.legacy_tests_dir,
+            TaskPaths.NATIVE_VERIFIER_DIRNAME,
+            TaskPaths.LEGACY_TESTS_DIRNAME,
+        ),
+    )
+    for native_dir, legacy_dir, native_name, legacy_name in pairs:
+        if not native_dir.is_dir() or not legacy_dir.is_dir():
+            continue
+        if _normalized_tree_map(native_dir) == _normalized_tree_map(legacy_dir):
+            continue
+        issues.append(
+            f"Alias collision: {native_name}/ and {legacy_name}/ both exist "
+            "but are not byte-identical"
+        )
+    return issues
 
 
 def _logical_dir_label(paths: TaskPaths, *, kind: Literal["verifier", "oracle"]) -> str:

--- a/src/benchflow/_utils/task_authoring.py
+++ b/src/benchflow/_utils/task_authoring.py
@@ -7,14 +7,15 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from benchflow.task.aliases import alias_dir_collision_issues
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import (
     TaskDocument,
     TaskDocumentParseError,
     render_task_md_from_legacy,
 )
-from benchflow.task.aliases import alias_dir_collision_issues
 from benchflow.task.paths import TaskPaths
+from benchflow.task.verifier_document import verifier_document_issues
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +47,10 @@ def check_task(task_dir: Path) -> list[str]:
     task_md = task_dir / TASK_DOCUMENT_FILE
     has_task_md = task_md.exists()
 
+    task_document: TaskDocument | None = None
     if has_task_md:
-        issues.extend(_check_task_document(task_md))
+        task_document, doc_issues = _check_task_document(task_md)
+        issues.extend(doc_issues)
     else:
         for f in LEGACY_REQUIRED_FILES:
             if not (task_dir / f).exists():
@@ -122,6 +125,18 @@ def check_task(task_dir: Path) -> list[str]:
                 f"{label}/solve.sh contains unreplaced placeholder — "
                 "write a real oracle solution before running the task"
             )
+
+    if task_document is not None:
+        benchflow = task_document.benchflow
+        if isinstance(benchflow, dict):
+            benchflow_verifier = benchflow.get("verifier")
+            if isinstance(benchflow_verifier, dict):
+                issues.extend(
+                    verifier_document_issues(
+                        task_dir,
+                        benchflow_verifier=benchflow_verifier,
+                    )
+                )
 
     return issues
 
@@ -326,14 +341,14 @@ def migrate_task_to_task_md(
     )
 
 
-def _check_task_document(task_md: Path) -> list[str]:
+def _check_task_document(task_md: Path) -> tuple[TaskDocument | None, list[str]]:
     issues: list[str] = []
     try:
         document = TaskDocument.from_path(task_md)
     except TaskDocumentParseError as e:
-        return [f"task.md parse error: {e}"]
+        return None, [f"task.md parse error: {e}"]
     except Exception as e:
-        return [f"task.md parse error: {e}"]
+        return None, [f"task.md parse error: {e}"]
 
     text = task_md.read_text()
     if not document.instruction.strip():
@@ -343,7 +358,7 @@ def _check_task_document(task_md: Path) -> list[str]:
             "task.md contains unreplaced placeholder - replace "
             "task prompts, role prompts, and simulated-user notes"
         )
-    return issues
+    return document, issues
 
 
 def _write_legacy_task_files(task_dir: Path, name: str) -> None:

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -736,13 +736,7 @@ def tasks_export(
     ] = None,
 ) -> None:
     """Export a native task.md package to Harbor/Pier split layout."""
-    import json
-
-    from benchflow.task.export import (
-        EXPORT_REPORT_REL_PATH,
-        export_report_json,
-        export_task_package,
-    )
+    from benchflow.task.export import export_task_package, materialize_export_result
 
     output_dir = output or (Path.cwd() / f"{task_dir.name}-export")
     try:
@@ -754,18 +748,7 @@ def tasks_export(
         console.print(f"[red]Export failed:[/red] {exc}")
         raise typer.Exit(1) from exc
 
-    output_dir.mkdir(parents=True, exist_ok=True)
-    for rel_path, content in result.files.items():
-        dest = output_dir / rel_path
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        dest.write_text(content)
-
-    report_path = output_dir / EXPORT_REPORT_REL_PATH
-    report_path.parent.mkdir(parents=True, exist_ok=True)
-    report_path.write_text(
-        json.dumps(export_report_json(result), indent=2) + "\n",
-        encoding="utf-8",
-    )
+    materialize_export_result(result, output_dir)
 
     console.print(
         f"[bold]Export[/bold] {result.target} ({result.mode}) "
@@ -784,6 +767,56 @@ def tasks_export(
             console.print(f"  [yellow]→[/yellow] {loss.concept}: {loss.reason}")
     else:
         console.print("[green]No export losses[/green]")
+
+
+@tasks_app.command("import")
+def tasks_import(
+    task_dir: Annotated[
+        Path, typer.Argument(help="Path to Harbor/Pier split-layout directory")
+    ],
+    native_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--native",
+            help="Optional native task.md directory for round-trip validation",
+        ),
+    ] = None,
+) -> None:
+    """Import a Harbor/Pier split package and optionally validate round-trip parity."""
+    from benchflow.task.export import (
+        import_split_task_package,
+        validate_export_round_trip,
+    )
+
+    try:
+        imported = import_split_task_package(task_dir)
+    except FileNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from None
+    except Exception as exc:
+        console.print(f"[red]Import failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    console.print(
+        f"[bold]Import[/bold] split package — "
+        f"{len(imported.oracle_hashes)} oracle file(s), "
+        f"{len(imported.verifier_hashes)} verifier file(s)"
+    )
+    if imported.native_comparison is not None:
+        comparison = imported.native_comparison
+        if comparison.config_equal and comparison.instruction_equal:
+            console.print("[green]Co-located native task.md matches split import[/green]")
+        else:
+            console.print("[yellow]Co-located native task.md differs from split import[/yellow]")
+
+    if native_dir is not None:
+        issues = validate_export_round_trip(native_dir, task_dir)
+        if issues:
+            console.print(f"[yellow]Round-trip issues ({len(issues)}):[/yellow]")
+            for issue in issues:
+                console.print(f"  [yellow]→[/yellow] {issue}")
+            raise typer.Exit(1)
+        console.print("[green]Round-trip parity OK[/green]")
 
 
 @tasks_app.command("migrate")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -819,6 +819,54 @@ def tasks_import(
         console.print("[green]Round-trip parity OK[/green]")
 
 
+@tasks_app.command("round-trip")
+def tasks_round_trip(
+    task_dir: Annotated[Path, typer.Argument(help="Path to native task.md directory")],
+    target: Annotated[
+        Literal["harbor", "pier"],
+        typer.Option("--target", help="Export target layout"),
+    ] = "harbor",
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", help="Directory to write exported files"),
+    ] = None,
+) -> None:
+    """Export a native package and validate Harbor/Pier round-trip parity."""
+    from benchflow.task.export import (
+        export_task_package,
+        materialize_export_result,
+        validate_export_round_trip,
+    )
+
+    output_dir = output or (Path.cwd() / f"{task_dir.name}-round-trip")
+    try:
+        result = export_task_package(task_dir, target=target)
+        materialize_export_result(result, output_dir)
+        issues = validate_export_round_trip(task_dir, output_dir)
+    except FileNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from None
+    except Exception as exc:
+        console.print(f"[red]Round-trip failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    console.print(
+        f"[bold]Round-trip[/bold] {result.target} ({result.mode}) "
+        f"— {len(result.files)} file(s) → {output_dir}"
+    )
+    if result.losses:
+        console.print(
+            f"[dim]Export losses ({len(result.losses)}) recorded in "
+            f"compatibility/export-report.json[/dim]"
+        )
+    if issues:
+        console.print(f"[red]Round-trip issues ({len(issues)}):[/red]")
+        for issue in issues:
+            console.print(f"  [red]→[/red] {issue}")
+        raise typer.Exit(1)
+    console.print("[green]Round-trip parity OK[/green]")
+
+
 @tasks_app.command("migrate")
 def tasks_migrate(
     task_dir: Annotated[Path, typer.Argument(help="Legacy task directory")],

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -670,6 +670,13 @@ def tasks_init(
 @tasks_app.command("check")
 def tasks_check(
     task_dir: Annotated[Path, typer.Argument(help="Path to task directory")],
+    sandbox: Annotated[
+        Literal["docker", "daytona"] | None,
+        typer.Option(
+            "--sandbox",
+            help="Also validate parsed fields against this sandbox backend",
+        ),
+    ] = None,
 ) -> None:
     """Validate a task directory structure."""
     from rich.markup import escape
@@ -686,6 +693,84 @@ def tasks_check(
             # render verbatim instead of being parsed as styling (#379).
             console.print(f"  [yellow]→[/yellow] {escape(issue)}")
         raise typer.Exit(1)
+
+    if sandbox is None:
+        return
+
+    from benchflow.task import Task
+    from benchflow.task.runtime_capabilities import validate_task_runtime_support
+
+    try:
+        task = Task(task_dir)
+    except ValueError as exc:
+        console.print(f"[red]Cannot load task for runtime check:[/red] {exc}")
+        raise typer.Exit(1) from None
+
+    runtime_issues = validate_task_runtime_support(task, sandbox, task_dir)
+    if runtime_issues:
+        console.print(
+            f"[red]✗[/red] {task_dir.name} — "
+            f"{len(runtime_issues)} unsupported feature(s) on {sandbox}:"
+        )
+        for issue in runtime_issues:
+            console.print(
+                f"  [yellow]→[/yellow] {escape(issue.path)}: {escape(issue.reason)}"
+            )
+        raise typer.Exit(1)
+
+    console.print(
+        f"[green]✓[/green] {task_dir.name} — runtime supported on {sandbox}"
+    )
+
+
+@tasks_app.command("export")
+def tasks_export(
+    task_dir: Annotated[Path, typer.Argument(help="Path to native task.md directory")],
+    target: Annotated[
+        Literal["harbor", "pier"],
+        typer.Option("--target", help="Export target layout"),
+    ] = "harbor",
+    output: Annotated[
+        Path | None,
+        typer.Option("--output", help="Directory to write exported files"),
+    ] = None,
+) -> None:
+    """Export a native task.md package to Harbor/Pier split layout."""
+    from benchflow.task.export import export_task_package
+
+    output_dir = output or (Path.cwd() / f"{task_dir.name}-export")
+    try:
+        result = export_task_package(task_dir, target=target)
+    except FileNotFoundError as exc:
+        console.print(f"[red]{exc}[/red]")
+        raise typer.Exit(1) from None
+    except Exception as exc:
+        console.print(f"[red]Export failed:[/red] {exc}")
+        raise typer.Exit(1) from exc
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for rel_path, content in result.files.items():
+        dest = output_dir / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+
+    console.print(
+        f"[bold]Export[/bold] {result.target} ({result.mode}) "
+        f"— {len(result.files)} file(s) → {output_dir}"
+    )
+    console.print(
+        f"  Definition: {result.selected_definition} → "
+        f"{result.exported_oracle_dir}, {result.exported_verifier_dir}"
+    )
+    if result.ignored_aliases:
+        console.print(f"  [dim]Ignored aliases:[/dim] {', '.join(result.ignored_aliases)}")
+
+    if result.losses:
+        console.print(f"[yellow]Losses ({len(result.losses)}):[/yellow]")
+        for loss in result.losses:
+            console.print(f"  [yellow]→[/yellow] {loss.concept}: {loss.reason}")
+    else:
+        console.print("[green]No export losses[/green]")
 
 
 @tasks_app.command("migrate")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -671,7 +671,7 @@ def tasks_init(
 def tasks_check(
     task_dir: Annotated[Path, typer.Argument(help="Path to task directory")],
     sandbox: Annotated[
-        Literal["docker", "daytona"] | None,
+        Literal["docker", "daytona", "modal"] | None,
         typer.Option(
             "--sandbox",
             help="Also validate parsed fields against this sandbox backend",

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -736,7 +736,13 @@ def tasks_export(
     ] = None,
 ) -> None:
     """Export a native task.md package to Harbor/Pier split layout."""
-    from benchflow.task.export import export_task_package
+    import json
+
+    from benchflow.task.export import (
+        EXPORT_REPORT_REL_PATH,
+        export_report_json,
+        export_task_package,
+    )
 
     output_dir = output or (Path.cwd() / f"{task_dir.name}-export")
     try:
@@ -753,6 +759,13 @@ def tasks_export(
         dest = output_dir / rel_path
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_text(content)
+
+    report_path = output_dir / EXPORT_REPORT_REL_PATH
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(export_report_json(result), indent=2) + "\n",
+        encoding="utf-8",
+    )
 
     console.print(
         f"[bold]Export[/bold] {result.target} ({result.mode}) "

--- a/src/benchflow/rewards/builtins.py
+++ b/src/benchflow/rewards/builtins.py
@@ -60,7 +60,7 @@ class TestRewardFunc:
             except RewardFileParseError:
                 return 0.0
             reward = rewards.get("reward")
-            if is_valid_reward_number(reward):
+            if isinstance(reward, int | float) and is_valid_reward_number(reward):
                 return float(reward)
             return 0.0
         return 0.0

--- a/src/benchflow/rewards/builtins.py
+++ b/src/benchflow/rewards/builtins.py
@@ -19,7 +19,11 @@ from benchflow.rewards.rubric_config import (
     _coerce_space,
     load_rubric,
 )
-from benchflow.rewards.validation import is_valid_reward_number
+from benchflow.rewards.validation import (
+    RewardFileParseError,
+    is_valid_reward_number,
+    parse_verifier_reward_files,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -29,23 +33,37 @@ class JudgeScoringError(RuntimeError):
 
 
 class TestRewardFunc:
-    """Wraps existing test.sh -> reward.txt flow. Backward compatible.
+    """Wraps existing test.sh reward file flow. Backward compatible.
 
-    Reads ``reward.txt`` from *rollout_dir* and parses the first float.
-    Returns 0.0 when the file is missing or unparseable.
+    Prefers ``reward.json`` over ``reward.txt`` under *rollout_dir* or
+    ``verifier/`` and returns the canonical scalar ``reward``. Returns 0.0 when
+    reward files are missing or unparseable.
     """
 
     async def score(self, rollout_dir: Path) -> float:
-        reward_path = rollout_dir / "reward.txt"
-        if not reward_path.exists():
+        candidates = (
+            (rollout_dir / "reward.txt", rollout_dir / "reward.json"),
+            (
+                rollout_dir / "verifier" / "reward.txt",
+                rollout_dir / "verifier" / "reward.json",
+            ),
+        )
+        for reward_text_path, reward_json_path in candidates:
+            if not reward_text_path.exists() and not reward_json_path.exists():
+                continue
+            try:
+                rewards = parse_verifier_reward_files(
+                    reward_text_path=reward_text_path,
+                    reward_json_path=reward_json_path,
+                    source="reward files",
+                )
+            except RewardFileParseError:
+                return 0.0
+            reward = rewards.get("reward")
+            if is_valid_reward_number(reward):
+                return float(reward)
             return 0.0
-        text = reward_path.read_text().strip()
-        if not text:
-            return 0.0
-        try:
-            return float(text.splitlines()[0].strip())
-        except (ValueError, IndexError):
-            return 0.0
+        return 0.0
 
 
 # ---------------------------------------------------------------------------

--- a/src/benchflow/rewards/rubric_config.py
+++ b/src/benchflow/rewards/rubric_config.py
@@ -120,8 +120,15 @@ class RubricConfig:
 
 
 def _parse_criterion(raw: dict) -> Criterion:
+    description = (
+        raw.get("description")
+        or raw.get("match_criteria")
+        or raw.get("title")
+        or raw.get("id")
+        or ""
+    )
     return Criterion(
-        description=raw.get("description", ""),
+        description=str(description),
         type=raw.get("type", "binary"),
         name=raw.get("name") or raw.get("id"),
         points=raw.get("points", 5),
@@ -157,7 +164,8 @@ def load_rubric_toml(path: Path) -> RubricConfig:
         data = tomllib.load(f)
 
     judge = _parse_judge(data.get("judge", {}))
-    criteria = [_parse_criterion(c) for c in data.get("criterion", [])]
+    raw_criteria = data.get("criteria", data.get("criterion", []))
+    criteria = [_parse_criterion(c) for c in raw_criteria]
     scoring = _parse_scoring(data.get("scoring", {}))
 
     return RubricConfig(judge=judge, criteria=criteria, scoring=scoring)

--- a/src/benchflow/rewards/validation.py
+++ b/src/benchflow/rewards/validation.py
@@ -11,6 +11,28 @@ from typing import Any
 RewardValue = float | int
 RewardMap = dict[str, Any]
 
+# Top-level reward JSON keys that are not scalar metrics in [0, 1].
+RESERVED_REWARD_KEYS = frozenset(
+    {
+        "reward",
+        "rubric",
+        "items",
+        "evidence",
+        "artifacts",
+        "metadata",
+        "reason",
+        "reasons",
+        "errors",
+        "metrics",
+        "regressions",
+        "participants",
+        "winner",
+        "raw",
+        "debug",
+        "aggregate_policy",
+    }
+)
+
 
 def is_valid_reward_number(value: Any) -> bool:
     """Return True for finite scalar rewards in BenchFlow's [0, 1] range."""
@@ -89,16 +111,49 @@ def _parse_reward_json_file(path: Path, *, source: str) -> RewardMap:
             f"Reward JSON file {path} must contain an object with numeric rewards"
         )
 
-    canonical_reward = rewards.get("reward")
-    if not is_valid_reward_number(canonical_reward):
-        raise RewardFileParseError(
-            f"Reward JSON file {path} is missing numeric 'reward' between 0.0 and 1.0"
-        )
-
     try:
         return validate_reward_map(rewards, source=source)
     except ValueError as exc:
         raise RewardFileParseError(f"Reward JSON file {path} {exc}") from exc
+
+
+def _resolve_canonical_reward(
+    rewards: Mapping[str, Any],
+    metric_keys: list[str],
+    *,
+    source: str,
+) -> float:
+    """Resolve the scalar aggregate from explicit or multi-metric reward maps."""
+    if "reward" in rewards:
+        explicit = rewards.get("reward")
+        if not is_valid_reward_number(explicit):
+            raise ValueError(
+                f"{source} returned rewards with invalid reward value for 'reward'"
+            )
+        assert isinstance(explicit, int | float)
+        return float(explicit)
+
+    if not metric_keys:
+        raise ValueError(
+            f"{source} returned rewards missing numeric 'reward' between 0.0 and 1.0"
+        )
+
+    aggregate_policy = rewards.get("aggregate_policy")
+    if isinstance(aggregate_policy, Mapping):
+        field = aggregate_policy.get("field")
+        if field is not None:
+            field_name = str(field)
+            selected = rewards.get(field_name)
+            if not is_valid_reward_number(selected):
+                raise ValueError(
+                    f"{source} returned rewards with aggregate_policy.field "
+                    f"{field_name!r} that is not a numeric reward between 0.0 and 1.0"
+                )
+            assert isinstance(selected, int | float)
+            return float(selected)
+
+    values = [float(rewards[key]) for key in metric_keys]
+    return sum(values) / len(values)
 
 
 def validate_reward_map(
@@ -108,22 +163,28 @@ def validate_reward_map(
     if rewards is None:
         raise ValueError(f"{source} returned no rewards")
 
-    reward = rewards.get("reward")
-    if not is_valid_reward_number(reward):
-        raise ValueError(
-            f"{source} returned rewards without numeric 'reward' between 0.0 and 1.0"
-        )
-
     parsed: RewardMap = {}
+    metric_keys: list[str] = []
+
     for key, value in rewards.items():
-        if key == "rubric":
-            parsed[str(key)] = _validate_rubric(value, source=source)
+        key_str = str(key)
+        if key_str == "rubric":
+            parsed[key_str] = _validate_rubric(value, source=source)
+            continue
+        if key_str in RESERVED_REWARD_KEYS:
+            if key_str != "reward":
+                parsed[key_str] = value
             continue
         if not is_valid_reward_number(value):
             raise ValueError(
-                f"{source} returned rewards with invalid reward value for {str(key)!r}"
+                f"{source} returned rewards with invalid reward value for {key_str!r}"
             )
-        parsed[str(key)] = value
+        parsed[key_str] = value
+        metric_keys.append(key_str)
+
+    parsed["reward"] = _resolve_canonical_reward(
+        rewards, metric_keys, source=source
+    )
     return parsed
 
 

--- a/src/benchflow/rewards/validation.py
+++ b/src/benchflow/rewards/validation.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import math
 from collections.abc import Mapping
+from pathlib import Path
 from typing import Any
 
 RewardValue = float | int
@@ -18,6 +20,85 @@ def is_valid_reward_number(value: Any) -> bool:
         and math.isfinite(float(value))
         and 0.0 <= float(value) <= 1.0
     )
+
+
+class RewardFileParseError(ValueError):
+    """Raised when verifier reward files cannot be parsed or disagree."""
+
+
+def parse_verifier_reward_files(
+    *,
+    reward_text_path: Path,
+    reward_json_path: Path,
+    source: str = "verifier",
+) -> RewardMap:
+    """Parse verifier reward outputs with JSON-first precedence."""
+    has_json = reward_json_path.exists()
+    has_text = reward_text_path.exists()
+
+    if has_json and has_text:
+        json_rewards = _parse_reward_json_file(reward_json_path, source=source)
+        text_rewards = _parse_reward_text_file(reward_text_path, source=source)
+        json_scalar = float(json_rewards["reward"])
+        text_scalar = float(text_rewards["reward"])
+        if json_scalar != text_scalar:
+            raise RewardFileParseError(
+                "reward.json aggregate "
+                f"{json_scalar} disagrees with reward.txt scalar {text_scalar}"
+            )
+        return json_rewards
+
+    if has_json:
+        return _parse_reward_json_file(reward_json_path, source=source)
+    if has_text:
+        return _parse_reward_text_file(reward_text_path, source=source)
+
+    raise RewardFileParseError(
+        f"No reward file found at {reward_text_path} or {reward_json_path}"
+    )
+
+
+def _parse_reward_text_file(path: Path, *, source: str) -> RewardMap:
+    if path.stat().st_size == 0:
+        raise RewardFileParseError(f"Reward file is empty at {path}")
+    text = path.read_text().strip()
+    if not text:
+        raise RewardFileParseError(f"Reward file is empty at {path}")
+    try:
+        reward = float(text.splitlines()[0].strip())
+    except (ValueError, TypeError, IndexError) as exc:
+        raise RewardFileParseError(f"Failed to parse rewards from text file {path}") from exc
+    if not is_valid_reward_number(reward):
+        raise RewardFileParseError(
+            f"Reward text file {path} must contain a finite numeric reward "
+            "between 0.0 and 1.0"
+        )
+    return {"reward": reward}
+
+
+def _parse_reward_json_file(path: Path, *, source: str) -> RewardMap:
+    if path.stat().st_size == 0:
+        raise RewardFileParseError(f"Reward file is empty at {path}")
+    try:
+        rewards = json.loads(path.read_text())
+    except (ValueError, TypeError) as exc:
+        raise RewardFileParseError(f"Failed to parse rewards from JSON file {path}") from exc
+
+    if not isinstance(rewards, dict):
+        raise RewardFileParseError(
+            f"Reward JSON file {path} must contain an object with numeric rewards"
+        )
+
+    canonical_reward = rewards.get("reward")
+    if not is_valid_reward_number(canonical_reward):
+        raise RewardFileParseError(
+            f"Reward JSON file {path} is missing numeric 'reward' between 0.0 and 1.0"
+        )
+
+    try:
+        return validate_reward_map(rewards, source=source)
+    except ValueError as exc:
+        raise RewardFileParseError(f"Reward JSON file {path} {exc}") from exc
 
 
 def validate_reward_map(

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -115,17 +115,10 @@ def _task_disallows_internet(task: Any) -> bool:
 
 
 def _read_task_instruction(task_path: Path) -> str:
-    """Read the agent-facing instruction from legacy files or ``task.md``."""
-    document_path = task_path / "task.md"
-    if document_path.exists():
-        from benchflow.task.document import TaskDocument
+    """Read the agent-facing instruction from the selected task entrypoint."""
+    from benchflow.task.package import TaskRuntimeView
 
-        return TaskDocument.from_path(document_path).instruction.strip()
-
-    instruction_path = task_path / "instruction.md"
-    if instruction_path.exists():
-        return instruction_path.read_text().strip()
-    raise FileNotFoundError(f"Task missing instruction.md or task.md: {task_path}")
+    return TaskRuntimeView.from_task_dir(task_path).materialize_instruction_md()
 
 
 def _environment_uses_prebuilt_image(
@@ -790,16 +783,21 @@ async def _start_env_and_upload(
         t0 = datetime.now()
         await env.start(force_build=False)
         timing["environment_setup"] = (datetime.now() - t0).total_seconds()
-    from benchflow.task.paths import SandboxPaths, TaskPaths
+    from benchflow.task.package import TaskRuntimeView
+    from benchflow.task.paths import SandboxPaths
 
     sandbox_paths = SandboxPaths()
-    paths = TaskPaths(task_path)
-    task_document_path = paths.task_document_path
-    instruction_path = task_path / "instruction.md"
-    if instruction_path.exists() and not task_document_path.exists():
-        await env.upload_file(instruction_path, str(sandbox_paths.instruction_path))
+    runtime_view = TaskRuntimeView.from_task_dir(task_path)
+    paths = runtime_view.paths
+    if (
+        runtime_view.entrypoint == "legacy-split"
+        and paths.instruction_path.exists()
+    ):
+        await env.upload_file(
+            paths.instruction_path, str(sandbox_paths.instruction_path)
+        )
     else:
-        instruction = _read_task_instruction(task_path)
+        instruction = runtime_view.materialize_instruction_md()
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
             f.write(instruction)
             f.write("\n")
@@ -810,17 +808,17 @@ async def _start_env_and_upload(
             )
         finally:
             temp_instruction.unlink(missing_ok=True)
-    if task_document_path.exists():
+    if paths.task_document_path.exists():
         await env.upload_file(
-            task_document_path, str(sandbox_paths.task_document_path)
+            paths.task_document_path, str(sandbox_paths.task_document_path)
         )
-    if paths.solution_dir.is_dir():
+    if runtime_view.oracle_dir.is_dir():
         target_dir = (
             sandbox_paths.oracle_dir
-            if paths.uses_native_oracle_dir
+            if runtime_view.uses_native_oracle_dir
             else sandbox_paths.solution_dir
         )
-        await env.upload_dir(paths.solution_dir, str(target_dir))
+        await env.upload_dir(runtime_view.oracle_dir, str(target_dir))
 
 
 async def _run_oracle(
@@ -1381,6 +1379,10 @@ class Rollout:
             self._job_name,
             self._rollout_name,
         ) = _init_rollout(cfg.task_path, cfg.job_name, cfg.rollout_name, cfg.jobs_dir)
+
+        from benchflow.task.runtime_capabilities import ensure_task_runtime_support
+
+        ensure_task_runtime_support(self._task, cfg.environment, cfg.task_path)
 
         self._disallow_web_tools = (
             _task_disallows_internet(self._task) or cfg.self_gen_no_internet

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1107,6 +1107,34 @@ class RolloutConfig:
                     role.reasoning_effort
                 )
 
+        if self.user is None:
+            self._apply_document_user_loop()
+
+    def _apply_document_user_loop(self) -> None:
+        """Auto-wire document-declared user loops when compilation succeeds."""
+        task_md = self.task_path / "task.md"
+        if not task_md.is_file():
+            return
+
+        from benchflow.task.task import Task
+        from benchflow.task.user_loop import (
+            compile_document_user_loop,
+            user_loop_rollout_compatible,
+        )
+
+        try:
+            compiled = compile_document_user_loop(Task(self.task_path))
+        except (FileNotFoundError, ValueError):
+            return
+
+        if (
+            compiled is not None
+            and compiled.executable
+            and user_loop_rollout_compatible(self.scenes)
+        ):
+            self.user = compiled.user
+            self.max_user_rounds = compiled.max_user_rounds
+
     @classmethod
     def from_legacy(
         cls,

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1058,6 +1058,7 @@ class RolloutConfig:
     # User-driven progressive-disclosure loop
     user: BaseUser | None = None
     max_user_rounds: int = 5
+    user_loop_plan: Any | None = None
     oracle_access: bool = False
 
     # Legacy compat fields — used by SDK.run() shim. Ignored when scenes is set.
@@ -1124,21 +1125,23 @@ class RolloutConfig:
         from benchflow.task.task import Task
         from benchflow.task.user_loop import (
             compile_document_user_loop,
-            user_loop_rollout_compatible,
+            infer_user_loop_scene_name,
+            resolve_user_loop_rollout_plan,
         )
 
         try:
-            compiled = compile_document_user_loop(Task(self.task_path))
+            task = Task(self.task_path)
+            compiled = compile_document_user_loop(task)
         except (FileNotFoundError, ValueError):
             return
 
-        if (
-            compiled is not None
-            and compiled.executable
-            and user_loop_rollout_compatible(self.scenes)
-        ):
+        document = task.document
+        scene_name = infer_user_loop_scene_name(document) if document else None
+        plan = resolve_user_loop_rollout_plan(self.scenes, user_loop_scene_name=scene_name)
+        if compiled is not None and compiled.executable and plan is not None:
             self.user = compiled.user
             self.max_user_rounds = compiled.max_user_rounds
+            self.user_loop_plan = plan
 
     @classmethod
     def from_legacy(
@@ -1443,6 +1446,22 @@ class Rollout:
         from benchflow.task.runtime_capabilities import ensure_task_runtime_support
 
         ensure_task_runtime_support(self._task, cfg.environment, cfg.task_path)
+
+        if (cfg.task_path / "task.md").is_file():
+            try:
+                from benchflow.task.package import TaskRuntimeView
+
+                summary = TaskRuntimeView.from_task_dir(
+                    cfg.task_path
+                ).document_runtime_summary()
+                logger.info(
+                    "Task runtime: entrypoint=%s scenes=%s verifier=%s",
+                    summary.get("entrypoint"),
+                    summary.get("scene_names"),
+                    summary.get("verifier_dir_kind"),
+                )
+            except (FileNotFoundError, ValueError):
+                pass
 
         self._disallow_web_tools = (
             _task_disallows_internet(self._task) or cfg.self_gen_no_internet
@@ -2250,7 +2269,7 @@ class Rollout:
                 try:
                     try:
                         if cfg.user is not None:
-                            await self._run_user_loop()
+                            await self._run_user_loop_scoped()
                         else:
                             await self._run_steps(
                                 compile_scenes_to_steps(
@@ -2443,7 +2462,38 @@ class Rollout:
             if current_role_key is not None:
                 await self.disconnect()
 
-    async def _run_user_loop(self) -> None:
+    async def _run_user_loop_scoped(self) -> None:
+        """Run optional pre-scenes, the user loop, then any post-scene turns."""
+        cfg = self._config
+        plan = cfg.user_loop_plan
+        default_prompt = (
+            self._resolved_prompts[0] if self._resolved_prompts else None
+        )
+
+        if plan is not None and plan.pre_scenes:
+            await self._run_steps(
+                compile_scenes_to_steps(
+                    list(plan.pre_scenes),
+                    default_prompt=default_prompt,
+                )
+            )
+
+        await self._run_user_loop(plan=plan, default_prompt=default_prompt)
+
+        if plan is not None and plan.post_scene is not None:
+            await self._run_steps(
+                compile_scenes_to_steps(
+                    [plan.post_scene],
+                    default_prompt=default_prompt,
+                )
+            )
+
+    async def _run_user_loop(
+        self,
+        *,
+        plan: Any | None = None,
+        default_prompt: str | None = None,
+    ) -> None:
         """Execute a user-driven progressive-disclosure loop.
 
         Each round: user.run() → connect → agent.execute() → disconnect →
@@ -2454,24 +2504,28 @@ class Rollout:
         user = cfg.user
         assert user is not None
 
-        if len(cfg.effective_scenes) > 1:
-            raise ValueError(
-                "User-driven loops operate on a single scene. "
-                f"Got {len(cfg.effective_scenes)} scenes."
+        plan = plan or cfg.user_loop_plan
+        if plan is not None:
+            role = plan.user_loop_role
+            instruction = plan.user_loop_prompt
+        else:
+            if len(cfg.effective_scenes) > 1:
+                raise ValueError(
+                    "User-driven loops operate on a single scene. "
+                    f"Got {len(cfg.effective_scenes)} scenes."
+                )
+            scene = cfg.effective_scenes[0]
+            if len(scene.roles) != 1:
+                raise ValueError(
+                    "User-driven loops require a single-role scene. "
+                    f"Got {len(scene.roles)} roles."
+                )
+            role = scene.roles[0]
+            instruction = default_prompt or (
+                self._resolved_prompts[0]
+                if self._resolved_prompts
+                else "Solve the task described in /app/instruction.md"
             )
-        scene = cfg.effective_scenes[0]
-        if len(scene.roles) != 1:
-            raise ValueError(
-                "User-driven loops require a single-role scene. "
-                f"Got {len(scene.roles)} roles."
-            )
-        role = scene.roles[0]
-
-        instruction = (
-            self._resolved_prompts[0]
-            if self._resolved_prompts
-            else ("Solve the task described in /app/instruction.md")
-        )
 
         # Oracle access: read /solution before the agent runs, then remove it
         solution: str | None = None

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -998,10 +998,15 @@ def _task_document_scenes(
     """Load scene declarations through ``TaskRuntimeView`` when applicable."""
     from benchflow.task.package import TaskRuntimeView
 
-    return TaskRuntimeView.from_task_dir(task_path).to_rollout_scenes(
-        prompts=prompts,
-        skill_mode=skill_mode,
-    )
+    if not (task_path / "task.md").is_file():
+        return []
+    try:
+        return TaskRuntimeView.from_task_dir(task_path).to_rollout_scenes(
+            prompts=prompts,
+            skill_mode=skill_mode,
+        )
+    except (FileNotFoundError, ValueError):
+        return []
 
 
 __all__ = [

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -1137,7 +1137,12 @@ class RolloutConfig:
 
         document = task.document
         scene_name = infer_user_loop_scene_name(document) if document else None
-        plan = resolve_user_loop_rollout_plan(self.scenes, user_loop_scene_name=scene_name)
+        benchflow = document.benchflow if document and isinstance(document.benchflow, dict) else {}
+        plan = resolve_user_loop_rollout_plan(
+            self.scenes,
+            user_loop_scene_name=scene_name,
+            nudges=benchflow.get("nudges"),
+        )
         if compiled is not None and compiled.executable and plan is not None:
             self.user = compiled.user
             self.max_user_rounds = compiled.max_user_rounds

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -495,6 +495,30 @@ def _scene_metadata(scenes: list[Scene]) -> list[dict[str, Any]]:
     ]
 
 
+def _reward_details_metadata(rollout_dir: Path) -> dict[str, Any] | None:
+    """Summarize verifier ``reward-details.json`` for persisted rollout metadata."""
+    path = rollout_dir / "verifier" / "reward-details.json"
+    if not path.is_file():
+        return None
+
+    raw = path.read_text(encoding="utf-8", errors="replace")
+    summary: dict[str, Any] = {
+        "path": "verifier/reward-details.json",
+        "size_bytes": path.stat().st_size,
+    }
+    try:
+        parsed = json.loads(raw)
+        if isinstance(parsed, dict):
+            summary["top_level_keys"] = sorted(str(key) for key in parsed)
+    except json.JSONDecodeError:
+        pass
+    if raw:
+        summary["content_preview"] = raw[:_DIAG_TRUNCATE]
+        if len(raw) > _DIAG_TRUNCATE:
+            summary["content_truncated"] = True
+    return summary
+
+
 def _build_rollout_result(
     rollout_dir: Path,
     *,
@@ -606,6 +630,7 @@ def _build_rollout_result(
         partial_trajectory=partial_trajectory,
         trajectory_source=trajectory_source,
     )
+    reward_details = _reward_details_metadata(rollout_dir)
     traj_dir = rollout_dir / "trajectory"
     traj_dir.mkdir(parents=True, exist_ok=True)
     # Final write — overwrites whatever the live streaming writer left
@@ -645,6 +670,11 @@ def _build_rollout_result(
                 **(
                     {"source": source_provenance}
                     if source_provenance is not None
+                    else {}
+                ),
+                **(
+                    {"reward_details": reward_details}
+                    if reward_details is not None
                     else {}
                 ),
             },
@@ -965,16 +995,13 @@ def _task_document_scenes(
     prompts: list[str | None] | None,
     skill_mode: str,
 ) -> list[Scene]:
-    """Load scene declarations from ``task.md`` when it is the task entrypoint."""
-    if prompts is not None or skill_mode == SKILL_MODE_SELF_GEN:
-        return []
-    document_path = task_path / "task.md"
-    if not document_path.exists():
-        return []
+    """Load scene declarations through ``TaskRuntimeView`` when applicable."""
+    from benchflow.task.package import TaskRuntimeView
 
-    from benchflow.task.document import TaskDocument
-
-    return list(TaskDocument.from_path(document_path).scenes)
+    return TaskRuntimeView.from_task_dir(task_path).to_rollout_scenes(
+        prompts=prompts,
+        skill_mode=skill_mode,
+    )
 
 
 __all__ = [

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -790,9 +790,14 @@ async def _start_env_and_upload(
         t0 = datetime.now()
         await env.start(force_build=False)
         timing["environment_setup"] = (datetime.now() - t0).total_seconds()
+    from benchflow.task.paths import SandboxPaths, TaskPaths
+
+    sandbox_paths = SandboxPaths()
+    paths = TaskPaths(task_path)
+    task_document_path = paths.task_document_path
     instruction_path = task_path / "instruction.md"
-    if instruction_path.exists() and not (task_path / "task.md").exists():
-        await env.upload_file(instruction_path, "/instruction.md")
+    if instruction_path.exists() and not task_document_path.exists():
+        await env.upload_file(instruction_path, str(sandbox_paths.instruction_path))
     else:
         instruction = _read_task_instruction(task_path)
         with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as f:
@@ -800,14 +805,16 @@ async def _start_env_and_upload(
             f.write("\n")
             temp_instruction = Path(f.name)
         try:
-            await env.upload_file(temp_instruction, "/instruction.md")
+            await env.upload_file(
+                temp_instruction, str(sandbox_paths.instruction_path)
+            )
         finally:
             temp_instruction.unlink(missing_ok=True)
-    from benchflow.task.paths import SandboxPaths, TaskPaths
-
-    paths = TaskPaths(task_path)
+    if task_document_path.exists():
+        await env.upload_file(
+            task_document_path, str(sandbox_paths.task_document_path)
+        )
     if paths.solution_dir.is_dir():
-        sandbox_paths = SandboxPaths()
         target_dir = (
             sandbox_paths.oracle_dir
             if paths.uses_native_oracle_dir

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -760,7 +760,8 @@ class DockerSandbox(BaseSandbox):
 
         exec_command: list[str] = ["exec"]
 
-        effective_cwd = cwd or self.task_env_config.workdir
+        task_env = getattr(self, "task_env_config", None)
+        effective_cwd = cwd or (task_env.workdir if task_env is not None else None)
         if effective_cwd:
             exec_command.extend(["-w", effective_cwd])
 

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -160,6 +160,7 @@ class DockerSandbox(BaseSandbox):
         self._keep_containers = keep_containers
         self._mounts_json = mounts_json
         self._mounts_compose_path: Path | None = None
+        self._workdir_compose_path: Path | None = None
 
         verifier_dir = (
             str(rollout_paths.verifier_dir.resolve().absolute())
@@ -246,6 +247,9 @@ class DockerSandbox(BaseSandbox):
         if self._mounts_compose_path:
             paths.append(self._mounts_compose_path)
 
+        if self._workdir_compose_path:
+            paths.append(self._workdir_compose_path)
+
         if not self.task_env_config.allow_internet:
             paths.append(self._DOCKER_COMPOSE_NO_NETWORK_PATH)
 
@@ -255,6 +259,17 @@ class DockerSandbox(BaseSandbox):
         compose = {"services": {"main": {"volumes": self._mounts_json}}}
         assert self.rollout_paths is not None
         path = self.rollout_paths.rollout_dir / "docker-compose-mounts.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(compose, indent=2))
+        return path
+
+    def _write_workdir_compose_file(self) -> Path:
+        workdir = self.task_env_config.workdir
+        if workdir is None:
+            raise ValueError("workdir compose file requires environment.workdir")
+        compose = {"services": {"main": {"working_dir": workdir}}}
+        assert self.rollout_paths is not None
+        path = self.rollout_paths.rollout_dir / "docker-compose-workdir.json"
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(compose, indent=2))
         return path
@@ -366,6 +381,9 @@ class DockerSandbox(BaseSandbox):
         if self._mounts_json:
             self._mounts_compose_path = self._write_mounts_compose_file()
 
+        if self.task_env_config.workdir:
+            self._workdir_compose_path = self._write_workdir_compose_file()
+
         self._use_prebuilt = not force_build and bool(self.task_env_config.docker_image)
 
         # Gate the entire startup phase (build + down + up) — not just build.
@@ -394,6 +412,12 @@ class DockerSandbox(BaseSandbox):
         await self.exec(
             f"chmod 777 {SandboxPaths.agent_dir} {SandboxPaths.verifier_dir}"
         )
+
+        if self.task_env_config.workdir:
+            await self.exec(
+                f"mkdir -p {shlex.quote(self.task_env_config.workdir)}",
+                user="root",
+            )
 
     async def stop(self, delete: bool) -> None:
         # Bounded chown: a hung agent container will make `docker exec` block
@@ -736,8 +760,9 @@ class DockerSandbox(BaseSandbox):
 
         exec_command: list[str] = ["exec"]
 
-        if cwd:
-            exec_command.extend(["-w", cwd])
+        effective_cwd = cwd or self.task_env_config.workdir
+        if effective_cwd:
+            exec_command.extend(["-w", effective_cwd])
 
         if user is not None:
             exec_command.extend(["-u", str(user)])

--- a/src/benchflow/sandbox/modal_impl.py
+++ b/src/benchflow/sandbox/modal_impl.py
@@ -184,6 +184,12 @@ class ModalSandbox(BaseSandbox):
             f"chmod 777 {SandboxPaths.agent_dir} {SandboxPaths.verifier_dir}"
         )
 
+        if self.task_env_config.workdir:
+            await self.exec(
+                f"mkdir -p {shlex.quote(self.task_env_config.workdir)}",
+                user="root",
+            )
+
     @retry(
         stop=stop_after_attempt(2),
         wait=wait_exponential(multiplier=1, min=1, max=10),
@@ -379,11 +385,14 @@ class ModalSandbox(BaseSandbox):
                 user_arg = shlex.quote(str(user))
             command = f"su {user_arg} -s /bin/bash -c {shlex.quote(command)}"
 
+        task_env = getattr(self, "task_env_config", None)
+        effective_cwd = cwd or (task_env.workdir if task_env is not None else None)
+
         process = await self._sandbox.exec.aio(
             "bash",
             "-c",
             command,
-            workdir=cwd,
+            workdir=effective_cwd,
             secrets=[Secret.from_dict(env)] if env else [],
             timeout=timeout_sec,
         )

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -651,6 +651,10 @@ def _create_sandbox_environment(
         env_config = env_config.model_copy(deep=True)
         env_config.allow_internet = True
 
+    from benchflow.task.runtime_capabilities import ensure_task_runtime_support
+
+    ensure_task_runtime_support(task, sandbox_type, task_path)
+
     manifest_env: dict[str, str] = {}
     if environment_manifest is not None:
         from benchflow.environment.manifest import (

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -38,6 +38,18 @@ from benchflow.task.document import (
     render_task_md_from_legacy,
 )
 from benchflow.task.env import resolve_env_vars
+from benchflow.task.export import (
+    ExportLoss,
+    ExportMode,
+    ExportResult,
+    ExportTarget,
+    export_task_package,
+)
+from benchflow.task.package import (
+    AliasCollisionStatus,
+    TaskPackage,
+    TaskRuntimeView,
+)
 from benchflow.task.paths import (
     RolloutPaths,
     SandboxPaths,
@@ -54,6 +66,15 @@ from benchflow.task.verifier import (
     VerifierOutputParseError,
     VerifierResult,
 )
+from benchflow.task.verifier_document import (
+    VERIFIER_DOCUMENT_FILENAME,
+    VerifierDocument,
+    VerifierDocumentParseError,
+    VerifierOutputs,
+    VerifierRubricFiles,
+    resolve_verifier_spec_path,
+    verifier_document_issues,
+)
 
 __all__ = [
     # Task ($T$)
@@ -63,6 +84,16 @@ __all__ = [
     "TASK_DOCUMENT_FILENAME",
     "TaskDocument",
     "TaskDocumentParseError",
+    "TaskPackage",
+    "TaskRuntimeView",
+    "AliasCollisionStatus",
+    "VERIFIER_DOCUMENT_FILENAME",
+    "VerifierDocument",
+    "VerifierDocumentParseError",
+    "VerifierOutputs",
+    "VerifierRubricFiles",
+    "resolve_verifier_spec_path",
+    "verifier_document_issues",
     # Configuration ($C$)
     "SandboxConfig",
     "VerifierConfig",
@@ -98,4 +129,10 @@ __all__ = [
     # Utilities
     "resolve_env_vars",
     "render_task_md_from_legacy",
+    # Export
+    "ExportLoss",
+    "ExportMode",
+    "ExportResult",
+    "ExportTarget",
+    "export_task_package",
 ]

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -39,16 +39,19 @@ from benchflow.task.document import (
 )
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.export import (
+    EXPORT_REPORT_REL_PATH,
     ExportLoss,
     ExportMode,
     ExportResult,
     ExportTarget,
     ImportResult,
     NativeComparison,
+    export_report_json,
     export_task_package,
     import_split_task_package,
     materialize_export_result,
     validate_export_round_trip,
+    write_export_report,
 )
 from benchflow.task.package import (
     AliasCollisionStatus,
@@ -66,13 +69,13 @@ from benchflow.task.runtime_capabilities import (
     ensure_task_runtime_support,
     validate_task_runtime_support,
 )
+from benchflow.task.task import Task
 from benchflow.task.user_loop import (
     CompiledUserLoop,
     DocumentSimulatedUser,
     compile_document_user_loop,
     parse_stop_rule_max_rounds,
 )
-from benchflow.task.task import Task
 from benchflow.task.verifier import (
     AddTestsDirError,
     DownloadVerifierDirError,
@@ -163,14 +166,17 @@ __all__ = [
     "resolve_env_vars",
     "render_task_md_from_legacy",
     # Export / import
+    "EXPORT_REPORT_REL_PATH",
     "ExportLoss",
     "ExportMode",
     "ExportResult",
     "ExportTarget",
     "ImportResult",
     "NativeComparison",
+    "export_report_json",
     "export_task_package",
     "import_split_task_package",
     "materialize_export_result",
     "validate_export_round_trip",
+    "write_export_report",
 ]

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -43,7 +43,12 @@ from benchflow.task.export import (
     ExportMode,
     ExportResult,
     ExportTarget,
+    ImportResult,
+    NativeComparison,
     export_task_package,
+    import_split_task_package,
+    materialize_export_result,
+    validate_export_round_trip,
 )
 from benchflow.task.package import (
     AliasCollisionStatus,
@@ -147,10 +152,15 @@ __all__ = [
     # Utilities
     "resolve_env_vars",
     "render_task_md_from_legacy",
-    # Export
+    # Export / import
     "ExportLoss",
     "ExportMode",
     "ExportResult",
     "ExportTarget",
+    "ImportResult",
+    "NativeComparison",
     "export_task_package",
+    "import_split_task_package",
+    "materialize_export_result",
+    "validate_export_round_trip",
 ]

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -50,16 +50,16 @@ from benchflow.task.package import (
     TaskPackage,
     TaskRuntimeView,
 )
+from benchflow.task.paths import (
+    RolloutPaths,
+    SandboxPaths,
+    TaskPaths,
+)
 from benchflow.task.runtime_capabilities import (
     UnsupportedTaskFeature,
     UnsupportedTaskRuntimeError,
     ensure_task_runtime_support,
     validate_task_runtime_support,
-)
-from benchflow.task.paths import (
-    RolloutPaths,
-    SandboxPaths,
-    TaskPaths,
 )
 from benchflow.task.task import Task
 from benchflow.task.verifier import (

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -50,6 +50,12 @@ from benchflow.task.package import (
     TaskPackage,
     TaskRuntimeView,
 )
+from benchflow.task.runtime_capabilities import (
+    UnsupportedTaskFeature,
+    UnsupportedTaskRuntimeError,
+    ensure_task_runtime_support,
+    validate_task_runtime_support,
+)
 from benchflow.task.paths import (
     RolloutPaths,
     SandboxPaths,
@@ -87,6 +93,10 @@ __all__ = [
     "TaskPackage",
     "TaskRuntimeView",
     "AliasCollisionStatus",
+    "UnsupportedTaskFeature",
+    "UnsupportedTaskRuntimeError",
+    "ensure_task_runtime_support",
+    "validate_task_runtime_support",
     "VERIFIER_DOCUMENT_FILENAME",
     "VerifierDocument",
     "VerifierDocumentParseError",

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -66,6 +66,12 @@ from benchflow.task.runtime_capabilities import (
     ensure_task_runtime_support,
     validate_task_runtime_support,
 )
+from benchflow.task.user_loop import (
+    CompiledUserLoop,
+    DocumentSimulatedUser,
+    compile_document_user_loop,
+    parse_stop_rule_max_rounds,
+)
 from benchflow.task.task import Task
 from benchflow.task.verifier import (
     AddTestsDirError,
@@ -106,6 +112,10 @@ __all__ = [
     "UnsupportedTaskRuntimeError",
     "ensure_task_runtime_support",
     "validate_task_runtime_support",
+    "CompiledUserLoop",
+    "DocumentSimulatedUser",
+    "compile_document_user_loop",
+    "parse_stop_rule_max_rounds",
     "VERIFIER_DOCUMENT_FILENAME",
     "VerifierDocument",
     "VerifierDocumentParseError",

--- a/src/benchflow/task/__init__.py
+++ b/src/benchflow/task/__init__.py
@@ -68,6 +68,7 @@ from benchflow.task.verifier import (
     RewardFileEmptyError,
     RewardFileNotFoundError,
     RubricNotFoundError,
+    UnsupportedVerifierStrategyError,
     Verifier,
     VerifierOutputParseError,
     VerifierResult,
@@ -78,8 +79,11 @@ from benchflow.task.verifier_document import (
     VerifierDocumentParseError,
     VerifierOutputs,
     VerifierRubricFiles,
+    is_executable_script_strategy,
+    resolve_default_strategy,
     resolve_verifier_spec_path,
     verifier_document_issues,
+    verifier_strategy_type,
 )
 
 __all__ = [
@@ -103,6 +107,9 @@ __all__ = [
     "VerifierOutputs",
     "VerifierRubricFiles",
     "resolve_verifier_spec_path",
+    "resolve_default_strategy",
+    "verifier_strategy_type",
+    "is_executable_script_strategy",
     "verifier_document_issues",
     # Configuration ($C$)
     "SandboxConfig",
@@ -133,6 +140,7 @@ __all__ = [
     "RewardFileEmptyError",
     "RewardFileNotFoundError",
     "RubricNotFoundError",
+    "UnsupportedVerifierStrategyError",
     "VerifierOutputParseError",
     "AddTestsDirError",
     "DownloadVerifierDirError",

--- a/src/benchflow/task/aliases.py
+++ b/src/benchflow/task/aliases.py
@@ -1,0 +1,47 @@
+"""Native/legacy task directory alias validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchflow.task.paths import TaskPaths
+
+
+def normalized_tree_map(root: Path) -> dict[str, bytes]:
+    """Map relative POSIX paths to file bytes for every file under *root*."""
+    if not root.is_dir():
+        return {}
+    files: dict[str, bytes] = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_file():
+            files[path.relative_to(root).as_posix()] = path.read_bytes()
+    return files
+
+
+def alias_dir_collision_issues(paths: TaskPaths) -> list[str]:
+    """Return fail-closed diagnostics when native and legacy alias trees disagree."""
+    issues: list[str] = []
+    pairs = (
+        (
+            paths.oracle_dir,
+            paths.legacy_solution_dir,
+            TaskPaths.NATIVE_ORACLE_DIRNAME,
+            TaskPaths.LEGACY_SOLUTION_DIRNAME,
+        ),
+        (
+            paths.verifier_source_dir,
+            paths.legacy_tests_dir,
+            TaskPaths.NATIVE_VERIFIER_DIRNAME,
+            TaskPaths.LEGACY_TESTS_DIRNAME,
+        ),
+    )
+    for native_dir, legacy_dir, native_name, legacy_name in pairs:
+        if not native_dir.is_dir() or not legacy_dir.is_dir():
+            continue
+        if normalized_tree_map(native_dir) == normalized_tree_map(legacy_dir):
+            continue
+        issues.append(
+            f"Alias collision: {native_name}/ and {legacy_name}/ both exist "
+            "but are not byte-identical"
+        )
+    return issues

--- a/src/benchflow/task/benchflow_schema.py
+++ b/src/benchflow/task/benchflow_schema.py
@@ -1,0 +1,134 @@
+"""Typed validation for the ``benchflow:`` document namespace (P3 subset)."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from benchflow.task.prompt_composition import (
+    PromptCompositionSettings,
+    prompt_composition_settings,
+)
+
+CompositionMode = Literal["append", "replace"]
+PromptPart = Literal["base", "role", "scene", "turn"]
+MetadataOnlyRuntime = Literal["metadata-only", "metadata_only"]
+
+
+class BenchflowPromptSection(BaseModel):
+    """``benchflow.prompt`` composition settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    composition: CompositionMode | None = None
+    order: list[PromptPart] | None = None
+
+
+class BenchflowNudgesSection(BaseModel):
+    """``benchflow.nudges`` simulated-user policy."""
+
+    model_config = ConfigDict(extra="allow")
+
+    mode: str | None = None
+    branchable: bool | None = None
+    nudge_budget: int | None = Field(default=None, ge=1)
+    confirmation_policy: dict[str, Any] | None = None
+    runtime: MetadataOnlyRuntime | str | None = None
+
+
+class BenchflowCompatibilitySection(BaseModel):
+    """``benchflow.compatibility`` export target metadata."""
+
+    model_config = ConfigDict(extra="allow")
+
+    target: str | None = None
+    mode: str | None = None
+    extra: list[str] | None = None
+
+
+class BenchflowVerifierSection(BaseModel):
+    """``benchflow.verifier`` native verifier package references."""
+
+    model_config = ConfigDict(extra="allow")
+
+    spec: str | None = None
+    rubric: str | None = None
+    structured_rubric: str | None = None
+    entrypoint: str | None = None
+    reward_kit: str | None = None
+
+
+class BenchflowMetadata(BaseModel):
+    """Typed subset of ``benchflow:`` frontmatter."""
+
+    model_config = ConfigDict(extra="allow")
+
+    document_version: str | None = None
+    prompt: BenchflowPromptSection | None = None
+    nudges: BenchflowNudgesSection | None = None
+    compatibility: BenchflowCompatibilitySection | None = None
+    verifier: BenchflowVerifierSection | None = None
+    user_runtime: MetadataOnlyRuntime | str | None = None
+
+
+def validate_benchflow_metadata(raw: Any) -> list[str]:
+    """Validate a ``benchflow`` block and return human-readable issues."""
+    if raw is None:
+        return []
+    if not isinstance(raw, dict):
+        return ["benchflow must be a mapping"]
+
+    issues: list[str] = []
+    try:
+        BenchflowMetadata.model_validate(raw)
+    except ValidationError as exc:
+        for error in exc.errors():
+            loc = ".".join(str(part) for part in error.get("loc", ()))
+            prefix = f"benchflow.{loc}" if loc else "benchflow"
+            issues.append(f"{prefix}: {error.get('msg', 'invalid value')}")
+
+    try:
+        prompt_composition_settings(raw)
+    except ValueError as exc:
+        issues.append(str(exc))
+
+    return issues
+
+
+def parse_benchflow_metadata(raw: Any) -> BenchflowMetadata | None:
+    """Parse ``benchflow`` frontmatter when validation succeeds."""
+    if not isinstance(raw, dict):
+        return None
+    if validate_benchflow_metadata(raw):
+        return None
+    return BenchflowMetadata.model_validate(raw)
+
+
+def prompt_settings_from_metadata(
+    metadata: BenchflowMetadata | None,
+    *,
+    raw: dict[str, Any] | None = None,
+) -> PromptCompositionSettings:
+    """Resolve prompt composition from typed metadata or raw benchflow."""
+    if raw is not None:
+        return prompt_composition_settings(raw)
+    if metadata is None or metadata.prompt is None:
+        return PromptCompositionSettings()
+    section = metadata.prompt
+    return PromptCompositionSettings(
+        composition=section.composition,
+        order=tuple(section.order) if section.order is not None else PromptCompositionSettings().order,
+    )
+
+
+__all__ = [
+    "BenchflowCompatibilitySection",
+    "BenchflowMetadata",
+    "BenchflowNudgesSection",
+    "BenchflowPromptSection",
+    "BenchflowVerifierSection",
+    "parse_benchflow_metadata",
+    "prompt_settings_from_metadata",
+    "validate_benchflow_metadata",
+]

--- a/src/benchflow/task/benchflow_schema.py
+++ b/src/benchflow/task/benchflow_schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
@@ -26,7 +26,13 @@ class BenchflowPromptSection(BaseModel):
 
 
 class BenchflowNudgesSection(BaseModel):
-    """``benchflow.nudges`` simulated-user policy."""
+    """``benchflow.nudges`` simulated-user policy.
+
+    ``branchable`` enables multi-turn user-loop scene splitting: the first turn
+    runs under the simulated user loop and later turns run as ``post_scene``.
+    ``confirmation_policy`` and ``scripted`` are metadata-only until the rollout
+    branch engine can execute agent permission branches.
+    """
 
     model_config = ConfigDict(extra="allow")
 
@@ -72,6 +78,50 @@ class BenchflowMetadata(BaseModel):
     user_runtime: MetadataOnlyRuntime | str | None = None
 
 
+def _validate_nudges_metadata(nudges: dict[str, Any]) -> list[str]:
+    """Validate metadata-only nudge fields that parse but do not execute yet."""
+    issues: list[str] = []
+
+    scripted = nudges.get("scripted")
+    if scripted is not None:
+        if not isinstance(scripted, list):
+            issues.append("benchflow.nudges.scripted: must be a list")
+        else:
+            for index, item in enumerate(scripted):
+                if not isinstance(item, dict):
+                    issues.append(
+                        f"benchflow.nudges.scripted[{index}]: must be a mapping"
+                    )
+                    continue
+                entry = cast(dict[str, Any], item)
+                if not isinstance(entry.get("trigger"), str):
+                    issues.append(
+                        f"benchflow.nudges.scripted[{index}].trigger: must be a string"
+                    )
+                if not isinstance(entry.get("reveal"), str):
+                    issues.append(
+                        f"benchflow.nudges.scripted[{index}].reveal: must be a string"
+                    )
+
+    confirmation_policy = nudges.get("confirmation_policy")
+    if confirmation_policy is not None:
+        if not isinstance(confirmation_policy, dict):
+            issues.append("benchflow.nudges.confirmation_policy: must be a mapping")
+        else:
+            for key, value in confirmation_policy.items():
+                if not isinstance(key, str):
+                    issues.append(
+                        "benchflow.nudges.confirmation_policy: keys must be strings"
+                    )
+                    break
+                if not isinstance(value, str):
+                    issues.append(
+                        f"benchflow.nudges.confirmation_policy.{key}: must be a string"
+                    )
+
+    return issues
+
+
 def validate_benchflow_metadata(raw: Any) -> list[str]:
     """Validate a ``benchflow`` block and return human-readable issues."""
     if raw is None:
@@ -92,6 +142,10 @@ def validate_benchflow_metadata(raw: Any) -> list[str]:
         prompt_composition_settings(raw)
     except ValueError as exc:
         issues.append(str(exc))
+
+    nudges = raw.get("nudges")
+    if isinstance(nudges, dict):
+        issues.extend(_validate_nudges_metadata(nudges))
 
     return issues
 

--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -232,8 +232,9 @@ class VerifierConfig(TaskConfigModel):
 
     ``type`` selects the verification method:
 
-    - ``"test-script"`` (default): run ``tests/test.sh`` in the sandbox and
-      parse ``reward.txt`` / ``reward.json``.
+    - ``"test-script"`` (default): run ``verifier/test.sh`` or legacy
+      ``tests/test.sh`` in the sandbox and parse ``reward.json`` /
+      ``reward.txt`` (JSON is authoritative when present).
     - ``"llm-judge"``: score the agent's deliverables against a human-authored
       rubric using an LLM judge (see :class:`JudgeVerifierConfig`).
     """

--- a/src/benchflow/task/document.py
+++ b/src/benchflow/task/document.py
@@ -17,6 +17,11 @@ import yaml
 
 from benchflow._types import Role, Scene, Turn
 from benchflow.task.config import TaskConfig
+from benchflow.task.prompt_composition import (
+    PromptCompositionSettings,
+    compose_task_prompt,
+    prompt_composition_settings,
+)
 
 TASK_DOCUMENT_FILENAME = "task.md"
 
@@ -65,15 +70,17 @@ class TaskDocument:
         prompt_sections = _extract_prompt_sections(body)
         config = _config_from_frontmatter(frontmatter)
         roles = _parse_roles(frontmatter)
+        user = _mapping(frontmatter.get("user"), "user", default={})
+        benchflow = _mapping(frontmatter.get("benchflow"), "benchflow", default={})
+        prompt_settings = _prompt_composition_settings(benchflow)
         scenes = _parse_scenes(
             frontmatter,
             roles=roles,
             instruction=prompt_sections.instruction,
             role_prompts=prompt_sections.role_prompts,
             scene_prompts=prompt_sections.scene_prompts,
+            prompt_settings=prompt_settings,
         )
-        user = _mapping(frontmatter.get("user"), "user", default={})
-        benchflow = _mapping(frontmatter.get("benchflow"), "benchflow", default={})
         return cls(
             frontmatter=frontmatter,
             body=body,
@@ -225,6 +232,7 @@ def _parse_scenes(
     instruction: str,
     role_prompts: dict[str, str],
     scene_prompts: dict[str, str],
+    prompt_settings: PromptCompositionSettings,
 ) -> list[Scene]:
     raw_scenes = frontmatter.get("scenes")
     if raw_scenes is None:
@@ -244,18 +252,27 @@ def _parse_scenes(
         turns = _parse_turns(
             scene_data.get("turns"),
             scene_name=name,
+            base_prompt=instruction,
             roles=roles,
             scene_role_names=scene_role_names,
             role_prompts=role_prompts,
             scene_prompts=scene_prompts,
+            prompt_settings=prompt_settings,
         )
         if not turns and scene_roles:
             turns = [
                 Turn(
                     role=role.name,
-                    prompt=scene_prompts.get(name)
-                    or role_prompts.get(role.name)
-                    or instruction,
+                    prompt=_compose_scene_turn_prompt(
+                        base_prompt=instruction,
+                        role_name=role.name,
+                        scene_name=name,
+                        role_prompts=role_prompts,
+                        scene_prompts=scene_prompts,
+                        turn_prompt=None,
+                        explicit_turn=False,
+                        prompt_settings=prompt_settings,
+                    ),
                 )
                 for role in scene_roles
             ]
@@ -294,14 +311,45 @@ def _scene_role_names(scene_data: dict[str, Any], roles: dict[str, Role]) -> lis
     return [name for name in raw_names if isinstance(name, str)]
 
 
+def _prompt_composition_settings(benchflow: dict[str, Any]) -> PromptCompositionSettings:
+    try:
+        return prompt_composition_settings(benchflow)
+    except ValueError as exc:
+        raise TaskDocumentParseError(str(exc)) from exc
+
+
+def _compose_scene_turn_prompt(
+    *,
+    base_prompt: str,
+    role_name: str,
+    scene_name: str,
+    role_prompts: dict[str, str],
+    scene_prompts: dict[str, str],
+    turn_prompt: str | None,
+    explicit_turn: bool,
+    prompt_settings: PromptCompositionSettings,
+) -> str:
+    return compose_task_prompt(
+        base_prompt,
+        role_prompts.get(role_name),
+        scene_prompts.get(scene_name),
+        turn_prompt,
+        composition=prompt_settings.composition,
+        order=prompt_settings.order,
+        explicit_turn=explicit_turn,
+    )
+
+
 def _parse_turns(
     raw_turns: Any,
     *,
     scene_name: str,
+    base_prompt: str,
     roles: dict[str, Role],
     scene_role_names: list[str],
     role_prompts: dict[str, str],
     scene_prompts: dict[str, str],
+    prompt_settings: PromptCompositionSettings,
 ) -> list[Turn]:
     if raw_turns is None:
         return []
@@ -312,13 +360,17 @@ def _parse_turns(
     for index, raw_turn in enumerate(raw_turns):
         if isinstance(raw_turn, str):
             role_name = raw_turn
-            prompt = None
+            turn_prompt = None
+            explicit_turn = False
         else:
             turn_data = _mapping(raw_turn, f"turns[{index}]", default={})
             role_name = turn_data.get("role")
             if not isinstance(role_name, str):
                 raise TaskDocumentParseError(f"turns[{index}].role is required")
-            prompt = _optional_str(turn_data.get("prompt"))
+            explicit_turn = "prompt" in turn_data
+            turn_prompt = (
+                _optional_str(turn_data.get("prompt")) if explicit_turn else None
+            )
         _lookup_role(roles, role_name, f"turns[{index}].role")
         if role_name not in scene_role_names:
             raise TaskDocumentParseError(
@@ -327,9 +379,16 @@ def _parse_turns(
         turns.append(
             Turn(
                 role=role_name,
-                prompt=prompt
-                or scene_prompts.get(scene_name)
-                or role_prompts.get(role_name),
+                prompt=_compose_scene_turn_prompt(
+                    base_prompt=base_prompt,
+                    role_name=role_name,
+                    scene_name=scene_name,
+                    role_prompts=role_prompts,
+                    scene_prompts=scene_prompts,
+                    turn_prompt=turn_prompt,
+                    explicit_turn=explicit_turn,
+                    prompt_settings=prompt_settings,
+                ),
             )
         )
     return turns

--- a/src/benchflow/task/export.py
+++ b/src/benchflow/task/export.py
@@ -267,10 +267,35 @@ def _sha256_text(content: str) -> str:
     return _sha256_bytes(content.encode("utf-8"))
 
 
+def export_report_json(result: ExportResult) -> dict[str, object]:
+    """Serialize an export result to the compatibility export-report schema."""
+    return {
+        "target": result.target,
+        "mode": result.mode,
+        "losses": [
+            {"concept": loss.concept, "reason": loss.reason}
+            for loss in result.losses
+        ],
+        "input_hashes": dict(result.input_hashes),
+        "output_hashes": dict(result.output_hashes),
+        "selected_definition": result.selected_definition,
+        "selected_oracle_dir": result.selected_oracle_dir,
+        "selected_verifier_dir": result.selected_verifier_dir,
+        "exported_oracle_dir": result.exported_oracle_dir,
+        "exported_verifier_dir": result.exported_verifier_dir,
+        "ignored_aliases": list(result.ignored_aliases),
+    }
+
+
+EXPORT_REPORT_REL_PATH = "compatibility/export-report.json"
+
+
 __all__ = [
+    "EXPORT_REPORT_REL_PATH",
     "ExportLoss",
     "ExportMode",
     "ExportResult",
     "ExportTarget",
+    "export_report_json",
     "export_task_package",
 ]

--- a/src/benchflow/task/export.py
+++ b/src/benchflow/task/export.py
@@ -1,0 +1,276 @@
+"""Native task.md export to Harbor/Pier split layout with loss reporting."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from benchflow.task.aliases import alias_dir_collision_issues, normalized_tree_map
+from benchflow.task.document import TaskDocument, TaskDocumentParseError
+from benchflow.task.paths import TaskPaths
+
+ExportTarget = Literal["harbor", "pier"]
+ExportMode = Literal["full", "degraded"]
+
+
+@dataclass(frozen=True)
+class ExportLoss:
+    """A native concept that the selected export target cannot express."""
+
+    concept: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    """In-memory Harbor/Pier split export plus an honest loss report."""
+
+    target: ExportTarget
+    mode: ExportMode
+    files: dict[str, str]
+    losses: tuple[ExportLoss, ...]
+    selected_definition: str
+    selected_oracle_dir: str
+    selected_verifier_dir: str
+    exported_oracle_dir: str
+    exported_verifier_dir: str
+    ignored_aliases: tuple[str, ...]
+    input_hashes: dict[str, str]
+    output_hashes: dict[str, str]
+
+
+def export_task_package(
+    task_dir: str | Path,
+    *,
+    target: ExportTarget = "harbor",
+) -> ExportResult:
+    """Export a native ``task.md`` package to Harbor/Pier split layout.
+
+    The exporter emits ``task.toml``, ``instruction.md``, ``solution/``, and
+    ``tests/`` for Harbor-compatible fields and records every native-only
+    concept that cannot be represented in the target format.
+    """
+    paths = TaskPaths(task_dir)
+    if not paths.task_document_path.is_file():
+        raise FileNotFoundError(
+            f"Native export requires {TaskPaths.DOCUMENT_FILENAME}: "
+            f"{paths.task_document_path}"
+        )
+
+    document = TaskDocument.from_path(paths.task_document_path)
+    losses = _collect_semantic_losses(document, paths)
+    ignored_aliases = _ignored_alias_notes(paths)
+    for issue in alias_dir_collision_issues(paths):
+        losses.append(
+            ExportLoss(
+                concept="alias.collision",
+                reason=issue,
+            )
+        )
+
+    files: dict[str, str] = {}
+    files["task.toml"] = document.config.model_dump_toml()
+    files["instruction.md"] = _format_instruction(document.instruction)
+
+    _copy_tree(
+        files,
+        source_dir=paths.environment_dir,
+        target_prefix="environment",
+    )
+    _copy_tree(
+        files,
+        source_dir=paths.oracle_dir,
+        target_prefix=TaskPaths.LEGACY_SOLUTION_DIRNAME,
+    )
+    _copy_tree(
+        files,
+        source_dir=paths.verifier_source_dir,
+        target_prefix=TaskPaths.LEGACY_TESTS_DIRNAME,
+    )
+
+    input_hashes = _hash_task_inputs(paths)
+    output_hashes = _hash_export_files(files)
+    mode: ExportMode = "degraded" if losses else "full"
+
+    return ExportResult(
+        target=target,
+        mode=mode,
+        files=files,
+        losses=tuple(losses),
+        selected_definition=TaskPaths.DOCUMENT_FILENAME,
+        selected_oracle_dir=f"{TaskPaths.NATIVE_ORACLE_DIRNAME}/",
+        selected_verifier_dir=f"{TaskPaths.NATIVE_VERIFIER_DIRNAME}/",
+        exported_oracle_dir=f"{TaskPaths.LEGACY_SOLUTION_DIRNAME}/",
+        exported_verifier_dir=f"{TaskPaths.LEGACY_TESTS_DIRNAME}/",
+        ignored_aliases=ignored_aliases,
+        input_hashes=input_hashes,
+        output_hashes=output_hashes,
+    )
+
+
+def _collect_semantic_losses(
+    document: TaskDocument,
+    paths: TaskPaths,
+) -> list[ExportLoss]:
+    losses: list[ExportLoss] = []
+
+    if document.frontmatter.get("agents"):
+        losses.append(
+            ExportLoss(
+                concept="agents",
+                reason="Harbor/Pier split layout has no native agents.roles surface",
+            )
+        )
+    if document.scenes:
+        losses.append(
+            ExportLoss(
+                concept="scenes",
+                reason="Harbor/Pier split layout cannot express interaction scenes",
+            )
+        )
+    if document.user:
+        losses.append(
+            ExportLoss(
+                concept="user",
+                reason="Harbor/Pier split layout cannot express simulated-user loops",
+            )
+        )
+
+    for key in sorted(document.benchflow):
+        losses.append(
+            ExportLoss(
+                concept=f"benchflow.{key}",
+                reason="BenchFlow document namespace is not exported to Harbor/Pier",
+            )
+        )
+
+    for role_name in sorted(document.role_prompts):
+        losses.append(
+            ExportLoss(
+                concept=f"prompt.role:{role_name}",
+                reason="Role prompts are not represented in instruction.md",
+            )
+        )
+    for scene_name in sorted(document.scene_prompts):
+        losses.append(
+            ExportLoss(
+                concept=f"prompt.scene:{scene_name}",
+                reason="Scene prompts are not represented in instruction.md",
+            )
+        )
+    if document.user_persona:
+        losses.append(
+            ExportLoss(
+                concept="prompt.user-persona",
+                reason="Simulated-user persona is not represented in instruction.md",
+            )
+        )
+
+    verifier_md = paths.verifier_source_dir / "verifier.md"
+    if verifier_md.is_file():
+        losses.append(
+            ExportLoss(
+                concept="verifier.verifier_md",
+                reason="Harbor/Pier tests/ has no verifier document surface",
+            )
+        )
+    rubrics_dir = paths.verifier_source_dir / "rubrics"
+    if rubrics_dir.is_dir() and any(rubrics_dir.iterdir()):
+        losses.append(
+            ExportLoss(
+                concept="verifier.rubrics",
+                reason="Harbor/Pier tests/ has no native rubric package surface",
+            )
+        )
+
+    return losses
+
+
+def _ignored_alias_notes(paths: TaskPaths) -> tuple[str, ...]:
+    notes: list[str] = []
+    if paths.uses_native_oracle_dir and paths.legacy_solution_dir.is_dir():
+        notes.append(
+            f"{TaskPaths.LEGACY_SOLUTION_DIRNAME}/ ignored; "
+            f"{TaskPaths.NATIVE_ORACLE_DIRNAME}/ selected"
+        )
+    if paths.uses_native_verifier_dir and paths.legacy_tests_dir.is_dir():
+        notes.append(
+            f"{TaskPaths.LEGACY_TESTS_DIRNAME}/ ignored; "
+            f"{TaskPaths.NATIVE_VERIFIER_DIRNAME}/ selected"
+        )
+    return tuple(notes)
+
+
+def _format_instruction(instruction: str) -> str:
+    text = instruction.strip()
+    if not text:
+        return ""
+    if not text.endswith("\n"):
+        text += "\n"
+    return text
+
+
+def _copy_tree(
+    files: dict[str, str],
+    *,
+    source_dir: Path,
+    target_prefix: str,
+) -> None:
+    if not source_dir.is_dir():
+        return
+    for rel_path, content in normalized_tree_map(source_dir).items():
+        files[f"{target_prefix}/{rel_path}"] = _decode_bytes(content)
+
+
+def _decode_bytes(content: bytes) -> str:
+    try:
+        return content.decode("utf-8")
+    except UnicodeDecodeError:
+        raise TaskDocumentParseError(
+            "Native export only supports UTF-8 text files in copied subtrees"
+        ) from None
+
+
+def _hash_task_inputs(paths: TaskPaths) -> dict[str, str]:
+    hashes: dict[str, str] = {}
+    _record_file_hash(hashes, paths.task_document_path)
+    for subtree in (
+        paths.environment_dir,
+        paths.oracle_dir,
+        paths.verifier_source_dir,
+    ):
+        if not subtree.is_dir():
+            continue
+        for rel_path, content in normalized_tree_map(subtree).items():
+            hashes[f"{subtree.name}/{rel_path}"] = _sha256_bytes(content)
+    return hashes
+
+
+def _hash_export_files(files: dict[str, str]) -> dict[str, str]:
+    return {
+        rel_path: _sha256_text(content) for rel_path, content in sorted(files.items())
+    }
+
+
+def _record_file_hash(hashes: dict[str, str], path: Path) -> None:
+    if path.is_file():
+        hashes[path.name] = _sha256_bytes(path.read_bytes())
+
+
+def _sha256_bytes(content: bytes) -> str:
+    return hashlib.sha256(content).hexdigest()
+
+
+def _sha256_text(content: str) -> str:
+    return _sha256_bytes(content.encode("utf-8"))
+
+
+__all__ = [
+    "ExportLoss",
+    "ExportMode",
+    "ExportResult",
+    "ExportTarget",
+    "export_task_package",
+]

--- a/src/benchflow/task/export.py
+++ b/src/benchflow/task/export.py
@@ -6,9 +6,10 @@ import hashlib
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from benchflow.task.aliases import alias_dir_collision_issues, normalized_tree_map
+from benchflow.task.config import TaskConfig
 from benchflow.task.document import TaskDocument, TaskDocumentParseError
 from benchflow.task.paths import TaskPaths
 
@@ -305,13 +306,285 @@ def write_export_report(
     return report_path
 
 
+def materialize_export_result(
+    result: ExportResult,
+    output_dir: str | Path,
+    *,
+    write_report: bool = True,
+) -> Path:
+    """Write an in-memory export result to disk as a Harbor/Pier split package."""
+    root = Path(output_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    for rel_path, content in result.files.items():
+        dest = root / rel_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content, encoding="utf-8")
+    if write_report:
+        write_export_report(root, result)
+    return root
+
+
+@dataclass(frozen=True)
+class NativeComparison:
+    """Semantic comparison of a split import against co-located native ``task.md``."""
+
+    has_native_document: bool
+    config_equal: bool | None
+    instruction_equal: bool | None
+    oracle_hash_equal: bool | None
+    verifier_hash_equal: bool | None
+    environment_hash_equal: bool | None
+    config_native_dump: dict[str, Any] | None
+    config_import_dump: dict[str, Any] | None
+    instruction_native_normalized: str | None
+    instruction_import_normalized: str | None
+    oracle_native_hashes: dict[str, str] | None
+    oracle_import_hashes: dict[str, str] | None
+    verifier_native_hashes: dict[str, str] | None
+    verifier_import_hashes: dict[str, str] | None
+    environment_native_hashes: dict[str, str] | None
+    environment_import_hashes: dict[str, str] | None
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    """Parsed Harbor/Pier split package plus optional native comparison."""
+
+    task_dir: Path
+    config: TaskConfig
+    instruction: str
+    instruction_normalized: str
+    oracle_hashes: dict[str, str]
+    verifier_hashes: dict[str, str]
+    environment_hashes: dict[str, str]
+    native_comparison: NativeComparison | None
+
+
+def import_split_task_package(task_dir: str | Path) -> ImportResult:
+    """Read a Harbor/Pier split package and compare against native ``task.md`` when present."""
+    root = Path(task_dir).resolve()
+    paths = TaskPaths(root)
+    if not paths.config_path.is_file():
+        raise FileNotFoundError(
+            f"Split import requires {TaskPaths.CONFIG_FILENAME}: {paths.config_path}"
+        )
+    if not paths.instruction_path.is_file():
+        raise FileNotFoundError(
+            f"Split import requires instruction.md: {paths.instruction_path}"
+        )
+
+    config = TaskConfig.model_validate_toml(paths.config_path.read_text(encoding="utf-8"))
+    instruction = paths.instruction_path.read_text(encoding="utf-8")
+    instruction_normalized = _format_instruction(instruction)
+
+    oracle_hashes = _subtree_hash_map(
+        paths.legacy_solution_dir,
+        TaskPaths.LEGACY_SOLUTION_DIRNAME,
+    )
+    verifier_hashes = _subtree_hash_map(
+        paths.legacy_tests_dir,
+        TaskPaths.LEGACY_TESTS_DIRNAME,
+    )
+    environment_hashes = _subtree_hash_map(paths.environment_dir, "environment")
+
+    native_comparison = _compare_split_against_native(paths)
+    return ImportResult(
+        task_dir=root,
+        config=config,
+        instruction=instruction,
+        instruction_normalized=instruction_normalized,
+        oracle_hashes=oracle_hashes,
+        verifier_hashes=verifier_hashes,
+        environment_hashes=environment_hashes,
+        native_comparison=native_comparison,
+    )
+
+
+def validate_export_round_trip(
+    native_dir: str | Path,
+    exported_dir: str | Path,
+) -> list[str]:
+    """Validate Harbor-compatible semantic parity between native and exported packages."""
+    native_root = Path(native_dir).resolve()
+    exported_root = Path(exported_dir).resolve()
+    native_paths = TaskPaths(native_root)
+    if not native_paths.task_document_path.is_file():
+        return [
+            f"Native round-trip requires {TaskPaths.DOCUMENT_FILENAME}: "
+            f"{native_paths.task_document_path}"
+        ]
+
+    document = TaskDocument.from_path(native_paths.task_document_path)
+    try:
+        imported = import_split_task_package(exported_root)
+    except FileNotFoundError as exc:
+        return [str(exc)]
+
+    issues: list[str] = []
+    native_config_dump = document.config.model_dump()
+    import_config_dump = imported.config.model_dump()
+    if native_config_dump != import_config_dump:
+        issues.append("Config drift: canonical TaskConfig dumps differ")
+
+    native_instruction = _format_instruction(document.instruction)
+    if native_instruction != imported.instruction_normalized:
+        issues.append("Prompt drift: normalized instruction text differs")
+
+    native_oracle_hashes = _subtree_hash_map(
+        native_paths.oracle_dir,
+        TaskPaths.NATIVE_ORACLE_DIRNAME,
+    )
+    if native_oracle_hashes != imported.oracle_hashes:
+        issues.extend(
+            _hash_map_diff_issues(
+                "Oracle",
+                native_oracle_hashes,
+                imported.oracle_hashes,
+                native_label=TaskPaths.NATIVE_ORACLE_DIRNAME,
+                import_label=TaskPaths.LEGACY_SOLUTION_DIRNAME,
+            )
+        )
+
+    native_verifier_hashes = _subtree_hash_map(
+        native_paths.verifier_source_dir,
+        TaskPaths.NATIVE_VERIFIER_DIRNAME,
+    )
+    if native_verifier_hashes != imported.verifier_hashes:
+        issues.extend(
+            _hash_map_diff_issues(
+                "Verifier",
+                native_verifier_hashes,
+                imported.verifier_hashes,
+                native_label=TaskPaths.NATIVE_VERIFIER_DIRNAME,
+                import_label=TaskPaths.LEGACY_TESTS_DIRNAME,
+            )
+        )
+
+    native_environment_hashes = _subtree_hash_map(
+        native_paths.environment_dir,
+        "environment",
+    )
+    if native_environment_hashes != imported.environment_hashes:
+        issues.extend(
+            _hash_map_diff_issues(
+                "Environment",
+                native_environment_hashes,
+                imported.environment_hashes,
+                native_label="environment",
+                import_label="environment",
+            )
+        )
+
+    return issues
+
+
+def _compare_split_against_native(paths: TaskPaths) -> NativeComparison | None:
+    if not paths.task_document_path.is_file():
+        return None
+
+    document = TaskDocument.from_path(paths.task_document_path)
+    native_config_dump = document.config.model_dump()
+    import_config_dump = TaskConfig.model_validate_toml(
+        paths.config_path.read_text(encoding="utf-8")
+    ).model_dump()
+    native_instruction = _format_instruction(document.instruction)
+    import_instruction = _format_instruction(
+        paths.instruction_path.read_text(encoding="utf-8")
+    )
+
+    native_oracle_hashes = _subtree_hash_map(
+        paths.oracle_dir,
+        TaskPaths.NATIVE_ORACLE_DIRNAME,
+    )
+    import_oracle_hashes = _subtree_hash_map(
+        paths.legacy_solution_dir,
+        TaskPaths.LEGACY_SOLUTION_DIRNAME,
+    )
+    native_verifier_hashes = _subtree_hash_map(
+        paths.verifier_source_dir,
+        TaskPaths.NATIVE_VERIFIER_DIRNAME,
+    )
+    import_verifier_hashes = _subtree_hash_map(
+        paths.legacy_tests_dir,
+        TaskPaths.LEGACY_TESTS_DIRNAME,
+    )
+    native_environment_hashes = _subtree_hash_map(paths.environment_dir, "environment")
+    import_environment_hashes = _subtree_hash_map(paths.environment_dir, "environment")
+
+    return NativeComparison(
+        has_native_document=True,
+        config_equal=native_config_dump == import_config_dump,
+        instruction_equal=native_instruction == import_instruction,
+        oracle_hash_equal=native_oracle_hashes == import_oracle_hashes,
+        verifier_hash_equal=native_verifier_hashes == import_verifier_hashes,
+        environment_hash_equal=native_environment_hashes == import_environment_hashes,
+        config_native_dump=native_config_dump,
+        config_import_dump=import_config_dump,
+        instruction_native_normalized=native_instruction,
+        instruction_import_normalized=import_instruction,
+        oracle_native_hashes=native_oracle_hashes,
+        oracle_import_hashes=import_oracle_hashes,
+        verifier_native_hashes=native_verifier_hashes,
+        verifier_import_hashes=import_verifier_hashes,
+        environment_native_hashes=native_environment_hashes,
+        environment_import_hashes=import_environment_hashes,
+    )
+
+
+def _subtree_hash_map(root: Path, prefix: str) -> dict[str, str]:
+    if not root.is_dir():
+        return {}
+    return {
+        f"{prefix}/{rel_path}": _sha256_bytes(content)
+        for rel_path, content in normalized_tree_map(root).items()
+    }
+
+
+def _hash_map_diff_issues(
+    label: str,
+    native_hashes: dict[str, str],
+    import_hashes: dict[str, str],
+    *,
+    native_label: str,
+    import_label: str,
+) -> list[str]:
+    issues: list[str] = []
+    native_rel = {path.removeprefix(f"{native_label}/"): digest for path, digest in native_hashes.items()}
+    import_rel = {path.removeprefix(f"{import_label}/"): digest for path, digest in import_hashes.items()}
+
+    for rel_path in sorted(set(native_rel) | set(import_rel)):
+        native_digest = native_rel.get(rel_path)
+        import_digest = import_rel.get(rel_path)
+        if native_digest == import_digest:
+            continue
+        if native_digest is None:
+            issues.append(
+                f"{label} drift: {import_label}/{rel_path} missing from native {native_label}/"
+            )
+        elif import_digest is None:
+            issues.append(
+                f"{label} drift: {native_label}/{rel_path} missing from exported {import_label}/"
+            )
+        else:
+            issues.append(
+                f"{label} drift: {rel_path} hash differs between "
+                f"{native_label}/ and {import_label}/"
+            )
+    return issues
+
+
 __all__ = [
     "EXPORT_REPORT_REL_PATH",
     "ExportLoss",
     "ExportMode",
     "ExportResult",
     "ExportTarget",
+    "ImportResult",
+    "NativeComparison",
     "export_report_json",
     "export_task_package",
+    "import_split_task_package",
+    "materialize_export_result",
+    "validate_export_round_trip",
     "write_export_report",
 ]

--- a/src/benchflow/task/export.py
+++ b/src/benchflow/task/export.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -290,6 +291,20 @@ def export_report_json(result: ExportResult) -> dict[str, object]:
 EXPORT_REPORT_REL_PATH = "compatibility/export-report.json"
 
 
+def write_export_report(
+    output_dir: str | Path,
+    result: ExportResult,
+) -> Path:
+    """Write ``compatibility/export-report.json`` for an export result."""
+    report_path = Path(output_dir) / EXPORT_REPORT_REL_PATH
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(
+        json.dumps(export_report_json(result), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return report_path
+
+
 __all__ = [
     "EXPORT_REPORT_REL_PATH",
     "ExportLoss",
@@ -298,4 +313,5 @@ __all__ = [
     "ExportTarget",
     "export_report_json",
     "export_task_package",
+    "write_export_report",
 ]

--- a/src/benchflow/task/package.py
+++ b/src/benchflow/task/package.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
 from benchflow._types import Scene
+from benchflow.skill_policy import SKILL_MODE_SELF_GEN
 from benchflow.task.aliases import alias_dir_collision_issues, normalized_tree_map
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import TaskDocument
@@ -217,6 +218,73 @@ class TaskRuntimeView:
             composition=settings.composition,
             order=settings.order,
         )
+
+    def compose_turn_prompt(
+        self,
+        scene_name: str,
+        role_name: str,
+        turn_prompt: str | None = None,
+        *,
+        explicit_turn: bool = False,
+    ) -> str:
+        """Compose one scene turn prompt using ``benchflow.prompt`` settings."""
+        settings = prompt_composition_settings(self.benchflow)
+        role_prompt = (
+            self.document.role_prompts.get(role_name) if self.document else None
+        )
+        scene_prompt = (
+            self.document.scene_prompts.get(scene_name) if self.document else None
+        )
+        return compose_task_prompt(
+            self.instruction_text,
+            role_prompt,
+            scene_prompt,
+            turn_prompt,
+            composition=settings.composition,
+            order=settings.order,
+            explicit_turn=explicit_turn,
+        )
+
+    def to_rollout_scenes(
+        self,
+        *,
+        prompts: list[str | None] | None = None,
+        skill_mode: str = "no-skill",
+    ) -> list[Scene]:
+        """Return document scenes for rollout when no explicit override applies."""
+        if prompts is not None or skill_mode == SKILL_MODE_SELF_GEN:
+            return []
+        return list(self.scenes)
+
+    def document_runtime_summary(self) -> dict[str, Any]:
+        """Return a compact runtime summary for logging and debug."""
+        settings = prompt_composition_settings(self.benchflow)
+        summary: dict[str, Any] = {
+            "task_dir": str(self.task_dir),
+            "entrypoint": self.entrypoint,
+            "instruction_chars": len(self.instruction_text),
+            "scene_names": list(self.scene_names),
+            "verifier_dir": str(self.verifier_dir),
+            "verifier_dir_kind": self.verifier_dir_kind,
+            "oracle_dir": str(self.oracle_dir),
+            "oracle_dir_kind": self.oracle_dir_kind,
+            "has_legacy_split_files": self.has_legacy_split_files,
+            "alias_collisions": list(self.alias_collisions.issues),
+            "prompt_composition": settings.composition,
+            "prompt_order": list(settings.order),
+        }
+        if self.document is not None:
+            summary["role_names"] = sorted(self.document.roles)
+            summary["role_prompt_sections"] = sorted(self.document.role_prompts)
+            summary["scene_prompt_sections"] = sorted(self.document.scene_prompts)
+        if self.benchflow:
+            summary["benchflow_keys"] = sorted(self.benchflow)
+        if self.verifier_document is not None:
+            summary["verifier_document"] = {
+                "name": self.verifier_document.name,
+                "default_strategy": self.verifier_document.default_strategy,
+            }
+        return summary
 
     def selected_verifier_tree_map(self) -> dict[str, bytes]:
         """Normalized file map for the selected verifier directory."""

--- a/src/benchflow/task/package.py
+++ b/src/benchflow/task/package.py
@@ -1,0 +1,214 @@
+"""Task package and runtime view for BenchFlow-native task directories.
+
+``TaskPackage`` is the on-disk authoring layout. ``TaskRuntimeView`` is the
+selected executable interpretation rollout, verifier, and validation code consume.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal
+
+from benchflow._types import Scene
+from benchflow.task.aliases import alias_dir_collision_issues, normalized_tree_map
+from benchflow.task.config import TaskConfig
+from benchflow.task.document import TaskDocument
+from benchflow.task.paths import TaskPaths
+
+if TYPE_CHECKING:
+    from benchflow.task.task import Task
+
+TaskEntrypoint = Literal["task-md", "legacy-split"]
+VerifierDirKind = Literal["native", "legacy"]
+OracleDirKind = Literal["native", "legacy"]
+
+
+@dataclass(frozen=True)
+class AliasCollisionStatus:
+    """Native/legacy directory alias equivalence diagnostics."""
+
+    issues: tuple[str, ...]
+
+    @property
+    def has_collisions(self) -> bool:
+        return bool(self.issues)
+
+
+@dataclass(frozen=True)
+class TaskPackage:
+    """Authoring package rooted at a task directory."""
+
+    task_dir: Path
+    paths: TaskPaths
+
+    @classmethod
+    def load(cls, task_dir: Path | str) -> TaskPackage:
+        root = Path(task_dir).resolve()
+        return cls(task_dir=root, paths=TaskPaths(root))
+
+
+@dataclass(frozen=True)
+class TaskRuntimeView:
+    """Selected executable interpretation of a task package."""
+
+    package: TaskPackage
+    entrypoint: TaskEntrypoint
+    instruction_text: str
+    config: TaskConfig
+    document: TaskDocument | None
+    scenes: tuple[Scene, ...]
+    verifier_dir_kind: VerifierDirKind
+    oracle_dir_kind: OracleDirKind
+    alias_collisions: AliasCollisionStatus
+    has_legacy_split_files: bool
+    benchflow: dict[str, Any]
+
+    @property
+    def task_dir(self) -> Path:
+        return self.package.task_dir
+
+    @property
+    def paths(self) -> TaskPaths:
+        return self.package.paths
+
+    @property
+    def uses_native_verifier_dir(self) -> bool:
+        return self.verifier_dir_kind == "native"
+
+    @property
+    def uses_native_oracle_dir(self) -> bool:
+        return self.oracle_dir_kind == "native"
+
+    @property
+    def verifier_dir(self) -> Path:
+        return self.paths.tests_dir
+
+    @property
+    def oracle_dir(self) -> Path:
+        return self.paths.solution_dir
+
+    @property
+    def scene_names(self) -> tuple[str, ...]:
+        return tuple(scene.name for scene in self.scenes)
+
+    @classmethod
+    def from_task_dir(
+        cls,
+        task_dir: Path | str,
+        *,
+        fail_on_alias_collision: bool = True,
+    ) -> TaskRuntimeView:
+        package = TaskPackage.load(task_dir)
+        alias_issues = alias_dir_collision_issues(package.paths)
+        if fail_on_alias_collision and alias_issues:
+            raise ValueError("; ".join(alias_issues))
+        return cls._build(package, alias_issues)
+
+    @classmethod
+    def from_task(cls, task: Task) -> TaskRuntimeView:
+        package = TaskPackage(task_dir=task.task_dir, paths=task.paths)
+        return cls._build(
+            package,
+            alias_dir_collision_issues(package.paths),
+            document=task.document,
+            config=task.config,
+            instruction_text=task.instruction.strip(),
+            scenes=tuple(task.scenes),
+        )
+
+    @classmethod
+    def _build(
+        cls,
+        package: TaskPackage,
+        alias_issues: list[str],
+        *,
+        document: TaskDocument | None = None,
+        config: TaskConfig | None = None,
+        instruction_text: str | None = None,
+        scenes: tuple[Scene, ...] | None = None,
+    ) -> TaskRuntimeView:
+        paths = package.paths
+        has_task_md = paths.task_document_path.exists()
+        has_legacy_split = (
+            paths.config_path.exists() and paths.instruction_path.exists()
+        )
+        has_instruction_only = (
+            paths.instruction_path.exists()
+            and not paths.config_path.exists()
+            and not has_task_md
+        )
+
+        if has_task_md:
+            entrypoint: TaskEntrypoint = "task-md"
+            if document is None:
+                document = TaskDocument.from_path(paths.task_document_path)
+            if config is None:
+                config = document.config
+            if instruction_text is None:
+                instruction_text = document.instruction.strip()
+            if scenes is None:
+                scenes = tuple(document.scenes)
+            benchflow = dict(document.benchflow)
+        elif has_legacy_split or has_instruction_only:
+            entrypoint = "legacy-split"
+            if config is None:
+                if has_legacy_split:
+                    config = TaskConfig.model_validate_toml(
+                        paths.config_path.read_text()
+                    )
+                else:
+                    config = TaskConfig()
+            if instruction_text is None:
+                instruction_text = paths.instruction_path.read_text().strip()
+            if scenes is None:
+                scenes = ()
+            benchflow = {}
+        else:
+            raise FileNotFoundError(
+                f"Task missing task.md or legacy task.toml + instruction.md: "
+                f"{package.task_dir}"
+            )
+
+        verifier_dir_kind: VerifierDirKind = (
+            "native" if paths.uses_native_verifier_dir else "legacy"
+        )
+        oracle_dir_kind: OracleDirKind = (
+            "native" if paths.uses_native_oracle_dir else "legacy"
+        )
+
+        return cls(
+            package=package,
+            entrypoint=entrypoint,
+            instruction_text=instruction_text,
+            config=config,
+            document=document,
+            scenes=scenes,
+            verifier_dir_kind=verifier_dir_kind,
+            oracle_dir_kind=oracle_dir_kind,
+            alias_collisions=AliasCollisionStatus(issues=tuple(alias_issues)),
+            has_legacy_split_files=has_legacy_split,
+            benchflow=benchflow,
+        )
+
+    def materialize_instruction_md(self) -> str:
+        """Return prompt text for the ``/instruction.md`` compatibility upload."""
+        return self.instruction_text
+
+    def selected_verifier_tree_map(self) -> dict[str, bytes]:
+        """Normalized file map for the selected verifier directory."""
+        return normalized_tree_map(self.verifier_dir)
+
+    def selected_oracle_tree_map(self) -> dict[str, bytes]:
+        """Normalized file map for the selected oracle directory."""
+        return normalized_tree_map(self.oracle_dir)
+
+
+__all__ = [
+    "AliasCollisionStatus",
+    "OracleDirKind",
+    "TaskEntrypoint",
+    "TaskPackage",
+    "TaskRuntimeView",
+    "VerifierDirKind",
+]

--- a/src/benchflow/task/package.py
+++ b/src/benchflow/task/package.py
@@ -15,6 +15,10 @@ from benchflow.task.aliases import alias_dir_collision_issues, normalized_tree_m
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import TaskDocument
 from benchflow.task.paths import TaskPaths
+from benchflow.task.prompt_composition import (
+    compose_task_prompt,
+    prompt_composition_settings,
+)
 from benchflow.task.verifier_document import (
     VerifierDocument,
     load_verifier_document,
@@ -204,7 +208,15 @@ class TaskRuntimeView:
 
     def materialize_instruction_md(self) -> str:
         """Return prompt text for the ``/instruction.md`` compatibility upload."""
-        return self.instruction_text
+        settings = prompt_composition_settings(self.benchflow)
+        return compose_task_prompt(
+            self.instruction_text,
+            None,
+            None,
+            None,
+            composition=settings.composition,
+            order=settings.order,
+        )
 
     def selected_verifier_tree_map(self) -> dict[str, bytes]:
         """Normalized file map for the selected verifier directory."""

--- a/src/benchflow/task/package.py
+++ b/src/benchflow/task/package.py
@@ -15,6 +15,10 @@ from benchflow.task.aliases import alias_dir_collision_issues, normalized_tree_m
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import TaskDocument
 from benchflow.task.paths import TaskPaths
+from benchflow.task.verifier_document import (
+    VerifierDocument,
+    load_verifier_document,
+)
 
 if TYPE_CHECKING:
     from benchflow.task.task import Task
@@ -63,6 +67,7 @@ class TaskRuntimeView:
     alias_collisions: AliasCollisionStatus
     has_legacy_split_files: bool
     benchflow: dict[str, Any]
+    verifier_document: VerifierDocument | None = None
 
     @property
     def task_dir(self) -> Path:
@@ -115,6 +120,7 @@ class TaskRuntimeView:
             config=task.config,
             instruction_text=task.instruction.strip(),
             scenes=tuple(task.scenes),
+            verifier_document=task.verifier_document,
         )
 
     @classmethod
@@ -127,6 +133,7 @@ class TaskRuntimeView:
         config: TaskConfig | None = None,
         instruction_text: str | None = None,
         scenes: tuple[Scene, ...] | None = None,
+        verifier_document: VerifierDocument | None = None,
     ) -> TaskRuntimeView:
         paths = package.paths
         has_task_md = paths.task_document_path.exists()
@@ -177,6 +184,9 @@ class TaskRuntimeView:
             "native" if paths.uses_native_oracle_dir else "legacy"
         )
 
+        if verifier_document is None and entrypoint == "task-md":
+            verifier_document = load_verifier_document(package.task_dir, benchflow)
+
         return cls(
             package=package,
             entrypoint=entrypoint,
@@ -189,6 +199,7 @@ class TaskRuntimeView:
             alias_collisions=AliasCollisionStatus(issues=tuple(alias_issues)),
             has_legacy_split_files=has_legacy_split,
             benchflow=benchflow,
+            verifier_document=verifier_document,
         )
 
     def materialize_instruction_md(self) -> str:

--- a/src/benchflow/task/paths.py
+++ b/src/benchflow/task/paths.py
@@ -112,6 +112,10 @@ class TaskPaths:
     def test_path(self) -> Path:
         return self.tests_dir / "test.sh"
 
+    @property
+    def verifier_document_path(self) -> Path:
+        return self.tests_dir / "verifier.md"
+
     def is_valid(self, disable_verification: bool = False) -> bool:
         has_legacy_definition = (
             self.config_path.exists() and self.instruction_path.exists()

--- a/src/benchflow/task/paths.py
+++ b/src/benchflow/task/paths.py
@@ -189,6 +189,10 @@ class RolloutPaths:
         return self.verifier_dir / "reward.json"
 
     @property
+    def reward_details_path(self) -> Path:
+        return self.verifier_dir / "reward-details.json"
+
+    @property
     def result_path(self) -> Path:
         return self.rollout_dir / "result.json"
 
@@ -220,3 +224,4 @@ class SandboxPaths:
     task_document_path: PurePosixPath = PurePosixPath("/task.md")  # noqa: RUF009
     reward_text_path: PurePosixPath = verifier_dir / "reward.txt"
     reward_json_path: PurePosixPath = verifier_dir / "reward.json"
+    reward_details_path: PurePosixPath = verifier_dir / "reward-details.json"

--- a/src/benchflow/task/paths.py
+++ b/src/benchflow/task/paths.py
@@ -212,5 +212,7 @@ class SandboxPaths:
     tests_dir: PurePosixPath = PurePosixPath("/tests")  # noqa: RUF009
     oracle_dir: PurePosixPath = PurePosixPath("/oracle")  # noqa: RUF009
     solution_dir: PurePosixPath = PurePosixPath("/solution")  # noqa: RUF009
+    instruction_path: PurePosixPath = PurePosixPath("/instruction.md")  # noqa: RUF009
+    task_document_path: PurePosixPath = PurePosixPath("/task.md")  # noqa: RUF009
     reward_text_path: PurePosixPath = verifier_dir / "reward.txt"
     reward_json_path: PurePosixPath = verifier_dir / "reward.json"

--- a/src/benchflow/task/prompt_composition.py
+++ b/src/benchflow/task/prompt_composition.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 PromptPart = Literal["base", "role", "scene", "turn"]
 CompositionMode = Literal["append", "replace"]
@@ -50,7 +50,7 @@ def prompt_composition_settings(benchflow: dict[str, Any]) -> PromptCompositionS
                     f"benchflow.prompt.order[{index}] must be one of "
                     f"base, role, scene, turn"
                 )
-            order_parts.append(item)
+            order_parts.append(cast(PromptPart, item))
         order = tuple(order_parts)
 
     return PromptCompositionSettings(
@@ -123,7 +123,11 @@ def compose_task_prompt(
         return ""
 
     if composition == "append":
-        chunks = [parts[part_name] for part_name in resolved_order if parts[part_name]]
+        chunks: list[str] = [
+            value
+            for part_name in resolved_order
+            if (value := parts[part_name])
+        ]
         return "\n\n".join(chunks)
 
     if explicit_turn:

--- a/src/benchflow/task/prompt_composition.py
+++ b/src/benchflow/task/prompt_composition.py
@@ -1,0 +1,146 @@
+"""Prompt composition for task-standard ``task.md`` documents."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+PromptPart = Literal["base", "role", "scene", "turn"]
+CompositionMode = Literal["append", "replace"]
+
+DEFAULT_PROMPT_ORDER: tuple[PromptPart, ...] = ("base", "role", "scene", "turn")
+_LEGACY_FALLBACK_ORDER: tuple[PromptPart, ...] = ("turn", "scene", "role", "base")
+_VALID_PARTS = frozenset(DEFAULT_PROMPT_ORDER)
+
+
+@dataclass(frozen=True)
+class PromptCompositionSettings:
+    """Resolved ``benchflow.prompt`` settings for a task document."""
+
+    composition: CompositionMode | None = None
+    order: tuple[PromptPart, ...] = DEFAULT_PROMPT_ORDER
+
+
+def prompt_composition_settings(benchflow: dict[str, Any]) -> PromptCompositionSettings:
+    """Read ``benchflow.prompt`` composition settings from a benchflow block."""
+
+    raw = benchflow.get("prompt")
+    if raw is None:
+        return PromptCompositionSettings()
+    if not isinstance(raw, dict):
+        raise ValueError("benchflow.prompt must be a mapping")
+
+    composition = raw.get("composition")
+    if composition is not None and composition not in ("append", "replace"):
+        raise ValueError(
+            "benchflow.prompt.composition must be 'append' or 'replace'"
+        )
+
+    order_raw = raw.get("order")
+    if order_raw is None:
+        order = DEFAULT_PROMPT_ORDER
+    else:
+        if not isinstance(order_raw, list) or not order_raw:
+            raise ValueError("benchflow.prompt.order must be a non-empty list")
+        order_parts: list[PromptPart] = []
+        for index, item in enumerate(order_raw):
+            if not isinstance(item, str) or item not in _VALID_PARTS:
+                raise ValueError(
+                    f"benchflow.prompt.order[{index}] must be one of "
+                    f"base, role, scene, turn"
+                )
+            order_parts.append(item)
+        order = tuple(order_parts)
+
+    return PromptCompositionSettings(
+        composition=composition,
+        order=order,
+    )
+
+
+def _normalize_optional_part(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def _parts_by_name(
+    base: str | None,
+    role: str | None,
+    scene: str | None,
+    turn: str | None,
+    *,
+    explicit_turn: bool,
+) -> dict[PromptPart, str | None]:
+    if explicit_turn:
+        turn_value = turn.strip() if isinstance(turn, str) else ""
+        return {
+            "base": _normalize_optional_part(base),
+            "role": _normalize_optional_part(role),
+            "scene": _normalize_optional_part(scene),
+            "turn": turn_value if turn_value else None,
+        }
+    return {
+        "base": _normalize_optional_part(base),
+        "role": _normalize_optional_part(role),
+        "scene": _normalize_optional_part(scene),
+        "turn": _normalize_optional_part(turn),
+    }
+
+
+def compose_task_prompt(
+    base: str | None,
+    role: str | None,
+    scene: str | None,
+    turn: str | None,
+    *,
+    composition: CompositionMode | None = None,
+    order: Sequence[PromptPart] | None = None,
+    explicit_turn: bool = False,
+) -> str:
+    """Compose prompt parts using legacy fallback or explicit composition rules.
+
+    When *composition* is ``None``, use legacy fallback precedence:
+    turn > scene > role > base.
+
+    ``append`` joins non-empty parts in *order* with double newlines.
+
+    ``replace`` returns the highest-priority non-empty part using reverse
+    *order* (turn wins by default). When *explicit_turn* is true, only the
+    inline turn prompt is used.
+    """
+
+    resolved_order = tuple(order) if order is not None else DEFAULT_PROMPT_ORDER
+    parts = _parts_by_name(base, role, scene, turn, explicit_turn=explicit_turn)
+
+    if composition is None:
+        for part_name in _LEGACY_FALLBACK_ORDER:
+            value = parts[part_name]
+            if value:
+                return value
+        return ""
+
+    if composition == "append":
+        chunks = [parts[part_name] for part_name in resolved_order if parts[part_name]]
+        return "\n\n".join(chunks)
+
+    if explicit_turn:
+        return parts["turn"] or ""
+
+    for part_name in reversed(resolved_order):
+        value = parts[part_name]
+        if value:
+            return value
+    return ""
+
+
+__all__ = [
+    "CompositionMode",
+    "DEFAULT_PROMPT_ORDER",
+    "PromptCompositionSettings",
+    "PromptPart",
+    "compose_task_prompt",
+    "prompt_composition_settings",
+]

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -1,0 +1,264 @@
+"""Fail-closed runtime capability validation for parsed task fields.
+
+Parsed Harbor-compatible fields that the selected sandbox backend cannot honor
+must be rejected before sandbox construction. See ``docs/task-standard.md``
+Runtime Capability Matrix (P1).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from benchflow.task.config import NetworkMode, TaskOS, VerifierEnvironmentMode
+
+if TYPE_CHECKING:
+    from benchflow.task.task import Task
+
+_GATED_SANDBOX_TYPES = frozenset({"docker", "daytona"})
+
+
+@dataclass(frozen=True)
+class UnsupportedTaskFeature:
+    """One parsed task field the selected sandbox cannot execute."""
+
+    path: str
+    reason: str
+    sandbox_type: str
+
+
+class UnsupportedTaskRuntimeError(ValueError):
+    """Raised when a task uses parsed fields unsupported on the selected sandbox."""
+
+    def __init__(
+        self,
+        issues: list[UnsupportedTaskFeature],
+        *,
+        task_path: Path | str,
+    ) -> None:
+        self.issues = issues
+        self.task_path = Path(task_path)
+        lines = [
+            f"{issue.path}: {issue.reason} (sandbox={issue.sandbox_type})"
+            for issue in issues
+        ]
+        message = (
+            f"Task {self.task_path} uses runtime fields unsupported on "
+            f"{issues[0].sandbox_type!r}: " + "; ".join(lines)
+        )
+        super().__init__(message)
+
+
+def _task_has_compose(task_path: Path) -> bool:
+    return (task_path / "environment" / "docker-compose.yaml").exists()
+
+
+def _append_allowlist_issue(
+    issues: list[UnsupportedTaskFeature],
+    *,
+    sandbox_type: str,
+    prefix: str,
+    network_mode: NetworkMode | None,
+    allowed_hosts: list[str] | None,
+) -> None:
+    if network_mode == NetworkMode.ALLOWLIST:
+        issues.append(
+            UnsupportedTaskFeature(
+                path=f"{prefix}.network_mode",
+                reason=(
+                    "network_mode='allowlist' is parsed but egress allowlists "
+                    "are not enforced by the selected sandbox yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+    elif allowed_hosts:
+        issues.append(
+            UnsupportedTaskFeature(
+                path=f"{prefix}.allowed_hosts",
+                reason=(
+                    "allowed_hosts is parsed but egress allowlists are not "
+                    "enforced by the selected sandbox yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+
+def validate_task_runtime_support(
+    task: Task,
+    sandbox_type: str,
+    task_path: Path | str,
+) -> list[UnsupportedTaskFeature]:
+    """Return unsupported parsed fields for *sandbox_type* (empty when supported)."""
+    if sandbox_type not in _GATED_SANDBOX_TYPES:
+        return []
+
+    root = Path(task_path).resolve()
+    config = task.config
+    env = config.environment
+    issues: list[UnsupportedTaskFeature] = []
+
+    if config.steps:
+        issues.append(
+            UnsupportedTaskFeature(
+                path="steps",
+                reason=(
+                    "Harbor multi-step tasks are parsed but step execution is "
+                    "not implemented for this sandbox yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+        for step in config.steps:
+            if step.artifacts:
+                issues.append(
+                    UnsupportedTaskFeature(
+                        path=f"steps[{step.name!r}].artifacts",
+                        reason=(
+                            "step-level artifact collection is parsed but not "
+                            "implemented for this sandbox yet"
+                        ),
+                        sandbox_type=sandbox_type,
+                    )
+                )
+            if step.healthcheck is not None:
+                issues.append(
+                    UnsupportedTaskFeature(
+                        path=f"steps[{step.name!r}].healthcheck",
+                        reason=(
+                            "step-level healthchecks are parsed but not "
+                            "implemented for this sandbox yet"
+                        ),
+                        sandbox_type=sandbox_type,
+                    )
+                )
+
+    if config.artifacts:
+        issues.append(
+            UnsupportedTaskFeature(
+                path="artifacts",
+                reason=(
+                    "root-level artifact collection is parsed but not "
+                    "implemented for this sandbox yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    _append_allowlist_issue(
+        issues,
+        sandbox_type=sandbox_type,
+        prefix="environment",
+        network_mode=env.network_mode,
+        allowed_hosts=env.allowed_hosts,
+    )
+    _append_allowlist_issue(
+        issues,
+        sandbox_type=sandbox_type,
+        prefix="agent",
+        network_mode=config.agent.network_mode,
+        allowed_hosts=config.agent.allowed_hosts,
+    )
+    _append_allowlist_issue(
+        issues,
+        sandbox_type=sandbox_type,
+        prefix="verifier",
+        network_mode=config.verifier.network_mode,
+        allowed_hosts=config.verifier.allowed_hosts,
+    )
+
+    verifier = config.verifier
+    if (
+        verifier.environment_mode == VerifierEnvironmentMode.SEPARATE
+        or verifier.environment is not None
+    ):
+        issues.append(
+            UnsupportedTaskFeature(
+                path="verifier.environment"
+                if verifier.environment is not None
+                else "verifier.environment_mode",
+                reason=(
+                    "separate verifier environments are parsed but not "
+                    "materialized for this sandbox yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if env.os == TaskOS.WINDOWS:
+        issues.append(
+            UnsupportedTaskFeature(
+                path="environment.os",
+                reason="Windows task containers are parsed but not runnable yet",
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if env.tpu is not None:
+        issues.append(
+            UnsupportedTaskFeature(
+                path="environment.tpu",
+                reason="TPU resource requests are parsed but not runnable yet",
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if env.healthcheck is not None:
+        issues.append(
+            UnsupportedTaskFeature(
+                path="environment.healthcheck",
+                reason=(
+                    "environment healthchecks are parsed but not executed "
+                    "during sandbox startup yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if env.workdir is not None:
+        issues.append(
+            UnsupportedTaskFeature(
+                path="environment.workdir",
+                reason=(
+                    "environment.workdir is parsed but default working "
+                    "directories are not applied by the materializer yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if verifier.service != "main" and not _task_has_compose(root):
+        issues.append(
+            UnsupportedTaskFeature(
+                path="verifier.service",
+                reason=(
+                    f"verifier.service={verifier.service!r} requires a "
+                    "multi-container docker-compose.yaml task, which is not "
+                    "present under environment/"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    return issues
+
+
+def ensure_task_runtime_support(
+    task: Task,
+    sandbox_type: str,
+    task_path: Path | str,
+) -> None:
+    """Raise :class:`UnsupportedTaskRuntimeError` when validation finds blockers."""
+    issues = validate_task_runtime_support(task, sandbox_type, task_path)
+    if issues:
+        raise UnsupportedTaskRuntimeError(issues, task_path=task_path)
+
+
+__all__ = [
+    "UnsupportedTaskFeature",
+    "UnsupportedTaskRuntimeError",
+    "ensure_task_runtime_support",
+    "validate_task_runtime_support",
+]

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -114,9 +114,16 @@ def _append_user_semantics_issues(
             )
         )
 
+    nudges = benchflow.get("nudges")
+    nudges_supported = (
+        isinstance(nudges, dict)
+        and nudges.get("mode") == "simulated-user"
+        and user_loop_executable
+    )
     if (
-        isinstance(benchflow.get("nudges"), dict)
+        isinstance(nudges, dict)
         and not _is_metadata_only_runtime(benchflow, "nudges")
+        and not nudges_supported
     ):
         issues.append(
             UnsupportedTaskFeature(

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -91,11 +91,17 @@ def _append_user_semantics_issues(
         return
 
     benchflow = document.benchflow
-    from benchflow.task.user_loop import compile_document_user_loop
+    from benchflow.task.user_loop import (
+        compile_document_user_loop,
+        user_loop_rollout_compatible_for_task,
+    )
 
     compiled_user_loop = compile_document_user_loop(task)
     user_loop_executable = (
         compiled_user_loop is not None and compiled_user_loop.executable
+    )
+    user_loop_rollout_ready = user_loop_executable and user_loop_rollout_compatible_for_task(
+        task
     )
 
     if (
@@ -118,7 +124,7 @@ def _append_user_semantics_issues(
     nudges_supported = (
         isinstance(nudges, dict)
         and nudges.get("mode") == "simulated-user"
-        and user_loop_executable
+        and user_loop_rollout_ready
     )
     if (
         isinstance(nudges, dict)

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -319,7 +319,7 @@ def validate_task_runtime_support(
             )
         )
 
-    if env.workdir is not None:
+    if env.workdir is not None and sandbox_type != "docker":
         issues.append(
             UnsupportedTaskFeature(
                 path="environment.workdir",

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -21,7 +21,7 @@ from benchflow.task.config import (
 if TYPE_CHECKING:
     from benchflow.task.task import Task
 
-_GATED_SANDBOX_TYPES = frozenset({"docker", "daytona"})
+_GATED_SANDBOX_TYPES = frozenset({"docker", "daytona", "modal"})
 _METADATA_ONLY_RUNTIME_VALUES = frozenset({"metadata-only", "metadata_only"})
 
 

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from benchflow.task.config import (
     NetworkMode,
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from benchflow.task.task import Task
 
 _GATED_SANDBOX_TYPES = frozenset({"docker", "daytona"})
+_METADATA_ONLY_RUNTIME_VALUES = frozenset({"metadata-only", "metadata_only"})
 
 
 @dataclass(frozen=True)
@@ -57,6 +58,80 @@ class UnsupportedTaskRuntimeError(ValueError):
 
 def _task_has_compose(task_path: Path) -> bool:
     return (task_path / "environment" / "docker-compose.yaml").exists()
+
+
+def _benchflow_section_runtime_mode(
+    benchflow: dict[str, Any],
+    section: str,
+) -> str | None:
+    value = benchflow.get(section)
+    if not isinstance(value, dict):
+        return None
+    runtime = value.get("runtime")
+    return runtime if isinstance(runtime, str) else None
+
+
+def _is_metadata_only_runtime(benchflow: dict[str, Any], section: str) -> bool:
+    """Return whether *section* user/nudge semantics are explicitly metadata-only."""
+    umbrella = benchflow.get("user_runtime")
+    if isinstance(umbrella, str) and umbrella in _METADATA_ONLY_RUNTIME_VALUES:
+        return True
+    mode = _benchflow_section_runtime_mode(benchflow, section)
+    return mode in _METADATA_ONLY_RUNTIME_VALUES if mode is not None else False
+
+
+def _append_user_semantics_issues(
+    issues: list[UnsupportedTaskFeature],
+    *,
+    task: Task,
+    sandbox_type: str,
+) -> None:
+    document = getattr(task, "document", None)
+    if document is None:
+        return
+
+    benchflow = document.benchflow
+    if document.user and not _is_metadata_only_runtime(benchflow, "user"):
+        issues.append(
+            UnsupportedTaskFeature(
+                path="user",
+                reason=(
+                    "document-declared simulated-user frontmatter is parsed but "
+                    "not compiled into a rollout user loop yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if (
+        isinstance(benchflow.get("nudges"), dict)
+        and not _is_metadata_only_runtime(benchflow, "nudges")
+    ):
+        issues.append(
+            UnsupportedTaskFeature(
+                path="benchflow.nudges",
+                reason=(
+                    "document-declared nudge policy is parsed but not executed "
+                    "by the selected sandbox yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
+
+    if (
+        document.user_persona
+        and not _is_metadata_only_runtime(benchflow, "user_persona")
+    ):
+        issues.append(
+            UnsupportedTaskFeature(
+                path="prompt.user-persona",
+                reason=(
+                    "document-declared user persona is parsed but not compiled "
+                    "into a rollout user loop yet"
+                ),
+                sandbox_type=sandbox_type,
+            )
+        )
 
 
 def _append_allowlist_issue(
@@ -249,6 +324,8 @@ def validate_task_runtime_support(
                 sandbox_type=sandbox_type,
             )
         )
+
+    _append_user_semantics_issues(issues, task=task, sandbox_type=sandbox_type)
 
     return issues
 

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -11,7 +11,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from benchflow.task.config import NetworkMode, TaskOS, VerifierEnvironmentMode
+from benchflow.task.config import (
+    NetworkMode,
+    TaskConfig,
+    TaskOS,
+    VerifierEnvironmentMode,
+)
 
 if TYPE_CHECKING:
     from benchflow.task.task import Task
@@ -95,8 +100,11 @@ def validate_task_runtime_support(
     if sandbox_type not in _GATED_SANDBOX_TYPES:
         return []
 
+    config = getattr(task, "config", None)
+    if not isinstance(config, TaskConfig):
+        return []
+
     root = Path(task_path).resolve()
-    config = task.config
     env = config.environment
     issues: list[UnsupportedTaskFeature] = []
 

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -319,7 +319,7 @@ def validate_task_runtime_support(
             )
         )
 
-    if env.workdir is not None and sandbox_type != "docker":
+    if env.workdir is not None and sandbox_type not in ("docker", "modal"):
         issues.append(
             UnsupportedTaskFeature(
                 path="environment.workdir",

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -91,7 +91,18 @@ def _append_user_semantics_issues(
         return
 
     benchflow = document.benchflow
-    if document.user and not _is_metadata_only_runtime(benchflow, "user"):
+    from benchflow.task.user_loop import compile_document_user_loop
+
+    compiled_user_loop = compile_document_user_loop(task)
+    user_loop_executable = (
+        compiled_user_loop is not None and compiled_user_loop.executable
+    )
+
+    if (
+        document.user
+        and not _is_metadata_only_runtime(benchflow, "user")
+        and not user_loop_executable
+    ):
         issues.append(
             UnsupportedTaskFeature(
                 path="user",
@@ -121,6 +132,7 @@ def _append_user_semantics_issues(
     if (
         document.user_persona
         and not _is_metadata_only_runtime(benchflow, "user_persona")
+        and not user_loop_executable
     ):
         issues.append(
             UnsupportedTaskFeature(

--- a/src/benchflow/task/task.py
+++ b/src/benchflow/task/task.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from benchflow.task.aliases import alias_dir_collision_issues
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import TaskDocument
 from benchflow.task.paths import TaskPaths
@@ -32,6 +33,9 @@ class Task:
     def __init__(self, task_dir: Path | str) -> None:
         self._task_dir = Path(task_dir).resolve()
         self.paths = TaskPaths(self._task_dir)
+        alias_issues = alias_dir_collision_issues(self.paths)
+        if alias_issues:
+            raise ValueError("; ".join(alias_issues))
         self.document: TaskDocument | None = None
         if self.paths.task_document_path.exists():
             self.document = TaskDocument.from_path(self.paths.task_document_path)

--- a/src/benchflow/task/task.py
+++ b/src/benchflow/task/task.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from benchflow.task.aliases import alias_dir_collision_issues
 from benchflow.task.config import TaskConfig
 from benchflow.task.document import TaskDocument
+from benchflow.task.package import TaskRuntimeView
 from benchflow.task.paths import TaskPaths
+from benchflow.task.verifier_document import (
+    VerifierDocument,
+    VerifierDocumentParseError,
+    resolve_verifier_spec_path,
+    verifier_document_issues,
+)
 
 
 class Task:
@@ -53,9 +60,33 @@ class Task:
         else:
             self.name = self.paths.task_dir.name
 
+        self.verifier_document: VerifierDocument | None = None
+        benchflow = self.document.benchflow if self.document is not None else {}
+        if isinstance(benchflow, dict):
+            benchflow_verifier = benchflow.get("verifier")
+            if isinstance(benchflow_verifier, dict):
+                spec_issues = verifier_document_issues(
+                    self._task_dir,
+                    benchflow_verifier=benchflow_verifier,
+                )
+                if spec_issues:
+                    raise ValueError("; ".join(spec_issues))
+                spec = benchflow_verifier.get("spec")
+                if isinstance(spec, str) and spec.strip():
+                    spec_path = resolve_verifier_spec_path(self._task_dir, spec.strip())
+                    try:
+                        self.verifier_document = VerifierDocument.from_path(spec_path)
+                    except VerifierDocumentParseError as exc:
+                        raise ValueError(f"{spec} parse error: {exc}") from exc
+
     @property
     def task_dir(self) -> Path:
         return self._task_dir
+
+    @property
+    def runtime_view(self) -> TaskRuntimeView:
+        """Selected executable interpretation for rollout and validation."""
+        return TaskRuntimeView.from_task(self)
 
     def __repr__(self) -> str:
         return f"Task({self.name!r}, dir={self._task_dir})"

--- a/src/benchflow/task/task.py
+++ b/src/benchflow/task/task.py
@@ -11,9 +11,7 @@ from benchflow.task.package import TaskRuntimeView
 from benchflow.task.paths import TaskPaths
 from benchflow.task.verifier_document import (
     VerifierDocument,
-    VerifierDocumentParseError,
-    resolve_verifier_spec_path,
-    verifier_document_issues,
+    load_verifier_document,
 )
 
 
@@ -60,24 +58,11 @@ class Task:
         else:
             self.name = self.paths.task_dir.name
 
-        self.verifier_document: VerifierDocument | None = None
         benchflow = self.document.benchflow if self.document is not None else {}
-        if isinstance(benchflow, dict):
-            benchflow_verifier = benchflow.get("verifier")
-            if isinstance(benchflow_verifier, dict):
-                spec_issues = verifier_document_issues(
-                    self._task_dir,
-                    benchflow_verifier=benchflow_verifier,
-                )
-                if spec_issues:
-                    raise ValueError("; ".join(spec_issues))
-                spec = benchflow_verifier.get("spec")
-                if isinstance(spec, str) and spec.strip():
-                    spec_path = resolve_verifier_spec_path(self._task_dir, spec.strip())
-                    try:
-                        self.verifier_document = VerifierDocument.from_path(spec_path)
-                    except VerifierDocumentParseError as exc:
-                        raise ValueError(f"{spec} parse error: {exc}") from exc
+        self.verifier_document: VerifierDocument | None = load_verifier_document(
+            self._task_dir,
+            benchflow,
+        )
 
     @property
     def task_dir(self) -> Path:

--- a/src/benchflow/task/user_loop.py
+++ b/src/benchflow/task/user_loop.py
@@ -43,6 +43,19 @@ def parse_stop_rule_max_rounds(stop_rule: str) -> int | None:
     return int(match.group(1))
 
 
+def _nudge_budget_max_rounds(nudges: Any) -> int | None:
+    if not isinstance(nudges, dict):
+        return None
+    budget = nudges.get("nudge_budget")
+    if isinstance(budget, bool) or budget is None:
+        return None
+    try:
+        max_rounds = int(budget)
+    except (TypeError, ValueError):
+        return None
+    return max_rounds if max_rounds >= 1 else None
+
+
 def _normalize_private_facts(raw: Any) -> dict[str, str] | None:
     if raw is None:
         return {}
@@ -157,15 +170,23 @@ def _compile_from_document(
     *,
     user_block: dict[str, Any],
     user_persona: str | None,
+    nudges: Any = None,
 ) -> CompiledUserLoop | None:
     if not user_block:
         return None
 
     stop_rule = user_block.get("stop_rule")
-    if not isinstance(stop_rule, str) or not stop_rule.strip():
-        return None
+    max_rounds: int | None = None
+    if isinstance(stop_rule, str) and stop_rule.strip():
+        max_rounds = parse_stop_rule_max_rounds(stop_rule)
+    else:
+        stop_rule = ""
 
-    max_rounds = parse_stop_rule_max_rounds(stop_rule)
+    if max_rounds is None:
+        max_rounds = _nudge_budget_max_rounds(nudges)
+        if max_rounds is not None and not stop_rule:
+            stop_rule = f"nudge-budget-{max_rounds}-rounds"
+
     if max_rounds is None or max_rounds < 1:
         return None
 
@@ -191,9 +212,11 @@ def compile_document_user_loop(task: Task) -> CompiledUserLoop | None:
     document = task.document
     if document is None:
         return None
+    benchflow = document.benchflow if isinstance(document.benchflow, dict) else {}
     return _compile_from_document(
         user_block=document.user,
         user_persona=document.user_persona,
+        nudges=benchflow.get("nudges"),
     )
 
 

--- a/src/benchflow/task/user_loop.py
+++ b/src/benchflow/task/user_loop.py
@@ -6,7 +6,9 @@ import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from benchflow._types import Role, Scene, Turn
 from benchflow.contracts.user import BaseUser, RoundResult
+from benchflow.scenes import DEFAULT_SCENE_PROMPT
 
 if TYPE_CHECKING:
     from benchflow.task.task import Task
@@ -33,6 +35,17 @@ class CompiledUserLoop:
     user: BaseUser
     max_user_rounds: int
     executable: bool
+
+
+@dataclass(frozen=True)
+class UserLoopRolloutPlan:
+    """Where a compiled user loop plugs into a multi-scene rollout."""
+
+    pre_scenes: tuple[Scene, ...]
+    user_loop_scene: Scene
+    user_loop_role: Role
+    user_loop_prompt: str
+    post_scene: Scene | None = None
 
 
 def parse_stop_rule_max_rounds(stop_rule: str) -> int | None:
@@ -220,19 +233,137 @@ def compile_document_user_loop(task: Task) -> CompiledUserLoop | None:
     )
 
 
-def user_loop_rollout_compatible(scenes: list[Any]) -> bool:
+def infer_user_loop_scene_name(document: Any) -> str | None:
+    """Return the scene that should host a document-declared user loop."""
+    scene_prompts = getattr(document, "scene_prompts", None)
+    if isinstance(scene_prompts, dict):
+        for scene_name in scene_prompts:
+            normalized = scene_name.lower().replace("_", "-")
+            if "user-loop" in normalized:
+                return scene_name
+
+    scenes = getattr(document, "scenes", None)
+    if isinstance(scenes, list):
+        for scene in scenes:
+            name = getattr(scene, "name", None)
+            if isinstance(name, str) and "user-loop" in name.lower().replace("_", "-"):
+                return name
+    return None
+
+
+def resolve_user_loop_rollout_plan(
+    scenes: list[Scene],
+    *,
+    user_loop_scene_name: str | None = None,
+    default_prompt: str | None = None,
+) -> UserLoopRolloutPlan | None:
+    """Return how a compiled user loop should execute across document scenes."""
+    if not scenes:
+        return None
+
+    fallback_prompt = default_prompt or DEFAULT_SCENE_PROMPT
+
+    if len(scenes) == 1:
+        scene = scenes[0]
+        if len(scene.roles) != 1 or not scene.turns:
+            return None
+        role = scene.roles[0]
+        if scene.turns[0].role != role.name:
+            return None
+        prompt = (
+            scene.turns[0].prompt
+            if scene.turns[0].prompt is not None
+            else fallback_prompt
+        )
+        return UserLoopRolloutPlan(
+            pre_scenes=(),
+            user_loop_scene=scene,
+            user_loop_role=role,
+            user_loop_prompt=prompt,
+        )
+
+    if user_loop_scene_name is None:
+        return None
+
+    anchor_index = next(
+        (
+            index
+            for index, scene in enumerate(scenes)
+            if scene.name == user_loop_scene_name
+        ),
+        None,
+    )
+    if anchor_index is None:
+        return None
+
+    anchor_scene = scenes[anchor_index]
+    if not anchor_scene.turns:
+        return None
+
+    role_map = {role.name: role for role in anchor_scene.roles}
+    first_turn = anchor_scene.turns[0]
+    anchor_role = role_map.get(first_turn.role)
+    if anchor_role is None:
+        return None
+
+    user_loop_prompt = (
+        first_turn.prompt if first_turn.prompt is not None else fallback_prompt
+    )
+    user_loop_scene = Scene(
+        name=anchor_scene.name,
+        roles=[anchor_role],
+        turns=[Turn(role=first_turn.role, prompt=first_turn.prompt)],
+        skills_dir=anchor_scene.skills_dir,
+    )
+
+    post_scene = None
+    if len(anchor_scene.turns) > 1:
+        post_turns = anchor_scene.turns[1:]
+        post_role_names = list(dict.fromkeys(turn.role for turn in post_turns))
+        post_roles = [role_map[name] for name in post_role_names if name in role_map]
+        post_scene = Scene(
+            name=anchor_scene.name,
+            roles=post_roles,
+            turns=post_turns,
+            skills_dir=anchor_scene.skills_dir,
+        )
+
+    return UserLoopRolloutPlan(
+        pre_scenes=tuple(scenes[:anchor_index]),
+        user_loop_scene=user_loop_scene,
+        user_loop_role=anchor_role,
+        user_loop_prompt=user_loop_prompt,
+        post_scene=post_scene,
+    )
+
+
+def user_loop_rollout_compatible(
+    scenes: list[Any],
+    *,
+    user_loop_scene_name: str | None = None,
+    default_prompt: str | None = None,
+) -> bool:
     """Return whether compiled user loops can drive rollout execution."""
-    if len(scenes) != 1:
+    typed_scenes = [scene for scene in scenes if isinstance(scene, Scene)]
+    if len(typed_scenes) != len(scenes):
         return False
-    scene = scenes[0]
-    roles = getattr(scene, "roles", None)
-    return isinstance(roles, list) and len(roles) == 1
+    return (
+        resolve_user_loop_rollout_plan(
+            typed_scenes,
+            user_loop_scene_name=user_loop_scene_name,
+            default_prompt=default_prompt,
+        )
+        is not None
+    )
 
 
 __all__ = [
     "CompiledUserLoop",
     "DocumentSimulatedUser",
+    "UserLoopRolloutPlan",
     "compile_document_user_loop",
+    "infer_user_loop_scene_name",
     "parse_stop_rule_max_rounds",
+    "resolve_user_loop_rollout_plan",
     "user_loop_rollout_compatible",
 ]

--- a/src/benchflow/task/user_loop.py
+++ b/src/benchflow/task/user_loop.py
@@ -56,6 +56,13 @@ def parse_stop_rule_max_rounds(stop_rule: str) -> int | None:
     return int(match.group(1))
 
 
+def branchable_simulated_user_nudges(nudges: Any) -> bool:
+    """Return whether nudges declare branchable simulated-user rollout splitting."""
+    if not isinstance(nudges, dict):
+        return False
+    return nudges.get("mode") == "simulated-user" and nudges.get("branchable") is True
+
+
 def _nudge_budget_max_rounds(nudges: Any) -> int | None:
     if not isinstance(nudges, dict):
         return None
@@ -256,6 +263,7 @@ def resolve_user_loop_rollout_plan(
     *,
     user_loop_scene_name: str | None = None,
     default_prompt: str | None = None,
+    nudges: Any = None,
 ) -> UserLoopRolloutPlan | None:
     """Return how a compiled user loop should execute across document scenes."""
     if not scenes:
@@ -318,6 +326,8 @@ def resolve_user_loop_rollout_plan(
 
     post_scene = None
     if len(anchor_scene.turns) > 1:
+        if not branchable_simulated_user_nudges(nudges):
+            return None
         post_turns = anchor_scene.turns[1:]
         post_role_names = list(dict.fromkeys(turn.role for turn in post_turns))
         post_roles = [role_map[name] for name in post_role_names if name in role_map]
@@ -342,6 +352,7 @@ def user_loop_rollout_compatible(
     *,
     user_loop_scene_name: str | None = None,
     default_prompt: str | None = None,
+    nudges: Any = None,
 ) -> bool:
     """Return whether compiled user loops can drive rollout execution."""
     typed_scenes = [scene for scene in scenes if isinstance(scene, Scene)]
@@ -352,8 +363,23 @@ def user_loop_rollout_compatible(
             typed_scenes,
             user_loop_scene_name=user_loop_scene_name,
             default_prompt=default_prompt,
+            nudges=nudges,
         )
         is not None
+    )
+
+
+def user_loop_rollout_compatible_for_task(task: Task) -> bool:
+    """Return whether *task* scenes and nudges support a document user loop."""
+    document = task.document
+    if document is None:
+        return False
+    benchflow = document.benchflow if isinstance(document.benchflow, dict) else {}
+    scene_name = infer_user_loop_scene_name(document)
+    return user_loop_rollout_compatible(
+        document.scenes,
+        user_loop_scene_name=scene_name,
+        nudges=benchflow.get("nudges"),
     )
 
 
@@ -361,9 +387,11 @@ __all__ = [
     "CompiledUserLoop",
     "DocumentSimulatedUser",
     "UserLoopRolloutPlan",
+    "branchable_simulated_user_nudges",
     "compile_document_user_loop",
     "infer_user_loop_scene_name",
     "parse_stop_rule_max_rounds",
     "resolve_user_loop_rollout_plan",
     "user_loop_rollout_compatible",
+    "user_loop_rollout_compatible_for_task",
 ]

--- a/src/benchflow/task/user_loop.py
+++ b/src/benchflow/task/user_loop.py
@@ -1,0 +1,215 @@
+"""Compile document-declared simulated-user metadata into rollout user loops."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from benchflow.contracts.user import BaseUser, RoundResult
+
+if TYPE_CHECKING:
+    from benchflow.task.task import Task
+
+_STOP_RULE_MAX_ROUNDS_RE = re.compile(r"-(\d+)-rounds$", re.IGNORECASE)
+_CLARIFICATION_HINTS = (
+    "clarif",
+    "question",
+    "what do you need",
+    "what should",
+    "could you explain",
+    "can you explain",
+    "more detail",
+    "more information",
+    "hidden need",
+    "requirement",
+)
+
+
+@dataclass(frozen=True)
+class CompiledUserLoop:
+    """Result of compiling ``task.md`` user metadata."""
+
+    user: BaseUser
+    max_user_rounds: int
+    executable: bool
+
+
+def parse_stop_rule_max_rounds(stop_rule: str) -> int | None:
+    """Parse ``satisfied-or-5-rounds`` style stop rules into a round cap."""
+    match = _STOP_RULE_MAX_ROUNDS_RE.search(stop_rule.strip())
+    if match is None:
+        return None
+    return int(match.group(1))
+
+
+def _normalize_private_facts(raw: Any) -> dict[str, str] | None:
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        return None
+    facts: dict[str, str] = {}
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            return None
+        facts[key] = str(value)
+    return facts
+
+
+def _reward_score(rewards: dict[str, Any] | None) -> float | None:
+    if not rewards:
+        return None
+    for key in ("reward", "exact_match"):
+        if key in rewards:
+            try:
+                return float(rewards[key])
+            except (TypeError, ValueError):
+                return None
+    return None
+
+
+def _is_satisfied(round_result: RoundResult | None) -> bool:
+    if round_result is None:
+        return False
+    score = _reward_score(round_result.rewards)
+    return score is not None and score >= 1.0
+
+
+def _trajectory_text(round_result: RoundResult | None) -> str:
+    if round_result is None:
+        return ""
+    chunks: list[str] = []
+    for event in round_result.trajectory:
+        if not isinstance(event, dict):
+            continue
+        for key in ("content", "text", "message", "prompt"):
+            value = event.get(key)
+            if isinstance(value, str):
+                chunks.append(value)
+    if round_result.verifier_output:
+        chunks.append(round_result.verifier_output)
+    return "\n".join(chunks).lower()
+
+
+def _agent_asked_clarification(round_result: RoundResult | None) -> bool:
+    text = _trajectory_text(round_result)
+    if "?" not in text:
+        return False
+    return any(hint in text for hint in _CLARIFICATION_HINTS)
+
+
+class DocumentSimulatedUser(BaseUser):
+    """Rule-based simulated user compiled from ``task.md`` user metadata."""
+
+    def __init__(
+        self,
+        *,
+        user_persona: str | None,
+        private_facts: dict[str, str],
+        stop_rule: str,
+        max_rounds: int,
+    ) -> None:
+        self.user_persona = user_persona
+        self._private_facts = dict(private_facts)
+        self._stop_rule = stop_rule
+        self._max_rounds = max_rounds
+        self._revealed_fact_keys: set[str] = set()
+
+    async def run(
+        self,
+        round: int,
+        instruction: str,
+        round_result: RoundResult | None = None,
+    ) -> str | None:
+        if round == 0:
+            return instruction
+
+        if _is_satisfied(round_result):
+            return None
+
+        if round >= self._max_rounds - 1:
+            return None
+
+        if (
+            round_result is not None
+            and self._private_facts
+            and _agent_asked_clarification(round_result)
+        ):
+            return self._reveal_private_facts()
+
+        return "Please continue working on the task."
+
+    def _reveal_private_facts(self) -> str:
+        pending = [
+            f"{key}: {value}"
+            for key, value in self._private_facts.items()
+            if key not in self._revealed_fact_keys
+        ]
+        if not pending:
+            return "Please continue working on the task."
+        for key in self._private_facts:
+            if key not in self._revealed_fact_keys:
+                self._revealed_fact_keys.add(key)
+        return "Clarification:\n" + "\n".join(pending)
+
+
+def _compile_from_document(
+    *,
+    user_block: dict[str, Any],
+    user_persona: str | None,
+) -> CompiledUserLoop | None:
+    if not user_block:
+        return None
+
+    stop_rule = user_block.get("stop_rule")
+    if not isinstance(stop_rule, str) or not stop_rule.strip():
+        return None
+
+    max_rounds = parse_stop_rule_max_rounds(stop_rule)
+    if max_rounds is None or max_rounds < 1:
+        return None
+
+    private_facts = _normalize_private_facts(user_block.get("private_facts"))
+    if private_facts is None:
+        return None
+
+    user = DocumentSimulatedUser(
+        user_persona=user_persona,
+        private_facts=private_facts,
+        stop_rule=stop_rule,
+        max_rounds=max_rounds,
+    )
+    return CompiledUserLoop(
+        user=user,
+        max_user_rounds=max_rounds,
+        executable=True,
+    )
+
+
+def compile_document_user_loop(task: Task) -> CompiledUserLoop | None:
+    """Compile ``task.md`` user metadata into a concrete rollout user loop."""
+    document = task.document
+    if document is None:
+        return None
+    return _compile_from_document(
+        user_block=document.user,
+        user_persona=document.user_persona,
+    )
+
+
+def user_loop_rollout_compatible(scenes: list[Any]) -> bool:
+    """Return whether compiled user loops can drive rollout execution."""
+    if len(scenes) != 1:
+        return False
+    scene = scenes[0]
+    roles = getattr(scene, "roles", None)
+    return isinstance(roles, list) and len(roles) == 1
+
+
+__all__ = [
+    "CompiledUserLoop",
+    "DocumentSimulatedUser",
+    "compile_document_user_loop",
+    "parse_stop_rule_max_rounds",
+    "user_loop_rollout_compatible",
+]

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -112,6 +112,7 @@ class Verifier:
         for path in (
             self._rollout_paths.reward_text_path,
             self._rollout_paths.reward_json_path,
+            self._rollout_paths.reward_details_path,
         ):
             path.unlink(missing_ok=True)
 

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -20,7 +20,10 @@ from typing import Any
 
 from pydantic import BaseModel
 
-from benchflow.rewards.validation import is_valid_reward_number, validate_reward_map
+from benchflow.rewards.validation import (
+    RewardFileParseError,
+    parse_verifier_reward_files,
+)
 from benchflow.sandbox.lockdown import _exec_return_code, clear_verifier_output_dir
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
@@ -85,88 +88,25 @@ class Verifier:
         self._sandbox = sandbox
         self._logger = (_logger or logger).getChild("verifier")
 
-    def _parse_reward_text(self) -> dict[str, float | int]:
-        if self._rollout_paths.reward_text_path.stat().st_size == 0:
-            raise RewardFileEmptyError(
-                f"Reward file is empty at {self._rollout_paths.reward_text_path}"
-            )
-        try:
-            reward = float(self._rollout_paths.reward_text_path.read_text())
-        except (ValueError, TypeError) as e:
-            raise VerifierOutputParseError(
-                f"Failed to parse rewards from text file {self._rollout_paths.reward_text_path}"
-            ) from e
-        if not is_valid_reward_number(reward):
-            raise VerifierOutputParseError(
-                f"Reward text file {self._rollout_paths.reward_text_path} "
-                "must contain a finite numeric reward between 0.0 and 1.0"
-            )
-        return {"reward": reward}
-
-    def _parse_reward_json(self) -> dict[str, Any]:
-        if self._rollout_paths.reward_json_path.stat().st_size == 0:
-            raise RewardFileEmptyError(
-                f"Reward file is empty at {self._rollout_paths.reward_json_path}"
-            )
-        try:
-            rewards = json.loads(self._rollout_paths.reward_json_path.read_text())
-        except (ValueError, TypeError) as e:
-            raise VerifierOutputParseError(
-                f"Failed to parse rewards from JSON file {self._rollout_paths.reward_json_path}"
-            ) from e
-
-        if not isinstance(rewards, dict):
-            raise VerifierOutputParseError(
-                f"Reward JSON file {self._rollout_paths.reward_json_path} "
-                "must contain an object with numeric rewards"
-            )
-
-        canonical_reward = rewards.get("reward")
-        if not is_valid_reward_number(canonical_reward):
-            raise VerifierOutputParseError(
-                f"Reward JSON file {self._rollout_paths.reward_json_path} "
-                "is missing numeric 'reward' between 0.0 and 1.0"
-            )
-
-        try:
-            return validate_reward_map(rewards, source="reward JSON")
-        except ValueError as e:
-            raise VerifierOutputParseError(
-                f"Reward JSON file {self._rollout_paths.reward_json_path} {e}"
-            ) from e
-
     def _parse_rewards(self, *, test_return_code: int) -> dict[str, Any]:
         """Parse verifier reward outputs with JSON-first precedence."""
-        has_json = self._rollout_paths.reward_json_path.exists()
-        has_text = self._rollout_paths.reward_text_path.exists()
-
-        if has_json and has_text:
-            json_rewards = self._parse_reward_json()
-            text_rewards = self._parse_reward_text()
-            json_scalar = float(json_rewards["reward"])
-            text_scalar = float(text_rewards["reward"])
-            if json_scalar != text_scalar:
-                raise VerifierOutputParseError(
-                    "reward.json aggregate "
-                    f"{json_scalar} disagrees with reward.txt scalar {text_scalar}"
-                )
-            return json_rewards
-
-        if has_json:
-            return self._parse_reward_json()
-        if has_text:
-            return self._parse_reward_text()
-
-        if test_return_code != 0:
-            raise RewardFileNotFoundError(
-                f"verifier exited with rc={test_return_code}; no reward file "
-                f"found at {self._rollout_paths.reward_text_path} or "
-                f"{self._rollout_paths.reward_json_path}"
+        try:
+            return parse_verifier_reward_files(
+                reward_text_path=self._rollout_paths.reward_text_path,
+                reward_json_path=self._rollout_paths.reward_json_path,
+                source="reward JSON",
             )
-        raise RewardFileNotFoundError(
-            f"No reward file found at {self._rollout_paths.reward_text_path} or "
-            f"{self._rollout_paths.reward_json_path}"
-        )
+        except RewardFileParseError as exc:
+            message = str(exc)
+            if "No reward file found" in message:
+                if test_return_code != 0:
+                    raise RewardFileNotFoundError(
+                        f"verifier exited with rc={test_return_code}; {message}"
+                    ) from exc
+                raise RewardFileNotFoundError(message) from exc
+            if "empty" in message:
+                raise RewardFileEmptyError(message) from exc
+            raise VerifierOutputParseError(message) from exc
 
     def _clear_reward_outputs(self) -> None:
         for path in (

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -27,6 +27,11 @@ from benchflow.rewards.validation import (
 from benchflow.sandbox.lockdown import _exec_return_code, clear_verifier_output_dir
 from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
+from benchflow.task.verifier_document import (
+    VerifierDocument,
+    is_executable_script_strategy,
+    resolve_default_strategy,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +66,28 @@ class DownloadVerifierDirError(Exception):
 
 class RubricNotFoundError(Exception):
     """Raised when an llm-judge verifier cannot locate its rubric file."""
+
+
+class UnsupportedVerifierStrategyError(ValueError):
+    """Raised when a verifier document selects a strategy the runtime cannot execute."""
+
+    def __init__(
+        self,
+        *,
+        strategy_name: str,
+        strategy_type: str | None,
+        task_path: Path | str | None = None,
+    ) -> None:
+        self.strategy_name = strategy_name
+        self.strategy_type = strategy_type
+        self.task_path = Path(task_path) if task_path is not None else None
+        type_label = strategy_type or "<missing>"
+        location = f" at {self.task_path}" if self.task_path is not None else ""
+        message = (
+            f"Verifier strategy {strategy_name!r} (type={type_label!r}){location} "
+            "is parsed but not executable by the runtime yet"
+        )
+        super().__init__(message)
 
 
 class Verifier:
@@ -116,9 +143,39 @@ class Verifier:
         ):
             path.unlink(missing_ok=True)
 
+    def _route_verifier_document_strategy(self) -> str | None:
+        """Log and validate the selected ``verifier/verifier.md`` strategy.
+
+        Returns ``"test-script"`` when the document routes to ``test.sh``,
+        or ``None`` when no document strategy is selected.
+        """
+        document = getattr(self._task, "verifier_document", None)
+        if not isinstance(document, VerifierDocument) or not document.default_strategy:
+            return None
+
+        strategy_name, strategy = resolve_default_strategy(document)
+        strategy_type = strategy.get("type")
+        self._logger.info(
+            "Selected verifier document strategy %r (type=%r)",
+            strategy_name,
+            strategy_type,
+        )
+        if is_executable_script_strategy(strategy):
+            return "test-script"
+
+        task_path = getattr(self._task, "task_dir", None)
+        raise UnsupportedVerifierStrategyError(
+            strategy_name=strategy_name,
+            strategy_type=strategy_type if isinstance(strategy_type, str) else None,
+            task_path=task_path,
+        )
+
     async def verify(self) -> VerifierResult:
         """Run the configured verifier and return the reward result."""
         self._clear_reward_outputs()
+        document_route = self._route_verifier_document_strategy()
+        if document_route == "test-script":
+            return await self._verify_test_script()
         if self._task.config.verifier.type == "llm-judge":
             return await self._verify_llm_judge()
         return await self._verify_test_script()

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -29,8 +29,12 @@ from benchflow.task.env import resolve_env_vars
 from benchflow.task.paths import RolloutPaths, SandboxPaths
 from benchflow.task.verifier_document import (
     VerifierDocument,
+    is_executable_agent_judge_strategy,
+    is_executable_reward_kit_strategy,
     is_executable_script_strategy,
+    resolve_agent_judge_role_prompt,
     resolve_default_strategy,
+    resolve_structured_rubric_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -143,11 +147,14 @@ class Verifier:
         ):
             path.unlink(missing_ok=True)
 
+    def _verifier_dir(self) -> Path:
+        return Path(self._task.paths.tests_dir)
+
     def _route_verifier_document_strategy(self) -> str | None:
         """Log and validate the selected ``verifier/verifier.md`` strategy.
 
-        Returns ``"test-script"`` when the document routes to ``test.sh``,
-        or ``None`` when no document strategy is selected.
+        Returns ``"test-script"``, ``"reward-kit"``, ``"agent-judge"``, or
+        ``None`` when no document strategy is selected.
         """
         document = getattr(self._task, "verifier_document", None)
         if not isinstance(document, VerifierDocument) or not document.default_strategy:
@@ -155,6 +162,7 @@ class Verifier:
 
         strategy_name, strategy = resolve_default_strategy(document)
         strategy_type = strategy.get("type")
+        verifier_dir = self._verifier_dir()
         self._logger.info(
             "Selected verifier document strategy %r (type=%r)",
             strategy_name,
@@ -162,6 +170,10 @@ class Verifier:
         )
         if is_executable_script_strategy(strategy):
             return "test-script"
+        if is_executable_reward_kit_strategy(strategy, verifier_dir):
+            return "reward-kit"
+        if is_executable_agent_judge_strategy(strategy, document, verifier_dir):
+            return "agent-judge"
 
         task_path = getattr(self._task, "task_dir", None)
         raise UnsupportedVerifierStrategyError(
@@ -174,8 +186,10 @@ class Verifier:
         """Run the configured verifier and return the reward result."""
         self._clear_reward_outputs()
         document_route = self._route_verifier_document_strategy()
-        if document_route == "test-script":
+        if document_route in {"test-script", "reward-kit"}:
             return await self._verify_test_script()
+        if document_route == "agent-judge":
+            return await self._verify_agent_judge_document()
         if self._task.config.verifier.type == "llm-judge":
             return await self._verify_llm_judge()
         return await self._verify_test_script()
@@ -367,6 +381,113 @@ class Verifier:
             raise DownloadVerifierDirError(
                 f"Failed to download llm-judge input from {judge.input_dir}"
             ) from e
+        return dest
+
+    async def _verify_agent_judge_document(self) -> VerifierResult:
+        """Score declared verifier inputs with a document agent-judge strategy."""
+        document = self._task.verifier_document
+        if not isinstance(document, VerifierDocument):
+            raise VerifierOutputParseError(
+                "agent-judge verifier requires a parsed verifier document"
+            )
+
+        strategy_name, strategy = resolve_default_strategy(document)
+        verifier_dir = self._verifier_dir()
+        role_prompt = resolve_agent_judge_role_prompt(strategy, document, verifier_dir)
+        rubric_path = resolve_structured_rubric_path(document, verifier_dir)
+        if role_prompt is None or rubric_path is None:
+            raise VerifierOutputParseError(
+                f"agent-judge strategy {strategy_name!r} is missing role prompt "
+                "or structured rubric"
+            )
+
+        deliverables_dir = await self._gather_agent_judge_inputs(strategy)
+        judge_env: dict[str, str] = {}
+        if self._task.config.verifier.env:
+            judge_env = resolve_env_vars(self._task.config.verifier.env)
+
+        from benchflow.rewards.builtins import LLMJudgeRewardFunc
+
+        reward_func = LLMJudgeRewardFunc(
+            prompt=role_prompt,
+            rubric_path=rubric_path,
+            judge_model=strategy.get("model")
+            if isinstance(strategy.get("model"), str)
+            else None,
+            judge_env=judge_env,
+            judge_errors_are_infra=True,
+        )
+        score = await reward_func.score(deliverables_dir)
+
+        self._logger.info(
+            "agent-judge verifier strategy %r: %d criteria → reward %.4f",
+            strategy_name,
+            len(reward_func.events),
+            score,
+        )
+
+        rewards = {"reward": score}
+        self._rollout_paths.reward_json_path.write_text(
+            json.dumps(rewards, indent=2, allow_nan=False)
+        )
+        if reward_func.events:
+            details = {
+                "strategy": strategy_name,
+                "criteria": [
+                    {
+                        "source": event.source,
+                        "score": event.reward,
+                    }
+                    for event in reward_func.events
+                ],
+            }
+            self._rollout_paths.reward_details_path.write_text(
+                json.dumps(details, indent=2, allow_nan=False)
+            )
+        return VerifierResult(rewards=rewards)
+
+    async def _gather_agent_judge_inputs(self, strategy: dict[str, Any]) -> Path:
+        """Collect verifier-scoped judge inputs into a local deliverables dir."""
+        dest = self._rollout_paths.verifier_dir / "agent_judge_inputs"
+        if dest.exists():
+            if dest.is_dir() and not dest.is_symlink():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
+        dest.mkdir(parents=True, exist_ok=True)
+
+        raw_inputs = strategy.get("inputs")
+        inputs = (
+            [item for item in raw_inputs if isinstance(item, str) and item.strip()]
+            if isinstance(raw_inputs, list)
+            else []
+        )
+        if not inputs:
+            return dest
+
+        rollout_dir = self._rollout_paths.rollout_dir
+        for index, input_path in enumerate(inputs):
+            stripped = input_path.strip()
+            target_name = f"input-{index}-{Path(stripped).name}"
+            target = dest / target_name
+
+            if stripped.startswith("trajectory/"):
+                host_path = rollout_dir / stripped
+                if host_path.is_file():
+                    target.write_bytes(host_path.read_bytes())
+                continue
+
+            if stripped.startswith("/logs/"):
+                sandbox_source = stripped
+            else:
+                sandbox_source = stripped if stripped.startswith("/") else f"/{stripped}"
+
+            try:
+                await self._sandbox.download_file(sandbox_source, target)
+            except Exception as exc:
+                self._logger.warning(
+                    "agent-judge input %r unavailable: %s", stripped, exc
+                )
         return dest
 
     async def _verify_llm_judge(self) -> VerifierResult:

--- a/src/benchflow/task/verifier.py
+++ b/src/benchflow/task/verifier.py
@@ -4,7 +4,7 @@ Internalized from Harbor's Verifier class. Supports two verification methods,
 selected by ``[verifier].type`` in ``task.toml``:
 
 - ``"test-script"`` (default): run ``tests/test.sh`` inside the sandbox and
-  parse ``reward.txt`` / ``reward.json``.
+  parse ``reward.json`` / ``reward.txt`` (JSON is authoritative when present).
 - ``"llm-judge"``: download the agent's deliverables and grade them against a
   human-authored rubric using an LLM judge (see #270).
 """
@@ -67,7 +67,7 @@ class Verifier:
 
     1. ``test-script`` — uploads the task's ``tests/`` directory into the
        sandbox at ``/tests``, runs ``test.sh`` with configured env vars/user,
-       and parses the reward from ``reward.txt`` or ``reward.json``.
+       and parses the reward from ``reward.json`` or ``reward.txt``.
     2. ``llm-judge`` — downloads the agent's deliverables from the sandbox and
        grades them against a rubric using an LLM judge, writing the aggregate
        reward to ``reward.json``.
@@ -134,6 +134,39 @@ class Verifier:
             raise VerifierOutputParseError(
                 f"Reward JSON file {self._rollout_paths.reward_json_path} {e}"
             ) from e
+
+    def _parse_rewards(self, *, test_return_code: int) -> dict[str, Any]:
+        """Parse verifier reward outputs with JSON-first precedence."""
+        has_json = self._rollout_paths.reward_json_path.exists()
+        has_text = self._rollout_paths.reward_text_path.exists()
+
+        if has_json and has_text:
+            json_rewards = self._parse_reward_json()
+            text_rewards = self._parse_reward_text()
+            json_scalar = float(json_rewards["reward"])
+            text_scalar = float(text_rewards["reward"])
+            if json_scalar != text_scalar:
+                raise VerifierOutputParseError(
+                    "reward.json aggregate "
+                    f"{json_scalar} disagrees with reward.txt scalar {text_scalar}"
+                )
+            return json_rewards
+
+        if has_json:
+            return self._parse_reward_json()
+        if has_text:
+            return self._parse_reward_text()
+
+        if test_return_code != 0:
+            raise RewardFileNotFoundError(
+                f"verifier exited with rc={test_return_code}; no reward file "
+                f"found at {self._rollout_paths.reward_text_path} or "
+                f"{self._rollout_paths.reward_json_path}"
+            )
+        raise RewardFileNotFoundError(
+            f"No reward file found at {self._rollout_paths.reward_text_path} or "
+            f"{self._rollout_paths.reward_json_path}"
+        )
 
     def _clear_reward_outputs(self) -> None:
         for path in (
@@ -294,22 +327,7 @@ class Verifier:
                 test_return_code,
             )
 
-        if self._rollout_paths.reward_text_path.exists():
-            rewards = self._parse_reward_text()
-        elif self._rollout_paths.reward_json_path.exists():
-            rewards = self._parse_reward_json()
-        else:
-            if test_return_code != 0:
-                raise RewardFileNotFoundError(
-                    f"verifier exited with rc={test_return_code}; no reward file "
-                    f"found at {self._rollout_paths.reward_text_path} or "
-                    f"{self._rollout_paths.reward_json_path}"
-                )
-            raise RewardFileNotFoundError(
-                f"No reward file found at {self._rollout_paths.reward_text_path} or "
-                f"{self._rollout_paths.reward_json_path}"
-            )
-
+        rewards = self._parse_rewards(test_return_code=test_return_code)
         return VerifierResult(rewards=rewards)
 
     # ------------------------------------------------------------------

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -179,6 +179,16 @@ def verifier_document_issues(
         except VerifierDocumentParseError as exc:
             issues.append(f"{spec} strategy {strategy_name!r} error: {exc}")
             continue
+        if strategy_type == "agent-judge":
+            _append_agent_judge_role_issues(
+                issues,
+                spec=spec,
+                strategy_name=strategy_name,
+                strategy=strategy,
+                document=document,
+                verifier_dir=verifier_dir,
+            )
+            continue
         if strategy_type != "reward-kit":
             continue
         raw_root = strategy.get("root")
@@ -195,6 +205,43 @@ def verifier_document_issues(
             )
 
     return issues
+
+
+def _is_agent_judge_role_file_path(role: str) -> bool:
+    return "/" in role or role.endswith(".md")
+
+
+def _append_agent_judge_role_issues(
+    issues: list[str],
+    *,
+    spec: str,
+    strategy_name: str,
+    strategy: dict[str, Any],
+    document: VerifierDocument,
+    verifier_dir: Path,
+) -> None:
+    raw_role = strategy.get("role")
+    if not isinstance(raw_role, str) or not raw_role.strip():
+        issues.append(
+            f"{spec} agent-judge strategy {strategy_name!r} is missing role"
+        )
+        return
+
+    role = raw_role.strip()
+    if _is_agent_judge_role_file_path(role):
+        role_path = (verifier_dir / role).resolve()
+        if not role_path.is_file():
+            issues.append(
+                f"{spec} agent-judge strategy {strategy_name!r} references "
+                f"missing role file: {role}"
+            )
+        return
+
+    if role not in document.role_prompts:
+        issues.append(
+            f"{spec} agent-judge strategy {strategy_name!r} references "
+            f"unknown role prompt ## role:{role}"
+        )
 
 
 def _declared_rubric_file_paths(

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -173,6 +173,27 @@ def verifier_document_issues(
                 f"benchflow.verifier declares missing {label} rubric file: {path}"
             )
 
+    for strategy_name, strategy in document.strategies.items():
+        try:
+            strategy_type = verifier_strategy_type(strategy)
+        except VerifierDocumentParseError as exc:
+            issues.append(f"{spec} strategy {strategy_name!r} error: {exc}")
+            continue
+        if strategy_type != "reward-kit":
+            continue
+        raw_root = strategy.get("root")
+        if not isinstance(raw_root, str) or not raw_root.strip():
+            issues.append(
+                f"{spec} reward-kit strategy {strategy_name!r} is missing root"
+            )
+            continue
+        root_path = (verifier_dir / raw_root.strip()).resolve()
+        if not root_path.is_dir():
+            issues.append(
+                f"{spec} reward-kit strategy {strategy_name!r} references "
+                f"missing root directory: {raw_root.strip()}"
+            )
+
     return issues
 
 

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -1,0 +1,315 @@
+"""Unified ``verifier/verifier.md`` authoring document support.
+
+The runtime still consumes script verifiers and reward files directly. This
+module owns the document-shaped verifier package layer so reward strategies,
+rubrics, judge roles, and output contracts can be parsed without overloading
+``task/config.py``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VERIFIER_DOCUMENT_FILENAME = "verifier.md"
+
+_ROLE_SECTION_RE = re.compile(
+    r"^##\s+role:([A-Za-z0-9_.-]+)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+class VerifierDocumentParseError(ValueError):
+    """Raised when a ``verifier/verifier.md`` document cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class VerifierRubricFiles:
+    """Human and structured rubric file references declared in verifier metadata."""
+
+    human: str | None = None
+    structured: str | None = None
+
+
+@dataclass(frozen=True)
+class VerifierOutputs:
+    """Declared verifier reward artifact paths and aggregate policy."""
+
+    reward_text: str | None = None
+    reward_json: str | None = None
+    reward_details: str | None = None
+    aggregate_policy: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class VerifierDocument:
+    """Parsed ``verifier/verifier.md`` document."""
+
+    frontmatter: dict[str, Any]
+    body: str
+    document_version: str | None
+    name: str | None
+    default_strategy: str | None
+    strategies: dict[str, dict[str, Any]]
+    rubric: dict[str, Any]
+    rubric_files: VerifierRubricFiles
+    outputs: VerifierOutputs
+    role_prompts: dict[str, str]
+    path: Path | None = None
+
+    @classmethod
+    def from_path(cls, path: str | Path) -> VerifierDocument:
+        doc_path = Path(path)
+        return cls.from_text(doc_path.read_text(), path=doc_path)
+
+    @classmethod
+    def from_text(cls, text: str, *, path: str | Path | None = None) -> VerifierDocument:
+        frontmatter, body = _split_frontmatter(text)
+        verifier = _mapping(frontmatter.get("verifier"), "verifier", default={})
+        strategies = _parse_strategies(verifier.get("strategies"))
+        rubric = _mapping(verifier.get("rubric"), "verifier.rubric", default={})
+        rubric_files = _parse_rubric_files(rubric.get("files"), strategies)
+        outputs = _parse_outputs(verifier.get("outputs"))
+        role_prompts = _extract_role_prompts(body)
+        return cls(
+            frontmatter=frontmatter,
+            body=body,
+            document_version=_optional_str(frontmatter.get("document_version")),
+            name=_optional_str(verifier.get("name")),
+            default_strategy=_optional_str(verifier.get("default_strategy")),
+            strategies=strategies,
+            rubric=rubric,
+            rubric_files=rubric_files,
+            outputs=outputs,
+            role_prompts=role_prompts,
+            path=Path(path) if path is not None else None,
+        )
+
+
+def resolve_verifier_spec_path(task_dir: Path, spec: str) -> Path:
+    """Resolve a ``benchflow.verifier.spec`` path relative to the task directory."""
+
+    spec_path = Path(spec)
+    if spec_path.is_absolute():
+        return spec_path
+    return (task_dir / spec_path).resolve()
+
+
+def verifier_document_issues(
+    task_dir: Path,
+    *,
+    benchflow_verifier: dict[str, Any] | None = None,
+) -> list[str]:
+    """Validate verifier document references for a task directory."""
+
+    issues: list[str] = []
+    if benchflow_verifier is None:
+        return issues
+
+    spec = benchflow_verifier.get("spec")
+    if not isinstance(spec, str) or not spec.strip():
+        return issues
+
+    spec_path = resolve_verifier_spec_path(task_dir, spec.strip())
+    if not spec_path.exists():
+        issues.append(f"benchflow.verifier.spec references missing file: {spec}")
+        return issues
+
+    try:
+        document = VerifierDocument.from_path(spec_path)
+    except VerifierDocumentParseError as exc:
+        issues.append(f"{spec} parse error: {exc}")
+        return issues
+    except OSError as exc:
+        issues.append(f"{spec} read error: {exc}")
+        return issues
+
+    default_strategy = document.default_strategy
+    if default_strategy and default_strategy not in document.strategies:
+        issues.append(
+            f"{spec} default_strategy {default_strategy!r} is not declared in "
+            "verifier.strategies"
+        )
+
+    verifier_dir = spec_path.parent
+    for label, path in _declared_rubric_file_paths(
+        task_dir=task_dir,
+        verifier_dir=verifier_dir,
+        document=document,
+        benchflow_verifier=benchflow_verifier,
+    ):
+        if not path.exists():
+            issues.append(
+                f"benchflow.verifier declares missing {label} rubric file: {path}"
+            )
+
+    return issues
+
+
+def _declared_rubric_file_paths(
+    *,
+    task_dir: Path,
+    verifier_dir: Path,
+    document: VerifierDocument,
+    benchflow_verifier: dict[str, Any],
+) -> list[tuple[str, Path]]:
+    refs: list[tuple[str, Path]] = []
+    seen: set[Path] = set()
+
+    def add(label: str, value: Any, *, base_dir: Path) -> None:
+        if not isinstance(value, str) or not value.strip():
+            return
+        path = (base_dir / value.strip()).resolve()
+        if path in seen:
+            return
+        seen.add(path)
+        refs.append((label, path))
+
+    add("human", document.rubric_files.human, base_dir=verifier_dir)
+    add("structured", document.rubric_files.structured, base_dir=verifier_dir)
+    add("human", benchflow_verifier.get("rubric"), base_dir=task_dir)
+    add("structured", benchflow_verifier.get("structured_rubric"), base_dir=task_dir)
+
+    rewardkit = document.strategies.get("rewardkit")
+    if isinstance(rewardkit, dict):
+        add("criteria", rewardkit.get("criteria"), base_dir=verifier_dir)
+
+    return refs
+
+
+def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    normalized = text.replace("\r\n", "\n")
+    lines = normalized.splitlines(keepends=True)
+    if not lines or lines[0].strip() != "---":
+        raise VerifierDocumentParseError(
+            "verifier.md must start with YAML frontmatter"
+        )
+
+    closing_index: int | None = None
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            closing_index = index
+            break
+    if closing_index is None:
+        raise VerifierDocumentParseError(
+            "verifier.md frontmatter is missing closing ---"
+        )
+
+    frontmatter_text = "".join(lines[1:closing_index])
+    body = "".join(lines[closing_index + 1 :]).lstrip("\n")
+    loaded = yaml.safe_load(frontmatter_text) if frontmatter_text.strip() else {}
+    if loaded is None:
+        loaded = {}
+    if not isinstance(loaded, dict):
+        raise VerifierDocumentParseError("verifier.md frontmatter must be a mapping")
+    return loaded, body
+
+
+def _extract_role_prompts(body: str) -> dict[str, str]:
+    matches = list(_ROLE_SECTION_RE.finditer(body))
+    if not matches:
+        return {}
+
+    role_prompts: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        role_name = match.group(1)
+        if role_name in role_prompts:
+            raise VerifierDocumentParseError(
+                f"verifier.md has duplicate section ## role:{role_name}"
+            )
+        next_start = (
+            matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        )
+        role_prompts[role_name] = body[match.end() : next_start].strip()
+    return role_prompts
+
+
+def _parse_strategies(value: Any) -> dict[str, dict[str, Any]]:
+    if value is None:
+        return {}
+    if not isinstance(value, dict):
+        raise VerifierDocumentParseError("verifier.strategies must be a mapping")
+    strategies: dict[str, dict[str, Any]] = {}
+    for name, raw_strategy in value.items():
+        if not isinstance(name, str):
+            raise VerifierDocumentParseError(
+                "verifier.strategies keys must be strategy names"
+            )
+        strategies[name] = _mapping(
+            raw_strategy,
+            f"verifier.strategies.{name}",
+            default={},
+        )
+    return strategies
+
+
+def _parse_rubric_files(
+    raw_files: Any,
+    strategies: dict[str, dict[str, Any]],
+) -> VerifierRubricFiles:
+    human: str | None = None
+    structured: str | None = None
+    if raw_files is not None:
+        files = _mapping(raw_files, "verifier.rubric.files", default={})
+        human = _optional_str(files.get("human"))
+        structured = _optional_str(files.get("structured"))
+
+    rewardkit = strategies.get("rewardkit")
+    if structured is None and isinstance(rewardkit, dict):
+        structured = _optional_str(rewardkit.get("criteria"))
+
+    return VerifierRubricFiles(human=human, structured=structured)
+
+
+def _parse_outputs(value: Any) -> VerifierOutputs:
+    if value is None:
+        return VerifierOutputs()
+    outputs = _mapping(value, "verifier.outputs", default={})
+    aggregate_policy = outputs.get("aggregate_policy")
+    if aggregate_policy is not None:
+        aggregate_policy = _mapping(
+            aggregate_policy,
+            "verifier.outputs.aggregate_policy",
+            default={},
+        )
+    return VerifierOutputs(
+        reward_text=_optional_str(outputs.get("reward_text")),
+        reward_json=_optional_str(outputs.get("reward_json")),
+        reward_details=_optional_str(outputs.get("details_json")),
+        aggregate_policy=aggregate_policy,
+    )
+
+
+def _mapping(
+    value: Any, source: str, *, default: dict[str, Any] | None = None
+) -> dict[str, Any]:
+    if value is None:
+        return {} if default is None else dict(default)
+    if not isinstance(value, dict):
+        raise VerifierDocumentParseError(f"{source} must be a mapping")
+    return value
+
+
+def _optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise VerifierDocumentParseError(
+            f"Expected string value, got {type(value).__name__}"
+        )
+    return value
+
+
+__all__ = [
+    "VERIFIER_DOCUMENT_FILENAME",
+    "VerifierDocument",
+    "VerifierDocumentParseError",
+    "VerifierOutputs",
+    "VerifierRubricFiles",
+    "resolve_verifier_spec_path",
+    "verifier_document_issues",
+]

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -99,6 +99,32 @@ def resolve_verifier_spec_path(task_dir: Path, spec: str) -> Path:
     return (task_dir / spec_path).resolve()
 
 
+def load_verifier_document(
+    task_dir: Path | str,
+    benchflow: dict[str, Any],
+) -> VerifierDocument | None:
+    """Load the verifier document referenced by ``benchflow.verifier.spec``."""
+    if not isinstance(benchflow, dict):
+        return None
+    benchflow_verifier = benchflow.get("verifier")
+    if not isinstance(benchflow_verifier, dict):
+        return None
+    spec_issues = verifier_document_issues(
+        Path(task_dir).resolve(),
+        benchflow_verifier=benchflow_verifier,
+    )
+    if spec_issues:
+        raise ValueError("; ".join(spec_issues))
+    spec = benchflow_verifier.get("spec")
+    if not isinstance(spec, str) or not spec.strip():
+        return None
+    spec_path = resolve_verifier_spec_path(Path(task_dir).resolve(), spec.strip())
+    try:
+        return VerifierDocument.from_path(spec_path)
+    except VerifierDocumentParseError as exc:
+        raise ValueError(f"{spec} parse error: {exc}") from exc
+
+
 def verifier_document_issues(
     task_dir: Path,
     *,
@@ -310,6 +336,7 @@ __all__ = [
     "VerifierDocumentParseError",
     "VerifierOutputs",
     "VerifierRubricFiles",
+    "load_verifier_document",
     "resolve_verifier_spec_path",
     "verifier_document_issues",
 ]

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -330,13 +330,55 @@ def _optional_str(value: Any) -> str | None:
     return value
 
 
+_SCRIPT_STRATEGY_TYPES = frozenset({"script", "deterministic"})
+
+
+def resolve_default_strategy(
+    document: VerifierDocument,
+) -> tuple[str, dict[str, Any]]:
+    """Return the selected default strategy name and config."""
+
+    strategy_name = document.default_strategy
+    if not strategy_name:
+        raise ValueError("verifier document has no default_strategy")
+    strategy = document.strategies.get(strategy_name)
+    if strategy is None:
+        raise ValueError(
+            f"verifier default_strategy {strategy_name!r} is not declared in "
+            "verifier.strategies"
+        )
+    return strategy_name, strategy
+
+
+def verifier_strategy_type(strategy: dict[str, Any]) -> str | None:
+    """Return the declared strategy ``type`` when present."""
+
+    raw_type = strategy.get("type")
+    if raw_type is None:
+        return None
+    if not isinstance(raw_type, str):
+        raise VerifierDocumentParseError(
+            f"verifier strategy type must be a string, got {type(raw_type).__name__}"
+        )
+    return raw_type
+
+
+def is_executable_script_strategy(strategy: dict[str, Any]) -> bool:
+    """Return whether the runtime can execute the strategy via ``test.sh``."""
+
+    return verifier_strategy_type(strategy) in _SCRIPT_STRATEGY_TYPES
+
+
 __all__ = [
     "VERIFIER_DOCUMENT_FILENAME",
     "VerifierDocument",
     "VerifierDocumentParseError",
     "VerifierOutputs",
     "VerifierRubricFiles",
+    "is_executable_script_strategy",
     "load_verifier_document",
+    "resolve_default_strategy",
     "resolve_verifier_spec_path",
     "verifier_document_issues",
+    "verifier_strategy_type",
 ]

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -437,14 +437,102 @@ def is_executable_script_strategy(strategy: dict[str, Any]) -> bool:
     return verifier_strategy_type(strategy) in _SCRIPT_STRATEGY_TYPES
 
 
+def resolve_reward_kit_criteria_path(
+    strategy: dict[str, Any],
+    verifier_dir: Path,
+) -> Path | None:
+    """Return the reward-kit criteria path when declared and present."""
+
+    raw_criteria = strategy.get("criteria")
+    if not isinstance(raw_criteria, str) or not raw_criteria.strip():
+        return None
+    criteria_path = (verifier_dir / raw_criteria.strip()).resolve()
+    return criteria_path if criteria_path.is_file() else None
+
+
+def is_executable_reward_kit_strategy(
+    strategy: dict[str, Any],
+    verifier_dir: Path,
+) -> bool:
+    """Return whether a reward-kit strategy can run via the script verifier."""
+
+    if verifier_strategy_type(strategy) != "reward-kit":
+        return False
+    if resolve_reward_kit_criteria_path(strategy, verifier_dir) is not None:
+        return True
+    raw_root = strategy.get("root")
+    if isinstance(raw_root, str) and raw_root.strip():
+        root_path = (verifier_dir / raw_root.strip()).resolve()
+        return root_path.is_dir() and (root_path / "test.sh").is_file()
+    return False
+
+
+def resolve_agent_judge_role_prompt(
+    strategy: dict[str, Any],
+    document: VerifierDocument,
+    verifier_dir: Path,
+) -> str | None:
+    """Resolve the verifier-scoped judge role prompt for an agent-judge strategy."""
+
+    raw_role = strategy.get("role")
+    if not isinstance(raw_role, str) or not raw_role.strip():
+        return None
+    role = raw_role.strip()
+    if _is_agent_judge_role_file_path(role):
+        role_path = (verifier_dir / role).resolve()
+        if not role_path.is_file():
+            return None
+        return role_path.read_text(encoding="utf-8").strip() or None
+    prompt = document.role_prompts.get(role)
+    return prompt.strip() if isinstance(prompt, str) and prompt.strip() else None
+
+
+def resolve_structured_rubric_path(
+    document: VerifierDocument,
+    verifier_dir: Path,
+) -> Path | None:
+    """Return the structured rubric path declared by a verifier document."""
+
+    structured = document.rubric_files.structured
+    if isinstance(structured, str) and structured.strip():
+        path = (verifier_dir / structured.strip()).resolve()
+        if path.is_file():
+            return path
+    rewardkit = document.strategies.get("rewardkit")
+    if isinstance(rewardkit, dict):
+        criteria = resolve_reward_kit_criteria_path(rewardkit, verifier_dir)
+        if criteria is not None:
+            return criteria
+    return None
+
+
+def is_executable_agent_judge_strategy(
+    strategy: dict[str, Any],
+    document: VerifierDocument,
+    verifier_dir: Path,
+) -> bool:
+    """Return whether an agent-judge strategy has role + rubric inputs to run."""
+
+    if verifier_strategy_type(strategy) != "agent-judge":
+        return False
+    if resolve_agent_judge_role_prompt(strategy, document, verifier_dir) is None:
+        return False
+    return resolve_structured_rubric_path(document, verifier_dir) is not None
+
+
 __all__ = [
     "VERIFIER_DOCUMENT_FILENAME",
     "VerifierDocument",
     "VerifierDocumentParseError",
     "VerifierOutputs",
     "VerifierRubricFiles",
+    "is_executable_agent_judge_strategy",
+    "is_executable_reward_kit_strategy",
     "is_executable_script_strategy",
     "load_verifier_document",
+    "resolve_agent_judge_role_prompt",
+    "resolve_reward_kit_criteria_path",
+    "resolve_structured_rubric_path",
     "resolve_default_strategy",
     "resolve_verifier_spec_path",
     "verifier_document_issues",

--- a/tests/fixtures/docker_dogfood_smoke_report.json
+++ b/tests/fixtures/docker_dogfood_smoke_report.json
@@ -1,0 +1,31 @@
+{
+  "branch": "cursor/task-standard-runtime-gaps-e453",
+  "date": "2026-06-06",
+  "docker_available": true,
+  "docker_notes": [
+    "docker.io installed manually; daemon started with vfs storage driver",
+    "overlayfs default failed in nested host",
+    "compose with deploy.resources.limits fails cgroupv2 threaded-mode on this VM"
+  ],
+  "bench_tasks_check": {
+    "verifier-package-reward-contract": {"valid": true, "runtime_docker": true},
+    "prompt-user-semantics": {"valid": true, "runtime_docker": true},
+    "compat-export-loss-reports": {"valid": true, "runtime_docker": true}
+  },
+  "dockerfile_build": {
+    "verifier-package-reward-contract": {"build": "ok", "workdir_pwd": "/repo"},
+    "prompt-user-semantics": {"build": "ok", "workdir_pwd": "/repo"},
+    "compat-export-loss-reports": {"build": "ok", "workdir_pwd": "/repo"}
+  },
+  "test_sh": {
+    "verifier-package-reward-contract": {"pytest": "99 passed", "reward_artifacts": true},
+    "prompt-user-semantics": {"pytest": "39 passed", "reward_artifacts": true},
+    "compat-export-loss-reports": {"pytest": "82 passed", "reward_artifacts": true}
+  },
+  "compose_workdir_smoke": {"pwd": "/repo", "benchflow_source_at_repo": true},
+  "docker_sandbox_compose": {
+    "status": "failed_on_this_vm",
+    "reason": "cgroupv2 threaded mode vs deploy.resources.limits"
+  },
+  "fixes_committed": []
+}

--- a/tests/fixtures/docker_dogfood_smoke_report.md
+++ b/tests/fixtures/docker_dogfood_smoke_report.md
@@ -1,0 +1,80 @@
+# Docker dogfood smoke report
+
+Branch: `cursor/task-standard-runtime-gaps-e453`  
+Date: 2026-06-06  
+Environment: Cursor cloud VM (nested container host)
+
+## Docker availability
+
+| Check | Result |
+|-------|--------|
+| Initial `docker info` | **Not installed** (`command not found`) |
+| After `apt install docker.io` | **Available** (daemon started manually) |
+| Storage driver | **vfs** required (default overlayfs failed with `invalid argument` in nested host) |
+| `DockerSandbox.preflight()` | **ok** |
+
+## `bench tasks check --sandbox docker`
+
+All three dogfood packages passed structural + runtime validation:
+
+| Task | `check_task` | runtime on docker |
+|------|--------------|-------------------|
+| `verifier-package-reward-contract` | ✓ valid | ✓ supported |
+| `prompt-user-semantics` | ✓ valid | ✓ supported |
+| `compat-export-loss-reports` | ✓ valid | ✓ supported |
+
+## Dockerfile build + `WORKDIR /repo`
+
+Built from each task's `environment/Dockerfile` (`FROM ghcr.io/astral-sh/uv:python3.12-bookworm`, `WORKDIR /repo`):
+
+| Task | Image tag | Build | `pwd` in container |
+|------|-----------|-------|--------------------|
+| verifier-package-reward-contract | `bf-dogfood-verifier-package-reward-contract` | ✓ | `/repo` |
+| prompt-user-semantics | `bf-dogfood-prompt-user-semantics` | ✓ | `/repo` |
+| compat-export-loss-reports | `bf-dogfood-compat-export-loss-reports` | ✓ | `/repo` |
+
+## `verifier/test.sh` (repo mounted at `/repo`)
+
+Ran inside built images with `-w /repo -v /workspace:/repo -v /tmp/...:/logs/verifier`.
+Network enabled only for `uv sync --extra dev --locked` (task declares `no-network`; pytest itself is offline).
+
+| Task | pytest result | reward artifacts |
+|------|---------------|------------------|
+| verifier-package-reward-contract | **99 passed** | `reward.txt`, `reward.json`, `reward-details.json` |
+| prompt-user-semantics | **39 passed** | `reward.txt`, `reward.json` |
+| compat-export-loss-reports | **82 passed** | `reward.txt`, `reward.json` |
+
+## Compose workdir overlay
+
+Manual compose with `working_dir: /repo` (no CPU/memory deploy limits):
+
+- `docker compose exec -w /repo main pwd` → `/repo`
+- Benchflow source visible at `/repo/src/benchflow/__init__.py`
+
+Matches `docker-compose-workdir.json` emitted by `DockerSandbox._write_workdir_compose_file()`.
+
+## `DockerSandbox` compose startup (benchflow path)
+
+`DockerSandbox.start(force_build=False)` failed in this VM when benchflow's base compose applied `deploy.resources.limits` (cpus/memory from task `environment`):
+
+```
+cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode
+```
+
+Reproduced with plain `docker run --cpus=4 --memory=8192m` (without limits, `docker run` and compose both work).
+
+**Assessment:** environment/cgroup limitation on this nested host, not a `environment.workdir` implementation bug. Workdir compose overlay and exec `-w` default behave correctly where containers can start.
+
+## Unit tests (workdir-related)
+
+```
+uv run python -m pytest tests/test_runtime_capabilities.py -k workdir \
+  tests/test_sandbox_multi_service.py::TestDockerSandboxServiceExec::test_exec_defaults_cwd_to_task_workdir \
+  tests/test_task_standard_dogfood.py
+```
+
+6 passed, 2 skipped, 1 failed (`test_create_sandbox_environment_workdir_supported_on_modal` — missing optional `tenacity`/modal extra; unrelated to docker workdir).
+
+## Fixes applied
+
+**None.** No workdir bugs found; no code changes committed.

--- a/tests/test_benchflow_schema.py
+++ b/tests/test_benchflow_schema.py
@@ -1,0 +1,64 @@
+"""Tests for typed ``benchflow:`` namespace validation (P3 subset)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from benchflow._utils.task_authoring import check_task
+from benchflow.task.benchflow_schema import (
+    BenchflowMetadata,
+    parse_benchflow_metadata,
+    validate_benchflow_metadata,
+)
+
+PROMPT_USER_SEMANTICS_TASK = (
+    "docs/examples/task-standard/benchflow-wanted-features/prompt-user-semantics"
+)
+
+
+class TestValidateBenchflowMetadata:
+    def test_prompt_user_semantics_dogfood_validates(self) -> None:
+        """Guards typed benchflow validation for prompt-user-semantics dogfood."""
+        issues = validate_benchflow_metadata(
+            {
+                "document_version": "0.3",
+                "prompt": {
+                    "composition": "append",
+                    "order": ["base", "role", "scene", "turn"],
+                },
+                "nudges": {
+                    "mode": "simulated-user",
+                    "branchable": True,
+                    "nudge_budget": 5,
+                },
+            }
+        )
+        assert issues == []
+
+    def test_invalid_prompt_composition_reports_issue(self) -> None:
+        issues = validate_benchflow_metadata(
+            {"prompt": {"composition": "shadow", "order": ["base"]}}
+        )
+        assert any("benchflow.prompt.composition" in issue for issue in issues)
+
+    def test_invalid_nudge_budget_reports_issue(self) -> None:
+        issues = validate_benchflow_metadata({"nudges": {"nudge_budget": 0}})
+        assert any("benchflow.nudges.nudge_budget" in issue for issue in issues)
+
+    def test_parse_returns_metadata_when_valid(self) -> None:
+        metadata = parse_benchflow_metadata(
+            {
+                "document_version": "0.3",
+                "compatibility": {"target": "harbor"},
+            }
+        )
+        assert isinstance(metadata, BenchflowMetadata)
+        assert metadata.document_version == "0.3"
+        assert metadata.compatibility is not None
+        assert metadata.compatibility.target == "harbor"
+
+
+class TestCheckTaskBenchflowValidation:
+    def test_prompt_user_semantics_check_task_passes_typed_benchflow(self) -> None:
+        """Guards check_task includes typed benchflow validation for dogfood."""
+        assert check_task(Path(PROMPT_USER_SEMANTICS_TASK)) == []

--- a/tests/test_benchflow_schema.py
+++ b/tests/test_benchflow_schema.py
@@ -45,6 +45,35 @@ class TestValidateBenchflowMetadata:
         issues = validate_benchflow_metadata({"nudges": {"nudge_budget": 0}})
         assert any("benchflow.nudges.nudge_budget" in issue for issue in issues)
 
+    def test_confirmation_policy_and_scripted_validate_as_metadata_only(self) -> None:
+        """Guards metadata-only nudge branch fields parse with typed validation."""
+        issues = validate_benchflow_metadata(
+            {
+                "nudges": {
+                    "mode": "simulated-user",
+                    "branchable": True,
+                    "confirmation_policy": {"destructive_actions": "human"},
+                    "scripted": [
+                        {
+                            "trigger": "asked_for_specific_sender",
+                            "reveal": "sender",
+                        }
+                    ],
+                }
+            }
+        )
+        assert issues == []
+
+    def test_invalid_scripted_nudge_reports_issue(self) -> None:
+        issues = validate_benchflow_metadata(
+            {
+                "nudges": {
+                    "scripted": [{"trigger": 1, "reveal": "sender"}],
+                }
+            }
+        )
+        assert any("benchflow.nudges.scripted[0].trigger" in issue for issue in issues)
+
     def test_parse_returns_metadata_when_valid(self) -> None:
         metadata = parse_benchflow_metadata(
             {

--- a/tests/test_dogfood_cli_integration.py
+++ b/tests/test_dogfood_cli_integration.py
@@ -1,0 +1,77 @@
+"""CLI integration tests for real task-standard dogfood packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+DOGFOOD_ROOT = Path("docs/examples/task-standard/benchflow-wanted-features")
+RUNTIME_GATE_TASK = DOGFOOD_ROOT / "runtime-capability-gate"
+SUPPORTED_TASKS = sorted(
+    path
+    for path in DOGFOOD_ROOT.iterdir()
+    if path.is_dir()
+    and (path / "task.md").is_file()
+    and path.name != RUNTIME_GATE_TASK.name
+)
+
+
+def _dogfood_task_dirs() -> list[Path]:
+    return sorted(
+        path
+        for path in DOGFOOD_ROOT.iterdir()
+        if path.is_dir() and (path / "task.md").is_file()
+    )
+
+
+class TestDogfoodTasksCheckCli:
+    def test_all_dogfood_tasks_pass_structural_check(self) -> None:
+        for task_dir in _dogfood_task_dirs():
+            result = CliRunner().invoke(app, ["tasks", "check", str(task_dir)])
+            assert result.exit_code == 0, f"{task_dir.name}: {result.output}"
+
+    def test_supported_tasks_pass_docker_sandbox_check(self) -> None:
+        for task_dir in SUPPORTED_TASKS:
+            result = CliRunner().invoke(
+                app,
+                ["tasks", "check", str(task_dir), "--sandbox", "docker"],
+            )
+            assert result.exit_code == 0, f"{task_dir.name}: {result.output}"
+            assert "runtime supported on docker" in result.output
+
+    def test_supported_tasks_pass_modal_sandbox_check(self) -> None:
+        for task_dir in SUPPORTED_TASKS:
+            result = CliRunner().invoke(
+                app,
+                ["tasks", "check", str(task_dir), "--sandbox", "modal"],
+            )
+            assert result.exit_code == 0, f"{task_dir.name}: {result.output}"
+            assert "runtime supported on modal" in result.output
+
+    def test_runtime_capability_gate_fails_sandbox_check(self) -> None:
+        for sandbox in ("docker", "modal"):
+            result = CliRunner().invoke(
+                app,
+                ["tasks", "check", str(RUNTIME_GATE_TASK), "--sandbox", sandbox],
+            )
+            assert result.exit_code == 1, result.output
+            assert "environment.healthcheck" in result.output
+
+    def test_compat_export_round_trip_cli(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "compat-round-trip"
+        result = CliRunner().invoke(
+            app,
+            [
+                "tasks",
+                "round-trip",
+                str(DOGFOOD_ROOT / "compat-export-loss-reports"),
+                "--output",
+                str(output_dir),
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Round-trip parity OK" in result.output
+        assert (output_dir / "compatibility" / "export-report.json").is_file()

--- a/tests/test_llm_judge_verifier.py
+++ b/tests/test_llm_judge_verifier.py
@@ -635,10 +635,10 @@ class TestTestScriptStillDefault:
     # covered by TestVerifierNonzeroExitRewardAcceptance in test_oracle_chokepoint.py.
 
     @pytest.mark.asyncio
-    async def test_reward_json_requires_canonical_reward_key(
+    async def test_reward_json_requires_scalar_or_metric_map(
         self, tmp_path: Path
     ) -> None:
-        """Guards the reward-output regression on v0.5-integration@ffef85d."""
+        """Guards reward maps that contain only reserved non-metric keys."""
         task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
         task.paths.tests_dir = task.task_dir / "tests"
         task.paths.test_path = task.task_dir / "tests" / "test.sh"
@@ -653,13 +653,46 @@ class TestTestScriptStillDefault:
         async def exec_malformed_reward(*_args: object, **_kwargs: object) -> MagicMock:
             if sandbox.exec.await_count == 1:
                 return MagicMock(return_code=0, stdout="")
-            rollout_paths.reward_json_path.write_text(json.dumps({"score": 1.0}))
+            rollout_paths.reward_json_path.write_text(
+                json.dumps({"metadata": {"source": "rewardkit"}})
+            )
             return MagicMock(return_code=0, stdout="")
 
         sandbox.exec = AsyncMock(side_effect=exec_malformed_reward)
 
         with pytest.raises(VerifierOutputParseError, match="missing numeric 'reward'"):
             await Verifier(task, rollout_paths, sandbox).verify()
+
+    @pytest.mark.asyncio
+    async def test_reward_json_accepts_single_metric_map_without_reward_key(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards Harbor Reward Kit maps that omit the canonical reward key."""
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        task.paths.tests_dir = task.task_dir / "tests"
+        task.paths.test_path = task.task_dir / "tests" / "test.sh"
+
+        sandbox = MagicMock()
+        sandbox.upload_dir = AsyncMock()
+        sandbox.is_mounted = True
+
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+
+        async def exec_single_metric_reward(
+            *_args: object, **_kwargs: object
+        ) -> MagicMock:
+            if sandbox.exec.await_count == 1:
+                return MagicMock(return_code=0, stdout="")
+            rollout_paths.reward_json_path.write_text(json.dumps({"score": 1.0}))
+            return MagicMock(return_code=0, stdout="")
+
+        sandbox.exec = AsyncMock(side_effect=exec_single_metric_reward)
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+        assert result.rewards["reward"] == pytest.approx(1.0)
+        assert result.rewards["score"] == 1.0
 
     @pytest.mark.asyncio
     async def test_reward_json_preserves_rubric_process_rewards(
@@ -699,10 +732,10 @@ class TestTestScriptStillDefault:
     @pytest.mark.parametrize(
         ("payload", "match"),
         [
-            ({"reward": float("nan")}, "missing numeric 'reward'"),
-            ({"reward": float("inf")}, "missing numeric 'reward'"),
-            ({"reward": True}, "missing numeric 'reward'"),
-            ({"reward": 1.2}, "missing numeric 'reward'"),
+            ({"reward": float("nan")}, "invalid reward value for 'reward'"),
+            ({"reward": float("inf")}, "invalid reward value for 'reward'"),
+            ({"reward": True}, "invalid reward value for 'reward'"),
+            ({"reward": 1.2}, "invalid reward value for 'reward'"),
             ({"reward": 0.5, "extra": float("nan")}, "invalid reward value"),
         ],
     )
@@ -797,3 +830,42 @@ class TestTestScriptStillDefault:
         result = await Verifier(task, rollout_paths, sandbox).verify()
 
         assert result.rewards == payload
+
+    @pytest.mark.asyncio
+    async def test_multi_metric_reward_json_synthesizes_scalar_for_txt_agreement(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards Harbor Reward Kit multi-metric maps in verifier reward parsing."""
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        task.paths.tests_dir = task.task_dir / "tests"
+        task.paths.test_path = task.task_dir / "tests" / "test.sh"
+
+        sandbox = MagicMock()
+        sandbox.upload_dir = AsyncMock()
+        sandbox.is_mounted = True
+
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+        payload = {
+            "correctness": 0.75,
+            "quality": 0.9,
+            "metadata": {"source": "rewardkit"},
+        }
+
+        async def exec_multi_metric_rewards(
+            *_args: object, **_kwargs: object
+        ) -> MagicMock:
+            if sandbox.exec.await_count == 1:
+                return MagicMock(return_code=0, stdout="")
+            rollout_paths.reward_text_path.write_text("0.825")
+            rollout_paths.reward_json_path.write_text(json.dumps(payload))
+            return MagicMock(return_code=0, stdout="")
+
+        sandbox.exec = AsyncMock(side_effect=exec_multi_metric_rewards)
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+        assert result.rewards["reward"] == pytest.approx(0.825)
+        assert result.rewards["correctness"] == 0.75
+        assert result.rewards["quality"] == 0.9
+        assert result.rewards["metadata"] == payload["metadata"]

--- a/tests/test_llm_judge_verifier.py
+++ b/tests/test_llm_judge_verifier.py
@@ -732,3 +732,68 @@ class TestTestScriptStillDefault:
 
         with pytest.raises(VerifierOutputParseError, match=match):
             await Verifier(task, rollout_paths, sandbox).verify()
+
+    @pytest.mark.asyncio
+    async def test_reward_json_takes_precedence_over_reward_txt(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards task-standard reward.json precedence over reward.txt."""
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        task.paths.tests_dir = task.task_dir / "tests"
+        task.paths.test_path = task.task_dir / "tests" / "test.sh"
+
+        sandbox = MagicMock()
+        sandbox.upload_dir = AsyncMock()
+        sandbox.is_mounted = True
+
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+        payload = {
+            "reward": 0.75,
+            "rubric": [{"name": "quality", "score": 0.75, "weight": 1.0}],
+        }
+
+        async def exec_both_rewards(*_args: object, **_kwargs: object) -> MagicMock:
+            if sandbox.exec.await_count == 1:
+                return MagicMock(return_code=0, stdout="")
+            rollout_paths.reward_text_path.write_text("0.25")
+            rollout_paths.reward_json_path.write_text(json.dumps(payload))
+            return MagicMock(return_code=0, stdout="")
+
+        sandbox.exec = AsyncMock(side_effect=exec_both_rewards)
+
+        with pytest.raises(VerifierOutputParseError, match=r"disagrees with reward\.txt"):
+            await Verifier(task, rollout_paths, sandbox).verify()
+
+    @pytest.mark.asyncio
+    async def test_reward_json_and_reward_txt_must_agree_when_both_present(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards task-standard scalar agreement when both reward files exist."""
+        task = _make_task(tmp_path, 'version = "1.0"\n[verifier]\n')
+        task.paths.tests_dir = task.task_dir / "tests"
+        task.paths.test_path = task.task_dir / "tests" / "test.sh"
+
+        sandbox = MagicMock()
+        sandbox.upload_dir = AsyncMock()
+        sandbox.is_mounted = True
+
+        rollout_paths = RolloutPaths(tmp_path / "rollout")
+        rollout_paths.mkdir()
+        payload = {
+            "reward": 0.75,
+            "rubric": [{"name": "quality", "score": 0.75, "weight": 1.0}],
+        }
+
+        async def exec_matching_rewards(*_args: object, **_kwargs: object) -> MagicMock:
+            if sandbox.exec.await_count == 1:
+                return MagicMock(return_code=0, stdout="")
+            rollout_paths.reward_text_path.write_text("0.75")
+            rollout_paths.reward_json_path.write_text(json.dumps(payload))
+            return MagicMock(return_code=0, stdout="")
+
+        sandbox.exec = AsyncMock(side_effect=exec_matching_rewards)
+
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+        assert result.rewards == payload

--- a/tests/test_prompt_composition.py
+++ b/tests/test_prompt_composition.py
@@ -1,0 +1,295 @@
+"""Tests for task-standard prompt composition."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.scenes import compile_scenes_to_steps, scene_step_prompt
+from benchflow.task import TaskDocument, TaskDocumentParseError, TaskRuntimeView
+from benchflow.task.prompt_composition import (
+    compose_task_prompt,
+    prompt_composition_settings,
+)
+
+PROMPT_USER_SEMANTICS = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/prompt-user-semantics"
+)
+
+
+def test_compose_task_prompt_legacy_fallback_precedence() -> None:
+    """Guards legacy turn > scene > role > base precedence without benchflow.prompt."""
+    assert compose_task_prompt("base", "role", "scene", "turn") == "turn"
+    assert compose_task_prompt("base", "role", "scene", None) == "scene"
+    assert compose_task_prompt("base", "role", None, None) == "role"
+    assert compose_task_prompt("base", None, None, None) == "base"
+    assert compose_task_prompt(None, None, None, None) == ""
+
+
+def test_compose_task_prompt_append_joins_non_empty_parts() -> None:
+    """Guards append composition joins ordered non-empty parts with blank lines."""
+    composed = compose_task_prompt(
+        "Base prompt.",
+        "Role guardrails.",
+        "Scene context.",
+        "Turn override.",
+        composition="append",
+        order=["base", "role", "scene", "turn"],
+    )
+
+    assert composed == (
+        "Base prompt.\n\n"
+        "Role guardrails.\n\n"
+        "Scene context.\n\n"
+        "Turn override."
+    )
+
+
+def test_compose_task_prompt_append_skips_empty_parts() -> None:
+    """Guards append composition ignores empty scene/turn sections."""
+    composed = compose_task_prompt(
+        "Base prompt.",
+        "Role guardrails.",
+        None,
+        None,
+        composition="append",
+    )
+
+    assert composed == "Base prompt.\n\nRole guardrails."
+
+
+def test_compose_task_prompt_replace_uses_highest_priority_part() -> None:
+    """Guards replace composition picks the highest-priority non-empty part."""
+    assert (
+        compose_task_prompt(
+            "Base prompt.",
+            "Role guardrails.",
+            "Scene context.",
+            None,
+            composition="replace",
+        )
+        == "Scene context."
+    )
+
+
+def test_compose_task_prompt_replace_explicit_turn_uses_only_turn() -> None:
+    """Guards explicit replace uses only the inline turn prompt when set."""
+    assert (
+        compose_task_prompt(
+            "Base prompt.",
+            "Role guardrails.",
+            "Scene context.",
+            "Turn override.",
+            composition="replace",
+            explicit_turn=True,
+        )
+        == "Turn override."
+    )
+    assert (
+        compose_task_prompt(
+            "Base prompt.",
+            "Role guardrails.",
+            "Scene context.",
+            None,
+            composition="replace",
+            explicit_turn=True,
+        )
+        == ""
+    )
+
+
+def test_prompt_composition_settings_reads_benchflow_prompt_block() -> None:
+    """Guards benchflow.prompt parsing for composition and order."""
+    settings = prompt_composition_settings(
+        {
+            "prompt": {
+                "composition": "append",
+                "order": ["base", "role", "scene", "turn"],
+            }
+        }
+    )
+
+    assert settings.composition == "append"
+    assert settings.order == ("base", "role", "scene", "turn")
+
+
+def test_prompt_composition_settings_rejects_invalid_composition() -> None:
+    """Guards invalid benchflow.prompt.composition values."""
+    with pytest.raises(ValueError, match="composition must be"):
+        prompt_composition_settings({"prompt": {"composition": "merge"}})
+
+
+def test_task_document_legacy_scene_prompts_shadow_role_prompts() -> None:
+    """Guards legacy fallback behavior when benchflow.prompt is absent."""
+    document = TaskDocument.from_text(
+        """---
+agents:
+  roles:
+    planner:
+      agent: codex
+    executor:
+      agent: openhands
+scenes:
+  - name: plan
+    roles: [planner]
+  - name: execute
+    turns:
+      - role: executor
+---
+## prompt
+
+Handle the refund request.
+
+## role:planner
+
+Draft the plan.
+
+## scene:execute
+
+Apply the plan.
+"""
+    )
+
+    steps = compile_scenes_to_steps(
+        document.scenes,
+        default_prompt=document.instruction,
+    )
+
+    assert [scene_step_prompt(step) for step in steps] == [
+        "Draft the plan.",
+        "Apply the plan.",
+    ]
+
+
+def test_task_document_append_composes_scene_turn_prompts() -> None:
+    """Guards append composition for inline task.md scene turns."""
+    document = TaskDocument.from_text(
+        """---
+benchflow:
+  prompt:
+    composition: append
+    order: [base, role, scene, turn]
+agents:
+  roles:
+    solver:
+      agent: codex
+scenes:
+  - name: solve
+    turns:
+      - role: solver
+        prompt: Turn-only override.
+---
+## prompt
+
+Base instructions.
+
+## role:solver
+
+Role guardrails.
+
+## scene:solve
+
+Scene framing.
+"""
+    )
+
+    turn_prompt = document.scenes[0].turns[0].prompt
+    assert turn_prompt == (
+        "Base instructions.\n\n"
+        "Role guardrails.\n\n"
+        "Scene framing.\n\n"
+        "Turn-only override."
+    )
+
+
+def test_task_document_replace_explicit_turn_prompt() -> None:
+    """Guards replace composition with an explicit inline turn prompt."""
+    document = TaskDocument.from_text(
+        """---
+benchflow:
+  prompt:
+    composition: replace
+agents:
+  roles:
+    solver:
+      agent: codex
+scenes:
+  - name: solve
+    turns:
+      - role: solver
+        prompt: Use only this turn prompt.
+---
+## prompt
+
+Base instructions.
+
+## role:solver
+
+Role guardrails.
+
+## scene:solve
+
+Scene framing.
+"""
+    )
+
+    assert document.scenes[0].turns[0].prompt == "Use only this turn prompt."
+
+
+def test_task_document_rejects_invalid_prompt_settings() -> None:
+    """Guards task.md parsing against invalid benchflow.prompt values."""
+    with pytest.raises(TaskDocumentParseError, match="composition must be"):
+        TaskDocument.from_text(
+            """---
+benchflow:
+  prompt:
+    composition: merge
+agents:
+  roles:
+    solver:
+      agent: codex
+scenes:
+  - name: solve
+    turns:
+      - role: solver
+---
+## prompt
+
+Solve it.
+"""
+        )
+
+
+def test_prompt_user_semantics_dogfood_append_scene_prompts() -> None:
+    """Guards prompt-user-semantics append composition for scene turns."""
+    document = TaskDocument.from_path(PROMPT_USER_SEMANTICS / "task.md")
+    scenes = {scene.name: scene for scene in document.scenes}
+
+    prompt_composition_scene = scenes["prompt-composition"]
+    user_loop_scene = scenes["user-loop"]
+
+    engineer_base_role = (
+        f"{document.instruction}\n\n"
+        f"{document.role_prompts['scene_engineer']}"
+    )
+    user_loop_engineer = (
+        f"{engineer_base_role}\n\n"
+        f"{document.scene_prompts['user-loop']}"
+    )
+    user_loop_reviewer = (
+        f"{document.instruction}\n\n"
+        f"{document.role_prompts['ux_reviewer']}\n\n"
+        f"{document.scene_prompts['user-loop']}"
+    )
+
+    assert prompt_composition_scene.turns[0].prompt == engineer_base_role
+    assert user_loop_scene.turns[0].prompt == user_loop_engineer
+    assert user_loop_scene.turns[1].prompt == user_loop_reviewer
+
+
+def test_prompt_user_semantics_dogfood_materialize_instruction_md() -> None:
+    """Guards prompt-user-semantics base-only /instruction.md materialization."""
+    view = TaskRuntimeView.from_task_dir(PROMPT_USER_SEMANTICS)
+
+    assert view.materialize_instruction_md() == view.instruction_text

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -15,6 +16,11 @@ from benchflow.rewards.builtins import (
 from benchflow.rewards.events import RewardEvent
 from benchflow.rewards.protocol import RewardFunc, VerifyResult
 from benchflow.rewards.rubric import Rubric
+from benchflow.rewards.validation import (
+    RewardFileParseError,
+    parse_verifier_reward_files,
+    validate_reward_map,
+)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -179,6 +185,89 @@ class TestRubricEvents:
 # ---------------------------------------------------------------------------
 # TestRewardFunc (backward compat)
 # ---------------------------------------------------------------------------
+
+
+class TestRewardValidation:
+    def test_multi_metric_map_synthesizes_unweighted_mean(self) -> None:
+        """Guards Harbor Reward Kit multi-metric maps without top-level reward."""
+        payload = {"correctness": 0.75, "quality": 0.9}
+        parsed = validate_reward_map(payload, source="verifier")
+        assert parsed["reward"] == pytest.approx(0.825)
+        assert parsed["correctness"] == 0.75
+        assert parsed["quality"] == 0.9
+
+    def test_multi_metric_honors_aggregate_policy_field(self) -> None:
+        payload = {
+            "correctness": 0.75,
+            "quality": 0.9,
+            "aggregate_policy": {"field": "quality", "fallback": "weighted_mean"},
+        }
+        parsed = validate_reward_map(payload, source="verifier")
+        assert parsed["reward"] == pytest.approx(0.9)
+        assert parsed["aggregate_policy"] == payload["aggregate_policy"]
+
+    def test_reserved_keys_are_not_required_to_be_numeric(self) -> None:
+        payload = {
+            "correctness": 1.0,
+            "items": {"correctness": 1.0},
+            "metadata": {"aggregate_policy": "correctness"},
+            "evidence": ["artifact.txt"],
+        }
+        parsed = validate_reward_map(payload, source="verifier")
+        assert parsed["reward"] == pytest.approx(1.0)
+        assert parsed["items"] == payload["items"]
+        assert parsed["metadata"] == payload["metadata"]
+        assert parsed["evidence"] == payload["evidence"]
+
+    def test_explicit_reward_takes_precedence_over_metrics(self) -> None:
+        payload = {"reward": 0.5, "correctness": 1.0, "quality": 0.0}
+        parsed = validate_reward_map(payload, source="verifier")
+        assert parsed["reward"] == pytest.approx(0.5)
+
+    def test_multi_metric_only_rejects_non_numeric_metric_keys(self) -> None:
+        with pytest.raises(ValueError, match="invalid reward value for 'notes'"):
+            validate_reward_map(
+                {"correctness": 0.75, "notes": "partial credit"},
+                source="verifier",
+            )
+
+    def test_multi_metric_only_requires_at_least_one_metric(self) -> None:
+        with pytest.raises(ValueError, match="missing numeric 'reward'"):
+            validate_reward_map({"metadata": {"source": "rewardkit"}}, source="verifier")
+
+    def test_reward_files_agree_with_synthesized_scalar(self, tmp_path: Path) -> None:
+        payload = {"correctness": 0.75, "quality": 0.9}
+        (tmp_path / "reward.txt").write_text("0.825\n")
+        (tmp_path / "reward.json").write_text(json.dumps(payload))
+        parsed = parse_verifier_reward_files(
+            reward_text_path=tmp_path / "reward.txt",
+            reward_json_path=tmp_path / "reward.json",
+            source="verifier",
+        )
+        assert parsed["reward"] == pytest.approx(0.825)
+
+    def test_reward_files_reject_disagreement_with_synthesized_scalar(
+        self, tmp_path: Path
+    ) -> None:
+        payload = {"correctness": 0.75, "quality": 0.9}
+        (tmp_path / "reward.txt").write_text("0.25\n")
+        (tmp_path / "reward.json").write_text(json.dumps(payload))
+        with pytest.raises(RewardFileParseError, match=r"disagrees with reward\.txt"):
+            parse_verifier_reward_files(
+                reward_text_path=tmp_path / "reward.txt",
+                reward_json_path=tmp_path / "reward.json",
+                source="verifier",
+            )
+
+    async def test_test_reward_func_scores_synthesized_multi_metric(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "reward.json").write_text(
+            json.dumps({"correctness": 0.75, "quality": 0.9})
+        )
+        func = TestRewardFunc()
+        score = await func.score(tmp_path)
+        assert score == pytest.approx(0.825)
 
 
 class TestTestRewardFunc:

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -211,6 +211,36 @@ class TestTestRewardFunc:
         score = await func.score(tmp_path)
         assert score == pytest.approx(1.0)
 
+    async def test_prefers_reward_json_over_reward_txt(self, tmp_path: Path) -> None:
+        """Guards task-standard reward.json precedence in reward-node scoring."""
+        import json
+
+        (tmp_path / "reward.json").write_text(json.dumps({"reward": 0.75}))
+        func = TestRewardFunc()
+        score = await func.score(tmp_path)
+        assert score == pytest.approx(0.75)
+
+    async def test_mismatched_reward_files_score_zero(self, tmp_path: Path) -> None:
+        """Guards fail-closed scalar agreement for reward-node scoring."""
+        import json
+
+        (tmp_path / "reward.txt").write_text("0.25\n")
+        (tmp_path / "reward.json").write_text(json.dumps({"reward": 0.75}))
+        func = TestRewardFunc()
+        score = await func.score(tmp_path)
+        assert score == 0.0
+
+    async def test_reads_verifier_subdir_reward_json(self, tmp_path: Path) -> None:
+        """Guards reward-node scoring against rollout verifier artifacts."""
+        import json
+
+        verifier_dir = tmp_path / "verifier"
+        verifier_dir.mkdir()
+        (verifier_dir / "reward.json").write_text(json.dumps({"reward": 0.4}))
+        func = TestRewardFunc()
+        score = await func.score(tmp_path)
+        assert score == pytest.approx(0.4)
+
 
 # ---------------------------------------------------------------------------
 # StringMatchRewardFunc

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -116,7 +116,17 @@ Solve from the unified document.
 
     assert env.started is True
     assert env.uploaded_file_contents == [
-        ("Solve from the unified document.\n", "/instruction.md")
+        ("Solve from the unified document.\n", "/instruction.md"),
+        (
+            """---
+version: "1.0"
+---
+## prompt
+
+Solve from the unified document.
+""",
+            "/task.md",
+        ),
     ]
 
 

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -401,16 +401,18 @@ workdir = "/repo"
 class TestPromptUserSemanticsDogfood:
     """Guards fail-closed user/nudge validation for prompt-user-semantics dogfood."""
 
-    def test_user_and_nudges_fail_closed(self, sandbox_type: str) -> None:
-        """Guards prompt-user-semantics dogfood user/nudge semantics on gated sandboxes."""
+    def test_nudges_still_fail_closed_after_user_loop_compilation(
+        self, sandbox_type: str
+    ) -> None:
+        """Guards prompt-user-semantics dogfood nudge semantics on gated sandboxes."""
         task = Task(PROMPT_USER_SEMANTICS_TASK)
         issues = validate_task_runtime_support(
             task, sandbox_type, PROMPT_USER_SEMANTICS_TASK
         )
         paths = {issue.path for issue in issues}
-        assert "user" in paths
+        assert "user" not in paths
         assert "benchflow.nudges" in paths
-        assert "prompt.user-persona" in paths
+        assert "prompt.user-persona" not in paths
         assert all(issue.sandbox_type == sandbox_type for issue in issues)
 
     def test_metadata_only_user_runtime_skips_user_semantics_issues(

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -36,9 +36,9 @@ def _load_task(task_dir: Path) -> Task:
     return Task(task_dir)
 
 
-@pytest.mark.parametrize("sandbox_type", ["docker", "daytona"])
+@pytest.mark.parametrize("sandbox_type", ["docker", "daytona", "modal"])
 class TestGatedSandboxesRejectUnsupportedFields:
-    """Guards P1 fail-closed validation for docker and daytona."""
+    """Guards P1 fail-closed validation for docker, daytona, and modal."""
 
     def test_minimal_task_has_no_runtime_issues(self, tmp_path: Path, sandbox_type: str) -> None:
         task_dir = _write_minimal_task(
@@ -269,16 +269,16 @@ service = "target"
             "services:\n  main: {}\n  target: {}\n"
         )
         task = _load_task(task_dir)
-        for sandbox_type in ("docker", "daytona"):
+        for sandbox_type in ("docker", "daytona", "modal"):
             assert validate_task_runtime_support(task, sandbox_type, task_dir) == []
 
 
 class TestUngatedSandboxes:
-    """Modal and unknown backends skip capability gating for now."""
+    """Unknown backends skip capability gating."""
 
-    def test_modal_skips_validation(self, tmp_path: Path) -> None:
+    def test_unknown_backend_skips_validation(self, tmp_path: Path) -> None:
         task_dir = _write_minimal_task(
-            tmp_path / "modal-task",
+            tmp_path / "k8s-task",
             """\
 version = "1.0"
 
@@ -289,7 +289,7 @@ allowed_hosts = ["example.com"]
 """,
         )
         task = _load_task(task_dir)
-        assert validate_task_runtime_support(task, "modal", task_dir) == []
+        assert validate_task_runtime_support(task, "kubernetes", task_dir) == []
 
 
 class TestHarborParityFixture:
@@ -397,7 +397,7 @@ workdir = "/repo"
         asyncio.run(rollout.setup())
 
 
-@pytest.mark.parametrize("sandbox_type", ["docker", "daytona"])
+@pytest.mark.parametrize("sandbox_type", ["docker", "daytona", "modal"])
 class TestPromptUserSemanticsDogfood:
     """Guards fail-closed user/nudge validation for prompt-user-semantics dogfood."""
 

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -451,6 +451,65 @@ class TestPromptUserSemanticsDogfood:
         assert "benchflow.nudges" not in paths
         assert "prompt.user-persona" not in paths
 
+    def test_branchable_multi_turn_user_loop_fails_without_branchable_nudges(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        """Guards branchable multi-turn user-loop scenes fail closed without branchable."""
+        task_dir = tmp_path / "branchable-user-loop-task"
+        task_dir.mkdir()
+        (task_dir / "task.md").write_text(
+            """\
+---
+schema_version: "1.3"
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+agents:
+  roles:
+    engineer:
+      agent: codex
+    reviewer:
+      agent: claude-agent-acp
+scenes:
+  - name: setup
+    turns:
+      - role: engineer
+  - name: user-loop
+    turns:
+      - role: engineer
+      - role: reviewer
+user:
+  stop_rule: satisfied-or-4-rounds
+  private_facts:
+    hidden_need: "Keep private until asked."
+benchflow:
+  nudges:
+    mode: simulated-user
+    nudge_budget: 4
+---
+
+## prompt
+
+Do the thing.
+"""
+        )
+        (task_dir / "task.toml").write_text(
+            'version = "1.0"\n[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n'
+        )
+        (task_dir / "instruction.md").write_text("Do the thing.\n")
+        env = task_dir / "environment"
+        env.mkdir()
+        (env / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        tests = task_dir / "tests"
+        tests.mkdir()
+        (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        paths = {issue.path for issue in issues}
+        assert "benchflow.nudges" in paths
+
     def test_nudges_fail_closed_without_executable_user_loop(
         self, tmp_path: Path, sandbox_type: str
     ) -> None:

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -593,6 +593,8 @@ def test_create_sandbox_environment_workdir_supported_on_modal(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Guards Modal sandbox creation accepts environment.workdir."""
+    pytest.importorskip("modal")
+    pytest.importorskip("tenacity")
     from benchflow.sandbox.modal_impl import ModalSandbox
     from benchflow.sandbox.setup import _create_sandbox_environment
     from benchflow.task import RolloutPaths

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -14,6 +14,10 @@ from benchflow.task.runtime_capabilities import (
     validate_task_runtime_support,
 )
 
+PROMPT_USER_SEMANTICS_TASK = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/prompt-user-semantics"
+)
+
 
 def _write_minimal_task(task_dir: Path, toml: str) -> Path:
     task_dir.mkdir(parents=True, exist_ok=True)
@@ -391,6 +395,71 @@ workdir = "/repo"
 
     with pytest.raises(UnsupportedTaskRuntimeError, match=r"environment\.workdir"):
         asyncio.run(rollout.setup())
+
+
+@pytest.mark.parametrize("sandbox_type", ["docker", "daytona"])
+class TestPromptUserSemanticsDogfood:
+    """Guards fail-closed user/nudge validation for prompt-user-semantics dogfood."""
+
+    def test_user_and_nudges_fail_closed(self, sandbox_type: str) -> None:
+        """Guards prompt-user-semantics dogfood user/nudge semantics on gated sandboxes."""
+        task = Task(PROMPT_USER_SEMANTICS_TASK)
+        issues = validate_task_runtime_support(
+            task, sandbox_type, PROMPT_USER_SEMANTICS_TASK
+        )
+        paths = {issue.path for issue in issues}
+        assert "user" in paths
+        assert "benchflow.nudges" in paths
+        assert "prompt.user-persona" in paths
+        assert all(issue.sandbox_type == sandbox_type for issue in issues)
+
+    def test_metadata_only_user_runtime_skips_user_semantics_issues(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "metadata-only-user-task",
+            """\
+version = "1.0"
+
+[agent]
+timeout_sec = 300
+
+[verifier]
+timeout_sec = 120
+""",
+        )
+        (task_dir / "task.md").write_text(
+            """\
+---
+schema_version: "1.3"
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+user:
+  model: claude-haiku
+  stop_rule: satisfied-or-5-rounds
+benchflow:
+  user_runtime: metadata-only
+  nudges:
+    mode: simulated-user
+---
+
+## prompt
+
+Do the thing.
+
+## user-persona
+
+You reveal private facts only when asked.
+"""
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        paths = {issue.path for issue in issues}
+        assert "user" not in paths
+        assert "benchflow.nudges" not in paths
+        assert "prompt.user-persona" not in paths
 
 
 def test_validator_accepts_task_like_object(tmp_path: Path) -> None:

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -401,19 +401,57 @@ workdir = "/repo"
 class TestPromptUserSemanticsDogfood:
     """Guards fail-closed user/nudge validation for prompt-user-semantics dogfood."""
 
-    def test_nudges_still_fail_closed_after_user_loop_compilation(
+    def test_simulated_user_nudges_supported_when_user_loop_executable(
         self, sandbox_type: str
     ) -> None:
-        """Guards prompt-user-semantics dogfood nudge semantics on gated sandboxes."""
+        """Guards simulated-user nudge execution when document user loop compiles."""
         task = Task(PROMPT_USER_SEMANTICS_TASK)
         issues = validate_task_runtime_support(
             task, sandbox_type, PROMPT_USER_SEMANTICS_TASK
         )
         paths = {issue.path for issue in issues}
         assert "user" not in paths
-        assert "benchflow.nudges" in paths
+        assert "benchflow.nudges" not in paths
         assert "prompt.user-persona" not in paths
-        assert all(issue.sandbox_type == sandbox_type for issue in issues)
+
+    def test_nudges_fail_closed_without_executable_user_loop(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "nudges-without-user-loop",
+            """\
+version = "1.0"
+
+[agent]
+timeout_sec = 300
+
+[verifier]
+timeout_sec = 120
+""",
+        )
+        (task_dir / "task.md").write_text(
+            """\
+---
+schema_version: "1.3"
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+benchflow:
+  nudges:
+    mode: simulated-user
+    nudge_budget: 4
+---
+
+## prompt
+
+Do the thing.
+"""
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        paths = {issue.path for issue in issues}
+        assert "benchflow.nudges" in paths
 
     def test_metadata_only_user_runtime_skips_user_semantics_issues(
         self, tmp_path: Path, sandbox_type: str

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -206,6 +206,8 @@ command = "python -m app.healthcheck"
         assert any(issue.path == "environment.healthcheck" for issue in issues)
 
     def test_workdir_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        if sandbox_type == "docker":
+            pytest.skip("docker applies environment.workdir via compose working_dir")
         task_dir = _write_minimal_task(
             tmp_path / "workdir-task",
             """\
@@ -238,6 +240,8 @@ service = "target"
     def test_ensure_raises_with_actionable_message(
         self, tmp_path: Path, sandbox_type: str
     ) -> None:
+        if sandbox_type == "docker":
+            pytest.skip("docker applies environment.workdir via compose working_dir")
         task_dir = _write_minimal_task(
             tmp_path / "raise-task",
             """\
@@ -339,7 +343,6 @@ artifacts = ["/app/scaffold.txt"]
         assert "environment.network_mode" in paths
         assert "agent.network_mode" in paths
         assert "verifier.environment" in paths
-        assert "environment.workdir" in paths
         assert "environment.tpu" in paths
         assert "environment.healthcheck" in paths
 
@@ -364,9 +367,39 @@ workdir = "/repo"
     rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
     rollout_paths.mkdir()
 
+    sandbox = _create_sandbox_environment(
+        "docker",
+        task,
+        task_dir,
+        "rollout-name",
+        rollout_paths,
+    )
+    assert sandbox.task_env_config.workdir == "/repo"
+
+
+def test_create_sandbox_environment_workdir_fail_closed_on_daytona(
+    tmp_path: Path,
+) -> None:
+    """Guards Daytona still rejects environment.workdir before sandbox creation."""
+    from benchflow.sandbox.setup import _create_sandbox_environment
+    from benchflow.task import RolloutPaths
+
+    task_dir = _write_minimal_task(
+        tmp_path / "setup-gate-daytona-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    task = _load_task(task_dir)
+    rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+    rollout_paths.mkdir()
+
     with pytest.raises(UnsupportedTaskRuntimeError, match=r"environment\.workdir"):
         _create_sandbox_environment(
-            "docker",
+            "daytona",
             task,
             task_dir,
             "rollout-name",
@@ -374,8 +407,8 @@ workdir = "/repo"
         )
 
 
-def test_rollout_setup_fails_before_environment_creation(tmp_path: Path) -> None:
-    """Guards rollout.setup() wiring before sandbox creation."""
+def test_rollout_setup_workdir_fail_closed_on_daytona(tmp_path: Path) -> None:
+    """Guards rollout.setup() rejects environment.workdir on Daytona."""
     import asyncio
 
     from benchflow.rollout import Rollout, RolloutConfig
@@ -390,7 +423,7 @@ workdir = "/repo"
 """,
     )
     rollout = Rollout(
-        RolloutConfig(task_path=task_dir, environment="docker", skip_verify=True)
+        RolloutConfig(task_path=task_dir, environment="daytona", skip_verify=True)
     )
 
     with pytest.raises(UnsupportedTaskRuntimeError, match=r"environment\.workdir"):
@@ -517,4 +550,20 @@ workdir = "/repo"
     task = MagicMock()
     task.config = config
     issues = validate_task_runtime_support(task, "docker", task_dir)
-    assert any(issue.path == "environment.workdir" for issue in issues)
+    assert not any(issue.path == "environment.workdir" for issue in issues)
+
+
+def test_docker_workdir_supported(tmp_path: Path) -> None:
+    """Guards docker runtime validation accepts environment.workdir."""
+    task_dir = _write_minimal_task(
+        tmp_path / "docker-workdir-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    task = _load_task(task_dir)
+    issues = validate_task_runtime_support(task, "docker", task_dir)
+    assert not any(issue.path == "environment.workdir" for issue in issues)

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -206,8 +206,10 @@ command = "python -m app.healthcheck"
         assert any(issue.path == "environment.healthcheck" for issue in issues)
 
     def test_workdir_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
-        if sandbox_type == "docker":
-            pytest.skip("docker applies environment.workdir via compose working_dir")
+        if sandbox_type in ("docker", "modal"):
+            pytest.skip(
+                f"{sandbox_type} applies environment.workdir via sandbox materializer"
+            )
         task_dir = _write_minimal_task(
             tmp_path / "workdir-task",
             """\
@@ -240,8 +242,10 @@ service = "target"
     def test_ensure_raises_with_actionable_message(
         self, tmp_path: Path, sandbox_type: str
     ) -> None:
-        if sandbox_type == "docker":
-            pytest.skip("docker applies environment.workdir via compose working_dir")
+        if sandbox_type in ("docker", "modal"):
+            pytest.skip(
+                f"{sandbox_type} applies environment.workdir via sandbox materializer"
+            )
         task_dir = _write_minimal_task(
             tmp_path / "raise-task",
             """\
@@ -567,3 +571,52 @@ workdir = "/repo"
     task = _load_task(task_dir)
     issues = validate_task_runtime_support(task, "docker", task_dir)
     assert not any(issue.path == "environment.workdir" for issue in issues)
+
+
+def test_modal_workdir_supported(tmp_path: Path) -> None:
+    """Guards modal runtime validation accepts environment.workdir."""
+    task_dir = _write_minimal_task(
+        tmp_path / "modal-workdir-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    task = _load_task(task_dir)
+    issues = validate_task_runtime_support(task, "modal", task_dir)
+    assert not any(issue.path == "environment.workdir" for issue in issues)
+
+
+def test_create_sandbox_environment_workdir_supported_on_modal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards Modal sandbox creation accepts environment.workdir."""
+    from benchflow.sandbox.modal_impl import ModalSandbox
+    from benchflow.sandbox.setup import _create_sandbox_environment
+    from benchflow.task import RolloutPaths
+
+    monkeypatch.setattr(ModalSandbox, "preflight", classmethod(lambda cls: None))
+
+    task_dir = _write_minimal_task(
+        tmp_path / "setup-gate-modal-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    task = _load_task(task_dir)
+    rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+    rollout_paths.mkdir()
+
+    sandbox = _create_sandbox_environment(
+        "modal",
+        task,
+        task_dir,
+        "rollout-name",
+        rollout_paths,
+    )
+    assert sandbox.task_env_config.workdir == "/repo"

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -1,0 +1,411 @@
+"""Tests for P1 runtime capability gates (task-standard)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchflow.task import Task, TaskConfig
+from benchflow.task.runtime_capabilities import (
+    UnsupportedTaskRuntimeError,
+    ensure_task_runtime_support,
+    validate_task_runtime_support,
+)
+
+
+def _write_minimal_task(task_dir: Path, toml: str) -> Path:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "task.toml").write_text(toml)
+    (task_dir / "instruction.md").write_text("Do the thing.\n")
+    env = task_dir / "environment"
+    env.mkdir()
+    (env / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    tests = task_dir / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    return task_dir
+
+
+def _load_task(task_dir: Path) -> Task:
+    return Task(task_dir)
+
+
+@pytest.mark.parametrize("sandbox_type", ["docker", "daytona"])
+class TestGatedSandboxesRejectUnsupportedFields:
+    """Guards P1 fail-closed validation for docker and daytona."""
+
+    def test_minimal_task_has_no_runtime_issues(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "ok-task",
+            'version = "1.0"\n[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n',
+        )
+        task = _load_task(task_dir)
+        assert validate_task_runtime_support(task, sandbox_type, task_dir) == []
+
+    def test_steps_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "steps-task",
+            """\
+version = "1.0"
+
+[[steps]]
+name = "scaffold"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "steps" for issue in issues)
+
+    def test_root_artifacts_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "artifacts-task",
+            """\
+version = "1.0"
+
+[[artifacts]]
+source = "/logs/artifacts"
+destination = "artifacts"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "artifacts" for issue in issues)
+
+    def test_step_artifacts_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "step-artifacts-task",
+            """\
+version = "1.0"
+
+[[steps]]
+name = "collect"
+artifacts = ["/app/out.txt"]
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "steps['collect'].artifacts" for issue in issues)
+
+    def test_environment_allowlist_fail_closed(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "allowlist-task",
+            """\
+version = "1.0"
+
+[environment]
+network_mode = "allowlist"
+allowed_hosts = ["datasets.example.com"]
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "environment.network_mode" for issue in issues)
+
+    def test_agent_allowlist_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "agent-allowlist-task",
+            """\
+version = "1.0"
+
+[agent]
+network_mode = "allowlist"
+allowed_hosts = ["api.example.com"]
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "agent.network_mode" for issue in issues)
+
+    def test_verifier_allowlist_fail_closed(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "verifier-allowlist-task",
+            """\
+version = "1.0"
+
+[verifier]
+network_mode = "allowlist"
+allowed_hosts = ["grader.example.com"]
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "verifier.network_mode" for issue in issues)
+
+    def test_separate_verifier_environment_fail_closed(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "separate-verifier-task",
+            """\
+version = "1.0"
+
+[verifier]
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "ghcr.io/example/grader:latest"
+cpus = 1
+memory_mb = 512
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path.startswith("verifier.environment") for issue in issues)
+
+    def test_windows_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "windows-task",
+            """\
+version = "1.0"
+
+[environment]
+os = "windows"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "environment.os" for issue in issues)
+
+    def test_tpu_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "tpu-task",
+            """\
+version = "1.0"
+
+[environment.tpu]
+type = "v6e"
+topology = "2x4"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "environment.tpu" for issue in issues)
+
+    def test_healthcheck_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "healthcheck-task",
+            """\
+version = "1.0"
+
+[environment.healthcheck]
+command = "python -m app.healthcheck"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "environment.healthcheck" for issue in issues)
+
+    def test_workdir_fail_closed(self, tmp_path: Path, sandbox_type: str) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "workdir-task",
+            """\
+version = "1.0"
+
+[environment]
+workdir = "/workspace"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "environment.workdir" for issue in issues)
+
+    def test_non_main_verifier_service_without_compose_fail_closed(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "target-verifier-task",
+            """\
+version = "1.0"
+
+[verifier]
+service = "target"
+""",
+        )
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, sandbox_type, task_dir)
+        assert any(issue.path == "verifier.service" for issue in issues)
+
+    def test_ensure_raises_with_actionable_message(
+        self, tmp_path: Path, sandbox_type: str
+    ) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "raise-task",
+            """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+        )
+        task = _load_task(task_dir)
+        with pytest.raises(UnsupportedTaskRuntimeError, match=r"environment\.workdir"):
+            ensure_task_runtime_support(task, sandbox_type, task_dir)
+
+
+class TestNonMainVerifierServiceWithCompose:
+    """Non-main verifier.service is allowed when compose topology exists."""
+
+    def test_target_service_allowed_with_compose(self, tmp_path: Path) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "compose-target-task",
+            """\
+version = "1.0"
+
+[verifier]
+service = "target"
+""",
+        )
+        (task_dir / "environment" / "docker-compose.yaml").write_text(
+            "services:\n  main: {}\n  target: {}\n"
+        )
+        task = _load_task(task_dir)
+        for sandbox_type in ("docker", "daytona"):
+            assert validate_task_runtime_support(task, sandbox_type, task_dir) == []
+
+
+class TestUngatedSandboxes:
+    """Modal and unknown backends skip capability gating for now."""
+
+    def test_modal_skips_validation(self, tmp_path: Path) -> None:
+        task_dir = _write_minimal_task(
+            tmp_path / "modal-task",
+            """\
+version = "1.0"
+
+[environment]
+workdir = "/workspace"
+network_mode = "allowlist"
+allowed_hosts = ["example.com"]
+""",
+        )
+        task = _load_task(task_dir)
+        assert validate_task_runtime_support(task, "modal", task_dir) == []
+
+
+class TestHarborParityFixture:
+    """Schema-only harbor-parity example fields are rejected on docker."""
+
+    def test_harbor_parity_frontmatter_is_blocked(self, tmp_path: Path) -> None:
+        parity_toml = """\
+version = "1.3"
+multi_step_reward_strategy = "final"
+
+[[artifacts]]
+source = "/logs/artifacts"
+destination = "artifacts"
+
+[agent]
+network_mode = "allowlist"
+allowed_hosts = ["api.example.com"]
+
+[verifier]
+environment_mode = "separate"
+
+[verifier.environment]
+docker_image = "ghcr.io/example/grader:latest"
+
+[environment]
+network_mode = "allowlist"
+allowed_hosts = ["datasets.example.com"]
+workdir = "/workspace"
+
+[environment.tpu]
+type = "v6e"
+topology = "2x4"
+
+[environment.healthcheck]
+command = "python -m app.healthcheck"
+
+[[steps]]
+name = "scaffold"
+artifacts = ["/app/scaffold.txt"]
+"""
+        task_dir = _write_minimal_task(tmp_path / "harbor-parity", parity_toml)
+        task = _load_task(task_dir)
+        issues = validate_task_runtime_support(task, "docker", task_dir)
+        paths = {issue.path for issue in issues}
+        assert "steps" in paths
+        assert "artifacts" in paths
+        assert "environment.network_mode" in paths
+        assert "agent.network_mode" in paths
+        assert "verifier.environment" in paths
+        assert "environment.workdir" in paths
+        assert "environment.tpu" in paths
+        assert "environment.healthcheck" in paths
+
+
+def test_create_sandbox_environment_fails_before_object_construction(
+    tmp_path: Path,
+) -> None:
+    """Guards integration before Docker/Daytona sandbox object construction."""
+    from benchflow.sandbox.setup import _create_sandbox_environment
+    from benchflow.task import RolloutPaths
+
+    task_dir = _write_minimal_task(
+        tmp_path / "setup-gate-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    task = _load_task(task_dir)
+    rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+    rollout_paths.mkdir()
+
+    with pytest.raises(UnsupportedTaskRuntimeError, match=r"environment\.workdir"):
+        _create_sandbox_environment(
+            "docker",
+            task,
+            task_dir,
+            "rollout-name",
+            rollout_paths,
+        )
+
+
+def test_rollout_setup_fails_before_environment_creation(tmp_path: Path) -> None:
+    """Guards rollout.setup() wiring before sandbox creation."""
+    import asyncio
+
+    from benchflow.rollout import Rollout, RolloutConfig
+
+    task_dir = _write_minimal_task(
+        tmp_path / "rollout-gate-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    rollout = Rollout(
+        RolloutConfig(task_path=task_dir, environment="docker", skip_verify=True)
+    )
+
+    with pytest.raises(UnsupportedTaskRuntimeError, match=r"environment\.workdir"):
+        asyncio.run(rollout.setup())
+
+
+def test_validator_accepts_task_like_object(tmp_path: Path) -> None:
+    """validate_task_runtime_support only needs config-bearing task objects."""
+    task_dir = _write_minimal_task(
+        tmp_path / "mock-task",
+        """\
+version = "1.0"
+
+[environment]
+workdir = "/repo"
+""",
+    )
+    config = TaskConfig.model_validate_toml((task_dir / "task.toml").read_text())
+    task = MagicMock()
+    task.config = config
+    issues = validate_task_runtime_support(task, "docker", task_dir)
+    assert any(issue.path == "environment.workdir" for issue in issues)

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -106,6 +106,24 @@ class TestDockerSandboxServiceExec:
             assert "K=v" not in arg
 
     @pytest.mark.asyncio
+    async def test_exec_defaults_cwd_to_task_workdir(self) -> None:
+        """Guards environment.workdir becomes the default exec working directory."""
+        sandbox = self._make_sandbox()
+        sandbox.task_env_config = MagicMock(workdir="/repo")
+        captured: list[list[str]] = []
+
+        async def fake_run(command, check=False, timeout_sec=None):
+            captured.append(command)
+            return ExecResult(stdout="", stderr="", return_code=0)
+
+        sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
+        await sandbox.exec("pwd")
+
+        cmd = captured[0]
+        assert "-w" in cmd
+        assert "/repo" in cmd
+
+    @pytest.mark.asyncio
     async def test_services_lists_compose_services(self) -> None:
         """#248: services() enumerates every container defined in the task."""
         sandbox = self._make_sandbox()

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -681,6 +681,34 @@ class TestModalRejectsMultiService:
             await sandbox.exec("echo hi", service="target")
 
     @pytest.mark.asyncio
+    async def test_modal_exec_defaults_cwd_to_task_workdir(self) -> None:
+        """Guards environment.workdir becomes the default exec working directory."""
+        pytest.importorskip("modal")  # sandbox-modal optional dependency
+        from benchflow.sandbox.modal_impl import ModalSandbox
+
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        sandbox._persistent_env = {}
+        sandbox.default_user = None
+        sandbox.task_env_config = MagicMock(workdir="/repo")
+        sandbox._sandbox = MagicMock()
+        captured: dict[str, object] = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured.update(kwargs)
+            process = MagicMock()
+            process.stdout = MagicMock()
+            process.stderr = MagicMock()
+            process.stdout.read.aio = AsyncMock(return_value="")
+            process.stderr.read.aio = AsyncMock(return_value="")
+            process.wait.aio = AsyncMock(return_value=0)
+            return process
+
+        sandbox._sandbox.exec.aio = fake_exec
+        await sandbox.exec("pwd")
+
+        assert captured.get("workdir") == "/repo"
+
+    @pytest.mark.asyncio
     async def test_modal_services_rejects_single_container(self) -> None:
         """#248: Modal has no compose topology — services() must error clearly."""
         pytest.importorskip("modal")  # sandbox-modal optional dependency

--- a/tests/test_task_export.py
+++ b/tests/test_task_export.py
@@ -1,0 +1,73 @@
+"""Tests for native task.md export to Harbor/Pier split layout."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.task import TaskConfig, TaskDocument
+from benchflow.task.export import ExportLoss, export_task_package
+
+COMPAT_EXPORT_EXAMPLE = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/compat-export-loss-reports"
+)
+
+
+def test_export_compat_example_emits_split_layout_and_loss_report() -> None:
+    """Guards F1/F6 compat-export-loss-reports dogfood acceptance."""
+    document = TaskDocument.from_path(COMPAT_EXPORT_EXAMPLE / "task.md")
+    result = export_task_package(COMPAT_EXPORT_EXAMPLE)
+
+    assert result.target == "harbor"
+    assert result.mode == "degraded"
+    assert result.selected_definition == "task.md"
+    assert result.selected_oracle_dir == "oracle/"
+    assert result.selected_verifier_dir == "verifier/"
+    assert result.exported_oracle_dir == "solution/"
+    assert result.exported_verifier_dir == "tests/"
+
+    assert "task.toml" in result.files
+    assert "instruction.md" in result.files
+    assert any(path.startswith("solution/") for path in result.files)
+    assert any(path.startswith("tests/") for path in result.files)
+    assert "environment/Dockerfile" in result.files
+
+    exported_config = TaskConfig.model_validate_toml(result.files["task.toml"])
+    assert exported_config.model_dump() == document.config.model_dump()
+    assert (
+        result.files["instruction.md"].strip()
+        == document.instruction.strip()
+    )
+
+    concepts = {loss.concept for loss in result.losses}
+    assert "agents" in concepts
+    assert "scenes" in concepts
+    assert "benchflow.document_version" in concepts
+    assert "benchflow.compatibility" in concepts
+    assert "benchflow.traceability" in concepts
+    assert "benchflow.verifier" in concepts
+    assert "prompt.role:adapter_engineer" in concepts
+    assert "prompt.role:compatibility_reviewer" in concepts
+    assert "verifier.verifier_md" in concepts
+    assert "verifier.rubrics" in concepts
+
+    assert result.input_hashes["task.md"]
+    assert result.output_hashes["task.toml"]
+    assert result.output_hashes["instruction.md"]
+    assert result.output_hashes["tests/test.sh"]
+    assert result.output_hashes["solution/solve.md"]
+
+
+def test_export_requires_task_md() -> None:
+    """Guards native export against legacy-only packages."""
+    with pytest.raises(FileNotFoundError, match=r"task\.md"):
+        export_task_package("src/benchflow/demo_task")
+
+
+def test_export_loss_is_typed() -> None:
+    """Guards F6 requirement for typed export losses."""
+    result = export_task_package(COMPAT_EXPORT_EXAMPLE)
+    assert result.losses
+    assert all(isinstance(loss, ExportLoss) for loss in result.losses)
+    assert all(loss.concept and loss.reason for loss in result.losses)

--- a/tests/test_task_export.py
+++ b/tests/test_task_export.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from benchflow.task import TaskConfig, TaskDocument
-from benchflow.task.export import ExportLoss, export_task_package
+from benchflow.task.export import (
+    EXPORT_REPORT_REL_PATH,
+    ExportLoss,
+    export_report_json,
+    export_task_package,
+)
 
 COMPAT_EXPORT_EXAMPLE = Path(
     "docs/examples/task-standard/benchflow-wanted-features/compat-export-loss-reports"
@@ -71,3 +77,32 @@ def test_export_loss_is_typed() -> None:
     assert result.losses
     assert all(isinstance(loss, ExportLoss) for loss in result.losses)
     assert all(loss.concept and loss.reason for loss in result.losses)
+
+
+def test_export_report_json_serializes_losses_hashes_mode_and_target() -> None:
+    """Guards on-disk compatibility/export-report.json schema for bench tasks export."""
+    result = export_task_package(COMPAT_EXPORT_EXAMPLE, target="pier")
+    report = export_report_json(result)
+
+    assert report["target"] == "pier"
+    assert report["mode"] == "degraded"
+    assert report["losses"] == [
+        {"concept": loss.concept, "reason": loss.reason} for loss in result.losses
+    ]
+    assert report["input_hashes"] == result.input_hashes
+    assert report["output_hashes"] == result.output_hashes
+    assert report["selected_definition"] == "task.md"
+    assert report["selected_oracle_dir"] == "oracle/"
+    assert report["selected_verifier_dir"] == "verifier/"
+    assert report["exported_oracle_dir"] == "solution/"
+    assert report["exported_verifier_dir"] == "tests/"
+    assert report["ignored_aliases"] == list(result.ignored_aliases)
+
+    # Round-trip through JSON to mirror CLI write path.
+    parsed = json.loads(json.dumps(report))
+    assert parsed["target"] == "pier"
+    assert parsed["mode"] == "degraded"
+    assert len(parsed["losses"]) == len(result.losses)
+    assert parsed["input_hashes"]["task.md"]
+    assert parsed["output_hashes"]["task.toml"]
+    assert EXPORT_REPORT_REL_PATH == "compatibility/export-report.json"

--- a/tests/test_task_export.py
+++ b/tests/test_task_export.py
@@ -13,6 +13,9 @@ from benchflow.task.export import (
     ExportLoss,
     export_report_json,
     export_task_package,
+    import_split_task_package,
+    materialize_export_result,
+    validate_export_round_trip,
 )
 
 COMPAT_EXPORT_EXAMPLE = Path(
@@ -106,3 +109,48 @@ def test_export_report_json_serializes_losses_hashes_mode_and_target() -> None:
     assert parsed["input_hashes"]["task.md"]
     assert parsed["output_hashes"]["task.toml"]
     assert EXPORT_REPORT_REL_PATH == "compatibility/export-report.json"
+
+
+def test_export_round_trip_preserves_harbor_compatible_fields(tmp_path: Path) -> None:
+    """Guards F1 compat-export-loss-reports export→materialize→import round-trip parity."""
+    result = export_task_package(COMPAT_EXPORT_EXAMPLE)
+    exported_dir = materialize_export_result(result, tmp_path / "exported")
+
+    assert (exported_dir / "task.toml").is_file()
+    assert (exported_dir / "instruction.md").is_file()
+    assert (exported_dir / EXPORT_REPORT_REL_PATH).is_file()
+
+    issues = validate_export_round_trip(COMPAT_EXPORT_EXAMPLE, exported_dir)
+    assert issues == []
+
+    imported = import_split_task_package(exported_dir)
+    document = TaskDocument.from_path(COMPAT_EXPORT_EXAMPLE / "task.md")
+
+    assert imported.config.model_dump() == document.config.model_dump()
+    assert imported.instruction_normalized == document.instruction.strip() + "\n"
+    assert imported.oracle_hashes["solution/solve.md"] == result.output_hashes["solution/solve.md"]
+    assert imported.verifier_hashes["tests/test.sh"] == result.output_hashes["tests/test.sh"]
+    assert imported.environment_hashes["environment/Dockerfile"]
+    assert imported.native_comparison is None
+
+
+def test_import_split_task_package_requires_split_layout(tmp_path: Path) -> None:
+    """Guards split import against native-only packages."""
+    native_only = tmp_path / "native-only"
+    native_only.mkdir()
+    (native_only / "task.md").write_text("---\n---\n\n## prompt\n\nHi.\n")
+
+    with pytest.raises(FileNotFoundError, match=r"task\.toml"):
+        import_split_task_package(native_only)
+
+
+def test_validate_export_round_trip_reports_config_drift(tmp_path: Path) -> None:
+    """Guards round-trip validation surfaces semantic drift."""
+    result = export_task_package(COMPAT_EXPORT_EXAMPLE)
+    exported_dir = materialize_export_result(result, tmp_path / "exported")
+    (exported_dir / "task.toml").write_text(
+        (exported_dir / "task.toml").read_text().replace("7200", "3600")
+    )
+
+    issues = validate_export_round_trip(COMPAT_EXPORT_EXAMPLE, exported_dir)
+    assert issues == ["Config drift: canonical TaskConfig dumps differ"]

--- a/tests/test_task_package.py
+++ b/tests/test_task_package.py
@@ -1,0 +1,221 @@
+"""Tests for TaskPackage and TaskRuntimeView."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.rollout import _read_task_instruction
+from benchflow.task import Task, TaskPackage, TaskRuntimeView
+from benchflow.task.paths import TaskPaths
+
+
+def _write_legacy_task(
+    task: Path,
+    *,
+    instruction: str = "Legacy prompt",
+    verifier_dirname: str = TaskPaths.LEGACY_TESTS_DIRNAME,
+    oracle_dirname: str = TaskPaths.LEGACY_SOLUTION_DIRNAME,
+) -> None:
+    task.mkdir(parents=True, exist_ok=True)
+    (task / "task.toml").write_text(
+        'version = "1.0"\n[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n'
+    )
+    (task / "instruction.md").write_text(instruction)
+    (task / "environment").mkdir()
+    (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    verifier = task / verifier_dirname
+    verifier.mkdir()
+    (verifier / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    if oracle_dirname:
+        oracle = task / oracle_dirname
+        oracle.mkdir()
+        (oracle / "solve.sh").write_text("#!/bin/bash\necho ok\n")
+
+
+def _write_task_md(
+    task: Path,
+    *,
+    prompt: str = "Native prompt",
+    scenes_yaml: str = "",
+    benchflow_yaml: str = "",
+) -> None:
+    task.mkdir(parents=True, exist_ok=True)
+    (task / "task.md").write_text(
+        f"""---
+version: "1.0"
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+environment:
+  cpus: 1
+  memory_mb: 2048
+agents:
+  roles:
+    solver:
+      agent: claude-agent-acp
+{scenes_yaml}{benchflow_yaml}---
+## prompt
+
+{prompt}
+"""
+    )
+    (task / "environment").mkdir()
+    (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    verifier = task / TaskPaths.NATIVE_VERIFIER_DIRNAME
+    verifier.mkdir()
+    (verifier / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+
+def test_task_package_loads_task_dir() -> None:
+    """Guards P0 TaskPackage boundary for on-disk task roots."""
+    task_dir = Path("src/benchflow/demo_task")
+    package = TaskPackage.load(task_dir)
+
+    resolved = task_dir.resolve()
+    assert package.task_dir == resolved
+    assert package.paths.config_path == resolved / "task.toml"
+
+
+def test_runtime_view_selects_legacy_split_entrypoint(tmp_path: Path) -> None:
+    """Guards P0 authoritative entrypoint selection for Harbor split layout."""
+    task = tmp_path / "legacy"
+    _write_legacy_task(task, instruction="Do the legacy thing")
+
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert view.entrypoint == "legacy-split"
+    assert view.instruction_text == "Do the legacy thing"
+    assert view.document is None
+    assert view.scenes == ()
+    assert view.verifier_dir_kind == "legacy"
+    assert view.oracle_dir_kind == "legacy"
+    assert view.verifier_dir == task / "tests"
+    assert view.oracle_dir == task / "solution"
+    assert view.uses_native_verifier_dir is False
+    assert view.uses_native_oracle_dir is False
+    assert view.has_legacy_split_files is True
+    assert view.alias_collisions.has_collisions is False
+
+
+def test_runtime_view_selects_task_md_entrypoint(tmp_path: Path) -> None:
+    """Guards P0 authoritative entrypoint selection for native task.md."""
+    task = tmp_path / "native"
+    _write_task_md(
+        task,
+        prompt="Solve from task.md",
+        scenes_yaml="""scenes:
+  - name: solve
+    turns:
+      - role: solver
+""",
+        benchflow_yaml="""benchflow:
+  document_version: "0.3"
+""",
+    )
+
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert view.entrypoint == "task-md"
+    assert view.instruction_text == "Solve from task.md"
+    assert view.document is not None
+    assert view.scene_names == ("solve",)
+    assert len(view.scenes) == 1
+    assert view.scenes[0].turns[0].role == "solver"
+    assert view.verifier_dir_kind == "native"
+    assert view.oracle_dir_kind == "legacy"
+    assert view.verifier_dir == task / "verifier"
+    assert view.benchflow["document_version"] == "0.3"
+    assert view.has_legacy_split_files is False
+
+
+def test_runtime_view_prefers_native_verifier_and_oracle_dirs(tmp_path: Path) -> None:
+    """Guards P0 native-vs-legacy directory selection."""
+    task = tmp_path / "native-dirs"
+    _write_task_md(task)
+    (task / "oracle").mkdir()
+    (task / "oracle" / "solve.sh").write_text("#!/bin/bash\necho native\n")
+
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert view.verifier_dir_kind == "native"
+    assert view.oracle_dir_kind == "native"
+    assert view.verifier_dir == task / "verifier"
+    assert view.oracle_dir == task / "oracle"
+    assert "test.sh" in view.selected_verifier_tree_map()
+    assert "solve.sh" in view.selected_oracle_tree_map()
+
+
+def test_runtime_view_reports_alias_collisions(tmp_path: Path) -> None:
+    """Guards P0 alias collision diagnostics without silent native preference."""
+    task = tmp_path / "collision"
+    _write_legacy_task(
+        task,
+        verifier_dirname=TaskPaths.NATIVE_VERIFIER_DIRNAME,
+        oracle_dirname=TaskPaths.NATIVE_ORACLE_DIRNAME,
+    )
+    (task / "tests").mkdir()
+    (task / "tests" / "test.sh").write_text("#!/bin/bash\necho legacy\n")
+    (task / "solution").mkdir()
+    (task / "solution" / "solve.sh").write_text("#!/bin/bash\necho legacy\n")
+
+    with pytest.raises(ValueError, match="verifier/"):
+        TaskRuntimeView.from_task_dir(task)
+
+    view = TaskRuntimeView.from_task_dir(task, fail_on_alias_collision=False)
+    assert view.alias_collisions.has_collisions is True
+    assert any("verifier/" in issue for issue in view.alias_collisions.issues)
+    assert any("tests/" in issue for issue in view.alias_collisions.issues)
+
+
+def test_runtime_view_accepts_byte_identical_alias_trees(tmp_path: Path) -> None:
+    """Equivalent native and legacy alias trees should not report collisions."""
+    task = tmp_path / "equivalent"
+    _write_legacy_task(
+        task,
+        verifier_dirname=TaskPaths.NATIVE_VERIFIER_DIRNAME,
+        oracle_dirname=TaskPaths.NATIVE_ORACLE_DIRNAME,
+    )
+    (task / "tests").mkdir()
+    (task / "tests" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    (task / "solution").mkdir()
+    (task / "solution" / "solve.sh").write_text("#!/bin/bash\necho ok\n")
+
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert view.alias_collisions.has_collisions is False
+
+
+def test_task_runtime_view_property_matches_from_task_dir(tmp_path: Path) -> None:
+    """Guards Task.runtime_view integration without duplicating parse logic."""
+    task = tmp_path / "task"
+    _write_task_md(task, prompt="Through Task class")
+
+    loaded = Task(task)
+    assert loaded.runtime_view.entrypoint == "task-md"
+    assert loaded.runtime_view.instruction_text == "Through Task class"
+    assert loaded.runtime_view.scene_names == ()
+
+
+def test_read_task_instruction_uses_runtime_view(tmp_path: Path) -> None:
+    """Guards rollout instruction materialization through TaskRuntimeView."""
+    task = tmp_path / "task-md"
+    _write_task_md(task, prompt="Materialized for /instruction.md")
+
+    assert _read_task_instruction(task) == "Materialized for /instruction.md"
+
+
+def test_runtime_view_detects_legacy_files_alongside_task_md(tmp_path: Path) -> None:
+    """Guards visibility of split files when task.md is authoritative."""
+    task = tmp_path / "mixed"
+    _write_task_md(task, prompt="Authoritative prompt")
+    (task / "task.toml").write_text('version = "1.0"\n')
+    (task / "instruction.md").write_text("Legacy prompt\n")
+
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert view.entrypoint == "task-md"
+    assert view.instruction_text == "Authoritative prompt"
+    assert view.has_legacy_split_files is True

--- a/tests/test_task_package.py
+++ b/tests/test_task_package.py
@@ -10,6 +10,11 @@ from benchflow.rollout import _read_task_instruction
 from benchflow.task import Task, TaskPackage, TaskRuntimeView
 from benchflow.task.paths import TaskPaths
 
+DOGFOOD_TASK_DIR = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/"
+    "verifier-package-reward-contract"
+)
+
 
 def _write_legacy_task(
     task: Path,
@@ -205,6 +210,18 @@ def test_read_task_instruction_uses_runtime_view(tmp_path: Path) -> None:
     _write_task_md(task, prompt="Materialized for /instruction.md")
 
     assert _read_task_instruction(task) == "Materialized for /instruction.md"
+
+
+def test_runtime_view_includes_verifier_document() -> None:
+    """Guards P0 TaskRuntimeView exposure of parsed verifier/verifier.md."""
+    view = TaskRuntimeView.from_task_dir(DOGFOOD_TASK_DIR)
+
+    assert view.verifier_document is not None
+    assert view.verifier_document.name == "verifier-package-reward-contract"
+    assert view.verifier_document.default_strategy == "deterministic"
+
+    loaded = Task(DOGFOOD_TASK_DIR)
+    assert loaded.runtime_view.verifier_document == view.verifier_document
 
 
 def test_runtime_view_detects_legacy_files_alongside_task_md(tmp_path: Path) -> None:

--- a/tests/test_task_package.py
+++ b/tests/test_task_package.py
@@ -7,8 +7,13 @@ from pathlib import Path
 import pytest
 
 from benchflow.rollout import _read_task_instruction
+from benchflow.skill_policy import SKILL_MODE_SELF_GEN
 from benchflow.task import Task, TaskPackage, TaskRuntimeView
 from benchflow.task.paths import TaskPaths
+
+PROMPT_USER_SEMANTICS = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/prompt-user-semantics"
+)
 
 DOGFOOD_TASK_DIR = Path(
     "docs/examples/task-standard/benchflow-wanted-features/"
@@ -222,6 +227,144 @@ def test_runtime_view_includes_verifier_document() -> None:
 
     loaded = Task(DOGFOOD_TASK_DIR)
     assert loaded.runtime_view.verifier_document == view.verifier_document
+
+
+def test_runtime_view_compose_turn_prompt_uses_append_composition(
+    tmp_path: Path,
+) -> None:
+    """Guards TaskRuntimeView.compose_turn_prompt for benchflow.prompt append."""
+    task = tmp_path / "append"
+    _write_task_md(
+        task,
+        prompt="Base prompt.",
+        scenes_yaml="""scenes:
+  - name: solve
+    turns:
+      - role: solver
+""",
+        benchflow_yaml="""benchflow:
+  prompt:
+    composition: append
+    order: [base, role, scene, turn]
+""",
+    )
+    (task / "task.md").write_text(
+        (task / "task.md").read_text()
+        + "\n## role:solver\n\nRole guardrails.\n\n## scene:solve\n\nScene context.\n"
+    )
+
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert view.compose_turn_prompt("solve", "solver") == (
+        "Base prompt.\n\nRole guardrails.\n\nScene context."
+    )
+
+    replace_task = tmp_path / "replace"
+    _write_task_md(
+        replace_task,
+        prompt="Base prompt.",
+        scenes_yaml="""scenes:
+  - name: solve
+    turns:
+      - role: solver
+""",
+        benchflow_yaml="""benchflow:
+  prompt:
+    composition: replace
+""",
+    )
+    (replace_task / "task.md").write_text(
+        (replace_task / "task.md").read_text()
+        + "\n## role:solver\n\nRole guardrails.\n\n## scene:solve\n\nScene context.\n"
+    )
+    replace_view = TaskRuntimeView.from_task_dir(replace_task)
+
+    assert replace_view.compose_turn_prompt(
+        "solve",
+        "solver",
+        "Turn override.",
+        explicit_turn=True,
+    ) == "Turn override."
+
+
+def test_runtime_view_to_rollout_scenes_centralizes_adoption(tmp_path: Path) -> None:
+    """Guards TaskRuntimeView.to_rollout_scenes rollout adoption rules."""
+    task = tmp_path / "native"
+    _write_task_md(
+        task,
+        scenes_yaml="""scenes:
+  - name: solve
+    turns:
+      - role: solver
+""",
+    )
+    view = TaskRuntimeView.from_task_dir(task)
+
+    assert [scene.name for scene in view.to_rollout_scenes()] == ["solve"]
+    assert view.to_rollout_scenes(prompts=["Manual prompt."]) == []
+    assert view.to_rollout_scenes(skill_mode=SKILL_MODE_SELF_GEN) == []
+
+    legacy = tmp_path / "legacy"
+    _write_legacy_task(legacy)
+    legacy_view = TaskRuntimeView.from_task_dir(legacy)
+    assert legacy_view.to_rollout_scenes() == []
+
+
+def test_runtime_view_document_runtime_summary(tmp_path: Path) -> None:
+    """Guards TaskRuntimeView.document_runtime_summary for logging/debug."""
+    task = tmp_path / "summary"
+    _write_task_md(
+        task,
+        prompt="Summary prompt.",
+        scenes_yaml="""scenes:
+  - name: solve
+    turns:
+      - role: solver
+""",
+        benchflow_yaml="""benchflow:
+  document_version: "0.3"
+  prompt:
+    composition: append
+    order: [base, role, scene, turn]
+""",
+    )
+
+    view = TaskRuntimeView.from_task_dir(task)
+    summary = view.document_runtime_summary()
+
+    assert summary["entrypoint"] == "task-md"
+    assert summary["instruction_chars"] == len("Summary prompt.")
+    assert summary["scene_names"] == ["solve"]
+    assert summary["verifier_dir_kind"] == "native"
+    assert summary["prompt_composition"] == "append"
+    assert summary["prompt_order"] == ["base", "role", "scene", "turn"]
+    assert summary["benchflow_keys"] == ["document_version", "prompt"]
+    assert summary["role_names"] == ["solver"]
+    assert summary["alias_collisions"] == []
+
+
+def test_runtime_view_compose_turn_prompt_matches_dogfood_scenes() -> None:
+    """Guards compose_turn_prompt parity with parsed prompt-user-semantics scenes."""
+    view = TaskRuntimeView.from_task_dir(PROMPT_USER_SEMANTICS)
+    document = view.document
+    assert document is not None
+
+    scenes = {scene.name: scene for scene in view.scenes}
+    prompt_composition_scene = scenes["prompt-composition"]
+    user_loop_scene = scenes["user-loop"]
+
+    assert view.compose_turn_prompt(
+        "prompt-composition",
+        "scene_engineer",
+    ) == prompt_composition_scene.turns[0].prompt
+    assert view.compose_turn_prompt(
+        "user-loop",
+        "scene_engineer",
+    ) == user_loop_scene.turns[0].prompt
+    assert view.compose_turn_prompt(
+        "user-loop",
+        "ux_reviewer",
+    ) == user_loop_scene.turns[1].prompt
 
 
 def test_runtime_view_detects_legacy_files_alongside_task_md(tmp_path: Path) -> None:

--- a/tests/test_task_standard_dogfood.py
+++ b/tests/test_task_standard_dogfood.py
@@ -196,3 +196,15 @@ def test_runtime_capability_gate_fails_on_docker() -> None:
     assert "environment.healthcheck" in paths
     assert "environment.workdir" not in paths
     assert all(issue.sandbox_type == "docker" for issue in issues)
+
+
+def test_runtime_capability_gate_fails_on_modal() -> None:
+    """Guards runtime-capability-gate fail-closed validation on modal."""
+    task = Task(RUNTIME_GATE_TASK)
+    issues = validate_task_runtime_support(task, "modal", RUNTIME_GATE_TASK)
+
+    assert issues
+    paths = {issue.path for issue in issues}
+    assert "environment.healthcheck" in paths
+    assert "environment.workdir" not in paths
+    assert all(issue.sandbox_type == "modal" for issue in issues)

--- a/tests/test_task_standard_dogfood.py
+++ b/tests/test_task_standard_dogfood.py
@@ -193,5 +193,6 @@ def test_runtime_capability_gate_fails_on_docker() -> None:
 
     assert issues
     paths = {issue.path for issue in issues}
-    assert "environment.workdir" in paths
+    assert "environment.healthcheck" in paths
+    assert "environment.workdir" not in paths
     assert all(issue.sandbox_type == "docker" for issue in issues)

--- a/tests/test_task_standard_dogfood.py
+++ b/tests/test_task_standard_dogfood.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -110,6 +111,28 @@ def test_prompt_user_semantics_sandbox_check_supports_executable_nudges() -> Non
     assert "benchflow.nudges" not in paths
     assert "user" not in paths
     assert "prompt.user-persona" not in paths
+
+
+def test_verifier_reward_contract_reward_kit_strategy_is_executable() -> None:
+    """Guards verifier-package-reward-contract reward-kit criteria executability."""
+    from benchflow.task.verifier_document import (
+        is_executable_agent_judge_strategy,
+        is_executable_reward_kit_strategy,
+        resolve_default_strategy,
+    )
+
+    task = Task(VERIFIER_REWARD_CONTRACT_TASK)
+    document = task.verifier_document
+    assert document is not None
+    verifier_dir = VERIFIER_REWARD_CONTRACT_TASK / "verifier"
+
+    _, rewardkit = resolve_default_strategy(
+        replace(document, default_strategy="rewardkit")
+    )
+    assert is_executable_reward_kit_strategy(rewardkit, verifier_dir)
+
+    _, judge = resolve_default_strategy(replace(document, default_strategy="judge"))
+    assert is_executable_agent_judge_strategy(judge, document, verifier_dir)
 
 
 def test_verifier_reward_contract_loads_deterministic_default_strategy() -> None:

--- a/tests/test_task_standard_dogfood.py
+++ b/tests/test_task_standard_dogfood.py
@@ -1,0 +1,92 @@
+"""Dogfood acceptance tests for task-standard benchflow-wanted-features packages."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow._utils.task_authoring import check_task
+from benchflow.task import Task, TaskRuntimeView
+from benchflow.task.export import ExportLoss, export_task_package
+from benchflow.task.runtime_capabilities import validate_task_runtime_support
+
+DOGFOOD_ROOT = Path(
+    "docs/examples/task-standard/benchflow-wanted-features"
+)
+COMPAT_EXPORT_TASK = DOGFOOD_ROOT / "compat-export-loss-reports"
+RUNTIME_GATE_TASK = DOGFOOD_ROOT / "runtime-capability-gate"
+
+_EXPECTED_EXPORT_LOSS_CONCEPTS = frozenset(
+    {
+        "agents",
+        "scenes",
+        "benchflow.document_version",
+        "benchflow.compatibility",
+        "benchflow.traceability",
+        "benchflow.verifier",
+        "prompt.role:adapter_engineer",
+        "prompt.role:compatibility_reviewer",
+        "verifier.verifier_md",
+        "verifier.rubrics",
+    }
+)
+
+
+def _dogfood_task_dirs() -> list[Path]:
+    return sorted(
+        path
+        for path in DOGFOOD_ROOT.iterdir()
+        if path.is_dir() and (path / "task.md").is_file()
+    )
+
+
+@pytest.mark.parametrize("task_dir", _dogfood_task_dirs(), ids=lambda p: p.name)
+def test_dogfood_check_task_passes(task_dir: Path) -> None:
+    """Guards bench tasks check acceptance for every wanted-features dogfood package."""
+    assert check_task(task_dir) == []
+
+
+@pytest.mark.parametrize("task_dir", _dogfood_task_dirs(), ids=lambda p: p.name)
+def test_dogfood_task_loads(task_dir: Path) -> None:
+    """Guards Task() loading for every wanted-features dogfood package."""
+    task = Task(task_dir)
+    assert task.runtime_view.entrypoint == "task-md"
+
+
+@pytest.mark.parametrize("task_dir", _dogfood_task_dirs(), ids=lambda p: p.name)
+def test_dogfood_runtime_view_from_task_dir(task_dir: Path) -> None:
+    """Guards TaskRuntimeView.from_task_dir for every wanted-features dogfood package."""
+    view = TaskRuntimeView.from_task_dir(task_dir)
+    assert view.task_dir == task_dir.resolve()
+    assert view.entrypoint == "task-md"
+    assert view.instruction_text.strip()
+
+
+def test_compat_export_loss_reports_degraded_export() -> None:
+    """Guards compat-export-loss-reports degraded Harbor export and loss concepts."""
+    result = export_task_package(COMPAT_EXPORT_TASK)
+
+    assert result.target == "harbor"
+    assert result.mode == "degraded"
+    assert result.selected_definition == "task.md"
+    assert result.selected_oracle_dir == "oracle/"
+    assert result.selected_verifier_dir == "verifier/"
+    assert result.exported_oracle_dir == "solution/"
+    assert result.exported_verifier_dir == "tests/"
+    assert result.losses
+    assert all(isinstance(loss, ExportLoss) for loss in result.losses)
+
+    concepts = {loss.concept for loss in result.losses}
+    assert concepts == _EXPECTED_EXPORT_LOSS_CONCEPTS
+
+
+def test_runtime_capability_gate_fails_on_docker() -> None:
+    """Guards runtime-capability-gate fail-closed validation before sandbox creation."""
+    task = Task(RUNTIME_GATE_TASK)
+    issues = validate_task_runtime_support(task, "docker", RUNTIME_GATE_TASK)
+
+    assert issues
+    paths = {issue.path for issue in issues}
+    assert "environment.workdir" in paths
+    assert all(issue.sandbox_type == "docker" for issue in issues)

--- a/tests/test_task_standard_dogfood.py
+++ b/tests/test_task_standard_dogfood.py
@@ -99,19 +99,17 @@ def test_prompt_user_semantics_append_composes_scene_turn_prompts() -> None:
     assert user_loop_scene.turns[1].prompt == user_loop_reviewer
 
 
-def test_prompt_user_semantics_fails_sandbox_check_on_docker_for_user_and_nudges() -> None:
-    """Guards prompt-user-semantics fail-closed user/nudge validation on docker."""
+def test_prompt_user_semantics_sandbox_check_supports_executable_nudges() -> None:
+    """Guards prompt-user-semantics simulated-user nudge execution on docker."""
     task = Task(PROMPT_USER_SEMANTICS_TASK)
     issues = validate_task_runtime_support(
         task, "docker", PROMPT_USER_SEMANTICS_TASK
     )
 
-    assert issues
     paths = {issue.path for issue in issues}
-    assert "user" in paths
-    assert "benchflow.nudges" in paths
-    assert "prompt.user-persona" in paths
-    assert all(issue.sandbox_type == "docker" for issue in issues)
+    assert "benchflow.nudges" not in paths
+    assert "user" not in paths
+    assert "prompt.user-persona" not in paths
 
 
 def test_verifier_reward_contract_loads_deterministic_default_strategy() -> None:

--- a/tests/test_task_standard_dogfood.py
+++ b/tests/test_task_standard_dogfood.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from benchflow._utils.task_authoring import check_task
-from benchflow.task import Task, TaskRuntimeView
-from benchflow.task.export import ExportLoss, export_task_package
+from benchflow.task import Task, TaskDocument, TaskRuntimeView, VerifierDocument
+from benchflow.task.export import (
+    EXPORT_REPORT_REL_PATH,
+    ExportLoss,
+    export_report_json,
+    export_task_package,
+    write_export_report,
+)
 from benchflow.task.runtime_capabilities import validate_task_runtime_support
 
 DOGFOOD_ROOT = Path(
@@ -16,6 +23,8 @@ DOGFOOD_ROOT = Path(
 )
 COMPAT_EXPORT_TASK = DOGFOOD_ROOT / "compat-export-loss-reports"
 RUNTIME_GATE_TASK = DOGFOOD_ROOT / "runtime-capability-gate"
+PROMPT_USER_SEMANTICS_TASK = DOGFOOD_ROOT / "prompt-user-semantics"
+VERIFIER_REWARD_CONTRACT_TASK = DOGFOOD_ROOT / "verifier-package-reward-contract"
 
 _EXPECTED_EXPORT_LOSS_CONCEPTS = frozenset(
     {
@@ -63,6 +72,63 @@ def test_dogfood_runtime_view_from_task_dir(task_dir: Path) -> None:
     assert view.instruction_text.strip()
 
 
+def test_prompt_user_semantics_append_composes_scene_turn_prompts() -> None:
+    """Guards prompt-user-semantics append composition for scene turns."""
+    document = TaskDocument.from_path(PROMPT_USER_SEMANTICS_TASK / "task.md")
+    scenes = {scene.name: scene for scene in document.scenes}
+
+    prompt_composition_scene = scenes["prompt-composition"]
+    user_loop_scene = scenes["user-loop"]
+
+    engineer_base_role = (
+        f"{document.instruction}\n\n"
+        f"{document.role_prompts['scene_engineer']}"
+    )
+    user_loop_engineer = (
+        f"{engineer_base_role}\n\n"
+        f"{document.scene_prompts['user-loop']}"
+    )
+    user_loop_reviewer = (
+        f"{document.instruction}\n\n"
+        f"{document.role_prompts['ux_reviewer']}\n\n"
+        f"{document.scene_prompts['user-loop']}"
+    )
+
+    assert prompt_composition_scene.turns[0].prompt == engineer_base_role
+    assert user_loop_scene.turns[0].prompt == user_loop_engineer
+    assert user_loop_scene.turns[1].prompt == user_loop_reviewer
+
+
+def test_prompt_user_semantics_fails_sandbox_check_on_docker_for_user_and_nudges() -> None:
+    """Guards prompt-user-semantics fail-closed user/nudge validation on docker."""
+    task = Task(PROMPT_USER_SEMANTICS_TASK)
+    issues = validate_task_runtime_support(
+        task, "docker", PROMPT_USER_SEMANTICS_TASK
+    )
+
+    assert issues
+    paths = {issue.path for issue in issues}
+    assert "user" in paths
+    assert "benchflow.nudges" in paths
+    assert "prompt.user-persona" in paths
+    assert all(issue.sandbox_type == "docker" for issue in issues)
+
+
+def test_verifier_reward_contract_loads_deterministic_default_strategy() -> None:
+    """Guards verifier-package-reward-contract VerifierDocument default strategy."""
+    task = Task(VERIFIER_REWARD_CONTRACT_TASK)
+    verifier_md = (
+        VERIFIER_REWARD_CONTRACT_TASK / "verifier" / "verifier.md"
+    )
+
+    assert task.verifier_document is not None
+    assert task.verifier_document.name == "verifier-package-reward-contract"
+    assert task.verifier_document.default_strategy == "deterministic"
+
+    document = VerifierDocument.from_path(verifier_md)
+    assert document.default_strategy == "deterministic"
+
+
 def test_compat_export_loss_reports_degraded_export() -> None:
     """Guards compat-export-loss-reports degraded Harbor export and loss concepts."""
     result = export_task_package(COMPAT_EXPORT_TASK)
@@ -79,6 +145,24 @@ def test_compat_export_loss_reports_degraded_export() -> None:
 
     concepts = {loss.concept for loss in result.losses}
     assert concepts == _EXPECTED_EXPORT_LOSS_CONCEPTS
+
+
+def test_compat_export_writes_export_report_json(tmp_path: Path) -> None:
+    """Guards compat-export-loss-reports on-disk compatibility/export-report.json."""
+    result = export_task_package(COMPAT_EXPORT_TASK)
+    report_path = write_export_report(tmp_path, result)
+
+    assert report_path == tmp_path / EXPORT_REPORT_REL_PATH
+    assert report_path.is_file()
+
+    parsed = json.loads(report_path.read_text(encoding="utf-8"))
+    expected = export_report_json(result)
+    assert parsed == expected
+    assert parsed["target"] == "harbor"
+    assert parsed["mode"] == "degraded"
+    assert len(parsed["losses"]) == len(result.losses)
+    assert parsed["input_hashes"]["task.md"]
+    assert parsed["output_hashes"]["task.toml"]
 
 
 def test_runtime_capability_gate_fails_on_docker() -> None:

--- a/tests/test_task_standard_rollout_smoke.py
+++ b/tests/test_task_standard_rollout_smoke.py
@@ -128,6 +128,7 @@ def test_smoke_prompt_user_semantics_user_loop_compile() -> None:
     plan = resolve_user_loop_rollout_plan(
         config_scenes := RolloutConfig(task_path=PROMPT_USER_SEMANTICS_TASK).scenes,
         user_loop_scene_name=scene_name,
+        nudges=document.benchflow.get("nudges"),
     )
     assert plan is not None
     assert [scene.name for scene in plan.pre_scenes] == ["prompt-composition"]

--- a/tests/test_task_standard_rollout_smoke.py
+++ b/tests/test_task_standard_rollout_smoke.py
@@ -1,0 +1,162 @@
+"""Smoke tests for task-standard rollout wiring on dogfood packages.
+
+Exercises real task loading and RolloutConfig wiring without starting
+sandboxes or agents.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.rollout import RolloutConfig
+from benchflow.task import (
+    Task,
+    TaskRuntimeView,
+    compile_document_user_loop,
+    export_task_package,
+)
+from benchflow.task.export import ExportLoss
+from benchflow.task.user_loop import (
+    DocumentSimulatedUser,
+    infer_user_loop_scene_name,
+    resolve_user_loop_rollout_plan,
+)
+
+DOGFOOD_ROOT = Path("docs/examples/task-standard/benchflow-wanted-features")
+PROMPT_USER_SEMANTICS_TASK = DOGFOOD_ROOT / "prompt-user-semantics"
+COMPAT_EXPORT_TASK = DOGFOOD_ROOT / "compat-export-loss-reports"
+
+_EXPECTED_SCENE_NAMES: dict[str, list[str]] = {
+    "runtime-capability-gate": ["design", "implement", "review"],
+    "verifier-package-reward-contract": ["implement", "rubric-review"],
+    "compat-export-loss-reports": ["implement-export", "compatibility-review"],
+    "prompt-user-semantics": ["prompt-composition", "user-loop"],
+}
+
+_EXPECTED_EXPORT_LOSS_CONCEPTS = frozenset(
+    {
+        "agents",
+        "scenes",
+        "benchflow.document_version",
+        "benchflow.compatibility",
+        "benchflow.traceability",
+        "benchflow.verifier",
+        "prompt.role:adapter_engineer",
+        "prompt.role:compatibility_reviewer",
+        "verifier.verifier_md",
+        "verifier.rubrics",
+    }
+)
+
+
+def _dogfood_task_dirs() -> list[Path]:
+    return sorted(
+        path
+        for path in DOGFOOD_ROOT.iterdir()
+        if path.is_dir() and (path / "task.md").is_file()
+    )
+
+
+@pytest.mark.parametrize("task_dir", _dogfood_task_dirs(), ids=lambda p: p.name)
+def test_smoke_task_load(task_dir: Path) -> None:
+    """Guards Task() loading for every wanted-features dogfood package."""
+    task = Task(task_dir)
+    assert task.runtime_view.entrypoint == "task-md"
+    assert task.runtime_view.instruction_text.strip()
+
+
+@pytest.mark.parametrize("task_dir", _dogfood_task_dirs(), ids=lambda p: p.name)
+def test_smoke_runtime_view_summary(task_dir: Path) -> None:
+    """Guards TaskRuntimeView.from_task_dir and document_runtime_summary."""
+    view = TaskRuntimeView.from_task_dir(task_dir)
+    assert view.task_dir == task_dir.resolve()
+    assert view.entrypoint == "task-md"
+
+    summary = view.document_runtime_summary()
+    assert summary["entrypoint"] == "task-md"
+    assert summary["task_dir"] == str(task_dir.resolve())
+    assert summary["instruction_chars"] > 0
+    assert summary["scene_names"] == _EXPECTED_SCENE_NAMES[task_dir.name]
+    assert summary["verifier_dir_kind"] in {"native", "legacy"}
+    assert isinstance(summary.get("alias_collisions", []), list)
+
+
+@pytest.mark.parametrize("task_dir", _dogfood_task_dirs(), ids=lambda p: p.name)
+def test_smoke_rollout_config_scenes(task_dir: Path) -> None:
+    """Guards RolloutConfig scene wiring from task.md for every dogfood task."""
+    config = RolloutConfig(task_path=task_dir)
+
+    assert isinstance(config.task_path, Path)
+    assert [scene.name for scene in config.scenes] == _EXPECTED_SCENE_NAMES[
+        task_dir.name
+    ]
+    assert all(scene.roles for scene in config.scenes)
+    assert all(scene.turns for scene in config.scenes)
+
+    if task_dir.name == "prompt-user-semantics":
+        assert config.user is not None
+        assert isinstance(config.user, DocumentSimulatedUser)
+        assert config.max_user_rounds == 5
+        assert config.user_loop_plan is not None
+        assert len(config.user_loop_plan.pre_scenes) == 1
+        assert config.user_loop_plan.pre_scenes[0].name == "prompt-composition"
+        assert config.user_loop_plan.user_loop_scene.name == "user-loop"
+        assert config.user_loop_plan.user_loop_role.name == "scene_engineer"
+        assert config.user_loop_plan.post_scene is not None
+        assert config.user_loop_plan.post_scene.turns[0].role == "ux_reviewer"
+    else:
+        assert config.user_loop_plan is None
+
+
+def test_smoke_prompt_user_semantics_user_loop_compile() -> None:
+    """Guards compile_document_user_loop + resolve_user_loop_rollout_plan wiring."""
+    task = Task(PROMPT_USER_SEMANTICS_TASK)
+    document = task.document
+    assert document is not None
+
+    compiled = compile_document_user_loop(task)
+    assert compiled is not None
+    assert compiled.executable is True
+    assert compiled.max_user_rounds == 5
+    assert isinstance(compiled.user, DocumentSimulatedUser)
+
+    scene_name = infer_user_loop_scene_name(document)
+    assert scene_name == "user-loop"
+
+    plan = resolve_user_loop_rollout_plan(
+        config_scenes := RolloutConfig(task_path=PROMPT_USER_SEMANTICS_TASK).scenes,
+        user_loop_scene_name=scene_name,
+    )
+    assert plan is not None
+    assert [scene.name for scene in plan.pre_scenes] == ["prompt-composition"]
+    assert plan.user_loop_role.name == "scene_engineer"
+    assert plan.post_scene is not None
+    assert plan.post_scene.turns[0].role == "ux_reviewer"
+
+    rollout_plan = RolloutConfig(task_path=PROMPT_USER_SEMANTICS_TASK).user_loop_plan
+    assert rollout_plan is not None
+    assert [scene.name for scene in rollout_plan.pre_scenes] == [
+        scene.name for scene in plan.pre_scenes
+    ]
+    assert rollout_plan.user_loop_role.name == plan.user_loop_role.name
+    assert len(config_scenes) == 2
+
+
+def test_smoke_compat_export_loss_reports() -> None:
+    """Guards export_task_package for compat-export-loss-reports dogfood task."""
+    result = export_task_package(COMPAT_EXPORT_TASK)
+
+    assert result.target == "harbor"
+    assert result.mode == "degraded"
+    assert result.selected_definition == "task.md"
+    assert result.selected_oracle_dir == "oracle/"
+    assert result.selected_verifier_dir == "verifier/"
+    assert result.exported_oracle_dir == "solution/"
+    assert result.exported_verifier_dir == "tests/"
+    assert result.losses
+    assert all(isinstance(loss, ExportLoss) for loss in result.losses)
+
+    concepts = {loss.concept for loss in result.losses}
+    assert concepts == _EXPECTED_EXPORT_LOSS_CONCEPTS

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -158,6 +158,61 @@ class TestTaskPathAliases:
         assert paths.uses_native_oracle_dir is False
         assert paths.uses_native_verifier_dir is False
 
+    def test_check_task_rejects_oracle_solution_alias_collision(self, tmp_path):
+        """Guards task-standard alias drift when both native and legacy dirs exist."""
+        task = tmp_path / "task"
+        task.mkdir()
+        (task / "task.toml").write_text('version = "1.0"\n[verifier]\n')
+        (task / "instruction.md").write_text("Do something\n")
+        (task / "environment").mkdir()
+        (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        (task / "oracle").mkdir()
+        (task / "oracle" / "solve.sh").write_text("#!/bin/bash\necho native\n")
+        (task / "solution").mkdir()
+        (task / "solution" / "solve.sh").write_text("#!/bin/bash\necho legacy\n")
+        (task / "verifier").mkdir()
+        (task / "verifier" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+        issues = check_task(task)
+
+        assert any("oracle/" in issue and "solution/" in issue for issue in issues)
+
+    def test_check_task_rejects_verifier_tests_alias_collision(self, tmp_path):
+        """Guards task-standard alias drift when both native and legacy dirs exist."""
+        task = tmp_path / "task"
+        task.mkdir()
+        (task / "task.toml").write_text('version = "1.0"\n[verifier]\n')
+        (task / "instruction.md").write_text("Do something\n")
+        (task / "environment").mkdir()
+        (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        (task / "verifier").mkdir()
+        (task / "verifier" / "test.sh").write_text("#!/bin/bash\necho native\n")
+        (task / "tests").mkdir()
+        (task / "tests" / "test.sh").write_text("#!/bin/bash\necho legacy\n")
+
+        issues = check_task(task)
+
+        assert any("verifier/" in issue and "tests/" in issue for issue in issues)
+
+    def test_check_task_accepts_byte_identical_alias_trees(self, tmp_path):
+        """Equivalent native and legacy alias trees should still pass check."""
+        task = tmp_path / "task"
+        task.mkdir()
+        (task / "task.toml").write_text('version = "1.0"\n[verifier]\n')
+        (task / "instruction.md").write_text("Do something\n")
+        (task / "environment").mkdir()
+        (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        (task / "oracle").mkdir()
+        (task / "oracle" / "solve.sh").write_text("#!/bin/bash\necho ok\n")
+        (task / "solution").mkdir()
+        (task / "solution" / "solve.sh").write_text("#!/bin/bash\necho ok\n")
+        (task / "verifier").mkdir()
+        (task / "verifier" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+        (task / "tests").mkdir()
+        (task / "tests" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+        assert check_task(task) == []
+
 
 class TestInitTask:
     """init_task(name, ...) -> Path"""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -12,7 +12,7 @@ from benchflow._utils.task_authoring import (
     migrate_task_to_task_md,
 )
 from benchflow.cli.main import app
-from benchflow.task import TaskConfig, TaskDocument
+from benchflow.task import Task, TaskConfig, TaskDocument
 from benchflow.task.paths import TaskPaths
 
 
@@ -193,6 +193,24 @@ class TestTaskPathAliases:
         issues = check_task(task)
 
         assert any("verifier/" in issue and "tests/" in issue for issue in issues)
+
+    def test_task_load_rejects_oracle_solution_alias_collision(self, tmp_path):
+        """Guards runtime fail-closed behavior for conflicting alias trees."""
+        task = tmp_path / "task"
+        task.mkdir()
+        (task / "task.toml").write_text('version = "1.0"\n[verifier]\n')
+        (task / "instruction.md").write_text("Do something\n")
+        (task / "environment").mkdir()
+        (task / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        (task / "oracle").mkdir()
+        (task / "oracle" / "solve.sh").write_text("#!/bin/bash\necho native\n")
+        (task / "solution").mkdir()
+        (task / "solution" / "solve.sh").write_text("#!/bin/bash\necho legacy\n")
+        (task / "verifier").mkdir()
+        (task / "verifier" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+        with pytest.raises(ValueError, match="oracle/"):
+            Task(task)
 
     def test_check_task_accepts_byte_identical_alias_trees(self, tmp_path):
         """Equivalent native and legacy alias trees should still pass check."""

--- a/tests/test_tasks_cli_export.py
+++ b/tests/test_tasks_cli_export.py
@@ -140,6 +140,17 @@ name = "scaffold"
         assert "valid" in result.output
         assert "runtime supported on daytona" in result.output
 
+    def test_check_with_modal_sandbox_passes_minimal_task(self, tmp_path: Path) -> None:
+        task = _write_minimal_legacy_task(tmp_path / "ok-task")
+        result = CliRunner().invoke(
+            app,
+            ["tasks", "check", str(task), "--sandbox", "modal"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "valid" in result.output
+        assert "runtime supported on modal" in result.output
+
 
 class TestTasksRoundTripCli:
     def test_round_trip_exports_and_validates_compat_example(

--- a/tests/test_tasks_cli_export.py
+++ b/tests/test_tasks_cli_export.py
@@ -139,3 +139,24 @@ name = "scaffold"
         assert result.exit_code == 0, result.output
         assert "valid" in result.output
         assert "runtime supported on daytona" in result.output
+
+
+class TestTasksRoundTripCli:
+    def test_round_trip_exports_and_validates_compat_example(
+        self, tmp_path: Path
+    ) -> None:
+        output_dir = tmp_path / "round-trip"
+        result = CliRunner().invoke(
+            app,
+            [
+                "tasks",
+                "round-trip",
+                str(COMPAT_EXPORT_EXAMPLE),
+                "--output",
+                str(output_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Round-trip parity OK" in result.output
+        assert (output_dir / "compatibility" / "export-report.json").is_file()

--- a/tests/test_tasks_cli_export.py
+++ b/tests/test_tasks_cli_export.py
@@ -1,0 +1,141 @@
+"""CLI tests for bench tasks export and sandbox-aware bench tasks check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+COMPAT_EXPORT_EXAMPLE = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/compat-export-loss-reports"
+)
+
+
+def _write_minimal_legacy_task(task_dir: Path) -> Path:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "task.toml").write_text(
+        'version = "1.0"\n[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n'
+    )
+    (task_dir / "instruction.md").write_text("Do the thing.\n")
+    env = task_dir / "environment"
+    env.mkdir()
+    (env / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    tests = task_dir / "tests"
+    tests.mkdir()
+    (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    return task_dir
+
+
+class TestTasksExportCli:
+    def test_export_writes_split_layout_and_prints_loss_summary(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "exported"
+        result = CliRunner().invoke(
+            app,
+            [
+                "tasks",
+                "export",
+                str(COMPAT_EXPORT_EXAMPLE),
+                "--output",
+                str(output_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (output_dir / "task.toml").is_file()
+        assert (output_dir / "instruction.md").is_file()
+        assert (output_dir / "tests" / "test.sh").is_file()
+        assert (output_dir / "solution" / "solve.md").is_file()
+        assert "Export harbor (degraded)" in result.output
+        assert "Losses (" in result.output
+        assert "agents:" in result.output
+        assert "verifier.verifier_md:" in result.output
+
+    def test_export_defaults_output_dir_to_cwd_task_name_export(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        task_dir = COMPAT_EXPORT_EXAMPLE.resolve()
+        monkeypatch.chdir(tmp_path)
+        result = CliRunner().invoke(
+            app,
+            ["tasks", "export", str(task_dir)],
+        )
+
+        default_output = tmp_path / f"{task_dir.name}-export"
+        assert result.exit_code == 0, result.output
+        assert default_output.is_dir()
+        assert (default_output / "task.toml").is_file()
+        assert "Export harbor (degraded)" in result.output
+
+    def test_export_accepts_pier_target(self, tmp_path: Path) -> None:
+        output_dir = tmp_path / "pier-export"
+        result = CliRunner().invoke(
+            app,
+            [
+                "tasks",
+                "export",
+                str(COMPAT_EXPORT_EXAMPLE),
+                "--target",
+                "pier",
+                "--output",
+                str(output_dir),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Export pier (degraded)" in result.output
+        assert (output_dir / "task.toml").is_file()
+
+    def test_export_fails_for_legacy_only_package(self, tmp_path: Path) -> None:
+        task = _write_minimal_legacy_task(tmp_path / "legacy-only")
+        result = CliRunner().invoke(
+            app,
+            ["tasks", "export", str(task), "--output", str(tmp_path / "out")],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "task.md" in result.output
+
+
+class TestTasksCheckSandboxCli:
+    def test_check_without_sandbox_skips_runtime_validation(self, tmp_path: Path) -> None:
+        task = _write_minimal_legacy_task(tmp_path / "ok-task")
+        result = CliRunner().invoke(app, ["tasks", "check", str(task)])
+
+        assert result.exit_code == 0, result.output
+        assert "valid" in result.output
+        assert "runtime supported" not in result.output
+
+    def test_check_with_sandbox_reports_unsupported_features(
+        self, tmp_path: Path
+    ) -> None:
+        task = _write_minimal_legacy_task(tmp_path / "steps-task")
+        (task / "task.toml").write_text(
+            """\
+version = "1.0"
+
+[[steps]]
+name = "scaffold"
+"""
+        )
+        result = CliRunner().invoke(
+            app,
+            ["tasks", "check", str(task), "--sandbox", "docker"],
+        )
+
+        assert result.exit_code == 1, result.output
+        assert "valid" in result.output
+        assert "unsupported feature(s) on docker" in result.output
+        assert "steps:" in result.output
+
+    def test_check_with_sandbox_passes_minimal_task(self, tmp_path: Path) -> None:
+        task = _write_minimal_legacy_task(tmp_path / "ok-task")
+        result = CliRunner().invoke(
+            app,
+            ["tasks", "check", str(task), "--sandbox", "daytona"],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "valid" in result.output
+        assert "runtime supported on daytona" in result.output

--- a/tests/test_tasks_cli_import.py
+++ b/tests/test_tasks_cli_import.py
@@ -1,0 +1,66 @@
+"""CLI tests for bench tasks import and export→import round-trip validation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+COMPAT_EXPORT_EXAMPLE = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/compat-export-loss-reports"
+)
+
+
+def _export_compat_example(output_dir: Path) -> None:
+    result = CliRunner().invoke(
+        app,
+        [
+            "tasks",
+            "export",
+            str(COMPAT_EXPORT_EXAMPLE),
+            "--output",
+            str(output_dir),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+
+class TestTasksImportCli:
+    def test_import_split_package_from_exported_compat_example(
+        self, tmp_path: Path
+    ) -> None:
+        exported_dir = tmp_path / "exported"
+        _export_compat_example(exported_dir)
+
+        result = CliRunner().invoke(
+            app,
+            ["tasks", "import", str(exported_dir)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Import" in result.output
+        assert "split package" in result.output
+        assert "oracle file(s)" in result.output
+        assert "verifier file(s)" in result.output
+
+    def test_import_native_round_trip_validation_passes(self, tmp_path: Path) -> None:
+        exported_dir = tmp_path / "exported"
+        _export_compat_example(exported_dir)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "tasks",
+                "import",
+                str(exported_dir),
+                "--native",
+                str(COMPAT_EXPORT_EXAMPLE),
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Import" in result.output
+        assert "split package" in result.output
+        assert "Round-trip parity OK" in result.output

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -424,7 +424,10 @@ class TestSoftVerify:
 
         assert rewards is None
         assert "soft verifier crashed" in error
-        assert "without numeric 'reward'" in error
+        assert (
+            "missing numeric 'reward'" in error
+            or "invalid reward value" in error
+        )
 
     @pytest.mark.asyncio
     async def test_soft_verify_runs_cleanup_cmd(self):

--- a/tests/test_user_loop.py
+++ b/tests/test_user_loop.py
@@ -9,7 +9,11 @@ import pytest
 from benchflow.rollout import RolloutConfig
 from benchflow.sandbox.user import RoundResult
 from benchflow.task import Task, compile_document_user_loop, parse_stop_rule_max_rounds
-from benchflow.task.user_loop import DocumentSimulatedUser
+from benchflow.task.user_loop import (
+    DocumentSimulatedUser,
+    infer_user_loop_scene_name,
+    resolve_user_loop_rollout_plan,
+)
 
 PROMPT_USER_SEMANTICS_TASK = Path(
     "docs/examples/task-standard/benchflow-wanted-features/prompt-user-semantics"
@@ -187,6 +191,27 @@ class TestDocumentSimulatedUser:
         assert "secret requirement" not in prompt
 
 
+class TestResolveUserLoopRolloutPlan:
+    def test_prompt_user_semantics_plans_pre_and_post_scenes(self) -> None:
+        """Guards multi-scene user-loop placement for prompt-user-semantics."""
+        task = Task(PROMPT_USER_SEMANTICS_TASK)
+        document = task.document
+        assert document is not None
+
+        scene_name = infer_user_loop_scene_name(document)
+        assert scene_name == "user-loop"
+
+        plan = resolve_user_loop_rollout_plan(
+            document.scenes,
+            user_loop_scene_name=scene_name,
+        )
+        assert plan is not None
+        assert [scene.name for scene in plan.pre_scenes] == ["prompt-composition"]
+        assert plan.user_loop_role.name == "scene_engineer"
+        assert plan.post_scene is not None
+        assert plan.post_scene.turns[0].role == "ux_reviewer"
+
+
 class TestRolloutConfigUserLoopWiring:
     def test_auto_wires_compatible_single_scene_task(self, tmp_path: Path) -> None:
         (tmp_path / "task.md").write_text(
@@ -219,15 +244,20 @@ Solve it.
         assert isinstance(config.user, DocumentSimulatedUser)
         assert config.max_user_rounds == 4
 
-    def test_skips_auto_wire_for_multi_scene_dogfood(self) -> None:
-        """Multi-scene prompt-user-semantics compiles but keeps scene rollout."""
+    def test_auto_wires_multi_scene_dogfood_user_loop_scene(self) -> None:
+        """Multi-scene prompt-user-semantics wires user loop on the user-loop scene."""
         config = RolloutConfig(task_path=PROMPT_USER_SEMANTICS_TASK)
 
-        assert config.user is None
-        assert len(config.effective_scenes) > 1
-        compiled = compile_document_user_loop(Task(PROMPT_USER_SEMANTICS_TASK))
-        assert compiled is not None
-        assert compiled.executable is True
+        assert config.user is not None
+        assert isinstance(config.user, DocumentSimulatedUser)
+        assert config.max_user_rounds == 5
+        assert config.user_loop_plan is not None
+        assert len(config.user_loop_plan.pre_scenes) == 1
+        assert config.user_loop_plan.pre_scenes[0].name == "prompt-composition"
+        assert config.user_loop_plan.user_loop_scene.name == "user-loop"
+        assert config.user_loop_plan.user_loop_role.name == "scene_engineer"
+        assert config.user_loop_plan.post_scene is not None
+        assert config.user_loop_plan.post_scene.turns[0].role == "ux_reviewer"
 
     def test_explicit_user_is_not_overridden(self, tmp_path: Path) -> None:
         from benchflow.sandbox.user import PassthroughUser

--- a/tests/test_user_loop.py
+++ b/tests/test_user_loop.py
@@ -11,8 +11,11 @@ from benchflow.sandbox.user import RoundResult
 from benchflow.task import Task, compile_document_user_loop, parse_stop_rule_max_rounds
 from benchflow.task.user_loop import (
     DocumentSimulatedUser,
+    branchable_simulated_user_nudges,
     infer_user_loop_scene_name,
     resolve_user_loop_rollout_plan,
+    user_loop_rollout_compatible,
+    user_loop_rollout_compatible_for_task,
 )
 
 PROMPT_USER_SEMANTICS_TASK = Path(
@@ -201,15 +204,55 @@ class TestResolveUserLoopRolloutPlan:
         scene_name = infer_user_loop_scene_name(document)
         assert scene_name == "user-loop"
 
+        nudges = document.benchflow.get("nudges")
+        assert branchable_simulated_user_nudges(nudges) is True
+
         plan = resolve_user_loop_rollout_plan(
             document.scenes,
             user_loop_scene_name=scene_name,
+            nudges=nudges,
         )
         assert plan is not None
         assert [scene.name for scene in plan.pre_scenes] == ["prompt-composition"]
         assert plan.user_loop_role.name == "scene_engineer"
         assert plan.post_scene is not None
         assert plan.post_scene.turns[0].role == "ux_reviewer"
+
+    def test_multi_turn_user_loop_requires_branchable_simulated_user_nudges(
+        self,
+    ) -> None:
+        """Guards branchable nudges gate multi-turn user-loop scene splitting."""
+        task = Task(PROMPT_USER_SEMANTICS_TASK)
+        document = task.document
+        assert document is not None
+
+        scene_name = infer_user_loop_scene_name(document)
+        assert scene_name == "user-loop"
+
+        without_branchable = {"mode": "simulated-user", "nudge_budget": 5}
+        assert (
+            resolve_user_loop_rollout_plan(
+                document.scenes,
+                user_loop_scene_name=scene_name,
+                nudges=without_branchable,
+            )
+            is None
+        )
+        assert not user_loop_rollout_compatible(
+            document.scenes,
+            user_loop_scene_name=scene_name,
+            nudges=without_branchable,
+        )
+
+        with_branchable = {**without_branchable, "branchable": True}
+        plan = resolve_user_loop_rollout_plan(
+            document.scenes,
+            user_loop_scene_name=scene_name,
+            nudges=with_branchable,
+        )
+        assert plan is not None
+        assert plan.post_scene is not None
+        assert user_loop_rollout_compatible_for_task(task) is True
 
 
 class TestRolloutConfigUserLoopWiring:

--- a/tests/test_user_loop.py
+++ b/tests/test_user_loop.py
@@ -1,0 +1,207 @@
+"""Tests for document-declared user loop compilation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.rollout import RolloutConfig
+from benchflow.sandbox.user import RoundResult
+from benchflow.task import Task, compile_document_user_loop, parse_stop_rule_max_rounds
+from benchflow.task.user_loop import DocumentSimulatedUser
+
+PROMPT_USER_SEMANTICS_TASK = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/prompt-user-semantics"
+)
+
+
+class TestParseStopRule:
+    @pytest.mark.parametrize(
+        ("stop_rule", "expected"),
+        [
+            ("satisfied-or-5-rounds", 5),
+            ("done-or-3-rounds", 3),
+            ("SATISFIED-OR-2-ROUNDS", 2),
+        ],
+    )
+    def test_parses_round_cap(self, stop_rule: str, expected: int) -> None:
+        assert parse_stop_rule_max_rounds(stop_rule) == expected
+
+    @pytest.mark.parametrize(
+        "stop_rule",
+        ["satisfied", "until-done", "5-rounds", ""],
+    )
+    def test_rejects_unparseable_rules(self, stop_rule: str) -> None:
+        assert parse_stop_rule_max_rounds(stop_rule) is None
+
+
+class TestCompileDocumentUserLoop:
+    def test_prompt_user_semantics_dogfood_compiles(self) -> None:
+        """Guards prompt-user-semantics dogfood user loop compilation."""
+        task = Task(PROMPT_USER_SEMANTICS_TASK)
+        compiled = compile_document_user_loop(task)
+
+        assert compiled is not None
+        assert compiled.executable is True
+        assert compiled.max_user_rounds == 5
+        assert isinstance(compiled.user, DocumentSimulatedUser)
+        assert compiled.user.user_persona is not None
+        assert "targeted clarification" in compiled.user.user_persona
+
+    def test_missing_user_block_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "task.md").write_text(
+            """---
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+---
+## prompt
+
+Solve it.
+"""
+        )
+        (tmp_path / "task.toml").write_text(
+            'version = "1.0"\n[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n'
+        )
+        (tmp_path / "instruction.md").write_text("Solve it.\n")
+        env = tmp_path / "environment"
+        env.mkdir()
+        (env / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+        task = Task(tmp_path)
+        assert compile_document_user_loop(task) is None
+
+
+class TestDocumentSimulatedUser:
+    @pytest.mark.asyncio
+    async def test_round_zero_returns_instruction_without_private_facts(self) -> None:
+        user = DocumentSimulatedUser(
+            user_persona="Verifier-only persona text.",
+            private_facts={"hidden_need": "secret requirement"},
+            stop_rule="satisfied-or-5-rounds",
+            max_rounds=5,
+        )
+        prompt = await user.run(0, "Solve the task.")
+        assert prompt == "Solve the task."
+        assert "secret requirement" not in prompt
+        assert "Verifier-only persona" not in prompt
+
+    @pytest.mark.asyncio
+    async def test_stops_when_verifier_is_satisfied(self) -> None:
+        user = DocumentSimulatedUser(
+            user_persona=None,
+            private_facts={},
+            stop_rule="satisfied-or-5-rounds",
+            max_rounds=5,
+        )
+        passing = RoundResult(round=0, rewards={"reward": 1.0})
+        assert await user.run(1, "Solve the task.", passing) is None
+
+    @pytest.mark.asyncio
+    async def test_reveals_private_facts_on_clarification_question(self) -> None:
+        user = DocumentSimulatedUser(
+            user_persona="Persona stays verifier-scoped.",
+            private_facts={"hidden_need": "Document user loops must be executable."},
+            stop_rule="satisfied-or-5-rounds",
+            max_rounds=5,
+        )
+        clarifying = RoundResult(
+            round=0,
+            trajectory=[{"content": "Could you clarify the hidden need requirement?"}],
+        )
+        prompt = await user.run(1, "Solve the task.", clarifying)
+        assert prompt is not None
+        assert "hidden_need" in prompt
+        assert "Document user loops must be executable." in prompt
+        assert "Persona stays verifier-scoped." not in prompt
+
+    @pytest.mark.asyncio
+    async def test_private_facts_stay_hidden_without_clarification(self) -> None:
+        user = DocumentSimulatedUser(
+            user_persona=None,
+            private_facts={"hidden_need": "secret requirement"},
+            stop_rule="satisfied-or-5-rounds",
+            max_rounds=5,
+        )
+        working = RoundResult(round=0, trajectory=[{"content": "Running tests now."}])
+        prompt = await user.run(1, "Solve the task.", working)
+        assert prompt == "Please continue working on the task."
+        assert "secret requirement" not in prompt
+
+
+class TestRolloutConfigUserLoopWiring:
+    def test_auto_wires_compatible_single_scene_task(self, tmp_path: Path) -> None:
+        (tmp_path / "task.md").write_text(
+            """---
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+agents:
+  roles:
+    solver:
+      agent: codex
+scenes:
+  - name: solve
+    roles: [solver]
+user:
+  stop_rule: satisfied-or-4-rounds
+  private_facts:
+    hidden_need: "Keep this private until asked."
+---
+## prompt
+
+Solve it.
+"""
+        )
+
+        config = RolloutConfig(task_path=tmp_path)
+
+        assert config.user is not None
+        assert isinstance(config.user, DocumentSimulatedUser)
+        assert config.max_user_rounds == 4
+
+    def test_skips_auto_wire_for_multi_scene_dogfood(self) -> None:
+        """Multi-scene prompt-user-semantics compiles but keeps scene rollout."""
+        config = RolloutConfig(task_path=PROMPT_USER_SEMANTICS_TASK)
+
+        assert config.user is None
+        assert len(config.effective_scenes) > 1
+        compiled = compile_document_user_loop(Task(PROMPT_USER_SEMANTICS_TASK))
+        assert compiled is not None
+        assert compiled.executable is True
+
+    def test_explicit_user_is_not_overridden(self, tmp_path: Path) -> None:
+        from benchflow.sandbox.user import PassthroughUser
+
+        (tmp_path / "task.md").write_text(
+            """---
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+agents:
+  roles:
+    solver:
+      agent: codex
+scenes:
+  - name: solve
+    roles: [solver]
+user:
+  stop_rule: satisfied-or-4-rounds
+---
+## prompt
+
+Solve it.
+"""
+        )
+
+        explicit = PassthroughUser()
+        config = RolloutConfig(task_path=tmp_path, user=explicit)
+
+        assert config.user is explicit

--- a/tests/test_user_loop.py
+++ b/tests/test_user_loop.py
@@ -49,6 +49,45 @@ class TestCompileDocumentUserLoop:
         assert compiled.user.user_persona is not None
         assert "targeted clarification" in compiled.user.user_persona
 
+    def test_nudge_budget_sets_max_rounds_when_stop_rule_absent(
+        self, tmp_path: Path
+    ) -> None:
+        (tmp_path / "task.md").write_text(
+            """---
+agent:
+  timeout_sec: 300
+verifier:
+  timeout_sec: 120
+user:
+  private_facts:
+    hidden_need: "Reveal only when asked."
+benchflow:
+  nudges:
+    mode: simulated-user
+    nudge_budget: 6
+---
+## prompt
+
+Solve it.
+"""
+        )
+        (tmp_path / "task.toml").write_text(
+            'version = "1.0"\n[agent]\ntimeout_sec = 300\n[verifier]\ntimeout_sec = 120\n'
+        )
+        (tmp_path / "instruction.md").write_text("Solve it.\n")
+        env = tmp_path / "environment"
+        env.mkdir()
+        (env / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        (tests / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+
+        compiled = compile_document_user_loop(Task(tmp_path))
+
+        assert compiled is not None
+        assert compiled.max_user_rounds == 6
+        assert isinstance(compiled.user, DocumentSimulatedUser)
+
     def test_missing_user_block_returns_none(self, tmp_path: Path) -> None:
         (tmp_path / "task.md").write_text(
             """---
@@ -119,6 +158,20 @@ class TestDocumentSimulatedUser:
         assert "hidden_need" in prompt
         assert "Document user loops must be executable." in prompt
         assert "Persona stays verifier-scoped." not in prompt
+
+    @pytest.mark.asyncio
+    async def test_stops_after_nudge_budget_round_cap(self) -> None:
+        user = DocumentSimulatedUser(
+            user_persona=None,
+            private_facts={},
+            stop_rule="nudge-budget-3-rounds",
+            max_rounds=3,
+        )
+        working = RoundResult(round=0, trajectory=[{"content": "Still working."}])
+        assert await user.run(1, "Solve the task.", working) == (
+            "Please continue working on the task."
+        )
+        assert await user.run(2, "Solve the task.", working) is None
 
     @pytest.mark.asyncio
     async def test_private_facts_stay_hidden_without_clarification(self) -> None:

--- a/tests/test_verifier_document.py
+++ b/tests/test_verifier_document.py
@@ -94,6 +94,33 @@ def test_verifier_document_issues_validate_dogfood_task() -> None:
     assert issues == []
 
 
+def test_verifier_document_issues_require_reward_kit_root_directory(
+    tmp_path: Path,
+) -> None:
+    """Guards reward-kit strategy root directory validation on dogfood verifier.md."""
+    task_dir = tmp_path / "task"
+    verifier_dir = task_dir / "verifier"
+    verifier_dir.mkdir(parents=True)
+    (verifier_dir / "rubrics").mkdir()
+    (verifier_dir / "rubrics" / "verifier.toml").write_text(
+        "[criterion]\nname = \"contract\"\n"
+    )
+    (verifier_dir / "verifier.md").write_text(
+        DOGFOOD_VERIFIER_MD.read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    issues = verifier_document_issues(
+        task_dir,
+        benchflow_verifier={"spec": "verifier/verifier.md"},
+    )
+
+    assert issues == [
+        "verifier/verifier.md reward-kit strategy 'rewardkit' references "
+        "missing root directory: reward_kit/"
+    ]
+
+
 def test_check_task_validates_verifier_spec_for_dogfood_task() -> None:
     """Guards task-standard benchflow.verifier.spec validation in check_task."""
     issues = check_task(DOGFOOD_TASK_DIR)

--- a/tests/test_verifier_document.py
+++ b/tests/test_verifier_document.py
@@ -2,16 +2,24 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from benchflow._utils.task_authoring import check_task
 from benchflow.task import (
+    RolloutPaths,
     Task,
+    UnsupportedVerifierStrategyError,
+    Verifier,
     VerifierDocument,
     VerifierDocumentParseError,
+    is_executable_script_strategy,
+    resolve_default_strategy,
     verifier_document_issues,
+    verifier_strategy_type,
 )
 from benchflow.task.verifier_document import resolve_verifier_spec_path
 
@@ -178,3 +186,82 @@ def _dogfood_benchflow_verifier() -> dict[str, object]:
     verifier = benchflow.get("verifier")
     assert isinstance(verifier, dict)
     return verifier
+
+
+def test_resolve_default_strategy_uses_dogfood_fixture() -> None:
+    """Guards verifier-package-reward-contract default strategy resolution."""
+    document = VerifierDocument.from_path(DOGFOOD_VERIFIER_MD)
+
+    strategy_name, strategy = resolve_default_strategy(document)
+
+    assert strategy_name == "deterministic"
+    assert verifier_strategy_type(strategy) == "script"
+    assert is_executable_script_strategy(strategy)
+
+
+@pytest.mark.asyncio
+async def test_verify_logs_and_routes_deterministic_strategy_to_test_script(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Guards verifier document script strategy routing on dogfood task."""
+    task = Task(DOGFOOD_TASK_DIR)
+    rollout_paths = RolloutPaths(Path("/tmp/verifier-strategy-rollout"))
+    rollout_paths.mkdir()
+
+    sandbox = MagicMock()
+    sandbox.upload_dir = AsyncMock()
+    sandbox.is_mounted = True
+
+    async def exec_writes_reward(*_args: object, **_kwargs: object) -> MagicMock:
+        if sandbox.exec.await_count == 1:
+            return MagicMock(return_code=0, stdout="")
+        rollout_paths.reward_text_path.write_text("1.0")
+        return MagicMock(return_code=0, stdout="")
+
+    sandbox.exec = AsyncMock(side_effect=exec_writes_reward)
+
+    with caplog.at_level("INFO"):
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+    assert result.rewards == {"reward": 1.0}
+    assert any(
+        "Selected verifier document strategy 'deterministic' (type='script')"
+        in record.getMessage()
+        for record in caplog.records
+    )
+    sandbox.upload_dir.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("default_strategy", "expected_type"),
+    [
+        ("rewardkit", "reward-kit"),
+        ("judge", "agent-judge"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_verify_rejects_unsupported_verifier_document_strategies(
+    default_strategy: str,
+    expected_type: str,
+) -> None:
+    """Guards fail-closed routing for non-script verifier document strategies."""
+    task = Task(DOGFOOD_TASK_DIR)
+    document = task.verifier_document
+    assert document is not None
+    task.verifier_document = replace(document, default_strategy=default_strategy)
+
+    rollout_paths = RolloutPaths(Path("/tmp/verifier-strategy-rollout"))
+    rollout_paths.mkdir()
+
+    sandbox = MagicMock()
+    sandbox.upload_dir = AsyncMock()
+    sandbox.exec = AsyncMock(side_effect=AssertionError("test.sh must not run"))
+
+    with pytest.raises(
+        UnsupportedVerifierStrategyError,
+        match=rf"type={expected_type!r}.*not executable",
+    ):
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+    sandbox.upload_dir.assert_not_called()
+    sandbox.exec.assert_not_called()

--- a/tests/test_verifier_document.py
+++ b/tests/test_verifier_document.py
@@ -1,0 +1,180 @@
+"""Tests for verifier/verifier.md authoring document parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow._utils.task_authoring import check_task
+from benchflow.task import (
+    Task,
+    VerifierDocument,
+    VerifierDocumentParseError,
+    verifier_document_issues,
+)
+from benchflow.task.verifier_document import resolve_verifier_spec_path
+
+DOGFOOD_VERIFIER_MD = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/"
+    "verifier-package-reward-contract/verifier/verifier.md"
+)
+DOGFOOD_TASK_DIR = DOGFOOD_VERIFIER_MD.parent.parent
+
+
+def test_verifier_document_parses_dogfood_fixture() -> None:
+    """Guards task-standard verifier.md dogfood against parser drift."""
+    document = VerifierDocument.from_path(DOGFOOD_VERIFIER_MD)
+
+    assert document.document_version == "0.3"
+    assert document.name == "verifier-package-reward-contract"
+    assert document.default_strategy == "deterministic"
+    assert set(document.strategies) == {"deterministic", "rewardkit", "judge"}
+    assert document.strategies["deterministic"]["type"] == "script"
+    assert document.strategies["deterministic"]["command"] == "./test.sh"
+    assert document.strategies["rewardkit"]["type"] == "reward-kit"
+    assert document.strategies["rewardkit"]["root"] == "reward_kit/"
+    assert document.strategies["rewardkit"]["criteria"] == "rubrics/verifier.toml"
+    assert document.strategies["judge"]["type"] == "agent-judge"
+    assert document.strategies["judge"]["role"] == "verifier_judge"
+    assert document.rubric["combine"] == "weighted_sum"
+    assert document.rubric["dimensions"]["reward_contract"]["weight"] == 0.35
+    assert document.rubric_files.structured == "rubrics/verifier.toml"
+    assert document.outputs.reward_text == "/logs/verifier/reward.txt"
+    assert document.outputs.reward_json == "/logs/verifier/reward.json"
+    assert document.outputs.reward_details == "/logs/verifier/reward-details.json"
+    assert document.outputs.aggregate_policy == {
+        "field": "reward",
+        "fallback": "weighted_mean",
+    }
+    assert "verifier_judge" in document.role_prompts
+    assert "hidden fixture leakage" in document.role_prompts["verifier_judge"]
+
+
+def test_verifier_document_rejects_missing_frontmatter() -> None:
+    with pytest.raises(VerifierDocumentParseError, match="YAML frontmatter"):
+        VerifierDocument.from_text("No frontmatter here.")
+
+
+def test_verifier_document_rejects_invalid_strategies() -> None:
+    with pytest.raises(VerifierDocumentParseError, match="strategies must be a mapping"):
+        VerifierDocument.from_text(
+            """---
+verifier:
+  strategies: not-a-mapping
+---
+"""
+        )
+
+
+def test_verifier_document_issues_require_spec_file() -> None:
+    task_dir = Path("/tmp/task")
+    issues = verifier_document_issues(
+        task_dir,
+        benchflow_verifier={"spec": "verifier/verifier.md"},
+    )
+    assert issues == [
+        "benchflow.verifier.spec references missing file: verifier/verifier.md"
+    ]
+
+
+def test_verifier_document_issues_validate_dogfood_task() -> None:
+    issues = verifier_document_issues(
+        DOGFOOD_TASK_DIR,
+        benchflow_verifier=_dogfood_benchflow_verifier(),
+    )
+    assert issues == []
+
+
+def test_check_task_validates_verifier_spec_for_dogfood_task() -> None:
+    """Guards task-standard benchflow.verifier.spec validation in check_task."""
+    issues = check_task(DOGFOOD_TASK_DIR)
+    assert not any("verifier.md" in issue and "missing" in issue for issue in issues)
+    assert not any("parse error" in issue for issue in issues if "verifier" in issue)
+
+
+def test_check_task_reports_missing_verifier_spec(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    (task_dir / "environment").mkdir()
+    (task_dir / "verifier").mkdir()
+    (task_dir / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    (task_dir / "verifier" / "test.sh").write_text("exit 0\n")
+    (task_dir / "task.md").write_text(
+        """---
+agent:
+  timeout_sec: 120
+environment:
+  cpus: 1
+benchflow:
+  verifier:
+    spec: verifier/verifier.md
+---
+## prompt
+
+Solve it.
+"""
+    )
+
+    issues = check_task(task_dir)
+
+    assert any(
+        "benchflow.verifier.spec references missing file: verifier/verifier.md"
+        in issue
+        for issue in issues
+    )
+
+
+def test_task_loads_verifier_document_from_benchflow_spec() -> None:
+    task = Task(DOGFOOD_TASK_DIR)
+
+    assert task.verifier_document is not None
+    assert task.verifier_document.name == "verifier-package-reward-contract"
+    assert task.verifier_document.default_strategy == "deterministic"
+
+
+def test_task_rejects_invalid_verifier_spec(tmp_path: Path) -> None:
+    task_dir = tmp_path / "task"
+    task_dir.mkdir()
+    (task_dir / "environment").mkdir()
+    (task_dir / "verifier").mkdir()
+    (task_dir / "environment" / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    (task_dir / "verifier" / "test.sh").write_text("exit 0\n")
+    (task_dir / "verifier" / "verifier.md").write_text("not valid frontmatter\n")
+    (task_dir / "task.md").write_text(
+        """---
+agent:
+  timeout_sec: 120
+environment:
+  cpus: 1
+benchflow:
+  verifier:
+    spec: verifier/verifier.md
+---
+## prompt
+
+Solve it.
+"""
+    )
+
+    with pytest.raises(ValueError, match="parse error"):
+        Task(task_dir)
+
+
+def test_resolve_verifier_spec_path_is_task_relative() -> None:
+    spec_path = resolve_verifier_spec_path(
+        DOGFOOD_TASK_DIR,
+        "verifier/verifier.md",
+    )
+    assert spec_path == DOGFOOD_VERIFIER_MD.resolve()
+
+
+def _dogfood_benchflow_verifier() -> dict[str, object]:
+    from benchflow.task import TaskDocument
+
+    document = TaskDocument.from_path(DOGFOOD_TASK_DIR / "task.md")
+    benchflow = document.benchflow
+    assert isinstance(benchflow, dict)
+    verifier = benchflow.get("verifier")
+    assert isinstance(verifier, dict)
+    return verifier

--- a/tests/test_verifier_document.py
+++ b/tests/test_verifier_document.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -378,36 +378,115 @@ async def test_verify_logs_and_routes_deterministic_strategy_to_test_script(
     sandbox.upload_dir.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    ("default_strategy", "expected_type"),
-    [
-        ("rewardkit", "reward-kit"),
-        ("judge", "agent-judge"),
-    ],
-)
 @pytest.mark.asyncio
-async def test_verify_rejects_unsupported_verifier_document_strategies(
-    default_strategy: str,
-    expected_type: str,
+async def test_verify_routes_reward_kit_strategy_to_test_script(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Guards fail-closed routing for non-script verifier document strategies."""
+    """Guards reward-kit strategy execution via script verifier when criteria exist."""
     task = Task(DOGFOOD_TASK_DIR)
     document = task.verifier_document
     assert document is not None
-    task.verifier_document = replace(document, default_strategy=default_strategy)
+    task.verifier_document = replace(document, default_strategy="rewardkit")
 
-    rollout_paths = RolloutPaths(Path("/tmp/verifier-strategy-rollout"))
+    rollout_paths = RolloutPaths(tmp_path / "rewardkit-rollout")
     rollout_paths.mkdir()
 
     sandbox = MagicMock()
     sandbox.upload_dir = AsyncMock()
-    sandbox.exec = AsyncMock(side_effect=AssertionError("test.sh must not run"))
+    sandbox.is_mounted = True
+
+    async def exec_writes_reward(*_args: object, **_kwargs: object) -> MagicMock:
+        if sandbox.exec.await_count == 1:
+            return MagicMock(return_code=0, stdout="")
+        rollout_paths.reward_json_path.write_text('{"reward": 1.0, "reward_contract": 1.0}')
+        return MagicMock(return_code=0, stdout="")
+
+    sandbox.exec = AsyncMock(side_effect=exec_writes_reward)
+
+    with caplog.at_level("INFO"):
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+    assert result.rewards is not None
+    assert result.rewards["reward"] == 1.0
+    assert any(
+        "Selected verifier document strategy 'rewardkit' (type='reward-kit')"
+        in record.getMessage()
+        for record in caplog.records
+    )
+    sandbox.upload_dir.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_verify_routes_agent_judge_strategy_to_llm_judge(
+    tmp_path: Path,
+) -> None:
+    """Guards agent-judge strategy execution via verifier-scoped LLM judge."""
+    task = Task(DOGFOOD_TASK_DIR)
+    document = task.verifier_document
+    assert document is not None
+    task.verifier_document = replace(document, default_strategy="judge")
+
+    rollout_paths = RolloutPaths(tmp_path / "agent-judge-rollout")
+    rollout_paths.mkdir()
+    (rollout_paths.rollout_dir / "trajectory").mkdir(parents=True)
+    (rollout_paths.rollout_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
+        '{"type":"message","content":"agent output"}\n'
+    )
+
+    sandbox = MagicMock()
+    sandbox.upload_dir = AsyncMock()
+    sandbox.download_file = AsyncMock()
+
+    with patch(
+        "benchflow.rewards.builtins.LLMJudgeRewardFunc.score",
+        new=AsyncMock(return_value=0.75),
+    ) as mock_score:
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+    mock_score.assert_awaited_once()
+    assert result.rewards == {"reward": 0.75}
+    assert rollout_paths.reward_json_path.is_file()
+    sandbox.upload_dir.assert_not_called()
+    sandbox.exec.assert_not_called()
+
+
+def test_reward_kit_not_executable_without_criteria_or_entrypoint(
+    tmp_path: Path,
+) -> None:
+    """Guards reward-kit executability requires criteria or root test.sh."""
+    from benchflow.task.verifier_document import is_executable_reward_kit_strategy
+
+    strategy = {"type": "reward-kit", "root": "reward_kit/"}
+    assert is_executable_reward_kit_strategy(strategy, tmp_path) is False
+
+
+@pytest.mark.asyncio
+async def test_verify_rejects_non_executable_reward_kit_strategy(
+    tmp_path: Path,
+) -> None:
+    """Guards fail-closed routing when reward-kit strategy cannot execute."""
+    task = Task(DOGFOOD_TASK_DIR)
+    document = task.verifier_document
+    assert document is not None
+    task.verifier_document = replace(
+        document,
+        default_strategy="rewardkit",
+        strategies={
+            "rewardkit": {
+                "type": "reward-kit",
+                "root": "missing_reward_kit/",
+            }
+        },
+    )
+
+    rollout_paths = RolloutPaths(tmp_path / "missing-rewardkit")
+    rollout_paths.mkdir()
+    sandbox = MagicMock()
+    sandbox.upload_dir = AsyncMock()
 
     with pytest.raises(
         UnsupportedVerifierStrategyError,
-        match=rf"type={expected_type!r}.*not executable",
+        match=r"type='reward-kit'.*not executable",
     ):
         await Verifier(task, rollout_paths, sandbox).verify()
-
-    sandbox.upload_dir.assert_not_called()
-    sandbox.exec.assert_not_called()

--- a/tests/test_verifier_document.py
+++ b/tests/test_verifier_document.py
@@ -94,6 +94,125 @@ def test_verifier_document_issues_validate_dogfood_task() -> None:
     assert issues == []
 
 
+def test_verifier_document_issues_require_agent_judge_role_field(
+    tmp_path: Path,
+) -> None:
+    """Guards agent-judge strategy role field presence on dogfood verifier.md."""
+    task_dir = tmp_path / "task"
+    verifier_dir = task_dir / "verifier"
+    verifier_dir.mkdir(parents=True)
+    (verifier_dir / "rubrics").mkdir()
+    (verifier_dir / "rubrics" / "verifier.toml").write_text(
+        "[criterion]\nname = \"contract\"\n"
+    )
+    (verifier_dir / "reward_kit").mkdir()
+    verifier_text = DOGFOOD_VERIFIER_MD.read_text(encoding="utf-8").replace(
+        "      role: verifier_judge\n",
+        "",
+    )
+    (verifier_dir / "verifier.md").write_text(verifier_text, encoding="utf-8")
+
+    issues = verifier_document_issues(
+        task_dir,
+        benchflow_verifier={"spec": "verifier/verifier.md"},
+    )
+
+    assert issues == [
+        "verifier/verifier.md agent-judge strategy 'judge' is missing role"
+    ]
+
+
+def test_verifier_document_issues_require_agent_judge_role_prompt(
+    tmp_path: Path,
+) -> None:
+    """Guards agent-judge inline role prompt validation on dogfood verifier.md."""
+    task_dir = tmp_path / "task"
+    verifier_dir = task_dir / "verifier"
+    verifier_dir.mkdir(parents=True)
+    (verifier_dir / "rubrics").mkdir()
+    (verifier_dir / "rubrics" / "verifier.toml").write_text(
+        "[criterion]\nname = \"contract\"\n"
+    )
+    (verifier_dir / "reward_kit").mkdir()
+    verifier_text = DOGFOOD_VERIFIER_MD.read_text(encoding="utf-8").replace(
+        "role: verifier_judge",
+        "role: missing_judge",
+    )
+    (verifier_dir / "verifier.md").write_text(verifier_text, encoding="utf-8")
+
+    issues = verifier_document_issues(
+        task_dir,
+        benchflow_verifier={"spec": "verifier/verifier.md"},
+    )
+
+    assert issues == [
+        "verifier/verifier.md agent-judge strategy 'judge' references "
+        "unknown role prompt ## role:missing_judge"
+    ]
+
+
+def test_verifier_document_issues_require_agent_judge_role_file(
+    tmp_path: Path,
+) -> None:
+    """Guards agent-judge judges/*.md role file validation on dogfood verifier.md."""
+    task_dir = tmp_path / "task"
+    verifier_dir = task_dir / "verifier"
+    verifier_dir.mkdir(parents=True)
+    (verifier_dir / "rubrics").mkdir()
+    (verifier_dir / "rubrics" / "verifier.toml").write_text(
+        "[criterion]\nname = \"contract\"\n"
+    )
+    (verifier_dir / "reward_kit").mkdir()
+    verifier_text = DOGFOOD_VERIFIER_MD.read_text(encoding="utf-8").replace(
+        "role: verifier_judge",
+        "role: judges/reviewer.md",
+    )
+    (verifier_dir / "verifier.md").write_text(verifier_text, encoding="utf-8")
+
+    issues = verifier_document_issues(
+        task_dir,
+        benchflow_verifier={"spec": "verifier/verifier.md"},
+    )
+
+    assert issues == [
+        "verifier/verifier.md agent-judge strategy 'judge' references "
+        "missing role file: judges/reviewer.md"
+    ]
+
+
+def test_verifier_document_issues_accepts_agent_judge_role_file(
+    tmp_path: Path,
+) -> None:
+    """Guards agent-judge role file path resolution relative to verifier/."""
+    task_dir = tmp_path / "task"
+    verifier_dir = task_dir / "verifier"
+    verifier_dir.mkdir(parents=True)
+    (verifier_dir / "rubrics").mkdir()
+    (verifier_dir / "rubrics" / "verifier.toml").write_text(
+        "[criterion]\nname = \"contract\"\n"
+    )
+    (verifier_dir / "reward_kit").mkdir()
+    (verifier_dir / "judges").mkdir()
+    (verifier_dir / "judges" / "reviewer.md").write_text(
+        "Grade only declared deliverables.\n",
+        encoding="utf-8",
+    )
+    verifier_text = DOGFOOD_VERIFIER_MD.read_text(encoding="utf-8")
+    verifier_text = verifier_text.replace("role: verifier_judge", "role: judges/reviewer.md")
+    verifier_text = verifier_text.replace(
+        "## role:verifier_judge\n\nEvaluate only declared deliverables",
+        "",
+    )
+    (verifier_dir / "verifier.md").write_text(verifier_text, encoding="utf-8")
+
+    issues = verifier_document_issues(
+        task_dir,
+        benchflow_verifier={"spec": "verifier/verifier.md"},
+    )
+
+    assert issues == []
+
+
 def test_verifier_document_issues_require_reward_kit_root_directory(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_verifier_multi_container.py
+++ b/tests/test_verifier_multi_container.py
@@ -18,6 +18,8 @@ All tests are unit tests with mocked sandboxes — no Docker/Daytona infra.
 
 from __future__ import annotations
 
+import json
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -198,6 +200,47 @@ class TestTargetSideTestScriptVerification:
         details = rollout_paths.reward_details_path.read_text()
         assert '"criteria"' in details
         assert '"stale"' not in details
+
+    @pytest.mark.asyncio
+    async def test_reward_details_json_in_persisted_result_artifacts(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards task-standard F8 reward-details.json metadata in result.json."""
+        from benchflow.rollout import _build_rollout_result
+
+        toml = 'version = "1.0"\n[verifier]\nservice = "target"\n'
+        task = _make_task(tmp_path, toml)
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        sandbox = _RecordingSandbox(rollout_paths, reward="1.0")
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        _build_rollout_result(
+            rollout_paths.rollout_dir,
+            task_name="task",
+            rollout_name="run-1",
+            agent="oracle",
+            agent_name="oracle",
+            model=None,
+            n_tool_calls=0,
+            prompts=["solve"],
+            error=None,
+            verifier_error=None,
+            trajectory=[],
+            partial_trajectory=False,
+            rewards={"reward": 1.0},
+            started_at=datetime.now(),
+            timing={"verifier": 1.0},
+        )
+
+        result = json.loads(
+            (rollout_paths.rollout_dir / "result.json").read_text(encoding="utf-8")
+        )
+        assert rollout_paths.reward_details_path.is_file()
+        assert result["reward_details"]["path"] == "verifier/reward-details.json"
+        assert "criteria" in result["reward_details"]["content_preview"]
+        assert result["reward_details"]["top_level_keys"] == ["criteria"]
 
     @pytest.mark.asyncio
     async def test_target_service_logs_verifier_dir_created_before_test_sh(

--- a/tests/test_verifier_multi_container.py
+++ b/tests/test_verifier_multi_container.py
@@ -113,10 +113,13 @@ class _RecordingSandbox:
         self.download_calls.append(
             {"source": source_dir, "target": target_dir, "service": service}
         )
-        # Mimic a target-side test.sh that wrote a reward file.
+        # Mimic a target-side test.sh that wrote reward artifacts.
         dest = Path(target_dir)
         dest.mkdir(parents=True, exist_ok=True)
         (dest / "reward.txt").write_text(self._reward)
+        (dest / "reward-details.json").write_text(
+            '{"criteria": {"correctness": {"score": 1.0}}}'
+        )
 
     async def exec(self, command, service: str = "main", **kwargs) -> ExecResult:
         self.exec_calls.append({"command": command, "service": service, **kwargs})
@@ -177,6 +180,24 @@ class TestTargetSideTestScriptVerification:
 
         assert sandbox.download_calls, "reward must be downloaded from the target"
         assert {c["service"] for c in sandbox.download_calls} == {"target"}
+
+    @pytest.mark.asyncio
+    async def test_reward_details_json_preserved_on_verifier_download(
+        self, tmp_path: Path
+    ) -> None:
+        """Guards task-standard F8 reward-details.json copy-through on download."""
+        toml = 'version = "1.0"\n[verifier]\nservice = "target"\n'
+        task = _make_task(tmp_path, toml)
+        rollout_paths = RolloutPaths(rollout_dir=tmp_path / "rollout")
+        rollout_paths.mkdir()
+        rollout_paths.reward_details_path.write_text('{"stale": true}')
+        sandbox = _RecordingSandbox(rollout_paths, reward="1.0")
+
+        await Verifier(task, rollout_paths, sandbox).verify()
+
+        details = rollout_paths.reward_details_path.read_text()
+        assert '"criteria"' in details
+        assert '"stale"' not in details
 
     @pytest.mark.asyncio
     async def test_target_service_logs_verifier_dir_created_before_test_sh(

--- a/tests/test_verifier_strategy_smoke.py
+++ b/tests/test_verifier_strategy_smoke.py
@@ -1,0 +1,205 @@
+"""Integration smoke tests for verifier strategy routing on dogfood package."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from benchflow.rewards.validation import parse_verifier_reward_files
+from benchflow.task import RolloutPaths, Task, Verifier
+
+DOGFOOD_TASK_DIR = Path(
+    "docs/examples/task-standard/benchflow-wanted-features/"
+    "verifier-package-reward-contract"
+)
+DOGFOOD_VERIFIER_MD = DOGFOOD_TASK_DIR / "verifier" / "verifier.md"
+
+# Mirrors verifier/test.sh reward artifact shape for multi-metric parsing.
+DOGFOOD_MULTI_METRIC_REWARD_JSON = {
+    "reward": 1.0,
+    "items": {"verifier_document": 1.0, "reward_contract": 1.0},
+    "metadata": {"aggregate_policy": "reward"},
+}
+DOGFOOD_REWARD_DETAILS_JSON = {
+    "criteria": [
+        {
+            "id": "reward_contract",
+            "score": 1.0,
+            "reason": "rich reward artifacts preserved",
+        }
+    ]
+}
+
+
+def _dogfood_task_with_strategy(strategy_name: str) -> Task:
+    task = Task(DOGFOOD_TASK_DIR)
+    document = task.verifier_document
+    assert document is not None
+    task.verifier_document = replace(document, default_strategy=strategy_name)
+    return task
+
+
+def _mounted_sandbox_mock() -> MagicMock:
+    sandbox = MagicMock()
+    sandbox.upload_dir = AsyncMock()
+    sandbox.is_mounted = True
+    return sandbox
+
+
+def _exec_writes_dogfood_rewards(
+    sandbox: MagicMock,
+    rollout_paths: RolloutPaths,
+) -> AsyncMock:
+    async def exec_side_effect(*_args: object, **_kwargs: object) -> MagicMock:
+        if sandbox.exec.await_count == 1:
+            return MagicMock(return_code=0, stdout="")
+        rollout_paths.reward_text_path.write_text("1.0")
+        rollout_paths.reward_json_path.write_text(
+            json.dumps(DOGFOOD_MULTI_METRIC_REWARD_JSON)
+        )
+        rollout_paths.reward_details_path.write_text(
+            json.dumps(DOGFOOD_REWARD_DETAILS_JSON)
+        )
+        return MagicMock(return_code=0, stdout="")
+
+    return AsyncMock(side_effect=exec_side_effect)
+
+
+def test_dogfood_package_declares_three_executable_strategies() -> None:
+    """Guards verifier-package-reward-contract strategy surface for smoke routing."""
+    from benchflow.task.verifier_document import (
+        is_executable_agent_judge_strategy,
+        is_executable_reward_kit_strategy,
+        is_executable_script_strategy,
+        resolve_default_strategy,
+    )
+
+    task = Task(DOGFOOD_TASK_DIR)
+    document = task.verifier_document
+    assert document is not None
+    verifier_dir = DOGFOOD_TASK_DIR / "verifier"
+
+    assert document.default_strategy == "deterministic"
+    assert set(document.strategies) == {"deterministic", "rewardkit", "judge"}
+
+    _, deterministic = resolve_default_strategy(document)
+    assert is_executable_script_strategy(deterministic)
+
+    _, rewardkit = resolve_default_strategy(
+        replace(document, default_strategy="rewardkit")
+    )
+    assert is_executable_reward_kit_strategy(rewardkit, verifier_dir)
+
+    _, judge = resolve_default_strategy(replace(document, default_strategy="judge"))
+    assert is_executable_agent_judge_strategy(judge, document, verifier_dir)
+
+
+def test_dogfood_multi_metric_reward_json_parses_with_explicit_aggregate(
+    tmp_path: Path,
+) -> None:
+    """Guards dogfood test.sh reward.json shape through verifier reward parsing."""
+    from benchflow.rewards.validation import validate_reward_map
+
+    reward_json_path = tmp_path / "reward.json"
+    reward_text_path = tmp_path / "reward.txt"
+    reward_json_path.write_text(json.dumps(DOGFOOD_MULTI_METRIC_REWARD_JSON))
+    reward_text_path.write_text("1.0")
+
+    parsed = parse_verifier_reward_files(
+        reward_text_path=reward_text_path,
+        reward_json_path=reward_json_path,
+        source="reward JSON",
+    )
+    assert parsed["reward"] == 1.0
+    assert parsed["items"] == DOGFOOD_MULTI_METRIC_REWARD_JSON["items"]
+    assert parsed["metadata"] == DOGFOOD_MULTI_METRIC_REWARD_JSON["metadata"]
+
+    validated = validate_reward_map(DOGFOOD_MULTI_METRIC_REWARD_JSON, source="verifier")
+    assert validated["reward"] == parsed["reward"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("strategy_name", ["deterministic", "rewardkit"])
+async def test_script_strategies_route_to_test_script_and_parse_multi_metric_rewards(
+    tmp_path: Path,
+    strategy_name: str,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Guards script and reward-kit strategy routing on dogfood verifier package."""
+    task = _dogfood_task_with_strategy(strategy_name)
+    rollout_paths = RolloutPaths(tmp_path / f"{strategy_name}-rollout")
+    rollout_paths.mkdir()
+
+    sandbox = _mounted_sandbox_mock()
+    sandbox.exec = _exec_writes_dogfood_rewards(sandbox, rollout_paths)
+
+    with caplog.at_level("INFO"):
+        result = await Verifier(task, rollout_paths, sandbox).verify()
+
+    assert result.rewards is not None
+    assert result.rewards["reward"] == 1.0
+    assert result.rewards["items"] == DOGFOOD_MULTI_METRIC_REWARD_JSON["items"]
+    assert result.rewards["metadata"] == DOGFOOD_MULTI_METRIC_REWARD_JSON["metadata"]
+    assert rollout_paths.reward_json_path.is_file()
+    assert json.loads(rollout_paths.reward_json_path.read_text()) == (
+        DOGFOOD_MULTI_METRIC_REWARD_JSON
+    )
+
+    expected_type = "script" if strategy_name == "deterministic" else "reward-kit"
+    assert any(
+        f"Selected verifier document strategy {strategy_name!r} (type={expected_type!r})"
+        in record.getMessage()
+        for record in caplog.records
+    )
+    sandbox.upload_dir.assert_called_once()
+    assert sandbox.exec.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_judge_strategy_routes_to_mocked_llm_judge(tmp_path: Path) -> None:
+    """Guards agent-judge strategy routing without live LLM calls."""
+    task = _dogfood_task_with_strategy("judge")
+    rollout_paths = RolloutPaths(tmp_path / "judge-rollout")
+    rollout_paths.mkdir()
+    trajectory_dir = rollout_paths.rollout_dir / "trajectory"
+    trajectory_dir.mkdir(parents=True)
+    (trajectory_dir / "acp_trajectory.jsonl").write_text(
+        '{"type":"message","content":"agent output"}\n'
+    )
+
+    sandbox = MagicMock()
+    sandbox.upload_dir = AsyncMock()
+    sandbox.download_file = AsyncMock()
+
+    document = task.verifier_document
+    assert document is not None
+
+    with patch(
+        "benchflow.rewards.builtins.LLMJudgeRewardFunc.score",
+        new=AsyncMock(return_value=0.82),
+    ) as mock_score:
+        with patch(
+            "benchflow.rewards.builtins.LLMJudgeRewardFunc",
+            wraps=__import__(
+                "benchflow.rewards.builtins", fromlist=["LLMJudgeRewardFunc"]
+            ).LLMJudgeRewardFunc,
+        ) as mock_judge_cls:
+            result = await Verifier(task, rollout_paths, sandbox).verify()
+
+    mock_judge_cls.assert_called_once()
+    judge_kwargs = mock_judge_cls.call_args.kwargs
+    assert judge_kwargs["prompt"] == document.role_prompts["verifier_judge"]
+    assert judge_kwargs["judge_errors_are_infra"] is True
+    assert str(judge_kwargs["rubric_path"]).endswith("rubrics/verifier.toml")
+
+    mock_score.assert_awaited_once()
+    assert result.rewards == {"reward": 0.82}
+    assert rollout_paths.reward_json_path.is_file()
+    assert json.loads(rollout_paths.reward_json_path.read_text()) == {"reward": 0.82}
+
+    sandbox.upload_dir.assert_not_called()
+    sandbox.exec.assert_not_called()

--- a/tests/test_verifier_strategy_smoke.py
+++ b/tests/test_verifier_strategy_smoke.py
@@ -178,17 +178,19 @@ async def test_judge_strategy_routes_to_mocked_llm_judge(tmp_path: Path) -> None
     document = task.verifier_document
     assert document is not None
 
-    with patch(
-        "benchflow.rewards.builtins.LLMJudgeRewardFunc.score",
-        new=AsyncMock(return_value=0.82),
-    ) as mock_score:
-        with patch(
+    with (
+        patch(
+            "benchflow.rewards.builtins.LLMJudgeRewardFunc.score",
+            new=AsyncMock(return_value=0.82),
+        ) as mock_score,
+        patch(
             "benchflow.rewards.builtins.LLMJudgeRewardFunc",
             wraps=__import__(
                 "benchflow.rewards.builtins", fromlist=["LLMJudgeRewardFunc"]
             ).LLMJudgeRewardFunc,
-        ) as mock_judge_cls:
-            result = await Verifier(task, rollout_paths, sandbox).verify()
+        ) as mock_judge_cls,
+    ):
+        result = await Verifier(task, rollout_paths, sandbox).verify()
 
     mock_judge_cls.assert_called_once()
     judge_kwargs = mock_judge_cls.call_args.kwargs

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -229,7 +229,6 @@ class TestSdkVerify:
         "rewards",
         [
             {},
-            {"score": 1.0},
             {"reward": float("nan")},
             {"reward": float("inf")},
             {"reward": True},
@@ -257,9 +256,37 @@ class TestSdkVerify:
                 env, task, tp, timing
             )
         assert parsed_rewards is None
-        assert "without numeric 'reward'" in verifier_error
+        assert verifier_error is not None
+        assert (
+            "missing numeric 'reward'" in verifier_error
+            or "invalid reward value" in verifier_error
+        )
         assert "verifier" in timing
         assert vti is None
+
+    @pytest.mark.asyncio
+    async def test_verifier_accepts_multi_metric_score_only_reward(
+        self, verify_harness
+    ):
+        """Guards Harbor Reward Kit multi-metric maps that synthesize canonical reward."""
+        sdk, env, task, tp = verify_harness
+        mock_result = MagicMock()
+        mock_result.rewards = {"score": 1.0}
+        mock_v = MagicMock()
+        mock_v.verify = AsyncMock(return_value=mock_result)
+        timing = {}
+        with (
+            patch("benchflow.task.Verifier", return_value=mock_v),
+            patch(
+                "benchflow.sandbox.lockdown.harden_before_verify",
+                new_callable=AsyncMock,
+            ),
+        ):
+            parsed_rewards, verifier_error, vti = await sdk._verify(
+                env, task, tp, timing
+            )
+        assert verifier_error is None
+        assert parsed_rewards == {"reward": 1.0, "score": 1.0}
 
     @patch("benchflow.rewards.llm.call_judge", new_callable=AsyncMock)
     @pytest.mark.asyncio

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -282,7 +282,7 @@ class TestSdkVerify:
                 new_callable=AsyncMock,
             ),
         ):
-            parsed_rewards, verifier_error, vti = await sdk._verify(
+            parsed_rewards, verifier_error, _vti = await sdk._verify(
                 env, task, tp, timing
             )
         assert verifier_error is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Task-standard runtime implementation on `handoff/task-standard-teaching-2026-06-05`, verified against **real dogfood packages** with subagent-driven test + verify passes.

### Real task verification (dogfood packages)

| Task | `check` | docker | modal | Notes |
|------|---------|--------|-------|-------|
| verifier-package-reward-contract | ✓ | ✓ | ✓ | Verifier strategies smoke-tested |
| prompt-user-semantics | ✓ | ✓ | ✓ | Multi-scene user-loop + branchable nudges |
| compat-export-loss-reports | ✓ | ✓ | ✓ | round-trip parity OK |
| runtime-capability-gate | ✓ | ✗ | ✗ | **Expected** — `environment.healthcheck` fail-closed |

**Docker real verifier runs** (repo mounted at `/repo`): verifier-package-reward-contract **99 passed**, prompt-user-semantics **39 passed**, compat-export-loss-reports **82 passed** — see `tests/fixtures/docker_dogfood_smoke_report.md`.

### Landed this session

- P3 typed `benchflow:` subset + `bench tasks check` validation
- Verifier strategy execution: script, reward-kit, agent-judge
- `environment.workdir` on **docker + modal** (compose overlay + exec defaults)
- Multi-scene user-loop auto-wiring + **branchable nudges** gate
- `bench tasks round-trip`, modal capability gates
- Integration tests: `test_dogfood_cli_integration.py`, `test_verifier_strategy_smoke.py`, `test_task_standard_rollout_smoke.py`

### Still open

- `environment.healthcheck` execution
- daytona `workdir`
- ORS/hybrid verifier strategies
- K8s/podman capability matrices
- Full `benchflow:` namespace (teams, evidence, runtime_policy)

### Tests

**2883 passed**, 55 skipped — full suite + ruff + ty clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f1fb0f4-58f2-4a14-9be0-6d4150fae453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f1fb0f4-58f2-4a14-9be0-6d4150fae453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

