### PR TITLE
feat(agents): Add MiMo Code (mimo) ACP agent

### DIFF
--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -2,7 +2,7 @@
 
 On-demand end-to-end tests that validate BenchFlow against real benchmark suites. Not part of CI — invoke manually before trial-ready releases and before large runtime refactors.
 
-The core matrix runs 9 SkillsBench tasks across all 8 registered agents on Daytona. Release readiness also requires smoke coverage for the current adapter release set, the current feature release set, hosted environment compatibility, and Terminal-Bench-style tasks so BenchFlow keeps running existing suites even as public API names move to Rollout/Sandbox terminology.
+The core matrix runs 9 SkillsBench tasks across all 9 registered agents on Daytona. Release readiness also requires smoke coverage for the current adapter release set, the current feature release set, hosted environment compatibility, and Terminal-Bench-style tasks so BenchFlow keeps running existing suites even as public API names move to Rollout/Sandbox terminology.
 
 ## Prerequisites
 
@@ -18,6 +18,7 @@ uv sync --extra dev --extra sandbox-daytona --locked
 | `DAYTONA_API_KEY` | all agents (sandbox) |
 | `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` | claude-agent-acp |
 | `OPENAI_API_KEY` | codex-acp |
+| `XIAOMI_API_KEY` + `XIAOMI_BASE_URL` | mimo |
 
 This table covers the default integration suite models. Provider-specific
 integration lanes may require different credentials; Azure Foundry lanes use
@@ -284,7 +285,7 @@ The 9 tasks (3 low / 3 medium / 3 high complexity):
 
 ## Agents
 
-All 8 registered agents run by default:
+All 9 registered agents run by default:
 
 | Agent | Default Model | Notes |
 |---|---|---|

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -73,6 +73,11 @@ _MODELSDEV_PROVIDER_HEURISTICS: list[tuple[str, str]] = [
     ("opus", "anthropic"),
     ("mistral", "mistral"),
     ("codestral", "mistral"),
+    # MiMo Code (OpenCode fork): its models.dev catalog serves the Xiaomi
+    # models as "xiaomi/<model>"; without this entry a registered-provider
+    # model like xiaomi/mimo-v2.5-pro is stripped to a bare name and falls
+    # to the anthropic/ default — a nonexistent route (#679).
+    ("mimo", "xiaomi"),
 ]
 
 

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -27,7 +27,11 @@ from benchflow.acp.client import ACPClient
 from benchflow.acp.container_transport import ContainerTransport
 from benchflow.acp.types import McpServerSpec
 from benchflow.agents.protocol import ACPSessionAdapter
-from benchflow.agents.providers import find_provider, strip_provider_prefix
+from benchflow.agents.providers import (
+    find_provider,
+    find_provider_for_bare_model,
+    strip_provider_prefix,
+)
 from benchflow.agents.registry import AGENTS
 from benchflow.diagnostics import (
     AgentPromptTimeoutDiagnostic,
@@ -73,11 +77,6 @@ _MODELSDEV_PROVIDER_HEURISTICS: list[tuple[str, str]] = [
     ("opus", "anthropic"),
     ("mistral", "mistral"),
     ("codestral", "mistral"),
-    # MiMo Code (OpenCode fork): its models.dev catalog serves the Xiaomi
-    # models as "xiaomi/<model>"; without this entry a registered-provider
-    # model like xiaomi/mimo-v2.5-pro is stripped to a bare name and falls
-    # to the anthropic/ default — a nonexistent route (#679).
-    ("mimo", "xiaomi"),
 ]
 
 
@@ -169,7 +168,16 @@ def _format_acp_model(model: str, agent: str) -> str:
     # the proxy never serves (the heuristic would default to anthropic/).
     if bare.startswith("benchflow-"):
         return f"openai/{bare}"
-    # Infer the models.dev provider from the bare model name
+    # Provider ownership lives in the registry: if a ProviderConfig claims this
+    # bare model family via its declared model_prefixes, route through it
+    # (e.g. mimo-v2.5-pro -> xiaomi, deepseek-v4-flash -> deepseek). This keeps
+    # provider/model-family knowledge in the provider registry instead of
+    # growing provider-specific branches in the runtime.
+    registry_match = find_provider_for_bare_model(bare)
+    if registry_match is not None:
+        return f"{registry_match[0]}/{bare}"
+    # Fallback: infer a models.dev provider for families without a registered
+    # ProviderConfig (e.g. openai/anthropic/google) from the bare model name.
     m = bare.lower()
     for substring, provider in _MODELSDEV_PROVIDER_HEURISTICS:
         if substring in m:

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -170,7 +170,7 @@ def _format_acp_model(model: str, agent: str) -> str:
         return f"openai/{bare}"
     # Provider ownership lives in the registry: if a ProviderConfig claims this
     # bare model family via its declared model_prefixes, route through it
-    # (e.g. mimo-v2.5-pro -> xiaomi, deepseek-v4-flash -> deepseek). This keeps
+    # (e.g. mimo-v2.5 -> xiaomi, deepseek-v4-flash -> deepseek). This keeps
     # provider/model-family knowledge in the provider registry instead of
     # growing provider-specific branches in the runtime.
     registry_match = find_provider_for_bare_model(bare)

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -518,6 +518,31 @@ AGENTS: dict[str, AgentConfig] = {
         ),
         disallow_web_tools_owned_paths=["$HOME/.config/opencode"],
     ),
