### PR TITLE
feat(trajectories): ATIF and ADP trajectory emitters

### DIFF
--- a/src/benchflow/trajectories/_export_common.py
+++ b/src/benchflow/trajectories/_export_common.py
@@ -1,0 +1,116 @@
+"""Shared plumbing for the trajectory export formats.
+
+The format emitters (:mod:`benchflow.trajectories.export` for Verifiers/ORS,
+:mod:`benchflow.trajectories.export_atif` for ATIF, and
+:mod:`benchflow.trajectories.export_adp` for ADP) all walk the same captured
+ACP events and write per-rollout artifacts under ``rollout_dir/trainer/``.
+This module owns the format-independent pieces:
+
+- :func:`content_blocks_to_text` — render ACP tool-call content blocks to
+  plain text. Sibling of the Verifiers-specific
+  :func:`benchflow.trajectories.export._tool_call_to_content`, which renders
+  the same blocks into a titled summary string.
+- :class:`ThoughtBuffer` — the ``agent_thought`` accumulator shared by the
+  ATIF and ADP event walkers.
+- :func:`aggregate_rollout_jsonl` — the job-level JSONL aggregator behind
+  ``write_job_verifiers_jsonl`` and ``write_job_adp_jsonl``.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from benchflow.trajectories.types import redact_trajectory_text
+
+logger = logging.getLogger(__name__)
+
+
+def content_blocks_to_text(content: Any) -> str:
+    """Render ACP tool-call content blocks to plain text.
+
+    Handles both the flat shape (``{"text": ...}`` / ``{"content": "..."}``)
+    and the nested ACP shape (``{"type": "content", "content": {"type":
+    "text", "text": ...}}``). Non-text blocks are skipped.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        inner = item.get("content")
+        if isinstance(inner, dict):
+            inner = inner.get("text")
+        text = item.get("text") or inner
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts)
+
+
+class ThoughtBuffer:
+    """Accumulate consecutive ``agent_thought`` texts between agent actions.
+
+    The ATIF and ADP walkers both join buffered thoughts with a blank line
+    and attach them as ``reasoning_content`` on the next agent action —
+    flushing them as a standalone item when a user event or the end of the
+    trajectory would otherwise drop them. The buffer owns the join-and-clear
+    bookkeeping; what a flushed thought becomes stays format-specific.
+    """
+
+    def __init__(self) -> None:
+        self._pending: list[str] = []
+
+    def push(self, text: str) -> None:
+        self._pending.append(text)
+
+    def take(self) -> str | None:
+        """Return the buffered thoughts joined by blank lines, then clear.
+
+        ``None`` when nothing is buffered, so callers attach
+        ``reasoning_content`` only when it exists.
+        """
+        if not self._pending:
+            return None
+        joined = "\n\n".join(self._pending)
+        self._pending.clear()
+        return joined
+
+
+def aggregate_rollout_jsonl(
+    job_dir: str | Path,
+    *,
+    rollout_relpath: str,
+    out_filename: str,
+) -> Path | None:
+    """Concatenate per-rollout JSONL artifacts into one job-level dataset.
+
+    Scans ``job_dir/*/<rollout_relpath>`` and writes their lines to
+    ``job_dir/<out_filename>``. Each artifact is normalized to end with a
+    newline and re-redacted on the way through, so a legacy or hand-placed
+    raw rollout file cannot leak secrets into the job dataset. Unreadable
+    artifacts are skipped with a warning rather than failing the whole
+    aggregation. Returns the artifact path, or ``None`` when no rollouts
+    have emitted records yet.
+    """
+    job_path = Path(job_dir)
+    if not job_path.is_dir():
+        return None
+    rollout_files = sorted(job_path.glob(f"*/{rollout_relpath}"))
+    if not rollout_files:
+        return None
+    out = job_path / out_filename
+    with out.open("w") as fout:
+        for src in rollout_files:
+            try:
+                text = src.read_text()
+            except OSError as e:
+                logger.warning("Skipping unreadable trainer artifact %s: %s", src, e)
+                continue
+            if not text.endswith("\n"):
+                text = text + "\n"
+            fout.write(redact_trajectory_text(text))
+    return out

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -26,16 +26,14 @@ This module also provides the live wiring used by ``Rollout`` and
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Any, cast
 
 from benchflow._utils.json_safe import scrub_non_finite
 from benchflow.adapters.ors import ORSAdapter
 from benchflow.rewards.protocol import VerifyResult
+from benchflow.trajectories._export_common import aggregate_rollout_jsonl
 from benchflow.trajectories.types import redact_trajectory_text
-
-logger = logging.getLogger(__name__)
 
 # Canonical artifact locations (see issue #385).
 ROLLOUT_ARTIFACT_RELPATH = "trainer/verifiers.jsonl"
@@ -284,21 +282,8 @@ def write_job_verifiers_jsonl(job_dir: str | Path) -> Path | None:
     dataset. Returns the artifact path, or ``None`` when no rollouts have
     emitted records yet.
     """
-    job_path = Path(job_dir)
-    if not job_path.is_dir():
-        return None
-    rollout_files = sorted(job_path.glob(f"*/{ROLLOUT_ARTIFACT_RELPATH}"))
-    if not rollout_files:
-        return None
-    out = job_path / JOB_ARTIFACT_FILENAME
-    with out.open("w") as fout:
-        for src in rollout_files:
-            try:
-                text = src.read_text()
-            except OSError as e:
-                logger.warning("Skipping unreadable trainer artifact %s: %s", src, e)
-                continue
-            if not text.endswith("\n"):
-                text = text + "\n"
-            fout.write(redact_trajectory_text(text))
-    return out
+    return aggregate_rollout_jsonl(
+        job_dir,
+        rollout_relpath=ROLLOUT_ARTIFACT_RELPATH,
+        out_filename=JOB_ARTIFACT_FILENAME,
+    )

--- a/src/benchflow/trajectories/export_adp.py
+++ b/src/benchflow/trajectories/export_adp.py
@@ -40,15 +40,16 @@ Mapping from BenchFlow ACP trajectory events (see
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 from typing import Any, cast
 
 from benchflow._utils.json_safe import dumps_finite
-from benchflow.trajectories.export_atif import content_blocks_to_text
+from benchflow.trajectories._export_common import (
+    ThoughtBuffer,
+    aggregate_rollout_jsonl,
+    content_blocks_to_text,
+)
 from benchflow.trajectories.types import redact_trajectory_text
-
-logger = logging.getLogger(__name__)
 
 ADP_SCHEMA_VERSION = "1.3.1"
 
@@ -73,7 +74,7 @@ def acp_events_to_adp_content(
     trajectory would otherwise drop them.
     """
     content: list[dict[str, Any]] = []
-    pending_thoughts: list[str] = []
+    thoughts = ThoughtBuffer()
     used_ids: set[str] = set()
     synth_count = 0
 
