### PR TITLE
feat(sandbox): auto-reap orphaned Daytona sandboxes at eval start

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -140,49 +140,32 @@ def _daytona_client_or_exit():
 
 
 def _cleanup_daytona_sandboxes(dry_run: bool, max_age_minutes: int) -> None:
-    """Clean up orphaned Daytona sandboxes."""
-    from datetime import datetime
+    """Clean up orphaned Daytona sandboxes (display wrapper over the library reaper)."""
+    from benchflow.sandbox.daytona import reap_stale_sandboxes
 
     d = _daytona_client_or_exit()
-    now = datetime.now(UTC)
-    total_deleted = 0
-    total_found = 0
-    total_skipped = 0
 
-    # daytona SDK >=0.18 replaced the paged ``list(page=, limit=)`` API (which
-    # returned a page object with ``.items``) with ``list()`` -> an
-    # auto-paginating ``Iterator[Sandbox]``. Iterate it directly.
-    for sb in d.list():
-        total_found += 1
-        if not sb.created_at:
-            continue
-        created_at = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
-        age_minutes = (now - created_at).total_seconds() / 60
-        if age_minutes < max_age_minutes:
-            total_skipped += 1
-            if dry_run:
-                console.print(
-                    f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [green](skip)[/green]"
-                )
-            continue
-        if dry_run:
+    def _show(sb, age_minutes, will_delete):
+        verdict = "[red](delete)[/red]" if will_delete else "[green](skip)[/green]"
+        if dry_run or not will_delete:
             console.print(
-                f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m [red](delete)[/red]"
+                f"  [dim]{sb.id}[/dim] state={sb.state} age={age_minutes:.0f}m {verdict}"
             )
-        else:
-            try:
-                d.delete(sb)
-                total_deleted += 1
-            except Exception as e:
-                console.print(f"  [yellow]Failed to delete {sb.id}: {e}[/yellow]")
 
+    counts = reap_stale_sandboxes(
+        d,
+        max_age_minutes=max_age_minutes,
+        failed_max_age_minutes=max_age_minutes,
+        dry_run=dry_run,
+        on_decision=_show,
+    )
     if dry_run:
         console.print(
-            f"\n[bold]{total_found} sandboxes found, {total_found - total_skipped} older than {max_age_minutes}m[/bold] (use without --dry-run to delete)"
+            f"\n[bold]{counts['found']} sandboxes found, {counts['deleted']} older than {max_age_minutes}m[/bold] (use without --dry-run to delete)"
         )
     else:
         console.print(
-            f"\n[bold green]{total_deleted} sandboxes deleted[/bold green] ({total_skipped} skipped, younger than {max_age_minutes}m)"
+            f"\n[bold green]{counts['deleted']} sandboxes deleted[/bold green] ({counts['skipped']} skipped, younger than {max_age_minutes}m)"
         )
 
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -1235,7 +1235,37 @@ class Evaluation:
         self.learner_nodes.append(node)
         return node
 
+    def _maybe_start_daytona_reap(self) -> None:
+        """Fire-and-forget auto-reap of orphaned Daytona sandboxes (issue: leakage at scale).
+
+        Gated by ``BENCHFLOW_DAYTONA_AUTO_REAP`` (default on). Conservative
+        TTLs (24h general / 2h failed states) mean concurrent live runs are
+        never touched. Runs in a daemon thread so eval startup never blocks
+        or fails on reaping.
+        """
+        if self._config.environment != "daytona":
+            return
+        if os.environ.get("BENCHFLOW_DAYTONA_AUTO_REAP", "1") == "0":
+            return
+
+        def _reap() -> None:
+            try:
+                from benchflow.sandbox.daytona import reap_stale_sandboxes
+
+                counts = reap_stale_sandboxes()
+                if counts["deleted"] or counts["failed"]:
+                    logger.info(
+                        "Daytona auto-reap: %s stale sandboxes deleted (%s failed)",
+                        counts["deleted"],
+                        counts["failed"],
+                    )
+            except Exception as e:
+                logger.debug("Daytona auto-reap skipped: %s", e)
+
+        threading.Thread(target=_reap, name="daytona-auto-reap", daemon=True).start()
+
     async def run(self) -> EvaluationResult:
+        self._maybe_start_daytona_reap()
         """Execute the job."""
         task_dirs = self._get_task_dirs()
         if not task_dirs:

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -199,6 +199,65 @@ _STARTUP_HARD_TIMEOUT_BUFFER_SEC = 120
 _DAYTONA_SHELL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+_REAP_DEFAULT_MAX_AGE_MIN = 1440
