### PR TITLE
docs: v0.6 release-candidate preview pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Use the exact `benchflow==0.5.2` pin for the public CLI. The
 release-candidate dependency; the exact BenchFlow pin keeps you off internal
 preview builds.
 
+> **Previewing v0.6?** v0.6 (the task.md task standard, the `bench agent`
+> adoption router, ATIF/ADP trajectory artifacts, OpenReward interop) is in
+> release-candidate testing. See [docs/v0.6-preview.md](docs/v0.6-preview.md)
+> for how to install the RC and which v0.6 docs to read. `pip install benchflow`
+> stays on `0.5.2` until v0.6 ships.
+
 Internal users who want the newest preview published from `main` should omit
 the exact public pin:
 

--- a/docs/v0.6-preview.md
+++ b/docs/v0.6-preview.md
@@ -1,0 +1,39 @@
+# BenchFlow v0.6 preview
+
+> **Status:** v0.6 is in **release-candidate testing**. The current stable public
+> release is still `0.5.2` — `pip install benchflow` is unchanged. v0.6 ships to
+> PyPI as `0.6.0` once RC testing completes.
+
+## Try the v0.6 release candidate
+
+```bash
+# pip — from the release-candidate wheel:
+pip install --pre 'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.1/benchflow-0.6.0rc1-py3-none-any.whl'
+
+# uv — from the tagged source:
+uv tool install --prerelease allow 'git+https://github.com/benchflow-ai/benchflow@0.6.0-rc.1'
+```
+
+`--pre` / `--prerelease allow` is required (benchflow pins a LiteLLM release
+candidate). After install, `bench --version` reports `0.6.0rc1`.
+
+## What's new in v0.6
+
+- **task.md task standard** — a single-file task format plus the authoring CLI
+  (`bench tasks init / check / migrate / export`).
+- **`bench agent` adoption router** — `create` / `run` / `verify` to adopt a
+  benchmark and prove conversion parity.
+- **ATIF + ADP trajectory artifacts** emitted from every scored rollout.
+- **OpenReward (ORS) reward-format interop** and **Daytona sandbox auto-reap**.
+
+## Which docs to reference (v0.6)
+
+These live on the `release/v0.6.0` branch until v0.6 merges to main:
+
+- [Agent quickstart — one copy-paste prompt](https://github.com/benchflow-ai/benchflow/blob/release/v0.6.0/docs/agent-quickstart.md)
+- [Getting started — install + first eval](https://github.com/benchflow-ai/benchflow/blob/release/v0.6.0/docs/getting-started.md)
+- [The task.md standard](https://github.com/benchflow-ai/benchflow/blob/release/v0.6.0/docs/task-standard.md)
+- [Authoring a native task.md task](https://github.com/benchflow-ai/benchflow/blob/release/v0.6.0/docs/task-authoring-task-md.md)
+- [CLI reference](https://github.com/benchflow-ai/benchflow/blob/release/v0.6.0/docs/reference/cli.md)
+
+Tracking PR: [#665](https://github.com/benchflow-ai/benchflow/pull/665).


### PR DESCRIPTION
Small, docs-only addition to `main` so the public line has a discovery path for v0.6 while it's in RC testing.

- New `docs/v0.6-preview.md`: how to install the RC (`pip install --pre` from the GitHub release wheel, or `uv ... git+...@0.6.0-rc.1`), what's new, and links to the v0.6 docs on `release/v0.6.0`.
- One README note under Install pointing at it.

No v0.6 feature code touches main; `pip install benchflow` stays on 0.5.2. The RC wheel is verified pip-installable (fresh venv → `bench --version` = 0.6.0rc1). Safe to merge independently of the v0.6 release (#665).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime, auth, or packaging behavior on main.
> 
> **Overview**
> Adds a **v0.6 release-candidate discovery path** on `main` without changing the stable install story (`benchflow==0.5.2` / `pip install benchflow`).
> 
> New **`docs/v0.6-preview.md`** documents RC status, **pip** (GitHub wheel) and **uv** (`git+...@0.6.0-rc.1`) install commands, a short **what's new** list (task.md, `bench agent`, ATIF/ADP, OpenReward, Daytona auto-reap), and links to v0.6 docs on `release/v0.6.0` plus tracking PR #665.
> 
> **README** gains a blockquote under Install that points readers to that page and clarifies that the public PyPI line stays on 0.5.2 until v0.6 ships.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4ea5b3282809b80a75c1bb4a674a2061f2e2b73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->