### PR TITLE
fix(openhands): pin CLI source revision

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -106,7 +106,7 @@ def _apt_install(*packages: str) -> str:
 _BENCHFLOW_NODE_PREFIX = "/opt/benchflow/node"
 _BENCHFLOW_JS_AGENT_PREFIX = "/opt/benchflow/js-agents"
 _BENCHFLOW_BIN_PREFIX = "/opt/benchflow/bin"
-_OPENHANDS_CLI_VERSION = "1.16.0"
+_OPENHANDS_CLI_GIT_REV = "3ca17446c5d9c1e35e054803478a3501ec251ecf"
 _OPENHANDS_SDK_VERSION = "1.22.1"
 _OPENHANDS_TOOLS_VERSION = "1.22.1"
 _JS_AGENT_PATH = (
@@ -546,15 +546,15 @@ AGENTS: dict[str, AgentConfig] = {
         install_cmd=(
             "export DEBIAN_FRONTEND=noninteractive && "
             'export PATH="$HOME/.local/bin:$PATH" && '
-            "( command -v curl >/dev/null 2>&1 || "
+            "( command -v curl >/dev/null 2>&1 && command -v git >/dev/null 2>&1 || "
             "  if command -v apt-get >/dev/null 2>&1; then "
-            f"    {_apt_install('curl', 'ca-certificates')}; "
+            f"    {_apt_install('curl', 'ca-certificates', 'git')}; "
             "  elif command -v dnf >/dev/null 2>&1; then "
-            "    dnf -y --allowerasing install curl ca-certificates >/dev/null 2>&1; "
+            "    dnf -y --allowerasing install curl ca-certificates git >/dev/null 2>&1; "
             "  elif command -v apk >/dev/null 2>&1; then "
-            "    apk add --no-cache curl ca-certificates >/dev/null 2>&1; "
+            "    apk add --no-cache curl ca-certificates git >/dev/null 2>&1; "
             "  else "
-            "    echo 'OpenHands install requires curl' >&2; "
+            "    echo 'OpenHands GitHub install requires curl and git' >&2; "
             "    exit 127; "
             "  fi ) && "
             "( UV_OK=0; "
@@ -569,18 +569,18 @@ AGENTS: dict[str, AgentConfig] = {
             "    curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 && "
             '    export PATH="$HOME/.local/bin:$PATH"; '
             "  fi && "
-            # OpenHands CLI 1.16.0 pins openhands-sdk/tools 1.21.0. That one
-            # SDK release makes the synthetic `security_risk` tool field
-            # required whenever LLMSecurityAnalyzer is attached; the ACP path
-            # attaches it even under --always-approve, so Claude Opus can loop
-            # on validation errors until timeout. 1.22.x restores the intended
-            # default-to-UNKNOWN behavior without the API drift seen in 1.26.x.
+            # Pin the OpenHands CLI source so the agent workflow cannot drift
+            # with GitHub main; only override the buggy sdk/tools 1.21.0 pins.
+            # SDK 1.22.x restores default-to-UNKNOWN for the synthetic
+            # `security_risk` tool field without the API drift seen in 1.26.x.
             f"printf 'openhands-sdk=={_OPENHANDS_SDK_VERSION}\\n"
             f"openhands-tools=={_OPENHANDS_TOOLS_VERSION}\\n' "
             "> /tmp/oh-sdk-overrides.txt && "
             "uv tool install --force --refresh "
             "--overrides /tmp/oh-sdk-overrides.txt "
-            f"openhands=={_OPENHANDS_CLI_VERSION} --python 3.12 && "
+            "--from "
+            f"'git+https://github.com/OpenHands/OpenHands-CLI.git@{_OPENHANDS_CLI_GIT_REV}' "
+            "openhands --python 3.12 && "
             "  uv tool list | grep -q '^openhands\\b' ) && "
             # Let sandbox user traverse to uv-managed Python interpreter path.
             "chmod o+x /root /root/.local /root/.local/share "

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -99,18 +99,23 @@ class TestOpenHandsConfig:
         assert "$HOME/.agents/skills" in cfg.skill_paths
         assert "$WORKSPACE/.agents/skills" in cfg.skill_paths
 
-    def test_openhands_install_cmd_pins_stable_pypi_release(self):
+    def test_openhands_install_cmd_pins_cli_git_revision(self):
         cfg = AGENTS["openhands"]
         assert (
-            "apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates"
+            "apt-get -o Acquire::Retries=3 install -y -qq curl ca-certificates git"
             in cfg.install_cmd
         )
         assert (
             "uv tool install --force --refresh "
             "--overrides /tmp/oh-sdk-overrides.txt "
-            "openhands==1.16.0 --python 3.12" in cfg.install_cmd
+            "--from "
+            "'git+https://github.com/OpenHands/OpenHands-CLI.git@"
+            "3ca17446c5d9c1e35e054803478a3501ec251ecf' "
+            "openhands --python 3.12" in cfg.install_cmd
         )
         assert "OpenHands/OpenHands-CLI.git@main" not in cfg.install_cmd
+        assert "openhands==1.16.0" not in cfg.install_cmd
+        assert "command -v git" in cfg.install_cmd
         assert "install.openhands.dev/install.sh" not in cfg.install_cmd
 
     def test_openhands_install_cmd_overrides_buggy_sdk_pin(self):

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -638,7 +638,9 @@ async def test_install_agent_writes_command_stdout_and_stderr_on_failure(
     assert (
         "uv tool install --force --refresh "
         "--overrides /tmp/oh-sdk-overrides.txt "
-        "openhands==1.16.0 --python 3.12" in log_text
+        "--from 'git+https://github.com/OpenHands/OpenHands-CLI.git@"
+        "3ca17446c5d9c1e35e054803478a3501ec251ecf' "
+        "openhands --python 3.12" in log_text
     )
     assert "=== stderr ===" in log_text
     assert "uv: command not found" in log_text


### PR DESCRIPTION
## Summary

Follow-up to #644. This keeps the `security_risk` fix but narrows the OpenHands change surface:

- Pin OpenHands CLI to an explicit git revision: `3ca17446c5d9c1e35e054803478a3501ec251ecf`.
- Keep exact overrides for `openhands-sdk==1.22.1` and `openhands-tools==1.22.1`.
- Avoid PyPI `openhands==1.16.0` as the install source so the CLI agent code can match the pinned GitHub source instead of changing to the release artifact.
- Keep `@main` out of the install command so future runs cannot drift.

This means the OpenHands agent workflow/source is frozen, and the only intended behavior change remains the SDK/tools bugfix for the `security_risk` validator loop.

## Validation

- `uv run --extra dev python -m pytest tests/test_agent_registry.py tests/test_agent_setup.py`
- `uv run --extra dev ruff check src/benchflow/agents/registry.py tests/test_agent_registry.py tests/test_agent_setup.py`
- `uv run --extra dev ty check src/`
- Smoke installed OpenHands from the pinned git SHA with the override file; verified:
  - `openhands --version` -> `OpenHands CLI 1.16.0`
  - `openhands acp --help` succeeds
  - package metadata: `openhands-sdk==1.22.1`, `openhands-tools==1.22.1`
  - `direct_url.json` records commit `3ca17446c5d9c1e35e054803478a3501ec251ecf`

_This PR was created by an AI agent on behalf of Bingran._

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/647" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->