### PR TITLE
feat: AgentBeats A2A adapter, re-ported onto the compiled-Steps engine

### DIFF
--- a/docs/agentbeats-a2a-adapter-audit.md
+++ b/docs/agentbeats-a2a-adapter-audit.md
@@ -1,0 +1,240 @@
+# AgentBeats A2A Adapter Audit
+
+Date: 2026-05-21
+
+Branch: `codex/agentbeats-a2a-adapter-audit`
+
+## Decision
+
+BenchFlow should add AgentBeats A2A as a sibling participant adapter, not as an
+ACP rename or an ACP transport flag.
+
+The reusable surfaces are `Role`, `Scene`, `Rollout`, sandbox lifecycle, skill
+deployment, trajectory/artifact directories, and verifier handoff. The
+non-reusable surface is the current participant execution path:
+`Rollout.connect_as()` -> `connect_acp()` -> `ACPClient` ->
+`execute_prompts()`. That path is ACP-specific from process launch through
+session updates.
+
+## Evidence
+
+- `src/benchflow/_types.py` has protocol-neutral `Role`, `Scene`, and `Turn`
+  declarations, but `Role.agent` currently names a local registered ACP agent.
+- `src/benchflow/rollout.py` owns setup, skill deployment, sandbox lockdown,
+  provider credential mapping, trajectory publication, verifier execution, and
+  result serialization.
+- `Rollout.connect_as()` installs a local agent binary, writes credentials, and
+  calls `connect_acp()` for every role turn.
+- `src/benchflow/acp/runtime.py` and `src/benchflow/acp/client.py` implement ACP
+  JSON-RPC session setup, prompt execution, cancellation, and update capture.
+- Multi-role scenes currently exchange messages through `/app/.outbox` prompt
+  injection. They do not target endpoint-based participants.
+- `Rollout.verify()` already publishes captured trajectory to
+  `/logs/agent/acp_trajectory.jsonl` and delegates scoring to the existing
+  verifier path.
+
+## Contract And Initial Implementation
+
+The future A2A participant adapter should live under
+`src/benchflow/agents/a2a.py` and expose a small contract independent from ACP:
+
+- `A2AParticipantRequest`: endpoint URL, role name, visible prompt, workspace,
+  optional skills directory, role timeout, role idle timeout, and redacted
+  metadata.
+- `A2ATaskHandle`: opaque started-task handle with task id, endpoint URL, and
+  role name.
+- `A2AParticipantResult`: terminal status, normalized A2A trajectory events,
+  artifact references, optional final response, and redacted error type.
+- `A2AParticipantAdapter`: `start(request)`, `wait(handle)`, and
+  `cancel(handle, reason)`.
+
+The module now also includes `A2AClientParticipantAdapter`, a small
+`a2a-sdk==0.3.20` backed implementation that sends one visible prompt to an A2A
+endpoint, normalizes task/message events, records artifact references, and
+returns a terminal `A2AParticipantResult`. The runtime dependency remains the
+client SDK; the `http-server` extra is a dev dependency for the toy endpoint
+smoke test.
+
+Rollout wiring now has a first implementation. `Role.transport` defaults to
+`"acp"`, and explicit A2A roles use `Role.transport="a2a"` plus
+`Role.endpoint_url`. ACP roles still use the existing `connect_acp()` and
+`execute_prompts()` path.
+
+## Done Signal
+
+The adapter must not infer completion from free-form text. A purple participant
+is done only when the A2A task reaches a terminal state:
+
+- `completed`: final response or artifact is available for verifier handoff.
+- `failed`: participant task failed without trustworthy output.
+- `cancelled`: BenchFlow or the caller cancelled the participant task.
+- `timeout`: BenchFlow timeout handling cancelled or abandoned the task.
+
+Only `completed` proceeds as a normal model attempt. Other terminal states
+should still persist trajectory and produce a classified run result.
+
+## Timeout And Cancellation
+
+- Use `Role.timeout_sec` when present, otherwise the task `[agent].timeout_sec`.
+- Use `Role.idle_timeout_sec` when present, otherwise rollout idle timeout.
+- On timeout, call `A2AParticipantAdapter.cancel()` before verifier handoff.
+- Persist timeout/cancel as participant communication failures, not verifier
+  failures.
+- Preserve ACP timeout behavior; do not route ACP roles through A2A timeout code.
+
+## Trajectory And Artifacts
+
+A2A updates are written separately from ACP trajectory data:
+
+- `trajectory/a2a_trajectory.jsonl` for normalized A2A task updates.
+- `artifacts/a2a_artifacts.json` for A2A artifact references.
+- A2A final responses may include file artifacts under a `files[]` payload;
+  BenchFlow materializes those files under the rollout workspace only, then
+  records them as `sandbox://...` refs in `artifacts/a2a_artifacts.json`.
+- Existing `trajectory/acp_trajectory.jsonl` remains ACP-only.
+- Public rows may reference redacted artifact ids or digests, not private paths,
+  raw provider payloads, credentials, or verifier logs.
+
+## Verifier Handoff
+
+The A2A adapter is not a verifier. It only drives the purple participant to a
+terminal state and materializes the participant output into the same sandbox or
+artifact layout that existing verifiers already consume.
+
+After a `completed` A2A result:
+
+1. Persist normalized A2A trajectory.
+2. Persist or reference participant artifacts.
+3. Publish any verifier-visible trajectory/artifact data required by the task.
+4. Call the existing `_verify_rollout()` path.
+5. Serialize result fields without changing ACP result semantics.
+
+AgentBeats/Amber worker runs add one Docker-sandbox caveat: the task container
+can run through Amber's Docker gateway while its bind-mounted verifier log path
+is not visible from inside the worker container. Set
+`BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED=false` in that worker environment so
+BenchFlow downloads `/logs/verifier` from the task container before parsing
+`reward.txt`. The default remains `true` for normal local Docker runs where the
+host mount is visible.
+
+## Runtime File Changes
+
+Phase 4 implementation has stayed scoped to these files:
+
+- `src/benchflow/agents/a2a.py`: concrete AgentBeats A2A participant
+  client/adapter.
+- `src/benchflow/_types.py`: explicit participant transport discriminator and
+  endpoint field on `Role`, with ACP as the default.
+- `src/benchflow/_utils/yaml_loader.py`: YAML role parsing for transport,
+  endpoint, role timeouts, role skills, and capabilities.
+- `src/benchflow/rollout.py`: branch role execution to ACP or A2A while keeping
+  setup, verifier, cleanup, and result serialization shared.
+- `src/benchflow/sandbox/docker.py`: allow worker environments to disable the
+  verifier-log host-mount fast path and avoid `--rmi all` cleanup for prebuilt
+  task images.
+- `src/benchflow/models.py`: add `a2a` as a trajectory source.
+- `tests/test_a2a_participant_adapter_contract.py`: convert pending runtime
+  tests into passing implementation tests.
+- `tests/test_docker_uploads.py`: cover the Docker log-mount flag and prebuilt
+  cleanup behavior.
+
+## Runtime Tests
+
+`tests/test_a2a_participant_adapter_contract.py` now contains:
+
+- passing contract-shape tests for request/result/artifact fields
+- passing client tests for message normalization, cancellation, unknown
+  handles, and a toy SDK-backed A2A endpoint smoke
+- passing runtime tests for endpoint invocation, timeout cancellation, artifact
+  capture, file materialization, verifier handoff, and A2A trajectory
+  persistence
+
+These tests deliberately keep ACP behavior untouched while documenting the
+implementation surface.
+
+## Verification
+
+Baseline before edits:
+
+```bash
+uv sync --extra dev
+uv run pytest tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+```
+
+Result: `69 passed, 3 skipped`.
+
+Post-edit focused verification:
+
+```bash
+uv run pytest tests/test_a2a_participant_adapter_contract.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run ruff check src/benchflow/agents/a2a.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py tests/test_a2a_participant_adapter_contract.py
+```
+
+Result: `71 passed, 3 skipped, 5 xfailed`; ruff check passed; ruff format
+reported `2 files already formatted`.
+
+Adapter implementation verification:
+
+```bash
+uv run pytest tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run ruff check src/benchflow/agents/a2a.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ty check src/benchflow/agents/a2a.py
+```
+
+Result: `74 passed, 3 skipped, 5 xfailed`; ruff check passed; ruff format
+reported `3 files already formatted`; `ty` passed.
+
+Rollout wiring verification:
+
+```bash
+uv run pytest tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py tests/test_scene_outbox_trial.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run pytest tests/test_yaml_config.py tests/test_adapters.py tests/test_connect_as_env.py tests/test_internet_policy.py -q
+uv run ruff check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ty check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py
+```
+
+Results: `95 passed, 3 skipped, 1 warning`; `59 passed, 6 warnings`; ruff
+check passed; ruff format reported `7 files already formatted`; `ty` passed.
+
+After adding file materialization:
+
+```bash
+uv run pytest tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py tests/test_scene_outbox_trial.py tests/test_acp.py tests/test_agent_registry.py tests/test_scene.py tests/test_runtime.py -q
+uv run pytest tests/test_yaml_config.py tests/test_adapters.py tests/test_connect_as_env.py tests/test_internet_policy.py -q
+uv run ruff check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ruff format --check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py tests/test_a2a_participant_client.py tests/test_a2a_participant_adapter_contract.py
+uv run ty check src/benchflow/agents/a2a.py src/benchflow/_types.py src/benchflow/_utils/yaml_loader.py src/benchflow/rollout.py src/benchflow/models.py
+```
+
+Results: `96 passed, 3 skipped, 1 warning`; `59 passed, 6 warnings`; ruff
+check passed; ruff format reported `7 files already formatted`; `ty` passed.
+
+Docker sandbox worker-gateway verification:
+
+```bash
+uv run pytest tests/test_docker_uploads.py tests/test_verifier_multi_container.py -q
+```
+
+Result: `19 passed, 20 warnings`.
+
+Real SkillsBench smoke:
+
+- Task:
+  `/Users/liu.10379/Documents/work/skillsbench/tasks/perf-cycle-optimization`.
+- Participant:
+  toy SDK-backed A2A endpoint through `A2AClientParticipantAdapter`.
+- Result:
+  success `true`, reward `0.13043478260869565`, trajectory source `a2a`,
+  verifier error `null`.
+- Important environment note:
+  the smoke failed when `jobs_dir` was under `/tmp` because Docker did not
+  surface the verifier reward file through the bind mount. The same smoke
+  passed when `jobs_dir` was under the `/Users/...` worktree path.
+
+Remaining implementation proof:
+
+- deployed or public-packaged green-agent worker integration using this A2A role
+  path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "litellm[proxy]==1.88.0rc1",
     "tomli-w>=1.0",
     "typer>=0.9",
