### PR TITLE
fix(verifier): alias /tests → /verifier so converted task.md verifiers run

### DIFF
--- a/src/benchflow/task/verifier_core.py
+++ b/src/benchflow/task/verifier_core.py
@@ -289,6 +289,49 @@ class Verifier:
             return None
         return load_verifier_document(verifier_dir)
 
+    async def _link_legacy_verifier_mount(
+        self,
+        *,
+        verifier_code_dir: PurePosixPath,
+        sandbox_paths: SandboxPaths,
+        service: str,
+    ) -> None:
+        """Alias the legacy ``/tests`` mount onto a native verifier dir.
+
+        ``bench tasks migrate`` mounts a task.md (native) verifier at
+        ``/verifier`` rather than the legacy ``/tests``. Verifier scripts carried
+        over from a legacy benchmark commonly hardcode ``/tests/...`` paths
+        (e.g. ``python3 /tests/evaluate.py``), so a faithful conversion must keep
+        those resolvable. When the native mount differs from ``/tests``, symlink
+        ``/tests`` → the native dir — but only when ``/tests`` is absent, so real
+        content is never clobbered. No-op for legacy tasks (already mounted at
+        ``/tests``) and harmless for native verifiers that reference
+        ``$BENCHFLOW_VERIFIER_DIR`` instead of a hardcoded path.
+        """
+        legacy_dir = sandbox_paths.tests_dir
+        if str(verifier_code_dir) == str(legacy_dir):
+            return
+        src = shlex.quote(str(verifier_code_dir))
+        dst = shlex.quote(str(legacy_dir))
+        try:
+            result = await self._sandbox.exec(
+                f"[ -e {dst} ] || ln -s {src} {dst}",
+                user="root",
+                service=service,
+                timeout_sec=10,
+            )
+        except Exception as e:  # best-effort; native verifiers may not need it
+            self._logger.debug("legacy verifier-mount symlink skipped: %s", e)
+            return
+        if _exec_return_code(result) != 0:
+            self._logger.debug(
+                "legacy verifier-mount symlink (%s -> %s) returned nonzero; "
+                "verifier scripts hardcoding %s may fail",
+                legacy_dir,
+                verifier_code_dir,
+                legacy_dir,
+            )
+
     # test-script verifier (default — Harbor-compatible)
 
     async def _verify_test_script(
@@ -339,6 +382,12 @@ class Verifier:
             raise AddTestsDirError(
                 "Failed to add verifier directory to sandbox."
             ) from e
+
+        await self._link_legacy_verifier_mount(
+            verifier_code_dir=verifier_code_dir,
+            sandbox_paths=sandbox_paths,
+            service=service,
+        )
 
         self._rollout_paths.test_stdout_path.touch()
 
@@ -719,6 +768,12 @@ class Verifier:
             raise AddTestsDirError(
                 "Failed to add verifier directory to sandbox."
             ) from e
+
+        await self._link_legacy_verifier_mount(
+            verifier_code_dir=verifier_code_dir,
+            sandbox_paths=sandbox_paths,
+            service=service,
+        )
 
         self._rollout_paths.test_stdout_path.touch()
         if service != "main":

--- a/tests/test_verifier_output.py
+++ b/tests/test_verifier_output.py
@@ -266,3 +266,90 @@ async def test_verify_test_script_recovers_reward_when_dir_download_fails(tmp_pa
     sandbox.download_dir.assert_awaited_once()
     assert rollout_paths.reward_text_path.read_text() == "0"
     assert rollout_paths.test_stdout_path.read_text() == "pytest output"
+
+
+# Legacy verifier-mount compat (family-2 / opaquetoolsbench parity finding)
+#
+# ``bench tasks migrate`` mounts a task.md verifier at /verifier instead of the
+# legacy /tests. Verifier scripts carried over from a legacy benchmark often
+# hardcode ``python3 /tests/evaluate.py``; without a /tests -> /verifier alias
+# every converted verifier crashes rc=2 "no reward file" while the legacy
+# variant passes. These guard the alias that keeps such conversions working.
+
+
+def _make_script_verifier(tmp_path, *, uses_native_verifier_dir):
+    """Verifier over a mounted sandbox driving the default test.sh path, with a
+    captured exec log. test.sh writes a passing reward so verify() completes."""
+    verifier_dir = tmp_path / "verifier"
+    verifier_dir.mkdir(parents=True, exist_ok=True)
+
+    rollout_paths = MagicMock()
+    rollout_paths.verifier_dir = verifier_dir
+    rollout_paths.test_stdout_path = verifier_dir / "test-stdout.txt"
+    rollout_paths.reward_text_path = verifier_dir / "reward.txt"
+    rollout_paths.reward_json_path = verifier_dir / "reward.json"
+
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir(exist_ok=True)
+    (tests_dir / "test.sh").write_text("#!/bin/sh\npython3 /tests/evaluate.py\n")
+
+    task = MagicMock()
+    task.config.verifier.type = "test-script"
+    task.config.verifier.service = "main"
+    task.config.verifier.user = "root"
+    task.config.verifier.env = None
+    task.config.verifier.timeout_sec = 60
+    task.paths.tests_dir = tests_dir
+    task.paths.test_path = tests_dir / "test.sh"
+    task.paths.uses_native_verifier_dir = uses_native_verifier_dir
+
+    calls: list[dict] = []
+
+    async def fake_exec(*args, **kwargs):
+        cmd = args[0] if args else kwargs.get("command", "")
+        calls.append({"command": cmd, "user": kwargs.get("user")})
+        if "ln -s" in cmd or "chmod" in cmd or cmd.startswith("mkdir") or "[ -e" in cmd:
+            return MagicMock(exit_code=0, returncode=0)
+        # The test.sh run: a passing reward + stdout, mounted in place.
+        rollout_paths.test_stdout_path.write_text("ok")
+        rollout_paths.reward_text_path.write_text("1")
+        return MagicMock(exit_code=0, returncode=0)
+
+    sandbox = MagicMock()
+    sandbox.is_mounted = True
+    sandbox.upload_dir = AsyncMock()
+    sandbox.exec = AsyncMock(side_effect=fake_exec)
+    verifier = Verifier(task=task, rollout_paths=rollout_paths, sandbox=sandbox)
+    return verifier, calls
+
+
+@pytest.mark.asyncio
+async def test_native_verifier_aliases_legacy_tests_mount(tmp_path):
+    """A native (task.md) verifier mounts at /verifier and must alias /tests so
+    legacy-convention verifier scripts (hardcoded /tests/...) still resolve."""
+    verifier, calls = _make_script_verifier(tmp_path, uses_native_verifier_dir=True)
+
+    result = await verifier._verify_test_script()
+
+    assert result.rewards == {"reward": 1.0}
+    link = [c for c in calls if "ln -s" in c["command"]]
+    assert link, (
+        f"expected a /tests->/verifier alias; got {[c['command'] for c in calls]}"
+    )
+    cmd = link[0]["command"]
+    assert "ln -s /verifier /tests" in cmd
+    # Guarded so real /tests content is never clobbered.
+    assert "[ -e /tests ]" in cmd
+    # Created as root so the verifier user (any) can traverse it.
+    assert link[0]["user"] == "root"
+
+
+@pytest.mark.asyncio
+async def test_legacy_verifier_does_not_alias_tests_mount(tmp_path):
+    """A legacy verifier already mounts at /tests, so no alias is created."""
+    verifier, calls = _make_script_verifier(tmp_path, uses_native_verifier_dir=False)
+
+    result = await verifier._verify_test_script()
+
+    assert result.rewards == {"reward": 1.0}
+    assert not [c for c in calls if "ln -s" in c["command"]]


### PR DESCRIPTION
## What

When `bench tasks migrate` converts a legacy benchmark to task.md, it moves the verifier sandbox mount from `/tests` (legacy) to `/verifier` (native). Verifier scripts carried over from the legacy benchmark commonly **hardcode** `/tests/...` paths:

```sh
python3 /tests/evaluate.py --ground-truth /tests/ground_truth.json ...
```

Under task.md the verifier is at `/verifier`, `/tests` doesn't exist, and the script dies `rc=2` → no reward file → `verifier crashed`. The agent ran fine; only verifier path resolution broke.

## How it was found

The **family-2 (opaquetoolsbench) legacy-vs-task.md parity gate** — a side-by-side oracle run of both variants:

| variant | pass | mean reward | verifier crash |
|---|---|---|---|
| legacy (oracle) | 30/30 | 1.000 | 0 |
| task.md (migrated) | **0/30** | — | **30** |

A one-sided task.md run would have reported "0% — model can't solve these" and buried the bug. The paired legacy baseline (perfect oracle pass) proved the tasks are solvable and isolated the fault to the conversion. Family 1 (SkillsBench) was clean only because its verifiers use `$BENCHFLOW_VERIFIER_DIR`; a second family with the legacy `/tests` convention surfaced this whole class.

## Fix

When a native verifier mounts at `/verifier`, symlink `/tests → /verifier` — guarded with `[ -e /tests ]` so real content is never clobbered. No-op for legacy tasks (already at `/tests`) and harmless for native verifiers that use `$BENCHFLOW_VERIFIER_DIR`. Best-effort (logs, never hard-fails) and applied at **both** verifier-upload sites (test-script + reward-kit). New helper `_link_legacy_verifier_mount` in `verifier_core.py`.

## Validation

- Unit: 2 new regression tests in `test_verifier_output.py` (native aliases `/tests` as root with the `[ -e ]` guard; legacy does not) + full `test_verifier_output` / `test_verifier_strategies` green (42 passed).
- **Live (Daytona):** the two task.md smoke tasks that crashed `rc=2` now score **reward=1.0**, matching legacy.

## Notes

- Scoped to the verifier-mount surface; does not touch migrate-time authoring. A complementary follow-up could add a migrate-time **lint** that warns when a verifier script hardcodes `/tests/` (defense-in-depth for runtimes without the symlink).
- Targets `release/v0.6.0`. Not merging — flagging for review (shared verifier-core surface; overlaps PR #639's task-standard runtime work).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared verifier-core sandbox setup for all test-script and reward-kit runs; symlink logic is guarded and best-effort but wrong behavior could still break or confuse verifier path resolution.
> 
> **Overview**
> Fixes migrated **task.md** verifiers that still invoke scripts under hardcoded **`/tests/...`** paths after the sandbox mount moves to **`/verifier`**.
> 
> Adds **`_link_legacy_verifier_mount`** in `verifier_core.py`: after uploading verifier files, it runs a guarded root **`ln -s`** so **`/tests`** points at the native verifier dir only when **`/tests`** is missing and the mount is not already legacy **`/tests`**. The helper is **best-effort** (debug logs on failure) and runs in both **test-script** and **reward-kit** upload paths.
> 
> Adds regression tests in **`test_verifier_output.py`** for native alias behavior (including **`[ -e /tests ]`** and root user) and for legacy tasks skipping the symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66f6aefe999a5ab393bcc27b84c8a3cf8d7c096. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->