### PR TITLE
docs: align quickstart and CLI reference with observed 0.5.2 behavior

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,8 +94,11 @@ native default auth. For Azure Foundry, use models such as
 from `AZURE_API_ENDPOINT` and routes the selected agent through a generated
 LiteLLM gateway config.
 
-Other provider-prefixed models follow the `<PROVIDER>_API_KEY` +
-`<PROVIDER>_BASE_URL` convention. For example, `deepseek/<model>` reads:
+Several providers with user-supplied endpoints — `deepseek`, `glm`, `kimi`,
+`minimax`, `hunyuan`, and others — follow the `<PROVIDER>_API_KEY` +
+`<PROVIDER>_BASE_URL` convention; providers with fixed endpoints (such as
+`zai` or `openai`) need only the API key. For example, `deepseek/<model>`
+reads:
 
 ```bash
 export DEEPSEEK_API_KEY=...
@@ -103,7 +106,7 @@ export DEEPSEEK_BASE_URL=https://api.deepseek.com
 ```
 
 If the base URL is missing, the run fails with
-`Provider 'deepseek' for model 'deepseek/<model>' requires DEEPSEEK_BASE_URL.`
+`Provider 'deepseek' for model 'deepseek/<model>' requires DEEPSEEK_BASE_URL to build the provider base URL.`
 
 These variables must be **exported** to reach the benchflow runtime — a plain
 shell assignment or a `source .env` without `export` stays local to your shell
@@ -164,9 +167,10 @@ directory or `--config <config.yaml>` for a YAML config.
 
 You can also fetch tasks straight from a remote repo with
 `--source-repo <org/repo> --source-path <subpath>`, but note that this clones
-the full repository (`git clone --depth 1` into `.cache/datasets/<org>/<repo>/`)
-— large for big task repos. To download only the task you need, use a sparse
-checkout and point `--tasks-dir` at it:
+the full repository (`git clone --depth 1` into `.cache/datasets/<org>/<repo>/`
+under the enclosing git repo root, or the current directory when you run
+outside one) — large for big task repos. To download only the task you need,
+use a sparse checkout and point `--tasks-dir` at it:
 
 ```bash
 git clone --depth 1 --filter=blob:none --sparse https://github.com/benchflow-ai/skillsbench
@@ -185,14 +189,14 @@ Each run writes under `--jobs-dir` (default `jobs/`):
 
 ```
 <jobs-dir>/
-  summary.json                      # eval-level aggregate (score, counts)
+  summary.json                      # copy of the latest job summary (overwritten by the next run)
   <YYYY-MM-DD__HH-MM-SS>/           # job directory, named by start time
     summary.json                    # job-level aggregate
     <task>__<hash8>/                # one rollout: task name + 8-char id
       result.json                   # rollout summary: rewards, errors, token usage/cost
       trajectory/
         acp_trajectory.jsonl        # full agent trace (ACP events)
-        llm_trajectory.jsonl        # raw provider requests/responses (usage tracking)
+        llm_trajectory.jsonl        # raw provider requests/responses (when the usage-tracking proxy captured exchanges)
       trainer/
         verifiers.jsonl             # trainer-ready scored trajectory
       verifier/
@@ -207,9 +211,9 @@ Exit code 0 means the pipeline completed — it is not a pass/fail signal. A
 rollout whose reward is below the pass threshold still exits 0 and prints
 `[FAIL]` with `Score: 0/1`: `Score` is pass-threshold aggregation (a task
 counts as passed only at reward 1.0), while `reward` — in `result.json` and
-`verifier/reward.txt` — is the raw verifier value. Config errors (bad flags,
-unknown agents, missing credentials) exit 1, and so do runs with agent or
-verifier errors.
+`verifier/reward.txt` — is the raw verifier value. Config errors (unknown
+agents, missing credentials) exit 1, and so do runs with agent or verifier
+errors. CLI usage errors (bad flags) exit 2.
 
 The Docker sandbox needs the Docker daemon running. There is no up-front
 check — if the daemon is down the run fails partway through rather than at

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -94,6 +94,29 @@ native default auth. For Azure Foundry, use models such as
 from `AZURE_API_ENDPOINT` and routes the selected agent through a generated
 LiteLLM gateway config.
 
+Other provider-prefixed models follow the `<PROVIDER>_API_KEY` +
+`<PROVIDER>_BASE_URL` convention. For example, `deepseek/<model>` reads:
+
+```bash
+export DEEPSEEK_API_KEY=...
+export DEEPSEEK_BASE_URL=https://api.deepseek.com
+```
+
+If the base URL is missing, the run fails with
+`Provider 'deepseek' for model 'deepseek/<model>' requires DEEPSEEK_BASE_URL.`
+
+These variables must be **exported** to reach the benchflow runtime — a plain
+shell assignment or a `source .env` without `export` stays local to your shell
+and never reaches the `bench` process. The portable pattern for a `.env` file:
+
+```bash
+set -a; source .env; set +a
+bench eval create ...
+```
+
+(benchflow also picks up well-known credential keys from a `.env` file in the
+current directory; exporting works from any directory.)
+
 ### Precedence
 
 If multiple credentials are set, benchflow / the agent CLI uses provider-specific
