### PR TITLE
feat(provenance): dev-run task_digest stamping + check_results dataset-stamp audit

### DIFF
--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -826,11 +826,20 @@ class Evaluation:
 
         dataset = None
         if cfg.dataset_name:
-            dataset = {
-                "name": cfg.dataset_name,
-                "version": cfg.dataset_version,
-                "task_digest": cfg.dataset_task_digests.get(task_dir.name),
-            }
+            dataset = {"name": cfg.dataset_name, "version": cfg.dataset_version}
+        task_digest_value = (
+            cfg.dataset_task_digests.get(task_dir.name) if cfg.dataset_name else None
+        )
+        if task_digest_value is None:
+            # Dev runs (--tasks-dir / --source-repo) stamp a live-computed
+            # digest so every trajectory stays attributable to the exact
+            # task content it ran, not just a directory name.
+            from benchflow._utils.task_authoring import task_digest
+
+            try:
+                task_digest_value = task_digest(task_dir)
+            except (OSError, ValueError, UnicodeError) as e:
+                logger.debug("Could not compute task digest for %s: %s", task_dir, e)
         skills_dir = (
             str(self._learner_skills_dir)
             if self._learner_skills_dir is not None
@@ -870,6 +879,7 @@ class Evaluation:
             export_generated_skills_to=export_to,
             source_provenance=task_source_provenance(cfg.source_provenance, task_dir),
             dataset=dataset,
+            task_digest=task_digest_value,
             usage_tracking=cfg.usage_tracking,
         )
         if skill_mode == SKILL_MODE_SELF_GEN:

