### PR TITLE
feat(eval): hard-gate out-of-range bench_version for dataset runs

### DIFF
--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -171,10 +171,12 @@ content digests. Resolution clones the pinned commit into
 `.cache/datasets`, materializes an immutable per-commit snapshot,
 recomputes every task's digest, and **fails before running anything** on
 any mismatch. Snapshot directories that are not part of the registry entry
-are excluded from the run. The entry's `bench_version` range is checked
-against the installed benchflow; running outside the range the dataset was
-validated against prints a warning — results may not be comparable with
-published runs.
+are excluded from the run. The entry's `bench_version` range is a hard
+gate: running on a benchflow outside the range the dataset was validated
+against fails before anything runs, because the results may not be
+comparable with published runs. `--ignore-bench-version` overrides the
+gate for local experimentation — the run then proceeds with a visible
+warning on the record.
 
 The registry is fetched from the skillsbench repo by default; point
 `--registry` at another URL or a local `registry.json` to override.

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1109,6 +1109,14 @@ def eval_create(
             "(default: the skillsbench registry). Only valid with --dataset.",
         ),
     ] = None,
+    ignore_bench_version: Annotated[
+        bool,
+        typer.Option(
+            "--ignore-bench-version",
+            help="Run a dataset even when this bench version is outside the "
+            "range it was validated against. Only valid with --dataset.",
+        ),
+    ] = False,
 ) -> None:
     """Run an evaluation — single task or batch.
 
@@ -1139,6 +1147,9 @@ def eval_create(
         raise typer.Exit(1)
     if registry and not dataset:
         console.print("[red]--registry requires --dataset[/red]")
+        raise typer.Exit(1)
+    if ignore_bench_version and not dataset:
+        console.print("[red]--ignore-bench-version requires --dataset[/red]")
         raise typer.Exit(1)
     if worker_concurrency is not None and not (tasks_dir or source_repo):
         console.print(
@@ -1383,8 +1394,20 @@ def eval_create(
             console.print(f"[red]{e}[/red]")
             raise typer.Exit(1) from None
         version_issue = bench_version_issue(resolved_dataset.bench_version)
+        if version_issue and not ignore_bench_version:
+            # Hard gate: published results must come from a harness the
+            # dataset version was validated against. The escape hatch keeps
+            # local experimentation possible without weakening the default.
+            console.print(f"[red]{version_issue}[/red]")
+            console.print(
+                "Pick a dataset version validated for this harness, or re-run "
+                "with --ignore-bench-version to proceed anyway."
+            )
+            raise typer.Exit(1)
         if version_issue:
-            console.print(f"[yellow]Warning:[/yellow] {version_issue}")
+            console.print(
+                f"[yellow]Warning:[/yellow] {version_issue} (--ignore-bench-version)"
+            )
         console.print(
             f"[green]✓[/green] {resolved_dataset.spec}: "
             f"{len(resolved_dataset.task_names)} tasks, digests verified "

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -39,7 +39,11 @@ def _make_task(parent: Path, name: str) -> Path:
 
 
 def _write_registry(
-    tmp_path: Path, tasks_parent: Path, *, digests: dict[str, str] | None = None
+    tmp_path: Path,
+    tasks_parent: Path,
+    *,
+    digests: dict[str, str] | None = None,
+    bench_version: str = ">=0.1,<999",
 ) -> Path:
     """Write a single-entry registry pinning the tasks under tasks_parent."""
     entry_tasks = []
@@ -61,7 +65,7 @@ def _write_registry(
                     "name": "skillsbench",
                     "version": "1.1",
                     "git_tag": "v1.1",
-                    "bench_version": ">=0.1,<999",
+                    "bench_version": bench_version,
                     "tasks": entry_tasks,
                 }
             ]
@@ -305,6 +309,80 @@ class TestEvalCreateDatasetCli:
         )
         assert result.exit_code == 1
         assert "--registry requires --dataset" in result.stdout
+
+    def test_out_of_range_bench_version_blocks(self, tmp_path, snapshot, monkeypatch):
+        """The bench_version range is a hard gate for dataset runs; the
+        registry declares what the version was validated against."""
+        registry = _write_registry(
+            tmp_path, snapshot.tasks_parent, bench_version="<0.0.1"
+        )
+        ran = {}
+
+        async def fake_eval_run(self):
+            ran["ran"] = True
+            return SimpleNamespace(passed=2, total=2, score=1.0, errored=0)
+
+        monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--dataset",
+                "skillsbench@1.1",
+                "--registry",
+                str(registry),
+                "--agent",
+                "oracle",
+                "--jobs-dir",
+                str(tmp_path / "jobs"),
+            ],
+        )
+        assert result.exit_code == 1
+        assert "outside the range" in result.stdout
+        assert "--ignore-bench-version" in result.stdout
+        assert not ran
+
+    def test_ignore_bench_version_overrides_gate(self, tmp_path, snapshot, monkeypatch):
+        registry = _write_registry(
+            tmp_path, snapshot.tasks_parent, bench_version="<0.0.1"
+        )
+        ran = {}
+
+        async def fake_eval_run(self):
+            ran["ran"] = True
+            return SimpleNamespace(passed=2, total=2, score=1.0, errored=0)
+
+        monkeypatch.setattr("benchflow.evaluation.Evaluation.run", fake_eval_run)
+
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--dataset",
+                "skillsbench@1.1",
+                "--registry",
+                str(registry),
+                "--ignore-bench-version",
+                "--agent",
+                "oracle",
+                "--jobs-dir",
+                str(tmp_path / "jobs"),
+            ],
+        )
+        assert result.exit_code == 0, result.stdout
+        assert ran == {"ran": True}
+        assert "Warning:" in result.stdout
+
+    def test_ignore_bench_version_requires_dataset(self, tmp_path):
+        result = CliRunner().invoke(
+            app,
+            ["eval", "create", "--ignore-bench-version", "--tasks-dir", str(tmp_path)],
+        )
+        assert result.exit_code == 1
+        assert "--ignore-bench-version requires --dataset" in result.stdout
 
     def test_resolution_error_exits_cleanly(self, tmp_path, snapshot):
         registry = _write_registry(tmp_path, snapshot.tasks_parent)


### PR DESCRIPTION
> ⛔ **Do not merge until [skillsbench#924](https://github.com/benchflow-ai/skillsbench/pull/924) lands.** Today the registry's `skillsbench@1.1` entry declares `bench_version ">=0.4,<0.5"`, so on bench 0.5.x this gate would make `-d skillsbench@1.1` unrunnable without the override flag. #924 corrects the 1.1 entry's range **in place**; once it merges, this gates cleanly while the default path Just Works.

Final piece of the dataset-versioning run plumbing (#690, #691, #693).

## What

A dataset entry's `bench_version` records the harness range the version was validated against. Out-of-range now **fails fast** instead of warning — published results must come from a validated harness:

```
$ bench eval create -d skillsbench@1.1 …
bench 0.5.3.dev0 is outside the range this dataset was validated against (>=0.4,<0.5) — results may not be comparable with published runs
Pick a dataset version validated for this harness, or re-run with --ignore-bench-version to proceed anyway.
```

`--ignore-bench-version` (dataset-only flag, rejected otherwise) keeps local experimentation possible; when used, the run proceeds with the original warning so the choice is on the record. The "Versioned dataset runs" docs section flips from warn-only to the gated description in the same commit.

## Tests

Gate blocks and `Evaluation.run` is never invoked; override runs with a visible warning; flag without `--dataset` errors. ruff/format/ty clean.