+    "a2a-sdk==0.3.20",
 ]
 authors = [
     { name = "Xiangyi Li", email = "xiangyi@benchflow.ai" },
@@ -162,4 +163,9 @@ exclude = [
     "src/benchflow/rewards/file_readers.py",
     "src/benchflow/rewards/rubric_config.py",
     "src/benchflow/experimental/mcp/reviewer_server.py",
+]
+
+[dependency-groups]
+dev = [
+    "a2a-sdk[http-server]==0.3.20",
 ]

--- a/src/benchflow/_types.py
+++ b/src/benchflow/_types.py
@@ -20,6 +20,9 @@ Concretely:
   environment variables and skills, and wires up the ACP transport.
 * BenchFlow ensures sandbox networking allows inter-agent communication
   (all roles in a scene share a sandbox, so localhost is reachable).
+* AgentBeats A2A participants are an explicit role transport boundary, not an
+  ACP alias. A2A roles supply a participant endpoint and skip ACP process
+  installation/connection.
 * The ``capabilities`` field on :class:`Role` is a **declaration** — it
   tells downstream tooling / dashboards what the agent supports, but
   BenchFlow itself does not act on it.
@@ -34,6 +37,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
+
+RoleTransport = Literal["acp", "a2a"]
 
 
 @dataclass
@@ -56,6 +62,8 @@ class Role:
     idle_timeout_sec: int | None = None
     skills_dir: str | Path | None = None
     capabilities: list[str] | None = None  # e.g. ["tool-use", "agent-as-tool", "loop"]
+    transport: RoleTransport = "acp"
+    endpoint_url: str | None = None
 
 
 @dataclass

--- a/src/benchflow/_utils/yaml_loader.py
+++ b/src/benchflow/_utils/yaml_loader.py
@@ -159,6 +159,12 @@ def _parse_role(raw: dict) -> Role:
         model=raw.get("model"),
         reasoning_effort=raw.get("reasoning_effort"),
         env=raw.get("env", {}),
+        timeout_sec=raw.get("timeout_sec"),
+        idle_timeout_sec=raw.get("idle_timeout_sec"),
+        skills_dir=raw.get("skills_dir"),
+        capabilities=raw.get("capabilities"),
+        transport=raw.get("transport", "acp"),
+        endpoint_url=raw.get("endpoint_url"),
     )
 
 

--- a/src/benchflow/agents/a2a.py
+++ b/src/benchflow/agents/a2a.py
@@ -1,8 +1,10 @@
-"""AgentBeats A2A participant adapter contract.
+"""AgentBeats A2A participant adapter: contract types and SDK-backed client.
 
-This module intentionally defines the contract only. Runtime wiring belongs in
-the later implementation phase after the SkillsBench green-agent skeleton can
-exercise this boundary against AgentBeats-style assessment requests.
+Defines the request/handle/result/trajectory contract for external A2A
+participant endpoints plus :class:`A2AClientParticipantAdapter`, an a2a-sdk
+based implementation that resolves the participant's agent card, sends one
+visible prompt per role turn, and normalizes the resulting task states and
+artifacts for the Rollout to persist and hand to the existing verifier path.
 """
 
 from __future__ import annotations
@@ -80,7 +82,7 @@ class A2AParticipantResult:
 
 
 class A2AParticipantAdapter(Protocol):
-    """Protocol a future BenchFlow A2A participant adapter must satisfy."""
+    """Protocol a BenchFlow A2A participant adapter must satisfy."""
 
     async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
         """Create a fresh participant task for one BenchFlow role turn."""
@@ -262,6 +264,11 @@ def _participant_result_from_events(
 
 
 def _normalize_task_status(value: str) -> A2ATaskStatus:
+    # The a2a-sdk TaskState enum has nine states. Benchmark turns are
+    # non-interactive, so any state in which the participant cannot make
+    # progress on its own (input-required, auth-required, rejected, unknown)
+    # is scored as "failed" rather than left waiting for input that will
+    # never arrive.
     if value == "completed":
         return "completed"
     if value in {"canceled", "cancelled"}:

--- a/src/benchflow/agents/a2a.py
+++ b/src/benchflow/agents/a2a.py
@@ -1,0 +1,325 @@
+"""AgentBeats A2A participant adapter contract.
+
+This module intentionally defines the contract only. Runtime wiring belongs in
+the later implementation phase after the SkillsBench green-agent skeleton can
+exercise this boundary against AgentBeats-style assessment requests.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+from uuid import uuid4
+
+import httpx
+from a2a.client import A2ACardResolver, ClientConfig, ClientFactory
+from a2a.types import DataPart, Message, Part, TextPart
+from a2a.types import Role as A2ARole
+
+A2ATaskStatus = Literal["running", "completed", "failed", "cancelled", "timeout"]
+A2AUpdateKind = Literal["task_update", "artifact", "final_response", "error"]
+
+
+@dataclass(frozen=True)
+class A2AParticipantRequest:
+    """Visible task payload sent from BenchFlow to a purple A2A endpoint."""
+
+    endpoint_url: str
+    role_name: str
+    prompt: str
+    workspace: str = "/app"
+    skills_dir: str | None = None
+    timeout_sec: int | None = None
+    idle_timeout_sec: int | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class A2ATaskHandle:
+    """Opaque handle for a started participant task."""
+
+    task_id: str
+    endpoint_url: str
+    role_name: str
+
+
+@dataclass(frozen=True)
+class A2ATrajectoryEvent:
+    """One normalized A2A update for BenchFlow trajectory persistence."""
+
+    kind: A2AUpdateKind
+    timestamp: str | None = None
+    payload: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class A2AArtifactRef:
+    """Reference to an artifact produced by the participant endpoint."""
+
+    name: str
+    uri: str
+    media_type: str | None = None
+    digest: str | None = None
+
+
+@dataclass(frozen=True)
+class A2AParticipantResult:
+    """Terminal normalized result from a purple A2A participant."""
+
+    status: A2ATaskStatus
+    trajectory: Sequence[A2ATrajectoryEvent] = field(default_factory=tuple)
+    artifacts: Sequence[A2AArtifactRef] = field(default_factory=tuple)
+    final_response: Mapping[str, Any] | None = None
+    error_type: str | None = None
+
+    @property
+    def done(self) -> bool:
+        return self.status in {"completed", "failed", "cancelled", "timeout"}
+
+
+class A2AParticipantAdapter(Protocol):
+    """Protocol a future BenchFlow A2A participant adapter must satisfy."""
+
+    async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
+        """Create a fresh participant task for one BenchFlow role turn."""
+
+    async def wait(self, handle: A2ATaskHandle) -> A2AParticipantResult:
+        """Wait until the participant task reaches a terminal status."""
+
+    async def cancel(self, handle: A2ATaskHandle, reason: str) -> None:
+        """Cancel an in-flight participant task before verifier handoff."""
+
+
+HTTPXClientFactory = Callable[[int], httpx.AsyncClient]
+
+
+class A2AClientParticipantAdapter:
+    """A2A SDK-backed participant adapter.
+
+    The adapter deliberately does not know about Rollout or verifier semantics.
+    It sends one visible prompt to a participant endpoint, records normalized A2A
+    events, and returns a terminal participant result for the caller to persist
+    and hand to the existing verifier path.
+    """
+
+    def __init__(
+        self,
+        *,
+        default_timeout_sec: int = 300,
+        streaming: bool = True,
+        httpx_client_factory: HTTPXClientFactory | None = None,
+    ):
+        self.default_timeout_sec = default_timeout_sec
+        self.streaming = streaming
+        self.httpx_client_factory = httpx_client_factory
+        self._pending: dict[str, A2AParticipantRequest] = {}
+        self._cancelled: dict[str, str] = {}
+
+    async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
+        task_id = uuid4().hex
+        self._pending[task_id] = request
+        return A2ATaskHandle(
+            task_id=task_id,
+            endpoint_url=request.endpoint_url,
+            role_name=request.role_name,
+        )
+
+    async def wait(self, handle: A2ATaskHandle) -> A2AParticipantResult:
+        if handle.task_id in self._cancelled:
+            reason = self._cancelled.pop(handle.task_id)
+            self._pending.pop(handle.task_id, None)
+            return A2AParticipantResult(
+                status="cancelled",
+                trajectory=(
+                    A2ATrajectoryEvent(
+                        kind="error",
+                        payload={"error_type": "cancelled", "reason": reason},
+                    ),
+                ),
+                error_type="cancelled",
+            )
+
+        request = self._pending.pop(handle.task_id, None)
+        if request is None:
+            raise KeyError(f"Unknown A2A task handle: {handle.task_id}")
+
+        events = [
+            event
+            async for event in self._send_message(
+                request,
+                message_id=handle.task_id,
+            )
+        ]
+        return _participant_result_from_events(handle, events)
+
+    async def cancel(self, handle: A2ATaskHandle, reason: str) -> None:
+        self._cancelled[handle.task_id] = reason
+
+    async def _send_message(
+        self,
+        request: A2AParticipantRequest,
+        *,
+        message_id: str,
+    ) -> AsyncIterator[object]:
+        timeout = request.timeout_sec or self.default_timeout_sec
+        client_factory = self.httpx_client_factory or (
+            lambda timeout_sec: httpx.AsyncClient(timeout=timeout_sec)
+        )
+        async with client_factory(timeout) as httpx_client:
+            resolver = A2ACardResolver(
+                httpx_client=httpx_client,
+                base_url=request.endpoint_url,
+            )
+            agent_card = await resolver.get_agent_card()
+            client = ClientFactory(
+                ClientConfig(httpx_client=httpx_client, streaming=self.streaming)
+            ).create(agent_card)
+            message = Message(
+                kind="message",
+                role=A2ARole.user,
+                parts=[Part(TextPart(kind="text", text=request.prompt))],
+                message_id=message_id,
+            )
+            async for event in client.send_message(message):
+                yield event
+
+
+def _participant_result_from_events(
+    handle: A2ATaskHandle,
+    events: Sequence[object],
+) -> A2AParticipantResult:
+    trajectory: list[A2ATrajectoryEvent] = []
+    artifacts: list[A2AArtifactRef] = []
+    artifact_uris: set[str] = set()
+    final_response: Mapping[str, Any] | None = None
+    status: A2ATaskStatus = "failed"
+    error_type: str | None = None
+
+    for event in events:
+        if isinstance(event, Message):
+            text = _merge_parts(event.parts)
+            trajectory.append(
+                A2ATrajectoryEvent(
+                    kind="final_response",
+                    payload={"message": text},
+                )
+            )
+            final_response = _final_response_from_message(event.parts, text)
+            status = "completed"
+            continue
+
+        if not isinstance(event, tuple) or not event:
+            trajectory.append(
+                A2ATrajectoryEvent(
+                    kind="error",
+                    payload={"error_type": "unknown_event", "repr": repr(event)},
+                )
+            )
+            error_type = error_type or "unknown_event"
+            continue
+
+        task = event[0]
+        update = event[1] if len(event) > 1 else None
+        dumped = _model_dump(task)
+        task_status = _task_status(task)
+        if task_status:
+            status = _normalize_task_status(task_status)
+        trajectory.append(
+            A2ATrajectoryEvent(
+                kind="task_update",
+                payload={"task": dumped, "update": _model_dump(update)},
+            )
+        )
+        task_artifacts = getattr(task, "artifacts", None) or []
+        for index, artifact in enumerate(task_artifacts):
+            name = getattr(artifact, "name", None) or f"artifact-{index}"
+            uri = f"a2a://{handle.task_id}/artifacts/{index}"
+            if uri in artifact_uris:
+                continue
+            artifact_uris.add(uri)
+            artifacts.append(
+                A2AArtifactRef(
+                    name=name,
+                    uri=uri,
+                    media_type=None,
+                    digest=None,
+                )
+            )
+        if task_artifacts and final_response is None:
+            final_response = {"artifacts": [_model_dump(a) for a in task_artifacts]}
+        if status in {"failed", "cancelled", "timeout"}:
+            error_type = error_type or f"a2a_{status}"
+
+    return A2AParticipantResult(
+        status=status,
+        trajectory=tuple(trajectory),
+        artifacts=tuple(artifacts),
+        final_response=final_response,
+        error_type=error_type,
+    )
+
+
+def _normalize_task_status(value: str) -> A2ATaskStatus:
+    if value == "completed":
+        return "completed"
+    if value in {"canceled", "cancelled"}:
+        return "cancelled"
+    if value == "working":
+        return "running"
+    if value == "submitted":
+        return "running"
+    return "failed"
+
+
+def _task_status(task: object) -> str | None:
+    status = getattr(task, "status", None)
+    state = getattr(status, "state", None)
+    value = getattr(state, "value", None)
+    return value if isinstance(value, str) else None
+
+
+def _merge_parts(parts: Sequence[Part]) -> str:
+    chunks: list[str] = []
+    for part in parts:
+        root = part.root
+        if isinstance(root, TextPart):
+            chunks.append(root.text)
+        elif isinstance(root, DataPart):
+            chunks.append(json.dumps(root.data, sort_keys=True))
+    return "\n".join(chunks)
+
+
+def _final_response_from_message(
+    parts: Sequence[Part],
+    text: str,
+) -> Mapping[str, Any]:
+    data_parts = [part.root.data for part in parts if isinstance(part.root, DataPart)]
+    if len(data_parts) == 1 and isinstance(data_parts[0], Mapping):
+        return {"message": text, **dict(data_parts[0])}
+    if data_parts:
+        return {"message": text, "data": data_parts}
+    return {"message": text}
+
+
+def _model_dump(value: object) -> Any:
+    if value is None:
+        return None
+    dump = getattr(value, "model_dump", None)
+    if callable(dump):
+        return dump(mode="json")
+    return repr(value)
+
+
+__all__ = [
+    "A2AClientParticipantAdapter",
+    "A2AArtifactRef",
+    "A2AParticipantAdapter",
+    "A2AParticipantRequest",
+    "A2AParticipantResult",
+    "A2ATaskHandle",
+    "A2ATaskStatus",
+    "A2ATrajectoryEvent",
+    "A2AUpdateKind",
+]

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from benchflow.rewards.events import RewardEvent
 