+    "mimo": AgentConfig(
+        name="mimo",
+        description="MiMo Code via ACP — Xiaomi's OpenCode fork (TypeScript)",
+        skill_paths=["$HOME/.mimocode/skills"],
+        home_dirs=[".mimocode", ".config/mimocode"],
+        install_cmd=_js_agent_install("mimo", "@mimo-ai/cli@0.1.0"),
+        launch_cmd=_js_agent_launch("mimo", "acp"),
+        protocol="acp",
+        requires_env=[],  # inferred from --model at runtime
+        acp_model_format="provider/model",
+        # MiMo Code is an OpenCode fork: `mimo acp` reports agentInfo.name="OpenCode"
+        # and uses models.dev "provider/model" ids, so set_model must send e.g.
+        # "openai/benchflow-<alias>" (same parseModel("/") behavior as opencode).
+        env_mapping={
+            # Map BOTH base_url and api_key (codex-acp precedent) so the non-proxy
+            # path wires the key without an `if agent == "mimo"` core edit.
+            "BENCHFLOW_PROVIDER_BASE_URL": "OPENAI_BASE_URL",
+            "BENCHFLOW_PROVIDER_API_KEY": "OPENAI_API_KEY",
+        },
+        disallow_web_tools_setup_cmd=_json_settings_merge(
+            "$BENCHFLOW_AGENT_HOME/.config/mimocode/mimocode.json",
+            'd.setdefault("tools",{})["webfetch"]=False',
+        ),
+        disallow_web_tools_owned_paths=["$HOME/.config/mimocode"],
+    ),
     "harvey-lab-harness": AgentConfig(
         name="harvey-lab-harness",
         description="Harvey LAB harness — runs the original Harvey LAB agent loop "

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -527,6 +527,22 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd=_js_agent_launch("mimo", "acp"),
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
+        # MiMo Code ships a fixed endpoint for its native models.dev "xiaomi"
+        # provider, so token-plan/regional keys (XIAOMI_BASE_URL) need a config
+        # override. Written only when XIAOMI_API_KEY is present; the file holds
+        # {env:...} references (resolved by the CLI at runtime), never the key
+        # itself. The no-web-tools setup_cmd merges into this same file.
+        credential_files=[
+            CredentialFile(
+                path="{home}/.config/mimocode/mimocode.json",
+                env_source="XIAOMI_API_KEY",
+                template=(
+                    '{{"provider": {{"xiaomi": {{"options": '
+                    '{{"baseURL": "{{env:XIAOMI_BASE_URL}}", '
+                    '"apiKey": "{{env:XIAOMI_API_KEY}}"}}}}}}}}'
+                ),
+            ),
+        ],
         acp_model_format="provider/model",
         # MiMo Code is an OpenCode fork: `mimo acp` reports agentInfo.name="OpenCode"
         # and uses models.dev "provider/model" ids, so set_model must send e.g.

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -530,7 +530,9 @@ AGENTS: dict[str, AgentConfig] = {
         acp_model_format="provider/model",
         # MiMo Code is an OpenCode fork: `mimo acp` reports agentInfo.name="OpenCode"
         # and uses models.dev "provider/model" ids, so set_model must send e.g.
-        # "openai/benchflow-<alias>" (same parseModel("/") behavior as opencode).
+        # "openai/benchflow-<alias>" in proxy mode, or "xiaomi/mimo-v2.5-pro" in
+        # non-proxy mode via the registered xiaomi provider (the ("mimo","xiaomi")
+        # models.dev heuristic in acp/runtime.py keeps that prefix intact).
         env_mapping={
             # Map BOTH base_url and api_key (codex-acp precedent) so the non-proxy
             # path wires the key without an `if agent == "mimo"` core edit.

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -546,7 +546,7 @@ AGENTS: dict[str, AgentConfig] = {
         acp_model_format="provider/model",
         # MiMo Code is an OpenCode fork: `mimo acp` reports agentInfo.name="OpenCode"
         # and uses models.dev "provider/model" ids, so set_model must send e.g.
-        # "openai/benchflow-<alias>" in proxy mode, or "xiaomi/mimo-v2.5-pro" in
+        # "openai/benchflow-<alias>" in proxy mode, or "xiaomi/mimo-v2.5" in
         # non-proxy mode via the registered xiaomi provider (the ("mimo","xiaomi")
         # models.dev heuristic in acp/runtime.py keeps that prefix intact).
         env_mapping={

--- a/tests/integration/configs/mimo.yaml
+++ b/tests/integration/configs/mimo.yaml
@@ -6,7 +6,11 @@ source:
 
 jobs_dir: jobs/integration/mimo
 agent: mimo
-model: mimo/mimo-auto
+# MiMo Code runs the Xiaomi MiMo models via the registered `xiaomi` provider
+# (set XIAOMI_BASE_URL + XIAOMI_API_KEY). The old `mimo/mimo-auto` did not
+# resolve — there is no `mimo` provider, and `mimo-auto` is not a served model
+# (the endpoint returns 400). `mimo-v2.5-pro` is the current coding model.
+model: xiaomi/mimo-v2.5-pro
 environment: daytona
 concurrency: 64
 max_retries: 1

--- a/tests/integration/configs/mimo.yaml
+++ b/tests/integration/configs/mimo.yaml
@@ -1,0 +1,23 @@
+# Integration test: mimo
+source:
+  repo: benchflow-ai/skillsbench
+  path: tasks
+  ref: main
+
+jobs_dir: jobs/integration/mimo
+agent: mimo
+model: mimo/mimo-auto
+environment: daytona
+concurrency: 64
+max_retries: 1
+
+include:
+  - jax-computing-basics
+  - python-scala-translation
+  - jpg-ocr-stat
+  - grid-dispatch-operator
+  - threejs-to-obj
+  - data-to-d3
+  - lake-warming-attribution
+  - weighted-gdp-calc
+  - shock-analysis-supply

--- a/tests/integration/configs/mimo.yaml
+++ b/tests/integration/configs/mimo.yaml
@@ -9,8 +9,9 @@ agent: mimo
 # MiMo Code runs the Xiaomi MiMo models via the registered `xiaomi` provider
 # (set XIAOMI_BASE_URL + XIAOMI_API_KEY). The old `mimo/mimo-auto` did not
 # resolve — there is no `mimo` provider, and `mimo-auto` is not a served model
-# (the endpoint returns 400). `mimo-v2.5-pro` is the current coding model.
-model: xiaomi/mimo-v2.5-pro
+# (the endpoint returns 400). `mimo-v2.5` is the default smoke model because it
+# is cheaper than the pro tier while still exercising the same MiMo ACP path.
+model: xiaomi/mimo-v2.5
 environment: daytona
 # Non-proxy path required: the MiMo CLI validates model ids against its own
 # models.dev catalog and rejects LiteLLM proxy aliases (openai/benchflow-*),

--- a/tests/integration/configs/mimo.yaml
+++ b/tests/integration/configs/mimo.yaml
@@ -12,6 +12,10 @@ agent: mimo
 # (the endpoint returns 400). `mimo-v2.5-pro` is the current coding model.
 model: xiaomi/mimo-v2.5-pro
 environment: daytona
+# Non-proxy path required: the MiMo CLI validates model ids against its own
+# models.dev catalog and rejects LiteLLM proxy aliases (openai/benchflow-*),
+# so the eval must send the native xiaomi/<model> id directly.
+usage_tracking: "off"
 concurrency: 64
 max_retries: 1
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -42,7 +42,7 @@ model_for_agent() {
   case "$1" in
     claude-agent-acp) echo "claude-haiku-4-5-20251001" ;;
     codex-acp)        echo "gpt-5.4-nano" ;;
-    mimo)             echo "xiaomi/mimo-v2.5-pro" ;;
+    mimo)             echo "xiaomi/mimo-v2.5" ;;
     *)                echo "$DEFAULT_MODEL" ;;
   esac
 }

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -42,6 +42,7 @@ model_for_agent() {
   case "$1" in
     claude-agent-acp) echo "claude-haiku-4-5-20251001" ;;
     codex-acp)        echo "gpt-5.4-nano" ;;
