### PR TITLE
fix(skillsbench): preserve token usage counters when publishing

### DIFF
--- a/experiments/skillsbench-fill/publish.py
+++ b/experiments/skillsbench-fill/publish.py
@@ -20,7 +20,7 @@ import io
 import json
 import os
 import re
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 REPO = "benchflow/skillsbench-leaderboard"
@@ -51,11 +51,53 @@ SECRET_VAL_RE = re.compile(
     r"(AQ\.[A-Za-z0-9._-]{8,}|AIza[A-Za-z0-9._-]{10,}|sk-api-[A-Za-z0-9_-]{8,}|sk-[A-Za-z0-9-]{16,}|"
     r"ABSK[A-Za-z0-9+/=]{8,}|Bearer\s+[A-Za-z0-9._-]{12,}|gh[pousr]_[A-Za-z0-9]{20,}|hf_[A-Za-z0-9]{20,})"
 )
+TOKEN_COUNTER_KEYS = {
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "cached_read_tokens",
+    "cached_tokens",
+    "cached_write_tokens",
+    "completion_tokens",
+    "input_tokens",
+    "max_tokens",
+    "n_cache_creation_tokens",
+    "n_cache_read_tokens",
+    "n_input_tokens",
+    "n_output_tokens",
+    "output_tokens",
+    "prompt_tokens",
+    "provider_total_tokens",
+    "thought_tokens",
+    "total_cached_tokens",
+    "total_completion_tokens",
+    "total_cost_usd",
+    "total_input_tokens",
+    "total_output_tokens",
+    "total_prompt_tokens",
+    "total_tokens",
+}
+
+
+def _is_token_counter(key: str, value) -> bool:
+    """Keep numeric usage telemetry while still redacting credential tokens."""
+    normalized = key.lower()
+    if normalized not in TOKEN_COUNTER_KEYS and not normalized.endswith("_tokens"):
+        return False
+    return value is None or (
+        isinstance(value, int | float) and not isinstance(value, bool)
+    )
 
 
 def _scrub(o):
     if isinstance(o, dict):
-        return {k: ("[REDACTED]" if SECRET_NAME_RE.search(k) else _scrub(v)) for k, v in o.items()}
+        return {
+            k: (
+                _scrub(v)
+                if _is_token_counter(k, v) or not SECRET_NAME_RE.search(k)
+                else "[REDACTED]"
+            )
+            for k, v in o.items()
+        }
     if isinstance(o, list):
         return [_scrub(x) for x in o]
     if isinstance(o, str):
@@ -65,7 +107,8 @@ def _scrub(o):
 
 def safe_bytes(path, is_config=False, mode="without"):
     """Return scrubbed bytes for upload; raise if any secret survives."""
-    raw = open(path, encoding="utf-8", errors="replace").read()
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        raw = fh.read()
     if str(path).endswith(".jsonl"):
         text = SECRET_VAL_RE.sub("[REDACTED]", raw)
     else:
@@ -83,10 +126,11 @@ def hf_token() -> str:
         return os.environ["HUGGING_FACE_TOKEN"]
     for p in (ENV_PATH, os.path.expanduser("~/keys.env"), os.path.expanduser("~/.env")):
         try:
-            for line in open(p):
-                m = re.match(r'^\s*(?:export\s+)?HUGGING_FACE_TOKEN\s*=\s*["\']?([^"\'\s]+)', line)
-                if m:
-                    return m.group(1)
+            with open(p) as fh:
+                for line in fh:
+                    m = re.match(r'^\s*(?:export\s+)?HUGGING_FACE_TOKEN\s*=\s*["\']?([^"\'\s]+)', line)
+                    if m:
+                        return m.group(1)
         except FileNotFoundError:
             continue
     raise SystemExit("no HUGGING_FACE_TOKEN (env, .env, or ~/keys.env)")
@@ -129,7 +173,7 @@ notes: |
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--dry-run", action="store_true")
-    ap.add_argument("--ts", default=datetime.now(timezone.utc).strftime("%Y-%m-%d__%H-%M-%S") + "-maxeffort")
+    ap.add_argument("--ts", default=datetime.now(UTC).strftime("%Y-%m-%d__%H-%M-%S") + "-maxeffort")
     ap.add_argument("--src-commit", default=os.environ.get("SB_SRC_COMMIT", "unknown"))
     ap.add_argument("--runs-root", default=str(ROOT / "runs"),
                     help="dir holding <cell>/<task>__<tid>/ rollouts (use 'jobs' when running on the VM)")
@@ -137,7 +181,7 @@ def main() -> int:
     runs_root = Path(a.runs_root)
 
     os.environ.setdefault("HF_TOKEN", hf_token())
-    from huggingface_hub import HfApi, CommitOperationAdd
+    from huggingface_hub import CommitOperationAdd, HfApi
     api = HfApi(token=os.environ["HF_TOKEN"])
 
     # existing cells per group: {trial_id: cell_dir_path} for dedup AND path recovery, cached.
@@ -164,7 +208,8 @@ def main() -> int:
     groups_seen = {}
     skipped = 0
     for rf in review_files:
-        rv = json.load(open(rf))
+        with open(rf) as fh:
+            rv = json.load(fh)
         if rv.get("verdict") != "pass":
             continue
         cell = rv["cell_id"]
@@ -189,11 +234,12 @@ def main() -> int:
             # already in PR5 (e.g. pushed earlier from another machine) — record its path
             # so the dashboard shows the HF link; don't re-upload.
             published.append({"cell_id": cell, "hf_path": exist[tid], "tid": tid, "already": True,
-                              "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")})
+                              "updated_at": datetime.now(UTC).isoformat(timespec="seconds")})
             skipped += 1
             continue
         dest = f"{V11}/{group}/{a.ts}/{task}__{tid}"