-TrajectorySource = Literal["acp", "scraped", "partial_acp", "hosted_env"]
+TrajectorySource = Literal["acp", "a2a", "scraped", "partial_acp", "hosted_env"]
 """Provenance label for a captured trajectory. See RunResult.trajectory_source.
 
 ``"hosted_env"`` marks UNTRUSTED imported evidence produced by an external

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -2725,8 +2725,9 @@ class Rollout:
         self._trajectory_source = (
             "a2a" if self._trajectory_source is None else self._trajectory_source
         )
-        if "agent_execution" not in self._timing:
-            self._timing["agent_execution"] = (datetime.now() - t0).total_seconds()
+        self._timing["agent_execution"] = self._timing.get(
+            "agent_execution", 0.0
+        ) + (datetime.now() - t0).total_seconds()
         self._phase = "executed"
 
     def _append_a2a_event(
@@ -2825,6 +2826,16 @@ class Rollout:
                 yield from self._iter_a2a_file_specs(item)
 
     def _normalize_a2a_output_path(self, path: str) -> str:
+        """Contain endpoint-supplied output paths to the rollout workspace.
+
+        final_response files[].path comes from an external (untrusted) A2A
+        endpoint while _upload_a2a_file runs mkdir/upload/chown as root, so
+        any path escaping the workspace (e.g. the verifier log dir) must be
+        rejected. Trust model: containment is enforced on the normalized
+        path string only — symlinks already present under the workspace are
+        not resolved, because only the sandboxed agent could have created
+        them and a write through one stays inside the sandbox.
+        """
         workspace = posixpath.normpath(self._agent_cwd or "/app")
         candidate = (
             posixpath.normpath(posixpath.join(workspace, path))

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -42,14 +42,15 @@ import contextlib
 import json
 import logging
 import os
+import posixpath
 import re
 import shlex
 import tempfile
 from collections.abc import Callable
-from dataclasses import dataclass, field, replace
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from benchflow._types import Role, Scene, Turn
 from benchflow._utils.config import (
@@ -110,6 +111,9 @@ from benchflow.usage_tracking import (
     is_token_usage_available,
     usage_unavailable,
 )
+
+if TYPE_CHECKING:
+    from benchflow.agents.a2a import A2AParticipantAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -228,6 +232,10 @@ def _apply_web_policy(agent_env: dict[str, str], *, disallow: bool) -> dict[str,
     if not disallow:
         return agent_env
     return {**agent_env, _DISALLOW_WEB_TOOLS_ENV: "1"}
+
+
+def _is_a2a_role(role: Role) -> bool:
+    return role.transport == "a2a"
 
 
 def _agent_launch_with_web_policy(
@@ -565,6 +573,8 @@ def _role_metadata(role: Role) -> dict[str, Any]:
         "idle_timeout_sec": role.idle_timeout_sec,
         "skills_dir": str(role.skills_dir) if role.skills_dir else None,
         "capabilities": role.capabilities,
+        "transport": role.transport,
+        "endpoint_url": role.endpoint_url if role.transport == "a2a" else None,
         "env_keys": sorted(role.env),
     }
 
@@ -582,6 +592,22 @@ def _scene_metadata(scenes: list[Scene]) -> list[dict[str, Any]]:
         }
         for scene in scenes
     ]
+
+
+def _split_protocol_trajectory(
+    trajectory: list[dict],
+) -> tuple[list[dict], list[dict]]:
+    a2a = [
+        event
+        for event in trajectory
+        if isinstance(event, dict) and event.get("protocol") == "a2a"
+    ]
+    acp = [
+        event
+        for event in trajectory
+        if not (isinstance(event, dict) and event.get("protocol") == "a2a")
+    ]
+    return acp, a2a
 
 
 def _build_rollout_result(
@@ -707,7 +733,11 @@ def _build_rollout_result(
     # the only writer for oracle / scraped-fallback / no-session paths.
     # Redaction is applied inside TrajectoryWriter so every write path
     # (streaming + final) is scrubbed (#537/#585).
-    TrajectoryWriter(traj_dir / "acp_trajectory.jsonl").write_final(trajectory)
+    acp_trajectory, a2a_trajectory = _split_protocol_trajectory(trajectory)
+    if a2a_trajectory:
+        TrajectoryWriter(traj_dir / "a2a_trajectory.jsonl").write_final(a2a_trajectory)
+    if acp_trajectory or not a2a_trajectory:
+        TrajectoryWriter(traj_dir / "acp_trajectory.jsonl").write_final(acp_trajectory)
     rollout_dir.mkdir(parents=True, exist_ok=True)
     (rollout_dir / "result.json").write_text(
         json.dumps(
@@ -945,8 +975,10 @@ async def _run_oracle(
     return trajectory, "oracle"
 
 
-async def _publish_trajectory_for_verifier(env, trajectory: list[dict]) -> None:
-    """Make the captured ACP trajectory available inside /logs for verifiers."""
+async def _publish_trajectory_for_verifier(
+    env, trajectory: list[dict], filename: str = "acp_trajectory.jsonl"
+) -> None:
+    """Make a captured participant trajectory available inside /logs for verifiers."""
     if not trajectory:
         return
     await env.exec("mkdir -p /logs/agent", user="root", timeout_sec=10)
@@ -955,7 +987,7 @@ async def _publish_trajectory_for_verifier(env, trajectory: list[dict]) -> None:
         f.write("\n")
         tmp_path = f.name
     try:
-        await env.upload_file(tmp_path, "/logs/agent/acp_trajectory.jsonl")
+        await env.upload_file(tmp_path, f"/logs/agent/{filename}")
     finally:
         with contextlib.suppress(FileNotFoundError):
             os.unlink(tmp_path)
@@ -1093,6 +1125,7 @@ class RolloutConfig:
     export_generated_skills_to: str | Path | None = None
     source_provenance: dict[str, Any] | None = None
     planes: RolloutPlanes | None = field(default=None, repr=False, compare=False)
+    a2a_adapter: A2AParticipantAdapter | None = None
 
     def __post_init__(self) -> None:
         from benchflow._utils.config import normalize_agent_idle_timeout
@@ -1122,6 +1155,8 @@ class RolloutConfig:
                 role.reasoning_effort = normalize_reasoning_effort(
                     role.reasoning_effort
                 )
+                if role.transport not in {"acp", "a2a"}:
+                    raise ValueError(f"Unknown role transport: {role.transport}")
 
     @classmethod
     def from_legacy(
@@ -1218,6 +1253,15 @@ class RolloutConfig:
             return scenes[0].roles[0].reasoning_effort
         return self.reasoning_effort
 
+    @property
+    def first_acp_role(self) -> Role | None:
+        """First role that still uses BenchFlow's ACP coding-agent transport."""
+        for scene in self.effective_scenes:
+            for role in scene.roles:
+                if role.transport == "acp":
+                    return role
+        return None
+
 
 class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