+_REAP_FAILED_MAX_AGE_MIN = 120
+_REAP_FAILED_STATE_MARKERS = ("FAILED", "ERROR")
+
+
+def reap_stale_sandboxes(
+    client: Any | None = None,
+    *,
+    max_age_minutes: int = _REAP_DEFAULT_MAX_AGE_MIN,
+    failed_max_age_minutes: int = _REAP_FAILED_MAX_AGE_MIN,
+    dry_run: bool = False,
+    on_decision: Any | None = None,
+) -> dict[str, int]:
+    """Delete orphaned Daytona sandboxes past their TTL.
+
+    Two tiers: sandboxes whose state contains a failure marker (e.g.
+    ``BUILD_FAILED``) are reaped after *failed_max_age_minutes*; everything
+    else after *max_age_minutes*. Defaults are deliberately conservative so
+    concurrent live runs are never touched — only multi-hour orphans from
+    crashed or interrupted sessions.
+
+    *on_decision* (sandbox, age_minutes, will_delete) is called per sandbox
+    when provided — the CLI uses it for per-row display. Returns counts:
+    ``{"found", "deleted", "skipped", "failed"}``.
+    """
+    from datetime import UTC, datetime
+
+    if client is None:
+        client = build_sync_client()
+    now = datetime.now(UTC)
+    counts = {"found": 0, "deleted": 0, "skipped": 0, "failed": 0}
+    for sb in client.list():
+        counts["found"] += 1
+        if not getattr(sb, "created_at", None):
+            counts["skipped"] += 1
+            continue
+        created_at = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
+        age_minutes = (now - created_at).total_seconds() / 60
+        state = str(getattr(sb, "state", "") or "").upper()
+        is_failed = any(marker in state for marker in _REAP_FAILED_STATE_MARKERS)
+        ttl = failed_max_age_minutes if is_failed else max_age_minutes
+        will_delete = age_minutes >= ttl
+        if on_decision is not None:
+            on_decision(sb, age_minutes, will_delete)
+        if not will_delete:
+            counts["skipped"] += 1
+            continue
+        if dry_run:
+            counts["deleted"] += 1
+            continue
+        try:
+            client.delete(sb)
+            counts["deleted"] += 1
+        except Exception:
+            logger.warning("Failed to delete sandbox %s", getattr(sb, "id", "?"))
+            counts["failed"] += 1
+    return counts
+
+
 def _wrap_daytona_command_with_env_file(env: dict[str, str], command: str) -> str:
     """Return *command* prefixed to materialize *env* from a file.
 

--- a/tests/test_daytona_reap.py
+++ b/tests/test_daytona_reap.py
@@ -1,0 +1,123 @@
+"""Daytona stale-sandbox auto-reaping (dogfood finding: leakage at scale)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from benchflow.sandbox.daytona import reap_stale_sandboxes
+
+
+def _sb(sb_id: str, state: str, age_minutes: float):
+    created = datetime.now(UTC) - timedelta(minutes=age_minutes)
+    return SimpleNamespace(
+        id=sb_id, state=state, created_at=created.isoformat().replace("+00:00", "Z")
+    )
+
+
+class FakeClient:
+    def __init__(self, sandboxes, fail_ids=()):
+        self._sandboxes = sandboxes
+        self._fail_ids = set(fail_ids)
+        self.deleted = []
+
+    def list(self):
+        return iter(self._sandboxes)
+
+    def delete(self, sb):
+        if sb.id in self._fail_ids:
+            raise RuntimeError("api error")
+        self.deleted.append(sb.id)
+
+
+def test_reaps_old_started_keeps_young():
+    client = FakeClient([_sb("old", "STARTED", 1500), _sb("young", "STARTED", 30)])
+    counts = reap_stale_sandboxes(client)
+    assert client.deleted == ["old"]
+    assert counts == {"found": 2, "deleted": 1, "skipped": 1, "failed": 0}
+
+
+def test_failed_states_use_short_ttl():
+    client = FakeClient(
+        [_sb("bf-old", "BUILD_FAILED", 180), _sb("bf-young", "BUILD_FAILED", 30)]
+    )
+    counts = reap_stale_sandboxes(client)
+    assert client.deleted == ["bf-old"]
+    assert counts["skipped"] == 1
+
+
+def test_error_state_counts_as_failed_tier():
+    client = FakeClient([_sb("err", "ERROR", 180)])
+    reap_stale_sandboxes(client)
+    assert client.deleted == ["err"]
+
+
+def test_dry_run_deletes_nothing_but_counts():
+    client = FakeClient([_sb("old", "STARTED", 1500)])
+    counts = reap_stale_sandboxes(client, dry_run=True)
+    assert client.deleted == []
+    assert counts["deleted"] == 1
+
+
+def test_delete_failure_is_counted_not_raised():
+    client = FakeClient([_sb("bad", "STARTED", 1500)], fail_ids={"bad"})
+    counts = reap_stale_sandboxes(client)
+    assert counts["failed"] == 1
+    assert counts["deleted"] == 0
+
+
+def test_missing_created_at_is_skipped():
+    client = FakeClient([SimpleNamespace(id="x", state="STARTED", created_at=None)])
+    counts = reap_stale_sandboxes(client)
+    assert counts == {"found": 1, "deleted": 0, "skipped": 1, "failed": 0}
+
+
+def test_on_decision_sees_every_sandbox():
+    seen = []
+    client = FakeClient([_sb("old", "STARTED", 1500), _sb("young", "STARTED", 5)])
+    reap_stale_sandboxes(client, on_decision=lambda sb, age, d: seen.append((sb.id, d)))
+    assert seen == [("old", True), ("young", False)]
+
+
+class TestEvaluationAutoReapGate:
+    def _eval(self, tmp_path, environment):
+        from benchflow.evaluation import Evaluation, EvaluationConfig
+
+        tasks = tmp_path / "tasks"
+        tasks.mkdir(exist_ok=True)
+        cfg = EvaluationConfig(environment=environment)
+        return Evaluation(tasks_dir=tasks, jobs_dir=tmp_path / "jobs", config=cfg)
+
+    def test_docker_runs_never_reap(self, tmp_path, monkeypatch):
+        started = []
+        monkeypatch.setattr(
+            "threading.Thread",
+            lambda *a, **k: started.append(k) or SimpleNamespace(start=lambda: None),
+        )
+        self._eval(tmp_path, "docker")._maybe_start_daytona_reap()
+        assert started == []
+
+    def test_daytona_reaps_by_default(self, tmp_path, monkeypatch):
+        started = []
+
+        class FakeThread:
+            def __init__(self, *a, **k):
+                started.append(k.get("name"))
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr("benchflow.evaluation.threading.Thread", FakeThread)
+        monkeypatch.delenv("BENCHFLOW_DAYTONA_AUTO_REAP", raising=False)
+        self._eval(tmp_path, "daytona")._maybe_start_daytona_reap()
+        assert started == ["daytona-auto-reap"]
+
+    def test_env_gate_disables(self, tmp_path, monkeypatch):
+        started = []
+        monkeypatch.setattr(
+            "benchflow.evaluation.threading.Thread",
+            lambda *a, **k: started.append(k) or SimpleNamespace(start=lambda: None),
+        )
+        monkeypatch.setenv("BENCHFLOW_DAYTONA_AUTO_REAP", "0")
+        self._eval(tmp_path, "daytona")._maybe_start_daytona_reap()
+        assert started == []