--- a/src/benchflow/rollout.py
+++ b/src/benchflow/rollout.py
@@ -526,6 +526,7 @@ def _write_config(
     scenes: list[Scene] | None = None,
     source_provenance: dict[str, Any] | None = None,
     dataset: dict[str, Any] | None = None,
+    task_digest: str | None = None,
 ) -> None:
     """Write config.json to rollout_dir with secrets filtered out."""
     recorded_env = {
@@ -556,7 +557,8 @@ def _write_config(
     if dataset is not None:
         config_data["dataset_name"] = dataset.get("name")
         config_data["dataset_version"] = dataset.get("version")
-        config_data["task_digest"] = dataset.get("task_digest")
+    if task_digest is not None:
+        config_data["task_digest"] = task_digest
     (rollout_dir / "config.json").write_text(json.dumps(config_data, indent=2))
 
 
@@ -622,6 +624,7 @@ def _build_rollout_result(
     evolved_skills: dict[str, str] | None = None,
     source_provenance: dict[str, Any] | None = None,
     dataset: dict[str, Any] | None = None,
+    task_digest: str | None = None,
     diagnostics: RolloutDiagnostics | None = None,
     skill_policy: TaskSkillPolicy | None = None,
     sandbox_id: str | None = None,
@@ -753,11 +756,11 @@ def _build_rollout_result(
                     {
                         "dataset_name": dataset.get("name"),
                         "dataset_version": dataset.get("version"),
-                        "task_digest": dataset.get("task_digest"),
                     }
                     if dataset is not None
                     else {}
                 ),
+                **({"task_digest": task_digest} if task_digest is not None else {}),
                 "sandbox_id": sandbox_id,
             },
             indent=2,
@@ -1107,10 +1110,14 @@ class RolloutConfig:
     skip_verify: bool = False
     export_generated_skills_to: str | Path | None = None
     source_provenance: dict[str, Any] | None = None
-    # Registry dataset identity for this task: {"name", "version",
-    # "task_digest"} — stamped into config.json/result.json so published
+    # Registry dataset identity: {"name", "version"} — stamped into
+    # config.json/result.json as dataset_name/dataset_version so published
     # runs declare the dataset version they ran (dataset-versioning plan).
     dataset: dict[str, Any] | None = None
+    # Content digest of the task directory ("sha256:<hex>", the skillsbench
+    # registry algorithm). Registry-pinned for dataset runs, computed live
+    # for dev runs — every result stays attributable to exact task content.
+    task_digest: str | None = None
     planes: RolloutPlanes | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -1560,6 +1567,7 @@ class Rollout:
             scenes=cfg.effective_scenes,
             source_provenance=cfg.source_provenance,
             dataset=cfg.dataset,
+            task_digest=cfg.task_digest,
         )
 
         self._phase = "setup"
@@ -2927,6 +2935,7 @@ class Rollout:
             evolved_skills=self._evolved_skills,
             source_provenance=self._config.source_provenance,
             dataset=self._config.dataset,
+            task_digest=self._config.task_digest,
             diagnostics=self._diagnostics,
             usage_tracking=self._usage_tracking_metadata(),
             skill_policy=getattr(self, "_task_skill_policy", None)

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -32,7 +32,11 @@ from benchflow._utils.scoring import (
     classify_verifier_error,
     count_result_outcomes,
 )
-from benchflow._utils.source_provenance import source_issues, source_matches_parent
+from benchflow._utils.source_provenance import (
+    is_sha256_digest,
+    source_issues,
+    source_matches_parent,
+)
 from benchflow.trajectories.metrics import (
     count_skill_invocations,
     result_skill_invocations,
@@ -304,6 +308,73 @@ def _source_hash_truth_issues(source: object, label: str) -> list[str]:
     return _source_git_truth_issues(source_dict, local_path, label)
 
 
+# Dataset identity stamp (dataset-versioning plan: benchflow #690 + dev-run
+# digest stamping follow-up). dataset_name/dataset_version mark registry
+# dataset runs; task_digest pins the exact task content for every run.
+_DATASET_STAMP_KEYS = ("dataset_name", "dataset_version", "task_digest")
+
+
+def _dataset_stamp_issues(artifact: object, label: str) -> list[str]:
+    """Audit the dataset identity stamp on one result.json/config.json.
+
+    Rules: dataset_name and dataset_version travel together; a dataset run
+    must carry a task_digest; any task_digest must be ``sha256:<64 hex>``.
+    A bare task_digest without dataset fields is a dev run — allowed.
+    """
+    if not isinstance(artifact, dict):
+        return []
+    artifact_dict = cast(dict[str, Any], artifact)
+    name = artifact_dict.get("dataset_name")
+    version = artifact_dict.get("dataset_version")
+    digest = artifact_dict.get("task_digest")
+    if name is None and version is None and digest is None:
+        return []
+    issues: list[str] = []
+    if (name is None) != (version is None):
+        issues.append(f"{label}: dataset_name and dataset_version must travel together")
+    for field_name, value in (("dataset_name", name), ("dataset_version", version)):
+        if value is not None and (not isinstance(value, str) or not value):
+            issues.append(f"{label}: {field_name} must be a non-empty string")
+    if name is not None and digest is None:
+        issues.append(f"{label}: dataset-stamped artifact missing task_digest")
+    if digest is not None and not is_sha256_digest(digest):
+        issues.append(f"{label}: task_digest must be 'sha256:<64 hex>'")
+    return issues
+
+
+def _task_digest_truth_issues(result: object, label: str) -> list[str]:
+    """Recompute the task content digest when the task dir is still on disk.
+
+    Complements ``_source_hash_truth_issues``: ``source.file_hashes`` audits
+    per-file hashes, this audits the single registry-algorithm digest the
+    leaderboard pipeline keys on.
+    """
+    if not isinstance(result, dict):
+        return []
+    result_dict = cast(dict[str, Any], result)
+    digest = result_dict.get("task_digest")
+    if not is_sha256_digest(digest):
+        return []  # absent or malformed — format issues reported elsewhere
+    source = result_dict.get("source")
+    if not isinstance(source, dict):
+        return []
+    local_path_raw = source.get("local_path")
+    if not isinstance(local_path_raw, str):
+        return []
+    local_path = Path(local_path_raw)
+    if not (local_path / "task.toml").exists():
+        return []
+    try:
+        from benchflow._utils.task_authoring import task_digest
+
+        actual = task_digest(local_path)
+    except Exception as e:
+        return [f"{label}: task_digest could not be recomputed: {e}"]
+    if actual != digest:
+        return [f"{label}: task_digest does not match local_path content"]
+    return []
+
+
 def _git_stdout(cwd: Path, *args: str) -> str | None:
     completed = subprocess.run(
         ["git", "-C", str(cwd), *args],
@@ -535,6 +606,18 @@ def check_agent(agent_dir: Path) -> dict:
         if source_truth_issues:
             findings["issues"].extend(source_truth_issues)
             findings["ok"] = False
+        dataset_stamp_issues = _dataset_stamp_issues(
+            r, f"{r.get('task_name', '?')}: result.json"
+        )
+        if dataset_stamp_issues:
+            findings["issues"].extend(dataset_stamp_issues)
+            findings["ok"] = False
+        digest_truth_issues = _task_digest_truth_issues(
+            r, f"{r.get('task_name', '?')}: result.json"
+        )
+        if digest_truth_issues:
+            findings["issues"].extend(digest_truth_issues)
+            findings["ok"] = False
         _config_path, config, config_error = _load_config(result_file)
         if config_error:
             findings["issues"].append(f"{r.get('task_name', '?')}: {config_error}")
@@ -637,6 +720,18 @@ def check_agent(agent_dir: Path) -> dict:
             if config.get("source") != r.get("source"):
                 findings["issues"].append(
                     f"{r.get('task_name', '?')}: config.json source does not match result.json"
+                )
+                findings["ok"] = False
+            config_dataset_issues = _dataset_stamp_issues(
+                config, f"{r.get('task_name', '?')}: config.json"
+            )
+            if config_dataset_issues:
+                findings["issues"].extend(config_dataset_issues)
+                findings["ok"] = False
+            if any(config.get(k) != r.get(k) for k in _DATASET_STAMP_KEYS):
+                findings["issues"].append(
+                    f"{r.get('task_name', '?')}: config.json dataset stamp "
+                    f"does not match result.json"
                 )
                 findings["ok"] = False
 
@@ -768,6 +863,17 @@ def check_agent(agent_dir: Path) -> dict:
                     "summary.json missing source provenance and not all results have source"
                 )
                 findings["ok"] = False
+            # Dataset identity must agree across summary.json and every
+            # result.json — one leaderboard namespace per dataset version.
+            for dataset_key in ("dataset_name", "dataset_version"):
+                dataset_values = {r.get(dataset_key) for r in results}
+                dataset_values.add(summary.get(dataset_key))
+                if len(dataset_values) > 1:
+                    findings["issues"].append(
+                        f"summary.json {dataset_key} does not agree across "
+                        f"summary and results: {sorted(map(repr, dataset_values))}"
+                    )
+                    findings["ok"] = False
             expected_model = _expected(agent, "model")
             expected_environment = _expected(agent, "environment")
             expected_concurrency = _expected(agent, "concurrency")

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -324,19 +324,20 @@ class TestEvalCreateDatasetCli:
 
 
 class TestDatasetStamping:
-    DATASET: ClassVar[dict] = {
-        "name": "skillsbench",
-        "version": "1.1",
-        "task_digest": "sha256:" + "f" * 64,
-    }
+    DATASET: ClassVar[dict] = {"name": "skillsbench", "version": "1.1"}
+    TASK_DIGEST = "sha256:" + "f" * 64
 
     def test_rollout_config_threads_dataset_through_from_legacy(self, tmp_path):
         from benchflow.rollout import RolloutConfig
 
         cfg = RolloutConfig.from_legacy(
-            task_path=tmp_path, agent="oracle", dataset=self.DATASET
+            task_path=tmp_path,
+            agent="oracle",
+            dataset=self.DATASET,
+            task_digest=self.TASK_DIGEST,
         )
         assert cfg.dataset == self.DATASET
+        assert cfg.task_digest == self.TASK_DIGEST
 
     def test_config_json_stamped(self, tmp_path):
         from benchflow.rollout import _write_config
@@ -361,11 +362,12 @@ class TestDatasetStamping:
             started_at=datetime(2026, 6, 12),
             agent_env={},
             dataset=self.DATASET,
+            task_digest=self.TASK_DIGEST,
         )
         config = json.loads((tmp_path / "config.json").read_text())
         assert config["dataset_name"] == "skillsbench"
         assert config["dataset_version"] == "1.1"
-        assert config["task_digest"] == self.DATASET["task_digest"]
+        assert config["task_digest"] == self.TASK_DIGEST
 
     def test_config_json_unstamped_without_dataset(self, tmp_path):
         from benchflow.rollout import _write_config
@@ -392,6 +394,7 @@ class TestDatasetStamping:
         )
         config = json.loads((tmp_path / "config.json").read_text())
         assert "dataset_name" not in config