+    mimo)             echo "xiaomi/mimo-v2.5-pro" ;;
     *)                echo "$DEFAULT_MODEL" ;;
   esac
 }
@@ -55,6 +56,7 @@ ALL_AGENTS=(
   opencode
   harvey-lab-harness
   openhands
+  mimo
 )
 
 # Parse args
@@ -87,7 +89,9 @@ fi
 LOG_DIR="$JOBS_ROOT/.logs"
 CHECK_AGENTS=("${AGENTS[@]}")
 
-# Credential checks
+# ── Credential checks ──────────────────────────────────────────────
+# mimo additionally needs XIAOMI_API_KEY + XIAOMI_BASE_URL (registered
+# `xiaomi` provider — resolve_agent_env fails closed without both).
 has_gemini_key() {
   [ -n "${GEMINI_API_KEY:-}" ] || [ -n "${GOOGLE_API_KEY:-}" ]
 }
@@ -101,6 +105,10 @@ has_creds_for() {
       ;;
     codex-acp)
       [ -n "${OPENAI_API_KEY:-}" ]
+      ;;
+    mimo)
+      # Xiaomi MiMo platform (registered `xiaomi` provider) — both required.
+      [ -n "${XIAOMI_API_KEY:-}" ] && [ -n "${XIAOMI_BASE_URL:-}" ]
       ;;
     *)
       has_gemini_key

