### PR TITLE
fix(ci): restore ty-clean + format-clean on release/v0.6.0

### DIFF
--- a/src/benchflow/_utils/reward_events.py
+++ b/src/benchflow/_utils/reward_events.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any
+from typing import Any, cast
 
 _EVENT_FIELDS = ("type", "reward", "source", "space", "granularity", "step")
 
@@ -32,6 +32,7 @@ def build_rewards_jsonl_events(
         for i, item in enumerate(rubric):
             if not isinstance(item, dict):
                 continue
+            item = cast("dict[str, Any]", item)
             score = item.get("score")
             if not isinstance(score, (int, float)) or isinstance(score, bool):
                 continue

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -1341,10 +1341,12 @@ class Evaluation:
         """
         if self._config.environment != "daytona":
             return
-        if (
-            os.environ.get("BENCHFLOW_DAYTONA_AUTO_REAP", "1").strip().lower()
-            in {"0", "false", "no", "off"}
-        ):
+        if os.environ.get("BENCHFLOW_DAYTONA_AUTO_REAP", "1").strip().lower() in {
+            "0",
+            "false",
+            "no",
+            "off",
+        }:
             return
 
         def _reap() -> None:

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -301,18 +301,13 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
     #    verifier_core / ors.ORSAdapter bounds enforcement).
     if reward is not None and not is_valid_reward_number(reward):
         verifiers_error = (
-            verifiers_error
-            or f"hosted reward out of [0,1] contract: {reward!r}"
+            verifiers_error or f"hosted reward out of [0,1] contract: {reward!r}"
         )
         reward = None
     # 2. returncode 0 but no parseable reward and no abort marker means the
     #    vf-eval summary format drifted — surface it as an error rather than a
     #    clean run with no rewards artifact.
-    elif (
-        reward is None
-        and proc.returncode == 0
-        and not verifiers_error
-    ):
+    elif reward is None and proc.returncode == 0 and not verifiers_error:
         verifiers_error = (
             "could not parse reward from vf-eval output "
             "(vf-eval summary format may have changed)"

--- a/src/benchflow/sandbox/daytona_reaper.py
+++ b/src/benchflow/sandbox/daytona_reaper.py
@@ -201,8 +201,7 @@ def reap_stale_sandboxes(
         # Failed sandboxes ignore the guard so they still reap on the short TTL.
         if will_delete and not is_failed:
             last_activity = _parse_sandbox_timestamp(
-                getattr(sb, "last_activity_at", None)
-                or getattr(sb, "updated_at", None)
+                getattr(sb, "last_activity_at", None) or getattr(sb, "updated_at", None)
             )
             if last_activity is not None:
                 idle_minutes = (now - last_activity).total_seconds() / 60


### PR DESCRIPTION
## What
Restores two CI gates that are currently **red on `release/v0.6.0`**. They slipped in via merged PRs because `test.yml` only runs on PRs to `main`, not release branches — so the v0.6.0 launch gate (ruff + ty + pytest clean) is broken.

## Fixes
1. **ty** — 4 errors in `src/benchflow/_utils/reward_events.py` (lines 35/44/46/47), one root cause: after `if not isinstance(item, dict): continue`, ty narrows `item` to `dict[Never, Never]`, so `item.get("score")` / `item.get("name", ...)` fail. Added `item = cast("dict[str, Any]", item)` after the guard — a **runtime no-op** that fixes the narrowing.
2. **ruff format** — line-wrapping drift in `evaluation.py`, `hosted_env.py`, `sandbox/daytona_reaper.py`. Reformatted (pure whitespace).

## Verification
- `uv run ty check` → All checks passed
- `uv run ruff check src tests tools` → All checks passed
- `uv run ruff format --check src tests tools` → 437 files already formatted
- `uv run python -m pytest tests/ -m "not integration"` → **3623 passed, 0 failed** (incl. 16 reward_events tests)

No behavior change. Suggest enabling CI on `release/**` so this can't recur.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Typing cast and formatter-only line breaks; reward and Daytona reaper logic is unchanged.
> 
> **Overview**
> Restores **ty** and **ruff format** CI on `release/v0.6.0` with no intended runtime behavior change.
> 
> In `reward_events.py`, after the `isinstance(item, dict)` guard, **ty** was narrowing `item` to `dict[Never, Never]` and rejecting `.get()` calls. The PR adds `item = cast("dict[str, Any]", item)` — a typing-only fix for rubric JSONL event building.
> 
> **Ruff format** reflows long lines in `evaluation.py` (Daytona auto-reap env gate), `hosted_env.py` (hosted reward / vf-eval parse checks), and `daytona_reaper.py` (activity timestamp fallback). Whitespace only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 801ab8fe12196d5a2d4a039ebb2d9b5f68cf7de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->