+        assert "task_digest" not in config
 
     def test_result_json_stamped(self, tmp_path):
         from benchflow.rollout import _build_rollout_result
@@ -413,13 +416,57 @@ class TestDatasetStamping:
             started_at=datetime(2026, 6, 12),
             timing={},
             dataset=self.DATASET,
+            task_digest=self.TASK_DIGEST,
         )
         result = json.loads((tmp_path / "result.json").read_text())
         assert result["dataset_name"] == "skillsbench"
         assert result["dataset_version"] == "1.1"
-        assert result["task_digest"] == self.DATASET["task_digest"]
+        assert result["task_digest"] == self.TASK_DIGEST
 
-    async def test_run_single_task_builds_per_task_dataset(self, tmp_path, monkeypatch):
+    def test_result_json_dev_run_stamps_digest_without_dataset(self, tmp_path):
+        """Dev runs carry task_digest but no dataset identity fields."""
+        from benchflow.rollout import _build_rollout_result
+
+        _build_rollout_result(
+            tmp_path,
+            task_name="task-a",
+            rollout_name="task-a__r1",
+            agent="oracle",
+            agent_name="oracle",
+            model=None,
+            n_tool_calls=0,
+            prompts=[],
+            error=None,
+            verifier_error=None,
+            trajectory=[],
+            partial_trajectory=False,
+            rewards={"reward": 1.0},
+            started_at=datetime(2026, 6, 12),
+            timing={},
+            task_digest=self.TASK_DIGEST,
+        )
+        result = json.loads((tmp_path / "result.json").read_text())
+        assert result["task_digest"] == self.TASK_DIGEST
+        assert "dataset_name" not in result
+        assert "dataset_version" not in result
+
+    @staticmethod
+    def _capture_rollout_create(monkeypatch):
+        captured = {}
+
+        async def _fake_run():
+            return SimpleNamespace(rewards={"reward": 1.0})
+
+        async def fake_create(rollout_config):
+            captured["config"] = rollout_config
+            return SimpleNamespace(run=_fake_run)
+
+        monkeypatch.setattr("benchflow.rollout.Rollout.create", fake_create)
+        return captured
+
+    async def test_run_single_task_uses_registry_digest_for_dataset_runs(
+        self, tmp_path, monkeypatch
+    ):
         from benchflow.evaluation import Evaluation, EvaluationConfig
 
         task_dir = _make_task(tmp_path / "tasks", "task-a")
