### PR TITLE
feat(trajectories): emit ATIF and ADP from every scored rollout

### DIFF
--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -1459,6 +1459,12 @@ class Evaluation:
             write_job_verifiers_jsonl(job_dir)
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("Job-level trainer artifact aggregation failed: %s", e)
+        try:
+            from benchflow.trajectories.export_adp import write_job_adp_jsonl
+
+            write_job_adp_jsonl(job_dir)
+        except Exception as e:  # pragma: no cover - defensive
+            logger.warning("Job-level ADP aggregation failed: %s", e)
 
         # Per-diagnostic summary warnings — driven by the registry so a
         # new diagnostic class adds its warning automatically (issue #503).

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -834,6 +834,8 @@ def _build_rollout_result(
     _write_trainer_artifact(
         rollout_dir,
         task_name=task_name,
+        rollout_name=rollout_name,
+        agent_name=agent_name or agent,
         prompts=prompts,
         trajectory=trajectory,
         rewards=rewards,
@@ -847,21 +849,34 @@ def _write_trainer_artifact(
     rollout_dir: Path,
     *,
     task_name: str,
+    rollout_name: str,
+    agent_name: str,
     prompts: list[str],
     trajectory: list[dict],
     rewards: dict | None,
     model: str | None,
     verifier_error: str | None,
 ) -> None:
-    """Emit ``rollout_dir/trainer/verifiers.jsonl`` for this scored rollout.
+    """Emit the trainer-format artifacts for this scored rollout.
 
     The architecture's train-mode seam (issue #385): every scored rollout
-    that reaches result-building should produce a trainer-ready Verifiers /
-    ORS record so prime-rl / Verifiers can ingest the run directly. Failures
-    here are logged but never block result writing.
+    that reaches result-building produces a trainer-ready Verifiers / ORS
+    record (``trainer/verifiers.jsonl``) plus the ecosystem trajectory
+    formats — ATIF (``trainer/atif.json``; omitted for empty trajectories,
+    which the schema forbids) and ADP (``trainer/adp.jsonl``). Each format
+    is written independently; failures are logged but never block result
+    writing or each other.
     """
     from benchflow.trajectories.export import write_rollout_verifiers_jsonl
+    from benchflow.trajectories.export_adp import write_rollout_adp_jsonl
+    from benchflow.trajectories.export_atif import write_rollout_atif_json
 
+    # Real rollout names already embed the task (``<task>__<hash>``); only
+    # prefix when they don't, so ids stay unique without doubling the task.
+    if rollout_name.startswith(f"{task_name}__"):
+        trajectory_id = rollout_name
+    else:
+        trajectory_id = f"{task_name}__{rollout_name}"
     try:
         write_rollout_verifiers_jsonl(
             rollout_dir,
@@ -875,6 +890,30 @@ def _write_trainer_artifact(
         )
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("Trainer artifact write failed: %s", e)
+    try:
+        write_rollout_atif_json(
+            rollout_dir,
+            session_id=trajectory_id,
+            agent_name=agent_name,
+            prompts=prompts,
+            trajectory=trajectory,
+            model=model,
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("ATIF artifact write failed: %s", e)
+    try:
+        write_rollout_adp_jsonl(
+            rollout_dir,
+            trajectory_id=trajectory_id,
+            task_id=task_name,
+            prompts=prompts,
+            trajectory=trajectory,
+            model=model,
+            environment=task_name,
+            reward=(rewards or {}).get("reward"),
+        )
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("ADP artifact write failed: %s", e)
 
 
 def _resolve_prompts(

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -326,3 +326,84 @@ def test_build_rollout_result_emits_trainer_artifact(tmp_path):
     assert parsed["reward"] == 1.0
     assert parsed["info"]["task_id"] == "archive-alice"
     assert parsed["info"]["model"] == "claude-haiku-4-5"
+
+
+def test_build_rollout_result_emits_atif_and_adp(tmp_path):
+    """Scored rollouts emit the ecosystem trajectory formats out of the box.
+
+    ATIF (trainer/atif.json) and ADP (trainer/adp.jsonl) must land beside
+    verifiers.jsonl from _build_rollout_result — library-only emitters that
+    no run ever calls are a doc-claim violation, not a feature.
+    """
+    rollout_dir = tmp_path / "rollout-formats"
+    rollout_dir.mkdir()
+    _build_rollout_result(
+        rollout_dir,
+        task_name="archive-alice",
+        rollout_name="r1",
+        agent="claude-agent-acp",
+        agent_name="claude-agent-acp",
+        model="claude-haiku-4-5",
+        n_tool_calls=1,
+        prompts=["Archive the email from Alice."],
+        error=None,
+        verifier_error=None,
+        trajectory=_acp_trajectory(),
+        partial_trajectory=False,
+        trajectory_source="acp",
+        rewards={"reward": 0.45},
+        started_at=datetime.now(),
+        timing={},
+    )
+    atif = json.loads((rollout_dir / "trainer/atif.json").read_text())
+    assert atif["session_id"] == "archive-alice__r1"
+    assert atif["agent"]["name"] == "claude-agent-acp"
+    assert atif["steps"], "non-empty trajectory must produce ATIF steps"
+
+    adp_line = (rollout_dir / "trainer/adp.jsonl").read_text().strip()
+    adp = json.loads(adp_line)
+    assert adp["id"] == "archive-alice__r1"
+    assert adp["details"]["task_id"] == "archive-alice"
+    action_rewards = [
+        item["reward"] for item in adp["content"] if "reward" in item
+    ]
+    assert action_rewards == [0.45], (
+        "terminal reward must attach to the final action per ADP convention"
+    )
+
+
+def test_build_rollout_result_atif_for_empty_trajectory_is_prompt_only(tmp_path):
+    """Oracle runs (no agent events) emit a prompts-only ATIF, never agent steps.
+
+    The emitter folds prompts into user steps by design, so the document
+    stays schema-valid (steps non-empty); what must never happen is a
+    fabricated agent step from an empty trajectory.
+    """
+    rollout_dir = tmp_path / "rollout-oracle"
+    rollout_dir.mkdir()
+    _build_rollout_result(
+        rollout_dir,
+        task_name="archive-alice",
+        rollout_name="oracle",
+        agent="oracle",
+        agent_name="oracle",
+        model=None,
+        n_tool_calls=0,
+        prompts=["Archive the email from Alice."],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        trajectory_source=None,
+        rewards={"reward": 1.0},
+        started_at=datetime.now(),
+        timing={},
+    )
+    atif = json.loads((rollout_dir / "trainer/atif.json").read_text())
+    sources = [s.get("source") for s in atif["steps"]]
+    assert sources == ["user"], (
+        f"oracle ATIF must contain only the prompt-derived user step, got {sources}"
+    )
+    assert (rollout_dir / "trainer/adp.jsonl").exists(), (
+        "ADP records prompts even without actions"
+    )


### PR DESCRIPTION
Closes the gap between the #658 emitters and reality: they were library-only with zero runtime callers, so no run ever produced the artifacts.

- `_write_trainer_artifact` now writes `trainer/atif.json` + `trainer/adp.jsonl` beside `verifiers.jsonl` for every scored rollout (independent, fail-soft per format)
- Job-level `adp.jsonl` aggregation beside the existing verifiers aggregate
- Oracle runs emit prompts-only ATIF (valid; no fabricated agent steps — pinned by test)
- Trajectory ids reuse the rollout name when it already embeds the task

Verified on a live Docker run from this branch: 23-step ATIF, 43-item ADP with terminal reward 0.45 on the final action, job aggregate present — zero flags needed. Full suite: 3,318 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive artifact I/O on the train-mode seam with isolated fail-soft handlers; no changes to scoring, auth, or rollout execution logic.
> 
> **Overview**
> **Every scored rollout now emits ATIF and ADP trainer artifacts at runtime**, not only via standalone library exporters.
> 
> `_write_trainer_artifact` (called from `_build_rollout_result`) writes **`trainer/atif.json`** and **`trainer/adp.jsonl`** next to the existing **`trainer/verifiers.jsonl`**, using rollout/task/agent metadata and a stable **`trajectory_id`** (`task__rollout` when the rollout name does not already embed the task). Each format is written in its own try/except so failures are logged and do not block the others or normal result persistence.
> 
> **Job completion** adds **`write_job_adp_jsonl`** beside the existing verifiers job aggregate, producing job-level **`adp.jsonl`**.
> 
> Tests assert ATIF/ADP paths, session/id fields, terminal reward on the final ADP action, and **oracle/empty-trajectory** ATIF as prompts-only user steps (no fabricated agent steps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b484858bdde75562554612d3f46bf7fe83dc4b0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->