### PR DESCRIPTION
Closes the last open dogfood finding (sandbox leakage at scale — 387 stale sandboxes observed).

- `reap_stale_sandboxes()` library function in `sandbox/daytona.py`; the CLI cleanup command is now a display wrapper over it (one canonical owner)
- Two TTL tiers: failure states (BUILD_FAILED/ERROR) after 2h, everything else after 24h — concurrent live runs are never touched
- Daytona-backed evals fire it in a daemon thread at `run()` start, gated by `BENCHFLOW_DAYTONA_AUTO_REAP` (default on); fail-soft, never blocks startup
- 10 tests: TTL tiers, dry-run, delete-failure tolerance, missing timestamps, the eval gate (docker never reaps, env var disables)

Full suite: 3,328 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Background deletion of remote Daytona resources could affect shared accounts if TTLs are mis-tuned, though defaults are conservative; eval path is fail-soft and env-gated.
> 
> **Overview**
> Adds **`reap_stale_sandboxes()`** in `sandbox/daytona.py` as the single place that lists Daytona sandboxes and deletes ones past TTL: **2h** for failure-like states (`FAILED`/`ERROR` in state), **24h** for everything else. Supports **dry-run**, per-sandbox **`on_decision`** callbacks, and returns **`found` / `deleted` / `skipped` / `failed`** counts; delete errors are logged and counted, not raised.
> 
> The **CLI cleanup** path (`_cleanup_daytona_sandboxes`) drops its inline list/delete loop and delegates to that helper (still using `--max-age` for both tiers when invoked manually).
> 
> **Daytona evals** call **`_maybe_start_daytona_reap()`** at the start of **`Evaluation.run()`**: a **daemon thread** runs the reaper with library defaults, gated by **`BENCHFLOW_DAYTONA_AUTO_REAP`** (default on, `0` disables). Non-Daytona environments skip it; failures are fail-soft so eval startup is not blocked.
> 
> New **`tests/test_daytona_reap.py`** covers TTL tiers, dry-run, delete failures, missing `created_at`, and the eval/env gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 072268316135cc4e0b53e0a6a3029cf86ec728f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->