@@ -430,24 +477,26 @@ class TestDatasetStamping:
             dataset_version="1.1",
             dataset_task_digests={"task-a": digest},
         )
-        captured = {}
-
-        class FakeRollout:
-            @staticmethod
-            async def create(rollout_config):
-                captured["config"] = rollout_config
-                return SimpleNamespace(run=_fake_run)
-
-        async def _fake_run():
-            return SimpleNamespace(rewards={"reward": 1.0})
-
-        monkeypatch.setattr("benchflow.rollout.Rollout.create", FakeRollout.create)
+        captured = self._capture_rollout_create(monkeypatch)
         evaluation = Evaluation(
             tasks_dir=tmp_path / "tasks", jobs_dir=tmp_path / "jobs", config=cfg
         )
         await evaluation._run_single_task(task_dir, cfg)
-        assert captured["config"].dataset == {
-            "name": "skillsbench",
-            "version": "1.1",
-            "task_digest": digest,
-        }
+        assert captured["config"].dataset == {"name": "skillsbench", "version": "1.1"}
+        assert captured["config"].task_digest == digest
+
+    async def test_run_single_task_computes_digest_for_dev_runs(
+        self, tmp_path, monkeypatch
+    ):
+        """Dev runs (no --dataset) stamp a live-computed content digest."""
+        from benchflow.evaluation import Evaluation, EvaluationConfig
+
+        task_dir = _make_task(tmp_path / "tasks", "task-a")
+        cfg = EvaluationConfig(agent="oracle")
+        captured = self._capture_rollout_create(monkeypatch)
+        evaluation = Evaluation(
+            tasks_dir=tmp_path / "tasks", jobs_dir=tmp_path / "jobs", config=cfg
+        )
+        await evaluation._run_single_task(task_dir, cfg)
+        assert captured["config"].dataset is None
+        assert captured["config"].task_digest == task_digest(task_dir)

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -2343,3 +2343,257 @@ def test_check_results_flags_verifier_timeout(tmp_path: Path) -> None:
         and "timeout" in issue.lower()
         for issue in findings["issues"]
     )
