### PR TITLE
feat(eval): registry dataset resolution — `bench eval create -d skillsbench@1.1`

### DIFF
--- a/src/benchflow/_utils/dataset_registry.py
+++ b/src/benchflow/_utils/dataset_registry.py
@@ -1,0 +1,216 @@
+"""Dataset registry resolution — `bench eval create -d skillsbench@1.1`.
+
+Resolves a published dataset version from the skillsbench registry
+(``registry.json``, see ``docs/dataset-versioning.md`` in
+benchflow-ai/skillsbench): clones the pinned snapshot, verifies every
+task's content digest against the registry entry, and hands back the
+task set plus source provenance for result stamping.
+"""
+
+import json
+import posixpath
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.request import urlopen
+
+from benchflow._utils import benchmark_repos
+from benchflow._utils.task_authoring import task_digest
+
+DEFAULT_REGISTRY_SOURCE = (
+    "https://raw.githubusercontent.com/benchflow-ai/skillsbench/main/registry.json"
+)
+
+_GITHUB_URL_RE = re.compile(
+    r"^(?:https://|git@)github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$"
+)
+
+
+class DatasetResolutionError(ValueError):
+    """A dataset spec could not be resolved against the registry."""
+
+
+class DatasetDigestMismatchError(DatasetResolutionError):
+    """Snapshot content does not match the registry's pinned digests."""
+
+
+@dataclass(frozen=True)
+class ResolvedDataset:
+    """A registry entry resolved to verified task directories on disk."""
+
+    name: str
+    version: str
+    bench_version: str | None
+    tasks_dir: Path
+    task_names: set[str]
+    task_digests: dict[str, str]
+    provenance: dict[str, Any]
+
+    @property
+    def spec(self) -> str:
+        return f"{self.name}@{self.version}"
+
+
+def parse_dataset_spec(spec: str) -> tuple[str, str]:
+    """Split ``<name>@<version>`` — the version is mandatory.
+
+    Published versions are immutable, so there is no "latest" default: a
+    run must name the exact version it pins.
+    """
+    name, sep, version = spec.partition("@")
+    if not sep or not name or not version:
+        raise DatasetResolutionError(
+            f"Invalid dataset spec {spec!r} — expected <name>@<version> "
+            f"(e.g. skillsbench@1.1)"
+        )
+    return name, version
+
+
+def load_registry(source: str) -> list[dict[str, Any]]:
+    """Load a dataset registry from an HTTP(S) URL or a local file path."""
+    if source.startswith(("http://", "https://")):
+        with urlopen(source, timeout=30) as response:
+            raw = response.read().decode("utf-8")
+    else:
+        raw = Path(source).read_text()
+    registry = json.loads(raw)
+    if not isinstance(registry, list):
+        raise DatasetResolutionError(
+            f"Registry at {source} is not a list of dataset entries"
+        )
+    return registry
+
+
+def bench_version_issue(declared_range: str | None) -> str | None:
+    """Warning text when the running bench falls outside the dataset's
+    validated ``bench_version`` range, else None. Advisory only — the
+    range records what the version was validated against, it is not a
+    hard gate."""
+    if not declared_range:
+        return None
+    from packaging.specifiers import InvalidSpecifier, SpecifierSet
+    from packaging.version import InvalidVersion, Version
+
+    from benchflow import __version__
+
+    try:
+        specifier = SpecifierSet(declared_range)
+    except InvalidSpecifier:
+        return f"registry declares an unparseable bench_version {declared_range!r}"
+    try:
+        current = Version(__version__)
+    except InvalidVersion:
+        return (
+            f"cannot compare bench version {__version__!r} against the "
+            f"dataset's validated range {declared_range!r}"
+        )
+    if specifier.contains(current, prereleases=True):
+        return None
+    return (
+        f"bench {__version__} is outside the range this dataset was "
+        f"validated against ({declared_range}) — results may not be "
+        f"comparable with published runs"
+    )
+
+
+def _github_org_repo(git_url: str) -> str:
+    match = _GITHUB_URL_RE.match(git_url)
+    if not match:
+        raise DatasetResolutionError(
+            f"Unsupported git_url {git_url!r} — expected a github.com repository"
+        )
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def resolve_dataset(
+    spec: str, registry: str = DEFAULT_REGISTRY_SOURCE
+) -> ResolvedDataset:
+    """Resolve ``<name>@<version>`` to digest-verified task dirs on disk.
+
+    Clones the snapshot pinned by the registry entry (by commit id, so a
+    moved git tag cannot change what runs), then recomputes every task's
+    content digest and fails hard on any mismatch — a dataset version is
+    an immutable artifact and must byte-match its registry entry.
+    """
+    name, version = parse_dataset_spec(spec)
+    entries = load_registry(registry)
+    entry = next(
+        (
+            e
+            for e in entries
+            if e.get("name") == name and str(e.get("version")) == version
+        ),
+        None,
+    )
+    if entry is None:
+        available = (
+            ", ".join(f"{e.get('name')}@{e.get('version')}" for e in entries) or "none"
+        )
+        raise DatasetResolutionError(
+            f"Dataset {spec!r} not found in registry (available: {available})"
+        )
+    tasks = entry.get("tasks") or []
+    if not tasks:
+        raise DatasetResolutionError(f"Dataset {spec!r} has no tasks in the registry")
+
+    snapshots = {(t["git_url"], t["git_commit_id"]) for t in tasks}
+    if len(snapshots) != 1:
+        raise DatasetResolutionError(
+            f"Dataset {spec!r} spans {len(snapshots)} git snapshots — "
+            f"only single-snapshot datasets are supported"
+        )
+    git_url, commit = next(iter(snapshots))
+
+    parents = {posixpath.dirname(t["path"].rstrip("/")) for t in tasks}
+    if len(parents) != 1:
+        raise DatasetResolutionError(
+            f"Dataset {spec!r} tasks live under {len(parents)} parent "
+            f"directories — only a single tasks directory is supported"
+        )
+    parent = next(iter(parents))
+
+    task_digests: dict[str, str] = {}
+    for t in tasks:
+        base = posixpath.basename(t["path"].rstrip("/"))
+        if base in task_digests:
+            raise DatasetResolutionError(
+                f"Dataset {spec!r} has two tasks named {base!r}"
+            )
+        task_digests[base] = t["digest"]
+
+    repo = _github_org_repo(git_url)
+    resolved = benchmark_repos.resolve_source_with_metadata(
+        repo, path=parent or None, ref=commit
+    )
+    resolved_sha = resolved.provenance.get("resolved_sha")
+    if resolved_sha != commit:
+        raise DatasetResolutionError(
+            f"Snapshot for {spec!r} resolved to {resolved_sha} but the "
+            f"registry pins {commit}"
+        )
+
+    mismatches = []
+    for base, expected in sorted(task_digests.items()):
+        candidate = resolved.path / base
+        if not candidate.is_dir():
+            mismatches.append(f"{base}: missing from snapshot")
+            continue
+        actual = task_digest(candidate)
+        if actual != expected:
+            mismatches.append(f"{base}: computed {actual}, registry pins {expected}")
+    if mismatches:
+        raise DatasetDigestMismatchError(
+            f"Dataset {spec!r} content does not match its registry digests:\n  "
+            + "\n  ".join(mismatches)
+        )
+
+    return ResolvedDataset(
+        name=name,
+        version=version,
+        bench_version=entry.get("bench_version"),
+        tasks_dir=resolved.path,
+        task_names=set(task_digests),
+        task_digests=task_digests,
+        provenance=resolved.provenance,
+    )

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1092,6 +1092,23 @@ def eval_create(
             help="Skip these task names; repeatable (e.g. --exclude quantum-numerical-simulation)",
         ),
     ] = None,
