### PR TITLE
fix(openhands): override buggy openhands-sdk 1.21.0 pin causing Opus 4.8 timeouts

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -566,7 +566,20 @@ AGENTS: dict[str, AgentConfig] = {
             "    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 && "
             '    export PATH="$HOME/.local/bin:$PATH"; '
             "  fi && "
+            # Pin openhands-sdk/tools past 1.21.0. That single release makes
+            # OpenHands' synthetic `security_risk` tool field *required*: the ACP
+            # path always attaches an LLMSecurityAnalyzer (even under
+            # --always-approve, where its verdict is discarded), so any model that
+            # omits the field hits a fatal "Failed to provide security_risk field"
+            # error that is fed back and retried in a loop until the run times out.
+            # Claude Opus omits it reliably (esp. with thinking), so opus-4.8 runs
+            # time out where other models pass. Fixed in sdk 1.22.0 (#3126: field
+            # optional, defaults to UNKNOWN); OpenHands-CLI @main still pins
+            # 1.21.0, so override the transitive pin to the fixed line.
+            "printf 'openhands-sdk>=1.22.0\\nopenhands-tools>=1.22.0\\n' "
+            "> /tmp/oh-sdk-overrides.txt && "
             "uv tool install --force --refresh "
+            "--overrides /tmp/oh-sdk-overrides.txt "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12 && "
             "  uv tool list | grep -q '^openhands\\b' ) && "

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -106,6 +106,9 @@ def _apt_install(*packages: str) -> str:
 _BENCHFLOW_NODE_PREFIX = "/opt/benchflow/node"
 _BENCHFLOW_JS_AGENT_PREFIX = "/opt/benchflow/js-agents"
 _BENCHFLOW_BIN_PREFIX = "/opt/benchflow/bin"
+_OPENHANDS_CLI_VERSION = "1.16.0"
+_OPENHANDS_SDK_VERSION = "1.22.1"
+_OPENHANDS_TOOLS_VERSION = "1.22.1"
 _JS_AGENT_PATH = (
     f"{_BENCHFLOW_BIN_PREFIX}:{_BENCHFLOW_JS_AGENT_PREFIX}/bin:"
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
@@ -543,15 +546,15 @@ AGENTS: dict[str, AgentConfig] = {
         install_cmd=(
             "export DEBIAN_FRONTEND=noninteractive && "
             'export PATH="$HOME/.local/bin:$PATH" && '
-            "( command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 || "
+            "( command -v curl >/dev/null 2>&1 || "
             "  if command -v apt-get >/dev/null 2>&1; then "
-            f"    {_apt_install('curl', 'ca-certificates', 'git')}; "
+            f"    {_apt_install('curl', 'ca-certificates')}; "
             "  elif command -v dnf >/dev/null 2>&1; then "
-            "    dnf -y --allowerasing install curl ca-certificates git >/dev/null 2>&1; "
+            "    dnf -y --allowerasing install curl ca-certificates >/dev/null 2>&1; "
             "  elif command -v apk >/dev/null 2>&1; then "
-            "    apk add --no-cache curl ca-certificates git >/dev/null 2>&1; "
+            "    apk add --no-cache curl ca-certificates >/dev/null 2>&1; "
             "  else "
-            "    echo 'OpenHands GitHub install requires curl and git' >&2; "
+            "    echo 'OpenHands install requires curl' >&2; "
             "    exit 127; "
             "  fi ) && "
             "( UV_OK=0; "
@@ -566,22 +569,18 @@ AGENTS: dict[str, AgentConfig] = {
             "    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 && "
             '    export PATH="$HOME/.local/bin:$PATH"; '
             "  fi && "
-            # Pin openhands-sdk/tools past 1.21.0. That single release makes
-            # OpenHands' synthetic `security_risk` tool field *required*: the ACP
-            # path always attaches an LLMSecurityAnalyzer (even under
-            # --always-approve, where its verdict is discarded), so any model that
-            # omits the field hits a fatal "Failed to provide security_risk field"
-            # error that is fed back and retried in a loop until the run times out.
-            # Claude Opus omits it reliably (esp. with thinking), so opus-4.8 runs
-            # time out where other models pass. Fixed in sdk 1.22.0 (#3126: field
-            # optional, defaults to UNKNOWN); OpenHands-CLI @main still pins
-            # 1.21.0, so override the transitive pin to the fixed line.
-            "printf 'openhands-sdk>=1.22.0\\nopenhands-tools>=1.22.0\\n' "
+            # OpenHands CLI 1.16.0 pins openhands-sdk/tools 1.21.0. That one
+            # SDK release makes the synthetic `security_risk` tool field
+            # required whenever LLMSecurityAnalyzer is attached; the ACP path
+            # attaches it even under --always-approve, so Claude Opus can loop
+            # on validation errors until timeout. 1.22.x restores the intended
+            # default-to-UNKNOWN behavior without the API drift seen in 1.26.x.
+            f"printf 'openhands-sdk=={_OPENHANDS_SDK_VERSION}\\n"
+            f"openhands-tools=={_OPENHANDS_TOOLS_VERSION}\\n' "
             "> /tmp/oh-sdk-overrides.txt && "
             "uv tool install --force --refresh "
             "--overrides /tmp/oh-sdk-overrides.txt "
-            "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
-            "openhands --python 3.12 && "
+            f"openhands=={_OPENHANDS_CLI_VERSION} --python 3.12 && "
             "  uv tool list | grep -q '^openhands\\b' ) && "
             # Let sandbox user traverse to uv-managed Python interpreter path.
             "chmod o+x /root /root/.local /root/.local/share "

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -107,11 +107,25 @@ class TestOpenHandsConfig:
         )
         assert (
             "uv tool install --force --refresh "
+            "--overrides /tmp/oh-sdk-overrides.txt "
             "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
             "openhands --python 3.12" in cfg.install_cmd
         )
         assert "command -v git" in cfg.install_cmd
         assert "install.openhands.dev/install.sh" not in cfg.install_cmd
+
+    def test_openhands_install_cmd_overrides_buggy_sdk_pin(self):
+        """sdk 1.21.0 makes `security_risk` required → Opus times out; force >=1.22.0.
+
+        OpenHands-CLI @main pins openhands-sdk==1.21.0, the one release where the
+        synthetic `security_risk` tool field is required. Models that omit it (Claude
+        Opus) loop on "Failed to provide security_risk field" until timeout. The fix
+        (#3126) landed in 1.22.0, so the install overrides the transitive pin.
+        """
+        cfg = AGENTS["openhands"]
+        assert "openhands-sdk>=1.22.0" in cfg.install_cmd
+        assert "openhands-tools>=1.22.0" in cfg.install_cmd
+        assert "--overrides /tmp/oh-sdk-overrides.txt" in cfg.install_cmd
 
     def test_openhands_install_cmd_does_not_deploy_bedrock_shim(self):
         """Guards the LiteLLM runtime refactor: Bedrock patches live with LiteLLM."""

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -99,32 +99,27 @@ class TestOpenHandsConfig:
         assert "$HOME/.agents/skills" in cfg.skill_paths
         assert "$WORKSPACE/.agents/skills" in cfg.skill_paths
 
-    def test_openhands_install_cmd_forces_github_main(self):
+    def test_openhands_install_cmd_pins_stable_pypi_release(self):
         cfg = AGENTS["openhands"]
         assert (
-            "apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates git"
+            "apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates"
             in cfg.install_cmd
         )
         assert (
             "uv tool install --force --refresh "
             "--overrides /tmp/oh-sdk-overrides.txt "
-            "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
-            "openhands --python 3.12" in cfg.install_cmd
+            "openhands==1.16.0 --python 3.12" in cfg.install_cmd
         )
-        assert "command -v git" in cfg.install_cmd
+        assert "OpenHands/OpenHands-CLI.git@main" not in cfg.install_cmd
         assert "install.openhands.dev/install.sh" not in cfg.install_cmd
 
     def test_openhands_install_cmd_overrides_buggy_sdk_pin(self):
-        """sdk 1.21.0 makes `security_risk` required → Opus times out; force >=1.22.0.
-
-        OpenHands-CLI @main pins openhands-sdk==1.21.0, the one release where the
-        synthetic `security_risk` tool field is required. Models that omit it (Claude
-        Opus) loop on "Failed to provide security_risk field" until timeout. The fix
-        (#3126) landed in 1.22.0, so the install overrides the transitive pin.
-        """
+        """Guards PR #644 against Opus timeouts from OpenHands SDK 1.21.0."""
         cfg = AGENTS["openhands"]
-        assert "openhands-sdk>=1.22.0" in cfg.install_cmd
-        assert "openhands-tools>=1.22.0" in cfg.install_cmd
+
+        assert "openhands-sdk==1.22.1" in cfg.install_cmd
+        assert "openhands-tools==1.22.1" in cfg.install_cmd
+        assert "openhands-sdk>=1.22.0" not in cfg.install_cmd
         assert "--overrides /tmp/oh-sdk-overrides.txt" in cfg.install_cmd
 
     def test_openhands_install_cmd_does_not_deploy_bedrock_shim(self):

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -637,6 +637,7 @@ async def test_install_agent_writes_command_stdout_and_stderr_on_failure(
     assert log_text.startswith("$ ")
     assert (
         "uv tool install --force --refresh "
+        "--overrides /tmp/oh-sdk-overrides.txt "
         "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
         "openhands --python 3.12" in log_text
     )

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -638,8 +638,7 @@ async def test_install_agent_writes_command_stdout_and_stderr_on_failure(
     assert (
         "uv tool install --force --refresh "
         "--overrides /tmp/oh-sdk-overrides.txt "
-        "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@main' "
-        "openhands --python 3.12" in log_text
+        "openhands==1.16.0 --python 3.12" in log_text
     )
     assert "=== stderr ===" in log_text
     assert "uv: command not found" in log_text


### PR DESCRIPTION
## Root cause

Opus 4.8 runs through OpenHands time out far more than other models. Many timeout trajectories contain the same failed step:

```
Error validating tool 'file_editor': Failed to provide security_risk field
in tool 'file_editor'. Parameters provided: ['command', 'path']
```

Traced to a one-release upstream bug:

1. OpenHands CLI 1.16.0 pins `openhands-sdk==1.21.0` and `openhands-tools==1.21.0`.
2. In SDK v1.21.0, `Agent._extract_security_risk` raises when an `LLMSecurityAnalyzer` is attached and the model omits the synthetic `security_risk` field. This was fixed in SDK v1.22.0 by OpenHands/software-agent-sdk#3126, which makes the field optional and defaults it to `UNKNOWN`.
3. The CLI ACP path attaches `LLMSecurityAnalyzer()` even under `--always-approve`, so the analyzer verdict is not used but its synthetic field is still enforced.
4. Claude Opus frequently omits that field, especially with extended/adaptive thinking, causing validation-error retry loops until the run times out.

## Fix

Install the stable PyPI CLI release `openhands==1.16.0` instead of GitHub `main`, and override the CLI's transitive SDK/tool pins to the verified compatible fixed line:

```
openhands-sdk==1.22.1
openhands-tools==1.22.1
```

Why exact `1.22.1` instead of `>=1.22.0`: as of 2026-06-08, `>=1.22.0` resolves to `1.26.0`; that version changes the tools API enough that OpenHands CLI 1.16.0 fails to import (`DelegateTool`). The `1.22.1` pair is the smallest fixed drift from the CLI's original 1.21.0 target and was verified locally with `openhands --version`, `openhands acp --help`, and package metadata inspection.

## Test

Local unit/static checks:

- `uv tool install --force --refresh --overrides <file> openhands==1.16.0 --python 3.12`
- `OPENHANDS_SUPPRESS_BANNER=1 openhands --version`
- `OPENHANDS_SUPPRESS_BANNER=1 openhands acp --help`
- `uv run --extra dev python -m pytest tests/test_agent_registry.py tests/test_agent_setup.py`
- `uv run --extra dev ruff check src/benchflow/agents/registry.py tests/test_agent_registry.py tests/test_agent_setup.py`
- `uv run --extra dev ty check src/`
- `uv run --extra dev python -m pytest tests/`

End-to-end canaries against SkillsBench snapshot `a8eefb4fdd9122c1821bad1db9fd361a3e074ec8`:

- `openhands` + Docker + Anthropic Haiku, `dialogue-parser`, no-skill: PASS, `reward=1.0`, no `security_risk` validator errors.
- `openhands` + Docker + Anthropic Haiku, `dialogue-parser`, with-skill: PASS, `reward=1.0`, task skill catalog recovered with `task_skills_loading=1`, no `security_risk` validator errors.
- Raw Bedrock Converse with `Authorization: Bearer $AWS_BEARER_TOKEN_BEDROCK`, region `us-west-2`, model `us.anthropic.claude-opus-4-8`: HTTP 200.
- `openhands` + Docker + Bedrock Opus 4.8 with `BENCHFLOW_BEDROCK_THINKING_EFFORT=max`, `offer-letter-generator`, with-skill: PASS, `reward=1.0`, `usage_tracking=required`, provider usage recorded, task skill catalog recovered with `task_skills_loading=1`, no `security_risk` validator errors. `llm_trajectory.jsonl` records `reasoning_effort: max` on all Bedrock requests.
- A harder Bedrock Opus 4.8 MAX `dialogue-parser` with-skill run completed cleanly with `errors=0` and no `security_risk` validator errors but scored `reward=0.0`; this is a model/task failure, not the OpenHands SDK validator loop.

CI on this PR: `test` and `pip-audit` pass.

_This PR description update was generated by an AI agent on behalf of Bingran._