@@ -106,15 +129,14 @@ option, unset the higher one in your shell before running.
 ## Run your first eval
 
 ```bash
-# Single task from a remote repo
+# Single task from a local directory
 GEMINI_API_KEY=... bench eval create \
-  --source-repo benchflow-ai/skillsbench \
-  --source-path tasks/edit-pdf \
+  --tasks-dir tasks/edit-pdf \
   --agent gemini \
   --model gemini-3.1-pro-preview \
   --sandbox docker
 
-# Single task from local path
+# Single task with mounted skills
 GEMINI_API_KEY=... bench eval create \
   --tasks-dir tasks/edit-pdf \
   --agent gemini \
@@ -127,9 +149,9 @@ GEMINI_API_KEY=... bench eval create \
 # A whole batch from YAML config
 bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
-# Batch from remote repo with concurrency
+# Batch over a local tasks directory with concurrency
 GEMINI_API_KEY=... bench eval create \
-    --source-repo benchflow-ai/skillsbench --source-path tasks \
+    --tasks-dir tasks \
     --agent gemini --model gemini-3.1-pro-preview --sandbox daytona --concurrency 32
 
 # List the registered agents
@@ -137,16 +159,61 @@ bench agent list
 ```
 
 `bench eval create` is the primary command for running evaluations — it works for