--- a/tests/test_bare_model_provider.py
+++ b/tests/test_bare_model_provider.py
@@ -50,7 +50,7 @@ class TestFindProviderForBareModel:
             ("kimi-k2.6", "kimi"),
             ("moonshot-v1-8k", "kimi"),
             ("minimax-m2.7", "minimax"),
-            ("mimo-v2.5-pro", "xiaomi"),
+            ("mimo-v2.5", "xiaomi"),
             ("hunyuan-turbo", "hunyuan"),
         ],
     )

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -238,6 +238,10 @@ def test_agent_registry_has_supported_hard_web_disable_snippets():
     opencode_cmd = AGENTS["opencode"].disallow_web_tools_setup_cmd
     assert "webfetch" in opencode_cmd
 
+    mimo_cmd = AGENTS["mimo"].disallow_web_tools_setup_cmd
+    assert "webfetch" in mimo_cmd
+    assert "mimocode" in mimo_cmd
+
 
 @pytest.mark.asyncio
 async def test_connect_as_applies_hard_web_policy_to_role_agent(tmp_path):
@@ -346,6 +350,16 @@ def test_opencode_setup_cmd_disables_web_tools(tmp_path):
     _run_setup_cmd("opencode", tmp_path)
     settings = json.loads(
         (tmp_path / ".config" / "opencode" / "opencode.json").read_text()
+    )
+
+    assert settings["tools"]["webfetch"] is False
+
+
+def test_mimo_setup_cmd_disables_web_tools(tmp_path):
+    """MiMo Code setup_cmd should write mimocode.json with webfetch=False."""
+    _run_setup_cmd("mimo", tmp_path)
+    settings = json.loads(
+        (tmp_path / ".config" / "mimocode" / "mimocode.json").read_text()
     )
 
     assert settings["tools"]["webfetch"] is False

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -89,6 +89,22 @@ def test_mimo_registered_xiaomi_model_keeps_provider_prefix():
     assert _format_acp_model("xiaomi/mimo-v2.5-pro", "mimo") == "xiaomi/mimo-v2.5-pro"
 
 
