### PR TITLE
feat: OpenReward hosted-environment inbound runner

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -71,6 +71,14 @@ bench eval create \
   --agent gemini \
   --model google/gemini-2.5-flash-lite
 
+# From an OpenReward (ORS) hosted environment
+# (requires `pip install openreward` and OPENREWARD_API_KEY)
+bench eval create \
+  --source-env openreward:GeneralReasoning/CTF \
+  --source-env-arg split=train \
+  --source-env-num-examples 2 \
+  --model openai/gpt-5-mini
+
 # Single task with mounted skills and the recommended skill nudge
 bench eval create \
   --tasks-dir tasks/pdf-fix \
@@ -88,14 +96,15 @@ bench eval create \
 | `--source-repo` | — | Remote repo as `org/repo` (e.g. `benchflow-ai/skillsbench`) |
 | `--source-path` | — | Subpath within the repo (e.g. `tasks`) |
 | `--source-ref` | — | Branch or tag to clone (e.g. `main`) |
-| `--source-env` | — | Hosted environment source (e.g. `primeintellect/general-agent`) |
-| `--source-env-version` | — | Hosted environment version |
-| `--source-env-arg` | — | Hosted environment argument as `KEY=VALUE`; repeatable |
+| `--source-env` | — | Hosted environment source (e.g. `primeintellect/general-agent` or `openreward:GeneralReasoning/CTF`) |
+| `--source-env-version` | — | Hosted environment version (for `openreward:` refs, the environment variant) |
+| `--source-env-arg` | — | Hosted environment argument as `KEY=VALUE`; repeatable (`split=train` selects the openreward task split) |
 | `--source-env-num-examples` | `1` | Number of hosted environment examples |
-| `--source-env-rollouts-per-example` | `1` | Rollouts per hosted environment example |
+| `--source-env-rollouts-per-example` | `1` | Rollouts per hosted environment example (Verifiers runner only) |
 | `--source-env-max-tokens` | `1024` | Max tokens for hosted environment model calls |
 | `--source-env-temperature` | `0.0` | Temperature for hosted environment model calls |
 | `--source-env-sampling-arg` | — | Verifiers sampling argument as `KEY=VALUE`; repeatable (for example `reasoning_effort=minimal`) |