@@ -86,15 +87,8 @@ def acp_events_to_adp_content(
         used_ids.add(candidate)
         return candidate
 
-    def take_reasoning() -> str | None:
-        if not pending_thoughts:
-            return None
-        joined = "\n\n".join(pending_thoughts)
-        pending_thoughts.clear()
-        return joined
-
     def flush_thoughts() -> None:
-        reasoning = take_reasoning()
+        reasoning = thoughts.take()
         if reasoning:
             content.append(
                 {
@@ -128,12 +122,12 @@ def acp_events_to_adp_content(
         elif etype == "agent_thought":
             text = str(event.get("text") or "")
             if text:
-                pending_thoughts.append(text)
+                thoughts.push(text)
         elif etype == "agent_message":
             text = str(event.get("text") or "")
             if text:
                 action: dict[str, Any] = {"class_": "message_action", "content": text}
-                reasoning = take_reasoning()
+                reasoning = thoughts.take()
                 if reasoning:
                     action["reasoning_content"] = reasoning
                 content.append(action)
@@ -148,7 +142,7 @@ def acp_events_to_adp_content(
             title = event.get("title")
             if title:
                 action["description"] = str(title)
-            reasoning = take_reasoning()
+            reasoning = thoughts.take()
             if reasoning:
                 action["reasoning_content"] = reasoning
             content.append(action)
@@ -240,21 +234,8 @@ def write_job_adp_jsonl(job_dir: str | Path) -> Path | None:
     into one job-level dataset. Returns the artifact path, or ``None``
     when no rollouts have emitted records yet.
     """
-    job_path = Path(job_dir)
-    if not job_path.is_dir():
-        return None
-    rollout_files = sorted(job_path.glob(f"*/{ROLLOUT_ADP_RELPATH}"))
-    if not rollout_files:
-        return None
-    out = job_path / JOB_ADP_FILENAME
-    with out.open("w") as fout:
-        for src in rollout_files:
-            try:
-                text = src.read_text()
-            except OSError as e:
-                logger.warning("Skipping unreadable trainer artifact %s: %s", src, e)
-                continue
-            if not text.endswith("\n"):
-                text = text + "\n"
-            fout.write(redact_trajectory_text(text))
-    return out
+    return aggregate_rollout_jsonl(
+        job_dir,
+        rollout_relpath=ROLLOUT_ADP_RELPATH,
+        out_filename=JOB_ADP_FILENAME,
+    )

--- a/src/benchflow/trajectories/export_adp.py
+++ b/src/benchflow/trajectories/export_adp.py
@@ -1,0 +1,260 @@
+"""Export captured trajectories in ADP (Agent Data Protocol) format.
+
+ADP is the standardized agent-trajectory schema used by the OpenHands
+training pipeline lineage. A BenchFlow rollout's ACP-style trajectory
+events become one ADP ``Trajectory`` record — JSONL datasets of these
+records feed ADP's SFT converters directly.
+
+The record shape is pinned against the ADP pydantic schemas
+(``neulab/agent-data-protocol``, ``schema/trajectory.py``,
+``schema/action/*.py``, ``schema/observation/*.py``) and
+``schema/SCHEMA.md``, schema version ``1.3.1``. Spec constraints honoured
+here:
+
+- every tool action (``api_action``) carries a ``tool_call_id`` and is
+  followed by exactly one matching ``text_observation`` with the same id —
+  ADP validation rejects unmatched or duplicate ids;
+- ``tool_call_id``s are unique within a trajectory; missing or colliding
+  ACP ids are replaced with synthesized ``call_NNNNNN`` ids;
+- tool results use ``source: "environment"`` (``source: "user"`` is
+  reserved for actual user input and is invalid on tool results);
+- ``message_action`` never carries a ``tool_call_id``.
+
+Mapping from BenchFlow ACP trajectory events (see
+:mod:`benchflow.trajectories._capture`):
+
+- *prompts* and ``user_message`` events → ``text_observation`` with
+  ``source: "user"``;
+- ``agent_message`` → ``message_action``;
+- ``agent_thought`` → ``reasoning_content`` on the next action, or a
+  standalone empty ``message_action`` when no action follows;
+- ``tool_call`` → an ``api_action``/``text_observation`` pair. ACP updates
+  carry no structured arguments, so ``kwargs`` is ``{}`` and the ACP
+  ``title`` becomes the action's ``description``; the ACP ``status`` has no
+  ADP slot (``extra`` fields are forbidden) and is dropped — failures
+  remain visible in the observation content;
+- ``oracle`` → a ``message_action`` rendering the command, mirroring
+  :func:`benchflow.trajectories.export.acp_events_to_messages`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, cast
+
+from benchflow._utils.json_safe import dumps_finite
+from benchflow.trajectories.export_atif import content_blocks_to_text
+from benchflow.trajectories.types import redact_trajectory_text
+
+logger = logging.getLogger(__name__)
+
+ADP_SCHEMA_VERSION = "1.3.1"
+
+# Canonical artifact locations, siblings of the verifiers.jsonl seam.
+ROLLOUT_ADP_RELPATH = "trainer/adp.jsonl"
+JOB_ADP_FILENAME = "adp.jsonl"
+
+_ACTION_CLASSES = ("api_action", "code_action", "message_action")
+
+
+def acp_events_to_adp_content(
+    events: list[dict[str, Any]],
+    prompts: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert BenchFlow ACP trajectory events to ADP content items.
+
+    *prompts* are the user-facing prompts handed to the agent before any
+    ACP event is captured; they become leading user ``text_observation``
+    items. Consecutive ``agent_thought`` events are joined and attached as
+    the next action's ``reasoning_content`` — flushed as a standalone
+    ``message_action`` when a user observation or the end of the
+    trajectory would otherwise drop them.
+    """
+    content: list[dict[str, Any]] = []
+    pending_thoughts: list[str] = []
+    used_ids: set[str] = set()
+    synth_count = 0
+
+    def claim_call_id(raw: Any) -> str:
+        nonlocal synth_count
+        candidate = str(raw or "")
+        while not candidate or candidate in used_ids:
+            synth_count += 1
+            candidate = f"call_{synth_count:06d}"
+        used_ids.add(candidate)
+        return candidate
+
+    def take_reasoning() -> str | None:
+        if not pending_thoughts:
+            return None
+        joined = "\n\n".join(pending_thoughts)
+        pending_thoughts.clear()
+        return joined
+
+    def flush_thoughts() -> None:
+        reasoning = take_reasoning()
+        if reasoning:
+            content.append(
+                {
+                    "class_": "message_action",
+                    "content": "",
+                    "reasoning_content": reasoning,
+                }
+            )
+
+    for prompt in prompts or []:
+        if prompt:
+            content.append(
+                {
+                    "class_": "text_observation",
+                    "content": str(prompt),
+                    "source": "user",
+                }
+            )
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "user_message":
+            text = str(event.get("text") or "")
+            if text:
+                flush_thoughts()
+                content.append(
+                    {"class_": "text_observation", "content": text, "source": "user"}
+                )
+        elif etype == "agent_thought":
+            text = str(event.get("text") or "")
+            if text:
+                pending_thoughts.append(text)
+        elif etype == "agent_message":
+            text = str(event.get("text") or "")
+            if text:
+                action: dict[str, Any] = {"class_": "message_action", "content": text}
+                reasoning = take_reasoning()
+                if reasoning:
+                    action["reasoning_content"] = reasoning
+                content.append(action)
+        elif etype == "tool_call":
+            call_id = claim_call_id(event.get("tool_call_id"))
+            action = {
+                "class_": "api_action",
+                "tool_call_id": call_id,
+                "function": str(event.get("kind") or "tool"),
+                "kwargs": {},
+            }
+            title = event.get("title")
+            if title:
+                action["description"] = str(title)
+            reasoning = take_reasoning()
+            if reasoning:
+                action["reasoning_content"] = reasoning
+            content.append(action)
+            content.append(
+                {
+                    "class_": "text_observation",
+                    "tool_call_id": call_id,
+                    "content": content_blocks_to_text(event.get("content")),
+                    "source": "environment",
+                }
+            )
+        elif etype == "oracle":
+            cmd = str(event.get("command") or "oracle")
+            content.append({"class_": "message_action", "content": f"[oracle: {cmd}]"})
+
+    flush_thoughts()
+    return content
+
+
+def trajectory_to_adp_record(
+    *,
+    trajectory_id: str,
+    events: list[dict[str, Any]],
+    prompts: list[str] | None = None,
+    reward: float | None = None,
+    details: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one ADP ``Trajectory`` record from a captured rollout.
+
+    *reward*, when given, is attached to the trajectory's final action as
+    ADP's per-step ``reward`` field — the terminal-reward convention for
+    RL training data. *details* passes through as the dataset-specific
+    metadata dict. ``available_apis`` is omitted: BenchFlow does not know
+    the agent's full tool universe, and the field is optional.
+    """
+    content = acp_events_to_adp_content(events, prompts)
+    if reward is not None:
+        for item in reversed(content):
+            if item["class_"] in _ACTION_CLASSES:
+                item["reward"] = reward
+                break
+    return {
+        "schema_version": ADP_SCHEMA_VERSION,
+        "id": trajectory_id,
+        "content": content,
+        "details": dict(details or {}),
+    }
+
+
+def _record_to_redacted_json_line(record: dict[str, Any]) -> str:
+    raw = dumps_finite(record, default=str)
+    return redact_trajectory_text(raw)
+
+
+def write_rollout_adp_jsonl(
+    rollout_dir: str | Path,
+    *,
+    trajectory_id: str,
+    task_id: str,
+    prompts: list[str] | None,
+    trajectory: list[dict[str, Any]],
+    model: str | None,
+    environment: str,
+    reward: float | None = None,
+) -> dict[str, Any]:
+    """Write one rollout's ADP record to ``rollout_dir/trainer/adp.jsonl``.
+
+    One record per line, matching the verifiers.jsonl seam. Returns the
+    redacted record so callers can aggregate across a job.
+    """
+    record = trajectory_to_adp_record(
+        trajectory_id=trajectory_id,
+        events=trajectory,
+        prompts=prompts,
+        reward=reward,
+        details={"task_id": task_id, "environment": environment, "model": model or ""},
+    )
+    out = Path(rollout_dir) / ROLLOUT_ADP_RELPATH
+    out.parent.mkdir(parents=True, exist_ok=True)
+    redacted = _record_to_redacted_json_line(record)
+    out.write_text(redacted + "\n")
+    return cast(dict[str, Any], json.loads(redacted))
+
+
+def write_job_adp_jsonl(job_dir: str | Path) -> Path | None:
+    """Aggregate per-rollout ADP JSONLs into ``job_dir/adp.jsonl``.
+
+    Scans ``job_dir/*/trainer/adp.jsonl`` and concatenates their lines
+    into one job-level dataset. Returns the artifact path, or ``None``
+    when no rollouts have emitted records yet.
+    """
+    job_path = Path(job_dir)
+    if not job_path.is_dir():
+        return None
+    rollout_files = sorted(job_path.glob(f"*/{ROLLOUT_ADP_RELPATH}"))
+    if not rollout_files:
+        return None
+    out = job_path / JOB_ADP_FILENAME
+    with out.open("w") as fout:
+        for src in rollout_files:
+            try:
+                text = src.read_text()
+            except OSError as e:
+                logger.warning("Skipping unreadable trainer artifact %s: %s", src, e)
+                continue
+            if not text.endswith("\n"):
+                text = text + "\n"
+            fout.write(redact_trajectory_text(text))
+    return out

--- a/src/benchflow/trajectories/export_atif.py
+++ b/src/benchflow/trajectories/export_atif.py
@@ -40,36 +40,13 @@ from pathlib import Path
 from typing import Any, cast
 
 from benchflow._utils.json_safe import dumps_finite
+from benchflow.trajectories._export_common import ThoughtBuffer, content_blocks_to_text
 from benchflow.trajectories.types import redact_trajectory_text
 
 ATIF_SCHEMA_VERSION = "ATIF-v1.7"
 
 # Canonical artifact location, sibling of ``trainer/verifiers.jsonl``.
 ROLLOUT_ATIF_RELPATH = "trainer/atif.json"
-
-
-def content_blocks_to_text(content: Any) -> str:
-    """Render ACP tool-call content blocks to plain text.
-
-    Handles both the flat shape (``{"text": ...}`` / ``{"content": "..."}``)
-    and the nested ACP shape (``{"type": "content", "content": {"type":
-    "text", "text": ...}}``). Non-text blocks are skipped.
-    """
-    if isinstance(content, str):
-        return content
-    if not isinstance(content, list):
-        return ""
-    parts: list[str] = []
-    for item in content:
-        if not isinstance(item, dict):
-            continue
-        inner = item.get("content")
-        if isinstance(inner, dict):
-            inner = inner.get("text")
-        text = item.get("text") or inner
-        if text:
-            parts.append(str(text))
-    return "\n".join(parts)
 
 
 def acp_events_to_atif_steps(
@@ -85,20 +62,13 @@ def acp_events_to_atif_steps(
     a user step or the end of the trajectory would otherwise drop them.
     """
     steps: list[dict[str, Any]] = []
-    pending_thoughts: list[str] = []
-
-    def take_reasoning() -> str | None:
-        if not pending_thoughts:
-            return None
-        joined = "\n\n".join(pending_thoughts)
-        pending_thoughts.clear()
-        return joined
+    thoughts = ThoughtBuffer()
 
     def append_step(source: str, body: dict[str, Any]) -> None:
         steps.append({"step_id": len(steps) + 1, "source": source, **body})
 
     def flush_thoughts() -> None:
-        reasoning = take_reasoning()
+        reasoning = thoughts.take()
         if reasoning:
             append_step("agent", {"message": "", "reasoning_content": reasoning})
 
@@ -118,16 +88,19 @@ def acp_events_to_atif_steps(
         elif etype == "agent_thought":
             text = str(event.get("text") or "")
             if text:
-                pending_thoughts.append(text)
+                thoughts.push(text)
         elif etype == "agent_message":
             text = str(event.get("text") or "")
             if text:
                 body: dict[str, Any] = {"message": text}
-                reasoning = take_reasoning()
+                reasoning = thoughts.take()
                 if reasoning:
                     body["reasoning_content"] = reasoning
                 append_step("agent", body)
         elif etype == "tool_call":
+            # The fallback id needs no trajectory-wide dedupe: ATIF resolves
+            # source_call_id within the same step's tool_calls only (unlike
+            # ADP, whose claim_call_id must keep ids unique per trajectory).
             call_id = str(event.get("tool_call_id") or "") or f"call_{len(steps) + 1}"
             tool_call: dict[str, Any] = {
                 "tool_call_id": call_id,
@@ -140,7 +113,7 @@ def acp_events_to_atif_steps(
             if extra:
                 tool_call["extra"] = extra
             body = cast(dict[str, Any], {"message": "", "tool_calls": [tool_call]})
-            reasoning = take_reasoning()
+            reasoning = thoughts.take()
             if reasoning:
                 body["reasoning_content"] = reasoning
             result_text = content_blocks_to_text(event.get("content"))
@@ -235,20 +208,21 @@ def write_rollout_atif_json(
     an empty ATIF document would be schema-invalid, so no artifact is
     produced in that case.
     """
-    if not acp_events_to_atif_steps(trajectory, prompts):
+    try:
+        record = trajectory_to_atif_record(
+            session_id=session_id,
+            agent_name=agent_name,
+            events=trajectory,
+            prompts=prompts,
+            agent_version=agent_version,
+            model=model,
+            total_prompt_tokens=total_prompt_tokens,
+            total_completion_tokens=total_completion_tokens,
+            total_cached_tokens=total_cached_tokens,
+            total_cost_usd=total_cost_usd,
+        )
+    except ValueError:
         return None
-    record = trajectory_to_atif_record(
-        session_id=session_id,
-        agent_name=agent_name,
-        events=trajectory,
-        prompts=prompts,
-        agent_version=agent_version,
-        model=model,
-        total_prompt_tokens=total_prompt_tokens,
-        total_completion_tokens=total_completion_tokens,
-        total_cached_tokens=total_cached_tokens,
-        total_cost_usd=total_cost_usd,
-    )
     out = Path(rollout_dir) / ROLLOUT_ATIF_RELPATH
     out.parent.mkdir(parents=True, exist_ok=True)
     redacted = _record_to_redacted_json(record)

--- a/src/benchflow/trajectories/export_atif.py
+++ b/src/benchflow/trajectories/export_atif.py
@@ -1,0 +1,256 @@
+"""Export captured trajectories in ATIF (Agent Trajectory Interchange Format).
+
+ATIF is the trajectory interchange format used by the Harbor evaluation
+framework (the terminal-bench lineage). A BenchFlow rollout's ACP-style
+trajectory events become one ATIF trajectory document that Harbor tooling
+(trajectory validator, viewer, SFT/RL pipelines) ingests directly.
+
+The record shape is pinned against the Harbor pydantic models
+(``harbor-framework/harbor``, ``src/harbor/models/trajectories/*.py``) and
+the ATIF RFC (``rfcs/0001-trajectory-format.md``), schema version
+``ATIF-v1.7``. Spec constraints honoured here:
+
+- ``steps`` is required with at least one entry; ``step_id`` is sequential
+  starting from 1.
+- ``reasoning_content``, ``tool_calls``, and ``metrics`` are only valid on
+  ``source: "agent"`` steps.
+- Every ``observation.results[].source_call_id`` must reference a
+  ``tool_call_id`` in the *same* step's ``tool_calls``.
+
+Mapping from BenchFlow ACP trajectory events (see
+:mod:`benchflow.trajectories._capture`):
+
+- *prompts* and ``user_message`` events → ``user`` steps;
+- ``agent_message`` → an ``agent`` step;
+- ``agent_thought`` → ``reasoning_content`` on the next agent step, or a
+  standalone agent step with an empty message when no agent event follows;
+- ``tool_call`` → an ``agent`` step whose single ``tool_calls`` entry carries
+  the ACP ``kind`` as ``function_name``. ACP updates carry no structured
+  arguments, so ``arguments`` is ``{}`` and the ACP ``title``/``status`` ride
+  in the tool call's ``extra`` (added in ATIF-v1.7) rather than being passed
+  off as arguments. Captured output text becomes the step's ``observation``;
+- ``oracle`` → an ``agent`` step rendering the command, mirroring
+  :func:`benchflow.trajectories.export.acp_events_to_messages`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from benchflow._utils.json_safe import dumps_finite
+from benchflow.trajectories.types import redact_trajectory_text
+
+ATIF_SCHEMA_VERSION = "ATIF-v1.7"
+
+# Canonical artifact location, sibling of ``trainer/verifiers.jsonl``.
+ROLLOUT_ATIF_RELPATH = "trainer/atif.json"
+
+
+def content_blocks_to_text(content: Any) -> str:
+    """Render ACP tool-call content blocks to plain text.
+
+    Handles both the flat shape (``{"text": ...}`` / ``{"content": "..."}``)
+    and the nested ACP shape (``{"type": "content", "content": {"type":
+    "text", "text": ...}}``). Non-text blocks are skipped.
+    """
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    parts: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            continue
+        inner = item.get("content")
+        if isinstance(inner, dict):
+            inner = inner.get("text")
+        text = item.get("text") or inner
+        if text:
+            parts.append(str(text))
+    return "\n".join(parts)
+
+
+def acp_events_to_atif_steps(
+    events: list[dict[str, Any]],
+    prompts: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert BenchFlow ACP trajectory events to ATIF step objects.
+
+    *prompts* are the user-facing prompts handed to the agent before any
+    ACP event is captured; they become leading ``user`` steps. Consecutive
+    ``agent_thought`` events are joined and attached as the next agent
+    step's ``reasoning_content`` — flushed as a standalone agent step when
+    a user step or the end of the trajectory would otherwise drop them.
+    """
+    steps: list[dict[str, Any]] = []
+    pending_thoughts: list[str] = []
+
+    def take_reasoning() -> str | None:
+        if not pending_thoughts:
+            return None
+        joined = "\n\n".join(pending_thoughts)
+        pending_thoughts.clear()
+        return joined
+
+    def append_step(source: str, body: dict[str, Any]) -> None:
+        steps.append({"step_id": len(steps) + 1, "source": source, **body})
+
+    def flush_thoughts() -> None:
+        reasoning = take_reasoning()
+        if reasoning:
+            append_step("agent", {"message": "", "reasoning_content": reasoning})
+
+    for prompt in prompts or []:
+        if prompt:
+            append_step("user", {"message": str(prompt)})
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        etype = event.get("type")
+        if etype == "user_message":
+            text = str(event.get("text") or "")
+            if text:
+                flush_thoughts()
+                append_step("user", {"message": text})
+        elif etype == "agent_thought":
+            text = str(event.get("text") or "")
+            if text:
+                pending_thoughts.append(text)
+        elif etype == "agent_message":
+            text = str(event.get("text") or "")
+            if text:
+                body: dict[str, Any] = {"message": text}
+                reasoning = take_reasoning()
+                if reasoning:
+                    body["reasoning_content"] = reasoning
+                append_step("agent", body)
+        elif etype == "tool_call":
+            call_id = str(event.get("tool_call_id") or "") or f"call_{len(steps) + 1}"
+            tool_call: dict[str, Any] = {
+                "tool_call_id": call_id,
+                "function_name": str(event.get("kind") or "tool"),
+                "arguments": {},
+            }
+            extra = {
+                key: str(event[key]) for key in ("title", "status") if event.get(key)
+            }
+            if extra:
+                tool_call["extra"] = extra
+            body = cast(dict[str, Any], {"message": "", "tool_calls": [tool_call]})
+            reasoning = take_reasoning()
+            if reasoning:
+                body["reasoning_content"] = reasoning
+            result_text = content_blocks_to_text(event.get("content"))
+            if result_text:
+                body["observation"] = {
+                    "results": [{"source_call_id": call_id, "content": result_text}]
+                }
+            append_step("agent", body)
+        elif etype == "oracle":
+            cmd = str(event.get("command") or "oracle")
+            append_step("agent", {"message": f"[oracle: {cmd}]"})
+
+    flush_thoughts()
+    return steps
+
+
+def trajectory_to_atif_record(
+    *,
+    session_id: str,
+    agent_name: str,
+    events: list[dict[str, Any]],
+    prompts: list[str] | None = None,
+    agent_version: str = "unknown",
+    model: str | None = None,
+    total_prompt_tokens: int | None = None,
+    total_completion_tokens: int | None = None,
+    total_cached_tokens: int | None = None,
+    total_cost_usd: float | None = None,
+) -> dict[str, Any]:
+    """Build one ATIF trajectory document from a captured rollout.
+
+    ``agent`` requires both ``name`` and ``version`` in ATIF; BenchFlow
+    does not track agent binary versions, so *agent_version* defaults to
+    ``"unknown"`` rather than fabricating one. Token totals come from the
+    raw LLM-traffic capture (``Trajectory.total_*`` in
+    :mod:`benchflow.trajectories.types`) when the caller has it; ATIF's
+    per-step ``metrics`` are omitted because ACP events carry no usage.
+
+    Raises ``ValueError`` for an empty trajectory — ATIF requires at least
+    one step, so there is no valid empty document to emit.
+    """
+    steps = acp_events_to_atif_steps(events, prompts)
+    if not steps:
+        raise ValueError("ATIF requires at least one step; trajectory is empty")
+    agent: dict[str, Any] = {
+        "name": agent_name or "unknown",
+        "version": agent_version,
+    }
+    if model:
+        agent["model_name"] = model
+    final_metrics: dict[str, Any] = {"total_steps": len(steps)}
+    for key, value in (
+        ("total_prompt_tokens", total_prompt_tokens),
+        ("total_completion_tokens", total_completion_tokens),
+        ("total_cached_tokens", total_cached_tokens),
+        ("total_cost_usd", total_cost_usd),
+    ):
+        if value is not None:
+            final_metrics[key] = value
+    record: dict[str, Any] = {"schema_version": ATIF_SCHEMA_VERSION}
+    if session_id:
+        record["session_id"] = session_id
+    record["agent"] = agent
+    record["steps"] = steps
+    record["final_metrics"] = final_metrics
+    return record
+
+
+def _record_to_redacted_json(record: dict[str, Any]) -> str:
+    raw = dumps_finite(record, default=str, indent=2)
+    return redact_trajectory_text(raw)
+
+
+def write_rollout_atif_json(
+    rollout_dir: str | Path,
+    *,
+    session_id: str,
+    agent_name: str,
+    prompts: list[str] | None,
+    trajectory: list[dict[str, Any]],
+    agent_version: str = "unknown",
+    model: str | None = None,
+    total_prompt_tokens: int | None = None,
+    total_completion_tokens: int | None = None,
+    total_cached_tokens: int | None = None,
+    total_cost_usd: float | None = None,
+) -> dict[str, Any] | None:
+    """Write one rollout's ATIF document to ``rollout_dir/trainer/atif.json``.
+
+    ATIF is a single JSON document per trajectory (not JSONL). Returns the
+    redacted record as written, or ``None`` when the trajectory is empty —
+    an empty ATIF document would be schema-invalid, so no artifact is
+    produced in that case.
+    """
+    if not acp_events_to_atif_steps(trajectory, prompts):
+        return None
+    record = trajectory_to_atif_record(
+        session_id=session_id,
+        agent_name=agent_name,
+        events=trajectory,
+        prompts=prompts,
+        agent_version=agent_version,
+        model=model,
+        total_prompt_tokens=total_prompt_tokens,
+        total_completion_tokens=total_completion_tokens,
+        total_cached_tokens=total_cached_tokens,
+        total_cost_usd=total_cost_usd,
+    )
+    out = Path(rollout_dir) / ROLLOUT_ATIF_RELPATH
+    out.parent.mkdir(parents=True, exist_ok=True)
+    redacted = _record_to_redacted_json(record)
+    out.write_text(redacted + "\n")
+    return cast(dict[str, Any], json.loads(redacted))

--- a/tests/trajectories/test_export_adp.py
+++ b/tests/trajectories/test_export_adp.py
@@ -1,0 +1,263 @@
+"""ADP (Agent Data Protocol) trajectory export.
+
+Record shape pinned against the ADP pydantic schemas
+(neulab/agent-data-protocol, schema/trajectory.py, schema/action/*.py,
+schema/observation/*.py), schema version 1.3.1.
+"""
+
+import json
+
+from benchflow.trajectories.export_adp import (
+    acp_events_to_adp_content,
+    trajectory_to_adp_record,
+    write_job_adp_jsonl,
+    write_rollout_adp_jsonl,
+)
+
+
+def _sample_events():
+    return [
+        {"type": "user_message", "text": "List the files."},
+        {"type": "agent_thought", "text": "I should run ls."},
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "ls",
+            "status": "completed",
+            "content": [
+                {"type": "content", "content": {"type": "text", "text": "README.md"}}
+            ],
+        },
+        {"type": "agent_message", "text": "One file: README.md."},
+    ]
+
+
+def test_golden_record():
+    rec = trajectory_to_adp_record(
+        trajectory_id="rollout-1",
+        events=_sample_events(),
+        prompts=["Solve the task."],
+        reward=1.0,
+        details={"task_id": "demo/list-files", "environment": "demo"},
+    )
+    assert rec == {
+        "schema_version": "1.3.1",
+        "id": "rollout-1",
+        "content": [
+            {
+                "class_": "text_observation",
+                "content": "Solve the task.",
+                "source": "user",
+            },
+            {
+                "class_": "text_observation",
+                "content": "List the files.",
+                "source": "user",
+            },
+            {
+                "class_": "api_action",
+                "tool_call_id": "tc1",
+                "function": "execute",
+                "kwargs": {},
+                "description": "ls",
+                "reasoning_content": "I should run ls.",
+            },
+            {
+                "class_": "text_observation",
+                "tool_call_id": "tc1",
+                "content": "README.md",
+                "source": "environment",
+            },
+            {
+                "class_": "message_action",
+                "content": "One file: README.md.",
+                "reward": 1.0,
+            },
+        ],
+        "details": {"task_id": "demo/list-files", "environment": "demo"},
+    }
+
+
+def test_no_reward_leaves_content_untouched():
+    rec = trajectory_to_adp_record(trajectory_id="r", events=_sample_events())
+    assert all("reward" not in item for item in rec["content"])
+    assert rec["details"] == {}
+
+
+def test_reward_lands_on_last_action_not_observation():
+    events = [
+        {"type": "agent_message", "text": "starting"},
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "ls",
+            "status": "completed",
+            "content": [{"text": "out"}],
+        },
+    ]
+    rec = trajectory_to_adp_record(trajectory_id="r", events=events, reward=0.5)
+    api_action, observation = rec["content"][-2:]
+    assert api_action["class_"] == "api_action"
+    assert api_action["reward"] == 0.5
+    assert "reward" not in observation
+
+
+def test_every_tool_action_pairs_with_environment_observation():
+    events = [
+        {
+            "type": "tool_call",
+            "tool_call_id": "",
+            "kind": "execute",
+            "title": "touch a",
+            "status": "completed",
+            "content": [],
+        },
+        {
+            "type": "tool_call",
+            "tool_call_id": "dup",
+            "kind": "read",
+            "title": "cat a",
+            "status": "completed",
+            "content": [{"text": "x"}],
+        },
+        {
+            "type": "tool_call",
+            "tool_call_id": "dup",
+            "kind": "read",
+            "title": "cat b",
+            "status": "completed",
+            "content": [{"text": "y"}],
+        },
+    ]
+    content = acp_events_to_adp_content(events)
+    actions = [c for c in content if c["class_"] == "api_action"]
+    observations = [c for c in content if c["class_"] == "text_observation"]
+    assert [a["tool_call_id"] for a in actions] == ["call_000001", "dup", "call_000002"]
+    assert [o["tool_call_id"] for o in observations] == [
+        "call_000001",
+        "dup",
+        "call_000002",
+    ]
+    # Empty output still yields the matched observation ADP requires.
+    assert observations[0]["content"] == ""
+    assert all(o["source"] == "environment" for o in observations)
+
+
+def test_thought_before_user_message_flushes_in_order():
+    content = acp_events_to_adp_content(
+        [
+            {"type": "agent_thought", "text": "hmm"},
+            {"type": "user_message", "text": "continue"},
+        ]
+    )
+    assert content == [
+        {"class_": "message_action", "content": "", "reasoning_content": "hmm"},
+        {"class_": "text_observation", "content": "continue", "source": "user"},
+    ]
+
+
+def test_trailing_thoughts_join_into_standalone_action():
+    content = acp_events_to_adp_content(
+        [
+            {"type": "agent_thought", "text": "first"},
+            {"type": "agent_thought", "text": "second"},
+        ]
+    )
+    assert content == [
+        {
+            "class_": "message_action",
+            "content": "",
+            "reasoning_content": "first\n\nsecond",
+        }
+    ]
+
+
+def test_oracle_event_renders_command():
+    content = acp_events_to_adp_content([{"type": "oracle", "command": "bash run.sh"}])
+    assert content == [{"class_": "message_action", "content": "[oracle: bash run.sh]"}]
+
+
+def test_empty_and_malformed_events_skipped():
+    content = acp_events_to_adp_content(
+        [
+            {"type": "agent_message", "text": ""},
+            "not-a-dict",
+            {"type": "unknown_event", "text": "x"},
+            {"type": "user_message", "text": "real"},
+        ]
+    )
+    assert content == [
+        {"class_": "text_observation", "content": "real", "source": "user"}
+    ]
+
+
+def test_write_rollout_adp_jsonl(tmp_path):
+    rec = write_rollout_adp_jsonl(
+        tmp_path,
+        trajectory_id="rollout-1",
+        task_id="demo/list-files",
+        prompts=["Solve the task."],
+        trajectory=_sample_events(),
+        model="claude-haiku-4-5",
+        environment="demo",
+        reward=1.0,
+    )
+    out = tmp_path / "trainer" / "adp.jsonl"
+    lines = out.read_text().splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == rec
+    assert rec["details"] == {
+        "task_id": "demo/list-files",
+        "environment": "demo",
+        "model": "claude-haiku-4-5",
+    }
+
+
+def test_write_redacts_secrets(tmp_path):
+    events = [
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "env",
+            "status": "completed",
+            "content": [{"text": "OPENAI_API_KEY=sk-abc123def456ghi789"}],
+        }
+    ]
+    rec = write_rollout_adp_jsonl(
+        tmp_path,
+        trajectory_id="r",
+        task_id="t",
+        prompts=None,
+        trajectory=events,
+        model=None,
+        environment="demo",
+    )
+    raw = (tmp_path / "trainer" / "adp.jsonl").read_text()
+    assert "sk-abc123def456ghi789" not in raw
+    observation = rec["content"][-1]
+    assert "***REDACTED***" in observation["content"]
+
+
+def test_write_job_adp_jsonl_aggregates_rollouts(tmp_path):
+    for i in range(2):
+        write_rollout_adp_jsonl(
+            tmp_path / f"rollout-{i}",
+            trajectory_id=f"rollout-{i}",
+            task_id=f"t{i}",
+            prompts=None,
+            trajectory=[{"type": "agent_message", "text": f"hi {i}"}],
+            model="m",
+            environment="demo",
+        )
+    out = write_job_adp_jsonl(tmp_path)
+    assert out == tmp_path / "adp.jsonl"
+    lines = out.read_text().splitlines()
+    assert [json.loads(line)["id"] for line in lines] == ["rollout-0", "rollout-1"]
+
+
+def test_write_job_adp_jsonl_returns_none_without_rollouts(tmp_path):
+    assert write_job_adp_jsonl(tmp_path) is None
+    assert write_job_adp_jsonl(tmp_path / "missing") is None

--- a/tests/trajectories/test_export_atif.py
+++ b/tests/trajectories/test_export_atif.py
@@ -1,0 +1,251 @@
+"""ATIF (Agent Trajectory Interchange Format) trajectory export.
+
+Record shape pinned against the Harbor pydantic models
+(harbor-framework/harbor, src/harbor/models/trajectories/*.py) and the
+ATIF RFC (rfcs/0001-trajectory-format.md), schema version ATIF-v1.7.
+"""
+
+import json
+
+import pytest
+
+from benchflow.trajectories.export_atif import (
+    acp_events_to_atif_steps,
+    trajectory_to_atif_record,
+    write_rollout_atif_json,
+)
+
+
+def _sample_events():
+    return [
+        {"type": "user_message", "text": "List the files."},
+        {"type": "agent_thought", "text": "I should run ls."},
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "ls",
+            "status": "completed",
+            "content": [
+                {"type": "content", "content": {"type": "text", "text": "README.md"}}
+            ],
+        },
+        {"type": "agent_message", "text": "One file: README.md."},
+    ]
+
+
+def test_golden_record():
+    rec = trajectory_to_atif_record(
+        session_id="sess-1",
+        agent_name="claude-code",
+        agent_version="2.0.1",
+        model="claude-haiku-4-5",
+        events=_sample_events(),
+        prompts=["Solve the task."],
+        total_prompt_tokens=220,
+        total_completion_tokens=80,
+        total_cost_usd=0.00135,
+    )
+    assert rec == {
+        "schema_version": "ATIF-v1.7",
+        "session_id": "sess-1",
+        "agent": {
+            "name": "claude-code",
+            "version": "2.0.1",
+            "model_name": "claude-haiku-4-5",
+        },
+        "steps": [
+            {"step_id": 1, "source": "user", "message": "Solve the task."},
+            {"step_id": 2, "source": "user", "message": "List the files."},
+            {
+                "step_id": 3,
+                "source": "agent",
+                "message": "",
+                "tool_calls": [
+                    {
+                        "tool_call_id": "tc1",
+                        "function_name": "execute",
+                        "arguments": {},
+                        "extra": {"title": "ls", "status": "completed"},
+                    }
+                ],
+                "reasoning_content": "I should run ls.",
+                "observation": {
+                    "results": [{"source_call_id": "tc1", "content": "README.md"}]
+                },
+            },
+            {"step_id": 4, "source": "agent", "message": "One file: README.md."},
+        ],
+        "final_metrics": {
+            "total_steps": 4,
+            "total_prompt_tokens": 220,
+            "total_completion_tokens": 80,
+            "total_cost_usd": 0.00135,
+        },
+    }
+
+
+def test_empty_trajectory_raises():
+    with pytest.raises(ValueError):
+        trajectory_to_atif_record(session_id="s", agent_name="a", events=[], prompts=[])
+
+
+def test_omitted_optionals_stay_absent():
+    rec = trajectory_to_atif_record(
+        session_id="",
+        agent_name="",
+        events=[{"type": "agent_message", "text": "hi"}],
+    )
+    assert "session_id" not in rec
+    assert rec["agent"] == {"name": "unknown", "version": "unknown"}
+    assert rec["final_metrics"] == {"total_steps": 1}
+
+
+def test_missing_tool_call_id_synthesized_and_referenced():
+    steps = acp_events_to_atif_steps(
+        [
+            {
+                "type": "tool_call",
+                "tool_call_id": "",
+                "kind": "read",
+                "title": "cat notes.txt",
+                "status": "completed",
+                "content": [{"text": "hello"}],
+            }
+        ]
+    )
+    (step,) = steps
+    call_id = step["tool_calls"][0]["tool_call_id"]
+    assert call_id == "call_1"
+    assert step["observation"]["results"][0]["source_call_id"] == call_id
+
+
+def test_empty_tool_output_omits_observation():
+    steps = acp_events_to_atif_steps(
+        [
+            {
+                "type": "tool_call",
+                "tool_call_id": "tc1",
+                "kind": "execute",
+                "title": "touch a",
+                "status": "failed",
+                "content": [],
+            }
+        ]
+    )
+    (step,) = steps
+    assert "observation" not in step
+    assert step["tool_calls"][0]["extra"]["status"] == "failed"
+
+
+def test_thought_before_user_message_flushes_in_order():
+    steps = acp_events_to_atif_steps(
+        [
+            {"type": "agent_thought", "text": "hmm"},
+            {"type": "user_message", "text": "continue"},
+        ]
+    )
+    assert steps == [
+        {"step_id": 1, "source": "agent", "message": "", "reasoning_content": "hmm"},
+        {"step_id": 2, "source": "user", "message": "continue"},
+    ]
+
+
+def test_trailing_thoughts_join_into_standalone_step():
+    steps = acp_events_to_atif_steps(
+        [
+            {"type": "agent_thought", "text": "first"},
+            {"type": "agent_thought", "text": "second"},
+        ]
+    )
+    assert steps == [
+        {
+            "step_id": 1,
+            "source": "agent",
+            "message": "",
+            "reasoning_content": "first\n\nsecond",
+        }
+    ]
+
+
+def test_oracle_event_renders_command():
+    steps = acp_events_to_atif_steps([{"type": "oracle", "command": "bash run.sh"}])
+    assert steps == [
+        {"step_id": 1, "source": "agent", "message": "[oracle: bash run.sh]"}
+    ]
+
+
+def test_empty_and_malformed_events_skipped():
+    steps = acp_events_to_atif_steps(
+        [
+            {"type": "agent_message", "text": ""},
+            "not-a-dict",
+            {"type": "unknown_event", "text": "x"},
+            {"type": "user_message", "text": "real"},
+        ]
+    )
+    assert steps == [{"step_id": 1, "source": "user", "message": "real"}]
+
+
+def test_write_rollout_atif_json(tmp_path):
+    rec = write_rollout_atif_json(
+        tmp_path,
+        session_id="sess-1",
+        agent_name="claude-code",
+        prompts=["Solve the task."],
+        trajectory=_sample_events(),
+        model="claude-haiku-4-5",
+    )
+    out = tmp_path / "trainer" / "atif.json"
+    assert json.loads(out.read_text()) == rec
+    assert rec["schema_version"] == "ATIF-v1.7"
+    assert [s["step_id"] for s in rec["steps"]] == [1, 2, 3, 4]
+
+
+def test_write_skips_empty_trajectory(tmp_path):
+    rec = write_rollout_atif_json(
+        tmp_path,
+        session_id="s",
+        agent_name="a",
+        prompts=[],
+        trajectory=[],
+    )
+    assert rec is None
+    assert not (tmp_path / "trainer" / "atif.json").exists()
+
+
+def test_write_redacts_secrets(tmp_path):
+    events = [
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "env",
+            "status": "completed",
+            "content": [{"text": "OPENAI_API_KEY=sk-abc123def456ghi789"}],
+        }
+    ]
+    rec = write_rollout_atif_json(
+        tmp_path,
+        session_id="s",
+        agent_name="a",
+        prompts=None,
+        trajectory=events,
+    )
+    raw = (tmp_path / "trainer" / "atif.json").read_text()
+    assert "sk-abc123def456ghi789" not in raw
+    content = rec["steps"][0]["observation"]["results"][0]["content"]
+    assert "***REDACTED***" in content
+
+
+def test_write_scrubs_non_finite_cost(tmp_path):
+    write_rollout_atif_json(
+        tmp_path,
+        session_id="s",
+        agent_name="a",
+        prompts=None,
+        trajectory=[{"type": "agent_message", "text": "hi"}],
+        total_cost_usd=float("nan"),
+    )
+    parsed = json.loads((tmp_path / "trainer" / "atif.json").read_text())
+    assert parsed["final_metrics"]["total_cost_usd"] is None

--- a/tests/trajectories/test_export_common.py
+++ b/tests/trajectories/test_export_common.py
@@ -1,0 +1,91 @@
+"""Shared export plumbing: content rendering, thought buffering, aggregation."""
+
+import json
+import logging
+
+from benchflow.trajectories._export_common import (
+    ThoughtBuffer,
+    aggregate_rollout_jsonl,
+    content_blocks_to_text,
+)
+
+
+def test_content_blocks_string_passes_through():
+    assert content_blocks_to_text("plain output") == "plain output"
+
+
+def test_content_blocks_non_list_yields_empty():
+    assert content_blocks_to_text(None) == ""
+    assert content_blocks_to_text({"text": "x"}) == ""
+
+
+def test_content_blocks_mixed_shapes_joined():
+    blocks = [
+        {"text": "flat"},
+        {"type": "content", "content": {"type": "text", "text": "nested"}},
+        {"type": "image", "data": "..."},
+        "not-a-dict",
+    ]
+    assert content_blocks_to_text(blocks) == "flat\nnested"
+
+
+def test_thought_buffer_joins_then_clears():
+    buf = ThoughtBuffer()
+    assert buf.take() is None
+    buf.push("first")
+    buf.push("second")
+    assert buf.take() == "first\n\nsecond"
+    assert buf.take() is None
+
+
+def _write_artifact(job_dir, rollout, text):
+    path = job_dir / rollout / "trainer" / "records.jsonl"
+    path.parent.mkdir(parents=True)
+    path.write_text(text)
+
+
+def test_aggregate_normalizes_missing_trailing_newline(tmp_path):
+    _write_artifact(tmp_path, "r1", '{"id": 1}')
+    _write_artifact(tmp_path, "r2", '{"id": 2}\n')
+    out = aggregate_rollout_jsonl(
+        tmp_path,
+        rollout_relpath="trainer/records.jsonl",
+        out_filename="records.jsonl",
+    )
+    assert out == tmp_path / "records.jsonl"
+    lines = out.read_text().splitlines()
+    assert [json.loads(line)["id"] for line in lines] == [1, 2]
+
+
+def test_aggregate_skips_unreadable_artifact(tmp_path, caplog):
+    # A directory where the artifact file should be: read_text raises OSError.
+    (tmp_path / "r1" / "trainer" / "records.jsonl").mkdir(parents=True)
+    _write_artifact(tmp_path, "r2", '{"id": 2}\n')
+    with caplog.at_level(logging.WARNING):
+        out = aggregate_rollout_jsonl(
+            tmp_path,
+            rollout_relpath="trainer/records.jsonl",
+            out_filename="records.jsonl",
+        )
+    assert out is not None
+    lines = out.read_text().splitlines()
+    assert [json.loads(line)["id"] for line in lines] == [2]
+    assert "Skipping unreadable trainer artifact" in caplog.text
+
+
+def test_aggregate_returns_none_without_rollouts(tmp_path):
+    assert (
+        aggregate_rollout_jsonl(
+            tmp_path, rollout_relpath="trainer/records.jsonl", out_filename="r.jsonl"
+        )
+        is None
+    )
+    assert (
+        aggregate_rollout_jsonl(
+            tmp_path / "missing",
+            rollout_relpath="trainer/records.jsonl",
+            out_filename="r.jsonl",
+        )
+        is None
+    )
+    assert not (tmp_path / "r.jsonl").exists()


### PR DESCRIPTION
Emitters for two ecosystem trajectory formats, converting the canonical in-house trajectory record:

- `export_atif.py` — agent trajectory interchange format (Harbor / terminal-bench lineage)
- `export_adp.py` — agent data protocol (OpenHands lineage), plus job-level `write_job_adp_jsonl`
- shared aggregation plumbing extracted to `_export_common.py` (verifiers + adp job exports now one canonical path)

Golden-fixture tests pin the exact emitted records; spec sources cited in module docstrings. Full suite green (2 pre-existing host-credential-dependent failures unrelated, reproduced on bare base).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive export paths and a refactor of verifiers job aggregation to shared code; outputs use existing redaction and are covered by extensive tests, with no changes to core rollout capture or scoring.
> 
> **Overview**
> Adds **ATIF** (Harbor) and **ADP** (OpenHands) trajectory exporters that map captured ACP events into schema-pinned rollout artifacts under `rollout_dir/trainer/` (`atif.json`, `adp.jsonl`), with optional job-level `adp.jsonl` aggregation.
> 
> Shared logic moves into `_export_common.py`: `content_blocks_to_text`, `ThoughtBuffer` for `agent_thought` → `reasoning_content`, and `aggregate_rollout_jsonl` (with re-redaction on aggregate). **`write_job_verifiers_jsonl`** now delegates to that aggregator instead of inlined duplication.
> 
> Both walkers handle prompts, user/agent messages, tool calls (paired ADP observations; ATIF `tool_calls` + in-step observations), oracle commands, and thought flushing. ADP enforces unique `tool_call_id`s and terminal reward on the last action; ATIF skips writing when the trajectory would be empty and scrubs non-finite metrics on write.
> 
> Golden-fixture tests cover record shapes, secret redaction, and aggregation edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6001f61aa2cfabd86f70f848cbfaf4666280ae0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->