+    dataset: Annotated[
+        str | None,
+        typer.Option(
+            "--dataset",
+            "-d",
+            help="Registry dataset to run, as <name>@<version> (e.g. skillsbench@1.1). "
+            "Resolves the pinned snapshot and verifies task content digests.",
+        ),
+    ] = None,
+    registry: Annotated[
+        str | None,
+        typer.Option(
+            "--registry",
+            help="Dataset registry JSON URL or local file "
+            "(default: the skillsbench registry). Only valid with --dataset.",
+        ),
+    ] = None,
 ) -> None:
     """Run an evaluation — single task or batch.
 
@@ -1107,11 +1124,21 @@ def eval_create(
     parsed_env = _parse_agent_env(agent_env)
     include_tasks = set(include) if include else set()
     exclude_tasks = set(exclude) if exclude else set()
-    sources = [bool(config_file), bool(tasks_dir), bool(source_repo), bool(source_env)]
+    sources = [
+        bool(config_file),
+        bool(tasks_dir),
+        bool(source_repo),
+        bool(source_env),
+        bool(dataset),
+    ]
     if sum(sources) > 1:
         console.print(
-            "[red]Choose only one source: --config, --tasks-dir, --source-repo, or --source-env[/red]"
+            "[red]Choose only one source: --config, --tasks-dir, --source-repo, "
+            "--source-env, or --dataset[/red]"
         )
+        raise typer.Exit(1)
+    if registry and not dataset:
+        console.print("[red]--registry requires --dataset[/red]")
         raise typer.Exit(1)
     if worker_concurrency is not None and not (tasks_dir or source_repo):
         console.print(
@@ -1340,6 +1367,63 @@ def eval_create(
         if run_result.error:
             console.print(f"[red]Error:[/red] {run_result.error}")
             raise typer.Exit(1)
+    elif dataset:
+        from benchflow._utils.dataset_registry import (
+            DEFAULT_REGISTRY_SOURCE,
+            DatasetResolutionError,
+            bench_version_issue,
+            resolve_dataset,
+        )
+
+        registry_source = registry or DEFAULT_REGISTRY_SOURCE
+        try:
+            with console.status(f"Resolving dataset {dataset}…"):
+                resolved_dataset = resolve_dataset(dataset, registry=registry_source)
+        except DatasetResolutionError as e:
+            console.print(f"[red]{e}[/red]")
+            raise typer.Exit(1) from None
+        version_issue = bench_version_issue(resolved_dataset.bench_version)
+        if version_issue:
+            console.print(f"[yellow]Warning:[/yellow] {version_issue}")
+        console.print(
+            f"[green]✓[/green] {resolved_dataset.spec}: "
+            f"{len(resolved_dataset.task_names)} tasks, digests verified "
+            f"({str(resolved_dataset.provenance.get('resolved_sha', ''))[:12]})"
+        )
+        dataset_include = (
+            resolved_dataset.task_names & include_tasks
+            if include_tasks
+            else resolved_dataset.task_names
+        )
+        eff_model = effective_model(eval_agent, model)
+        _run_batch_eval(
+            resolved_dataset.tasks_dir,
+            EvaluationConfig(
+                agent=eval_agent,
+                model=eff_model,
+                reasoning_effort=eval_reasoning_effort,
+                environment=eval_environment,
+                concurrency=eval_concurrency,
+                build_concurrency=build_concurrency,
+                prompts=eval_prompts,
+                agent_idle_timeout=eval_agent_idle_timeout,
+                agent_env=parsed_env,
+                sandbox_user=sandbox_user,
+                sandbox_setup_timeout=sandbox_setup_timeout,
+                skills_dir=str(skills_dir) if skills_dir else None,
+                skill_mode=skill_mode,
+                skill_creator_dir=str(skill_creator_dir) if skill_creator_dir else None,
+                self_gen_no_internet=self_gen_no_internet,
+                source_provenance=resolved_dataset.provenance,
+                include_tasks=dataset_include,
+                exclude_tasks=exclude_tasks,
+                usage_tracking=eval_usage_tracking,
+                environment_manifest=eval_env_manifest,
+                dataset_name=resolved_dataset.name,
+                dataset_version=resolved_dataset.version,
+                dataset_task_digests=resolved_dataset.task_digests,
+            ),
+        )
     elif source_repo:
         from benchflow._utils.benchmark_repos import resolve_source_with_metadata
 
@@ -1408,7 +1492,8 @@ def eval_create(
         )
     else:
         console.print(
-            "[red]Provide --config, --tasks-dir, --source-repo, or --source-env[/red]"
+            "[red]Provide --config, --tasks-dir, --source-repo, --source-env, "
+            "or --dataset[/red]"
         )
         raise typer.Exit(1)
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -267,6 +267,13 @@ class EvaluationConfig:
     self_gen_no_internet: bool = False
     job_mode: str = DEFAULT_JOB_MODE
     source_provenance: dict[str, Any] | None = None
+    # Registry dataset identity (`bench eval create -d name@version`). When
+    # set, every result.json/config.json is stamped with dataset_name,
+    # dataset_version, and the task's registry content digest — see
+    # docs/dataset-versioning.md in benchflow-ai/skillsbench.
+    dataset_name: str | None = None
+    dataset_version: str | None = None
+    dataset_task_digests: dict[str, str] = field(default_factory=dict)
     usage_tracking: UsageTrackingConfig = field(default_factory=UsageTrackingConfig)
     # Environment-plane manifest applied to every rollout in the batch.
     # When set, each task's RolloutConfig.environment_manifest is populated
@@ -817,6 +824,13 @@ class Evaluation:
         from benchflow._utils.benchmark_repos import task_source_provenance
         from benchflow.rollout import Rollout, RolloutConfig
 
+        dataset = None
+        if cfg.dataset_name:
+            dataset = {
+                "name": cfg.dataset_name,
+                "version": cfg.dataset_version,
+                "task_digest": cfg.dataset_task_digests.get(task_dir.name),
+            }
         skills_dir = (
             str(self._learner_skills_dir)
             if self._learner_skills_dir is not None
@@ -855,6 +869,7 @@ class Evaluation:
             self_gen_no_internet=cfg.self_gen_no_internet,
             export_generated_skills_to=export_to,
             source_provenance=task_source_provenance(cfg.source_provenance, task_dir),
+            dataset=dataset,
             usage_tracking=cfg.usage_tracking,
         )
         if skill_mode == SKILL_MODE_SELF_GEN:
@@ -1383,6 +1398,14 @@ class Evaluation:
             **trajectory_step_summary(all_results),
             **phase_timing_summary(all_results),
             **summary_source_fields(cfg.source_provenance, all_results),
+            **(
+                {
+                    "dataset_name": cfg.dataset_name,
+                    "dataset_version": cfg.dataset_version,
+                }
+                if cfg.dataset_name
+                else {}
+            ),
         }
         # Surface continual-learning provenance — generation, curve — so a
         # resumed run can be audited end-to-end (#394).

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -525,6 +525,7 @@ def _write_config(
     agent_idle_timeout: int | None = None,
     scenes: list[Scene] | None = None,
     source_provenance: dict[str, Any] | None = None,
+    dataset: dict[str, Any] | None = None,
 ) -> None:
     """Write config.json to rollout_dir with secrets filtered out."""
     recorded_env = {
@@ -552,6 +553,10 @@ def _write_config(
         config_data["usage_tracking"] = usage_tracking.to_config_artifact()
     if source_provenance is not None:
         config_data["source"] = source_provenance
+    if dataset is not None:
+        config_data["dataset_name"] = dataset.get("name")
+        config_data["dataset_version"] = dataset.get("version")
+        config_data["task_digest"] = dataset.get("task_digest")
     (rollout_dir / "config.json").write_text(json.dumps(config_data, indent=2))
 
 
@@ -616,6 +621,7 @@ def _build_rollout_result(
     usage_tracking: dict[str, Any] | None = None,
     evolved_skills: dict[str, str] | None = None,
     source_provenance: dict[str, Any] | None = None,
+    dataset: dict[str, Any] | None = None,
     diagnostics: RolloutDiagnostics | None = None,
     skill_policy: TaskSkillPolicy | None = None,
     sandbox_id: str | None = None,
@@ -741,6 +747,15 @@ def _build_rollout_result(
                 **(
                     {"source": source_provenance}
                     if source_provenance is not None
+                    else {}
+                ),
+                **(
+                    {
+                        "dataset_name": dataset.get("name"),
+                        "dataset_version": dataset.get("version"),
+                        "task_digest": dataset.get("task_digest"),
+                    }
+                    if dataset is not None
                     else {}
                 ),
                 "sandbox_id": sandbox_id,
@@ -1092,6 +1107,10 @@ class RolloutConfig:
     skip_verify: bool = False
     export_generated_skills_to: str | Path | None = None
     source_provenance: dict[str, Any] | None = None
+    # Registry dataset identity for this task: {"name", "version",
+    # "task_digest"} — stamped into config.json/result.json so published
+    # runs declare the dataset version they ran (dataset-versioning plan).
+    dataset: dict[str, Any] | None = None
     planes: RolloutPlanes | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -1540,6 +1559,7 @@ class Rollout:
             agent_idle_timeout=cfg.agent_idle_timeout,
             scenes=cfg.effective_scenes,
             source_provenance=cfg.source_provenance,
+            dataset=cfg.dataset,
         )
 
         self._phase = "setup"
@@ -2906,6 +2926,7 @@ class Rollout:
             scenes=self._config.effective_scenes,
             evolved_skills=self._evolved_skills,
             source_provenance=self._config.source_provenance,
+            dataset=self._config.dataset,
             diagnostics=self._diagnostics,
             usage_tracking=self._usage_tracking_metadata(),
             skill_policy=getattr(self, "_task_skill_policy", None)

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -1,0 +1,453 @@
+"""Tests for registry dataset resolution (`bench eval create -d name@version`).
+
+Step 2 of the dataset-versioning plan (docs/dataset-versioning.md in
+benchflow-ai/skillsbench, registry added in skillsbench PR #922): resolving a
+registry entry clones the pinned snapshot, verifies every task's content
+digest, and stamps results with dataset_name / dataset_version / task_digest.
+"""
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+from typer.testing import CliRunner
+
+from benchflow._utils.dataset_registry import (
+    DatasetDigestMismatchError,
+    DatasetResolutionError,
+    ResolvedDataset,
+    bench_version_issue,
+    parse_dataset_spec,
+    resolve_dataset,
+)
+from benchflow._utils.task_authoring import task_digest
+from benchflow.cli.main import app
+
+COMMIT = "a" * 40
+
+
+def _make_task(parent: Path, name: str) -> Path:
+    task = parent / name
+    (task / "tests").mkdir(parents=True)
+    (task / "task.toml").write_text('version = "1.1"\n')
+    (task / "instruction.md").write_text(f"Solve {name}.\n")
+    (task / "tests" / "test.sh").write_text("exit 0\n")
+    return task
+
+
+def _write_registry(
+    tmp_path: Path, tasks_parent: Path, *, digests: dict[str, str] | None = None
+) -> Path:
+    """Write a single-entry registry pinning the tasks under tasks_parent."""
+    entry_tasks = []
+    for task_dir in sorted(tasks_parent.iterdir()):
+        entry_tasks.append(
+            {
+                "name": task_dir.name,
+                "git_url": "https://github.com/acme/benchmarks.git",
+                "git_commit_id": COMMIT,
+                "path": f"tasks/{task_dir.name}",
+                "digest": (digests or {}).get(task_dir.name) or task_digest(task_dir),
+            }
+        )
+    registry_file = tmp_path / "registry.json"
+    registry_file.write_text(
+        json.dumps(
+            [
+                {
+                    "name": "skillsbench",
+                    "version": "1.1",
+                    "git_tag": "v1.1",
+                    "bench_version": ">=0.1,<999",
+                    "tasks": entry_tasks,
+                }
+            ]
+        )
+    )
+    return registry_file
+
+
+@pytest.fixture
+def snapshot(tmp_path, monkeypatch):
+    """Two fake tasks plus a stubbed resolve_source_with_metadata."""
+    tasks_parent = tmp_path / "snap" / "tasks"
+    _make_task(tasks_parent, "task-a")
+    _make_task(tasks_parent, "task-b")
+    calls = {}
+
+    def fake_resolve(repo, path=None, ref=None):
+        calls.update(repo=repo, path=path, ref=ref)
+        return SimpleNamespace(
+            path=tasks_parent,
+            provenance={
+                "type": "github",
+                "repo": repo,
+                "requested_ref": ref,
+                "resolved_sha": COMMIT,
+                "path": path or "",
+                "local_path": str(tasks_parent),
+                "dirty": False,
+                "file_hashes": {},
+            },
+        )
+
+    monkeypatch.setattr(
+        "benchflow._utils.benchmark_repos.resolve_source_with_metadata",
+        fake_resolve,
+    )
+    return SimpleNamespace(tasks_parent=tasks_parent, calls=calls)
+
+
+class TestParseDatasetSpec:
+    def test_valid(self):
+        assert parse_dataset_spec("skillsbench@1.1") == ("skillsbench", "1.1")
+
+    @pytest.mark.parametrize("spec", ["skillsbench", "@1.1", "skillsbench@", ""])
+    def test_invalid(self, spec):
+        with pytest.raises(DatasetResolutionError, match="name>@<version"):
+            parse_dataset_spec(spec)
+
+
+class TestBenchVersionIssue:
+    def test_no_declared_range(self):
+        assert bench_version_issue(None) is None
+        assert bench_version_issue("") is None
+
+    def test_in_range(self):
+        assert bench_version_issue(">=0,<999") is None
+
+    def test_out_of_range_warns(self):
+        issue = bench_version_issue("<0.0.1")
+        assert issue is not None and "outside the range" in issue
+
+    def test_unparseable_range_warns(self):
+        issue = bench_version_issue("not-a-range")
+        assert issue is not None and "unparseable" in issue
+
+
+class TestResolveDataset:
+    def test_resolves_and_verifies_digests(self, tmp_path, snapshot):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        resolved = resolve_dataset("skillsbench@1.1", registry=str(registry))
+        assert isinstance(resolved, ResolvedDataset)
+        assert resolved.spec == "skillsbench@1.1"
+        assert resolved.tasks_dir == snapshot.tasks_parent
+        assert resolved.task_names == {"task-a", "task-b"}
+        assert set(resolved.task_digests) == {"task-a", "task-b"}
+        assert resolved.bench_version == ">=0.1,<999"
+        assert resolved.provenance["resolved_sha"] == COMMIT
+        # snapshot is cloned by pinned commit, not by (movable) tag
+        assert snapshot.calls == {
+            "repo": "acme/benchmarks",
+            "path": "tasks",
+            "ref": COMMIT,
+        }
+
+    def test_digest_mismatch_fails_hard(self, tmp_path, snapshot):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        (snapshot.tasks_parent / "task-b" / "instruction.md").write_text("tampered\n")
+        with pytest.raises(DatasetDigestMismatchError, match="task-b"):
+            resolve_dataset("skillsbench@1.1", registry=str(registry))
+
+    def test_missing_task_dir_fails_hard(self, tmp_path, snapshot):
+        registry = _write_registry(
+            tmp_path,
+            snapshot.tasks_parent,
+            digests={"task-c": "sha256:" + "0" * 64},
+        )
+        # registry pins task-c which the snapshot does not contain
+        registry_data = json.loads(registry.read_text())
+        registry_data[0]["tasks"].append(
+            {
+                "name": "task-c",
+                "git_url": "https://github.com/acme/benchmarks.git",
+                "git_commit_id": COMMIT,
+                "path": "tasks/task-c",
+                "digest": "sha256:" + "0" * 64,
+            }
+        )
+        registry.write_text(json.dumps(registry_data))
+        with pytest.raises(DatasetDigestMismatchError, match="task-c: missing"):
+            resolve_dataset("skillsbench@1.1", registry=str(registry))
+
+    def test_unknown_version_lists_available(self, tmp_path, snapshot):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        with pytest.raises(
+            DatasetResolutionError, match=r"available: skillsbench@1\.1"
+        ):
+            resolve_dataset("skillsbench@9.9", registry=str(registry))
+
+    def test_resolved_sha_must_match_registry_commit(
+        self, tmp_path, snapshot, monkeypatch
+    ):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        monkeypatch.setattr(
+            "benchflow._utils.benchmark_repos.resolve_source_with_metadata",
+            lambda repo, path=None, ref=None: SimpleNamespace(
+                path=snapshot.tasks_parent,
+                provenance={"resolved_sha": "b" * 40},
+            ),
+        )
+        with pytest.raises(DatasetResolutionError, match="registry pins"):
+            resolve_dataset("skillsbench@1.1", registry=str(registry))
+
+    def test_multi_snapshot_dataset_rejected(self, tmp_path, snapshot):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        registry_data = json.loads(registry.read_text())
+        registry_data[0]["tasks"][0]["git_commit_id"] = "c" * 40
+        registry.write_text(json.dumps(registry_data))
+        with pytest.raises(DatasetResolutionError, match="snapshots"):
+            resolve_dataset("skillsbench@1.1", registry=str(registry))
+
+    def test_non_github_git_url_rejected(self, tmp_path, snapshot):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        registry_data = json.loads(registry.read_text())
+        for t in registry_data[0]["tasks"]:
+            t["git_url"] = "https://gitlab.com/acme/benchmarks.git"
+        registry.write_text(json.dumps(registry_data))
+        with pytest.raises(DatasetResolutionError, match=r"github\.com"):
+            resolve_dataset("skillsbench@1.1", registry=str(registry))
+
+
+class TestEvalCreateDatasetCli:
+    def test_dataset_threads_config_and_filter(self, tmp_path, snapshot, monkeypatch):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        captured = {}
+
+        async def fake_eval_run(self):
+            captured["tasks_dir"] = self._tasks_dir
+            captured["include_tasks"] = self._config.include_tasks
+            captured["source"] = self._config.source_provenance
+            captured["dataset_name"] = self._config.dataset_name
+            captured["dataset_version"] = self._config.dataset_version
+            captured["dataset_task_digests"] = self._config.dataset_task_digests
+            return SimpleNamespace(passed=2, total=2, score=1.0, errored=0)
+
+        monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--dataset",
+                "skillsbench@1.1",
+                "--registry",
+                str(registry),
+                "--agent",
+                "oracle",
+                "--jobs-dir",
+                str(tmp_path / "jobs"),
+            ],
+        )
+
+        assert result.exit_code == 0, result.stdout
+        assert captured["tasks_dir"] == snapshot.tasks_parent
+        assert captured["include_tasks"] == {"task-a", "task-b"}
+        assert captured["source"]["resolved_sha"] == COMMIT
+        assert captured["dataset_name"] == "skillsbench"
+        assert captured["dataset_version"] == "1.1"
+        assert set(captured["dataset_task_digests"]) == {"task-a", "task-b"}
+        assert "digests verified" in result.stdout
+
+    def test_user_include_intersects_dataset(self, tmp_path, snapshot, monkeypatch):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        captured = {}
+
+        async def fake_eval_run(self):
+            captured["include_tasks"] = self._config.include_tasks
+            return SimpleNamespace(passed=1, total=1, score=1.0, errored=0)
+
+        monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--dataset",
+                "skillsbench@1.1",
+                "--registry",
+                str(registry),
+                "--include",
+                "task-a",
+                "--agent",
+                "oracle",
+                "--jobs-dir",
+                str(tmp_path / "jobs"),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert captured["include_tasks"] == {"task-a"}
+
+    def test_dataset_is_exclusive_with_tasks_dir(self, tmp_path):
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--dataset",
+                "skillsbench@1.1",
+                "--tasks-dir",
+                str(tmp_path),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "only one source" in result.stdout
+
+    def test_registry_requires_dataset(self, tmp_path):
+        result = CliRunner().invoke(
+            app,
+            ["eval", "create", "--registry", str(tmp_path / "r.json")],
+        )
+        assert result.exit_code == 1
+        assert "--registry requires --dataset" in result.stdout
+
+    def test_resolution_error_exits_cleanly(self, tmp_path, snapshot):
+        registry = _write_registry(tmp_path, snapshot.tasks_parent)
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--dataset",
+                "skillsbench@9.9",
+                "--registry",
+                str(registry),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "not found in registry" in result.stdout
+
+
+class TestDatasetStamping:
+    DATASET: ClassVar[dict] = {
+        "name": "skillsbench",
+        "version": "1.1",
+        "task_digest": "sha256:" + "f" * 64,
+    }
+
+    def test_rollout_config_threads_dataset_through_from_legacy(self, tmp_path):
+        from benchflow.rollout import RolloutConfig
+
+        cfg = RolloutConfig.from_legacy(
+            task_path=tmp_path, agent="oracle", dataset=self.DATASET
+        )
+        assert cfg.dataset == self.DATASET
+
+    def test_config_json_stamped(self, tmp_path):
+        from benchflow.rollout import _write_config
+        from benchflow.skill_policy import resolve_task_skill_policy
+
+        policy = resolve_task_skill_policy(
+            task_path=tmp_path,
+            skill_mode="no-skill",
+            runtime_skills_dir=None,
+            declared_sandbox_skills_dir=None,
+        )
+        _write_config(
+            tmp_path,
+            task_path=tmp_path / "task",
+            agent="oracle",
+            model=None,
+            environment="docker",
+            skill_policy=policy,
+            sandbox_user="agent",
+            context_root=None,
+            timeout=60,
+            started_at=datetime(2026, 6, 12),
+            agent_env={},
+            dataset=self.DATASET,
+        )
+        config = json.loads((tmp_path / "config.json").read_text())
+        assert config["dataset_name"] == "skillsbench"
+        assert config["dataset_version"] == "1.1"
+        assert config["task_digest"] == self.DATASET["task_digest"]
+
+    def test_config_json_unstamped_without_dataset(self, tmp_path):
+        from benchflow.rollout import _write_config
+        from benchflow.skill_policy import resolve_task_skill_policy
+
+        policy = resolve_task_skill_policy(
+            task_path=tmp_path,
+            skill_mode="no-skill",
+            runtime_skills_dir=None,
+            declared_sandbox_skills_dir=None,
+        )
+        _write_config(
+            tmp_path,
+            task_path=tmp_path / "task",
+            agent="oracle",
+            model=None,
+            environment="docker",
+            skill_policy=policy,
+            sandbox_user="agent",
+            context_root=None,
+            timeout=60,
+            started_at=datetime(2026, 6, 12),
+            agent_env={},
+        )
+        config = json.loads((tmp_path / "config.json").read_text())
+        assert "dataset_name" not in config
+
+    def test_result_json_stamped(self, tmp_path):
+        from benchflow.rollout import _build_rollout_result
+
+        _build_rollout_result(
+            tmp_path,
+            task_name="task-a",
+            rollout_name="task-a__r1",
+            agent="oracle",
+            agent_name="oracle",
+            model=None,
+            n_tool_calls=0,
+            prompts=[],
+            error=None,
+            verifier_error=None,
+            trajectory=[],
+            partial_trajectory=False,
+            rewards={"reward": 1.0},
+            started_at=datetime(2026, 6, 12),
+            timing={},
+            dataset=self.DATASET,
+        )
+        result = json.loads((tmp_path / "result.json").read_text())
+        assert result["dataset_name"] == "skillsbench"
+        assert result["dataset_version"] == "1.1"
+        assert result["task_digest"] == self.DATASET["task_digest"]
+
+    async def test_run_single_task_builds_per_task_dataset(self, tmp_path, monkeypatch):
+        from benchflow.evaluation import Evaluation, EvaluationConfig
+
+        task_dir = _make_task(tmp_path / "tasks", "task-a")
+        digest = task_digest(task_dir)
+        cfg = EvaluationConfig(
+            agent="oracle",
+            dataset_name="skillsbench",
+            dataset_version="1.1",
+            dataset_task_digests={"task-a": digest},
+        )
+        captured = {}
+
+        class FakeRollout:
+            @staticmethod
+            async def create(rollout_config):
+                captured["config"] = rollout_config
+                return SimpleNamespace(run=_fake_run)
+
+        async def _fake_run():
+            return SimpleNamespace(rewards={"reward": 1.0})
+
+        monkeypatch.setattr("benchflow.rollout.Rollout.create", FakeRollout.create)
+        evaluation = Evaluation(
+            tasks_dir=tmp_path / "tasks", jobs_dir=tmp_path / "jobs", config=cfg
+        )
+        await evaluation._run_single_task(task_dir, cfg)
+        assert captured["config"].dataset == {
+            "name": "skillsbench",
+            "version": "1.1",
+            "task_digest": digest,
+        }


### PR DESCRIPTION
Step 2 of the dataset-versioning plan ([docs/dataset-versioning.md](https://github.com/benchflow-ai/skillsbench/blob/main/docs/dataset-versioning.md), skillsbench#922 — merged, with skillsbench#923 covering the website side): the "run plumbing" — publishable runs name an immutable dataset version, and every result declares the dataset it ran.

> **Stacked on #689** (`bench tasks digest`) — the diff includes that commit until it merges; review only the top commit here, or wait for #689 first.

## What

**Resolution** (`src/benchflow/_utils/dataset_registry.py`)
- `bench eval create -d skillsbench@1.1` loads the registry (default: skillsbench `registry.json` on main; `--registry <url-or-file>` overrides), finds the `name@version` entry, and clones the snapshot **by its pinned `git_commit_id`**, not the tag — a re-pointed tag cannot change what runs; resolution double-checks `resolved_sha == git_commit_id`.
- Every task's content digest is recomputed (`task_digest` from #689) and compared to the registry entry. **Any mismatch is a hard failure** — a dataset version is an immutable artifact.
- The entry's task set becomes the `include_tasks` filter, so snapshot dirs outside the entry don't run (the `1.0` entry pins 84 of the 86 task dirs in its snapshot). User `--include` intersects, `--exclude` still applies.
- The entry's `bench_version` range is advisory: out-of-range harnesses get a warning, not a refusal.
- Reuses `resolve_source_with_metadata` wholesale: the snapshot cache, locking, and `source` provenance stamping (`resolved_sha`, per-task `file_hashes`, …) behave exactly like `--source-repo`.

**Stamping** (doc'd field names, consumed by the leaderboard pipeline)
- `result.json` + `config.json`: `dataset_name`, `dataset_version`, per-task `task_digest`.
- `summary.json`: `dataset_name`, `dataset_version`.
- Local `--tasks-dir` runs stay visibly distinct: no dataset fields at all.

## Validation

Live end-to-end against the merged registry (no mocks):
- `skillsbench@1.1` → 87/87 digests verified, `3d-scan-calc` reproduces `sha256:587a79f1…`, resolution ~45 s cold.
- `skillsbench@1.0` → 84/84 digests verified; the two non-registry dirs in the v1.0 snapshot (`fix-visual-stability`, `mhc-layer-impl` — "86 tasks, 84 evaluated") are correctly excluded.
- 26 new tests (`tests/test_dataset_registry.py`): spec parsing, digest-mismatch/missing-task/moved-tag/multi-snapshot failures, CLI threading + source-exclusivity, config/result/summary stamping, per-task digest threading into `RolloutConfig`. Full suite: 2838 passed (the one `test_litellm_runtime` failure is preexisting and env-dependent, reproduces on clean main).

## Notes for review

- ⚠️ The registry declares `bench_version ">=0.4,<0.5"` for `1.1`, so current `0.5.3.dev0` triggers the advisory warning on every run. If 1.1 is in fact fine on 0.5.x, the doc's patch-bump semantics ("widen `bench_version` for a new harness") suggest a `skillsbench@1.1.1`-style registry patch — upstream call to make.
- Not in scope (follow-ups): `--worker-concurrency` for dataset runs, `dataset:` in YAML configs, and teaching `check_results.py` to validate the dataset stamp (touches #555/#524 territory).