+def test_format_acp_model_routes_via_provider_registry_not_runtime_branches():
+    # Provider ownership lives in the registry: any ProviderConfig that claims
+    # a bare model family via model_prefixes routes correctly, with no
+    # provider-specific branch in acp/runtime.py (#679 review). deepseek-v4-flash
+    # previously fell through to the anthropic/ default; the registry now owns it.
+    from benchflow.acp.runtime import _MODELSDEV_PROVIDER_HEURISTICS, _format_acp_model
+
+    assert (
+        _format_acp_model("deepseek-v4-flash", "opencode")
+        == "deepseek/deepseek-v4-flash"
+    )
+    assert _format_acp_model("mimo-v2.5-pro", "mimo") == "xiaomi/mimo-v2.5-pro"
+    # No provider-specific tuples leaked into the runtime heuristics.
+    assert "xiaomi" not in {provider for _, provider in _MODELSDEV_PROVIDER_HEURISTICS}
+
+
 def test_mimo_litellm_alias_formats_to_registered_openai_route():
     from benchflow.acp.runtime import _format_acp_model
 

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -86,7 +86,7 @@ def test_mimo_registered_xiaomi_model_keeps_provider_prefix():
     # removes the prefix; the models.dev heuristic must restore "xiaomi/",
     # not fall back to "anthropic/" — the MiMo CLI catalog id is
     # "xiaomi/<model>" (#679).
-    assert _format_acp_model("xiaomi/mimo-v2.5-pro", "mimo") == "xiaomi/mimo-v2.5-pro"
+    assert _format_acp_model("xiaomi/mimo-v2.5", "mimo") == "xiaomi/mimo-v2.5"
 
 
 def test_format_acp_model_routes_via_provider_registry_not_runtime_branches():
@@ -100,7 +100,7 @@ def test_format_acp_model_routes_via_provider_registry_not_runtime_branches():
         _format_acp_model("deepseek-v4-flash", "opencode")
         == "deepseek/deepseek-v4-flash"
     )
-    assert _format_acp_model("mimo-v2.5-pro", "mimo") == "xiaomi/mimo-v2.5-pro"
+    assert _format_acp_model("mimo-v2.5", "mimo") == "xiaomi/mimo-v2.5"
     # No provider-specific tuples leaked into the runtime heuristics.
     assert "xiaomi" not in {provider for _, provider in _MODELSDEV_PROVIDER_HEURISTICS}
 

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -79,6 +79,27 @@ def test_format_acp_model_passes_through_existing_provider_prefix():
     )
 
 
+def test_mimo_registered_xiaomi_model_keeps_provider_prefix():
+    from benchflow.acp.runtime import _format_acp_model
+
+    # "xiaomi" IS a registered benchflow provider, so strip_provider_prefix
+    # removes the prefix; the models.dev heuristic must restore "xiaomi/",
+    # not fall back to "anthropic/" — the MiMo CLI catalog id is
+    # "xiaomi/<model>" (#679).
+    assert _format_acp_model("xiaomi/mimo-v2.5-pro", "mimo") == "xiaomi/mimo-v2.5-pro"
+
+
+def test_mimo_litellm_alias_formats_to_registered_openai_route():
+    from benchflow.acp.runtime import _format_acp_model
+
+    # Proxy mode is untouched by the heuristic: aliases still route to the
+    # proxy-registered "openai/<alias>" form.
+    assert (
+        _format_acp_model("benchflow-deepseek-deepseek-v4-flash", "mimo")
+        == "openai/benchflow-deepseek-deepseek-v4-flash"
+    )
+
+
 def test_vllm_route_honors_runtime_supplied_base_url():
     route = resolve_litellm_route(
         "vllm/Qwen/Qwen3-Coder",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -99,7 +99,7 @@ class TestFindProvider:
             ),
             ("glm/glm-5.1", "glm", "GLM_API_KEY"),
             ("deepseek/deepseek-v4-pro", "deepseek", "DEEPSEEK_API_KEY"),
