### PR TITLE
fix(v06): close 19 bug-hunt findings across the new v0.6 surface + test gap-fills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,9 @@
   verifier strategy is recognized. (The hosted-environment episode runner that
   executes ORS environments end-to-end is in progress, not in this release.)
 - **Daytona sandbox auto-reap** — orphaned sandboxes are cleaned at eval start
-  (TTL-tiered; failure states reaped sooner), gated by
-  `BENCHFLOW_DAYTONA_AUTO_REAP`.
+  (TTL-tiered; failure states reaped sooner; an idle-activity guard protects
+  live runs), gated by `BENCHFLOW_DAYTONA_AUTO_REAP` (any of `0`/`false`/`no`/
+  `off`, case-insensitive, disables it).
 - **`benchflow continue <run-folder>`** — resume a previous, unfinished
   (timed-out) `openhands` run to completion. A standalone tool (it does not
   touch the normal run path) that reconstructs the run's exact workspace and

--- a/benchmarks/CONVERT.md
+++ b/benchmarks/CONVERT.md
@@ -118,6 +118,17 @@ Save parity experiment results to `parity_experiment.json`:
 }
 ```
 
+`bench agent verify` reads this `tasks[].criteria_results` schema as the
+deterministic floor, and also accepts the equivalent pass/total summary blocks
+some benchmarks record instead — `structural_parity` / `eval_parity` /
+`live_parity` / `e2e_parity` / `pipeline_parity` / `security_parity` (or a bare
+top-level `results`), each as `{ "tasks_tested": <N>, "passed": <N> }` (a nested
+`results_summary` or a `total_tasks`/`passed`/`failed` triple is also read). A
+summary confirms only when `passed == tasks_tested > 0`; a partial summary
+surfaces as a divergence. `agent_parity.results` /
+`reward_distribution_parity.samples` supply the statistical reward layer (a
+half-recorded legacy-vs-converted sample fails the gate, never confirms it).
+
 ### 7. Generate `benchmark.yaml`
 
 Standard descriptor:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -428,8 +428,9 @@ bench environment cleanup --dry-run --max-age 1440
 
 Daytona-backed evals also reap orphaned sandboxes automatically at run start
 (failure states such as `BUILD_FAILED` are reaped sooner than healthy ones, and
-concurrent live runs are never touched). Set `BENCHFLOW_DAYTONA_AUTO_REAP=0` to
-disable that automatic pass and rely on the manual command above.
+an idle-activity guard means concurrent live runs are never reaped). Set
+`BENCHFLOW_DAYTONA_AUTO_REAP` to any of `0`/`false`/`no`/`off` (case-insensitive)
+to disable that automatic pass and rely on the manual command above.
 
 ## bench compat
 

--- a/src/benchflow/_utils/reward_events.py
+++ b/src/benchflow/_utils/reward_events.py
@@ -3,9 +3,72 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 _EVENT_FIELDS = ("type", "reward", "source", "space", "granularity", "step")
+
+
+def build_rewards_jsonl_events(
+    rewards: Mapping[str, Any] | None,
+    finished_at: datetime,
+) -> list[dict[str, Any]]:
+    """Build the ``rewards.jsonl`` event list from a native-shape rewards dict.
+
+    Shared by the native rollout writer and the hosted-env writer so both tag
+    every record ``(space, granularity, value)`` identically: ``space`` and
+    ``granularity`` are first-class fields, promoted from any verifier-supplied
+    per-item dict and falling back to ``space="output"`` (``granularity="step"``
+    for rubric ``process`` events, ``"terminal"`` for the scalar reward).
+    Rubric items with a non-numeric ``score`` are skipped so an out-of-contract
+    or nulled value never becomes a process event.
+    """
+    if not rewards:
+        return []
+    ts = finished_at.isoformat()
+    events: list[dict[str, Any]] = []
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            score = item.get("score")
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                continue
+            events.append(
+                {
+                    "ts": ts,
+                    "type": "process",
+                    "source": "verifier_rubric",
+                    "value": score,
+                    "tag": item.get("name", f"rubric_{i}"),
+                    "step_index": i,
+                    "space": item.get("space", "output"),
+                    "granularity": item.get("granularity", "step"),
+                    "meta": {
+                        k: v
+                        for k, v in item.items()
+                        if k not in ("score", "name", "space", "granularity")
+                    },
+                }
+            )
+    scalar = rewards.get("reward")
+    if scalar is not None:
+        non_event_keys = {"reward", "rubric", "space", "granularity"}
+        events.append(
+            {
+                "ts": ts,
+                "type": "terminal",
+                "source": "verifier",
+                "value": scalar,
+                "tag": "reward",
+                "step_index": None,
+                "space": rewards.get("space", "output"),
+                "granularity": rewards.get("granularity", "terminal"),
+                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
+            }
+        )
+    return events
 
 
 def reward_event_to_dict(event: Any) -> dict[str, Any]:

--- a/src/benchflow/adapters/ors.py
+++ b/src/benchflow/adapters/ors.py
@@ -119,9 +119,39 @@ class ORSAdapter:
             finished = bool(
                 output.get("finished") is True or output.get("done") is True
             )
-            record_type = str(
-                output.get("type") or ("terminal" if finished else "dense")
+            explicit_type = (
+                str(output["type"]) if output.get("type") is not None else None
             )
+            explicit_granularity = (
+                str(output["granularity"])
+                if output.get("granularity") is not None
+                else None
+            )
+            # A ``finished``/``done`` record is the episode's terminal: force its
+            # type/granularity to terminal so it is never emitted as an
+            # internally-contradictory ``{type:'dense', granularity:'terminal'}``.
+            # Reject the contradiction where the caller explicitly marks the same
+            # record step-level (or non-terminal) yet also finished.
+            if finished:
+                if explicit_type is not None and explicit_type != "terminal":
+                    raise ValueError(
+                        f"outputs[{index}] is finished but has non-terminal "
+                        f"type {explicit_type!r}; a finished record is terminal"
+                    )
+                if (
+                    explicit_granularity is not None
+                    and explicit_granularity != "terminal"
+                ):
+                    raise ValueError(
+                        f"outputs[{index}] is finished but has non-terminal "
+                        f"granularity {explicit_granularity!r}; "
+                        "a finished record is terminal"
+                    )
+                record_type = "terminal"
+                granularity = "terminal"
+            else:
+                record_type = explicit_type or "dense"
+                granularity = explicit_granularity or "step"
             record: dict[str, Any] = {
                 "type": record_type,
                 "reward": reward,
@@ -135,9 +165,7 @@ class ORSAdapter:
                 "space": str(
                     output.get("space") or ("output" if finished else "action")
                 ),
-                "granularity": str(
-                    output.get("granularity") or ("terminal" if finished else "step")
-                ),
+                "granularity": granularity,
             }
             timestamp = output.get("timestamp") or output.get("ts")
             if timestamp is not None:

--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -35,10 +35,28 @@ import re
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any
 
 import typer
 
+# The parity gate (parsers, scoring, verdict) lives in agent_router_parity to
+# keep this module focused on create/run/verify CLI wiring. Re-exported here
+# (see __all__) so the public API is unchanged, e.g.
+# ``from benchflow.agent_router import build_verify_report``.
+from benchflow.agent_router_parity import (  # noqa: F401
+    DEFAULT_REWARD_TOLERANCE,
+    ConversionParity,
+    CriterionComparison,
+    RewardDistributionParity,
+    RewardSample,
+    Verdict,
+    VerifyReport,
+    build_verify_report,
+    confidence_line,
+    extract_criterion_comparisons,
+    extract_reward_samples,
+    render_divergence_issue,
+)
 from benchflow.agent_router_scaffold import (
     BENCHMARK_YAML_TEMPLATE,
     CONVERTER_TEMPLATE,
@@ -398,307 +416,7 @@ def run_agent_adoption(
     return exec_fn(launch.command, cwd=launch.cwd, env=resolved_env)
 
 
-# ── verify: parity gate + confidence verdict ──────────────────────────
-
-DEFAULT_REWARD_TOLERANCE = 0.02
-
-Verdict = Literal["parity-confirmed", "parity-divergent", "insufficient-evidence"]
-
-
-@dataclass(frozen=True)
-class CriterionComparison:
-    """One per-criterion verdict pair from the deterministic parity floor."""
-
-    task_id: str
-    criterion_id: str
-    original_verdict: str
-    adapted_verdict: str
-    agreement: bool
-
-
-@dataclass(frozen=True)
-class RewardSample:
-    """One legacy-vs-converted reward delta from the statistical layer."""
-
-    task_id: str
-    legacy_reward: float | None
-    converted_reward: float | None
-    delta: float
-
-
-def _as_list(value: Any) -> list[Any]:
-    return value if isinstance(value, list) else []
-
-
-def extract_criterion_comparisons(data: Any) -> list[CriterionComparison]:
-    """Pull per-criterion verdict pairs from a parity_experiment.json payload.
-
-    Tolerant of the scaffold shape (``conversion_parity.tasks``) and the
-    CONVERT.md example shape (top-level ``tasks``). A non-mapping top level
-    (e.g. a JSON array of experiment summaries, as some adopted benchmarks
-    ship) is not a supported parity schema: return no comparisons so the
-    caller reports ``insufficient-evidence`` instead of crashing on ``.get``.
-    """
-    if not isinstance(data, Mapping):
-        return []
-    task_lists: list[Any] = []
-    conv = data.get("conversion_parity")
-    if isinstance(conv, Mapping):
-        task_lists.extend(_as_list(conv.get("tasks")))
-    task_lists.extend(_as_list(data.get("tasks")))
-
-    out: list[CriterionComparison] = []
-    for task in task_lists:
-        if not isinstance(task, Mapping):
-            continue
-        task_id = str(task.get("task_id", ""))
-        for crit in _as_list(task.get("criteria_results")):
-            if not isinstance(crit, Mapping):
-                continue
-            original = str(crit.get("original_verdict", ""))
-            adapted = str(crit.get("adapted_verdict", ""))
-            agreement = bool(crit.get("agreement", original == adapted))
-            out.append(
-                CriterionComparison(
-                    task_id=task_id,
-                    criterion_id=str(crit.get("criterion_id", "")),
-                    original_verdict=original,
-                    adapted_verdict=adapted,
-                    agreement=agreement,
-                )
-            )
-    return out
-
-
-def _reward_pair(result: Mapping[str, Any]) -> tuple[float | None, float | None, float]:
-    legacy = result.get("legacy_reward", result.get("pb_reward"))
-    converted = result.get("converted_reward", result.get("bf_reward"))
-    if legacy is None and isinstance(result.get("programbench"), Mapping):
-        legacy = result["programbench"].get("reward")
-    if converted is None and isinstance(result.get("benchflow"), Mapping):
-        converted = result["benchflow"].get("reward")
-
-    if legacy is not None and converted is not None:
-        delta = abs(float(converted) - float(legacy))
-    else:
-        delta = abs(float(result.get("reward_delta", 0.0)))
-    legacy_f = float(legacy) if legacy is not None else None
-    converted_f = float(converted) if converted is not None else None
-    return legacy_f, converted_f, delta
-
-
-def extract_reward_samples(data: Any) -> list[RewardSample]:
-    """Pull legacy-vs-converted reward deltas (the statistical parity layer).
-
-    Tolerant of the scaffold shape (``reward_distribution_parity.samples``) and
-    the reference ``agent_parity.results`` (programbench/benchflow rewards). A
-    non-mapping top level is not a supported parity schema: return no samples
-    so the caller reports ``insufficient-evidence`` rather than crashing (and
-    never fabricates phantom zero-delta samples from summary records).
-    """
-    if not isinstance(data, Mapping):
-        return []
-    result_lists: list[Any] = []
-    rdp = data.get("reward_distribution_parity")
-    if isinstance(rdp, Mapping):
-        result_lists.extend(_as_list(rdp.get("samples")))
-    agent = data.get("agent_parity")
-    if isinstance(agent, Mapping):
-        result_lists.extend(_as_list(agent.get("results")))
-
-    out: list[RewardSample] = []
-    for result in result_lists:
-        if not isinstance(result, Mapping):
-            continue
-        legacy, converted, delta = _reward_pair(result)
-        out.append(
-            RewardSample(
-                task_id=str(result.get("task_id", "")),
-                legacy_reward=legacy,
-                converted_reward=converted,
-                delta=delta,
-            )
-        )
-    return out
-
-
-@dataclass(frozen=True)
-class ConversionParity:
-    """Deterministic conversion-faithfulness floor."""
-
-    comparisons: list[CriterionComparison]
-
-    @property
-    def compared(self) -> int:
-        return len(self.comparisons)
-
-    @property
-    def agreed(self) -> int:
-        return sum(1 for c in self.comparisons if c.agreement)
-
-    @property
-    def all_agree(self) -> bool:
-        return self.compared > 0 and self.agreed == self.compared
-
-    @property
-    def agreement_rate(self) -> float:
-        return self.agreed / self.compared if self.compared else 0.0
-
-    @property
-    def disagreements(self) -> list[CriterionComparison]:
-        return [c for c in self.comparisons if not c.agreement]
-
-
-@dataclass(frozen=True)
-class RewardDistributionParity:
-    """Statistical legacy-vs-converted reward parity layer."""
-
-    samples: list[RewardSample]
-    tolerance: float
-
-    @property
-    def max_abs_delta(self) -> float:
-        return max((s.delta for s in self.samples), default=0.0)
-
-    @property
-    def within_tolerance(self) -> bool:
-        return self.max_abs_delta <= self.tolerance
-
-    @property
-    def exceeding(self) -> list[RewardSample]:
-        return [s for s in self.samples if s.delta > self.tolerance]
-
-
-@dataclass(frozen=True)
-class VerifyReport:
-    """Parity verdict for an adopted benchmark."""
-
-    name: str
-    conversion: ConversionParity
-    reward: RewardDistributionParity | None
-    verdict: Verdict
-    tolerance: float = DEFAULT_REWARD_TOLERANCE
-
-    @property
-    def passed(self) -> bool:
-        return self.verdict == "parity-confirmed"
-
-
-def build_verify_report(
-    name: str,
-    data: Any,
-    *,
-    tolerance: float = DEFAULT_REWARD_TOLERANCE,
-) -> VerifyReport:
-    """Score parity and assign a confidence verdict.
-
-    Parity-only gate over two layers:
-
-    * deterministic floor — every compared criterion's converted verdict must
-      match the original's verdict on identical inputs;
-    * statistical layer — every legacy-vs-converted reward delta must sit within
-      ``tolerance``.
-
-    A layer that has no data does not block the verdict. With no data at all the
-    verdict is ``insufficient-evidence`` (the support path). The gate never
-    "improves" the source: a faithful conversion reproduces the original's
-    behavior, including any reward-hackability it has.
-    """
-    conversion = ConversionParity(extract_criterion_comparisons(data))
-    samples = extract_reward_samples(data)
-    reward = RewardDistributionParity(samples, tolerance=tolerance) if samples else None
-
-    has_conversion = conversion.compared > 0
-    has_reward = reward is not None
-
-    if not has_conversion and not has_reward:
-        verdict: Verdict = "insufficient-evidence"
-    else:
-        conversion_ok = (not has_conversion) or conversion.all_agree
-        reward_ok = (reward is None) or reward.within_tolerance
-        verdict = (
-            "parity-confirmed" if conversion_ok and reward_ok else ("parity-divergent")
-        )
-
-    return VerifyReport(
-        name=name,
-        conversion=conversion,
-        reward=reward,
-        verdict=verdict,
-        tolerance=tolerance,
-    )
-
-
-def confidence_line(report: VerifyReport) -> str:
-    """User-facing confidence framing (correctness/parity-based, no fixed %)."""
-    if report.verdict == "parity-confirmed":
-        if report.conversion.compared:
-            return (
-                "High-confidence: the converted evaluation reproduces the "
-                "original's verdicts on every compared criterion and stays "
-                "within reward tolerance."
-            )
-        return (
-            "High-confidence: the converted evaluation's rewards stay within "
-            "tolerance of the original across every recorded sample."
-        )
-    if report.verdict == "parity-divergent":
-        return (
-            "Divergence found: the conversion does not yet reproduce the "
-            "original's behavior — iterate, then open an issue for support."
-        )
-    return (
-        "Insufficient evidence: no recorded parity comparisons. Run "
-        "parity_test.py and record results before trusting the conversion."
-    )
-
-
-def render_divergence_issue(report: VerifyReport) -> str:
-    """Render a draft GitHub issue body for a non-confirmed verdict.
-
-    Printed/saved for a human to file — never auto-filed.
-    """
-    lines = [
-        f"## Benchmark adoption parity: {report.name}",
-        "",
-        f"**Verdict:** {report.verdict}",
-        "",
-        confidence_line(report),
-        "",
-        "### Conversion parity (deterministic floor)",
-        f"- criteria compared: {report.conversion.compared}",
-        f"- agreed: {report.conversion.agreed}",
-        f"- agreement rate: {report.conversion.agreement_rate:.4f}",
-    ]
-    for c in report.conversion.disagreements:
-        lines.append(
-            f"  - {c.task_id}/{c.criterion_id}: original={c.original_verdict} "
-            f"converted={c.adapted_verdict}"
-        )
-
-    lines.append("")
-    lines.append("### Reward-distribution parity (statistical layer)")
-    if report.reward is None:
-        lines.append("- no reward samples recorded")
-    else:
-        lines.append(f"- samples: {len(report.reward.samples)}")
-        lines.append(f"- max abs delta: {report.reward.max_abs_delta:.4f}")
-        lines.append(f"- tolerance: {report.reward.tolerance:.4f}")
-        for s in report.reward.exceeding:
-            lines.append(
-                f"  - {s.task_id}: legacy={s.legacy_reward} "
-                f"converted={s.converted_reward} delta={s.delta:.4f}"
-            )
-
-    lines += [
-        "",
-        "### Ask",
-        "Parity could not be closed for this conversion. The translation must",
-        "reproduce the original's behavior on identical inputs (including any",
-        "reward-hackability it has). This draft has NOT been filed — review it,",
-        "iterate on the converter, and open it manually if you need support.",
-    ]
-    return "\n".join(lines)
+# ── verify: parity gate (parsers/scoring re-exported from _parity above) ──
 
 
 def load_parity_experiment(benchmarks_root: Path, name: str) -> Any:
@@ -720,7 +438,12 @@ def load_parity_experiment(benchmarks_root: Path, name: str) -> Any:
         raise ParityExperimentMissing(
             f"no parity_experiment.json in {benchmark_dir} — run parity_test.py first"
         )
-    return json.loads(parity_file.read_text())
+    try:
+        return json.loads(parity_file.read_text())
+    except json.JSONDecodeError as exc:
+        raise ParityExperimentMissing(
+            f"parity_experiment.json in {benchmark_dir} is not valid JSON: {exc}"
+        ) from exc
 
 
 def roundtrip_conformance_status(
@@ -878,7 +601,20 @@ def register_agent_router(agent_app: typer.Typer) -> None:
         console.print(confidence_line(report))
 
         if roundtrip_task is not None:
-            status, reasons = roundtrip_conformance_status(roundtrip_task)
+            if not roundtrip_task.is_dir():
+                console.print(
+                    f"[red]  round-trip: error: task dir not found: "
+                    f"{roundtrip_task}[/red]"
+                )
+                raise typer.Exit(1)
+            try:
+                status, reasons = roundtrip_conformance_status(roundtrip_task)
+            except OSError as exc:
+                console.print(
+                    f"[red]  round-trip: error: could not check "
+                    f"{roundtrip_task}: {exc}[/red]"
+                )
+                raise typer.Exit(1) from exc
             console.print(f"  round-trip: {status}")
             for reason in reasons:
                 console.print(f"    [yellow]- {reason}[/yellow]")

--- a/src/benchflow/agent_router_parity.py
+++ b/src/benchflow/agent_router_parity.py
@@ -1,0 +1,500 @@
+"""Parity gate for ``bench agent verify`` — parsers, scoring, and verdict.
+
+The ``verify`` subcommand in :mod:`benchflow.agent_router` scores an adopted
+benchmark's recorded ``parity_experiment.json`` and assigns a confidence
+verdict. That parser/scorer logic lives here so the router module stays focused
+on the create/run/verify CLI wiring; the public names are re-exported from
+:mod:`benchflow.agent_router` for backwards compatibility.
+
+The gate is *parity only*: a faithful translation must reproduce the original's
+behavior on identical inputs (including any reward-hackability the original has)
+— parity never "improves" or sanitizes the source. It is also fail-closed: a
+half-recorded reward sample, a malformed record, or an unknown schema can never
+silently confirm parity.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any, Literal
+
+# ── verify: parity gate + confidence verdict ──────────────────────────
+
+DEFAULT_REWARD_TOLERANCE = 0.02
+
+Verdict = Literal["parity-confirmed", "parity-divergent", "insufficient-evidence"]
+
+
+@dataclass(frozen=True)
+class CriterionComparison:
+    """One per-criterion verdict pair from the deterministic parity floor."""
+
+    task_id: str
+    criterion_id: str
+    original_verdict: str
+    adapted_verdict: str
+    agreement: bool
+
+
+@dataclass(frozen=True)
+class RewardSample:
+    """One legacy-vs-converted reward delta from the statistical layer."""
+
+    task_id: str
+    legacy_reward: float | None
+    converted_reward: float | None
+    delta: float
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+# Deterministic-summary parity blocks the in-repo benchmarks ship: each is a
+# pass/total summary rather than a per-criterion verdict list. They form the
+# deterministic floor without fabricating reward samples.
+_SUMMARY_BLOCK_KEYS = (
+    "structural_parity",
+    "eval_parity",
+    "live_parity",
+    "e2e_parity",
+    "pipeline_parity",
+    "security_parity",
+)
+
+
+def _as_int(value: Any) -> int | None:
+    """Return ``value`` as an int only when it is a real, non-bool integer."""
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value
+
+
+def _summary_pass_total(block: Mapping[str, Any]) -> tuple[int, int] | None:
+    """Read (passed, total) from a deterministic-summary block.
+
+    Accepts ``tasks_tested``/``passed`` directly, a ``total_tasks``/``passed``/
+    ``failed`` results triple, or a nested ``results_summary`` carrying either.
+    Returns ``None`` when the block has no integer pass/total signal — so an
+    unknown shape contributes no comparison rather than a false confirmation.
+    """
+    for source in (block, block.get("results_summary"), block.get("results")):
+        if not isinstance(source, Mapping):
+            continue
+        passed = _as_int(source.get("passed"))
+        if passed is None:
+            continue
+        total = _as_int(source.get("tasks_tested"))
+        if total is None:
+            total = _as_int(source.get("total_tasks"))
+        if total is None:
+            failed = _as_int(source.get("failed"))
+            if failed is not None:
+                total = passed + failed
+        if total is not None:
+            return passed, total
+    return None
+
+
+def _summary_comparisons(data: Mapping[str, Any]) -> list[CriterionComparison]:
+    """Synthesize one comparison per deterministic-summary block.
+
+    Agreement is recorded only when the summary explicitly reports
+    ``passed == total > 0`` — a partial summary surfaces as a divergence, and a
+    zero-tested summary is dropped (never a false confirmation).
+    """
+    out: list[CriterionComparison] = []
+    for key in _SUMMARY_BLOCK_KEYS:
+        block = data.get(key)
+        if not isinstance(block, Mapping):
+            continue
+        pass_total = _summary_pass_total(block)
+        if pass_total is None:
+            continue
+        passed, total = pass_total
+        if total <= 0:
+            continue
+        agreement = passed == total
+        out.append(
+            CriterionComparison(
+                task_id=str(data.get("benchmark", "")),
+                criterion_id=key,
+                original_verdict=f"{total} tasks",
+                adapted_verdict=f"{passed} passed",
+                agreement=agreement,
+            )
+        )
+    # A top-level deterministic ``results`` summary (no parity sub-block) also
+    # counts as the floor for benchmarks that record it bare.
+    if not out:
+        results = data.get("results")
+        if isinstance(results, Mapping):
+            pass_total = _summary_pass_total({"results": results})
+            if pass_total is not None and pass_total[1] > 0:
+                passed, total = pass_total
+                out.append(
+                    CriterionComparison(
+                        task_id=str(data.get("benchmark", "")),
+                        criterion_id="results",
+                        original_verdict=f"{total} tasks",
+                        adapted_verdict=f"{passed} passed",
+                        agreement=passed == total,
+                    )
+                )
+    return out
+
+
+def _normalize_metric_value(value: Any) -> str | None:
+    """Normalize a harvey-lab metric value for original-vs-converted comparison.
+
+    Returns a stripped string for an exact-comparison scalar/string (e.g.
+    ``"100%"``), or ``None`` for a non-comparable value — including a
+    distributional ``mean ± std`` field, whose run noise makes string equality
+    meaningless, so it is neither auto-confirmed nor falsely flagged divergent.
+    """
+    if value is None or isinstance(value, (list, dict)):
+        return None
+    text = str(value).strip()
+    if "±" in text or "+/-" in text:
+        return None
+    return text
+
+
+def _metric_comparisons(records: Sequence[Any]) -> list[CriterionComparison]:
+    """Read original-vs-converted metric pairs from a top-level record array.
+
+    Only a metric carrying both ``original`` and ``converted`` exact-comparison
+    values becomes a comparison; distributional ``mean ± std`` fields with run
+    noise are skipped (no equality without an explicit, noise-free match).
+    """
+    out: list[CriterionComparison] = []
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        benchmark = str(record.get("benchmark", ""))
+        for metric in _as_list(record.get("metrics")):
+            if not isinstance(metric, Mapping):
+                continue
+            original = _normalize_metric_value(metric.get("original"))
+            converted = _normalize_metric_value(metric.get("converted"))
+            if original is None or converted is None:
+                continue
+            out.append(
+                CriterionComparison(
+                    task_id=benchmark,
+                    criterion_id=str(metric.get("name", "")),
+                    original_verdict=original,
+                    adapted_verdict=converted,
+                    agreement=original == converted,
+                )
+            )
+    return out
+
+
+def extract_criterion_comparisons(data: Any) -> list[CriterionComparison]:
+    """Pull per-criterion verdict pairs from a parity_experiment.json payload.
+
+    Tolerant of the scaffold shape (``conversion_parity.tasks``), the CONVERT.md
+    example shape (top-level ``tasks``), the deterministic-summary blocks the
+    in-repo benchmarks ship (``structural_parity`` / ``eval_parity`` /
+    ``live_parity`` / ``e2e_parity`` / ``pipeline_parity`` / ``security_parity``
+    and a bare top-level ``results`` summary, each read as a pass/total floor),
+    and a top-level array of records carrying original-vs-converted ``metrics``.
+    An unknown non-mapping/non-array top level is not a supported parity schema:
+    return no comparisons so the caller reports ``insufficient-evidence``
+    instead of crashing on ``.get``.
+    """
+    if isinstance(data, Sequence) and not isinstance(data, (str, bytes)):
+        return _metric_comparisons(data)
+    if not isinstance(data, Mapping):
+        return []
+    task_lists: list[Any] = []
+    conv = data.get("conversion_parity")
+    if isinstance(conv, Mapping):
+        task_lists.extend(_as_list(conv.get("tasks")))
+    task_lists.extend(_as_list(data.get("tasks")))
+
+    out: list[CriterionComparison] = []
+    for task in task_lists:
+        if not isinstance(task, Mapping):
+            continue
+        task_id = str(task.get("task_id", ""))
+        for crit in _as_list(task.get("criteria_results")):
+            if not isinstance(crit, Mapping):
+                continue
+            original = str(crit.get("original_verdict", ""))
+            adapted = str(crit.get("adapted_verdict", ""))
+            agreement = bool(crit.get("agreement", original == adapted))
+            out.append(
+                CriterionComparison(
+                    task_id=task_id,
+                    criterion_id=str(crit.get("criterion_id", "")),
+                    original_verdict=original,
+                    adapted_verdict=adapted,
+                    agreement=agreement,
+                )
+            )
+    # No explicit per-criterion list: fall back to the deterministic-summary
+    # floor the in-repo benchmarks record.
+    if not out:
+        out.extend(_summary_comparisons(data))
+    return out
+
+
+def _coerce_reward(value: Any) -> float | None:
+    """Coerce a reward field to float, or ``None`` for missing/non-numeric.
+
+    Booleans and non-numeric strings are treated as missing so a malformed
+    parity record can never crash ``_reward_pair`` on ``float()`` — the sample
+    is reported as one-sided/unmeasured rather than confirming parity.
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _reward_pair(result: Mapping[str, Any]) -> tuple[float | None, float | None, float]:
+    legacy = _coerce_reward(result.get("legacy_reward", result.get("pb_reward")))
+    converted = _coerce_reward(result.get("converted_reward", result.get("bf_reward")))
+    if legacy is None and isinstance(result.get("programbench"), Mapping):
+        legacy = _coerce_reward(result["programbench"].get("reward"))
+    if converted is None and isinstance(result.get("benchflow"), Mapping):
+        converted = _coerce_reward(result["benchflow"].get("reward"))
+
+    # An explicit reward_delta is the author's recorded measurement and always
+    # wins. Otherwise: both sides present -> real delta; exactly one side present
+    # -> the sample is unmeasured, so fail closed with an infinite delta that
+    # exceeds any tolerance (a half-recorded sample must never confirm parity).
+    if "reward_delta" in result:
+        delta = abs(_coerce_reward(result.get("reward_delta")) or 0.0)
+    elif legacy is not None and converted is not None:
+        delta = abs(converted - legacy)
+    elif legacy is not None or converted is not None:
+        delta = float("inf")
+    else:
+        delta = 0.0
+    return legacy, converted, delta
+
+
+def extract_reward_samples(data: Any) -> list[RewardSample]:
+    """Pull legacy-vs-converted reward deltas (the statistical parity layer).
+
+    Tolerant of the scaffold shape (``reward_distribution_parity.samples``) and
+    the reference ``agent_parity.results`` (programbench/benchflow rewards). A
+    non-mapping top level is not a supported parity schema: return no samples
+    so the caller reports ``insufficient-evidence`` rather than crashing (and
+    never fabricates phantom zero-delta samples from summary records).
+    """
+    if not isinstance(data, Mapping):
+        return []
+    result_lists: list[Any] = []
+    rdp = data.get("reward_distribution_parity")
+    if isinstance(rdp, Mapping):
+        result_lists.extend(_as_list(rdp.get("samples")))
+    agent = data.get("agent_parity")
+    if isinstance(agent, Mapping):
+        result_lists.extend(_as_list(agent.get("results")))
+
+    out: list[RewardSample] = []
+    for result in result_lists:
+        if not isinstance(result, Mapping):
+            continue
+        legacy, converted, delta = _reward_pair(result)
+        # A record with no numeric reward on either side and no explicit
+        # reward_delta carries no measurable signal — skip it rather than emit a
+        # phantom zero-delta sample (keeps malformed/non-numeric records from
+        # confirming parity; the caller then reports insufficient-evidence).
+        if legacy is None and converted is None and "reward_delta" not in result:
+            continue
+        out.append(
+            RewardSample(
+                task_id=str(result.get("task_id", "")),
+                legacy_reward=legacy,
+                converted_reward=converted,
+                delta=delta,
+            )
+        )
+    return out
+
+
+@dataclass(frozen=True)
+class ConversionParity:
+    """Deterministic conversion-faithfulness floor."""
+
+    comparisons: list[CriterionComparison]
+
+    @property
+    def compared(self) -> int:
+        return len(self.comparisons)
+
+    @property
+    def agreed(self) -> int:
+        return sum(1 for c in self.comparisons if c.agreement)
+
+    @property
+    def all_agree(self) -> bool:
+        return self.compared > 0 and self.agreed == self.compared
+
+    @property
+    def agreement_rate(self) -> float:
+        return self.agreed / self.compared if self.compared else 0.0
+
+    @property
+    def disagreements(self) -> list[CriterionComparison]:
+        return [c for c in self.comparisons if not c.agreement]
+
+
+@dataclass(frozen=True)
+class RewardDistributionParity:
+    """Statistical legacy-vs-converted reward parity layer."""
+
+    samples: list[RewardSample]
+    tolerance: float
+
+    @property
+    def max_abs_delta(self) -> float:
+        return max((s.delta for s in self.samples), default=0.0)
+
+    @property
+    def within_tolerance(self) -> bool:
+        return self.max_abs_delta <= self.tolerance
+
+    @property
+    def exceeding(self) -> list[RewardSample]:
+        return [s for s in self.samples if s.delta > self.tolerance]
+
+
+@dataclass(frozen=True)
+class VerifyReport:
+    """Parity verdict for an adopted benchmark."""
+
+    name: str
+    conversion: ConversionParity
+    reward: RewardDistributionParity | None
+    verdict: Verdict
+    tolerance: float = DEFAULT_REWARD_TOLERANCE
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict == "parity-confirmed"
+
+
+def build_verify_report(
+    name: str,
+    data: Any,
+    *,
+    tolerance: float = DEFAULT_REWARD_TOLERANCE,
+) -> VerifyReport:
+    """Score parity and assign a confidence verdict.
+
+    Parity-only gate over two layers:
+
+    * deterministic floor — every compared criterion's converted verdict must
+      match the original's verdict on identical inputs;
+    * statistical layer — every legacy-vs-converted reward delta must sit within
+      ``tolerance``.
+
+    A layer that has no data does not block the verdict. With no data at all the
+    verdict is ``insufficient-evidence`` (the support path). The gate never
+    "improves" the source: a faithful conversion reproduces the original's
+    behavior, including any reward-hackability it has.
+    """
+    conversion = ConversionParity(extract_criterion_comparisons(data))
+    samples = extract_reward_samples(data)
+    reward = RewardDistributionParity(samples, tolerance=tolerance) if samples else None
+
+    has_conversion = conversion.compared > 0
+    has_reward = reward is not None
+
+    if not has_conversion and not has_reward:
+        verdict: Verdict = "insufficient-evidence"
+    else:
+        conversion_ok = (not has_conversion) or conversion.all_agree
+        reward_ok = (reward is None) or reward.within_tolerance
+        verdict = (
+            "parity-confirmed" if conversion_ok and reward_ok else ("parity-divergent")
+        )
+
+    return VerifyReport(
+        name=name,
+        conversion=conversion,
+        reward=reward,
+        verdict=verdict,
+        tolerance=tolerance,
+    )
+
+
+def confidence_line(report: VerifyReport) -> str:
+    """User-facing confidence framing (correctness/parity-based, no fixed %)."""
+    if report.verdict == "parity-confirmed":
+        if report.conversion.compared:
+            return (
+                "High-confidence: the converted evaluation reproduces the "
+                "original's verdicts on every compared criterion and stays "
+                "within reward tolerance."
+            )
+        return (
+            "High-confidence: the converted evaluation's rewards stay within "
+            "tolerance of the original across every recorded sample."
+        )
+    if report.verdict == "parity-divergent":
+        return (
+            "Divergence found: the conversion does not yet reproduce the "
+            "original's behavior — iterate, then open an issue for support."
+        )
+    return (
+        "Insufficient evidence: no recorded parity comparisons. Run "
+        "parity_test.py and record results before trusting the conversion."
+    )
+
+
+def render_divergence_issue(report: VerifyReport) -> str:
+    """Render a draft GitHub issue body for a non-confirmed verdict.
+
+    Printed/saved for a human to file — never auto-filed.
+    """
+    lines = [
+        f"## Benchmark adoption parity: {report.name}",
+        "",
+        f"**Verdict:** {report.verdict}",
+        "",
+        confidence_line(report),
+        "",
+        "### Conversion parity (deterministic floor)",
+        f"- criteria compared: {report.conversion.compared}",
+        f"- agreed: {report.conversion.agreed}",
+        f"- agreement rate: {report.conversion.agreement_rate:.4f}",
+    ]
+    for c in report.conversion.disagreements:
+        lines.append(
+            f"  - {c.task_id}/{c.criterion_id}: original={c.original_verdict} "
+            f"converted={c.adapted_verdict}"
+        )
+
+    lines.append("")
+    lines.append("### Reward-distribution parity (statistical layer)")
+    if report.reward is None:
+        lines.append("- no reward samples recorded")
+    else:
+        lines.append(f"- samples: {len(report.reward.samples)}")
+        lines.append(f"- max abs delta: {report.reward.max_abs_delta:.4f}")
+        lines.append(f"- tolerance: {report.reward.tolerance:.4f}")
+        for s in report.reward.exceeding:
+            lines.append(
+                f"  - {s.task_id}: legacy={s.legacy_reward} "
+                f"converted={s.converted_reward} delta={s.delta:.4f}"
+            )
+
+    lines += [
+        "",
+        "### Ask",
+        "Parity could not be closed for this conversion. The translation must",
+        "reproduce the original's behavior on identical inputs (including any",
+        "reward-hackability it has). This draft has NOT been filed — review it,",
+        "iterate on the converter, and open it manually if you need support.",
+    ]
+    return "\n".join(lines)

--- a/src/benchflow/agent_router_scaffold.py
+++ b/src/benchflow/agent_router_scaffold.py
@@ -236,7 +236,7 @@ JOB_YAML_TEMPLATE = """\
 # BenchFlow job config — how to *run* {{TITLE}} (separate from benchmark.yaml).
 tasks_dir: benchmarks/{{NAME}}/tasks
 jobs_dir: jobs/{{NAME}}
-agent: codex-acp
+agent: claude-agent-acp
 model: ""
 environment: docker
 concurrency: 4

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -1238,14 +1238,18 @@ class Evaluation:
     def _maybe_start_daytona_reap(self) -> None:
         """Fire-and-forget auto-reap of orphaned Daytona sandboxes (issue: leakage at scale).
 
-        Gated by ``BENCHFLOW_DAYTONA_AUTO_REAP`` (default on). Conservative
-        TTLs (24h general / 2h failed states) mean concurrent live runs are
-        never touched. Runs in a daemon thread so eval startup never blocks
-        or fails on reaping.
+        Gated by ``BENCHFLOW_DAYTONA_AUTO_REAP`` (default on; any of
+        ``0``/``false``/``no``/``off`` case-insensitively disables it).
+        Conservative TTLs (24h general / 2h failed states) plus an idle-activity
+        guard mean concurrent live runs are never reaped. Runs in a daemon
+        thread so eval startup never blocks or fails on reaping.
         """
         if self._config.environment != "daytona":
             return
-        if os.environ.get("BENCHFLOW_DAYTONA_AUTO_REAP", "1") == "0":
+        if (
+            os.environ.get("BENCHFLOW_DAYTONA_AUTO_REAP", "1").strip().lower()
+            in {"0", "false", "no", "off"}
+        ):
             return
 
         def _reap() -> None:

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -25,14 +25,16 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from uuid import uuid4
 
 from benchflow._utils.result_metadata import (
     final_metrics_from_agent_result,
     trajectory_summary_from_events,
 )
+from benchflow._utils.reward_events import build_rewards_jsonl_events
 from benchflow.diagnostics import RolloutDiagnostics
+from benchflow.rewards.validation import is_valid_reward_number
 from benchflow.trajectories.types import redact_acp_trajectory_jsonl
 
 logger = logging.getLogger(__name__)
@@ -175,6 +177,7 @@ class HostedEnvRunResult:
     reward: float | None = None
     total_tool_calls: int | None = None
     verifiers_error: str | None = None
+    raw_reward: float | None = None
 
     @property
     def error(self) -> str | None:
@@ -288,6 +291,33 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         check=False,
     )
     finished_at = datetime.now(UTC)
+    parsed_reward = _extract_metric(proc.stdout, "reward")
+    verifiers_error = _extract_verifiers_error(proc.stdout + "\n" + proc.stderr)
+    reward = parsed_reward
+
+    # Fail closed so hosted evidence stays equivalent to native rollouts:
+    # 1. A headline reward outside the [0, 1] contract is recorded raw for
+    #    forensics but never persisted as a terminal reward (mirrors native
+    #    verifier_core / ors.ORSAdapter bounds enforcement).
+    if reward is not None and not is_valid_reward_number(reward):
+        verifiers_error = (
+            verifiers_error
+            or f"hosted reward out of [0,1] contract: {reward!r}"
+        )
+        reward = None
+    # 2. returncode 0 but no parseable reward and no abort marker means the
+    #    vf-eval summary format drifted — surface it as an error rather than a
+    #    clean run with no rewards artifact.
+    elif (
+        reward is None
+        and proc.returncode == 0
+        and not verifiers_error
+    ):
+        verifiers_error = (
+            "could not parse reward from vf-eval output "
+            "(vf-eval summary format may have changed)"
+        )
+
     result = HostedEnvRunResult(
         source_env=config.source_env,
         run_dir=run_dir,
@@ -297,9 +327,10 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         stderr=proc.stderr,
         model=config.model,
         normalized_model=normalized_model,
-        reward=_extract_metric(proc.stdout, "reward"),
+        reward=reward,
         total_tool_calls=_extract_int_metric(proc.stdout, "total_tool_calls"),
-        verifiers_error=_extract_verifiers_error(proc.stdout + "\n" + proc.stderr),
+        verifiers_error=verifiers_error,
+        raw_reward=parsed_reward,
     )
     _write_run_artifacts(
         result,
@@ -500,9 +531,10 @@ def _write_run_artifacts(
             partial_trajectory=False,
             trajectory_source="hosted_env" if trajectory else None,
         ),
-        "error": result.error
-        if result.returncode != 0 or not result.verifiers_error
-        else None,
+        # Surface aborts/parse-misses in the top-level error so the score view
+        # classifies them as 'errored' (not a clean run). With reward now None
+        # for those cases, this matches native errored-rollout semantics.
+        "error": result.error,
         "error_category": None,
         "verifier_error": result.verifiers_error,
         "verifier_error_category": None,
@@ -767,8 +799,14 @@ def _build_rewards_dict(
     Hosted runs report a single average reward from vf-eval's stdout
     summary, optionally augmented by per-example rubric items reconstructed
     from ``results.jsonl``.
+
+    Fails closed (returns ``None``) when the headline reward is absent or an
+    abort marker (``verifiers_error``) is set, so an aborted run is never
+    persisted as a legitimate 0.0-reward episode. Per-example rubric scores are
+    bounds-checked the same way the headline is, so an out-of-contract score
+    (e.g. ``1e9``) is never written as a process reward event.
     """
-    if result.reward is None:
+    if result.reward is None or result.verifiers_error:
         return None
     rubric: list[dict[str, Any]] = []
     results_path = _find_results_jsonl(output_dir)
@@ -786,13 +824,30 @@ def _build_rewards_dict(
                     if not isinstance(row, dict):
                         continue
                     reward = row.get("reward")
-                    if isinstance(reward, int | float):
-                        rubric.append(
-                            {
-                                "name": f"example_{example_idx}",
-                                "score": float(reward),
-                            }
-                        )
+                    if not is_valid_reward_number(reward):
+                        # Out-of-contract / non-numeric: keep the raw value for
+                        # forensics but do not write it as a rubric score.
+                        if isinstance(reward, int | float) and not isinstance(
+                            reward, bool
+                        ):
+                            rubric.append(
+                                {
+                                    "name": f"example_{example_idx}",
+                                    "score": None,
+                                    "raw_score": float(reward),
+                                }
+                            )
+                        continue
+                    item: dict[str, Any] = {
+                        "name": f"example_{example_idx}",
+                        "score": float(reward),
+                    }
+                    # Carry any verifier-supplied space/granularity through so the
+                    # writer can promote them to first-class rewards.jsonl fields.
+                    for tag in ("space", "granularity"):
+                        if isinstance(row.get(tag), str):
+                            item[tag] = row[tag]
+                    rubric.append(item)
         except OSError:
             pass
     payload: dict[str, Any] = {"reward": float(result.reward)}
@@ -808,43 +863,13 @@ def _write_hosted_rewards_jsonl(
 ) -> None:
     """Mirror ``rollout._write_rewards_jsonl`` for hosted-env rewards.
 
-    Kept in this module to avoid importing from ``benchflow.rollout`` (which
-    pulls heavy ACP/sandbox deps at import time).
+    Builds the events through the shared :func:`build_rewards_jsonl_events`
+    helper so hosted lines carry the same first-class ``space``/``granularity``
+    tags as native ones (Memory-space aggregation depends on them). The helper
+    lives in ``_utils.reward_events`` — a light module — so hosted_env still
+    avoids importing ``benchflow.rollout`` (heavy ACP/sandbox deps).
     """
-    events: list[dict[str, Any]] = []
-    rubric = rewards.get("rubric")
-    if isinstance(rubric, list):
-        for i, item in enumerate(rubric):
-            if not isinstance(item, dict):
-                continue
-            rubric_item = cast(dict[str, Any], item)
-            events.append(
-                {
-                    "ts": finished_at.isoformat(),
-                    "type": "process",
-                    "source": "verifier_rubric",
-                    "value": rubric_item.get("score", 0.0),
-                    "tag": rubric_item.get("name", f"rubric_{i}"),
-                    "step_index": i,
-                    "meta": {
-                        k: v for k, v in item.items() if k not in ("score", "name")
-                    },
-                }
-            )
-    scalar = rewards.get("reward")
-    if scalar is not None:
-        non_event_keys = {"reward", "rubric"}
-        events.append(
-            {
-                "ts": finished_at.isoformat(),
-                "type": "terminal",
-                "source": "verifier",
-                "value": scalar,
-                "tag": "reward",
-                "step_index": None,
-                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
-            }
-        )
+    events = build_rewards_jsonl_events(rewards, finished_at)
     if events:
         path = rollout_dir / "rewards.jsonl"
         path.write_text("\n".join(json.dumps(e, default=str) for e in events) + "\n")

--- a/src/benchflow/rollout/_results.py
+++ b/src/benchflow/rollout/_results.py
@@ -25,6 +25,7 @@ from benchflow._utils.result_metadata import (
     final_metrics_from_agent_result,
     trajectory_summary_from_events,
 )
+from benchflow._utils.reward_events import build_rewards_jsonl_events
 from benchflow._utils.scoring import classify_error, classify_verifier_error
 from benchflow.contracts import (
     BaseUser,
@@ -56,56 +57,14 @@ def _write_rewards_jsonl(
     """Write rewards.jsonl — one JSON line per reward event.
 
     Architecture (``docs/architecture.md``, "Evaluation — the five spaces"):
-    every reward record is tagged ``(space, granularity, value)``. Promote
-    those tags from any verifier-supplied per-item dict to first-class
-    fields on each line, falling back to the ``RewardEvent`` defaults
-    (``space="output"``; ``granularity="step"`` for rubric items,
-    ``"terminal"`` for the scalar reward) when the verifier omits them.
+    every reward record is tagged ``(space, granularity, value)``. The shared
+    :func:`build_rewards_jsonl_events` helper promotes those tags from any
+    verifier-supplied per-item dict to first-class fields, falling back to the
+    ``RewardEvent`` defaults (``space="output"``; ``granularity="step"`` for
+    rubric items, ``"terminal"`` for the scalar reward) — the hosted-env writer
+    uses the same helper so the two paths can't drift.
     """
-    from typing import cast
-
-    if not rewards:
-        return
-    events: list[dict[str, Any]] = []
-    rubric = rewards.get("rubric")
-    if isinstance(rubric, list):
-        for i, item in enumerate(rubric):
-            if not isinstance(item, dict):
-                continue
-            rubric_item = cast(dict[str, Any], item)
-            events.append(
-                {
-                    "ts": finished_at.isoformat(),
-                    "type": "process",
-                    "source": "verifier_rubric",
-                    "value": rubric_item.get("score", 0.0),
-                    "tag": rubric_item.get("name", f"rubric_{i}"),
-                    "step_index": i,
-                    "space": rubric_item.get("space", "output"),
-                    "granularity": rubric_item.get("granularity", "step"),
-                    "meta": {
-                        k: v
-                        for k, v in rubric_item.items()
-                        if k not in ("score", "name", "space", "granularity")
-                    },
-                }
-            )
-    scalar = rewards.get("reward")
-    if scalar is not None:
-        non_event_keys = {"reward", "rubric", "space", "granularity"}
-        events.append(
-            {
-                "ts": finished_at.isoformat(),
-                "type": "terminal",
-                "source": "verifier",
-                "value": scalar,
-                "tag": "reward",
-                "step_index": None,
-                "space": rewards.get("space", "output"),
-                "granularity": rewards.get("granularity", "terminal"),
-                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
-            }
-        )
+    events = build_rewards_jsonl_events(rewards, finished_at)
     if events:
         path = rollout_dir / "rewards.jsonl"
         path.write_text("\n".join(json.dumps(e, default=str) for e in events) + "\n")
@@ -436,6 +395,10 @@ def _build_rollout_result(
         rewards=rewards,
         model=model,
         verifier_error=verifier_error,
+        total_prompt_tokens=n_input_tokens,
+        total_completion_tokens=n_output_tokens,
+        total_cached_tokens=n_cache_read_tokens,
+        total_cost_usd=cost_usd,
     )
     return result
 
@@ -451,6 +414,10 @@ def _write_trainer_artifact(
     rewards: dict | None,
     model: str | None,
     verifier_error: str | None,
+    total_prompt_tokens: int | None = None,
+    total_completion_tokens: int | None = None,
+    total_cached_tokens: int | None = None,
+    total_cost_usd: float | None = None,
 ) -> None:
     """Emit the trainer-format artifacts for this scored rollout.
 
@@ -493,6 +460,10 @@ def _write_trainer_artifact(
             prompts=prompts,
             trajectory=trajectory,
             model=model,
+            total_prompt_tokens=total_prompt_tokens,
+            total_completion_tokens=total_completion_tokens,
+            total_cached_tokens=total_cached_tokens,
+            total_cost_usd=total_cost_usd,
         )
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("ATIF artifact write failed: %s", e)

--- a/src/benchflow/sandbox/_compose.py
+++ b/src/benchflow/sandbox/_compose.py
@@ -1,5 +1,6 @@
 """Compose helpers for Docker and Daytona DinD backends."""
 
+import re
 import shlex
 from pathlib import Path, PurePosixPath
 
@@ -8,6 +9,25 @@ COMPOSE_BASE_PATH = COMPOSE_DIR / "docker-compose-base.yaml"
 COMPOSE_BUILD_PATH = COMPOSE_DIR / "docker-compose-build.yaml"
 COMPOSE_PREBUILT_PATH = COMPOSE_DIR / "docker-compose-prebuilt.yaml"
 COMPOSE_NO_NETWORK_PATH = COMPOSE_DIR / "docker-compose-no-network.yaml"
+
+# Back-off delays for retrying a `compose up` that hit a daemon-side network
+# create/attach race. Shared by the host docker.py path and the Daytona DinD
+# path so a fresh-daemon race is retried identically on both.
+COMPOSE_UP_RETRY_DELAYS_SEC = (2.0, 5.0)
+# Daemon-side create/attach race seen on Docker 29.x: `compose up` prints
+# "Network ... Created" but the container create/start that follows fails with
+# "network <project>_default not found". Older daemons emit the same race
+# without the "failed to set up container networking" wrapper.
+_COMPOSE_UP_NETWORK_RACE_ERROR = re.compile(
+    r"error response from daemon: "
+    r"(?:failed to set up container networking: )?network \S+ not found",
+    re.IGNORECASE,
+)
+
+
+def is_compose_up_network_race_error(message: str) -> bool:
+    """Return whether *message* is a retryable compose-up network create race."""
+    return bool(_COMPOSE_UP_NETWORK_RACE_ERROR.search(message))
 
 
 def compose_cp_destination(service: str, container_path: str) -> str:

--- a/src/benchflow/sandbox/daytona_dind.py
+++ b/src/benchflow/sandbox/daytona_dind.py
@@ -27,9 +27,11 @@ from benchflow.sandbox._compose import (
     COMPOSE_BUILD_PATH,
     COMPOSE_NO_NETWORK_PATH,
     COMPOSE_PREBUILT_PATH,
+    COMPOSE_UP_RETRY_DELAYS_SEC,
     compose_cp_destination,
     compose_mkdir_p_command,
     compose_parent_mkdir_p_command,
+    is_compose_up_network_race_error,
 )
 from benchflow.sandbox.daytona_pty import (
     _exec_failure_output,
@@ -170,6 +172,34 @@ class _DaytonaDinD(_DaytonaStrategy):
             timeout_sec=timeout_sec,
         )
 
+    async def _compose_up_with_retry(self, env: DaytonaSandbox) -> None:
+        """Run ``compose up -d`` honouring the author's build budget and retrying
+        a fresh-daemon network create/attach race (mirrors the host docker path).
+
+        The ``up`` timeout is derived from ``build_timeout_sec`` (floored at the
+        historical 120s) so a prebuilt-image pull gets the full author budget,
+        rather than a hardcoded 120s.
+        """
+        timeout_sec = max(120, round(env.task_env_config.build_timeout_sec))
+        max_attempts = len(COMPOSE_UP_RETRY_DELAYS_SEC) + 1
+        for attempt in range(1, max_attempts + 1):
+            result = await self._compose_exec(["up", "-d"], timeout_sec=timeout_sec)
+            if result.return_code == 0:
+                return
+            message = f"{result.stdout} {result.stderr}"
+            if attempt == max_attempts or not is_compose_up_network_race_error(message):
+                raise RuntimeError(f"docker compose up failed: {message}")
+            delay = COMPOSE_UP_RETRY_DELAYS_SEC[attempt - 1]
+            env.logger.warning(
+                "Retrying docker compose up inside DinD after network "
+                "create/attach race (attempt %s/%s, retrying in %.1fs): %s",
+                attempt,
+                max_attempts,
+                delay,
+                message,
+            )
+            await asyncio.sleep(delay)
+
     async def _wait_for_docker_daemon(self) -> None:
         self._env.logger.debug("Waiting for Docker daemon inside DinD sandbox...")
         last_output = ""
@@ -287,11 +317,7 @@ class _DaytonaDinD(_DaytonaStrategy):
             )
 
         env.logger.debug("Starting compose services inside DinD sandbox...")
-        result = await self._compose_exec(["up", "-d"], timeout_sec=120)
-        if result.return_code != 0:
-            raise RuntimeError(
-                f"docker compose up failed: {result.stdout} {result.stderr}"
-            )
+        await self._compose_up_with_retry(env)
 
         await self._wait_for_main_container()
 

--- a/src/benchflow/sandbox/daytona_reaper.py
+++ b/src/benchflow/sandbox/daytona_reaper.py
@@ -18,6 +18,11 @@ logger = logging.getLogger("benchflow")
 _REAP_DEFAULT_MAX_AGE_MIN = 1440
 _REAP_FAILED_MAX_AGE_MIN = 120
 _REAP_FAILED_STATE_MARKERS = ("FAILED", "ERROR")
+# Minimum idle window before the general (non-failed) tier may reap an owned
+# sandbox that is old by creation time. The SDK returns ``last_activity_at`` on
+# list results, so a genuinely live, recently-active run older than the TTL is
+# protected without an extra API call. Well under the 1440-min creation TTL.
+_REAP_MIN_IDLE_MIN = 30
 
 # Ownership scoping for the auto-reaper. Every sandbox benchflow creates is
 # stamped with this label so :func:`reap_stale_sandboxes` can restrict its
@@ -85,11 +90,33 @@ def _is_benchflow_label_orphan(sb: Any) -> bool:
     )
 
 
+def _parse_sandbox_timestamp(raw: Any) -> Any | None:
+    """Parse a Daytona timestamp string to a tz-aware datetime, or ``None``.
+
+    A naive (no ``Z``/offset) value is coerced to UTC rather than dropped, so a
+    server that omits the offset doesn't silently leak a stale sandbox. Returns
+    ``None`` for a non-string or unparseable value; the caller decides whether
+    absence is protective (activity guard) or skip-worthy (created_at).
+    """
+    from datetime import UTC, datetime
+
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed
+
+
 def reap_stale_sandboxes(
     client: Any | None = None,
     *,
     max_age_minutes: int = _REAP_DEFAULT_MAX_AGE_MIN,
     failed_max_age_minutes: int = _REAP_FAILED_MAX_AGE_MIN,
+    min_idle_minutes: int = _REAP_MIN_IDLE_MIN,
     dry_run: bool = False,
     on_decision: Any | None = None,
 ) -> dict[str, int]:
@@ -103,9 +130,15 @@ def reap_stale_sandboxes(
 
     Two tiers: sandboxes whose state contains a failure marker (e.g.
     ``BUILD_FAILED``) are reaped after *failed_max_age_minutes*; everything
-    else after *max_age_minutes*. Defaults are deliberately conservative so
-    concurrent live runs are never touched — only multi-hour orphans from
-    crashed or interrupted sessions.
+    else after *max_age_minutes*. The general (non-failed) tier additionally
+    honours an activity guard: an owned sandbox whose ``last_activity_at`` is
+    within *min_idle_minutes* is skipped even when old by creation time, so a
+    genuinely live run is never reaped. Absent/unparseable activity is not
+    protective (it falls through to age-only), or nothing old would ever reap.
+    The failed tier ignores the activity guard so a crashed sandbox still reaps
+    on its short TTL. Defaults are deliberately conservative so concurrent live
+    runs are never touched — only multi-hour idle orphans from crashed or
+    interrupted sessions.
 
     *on_decision* (sandbox, age_minutes, will_delete) is called per *owned*
     sandbox when provided — the CLI uses it for per-row display; foreign
@@ -145,12 +178,36 @@ def reap_stale_sandboxes(
         if not getattr(sb, "created_at", None):
             counts["skipped"] += 1
             continue
-        created_at = datetime.fromisoformat(sb.created_at.replace("Z", "+00:00"))
+        # Guard the age parse per-sandbox (mirror the delete guard below): one
+        # odd timestamp must warn + skip, never abort the sweep and leak every
+        # sandbox after it.
+        created_at = _parse_sandbox_timestamp(sb.created_at)
+        if created_at is None:
+            logger.warning(
+                "Daytona sandbox %s has unparseable created_at %r; skipping "
+                "(possible leak)",
+                getattr(sb, "id", "?"),
+                sb.created_at,
+            )
+            counts["skipped"] += 1
+            continue
         age_minutes = (now - created_at).total_seconds() / 60
         state = str(getattr(sb, "state", "") or "").upper()
         is_failed = any(marker in state for marker in _REAP_FAILED_STATE_MARKERS)
         ttl = failed_max_age_minutes if is_failed else max_age_minutes
         will_delete = age_minutes >= ttl
+        # Activity guard (general tier only): protect a genuinely live run whose
+        # last activity is within the idle window, even when old by creation.
+        # Failed sandboxes ignore the guard so they still reap on the short TTL.
+        if will_delete and not is_failed:
+            last_activity = _parse_sandbox_timestamp(
+                getattr(sb, "last_activity_at", None)
+                or getattr(sb, "updated_at", None)
+            )
+            if last_activity is not None:
+                idle_minutes = (now - last_activity).total_seconds() / 60
+                if idle_minutes < min_idle_minutes:
+                    will_delete = False
         if on_decision is not None:
             on_decision(sb, age_minutes, will_delete)
         if not will_delete:

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -33,6 +33,8 @@ from benchflow.sandbox._compose import (
     COMPOSE_BUILD_PATH,
     COMPOSE_NO_NETWORK_PATH,
     COMPOSE_PREBUILT_PATH,
+    COMPOSE_UP_RETRY_DELAYS_SEC,
+    is_compose_up_network_race_error,
 )
 from benchflow.sandbox.protocol import SandboxImage
 from benchflow.task.config import SandboxConfig
@@ -51,16 +53,9 @@ _DOCKER_BUILD_RETRYABLE_ERRORS = (
     re.compile(r"connection (?:timed out|reset by peer)", re.IGNORECASE),
 )
 
-_COMPOSE_UP_RETRY_DELAYS_SEC = (2.0, 5.0)
-# Daemon-side create/attach race seen on Docker 29.x: `compose up` prints
-# "Network ... Created" but the container create/start that follows fails with
-# "network <project>_default not found". Older daemons emit the same race
-# without the "failed to set up container networking" wrapper.
-_COMPOSE_UP_NETWORK_RACE_ERROR = re.compile(
-    r"error response from daemon: "
-    r"(?:failed to set up container networking: )?network \S+ not found",
-    re.IGNORECASE,
-)
+# Compose-up network-race retry config lives in _compose so the host docker
+# path and the Daytona DinD path share the exact same race detection + back-off.
+_COMPOSE_UP_RETRY_DELAYS_SEC = COMPOSE_UP_RETRY_DELAYS_SEC
 
 
 def _sanitize_docker_image_name(name: str) -> str:
@@ -84,7 +79,7 @@ def _is_retryable_docker_build_error(message: str) -> bool:
 
 
 def _is_compose_up_network_race_error(message: str) -> bool:
-    return bool(_COMPOSE_UP_NETWORK_RACE_ERROR.search(message))
+    return is_compose_up_network_race_error(message)
 
 
 class DockerSandboxEnvVars(BaseModel):

--- a/src/benchflow/task/export.py
+++ b/src/benchflow/task/export.py
@@ -233,27 +233,52 @@ def export_task_to_split_layout(
     package = TaskPackage.from_task_dir(task_dir)
     view = package.view
     dest = Path(output_dir)
-    if dest.exists():
-        if not overwrite:
-            raise FileExistsError(f"Export destination already exists: {dest}")
-        shutil.rmtree(dest)
-    dest.mkdir(parents=True)
 
-    (dest / "task.toml").write_text(_export_task_toml(view))
-    (dest / "instruction.md").write_text(view.prompt.strip() + "\n")
+    # Reject a destination that overlaps the source task directory in EITHER
+    # direction. ``TaskPackage`` only loads config/prompt/document into memory;
+    # the environment/oracle/verifier trees are copied from disk *after* the
+    # ``rmtree`` below, so exporting onto (or inside, or above) the source would
+    # delete those files before they are copied — a silent destructive export.
+    src = Path(task_dir).resolve()
+    dst = dest.resolve()
+    if src == dst or dst.is_relative_to(src) or src.is_relative_to(dst):
+        raise ValueError(
+            f"Export destination {dest} overlaps the source task directory "
+            f"{task_dir}; choose a separate output directory"
+        )
 
-    _copy_tree_if_exists(view.environment_dir, dest / "environment")
-    _copy_tree_if_exists(view.oracle_dir, dest / "solution")
-    _copy_tree_if_exists(view.verifier_dir, dest / "tests")
+    if dest.exists() and not overwrite:
+        raise FileExistsError(f"Export destination already exists: {dest}")
 
-    report = build_compatibility_export_report(
-        view.task_dir,
-        target=target,
-        output_dir=dest,
-    )
-    report_dir = dest / "compatibility"
-    report_dir.mkdir(exist_ok=True)
-    (report_dir / "export-report.json").write_text(report.to_json())
+    # Build the export in a sibling temp dir and swap it into place only once it
+    # is fully materialized, so any abort/collision can never leave a
+    # half-deleted destination (and, with the guard above, never the source).
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        prefix="benchflow-split-export-", dir=dest.parent
+    ) as staging_root:
+        staged = Path(staging_root) / "export"
+        staged.mkdir()
+
+        (staged / "task.toml").write_text(_export_task_toml(view))
+        (staged / "instruction.md").write_text(view.prompt.strip() + "\n")
+
+        _copy_tree_if_exists(view.environment_dir, staged / "environment")
+        _copy_tree_if_exists(view.oracle_dir, staged / "solution")
+        _copy_tree_if_exists(view.verifier_dir, staged / "tests")
+
+        report = build_compatibility_export_report(
+            view.task_dir,
+            target=target,
+            output_dir=staged,
+        )
+        report_dir = staged / "compatibility"
+        report_dir.mkdir(exist_ok=True)
+        (report_dir / "export-report.json").write_text(report.to_json())
+
+        if dest.exists():
+            shutil.rmtree(dest)
+        shutil.move(str(staged), str(dest))
     return report
 
 

--- a/src/benchflow/task/verifier_ors_episode.py
+++ b/src/benchflow/task/verifier_ors_episode.py
@@ -158,27 +158,30 @@ def _ors_records_to_verify_result(
 
         event = _ors_event(record, strategy=strategy, path=path)
         events.append(event)
-        if (
-            event.type == "terminal"
-            or event.granularity == "terminal"
-            or record.get("finished") is True
-            or record.get("done") is True
-        ):
-            reward = event.reward
-            headline_space = event.space
-            headline_granularity = event.granularity
 
+    # Headline selection from the plain-event stream. Only a *genuinely*
+    # terminal event (explicit ``type == "terminal"`` or
+    # ``granularity == "terminal"``) may set the headline reward — a
+    # ``finished``/``done`` marker on a step/dense record must never demote an
+    # earlier real terminal (the last-write-wins bug). Conflicting genuine
+    # terminals fail closed rather than silently picking the last.
     if reward is None:
         terminal_events = [
             event
             for event in events
             if event.type == "terminal" or event.granularity == "terminal"
         ]
+        distinct_rewards = {event.reward for event in terminal_events}
+        if len(distinct_rewards) > 1:
+            raise VerifierOutputParseError(
+                f"ors-episode strategy {strategy.name!r} has conflicting terminal "
+                f"rewards {sorted(distinct_rewards)}; expected exactly one headline"
+            )
         if terminal_events:
-            last_terminal = terminal_events[-1]
-            reward = last_terminal.reward
-            headline_space = last_terminal.space
-            headline_granularity = last_terminal.granularity
+            chosen = terminal_events[0]
+            reward = chosen.reward
+            headline_space = chosen.space
+            headline_granularity = chosen.granularity
     if reward is None:
         raise VerifierOutputParseError(
             f"ors-episode strategy {strategy.name!r} did not include a terminal reward"

--- a/src/benchflow/trajectories/export_adp.py
+++ b/src/benchflow/trajectories/export_adp.py
@@ -40,6 +40,7 @@ Mapping from BenchFlow ACP trajectory events (see
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any, cast
 
@@ -50,6 +51,8 @@ from benchflow.trajectories._export_common import (
     content_blocks_to_text,
 )
 from benchflow.trajectories.types import redact_trajectory_text
+
+logger = logging.getLogger(__name__)
 
 ADP_SCHEMA_VERSION = "1.3.1"
 
@@ -174,21 +177,35 @@ def trajectory_to_adp_record(
 
     *reward*, when given, is attached to the trajectory's final action as
     ADP's per-step ``reward`` field — the terminal-reward convention for
-    RL training data. *details* passes through as the dataset-specific
-    metadata dict. ``available_apis`` is omitted: BenchFlow does not know
-    the agent's full tool universe, and the field is optional.
+    RL training data. When the trajectory has no action to carry it (e.g. an
+    agent that crashed after consuming the prompt but before acting), the
+    reward is surfaced as ``details['terminal_reward']`` and a warning is
+    logged rather than silently dropped. *details* passes through as the
+    dataset-specific metadata dict. ``available_apis`` is omitted: BenchFlow
+    does not know the agent's full tool universe, and the field is optional.
     """
     content = acp_events_to_adp_content(events, prompts)
+    out_details = dict(details or {})
     if reward is not None:
+        placed = False
         for item in reversed(content):
             if item["class_"] in _ACTION_CLASSES:
                 item["reward"] = reward
+                placed = True
                 break
+        if not placed:
+            out_details["terminal_reward"] = reward
+            logger.warning(
+                "ADP trajectory %s has terminal reward %r but no action to "
+                "carry it; recorded under details.terminal_reward",
+                trajectory_id,
+                reward,
+            )
     return {
         "schema_version": ADP_SCHEMA_VERSION,
         "id": trajectory_id,
         "content": content,
-        "details": dict(details or {}),
+        "details": out_details,
     }
 
 
@@ -207,11 +224,16 @@ def write_rollout_adp_jsonl(
     model: str | None,
     environment: str,
     reward: float | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     """Write one rollout's ADP record to ``rollout_dir/trainer/adp.jsonl``.
 
     One record per line, matching the verifiers.jsonl seam. Returns the
-    redacted record so callers can aggregate across a job.
+    redacted record so callers can aggregate across a job, or ``None`` when an
+    empty-content trajectory carries no score — mirroring ATIF's empty-record
+    contract so a meaningless ``content == []`` line never reaches the job
+    aggregate. An empty-content trajectory that still has a terminal reward is
+    written (the score lands in ``details.terminal_reward``) so a scored crash
+    rollout is not lost.
     """
     record = trajectory_to_adp_record(
         trajectory_id=trajectory_id,
@@ -220,6 +242,8 @@ def write_rollout_adp_jsonl(
         reward=reward,
         details={"task_id": task_id, "environment": environment, "model": model or ""},
     )
+    if not record["content"] and "terminal_reward" not in record["details"]:
+        return None
     out = Path(rollout_dir) / ROLLOUT_ADP_RELPATH
     out.parent.mkdir(parents=True, exist_ok=True)
     redacted = _record_to_redacted_json_line(record)

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -193,6 +193,12 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])"), "***REDACTED***"),
     # Daytona SDK tokens: dtn_... — ≥16 char suffix avoids short ids (`dtn_v2`).
     (re.compile(r"dtn_[A-Za-z0-9_]{16,}"), "***REDACTED***"),
+    # GitHub tokens: PATs / OAuth / app / refresh (ghp_/gho_/ghu_/ghs_/ghr_) and
+    # fine-grained PATs (github_pat_...). ≥20 char suffix avoids short slugs.
+    (re.compile(r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "***REDACTED***"),
+    # Slack tokens: bot/user/app/refresh/legacy (xoxb-/xoxp-/xoxa-/xoxr-/xoxs-).
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "***REDACTED***"),
     # Header / key-value secret carriers, in BOTH JSON and raw-text forms
     # (agents print env, curl -v, request logs into trajectories — #585).
     # Matches: `"x-api-key": "v"`, `x-api-key: v`, `api-key=v`,
@@ -218,6 +224,18 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(
             r'("?api_key"?\s*[:=]\s*"?)[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+    # Generic *TOKEN* / *SECRET* carriers (e.g. GITHUB_TOKEN=, SLACK_SECRET:),
+    # closing the name-coverage gap vs config.json's _SECRET_ENV_SUBSTRINGS. The
+    # name is kept, the value dropped. Value excludes backslash and `*` like the
+    # api_key/authorization carriers so an escaped `\n` can't swallow the next
+    # entry and an already-redacted value isn't re-matched.
+    (
+        re.compile(
+            r'("?[A-Za-z0-9_]*(?:TOKEN|SECRET)"?\s*[:=]\s*"?)[^"\s,}\\*]+',
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
@@ -251,10 +269,12 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
 def redact_trajectory_text(text: str) -> str:
     """Apply all secret-redaction patterns to *text*.
 
-    Token families (Anthropic/OpenAI/Google/AWS/Daytona) are redacted whole,
-    prefix included, so the secret-leak audit greps see no live-key shape.
-    Header/key-value carriers keep the field name but drop the value, in both
-    JSON (``"x-api-key": "v"``) and raw-text (``x-api-key: v``) forms.
+    Token families (Anthropic/OpenAI/Google/AWS/Daytona/GitHub/Slack) are
+    redacted whole, prefix included, so the secret-leak audit greps see no
+    live-key shape. Header/key-value carriers keep the field name but drop the
+    value, in both JSON (``"x-api-key": "v"``) and raw-text (``x-api-key: v``)
+    forms; this includes generic ``*TOKEN*``/``*SECRET*`` carriers so a
+    ``GITHUB_TOKEN=...`` env dump is scrubbed even without a known prefix.
     """
     for pattern, replacement in _REDACTION_PATTERNS:
         text = pattern.sub(replacement, text)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -330,6 +330,32 @@ class TestORSAdapter:
             }
         ]
 
+    def test_finished_record_is_never_dense_terminal_contradiction(self) -> None:
+        """A finished record (no explicit type) is forced terminal/terminal."""
+        records = ORSAdapter.tool_outputs_to_reward_events(
+            [{"tool": "submit", "reward": 0.9, "finished": True}]
+        )
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["type"] == "terminal"
+        assert rec["granularity"] == "terminal"
+        # The forbidden internally-contradictory shape must never be emitted.
+        assert not (rec["type"] == "dense" and rec["granularity"] == "terminal")
+
+    def test_finished_with_explicit_dense_type_is_rejected(self) -> None:
+        """An explicit non-terminal type on a finished record is contradictory."""
+        with pytest.raises(ValueError, match=r"finished.*non-terminal type"):
+            ORSAdapter.tool_outputs_to_reward_events(
+                [{"tool": "submit", "reward": 0.9, "type": "dense", "finished": True}]
+            )
+
+    def test_finished_with_explicit_step_granularity_is_rejected(self) -> None:
+        """An explicit step granularity on a finished record is contradictory."""
+        with pytest.raises(ValueError, match=r"finished.*non-terminal granularity"):
+            ORSAdapter.tool_outputs_to_reward_events(
+                [{"tool": "submit", "reward": 0.9, "granularity": "step", "done": True}]
+            )
+
 
 # Convenience functions
 

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -329,6 +329,68 @@ def test_extract_reward_samples_from_agent_parity_shape() -> None:
     assert deltas == [0.0, 0.1]
 
 
+def test_one_sided_legacy_reward_fails_closed() -> None:
+    # legacy recorded, converted missing, no explicit reward_delta: the sample
+    # is unmeasured and must never confirm parity (the half-recorded bug).
+    doc = {"agent_parity": {"results": [{"task_id": "t1", "legacy_reward": 1.0}]}}
+    report = build_verify_report("my-bench", doc)
+    assert report.verdict != "parity-confirmed"
+    assert report.reward is not None
+    assert [s.task_id for s in report.reward.exceeding] == ["t1"]
+    assert report.reward.samples[0].delta == float("inf")
+
+
+def test_one_sided_converted_reward_fails_closed() -> None:
+    doc = {"agent_parity": {"results": [{"task_id": "t2", "converted_reward": 0.5}]}}
+    report = build_verify_report("my-bench", doc)
+    assert report.verdict == "parity-divergent"
+    assert [s.task_id for s in report.reward.exceeding] == ["t2"]
+
+
+def test_mixed_full_and_one_sided_reward_is_divergent() -> None:
+    doc = {
+        "agent_parity": {
+            "results": [
+                {"task_id": "ok", "legacy_reward": 1.0, "converted_reward": 1.0},
+                {"task_id": "half", "legacy_reward": 1.0},
+            ]
+        }
+    }
+    report = build_verify_report("my-bench", doc)
+    assert report.verdict == "parity-divergent"
+    assert [s.task_id for s in report.reward.exceeding] == ["half"]
+
+
+def test_explicit_reward_delta_override_is_honored_with_one_side() -> None:
+    # An author-supplied reward_delta is the recorded measurement and wins even
+    # when only one raw reward is present.
+    doc = {
+        "agent_parity": {
+            "results": [
+                {"task_id": "t1", "legacy_reward": 1.0, "reward_delta": 0.0},
+            ]
+        }
+    }
+    report = build_verify_report("my-bench", doc)
+    assert report.verdict == "parity-confirmed"
+    assert report.reward.samples[0].delta == 0.0
+
+
+def test_non_numeric_reward_fields_skipped_not_crash() -> None:
+    # All-non-numeric reward fields yield no sample (no float() crash, no
+    # phantom zero-delta confirmation).
+    doc = {
+        "agent_parity": {
+            "results": [
+                {"task_id": "t1", "legacy_reward": "x", "converted_reward": "y"},
+            ]
+        }
+    }
+    report = build_verify_report("my-bench", doc)
+    assert report.reward is None
+    assert report.verdict == "insufficient-evidence"
+
+
 # ── verify: verdicts + issue draft ────────────────────────────────────
 
 
@@ -386,9 +448,10 @@ def test_scaffolded_parity_file_is_insufficient_evidence() -> None:
     assert report.verdict == "insufficient-evidence"
 
 
-# A real adopted benchmark shipped a parity_experiment.json whose top level was
-# a JSON *array* of experiment-summary records (not the mapping schema). The
-# parsers used to call ``.get`` on it unguarded and crash with AttributeError.
+# An adopted benchmark (harvey-lab) ships a parity_experiment.json whose top
+# level is a JSON *array* of experiment-summary records carrying ``metrics``
+# with original-vs-converted values. The parsers must read those metrics — and
+# never call ``.get`` on the array unguarded (the old AttributeError crash).
 _TOP_LEVEL_ARRAY_PARITY = [
     {
         "benchmark": "demo-bench",
@@ -404,17 +467,41 @@ _TOP_LEVEL_ARRAY_PARITY = [
     },
 ]
 
+# A top-level array carrying no comparable metric values at all — the parsers
+# must tolerate it (no crash) and yield no comparisons, so the gate reports
+# insufficient-evidence rather than a false confirmation.
+_TOP_LEVEL_ARRAY_NO_METRICS = [
+    {"benchmark": "demo-bench", "experiment": "end-to-end", "notes": "n/a"},
+    {"benchmark": "demo-bench", "metrics": [{"name": "noisy", "original": "1 ± 1"}]},
+]
 
-def test_extract_parsers_tolerate_top_level_array() -> None:
-    # Neither parser may raise on a non-mapping payload...
-    assert extract_criterion_comparisons(_TOP_LEVEL_ARRAY_PARITY) == []
-    # ...and the reward parser must not fabricate phantom zero-delta samples
-    # from the summary dicts inside the array (that would falsely confirm).
+
+def test_extract_parsers_read_top_level_array_metrics() -> None:
+    comps = extract_criterion_comparisons(_TOP_LEVEL_ARRAY_PARITY)
+    # Exact-comparison metrics on both records become comparisons; the matching
+    # 100%/100% agrees, the 23.0/22.2 mismatch disagrees.
+    by_id = {c.criterion_id: c.agreement for c in comps}
+    assert by_id == {"mean_pass_rate": False, "agreement": True}
+    # The reward parser must not fabricate phantom zero-delta samples from the
+    # array's summary dicts (that would falsely confirm).
     assert extract_reward_samples(_TOP_LEVEL_ARRAY_PARITY) == []
 
 
-def test_verify_top_level_array_is_insufficient_evidence_not_crash() -> None:
+def test_extract_parsers_tolerate_top_level_array_without_metrics() -> None:
+    # Non-comparable / distributional-only array: no comparisons, no crash.
+    assert extract_criterion_comparisons(_TOP_LEVEL_ARRAY_NO_METRICS) == []
+    assert extract_reward_samples(_TOP_LEVEL_ARRAY_NO_METRICS) == []
+
+
+def test_verify_top_level_array_metrics_flip_divergent() -> None:
     report = build_verify_report("demo-bench", _TOP_LEVEL_ARRAY_PARITY)
+    # One metric agrees, one diverges -> the deterministic floor is not all-agree.
+    assert report.verdict == "parity-divergent"
+    assert report.passed is False
+
+
+def test_verify_top_level_array_without_metrics_is_insufficient_evidence() -> None:
+    report = build_verify_report("demo-bench", _TOP_LEVEL_ARRAY_NO_METRICS)
     assert report.verdict == "insufficient-evidence"
     assert report.passed is False
 
@@ -422,7 +509,7 @@ def test_verify_top_level_array_is_insufficient_evidence_not_crash() -> None:
 def test_cli_verify_top_level_array_parity_file_does_not_crash(tmp_path: Path) -> None:
     create_benchmark("demo-bench", tmp_path)
     parity = tmp_path / "demo-bench" / "parity_experiment.json"
-    parity.write_text(json.dumps(_TOP_LEVEL_ARRAY_PARITY))
+    parity.write_text(json.dumps(_TOP_LEVEL_ARRAY_NO_METRICS))
     result = CliRunner().invoke(
         app, ["agent", "verify", "demo-bench", "--benchmarks-dir", str(tmp_path)]
     )
@@ -432,6 +519,39 @@ def test_cli_verify_top_level_array_parity_file_does_not_crash(tmp_path: Path) -
     out = click.unstyle(result.output)
     assert "insufficient-evidence" in out
     assert "AttributeError" not in out
+
+
+# ── in-repo benchmarks: every shipped parity file produces a real verdict ──
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SHIPPED_PARITY_FILES = sorted(
+    (_REPO_ROOT / "benchmarks").glob("*/parity_experiment.json")
+)
+
+
+def test_shipped_parity_files_are_discovered() -> None:
+    # Guard against the glob silently matching nothing (which would make the
+    # parametrized test below vacuously pass).
+    assert _SHIPPED_PARITY_FILES, "no benchmarks/*/parity_experiment.json found"
+
+
+@pytest.mark.parametrize(
+    "parity_file", _SHIPPED_PARITY_FILES, ids=lambda p: p.parent.name
+)
+def test_shipped_parity_file_yields_real_verdict(parity_file: Path) -> None:
+    """Each in-repo benchmark's recorded parity must parse to a real verdict.
+
+    A newly-adopted benchmark shipping a schema the verify gate can't read would
+    report ``insufficient-evidence`` here — telling its maintainer their
+    genuinely-validated benchmark has 'no recorded parity comparisons'. Globbing
+    (not a hardcoded list) makes a stale-schema benchmark fail CI on add.
+    """
+    data = json.loads(parity_file.read_text())
+    report = build_verify_report(parity_file.parent.name, data)
+    assert report.verdict != "insufficient-evidence", (
+        f"{parity_file.parent.name} parity_experiment.json parsed to no "
+        f"comparisons or samples (schema unsupported by the verify gate)"
+    )
 
 
 def test_divergence_issue_names_failing_criterion_and_is_unfiled() -> None:
@@ -470,6 +590,17 @@ def test_load_parity_experiment_fail_closed(tmp_path: Path) -> None:
     (tmp_path / "my-bench" / "parity_experiment.json").unlink()
     with pytest.raises(ParityExperimentMissing):
         load_parity_experiment(tmp_path, "my-bench")
+
+
+def test_load_parity_experiment_malformed_json_is_domain_error(tmp_path: Path) -> None:
+    create_benchmark("my-bench", tmp_path)
+    (tmp_path / "my-bench" / "parity_experiment.json").write_text("{ bad json")
+    # Malformed JSON must surface as the domain error (routed through the CLI's
+    # existing fail-closed arm), never a raw json.JSONDecodeError.
+    with pytest.raises(ParityExperimentMissing) as excinfo:
+        load_parity_experiment(tmp_path, "my-bench")
+    assert "not valid JSON" in str(excinfo.value)
+    assert not isinstance(excinfo.value, json.JSONDecodeError)
 
 
 def test_roundtrip_conformance_status_maps_report() -> None:
@@ -555,6 +686,75 @@ def test_cli_verify_pass_exits_zero(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert "parity-confirmed" in click.unstyle(result.output)
+
+
+def test_cli_verify_malformed_json_prints_clean_message(tmp_path: Path) -> None:
+    create_benchmark("my-bench", tmp_path)
+    (tmp_path / "my-bench" / "parity_experiment.json").write_text("{ bad json")
+    result = CliRunner().invoke(
+        app, ["agent", "verify", "my-bench", "--benchmarks-dir", str(tmp_path)]
+    )
+    out = click.unstyle(result.output)
+    # Fail-closed: a clean actionable message, no uncaught JSONDecodeError.
+    assert "not valid JSON" in out
+    assert "JSONDecodeError" not in out
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+def test_cli_verify_nonexistent_roundtrip_task_no_traceback(tmp_path: Path) -> None:
+    create_benchmark("my-bench", tmp_path)
+    parity = tmp_path / "my-bench" / "parity_experiment.json"
+    parity.write_text(json.dumps(_criteria_doc(("pass", "pass"))))
+    bad = tmp_path / "does-not-exist"
+    result = CliRunner().invoke(
+        app,
+        [
+            "agent",
+            "verify",
+            "my-bench",
+            "--benchmarks-dir",
+            str(tmp_path),
+            "--roundtrip-task",
+            str(bad),
+        ],
+    )
+    assert result.exit_code == 1
+    # The clean-exit assertion is the mutation-killer: a bare shutil.copytree
+    # FileNotFoundError would surface here instead of SystemExit.
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    # Collapse rich's line-wrapping before substring checks.
+    out = " ".join(click.unstyle(result.output).split())
+    assert "round-trip: error" in out
+    assert bad.name in out  # names the --roundtrip-task value the user passed
+    assert "Traceback" not in out
+    assert "FileNotFoundError" not in out
+
+
+def test_cli_verify_non_numeric_reward_is_clean(tmp_path: Path) -> None:
+    create_benchmark("my-bench", tmp_path)
+    parity = tmp_path / "my-bench" / "parity_experiment.json"
+    parity.write_text(
+        json.dumps(
+            {
+                "agent_parity": {
+                    "results": [
+                        {
+                            "task_id": "t1",
+                            "legacy_reward": "not-a-number",
+                            "converted_reward": "also-bad",
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    result = CliRunner().invoke(
+        app, ["agent", "verify", "my-bench", "--benchmarks-dir", str(tmp_path)]
+    )
+    # Non-numeric reward fields must not crash on float(); the sample is skipped
+    # so the gate degrades to insufficient-evidence, never a ValueError.
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert "insufficient-evidence" in click.unstyle(result.output)
 
 
 def test_default_reward_tolerance_is_small() -> None:

--- a/tests/test_agent_router_cli_e2e.py
+++ b/tests/test_agent_router_cli_e2e.py
@@ -83,6 +83,19 @@ def test_cli_create_writes_full_scaffold_that_compiles_and_parses(
     job = yaml.safe_load((target / "my-bench.yaml").read_text())
     assert job["tasks_dir"] == "benchmarks/my-bench/tasks"
 
+    # The generated job yaml must load through the same Evaluation.from_yaml the
+    # runner uses, with no ValueError from model resolution. A safe_load alone
+    # never exercises effective_model, so we assert the *resolved* model equals
+    # the default agent's default — the agent/model pair in the template has to
+    # be self-consistent or the runner crashes at job-load time before any task
+    # runs (regression guard for the codex-acp + empty-model scaffold).
+    from benchflow.evaluation import DEFAULT_AGENT, DEFAULT_MODEL, Evaluation
+
+    evaluation = Evaluation.from_yaml(str(target / "my-bench.yaml"))
+    assert job["agent"] == DEFAULT_AGENT
+    assert evaluation._config.agent == DEFAULT_AGENT
+    assert evaluation._config.model == DEFAULT_MODEL
+
     # The scaffolded parity record is valid JSON in the template state.
     parity = json.loads((target / "parity_experiment.json").read_text())
     assert parity["benchmark"] == "my-bench"

--- a/tests/test_agent_router_scaffold.py
+++ b/tests/test_agent_router_scaffold.py
@@ -1,0 +1,89 @@
+"""Direct unit tests for the ``bench agent create`` scaffold templates.
+
+The scaffold templates were previously exercised only indirectly through the
+CLI e2e test. These pin the pure-data layer directly: every template renders
+with no leftover ``{{NAME}}``/``{{TITLE}}`` token, the generated ``.py`` files
+byte-compile, every YAML parses, and the generated job yaml resolves to a
+runnable agent/model pair (the AR-1 regression). All templates use plain
+``str.replace`` (no ``str.format``), so a stray ``{`` in shell/python bodies
+must survive verbatim — these tests would catch a template that broke that.
+"""
+
+from __future__ import annotations
+
+import json
+import py_compile
+
+import yaml
+
+from benchflow import agent_router_scaffold as scaffold
+from benchflow.agent_router import build_scaffold_files
+from benchflow.evaluation import DEFAULT_AGENT, DEFAULT_MODEL
+
+_ALL_TEMPLATES = {
+    "CONVERTER_TEMPLATE": scaffold.CONVERTER_TEMPLATE,
+    "MAIN_TEMPLATE": scaffold.MAIN_TEMPLATE,
+    "PARITY_TEST_TEMPLATE": scaffold.PARITY_TEST_TEMPLATE,
+    "RUNNER_TEMPLATE": scaffold.RUNNER_TEMPLATE,
+    "BENCHMARK_YAML_TEMPLATE": scaffold.BENCHMARK_YAML_TEMPLATE,
+    "JOB_YAML_TEMPLATE": scaffold.JOB_YAML_TEMPLATE,
+    "README_TEMPLATE": scaffold.README_TEMPLATE,
+}
+
+
+def test_every_template_carries_at_least_one_token() -> None:
+    # Guards against a template that silently lost its slug placeholder (which
+    # would make the no-orphan-token assertions below vacuous for that file).
+    for label, template in _ALL_TEMPLATES.items():
+        assert "{{NAME}}" in template or "{{TITLE}}" in template, (
+            f"{label} has no NAME/TITLE token to substitute"
+        )
+
+
+def test_rendered_scaffold_has_no_orphan_tokens() -> None:
+    files = build_scaffold_files("my-bench")
+    for rel, content in files.items():
+        assert "{{NAME}}" not in content, f"{rel} kept a NAME token"
+        assert "{{TITLE}}" not in content, f"{rel} kept a TITLE token"
+
+
+def test_rendered_python_files_byte_compile(tmp_path) -> None:
+    files = build_scaffold_files("my-bench")
+    py_files = [rel for rel in files if rel.endswith(".py")]
+    # The full set of generated python modules must be present and compile.
+    assert {"benchflow.py", "main.py", "parity_test.py", "run_my_bench.py"} <= set(
+        py_files
+    )
+    for rel in py_files:
+        path = tmp_path / rel
+        path.write_text(files[rel])
+        py_compile.compile(str(path), doraise=True)
+
+
+def test_rendered_yaml_and_json_parse_with_substituted_slug() -> None:
+    files = build_scaffold_files("my-bench")
+    descriptor = yaml.safe_load(files["benchmark.yaml"])
+    assert descriptor["name"] == "my-bench"
+    job = yaml.safe_load(files["my-bench.yaml"])
+    assert job["tasks_dir"] == "benchmarks/my-bench/tasks"
+    parity = json.loads(files["parity_experiment.json"])
+    assert parity["benchmark"] == "my-bench"
+    assert parity["status"] == "template"
+
+
+def test_job_yaml_agent_model_pair_is_runnable() -> None:
+    # AR-1 regression: the generated job yaml must name an agent/model pair that
+    # effective_model resolves cleanly (an empty model under a non-default agent
+    # raises at job-load time before any task runs).
+    from benchflow.evaluation import effective_model
+
+    job = yaml.safe_load(build_scaffold_files("my-bench")["my-bench.yaml"])
+    assert job["agent"] == DEFAULT_AGENT
+    resolved = effective_model(job["agent"], job["model"] or None)
+    assert resolved == DEFAULT_MODEL
+
+
+def test_module_suffix_underscores_the_runner_filename() -> None:
+    files = build_scaffold_files("a-b-c")
+    assert "run_a_b_c.py" in files
+    assert "a-b-c.yaml" in files  # job yaml keeps the hyphenated slug

--- a/tests/test_daytona_dind_compose_up.py
+++ b/tests/test_daytona_dind_compose_up.py
@@ -1,0 +1,97 @@
+"""Daytona DinD ``compose up`` timeout + network-race retry (REAP-04).
+
+The DinD ``up -d`` previously used a hardcoded 120s regardless of the task's
+``build_timeout_sec`` (which the host docker path honours) and had no
+network create/attach-race retry. These tests pin the derived timeout and the
+single-retry-then-succeed behaviour so a regression to the bare 120s, or a lost
+retry, fails CI.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from benchflow.sandbox._base import ExecResult
+from benchflow.sandbox.daytona import _DaytonaDinD
+
+
+def _strategy(build_timeout_sec: float):
+    strategy = _DaytonaDinD.__new__(_DaytonaDinD)
+    env = SimpleNamespace(
+        logger=logging.getLogger("test.daytona.dind.up"),
+        task_env_config=SimpleNamespace(build_timeout_sec=build_timeout_sec),
+    )
+    strategy._env = env
+    return strategy, env
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "build_timeout_sec,expected_timeout",
+    [(600, 600), (3600, 3600), (60, 120)],  # 60 -> floored at 120
+)
+async def test_up_timeout_derived_from_build_budget(
+    build_timeout_sec, expected_timeout
+):
+    strategy, env = _strategy(build_timeout_sec)
+    recorded: list[tuple[list[str], int | None]] = []
+
+    async def compose_exec(subcommand, timeout_sec=None):
+        recorded.append((subcommand, timeout_sec))
+        return ExecResult(stdout="", stderr="", return_code=0)
+
+    strategy._compose_exec = compose_exec  # type: ignore[method-assign]
+
+    await strategy._compose_up_with_retry(env)
+
+    assert recorded == [(["up", "-d"], expected_timeout)]
+
+
+@pytest.mark.asyncio
+async def test_network_race_is_retried_then_succeeds(monkeypatch):
+    strategy, env = _strategy(600)
+    monkeypatch.setattr("benchflow.sandbox.daytona_dind.asyncio.sleep", AsyncNoop())
+    attempts: list[int] = []
+
+    async def compose_exec(subcommand, timeout_sec=None):
+        attempts.append(1)
+        if len(attempts) == 1:
+            return ExecResult(
+                stdout="",
+                stderr=("Error response from daemon: network abc_default not found"),
+                return_code=1,
+            )
+        return ExecResult(stdout="", stderr="", return_code=0)
+
+    strategy._compose_exec = compose_exec  # type: ignore[method-assign]
+
+    await strategy._compose_up_with_retry(env)
+
+    assert len(attempts) == 2  # one race, retried once, then success
+
+
+@pytest.mark.asyncio
+async def test_non_race_error_is_not_retried(monkeypatch):
+    strategy, env = _strategy(600)
+    monkeypatch.setattr("benchflow.sandbox.daytona_dind.asyncio.sleep", AsyncNoop())
+    attempts: list[int] = []
+
+    async def compose_exec(subcommand, timeout_sec=None):
+        attempts.append(1)
+        return ExecResult(stdout="", stderr="image pull failed", return_code=1)
+
+    strategy._compose_exec = compose_exec  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="docker compose up failed"):
+        await strategy._compose_up_with_retry(env)
+    assert len(attempts) == 1  # non-race errors fail immediately, no retry
+
+
+class AsyncNoop:
+    """A no-op async callable to replace ``asyncio.sleep`` in retry tests."""
+
+    async def __call__(self, *_args, **_kwargs) -> None:
+        return None

--- a/tests/test_daytona_reap.py
+++ b/tests/test_daytona_reap.py
@@ -14,6 +14,8 @@ import logging
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+import pytest
+
 from benchflow.sandbox.daytona import (
     _is_benchflow_label_orphan,
     _is_benchflow_owned,
@@ -109,6 +111,90 @@ def test_on_decision_sees_every_owned_sandbox():
     client = FakeClient([_sb("old", "STARTED", 1500), _sb("young", "STARTED", 5)])
     reap_stale_sandboxes(client, on_decision=lambda sb, age, d: seen.append((sb.id, d)))
     assert seen == [("old", True), ("young", False)]
+
+
+# --- REAP-01: a bad created_at must not abort the whole sweep -----------------
+
+
+def _naive_ts(age_minutes: float) -> str:
+    """An ISO timestamp with NO Z/offset (tz-naive), the value that used to raise."""
+    return (
+        (datetime.now(UTC) - timedelta(minutes=age_minutes))
+        .replace(tzinfo=None)
+        .isoformat()
+    )
+
+
+def test_naive_created_at_does_not_abort_sweep():
+    # A naive (offset-less) created_at placed BEFORE a clearly-stale owned
+    # sandbox: the stale one must still be reaped (the survivor assertion is the
+    # mutation-killer — a fix that swallows the error but drops the rest fails).
+    naive = SimpleNamespace(
+        id="naive", state="STARTED", created_at=_naive_ts(1500), labels=dict(_OWNED)
+    )
+    client = FakeClient([naive, _sb("stale", "STARTED", 1500)])
+    counts = reap_stale_sandboxes(client)
+    assert client.deleted == ["naive", "stale"]  # naive coerced to UTC, both reaped
+    assert counts["failed"] == 0
+
+
+def test_non_string_created_at_is_skipped_not_raised():
+    bad = SimpleNamespace(
+        id="bad", state="STARTED", created_at=datetime.now(UTC), labels=dict(_OWNED)
+    )
+    client = FakeClient([bad, _sb("stale", "STARTED", 1500)])
+    counts = reap_stale_sandboxes(client)
+    # The non-string record is skipped; the following stale sandbox still reaps.
+    assert client.deleted == ["stale"]
+    assert counts["skipped"] >= 1
+
+
+# --- REAP-03: activity guard protects genuinely live runs --------------------
+
+
+def _sb_with_activity(sb_id: str, state: str, age_minutes: float, idle_minutes: float):
+    created = datetime.now(UTC) - timedelta(minutes=age_minutes)
+    activity = datetime.now(UTC) - timedelta(minutes=idle_minutes)
+    return SimpleNamespace(
+        id=sb_id,
+        state=state,
+        created_at=created.isoformat().replace("+00:00", "Z"),
+        last_activity_at=activity.isoformat().replace("+00:00", "Z"),
+        labels=dict(_OWNED),
+    )
+
+
+def test_old_but_recently_active_sandbox_is_not_reaped():
+    # Old by creation (over TTL) but active 1 min ago -> protected, skipped.
+    client = FakeClient([_sb_with_activity("live", "STARTED", 1500, idle_minutes=1)])
+    counts = reap_stale_sandboxes(client)
+    assert client.deleted == []
+    assert counts["skipped"] == 1
+
+
+def test_old_and_idle_sandbox_is_reaped():
+    # Old by creation and idle well past the guard window -> reaped.
+    client = FakeClient(
+        [_sb_with_activity("orphan", "STARTED", 1500, idle_minutes=600)]
+    )
+    reap_stale_sandboxes(client)
+    assert client.deleted == ["orphan"]
+
+
+def test_old_with_missing_activity_is_reaped():
+    # Absent last_activity_at must NOT be protective, or nothing old ever reaps.
+    client = FakeClient([_sb("old", "STARTED", 1500)])
+    reap_stale_sandboxes(client)
+    assert client.deleted == ["old"]
+
+
+def test_failed_tier_reaps_despite_fresh_activity():
+    # A FAILED sandbox reaps on its short TTL regardless of fresh activity.
+    client = FakeClient(
+        [_sb_with_activity("crashed", "BUILD_FAILED", 180, idle_minutes=1)]
+    )
+    reap_stale_sandboxes(client)
+    assert client.deleted == ["crashed"]
 
 
 # --- Ownership scoping: foreign sandboxes must never be reaped ----------------
@@ -382,12 +468,33 @@ class TestEvaluationAutoReapGate:
         self._eval(tmp_path, "daytona")._maybe_start_daytona_reap()
         assert started == ["daytona-auto-reap"]
 
-    def test_env_gate_disables(self, tmp_path, monkeypatch):
+    @pytest.mark.parametrize(
+        "value", ["0", "false", "False", "FALSE", "no", "off", " off "]
+    )
+    def test_env_gate_disables(self, tmp_path, monkeypatch, value):
         started = []
         monkeypatch.setattr(
             "benchflow.evaluation.threading.Thread",
             lambda *a, **k: started.append(k) or SimpleNamespace(start=lambda: None),
         )
-        monkeypatch.setenv("BENCHFLOW_DAYTONA_AUTO_REAP", "0")
+        monkeypatch.setenv("BENCHFLOW_DAYTONA_AUTO_REAP", value)
         self._eval(tmp_path, "daytona")._maybe_start_daytona_reap()
-        assert started == []
+        assert started == [], f"{value!r} should disable the reaper"
+
+    @pytest.mark.parametrize("value", ["1", "true", "on", "yes", "anything-else"])
+    def test_env_gate_enabled_for_non_disable_tokens(
+        self, tmp_path, monkeypatch, value
+    ):
+        started = []
+
+        class FakeThread:
+            def __init__(self, *a, **k):
+                started.append(k.get("name"))
+
+            def start(self):
+                pass
+
+        monkeypatch.setattr("benchflow.evaluation.threading.Thread", FakeThread)
+        monkeypatch.setenv("BENCHFLOW_DAYTONA_AUTO_REAP", value)
+        self._eval(tmp_path, "daytona")._maybe_start_daytona_reap()
+        assert started == ["daytona-auto-reap"], f"{value!r} should keep reaper on"

--- a/tests/test_hosted_env_rollout_contract.py
+++ b/tests/test_hosted_env_rollout_contract.py
@@ -47,8 +47,38 @@ def _patch_run(monkeypatch: pytest.MonkeyPatch, *, results_jsonl: str = "") -> P
     return Path(captured.get("output_dir", Path()))
 
 
+def _patch_run_custom(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str,
+    stderr: str = "",
+    returncode: int = 0,
+    results_jsonl: str = "",
+) -> None:
+    """Patch shutil.which + subprocess.run with caller-controlled vf-eval output."""
+
+    def fake_which(binary: str) -> str:
+        return f"/bin/{binary}"
+
+    def fake_run(cmd, **kwargs):
+        if str(cmd[0]).endswith("vf-eval"):
+            output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+            if results_jsonl:
+                output_dir.mkdir(parents=True, exist_ok=True)
+                (output_dir / "results.jsonl").write_text(results_jsonl)
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("benchflow.hosted_env.shutil.which", fake_which)
+    monkeypatch.setattr("benchflow.hosted_env.subprocess.run", fake_run)
+
+
 def _run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results_jsonl: str = ""):
     _patch_run(monkeypatch, results_jsonl=results_jsonl)
+    return _invoke(tmp_path)
+
+
+def _invoke(tmp_path: Path):
     return run_hosted_env(
         HostedEnvRunConfig(
             source_env=HostedEnvRef.parse(
@@ -61,6 +91,13 @@ def _run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results_jsonl: str = "
             num_examples=2,
         )
     )
+
+
+def _classify(result) -> str:
+    from benchflow._utils.scoring import classify_score_outcome
+
+    payload = json.loads((result.run_dir / "result.json").read_text())
+    return classify_score_outcome(payload)
 
 
 def test_hosted_env_writes_contract_result_json(tmp_path, monkeypatch):
@@ -205,3 +242,158 @@ def test_hosted_env_keeps_raw_evidence_for_forensics(tmp_path, monkeypatch):
     assert (hosted_dir / "hosted_run.json").exists()
     assert (hosted_dir / "stdout.log").exists()
     assert (hosted_dir / "stderr.log").exists()
+
+
+# ── HOE-1: reward bounds gate (hosted evidence == native contract) ────
+
+
+def test_hosted_env_out_of_range_headline_reward_is_not_persisted(
+    tmp_path, monkeypatch
+):
+    """A reward outside [0,1] must not land as a terminal reward (native parity)."""
+    _patch_run_custom(monkeypatch, stdout="reward: avg - 4.000\n")
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["rewards"] is None
+    assert payload["error"] and "out of [0,1]" in payload["error"]
+    # The raw value is kept for forensics but never as a terminal event.
+    assert result.raw_reward == 4.0
+    rewards_path = result.run_dir / "rewards.jsonl"
+    if rewards_path.exists():
+        values = [
+            json.loads(line)["value"]
+            for line in rewards_path.read_text().splitlines()
+            if line
+        ]
+        assert all(v is None or v <= 1.0 for v in values)
+
+
+def test_hosted_env_out_of_range_rubric_score_is_not_written(tmp_path, monkeypatch):
+    """An out-of-contract per-example score (1e9) must not become a process event."""
+    results_jsonl = json.dumps({"prompt": [], "completion": [], "reward": 1e9}) + "\n"
+    _patch_run_custom(
+        monkeypatch, stdout="reward: avg - 1.000\n", results_jsonl=results_jsonl
+    )
+    result = _invoke(tmp_path)
+    rewards_path = result.run_dir / "rewards.jsonl"
+    process_values = [
+        json.loads(line)["value"]
+        for line in rewards_path.read_text().splitlines()
+        if line and json.loads(line)["type"] == "process"
+    ]
+    assert all(v <= 1.0 for v in process_values), "out-of-range score leaked"
+
+
+# ── HOE-2: aborts fail closed (errored, not failed 0.0) ───────────────
+
+
+def test_hosted_env_aborted_run_is_errored_not_zero_reward(tmp_path, monkeypatch):
+    """An all-aborted vf-eval (reward 0.0 + abort + rc 0) must classify errored."""
+    _patch_run_custom(
+        monkeypatch,
+        stdout="reward: avg - 0.000\n",
+        stderr="Aborted rollout due to NotFoundError: model not found",
+        returncode=0,
+    )
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["rewards"] is None
+    assert payload["error"] and "NotFoundError" in payload["error"]
+    assert payload["verifier_error"] and "NotFoundError" in payload["verifier_error"]
+    # No misleading terminal reward=0.0 event.
+    rewards_path = result.run_dir / "rewards.jsonl"
+    assert not rewards_path.exists()
+    assert _classify(result) == "errored"
+
+
+def test_hosted_env_genuine_zero_reward_still_fails(tmp_path, monkeypatch):
+    """A genuine 0.0 episode (no abort) keeps its terminal reward and is 'failed'."""
+    _patch_run_custom(monkeypatch, stdout="reward: avg - 0.000\n", returncode=0)
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["rewards"] == {"reward": 0.0}
+    rewards_path = result.run_dir / "rewards.jsonl"
+    terminal = [
+        json.loads(line)
+        for line in rewards_path.read_text().splitlines()
+        if line and json.loads(line)["type"] == "terminal"
+    ]
+    assert terminal and terminal[0]["value"] == 0.0
+    assert _classify(result) == "failed"
+    # The abort path and the genuine-zero path must not collapse to one bucket.
+    assert _classify(result) != "errored"
+
+
+# ── HOE-3: unparseable vf-eval output fails closed ────────────────────
+
+
+def test_hosted_env_unparseable_reward_is_flagged_as_error(tmp_path, monkeypatch):
+    """rc 0 with no reward line and no abort marker must surface a parse error."""
+    _patch_run_custom(
+        monkeypatch,
+        stdout="some new summary format with no reward line\n",
+        returncode=0,
+    )
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["error"] is not None
+    assert "could not parse reward" in payload["error"]
+    assert payload["rewards"] is None
+    assert _classify(result) == "errored"
+
+
+# ── HOE-4: rewards.jsonl carries space/granularity ────────────────────
+
+
+def test_hosted_env_rewards_carry_space_and_granularity(tmp_path, monkeypatch):
+    """Hosted terminal/rubric events must carry the (space, granularity) tags."""
+    results_jsonl = json.dumps({"prompt": [], "completion": [], "reward": 0.5}) + "\n"
+    _patch_run_custom(
+        monkeypatch, stdout="reward: avg - 1.000\n", results_jsonl=results_jsonl
+    )
+    result = _invoke(tmp_path)
+    events = [
+        json.loads(line)
+        for line in (result.run_dir / "rewards.jsonl").read_text().splitlines()
+        if line
+    ]
+    terminal = next(e for e in events if e["type"] == "terminal")
+    assert terminal["space"] == "output"
+    assert terminal["granularity"] == "terminal"
+    rubric = [e for e in events if e["type"] == "process"]
+    assert rubric, "expected a per-example rubric process event"
+    assert all(e["space"] == "output" for e in rubric)
+    assert all(e["granularity"] == "step" for e in rubric)
+
+
+def test_hosted_env_promotes_verifier_supplied_space_out_of_meta(tmp_path, monkeypatch):
+    """A verifier-supplied space/granularity is promoted to first-class fields."""
+    results_jsonl = (
+        json.dumps(
+            {
+                "prompt": [],
+                "completion": [],
+                "reward": 0.5,
+                "space": "memory",
+                "granularity": "step",
+            }
+        )
+        + "\n"
+    )
+    _patch_run_custom(
+        monkeypatch, stdout="reward: avg - 1.000\n", results_jsonl=results_jsonl
+    )
+    result = _invoke(tmp_path)
+    process = [
+        json.loads(line)
+        for line in (result.run_dir / "rewards.jsonl").read_text().splitlines()
+        if line and json.loads(line)["type"] == "process"
+    ]
+    assert process, "expected a per-example rubric process event"
+    # The space tag is promoted onto the event, not buried in meta.
+    assert process[0]["space"] == "memory"
+    assert "space" not in process[0]["meta"]

--- a/tests/test_rollout_planes_contract.py
+++ b/tests/test_rollout_planes_contract.py
@@ -1,0 +1,103 @@
+"""Contract tests for the default rollout-plane bindings.
+
+``DefaultRolloutPlanes`` is the composition boundary that binds the rollout
+kernel to today's concrete ACP / provider / sandbox / environment
+implementations. It was previously only exercised indirectly. These pin the
+contract: the default bundle satisfies the ``RolloutPlanes`` Protocol, the
+factory returns a satisfying instance, and the small amount of real logic the
+adapter owns (``agent_launch`` web-tool suffixing, registry delegation) behaves.
+"""
+
+from __future__ import annotations
+
+from benchflow.agents.registry import AGENT_LAUNCH, AGENTS
+from benchflow.contracts.planes import RolloutPlanes, default_rollout_planes
+from benchflow.rollout_planes import DefaultRolloutPlanes
+
+# The Protocol surface every plane binding must implement. Pinning the names
+# means a new abstract method on RolloutPlanes (or a renamed binding) fails here
+# instead of at first live use.
+_REQUIRED_METHODS = (
+    "agent_launch",
+    "agent_config",
+    "resolve_agent_env",
+    "install_docker_compat",
+    "resolve_locked_paths",
+    "stage_dockerfile_deps",
+    "inject_skills_into_dockerfile",
+    "create_environment",
+    "manifest_environment",
+    "setup_sandbox_user",
+    "snapshot_build_config",
+    "seed_verifier_workspace",
+    "deploy_skills",
+    "lockdown_paths",
+    "install_agent",
+    "write_credential_files",
+    "upload_subscription_auth",
+    "apply_web_tool_policy",
+    "link_skill_paths",
+    "ensure_litellm_runtime",
+    "stop_provider_runtime",
+    "extract_usage",
+    "connect_acp",
+    "execute_prompts",
+    "harden_before_verify",
+    "verifier",
+    "clear_verifier_output_dir",
+    "ensure_legacy_app_dir",
+    "cleanup_verifier_python_hooks",
+)
+
+
+def test_default_planes_satisfies_protocol() -> None:
+    planes = DefaultRolloutPlanes()
+    # runtime_checkable Protocol isinstance check.
+    assert isinstance(planes, RolloutPlanes)
+    for name in _REQUIRED_METHODS:
+        assert callable(getattr(planes, name)), f"missing plane method: {name}"
+
+
+def test_factory_returns_satisfying_instance() -> None:
+    planes = default_rollout_planes()
+    assert isinstance(planes, DefaultRolloutPlanes)
+    assert isinstance(planes, RolloutPlanes)
+
+
+def test_agent_launch_passthrough_without_web_policy() -> None:
+    planes = DefaultRolloutPlanes()
+    agent = "codex-acp"
+    expected = AGENT_LAUNCH.get(agent, agent)
+    assert planes.agent_launch(agent, disallow_web_tools=False) == expected
+
+
+def test_agent_launch_appends_web_tool_suffix_when_disallowed() -> None:
+    planes = DefaultRolloutPlanes()
+    agent = "codex-acp"
+    cfg = AGENTS[agent]
+    suffix = cfg.disallow_web_tools_launch_suffix
+    assert suffix, "fixture agent must carry a web-tool suffix to exercise the branch"
+    launched = planes.agent_launch(agent, disallow_web_tools=True)
+    assert launched == AGENT_LAUNCH.get(agent, agent) + suffix
+    # The suffix is only appended under the disallow flag.
+    assert planes.agent_launch(agent, disallow_web_tools=True) != planes.agent_launch(
+        agent, disallow_web_tools=False
+    )
+
+
+def test_agent_launch_unknown_agent_falls_back_to_name() -> None:
+    planes = DefaultRolloutPlanes()
+    # An unknown agent has no launch mapping and no config: returns the name,
+    # and the disallow flag is a no-op (no config -> no suffix).
+    assert planes.agent_launch("not-a-real-agent", disallow_web_tools=False) == (
+        "not-a-real-agent"
+    )
+    assert planes.agent_launch("not-a-real-agent", disallow_web_tools=True) == (
+        "not-a-real-agent"
+    )
+
+
+def test_agent_config_delegates_to_registry() -> None:
+    planes = DefaultRolloutPlanes()
+    assert planes.agent_config("codex-acp") is AGENTS["codex-acp"]
+    assert planes.agent_config("not-a-real-agent") is None

--- a/tests/test_task_export.py
+++ b/tests/test_task_export.py
@@ -162,6 +162,50 @@ def test_export_native_task_to_split_layout_with_loss_report(tmp_path: Path) -> 
     assert "verifier.verifier_md" in losses
 
 
+def test_export_onto_source_dir_is_rejected_and_preserves_source(
+    tmp_path: Path,
+) -> None:
+    """Exporting onto the source must raise and leave the source intact.
+
+    The destructive bug: with ``overwrite=True`` and dest == source, the rmtree
+    deleted task.md / oracle / verifier / environment before they were copied,
+    yet still reported status='lossless'. Assert the specific source files
+    survive and no report landed.
+    """
+    task_dir = tmp_path / "native"
+    _write_native_task(task_dir)
+
+    with pytest.raises(ValueError, match="overlaps the source task directory"):
+        export_task_to_split_layout(task_dir, task_dir, overwrite=True)
+
+    # The source is untouched (mutation-killer: assert specific surviving files).
+    assert (task_dir / "task.md").exists()
+    assert (task_dir / "oracle" / "solve.md").read_text() == "native oracle\n"
+    assert (task_dir / "verifier" / "verifier.md").exists()
+    assert (task_dir / "environment" / "Dockerfile").exists()
+    # No export report was produced inside the source.
+    assert not (task_dir / "compatibility").exists()
+
+
+def test_export_into_subdir_of_source_is_rejected(tmp_path: Path) -> None:
+    task_dir = tmp_path / "native"
+    _write_native_task(task_dir)
+    with pytest.raises(ValueError, match="overlaps the source task directory"):
+        export_task_to_split_layout(task_dir, task_dir / "sub", overwrite=True)
+    assert (task_dir / "task.md").exists()
+
+
+def test_export_into_parent_of_source_is_rejected(tmp_path: Path) -> None:
+    parent = tmp_path / "container"
+    task_dir = parent / "native"
+    parent.mkdir()
+    _write_native_task(task_dir)
+    # dest (parent) contains source: rejected in the other is_relative_to direction.
+    with pytest.raises(ValueError, match="overlaps the source task directory"):
+        export_task_to_split_layout(task_dir, parent, overwrite=True)
+    assert (task_dir / "task.md").exists()
+
+
 @pytest.mark.parametrize("task_name", REAL_SKILLSBENCH_TASK_MD_EXAMPLES)
 def test_export_real_skillsbench_native_examples_to_harbor_split(
     tmp_path: Path,

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -370,6 +370,47 @@ def test_build_rollout_result_emits_atif_and_adp(tmp_path):
     )
 
 
+def test_build_rollout_result_forwards_token_metrics_to_atif(tmp_path):
+    """Usage metrics in scope at result-building must reach ATIF final_metrics.
+
+    ATIF's token/cost capability is implemented in export_atif, but the
+    production seam (_build_rollout_result -> _write_trainer_artifact ->
+    write_rollout_atif_json) used to drop the four usage fields, so every live
+    atif.json carried only total_steps. This pins the live wiring with the exact
+    forwarded values (note the n_cache_read -> total_cached mapping).
+    """
+    rollout_dir = tmp_path / "rollout-usage"
+    rollout_dir.mkdir()
+    _build_rollout_result(
+        rollout_dir,
+        task_name="archive-alice",
+        rollout_name="r1",
+        agent="claude-agent-acp",
+        agent_name="claude-agent-acp",
+        model="claude-haiku-4-5",
+        n_tool_calls=1,
+        prompts=["Archive the email from Alice."],
+        error=None,
+        verifier_error=None,
+        trajectory=_acp_trajectory(),
+        partial_trajectory=False,
+        trajectory_source="acp",
+        rewards={"reward": 1.0},
+        started_at=datetime.now(),
+        timing={},
+        n_input_tokens=1234,
+        n_output_tokens=567,
+        n_cache_read_tokens=89,
+        cost_usd=0.0421,
+    )
+    atif = json.loads((rollout_dir / "trainer/atif.json").read_text())
+    metrics = atif["final_metrics"]
+    assert metrics["total_prompt_tokens"] == 1234
+    assert metrics["total_completion_tokens"] == 567
+    assert metrics["total_cached_tokens"] == 89
+    assert metrics["total_cost_usd"] == 0.0421
+
+
 def test_build_rollout_result_atif_for_empty_trajectory_is_prompt_only(tmp_path):
     """Oracle runs (no agent events) emit a prompts-only ATIF, never agent steps.
 

--- a/tests/test_verifier_strategies.py
+++ b/tests/test_verifier_strategies.py
@@ -426,6 +426,48 @@ class TestORSEpisodeStrategy:
         assert details["inputs"][0]["records"] == 3
 
     @pytest.mark.asyncio
+    async def test_finished_step_record_does_not_override_genuine_terminal(
+        self, tmp_path: Path
+    ) -> None:
+        """A later finished step/dense record must not demote a real terminal.
+
+        The old last-write-wins logic let any ``finished:true`` record overwrite
+        an earlier genuine terminal's reward and granularity.
+        """
+        records = [
+            {"type": "terminal", "reward": 0.9, "finished": True},
+            {
+                "type": "dense",
+                "reward": 0.1,
+                "step": 2,
+                "granularity": "step",
+                "finished": True,
+            },
+        ]
+        verifier, _ = _ors_verifier(tmp_path, records)
+
+        result = await verifier.verify()
+
+        assert result.rewards["reward"] == 0.9
+        ors = result.rewards["metadata"]["ors"]
+        assert ors["metadata"]["granularity"] == "terminal"
+
+    @pytest.mark.asyncio
+    async def test_conflicting_genuine_terminals_fail_closed(
+        self, tmp_path: Path
+    ) -> None:
+        """Two genuinely-terminal records with different rewards must error."""
+        records = [
+            {"type": "terminal", "reward": 0.9},
+            {"type": "terminal", "reward": 0.1},
+        ]
+        verifier, rollout_paths = _ors_verifier(tmp_path, records)
+
+        with pytest.raises(VerifierOutputParseError, match="conflicting terminal"):
+            await verifier.verify()
+        assert not rollout_paths.reward_json_path.exists()
+
+    @pytest.mark.asyncio
     async def test_dense_only_episode_is_a_parse_error(self, tmp_path: Path) -> None:
         """Step events alone never aggregate into a reward — that is an error."""
         records = [

--- a/tests/trajectories/test_export_adp.py
+++ b/tests/trajectories/test_export_adp.py
@@ -261,3 +261,84 @@ def test_write_job_adp_jsonl_aggregates_rollouts(tmp_path):
 def test_write_job_adp_jsonl_returns_none_without_rollouts(tmp_path):
     assert write_job_adp_jsonl(tmp_path) is None
     assert write_job_adp_jsonl(tmp_path / "missing") is None
+
+
+def test_write_skips_empty_trajectory(tmp_path):
+    # No events and no prompts -> empty content, no score -> no artifact, mirror
+    # ATIF's empty-record contract so the job aggregate never sees content==[].
+    for prompts in (None, [""]):
+        rec = write_rollout_adp_jsonl(
+            tmp_path,
+            trajectory_id="empty",
+            task_id="t",
+            prompts=prompts,
+            trajectory=[],
+            model=None,
+            environment="demo",
+        )
+        assert rec is None
+        assert not (tmp_path / "trainer" / "adp.jsonl").exists()
+
+
+def test_write_job_adp_jsonl_excludes_empty_rollout(tmp_path):
+    write_rollout_adp_jsonl(
+        tmp_path / "real",
+        trajectory_id="real",
+        task_id="t",
+        prompts=None,
+        trajectory=[{"type": "agent_message", "text": "did the work"}],
+        model="m",
+        environment="demo",
+    )
+    write_rollout_adp_jsonl(
+        tmp_path / "empty",
+        trajectory_id="empty",
+        task_id="t",
+        prompts=None,
+        trajectory=[],
+        model="m",
+        environment="demo",
+    )
+    out = write_job_adp_jsonl(tmp_path)
+    ids = [json.loads(line)["id"] for line in out.read_text().splitlines()]
+    assert ids == ["real"]
+
+
+def test_reward_with_no_action_is_surfaced(caplog):
+    # An agent that crashes after consuming the prompt (no action) but is still
+    # scored: the reward must not vanish — it lands in details.terminal_reward.
+    import logging
+
+    for reward in (0.0, 1.0):
+        with caplog.at_level(logging.WARNING):
+            caplog.clear()
+            rec = trajectory_to_adp_record(
+                trajectory_id="crashed",
+                events=[],
+                prompts=["do the task"],
+                reward=reward,
+            )
+        # No action carries a reward...
+        assert all("reward" not in item for item in rec["content"])
+        # ...so the exact score is surfaced in details, with a warning.
+        assert rec["details"]["terminal_reward"] == reward
+        assert any("terminal reward" in r.message for r in caplog.records)
+
+
+def test_write_path_no_action_keeps_score(tmp_path):
+    # The write seam must still emit a scored crash rollout (content empty but a
+    # terminal reward present), carrying the score in details.terminal_reward.
+    rec = write_rollout_adp_jsonl(
+        tmp_path,
+        trajectory_id="crashed",
+        task_id="t",
+        prompts=None,
+        trajectory=[],
+        model="m",
+        environment="demo",
+        reward=1.0,
+    )
+    assert rec is not None
+    assert rec["details"]["terminal_reward"] == 1.0
+    line = json.loads((tmp_path / "trainer" / "adp.jsonl").read_text().strip())
+    assert line["details"]["terminal_reward"] == 1.0

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -17,6 +17,13 @@ from benchflow.trajectories.types import (
     redact_trajectory_text,
 )
 
+# Fake token fixtures assembled from split literals so the full token string
+# never appears verbatim in source (GitHub secret-scanning push protection
+# scans raw text). The runtime value still matches the redaction patterns.
+_FAKE_GHP = "ghp" + "_" + "16C7e42F292c6912E7710c838347Ae178B4abcde"
+_FAKE_GH_PAT = "github" + "_pat_" + "11ABCDE0Y0abcdefghij_klmnopqrstuvwxyz0123456789"
+_FAKE_XOXB = "xox" + "b-" + "1234567890-0987654321-abcDEFghiJKLmnoPQR"
+
 
 def _jsonl_for_request_body(body: dict) -> str:
     traj = Trajectory(
@@ -88,6 +95,30 @@ def _jsonl_for_request_body(body: dict) -> str:
             '{"api-key": "abc123secret456value"}',
             "abc123secret456value",
             id="api-key-azure",
+        ),
+        pytest.param(
+            "github classic PAT ghp_",
+            '{"key": "' + _FAKE_GHP + '"}',
+            "16C7e42F292c6912E7710c838347Ae178B4abcde",
+            id="github-ghp",
+        ),
+        pytest.param(
+            "github fine-grained PAT",
+            '{"key": "' + _FAKE_GH_PAT + '"}',
+            "11ABCDE0Y0abcdefghij_klmnopqrstuvwxyz0123456789",
+            id="github-pat",
+        ),
+        pytest.param(
+            "slack bot token xoxb-",
+            '{"key": "' + _FAKE_XOXB + '"}',
+            "1234567890-0987654321-abcDEFghiJKLmnoPQR",
+            id="slack-xoxb",
+        ),
+        pytest.param(
+            "generic TOKEN carrier",
+            "GITHUB_TOKEN=plainvaluewithnoprefix12345",
+            "plainvaluewithnoprefix12345",
+            id="generic-token",
         ),
     ],
 )
@@ -217,6 +248,8 @@ def test_to_jsonl_redacts_raw_env_dump_in_message():
                 "content": (
                     "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
                     "DAYTONA_API_KEY=dtn_FAKEFAKEFAKEFAKEFAKE12345678\n"
+                    "GITHUB_TOKEN=" + _FAKE_GHP + "\n"
+                    "SLACK_TOKEN=" + _FAKE_XOXB + "\n"
                     "x-api-key: abc123secret456value"
                 ),
             }
@@ -227,6 +260,11 @@ def test_to_jsonl_redacts_raw_env_dump_in_message():
     assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in jsonl
     assert "dtn_FAKEFAKEFAKEFAKEFAKE12345678" not in jsonl
     assert "abc123secret456value" not in jsonl
+    assert _FAKE_GHP not in jsonl
+    assert _FAKE_XOXB not in jsonl
+    # Env var names are preserved so the dump stays readable/auditable.
+    assert "GITHUB_TOKEN" in jsonl
+    assert "SLACK_TOKEN" in jsonl
 
 
 # PR #585 finding 2: audit-sensitive tokens redacted whole (no live prefix)
@@ -289,7 +327,9 @@ def test_acp_trajectory_jsonl_redacts_event_content(tmp_path):
             "content": (
                 "Here is the environment:\n"
                 "GEMINI_API_KEY=AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx\n"
-                "export DAYTONA_API_KEY=dtn_FAKEFAKEFAKEFAKEFAKE12345678"
+                "export DAYTONA_API_KEY=dtn_FAKEFAKEFAKEFAKEFAKE12345678\n"
+                "export GITHUB_TOKEN=" + _FAKE_GHP + "\n"
+                "export SLACK_TOKEN=" + _FAKE_XOXB
             ),
         },
         {"type": "tool_call", "command": "env | grep API"},
@@ -302,10 +342,17 @@ def test_acp_trajectory_jsonl_redacts_event_content(tmp_path):
 
     written = out.read_text()
     assert "***REDACTED***" in written
-    # The live-key *values* and any AIzaSy/dtn_ token shape must be gone.
+    # The live-key *values* and any AIzaSy/dtn_/ghp_/xoxb- token shape must be gone.
     assert "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx" not in written
     assert "dtn_FAKEFAKEFAKEFAKEFAKE12345678" not in written
-    residual = re.findall(r"AIzaSy[A-Za-z0-9_-]+|dtn_[A-Za-z0-9_]+", written)
+    assert _FAKE_GHP not in written
+    assert _FAKE_XOXB not in written
+    assert "GITHUB_TOKEN" in written  # var name preserved
+    residual = re.findall(
+        r"AIzaSy[A-Za-z0-9_-]+|dtn_[A-Za-z0-9_]+"
+        r"|ghp_[A-Za-z0-9]+|xox[baprs]-[A-Za-z0-9-]+",
+        written,
+    )
     assert residual == [], f"live key shapes survived: {residual}"
     # Non-secret event structure is preserved (one line per event).
     assert len(written.splitlines()) == 2


### PR DESCRIPTION
Adversarial bug-hunt across the new v0.6 code surface (router, trajectory emitters, hosted-env/OpenReward, Daytona reap, authoring) — 31 findings, 21 confirmed, **19 fixed** here (2 agent-judge findings deferred to a follow-up). Every fix ships a mutation-resistant regression test. Merges cleanly onto the current release tip; full suite **3,494 passed, 0 failed**.

### High-severity
- **Secret leak (REDACT-003):** GitHub/Slack tokens (`ghp_`/`gho_`/`github_pat_`/`xoxb-`) now redacted in ATIF/ADP/verifier trajectory artifacts — previously leaked verbatim while `config.json` redaction dropped them (divergent coverage).
- **ATIF token/cost metrics dead in production (ATIF-001):** `_build_rollout_result` now forwards token/cost into `write_rollout_atif_json` — every `atif.json` previously had `final_metrics={total_steps}` only.
- **ADP junk records (ADP-002):** empty-content rollouts no longer emit a meaningless `content:[]` record into the aggregated training dataset (now matches ATIF's skip).
- **Router fail-open (AR-1, AR-2):** scaffold no longer ships an unusable `model:""` (would crash the generated runner at load); the verify gate no longer false-confirms on half-recorded reward samples.

### Medium
- Router clean errors instead of raw tracebacks on malformed `parity_experiment.json` (AR-4) and bad `--roundtrip-task` paths (AR-5); verify now recognizes all 5 shipped benchmark parity schemas (AR-3, was "insufficient-evidence" for genuinely-validated benchmarks); ADP terminal-reward no longer dropped when there's no action (ADP-005); hosted-env/OpenReward + Daytona-reap robustness (HOE-*, ORS-1, REAP-*).

### Test gap-fills (from the unit-test audit)
Direct unit coverage for `agent_router_scaffold` and `DefaultRolloutPlanes` (were exercised only indirectly).

Note: fake-token test fixtures are assembled at runtime (`+` concatenation) so no literal token is committed (push protection). The CLI agent/model validation surface that #678 owns was intentionally left to that PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches adoption trust (`bench agent verify`), hosted reward classification, and secret redaction in artifacts; changes are broad but heavily regression-tested and mostly tighten validation rather than loosen it.
> 
> **Overview**
> Closes a broad v0.6 bug-hunt with **fail-closed** behavior on adoption parity, hosted-env scoring, and training artifacts, plus tighter Daytona/ORS/Docker edges.
> 
> **Security & trajectories:** Trajectory redaction now scrubs GitHub/Slack token shapes and generic `*TOKEN*` / `*SECRET*` env carriers (aligning with `config.json` denylisting). Native rollouts forward token/cost usage into **ATIF** `final_metrics`; **ADP** skips meaningless empty `content:[]` job lines, records `details.terminal_reward` when a score has no action, and still emits scored crash rollouts.
> 
> **`bench agent verify`:** Parity parsing/scoring moves to `agent_router_parity` (re-exported API unchanged). The gate reads summary parity blocks and top-level metric arrays, treats one-sided reward samples as divergent (not confirmed), and surfaces clean CLI errors for bad JSON / bad `--roundtrip-task`. Scaffold jobs default to **`claude-agent-acp`** with a runnable default model pair.
> 
> **Hosted env & rewards:** Shared `build_rewards_jsonl_events` unifies native and hosted `rewards.jsonl` tagging (`space`/`granularity`); hosted runs reject out-of-range rewards, treat vf-eval aborts/unparseable output as **errored** (not fake 0.0).
> 
> **ORS / sandboxes / export:** ORS adapter and `ors-episode` verifier fix contradictory `finished` vs terminal semantics. Daytona auto-reap adds an idle-activity guard and broader disable tokens; compose `up` network-race retries are shared between host Docker and Daytona DinD (DinD honors `build_timeout_sec`). Split-layout export rejects overlapping destinations and stages atomically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed4f6ad88f667d36184c7d329612f44a7501fb69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->