+
+
+# ── Dataset identity stamp validation (dataset-versioning plan) ──────────────
+# Guards the stamp contract introduced by #690 (dataset_name/dataset_version/
+# task_digest in result.json/config.json) and the dev-run digest follow-up.
+
+from tests.integration.check_results import (  # noqa: E402
+    _dataset_stamp_issues,
+    _task_digest_truth_issues,
+)
+
+_DIGEST = "sha256:" + "f" * 64
+
+
+def test_dataset_stamp_issues_accepts_valid_and_absent() -> None:
+    assert _dataset_stamp_issues({}, "x") == []
+    assert _dataset_stamp_issues({"task_digest": _DIGEST}, "x") == []  # dev run
+    assert (
+        _dataset_stamp_issues(
+            {
+                "dataset_name": "skillsbench",
+                "dataset_version": "1.1",
+                "task_digest": _DIGEST,
+            },
+            "x",
+        )
+        == []
+    )
+
+
+def test_dataset_stamp_issues_flags_malformed() -> None:
+    split = _dataset_stamp_issues({"dataset_name": "skillsbench"}, "x")
+    assert any("travel together" in i for i in split)
+    assert any("missing task_digest" in i for i in split)
+
+    bad_digest = _dataset_stamp_issues(
+        {
+            "dataset_name": "skillsbench",
+            "dataset_version": "1.1",
+            "task_digest": "deadbeef",
+        },
+        "x",
+    )
+    assert any("sha256" in i for i in bad_digest)
+
+    empty_name = _dataset_stamp_issues(
+        {"dataset_name": "", "dataset_version": "1.1", "task_digest": _DIGEST}, "x"
+    )
+    assert any("non-empty string" in i for i in empty_name)
+
+
+def test_task_digest_truth_check_recomputes_from_local_path(tmp_path: Path) -> None:
+    from benchflow._utils.task_authoring import task_digest
+
+    task_dir = tmp_path / "task-a"
+    task_dir.mkdir()
+    (task_dir / "task.toml").write_text('version = "1.1"\n')
+    (task_dir / "instruction.md").write_text("Solve it.\n")
+    result = {
+        "task_digest": task_digest(task_dir),
+        "source": {"local_path": str(task_dir)},
+    }
+    assert _task_digest_truth_issues(result, "x") == []
+
+    (task_dir / "instruction.md").write_text("tampered\n")
+    issues = _task_digest_truth_issues(result, "x")
+    assert issues and "does not match local_path content" in issues[0]
+
+
+def test_check_results_flags_config_result_dataset_mismatch(tmp_path: Path) -> None:
+    """config.json and result.json must carry the same dataset stamp."""
+    from benchflow._utils.task_authoring import task_digest
+
+    real_digest = task_digest(Path(_source()["local_path"]))
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-06-12__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "dataset_name": "skillsbench",
+                "dataset_version": "1.1",
+                "task_digest": real_digest,
+                "source": _source(),
+            }
+        )
+    )
+    config = {
+        "task_path": "/tmp/tasks/task-a",
+        "agent": "agentA",
+        "model": "test-model",
+        "environment": "daytona",
+        "concurrency": 64,
+        "agent_idle_timeout_sec": 600,
+        "skills_dir": "/tmp/skills",
+        "include_task_skills": False,
+        "source": _source(),
+        "dataset_name": "skillsbench",
+        "dataset_version": "1.0",
+        "task_digest": real_digest,
+    }
+    (run_dir / "config.json").write_text(json.dumps(config))
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "100.0%",
+                "source": _source(),
+                "dataset_name": "skillsbench",
+                "dataset_version": "1.1",
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is False
+    assert any(
+        "config.json dataset stamp does not match result.json" in issue
+        for issue in findings["issues"]
+    )
+
+
+def test_check_results_flags_summary_dataset_disagreement(tmp_path: Path) -> None:
+    """summary.json dataset identity must agree with every result.json."""
+    from benchflow._utils.task_authoring import task_digest
+
+    real_digest = task_digest(Path(_source()["local_path"]))
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-06-12__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    stamp = {
+        "dataset_name": "skillsbench",
+        "dataset_version": "1.1",
+        "task_digest": real_digest,
+    }
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "source": _source(),
+                **stamp,
+            }
+        )
+    )
+    config = {
+        "task_path": "/tmp/tasks/task-a",
+        "agent": "agentA",
+        "model": "test-model",
+        "environment": "daytona",
+        "concurrency": 64,
+        "agent_idle_timeout_sec": 600,
+        "skills_dir": "/tmp/skills",
+        "include_task_skills": False,
+        "source": _source(),
+        **stamp,
+    }
+    (run_dir / "config.json").write_text(json.dumps(config))
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "100.0%",
+                "source": _source(),
+                "dataset_name": "skillsbench",
+                "dataset_version": "1.0",
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    assert findings["ok"] is False
+    assert any(
+        "dataset_version does not agree" in issue for issue in findings["issues"]
+    )
+
+
+def test_check_results_accepts_consistent_dataset_stamp(tmp_path: Path) -> None:
+    """A consistently stamped dataset run adds no dataset issues."""
+    from benchflow._utils.task_authoring import task_digest
+
+    agent_dir = tmp_path / "agentA"
+    run_dir = agent_dir / "2026-06-12__00-00-00" / "task-a"
+    run_dir.mkdir(parents=True)
+    stamp = {
+        "dataset_name": "skillsbench",
+        "dataset_version": "1.1",
+        "task_digest": task_digest(Path(_source()["local_path"])),
+    }
+    (run_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "agent": "agentA",
+                "rewards": {"reward": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "source": _source(),
+                **stamp,
+            }
+        )
+    )
+    config = {
+        "task_path": "/tmp/tasks/task-a",
+        "agent": "agentA",
+        "model": "test-model",
+        "environment": "daytona",
+        "concurrency": 64,
+        "agent_idle_timeout_sec": 600,
+        "skills_dir": "/tmp/skills",
+        "include_task_skills": False,
+        "source": _source(),
+        **stamp,
+    }
+    (run_dir / "config.json").write_text(json.dumps(config))
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "total": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "verifier_errored": 0,
+                "score": "100.0%",
+                "source": _source(),
+                "dataset_name": "skillsbench",
+                "dataset_version": "1.1",
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    assert not any(
+        "dataset" in issue or "task_digest" in issue for issue in findings["issues"]
+    )