-        rd = json.load(open(inner / "result.json"))
+        with open(inner / "result.json") as fh:
+            rd = json.load(fh)
         cell_ops = []
         try:
             for f in CANON:
@@ -214,7 +260,7 @@ def main() -> int:
         ops.extend(cell_ops)
         groups_seen.setdefault((model_key, mode), group)
         published.append({"cell_id": cell, "hf_path": dest, "tid": tid,
-                          "updated_at": datetime.now(timezone.utc).isoformat(timespec="seconds")})
+                          "updated_at": datetime.now(UTC).isoformat(timespec="seconds")})
 
     # group metadata.yaml (once per group)
     for (model_key, mode), group in groups_seen.items():
@@ -229,7 +275,8 @@ def main() -> int:
     # Always (re)write publish records so the dashboard links every cell that IS in PR5.
     (ROOT / "published").mkdir(exist_ok=True)
     for p in published:
-        json.dump(p, open(ROOT / "published" / f"{p['cell_id']}.json", "w"), indent=2)
+        with open(ROOT / "published" / f"{p['cell_id']}.json", "w") as fh:
+            json.dump(p, fh, indent=2)
     if ops:
         CH = 400
         for i in range(0, len(ops), CH):

--- a/tests/test_skillsbench_publish_scrub.py
+++ b/tests/test_skillsbench_publish_scrub.py
@@ -1,0 +1,75 @@
+import importlib.util
+import json
+from pathlib import Path
+
+
+def _load_publish_module():
+    path = (
+        Path(__file__).resolve().parents[1]
+        / "experiments"
+        / "skillsbench-fill"
+        / "publish.py"
+    )
+    spec = importlib.util.spec_from_file_location("skillsbench_fill_publish", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_safe_bytes_preserves_token_usage_counters(tmp_path):
+    """Guards Hugging Face PR #4 token-usage recovery against scrub redaction."""
+    publish = _load_publish_module()
+    result = {
+        "agent_result": {
+            "n_input_tokens": 123,
+            "n_output_tokens": 45,
+            "n_cache_read_tokens": 678,
+            "n_cache_creation_tokens": 90,
+            "total_tokens": 936,
+            "usage_source": "provider_response",
+        },
+        "final_metrics": {
+            "total_prompt_tokens": 123,
+            "total_completion_tokens": 45,
+            "total_cached_tokens": 678,
+            "total_cost_usd": 1.23,
+        },
+        "HUGGING_FACE_TOKEN": "hf_abcdefghijklmnopqrstuvwxyz",
+    }
+    src = tmp_path / "result.json"
+    src.write_text(json.dumps(result))
+
+    scrubbed = json.loads(publish.safe_bytes(src))
+
+    assert scrubbed["agent_result"]["n_input_tokens"] == 123
+    assert scrubbed["agent_result"]["n_output_tokens"] == 45
+    assert scrubbed["agent_result"]["n_cache_read_tokens"] == 678
+    assert scrubbed["agent_result"]["n_cache_creation_tokens"] == 90
+    assert scrubbed["agent_result"]["total_tokens"] == 936
+    assert scrubbed["final_metrics"]["total_prompt_tokens"] == 123
+    assert scrubbed["final_metrics"]["total_completion_tokens"] == 45
+    assert scrubbed["final_metrics"]["total_cached_tokens"] == 678
+    assert scrubbed["HUGGING_FACE_TOKEN"] == "[REDACTED]"
+
+
+def test_safe_bytes_normalizes_config_without_leaking_secret_tokens(tmp_path):
+    """Guards Hugging Face PR #4 token-usage recovery against credential leakage."""
+    publish = _load_publish_module()
+    config = {
+        "include_task_skills": False,
+        "agent_env": {
+            "AWS_BEARER_TOKEN_BEDROCK": "Bearer abcdefghijklmnop",
+            "OPENAI_API_KEY": "sk-abcdefghijklmnopqrstuvwxyz",
+            "BENCHFLOW_MODEL_MAX_TOKENS": 8192,
+        },
+    }
+    src = tmp_path / "config.json"
+    src.write_text(json.dumps(config))
+
+    scrubbed = json.loads(publish.safe_bytes(src, is_config=True, mode="with"))
+
+    assert scrubbed["include_task_skills"] is True
+    assert scrubbed["agent_env"]["AWS_BEARER_TOKEN_BEDROCK"] == "[REDACTED]"
+    assert scrubbed["agent_env"]["OPENAI_API_KEY"] == "[REDACTED]"
+    assert scrubbed["agent_env"]["BENCHFLOW_MODEL_MAX_TOKENS"] == 8192


### PR DESCRIPTION
## Summary
- keep numeric token usage counters during SkillsBench HF publish scrubbing
- continue redacting credential-like token keys and secret-shaped values
- add regression coverage for Hugging Face PR #4 token usage recovery

## Verification
- uv run ruff check experiments/skillsbench-fill/publish.py tests/test_skillsbench_publish_scrub.py
- uv run python -m pytest tests/test_skillsbench_publish_scrub.py
- git diff --check

## Data repair
- Rebuilt token usage for 447 redacted PR4 result.json files from their PR4 llm_trajectory.jsonl provider usage events.
- Committed the repaired result.json files back to benchflow/skillsbench-leaderboard refs/pr/4 in 3 batches.
- Forced re-download verification: 447/447 repaired files now have numeric token counters; bad=0.