### PR TITLE
fix(daytona): make PTY idle timeout configurable

### DIFF
--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -24,6 +24,27 @@ _BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB readline buffer
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stderr in error messages
 _BOOTSTRAP_DONE = "__BENCHFLOW_BOOTSTRAP_DONE__"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DAYTONA_PTY_READLINE_TIMEOUT_ENV = "BENCHFLOW_DAYTONA_PTY_READLINE_TIMEOUT"
+_DAYTONA_PTY_READLINE_TIMEOUT_DEFAULT_SEC = 900.0
+
+
+def _daytona_pty_readline_timeout_sec() -> float:
+    value = os.environ.get(_DAYTONA_PTY_READLINE_TIMEOUT_ENV)
+    if value is None:
+        return _DAYTONA_PTY_READLINE_TIMEOUT_DEFAULT_SEC
+    try:
+        timeout = float(value)
+    except ValueError:
+        logger.warning(
+            "Invalid %s=%r; using default %.0fs",
+            _DAYTONA_PTY_READLINE_TIMEOUT_ENV,
+            value,
+            _DAYTONA_PTY_READLINE_TIMEOUT_DEFAULT_SEC,
+        )
+        return _DAYTONA_PTY_READLINE_TIMEOUT_DEFAULT_SEC
+    if timeout <= 0:
+        return _DAYTONA_PTY_READLINE_TIMEOUT_DEFAULT_SEC
+    return timeout
 
 
 async def _cleanup_daytona_remote_env_file(
@@ -790,11 +811,12 @@ class DaytonaPtyProcess(LiveProcess):
                     raw_message=msg, transport_diagnosis="pty_error"
                 ),
             )
+        timeout = _daytona_pty_readline_timeout_sec()
         try:
-            line = await asyncio.wait_for(self._line_buffer.get(), timeout=900)
+            line = await asyncio.wait_for(self._line_buffer.get(), timeout=timeout)
             return line
         except TimeoutError as e:
-            msg = "PTY readline timeout (900s)"
+            msg = f"PTY readline timeout ({timeout:g}s)"
             raise TransportClosedError(
                 msg,
                 TransportClosedDiagnostic(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -712,6 +712,56 @@ class TestDaytonaPtyProcessSecretTransport:
         assert "secret" not in calls[1].args[0]
 
     @pytest.mark.asyncio
+    async def test_pty_readline_timeout_uses_default_when_env_is_missing(
+        self, monkeypatch
+    ):
+        """Guards the fix for the Daytona PTY timeout issue seen at cb65fe8."""
+        from benchflow.diagnostics import TransportClosedError
+
+        monkeypatch.delenv("BENCHFLOW_DAYTONA_PTY_READLINE_TIMEOUT", raising=False)
+        sandbox, _ptys = _make_daytona_pty_sandbox()
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+
+        async def fake_wait_for(awaitable, *, timeout):
+            awaitable.close()
+            raise TimeoutError
+
+        with (
+            patch("asyncio.wait_for", side_effect=fake_wait_for) as wait_for,
+            pytest.raises(TransportClosedError) as exc_info,
+        ):
+            await proc.readline()
+
+        assert wait_for.call_args.kwargs["timeout"] == 900.0
+        assert exc_info.value.diagnostic.raw_message == "PTY readline timeout (900s)"
+        assert exc_info.value.diagnostic.transport_diagnosis == "pty_error"
+
+    @pytest.mark.asyncio
+    async def test_pty_readline_timeout_can_be_extended_for_long_agent_thinking(
+        self, monkeypatch
+    ):
+        """Guards the fix for the Daytona PTY timeout issue seen at cb65fe8."""
+        from benchflow.diagnostics import TransportClosedError
+
+        monkeypatch.setenv("BENCHFLOW_DAYTONA_PTY_READLINE_TIMEOUT", "0.01")
+        sandbox, _ptys = _make_daytona_pty_sandbox()
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="docker compose -p test",
+        )
+
+        with pytest.raises(TransportClosedError) as exc_info:
+            await proc.readline()
+
+        assert exc_info.value.diagnostic.raw_message == "PTY readline timeout (0.01s)"
+        assert exc_info.value.diagnostic.transport_diagnosis == "pty_error"
+
+    @pytest.mark.asyncio
     async def test_bootstrapped_env_file_is_removed_when_pty_bootstrap_marker_missing(
         self,
     ):


### PR DESCRIPTION
## Summary
- Add BENCHFLOW_DAYTONA_PTY_READLINE_TIMEOUT so long silent Daytona PTY agent turns can outlive the previous hard-coded 900s transport timeout.
- Preserve the 900s default when the env var is unset or invalid.
- Cover the default and override paths in Daytona PTY process tests.

## Test Plan
- UV_PYTHON=/opt/homebrew/bin/python3.12 uv run python -m pytest tests/test_process.py -k "pty_readline_timeout" -vv
- UV_PYTHON=/opt/homebrew/bin/python3.12 uv run ruff check src/benchflow/sandbox/process.py tests/test_process.py
- UV_PYTHON=/opt/homebrew/bin/python3.12 uv run ty check src/benchflow/sandbox/process.py

## Notes
This is needed for long SkillsBench Daytona/OpenHands runs where the agent can think or execute silently for longer than 900s while the task-level timeout is intentionally higher.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/646" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->