@@ -1296,6 +1340,8 @@ class Rollout:
 
         # Populated by execute()
         self._trajectory: list[dict] = []
+        self._a2a_adapter: A2AParticipantAdapter | None = config.a2a_adapter
+        self._a2a_artifacts: list[dict[str, Any]] = []
         self._n_tool_calls: int = 0
         self._trajectory_source: TrajectorySource | None = None
         self._partial_trajectory: bool = False
@@ -1427,15 +1473,24 @@ class Rollout:
             self._rollout_name,
         ) = _init_rollout(cfg.task_path, cfg.job_name, cfg.rollout_name, cfg.jobs_dir)
 
+        first_acp_role = cfg.first_acp_role
+        env_agent = first_acp_role.agent if first_acp_role else cfg.primary_agent
+        env_model = first_acp_role.model if first_acp_role else cfg.primary_model
+        env_overrides = {**(cfg.agent_env or {})}
+        if first_acp_role:
+            env_overrides.update(first_acp_role.env or {})
         self._disallow_web_tools = (
-            _task_disallows_internet(self._task) or cfg.self_gen_no_internet
-        ) and cfg.primary_agent != "oracle"
-        self._agent_env = _apply_web_policy(
-            self._planes.resolve_agent_env(
-                cfg.primary_agent, cfg.primary_model, cfg.agent_env
-            ),
-            disallow=self._disallow_web_tools,
+            (_task_disallows_internet(self._task) or cfg.self_gen_no_internet)
+            and env_agent != "oracle"
+            and first_acp_role is not None
         )
+        if first_acp_role:
+            self._agent_env = _apply_web_policy(
+                self._planes.resolve_agent_env(env_agent, env_model, env_overrides),
+                disallow=self._disallow_web_tools,
+            )
+        else:
+            self._agent_env = dict(cfg.agent_env or {})
         env_config = getattr(getattr(self._task, "config", None), "environment", None)
         task_skill_policy = resolve_task_skill_policy(
             task_path=cfg.task_path,
@@ -1452,9 +1507,13 @@ class Rollout:
             agent=cfg.primary_agent,
             planes=self._planes,
         )
-        self._agent_launch = self._planes.agent_launch(
-            cfg.primary_agent,
-            disallow_web_tools=self._disallow_web_tools,
+        self._agent_launch = (
+            self._planes.agent_launch(
+                env_agent,
+                disallow_web_tools=self._disallow_web_tools,
+            )
+            if first_acp_role
+            else ""
         )
 
         # Copy task dir to temp when Dockerfile mutations are needed
@@ -1639,7 +1698,43 @@ class Rollout:
             self._phase = "installed"
             return
 
-        agent_name = cfg.primary_agent
+        install_role = cfg.first_acp_role
+        if install_role is None:
+            # All roles are A2A participants: no coding-agent binary to
+            # install. Still prepare the sandbox baseline (user, verifier
+            # workspace, skills, lockdown) exactly like the oracle path.
+            if cfg.sandbox_user:
+                self._agent_cwd = await self._planes.setup_sandbox_user(
+                    self._env,
+                    cfg.sandbox_user,
+                    workspace=self._agent_cwd,
+                    timeout_sec=cfg.sandbox_setup_timeout,
+                )
+            await self._planes.snapshot_build_config(
+                self._env, workspace=self._agent_cwd
+            )
+            await self._planes.seed_verifier_workspace(
+                self._env, workspace=self._agent_cwd, sandbox_user=cfg.sandbox_user
+            )
+            await self._planes.deploy_skills(
+                self._env,
+                getattr(self, "_effective_task_path", cfg.task_path),
+                self._effective_skills_dir,
+                None,
+                cfg.sandbox_user,
+                self._agent_cwd,
+                skills_sandbox_dir=self._effective_skills_sandbox_dir,
+            )
+            if cfg.export_generated_skills_to:
+                await _ensure_sandbox_dir(
+                    self._env, cfg.generated_skills_root, cfg.sandbox_user
+                )
+            await self._planes.lockdown_paths(self._env, self._effective_locked)
+            self._phase = "installed"
+            return
+
+        agent_name = install_role.agent
+        agent_model = install_role.model
         self._agent_cfg = await self._planes.install_agent(
             self._env, agent_name, rollout_dir
         )
@@ -1656,7 +1751,7 @@ class Rollout:
             agent_name,
             self._agent_env,
             self._agent_cfg,
-            cfg.primary_model,
+            agent_model,
             cred_home,
         )
         if self._agent_env.get("_BENCHFLOW_SUBSCRIPTION_AUTH"):
@@ -2075,7 +2170,13 @@ class Rollout:
                     f"Using scraped trajectory ({len(scraped)} events) — UNTRUSTED"
                 )
 
-        await _publish_trajectory_for_verifier(self._env, self._trajectory)
+        acp_trajectory, a2a_trajectory = _split_protocol_trajectory(self._trajectory)
+        await _publish_trajectory_for_verifier(
+            self._env, acp_trajectory, "acp_trajectory.jsonl"
+        )
+        await _publish_trajectory_for_verifier(
+            self._env, a2a_trajectory, "a2a_trajectory.jsonl"
+        )
 
         (
             self._rewards,
@@ -2494,6 +2595,276 @@ class Rollout:
             self._config.sandbox_user,
         )
 