-single tasks, batch runs, and remote repos. Use `--source-repo <org/repo>
---source-path <subpath>` to fetch from a remote repo, `--tasks-dir <dir>` for a
-local directory, or `--config <config.yaml>` for a YAML config. Results land under
-`jobs/<eval-name>/<rollout-name>/` — `result.json` for the verifier output,
-`trajectory/acp_trajectory.jsonl` for the full agent trace.
+single tasks, batch runs, and remote repos. Use `--tasks-dir <dir>` for a local
+directory or `--config <config.yaml>` for a YAML config.
+
+You can also fetch tasks straight from a remote repo with
+`--source-repo <org/repo> --source-path <subpath>`, but note that this clones
+the full repository (`git clone --depth 1` into `.cache/datasets/<org>/<repo>/`)
+— large for big task repos. To download only the task you need, use a sparse
+checkout and point `--tasks-dir` at it:
+
+```bash
+git clone --depth 1 --filter=blob:none --sparse https://github.com/benchflow-ai/skillsbench
+cd skillsbench && git sparse-checkout set tasks/edit-pdf
+bench eval create --tasks-dir tasks/edit-pdf --agent gemini --model gemini-3.1-pro-preview
+```
 
 When you mount skills, use `BENCHFLOW_SKILL_NUDGE=name` as the default docs
 option. See [Architecture: skill loading](./architecture.md#skill-loading) for
 how mounted skills reach the agent and how `name`, `description`, and `full`
 differ.
+
+### Where results land
+
+Each run writes under `--jobs-dir` (default `jobs/`):
+
+```
+<jobs-dir>/
+  summary.json                      # eval-level aggregate (score, counts)
+  <YYYY-MM-DD__HH-MM-SS>/           # job directory, named by start time
+    summary.json                    # job-level aggregate
+    <task>__<hash8>/                # one rollout: task name + 8-char id
+      result.json                   # rollout summary: rewards, errors, token usage/cost
+      trajectory/
+        acp_trajectory.jsonl        # full agent trace (ACP events)
+        llm_trajectory.jsonl        # raw provider requests/responses (usage tracking)
+      trainer/
+        verifiers.jsonl             # trainer-ready scored trajectory
+      verifier/
+        ctrf.json                   # CTRF test report (when test.sh emits one)
+        reward.txt                  # raw verifier reward (0.0-1.0)
+        test-stdout.txt             # verifier stdout
+```
+
+### Reading results
+
+Exit code 0 means the pipeline completed — it is not a pass/fail signal. A
+rollout whose reward is below the pass threshold still exits 0 and prints
+`[FAIL]` with `Score: 0/1`: `Score` is pass-threshold aggregation (a task
+counts as passed only at reward 1.0), while `reward` — in `result.json` and
+`verifier/reward.txt` — is the raw verifier value. Config errors (bad flags,
+unknown agents, missing credentials) exit 1, and so do runs with agent or
+verifier errors.
+
+The Docker sandbox needs the Docker daemon running. There is no up-front
+check — if the daemon is down the run fails partway through rather than at
+startup, so start Docker before `bench eval create --sandbox docker`.
 
 ## Run from Python
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,6 +187,49 @@ Validate a task directory (Dockerfile, instruction.md, tests/).
 bench tasks check tasks/my-task
 ```
 
+On the development branch, `bench tasks check` gains a `--level` option
+(`schema`, `structural`, `runtime-capability`, `publication-grade`,
+`acceptance`, `acceptance-live`). Acceptance-level errors such as
+`acceptance validation requires benchflow.evidence mapping` refer to the
+`benchflow.evidence` schema documented in the "Assets, Provenance, And
+Evidence" section of `docs/task-standard.md` on the same branch.
+
+### bench tasks migrate
+
+> Available on the development branch; not yet in this release.
+
+Convert a legacy `task.toml` + `instruction.md` task into the unified
+`task.md` format. By default the legacy files are kept alongside the new
+`task.md`.
+
+```bash
+bench tasks migrate tasks/my-task
+bench tasks migrate tasks/my-task --overwrite --remove-legacy
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--overwrite` | `false` | Replace an existing task.md |
+| `--remove-legacy` | `false` | Delete split files and promote tests/solution aliases after task.md is verified |
+
+### bench tasks normalize
+
+> Available on the development branch; not yet in this release.
+
+Expand minimal `task.md` authoring profiles into the canonical `task.md`
+form. Prints the normalized document to stdout unless told otherwise.
+
+```bash
+bench tasks normalize tasks/my-task
+bench tasks normalize tasks/my-task --write
+bench tasks normalize tasks/my-task -o normalized-task.md
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output`, `-o` | — | Write normalized task.md to this path instead of stdout |
+| `--write` | `false` | Replace task.md in place with the normalized canonical form |
+
 ### bench tasks generate
 
 Generate benchmark task directories from real agent traces.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,9 +187,11 @@ Validate a task directory (Dockerfile, instruction.md, tests/).
 bench tasks check tasks/my-task
 ```
 
-On the development branch, `bench tasks check` gains a `--level` option
-(`schema`, `structural`, `runtime-capability`, `publication-grade`,
-`acceptance`, `acceptance-live`). Acceptance-level errors such as
+> The `--level` option is available on the development branch; not yet in this release.
+
+With `--level`, validation runs at a chosen depth: `schema`, `structural`,
+`runtime-capability`, `publication-grade`, `acceptance`, or `acceptance-live`.
+Acceptance-level errors such as
 `acceptance validation requires benchflow.evidence mapping` refer to the
 `benchflow.evidence` schema documented in the "Assets, Provenance, And
 Evidence" section of `docs/task-standard.md` on the same branch.


### PR DESCRIPTION
Documentation truth pass, every claim verified against live runs or source:

- Quickstart leads with the local `--tasks-dir` pattern; `--source-repo` full-clone cost noted with a sparse-checkout alternative
- `<PROVIDER>_API_KEY` + `<PROVIDER>_BASE_URL` convention documented (with the exact missing-base-URL error) and the `set -a` export pattern
- Output layout corrected to the real contract (`<jobs-dir>/<timestamp>/<task>__<hash8>/`) with the full artifact map (trajectory/, trainer/, verifier/, summaries)
- 'Reading results' section: reward vs pass-threshold score, exit-code semantics (0 = pipeline completed, 1 = run failure, 2 = CLI usage error), Docker daemon prerequisite
- `bench tasks migrate`/`normalize` documented; stale init/check flags fixed
- acceptance-check error now points at the evidence schema section

Docs only; no code changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime or API impact.
> 
> **Overview**
> **Docs-only alignment** with observed **0.5.2** behavior in the quickstart and CLI reference—no code changes.
> 
> **Getting started** now leads with **`--tasks-dir`** examples, documents **`<PROVIDER>_API_KEY` / `<PROVIDER>_BASE_URL`** (including the exact missing-base-URL error), and explains **exporting** env vars via **`set -a; source .env`**. **`--source-repo`** is de-emphasized with notes on full shallow clones and a **sparse-checkout** alternative. New sections spell out the real **jobs output tree** (`<jobs-dir>/<timestamp>/<task>__<hash8>/` and artifacts under `trajectory/`, `trainer/`, `verifier/`), plus **how to read results** (reward vs pass-threshold score, exit codes 0/1/2, Docker daemon prerequisite).
> 
> **CLI reference** adds **`bench tasks check --level`** (dev-branch only), **`bench tasks migrate`**, and **`bench tasks normalize`** with flags, and points acceptance-check errors at the **`benchflow.evidence`** section in `task-standard.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 104ea206dd9587249a49eb74c489915758ea656e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->