### PR TITLE
feat(continue): resume timed-out openhands runs via record-replay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`benchflow continue <run-folder>`** — resume a previous, unfinished
+  (timed-out) `openhands` run to completion. A standalone tool (it does not
+  touch the normal run path) that reconstructs the run's exact workspace and
+  agent memory from the recorded `llm_trajectory.jsonl` via record-replay,
+  then continues with the live model — no injected prompt — and writes a new
+  HF-compatible folder with `continued_from` provenance. See
+  [`docs/continue-runs.md`](docs/continue-runs.md).
+
 ### Changed
 
 - Document the public vs internal preview install/upgrade command matrix,

--- a/docs.json
+++ b/docs.json
@@ -18,6 +18,7 @@
         "group": "Guides",
         "pages": [
           "docs/running-benchmarks",
+          "docs/continue-runs",
           "docs/task-authoring",
           "docs/use-cases",
           "docs/progressive-disclosure",

--- a/docs/continue-runs.md
+++ b/docs/continue-runs.md
@@ -1,0 +1,88 @@
+# Continuing timed-out runs (`benchflow continue`)
+
+`benchflow continue` resumes a previous, **unfinished** (timed-out) agent run to
+completion. It is a standalone tool — it does **not** modify benchflow's normal
+`eval`/run path — and currently targets the **`openhands`** agent.
+
+The goal is a *transparent* resume: the continued run behaves as if the original
+timeout had simply been larger. The agent keeps its exact context and
+environment and continues its own loop with **no injected prompt**.
+
+## The problem it solves
+
+A finished run keeps nothing of the container — cleanup tears the sandbox down.
+What survives on disk is the run folder: `config.json`, `result.json`,
+`prompts.json`, and `trajectory/llm_trajectory.jsonl`. So a historical timeout
+has only its *trajectory* + the *task*; there is no saved container to restore.
+
+`benchflow continue` reconstructs the missing state from the trajectory.
+
+## How it works — record-replay
+
+The recorded `llm_trajectory.jsonl` is the exact sequence of LLM
+request/response pairs from the original run. `benchflow continue`:
+
+1. **Loads** the original run folder and the recorded exchanges.
+2. **Boots a fresh, pristine sandbox** from the same base image.
+3. Stands up a **replay proxy** that OpenHands talks to via `LLM_BASE_URL`. For
+   the first *N* requests it returns the recorded responses **in order**, so the
+   agent re-executes its own past decisions *for real* — rebuilding the
+   byte-exact workspace and its exact internal conversation/event state.
+4. When the recorded responses run out (the timeout cut-point), the proxy flips
+   to the **live model** and the agent continues — no new prompt.
+5. **Re-verifies** with the task verifier and writes a new HF-compatible folder,
+   with a stitched `llm_trajectory.jsonl` (recorded prefix + live suffix) and
+   `continued_from` provenance — a drop-in replacement for the timed-out entry.
+
+Because the agent rebuilds its own state by re-doing its own steps, no
+reverse-engineering of OpenHands internals is needed, and the result is a single
+continuous run rather than a fresh agent on a warm filesystem.
+
+## Usage
+
+```bash
+benchflow continue path/to/original/run-folder \
+  --tasks-dir path/to/tasks          # where the task source (verifier) lives
+```
+
+The uploaded run folder does **not** ship the task's verifier, so point
+`--tasks-dir` at the directory containing the task (matched by name). If the
+`task_path` recorded in `config.json` still exists on disk, `--tasks-dir` is
+optional.
+
+### Options
+
+| Flag | Default | Meaning |
+| --- | --- | --- |
+| `--tasks-dir DIR` | recorded `task_path` | Task source (instruction + verifier). |
+| `--model MODEL` | original run's model | Override the **live-continuation** model. |
+| `--timeout SEC` | original run's timeout | Wall-clock budget for the continuation. |
+| `--output DIR` | `<orig-parent>/continued` | Output jobs dir for the new run. |
+| `--require-timeout` | off | Refuse runs whose recorded status isn't a timeout. |
+| `--strict-divergence` | off | Abort if replay leaves the original rails. |
+| `--replay-only` | off | Rebuild via replay and stop at the cut-point (no live model needed). |
+
+### Models and credentials
+
+- The **live-continuation model** defaults to the original run's model so the
+  continuation is a faithful continuation of the same brain. Tests use
+  `--model gemini-3.1-flash-lite-preview` for a cheap path.
+- The **replay phase needs no API key** — responses are served from the
+  recording. Only the **live continuation** calls the real provider, so the
+  host needs that provider's credentials (e.g. `GEMINI_API_KEY`) in its
+  environment. `--replay-only` skips the live leg entirely.
+
+## Limitations and caveats
+
+- **`openhands` only** for now (the proxy seam relies on `LLM_BASE_URL`).
+- **Replay fidelity is best-effort.** Replay re-runs the original shell
+  commands for real; if a command's output diverges from the original
+  (network, timestamps, nondeterminism), the agent may see a different
+  observation than recorded. A message-count check warns on divergence
+  (`--strict-divergence` aborts instead).
+- **"Identical output" means a faithful continuation**, not a bit-identical
+  result — the model samples, and no "original full run" exists past the
+  timeout. The bar is: the stitched trajectory reads as one continuous run, as
+  if the timeout had been larger.
+- Re-running the episode's commands costs wall-clock time (model latency is
+  skipped, since recorded responses are served instantly).

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -343,3 +343,20 @@ scenes:
     turns:
       - role: solver
 ```
+
+---
+
+## bench continue
+
+Resume a previous, unfinished (timed-out) `openhands` run to completion via
+record-replay. Standalone — it does not touch the normal run path. See
+[Continuing timed-out runs](../continue-runs.md) for the full guide.
+
+```bash
+bench continue path/to/original/run-folder --tasks-dir path/to/tasks
+```
+
+Key options: `--model` (override the live-continuation model; defaults to the
+original run's model), `--timeout`, `--output`, `--require-timeout`,
+`--strict-divergence`, and `--replay-only` (rebuild via replay and stop at the
+cut-point — no live model or API key needed).

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -10,12 +10,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 from typing import Annotated
 
 import typer
 
 logger = logging.getLogger(__name__)
+
+
+def _load_env_defaults() -> None:
+    from benchflow._dotenv import load_dotenv_env
+
+    for key, value in load_dotenv_env().items():
+        os.environ.setdefault(key, value)
 
 
 def register_continue(app: typer.Typer) -> None:
@@ -85,13 +93,22 @@ def register_continue(app: typer.Typer) -> None:
                 "(no live model needed) — useful for testing.",
             ),
         ] = False,
+        proxy_mode: Annotated[
+            str,
+            typer.Option(
+                "--proxy-mode",
+                help=(
+                    "Replay proxy placement: auto, host, or sandbox. Auto uses "
+                    "sandbox-local replay for Daytona/Modal and host replay for Docker."
+                ),
+            ),
+        ] = "auto",
     ) -> None:
         """Resume a previous unfinished (timed-out) openhands run to completion."""
-        from benchflow._dotenv import load_dotenv_env
         from benchflow.continue_run.orchestrator import continue_run
         from benchflow.continue_run.run_folder import RunFolderError
 
-        load_dotenv_env()
+        _load_env_defaults()
 
         try:
             result = asyncio.run(
@@ -104,6 +121,7 @@ def register_continue(app: typer.Typer) -> None:
                     require_timeout=require_timeout,
                     strict_divergence=strict_divergence,
                     replay_only=replay_only,
+                    proxy_mode=proxy_mode,
                 )
             )
         except RunFolderError as exc:
@@ -121,3 +139,98 @@ def register_continue(app: typer.Typer) -> None:
             typer.echo(f"  rewards: {result.rewards}")
         if result.error:
             typer.secho(f"  agent error: {result.error}", fg=typer.colors.YELLOW)
+
+    @app.command("continue-batch")
+    def continue_batch_cmd(
+        root: Annotated[
+            Path,
+            typer.Argument(
+                help=(
+                    "Run folder or directory tree containing timeout run folders "
+                    "(config.json + trajectory/llm_trajectory.jsonl)."
+                )
+            ),
+        ],
+        tasks_dir: Annotated[
+            Path | None,
+            typer.Option(
+                "--tasks-dir",
+                help="Directory holding task sources; required unless recorded task_path exists.",
+            ),
+        ] = None,
+        model: Annotated[
+            str | None,
+            typer.Option("--model", help="Override live-continuation model."),
+        ] = None,
+        timeout: Annotated[
+            int | None,
+            typer.Option("--timeout", help="Wall-clock budget per continuation."),
+        ] = None,
+        output: Annotated[
+            Path | None,
+            typer.Option("--output", help="Output jobs dir for continued runs."),
+        ] = None,
+        concurrency: Annotated[
+            int,
+            typer.Option(
+                "--concurrency",
+                help="Maximum number of continuation runs in flight.",
+            ),
+        ] = 100,
+        limit: Annotated[
+            int | None,
+            typer.Option("--limit", help="Limit discovered timeout folders."),
+        ] = None,
+        strict_divergence: Annotated[
+            bool,
+            typer.Option(
+                "--strict-divergence/--no-strict-divergence",
+                help="Abort a run if replay leaves the original rails.",
+            ),
+        ] = False,
+        proxy_mode: Annotated[
+            str,
+            typer.Option(
+                "--proxy-mode",
+                help=(
+                    "Replay proxy placement: auto, host, or sandbox. For PR5 "
+                    "Daytona runs, use the default auto or sandbox."
+                ),
+            ),
+        ] = "auto",
+    ) -> None:
+        """Continue all timed-out OpenHands runs under a directory tree."""
+        import json
+
+        from benchflow.continue_run.batch import (
+            continue_batch,
+            discover_timeout_run_folders,
+            summarize_batch,
+        )
+
+        _load_env_defaults()
+        folders = discover_timeout_run_folders(root, limit=limit)
+        if not folders:
+            typer.secho("No timeout run folders found.", fg=typer.colors.YELLOW)
+            return
+
+        typer.echo(
+            f"Continuing {len(folders)} timeout run(s) with concurrency={concurrency}"
+        )
+        results = asyncio.run(
+            continue_batch(
+                folders,
+                concurrency=concurrency,
+                tasks_dir=tasks_dir,
+                model=model,
+                timeout=timeout,
+                output_dir=output,
+                require_timeout=True,
+                strict_divergence=strict_divergence,
+                proxy_mode=proxy_mode,
+            )
+        )
+        summary = summarize_batch(results)
+        typer.echo(json.dumps(summary, indent=2))
+        if summary["failed"]:
+            raise typer.Exit(1)

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -1,0 +1,121 @@
+"""``benchflow continue`` — resume a timed-out run to completion.
+
+Standalone command (does not touch the normal eval/run path): reconstruct a
+previous unfinished ``openhands`` run's exact env + memory from its recorded
+trajectory via record-replay, continue it live, and write a new HF-compatible
+folder linked to the parent. See :mod:`benchflow.continue_run`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+logger = logging.getLogger(__name__)
+
+
+def register_continue(app: typer.Typer) -> None:
+    """Attach the ``continue`` command to the top-level benchflow app."""
+
+    @app.command("continue")
+    def continue_cmd(
+        folder: Annotated[
+            Path,
+            typer.Argument(
+                help="Original run output folder (contains config.json + "
+                "trajectory/llm_trajectory.jsonl)."
+            ),
+        ],
+        tasks_dir: Annotated[
+            Path | None,
+            typer.Option(
+                "--tasks-dir",
+                help="Directory holding the task source (instruction + verifier). "
+                "Required unless the recorded task_path still exists on disk.",
+            ),
+        ] = None,
+        model: Annotated[
+            str | None,
+            typer.Option(
+                "--model",
+                help="Override the live-continuation model (default: the "
+                "original run's model). Tests use gemini-3.1-flash-lite-preview.",
+            ),
+        ] = None,
+        timeout: Annotated[
+            int | None,
+            typer.Option(
+                "--timeout",
+                help="Wall-clock budget for the continuation, in seconds "
+                "(default: the original run's timeout).",
+            ),
+        ] = None,
+        output: Annotated[
+            Path | None,
+            typer.Option(
+                "--output",
+                help="Output jobs dir for the new run (default: "
+                "<orig-parent>/continued).",
+            ),
+        ] = None,
+        require_timeout: Annotated[
+            bool,
+            typer.Option(
+                "--require-timeout/--no-require-timeout",
+                help="Refuse runs whose recorded status is not a timeout.",
+            ),
+        ] = False,
+        strict_divergence: Annotated[
+            bool,
+            typer.Option(
+                "--strict-divergence/--no-strict-divergence",
+                help="Abort if replay leaves the original rails (message-count "
+                "mismatch) instead of warning.",
+            ),
+        ] = False,
+        replay_only: Annotated[
+            bool,
+            typer.Option(
+                "--replay-only/--no-replay-only",
+                help="Rebuild the env via replay and stop at the cut-point "
+                "(no live model needed) — useful for testing.",
+            ),
+        ] = False,
+    ) -> None:
+        """Resume a previous unfinished (timed-out) openhands run to completion."""
+        from benchflow._dotenv import load_dotenv_env
+        from benchflow.continue_run.orchestrator import continue_run
+        from benchflow.continue_run.run_folder import RunFolderError
+
+        load_dotenv_env()
+
+        try:
+            result = asyncio.run(
+                continue_run(
+                    folder,
+                    tasks_dir=tasks_dir,
+                    model=model,
+                    timeout=timeout,
+                    output_dir=output,
+                    require_timeout=require_timeout,
+                    strict_divergence=strict_divergence,
+                    replay_only=replay_only,
+                )
+            )
+        except RunFolderError as exc:
+            typer.secho(f"benchflow continue: {exc}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(1) from exc
+
+        typer.secho(f"\n✓ continued run written to {result.rollout_dir}", fg=typer.colors.GREEN)
+        typer.echo(
+            f"  replayed {result.n_recorded} recorded turn(s); "
+            f"{result.n_live} live turn(s); {result.divergences} divergence(s)"
+        )
+        if result.rewards is not None:
+            typer.echo(f"  rewards: {result.rewards}")
+        if result.error:
+            typer.secho(f"  agent error: {result.error}", fg=typer.colors.YELLOW)

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -110,7 +110,9 @@ def register_continue(app: typer.Typer) -> None:
             typer.secho(f"benchflow continue: {exc}", fg=typer.colors.RED, err=True)
             raise typer.Exit(1) from exc
 
-        typer.secho(f"\n✓ continued run written to {result.rollout_dir}", fg=typer.colors.GREEN)
+        typer.secho(
+            f"\n✓ continued run written to {result.rollout_dir}", fg=typer.colors.GREEN
+        )
         typer.echo(
             f"  replayed {result.n_recorded} recorded turn(s); "
             f"{result.n_live} live turn(s); {result.divergences} divergence(s)"

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -21,6 +21,7 @@ from benchflow._utils.config import (
     normalize_sandbox_user,
 )
 from benchflow.agents.registry import parse_agent_spec
+from benchflow.cli.continue_cmd import register_continue
 from benchflow.cli.trace_import import register_tasks_generate
 from benchflow.evaluation import DEFAULT_AGENT, effective_model
 from benchflow.skill_policy import SKILL_MODE_NO_SKILL
@@ -39,6 +40,9 @@ app = typer.Typer(
     help="ACP-native agent benchmarking framework.",
     no_args_is_help=True,
 )
+
+# Standalone `benchflow continue <orig-run-folder>` — resume a timed-out run.
+register_continue(app)
 
 
 def _version_callback(value: bool) -> None:

--- a/src/benchflow/continue_run/__init__.py
+++ b/src/benchflow/continue_run/__init__.py
@@ -1,0 +1,35 @@
+"""Resume a previous, unfinished (timed-out) agent run to completion.
+
+``benchflow continue <orig-run-output-folder>`` is a *standalone* tool that does
+**not** touch benchflow's normal run path. It reconstructs a timed-out run's
+exact workspace and agent memory from the recorded trajectory (record-replay),
+then lets the agent continue as if the timeout had simply been larger, and
+writes a new HF-compatible result folder linked to the parent.
+
+The mechanism (agreed design):
+
+1. Load the original run folder (``config.json`` + ``trajectory/llm_trajectory.jsonl``).
+2. Boot a fresh *pristine* sandbox from the same base image.
+3. Stand up a :class:`~benchflow.continue_run.replay_proxy.ReplayProxy` that
+   OpenHands talks to via ``LLM_BASE_URL``. It serves the recorded LLM
+   responses **in order**, so the agent re-executes its own past decisions for
+   real — rebuilding the byte-exact workspace and its exact internal state.
+4. When the recorded responses run out (the timeout cut-point), the proxy flips
+   to the **live** model and the agent continues — no injected prompt.
+5. Re-verify and write a new folder with ``continued_from`` provenance.
+
+Only the ``openhands`` agent is supported for now (the LLM-proxy seam this relies
+on is wired for openhands via ``LLM_BASE_URL``).
+"""
+
+from benchflow.continue_run.run_folder import (
+    RunFolder,
+    RunFolderError,
+    load_run_folder,
+)
+
+__all__ = [
+    "RunFolder",
+    "RunFolderError",
+    "load_run_folder",
+]

--- a/src/benchflow/continue_run/batch.py
+++ b/src/benchflow/continue_run/batch.py
@@ -1,0 +1,125 @@
+"""Batch orchestration for continuing many timed-out runs."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from benchflow.continue_run.orchestrator import ContinueResult, continue_run
+from benchflow.continue_run.run_folder import RunFolderError, load_run_folder
+
+ContinueRunner = Callable[..., Awaitable[ContinueResult]]
+
+
+@dataclass(frozen=True)
+class BatchContinueResult:
+    """Result for one source folder in a batch continuation."""
+
+    folder: Path
+    ok: bool
+    continued: ContinueResult | None = None
+    error: str | None = None
+
+
+def discover_timeout_run_folders(
+    root: str | Path, *, limit: int | None = None
+) -> list[Path]:
+    """Find OpenHands timeout run folders below ``root``.
+
+    Discovery is intentionally artifact-based: a candidate must have a
+    ``config.json`` and a usable ``trajectory/llm_trajectory.jsonl``. Non-timeout
+    runs are skipped by ``load_run_folder(require_timeout=True)``.
+    """
+    root_path = Path(root).expanduser()
+    candidates = [root_path] if (root_path / "config.json").is_file() else []
+    candidates.extend(path.parent for path in root_path.rglob("config.json"))
+
+    folders: list[Path] = []
+    seen: set[Path] = set()
+    for folder in sorted(candidates):
+        resolved = folder.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        try:
+            load_run_folder(folder, require_timeout=True)
+        except RunFolderError:
+            continue
+        folders.append(folder)
+        if limit is not None and len(folders) >= limit:
+            break
+    return folders
+
+
+async def continue_batch(
+    folders: list[Path],
+    *,
+    concurrency: int,
+    tasks_dir: str | Path | None,
+    model: str | None,
+    timeout: int | None,
+    output_dir: str | Path | None,
+    require_timeout: bool = True,
+    strict_divergence: bool = False,
+    proxy_mode: str = "auto",
+    runner: ContinueRunner = continue_run,
+) -> list[BatchContinueResult]:
+    """Run ``benchflow continue`` over folders with rolling concurrency."""
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    semaphore = asyncio.Semaphore(concurrency)
+
+    async def _one(folder: Path) -> BatchContinueResult:
+        async with semaphore:
+            try:
+                result = await runner(
+                    folder,
+                    tasks_dir=tasks_dir,
+                    model=model,
+                    timeout=timeout,
+                    output_dir=output_dir,
+                    require_timeout=require_timeout,
+                    strict_divergence=strict_divergence,
+                    proxy_mode=proxy_mode,
+                )
+            except Exception as exc:
+                return BatchContinueResult(folder=folder, ok=False, error=str(exc))
+            if result.error:
+                return BatchContinueResult(
+                    folder=folder,
+                    ok=False,
+                    continued=result,
+                    error=result.error,
+                )
+            return BatchContinueResult(folder=folder, ok=True, continued=result)
+
+    return list(await asyncio.gather(*(_one(folder) for folder in folders)))
+
+
+def summarize_batch(results: list[BatchContinueResult]) -> dict[str, Any]:
+    """Small JSON-serializable summary for CLI output and dashboards."""
+    ok = [result for result in results if result.ok]
+    failed = [result for result in results if not result.ok]
+    return {
+        "total": len(results),
+        "succeeded": len(ok),
+        "failed": len(failed),
+        "outputs": [
+            str(result.continued.rollout_dir)
+            for result in ok
+            if result.continued is not None
+        ],
+        "errors": [
+            {
+                "folder": str(result.folder),
+                "output": str(result.continued.rollout_dir)
+                if result.continued is not None
+                else None,
+                "error": result.error,
+            }
+            for result in failed
+        ],
+    }

--- a/src/benchflow/continue_run/orchestrator.py
+++ b/src/benchflow/continue_run/orchestrator.py
@@ -1,0 +1,310 @@
+"""Orchestrate ``benchflow continue`` — boot, replay, continue live, stitch.
+
+Reuses benchflow's normal :class:`~benchflow.rollout.Rollout` machinery (so the
+new run produces a standard HF-compatible folder) but injects a record-replay
+proxy in front of OpenHands and disables benchflow's own LiteLLM gateway:
+
+- ``usage_tracking="off"`` makes ``ensure_litellm_runtime`` a no-op, so the
+  ``agent_env`` we pass through (``LLM_BASE_URL`` → the replay proxy) is left
+  untouched (``providers/litellm_runtime.py``).
+- The original first prompt (task instruction) starts OpenHands; the proxy then
+  drives the exact replay and, past the cut-point, the live continuation.
+
+The async :func:`continue_run` is the integration entrypoint (it needs Docker +
+the openhands install); the helpers it composes (config assembly, live
+forwarder request-building, trajectory stitching) are pure and unit-tested.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from benchflow.continue_run.replay_proxy import ReplayProxy, ReplayRouter
+from benchflow.continue_run.run_folder import RunFolder, RunFolderError, load_run_folder
+from benchflow.trajectories.types import LLMExchange, redact_trajectory_text
+
+logger = logging.getLogger(__name__)
+
+# agent_env values handed to OpenHands so it talks to the replay proxy instead
+# of a real provider. The model name is irrelevant (the proxy serves by index),
+# but litellm needs an ``openai/`` prefix to treat LLM_BASE_URL as an
+# OpenAI-compatible endpoint.
+_REPLAY_API_KEY = "sk-benchflow-replay"
+_REPLAY_MODEL = "openai/replay"
+
+
+@dataclass
+class ContinueResult:
+    """Outcome of a ``benchflow continue`` run."""
+
+    rollout_dir: Path
+    rewards: dict[str, Any] | None
+    error: str | None
+    n_recorded: int
+    n_live: int
+    divergences: int
+
+
+def resolve_task_path(run: RunFolder, tasks_dir: str | Path | None) -> Path:
+    """Find the task directory (instruction + verifier + image) to run against.
+
+    The uploaded run folder does **not** ship the task files, so we need the
+    original task source: ``--tasks-dir/<task_name>`` if given, else the
+    ``task_path`` recorded in ``config.json`` if it still exists on disk.
+    """
+    if tasks_dir is not None:
+        candidate = Path(tasks_dir).expanduser() / run.task_name
+        if candidate.is_dir():
+            return candidate
+        raise RunFolderError(
+            f"--tasks-dir given but {candidate} does not exist; expected the "
+            f"task source for {run.task_name!r} there."
+        )
+    recorded = Path(run.task_path) if run.task_path else None
+    if recorded is not None and recorded.is_dir():
+        return recorded
+    raise RunFolderError(
+        f"cannot locate task source for {run.task_name!r}. Pass --tasks-dir "
+        "pointing at the directory that contains the task (its instruction and "
+        "verifier are needed to re-run and re-verify)."
+    )
+
+
+def build_agent_env(proxy_base_url: str) -> dict[str, str]:
+    """Env that points OpenHands' LiteLLM client at the replay proxy."""
+    return {
+        "LLM_BASE_URL": proxy_base_url,
+        "LLM_API_KEY": _REPLAY_API_KEY,
+        "LLM_MODEL": _REPLAY_MODEL,
+    }
+
+
+def build_rollout_config(
+    run: RunFolder,
+    *,
+    task_path: Path,
+    live_model: str | None,
+    agent_env: dict[str, str],
+    timeout: int | None,
+    output_dir: str | Path,
+    rollout_name: str,
+) -> Any:
+    """Assemble the RolloutConfig that re-runs the task through the proxy.
+
+    Imported lazily so ``benchflow.continue_run`` stays importable without
+    pulling the full rollout stack (keeps unit tests light).
+    """
+    from benchflow.rollout import RolloutConfig
+
+    return RolloutConfig.from_legacy(
+        task_path=task_path,
+        agent="openhands",
+        # model=None on purpose: the agent targets the replay proxy purely via
+        # agent_env LLM_*. A real model here would make resolve_agent_env run
+        # provider resolution and *validate the model's API key* — which would
+        # wrongly fail the key-free replay phase and could clobber LLM_BASE_URL.
+        # The live model lives in the forwarder + provenance instead.
+        model=None,
+        reasoning_effort=run.reasoning_effort,
+        # values are str (a subset of str | None); list invariance needs the cast.
+        prompts=cast("list[str | None] | None", run.prompts or None),
+        environment=run.environment,
+        sandbox_user=run.sandbox_user,
+        agent_env=agent_env,
+        # The seam that stops benchflow starting its own gateway / rewriting
+        # LLM_BASE_URL — our replay proxy stays in front of the agent.
+        usage_tracking="off",
+        timeout=timeout,
+        agent_idle_timeout=run.agent_idle_timeout_sec,
+        jobs_dir=str(output_dir),
+        rollout_name=rollout_name,
+        source_provenance={
+            "kind": "benchflow-continue",
+            "continued_from": str(run.path),
+            "original_error_category": run.error_category,
+            "original_model": run.model,
+            "live_model": live_model,
+            "n_recorded_exchanges": run.n_recorded_exchanges,
+        },
+    )
+
+
+class LiteLLMLiveForwarder:
+    """Live forwarder backed by the in-process LiteLLM SDK.
+
+    Past the replay cut-point the agent's request is sent to the real model and
+    the final (non-streamed) ChatCompletion is returned for the proxy to emit.
+    Resolving the provider route once keeps each call cheap; litellm reads
+    provider credentials (e.g. ``GEMINI_API_KEY``) from the environment.
+    """
+
+    # Request fields worth forwarding verbatim when present.
+    _PASSTHROUGH = (
+        "tools",
+        "tool_choice",
+        "temperature",
+        "top_p",
+        "max_tokens",
+        "max_completion_tokens",
+        "stop",
+        "response_format",
+        "reasoning_effort",
+        "parallel_tool_calls",
+    )
+
+    def __init__(self, model: str, *, env: dict[str, str] | None = None) -> None:
+        from benchflow.providers.litellm_config import resolve_litellm_route
+
+        merged_env = {**os.environ, **(env or {})}
+        route = resolve_litellm_route(model, merged_env)
+        self.model = model
+        self.upstream_model = route.upstream_model
+
+    def build_kwargs(self, request_body: dict[str, Any]) -> dict[str, Any]:
+        """Translate an OpenAI request body into ``litellm.completion`` kwargs."""
+        kwargs: dict[str, Any] = {
+            "model": self.upstream_model,
+            "messages": request_body.get("messages") or [],
+            "stream": False,
+        }
+        for key in self._PASSTHROUGH:
+            if request_body.get(key) is not None:
+                kwargs[key] = request_body[key]
+        return kwargs
+
+    def __call__(self, request_body: dict[str, Any]) -> dict[str, Any]:
+        import litellm
+
+        response = litellm.completion(**self.build_kwargs(request_body))
+        dump = getattr(response, "model_dump", None)
+        return dump() if callable(dump) else dict(response)
+
+
+def stitched_trajectory_lines(
+    original_llm_trajectory: Path, live_exchanges: list[LLMExchange]
+) -> list[str]:
+    """Build the continuous llm_trajectory: recorded prefix + live suffix.
+
+    The recorded prefix is taken verbatim from the source file (already redacted
+    and byte-identical to what the agent replayed); the live suffix is the
+    exchanges the proxy captured after the cut-point, redacted on the way out.
+    """
+    lines: list[str] = []
+    if original_llm_trajectory.is_file():
+        for raw in original_llm_trajectory.read_text().splitlines():
+            if raw.strip():
+                lines.append(raw)
+    for exchange in live_exchanges:
+        raw = json.dumps(exchange.model_dump(mode="json"), default=str)
+        lines.append(redact_trajectory_text(raw))
+    return lines
+
+
+def write_stitched_trajectory(
+    rollout_dir: Path, original_llm_trajectory: Path, live_exchanges: list[LLMExchange]
+) -> Path:
+    """Write the stitched continuous trajectory into the new rollout folder."""
+    out = rollout_dir / "trajectory" / "llm_trajectory.jsonl"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    lines = stitched_trajectory_lines(original_llm_trajectory, live_exchanges)
+    out.write_text("\n".join(lines) + ("\n" if lines else ""))
+    return out
+
+
+def _host_proxy_binding(environment: str) -> tuple[str, str]:
+    """(bind_host, advertise_host) so a Docker agent can reach the host proxy.
+
+    Reuses benchflow's existing bridge-gateway logic so the container can talk
+    back to the host-run proxy; non-docker environments use loopback.
+    """
+    from benchflow.providers.litellm_runtime import (
+        _agent_endpoint_for_environment,
+        _host_bind_address,
+    )
+
+    bind = _host_bind_address(environment)
+    endpoint = _agent_endpoint_for_environment(0, environment, bind)
+    advertise = endpoint.agent_base_url.split("//", 1)[-1].rsplit(":", 1)[0]
+    return bind, advertise
+
+
+async def continue_run(
+    folder: str | Path,
+    *,
+    tasks_dir: str | Path | None = None,
+    model: str | None = None,
+    timeout: int | None = None,
+    output_dir: str | Path | None = None,
+    require_timeout: bool = False,
+    strict_divergence: bool = False,
+    replay_only: bool = False,
+) -> ContinueResult:
+    """Resume ``folder`` to completion via record-replay + live continuation.
+
+    ``model`` overrides the live-continuation model (tests pass
+    ``gemini-3.1-flash-lite-preview``); defaults to the original run's model.
+    ``replay_only`` skips the live leg (rebuild-and-stop) — useful for testing
+    the replay without provider credentials.
+    """
+    run = load_run_folder(folder, require_timeout=require_timeout)
+    task_path = resolve_task_path(run, tasks_dir)
+
+    live_model = model or run.model
+    live_forwarder = None
+    if not replay_only:
+        if live_model is None:
+            raise RunFolderError(
+                "no live-continuation model: the run recorded no model and "
+                "--model was not given."
+            )
+        live_forwarder = LiteLLMLiveForwarder(live_model)
+
+    router = ReplayRouter(
+        run.exchanges,
+        live_forwarder=live_forwarder,
+        strict_divergence=strict_divergence,
+    )
+
+    bind_host, advertise_host = _host_proxy_binding(run.environment)
+    proxy = ReplayProxy(router, host=bind_host, advertise_host=advertise_host).start()
+
+    out_root = Path(output_dir) if output_dir else run.path.parent / "continued"
+    rollout_name = f"{run.task_name}__continued"
+
+    try:
+        from benchflow.rollout import Rollout
+
+        config = build_rollout_config(
+            run,
+            task_path=task_path,
+            live_model=live_model,
+            agent_env=build_agent_env(proxy.base_url),
+            timeout=timeout if timeout is not None else run.timeout_sec,
+            output_dir=out_root,
+            rollout_name=rollout_name,
+        )
+        rollout = await Rollout.create(config)
+        result = await rollout.run()
+        rollout_dir = Path(rollout._rollout_dir or (out_root / rollout_name))
+    finally:
+        proxy.stop()
+
+    write_stitched_trajectory(
+        rollout_dir,
+        run.path / "trajectory" / "llm_trajectory.jsonl",
+        router.live_exchanges,
+    )
+
+    return ContinueResult(
+        rollout_dir=rollout_dir,
+        rewards=getattr(result, "rewards", None),
+        error=getattr(result, "error", None),
+        n_recorded=run.n_recorded_exchanges,
+        n_live=len(router.live_exchanges),
+        divergences=router.divergences,
+    )

--- a/src/benchflow/continue_run/orchestrator.py
+++ b/src/benchflow/continue_run/orchestrator.py
@@ -2,11 +2,15 @@
 
 Reuses benchflow's normal :class:`~benchflow.rollout.Rollout` machinery (so the
 new run produces a standard HF-compatible folder) but injects a record-replay
-proxy in front of OpenHands and disables benchflow's own LiteLLM gateway:
+proxy in front of OpenHands:
 
-- ``usage_tracking="off"`` makes ``ensure_litellm_runtime`` a no-op, so the
+- Host proxy mode uses ``usage_tracking="off"`` so ``ensure_litellm_runtime`` is
+  a no-op and the
   ``agent_env`` we pass through (``LLM_BASE_URL`` → the replay proxy) is left
   untouched (``providers/litellm_runtime.py``).
+- Sandbox proxy mode starts the provider LiteLLM proxy inside the sandbox and
+  keeps the replay proxy on sandbox loopback, so remote environments such as
+  Daytona do not need host-loopback connectivity.
 - The original first prompt (task instruction) starts OpenHands; the proxy then
   drives the exact replay and, past the cut-point, the live continuation.
 
@@ -20,12 +24,20 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
 from benchflow.continue_run.replay_proxy import ReplayProxy, ReplayRouter
 from benchflow.continue_run.run_folder import RunFolder, RunFolderError, load_run_folder
+from benchflow.continue_run.sandbox_proxy import (
+    SandboxReplayProxy,
+    sandbox_replay_base_url,
+)
+from benchflow.contracts import AgentProtocolError, SandboxStartupFailure
+from benchflow.scenes import compile_scenes_to_steps
 from benchflow.trajectories.types import LLMExchange, redact_trajectory_text
 
 logger = logging.getLogger(__name__)
@@ -36,6 +48,8 @@ logger = logging.getLogger(__name__)
 # OpenAI-compatible endpoint.
 _REPLAY_API_KEY = "sk-benchflow-replay"
 _REPLAY_MODEL = "openai/replay"
+_SANDBOX_LOCAL_REPLAY_ENVIRONMENTS = frozenset({"daytona", "modal"})
+_PROXY_MODES = frozenset({"auto", "host", "sandbox"})
 
 
 @dataclass
@@ -48,6 +62,56 @@ class ContinueResult:
     n_recorded: int
     n_live: int
     divergences: int
+
+
+def select_proxy_mode(requested: str, environment: str) -> str:
+    """Resolve the replay proxy placement for a continuation run."""
+    if requested not in _PROXY_MODES:
+        raise RunFolderError(
+            f"invalid proxy mode {requested!r}; expected one of "
+            f"{', '.join(sorted(_PROXY_MODES))}."
+        )
+    if requested != "auto":
+        return requested
+    return "sandbox" if environment in _SANDBOX_LOCAL_REPLAY_ENVIRONMENTS else "host"
+
+
+def continued_rollout_name(run: RunFolder) -> str:
+    """Derive a stable, collision-resistant rollout name from the source run."""
+    source = run.path.name or run.task_name
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "-", source).strip("-")
+    if not cleaned:
+        cleaned = run.task_name or "run"
+    return f"{cleaned}__continued"
+
+
+@dataclass(frozen=True)
+class ContinuedUsageSummary:
+    """Token usage recovered from the stitched LLM trajectory."""
+
+    n_input_tokens: int
+    n_output_tokens: int
+    n_cache_read_tokens: int
+    n_cache_creation_tokens: int
+    total_tokens: int
+    recorded_total_tokens: int
+    live_total_tokens: int
+    usage_source: str
+
+    def as_agent_result_patch(self) -> dict[str, Any]:
+        return {
+            "n_input_tokens": self.n_input_tokens,
+            "n_output_tokens": self.n_output_tokens,
+            "n_cache_read_tokens": self.n_cache_read_tokens,
+            "n_cache_creation_tokens": self.n_cache_creation_tokens,
+            "total_tokens": self.total_tokens,
+            "usage_source": self.usage_source,
+            "usage_details": {
+                "source": "stitched_llm_trajectory",
+                "recorded_total_tokens": self.recorded_total_tokens,
+                "live_total_tokens": self.live_total_tokens,
+            },
+        }
 
 
 def resolve_task_path(run: RunFolder, tasks_dir: str | Path | None) -> Path:
@@ -216,6 +280,133 @@ def write_stitched_trajectory(
     return out
 
 
+def _usage_int(usage: dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, (int, float)):
+            return int(value)
+    return 0
+
+
+def summarize_llm_trajectory_usage(
+    trajectory_path: Path, *, n_recorded: int
+) -> ContinuedUsageSummary:
+    """Recover aggregate token usage from provider responses in a trajectory."""
+    input_tokens = 0
+    output_tokens = 0
+    cache_read = 0
+    cache_creation = 0
+    total_tokens = 0
+    recorded_total = 0
+    live_total = 0
+    for idx, raw in enumerate(trajectory_path.read_text().splitlines()):
+        if not raw.strip():
+            continue
+        try:
+            payload = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        response = payload.get("response")
+        if not isinstance(response, dict):
+            continue
+        body = response.get("body")
+        if not isinstance(body, dict):
+            continue
+        usage = body.get("usage")
+        if not isinstance(usage, dict):
+            continue
+        prompt = _usage_int(usage, "prompt_tokens", "input_tokens")
+        completion = _usage_int(usage, "completion_tokens", "output_tokens")
+        total = _usage_int(usage, "total_tokens")
+        if total <= 0:
+            total = prompt + completion
+        input_tokens += prompt
+        output_tokens += completion
+        total_tokens += total
+        cache_read += _usage_int(usage, "cache_read_input_tokens")
+        cache_creation += _usage_int(usage, "cache_creation_input_tokens")
+        if idx < n_recorded:
+            recorded_total += total
+        else:
+            live_total += total
+    return ContinuedUsageSummary(
+        n_input_tokens=input_tokens,
+        n_output_tokens=output_tokens,
+        n_cache_read_tokens=cache_read,
+        n_cache_creation_tokens=cache_creation,
+        total_tokens=total_tokens,
+        recorded_total_tokens=recorded_total,
+        live_total_tokens=live_total,
+        usage_source="provider_response" if total_tokens > 0 else "unavailable",
+    )
+
+
+def update_continued_metadata(
+    rollout_dir: Path,
+    *,
+    live_model: str | None,
+    usage: ContinuedUsageSummary,
+    environment: str,
+) -> None:
+    """Patch output metadata that Rollout could not know while model=None.
+
+    ``benchflow continue`` intentionally runs Rollout with ``model=None`` so
+    provider resolution does not clobber the replay proxy. After the run, the
+    HF-compatible artifacts still need the actual live model and token usage.
+    The stitched LLM trajectory is authoritative for provider usage.
+    """
+    config_path = rollout_dir / "config.json"
+    if config_path.is_file():
+        config = json.loads(config_path.read_text())
+        config["model"] = live_model
+        config.setdefault("source", {})["usage_source"] = "stitched_llm_trajectory"
+        config["usage_tracking"] = {
+            "requested": "required",
+            "status": (
+                "captured_from_stitched_llm_trajectory"
+                if usage.total_tokens > 0
+                else "unavailable"
+            ),
+            "environment": environment,
+            "endpoint_kind": "sandbox"
+            if environment in _SANDBOX_LOCAL_REPLAY_ENVIRONMENTS
+            else "host",
+            "usage_source": usage.usage_source,
+        }
+        config_path.write_text(json.dumps(config, indent=2) + "\n")
+
+    result_path = rollout_dir / "result.json"
+    if not result_path.is_file():
+        return
+    result = json.loads(result_path.read_text())
+    result["model"] = live_model
+    agent_result = result.setdefault("agent_result", {})
+    if isinstance(agent_result, dict):
+        agent_result.update(usage.as_agent_result_patch())
+    result["final_metrics"] = {
+        "total_prompt_tokens": usage.n_input_tokens,
+        "total_completion_tokens": usage.n_output_tokens,
+        "total_cached_tokens": usage.n_cache_read_tokens,
+        "total_cost_usd": agent_result.get("cost_usd")
+        if isinstance(agent_result, dict)
+        else None,
+    }
+    usage_tracking = result.setdefault("usage_tracking", {})
+    if isinstance(usage_tracking, dict):
+        usage_tracking["requested"] = "required"
+        usage_tracking["usage_source"] = usage.usage_source
+        usage_tracking["environment"] = environment
+        usage_tracking["endpoint_kind"] = (
+            "sandbox" if environment in _SANDBOX_LOCAL_REPLAY_ENVIRONMENTS else "host"
+        )
+        usage_tracking["status"] = (
+            "captured_from_stitched_llm_trajectory"
+            if usage.total_tokens > 0
+            else usage_tracking.get("status", "off")
+        )
+    result_path.write_text(json.dumps(result, indent=2) + "\n")
+
+
 def _host_proxy_binding(environment: str) -> tuple[str, str]:
     """(bind_host, advertise_host) so a Docker agent can reach the host proxy.
 
@@ -233,6 +424,53 @@ def _host_proxy_binding(environment: str) -> tuple[str, str]:
     return bind, advertise
 
 
+async def _safe_sandbox_continuation_teardown(
+    *,
+    rollout: Any,
+    replay_proxy: SandboxReplayProxy | None,
+    provider_runtime: Any | None,
+    stop_provider_runtime: Callable[[Any], Awaitable[None]],
+    before_cleanup: Callable[[], Awaitable[None]] | None = None,
+) -> list[str]:
+    """Stop continuation sidecars but always let Rollout write final artifacts."""
+    errors: list[str] = []
+
+    async def _capture(label: str, awaitable: Awaitable[Any]) -> None:
+        try:
+            await awaitable
+        except Exception as exc:
+            message = f"{label}: {exc}"
+            errors.append(message)
+            logger.warning("Continuation teardown step failed: %s", message)
+
+    if replay_proxy is not None:
+        await _capture("sandbox replay proxy stop", replay_proxy.stop())
+    if provider_runtime is not None:
+        await _capture("provider runtime stop", stop_provider_runtime(provider_runtime))
+
+    if errors and getattr(rollout, "_error", None) is None:
+        rollout._error = "Continuation teardown warning: " + "; ".join(errors)
+
+    if before_cleanup is not None:
+        await _capture("continuation artifact write", before_cleanup())
+
+    await _capture("rollout cleanup", rollout.cleanup())
+
+    return errors
+
+
+def _result_after_sandbox_teardown(rollout: Any) -> Any | None:
+    """Return a Rollout result, forcing artifact emission after cleanup warnings."""
+    result = rollout.result
+    if result is not None:
+        return result
+    if getattr(rollout, "_rollout_dir", None) is None:
+        return None
+    if getattr(rollout, "_phase", None) not in ("verified", "cleaned"):
+        rollout._phase = "cleaned"
+    return rollout.result
+
+
 async def continue_run(
     folder: str | Path,
     *,
@@ -243,6 +481,7 @@ async def continue_run(
     require_timeout: bool = False,
     strict_divergence: bool = False,
     replay_only: bool = False,
+    proxy_mode: str = "auto",
 ) -> ContinueResult:
     """Resume ``folder`` to completion via record-replay + live continuation.
 
@@ -264,6 +503,29 @@ async def continue_run(
             )
         live_forwarder = LiteLLMLiveForwarder(live_model)
 
+    resolved_proxy_mode = select_proxy_mode(proxy_mode, run.environment)
+    if replay_only and resolved_proxy_mode == "sandbox":
+        raise RunFolderError("replay-only mode is only supported with host proxy mode.")
+
+    out_root = Path(output_dir) if output_dir else run.path.parent / "continued"
+    rollout_name = continued_rollout_name(run)
+
+    if resolved_proxy_mode == "sandbox":
+        if live_model is None:
+            raise RunFolderError(
+                "no live-continuation model: the run recorded no model and "
+                "--model was not given."
+            )
+        return await _continue_run_with_sandbox_proxy(
+            run,
+            task_path=task_path,
+            live_model=live_model,
+            timeout=timeout,
+            output_dir=out_root,
+            rollout_name=rollout_name,
+            strict_divergence=strict_divergence,
+        )
+
     router = ReplayRouter(
         run.exchanges,
         live_forwarder=live_forwarder,
@@ -272,9 +534,6 @@ async def continue_run(
 
     bind_host, advertise_host = _host_proxy_binding(run.environment)
     proxy = ReplayProxy(router, host=bind_host, advertise_host=advertise_host).start()
-
-    out_root = Path(output_dir) if output_dir else run.path.parent / "continued"
-    rollout_name = f"{run.task_name}__continued"
 
     try:
         from benchflow.rollout import Rollout
@@ -294,10 +553,19 @@ async def continue_run(
     finally:
         proxy.stop()
 
-    write_stitched_trajectory(
+    stitched_path = write_stitched_trajectory(
         rollout_dir,
         run.path / "trajectory" / "llm_trajectory.jsonl",
         router.live_exchanges,
+    )
+    update_continued_metadata(
+        rollout_dir,
+        live_model=live_model,
+        usage=summarize_llm_trajectory_usage(
+            stitched_path,
+            n_recorded=run.n_recorded_exchanges,
+        ),
+        environment=run.environment,
     )
 
     return ContinueResult(
@@ -307,4 +575,169 @@ async def continue_run(
         n_recorded=run.n_recorded_exchanges,
         n_live=len(router.live_exchanges),
         divergences=router.divergences,
+    )
+
+
+async def _continue_run_with_sandbox_proxy(
+    run: RunFolder,
+    *,
+    task_path: Path,
+    live_model: str,
+    timeout: int | None,
+    output_dir: Path,
+    rollout_name: str,
+    strict_divergence: bool,
+) -> ContinueResult:
+    """Run continuation with replay and provider proxies inside the sandbox."""
+    from benchflow.providers.runtime import (
+        ensure_litellm_runtime,
+        stop_provider_runtime,
+    )
+    from benchflow.rollout import Rollout
+
+    config = build_rollout_config(
+        run,
+        task_path=task_path,
+        live_model=live_model,
+        agent_env=build_agent_env(sandbox_replay_base_url()),
+        timeout=timeout if timeout is not None else run.timeout_sec,
+        output_dir=output_dir,
+        rollout_name=rollout_name,
+    )
+    rollout = await Rollout.create(config)
+    replay_proxy: SandboxReplayProxy | None = None
+    provider_runtime: Any | None = None
+    result: Any | None = None
+    pending_acp_error: AgentProtocolError | None = None
+    agent_timed_out = False
+    rollout_dir: Path | None = None
+    live_exchanges: list[LLMExchange] = []
+    artifacts_written = False
+
+    async def _write_artifacts_before_cleanup() -> None:
+        nonlocal artifacts_written, live_exchanges, result, rollout_dir
+        if artifacts_written:
+            return
+        result = _result_after_sandbox_teardown(rollout)
+        if result is None:
+            return
+        rollout_dir = Path(rollout._rollout_dir or (output_dir / rollout_name))
+        live_exchanges = replay_proxy.live_exchanges if replay_proxy is not None else []
+        stitched_path = write_stitched_trajectory(
+            rollout_dir,
+            run.path / "trajectory" / "llm_trajectory.jsonl",
+            live_exchanges,
+        )
+        update_continued_metadata(
+            rollout_dir,
+            live_model=live_model,
+            usage=summarize_llm_trajectory_usage(
+                stitched_path,
+                n_recorded=run.n_recorded_exchanges,
+            ),
+            environment=run.environment,
+        )
+        artifacts_written = True
+
+    try:
+        await rollout.setup()
+        await rollout.start()
+        await rollout.install_agent()
+
+        provider_env = rollout._planes.resolve_agent_env("openhands", live_model, {})
+        provider_env, provider_runtime = await ensure_litellm_runtime(
+            agent="openhands",
+            agent_env=provider_env,
+            model=live_model,
+            runtime=None,
+            environment=run.environment,
+            session_id=rollout_name,
+            usage_tracking="required",
+            sandbox=rollout.env,
+        )
+        replay_proxy = await SandboxReplayProxy.start(
+            sandbox=rollout.env,
+            recorded=run.exchanges,
+            upstream_url=provider_env["LLM_BASE_URL"],
+            upstream_api_key=provider_env["LLM_API_KEY"],
+            upstream_model=provider_env["LLM_MODEL"],
+            strict_divergence=strict_divergence,
+        )
+
+        try:
+            if config.user is not None:
+                await rollout._run_user_loop()
+            else:
+                await rollout._run_steps(
+                    compile_scenes_to_steps(
+                        config.effective_scenes,
+                        default_prompt=(
+                            rollout._resolved_prompts[0]
+                            if rollout._resolved_prompts
+                            else None
+                        ),
+                    )
+                )
+        except TimeoutError as exc:
+            agent_timed_out = True
+            detail = str(exc).strip()
+            rollout._error = detail or f"Agent timed out after {rollout._timeout}s"
+            rollout._diagnostics.capture_idle(exc)
+            logger.error(rollout._error)
+
+        if not config.skip_verify:
+            await rollout.verify()
+            if (
+                agent_timed_out
+                and rollout._rewards is None
+                and rollout._verifier_error is None
+            ):
+                rollout._rewards = {"reward": 0.0}
+                rollout._verifier_error = None
+
+    except TimeoutError as exc:
+        detail = str(exc).strip()
+        rollout._error = detail or f"Agent timed out after {rollout._timeout}s"
+        rollout._diagnostics.capture_idle(exc)
+        logger.error(rollout._error)
+    except ConnectionError as exc:
+        rollout._error = str(exc)
+        rollout._diagnostics.capture_transport(exc)
+        await rollout._probe_sandbox_health()
+        logger.error("Agent connection lost: %s", rollout._error)
+    except SandboxStartupFailure as exc:
+        rollout._error = f"Sandbox startup failed: {exc}"
+        rollout._diagnostics.set(exc.diagnostic)
+        logger.error(rollout._error)
+    except AgentProtocolError as exc:
+        pending_acp_error = exc
+        rollout._error = str(exc)
+        logger.error(str(exc))
+    except Exception as exc:
+        rollout._error = str(exc)
+        logger.error("Run failed", exc_info=True)
+    finally:
+        await _safe_sandbox_continuation_teardown(
+            rollout=rollout,
+            replay_proxy=replay_proxy,
+            provider_runtime=provider_runtime,
+            stop_provider_runtime=stop_provider_runtime,
+            before_cleanup=_write_artifacts_before_cleanup,
+        )
+
+    if pending_acp_error is not None:
+        rollout._error = rollout._classify_acp_error(pending_acp_error)
+        logger.error(rollout._error)
+
+    await _write_artifacts_before_cleanup()
+    if rollout_dir is None:
+        rollout_dir = Path(rollout._rollout_dir or (output_dir / rollout_name))
+
+    return ContinueResult(
+        rollout_dir=rollout_dir,
+        rewards=getattr(result, "rewards", None),
+        error=getattr(result, "error", None),
+        n_recorded=run.n_recorded_exchanges,
+        n_live=len(live_exchanges),
+        divergences=0,
     )

--- a/src/benchflow/continue_run/replay_proxy.py
+++ b/src/benchflow/continue_run/replay_proxy.py
@@ -84,7 +84,9 @@ class ReplayRouter:
     def exhausted(self) -> bool:
         return self._cursor >= len(self._recorded)
 
-    def _check_divergence(self, incoming: dict[str, Any], recorded_req: dict[str, Any]) -> None:
+    def _check_divergence(
+        self, incoming: dict[str, Any], recorded_req: dict[str, Any]
+    ) -> None:
         """Soft-validate that replay is still on the original rails.
 
         The recorded request is a *normalized projection* (model/messages/tools),
@@ -186,9 +188,7 @@ def completion_to_sse(body: dict[str, Any]) -> list[str]:
                 "object": "chat.completion.chunk",
                 "created": created,
                 "model": model,
-                "choices": [
-                    {"index": 0, "delta": delta, "finish_reason": finish}
-                ],
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
             }
         )
 
@@ -258,7 +258,9 @@ class _ProxyState:
 class _ReplayHTTPServer(ThreadingHTTPServer):
     """ThreadingHTTPServer that carries the proxy state for its handlers."""
 
-    def __init__(self, addr: tuple[str, int], handler: type, state: _ProxyState) -> None:
+    def __init__(
+        self, addr: tuple[str, int], handler: type, state: _ProxyState
+    ) -> None:
         super().__init__(addr, handler)
         self.state = state
 

--- a/src/benchflow/continue_run/replay_proxy.py
+++ b/src/benchflow/continue_run/replay_proxy.py
@@ -1,0 +1,407 @@
+"""Record-replay LLM proxy for ``benchflow continue``.
+
+OpenHands talks to this proxy via ``LLM_BASE_URL`` (OpenAI chat-completions
+wire protocol). For the first *N* requests it returns the *recorded* responses
+from the original run's ``llm_trajectory.jsonl`` **in order**, so the agent
+re-executes its own past decisions for real and rebuilds its exact workspace and
+internal state. Once the recorded responses are exhausted (the timeout
+cut-point), it forwards to the **live** upstream and the agent continues with no
+injected prompt.
+
+Two layers, kept separate so the routing logic is testable without sockets:
+
+- :class:`ReplayRouter` — pure: maps the *i*-th incoming request to the *i*-th
+  recorded response, then to the live forwarder. Captures the live-leg exchanges
+  so the caller can stitch a continuous ``llm_trajectory.jsonl``.
+- :class:`ReplayProxy` — a tiny stdlib ``http.server`` wrapper (no extra deps)
+  that parses requests, calls the router, and emits the result as JSON or as
+  reconstructed SSE depending on the request's ``stream`` flag.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, cast
+
+from benchflow.trajectories.types import LLMExchange, LLMRequest, LLMResponse
+
+logger = logging.getLogger(__name__)
+
+# A callable that takes the agent's request body and returns a final
+# (non-streamed) ChatCompletion dict from the real model. The orchestrator wires
+# this to a LiteLLM gateway; ``None`` means "no live leg" (replay-only).
+LiveForwarder = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+@dataclass
+class ReplayResult:
+    """Outcome of routing one request: a final ChatCompletion to emit."""
+
+    source: str  # "replay" | "live" | "error"
+    status: int
+    body: dict[str, Any]
+
+
+def _n_messages(body: dict[str, Any]) -> int:
+    msgs = body.get("messages")
+    return len(msgs) if isinstance(msgs, list) else 0
+
+
+class ReplayRouter:
+    """Serve recorded responses in order, then live — the core replay logic.
+
+    Thread-safe: a single agent is typically serial, but ``ThreadingHTTPServer``
+    may overlap requests, so the cursor is advanced under a lock.
+    """
+
+    def __init__(
+        self,
+        recorded: list[LLMExchange],
+        *,
+        live_forwarder: LiveForwarder | None = None,
+        strict_divergence: bool = False,
+    ) -> None:
+        self._recorded = recorded
+        self._live_forwarder = live_forwarder
+        self._strict = strict_divergence
+        self._lock = threading.Lock()
+        self._cursor = 0
+        self.divergences = 0
+        # Live-leg exchanges, in order, for stitching onto the recorded prefix.
+        self.live_exchanges: list[LLMExchange] = []
+
+    @property
+    def cursor(self) -> int:
+        return self._cursor
+
+    @property
+    def exhausted(self) -> bool:
+        return self._cursor >= len(self._recorded)
+
+    def _check_divergence(self, incoming: dict[str, Any], recorded_req: dict[str, Any]) -> None:
+        """Soft-validate that replay is still on the original rails.
+
+        The recorded request is a *normalized projection* (model/messages/tools),
+        not the verbatim HTTP body, so we only compare message counts — a cheap
+        signal that the agent's conversation has the expected shape at this turn.
+        """
+        want = _n_messages(recorded_req)
+        got = _n_messages(incoming)
+        if want and got and got != want:
+            self.divergences += 1
+            msg = (
+                f"replay divergence at turn {self._cursor}: agent sent {got} "
+                f"messages, recorded turn had {want}"
+            )
+            if self._strict:
+                raise ReplayDivergenceError(msg)
+            logger.warning(msg)
+
+    def next_response(self, request_body: dict[str, Any]) -> ReplayResult:
+        """Route one request to its recorded response, or to the live model."""
+        with self._lock:
+            if self._cursor < len(self._recorded):
+                exchange = self._recorded[self._cursor]
+                self._check_divergence(request_body, exchange.request.body)
+                self._cursor += 1
+                return ReplayResult(
+                    source="replay",
+                    status=exchange.response.status_code or 200,
+                    body=dict(exchange.response.body),
+                )
+            # Past the cut-point: live continuation.
+            self._cursor += 1
+            forwarder = self._live_forwarder
+
+        if forwarder is None:
+            logger.error(
+                "recorded responses exhausted at turn %d and no live forwarder "
+                "is configured — returning an error to the agent.",
+                self._cursor - 1,
+            )
+            return ReplayResult(
+                source="error",
+                status=503,
+                body={
+                    "error": {
+                        "message": (
+                            "benchflow continue: recorded trajectory exhausted "
+                            "and no live model configured."
+                        ),
+                        "type": "replay_exhausted",
+                    }
+                },
+            )
+
+        body = forwarder(request_body)
+        # Capture the live exchange so the caller can stitch a continuous
+        # llm_trajectory.jsonl (recorded prefix + live suffix).
+        self.live_exchanges.append(
+            LLMExchange(
+                request=LLMRequest(body=request_body),
+                response=LLMResponse(status_code=200, body=body),
+            )
+        )
+        return ReplayResult(source="live", status=200, body=body)
+
+
+class ReplayDivergenceError(RuntimeError):
+    """Raised (only in ``strict_divergence`` mode) when replay leaves the rails."""
+
+
+# ── SSE reconstruction ────────────────────────────────────────────────────
+#
+# The recorded/live body is a *final* ChatCompletion. When the agent asked for
+# ``stream: true`` we must re-emit it as ``chat.completion.chunk`` SSE events so
+# the agent's LiteLLM client reassembles the identical final message. Emitting
+# the whole content / each tool call in a single delta is accepted by
+# OpenAI-compatible stream parsers (LiteLLM included).
+
+
+def completion_to_sse(body: dict[str, Any]) -> list[str]:
+    """Render a final ChatCompletion as a list of SSE ``data:`` payload strings.
+
+    The returned strings are the JSON payloads (without the ``data: `` prefix or
+    trailing blank line); the HTTP layer frames them. The final ``[DONE]``
+    sentinel is appended by the caller.
+    """
+    base_id = body.get("id") or f"chatcmpl-replay-{int(time.time() * 1000)}"
+    created = body.get("created") or int(time.time())
+    model = body.get("model") or "replay"
+    choices = body.get("choices") or [{}]
+    choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = choice.get("message") or {}
+    finish_reason = choice.get("finish_reason") or "stop"
+
+    def chunk(delta: dict[str, Any], finish: str | None = None) -> str:
+        return json.dumps(
+            {
+                "id": base_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [
+                    {"index": 0, "delta": delta, "finish_reason": finish}
+                ],
+            }
+        )
+
+    payloads: list[str] = [chunk({"role": "assistant"})]
+
+    content = message.get("content")
+    if content:
+        delta: dict[str, Any] = {"content": content}
+        # Preserve reasoning when the provider surfaces it on the message.
+        for key in ("reasoning_content", "thinking"):
+            if message.get(key):
+                delta[key] = message[key]
+        payloads.append(chunk(delta))
+
+    tool_calls = message.get("tool_calls") or []
+    for i, tc in enumerate(tool_calls):
+        if not isinstance(tc, dict):
+            continue
+        fn = tc.get("function") or {}
+        payloads.append(
+            chunk(
+                {
+                    "tool_calls": [
+                        {
+                            "index": tc.get("index", i),
+                            "id": tc.get("id"),
+                            "type": tc.get("type", "function"),
+                            "function": {
+                                "name": fn.get("name"),
+                                "arguments": fn.get("arguments", ""),
+                            },
+                        }
+                    ]
+                }
+            )
+        )
+
+    final = {
+        "id": base_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+    }
+    usage = body.get("usage")
+    if isinstance(usage, dict):
+        final["usage"] = usage
+    payloads.append(json.dumps(final))
+    return payloads
+
+
+# ── HTTP layer ────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _ProxyState:
+    router: ReplayRouter
+    requests_seen: int = 0
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def bump(self) -> int:
+        with self._lock:
+            self.requests_seen += 1
+            return self.requests_seen
+
+
+class _ReplayHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer that carries the proxy state for its handlers."""
+
+    def __init__(self, addr: tuple[str, int], handler: type, state: _ProxyState) -> None:
+        super().__init__(addr, handler)
+        self.state = state
+
+
+class _ReplayHandler(BaseHTTPRequestHandler):
+    # Silence the default per-request stderr logging; route through logging.
+    def log_message(self, format: str, *args: Any) -> None:
+        logger.debug("replay-proxy %s - " + format, self.address_string(), *args)
+
+    @property
+    def _state(self) -> _ProxyState:
+        return cast("_ReplayHTTPServer", self.server).state
+
+    def _send_json(self, status: int, payload: dict[str, Any]) -> None:
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_sse(self, payloads: list[str]) -> None:
+        # A finite SSE reply: emit all chunks + [DONE], then close the
+        # connection so length-agnostic clients see a clean end-of-stream
+        # (no Content-Length is sent for event-streams).
+        self.close_connection = True
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        for payload in payloads:
+            self.wfile.write(f"data: {payload}\n\n".encode())
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def do_GET(self) -> None:
+        path = self.path.split("?", 1)[0]
+        if path in ("/health", "/health/liveliness", "/v1/health"):
+            self._send_json(200, {"status": "ok"})
+            return
+        if path in ("/v1/models", "/models"):
+            self._send_json(
+                200,
+                {"object": "list", "data": [{"id": "replay", "object": "model"}]},
+            )
+            return
+        self._send_json(404, {"error": {"message": f"not found: {path}"}})
+
+    def do_POST(self) -> None:
+        path = self.path.split("?", 1)[0]
+        if path not in ("/v1/chat/completions", "/chat/completions"):
+            self._send_json(404, {"error": {"message": f"not found: {path}"}})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length) if length else b"{}"
+            request_body = json.loads(raw or b"{}")
+            if not isinstance(request_body, dict):
+                raise ValueError("request body must be a JSON object")
+        except (ValueError, json.JSONDecodeError) as exc:
+            self._send_json(400, {"error": {"message": f"bad request: {exc}"}})
+            return
+
+        self._state.bump()
+        want_stream = bool(request_body.get("stream"))
+        try:
+            result = self._state.router.next_response(request_body)
+        except ReplayDivergenceError as exc:
+            self._send_json(409, {"error": {"message": str(exc), "type": "divergence"}})
+            return
+        except Exception as exc:
+            logger.exception("replay router failed")
+            self._send_json(500, {"error": {"message": str(exc)}})
+            return
+
+        if result.status >= 400 or not result.body.get("choices"):
+            # Errors (and recorded failure exchanges) are returned verbatim as
+            # JSON regardless of stream, so the agent's client surfaces them.
+            self._send_json(result.status, result.body)
+            return
+
+        if want_stream:
+            self._send_sse(completion_to_sse(result.body))
+        else:
+            self._send_json(result.status, result.body)
+
+
+class ReplayProxy:
+    """A running record-replay proxy bound to ``host:port``.
+
+    ``base_url`` is the OpenAI-style root (``http://host:port/v1``) to hand the
+    agent as ``LLM_BASE_URL``. Use as a context manager or call
+    :meth:`start`/:meth:`stop`.
+    """
+
+    def __init__(
+        self,
+        router: ReplayRouter,
+        *,
+        host: str = "127.0.0.1",
+        port: int = 0,
+        advertise_host: str | None = None,
+    ) -> None:
+        self._router = router
+        self._host = host
+        self._advertise_host = advertise_host or host
+        self._server = _ReplayHTTPServer(
+            (host, port), _ReplayHandler, _ProxyState(router=router)
+        )
+        self._thread: threading.Thread | None = None
+
+    @property
+    def router(self) -> ReplayRouter:
+        return self._router
+
+    @property
+    def port(self) -> int:
+        return int(self._server.server_address[1])
+
+    @property
+    def base_url(self) -> str:
+        """The ``/v1`` root the agent should use as ``LLM_BASE_URL``."""
+        return f"http://{self._advertise_host}:{self.port}/v1"
+
+    def start(self) -> ReplayProxy:
+        self._thread = threading.Thread(
+            target=self._server.serve_forever,
+            name="benchflow-replay-proxy",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info("replay proxy listening on %s", self.base_url)
+        return self
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def __enter__(self) -> ReplayProxy:
+        return self.start()
+
+    def __exit__(self, *exc: object) -> None:
+        self.stop()

--- a/src/benchflow/continue_run/run_folder.py
+++ b/src/benchflow/continue_run/run_folder.py
@@ -1,0 +1,209 @@
+"""Load and validate an original run's output folder for ``benchflow continue``.
+
+A benchflow rollout (or an HF-downloaded copy of one) is a directory containing:
+
+- ``config.json``   — task identity, agent, model, environment, original timeout,
+  and ``source`` provenance (written by ``benchflow.rollout._write_config``).
+- ``result.json``   — terminal status (``error`` / ``error_category``), rewards.
+- ``prompts.json``  — the prompts handed to the agent (the first is the task
+  instruction).
+- ``trajectory/llm_trajectory.jsonl`` — one :class:`LLMExchange` per line
+  (``Trajectory.to_jsonl``): the recorded LLM request/response pairs that
+  drive record-replay.
+
+This module is pure (no sandbox, no network) so the whole load + validate path
+is unit-testable offline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from benchflow.trajectories.types import LLMExchange
+
+logger = logging.getLogger(__name__)
+
+# error_category values (see benchflow._utils.scoring.classify_error) that mean
+# "the agent ran out of time", i.e. the run is genuinely *unfinished* and worth
+# continuing rather than a clean pass/fail.
+_TIMEOUT_CATEGORIES = frozenset({"timeout", "idle_timeout"})
+
+
+class RunFolderError(ValueError):
+    """Raised when a run folder is missing required artifacts or malformed."""
+
+
+@dataclass(frozen=True)
+class RunFolder:
+    """Parsed view of an original run's output folder.
+
+    Only fields ``benchflow continue`` needs are surfaced; the raw ``config``
+    and ``result`` dicts are kept for anything else the orchestrator wants.
+    """
+
+    path: Path
+    config: dict[str, Any]
+    result: dict[str, Any]
+    prompts: list[str]
+    exchanges: list[LLMExchange]
+
+    # ── derived task identity (from config.json) ──────────────────────────
+    @property
+    def task_path(self) -> str:
+        return str(self.config.get("task_path") or "")
+
+    @property
+    def task_name(self) -> str:
+        """The task directory name (e.g. ``energy-unit-commitment``)."""
+        tp = self.task_path
+        return Path(tp).name if tp else str(self.result.get("task_name") or "")
+
+    @property
+    def agent(self) -> str:
+        return str(self.config.get("agent") or self.result.get("agent") or "")
+
+    @property
+    def model(self) -> str | None:
+        model = self.config.get("model") or self.result.get("model")
+        return str(model) if model else None
+
+    @property
+    def environment(self) -> str:
+        return str(self.config.get("environment") or "docker")
+
+    @property
+    def sandbox_user(self) -> str | None:
+        user = self.config.get("sandbox_user")
+        return str(user) if user else None
+
+    @property
+    def reasoning_effort(self) -> str | None:
+        effort = self.config.get("reasoning_effort")
+        return str(effort) if effort else None
+
+    @property
+    def timeout_sec(self) -> int | None:
+        value = self.config.get("timeout_sec")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def agent_idle_timeout_sec(self) -> int | None:
+        value = self.config.get("agent_idle_timeout_sec")
+        return int(value) if isinstance(value, (int, float)) else None
+
+    @property
+    def error_category(self) -> str | None:
+        cat = self.result.get("error_category")
+        return str(cat) if cat else None
+
+    @property
+    def is_timeout(self) -> bool:
+        """Whether the recorded terminal status is a timeout/idle-timeout."""
+        return self.error_category in _TIMEOUT_CATEGORIES
+
+    @property
+    def n_recorded_exchanges(self) -> int:
+        return len(self.exchanges)
+
+
+def _read_json(path: Path, *, required: bool) -> dict[str, Any]:
+    if not path.is_file():
+        if required:
+            raise RunFolderError(f"missing required artifact: {path}")
+        return {}
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunFolderError(f"could not parse {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise RunFolderError(f"expected a JSON object in {path}, got {type(data).__name__}")
+    return data
+
+
+def _load_prompts(path: Path) -> list[str]:
+    """Read ``prompts.json`` — a JSON list of strings (or ``{"prompts": [...]}``)."""
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RunFolderError(f"could not parse {path}: {exc}") from exc
+    if isinstance(data, dict):
+        data = data.get("prompts", [])
+    if not isinstance(data, list):
+        raise RunFolderError(f"expected a JSON list in {path}")
+    return [str(p) for p in data if p is not None]
+
+
+def load_llm_exchanges(path: Path) -> list[LLMExchange]:
+    """Parse ``llm_trajectory.jsonl`` into ordered :class:`LLMExchange` records.
+
+    One exchange per line (``Trajectory.to_jsonl``). Blank lines are skipped;
+    a malformed line is skipped with a warning rather than aborting the whole
+    resume (a single bad record should not strand a recoverable run).
+    """
+    if not path.is_file():
+        raise RunFolderError(
+            f"missing required artifact: {path} — record-replay needs the LLM "
+            "trajectory. Was this run captured with usage tracking enabled?"
+        )
+    exchanges: list[LLMExchange] = []
+    for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
+        if not raw.strip():
+            continue
+        try:
+            exchanges.append(LLMExchange.model_validate_json(raw))
+        except Exception as exc:
+            logger.warning("skipping malformed llm_trajectory line %d: %s", lineno, exc)
+    if not exchanges:
+        raise RunFolderError(
+            f"{path} contained no usable LLM exchanges — nothing to replay."
+        )
+    return exchanges
+
+
+def load_run_folder(folder: str | Path, *, require_timeout: bool = False) -> RunFolder:
+    """Load + validate an original run folder.
+
+    ``require_timeout`` rejects runs whose recorded status is not a
+    timeout/idle-timeout. The default is permissive (warn only): a run with no
+    recorded ``error_category`` may still be worth continuing, and the user can
+    opt into strictness.
+    """
+    path = Path(folder).expanduser()
+    if not path.is_dir():
+        raise RunFolderError(f"not a directory: {path}")
+
+    config = _read_json(path / "config.json", required=True)
+    result = _read_json(path / "result.json", required=False)
+    prompts = _load_prompts(path / "prompts.json")
+    exchanges = load_llm_exchanges(path / "trajectory" / "llm_trajectory.jsonl")
+
+    run = RunFolder(
+        path=path,
+        config=config,
+        result=result,
+        prompts=prompts,
+        exchanges=exchanges,
+    )
+
+    if run.agent != "openhands":
+        raise RunFolderError(
+            f"benchflow continue currently supports the 'openhands' agent only; "
+            f"this run used {run.agent!r}."
+        )
+
+    if not run.is_timeout:
+        msg = (
+            f"run {path.name} has error_category={run.error_category!r}, not a "
+            "timeout/idle_timeout — continuing it may not be meaningful."
+        )
+        if require_timeout:
+            raise RunFolderError(msg)
+        logger.warning(msg)
+
+    return run

--- a/src/benchflow/continue_run/run_folder.py
+++ b/src/benchflow/continue_run/run_folder.py
@@ -120,7 +120,9 @@ def _read_json(path: Path, *, required: bool) -> dict[str, Any]:
     except (OSError, json.JSONDecodeError) as exc:
         raise RunFolderError(f"could not parse {path}: {exc}") from exc
     if not isinstance(data, dict):
-        raise RunFolderError(f"expected a JSON object in {path}, got {type(data).__name__}")
+        raise RunFolderError(
+            f"expected a JSON object in {path}, got {type(data).__name__}"
+        )
     return data
 
 

--- a/src/benchflow/continue_run/sandbox_proxy.py
+++ b/src/benchflow/continue_run/sandbox_proxy.py
@@ -1,0 +1,472 @@
+"""Sandbox-local replay proxy for ``benchflow continue``.
+
+Remote sandboxes such as Daytona cannot reach a host-local replay proxy at
+``127.0.0.1``. For those environments the continuation stack runs entirely
+inside the sandbox:
+
+    OpenHands -> sandbox replay proxy -> sandbox LiteLLM proxy -> provider
+
+The host uploads the recorded exchanges and a small stdlib-only proxy script,
+then downloads the live suffix after the rollout finishes so the normal stitched
+``llm_trajectory.jsonl`` artifact remains identical in shape to host replay.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import shlex
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from benchflow.trajectories.types import LLMExchange
+
+SANDBOX_REPLAY_ROOT = "/tmp/benchflow-replay"
+DEFAULT_SANDBOX_REPLAY_PORT = 61357
+
+
+def sandbox_replay_base_url(port: int = DEFAULT_SANDBOX_REPLAY_PORT) -> str:
+    """Return the in-sandbox OpenAI-compatible replay endpoint."""
+    return f"http://127.0.0.1:{port}/v1"
+
+
+def _sandbox_proxy_source() -> str:
+    return r"""
+from __future__ import annotations
+
+import json
+import sys
+import threading
+import time
+import traceback
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+
+def _n_messages(body):
+    messages = body.get("messages")
+    return len(messages) if isinstance(messages, list) else 0
+
+
+def _completion_to_sse(body):
+    base_id = body.get("id") or f"chatcmpl-replay-{int(time.time() * 1000)}"
+    created = body.get("created") or int(time.time())
+    model = body.get("model") or "replay"
+    choices = body.get("choices") or [{}]
+    choice = choices[0] if choices and isinstance(choices[0], dict) else {}
+    message = choice.get("message") or {}
+    finish_reason = choice.get("finish_reason") or "stop"
+
+    def chunk(delta, finish=None):
+        return json.dumps(
+            {
+                "id": base_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": model,
+                "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+            }
+        )
+
+    payloads = [chunk({"role": "assistant"})]
+    content = message.get("content")
+    if content:
+        delta = {"content": content}
+        for key in ("reasoning_content", "thinking"):
+            if message.get(key):
+                delta[key] = message[key]
+        payloads.append(chunk(delta))
+
+    for i, tool_call in enumerate(message.get("tool_calls") or []):
+        if not isinstance(tool_call, dict):
+            continue
+        function = tool_call.get("function") or {}
+        payloads.append(
+            chunk(
+                {
+                    "tool_calls": [
+                        {
+                            "index": tool_call.get("index", i),
+                            "id": tool_call.get("id"),
+                            "type": tool_call.get("type", "function"),
+                            "function": {
+                                "name": function.get("name"),
+                                "arguments": function.get("arguments", ""),
+                            },
+                        }
+                    ]
+                }
+            )
+        )
+
+    final = {
+        "id": base_id,
+        "object": "chat.completion.chunk",
+        "created": created,
+        "model": model,
+        "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
+    }
+    if isinstance(body.get("usage"), dict):
+        final["usage"] = body["usage"]
+    payloads.append(json.dumps(final))
+    return payloads
+
+
+@dataclass
+class ReplayState:
+    recorded: list
+    upstream_url: str
+    upstream_api_key: str
+    upstream_model: str
+    live_log_path: str
+    strict_divergence: bool = False
+    cursor: int = 0
+    divergences: int = 0
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def _check_divergence(self, incoming, recorded_request):
+        want = _n_messages(recorded_request)
+        got = _n_messages(incoming)
+        if want and got and want != got:
+            self.divergences += 1
+            message = (
+                f"replay divergence at turn {self.cursor}: agent sent {got} "
+                f"messages, recorded turn had {want}"
+            )
+            if self.strict_divergence:
+                raise RuntimeError(message)
+            print(message, file=sys.stderr, flush=True)
+
+    def next_response(self, request_body):
+        with self.lock:
+            if self.cursor < len(self.recorded):
+                exchange = self.recorded[self.cursor]
+                self._check_divergence(
+                    request_body,
+                    ((exchange.get("request") or {}).get("body") or {}),
+                )
+                self.cursor += 1
+                response = exchange.get("response") or {}
+                return "replay", int(response.get("status_code") or 200), dict(response.get("body") or {})
+            self.cursor += 1
+
+        status, body = self._forward_live(request_body)
+        self._append_live_exchange(request_body, status, body)
+        return "live", status, body
+
+    def _forward_live(self, request_body):
+        forwarded = dict(request_body)
+        forwarded["model"] = self.upstream_model
+        forwarded["stream"] = False
+        data = json.dumps(forwarded).encode("utf-8")
+        request = urllib.request.Request(
+            self.upstream_url.rstrip("/") + "/chat/completions",
+            data=data,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.upstream_api_key}",
+            },
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=600) as response:
+                raw = response.read().decode("utf-8")
+                return int(response.status), json.loads(raw or "{}")
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            try:
+                body = json.loads(raw or "{}")
+            except json.JSONDecodeError:
+                body = {"error": {"message": raw or str(exc)}}
+            return int(exc.code), body
+        except Exception as exc:
+            traceback.print_exc()
+            return 500, {"error": {"message": str(exc)}}
+
+    def _append_live_exchange(self, request_body, status, body):
+        row = {
+            "request": {"body": request_body},
+            "response": {"status_code": status, "body": body},
+        }
+        with open(self.live_log_path, "a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row) + "\n")
+            handle.flush()
+
+
+class ReplayHandler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        print("replay-proxy " + fmt % args, file=sys.stderr, flush=True)
+
+    @property
+    def state(self):
+        return self.server.state
+
+    def _send_json(self, status, payload):
+        data = json.dumps(payload).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_sse(self, payloads):
+        self.close_connection = True
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        for payload in payloads:
+            self.wfile.write(f"data: {payload}\n\n".encode("utf-8"))
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+
+    def do_GET(self):
+        path = self.path.split("?", 1)[0]
+        if path in ("/health", "/health/liveliness", "/v1/health"):
+            self._send_json(200, {"status": "ok"})
+            return
+        if path in ("/v1/models", "/models"):
+            self._send_json(200, {"object": "list", "data": [{"id": "replay", "object": "model"}]})
+            return
+        self._send_json(404, {"error": {"message": f"not found: {path}"}})
+
+    def do_POST(self):
+        path = self.path.split("?", 1)[0]
+        if path not in ("/v1/chat/completions", "/chat/completions"):
+            self._send_json(404, {"error": {"message": f"not found: {path}"}})
+            return
+        try:
+            length = int(self.headers.get("Content-Length") or 0)
+            raw = self.rfile.read(length) if length else b"{}"
+            body = json.loads(raw or b"{}")
+            if not isinstance(body, dict):
+                raise ValueError("request body must be a JSON object")
+        except Exception as exc:
+            self._send_json(400, {"error": {"message": f"bad request: {exc}"}})
+            return
+
+        want_stream = bool(body.get("stream"))
+        try:
+            _, status, response = self.state.next_response(body)
+        except RuntimeError as exc:
+            self._send_json(409, {"error": {"message": str(exc), "type": "divergence"}})
+            return
+        except Exception as exc:
+            traceback.print_exc()
+            self._send_json(500, {"error": {"message": str(exc)}})
+            return
+
+        if status >= 400 or not response.get("choices"):
+            self._send_json(status, response)
+            return
+        if want_stream:
+            self._send_sse(_completion_to_sse(response))
+        else:
+            self._send_json(status, response)
+
+
+class ReplayServer(ThreadingHTTPServer):
+    def __init__(self, address, handler, state):
+        super().__init__(address, handler)
+        self.state = state
+
+
+def main():
+    cfg = json.load(open(sys.argv[1], encoding="utf-8"))
+    state = ReplayState(
+        recorded=cfg["recorded"],
+        upstream_url=cfg["upstream_url"],
+        upstream_api_key=cfg["upstream_api_key"],
+        upstream_model=cfg["upstream_model"],
+        live_log_path=cfg["live_log_path"],
+        strict_divergence=bool(cfg.get("strict_divergence")),
+    )
+    server = ReplayServer(("127.0.0.1", int(cfg["port"])), ReplayHandler, state)
+    with open(cfg["state_path"], "w", encoding="utf-8") as handle:
+        json.dump({"port": int(cfg["port"])}, handle)
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()
+"""
+
+
+async def _upload_text(sandbox: Any, text: str, target_path: str, suffix: str) -> None:
+    with tempfile.NamedTemporaryFile("w", suffix=suffix, delete=False) as tmp:
+        tmp.write(text)
+        tmp_path = Path(tmp.name)
+    try:
+        await sandbox.upload_file(tmp_path, target_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+async def _read_remote_text(sandbox: Any, path: str, *, timeout_sec: int = 15) -> str:
+    download_file = getattr(sandbox, "download_file", None)
+    if download_file is not None:
+        with tempfile.NamedTemporaryFile("r", delete=False) as tmp:
+            tmp_path = Path(tmp.name)
+        try:
+            await download_file(path, tmp_path)
+            return tmp_path.read_text()
+        except Exception:
+            pass
+        finally:
+            tmp_path.unlink(missing_ok=True)
+    result = await sandbox.exec(
+        f"cat {shlex.quote(path)} 2>/dev/null || true",
+        timeout_sec=timeout_sec,
+    )
+    return result.stdout or ""
+
+
+@dataclass
+class SandboxReplayProxy:
+    """A replay proxy process running on sandbox loopback."""
+
+    sandbox: Any
+    runtime_dir: str
+    port: int
+    pid_path: str
+    live_log_path: str
+    state_path: str
+    stdout_path: str
+    stderr_path: str
+    live_exchanges: list[LLMExchange] = field(default_factory=list)
+
+    @property
+    def base_url(self) -> str:
+        return sandbox_replay_base_url(self.port)
+
+    @classmethod
+    async def start(
+        cls,
+        *,
+        sandbox: Any,
+        recorded: list[LLMExchange],
+        upstream_url: str,
+        upstream_api_key: str,
+        upstream_model: str,
+        strict_divergence: bool = False,
+        port: int = DEFAULT_SANDBOX_REPLAY_PORT,
+    ) -> SandboxReplayProxy:
+        token = uuid4().hex[:16]
+        runtime_dir = f"{SANDBOX_REPLAY_ROOT}/{token}"
+        paths = {
+            "script": f"{runtime_dir}/replay_proxy.py",
+            "config": f"{runtime_dir}/config.json",
+            "state": f"{runtime_dir}/state.json",
+            "pid": f"{runtime_dir}/replay.pid",
+            "stdout": f"{runtime_dir}/stdout.log",
+            "stderr": f"{runtime_dir}/stderr.log",
+            "live_log": f"{runtime_dir}/live_exchanges.jsonl",
+        }
+        result = await sandbox.exec(
+            f"mkdir -p {shlex.quote(runtime_dir)} && "
+            f"chmod 700 {shlex.quote(runtime_dir)}",
+            timeout_sec=20,
+        )
+        if result.return_code != 0:
+            raise RuntimeError(
+                "prepare sandbox replay runtime failed: "
+                f"{result.stderr or result.stdout}"
+            )
+
+        recorded_rows = [
+            exchange.model_dump(mode="json", exclude_none=True) for exchange in recorded
+        ]
+        config = {
+            "recorded": recorded_rows,
+            "upstream_url": upstream_url,
+            "upstream_api_key": upstream_api_key,
+            "upstream_model": upstream_model,
+            "strict_divergence": strict_divergence,
+            "port": port,
+            "state_path": paths["state"],
+            "live_log_path": paths["live_log"],
+        }
+        await _upload_text(sandbox, _sandbox_proxy_source(), paths["script"], ".py")
+        await _upload_text(sandbox, json.dumps(config), paths["config"], ".json")
+
+        command = (
+            f"rm -f {shlex.quote(paths['state'])} {shlex.quote(paths['pid'])} "
+            f"{shlex.quote(paths['live_log'])}; "
+            f"(python3 {shlex.quote(paths['script'])} {shlex.quote(paths['config'])} "
+            f"> {shlex.quote(paths['stdout'])} 2> {shlex.quote(paths['stderr'])} & "
+            f"echo $! > {shlex.quote(paths['pid'])})"
+        )
+        result = await sandbox.exec(command, timeout_sec=20)
+        if result.return_code != 0:
+            raise RuntimeError(
+                f"start sandbox replay proxy failed: {result.stderr or result.stdout}"
+            )
+        proxy = cls(
+            sandbox=sandbox,
+            runtime_dir=runtime_dir,
+            port=port,
+            pid_path=paths["pid"],
+            live_log_path=paths["live_log"],
+            state_path=paths["state"],
+            stdout_path=paths["stdout"],
+            stderr_path=paths["stderr"],
+        )
+        try:
+            await proxy._wait_until_ready()
+        except BaseException:
+            await proxy.stop()
+            raise
+        return proxy
+
+    async def _wait_until_ready(self) -> None:
+        probe = (
+            "python3 - <<'PY'\n"
+            "import urllib.request\n"
+            f"urllib.request.urlopen('http://127.0.0.1:{self.port}/health', timeout=2).read()\n"
+            "PY"
+        )
+        last = ""
+        for _ in range(120):
+            result = await self.sandbox.exec(probe, timeout_sec=5)
+            if result.return_code == 0:
+                return
+            last = (result.stderr or result.stdout or "").strip()
+            await asyncio.sleep(0.25)
+        stderr = await _read_remote_text(self.sandbox, self.stderr_path, timeout_sec=5)
+        raise RuntimeError(
+            f"sandbox replay proxy did not become healthy: {last or stderr.strip()}"
+        )
+
+    async def stop(self) -> None:
+        self.live_exchanges = await self._load_live_exchanges()
+        with contextlib.suppress(Exception):
+            await self.sandbox.exec(
+                f"if [ -s {shlex.quote(self.pid_path)} ]; then "
+                f"kill -TERM $(cat {shlex.quote(self.pid_path)}) 2>/dev/null || true; "
+                "fi",
+                timeout_sec=10,
+            )
+        with contextlib.suppress(Exception):
+            await self.sandbox.exec(
+                f"rm -rf {shlex.quote(self.runtime_dir)}",
+                timeout_sec=10,
+            )
+
+    async def _load_live_exchanges(self) -> list[LLMExchange]:
+        text = await _read_remote_text(self.sandbox, self.live_log_path)
+        exchanges: list[LLMExchange] = []
+        for raw in text.splitlines():
+            if not raw.strip():
+                continue
+            try:
+                exchanges.append(LLMExchange.model_validate_json(raw))
+            except Exception:
+                continue
+        return exchanges

--- a/tests/continue_run/_helpers.py
+++ b/tests/continue_run/_helpers.py
@@ -92,7 +92,9 @@ def write_run_folder(
     traj = root / "trajectory"
     traj.mkdir(exist_ok=True)
     (traj / "llm_trajectory.jsonl").write_text(
-        "\n".join(json.dumps(ex.model_dump(mode="json"), default=str) for ex in exchanges)
+        "\n".join(
+            json.dumps(ex.model_dump(mode="json"), default=str) for ex in exchanges
+        )
         + "\n"
     )
     return root

--- a/tests/continue_run/_helpers.py
+++ b/tests/continue_run/_helpers.py
@@ -1,0 +1,98 @@
+"""Shared fixtures for continue_run tests — synthetic run folders/exchanges."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from benchflow.trajectories.types import LLMExchange, LLMRequest, LLMResponse
+
+
+def completion(
+    *,
+    content: str | None = None,
+    tool_calls: list[dict[str, Any]] | None = None,
+    model: str = "test-model",
+    cmpl_id: str = "cmpl-1",
+) -> dict[str, Any]:
+    """A minimal but valid OpenAI ChatCompletion response body."""
+    message: dict[str, Any] = {"role": "assistant"}
+    if content is not None:
+        message["content"] = content
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return {
+        "id": cmpl_id,
+        "object": "chat.completion",
+        "created": 1,
+        "model": model,
+        "choices": [
+            {
+                "index": 0,
+                "message": message,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+def exchange(
+    response_body: dict[str, Any],
+    *,
+    n_request_messages: int = 1,
+    status: int = 200,
+) -> LLMExchange:
+    """Build an LLMExchange with a request carrying ``n_request_messages``."""
+    return LLMExchange(
+        request=LLMRequest(body={"messages": [{"role": "user"}] * n_request_messages}),
+        response=LLMResponse(status_code=status, body=response_body),
+    )
+
+
+def write_run_folder(
+    root: Path,
+    *,
+    exchanges: list[LLMExchange],
+    agent: str = "openhands",
+    model: str | None = "aws-bedrock/us.anthropic.claude-opus-4-8",
+    error_category: str | None = "timeout",
+    task_name: str = "demo-task",
+    prompts: list[str] | None = None,
+    timeout_sec: int = 3600,
+) -> Path:
+    """Materialize a synthetic run folder benchflow continue can load."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "config.json").write_text(
+        json.dumps(
+            {
+                "task_path": f"/tasks/{task_name}",
+                "agent": agent,
+                "model": model,
+                "environment": "docker",
+                "sandbox_user": "agent",
+                "timeout_sec": timeout_sec,
+                "agent_idle_timeout_sec": 600,
+            }
+        )
+    )
+    (root / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": task_name,
+                "agent": agent,
+                "model": model,
+                "error_category": error_category,
+                "rewards": None,
+            }
+        )
+    )
+    (root / "prompts.json").write_text(json.dumps(prompts or ["Do the task."]))
+    traj = root / "trajectory"
+    traj.mkdir(exist_ok=True)
+    (traj / "llm_trajectory.jsonl").write_text(
+        "\n".join(json.dumps(ex.model_dump(mode="json"), default=str) for ex in exchanges)
+        + "\n"
+    )
+    return root

--- a/tests/continue_run/test_batch.py
+++ b/tests/continue_run/test_batch.py
@@ -1,0 +1,111 @@
+"""Tests for batch continuation discovery and scheduling."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from benchflow.continue_run.batch import (
+    continue_batch,
+    discover_timeout_run_folders,
+    summarize_batch,
+)
+from benchflow.continue_run.orchestrator import ContinueResult
+
+from ._helpers import completion, exchange, write_run_folder
+
+
+def test_discover_timeout_run_folders_filters_non_timeouts(tmp_path):
+    """Guards PR #648 follow-up: batch mode must only pick unfinished runs."""
+    timeout = write_run_folder(
+        tmp_path / "timeout",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="timeout",
+    )
+    write_run_folder(
+        tmp_path / "agent-error",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="agent_error",
+    )
+
+    assert discover_timeout_run_folders(tmp_path) == [timeout]
+
+
+@pytest.mark.asyncio
+async def test_continue_batch_runs_with_bounded_concurrency(tmp_path):
+    """Guards PR #648 follow-up rolling scheduler for large Daytona batches."""
+    folders = [
+        write_run_folder(
+            tmp_path / f"run-{idx}",
+            exchanges=[exchange(completion(content="a"))],
+            error_category="timeout",
+        )
+        for idx in range(3)
+    ]
+    active = 0
+    max_active = 0
+
+    async def runner(folder: Path, **kwargs):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+        return ContinueResult(
+            rollout_dir=folder / "continued",
+            rewards={"reward": 1.0},
+            error=None,
+            n_recorded=1,
+            n_live=1,
+            divergences=0,
+        )
+
+    results = await continue_batch(
+        folders,
+        concurrency=2,
+        tasks_dir=None,
+        model=None,
+        timeout=None,
+        output_dir=None,
+        runner=runner,
+    )
+
+    assert [result.ok for result in results] == [True, True, True]
+    assert max_active <= 2
+
+
+@pytest.mark.asyncio
+async def test_continue_batch_marks_agent_error_as_failed(tmp_path):
+    """Guards PR #648 follow-up: batch progress must not hide failed artifacts."""
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="timeout",
+    )
+
+    async def runner(folder: Path, **kwargs):
+        return ContinueResult(
+            rollout_dir=folder / "continued",
+            rewards=None,
+            error="Failed to create session",
+            n_recorded=1,
+            n_live=0,
+            divergences=0,
+        )
+
+    results = await continue_batch(
+        [folder],
+        concurrency=1,
+        tasks_dir=None,
+        model=None,
+        timeout=None,
+        output_dir=None,
+        runner=runner,
+    )
+
+    summary = summarize_batch(results)
+    assert results[0].ok is False
+    assert summary["failed"] == 1
+    assert summary["errors"][0]["output"].endswith("/continued")

--- a/tests/continue_run/test_orchestrator.py
+++ b/tests/continue_run/test_orchestrator.py
@@ -20,7 +20,9 @@ from ._helpers import completion, exchange, write_run_folder
 
 
 def _load(tmp_path, **kw):
-    folder = write_run_folder(tmp_path / "run", exchanges=[exchange(completion(content="a"))], **kw)
+    folder = write_run_folder(
+        tmp_path / "run", exchanges=[exchange(completion(content="a"))], **kw
+    )
     return load_run_folder(folder)
 
 
@@ -127,6 +129,8 @@ def test_write_stitched_trajectory_creates_file(tmp_path):
     original = tmp_path / "orig.jsonl"
     original.write_text('{"a": 1}\n')
     rollout_dir = tmp_path / "rollout"
-    out = write_stitched_trajectory(rollout_dir, original, [exchange(completion(content="L"))])
+    out = write_stitched_trajectory(
+        rollout_dir, original, [exchange(completion(content="L"))]
+    )
     assert out == rollout_dir / "trajectory" / "llm_trajectory.jsonl"
     assert len(out.read_text().strip().splitlines()) == 2

--- a/tests/continue_run/test_orchestrator.py
+++ b/tests/continue_run/test_orchestrator.py
@@ -8,10 +8,15 @@ import pytest
 
 from benchflow.continue_run.orchestrator import (
     LiteLLMLiveForwarder,
+    _safe_sandbox_continuation_teardown,
     build_agent_env,
     build_rollout_config,
+    continued_rollout_name,
     resolve_task_path,
+    select_proxy_mode,
     stitched_trajectory_lines,
+    summarize_llm_trajectory_usage,
+    update_continued_metadata,
     write_stitched_trajectory,
 )
 from benchflow.continue_run.run_folder import RunFolderError, load_run_folder
@@ -31,6 +36,25 @@ def test_build_agent_env_points_at_proxy():
     assert env["LLM_BASE_URL"] == "http://10.0.0.1:9000/v1"
     assert env["LLM_MODEL"].startswith("openai/")
     assert env["LLM_API_KEY"]
+
+
+def test_select_proxy_mode_uses_sandbox_for_remote_environments():
+    """Guards PR #648 follow-up: Daytona cannot reach host-loopback replay."""
+    assert select_proxy_mode("auto", "daytona") == "sandbox"
+    assert select_proxy_mode("auto", "modal") == "sandbox"
+    assert select_proxy_mode("auto", "docker") == "host"
+    assert select_proxy_mode("host", "daytona") == "host"
+
+
+def test_continued_rollout_name_is_unique_to_source_folder(tmp_path):
+    """Guards PR #648 follow-up against batch continuation directory collisions."""
+    folder = write_run_folder(
+        tmp_path / "demo-task__abc123",
+        exchanges=[exchange(completion(content="a"))],
+        task_name="demo-task",
+    )
+    run = load_run_folder(folder)
+    assert continued_rollout_name(run) == "demo-task__abc123__continued"
 
 
 def test_resolve_task_path_via_tasks_dir(tmp_path):
@@ -134,3 +158,145 @@ def test_write_stitched_trajectory_creates_file(tmp_path):
     )
     assert out == rollout_dir / "trajectory" / "llm_trajectory.jsonl"
     assert len(out.read_text().strip().splitlines()) == 2
+
+
+def test_summarize_llm_trajectory_usage_splits_recorded_and_live(tmp_path):
+    """Guards the PR #648 continuation metadata fix for stitched token usage."""
+    traj = tmp_path / "llm_trajectory.jsonl"
+    rows = [
+        {
+            "response": {
+                "body": {
+                    "usage": {
+                        "prompt_tokens": 10,
+                        "completion_tokens": 2,
+                        "total_tokens": 12,
+                        "cache_creation_input_tokens": 3,
+                    }
+                }
+            }
+        },
+        {
+            "response": {
+                "body": {
+                    "usage": {
+                        "prompt_tokens": 20,
+                        "completion_tokens": 5,
+                        "total_tokens": 25,
+                        "cache_read_input_tokens": 7,
+                    }
+                }
+            }
+        },
+    ]
+    traj.write_text("".join(json.dumps(row) + "\n" for row in rows))
+
+    usage = summarize_llm_trajectory_usage(traj, n_recorded=1)
+
+    assert usage.n_input_tokens == 30
+    assert usage.n_output_tokens == 7
+    assert usage.total_tokens == 37
+    assert usage.recorded_total_tokens == 12
+    assert usage.live_total_tokens == 25
+    assert usage.n_cache_creation_tokens == 3
+    assert usage.n_cache_read_tokens == 7
+    assert usage.usage_source == "provider_response"
+
+
+def test_update_continued_metadata_writes_model_and_usage(tmp_path):
+    """Guards the PR #648 continuation metadata fix for HF-compatible results."""
+    rollout = tmp_path / "rollout"
+    rollout.mkdir()
+    (rollout / "config.json").write_text(json.dumps({"model": None, "source": {}}))
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {
+                "model": None,
+                "agent_result": {
+                    "total_tokens": 0,
+                    "usage_source": "unavailable",
+                    "cost_usd": None,
+                },
+                "final_metrics": {},
+                "usage_tracking": {"requested": "off", "status": "off"},
+            }
+        )
+    )
+    traj = tmp_path / "llm_trajectory.jsonl"
+    traj.write_text(
+        json.dumps(
+            {
+                "response": {
+                    "body": {
+                        "usage": {
+                            "prompt_tokens": 10,
+                            "completion_tokens": 2,
+                            "total_tokens": 12,
+                        }
+                    }
+                }
+            }
+        )
+        + "\n"
+    )
+
+    update_continued_metadata(
+        rollout,
+        live_model="aws-bedrock/us.anthropic.claude-opus-4-8",
+        usage=summarize_llm_trajectory_usage(traj, n_recorded=0),
+        environment="daytona",
+    )
+
+    config = json.loads((rollout / "config.json").read_text())
+    result = json.loads((rollout / "result.json").read_text())
+    assert config["model"] == "aws-bedrock/us.anthropic.claude-opus-4-8"
+    assert result["model"] == "aws-bedrock/us.anthropic.claude-opus-4-8"
+    assert result["agent_result"]["total_tokens"] == 12
+    assert result["agent_result"]["usage_source"] == "provider_response"
+    assert result["usage_tracking"]["requested"] == "required"
+    assert result["usage_tracking"]["endpoint_kind"] == "sandbox"
+    assert result["usage_tracking"]["status"] == "captured_from_stitched_llm_trajectory"
+    assert config["usage_tracking"]["requested"] == "required"
+
+
+@pytest.mark.asyncio
+async def test_sandbox_teardown_still_runs_rollout_cleanup_after_sidecar_failure():
+    """Guards PR #648 follow-up: Daytona artifacts must survive stop failures."""
+
+    class FailingProxy:
+        async def stop(self):
+            raise RuntimeError("proxy unavailable")
+
+    class FakeRollout:
+        _error = None
+
+        def __init__(self):
+            self.cleaned = False
+
+        async def cleanup(self):
+            self.cleaned = True
+
+    async def stop_provider_runtime(runtime):
+        raise RuntimeError(f"{runtime} refused stop")
+
+    rollout = FakeRollout()
+    events: list[str] = []
+
+    async def before_cleanup():
+        events.append("artifact")
+        assert rollout._error is not None
+
+    errors = await _safe_sandbox_continuation_teardown(
+        rollout=rollout,
+        replay_proxy=FailingProxy(),
+        provider_runtime="provider",
+        stop_provider_runtime=stop_provider_runtime,
+        before_cleanup=before_cleanup,
+    )
+
+    assert rollout.cleaned is True
+    assert events == ["artifact"]
+    assert len(errors) == 2
+    assert rollout._error is not None
+    assert "proxy unavailable" in rollout._error
+    assert "provider refused stop" in rollout._error

--- a/tests/continue_run/test_orchestrator.py
+++ b/tests/continue_run/test_orchestrator.py
@@ -1,0 +1,132 @@
+"""Tests for the pure orchestration helpers (no sandbox / no network)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchflow.continue_run.orchestrator import (
+    LiteLLMLiveForwarder,
+    build_agent_env,
+    build_rollout_config,
+    resolve_task_path,
+    stitched_trajectory_lines,
+    write_stitched_trajectory,
+)
+from benchflow.continue_run.run_folder import RunFolderError, load_run_folder
+
+from ._helpers import completion, exchange, write_run_folder
+
+
+def _load(tmp_path, **kw):
+    folder = write_run_folder(tmp_path / "run", exchanges=[exchange(completion(content="a"))], **kw)
+    return load_run_folder(folder)
+
+
+def test_build_agent_env_points_at_proxy():
+    env = build_agent_env("http://10.0.0.1:9000/v1")
+    assert env["LLM_BASE_URL"] == "http://10.0.0.1:9000/v1"
+    assert env["LLM_MODEL"].startswith("openai/")
+    assert env["LLM_API_KEY"]
+
+
+def test_resolve_task_path_via_tasks_dir(tmp_path):
+    run = _load(tmp_path)
+    tasks_dir = tmp_path / "tasks"
+    (tasks_dir / "demo-task").mkdir(parents=True)
+    assert resolve_task_path(run, tasks_dir) == tasks_dir / "demo-task"
+
+
+def test_resolve_task_path_missing_in_tasks_dir(tmp_path):
+    run = _load(tmp_path)
+    (tmp_path / "tasks").mkdir()
+    with pytest.raises(RunFolderError, match="does not exist"):
+        resolve_task_path(run, tmp_path / "tasks")
+
+
+def test_resolve_task_path_no_source_errors(tmp_path):
+    run = _load(tmp_path)  # recorded task_path is /tasks/demo-task (absent)
+    with pytest.raises(RunFolderError, match="cannot locate task source"):
+        resolve_task_path(run, None)
+
+
+def test_resolve_task_path_falls_back_to_recorded(tmp_path):
+    real_task = tmp_path / "real-task"
+    real_task.mkdir()
+    folder = write_run_folder(
+        tmp_path / "run", exchanges=[exchange(completion(content="a"))]
+    )
+    # repoint config.task_path at an existing dir
+    cfg = json.loads((folder / "config.json").read_text())
+    cfg["task_path"] = str(real_task)
+    (folder / "config.json").write_text(json.dumps(cfg))
+    run = load_run_folder(folder)
+    assert resolve_task_path(run, None) == real_task
+
+
+def test_build_rollout_config_disables_litellm_and_points_at_proxy(tmp_path):
+    run = _load(tmp_path, prompts=["go"])
+    task = tmp_path / "real-task"
+    task.mkdir()
+    cfg = build_rollout_config(
+        run,
+        task_path=task,
+        live_model="gemini-3.1-flash-lite-preview",
+        agent_env=build_agent_env("http://host:1/v1"),
+        timeout=123,
+        output_dir=tmp_path / "out",
+        rollout_name="demo-task__continued",
+    )
+    assert cfg.agent == "openhands"
+    # the seam that stops benchflow starting its own gateway
+    assert cfg.usage_tracking.mode == "off"
+    assert cfg.agent_env["LLM_BASE_URL"] == "http://host:1/v1"
+    assert cfg.timeout == 123
+    # model is None so resolve_agent_env skips provider key validation; the live
+    # model is carried in provenance and used only by the forwarder.
+    assert cfg.model is None
+    assert cfg.source_provenance["live_model"] == "gemini-3.1-flash-lite-preview"
+    assert cfg.prompts == ["go"]
+    assert cfg.source_provenance["continued_from"] == str(run.path)
+    assert cfg.source_provenance["kind"] == "benchflow-continue"
+
+
+def test_live_forwarder_build_kwargs_resolves_route_offline():
+    fwd = LiteLLMLiveForwarder(
+        "gemini-3.1-flash-lite-preview", env={"GEMINI_API_KEY": "x"}
+    )
+    assert fwd.upstream_model.startswith("gemini/")
+    kwargs = fwd.build_kwargs(
+        {
+            "messages": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "function", "function": {"name": "bash"}}],
+            "temperature": 0.5,
+            "stream": True,  # must be forced False for the non-streamed capture
+        }
+    )
+    assert kwargs["model"] == fwd.upstream_model
+    assert kwargs["messages"][0]["content"] == "hi"
+    assert kwargs["stream"] is False
+    assert kwargs["tools"][0]["function"]["name"] == "bash"
+    assert kwargs["temperature"] == 0.5
+
+
+def test_stitched_trajectory_recorded_prefix_plus_live_suffix(tmp_path):
+    original = tmp_path / "orig.jsonl"
+    original.write_text('{"a": 1}\n{"b": 2}\n')
+    live = [exchange(completion(content="LIVE"))]
+    lines = stitched_trajectory_lines(original, live)
+    assert len(lines) == 3
+    assert json.loads(lines[0]) == {"a": 1}
+    last = json.loads(lines[2])
+    assert last["response"]["body"]["choices"][0]["message"]["content"] == "LIVE"
+
+
+def test_write_stitched_trajectory_creates_file(tmp_path):
+    original = tmp_path / "orig.jsonl"
+    original.write_text('{"a": 1}\n')
+    rollout_dir = tmp_path / "rollout"
+    out = write_stitched_trajectory(rollout_dir, original, [exchange(completion(content="L"))])
+    assert out == rollout_dir / "trajectory" / "llm_trajectory.jsonl"
+    assert len(out.read_text().strip().splitlines()) == 2

--- a/tests/continue_run/test_replay_proxy.py
+++ b/tests/continue_run/test_replay_proxy.py
@@ -1,0 +1,175 @@
+"""Tests for the record-replay router, SSE reconstruction, and HTTP proxy."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from benchflow.continue_run.replay_proxy import (
+    ReplayDivergenceError,
+    ReplayProxy,
+    ReplayRouter,
+    completion_to_sse,
+)
+
+from ._helpers import completion, exchange
+
+# ── ReplayRouter ──────────────────────────────────────────────────────────
+
+
+def test_serves_recorded_responses_in_order_then_live():
+    recorded = [
+        exchange(completion(content="first")),
+        exchange(completion(content="second")),
+    ]
+    live = []
+
+    def forwarder(req):
+        live.append(req)
+        return completion(content="LIVE")
+
+    router = ReplayRouter(recorded, live_forwarder=forwarder)
+
+    r1 = router.next_response({"messages": [{"role": "user"}]})
+    assert r1.source == "replay"
+    assert r1.body["choices"][0]["message"]["content"] == "first"
+
+    r2 = router.next_response({"messages": [{"role": "user"}]})
+    assert r2.source == "replay"
+    assert r2.body["choices"][0]["message"]["content"] == "second"
+    assert router.exhausted is True
+
+    r3 = router.next_response({"messages": [{"role": "user"}]})
+    assert r3.source == "live"
+    assert r3.body["choices"][0]["message"]["content"] == "LIVE"
+    # the live exchange was captured for stitching
+    assert len(router.live_exchanges) == 1
+    assert len(live) == 1
+
+
+def test_exhausted_without_forwarder_returns_error():
+    router = ReplayRouter([exchange(completion(content="a"))], live_forwarder=None)
+    router.next_response({"messages": [{}]})  # consume the one recorded
+    result = router.next_response({"messages": [{}]})
+    assert result.source == "error"
+    assert result.status == 503
+
+
+def test_divergence_warns_by_default():
+    recorded = [exchange(completion(content="a"), n_request_messages=3)]
+    router = ReplayRouter(recorded)
+    # agent sends 2 messages where the recorded turn had 3
+    router.next_response({"messages": [{}, {}]})
+    assert router.divergences == 1
+
+
+def test_divergence_strict_raises():
+    recorded = [exchange(completion(content="a"), n_request_messages=3)]
+    router = ReplayRouter(recorded, strict_divergence=True)
+    with pytest.raises(ReplayDivergenceError):
+        router.next_response({"messages": [{}, {}]})
+
+
+def test_recorded_failure_passed_through():
+    recorded = [exchange({"error": {"message": "boom"}}, status=500)]
+    router = ReplayRouter(recorded)
+    result = router.next_response({"messages": [{}]})
+    assert result.status == 500
+    assert result.body["error"]["message"] == "boom"
+
+
+# ── SSE reconstruction ────────────────────────────────────────────────────
+
+
+def test_completion_to_sse_content_and_tools():
+    body = completion(
+        content="hello",
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "bash", "arguments": '{"cmd":"ls"}'},
+            }
+        ],
+    )
+    payloads = completion_to_sse(body)
+    chunks = [json.loads(p) for p in payloads]
+
+    # first chunk announces the assistant role
+    assert chunks[0]["choices"][0]["delta"]["role"] == "assistant"
+    # content delta present
+    assert any(c["choices"][0]["delta"].get("content") == "hello" for c in chunks)
+    # tool call delta carries the full function name + arguments
+    tool_deltas = [
+        c["choices"][0]["delta"]["tool_calls"][0]
+        for c in chunks
+        if c["choices"][0]["delta"].get("tool_calls")
+    ]
+    assert tool_deltas[0]["function"]["name"] == "bash"
+    assert tool_deltas[0]["function"]["arguments"] == '{"cmd":"ls"}'
+    # final chunk carries finish_reason + usage
+    assert chunks[-1]["choices"][0]["finish_reason"] == "tool_calls"
+    assert chunks[-1]["usage"]["total_tokens"] == 2
+
+
+# ── HTTP proxy end-to-end (real server, httpx client) ─────────────────────
+
+
+@pytest.fixture()
+def proxy_with(request):
+    proxies: list[ReplayProxy] = []
+
+    def _make(router: ReplayRouter) -> ReplayProxy:
+        proxy = ReplayProxy(router, host="127.0.0.1", port=0).start()
+        proxies.append(proxy)
+        return proxy
+
+    yield _make
+    for p in proxies:
+        p.stop()
+
+
+def test_http_non_stream_serves_recorded_then_live(proxy_with):
+    recorded = [exchange(completion(content="r1"))]
+    router = ReplayRouter(recorded, live_forwarder=lambda req: completion(content="L1"))
+    proxy = proxy_with(router)
+
+    with httpx.Client(base_url=proxy.base_url, timeout=10) as client:
+        resp1 = client.post("/chat/completions", json={"messages": [{"role": "user"}]})
+        assert resp1.status_code == 200
+        assert resp1.json()["choices"][0]["message"]["content"] == "r1"
+
+        resp2 = client.post("/chat/completions", json={"messages": [{"role": "user"}]})
+        assert resp2.json()["choices"][0]["message"]["content"] == "L1"
+
+
+def test_http_stream_emits_sse(proxy_with):
+    recorded = [exchange(completion(content="streamed"))]
+    proxy = proxy_with(ReplayRouter(recorded))
+
+    with httpx.Client(base_url=proxy.base_url, timeout=10) as client, client.stream(
+        "POST",
+        "/chat/completions",
+        json={"messages": [{"role": "user"}], "stream": True},
+    ) as resp:
+        assert resp.status_code == 200
+        assert "text/event-stream" in resp.headers["content-type"]
+        lines = [ln for ln in resp.iter_lines() if ln.startswith("data:")]
+
+    assert lines[-1].strip() == "data: [DONE]"
+    payloads = [
+        json.loads(ln[len("data: ") :]) for ln in lines if not ln.endswith("[DONE]")
+    ]
+    assert any(
+        p["choices"][0]["delta"].get("content") == "streamed" for p in payloads
+    )
+
+
+def test_http_health_and_models(proxy_with):
+    proxy = proxy_with(ReplayRouter([exchange(completion(content="a"))]))
+    with httpx.Client(base_url=proxy.base_url, timeout=10) as client:
+        assert client.get("/health").status_code == 200
+        models = client.get("/models").json()
+        assert models["object"] == "list"

--- a/tests/continue_run/test_replay_proxy.py
+++ b/tests/continue_run/test_replay_proxy.py
@@ -149,11 +149,14 @@ def test_http_stream_emits_sse(proxy_with):
     recorded = [exchange(completion(content="streamed"))]
     proxy = proxy_with(ReplayRouter(recorded))
 
-    with httpx.Client(base_url=proxy.base_url, timeout=10) as client, client.stream(
-        "POST",
-        "/chat/completions",
-        json={"messages": [{"role": "user"}], "stream": True},
-    ) as resp:
+    with (
+        httpx.Client(base_url=proxy.base_url, timeout=10) as client,
+        client.stream(
+            "POST",
+            "/chat/completions",
+            json={"messages": [{"role": "user"}], "stream": True},
+        ) as resp,
+    ):
         assert resp.status_code == 200
         assert "text/event-stream" in resp.headers["content-type"]
         lines = [ln for ln in resp.iter_lines() if ln.startswith("data:")]
@@ -162,9 +165,7 @@ def test_http_stream_emits_sse(proxy_with):
     payloads = [
         json.loads(ln[len("data: ") :]) for ln in lines if not ln.endswith("[DONE]")
     ]
-    assert any(
-        p["choices"][0]["delta"].get("content") == "streamed" for p in payloads
-    )
+    assert any(p["choices"][0]["delta"].get("content") == "streamed" for p in payloads)
 
 
 def test_http_health_and_models(proxy_with):

--- a/tests/continue_run/test_run_folder.py
+++ b/tests/continue_run/test_run_folder.py
@@ -1,0 +1,94 @@
+"""Tests for loading/validating an original run folder."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from benchflow.continue_run.run_folder import RunFolderError, load_run_folder
+
+from ._helpers import completion, exchange, write_run_folder
+
+
+def test_loads_valid_timeout_folder(tmp_path):
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a")), exchange(completion(content="b"))],
+        prompts=["Solve it."],
+    )
+    run = load_run_folder(folder)
+
+    assert run.agent == "openhands"
+    assert run.task_name == "demo-task"
+    assert run.environment == "docker"
+    assert run.timeout_sec == 3600
+    assert run.agent_idle_timeout_sec == 600
+    assert run.is_timeout is True
+    assert run.prompts == ["Solve it."]
+    assert run.n_recorded_exchanges == 2
+    # response bodies survive the round-trip
+    assert run.exchanges[0].response.body["choices"][0]["message"]["content"] == "a"
+
+
+def test_missing_config_is_error(tmp_path):
+    folder = tmp_path / "run"
+    (folder / "trajectory").mkdir(parents=True)
+    (folder / "trajectory" / "llm_trajectory.jsonl").write_text("{}\n")
+    with pytest.raises(RunFolderError, match="missing required artifact"):
+        load_run_folder(folder)
+
+
+def test_missing_llm_trajectory_is_error(tmp_path):
+    folder = tmp_path / "run"
+    folder.mkdir()
+    (folder / "config.json").write_text(json.dumps({"agent": "openhands"}))
+    with pytest.raises(RunFolderError, match="record-replay needs the LLM"):
+        load_run_folder(folder)
+
+
+def test_empty_trajectory_is_error(tmp_path):
+    folder = write_run_folder(tmp_path / "run", exchanges=[])
+    with pytest.raises(RunFolderError, match="no usable LLM exchanges"):
+        load_run_folder(folder)
+
+
+def test_non_openhands_agent_rejected(tmp_path):
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+    )
+    with pytest.raises(RunFolderError, match="openhands"):
+        load_run_folder(folder)
+
+
+def test_non_timeout_warns_but_loads_by_default(tmp_path):
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="agent_error",
+    )
+    run = load_run_folder(folder)  # permissive default — warn only
+    assert run.is_timeout is False
+
+
+def test_require_timeout_rejects_non_timeout(tmp_path):
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="agent_error",
+    )
+    with pytest.raises(RunFolderError, match="not a"):
+        load_run_folder(folder, require_timeout=True)
+
+
+def test_malformed_line_skipped_not_fatal(tmp_path):
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+    )
+    traj = folder / "trajectory" / "llm_trajectory.jsonl"
+    traj.write_text(traj.read_text() + "this is not json\n")
+    run = load_run_folder(folder)
+    assert run.n_recorded_exchanges == 1  # bad line dropped, good one kept

--- a/tests/continue_run/test_run_folder.py
+++ b/tests/continue_run/test_run_folder.py
@@ -14,7 +14,10 @@ from ._helpers import completion, exchange, write_run_folder
 def test_loads_valid_timeout_folder(tmp_path):
     folder = write_run_folder(
         tmp_path / "run",
-        exchanges=[exchange(completion(content="a")), exchange(completion(content="b"))],
+        exchanges=[
+            exchange(completion(content="a")),
+            exchange(completion(content="b")),
+        ],
         prompts=["Solve it."],
     )
     run = load_run_folder(folder)


### PR DESCRIPTION
## What

Adds a standalone **`benchflow continue <orig-run-output-folder>`** command that resumes a previous, **unfinished (timed-out)** `openhands` run to completion — without touching benchflow's normal run path.

The design was reached via a structured grilling session; the agreed spec:
- **Transparent resume:** restore the exact env + agent memory and continue with **no injected prompt**, so the stitched run reads as one continuous run that simply had a larger timeout.
- **Recover from the trajectory:** a finished run keeps nothing of the container, so a historical timeout has only its trajectory + task. We reconstruct the missing state from the recorded `llm_trajectory.jsonl`.
- **Mechanism = record-replay through the real agent** (highest fidelity, no reverse-engineering of OpenHands internals).
- **Backends:** Docker first (testable), Daytona-direct for prod durability (reuses existing host-bind logic).
- **Output:** a new HF-compatible folder, re-verified, linked to the parent via `continued_from`.

## How it works

1. Load the original run folder (`config.json` + `trajectory/llm_trajectory.jsonl`).
2. Boot a fresh **pristine** sandbox from the same base image.
3. Stand up a **replay proxy** (stdlib `http.server`, OpenAI chat-completions, SSE-aware) that OpenHands talks to via `LLM_BASE_URL`. It serves the recorded responses **in order**, so the agent re-executes its own past decisions *for real* — rebuilding the byte-exact workspace and its exact internal state.
4. At the cut-point (recorded responses exhausted) the proxy flips to the **live model**; the agent continues its own loop, no new prompt.
5. Re-verify and write a new HF-compatible folder with a stitched `llm_trajectory.jsonl` (recorded prefix + live suffix) and `continued_from` provenance.

Reuses `Rollout` via `RolloutConfig(agent_env → proxy, model=None, usage_tracking="off")`:
- `usage_tracking="off"` makes benchflow's own LiteLLM gateway a no-op, so the `agent_env` `LLM_*` we pass survive untouched.
- `model=None` avoids `resolve_agent_env` running provider resolution and **validating the model's API key** — which would wrongly fail the **key-free replay phase**. The live model is carried in the forwarder + provenance instead.

The live continuation defaults to the original run's model; `--model` overrides it (tests use `gemini-3.1-flash-lite-preview`). `--replay-only` rebuilds via replay and stops at the cut-point (no key needed).

## Files

- `src/benchflow/continue_run/{run_folder,replay_proxy,orchestrator}.py` — loader, replay router + proxy, orchestration.
- `src/benchflow/cli/continue_cmd.py` + `cli/main.py` — the `continue` command.
- `tests/continue_run/` — 26 offline tests.
- `docs/continue-runs.md`, `docs/reference/cli.md`, `docs.json`, `CHANGELOG.md`.

## Testing

- ✅ 26 offline tests (folder loading, replay router + SSE reconstruction + HTTP proxy replay→live handoff, orchestration helpers). No sandbox or API key needed for the replay leg.
- ✅ `ruff` + `ty` clean on all new/changed files.
- ✅ Existing CLI/docs-drift tests pass; `benchflow continue --help` wired.
- ⏳ **Live Docker e2e is gated on a provider key** (none in this environment). To run end-to-end: a real timed-out openhands run folder + `--tasks-dir` + a live `GEMINI_API_KEY`, continuing with `--model gemini-3.1-flash-lite-preview`.

## Known caveats / follow-ups

- **`openhands` only** for now (the proxy seam relies on `LLM_BASE_URL`).
- **Replay fidelity is best-effort:** re-running the episode's shell commands can diverge from the original (network/time/nondeterminism); a message-count check warns (`--strict-divergence` aborts).
- The orchestrator's `Rollout` integration is implemented but exercised only by the (gated) live e2e — the one unverified assumption is that `agent_env` `LLM_*` reach the in-sandbox launch with `usage_tracking="off"` (traced through `resolve_agent_env`, looks correct).
- Natural follow-up: a "snapshot going forward" fast path so `benchflow continue` can restore a real saved snapshot when present and fall back to replay otherwise.

https://claude.ai/code/session_01KW8hLTvhspzDY5Uoshq4DK

---
_Generated by [Claude Code](https://claude.ai/code/session_01KW8hLTvhspzDY5Uoshq4DK)_