+    def _get_a2a_adapter(self) -> A2AParticipantAdapter:
+        if self._a2a_adapter is None:
+            from benchflow.agents.a2a import A2AClientParticipantAdapter
+
+            self._a2a_adapter = A2AClientParticipantAdapter()
+        return self._a2a_adapter
+
+    def _a2a_request_for_role(
+        self,
+        role: Role,
+        prompts: list[str],
+        *,
+        scene_name: str,
+        scene_skills_dir: str | Path | None,
+    ):
+        if not role.endpoint_url:
+            raise ValueError(f"A2A role {role.name!r} requires endpoint_url")
+        from benchflow.agents.a2a import A2AParticipantRequest
+
+        skills_dir = role.skills_dir or scene_skills_dir or self._config.skills_dir
+        if skills_dir is None:
+            # Task-bundled skills: point the participant at the sandbox path
+            # the task skill policy deployed them to (None when the rollout
+            # runs skill-free).
+            policy = getattr(self, "_task_skill_policy", None)
+            if policy is not None and policy.include_task_skills:
+                skills_dir = policy.sandbox_dir
+        timeout = role.timeout_sec if role.timeout_sec is not None else self._timeout
+        idle_timeout = (
+            role.idle_timeout_sec
+            if role.idle_timeout_sec is not None
+            else self._config.agent_idle_timeout
+        )
+        return A2AParticipantRequest(
+            endpoint_url=role.endpoint_url,
+            role_name=role.name,
+            prompt="\n\n".join(prompts),
+            workspace=self._agent_cwd,
+            skills_dir=str(skills_dir) if skills_dir else None,
+            timeout_sec=timeout,
+            idle_timeout_sec=idle_timeout,
+            metadata={
+                "task_name": self._config.task_path.name,
+                "rollout_name": self._rollout_name,
+                "scene": scene_name,
+                "role": role.name,
+                "transport": role.transport,
+            },
+        )
+
+    async def _execute_a2a_turn(
+        self,
+        role: Role,
+        prompts: list[str],
+        *,
+        scene_name: str,
+        scene_skills_dir: str | Path | None = None,
+    ) -> None:
+        """Execute one role turn through the AgentBeats A2A participant adapter."""
+        from benchflow.agents.a2a import A2AParticipantResult, A2ATrajectoryEvent
+
+        adapter = self._get_a2a_adapter()
+        request = self._a2a_request_for_role(
+            role, prompts, scene_name=scene_name, scene_skills_dir=scene_skills_dir
+        )
+        timeout = request.timeout_sec if request.timeout_sec is not None else None
+        t0 = datetime.now()
+        handle = await adapter.start(request)
+        self._append_a2a_event(
+            role,
+            scene_name,
+            handle.task_id,
+            A2ATrajectoryEvent(
+                kind="task_update",
+                payload={
+                    "status": "started",
+                    "endpoint_url": request.endpoint_url,
+                    "workspace": request.workspace,
+                    "skills_dir": request.skills_dir,
+                },
+            ),
+        )
+        try:
+            result = await asyncio.wait_for(adapter.wait(handle), timeout=timeout)
+        except TimeoutError:
+            await adapter.cancel(handle, "timeout")
+            result = A2AParticipantResult(
+                status="timeout",
+                trajectory=(
+                    A2ATrajectoryEvent(
+                        kind="error",
+                        payload={
+                            "error_type": "a2a_timeout",
+                            "timeout_sec": timeout,
+                        },
+                    ),
+                ),
+                error_type="a2a_timeout",
+            )
+
+        for event in result.trajectory:
+            self._append_a2a_event(role, scene_name, handle.task_id, event)
+        self._append_a2a_event(
+            role,
+            scene_name,
+            handle.task_id,
+            A2ATrajectoryEvent(
+                kind="task_update",
+                payload={"status": result.status, "error_type": result.error_type},
+            ),
+        )
+        await self._materialize_a2a_files(role, scene_name, handle.task_id, result)
+        self._persist_a2a_artifacts(role, scene_name, handle.task_id, result)
+        if result.final_response is not None:
+            self._append_a2a_event(
+                role,
+                scene_name,
+                handle.task_id,
+                A2ATrajectoryEvent(
+                    kind="final_response",
+                    payload=dict(result.final_response),
+                ),
+            )
+
+        if result.status != "completed":
+            self._error = result.error_type or f"a2a_{result.status}"
+        self._agent_name = role.agent or role.name
+        self._trajectory_source = (
+            "a2a" if self._trajectory_source is None else self._trajectory_source
+        )
+        if "agent_execution" not in self._timing:
+            self._timing["agent_execution"] = (datetime.now() - t0).total_seconds()
+        self._phase = "executed"
+
+    def _append_a2a_event(
+        self,
+        role: Role,
+        scene_name: str,
+        task_id: str,
+        event: Any,
+    ) -> None:
+        payload = dict(getattr(event, "payload", {}) or {})
+        self._trajectory.append(
+            {
+                "protocol": "a2a",
+                "type": getattr(event, "kind", "task_update"),
+                "timestamp": getattr(event, "timestamp", None),
+                "task_id": task_id,
+                "scene": scene_name,
+                "role": role.name,
+                "participant": role.agent,
+                "payload": payload,
+            }
+        )
+
+    def _persist_a2a_artifacts(
+        self,
+        role: Role,
+        scene_name: str,
+        task_id: str,
+        result: Any,
+    ) -> None:
+        if not result.artifacts:
+            return
+        rollout_dir = self._require_rollout_dir()
+        artifact_dir = rollout_dir / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        for artifact in result.artifacts:
+            data = {
+                **asdict(artifact),
+                "protocol": "a2a",
+                "task_id": task_id,
+                "scene": scene_name,
+                "role": role.name,
+            }
+            self._a2a_artifacts.append(data)
+        self._write_a2a_artifact_manifest()
+
+    async def _materialize_a2a_files(
+        self,
+        role: Role,
+        scene_name: str,
+        task_id: str,
+        result: Any,
+    ) -> None:
+        file_specs = list(self._iter_a2a_file_specs(result.final_response))
+        if not file_specs:
+            return
+        artifact_dir = self._require_rollout_dir() / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        for index, spec in enumerate(file_specs):
+            raw_path = spec.get("path") or spec.get("name")
+            if not isinstance(raw_path, str) or not raw_path.strip():
+                raise ValueError("A2A file artifact requires a non-empty path")
+            remote_path = self._normalize_a2a_output_path(raw_path)
+            content = spec.get("content", "")
+            if not isinstance(content, str):
+                content = json.dumps(content, indent=2, sort_keys=True)
+            await self._upload_a2a_file(remote_path, content)
+            self._a2a_artifacts.append(
+                {
+                    "name": spec.get("name") or posixpath.basename(remote_path),
+                    "uri": f"sandbox://{remote_path}",
+                    "media_type": spec.get("media_type") or "text/plain",
+                    "digest": spec.get("digest"),
+                    "protocol": "a2a",
+                    "task_id": task_id,
+                    "scene": scene_name,
+                    "role": role.name,
+                    "materialized": True,
+                    "index": index,
+                }
+            )
+        self._write_a2a_artifact_manifest()
+
+    def _iter_a2a_file_specs(self, value: Any):
+        if isinstance(value, dict):
+            files = value.get("files")
+            if isinstance(files, list):
+                for item in files:
+                    if isinstance(item, dict):
+                        yield item
+            for key in ("data", "artifacts", "parts", "root"):
+                if key in value:
+                    yield from self._iter_a2a_file_specs(value[key])
+        elif isinstance(value, list):
+            for item in value:
+                yield from self._iter_a2a_file_specs(item)
+
+    def _normalize_a2a_output_path(self, path: str) -> str:
+        workspace = posixpath.normpath(self._agent_cwd or "/app")
+        candidate = (
+            posixpath.normpath(posixpath.join(workspace, path))
+            if not path.startswith("/")
+            else posixpath.normpath(path)
+        )
+        if candidate != workspace and not candidate.startswith(f"{workspace}/"):
+            raise ValueError(
+                "A2A materialized files must stay under the rollout workspace"
+            )
+        return candidate
+
+    async def _upload_a2a_file(self, remote_path: str, content: str) -> None:
+        parent = shlex.quote(posixpath.dirname(remote_path))
+        await self._env.exec(f"mkdir -p {parent}", user="root", timeout_sec=10)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".a2a", delete=False) as f:
+            f.write(content)
+            tmp_path = f.name
+        try:
+            await self._env.upload_file(tmp_path, remote_path)
+        finally:
+            with contextlib.suppress(FileNotFoundError):
+                os.unlink(tmp_path)
+        if self._config.sandbox_user:
+            user = shlex.quote(self._config.sandbox_user)
+            await self._env.exec(
+                f"chown {user}:{user} {shlex.quote(remote_path)}",
+                user="root",
+                timeout_sec=10,
+            )
+
+    def _write_a2a_artifact_manifest(self) -> None:
+        if not self._a2a_artifacts:
+            return
+        artifact_dir = self._require_rollout_dir() / "artifacts"
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        (artifact_dir / "a2a_artifacts.json").write_text(
+            json.dumps(self._a2a_artifacts, indent=2, default=str)
+        )
+
     async def _run_steps(self, steps: list[Step]) -> None:
         """Execute already-compiled rollout Steps in declaration order."""
         current_role_key: tuple[Any, ...] | None = None
@@ -2515,6 +2886,20 @@ class Rollout:
                     role.name,
                 )
                 await self._activate_step_skills(step)
+                if _is_a2a_role(role):
+                    # A2A participants are external endpoints: no ACP process
+                    # to connect to. Tear down any live ACP session first so
+                    # the participant sees the agent's finished workspace.
+                    if current_role_key is not None:
+                        await self.disconnect()
+                        current_role_key = None
+                    await self._execute_a2a_turn(
+                        role,
+                        [scene_step_prompt(step)],
+                        scene_name=str(step.data.get("scene") or "scene"),
+                        scene_skills_dir=scene_step_skills_dir(step),
+                    )
+                    continue
                 if current_role_key != role_key:
                     if current_role_key is not None:
                         await self.disconnect()