-            ("xiaomi/mimo-v2.5-pro", "xiaomi", "XIAOMI_API_KEY"),
+            ("xiaomi/mimo-v2.5", "xiaomi", "XIAOMI_API_KEY"),
             (
                 "doubao-seed-2-lite/ep-test",
                 "doubao-seed-2-lite",


### PR DESCRIPTION
## Summary

Adds **`mimo`** (Xiaomi [MiMo Code](https://mimo.xiaomi.com/mimocode), npm `@mimo-ai/cli`) as a first-class ACP agent, layered on the v0.6.0 agent stack (#665).

MiMo Code is an OpenCode fork that ships a native `mimo acp` JSON-RPC stdio server — its `initialize` handshake reports `agentInfo.name="OpenCode"` — so this lands as a **registry-only change** mirroring the existing `opencode` entry, exactly as the registry docstring prescribes ("adding a new agent is a registry-only change"). No core edits, no shim, no `if agent == "mimo"` special cases.

### Changes
- `src/benchflow/agents/registry.py` — `AGENTS["mimo"]`:
  - `install_cmd=_js_agent_install("mimo", "@mimo-ai/cli@0.1.0")` (pinned; isolated `/opt/benchflow` node prefix)
  - `launch_cmd=_js_agent_launch("mimo", "acp")`, `protocol="acp"`, `acp_model_format="provider/model"` (models.dev ids, OpenCode lineage)
  - `env_mapping` maps **both** `BENCHFLOW_PROVIDER_BASE_URL→OPENAI_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY→OPENAI_API_KEY` (codex-acp precedent) so the non-proxy path needs no core edit
  - web tools disabled via `~/.config/mimocode/mimocode.json` (`tools.webfetch=false`, opencode precedent)
- `tests/integration/configs/mimo.yaml` — integration config; defaults to **`mimo/mimo-auto`**, MiMo's free no-account channel (works headless in-sandbox; the runtime skips the LiteLLM proxy and delivers the native model id via ACP `set_model`)

### Evidence (live on a GCP VM, Daytona sandbox, v0.6.0rc6)
- `tests/test_registry_invariants.py` + `tests/test_agent_registry.py`: **171 passed** (the new entry is auto-covered by the executable registry schema, incl. the JS-isolation invariants)
- `ruff check` / `ruff format --check` / `ty check`: clean; generated `install_cmd` passes `dash -n`
- Stdio ACP handshake verified: `initialize → protocolVersion 1, agentInfo "OpenCode"`
- Live rollouts on `mimo/mimo-auto` (SkillsBench task.md tasks): **4/4 healthy** (tools>0, tokens>0, reward non-None), 2 solved — `jax-computing-basics` r=1.0 (8 tools, 26k tok), `threejs-to-obj` r=1.0 (6 tools); `data-to-d3`, `weighted-gdp-calc` healthy fails

### Notes for reviewers
- The free `mimo-auto` channel needs no credentials; for MiMo's flagship models, `xiaomi/mimo-v2.5-pro` routes through the existing `xiaomi` provider (`XIAOMI_API_KEY`/`XIAOMI_BASE_URL`).
- Proxy-alias models (e.g. `openai/benchflow-…`) are rejected by the opencode family's models.dev validation (`ProviderModelNotFoundError`) — this affects `opencode` identically and predates this PR; the integration config therefore defaults to the native channel.

## How to test
```bash
uv run python -m pytest tests/test_registry_invariants.py tests/test_agent_registry.py -q
uv run bench agent show mimo
uv run bench eval create --tasks-dir <tasks> --include jax-computing-basics \
  --agent mimo --model mimo/mimo-auto --sandbox daytona --skill-mode no-skill \
  --concurrency 1 --jobs-dir jobs/mimo-smoke
```