### PR TITLE
fix: validate skills eval model count before running (#550)

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -568,6 +568,12 @@ def skills_eval(
             f"Create one with test cases. See: benchflow skills eval --help"
         )
         raise typer.Exit(1)
+    if model is not None and len(model) not in {1, len(agent)}:
+        console.print(
+            "[red]--model may be provided once for all agents or once per --agent; "
+            f"got {len(model)} models for {len(agent)} agents[/red]"
+        )
+        raise typer.Exit(1)
 
     evaluator = SkillEvaluator(skill_dir)
     console.print(

--- a/tests/test_skill_eval_cli.py
+++ b/tests/test_skill_eval_cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import click
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+
+def test_skills_eval_rejects_model_agent_length_mismatch_before_header(tmp_path):
+    skill_dir = tmp_path / "skill"
+    evals_dir = skill_dir / "evals"
+    evals_dir.mkdir(parents=True)
+    (evals_dir / "evals.json").write_text(
+        '{"skill_name":"citation-management",'
+        '"cases":[{"id":"case-1","question":"Q?","ground_truth":"A"}]}'
+    )
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "skills",
+            "eval",
+            str(skill_dir),
+            "--agent",
+            "gemini",
+            "--model",
+            "gemini-2.5-flash",
+            "--model",
+            "extra-model",
+            "--no-baseline",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+        ],
+    )
+
+    output = click.unstyle(result.output)
+    assert result.exit_code == 1
+    assert "--model may be provided once for all agents or once per --agent" in output
+    assert "got 2 models" in output
+    assert "for 1 agents" in output
+    assert "Skill eval:" not in output
+    assert "Traceback" not in output


### PR DESCRIPTION
## Summary

Closes #550.

`benchflow skills eval` currently validates the number of `--model` values inside `SkillEvaluator.run()`. When the user passes two models for one agent, the CLI has already printed the eval header and then surfaces a Rich traceback from a `ValueError`.

This PR moves that cardinality check to the Typer command boundary so the CLI fails before starting the eval and prints a concise validation message instead.

## Changes

- Validate `--model` count before constructing and running the skill evaluator.
- Keep the existing accepted forms:
  - no `--model`
  - one `--model` broadcast to all agents
  - one model per `--agent`
- Add a CLI regression test that asserts:
  - exit code is 1
  - the friendly validation message is shown
  - no `Skill eval:` header is printed
  - no traceback is printed

## Testing

Reproduced the current failure before the fix:

```text
Skill eval: citation-management (1 cases)
  Agents: gemini
  Environment: docker
  Baseline skipped (--no-baseline)
...
ValueError: models length (2) must match agents (1) or be 1
```

After the fix:

```text
--model may be provided once for all agents or once per --agent; got 2 models for 1 agents
```

Ran:

```text
python -m pytest -q tests/test_skill_eval_cli.py tests/test_agent_cli.py
python -m compileall -q src/benchflow/cli/main.py tests/test_skill_eval_cli.py
```

Result:

```text
3 passed in 2.07s
```
