### PR TITLE
fix(agent-router): clean insufficient-evidence verify output (dogfood residual)

### DIFF
--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -621,6 +621,11 @@ def register_agent_router(agent_app: typer.Typer) -> None:
 
         if report.passed:
             return
+        if report.verdict == "insufficient-evidence":
+            # No parity data recorded yet — nothing diverged, so do not emit a
+            # "parity could not be closed" divergence issue draft. confidence_line
+            # above already told the author to run parity_test.py and record results.
+            raise typer.Exit(1)
         issue = render_divergence_issue(report)
         if issue_out is not None:
             Path(issue_out).write_text(issue)

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -644,14 +644,15 @@ def test_cli_create_then_verify_roundtrip(tmp_path: Path) -> None:
     assert (tmp_path / "my-bench" / "benchflow.py").exists()
 
     # a fresh scaffold has no parity evidence → verify exits non-zero and
-    # prints the support-path issue draft.
+    # points the author at parity_test.py (no divergence draft — nothing diverged).
     verify = runner.invoke(
         app, ["agent", "verify", "my-bench", "--benchmarks-dir", str(tmp_path)]
     )
     assert verify.exit_code == 1
     out = click.unstyle(verify.output)
     assert "insufficient-evidence" in out
-    assert "NOT been filed" in out
+    assert "NOT been filed" not in out
+    assert "parity_test.py" in out
 
 
 def test_cli_create_refuses_existing(tmp_path: Path) -> None:

--- a/tests/test_agent_router_cli_e2e.py
+++ b/tests/test_agent_router_cli_e2e.py
@@ -292,7 +292,11 @@ def test_cli_verify_fresh_scaffold_is_insufficient_evidence(tmp_path: Path) -> N
     assert verify.exit_code == 1
     out = click.unstyle(verify.output)
     assert "insufficient-evidence" in out
-    assert "NOT been filed" in out
+    # A fresh scaffold has not diverged — it simply has no recorded parity data —
+    # so the divergence "could not be closed / open an issue" draft must NOT be
+    # dumped; the gate points the author at parity_test.py instead.
+    assert "NOT been filed" not in out
+    assert "parity_test.py" in out
 
 
 # ── run: dry-run prints the command; live path fails closed ───────────


### PR DESCRIPTION
Final dogfood residual on the router verify gate: a fresh scaffold (no parity data recorded) is `insufficient-evidence`, not divergence — so `bench agent verify` no longer dumps the 'parity could not be closed / open an issue' draft on someone who just ran `create`. It points them at `parity_test.py` instead (`confidence_line` already said so). Two tests that pinned the old confusing behavior are corrected. Full suite: 3,551 passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI output branching only; real divergence paths and exit codes are unchanged aside from less noisy messaging for empty parity records.
> 
> **Overview**
> **`bench agent verify`** now treats **`insufficient-evidence`** (e.g. right after **`create`**, with no parity data yet) separately from **`parity-divergent`**. Verify still exits **1** and still prints the verdict plus **`confidence_line`** guidance, but it **no longer** prints or writes the “parity could not be closed / open an issue” divergence draft when nothing has actually diverged.
> 
> **`parity-divergent`** behavior is unchanged: the divergence issue draft (including “NOT been filed”) still appears for real mismatches.
> 
> CLI/e2e tests for a fresh scaffold were updated to assert the divergence draft is absent and **`parity_test.py`** appears in the output instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f0fde524a61d5758b1af97e687f639b0701c055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->