@@ -2671,6 +3056,8 @@ class Rollout:
         from the primary agent (which was set up in install_agent()).
         Updates _agent_launch so disconnect() kills the correct process.
         """
+        if _is_a2a_role(role):
+            raise RuntimeError("A2A roles must execute through _execute_a2a_turn()")
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
         t0 = datetime.now()

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -746,7 +746,7 @@ class DockerSandbox(BaseSandbox):
         user = self._resolve_user(user)
         env = self._merge_env(env)
 
-        exec_command: list[str] = ["exec"]
+        exec_command: list[str] = ["exec", "-T"]
 
         if cwd:
             exec_command.extend(["-w", cwd])

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -436,10 +436,11 @@ class DockerSandbox(BaseSandbox):
                     ["stop", "-t", "5"], timeout_sec=90
                 )
             elif delete:
-                # Prebuilt images are shared across rollouts; only remove
-                # images that this sandbox built itself.
-                down_command = ["down", "--volumes", "--remove-orphans", "-t", "5"]
-                if not self._use_prebuilt:
+                if _env_flag_enabled("BENCHFLOW_DOCKER_SAFE_CLEANUP", default=False):
+                    # Shared-runtime mode: leave images and volumes in place,
+                    # only remove this rollout's containers.
+                    down_command = ["down", "--remove-orphans", "-t", "5"]
+                elif not self._use_prebuilt:
                     down_command = [
                         "down",
                         "--rmi",
@@ -449,6 +450,10 @@ class DockerSandbox(BaseSandbox):
                         "-t",
                         "5",
                     ]
+                else:
+                    # Prebuilt images are shared across rollouts; only remove
+                    # images that this sandbox built itself.
+                    down_command = ["down", "--volumes", "--remove-orphans", "-t", "5"]
                 await self._run_docker_compose_command(down_command, timeout_sec=120)
             else:
                 await self._run_docker_compose_command(

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import uuid
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from pydantic import BaseModel
 
@@ -50,6 +50,16 @@ _DOCKER_BUILD_RETRYABLE_ERRORS = (
     re.compile(r"read timed out", re.IGNORECASE),
     re.compile(r"connection (?:timed out|reset by peer)", re.IGNORECASE),
 )
+
+
+_FALSE_ENV_VALUES = {"0", "false", "no", "off"}
+
+
+def _env_flag_enabled(name: str, *, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() not in _FALSE_ENV_VALUES
 
 
 def _sanitize_docker_image_name(name: str) -> str:
@@ -145,8 +155,8 @@ class DockerSandbox(BaseSandbox):
         task_env_config: SandboxConfig,
         keep_containers: bool = False,
         mounts_json: list[dict[str, str]] | None = None,
-        *args: object,
-        **kwargs: object,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             environment_dir=environment_dir,
@@ -216,7 +226,7 @@ class DockerSandbox(BaseSandbox):
 
     @property
     def is_mounted(self) -> bool:
-        return True
+        return _env_flag_enabled("BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED", default=True)
 
     @property
     def _dockerfile_path(self) -> Path:
@@ -426,8 +436,11 @@ class DockerSandbox(BaseSandbox):
                     ["stop", "-t", "5"], timeout_sec=90
                 )
             elif delete:
-                await self._run_docker_compose_command(
-                    [
+                # Prebuilt images are shared across rollouts; only remove
+                # images that this sandbox built itself.
+                down_command = ["down", "--volumes", "--remove-orphans", "-t", "5"]
+                if not self._use_prebuilt:
+                    down_command = [
                         "down",
                         "--rmi",
                         "all",
@@ -435,9 +448,8 @@ class DockerSandbox(BaseSandbox):
                         "--remove-orphans",
                         "-t",
                         "5",
-                    ],
-                    timeout_sec=120,
-                )
+                    ]
+                await self._run_docker_compose_command(down_command, timeout_sec=120)
             else:
                 await self._run_docker_compose_command(
                     ["down", "-t", "5"], timeout_sec=90

--- a/tests/test_a2a_participant_adapter_contract.py
+++ b/tests/test_a2a_participant_adapter_contract.py
@@ -1,0 +1,370 @@
+"""Contract tests and pending runtime tests for AgentBeats A2A participants."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.agents.a2a import (
+    A2AArtifactRef,
+    A2AParticipantRequest,
+    A2AParticipantResult,
+    A2ATaskHandle,
+    A2ATrajectoryEvent,
+)
+from benchflow.rollout import Role, Rollout, RolloutConfig, Scene, Turn
+from benchflow.scenes import compile_scenes_to_steps
+from benchflow.skill_policy import resolve_task_skill_policy
+
+
+@dataclass
+class FakeExecResult:
+    stdout: str = ""
+    stderr: str = ""
+    return_code: int = 0
+
+
+class FakeEnv:
+    def __init__(self) -> None:
+        self.exec_log: list[str] = []
+        self.uploads: dict[str, str] = {}
+
+    async def exec(self, cmd: str, **kwargs: Any) -> FakeExecResult:
+        self.exec_log.append(cmd)
+        return FakeExecResult()
+
+    async def upload_file(self, src: str | Path, dst: str) -> None:
+        self.uploads[dst] = Path(src).read_text()
+
+
+@dataclass
+class FakeRolloutPaths:
+    verifier_dir: Path
+
+
+class FakeA2AAdapter:
+    def __init__(
+        self,
+        result: A2AParticipantResult | None = None,
+        *,
+        block_wait: bool = False,
+    ) -> None:
+        self.result = result or A2AParticipantResult(status="completed")
+        self.block_wait = block_wait
+        self.requests: list[A2AParticipantRequest] = []
+        self.waited: list[A2ATaskHandle] = []
+        self.cancelled: list[tuple[A2ATaskHandle, str]] = []
+
+    async def start(self, request: A2AParticipantRequest) -> A2ATaskHandle:
+        self.requests.append(request)
+        return A2ATaskHandle(
+            task_id=f"a2a-task-{len(self.requests)}",
+            endpoint_url=request.endpoint_url,
+            role_name=request.role_name,
+        )
+
+    async def wait(self, handle: A2ATaskHandle) -> A2AParticipantResult:
+        self.waited.append(handle)
+        if self.block_wait:
+            await asyncio.sleep(60)
+        return self.result
+
+    async def cancel(self, handle: A2ATaskHandle, reason: str) -> None:
+        self.cancelled.append((handle, reason))
+
+
+def _a2a_role(**overrides: Any) -> Role:
+    data: dict[str, Any] = {
+        "name": "agent",
+        "agent": "registered-purple-agent",
+        "transport": "a2a",
+        "endpoint_url": "http://purple.example/a2a",
+    }
+    data.update(overrides)
+    return Role(**data)
+
+
+def _make_rollout(
+    tmp_path: Path,
+    adapter: FakeA2AAdapter,
+    scene: Scene,
+) -> Rollout:
+    task_path = tmp_path / "tasks" / "citation-check"
+    task_path.mkdir(parents=True)
+    (task_path / "instruction.md").write_text("Solve the task.")
+    rollout_dir = tmp_path / "jobs" / "run" / "trial"
+    (rollout_dir / "artifacts").mkdir(parents=True)
+    (rollout_dir / "trajectory").mkdir(parents=True)
+
+    trial = Rollout(
+        RolloutConfig(
+            task_path=task_path,
+            scenes=[scene],
+            a2a_adapter=adapter,
+        )
+    )
+    trial._env = FakeEnv()
+    trial._rollout_dir = rollout_dir
+    trial._rollout_paths = FakeRolloutPaths(verifier_dir=rollout_dir / "verifier")
+    trial._rollout_name = "trial"
+    trial._started_at = datetime.now()
+    trial._agent_cwd = "/app"
+    trial._timeout = 5
+    trial._task = object()
+    trial._resolved_prompts = ["Solve the task."]
+    return trial
+
+
+def test_a2a_contract_result_done_statuses() -> None:
+    assert A2AParticipantResult(status="running").done is False
+    for status in ("completed", "failed", "cancelled", "timeout"):
+        assert A2AParticipantResult(status=status).done is True
+
+
+def test_a2a_contract_carries_endpoint_visible_prompt_and_redactable_refs() -> None:
+    request = A2AParticipantRequest(
+        endpoint_url="https://purple.example/a2a",
+        role_name="agent",
+        prompt="Solve the task visible in /app.",
+        skills_dir="/skills",
+        timeout_sec=300,
+        metadata={"task_id": "citation-check", "condition": "with_skills"},
+    )
+    handle = A2ATaskHandle(
+        task_id="a2a-task-1",
+        endpoint_url=request.endpoint_url,
+        role_name=request.role_name,
+    )
+    result = A2AParticipantResult(
+        status="completed",
+        trajectory=(
+            A2ATrajectoryEvent(kind="task_update", payload={"state": "working"}),
+            A2ATrajectoryEvent(kind="final_response", payload={"ok": True}),
+        ),
+        artifacts=(
+            A2AArtifactRef(
+                name="answer",
+                uri="benchflow-private://rollout/artifacts/answer.json",
+                media_type="application/json",
+                digest="sha256:abc123",
+            ),
+        ),
+        final_response={"done": True},
+    )
+
+    assert handle.endpoint_url == "https://purple.example/a2a"
+    assert request.skills_dir == "/skills"
+    assert result.status == "completed"
+    assert result.artifacts[0].uri.startswith("benchflow-private://")
+
+
+async def test_a2a_endpoint_role_skips_acp_install_and_invokes_endpoint(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            trajectory=(
+                A2ATrajectoryEvent(
+                    kind="task_update",
+                    payload={"state": "completed"},
+                ),
+            ),
+            final_response={"message": "done"},
+        )
+    )
+    scene = Scene(
+        roles=[_a2a_role()],
+        turns=[Turn("agent", "Solve visible workspace task.")],
+    )
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    async def fail_acp(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("A2A roles must not use ACP execution")
+
+    trial.connect_as = fail_acp  # type: ignore[method-assign]
+    trial.execute = fail_acp  # type: ignore[method-assign]
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert len(adapter.requests) == 1
+    request = adapter.requests[0]
+    assert request.endpoint_url == "http://purple.example/a2a"
+    assert request.prompt == "Solve visible workspace task."
+    # Default config runs skill-free: the participant gets no skills path.
+    assert request.skills_dir is None
+    assert adapter.waited[0].role_name == "agent"
+
+
+async def test_a2a_request_points_at_task_skill_policy_sandbox_dir(
+    tmp_path: Path,
+) -> None:
+    """When task skills are deployed, the A2A request carries their sandbox path."""
+    adapter = FakeA2AAdapter()
+    scene = Scene(
+        roles=[_a2a_role()],
+        turns=[Turn("agent", "Solve visible workspace task.")],
+    )
+    trial = _make_rollout(tmp_path, adapter, scene)
+    skills_dir = trial._config.task_path / "environment" / "skills" / "demo"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("# demo skill")
+    trial._task_skill_policy = resolve_task_skill_policy(
+        task_path=trial._config.task_path,
+        skill_mode="with-skill",
+        runtime_skills_dir=None,
+        declared_sandbox_skills_dir=None,
+    )
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert adapter.requests[0].skills_dir == "/skills"
+
+
+async def test_a2a_timeout_cancels_task_and_records_timeout_result(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(block_wait=True)
+    scene = Scene(
+        roles=[_a2a_role(timeout_sec=0)],
+        turns=[Turn("agent", "Solve visible workspace task.")],
+    )
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert adapter.cancelled
+    assert adapter.cancelled[0][1] == "timeout"
+    assert trial._error == "a2a_timeout"
+    assert any(
+        event["payload"].get("error_type") == "a2a_timeout"
+        for event in trial.trajectory
+    )
+
+
+async def test_a2a_artifacts_are_persisted_before_verifier_handoff(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            artifacts=(
+                A2AArtifactRef(
+                    name="answer",
+                    uri="a2a://task/artifacts/0",
+                    media_type="application/json",
+                    digest="sha256:abc",
+                ),
+            ),
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    artifact_path = trial._rollout_dir / "artifacts" / "a2a_artifacts.json"
+    artifacts = json.loads(artifact_path.read_text())
+    assert artifacts == [
+        {
+            "name": "answer",
+            "uri": "a2a://task/artifacts/0",
+            "media_type": "application/json",
+            "digest": "sha256:abc",
+            "protocol": "a2a",
+            "task_id": "a2a-task-1",
+            "scene": "default",
+            "role": "agent",
+        }
+    ]
+
+
+async def test_a2a_file_artifacts_are_materialized_under_workspace(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            final_response={
+                "files": [
+                    {
+                        "path": "reports/answer.txt",
+                        "content": "materialized answer",
+                        "media_type": "text/plain",
+                    }
+                ]
+            },
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert trial._env.uploads["/app/reports/answer.txt"] == "materialized answer"
+    artifact_path = trial._rollout_dir / "artifacts" / "a2a_artifacts.json"
+    artifacts = json.loads(artifact_path.read_text())
+    assert artifacts[0]["uri"] == "sandbox:///app/reports/answer.txt"
+    assert artifacts[0]["materialized"] is True
+
+
+async def test_a2a_successful_done_signal_runs_existing_verifier(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            trajectory=(A2ATrajectoryEvent(kind="task_update", payload={}),),
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+    calls: dict[str, Any] = {}
+
+    async def fake_verify_rollout(*args: Any, **kwargs: Any):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return {"reward": 1.0}, None, None
+
+    monkeypatch.setattr("benchflow.rollout._verify_rollout", fake_verify_rollout)
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+    rewards = await trial.verify()
+
+    assert rewards == {"reward": 1.0}
+    assert calls["kwargs"]["workspace"] == "/app"
+    assert "/logs/agent/a2a_trajectory.jsonl" in trial._env.uploads
+
+
+async def test_a2a_updates_are_written_to_a2a_trajectory_jsonl(
+    tmp_path: Path,
+) -> None:
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            trajectory=(
+                A2ATrajectoryEvent(
+                    kind="task_update",
+                    payload={"state": "working"},
+                ),
+            ),
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+    trial._build_result()
+
+    trajectory_path = trial._rollout_dir / "trajectory" / "a2a_trajectory.jsonl"
+    assert trajectory_path.exists()
+    lines = [json.loads(line) for line in trajectory_path.read_text().splitlines()]
+    assert all(line["protocol"] == "a2a" for line in lines)
+    assert not (trial._rollout_dir / "trajectory" / "acp_trajectory.jsonl").exists()

--- a/tests/test_a2a_participant_adapter_contract.py
+++ b/tests/test_a2a_participant_adapter_contract.py
@@ -352,6 +352,58 @@ async def test_a2a_file_artifacts_are_materialized_under_workspace(
     assert artifacts[0]["materialized"] is True
 
 
+@pytest.mark.parametrize(
+    "malicious_path",
+    [
+        "../../logs/verifier/reward.txt",  # relative traversal out of /app
+        "/logs/verifier/reward.txt",  # absolute path outside the workspace
+        "/application/escape.txt",  # sibling dir sharing the /app prefix
+    ],
+)
+async def test_a2a_file_artifacts_outside_workspace_are_rejected(
+    tmp_path: Path,
+    malicious_path: str,
+) -> None:
+    """Endpoint-supplied paths escaping the workspace must hard-fail.
+
+    final_response files[].path comes from an external (untrusted) A2A
+    endpoint and _upload_a2a_file runs mkdir/upload/chown as root, so a
+    traversal or absolute path here is a reward-forgery seam (e.g. writing
+    /logs/verifier/reward.txt). The containment check must raise before any
+    sandbox command or upload runs.
+    """
+    adapter = FakeA2AAdapter(
+        A2AParticipantResult(
+            status="completed",
+            final_response={"files": [{"path": malicious_path, "content": "forged"}]},
+        )
+    )
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+
+    with pytest.raises(ValueError, match="must stay under the rollout workspace"):
+        await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert trial._env.uploads == {}
+    assert not any("mkdir" in cmd for cmd in trial._env.exec_log)
+
+
+async def test_a2a_turn_accumulates_agent_execution_timing(tmp_path: Path) -> None:
+    """An A2A turn adds to agent_execution instead of only recording the first.
+
+    Matches the ACP execute() accumulation semantics: in multi-turn scenes the
+    reported agent execution time is the sum over turns, not the first turn.
+    """
+    adapter = FakeA2AAdapter()
+    scene = Scene(roles=[_a2a_role()], turns=[Turn("agent", "Solve.")])
+    trial = _make_rollout(tmp_path, adapter, scene)
+    trial._timing["agent_execution"] = 5.0  # a prior turn already recorded time
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert trial._timing["agent_execution"] > 5.0
+
+
 async def test_a2a_successful_done_signal_runs_existing_verifier(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_a2a_participant_adapter_contract.py
+++ b/tests/test_a2a_participant_adapter_contract.py
@@ -202,6 +202,44 @@ async def test_a2a_endpoint_role_skips_acp_install_and_invokes_endpoint(
     assert adapter.waited[0].role_name == "agent"
 
 
+async def test_a2a_step_after_acp_step_tears_down_acp_session(
+    tmp_path: Path,
+) -> None:
+    """Switching from an ACP turn to an A2A turn disconnects the ACP session.
+
+    Guards the Steps-engine dispatch: the A2A turn must run through the
+    participant adapter only, after exactly one ACP disconnect (no trailing
+    disconnect, since no ACP session remains live after the A2A turn).
+    """
+    adapter = FakeA2AAdapter()
+    acp_role = Role(name="coder", agent="claude-agent-acp")
+    scene = Scene(
+        roles=[acp_role, _a2a_role()],
+        turns=[Turn("coder", "Write code."), Turn("agent", "Review the workspace.")],
+    )
+    trial = _make_rollout(tmp_path, adapter, scene)
+    calls: list[str] = []
+
+    async def fake_connect_as(role: Role) -> None:
+        calls.append(f"connect:{role.name}")
+
+    async def fake_execute(prompts: list[str]) -> None:
+        calls.append(f"execute:{prompts[0]}")
+
+    async def fake_disconnect() -> None:
+        calls.append("disconnect")
+
+    trial.connect_as = fake_connect_as  # type: ignore[method-assign]
+    trial.execute = fake_execute  # type: ignore[method-assign]
+    trial.disconnect = fake_disconnect  # type: ignore[method-assign]
+
+    await trial._run_steps(compile_scenes_to_steps([scene]))
+
+    assert calls == ["connect:coder", "execute:Write code.", "disconnect"]
+    assert [request.role_name for request in adapter.requests] == ["agent"]
+    assert adapter.requests[0].prompt == "Review the workspace."
+
+
 async def test_a2a_request_points_at_task_skill_policy_sandbox_dir(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_a2a_participant_client.py
+++ b/tests/test_a2a_participant_client.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+from a2a.server.agent_execution import AgentExecutor, RequestContext
+from a2a.server.apps import A2AStarletteApplication
+from a2a.server.events import EventQueue
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.tasks import InMemoryTaskStore, TaskUpdater
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    DataPart,
+    Message,
+    Part,
+    Role,
+    TaskState,
+    TextPart,
+    UnsupportedOperationError,
+)
+from a2a.utils import new_agent_text_message, new_task
+from a2a.utils.errors import ServerError
+
+from benchflow.agents.a2a import (
+    A2AClientParticipantAdapter,
+    A2AParticipantRequest,
+)
+
+
+@dataclass
+class FakeState:
+    value: str
+
+
+@dataclass
+class FakeStatus:
+    state: FakeState
+
+
+@dataclass
+class FakeArtifact:
+    name: str
+
+    def model_dump(self, *, mode: str = "json") -> dict[str, Any]:
+        return {"name": self.name, "mode": mode}
+
+
+@dataclass
+class FakeTask:
+    state: str
+    artifacts: list[FakeArtifact]
+
+    @property
+    def status(self) -> FakeStatus:
+        return FakeStatus(FakeState(self.state))
+
+    def model_dump(self, *, mode: str = "json") -> dict[str, Any]:
+        return {"status": {"state": self.state}, "mode": mode}
+
+
+class FakeAdapter(A2AClientParticipantAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.seen_request: A2AParticipantRequest | None = None
+        self.seen_message_id: str | None = None
+
+    async def _send_message(
+        self,
+        request: A2AParticipantRequest,
+        *,
+        message_id: str,
+    ) -> AsyncIterator[object]:
+        self.seen_request = request
+        self.seen_message_id = message_id
+        yield Message(
+            kind="message",
+            role=Role.agent,
+            parts=[Part(TextPart(kind="text", text="participant finished"))],
+            message_id="reply-1",
+        )
+        yield (FakeTask("completed", [FakeArtifact("answer")]), None)
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_normalizes_completed_message_flow() -> None:
+    adapter = FakeAdapter()
+    request = A2AParticipantRequest(
+        endpoint_url="http://purple.example/",
+        role_name="agent",
+        prompt="Solve the visible task.",
+        skills_dir="/skills",
+    )
+
+    handle = await adapter.start(request)
+    result = await adapter.wait(handle)
+
+    assert adapter.seen_request == request
+    assert adapter.seen_message_id == handle.task_id
+    assert result.status == "completed"
+    assert result.done is True
+    assert result.final_response is not None
+    assert len(result.trajectory) == 2
+    assert result.artifacts[0].uri == f"a2a://{handle.task_id}/artifacts/0"
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_cancel_before_wait_returns_cancelled() -> None:
+    adapter = FakeAdapter()
+    handle = await adapter.start(
+        A2AParticipantRequest(
+            endpoint_url="http://purple.example/",
+            role_name="agent",
+            prompt="Solve the visible task.",
+        )
+    )
+
+    await adapter.cancel(handle, "outer timeout")
+    result = await adapter.wait(handle)
+
+    assert result.status == "cancelled"
+    assert result.error_type == "cancelled"
+    assert result.trajectory[0].payload["reason"] == "outer timeout"
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_rejects_unknown_handle() -> None:
+    adapter = FakeAdapter()
+    handle = await adapter.start(
+        A2AParticipantRequest(
+            endpoint_url="http://purple.example/",
+            role_name="agent",
+            prompt="Solve the visible task.",
+        )
+    )
+    await adapter.wait(handle)
+
+    with pytest.raises(KeyError):
+        await adapter.wait(handle)
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_adapter_toy_server_smoke() -> None:
+    app = _build_toy_a2a_app("http://toy.local/")
+
+    def client_factory(timeout_sec: int) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://toy.local",
+            timeout=timeout_sec,
+        )
+
+    adapter = A2AClientParticipantAdapter(httpx_client_factory=client_factory)
+    handle = await adapter.start(
+        A2AParticipantRequest(
+            endpoint_url="http://toy.local/",
+            role_name="agent",
+            prompt="Solve the visible toy task.",
+        )
+    )
+
+    result = await adapter.wait(handle)
+
+    assert result.status == "completed"
+    assert result.done is True
+    assert result.final_response is not None
+    assert result.artifacts
+    assert any(event.kind == "task_update" for event in result.trajectory)
+
+
+class ToyExecutor(AgentExecutor):
+    async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
+        message = context.message
+        if message is None:
+            return
+        task = new_task(message)
+        await event_queue.enqueue_event(task)
+        updater = TaskUpdater(event_queue, task.id, task.context_id)
+        await updater.update_status(
+            TaskState.working,
+            new_agent_text_message(
+                "Solving toy task.",
+                context_id=context.context_id,
+            ),
+        )
+        await updater.add_artifact(
+            parts=[
+                Part(root=TextPart(text="toy result")),
+                Part(root=DataPart(data={"echo": context.get_user_input()})),
+            ],
+            name="answer",
+        )
+        await updater.complete()
+
+    async def cancel(self, request: RequestContext, event_queue: EventQueue) -> None:
+        raise ServerError(error=UnsupportedOperationError())
+
+
+def _build_toy_a2a_app(card_url: str) -> Any:
+    request_handler = DefaultRequestHandler(
+        agent_executor=ToyExecutor(),
+        task_store=InMemoryTaskStore(),
+    )
+    server = A2AStarletteApplication(
+        agent_card=AgentCard(
+            name="Toy Purple Agent",
+            description="Toy A2A participant for BenchFlow smoke tests.",
+            url=card_url,
+            version="0.1.0",
+            default_input_modes=["text"],
+            default_output_modes=["text"],
+            capabilities=AgentCapabilities(streaming=True),
+            skills=[
+                AgentSkill(
+                    id="toy-solve",
+                    name="Toy Solve",
+                    description="Return a toy artifact.",
+                    tags=["test"],
+                )
+            ],
+        ),
+        http_handler=request_handler,
+    )
+    return server.build()

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -3,7 +3,40 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from benchflow.sandbox._base import ExecResult
 from benchflow.sandbox.docker import DockerSandbox
+
+
+def test_docker_logs_mount_fast_path_enabled_by_default(monkeypatch) -> None:
+    monkeypatch.delenv("BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED", raising=False)
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+
+    assert sandbox.is_mounted is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", "False", "no", "off"])
+def test_docker_logs_mount_fast_path_can_be_disabled(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("BENCHFLOW_DOCKER_LOGS_HOST_MOUNTED", value)
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+
+    assert sandbox.is_mounted is False
+
+
+@pytest.mark.asyncio
+async def test_prebuilt_stop_does_not_remove_images() -> None:
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._keep_containers = False
+    sandbox._use_prebuilt = True
+    sandbox._chown_to_host_user = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock(
+        return_value=ExecResult(stdout="", stderr=None, return_code=0)
+    )
+
+    await sandbox.stop(delete=True)
+
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["down", "--volumes", "--remove-orphans", "-t", "5"], timeout_sec=120
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -40,6 +40,26 @@ async def test_prebuilt_stop_does_not_remove_images() -> None:
 
 
 @pytest.mark.asyncio
+async def test_self_built_delete_removes_images_and_volumes(monkeypatch) -> None:
+    """Self-built images are torn down fully when safe-cleanup is off."""
+    monkeypatch.delenv("BENCHFLOW_DOCKER_SAFE_CLEANUP", raising=False)
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._keep_containers = False
+    sandbox._use_prebuilt = False
+    sandbox._chown_to_host_user = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock(
+        return_value=ExecResult(stdout="", stderr=None, return_code=0)
+    )
+
+    await sandbox.stop(delete=True)
+
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["down", "--rmi", "all", "--volumes", "--remove-orphans", "-t", "5"],
+        timeout_sec=120,
+    )
+
+
+@pytest.mark.asyncio
 async def test_agentbeats_safe_cleanup_skips_image_and_volume_removal(
     monkeypatch,
 ) -> None:

--- a/tests/test_docker_uploads.py
+++ b/tests/test_docker_uploads.py
@@ -40,6 +40,26 @@ async def test_prebuilt_stop_does_not_remove_images() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agentbeats_safe_cleanup_skips_image_and_volume_removal(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("BENCHFLOW_DOCKER_SAFE_CLEANUP", "true")
+    sandbox = DockerSandbox.__new__(DockerSandbox)
+    sandbox._keep_containers = False
+    sandbox._use_prebuilt = False
+    sandbox._chown_to_host_user = AsyncMock()
+    sandbox._run_docker_compose_command = AsyncMock(
+        return_value=ExecResult(stdout="", stderr=None, return_code=0)
+    )
+
+    await sandbox.stop(delete=True)
+
+    sandbox._run_docker_compose_command.assert_awaited_once_with(
+        ["down", "--remove-orphans", "-t", "5"], timeout_sec=120
+    )
+
+
+@pytest.mark.asyncio
 async def test_docker_upload_dir_creates_target_before_compose_cp() -> None:
     """Guards the v0.5 edit-pdf Docker failure where /app did not exist."""
     sandbox = DockerSandbox.__new__(DockerSandbox)

--- a/tests/test_sandbox_multi_service.py
+++ b/tests/test_sandbox_multi_service.py
@@ -45,7 +45,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec("echo hi")
 
-        assert captured[0] == ["exec", "main", "sh", "-c", "echo hi"]
+        assert captured[0] == ["exec", "-T", "main", "sh", "-c", "echo hi"]
 
     @pytest.mark.asyncio
     async def test_exec_targets_named_service(self) -> None:
@@ -60,7 +60,14 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec("test -f /tmp/pwned", service="target")
 
-        assert captured[0] == ["exec", "target", "sh", "-c", "test -f /tmp/pwned"]
+        assert captured[0] == [
+            "exec",
+            "-T",
+            "target",
+            "sh",
+            "-c",
+            "test -f /tmp/pwned",
+        ]
 
     @pytest.mark.asyncio
     async def test_exec_in_service_wrapper(self) -> None:
@@ -75,7 +82,7 @@ class TestDockerSandboxServiceExec:
         sandbox._run_docker_compose_command = fake_run  # type: ignore[method-assign]
         await sandbox.exec_in_service("db", "mysql -e 'SELECT 1'")
 
-        assert captured[0] == ["exec", "db", "sh", "-c", "mysql -e 'SELECT 1'"]
+        assert captured[0] == ["exec", "-T", "db", "sh", "-c", "mysql -e 'SELECT 1'"]
 
     @pytest.mark.asyncio
     async def test_exec_service_with_user_and_cwd(self) -> None:

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -488,6 +488,8 @@ class TestWriteConfig:
                         "idle_timeout_sec": 3,
                         "skills_dir": "/role-skills",
                         "capabilities": ["tool-use"],
+                        "transport": "acp",
+                        "endpoint_url": None,
                         "env_keys": ["ROLE_TOKEN"],
                     }
                 ],

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -239,6 +239,53 @@ def test_rollout_yaml_reasoning_effort_reaches_primary_role():
     assert cfg.primary_reasoning_effort == "max"
 
 
+def test_rollout_yaml_scene_role_parses_transport_and_runtime_keys():
+    """Pins _parse_role wiring for A2A transport plus newly honored role keys.
+
+    transport/endpoint_url arrived with the A2A participant adapter. The same
+    change also made the loader honor timeout_sec, idle_timeout_sec,
+    skills_dir, and capabilities, which were previously ignored on role
+    dicts — a behavior change for existing YAML files that already carried
+    them, so pin all six keys here.
+    """
+    from benchflow._utils.yaml_loader import rollout_config_from_dict
+
+    cfg = rollout_config_from_dict(
+        {
+            "task_dir": "tests/examples/hello-world-task",
+            "scenes": [
+                {
+                    "roles": [
+                        {
+                            "name": "participant",
+                            "agent": "external-participant",
+                            "transport": "a2a",
+                            "endpoint_url": "http://participant.example/a2a",
+                            "timeout_sec": 120,
+                            "idle_timeout_sec": 30,
+                            "skills_dir": "/skills/demo",
+                            "capabilities": ["tool-use"],
+                        },
+                        {"name": "coder", "agent": "claude-agent-acp"},
+                    ],
+                    "turns": [{"role": "participant", "prompt": "Review."}],
+                }
+            ],
+        }
+    )
+
+    role = cfg.scenes[0].roles[0]
+    assert role.transport == "a2a"
+    assert role.endpoint_url == "http://participant.example/a2a"
+    assert role.timeout_sec == 120
+    assert role.idle_timeout_sec == 30
+    assert role.skills_dir == "/skills/demo"
+    assert role.capabilities == ["tool-use"]
+    acp_role = cfg.scenes[0].roles[1]
+    assert acp_role.transport == "acp"
+    assert acp_role.endpoint_url is None
+
+
 def test_native_yaml_rejects_bool_agent_idle_timeout(tmp_path):
     """Guards v0.5-idle-timeout@1566fed against bool-to-int coercion."""
     tasks = tmp_path / "tasks" / "task-a"

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,31 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version == '3.13.*'",
+    "python_full_version < '3.13'",
+]
+
+[[package]]
+name = "a2a-sdk"
+version = "0.3.20"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/c1/4c7968e44a318fbfaf82e142b2f63aedcf62ca8da5ee0cea6104a1a29580/a2a_sdk-0.3.20.tar.gz", hash = "sha256:f05bbdf4a8ada6be81dc7e7c73da3add767b20065195d94e8eb6d671d7ea658a", size = 229272, upload-time = "2025-12-03T15:48:22.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/33/719a9331421ee5df0338505548b58b4129a6aca82bba5c8e0593ac8864c7/a2a_sdk-0.3.20-py3-none-any.whl", hash = "sha256:35da261aae28fd22440b61f8eb16a8343b60809e1f7ef028a06d01f17b48a8b9", size = 141547, upload-time = "2025-12-03T15:48:20.812Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
 ]
 
 [[package]]
@@ -291,6 +315,7 @@ name = "benchflow"
 version = "0.5.3.dev0"
 source = { editable = "." }
 dependencies = [
+    { name = "a2a-sdk" },
     { name = "agent-client-protocol" },
     { name = "anyio" },
     { name = "httpx" },
@@ -328,8 +353,14 @@ sandbox-modal = [
     { name = "tenacity" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "a2a-sdk", extra = ["http-server"] },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", specifier = "==0.3.20" },
     { name = "agent-client-protocol", specifier = ">=0.10" },
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
     { name = "anyio", specifier = ">=4.0" },
@@ -355,6 +386,9 @@ requires-dist = [
     { name = "typer", specifier = ">=0.9" },
 ]
 provides-extras = ["dev", "sandbox-daytona", "sandbox-modal", "bedrock", "judge"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "a2a-sdk", extras = ["http-server"], specifier = "==0.3.20" }]
 
 [[package]]
 name = "boto3"
@@ -990,6 +1024,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
 ]
 
 [[package]]
@@ -2259,6 +2309,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
     { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
     { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
+]
+
+[[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
A clean-base port of the AgentBeats Agent-to-Agent adapter work from #345 by @Yiminnn — all original commits cherry-picked with authorship preserved (`-x` provenance trailers), re-ported from the retired `_run_scene` loop onto the current compiled-Steps engine and three-way Docker teardown.

On top of the port: workspace-containment regression tests (mutation-verified — traversal/absolute/shared-prefix paths all rejected), per-turn `agent_execution` timing accumulation matching ACP semantics, role-parse pins for the now-honored `timeout_sec`/`idle_timeout_sec`/`skills_dir`/`capabilities` keys, and honest docstrings for the non-interactive task-status mapping. Full suite green (2,829 passed).

This does NOT close #345 — it exists because #345 conflicts with the current base, and lands only with @Yiminnn's review/sign-off.