### PR TITLE
fix: make pre-verifier cache reclaim symlink- and workspace-safe (#601)

### DIFF
--- a/src/benchflow/sandbox/_cache_reclaim.py
+++ b/src/benchflow/sandbox/_cache_reclaim.py
@@ -1,0 +1,94 @@
+"""Pre-verifier cache reclaim command construction.
+
+The sandbox cannot import benchflow internals, so the reclaim implementation is
+an embedded Python snippet passed to ``python3 -c``. Keep it here instead of in
+``lockdown.py`` so the hardening orchestrator stays readable.
+"""
+
+import shlex
+
+# Symlink- and workspace-safe cache reclaim for #601.
+#
+# The previous shell form (`rm -rf "$u/.cache/uv" ...; rm -rf /tmp/uv-*`) could
+# delete agent-visible state before scoring: `rm -rf` traverses intermediate
+# symlinks (an agent-planted `~/.cache -> /app` turned the cache delete into
+# `rm -rf /app/uv`), and the `/tmp/uv-*` glob matched a legitimate
+# `/tmp/uv-workspace`. The textual `$WS`/`$u` guard saw none of that. Since
+# ``restore_workspace`` defaults to False, nothing undid the damage.
+#
+# This snippet hardens every deletion candidate:
+#  - rejects any candidate with a symlink path component, including the final
+#    one, so agent-controlled parents can no longer redirect the delete;
+#  - resolves protected roots (workspace + /logs, covering /logs/artifacts and
+#    /logs/verifier) via realpath and skips candidates overlapping in either
+#    direction, applied uniformly to per-user caches, /tmp globs, and apt;
+#  - deletes with shutil.rmtree, which removes child symlinks without following
+#    them.
+#
+# argv[1] = active workspace (or /nonexistent). argv[2] = optional filesystem
+# prefix, "" in production; tests pass a temp root so the exact production code
+# runs hermetically against a fake filesystem.
+#
+# Fail-safe by construction: if python3 is unavailable the reclaim simply does
+# not run (the trailing `true` swallows it). Losing best-effort ENOSPC mitigation
+# is strictly better than deleting the wrong state.
+RECLAIM_CACHES_PY = (
+    "import glob, os, shutil, sys;"
+    "ws = sys.argv[1];"
+    "px = sys.argv[2] if len(sys.argv) > 2 else '';"
+    "\n"
+    "def linked(path):\n"
+    "    p = px or ''\n"
+    "    for part in path[len(px):].strip('/').split('/'):\n"
+    "        p = p + '/' + part\n"
+    "        if os.path.islink(p):\n"
+    "            return True\n"
+    "    return False\n"
+    "\n"
+    "protected = []\n"
+    "for root in (ws, px + '/logs'):\n"
+    "    try:\n"
+    "        if root and os.path.exists(root):\n"
+    "            protected.append(os.path.realpath(root))\n"
+    "    except OSError:\n"
+    "        pass\n"
+    "\n"
+    "def overlaps(path):\n"
+    "    return any(\n"
+    "        path == r or path.startswith(r + '/') or r.startswith(path + '/')\n"
+    "        for r in protected\n"
+    "    )\n"
+    "\n"
+    "cands = [\n"
+    "    u + '/.cache/' + name\n"
+    "    for u in [px + '/root'] + sorted(glob.glob(px + '/home/*'))\n"
+    "    for name in ('uv', 'pip', 'uv_build')\n"
+    "]\n"
+    "cands += sorted(glob.glob(px + '/tmp/uv-*'))\n"
+    "cands += sorted(glob.glob(px + '/tmp/.uv-*'))\n"
+    "cands += sorted(glob.glob(px + '/var/cache/apt/archives/*.deb'))\n"
+    "for c in cands:\n"
+    "    try:\n"
+    "        if not os.path.lexists(c) or linked(c):\n"
+    "            continue\n"
+    "        # linked() proved no symlink components below the prefix, so\n"
+    "        # realpath only normalizes the prefix itself - consistent with\n"
+    "        # the realpath'd protected roots.\n"
+    "        if overlaps(os.path.realpath(c)):\n"
+    "            continue\n"
+    "        if os.path.isdir(c):\n"
+    "            shutil.rmtree(c, ignore_errors=True)\n"
+    "        else:\n"
+    "            os.remove(c)\n"
+    "    except OSError:\n"
+    "        pass\n"
+)
+
+
+def build_reclaim_caches_cmd(workspace: str | None) -> str:
+    """Build the best-effort cache reclaim shell command."""
+    workspace_arg = shlex.quote(workspace) if workspace else "/nonexistent"
+    return (
+        f"python3 -c {shlex.quote(RECLAIM_CACHES_PY)} {workspace_arg} "
+        "2>/dev/null; true"
+    )

--- a/src/benchflow/sandbox/_cache_reclaim.py
+++ b/src/benchflow/sandbox/_cache_reclaim.py
@@ -89,6 +89,5 @@ def build_reclaim_caches_cmd(workspace: str | None) -> str:
     """Build the best-effort cache reclaim shell command."""
     workspace_arg = shlex.quote(workspace) if workspace else "/nonexistent"
     return (
-        f"python3 -c {shlex.quote(RECLAIM_CACHES_PY)} {workspace_arg} "
-        "2>/dev/null; true"
+        f"python3 -c {shlex.quote(RECLAIM_CACHES_PY)} {workspace_arg} 2>/dev/null; true"
     )

--- a/src/benchflow/sandbox/_cache_reclaim.py
+++ b/src/benchflow/sandbox/_cache_reclaim.py
@@ -6,6 +6,7 @@ an embedded Python snippet passed to ``python3 -c``. Keep it here instead of in
 """
 
 import shlex
+from textwrap import dedent
 
 # Symlink- and workspace-safe cache reclaim for #601.
 #
@@ -32,57 +33,60 @@ import shlex
 # Fail-safe by construction: if python3 is unavailable the reclaim simply does
 # not run (the trailing `true` swallows it). Losing best-effort ENOSPC mitigation
 # is strictly better than deleting the wrong state.
-RECLAIM_CACHES_PY = (
-    "import glob, os, shutil, sys;"
-    "ws = sys.argv[1];"
-    "px = sys.argv[2] if len(sys.argv) > 2 else '';"
-    "\n"
-    "def linked(path):\n"
-    "    p = px or ''\n"
-    "    for part in path[len(px):].strip('/').split('/'):\n"
-    "        p = p + '/' + part\n"
-    "        if os.path.islink(p):\n"
-    "            return True\n"
-    "    return False\n"
-    "\n"
-    "protected = []\n"
-    "for root in (ws, px + '/logs'):\n"
-    "    try:\n"
-    "        if root and os.path.exists(root):\n"
-    "            protected.append(os.path.realpath(root))\n"
-    "    except OSError:\n"
-    "        pass\n"
-    "\n"
-    "def overlaps(path):\n"
-    "    return any(\n"
-    "        path == r or path.startswith(r + '/') or r.startswith(path + '/')\n"
-    "        for r in protected\n"
-    "    )\n"
-    "\n"
-    "cands = [\n"
-    "    u + '/.cache/' + name\n"
-    "    for u in [px + '/root'] + sorted(glob.glob(px + '/home/*'))\n"
-    "    for name in ('uv', 'pip', 'uv_build')\n"
-    "]\n"
-    "cands += sorted(glob.glob(px + '/tmp/uv-*'))\n"
-    "cands += sorted(glob.glob(px + '/tmp/.uv-*'))\n"
-    "cands += sorted(glob.glob(px + '/var/cache/apt/archives/*.deb'))\n"
-    "for c in cands:\n"
-    "    try:\n"
-    "        if not os.path.lexists(c) or linked(c):\n"
-    "            continue\n"
-    "        # linked() proved no symlink components below the prefix, so\n"
-    "        # realpath only normalizes the prefix itself - consistent with\n"
-    "        # the realpath'd protected roots.\n"
-    "        if overlaps(os.path.realpath(c)):\n"
-    "            continue\n"
-    "        if os.path.isdir(c):\n"
-    "            shutil.rmtree(c, ignore_errors=True)\n"
-    "        else:\n"
-    "            os.remove(c)\n"
-    "    except OSError:\n"
-    "        pass\n"
-)
+RECLAIM_CACHES_PY = dedent(
+    """
+    import glob, os, shutil, sys
+
+    ws = sys.argv[1]
+    px = sys.argv[2] if len(sys.argv) > 2 else ''
+
+    def linked(path):
+        p = px or ''
+        for part in path[len(px):].strip('/').split('/'):
+            p = p + '/' + part
+            if os.path.islink(p):
+                return True
+        return False
+
+    protected = []
+    for root in (ws, px + '/logs'):
+        try:
+            if root and os.path.exists(root):
+                protected.append(os.path.realpath(root))
+        except OSError:
+            pass
+
+    def overlaps(path):
+        return any(
+            path == r or path.startswith(r + '/') or r.startswith(path + '/')
+            for r in protected
+        )
+
+    cands = [
+        u + '/.cache/' + name
+        for u in [px + '/root'] + sorted(glob.glob(px + '/home/*'))
+        for name in ('uv', 'pip', 'uv_build')
+    ]
+    cands += sorted(glob.glob(px + '/tmp/uv-*'))
+    cands += sorted(glob.glob(px + '/tmp/.uv-*'))
+    cands += sorted(glob.glob(px + '/var/cache/apt/archives/*.deb'))
+    for c in cands:
+        try:
+            if not os.path.lexists(c) or linked(c):
+                continue
+            # linked() proved no symlink components below the prefix, so
+            # realpath only normalizes the prefix itself - consistent with
+            # the realpath'd protected roots.
+            if overlaps(os.path.realpath(c)):
+                continue
+            if os.path.isdir(c):
+                shutil.rmtree(c, ignore_errors=True)
+            else:
+                os.remove(c)
+        except OSError:
+            pass
+    """
+).strip()
 
 
 def build_reclaim_caches_cmd(workspace: str | None) -> str:

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -810,6 +810,85 @@ def _build_cleanup_cmd(hardening: dict[str, bool] | None = None) -> str:
 CLEANUP_CMD = _build_cleanup_cmd()
 
 
+# Pre-verifier disk reclaim, symlink- and workspace-safe (#601).
+#
+# The previous shell form (`rm -rf "$u/.cache/uv" ...; rm -rf /tmp/uv-*`) could
+# delete agent-visible state before scoring: `rm -rf` traverses *intermediate*
+# symlinks (an agent-planted `~/.cache -> /app` turned the cache delete into
+# `rm -rf /app/uv`), and the `/tmp/uv-*` glob matched a legitimate
+# `/tmp/uv-workspace`. The textual `$WS`/`$u` guard saw none of that. Since
+# ``restore_workspace`` defaults to False, nothing undid the damage.
+#
+# This snippet hardens every deletion candidate:
+#  - rejects any candidate with a symlink path component (including the final
+#    one) — agent-controlled parents can no longer redirect the delete;
+#  - resolves protected roots (workspace + /logs, covering /logs/artifacts and
+#    /logs/verifier) via realpath and skips candidates overlapping in either
+#    direction — applied uniformly to per-user caches, /tmp globs, AND apt;
+#  - deletes with shutil.rmtree, which removes child symlinks without
+#    following them.
+#
+# argv[1] = active workspace (or /nonexistent). argv[2] = optional filesystem
+# prefix, "" in production; tests pass a temp root so the exact production
+# code runs hermetically against a fake filesystem.
+#
+# Fail-safe by construction: if python3 is unavailable the reclaim simply does
+# not run (the trailing `true` swallows it) — losing best-effort ENOSPC
+# mitigation is strictly better than deleting the wrong state. The same
+# python3 assumption already underpins the symlink purge below.
+_RECLAIM_CACHES_PY = (
+    "import glob, os, shutil, sys;"
+    "ws = sys.argv[1];"
+    "px = sys.argv[2] if len(sys.argv) > 2 else '';"
+    "\n"
+    "def linked(path):\n"
+    "    p = px or ''\n"
+    "    for part in path[len(px):].strip('/').split('/'):\n"
+    "        p = p + '/' + part\n"
+    "        if os.path.islink(p):\n"
+    "            return True\n"
+    "    return False\n"
+    "\n"
+    "protected = []\n"
+    "for root in (ws, px + '/logs'):\n"
+    "    try:\n"
+    "        if root and os.path.exists(root):\n"
+    "            protected.append(os.path.realpath(root))\n"
+    "    except OSError:\n"
+    "        pass\n"
+    "\n"
+    "def overlaps(path):\n"
+    "    return any(\n"
+    "        path == r or path.startswith(r + '/') or r.startswith(path + '/')\n"
+    "        for r in protected\n"
+    "    )\n"
+    "\n"
+    "cands = [\n"
+    "    u + '/.cache/' + name\n"
+    "    for u in [px + '/root'] + sorted(glob.glob(px + '/home/*'))\n"
+    "    for name in ('uv', 'pip', 'uv_build')\n"
+    "]\n"
+    "cands += sorted(glob.glob(px + '/tmp/uv-*'))\n"
+    "cands += sorted(glob.glob(px + '/tmp/.uv-*'))\n"
+    "cands += sorted(glob.glob(px + '/var/cache/apt/archives/*.deb'))\n"
+    "for c in cands:\n"
+    "    try:\n"
+    "        if not os.path.lexists(c) or linked(c):\n"
+    "            continue\n"
+    "        # linked() proved no symlink components below the prefix, so\n"
+    "        # realpath only normalizes the prefix itself - consistent with\n"
+    "        # the realpath'd protected roots.\n"
+    "        if overlaps(os.path.realpath(c)):\n"
+    "            continue\n"
+    "        if os.path.isdir(c):\n"
+    "            shutil.rmtree(c, ignore_errors=True)\n"
+    "        else:\n"
+    "            os.remove(c)\n"
+    "    except OSError:\n"
+    "        pass\n"
+)
+
+
 async def harden_before_verify(
     env,
     task: "Task",
@@ -877,22 +956,18 @@ async def harden_before_verify(
     # installed tools, or task assets — and a failure here never blocks the
     # verifier. Runs on `main` only, consistent with the hardening policy above.
     #
-    # Workspace-aware: a task can legitimately use /root or /home/<user> as its
-    # workspace (so "$u/.cache" would be workspace state the verifier must see
-    # untouched). Skip any per-user cache that overlaps the active workspace in
-    # either direction — this matters because restore_workspace defaults to False,
-    # so the later full restore does NOT run to undo a stray deletion.
+    # Workspace-aware AND symlink-safe (#601): a task can legitimately use
+    # /root, /home/<user>, or /tmp/uv-* as its workspace, and an agent can
+    # plant `~/.cache -> /app` so a naive `rm -rf "$u/.cache/uv"` traverses
+    # into workspace/output state. _RECLAIM_CACHES_PY rejects symlinked
+    # candidates and realpath-guards every deletion against the workspace and
+    # /logs — this matters because restore_workspace defaults to False, so the
+    # later full restore does NOT run to undo a stray deletion.
     workspace_guard = shlex.quote(workspace) if workspace else "/nonexistent"
     try:
         await env.exec(
-            f"WS={workspace_guard}; "
-            "for u in /root /home/*; do "
-            '  case "$WS" in "$u" | "$u"/*) continue ;; esac; '
-            '  case "$u" in "$WS"/*) continue ;; esac; '
-            '  rm -rf "$u/.cache/uv" "$u/.cache/pip" "$u/.cache/uv_build" 2>/dev/null; '
-            "done; "
-            "rm -rf /tmp/uv-* /tmp/.uv-* /var/cache/apt/archives/*.deb 2>/dev/null; "
-            "true",
+            f"python3 -c {shlex.quote(_RECLAIM_CACHES_PY)} {workspace_guard} "
+            "2>/dev/null; true",
             user="root",
             timeout_sec=30,
         )

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from benchflow.agents.registry import get_sandbox_home_dirs
+from benchflow.sandbox._cache_reclaim import build_reclaim_caches_cmd
 
 if TYPE_CHECKING:
     from benchflow.task import Task
@@ -810,85 +811,6 @@ def _build_cleanup_cmd(hardening: dict[str, bool] | None = None) -> str:
 CLEANUP_CMD = _build_cleanup_cmd()
 
 
-# Pre-verifier disk reclaim, symlink- and workspace-safe (#601).
-#
-# The previous shell form (`rm -rf "$u/.cache/uv" ...; rm -rf /tmp/uv-*`) could
-# delete agent-visible state before scoring: `rm -rf` traverses *intermediate*
-# symlinks (an agent-planted `~/.cache -> /app` turned the cache delete into
-# `rm -rf /app/uv`), and the `/tmp/uv-*` glob matched a legitimate
-# `/tmp/uv-workspace`. The textual `$WS`/`$u` guard saw none of that. Since
-# ``restore_workspace`` defaults to False, nothing undid the damage.
-#
-# This snippet hardens every deletion candidate:
-#  - rejects any candidate with a symlink path component (including the final
-#    one) — agent-controlled parents can no longer redirect the delete;
-#  - resolves protected roots (workspace + /logs, covering /logs/artifacts and
-#    /logs/verifier) via realpath and skips candidates overlapping in either
-#    direction — applied uniformly to per-user caches, /tmp globs, AND apt;
-#  - deletes with shutil.rmtree, which removes child symlinks without
-#    following them.
-#
-# argv[1] = active workspace (or /nonexistent). argv[2] = optional filesystem
-# prefix, "" in production; tests pass a temp root so the exact production
-# code runs hermetically against a fake filesystem.
-#
-# Fail-safe by construction: if python3 is unavailable the reclaim simply does
-# not run (the trailing `true` swallows it) — losing best-effort ENOSPC
-# mitigation is strictly better than deleting the wrong state. The same
-# python3 assumption already underpins the symlink purge below.
-_RECLAIM_CACHES_PY = (
-    "import glob, os, shutil, sys;"
-    "ws = sys.argv[1];"
-    "px = sys.argv[2] if len(sys.argv) > 2 else '';"
-    "\n"
-    "def linked(path):\n"
-    "    p = px or ''\n"
-    "    for part in path[len(px):].strip('/').split('/'):\n"
-    "        p = p + '/' + part\n"
-    "        if os.path.islink(p):\n"
-    "            return True\n"
-    "    return False\n"
-    "\n"
-    "protected = []\n"
-    "for root in (ws, px + '/logs'):\n"
-    "    try:\n"
-    "        if root and os.path.exists(root):\n"
-    "            protected.append(os.path.realpath(root))\n"
-    "    except OSError:\n"
-    "        pass\n"
-    "\n"
-    "def overlaps(path):\n"
-    "    return any(\n"
-    "        path == r or path.startswith(r + '/') or r.startswith(path + '/')\n"
-    "        for r in protected\n"
-    "    )\n"
-    "\n"
-    "cands = [\n"
-    "    u + '/.cache/' + name\n"
-    "    for u in [px + '/root'] + sorted(glob.glob(px + '/home/*'))\n"
-    "    for name in ('uv', 'pip', 'uv_build')\n"
-    "]\n"
-    "cands += sorted(glob.glob(px + '/tmp/uv-*'))\n"
-    "cands += sorted(glob.glob(px + '/tmp/.uv-*'))\n"
-    "cands += sorted(glob.glob(px + '/var/cache/apt/archives/*.deb'))\n"
-    "for c in cands:\n"
-    "    try:\n"
-    "        if not os.path.lexists(c) or linked(c):\n"
-    "            continue\n"
-    "        # linked() proved no symlink components below the prefix, so\n"
-    "        # realpath only normalizes the prefix itself - consistent with\n"
-    "        # the realpath'd protected roots.\n"
-    "        if overlaps(os.path.realpath(c)):\n"
-    "            continue\n"
-    "        if os.path.isdir(c):\n"
-    "            shutil.rmtree(c, ignore_errors=True)\n"
-    "        else:\n"
-    "            os.remove(c)\n"
-    "    except OSError:\n"
-    "        pass\n"
-)
-
-
 async def harden_before_verify(
     env,
     task: "Task",
@@ -959,15 +881,12 @@ async def harden_before_verify(
     # Workspace-aware AND symlink-safe (#601): a task can legitimately use
     # /root, /home/<user>, or /tmp/uv-* as its workspace, and an agent can
     # plant `~/.cache -> /app` so a naive `rm -rf "$u/.cache/uv"` traverses
-    # into workspace/output state. _RECLAIM_CACHES_PY rejects symlinked
+    # into workspace/output state. The reclaim command rejects symlinked
     # candidates and realpath-guards every deletion against the workspace and
-    # /logs — this matters because restore_workspace defaults to False, so the
-    # later full restore does NOT run to undo a stray deletion.
-    workspace_guard = shlex.quote(workspace) if workspace else "/nonexistent"
+    # /logs — this matters because restore_workspace defaults to False.
     try:
         await env.exec(
-            f"python3 -c {shlex.quote(_RECLAIM_CACHES_PY)} {workspace_guard} "
-            "2>/dev/null; true",
+            build_reclaim_caches_cmd(workspace),
             user="root",
             timeout_sec=30,
         )

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -287,30 +287,28 @@ class TestVerifierDirWipe:
         await harden_before_verify(env, _make_task(), sandbox_user=None)
 
         reclaim = next(
-            (c for c in env.exec.call_args_list if ".cache/uv" in c.args[0]),
+            (c for c in env.exec.call_args_list if "/.cache/" in c.args[0]),
             None,
         )
         assert reclaim is not None, "expected a pre-verifier disk reclaim exec"
         cmd = reclaim.args[0]
-        # clears only re-downloadable caches ...
-        assert ".cache/pip" in cmd and "apt/archives" in cmd
-        # ... and never the workspace, agent outputs, installed tools, or assets
-        for forbidden in ("/app", "/workspace", "/tests", "site-packages", ".venv"):
-            assert forbidden not in cmd, f"reclaim must not touch {forbidden}"
+        # clears only re-downloadable caches (uv/pip/apt) ...
+        assert "uv_build" in cmd and "pip" in cmd and "apt/archives" in cmd
+        # ... guarded against symlinks and the workspace/output roots (#601)
+        assert "islink" in cmd and "realpath" in cmd and "/logs" in cmd
+        # no active workspace -> the guard placeholder is plumbed through
+        assert "/nonexistent" in cmd
         # best-effort: swallows errors and never aborts hardening
         assert "2>/dev/null" in cmd and cmd.rstrip().endswith("true")
         # runs as root so it can clear every user's cache
         assert reclaim.kwargs.get("user") == "root"
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("workspace", ["/root", "/home/agent"])
-    async def test_reclaim_skips_caches_inside_the_workspace(self, workspace):
-        """When a task uses /root or /home/<user> as its workspace, the reclaim
-        must NOT delete "$workspace/.cache" — that is workspace state the verifier
-        must see untouched. restore_workspace defaults False, so nothing would
-        restore a stray deletion. Guards the workspace-fidelity review blocker."""
+    @pytest.mark.parametrize("workspace", ["/root", "/home/agent", "/app"])
+    async def test_reclaim_plumbs_workspace_into_guard(self, workspace):
+        """The active workspace is passed to the reclaim snippet as argv[1] so
+        the realpath overlap guard can protect it (#601)."""
         import shlex
-        import subprocess
 
         from benchflow.sandbox.lockdown import harden_before_verify
 
@@ -320,47 +318,104 @@ class TestVerifierDirWipe:
         )
 
         reclaim = next(
-            (c for c in env.exec.call_args_list if ".cache/uv" in c.args[0]), None
+            (c for c in env.exec.call_args_list if "/.cache/" in c.args[0]), None
         )
         assert reclaim is not None
-        cmd = reclaim.args[0]
-        # the active workspace is plumbed into the guard ...
-        assert f"WS={shlex.quote(workspace)}" in cmd
-        # ... and overlap is guarded in both directions
-        assert 'case "$WS" in "$u" | "$u"/*) continue' in cmd
-        assert 'case "$u" in "$WS"/*) continue' in cmd
+        assert (
+            reclaim.args[0]
+            .rstrip()
+            .endswith(f"{shlex.quote(workspace)} 2>/dev/null; true")
+        )
 
-        # behaviorally: the guard skips the workspace dir itself (hermetic check)
-        decide = subprocess.run(
-            [
-                "sh",
-                "-c",
-                f"WS={shlex.quote(workspace)}; u={shlex.quote(workspace)}; "
-                'case "$WS" in "$u" | "$u"/*) echo skip; exit ;; esac; '
-                'case "$u" in "$WS"/*) echo skip; exit ;; esac; echo clear',
-            ],
+    # ── Behavior tests: run the REAL reclaim snippet against a temp root ──────
+    # (#601 regression suite — the old string-shape tests passed while the
+    # shell command deleted agent state through symlinks and /tmp globs.)
+
+    @staticmethod
+    def _run_reclaim(workspace: str, prefix) -> None:
+        """Execute the production _RECLAIM_CACHES_PY hermetically under
+        ``prefix`` — the same code, same interpreter contract as the sandbox."""
+        import subprocess
+        import sys
+
+        from benchflow.sandbox.lockdown import _RECLAIM_CACHES_PY
+
+        result = subprocess.run(
+            [sys.executable, "-c", _RECLAIM_CACHES_PY, workspace, str(prefix)],
             capture_output=True,
             text=True,
-        ).stdout.strip()
-        assert decide == "skip", (
-            f"workspace {workspace} should be skipped, got {decide}"
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_reclaim_does_not_traverse_cache_symlink_into_workspace(self, tmp_path):
+        """Guards PR #669 for issue #601 (repro 1): an agent-planted
+        ``~/.cache -> /app`` must not turn the cache delete into
+        ``rm -rf /app/uv`` — the old shell form did exactly that."""
+        (tmp_path / "app" / "uv").mkdir(parents=True)
+        (tmp_path / "app" / "uv" / "state.txt").write_text("agent state")
+        (tmp_path / "root").mkdir()
+        (tmp_path / "root" / ".cache").symlink_to(tmp_path / "app")
+
+        self._run_reclaim(str(tmp_path / "app"), tmp_path)
+
+        assert (tmp_path / "app" / "uv" / "state.txt").exists()
+
+    def test_reclaim_does_not_traverse_symlink_into_artifacts(self, tmp_path):
+        """Guards PR #669 for issue #601 (repro 2): ``.cache -> /logs/artifacts``
+        must not delete artifact state — /logs is a protected root even when it
+        is not the workspace."""
+        (tmp_path / "logs" / "artifacts" / "uv").mkdir(parents=True)
+        (tmp_path / "logs" / "artifacts" / "uv" / "state.txt").write_text("x")
+        (tmp_path / "home" / "agent").mkdir(parents=True)
+        (tmp_path / "home" / "agent" / ".cache").symlink_to(
+            tmp_path / "logs" / "artifacts"
         )
 
-    @pytest.mark.asyncio
-    async def test_reclaim_still_clears_caches_outside_the_workspace(self):
-        """A workspace like /app (not under /root or /home) leaves the per-user
-        cache reclaim fully active."""
-        from benchflow.sandbox.lockdown import harden_before_verify
+        self._run_reclaim("/nonexistent", tmp_path)
 
-        env = _make_env()
-        await harden_before_verify(
-            env, _make_task(), sandbox_user=None, workspace="/app"
-        )
-        reclaim = next(
-            (c for c in env.exec.call_args_list if ".cache/uv" in c.args[0]), None
-        )
-        assert reclaim is not None
-        assert "WS=/app" in reclaim.args[0]
+        assert (tmp_path / "logs" / "artifacts" / "uv" / "state.txt").exists()
+
+    def test_reclaim_spares_tmp_workspace_matching_glob(self, tmp_path):
+        """Guards PR #669 for issue #601 (repro 3): a legitimate
+        ``/tmp/uv-workspace`` workspace must survive the ``/tmp/uv-*`` glob —
+        the old form deleted it unconditionally."""
+        ws = tmp_path / "tmp" / "uv-workspace"
+        ws.mkdir(parents=True)
+        (ws / "state.txt").write_text("answer")
+
+        self._run_reclaim(str(ws), tmp_path)
+
+        assert (ws / "state.txt").exists()
+
+    def test_reclaim_still_clears_real_caches_outside_workspace(self, tmp_path):
+        """Guards PR #669 for issue #601 (repro 4): real, non-symlinked caches
+        outside the workspace are still reclaimed, so the ENOSPC mitigation
+        the reclaim exists for stays effective."""
+        (tmp_path / "root" / ".cache" / "uv" / "blob").mkdir(parents=True)
+        (tmp_path / "home" / "u1" / ".cache" / "pip").mkdir(parents=True)
+        (tmp_path / "tmp" / "uv-build123").mkdir(parents=True)
+        (tmp_path / "var" / "cache" / "apt" / "archives").mkdir(parents=True)
+        (tmp_path / "var" / "cache" / "apt" / "archives" / "x.deb").write_text("d")
+
+        self._run_reclaim(str(tmp_path / "app"), tmp_path)
+
+        assert not (tmp_path / "root" / ".cache" / "uv").exists()
+        assert not (tmp_path / "home" / "u1" / ".cache" / "pip").exists()
+        assert not (tmp_path / "tmp" / "uv-build123").exists()
+        assert not (tmp_path / "var" / "cache" / "apt" / "archives" / "x.deb").exists()
+
+    def test_reclaim_skips_caches_inside_the_workspace(self, tmp_path):
+        """When a task uses /root as its workspace, "$ws/.cache" is workspace
+        state the verifier must see untouched (the pre-#601 guarantee, now
+        enforced by realpath overlap instead of string comparison)."""
+        cache = tmp_path / "root" / ".cache" / "uv"
+        cache.mkdir(parents=True)
+        (cache / "state.txt").write_text("workspace state")
+
+        self._run_reclaim(str(tmp_path / "root"), tmp_path)
+
+        assert (cache / "state.txt").exists()
 
 
 # ── TestBuildConfigSnapshot ───────────────────────────────────────────────────

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -307,7 +307,7 @@ class TestVerifierDirWipe:
     @pytest.mark.parametrize("workspace", ["/root", "/home/agent", "/app"])
     async def test_reclaim_plumbs_workspace_into_guard(self, workspace):
         """The active workspace is passed to the reclaim snippet as argv[1] so
-        the realpath overlap guard can protect it (#601)."""
+        the realpath overlap guard can protect it. Guards PR #669."""
         import shlex
 
         from benchflow.sandbox.lockdown import harden_before_verify
@@ -333,15 +333,15 @@ class TestVerifierDirWipe:
 
     @staticmethod
     def _run_reclaim(workspace: str, prefix) -> None:
-        """Execute the production _RECLAIM_CACHES_PY hermetically under
-        ``prefix`` — the same code, same interpreter contract as the sandbox."""
+        """Execute the production reclaim snippet hermetically under
+        ``prefix`` - the same code, same interpreter contract as the sandbox."""
         import subprocess
         import sys
 
-        from benchflow.sandbox.lockdown import _RECLAIM_CACHES_PY
+        from benchflow.sandbox._cache_reclaim import RECLAIM_CACHES_PY
 
         result = subprocess.run(
-            [sys.executable, "-c", _RECLAIM_CACHES_PY, workspace, str(prefix)],
+            [sys.executable, "-c", RECLAIM_CACHES_PY, workspace, str(prefix)],
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -280,7 +280,8 @@ class TestVerifierDirWipe:
     async def test_reclaims_redownloadable_caches_before_verify(self):
         """Frees uv/pip/apt download caches so the verifier's own deps fit on
         disk-constrained sandboxes (e.g. Daytona's 10GB cap), without ever
-        touching the workspace, agent outputs, installed tools, or task assets."""
+        touching the workspace, agent outputs, installed tools, or task assets.
+        Guards PR #669."""
         from benchflow.sandbox.lockdown import harden_before_verify
 
         env = _make_env()
@@ -408,7 +409,7 @@ class TestVerifierDirWipe:
     def test_reclaim_skips_caches_inside_the_workspace(self, tmp_path):
         """When a task uses /root as its workspace, "$ws/.cache" is workspace
         state the verifier must see untouched (the pre-#601 guarantee, now
-        enforced by realpath overlap instead of string comparison)."""
+        enforced by realpath overlap instead of string comparison). Guards PR #669."""
         cache = tmp_path / "root" / ".cache" / "uv"
         cache.mkdir(parents=True)
         (cache / "state.txt").write_text("workspace state")


### PR DESCRIPTION
## Summary

Issue #601 (P0): the pre-verifier disk reclaim ran `rm -rf "$u/.cache/uv" ...` plus unconditional `/tmp/uv-*` globs **as root**, guarded only by a textual `$WS`/`$u` string comparison. Two reproduced escapes deleted agent-visible state **before scoring**:

1. **Intermediate symlink traversal** — `rm -rf` follows symlinks in parent components: an agent-planted `~/.cache -> /app` turned the cache delete into `rm -rf /app/uv`.
2. **Unguarded `/tmp` glob** — `/tmp/uv-*` matched a legitimate `/tmp/uv-workspace` workspace and deleted it outright.

`restore_workspace` defaults to `False`, so neither mutation was undone → falsely failed or unhealthy trials.

## Fix

Replace the shell reclaim with `_RECLAIM_CACHES_PY` (`python3 -c`, the same mechanism the adjacent symlink purge in `harden_before_verify` already relies on), hardening **every** deletion candidate per the issue's fix direction:

- **No symlink components**: any candidate with a symlink path component (including the final one) is rejected — agent-controlled parents can no longer redirect the delete.
- **Realpath overlap guard on everything**: protected roots (workspace + `/logs`, covering `/logs/artifacts` and `/logs/verifier`) are realpath-resolved and compared in both directions — applied uniformly to per-user caches, `/tmp` globs, **and** apt archives (previously wholly unguarded).
- **Safe deletion**: `shutil.rmtree` removes child symlinks without following them.
- **Fail-safe direction**: if `python3` is unavailable the reclaim does nothing (trailing `true`) — losing best-effort ENOSPC mitigation is strictly better than deleting the wrong state.

`argv[2]` accepts an optional filesystem prefix (production passes none) so tests execute the **exact production snippet** hermetically against a temp root — closing the issue's coverage-gap complaint that old tests only asserted command-string shape.

## Test plan (the issue's four scenarios, behaviorally)

- [x] `test_reclaim_does_not_traverse_cache_symlink_into_workspace` — `.cache -> /app`, `/app/uv/state.txt` survives
- [x] `test_reclaim_does_not_traverse_symlink_into_artifacts` — `.cache -> /logs/artifacts`, artifact state survives
- [x] `test_reclaim_spares_tmp_workspace_matching_glob` — `/tmp/uv-workspace` survives the `/tmp/uv-*` glob
- [x] `test_reclaim_still_clears_real_caches_outside_workspace` — real uv/pip/tmp/apt caches still reclaimed (ENOSPC mitigation intact)
- [x] `test_reclaim_skips_caches_inside_the_workspace` — /root-as-workspace `.cache` untouched (pre-#601 guarantee preserved, now via realpath)
- [x] **Fail-then-pass verified**: with the symlink/overlap guards neutered, all four protection tests fail
- [x] Full hardening suite 91 passed; broader lockdown/verify slice 241 passed; ruff check+format, ty clean

Closes #601

🤖 Generated with [Claude Code](https://claude.com/claude-code)