### PR DESCRIPTION
Follow-up to #690, closing the highest-value gaps in the dataset-versioning run plumbing.

## What

**Dev-run digest stamping** — `--tasks-dir` / `--source-repo` runs now stamp a live-computed `task_digest` (skillsbench registry algorithm) into `result.json`/`config.json`. Any trajectory — including local dev runs — is attributable to the exact task content it ran, which also closes a gap behind #555-style audits. `dataset_name`/`dataset_version` stay **absent** on dev runs: attributability comes from the digest, and field absence remains the clean "not a publishable dataset run" signal. Dataset runs keep the registry-pinned digest. Internal shape change: `RolloutConfig.task_digest` is its own field; `dataset` carries identity only (`{"name", "version"}`) — #690's stamping tests updated for the shape.

**check_results.py dataset-stamp audit** (closes the "leaderboard can trust the stamps" loop):
- `dataset_name`/`dataset_version` must travel together; a dataset run must carry `task_digest`; any `task_digest` must be `sha256:<64 hex>`.
- `config.json` stamp must equal `result.json`'s (same pattern as the `source` consistency check).
- `summary.json` dataset identity must agree with every `result.json` (one leaderboard namespace per dataset version).
- **Truth check**: `task_digest` is recomputed from `source.local_path` when the task dir is still on disk — same posture as the existing `source.file_hashes` audit, but for the single digest the leaderboard pipeline keys on.

## Tests

- `test_dataset_registry.py`: registry-digest vs live-digest threading through `_run_single_task` (dataset run vs dev run), writer stamping for both shapes.
- `test_integration_check_results.py`: stamp-format violations, config/result mismatch, summary disagreement, truth-check catches tampered content, and a fully-consistent run adds no issues.
- Full suite: 2864 passed; ruff/format/ty clean.

Related: skillsbench#924 (registry `1.1.1` metadata patch) and the held hard-gate PR that depends on it.