+| `--source-env-max-turns` | `16` | Max model turns per hosted episode (openreward runner only) |
 | `--agent` | `claude-agent-acp` | Agent name |
 | `--model` | Agent default | Model ID |
 | `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1293,6 +1293,12 @@ def eval_create(
                         "[yellow]--source-env-rollouts-per-example is for Verifiers "
                         "runs; ignoring for the openreward runner.[/yellow]"
                     )
+                if concurrency is not None:
+                    console.print(
+                        "[yellow]--concurrency is for Verifiers runs; the "
+                        "openreward runner drives episodes sequentially. "
+                        "Ignoring.[/yellow]"
+                    )
                 run_result = run_openreward_env(
                     OpenRewardRunConfig(
                         source_env=ref,
@@ -1307,6 +1313,12 @@ def eval_create(
                     )
                 )
             else:
+                if source_env_max_turns != 16:  # 16 is the CLI default
+                    console.print(
+                        "[yellow]--source-env-max-turns is for the openreward "
+                        "runner; ignoring for Verifiers runs (vf-eval owns the "
+                        "episode loop).[/yellow]"
+                    )
                 run_result = run_hosted_env(
                     HostedEnvRunConfig(
                         source_env=ref,

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -861,12 +861,18 @@ def eval_create(
         str | None,
         typer.Option(
             "--source-env",
-            help="Hosted environment source (e.g. primeintellect/general-agent)",
+            help=(
+                "Hosted environment source (e.g. primeintellect/general-agent "
+                "or openreward:GeneralReasoning/CTF)"
+            ),
         ),
     ] = None,
     source_env_version: Annotated[
         str | None,
-        typer.Option("--source-env-version", help="Hosted environment version"),
+        typer.Option(
+            "--source-env-version",
+            help="Hosted environment version (openreward: variant)",
+        ),
     ] = None,
     source_env_arg: Annotated[
         list[str] | None,
@@ -901,6 +907,13 @@ def eval_create(
             help="Hosted env sampling arg as KEY=VALUE; repeatable (e.g. reasoning_effort=minimal)",
         ),
     ] = None,
+    source_env_max_turns: Annotated[
+        int,
+        typer.Option(
+            "--source-env-max-turns",
+            help="Max model turns per hosted episode (openreward runner)",
+        ),
+    ] = 16,
     agent: Annotated[
         str | None,
         typer.Option("--agent", help="Agent name"),
@@ -1244,7 +1257,7 @@ def eval_create(
             )
         if eval_agent != DEFAULT_AGENT:
             console.print(
-                f"[dim]source-env records --agent {eval_agent!r}, but executes the model endpoint through Verifiers.[/dim]"
+                f"[dim]source-env records --agent {eval_agent!r}, but executes the model endpoint through the hosted runner.[/dim]"
             )
         if eval_env_manifest is not None:
             console.print(
@@ -1264,21 +1277,51 @@ def eval_create(
 
         try:
             ref = HostedEnvRef.parse(source_env, version=source_env_version)
-            run_result = run_hosted_env(
-                HostedEnvRunConfig(
-                    source_env=ref,
-                    model=model or "",
-                    env_args=parse_source_env_args(source_env_arg),
-                    agent=eval_agent,
-                    jobs_dir=Path(output_jobs_dir),
-                    concurrency=eval_concurrency,
-                    num_examples=source_env_num_examples,
-                    rollouts_per_example=source_env_rollouts_per_example,
-                    max_tokens=source_env_max_tokens,
-                    temperature=source_env_temperature,
-                    sampling_args=parse_sampling_args(source_env_sampling_arg),
+            if ref.provider == "openreward":
+                from benchflow.hosted_env_openreward import (
+                    OpenRewardRunConfig,
+                    run_openreward_env,
                 )
-            )
+
+                if source_env_sampling_arg:
+                    console.print(
+                        "[yellow]--source-env-sampling-arg is for Verifiers runs; "
+                        "ignoring for the openreward runner.[/yellow]"
+                    )
+                if source_env_rollouts_per_example != 1:
+                    console.print(
+                        "[yellow]--source-env-rollouts-per-example is for Verifiers "
+                        "runs; ignoring for the openreward runner.[/yellow]"
+                    )
+                run_result = run_openreward_env(
+                    OpenRewardRunConfig(
+                        source_env=ref,
+                        model=model or "",
+                        env_args=parse_source_env_args(source_env_arg),
+                        agent=eval_agent,
+                        jobs_dir=Path(output_jobs_dir),
+                        num_examples=source_env_num_examples,
+                        max_turns=source_env_max_turns,
+                        max_tokens=source_env_max_tokens,
+                        temperature=source_env_temperature,
+                    )
+                )
+            else:
+                run_result = run_hosted_env(
+                    HostedEnvRunConfig(
+                        source_env=ref,
+                        model=model or "",
+                        env_args=parse_source_env_args(source_env_arg),
+                        agent=eval_agent,
+                        jobs_dir=Path(output_jobs_dir),
+                        concurrency=eval_concurrency,
+                        num_examples=source_env_num_examples,
+                        rollouts_per_example=source_env_rollouts_per_example,
+                        max_tokens=source_env_max_tokens,
+                        temperature=source_env_temperature,
+                        sampling_args=parse_sampling_args(source_env_sampling_arg),
+                    )
+                )
         except HostedEnvError as e:
             console.print(f"[red]{e}[/red]")
             raise typer.Exit(1) from None

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -6,6 +6,11 @@ they do not use BenchFlow's Docker/Daytona sandbox runner directly. The adapter
 keeps their hosted identity intact and runs them through their native Verifiers
 execution surface.
 
+:class:`HostedEnvRef` is the shared addressing scheme for all hosted hubs.
+This module's runner (:func:`run_hosted_env`) executes ``primeintellect``
+references through ``vf-eval``; ``openreward`` references execute through
+:mod:`benchflow.hosted_env_openreward`.
+
 Hosted runs share the rollout artifact contract — ``result.json``,
 ``rewards.jsonl``, ``trajectory/acp_trajectory.jsonl``, ``config.json``,
 ``timing.json``, and ``prompts.json`` — so dashboards and release checks can
@@ -39,6 +44,12 @@ logger = logging.getLogger(__name__)
 
 PRIME_SIMPLE_INDEX = "https://hub.primeintellect.ai/primeintellect/simple/"
 PRIME_HUB_ENV_URL = "https://app.primeintellect.ai/dashboard/environments"
+OPENREWARD_HUB_ENV_URL = "https://openreward.ai/environments"
+
+# Providers HostedEnvRef.parse accepts. Each one has a native runner:
+# primeintellect -> run_hosted_env (vf-eval), openreward ->
+# benchflow.hosted_env_openreward.run_openreward_env.
+EXECUTABLE_PROVIDERS = ("primeintellect", "openreward")
 
 
 class HostedEnvError(RuntimeError):
@@ -69,6 +80,17 @@ class HostedEnvRef:
         - ``primeintellect/general-agent@0.1.1``
         - ``primeintellect:general-agent@0.1.1``
         - ``primeintellect:primeintellect/general-agent@0.1.1``
+        - ``openreward:GeneralReasoning/CTF``
+        - ``openreward:GeneralReasoning/CTF@somevariant``
+
+        Provider-less references default to *default_provider*
+        (``primeintellect``), so OpenReward environments always carry the
+        explicit ``openreward:`` prefix. For OpenReward the ``@`` slot
+        selects the environment *variant* (the ``variant`` parameter of the
+        ORS client's ``environments.get``,
+        https://docs.openreward.ai/environments/using-environment-variants.md);
+        OpenReward deployments are otherwise unversioned — every run hits
+        the currently deployed build.
         """
         provider = default_provider
         value = raw.strip()
@@ -98,10 +120,10 @@ class HostedEnvRef:
             owner, name = None, value
 
         provider = provider.lower()
-        if provider != "primeintellect":
+        if provider not in EXECUTABLE_PROVIDERS:
             raise HostedEnvError(
                 f"Unsupported hosted environment provider: {provider}. "
-                "Only primeintellect Verifiers environments are executable today."
+                f"Executable providers: {', '.join(EXECUTABLE_PROVIDERS)}."
             )
         if not name:
             raise HostedEnvError(f"Invalid hosted environment reference: {raw}")
@@ -126,6 +148,8 @@ class HostedEnvRef:
     @property
     def hub_url(self) -> str:
         """Canonical hosted hub URL."""
+        if self.provider == "openreward":
+            return OPENREWARD_HUB_ENV_URL
         if self.provider == "primeintellect" and self.owner:
             return f"{PRIME_HUB_ENV_URL}/{self.owner}/{self.name}"
         return PRIME_HUB_ENV_URL
@@ -215,6 +239,12 @@ def normalize_verifiers_model(model: str) -> str:
 
 def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
     """Run a hosted environment using a controlled local Verifiers install."""
+    if config.source_env.provider != "primeintellect":
+        raise HostedEnvError(
+            f"run_hosted_env executes primeintellect Verifiers environments; "
+            f"{config.source_env.provider!r} references run through "
+            "benchflow.hosted_env_openreward.run_openreward_env."
+        )
     if config.runner != "verifiers":
         raise HostedEnvError(
             "Only runner='verifiers' is implemented. Use Prime CLI directly for "
@@ -331,6 +361,7 @@ def prime_env_list(
 
 def prime_env_info(ref: HostedEnvRef) -> str:
     """Return Prime environment info output."""
+    _require_prime_ref(ref)
     cmd = ["prime", "--plain", "env", "info", ref.env_id]
     if ref.version:
         cmd.extend(["-v", ref.version])
@@ -339,9 +370,18 @@ def prime_env_info(ref: HostedEnvRef) -> str:
 
 def prime_env_inspect(ref: HostedEnvRef, path: str = "README.md") -> str:
     """Return a file from a Prime environment package."""
+    _require_prime_ref(ref)
     return _run_prime(
         ["prime", "--plain", "env", "inspect", ref.versioned_env_id, path]
     )
+
+
+def _require_prime_ref(ref: HostedEnvRef) -> None:
+    if ref.provider != "primeintellect":
+        raise HostedEnvError(
+            f"Environment metadata via the prime CLI only covers primeintellect "
+            f"references; browse {ref.provider!r} environments at {ref.hub_url}."
+        )
 
 
 def _parse_scalar(value: str) -> Any:

--- a/src/benchflow/hosted_env_openreward.py
+++ b/src/benchflow/hosted_env_openreward.py
@@ -1,0 +1,913 @@
+"""OpenReward (ORS) hosted environment runner.
+
+Runs environments hosted on OpenReward — the reference deployment of the
+Open Reward Standard (https://openrewardstandard.io) — and lands their
+evidence in BenchFlow's rollout artifact contract, mirroring the
+PrimeIntellect Verifiers runner in :mod:`benchflow.hosted_env`.
+
+Unlike Verifiers (where ``vf-eval`` owns the agent loop and we reconstruct
+artifacts afterwards), the ORS client hands *us* the loop: a session yields
+a prompt and tools, the model picks tool calls, and every
+``session.call_tool`` returns a ``ToolOutput`` carrying ``blocks`` /
+``reward`` / ``finished`` / ``metadata``. This module drives that episode
+loop, captures each step as native ACP-shaped trajectory events plus reward
+events, and emits the standard scored artifacts — ``result.json``,
+``rewards.jsonl``, ``trajectory/acp_trajectory.jsonl``, ``config.json``,
+``timing.json``, ``prompts.json``, and ``trainer/verifiers.jsonl`` — with
+``source.type="hosted_env"`` / ``trajectory_source="hosted_env"`` lineage.
+Raw per-episode evidence is preserved under ``hosted_env/`` for forensics.
+
+The model side goes through BenchFlow's existing provider plumbing: an
+explicit ``BENCHFLOW_PROVIDER_*`` contract (e.g. injected by the LiteLLM
+runtime) wins, otherwise the provider registry in
+:mod:`benchflow.agents.providers` resolves an OpenAI-compatible
+chat-completions endpoint for the model. Episodes are driven over that
+endpoint with the environment's ``list_tools(format="openai")`` schema.
+
+Primary sources for the hosted API surface (verified 2026-06-10):
+
+- https://openreward.ai — platform; built on the Open Reward Standard.
+- https://docs.openreward.ai/quickstart.md — ``OpenReward()`` client,
+  ``environments.get(name="GeneralReasoning/CTF")`` addressing,
+  ``environment.list_tasks(split=...)`` / ``list_tools(format="openai")``,
+  ``with environment.session(task=task) as session``, ``session.get_prompt()``
+  (block list; ``prompt[0].text``), ``session.call_tool(name, args)`` with
+  JSON-parsed arguments, and the ``finished`` / ``reward`` episode loop.
+- https://pypi.org/project/openreward/ — ``pip install openreward``
+  (Python 3.11+), ``orwd`` CLI, ``ToolOutput`` fields
+  (``blocks``/``reward``/``finished``/``metadata``), auth via
+  ``OPENREWARD_API_KEY`` (+ ``OPENREWARD_URL`` base-URL override).
+- https://docs.openreward.ai/environments/using-environment-variants.md —
+  variant selection via the ``variant`` parameter of ``environments.get``.
+- https://docs.openreward.ai/environments/ways-to-access-tasks.md — task
+  dicts are environment-defined JSON objects (e.g. ``{"task_id": ...}``).
+- https://docs.openreward.ai/environments/evaluation.md — per-task rewards
+  aggregate over all attempted tasks (errored/unfinished count as 0).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from benchflow._utils.result_metadata import (
+    final_metrics_from_agent_result,
+    trajectory_summary_from_events,
+)
+from benchflow.diagnostics import RolloutDiagnostics
+from benchflow.hosted_env import (
+    HostedEnvError,
+    HostedEnvRef,
+    _hosted_source_provenance,
+    _write_hosted_rewards_jsonl,
+    normalize_verifiers_model,
+)
+from benchflow.trajectories.types import (
+    redact_acp_trajectory_jsonl,
+    redact_trajectory_text,
+)
+
+logger = logging.getLogger(__name__)
+
+OPENREWARD_PROVIDER = "openreward"
+OPENREWARD_API_KEY_ENV = "OPENREWARD_API_KEY"
+OPENREWARD_RUNNER = "openreward"
+_OPENAI_COMPLETIONS = "openai-completions"
+_CHAT_TIMEOUT_SEC = 600.0
+_DEFAULT_SPLIT = "train"
+
+
+@dataclass(frozen=True)
+class ModelEndpoint:
+    """Resolved OpenAI-compatible chat-completions endpoint for the model."""
+
+    base_url: str
+    api_key: str
+    model_id: str
+    provider: str
+
+
+@dataclass
+class ChatTurn:
+    """One assistant turn from the model endpoint.
+
+    ``message`` is the OpenAI chat-completions assistant message dict
+    (``content`` and/or ``tool_calls``); ``usage`` is the response-level
+    token usage dict when the provider reports one.
+    """
+
+    message: dict[str, Any]
+    usage: dict[str, Any] | None = None
+
+
+ChatCompletionFn = Callable[..., ChatTurn]
+ClientFactory = Callable[[], Any]
+
+
+@dataclass
+class OpenRewardRunConfig:
+    """Configuration for running an OpenReward-hosted environment."""
+
+    source_env: HostedEnvRef
+    model: str
+    env_args: dict[str, Any] = field(default_factory=dict)
+    agent: str = ""
+    jobs_dir: Path = Path("jobs")
+    num_examples: int = 1
+    max_turns: int = 16
+    max_tokens: int = 1024
+    temperature: float = 0.0
+
+    @property
+    def split(self) -> str:
+        """Task split, selectable via ``--source-env-arg split=...``."""
+        return str(self.env_args.get("split") or _DEFAULT_SPLIT)
+
+
+@dataclass
+class EpisodeOutcome:
+    """Evidence from one driven episode (one task)."""
+
+    example_index: int
+    task: Any
+    prompt: str
+    events: list[dict[str, Any]]
+    reward: float | None
+    finished: bool
+    truncated: bool
+    n_tool_calls: int
+    usage: dict[str, int]
+    error: str | None
+
+    @property
+    def task_id(self) -> str:
+        if isinstance(self.task, dict):
+            raw = self.task.get("task_id") or self.task.get("id")
+            if raw is not None:
+                return str(raw)
+        return f"example_{self.example_index}"
+
+
+@dataclass
+class OpenRewardRunResult:
+    """Result from an OpenReward-hosted run (CLI display contract matches
+    :class:`benchflow.hosted_env.HostedEnvRunResult`)."""
+
+    source_env: HostedEnvRef
+    run_dir: Path
+    model: str
+    normalized_model: str
+    reward: float | None
+    total_tool_calls: int
+    episodes: list[EpisodeOutcome]
+    error: str | None
+
+
+def resolve_model_endpoint(
+    model: str,
+    env: Mapping[str, str],
+) -> ModelEndpoint:
+    """Resolve the model to an OpenAI-compatible endpoint, fail-closed.
+
+    Resolution order:
+
+    1. An explicit ``BENCHFLOW_PROVIDER_BASE_URL`` contract in *env* (the
+       LiteLLM-runtime / pre-resolved agent-env path) wins.
+    2. Otherwise the model's registered provider prefix
+       (:func:`benchflow.agents.providers.find_provider`) supplies the
+       ``openai-completions`` endpoint and API-key env var. Bare OpenAI
+       model ids are normalized via
+       :func:`benchflow.hosted_env.normalize_verifiers_model`.
+
+    Anything else — unknown model, provider without an openai-completions
+    endpoint, non-API-key auth, missing key — raises :class:`HostedEnvError`.
+    """
+    from benchflow.agents.providers import (
+        find_provider,
+        resolve_base_url,
+        strip_provider_prefix,
+    )
+
+    if not model:
+        raise HostedEnvError("--model is required for openreward source-env runs")
+
+    protocol = (env.get("BENCHFLOW_PROVIDER_PROTOCOL") or "").strip()
+    explicit_base = (env.get("BENCHFLOW_PROVIDER_BASE_URL") or "").strip()
+    if explicit_base:
+        if protocol and protocol != _OPENAI_COMPLETIONS:
+            raise HostedEnvError(
+                "The openreward runner drives models over openai-completions; "
+                f"BENCHFLOW_PROVIDER_PROTOCOL={protocol!r} is not supported."
+            )
+        model_id = (env.get("BENCHFLOW_PROVIDER_MODEL") or "").strip()
+        return ModelEndpoint(
+            base_url=explicit_base,
+            api_key=(env.get("BENCHFLOW_PROVIDER_API_KEY") or "").strip(),
+            model_id=model_id or strip_provider_prefix(model),
+            provider=(env.get("BENCHFLOW_PROVIDER_NAME") or "").strip() or "explicit",
+        )
+
+    normalized = normalize_verifiers_model(model)
+    found = find_provider(normalized)
+    if found is None:
+        raise HostedEnvError(
+            f"No OpenAI-compatible provider is registered for model {model!r}. "
+            "Use a registered provider prefix (e.g. openai/, deepseek/) or set "
+            "BENCHFLOW_PROVIDER_BASE_URL / BENCHFLOW_PROVIDER_API_KEY explicitly."
+        )
+    name, cfg = found
+    if cfg.api_protocol != _OPENAI_COMPLETIONS and not cfg.endpoints.get(
+        _OPENAI_COMPLETIONS
+    ):
+        raise HostedEnvError(
+            f"Provider {name!r} does not expose an openai-completions endpoint; "
+            "the openreward runner cannot drive this model. Set "
+            "BENCHFLOW_PROVIDER_BASE_URL to an OpenAI-compatible endpoint instead."
+        )
+    if cfg.auth_type != "api_key":
+        raise HostedEnvError(
+            f"Provider {name!r} uses {cfg.auth_type!r} auth, which the openreward "
+            "runner does not support. Set BENCHFLOW_PROVIDER_BASE_URL / "
+            "BENCHFLOW_PROVIDER_API_KEY explicitly (e.g. via the LiteLLM runtime)."
+        )
+    try:
+        base_url = resolve_base_url(cfg, dict(env), protocol=_OPENAI_COMPLETIONS)
+    except KeyError as exc:
+        raise HostedEnvError(str(exc.args[0]) if exc.args else str(exc)) from exc
+    if not base_url:
+        raise HostedEnvError(
+            f"Provider {name!r} has no fixed endpoint; set "
+            "BENCHFLOW_PROVIDER_BASE_URL to the server's OpenAI-compatible URL."
+        )
+    api_key = (env.get(cfg.auth_env) or "").strip() if cfg.auth_env else ""
+    if not api_key:
+        raise HostedEnvError(
+            f"{cfg.auth_env or 'an API key'} is required for provider {name!r} "
+            f"(model {model!r})."
+        )
+    return ModelEndpoint(
+        base_url=base_url,
+        api_key=api_key,
+        model_id=strip_provider_prefix(normalized),
+        provider=name,
+    )
+
+
+def _default_client_factory(env: Mapping[str, str]) -> Any:
+    """Build the official OpenReward client, fail-closed on auth/install.
+
+    The client authenticates via the ``OPENREWARD_API_KEY`` process
+    environment variable (https://pypi.org/project/openreward/); we check it
+    up front so a missing key fails before any network call.
+    """
+    if not (env.get(OPENREWARD_API_KEY_ENV) or "").strip():
+        raise HostedEnvError(
+            f"{OPENREWARD_API_KEY_ENV} is required to run OpenReward-hosted "
+            "environments (see https://docs.openreward.ai/quickstart)."
+        )
+    try:
+        from openreward import OpenReward
+    except ImportError as exc:
+        raise HostedEnvError(
+            "The 'openreward' package is required for openreward source-env "
+            "runs: pip install openreward (Python 3.11+, "
+            "https://pypi.org/project/openreward/)."
+        ) from exc
+    return OpenReward()
+
+
+def _default_chat_completion(
+    *,
+    endpoint: ModelEndpoint,
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]],
+    max_tokens: int,
+    temperature: float,
+) -> ChatTurn:
+    """POST one OpenAI chat-completions request to the resolved endpoint."""
+    import httpx
+
+    payload: dict[str, Any] = {
+        "model": endpoint.model_id,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+    }
+    if tools:
+        payload["tools"] = tools
+    headers = (
+        {"Authorization": f"Bearer {endpoint.api_key}"} if endpoint.api_key else {}
+    )
+    response = httpx.post(
+        endpoint.base_url.rstrip("/") + "/chat/completions",
+        json=payload,
+        headers=headers,
+        timeout=_CHAT_TIMEOUT_SEC,
+    )
+    response.raise_for_status()
+    data = response.json()
+    choices = data.get("choices") or []
+    if not choices or not isinstance(choices[0], dict):
+        raise HostedEnvError(
+            f"Model endpoint returned no choices: {json.dumps(data)[:200]}"
+        )
+    message = choices[0].get("message")
+    if not isinstance(message, dict):
+        raise HostedEnvError(
+            f"Model endpoint returned no assistant message: "
+            f"{json.dumps(choices[0])[:200]}"
+        )
+    usage = data.get("usage")
+    return ChatTurn(message=message, usage=usage if isinstance(usage, dict) else None)
+
+
+def run_openreward_env(
+    config: OpenRewardRunConfig,
+    *,
+    env: Mapping[str, str] | None = None,
+    client_factory: ClientFactory | None = None,
+    chat_completion: ChatCompletionFn | None = None,
+) -> OpenRewardRunResult:
+    """Run an OpenReward-hosted environment and emit contract artifacts.
+
+    *client_factory* / *chat_completion* are injection seams for tests (a
+    faked ORS client and model transport); production runs use the official
+    ``openreward`` client and an httpx chat-completions transport.
+    """
+    ref = config.source_env
+    if ref.provider != OPENREWARD_PROVIDER:
+        raise HostedEnvError(
+            f"run_openreward_env executes openreward references; "
+            f"{ref.provider!r} references run through benchflow.hosted_env."
+        )
+    if config.num_examples < 1:
+        raise HostedEnvError("--source-env-num-examples must be >= 1")
+    if config.max_turns < 1:
+        raise HostedEnvError("--source-env-max-turns must be >= 1")
+
+    run_env: Mapping[str, str] = dict(env) if env is not None else os.environ.copy()
+    endpoint = resolve_model_endpoint(config.model, run_env)
+    chat = chat_completion or _default_chat_completion
+    client = client_factory() if client_factory else _default_client_factory(run_env)
+
+    try:
+        get_kwargs: dict[str, Any] = {"name": ref.env_id}
+        if ref.version:
+            get_kwargs["variant"] = ref.version
+        environment = client.environments.get(**get_kwargs)
+        tools = list(environment.list_tools(format="openai") or [])
+        tasks = list(environment.list_tasks(split=config.split) or [])
+    except HostedEnvError:
+        raise
+    except Exception as exc:
+        raise HostedEnvError(
+            f"Could not resolve OpenReward environment {ref.env_uid}: "
+            f"{type(exc).__name__}: {exc}"
+        ) from exc
+    if not tasks:
+        raise HostedEnvError(
+            f"OpenReward environment {ref.env_uid} returned no tasks for "
+            f"split {config.split!r}."
+        )
+
+    run_dir = _create_run_dir(config)
+    started_at = datetime.now(UTC)
+    episodes = [
+        _run_episode(
+            environment,
+            task,
+            example_index=i,
+            chat=chat,
+            endpoint=endpoint,
+            tools=tools,
+            max_turns=config.max_turns,
+            max_tokens=config.max_tokens,
+            temperature=config.temperature,
+        )
+        for i, task in enumerate(tasks[: config.num_examples])
+    ]
+    finished_at = datetime.now(UTC)
+
+    # Aggregation matches the hosted evaluation convention
+    # (docs.openreward.ai/environments/evaluation.md): every attempted task
+    # is in the denominator; errored/unscored episodes count as 0.
+    reward = round(
+        sum(ep.reward if ep.reward is not None else 0.0 for ep in episodes)
+        / len(episodes),
+        6,
+    )
+    errors = [f"{ep.task_id}: {ep.error}" for ep in episodes if ep.error]
+    result = OpenRewardRunResult(
+        source_env=ref,
+        run_dir=run_dir,
+        model=config.model,
+        normalized_model=endpoint.model_id,
+        reward=reward,
+        total_tool_calls=sum(ep.n_tool_calls for ep in episodes),
+        episodes=episodes,
+        error="; ".join(errors) if errors else None,
+    )
+    _write_run_artifacts(
+        result,
+        config,
+        endpoint,
+        started_at=started_at,
+        finished_at=finished_at,
+    )
+    return result
+
+
+def _create_run_dir(config: OpenRewardRunConfig) -> Path:
+    """Collision-safe run dir under ``jobs/hosted-env/`` (same scheme as
+    the Verifiers runner)."""
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d__%H-%M-%S-%f")
+    safe_name = re.sub(r"[^A-Za-z0-9_.-]+", "_", config.source_env.env_id)
+    jobs_dir = config.jobs_dir.expanduser().resolve()
+    run_id = f"{timestamp}__pid-{os.getpid()}__{uuid4().hex[:8]}"
+    run_dir = jobs_dir / "hosted-env" / f"{safe_name}__{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=False)
+    return run_dir
+
+
+def _run_episode(
+    environment: Any,
+    task: Any,
+    *,
+    example_index: int,
+    chat: ChatCompletionFn,
+    endpoint: ModelEndpoint,
+    tools: list[dict[str, Any]],
+    max_turns: int,
+    max_tokens: int,
+    temperature: float,
+) -> EpisodeOutcome:
+    """Drive one session to completion; failures are episode-local.
+
+    Any exception from the hosted client or the model transport fails this
+    episode closed (``reward=None`` + ``error``) while preserving the events
+    captured so far — the run-level aggregate then scores it as 0.
+    """
+    events: list[dict[str, Any]] = []
+    usage = {"input": 0, "output": 0}
+    try:
+        with environment.session(task=task) as session:
+            return _drive_episode(
+                session,
+                events=events,
+                usage=usage,
+                example_index=example_index,
+                task=task,
+                chat=chat,
+                endpoint=endpoint,
+                tools=tools,
+                max_turns=max_turns,
+                max_tokens=max_tokens,
+                temperature=temperature,
+            )
+    except Exception as exc:  # fail-closed per episode
+        logger.warning(
+            "openreward episode %d failed: %s: %s",
+            example_index,
+            type(exc).__name__,
+            exc,
+        )
+        return EpisodeOutcome(
+            example_index=example_index,
+            task=task,
+            prompt=_first_user_text(events),
+            events=events,
+            reward=None,
+            finished=False,
+            truncated=False,
+            n_tool_calls=sum(1 for e in events if e.get("type") == "tool_call"),
+            usage=usage,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def _drive_episode(
+    session: Any,
+    *,
+    events: list[dict[str, Any]],
+    usage: dict[str, int],
+    example_index: int,
+    task: Any,
+    chat: ChatCompletionFn,
+    endpoint: ModelEndpoint,
+    tools: list[dict[str, Any]],
+    max_turns: int,
+    max_tokens: int,
+    temperature: float,
+) -> EpisodeOutcome:
+    """The ORS episode loop (docs.openreward.ai/quickstart.md):
+
+    prompt -> model turn -> ``session.call_tool`` per tool call -> feed each
+    ``ToolOutput``'s blocks back as a tool message -> stop when a tool output
+    sets ``finished`` (or the model stops calling tools / hits *max_turns*).
+    """
+    prompt_text = _prompt_to_text(session.get_prompt())
+    messages: list[dict[str, Any]] = [{"role": "user", "content": prompt_text}]
+    events.append(_event("user_message", example_index, text=prompt_text))
+
+    finished = False
+    truncated = False
+    last_reward: float | None = None
+    n_tool_calls = 0
+    for _turn in range(max_turns):
+        turn = chat(
+            endpoint=endpoint,
+            messages=messages,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        if turn.usage:
+            usage["input"] += int(turn.usage.get("prompt_tokens") or 0)
+            usage["output"] += int(turn.usage.get("completion_tokens") or 0)
+
+        content = turn.message.get("content")
+        tool_calls = turn.message.get("tool_calls") or []
+        assistant: dict[str, Any] = {"role": "assistant", "content": content}
+        if tool_calls:
+            assistant["tool_calls"] = tool_calls
+        messages.append(assistant)
+        if isinstance(content, str) and content:
+            events.append(_event("agent_message", example_index, text=content))
+
+        if not tool_calls:
+            break  # the model stopped without a finishing tool call
+
+        # Execute the full tool-call batch before checking the finished
+        # flag — the documented quickstart loop does the same.
+        for tool_call in tool_calls:
+            name, arguments, call_id = _parse_tool_call(tool_call)
+            output = session.call_tool(name, arguments)
+            output_text = _blocks_to_text(getattr(output, "blocks", None))
+            n_tool_calls += 1
+            messages.append(
+                {"role": "tool", "tool_call_id": call_id, "content": output_text}
+            )
+            events.append(
+                _event(
+                    "tool_call",
+                    example_index,
+                    tool_call_id=call_id,
+                    kind="other",
+                    title=name,
+                    status="completed",
+                    content=[{"type": "content", "text": output_text}],
+                )
+            )
+            step_reward = getattr(output, "reward", None)
+            if isinstance(step_reward, (int, float)) and not isinstance(
+                step_reward, bool
+            ):
+                last_reward = float(step_reward)
+                events.append(
+                    _event(
+                        "reward",
+                        example_index,
+                        value=float(step_reward),
+                        source="openreward",
+                    )
+                )
+            if bool(getattr(output, "finished", False)):
+                finished = True
+        if finished:
+            break
+    else:
+        truncated = True
+
+    return EpisodeOutcome(
+        example_index=example_index,
+        task=task,
+        prompt=prompt_text,
+        events=events,
+        reward=last_reward,
+        finished=finished,
+        truncated=truncated,
+        n_tool_calls=n_tool_calls,
+        usage=usage,
+        error=None,
+    )
+
+
+def _event(event_type: str, example_index: int, **fields: Any) -> dict[str, Any]:
+    return {
+        "type": event_type,
+        "ts": datetime.now(UTC).isoformat(),
+        "example_index": example_index,
+        **fields,
+    }
+
+
+def _parse_tool_call(tool_call: Any) -> tuple[str, dict[str, Any], str | None]:
+    """Extract (name, arguments, call_id) from an OpenAI-format tool call.
+
+    Malformed tool calls raise — the episode fails closed rather than
+    sending the environment a guessed payload.
+    """
+    if not isinstance(tool_call, dict):
+        raise HostedEnvError(f"Malformed tool call from model: {tool_call!r}")
+    function = tool_call.get("function") or {}
+    name = function.get("name")
+    if not name or not isinstance(name, str):
+        raise HostedEnvError(f"Tool call without a function name: {tool_call!r}")
+    raw_arguments = function.get("arguments")
+    if raw_arguments is None or raw_arguments == "":
+        arguments: dict[str, Any] = {}
+    elif isinstance(raw_arguments, str):
+        try:
+            arguments = json.loads(raw_arguments)
+        except json.JSONDecodeError as exc:
+            raise HostedEnvError(
+                f"Tool call {name!r} has non-JSON arguments: {raw_arguments[:200]!r}"
+            ) from exc
+    elif isinstance(raw_arguments, dict):
+        arguments = raw_arguments
+    else:
+        raise HostedEnvError(
+            f"Tool call {name!r} has unsupported arguments type: "
+            f"{type(raw_arguments).__name__}"
+        )
+    if not isinstance(arguments, dict):
+        raise HostedEnvError(
+            f"Tool call {name!r} arguments must be a JSON object, got: {arguments!r}"
+        )
+    call_id = tool_call.get("id")
+    return name, arguments, str(call_id) if call_id is not None else None
+
+
+def _block_text(block: Any) -> str:
+    """Text of one ORS content block (object with ``.text`` or plain dict)."""
+    text = getattr(block, "text", None)
+    if text is None and isinstance(block, dict):
+        text = block.get("text")
+    return text if isinstance(text, str) else ""
+
+
+def _blocks_to_text(blocks: Any) -> str:
+    if isinstance(blocks, (list, tuple)):
+        return "".join(_block_text(b) for b in blocks)
+    return _block_text(blocks) if blocks is not None else ""
+
+
+def _prompt_to_text(prompt: Any) -> str:
+    if isinstance(prompt, str):
+        return prompt
+    return _blocks_to_text(prompt)
+
+
+def _first_user_text(events: list[dict[str, Any]]) -> str:
+    for event in events:
+        if event.get("type") == "user_message":
+            return str(event.get("text") or "")
+    return ""
+
+
+def _write_run_artifacts(
+    result: OpenRewardRunResult,
+    config: OpenRewardRunConfig,
+    endpoint: ModelEndpoint,
+    *,
+    started_at: datetime,
+    finished_at: datetime,
+) -> None:
+    """Write the rollout-contract artifacts plus openreward-specific evidence.
+
+    The contract files match :func:`benchflow.hosted_env._write_run_artifacts`
+    so dashboards, release checks, and trainer exports treat OpenReward runs
+    exactly like Verifiers runs and native rollouts.
+    """
+    ref = result.source_env
+    run_dir = result.run_dir
+    (run_dir / "trajectory").mkdir(parents=True, exist_ok=True)
+    (run_dir / "agent").mkdir(parents=True, exist_ok=True)
+    (run_dir / "verifier").mkdir(parents=True, exist_ok=True)
+    (run_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+    hosted_dir = run_dir / "hosted_env"
+    hosted_dir.mkdir(parents=True, exist_ok=True)
+
+    trajectory = [event for ep in result.episodes for event in ep.events]
+    rewards = _build_rewards_dict(result)
+    prompts = _collect_prompts(result, config)
+    timing = {"total": round((finished_at - started_at).total_seconds(), 1)}
+    source_provenance = _hosted_source_provenance(
+        ref,
+        runner=OPENREWARD_RUNNER,
+        env_args=config.env_args,
+    )
+
+    # OpenReward-specific evidence (forensics, debugging). Redacted line by
+    # line — episode tasks/errors may echo headers or env material.
+    hosted_payload = {
+        "source_env": ref.env_id,
+        "source_env_variant": ref.version,
+        "env_uid": ref.env_uid,
+        "hub_url": ref.hub_url,
+        "runner": OPENREWARD_RUNNER,
+        "agent": config.agent or None,
+        "model": result.model,
+        "normalized_model": result.normalized_model,
+        "model_provider": endpoint.provider,
+        "model_base_url": endpoint.base_url,
+        "env_args": config.env_args,
+        "split": config.split,
+        "num_episodes": len(result.episodes),
+        "rewards": rewards,
+        "total_tool_calls": result.total_tool_calls,
+        "error": result.error,
+    }
+    (hosted_dir / "hosted_run.json").write_text(
+        redact_trajectory_text(json.dumps(hosted_payload, indent=2, default=str))
+    )
+    episode_lines = [
+        json.dumps(
+            {
+                "example_index": ep.example_index,
+                "task_id": ep.task_id,
+                "task": ep.task,
+                "reward": ep.reward,
+                "finished": ep.finished,
+                "truncated": ep.truncated,
+                "n_tool_calls": ep.n_tool_calls,
+                "usage": ep.usage,
+                "error": ep.error,
+            },
+            default=str,
+        )
+        for ep in result.episodes
+    ]
+    (hosted_dir / "episodes.jsonl").write_text(
+        redact_trajectory_text("\n".join(episode_lines) + "\n")
+    )
+
+    # Rollout-contract artifacts.
+    (run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
+        redact_acp_trajectory_jsonl(trajectory) + ("\n" if trajectory else "")
+    )
+
+    n_input = sum(ep.usage.get("input", 0) for ep in result.episodes)
+    n_output = sum(ep.usage.get("output", 0) for ep in result.episodes)
+    has_usage = (n_input + n_output) > 0
+    agent_result = {
+        "n_tool_calls": result.total_tool_calls,
+        "n_prompts": len(prompts),
+        "n_input_tokens": n_input if has_usage else None,
+        "n_output_tokens": n_output if has_usage else None,
+        "n_cache_read_tokens": None,
+        "n_cache_creation_tokens": None,
+        "total_tokens": (n_input + n_output) if has_usage else None,
+        "cost_usd": None,
+        "usage_source": "provider_response" if has_usage else "unavailable",
+        "price_source": None,
+    }
+
+    result_payload: dict[str, Any] = {
+        "task_name": ref.env_uid,
+        "rollout_name": run_dir.name,
+        "rewards": rewards,
+        "agent": config.agent or None,
+        "agent_name": OPENREWARD_RUNNER,
+        "model": result.normalized_model or result.model or None,
+        "n_tool_calls": result.total_tool_calls,
+        "n_prompts": len(prompts),
+        "agent_result": agent_result,
+        "final_metrics": final_metrics_from_agent_result(agent_result),
+        "trajectory_summary": trajectory_summary_from_events(
+            trajectory,
+            partial_trajectory=False,
+            trajectory_source="hosted_env" if trajectory else None,
+        ),
+        "error": result.error,
+        "error_category": None,
+        "verifier_error": None,
+        "verifier_error_category": None,
+        # Empty diagnostic slots — hosted runs execute remotely, so every
+        # registered diagnostic serializes as ``None`` (see hosted_env.py).
+        **RolloutDiagnostics().to_result_fields(),
+        "partial_trajectory": False,
+        "trajectory_source": "hosted_env" if trajectory else None,
+        "started_at": str(started_at),
+        "finished_at": str(finished_at),
+        "timing": timing,
+        "scenes": [],
+        "source": source_provenance,
+    }
+    (run_dir / "result.json").write_text(json.dumps(result_payload, indent=2))
+    (run_dir / "timing.json").write_text(json.dumps(timing, indent=2))
+    (run_dir / "prompts.json").write_text(
+        redact_trajectory_text(json.dumps(prompts, indent=2))
+    )
+
+    config_payload: dict[str, Any] = {
+        "task_path": None,
+        "agent": config.agent or None,
+        "model": result.normalized_model or result.model or None,
+        "environment": "hosted_env",
+        "skills_dir": None,
+        "sandbox_user": None,
+        "sandbox_locked_paths": None,
+        "sandbox_setup_timeout": None,
+        "context_root": None,
+        "timeout_sec": None,
+        "concurrency": 1,
+        "agent_idle_timeout_sec": None,
+        "started_at": str(started_at),
+        "agent_env": {},
+        "scenes": [],
+        "source": source_provenance,
+        "hosted_env": {
+            "provider": ref.provider,
+            "env_uid": ref.env_uid,
+            "runner": OPENREWARD_RUNNER,
+            "split": config.split,
+            "num_examples": config.num_examples,
+            "max_turns": config.max_turns,
+            "max_tokens": config.max_tokens,
+            "temperature": config.temperature,
+            "env_args": config.env_args,
+        },
+    }
+    (run_dir / "config.json").write_text(json.dumps(config_payload, indent=2))
+
+    if rewards:
+        _write_hosted_rewards_jsonl(run_dir, rewards, finished_at)
+    _write_trainer_verifiers_jsonl(result)
+
+
+def _build_rewards_dict(result: OpenRewardRunResult) -> dict[str, Any] | None:
+    """Rewards dict in the native rollout shape — headline mean + rubric."""
+    if result.reward is None:
+        return None
+    rubric = [
+        {
+            "name": f"example_{ep.example_index}",
+            "score": float(ep.reward) if ep.reward is not None else 0.0,
+        }
+        for ep in result.episodes
+    ]
+    payload: dict[str, Any] = {"reward": float(result.reward)}
+    if rubric:
+        payload["rubric"] = rubric
+    return payload
+
+
+def _collect_prompts(
+    result: OpenRewardRunResult,
+    config: OpenRewardRunConfig,
+) -> list[str]:
+    prompts: list[str] = []
+    seen: set[str] = set()
+    for ep in result.episodes:
+        if ep.prompt and ep.prompt not in seen:
+            seen.add(ep.prompt)
+            prompts.append(ep.prompt)
+    if not prompts:
+        prompts.append(
+            f"<hosted_env:{config.source_env.env_uid} "
+            f"num_examples={config.num_examples}>"
+        )
+    return prompts
+
+
+def _write_trainer_verifiers_jsonl(result: OpenRewardRunResult) -> None:
+    """Emit the trainer seam — ``trainer/verifiers.jsonl``, one record per
+    episode — through the shared ORS-backed export pipeline."""
+    from benchflow.trajectories.export import (
+        ROLLOUT_ARTIFACT_RELPATH,
+        acp_events_to_messages,
+        export_trajectories_to_jsonl,
+        reward_map_to_verify_result,
+        trajectory_to_verifiers_record,
+    )
+
+    records: list[dict[str, Any]] = []
+    for ep in result.episodes:
+        messages = acp_events_to_messages(ep.events)
+        verify_result = reward_map_to_verify_result(
+            {"reward": ep.reward if ep.reward is not None else 0.0},
+            error=ep.error,
+        )
+        records.append(
+            trajectory_to_verifiers_record(
+                task_id=f"{result.source_env.env_uid}#{ep.task_id}",
+                messages=messages,
+                verify_result=verify_result,
+                model=result.normalized_model or result.model,
+                environment=result.source_env.env_uid,
+                example_id=ep.example_index,
+                is_completed=ep.finished,
+                is_truncated=ep.truncated,
+            )
+        )
+    if records:
+        export_trajectories_to_jsonl(records, result.run_dir / ROLLOUT_ARTIFACT_RELPATH)

--- a/src/benchflow/hosted_env_openreward.py
+++ b/src/benchflow/hosted_env_openreward.py
@@ -41,8 +41,11 @@ Primary sources for the hosted API surface (verified 2026-06-10):
   variant selection via the ``variant`` parameter of ``environments.get``.
 - https://docs.openreward.ai/environments/ways-to-access-tasks.md — task
   dicts are environment-defined JSON objects (e.g. ``{"task_id": ...}``).
-- https://docs.openreward.ai/environments/evaluation.md — per-task rewards
-  aggregate over all attempted tasks (errored/unfinished count as 0).
+- https://docs.openreward.ai/environments/evaluation.md — the page does not
+  state a general aggregation rule; our convention (every attempted task in
+  the denominator, errored/unscored episodes count as 0) is consistent with
+  its documented pass@1 example, which counts ``r == 1`` results (skipping
+  ``None``) over ``num_samples``.
 """
 
 from __future__ import annotations
@@ -266,9 +269,13 @@ def _default_client_factory(env: Mapping[str, str]) -> Any:
 
     The client authenticates via the ``OPENREWARD_API_KEY`` process
     environment variable (https://pypi.org/project/openreward/); we check it
-    up front so a missing key fails before any network call.
+    up front so a missing key fails before any network call. Because the SDK
+    reads ``os.environ`` internally, the validated key from *env* is mirrored
+    into the process environment before construction — an injected mapping
+    therefore works even when it does not alias ``os.environ``.
     """
-    if not (env.get(OPENREWARD_API_KEY_ENV) or "").strip():
+    api_key = (env.get(OPENREWARD_API_KEY_ENV) or "").strip()
+    if not api_key:
         raise HostedEnvError(
             f"{OPENREWARD_API_KEY_ENV} is required to run OpenReward-hosted "
             "environments (see https://docs.openreward.ai/quickstart)."
@@ -281,6 +288,7 @@ def _default_client_factory(env: Mapping[str, str]) -> Any:
             "runs: pip install openreward (Python 3.11+, "
             "https://pypi.org/project/openreward/)."
         ) from exc
+    os.environ[OPENREWARD_API_KEY_ENV] = api_key
     return OpenReward()
 
 
@@ -396,9 +404,10 @@ def run_openreward_env(
     ]
     finished_at = datetime.now(UTC)
 
-    # Aggregation matches the hosted evaluation convention
-    # (docs.openreward.ai/environments/evaluation.md): every attempted task
-    # is in the denominator; errored/unscored episodes count as 0.
+    # Every attempted task is in the denominator; errored/unscored episodes
+    # count as 0. This is consistent with the pass@1 example documented at
+    # docs.openreward.ai/environments/evaluation.md (no general aggregation
+    # rule is stated there).
     reward = round(
         sum(ep.reward if ep.reward is not None else 0.0 for ep in episodes)
         / len(episodes),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Test fixtures."""
 
 import json
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -11,6 +12,13 @@ REPO_ROOT = Path(__file__).parent.parent
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
+
+# litellm (imported transitively by provider tests) calls load_dotenv() at
+# import time when LITELLM_MODE is unset ("DEV" default). python-dotenv walks
+# ancestor directories, so a developer's real `.env` above the checkout leaks
+# live API keys into os.environ mid-suite and breaks env-sensitive tests.
+# Force PRODUCTION mode before any test module imports litellm.
+os.environ.setdefault("LITELLM_MODE", "PRODUCTION")
 
 REF_TASKS = REPO_ROOT / ".cache" / "datasets" / "benchflow" / "examples" / "tasks"
 

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -59,6 +59,7 @@ def test_eval_create_help_lists_all_documented_flags() -> None:
         "--source-env-max-tokens",
         "--source-env-temperatu",
         "--source-env-sampling-",
+        "--source-env-max-turns",
         "--agent",
         "--model",
         "--sandbox",

--- a/tests/test_hosted_env.py
+++ b/tests/test_hosted_env.py
@@ -268,3 +268,47 @@ def test_eval_create_source_env_routes_to_hosted_runner(tmp_path, monkeypatch):
     assert config.agent == "gemini"
     assert config.model == "gemini-3.1-flash-lite-preview"
     assert "not used by source-env runs" in result.output
+
+
+def test_eval_create_source_env_warns_on_max_turns_flag(tmp_path, monkeypatch):
+    """--source-env-max-turns only drives the openreward episode loop; the
+    Verifiers path (vf-eval owns the loop) must warn instead of silently
+    ignoring it."""
+    seen: dict[str, object] = {}
+
+    def fake_run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
+        seen["config"] = config
+        return HostedEnvRunResult(
+            source_env=config.source_env,
+            run_dir=tmp_path / "run",
+            command=["vf-eval"],
+            returncode=0,
+            stdout="",
+            stderr="",
+            model=config.model,
+            normalized_model=normalize_verifiers_model(config.model),
+            reward=1.0,
+            total_tool_calls=0,
+        )
+
+    monkeypatch.setattr("benchflow.hosted_env.run_hosted_env", fake_run_hosted_env)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--source-env",
+            "primeintellect/general-agent",
+            "--source-env-max-turns",
+            "8",
+            "--model",
+            "gpt-5-mini",
+            "--jobs-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--source-env-max-turns is for the openreward" in result.output
+    assert "config" in seen  # the run still executes

--- a/tests/test_hosted_env_openreward.py
+++ b/tests/test_hosted_env_openreward.py
@@ -1,0 +1,886 @@
+"""Unit coverage for the OpenReward (ORS) hosted environment runner.
+
+Everything runs against a FAKED OpenReward client and model transport — no
+network, no API keys. The fakes mirror the documented client surface
+(https://docs.openreward.ai/quickstart.md, https://pypi.org/project/openreward/):
+``environments.get(name=..., variant=...)``, ``list_tasks(split=...)``,
+``list_tools(format="openai")``, ``session(task=...)`` context manager,
+``session.get_prompt()`` block list, and ``session.call_tool`` returning
+``ToolOutput`` objects with ``blocks`` / ``reward`` / ``finished``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+from benchflow.hosted_env import (
+    HostedEnvError,
+    HostedEnvRef,
+    HostedEnvRunConfig,
+    prime_env_info,
+    run_hosted_env,
+)
+from benchflow.hosted_env_openreward import (
+    ChatTurn,
+    OpenRewardRunConfig,
+    OpenRewardRunResult,
+    _default_client_factory,
+    resolve_model_endpoint,
+    run_openreward_env,
+)
+
+PROXY_ENV = {
+    "BENCHFLOW_PROVIDER_BASE_URL": "http://proxy.test/v1",
+    "BENCHFLOW_PROVIDER_API_KEY": "proxy-key",
+    "BENCHFLOW_PROVIDER_MODEL": "served-model",
+    "BENCHFLOW_PROVIDER_NAME": "litellm",
+    "BENCHFLOW_PROVIDER_PROTOCOL": "openai-completions",
+}
+
+PROMPT = "Capture the flag hidden in the container."
+
+
+# ── Fakes for the documented OpenReward client surface ──
+
+
+class FakeBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class FakeToolOutput:
+    def __init__(
+        self,
+        text: str = "",
+        reward: float | None = None,
+        finished: bool = False,
+    ) -> None:
+        self.blocks = [FakeBlock(text)]
+        self.reward = reward
+        self.finished = finished
+        self.metadata: dict = {}
+
+
+class FakeSession:
+    """Context-manager session with scripted call_tool outputs."""
+
+    def __init__(self, prompt: str, outputs: list) -> None:
+        self._prompt = prompt
+        self._outputs = outputs
+        self.calls: list[tuple[str, dict]] = []
+
+    def __enter__(self) -> FakeSession:
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def get_prompt(self) -> list[FakeBlock]:
+        return [FakeBlock(self._prompt)]
+
+    def call_tool(self, name: str, arguments: dict) -> FakeToolOutput:
+        self.calls.append((name, arguments))
+        out = self._outputs.pop(0)
+        if isinstance(out, Exception):
+            raise out
+        return out
+
+
+class FakeEnvironment:
+    def __init__(self, tasks: list, tools: list, sessions: list[FakeSession]) -> None:
+        self._tasks = tasks
+        self._tools = tools
+        self._sessions = sessions
+        self.sessions_used: list[FakeSession] = []
+        self.split_seen: str | None = None
+
+    def list_tasks(self, split: str) -> list:
+        self.split_seen = split
+        return self._tasks
+
+    def list_tools(self, format: str) -> list:
+        assert format == "openai"
+        return self._tools
+
+    def session(self, task: dict) -> FakeSession:
+        session = self._sessions.pop(0)
+        self.sessions_used.append(session)
+        return session
+
+
+class FakeClient:
+    def __init__(self, environment: FakeEnvironment) -> None:
+        self.get_kwargs: dict = {}
+
+        def get(**kwargs):
+            self.get_kwargs = kwargs
+            return environment
+
+        self.environments = SimpleNamespace(get=get)
+
+
+def tool_call(name: str, arguments: str, call_id: str = "call_1") -> dict:
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": arguments},
+    }
+
+
+def scripted_chat(turns: list[ChatTurn]):
+    """Chat transport fake — returns scripted turns, records every request."""
+    requests: list[dict] = []
+
+    def chat(*, endpoint, messages, tools, max_tokens, temperature) -> ChatTurn:
+        requests.append(
+            {
+                "endpoint": endpoint,
+                "messages": [dict(m) for m in messages],
+                "tools": tools,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            }
+        )
+        return turns.pop(0)
+
+    return chat, requests
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "submit_answer",
+            "description": "Submit the final answer",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+]
+
+
+def run_fake(
+    tmp_path: Path,
+    *,
+    turns: list[ChatTurn],
+    outputs_per_task: list[list],
+    tasks: list | None = None,
+    source_env: str = "openreward:GeneralReasoning/CTF",
+    version: str | None = None,
+    num_examples: int = 1,
+    max_turns: int = 16,
+) -> tuple[OpenRewardRunResult, FakeClient, FakeEnvironment, list[dict]]:
+    tasks = tasks if tasks is not None else [{"task_id": "t0"}]
+    sessions = [FakeSession(PROMPT, outputs) for outputs in outputs_per_task]
+    environment = FakeEnvironment(tasks, TOOLS, sessions)
+    client = FakeClient(environment)
+    chat, requests = scripted_chat(turns)
+    result = run_openreward_env(
+        OpenRewardRunConfig(
+            source_env=HostedEnvRef.parse(source_env, version=version),
+            model="openai/gpt-test",
+            env_args={"split": "train"},
+            agent="openreward-driver",
+            jobs_dir=tmp_path,
+            num_examples=num_examples,
+            max_turns=max_turns,
+            max_tokens=512,
+            temperature=0.0,
+        ),
+        env=PROXY_ENV,
+        client_factory=lambda: client,
+        chat_completion=chat,
+    )
+    return result, client, environment, requests
+
+
+def happy_turns() -> list[ChatTurn]:
+    return [
+        ChatTurn(
+            message={
+                "content": "Let me solve this.",
+                "tool_calls": [tool_call("submit_answer", '{"answer": 42}')],
+            },
+            usage={"prompt_tokens": 10, "completion_tokens": 5},
+        )
+    ]
+
+
+def happy_outputs() -> list[list]:
+    return [[FakeToolOutput("correct", reward=1.0, finished=True)]]
+
+
+# ── Reference parsing / provider recognition ──
+
+
+def test_hosted_env_ref_recognizes_openreward_provider():
+    ref = HostedEnvRef.parse("openreward:GeneralReasoning/CTF")
+
+    assert ref.provider == "openreward"
+    assert ref.owner == "GeneralReasoning"
+    assert ref.name == "CTF"
+    assert ref.env_id == "GeneralReasoning/CTF"
+    assert ref.env_uid == "openreward:GeneralReasoning/CTF@latest"
+    assert ref.hub_url == "https://openreward.ai/environments"
+
+
+def test_hosted_env_ref_openreward_variant_rides_the_version_slot():
+    ref = HostedEnvRef.parse("openreward:GeneralReasoning/ArithmeticEnv@bitwise")
+
+    assert ref.version == "bitwise"
+    assert ref.env_uid == "openreward:GeneralReasoning/ArithmeticEnv@bitwise"
+
+
+def test_hosted_env_ref_still_rejects_unknown_providers():
+    with pytest.raises(HostedEnvError, match="primeintellect, openreward"):
+        HostedEnvRef.parse("otherhub:owner/name")
+
+
+def test_run_hosted_env_rejects_openreward_refs(tmp_path):
+    with pytest.raises(HostedEnvError, match="run_openreward_env"):
+        run_hosted_env(
+            HostedEnvRunConfig(
+                source_env=HostedEnvRef.parse("openreward:GeneralReasoning/CTF"),
+                model="openai/gpt-test",
+                jobs_dir=tmp_path,
+            )
+        )
+
+
+def test_run_openreward_env_rejects_prime_refs(tmp_path):
+    with pytest.raises(HostedEnvError, match=r"benchflow\.hosted_env"):
+        run_openreward_env(
+            OpenRewardRunConfig(
+                source_env=HostedEnvRef.parse(
+                    "primeintellect/general-agent", version="0.1.1"
+                ),
+                model="openai/gpt-test",
+                jobs_dir=tmp_path,
+            ),
+            env=PROXY_ENV,
+        )
+
+
+def test_prime_env_info_rejects_openreward_refs():
+    with pytest.raises(HostedEnvError, match="primeintellect"):
+        prime_env_info(HostedEnvRef.parse("openreward:GeneralReasoning/CTF"))
+
+
+# ── Model endpoint resolution (fail-closed) ──
+
+
+def test_resolve_model_endpoint_honors_explicit_provider_contract():
+    endpoint = resolve_model_endpoint("openai/gpt-test", PROXY_ENV)
+
+    assert endpoint.base_url == "http://proxy.test/v1"
+    assert endpoint.api_key == "proxy-key"
+    assert endpoint.model_id == "served-model"
+    assert endpoint.provider == "litellm"
+
+
+def test_resolve_model_endpoint_rejects_non_openai_protocol_contract():
+    env = {**PROXY_ENV, "BENCHFLOW_PROVIDER_PROTOCOL": "anthropic-messages"}
+    with pytest.raises(HostedEnvError, match="anthropic-messages"):
+        resolve_model_endpoint("openai/gpt-test", env)
+
+
+def test_resolve_model_endpoint_uses_registered_provider_registry():
+    env = {
+        "DEEPSEEK_BASE_URL": "https://api.deepseek.test/v1",
+        "DEEPSEEK_API_KEY": "ds-key",
+    }
+    endpoint = resolve_model_endpoint("deepseek/deepseek-chat", env)
+
+    assert endpoint.base_url == "https://api.deepseek.test/v1"
+    assert endpoint.api_key == "ds-key"
+    assert endpoint.model_id == "deepseek-chat"
+    assert endpoint.provider == "deepseek"
+
+
+def test_resolve_model_endpoint_normalizes_bare_openai_models():
+    endpoint = resolve_model_endpoint("gpt-5-mini", {"OPENAI_API_KEY": "oa-key"})
+
+    assert endpoint.base_url == "https://api.openai.com/v1"
+    assert endpoint.model_id == "gpt-5-mini"
+    assert endpoint.provider == "openai"
+
+
+def test_resolve_model_endpoint_fails_closed_without_api_key():
+    env = {"DEEPSEEK_BASE_URL": "https://api.deepseek.test/v1"}
+    with pytest.raises(HostedEnvError, match="DEEPSEEK_API_KEY"):
+        resolve_model_endpoint("deepseek/deepseek-chat", env)
+
+
+def test_resolve_model_endpoint_fails_closed_for_unknown_models():
+    with pytest.raises(HostedEnvError, match="No OpenAI-compatible provider"):
+        resolve_model_endpoint("gemini-2.5-flash", {})
+
+
+def test_resolve_model_endpoint_rejects_anthropic_only_providers():
+    env = {"AZURE_RESOURCE": "res", "AZURE_API_KEY": "az-key"}
+    with pytest.raises(HostedEnvError, match="openai-completions"):
+        resolve_model_endpoint("azure-foundry-anthropic/claude-test", env)
+
+
+def test_resolve_model_endpoint_requires_base_url_for_serverless_providers():
+    with pytest.raises(HostedEnvError, match="BENCHFLOW_PROVIDER_BASE_URL"):
+        resolve_model_endpoint("vllm/Qwen/Qwen3", {"OPENAI_API_KEY": "k"})
+
+
+# ── Default client factory (auth fail-closed, no network) ──
+
+
+def test_default_client_factory_requires_api_key():
+    with pytest.raises(HostedEnvError, match="OPENREWARD_API_KEY"):
+        _default_client_factory({})
+
+
+def test_default_client_factory_requires_openreward_package(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openreward", None)
+    with pytest.raises(HostedEnvError, match="pip install openreward"):
+        _default_client_factory({"OPENREWARD_API_KEY": "or-key"})
+
+
+# ── Episode happy path ──
+
+
+def test_happy_path_drives_episode_and_scores(tmp_path):
+    result, client, environment, requests = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+
+    assert result.error is None
+    assert result.reward == 1.0
+    assert result.total_tool_calls == 1
+    assert result.normalized_model == "served-model"
+    assert client.get_kwargs == {"name": "GeneralReasoning/CTF"}
+    assert environment.split_seen == "train"
+    episode = result.episodes[0]
+    assert episode.finished is True
+    assert episode.truncated is False
+    assert episode.reward == 1.0
+    assert episode.task_id == "t0"
+
+    # The model request carried the resolved endpoint, prompt, and tools.
+    assert requests[0]["endpoint"].base_url == "http://proxy.test/v1"
+    assert requests[0]["messages"] == [{"role": "user", "content": PROMPT}]
+    assert requests[0]["tools"] == TOOLS
+    assert requests[0]["max_tokens"] == 512
+
+
+def test_happy_path_parses_tool_arguments_as_json(tmp_path):
+    result, _, environment, _ = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+    # The faked session recorded the exact call the runner made: JSON-parsed
+    # arguments, not the raw string.
+    assert environment.sessions_used[0].calls == [("submit_answer", {"answer": 42})]
+    assert result.episodes[0].n_tool_calls == 1
+
+
+def test_happy_path_trajectory_events_exact(tmp_path):
+    result, _, _, _ = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+
+    traj_path = result.run_dir / "trajectory" / "acp_trajectory.jsonl"
+    events = [json.loads(line) for line in traj_path.read_text().splitlines() if line]
+    assert [e["type"] for e in events] == [
+        "user_message",
+        "agent_message",
+        "tool_call",
+        "reward",
+    ]
+    assert events[0]["text"] == PROMPT
+    assert events[0]["example_index"] == 0
+    assert events[1]["text"] == "Let me solve this."
+    assert events[2]["title"] == "submit_answer"
+    assert events[2]["status"] == "completed"
+    assert events[2]["tool_call_id"] == "call_1"
+    assert events[2]["content"] == [{"type": "content", "text": "correct"}]
+    assert events[3]["value"] == 1.0
+    assert events[3]["source"] == "openreward"
+
+
+def test_happy_path_variant_is_passed_to_environments_get(tmp_path):
+    _, client, _, _ = run_fake(
+        tmp_path,
+        turns=happy_turns(),
+        outputs_per_task=happy_outputs(),
+        source_env="openreward:GeneralReasoning/ArithmeticEnv",
+        version="bitwise",
+    )
+    assert client.get_kwargs == {
+        "name": "GeneralReasoning/ArithmeticEnv",
+        "variant": "bitwise",
+    }
+
+
+# ── Rollout artifact contract ──
+
+
+def test_openreward_writes_contract_result_json(tmp_path):
+    result, _, _, _ = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    for key in (
+        "task_name",
+        "rollout_name",
+        "rewards",
+        "agent",
+        "agent_name",
+        "model",
+        "n_tool_calls",
+        "n_prompts",
+        "agent_result",
+        "final_metrics",
+        "trajectory_summary",
+        "error",
+        "verifier_error",
+        "partial_trajectory",
+        "trajectory_source",
+        "started_at",
+        "finished_at",
+        "timing",
+        "source",
+    ):
+        assert key in payload, f"missing contract key: {key}"
+
+    assert payload["task_name"] == "openreward:GeneralReasoning/CTF@latest"
+    assert payload["rewards"] == {
+        "reward": 1.0,
+        "rubric": [{"name": "example_0", "score": 1.0}],
+    }
+    assert payload["agent"] == "openreward-driver"
+    assert payload["agent_name"] == "openreward"
+    assert payload["model"] == "served-model"
+    assert payload["n_tool_calls"] == 1
+    assert payload["trajectory_source"] == "hosted_env"
+    assert payload["error"] is None
+    assert payload["source"]["type"] == "hosted_env"
+    assert payload["source"]["provider"] == "openreward"
+    assert payload["source"]["env_uid"] == "openreward:GeneralReasoning/CTF@latest"
+    assert payload["source"]["runner"] == "openreward"
+    # Token usage flows from the provider response into the contract.
+    assert payload["agent_result"]["n_input_tokens"] == 10
+    assert payload["agent_result"]["n_output_tokens"] == 5
+    assert payload["agent_result"]["total_tokens"] == 15
+    assert payload["agent_result"]["usage_source"] == "provider_response"
+    assert payload["trajectory_summary"]["tool_call_steps"] == 1
+
+
+def test_openreward_writes_rewards_jsonl(tmp_path):
+    result, _, _, _ = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+    rewards_path = result.run_dir / "rewards.jsonl"
+    events = [
+        json.loads(line) for line in rewards_path.read_text().splitlines() if line
+    ]
+    terminal = [e for e in events if e["type"] == "terminal"]
+    rubric = [e for e in events if e["type"] == "process"]
+    assert len(terminal) == 1
+    assert terminal[0]["value"] == 1.0
+    assert terminal[0]["tag"] == "reward"
+    assert terminal[0]["source"] == "verifier"
+    assert [(e["tag"], e["value"]) for e in rubric] == [("example_0", 1.0)]
+
+
+def test_openreward_writes_trainer_verifiers_jsonl(tmp_path):
+    result, _, _, _ = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+    records = [
+        json.loads(line)
+        for line in (result.run_dir / "trainer" / "verifiers.jsonl")
+        .read_text()
+        .splitlines()
+        if line
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record["example_id"] == 0
+    assert record["reward"] == 1.0
+    assert record["is_completed"] is True
+    assert record["is_truncated"] is False
+    assert record["prompt"] == [{"role": "user", "content": PROMPT}]
+    assert record["completion"] == [
+        {"role": "assistant", "content": "Let me solve this."},
+        {"role": "assistant", "content": "[tool_call: submit_answer]\ncorrect"},
+    ]
+    assert record["info"]["task_id"] == "openreward:GeneralReasoning/CTF@latest#t0"
+    assert record["info"]["environment"] == "openreward:GeneralReasoning/CTF@latest"
+    assert record["info"]["model"] == "served-model"
+    assert record["info"]["reward_valid"] is True
+
+
+def test_openreward_writes_config_timing_prompts_and_evidence(tmp_path):
+    result, _, _, _ = run_fake(
+        tmp_path, turns=happy_turns(), outputs_per_task=happy_outputs()
+    )
+    run_dir = result.run_dir
+    assert json.loads((run_dir / "prompts.json").read_text()) == [PROMPT]
+    assert "total" in json.loads((run_dir / "timing.json").read_text())
+
+    config = json.loads((run_dir / "config.json").read_text())
+    assert config["environment"] == "hosted_env"
+    assert config["hosted_env"]["provider"] == "openreward"
+    assert config["hosted_env"]["runner"] == "openreward"
+    assert config["hosted_env"]["env_uid"] == "openreward:GeneralReasoning/CTF@latest"
+    assert config["hosted_env"]["split"] == "train"
+    assert config["hosted_env"]["max_turns"] == 16
+
+    hosted = json.loads((run_dir / "hosted_env" / "hosted_run.json").read_text())
+    assert hosted["env_uid"] == "openreward:GeneralReasoning/CTF@latest"
+    assert hosted["runner"] == "openreward"
+    assert hosted["model_base_url"] == "http://proxy.test/v1"
+    assert "api_key" not in json.dumps(hosted).lower()
+    episodes = [
+        json.loads(line)
+        for line in (run_dir / "hosted_env" / "episodes.jsonl").read_text().splitlines()
+        if line
+    ]
+    assert episodes == [
+        {
+            "example_index": 0,
+            "task_id": "t0",
+            "task": {"task_id": "t0"},
+            "reward": 1.0,
+            "finished": True,
+            "truncated": False,
+            "n_tool_calls": 1,
+            "usage": {"input": 10, "output": 5},
+            "error": None,
+        }
+    ]
+
+
+# ── Finished-flag handling ──
+
+
+def test_episode_continues_until_finished_flag(tmp_path):
+    turns = [
+        ChatTurn(
+            message={
+                "content": "Trying a probe first.",
+                "tool_calls": [tool_call("submit_answer", '{"answer": 1}', "call_1")],
+            }
+        ),
+        ChatTurn(
+            message={
+                "content": None,
+                "tool_calls": [tool_call("submit_answer", '{"answer": 42}', "call_2")],
+            }
+        ),
+    ]
+    outputs = [
+        [
+            FakeToolOutput("nope", reward=0.25, finished=False),
+            FakeToolOutput("correct", reward=1.0, finished=True),
+        ]
+    ]
+    result, _, _, requests = run_fake(tmp_path, turns=turns, outputs_per_task=outputs)
+
+    assert len(requests) == 2
+    episode = result.episodes[0]
+    assert episode.finished is True
+    assert episode.n_tool_calls == 2
+    # Final reward is the last reward observed in the episode.
+    assert result.reward == 1.0
+    # The first tool result was threaded back to the model as a tool message.
+    assert {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "content": "nope",
+    } in requests[1]["messages"]
+    # Both step rewards are captured as reward events.
+    traj = (result.run_dir / "trajectory" / "acp_trajectory.jsonl").read_text()
+    reward_events = [
+        json.loads(line) for line in traj.splitlines() if '"reward"' in line
+    ]
+    assert [e["value"] for e in reward_events if e["type"] == "reward"] == [0.25, 1.0]
+
+
+def test_episode_stops_when_model_returns_no_tool_calls(tmp_path):
+    turns = [ChatTurn(message={"content": "I cannot solve this."})]
+    result, _, _, requests = run_fake(tmp_path, turns=turns, outputs_per_task=[[]])
+
+    assert len(requests) == 1
+    episode = result.episodes[0]
+    assert episode.finished is False
+    assert episode.truncated is False
+    assert episode.reward is None
+    # Unscored episodes fail closed to 0 in the aggregate.
+    assert result.reward == 0.0
+    assert result.error is None
+    record = json.loads(
+        (result.run_dir / "trainer" / "verifiers.jsonl").read_text().splitlines()[0]
+    )
+    assert record["reward"] == 0.0
+    assert record["is_completed"] is False
+
+
+def test_episode_truncates_at_max_turns(tmp_path):
+    turns = [
+        ChatTurn(
+            message={
+                "content": None,
+                "tool_calls": [tool_call("submit_answer", "{}", f"call_{i}")],
+            }
+        )
+        for i in range(2)
+    ]
+    outputs = [[FakeToolOutput("keep going") for _ in range(2)]]
+    result, _, _, requests = run_fake(
+        tmp_path, turns=turns, outputs_per_task=outputs, max_turns=2
+    )
+
+    assert len(requests) == 2  # hard stop at max_turns
+    episode = result.episodes[0]
+    assert episode.truncated is True
+    assert episode.finished is False
+    record = json.loads(
+        (result.run_dir / "trainer" / "verifiers.jsonl").read_text().splitlines()[0]
+    )
+    assert record["is_truncated"] is True
+
+
+# ── Error handling (fail-closed) ──
+
+
+def test_tool_error_fails_episode_closed(tmp_path):
+    turns = happy_turns()
+    outputs = [[RuntimeError("boom")]]
+    result, _, _, _ = run_fake(tmp_path, turns=turns, outputs_per_task=outputs)
+
+    episode = result.episodes[0]
+    assert episode.error == "RuntimeError: boom"
+    assert episode.reward is None
+    assert result.error == "t0: RuntimeError: boom"
+    assert result.reward == 0.0
+
+    payload = json.loads((result.run_dir / "result.json").read_text())
+    assert payload["error"] == "t0: RuntimeError: boom"
+    record = json.loads(
+        (result.run_dir / "trainer" / "verifiers.jsonl").read_text().splitlines()[0]
+    )
+    assert record["reward"] == 0.0
+    assert record["info"]["reward_valid"] is False
+
+
+def test_malformed_tool_arguments_fail_episode_closed(tmp_path):
+    turns = [
+        ChatTurn(
+            message={
+                "content": None,
+                "tool_calls": [tool_call("submit_answer", "not-json")],
+            }
+        )
+    ]
+    result, _, _, _ = run_fake(tmp_path, turns=turns, outputs_per_task=[[]])
+
+    episode = result.episodes[0]
+    assert episode.error is not None
+    assert "non-JSON arguments" in episode.error
+    assert episode.n_tool_calls == 0
+    assert result.reward == 0.0
+
+
+def test_environment_resolution_failure_raises(tmp_path):
+    def broken_factory():
+        def get(**kwargs):
+            raise ConnectionError("hub unreachable")
+
+        return SimpleNamespace(environments=SimpleNamespace(get=get))
+
+    with pytest.raises(HostedEnvError, match="hub unreachable"):
+        run_openreward_env(
+            OpenRewardRunConfig(
+                source_env=HostedEnvRef.parse("openreward:GeneralReasoning/CTF"),
+                model="openai/gpt-test",
+                jobs_dir=tmp_path,
+            ),
+            env=PROXY_ENV,
+            client_factory=broken_factory,
+        )
+
+
+def test_empty_task_split_raises(tmp_path):
+    environment = FakeEnvironment([], TOOLS, [])
+    with pytest.raises(HostedEnvError, match="no tasks"):
+        run_openreward_env(
+            OpenRewardRunConfig(
+                source_env=HostedEnvRef.parse("openreward:GeneralReasoning/CTF"),
+                model="openai/gpt-test",
+                jobs_dir=tmp_path,
+            ),
+            env=PROXY_ENV,
+            client_factory=lambda: FakeClient(environment),
+        )
+
+
+def test_model_endpoint_failure_blocks_run_before_any_client_call(tmp_path):
+    """Endpoint resolution fails closed before the hosted client is built."""
+    constructed: list[bool] = []
+
+    def factory():
+        constructed.append(True)
+        raise AssertionError("client must not be constructed")
+
+    with pytest.raises(HostedEnvError, match="No OpenAI-compatible provider"):
+        run_openreward_env(
+            OpenRewardRunConfig(
+                source_env=HostedEnvRef.parse("openreward:GeneralReasoning/CTF"),
+                model="mystery-model",
+                jobs_dir=tmp_path,
+            ),
+            env={},
+            client_factory=factory,
+        )
+    assert constructed == []
+
+
+# ── Multi-episode aggregation ──
+
+
+def test_rewards_aggregate_as_mean_over_all_episodes(tmp_path):
+    turns = [
+        ChatTurn(
+            message={
+                "content": None,
+                "tool_calls": [tool_call("submit_answer", "{}", "call_a")],
+            }
+        ),
+        ChatTurn(
+            message={
+                "content": None,
+                "tool_calls": [tool_call("submit_answer", "{}", "call_b")],
+            }
+        ),
+    ]
+    outputs = [
+        [FakeToolOutput("right", reward=1.0, finished=True)],
+        [FakeToolOutput("wrong", reward=0.0, finished=True)],
+    ]
+    result, _, _, _ = run_fake(
+        tmp_path,
+        turns=turns,
+        outputs_per_task=outputs,
+        tasks=[{"task_id": "t0"}, {"task_id": "t1"}],
+        num_examples=2,
+    )
+
+    assert result.reward == 0.5
+    assert result.total_tool_calls == 2
+    payload = json.loads((result.run_dir / "result.json").read_text())
+    assert payload["rewards"]["rubric"] == [
+        {"name": "example_0", "score": 1.0},
+        {"name": "example_1", "score": 0.0},
+    ]
+    records = (result.run_dir / "trainer" / "verifiers.jsonl").read_text().splitlines()
+    assert [json.loads(r)["example_id"] for r in records] == [0, 1]
+
+
+def test_num_examples_limits_episode_count(tmp_path):
+    result, _, _, requests = run_fake(
+        tmp_path,
+        turns=happy_turns(),
+        outputs_per_task=happy_outputs(),
+        tasks=[{"task_id": "t0"}, {"task_id": "t1"}, {"task_id": "t2"}],
+        num_examples=1,
+    )
+    assert len(result.episodes) == 1
+    assert len(requests) == 1
+
+
+# ── CLI routing ──
+
+
+def test_eval_create_openreward_routes_to_openreward_runner(tmp_path, monkeypatch):
+    seen: dict[str, object] = {}
+
+    def fake_run(config: OpenRewardRunConfig, **kwargs) -> OpenRewardRunResult:
+        seen["config"] = config
+        return OpenRewardRunResult(
+            source_env=config.source_env,
+            run_dir=tmp_path / "run",
+            model=config.model,
+            normalized_model="gpt-test",
+            reward=1.0,
+            total_tool_calls=3,
+            episodes=[],
+            error=None,
+        )
+
+    monkeypatch.setattr("benchflow.hosted_env_openreward.run_openreward_env", fake_run)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--source-env",
+            "openreward:GeneralReasoning/CTF",
+            "--source-env-arg",
+            "split=train",
+            "--source-env-num-examples",
+            "2",
+            "--source-env-max-turns",
+            "8",
+            "--model",
+            "openai/gpt-test",
+            "--jobs-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    config = seen["config"]
+    assert isinstance(config, OpenRewardRunConfig)
+    assert config.source_env.env_uid == "openreward:GeneralReasoning/CTF@latest"
+    assert config.env_args == {"split": "train"}
+    assert config.num_examples == 2
+    assert config.max_turns == 8
+    assert config.model == "openai/gpt-test"
+    assert "openreward:GeneralReasoning/CTF@latest" in result.output
+
+
+def test_eval_create_openreward_run_error_exits_nonzero(tmp_path, monkeypatch):
+    def fake_run(config: OpenRewardRunConfig, **kwargs) -> OpenRewardRunResult:
+        return OpenRewardRunResult(
+            source_env=config.source_env,
+            run_dir=tmp_path / "run",
+            model=config.model,
+            normalized_model="gpt-test",
+            reward=0.0,
+            total_tool_calls=0,
+            episodes=[],
+            error="t0: RuntimeError: boom",
+        )
+
+    monkeypatch.setattr("benchflow.hosted_env_openreward.run_openreward_env", fake_run)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--source-env",
+            "openreward:GeneralReasoning/CTF",
+            "--model",
+            "openai/gpt-test",
+            "--jobs-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "boom" in result.output

--- a/tests/test_hosted_env_openreward.py
+++ b/tests/test_hosted_env_openreward.py
@@ -12,6 +12,7 @@ network, no API keys. The fakes mirror the documented client surface
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 from types import SimpleNamespace
@@ -100,6 +101,7 @@ class FakeEnvironment:
         self._sessions = sessions
         self.sessions_used: list[FakeSession] = []
         self.split_seen: str | None = None
+        self.tasks_seen: list = []
 
     def list_tasks(self, split: str) -> list:
         self.split_seen = split
@@ -110,6 +112,7 @@ class FakeEnvironment:
         return self._tools
 
     def session(self, task: dict) -> FakeSession:
+        self.tasks_seen.append(task)
         session = self._sessions.pop(0)
         self.sessions_used.append(session)
         return session
@@ -347,6 +350,26 @@ def test_default_client_factory_requires_openreward_package(monkeypatch):
         _default_client_factory({"OPENREWARD_API_KEY": "or-key"})
 
 
+def test_default_client_factory_mirrors_injected_key_into_process_env(monkeypatch):
+    """The SDK reads os.environ internally; the validated key from the
+    injected mapping must be set there before the client is constructed."""
+    seen_at_construction: list[str | None] = []
+
+    class FakeOpenReward:
+        def __init__(self) -> None:
+            seen_at_construction.append(os.environ.get("OPENREWARD_API_KEY"))
+
+    monkeypatch.setitem(
+        sys.modules, "openreward", SimpleNamespace(OpenReward=FakeOpenReward)
+    )
+    monkeypatch.setenv("OPENREWARD_API_KEY", "stale-process-key")
+
+    client = _default_client_factory({"OPENREWARD_API_KEY": "injected-key"})
+
+    assert isinstance(client, FakeOpenReward)
+    assert seen_at_construction == ["injected-key"]
+
+
 # ── Episode happy path ──
 
 
@@ -361,6 +384,8 @@ def test_happy_path_drives_episode_and_scores(tmp_path):
     assert result.normalized_model == "served-model"
     assert client.get_kwargs == {"name": "GeneralReasoning/CTF"}
     assert environment.split_seen == "train"
+    # The session was started on the exact task the artifacts claim was run.
+    assert environment.tasks_seen == [{"task_id": "t0"}]
     episode = result.episodes[0]
     assert episode.finished is True
     assert episode.truncated is False
@@ -770,7 +795,7 @@ def test_rewards_aggregate_as_mean_over_all_episodes(tmp_path):
         [FakeToolOutput("right", reward=1.0, finished=True)],
         [FakeToolOutput("wrong", reward=0.0, finished=True)],
     ]
-    result, _, _, _ = run_fake(
+    result, _, environment, _ = run_fake(
         tmp_path,
         turns=turns,
         outputs_per_task=outputs,
@@ -780,6 +805,9 @@ def test_rewards_aggregate_as_mean_over_all_episodes(tmp_path):
 
     assert result.reward == 0.5
     assert result.total_tool_calls == 2
+    # Each session was opened on its own task, in task order — the runner
+    # must pass the task it scores, not None or a stale loop variable.
+    assert environment.tasks_seen == [{"task_id": "t0"}, {"task_id": "t1"}]
     payload = json.loads((result.run_dir / "result.json").read_text())
     assert payload["rewards"]["rubric"] == [
         {"name": "example_0", "score": 1.0},
@@ -851,6 +879,47 @@ def test_eval_create_openreward_routes_to_openreward_runner(tmp_path, monkeypatc
     assert config.max_turns == 8
     assert config.model == "openai/gpt-test"
     assert "openreward:GeneralReasoning/CTF@latest" in result.output
+
+
+def test_eval_create_openreward_warns_on_concurrency_flag(tmp_path, monkeypatch):
+    """--concurrency has no effect on the openreward path (episodes run
+    sequentially); the CLI must say so instead of silently ignoring it."""
+    seen: dict[str, object] = {}
+
+    def fake_run(config: OpenRewardRunConfig, **kwargs) -> OpenRewardRunResult:
+        seen["config"] = config
+        return OpenRewardRunResult(
+            source_env=config.source_env,
+            run_dir=tmp_path / "run",
+            model=config.model,
+            normalized_model="gpt-test",
+            reward=1.0,
+            total_tool_calls=0,
+            episodes=[],
+            error=None,
+        )
+
+    monkeypatch.setattr("benchflow.hosted_env_openreward.run_openreward_env", fake_run)
+
+    result = CliRunner().invoke(
+        app,
+        [
+            "eval",
+            "create",
+            "--source-env",
+            "openreward:GeneralReasoning/CTF",
+            "--concurrency",
+            "8",
+            "--model",
+            "openai/gpt-test",
+            "--jobs-dir",
+            str(tmp_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--concurrency is for Verifiers runs" in result.output
+    assert "config" in seen  # the run still executes
 
 
 def test_eval_create_openreward_run_error_exits_nonzero(tmp_path, monkeypatch):

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -153,7 +153,17 @@ async def test_runtime_reuse_and_stop(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_required_usage_fails_when_litellm_lacks_provider_key():
+async def test_required_usage_fails_when_litellm_lacks_provider_key(monkeypatch):
+    # Isolate from host state: a developer's Codex CLI login
+    # (~/.codex/auth.json) would otherwise satisfy subscription auth and
+    # skip LiteLLM entirely. This test is about the no-key, no-subscription
+    # path.
+    monkeypatch.setattr(
+        runtime_mod,
+        "uses_native_subscription_auth",
+        lambda *_args, **_kwargs: False,
+    )
+
     with pytest.raises(RuntimeError, match="requires OPENAI_API_KEY"):
         await ensure_litellm_runtime(
             agent="codex-acp",


### PR DESCRIPTION
Inbound runner for OpenReward (ORS) hosted environments — the counterpart to the existing outbound `adapters/ors.py` reward bridge, following the `hosted_env.py` Verifiers pattern.

- Provider references (`openreward:owner/name@variant`), fail-closed model-endpoint resolution
- Full episode driving: prompt → tool calls → `ToolOutput{reward, finished}`, finished-flag + max-turns truncation, fail-closed episode errors
- Standard artifact contract: result.json, rewards.jsonl, acp_trajectory.jsonl, episodes.jsonl, trainer/verifiers.jsonl
- Unit-proven with faked SDK client (no network); task-dispatch integrity mutation-verified; full suite green (2,840 passed)

Draft until a live smoke episode runs against a real OpenReward environment (needs `OPENREWARD_API_KEY`) to confirm the sync client surface.