### PR TITLE
fix(deps): promote packaging to core deps; document dataset runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@
 
 ### Added
 
+- **Registry-pinned dataset runs** — `bench eval create -d name@version`
+  (e.g. `-d skillsbench@1.1`) resolves a dataset from a git-backed
+  `registry.json` (see skillsbench `docs/dataset-versioning.md`): tasks are
+  cloned at their pinned `git_commit_id` into `.cache/datasets` and every
+  task directory is verified against its sha256 content digest before
+  anything runs; the entry's `bench_version` range is checked against the
+  installed benchflow. `--registry` overrides the default (skillsbench)
+  registry. `result.json`/`config.json` are stamped with `dataset_name`,
+  `dataset_version`, and a per-task `task_digest` (`summary.json` carries
+  the name/version); `--tasks-dir` dev runs carry no dataset fields but
+  still stamp a live-computed `task_digest`, so every trajectory stays
+  attributable to exact task content. `bench tasks digest <dir>` prints
+  the digest for task authoring, and `check_results.py` audits the stamps.
+  See [`docs/running-benchmarks.md`](docs/running-benchmarks.md). (#689,
+  #690, #691; `packaging` promoted to a core dependency for the
+  `bench_version` check.)
+
 - **`benchflow continue <run-folder>`** — resume a previous, unfinished
   (timed-out) `openhands` run to completion. A standalone tool (it does not
   touch the normal run path) that reconstructs the run's exact workspace and

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -147,6 +147,49 @@ print(result.rewards)
 
 ---
 
+## Versioned dataset runs (`--dataset`)
+
+For runs whose results should be attributable to a published, immutable
+dataset version (leaderboards, papers, release evidence), resolve the task
+set from a dataset registry instead of pointing at a directory or branch:
+
+```bash
+# Resolve skillsbench@1.1 from the registry, verify every task's content
+# digest against the pinned snapshot, then run.
+bench eval create -d skillsbench@1.1 \
+  --agent claude-agent-acp --model claude-haiku-4-5-20251001
+
+# Versions are immutable, so the version is always explicit — there is no
+# floating "latest". --include/--exclude filter the registry roster.
+bench eval create -d skillsbench@1.1 --include xlsx-recover-data ...
+```
+
+A registry (`registry.json` at a dataset repo's root — see skillsbench's
+[`docs/dataset-versioning.md`](https://github.com/benchflow-ai/skillsbench/blob/main/docs/dataset-versioning.md))
+pins each dataset version to an exact `git_commit_id` and per-task sha256
+content digests. Resolution clones the pinned commit into
+`.cache/datasets`, materializes an immutable per-commit snapshot,
+recomputes every task's digest, and **fails before running anything** on
+any mismatch. Snapshot directories that are not part of the registry entry
+are excluded from the run. The entry's `bench_version` range is checked
+against the installed benchflow; running outside the range the dataset was
+validated against prints a warning — results may not be comparable with
+published runs.
+
+The registry is fetched from the skillsbench repo by default; point
+`--registry` at another URL or a local `registry.json` to override.
+
+Every `result.json`/`config.json` is stamped with `dataset_name`,
+`dataset_version`, and the per-task `task_digest` (`summary.json` carries
+the name/version), so downstream tooling can group results by
+`dataset@version`. `--tasks-dir` stays as the visibly distinct dev mode:
+its artifacts carry no dataset fields — but they still stamp a
+live-computed `task_digest`, so even dev trajectories remain attributable
+to exact task content. `bench tasks digest <task-dir>` prints the same
+digest for any task directory.
+
+---
+
 ## Running a subset of tasks
 
 ### Single task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "pydantic>=2.7",
     "pyyaml>=6.0",
     "rich>=13.0",
+    # Dataset registry bench_version checks (PEP 440 specifier sets).
+    "packaging>=24",
     "litellm[proxy]==1.88.0rc1",
     "tomli-w>=1.0",
     "typer>=0.9",
@@ -38,7 +40,6 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "packaging>=24",
     "pre-commit>=3.7",
     "pytest>=9.0.3",
     "pytest-asyncio>=0.24.0",

--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,7 @@ dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "litellm", extra = ["proxy"] },
+    { name = "packaging" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -307,7 +308,6 @@ bedrock = [
     { name = "boto3" },
 ]
 dev = [
-    { name = "packaging" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -340,7 +340,7 @@ requires-dist = [
     { name = "litellm", extras = ["proxy"], specifier = "==1.88.0rc1" },
     { name = "modal", marker = "extra == 'sandbox-modal'", specifier = ">=0.73" },
     { name = "openai", marker = "extra == 'judge'", specifier = ">=1.40" },
-    { name = "packaging", marker = "extra == 'dev'", specifier = ">=24" },
+    { name = "packaging", specifier = ">=24" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },


### PR DESCRIPTION
Two follow-ups to the dataset-versioning landings (#689/#690/#691):

**Dependency fix (real runtime bug):** `bench_version_issue()` imports `packaging` at runtime, but `packaging>=24` only existed in the **dev extra**. A non-dev install (`uv tool install benchflow`) crashed with `ModuleNotFoundError` on any `-d` run whose registry entry declares `bench_version` — i.e. every skillsbench entry. CI can't catch this class of bug because the workflow always syncs `--extra dev`. Promoted to `[project].dependencies` (and dropped the now-redundant dev-extra pin); `uv.lock` refreshed.

**Docs:** the feature had no user-facing documentation. Adds a "Versioned dataset runs (`--dataset`)" section to `docs/running-benchmarks.md` (resolution semantics, digest verification, stamping, dev-mode distinction) and the `[Unreleased]` CHANGELOG entry.

The bench_version paragraph describes today's warn-only behavior; #692 (held for skillsbench#924) flips it to a hard gate and will amend that sentence.