### PR TITLE
feat(agent-router): bench agent verify --rerun (independent parity re-execution)

### DIFF
--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -478,11 +478,20 @@ def rerun_parity_experiment(
 
     The default verify gate *scores the recorded* ``parity_experiment.json`` —
     fast, but it trusts an artifact the conversion produced about itself. This
-    runs ``python <benchmark>/parity_test.py --mode side-by-side`` (the scaffold
-    contract) and parses the JSON it prints, so ``verify --rerun`` validates the
-    conversion independently. Fail-closed: a missing script, a nonzero exit, or
-    unparseable output all raise — ``--rerun`` never silently falls back to
-    stale or absent data.
+    runs ``python <benchmark>/parity_test.py --mode side-by-side`` and parses the
+    JSON it prints, so ``verify --rerun`` validates the conversion independently.
+
+    CONTRACT: ``--mode side-by-side`` must emit (to stdout) the same shape the
+    recorded ``parity_experiment.json`` uses and that :func:`build_verify_report`
+    scores — i.e. per-criterion comparisons (``conversion_parity.tasks[].
+    criteria_results[]`` or a recognized ``*_parity`` summary block) and/or
+    reward samples. The scaffolded ``parity_test.py`` already prints this shape.
+
+    Fail-closed: a missing script, a nonzero exit, unparseable output, OR output
+    that parses but carries NO scoreable parity data all raise
+    ``ParityRerunError`` — ``--rerun`` never silently falls back to stale/absent
+    data, and never reports a misleading ``insufficient-evidence`` verdict on a
+    shape the gate cannot read (a benchmark whose recorded JSON *would* score).
 
     ``runner`` is injected in tests; it returns ``(returncode, stdout, stderr)``.
     """
@@ -506,11 +515,42 @@ def rerun_parity_experiment(
             f"parity_test.py --mode side-by-side exited {returncode}: "
             f"{(stderr or stdout).strip()[-2000:]}"
         )
-    # Tolerate leading log lines: extract the JSON object the script prints.
+    data = _parse_parity_stdout(stdout)
+    # Fail closed if the re-run output parses but is not in the scoreable shape:
+    # without this, build_verify_report would report `insufficient-evidence` and
+    # `--rerun` would silently FAIL the gate on a benchmark whose recorded JSON
+    # would pass — defeating the feature (gh review on #694).
+    if not extract_criterion_comparisons(data) and not extract_reward_samples(data):
+        shape = (
+            f"top-level keys {sorted(data)}"
+            if isinstance(data, dict)
+            else f"a top-level {type(data).__name__}"
+        )
+        raise ParityRerunError(
+            "parity_test.py --mode side-by-side produced no scoreable parity data "
+            "(no criterion comparisons and no reward samples) in the "
+            f"parity_experiment.json shape the gate scores — got {shape}. Expected "
+            "conversion_parity.tasks[].criteria_results[] (or a recognized "
+            "*_parity summary block) and/or reward samples."
+        )
+    return data
+
+
+def _parse_parity_stdout(stdout: str) -> Any:
+    """Parse a ``parity_test.py`` JSON payload, tolerating leading log lines.
+
+    Parses the whole (stripped) output first so a clean JSON object OR a
+    top-level array parses directly; only falls back to slicing the outermost
+    ``{...}`` object when the whole-string parse fails (e.g. log preamble)."""
+    text = stdout.strip()
     try:
-        start = stdout.index("{")
-        end = stdout.rindex("}") + 1
-        return json.loads(stdout[start:end])
+        return json.loads(text)
+    except (ValueError, json.JSONDecodeError):
+        pass
+    try:
+        start = text.index("{")
+        end = text.rindex("}") + 1
+        return json.loads(text[start:end])
     except (ValueError, json.JSONDecodeError) as exc:
         raise ParityRerunError(
             "could not parse parity_test.py --mode side-by-side output as JSON "
@@ -518,13 +558,23 @@ def rerun_parity_experiment(
         ) from exc
 
 
-def _run_parity_script(command: list[str], cwd: Path) -> tuple[int, str, str]:
+def _run_parity_script(
+    command: list[str], cwd: Path, *, timeout_sec: int = 600
+) -> tuple[int, str, str]:
     import subprocess
     import sys
 
     # Use the interpreter running benchflow so parity_test.py imports resolve.
     argv = [sys.executable, *command[1:]] if command[:1] == ["python"] else command
-    proc = subprocess.run(argv, cwd=str(cwd), capture_output=True, text=True)
+    try:
+        proc = subprocess.run(
+            argv, cwd=str(cwd), capture_output=True, text=True, timeout=timeout_sec
+        )
+    except subprocess.TimeoutExpired as exc:
+        # A hung parity_test.py must not wedge the gate forever.
+        raise ParityRerunError(
+            f"parity_test.py --mode side-by-side timed out after {timeout_sec}s"
+        ) from exc
     return proc.returncode, proc.stdout, proc.stderr
 
 

--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -90,6 +90,10 @@ class CodexLaunchError(RuntimeError):
     """Raised when the host codex CLI cannot be launched (e.g. no credentials)."""
 
 
+class ParityRerunError(RuntimeError):
+    """Raised when ``verify --rerun`` cannot independently re-execute parity."""
+
+
 # ── Paths ─────────────────────────────────────────────────────────────
 
 
@@ -446,6 +450,67 @@ def load_parity_experiment(benchmarks_root: Path, name: str) -> Any:
         ) from exc
 
 
+def rerun_parity_experiment(
+    benchmarks_root: Path,
+    name: str,
+    *,
+    runner: Callable[[list[str], Path], tuple[int, str, str]] | None = None,
+) -> Any:
+    """Independently re-execute a benchmark's ``parity_test.py`` and return its
+    fresh side-by-side results, instead of trusting the recorded JSON.
+
+    The default verify gate *scores the recorded* ``parity_experiment.json`` —
+    fast, but it trusts an artifact the conversion produced about itself. This
+    runs ``python <benchmark>/parity_test.py --mode side-by-side`` (the scaffold
+    contract) and parses the JSON it prints, so ``verify --rerun`` validates the
+    conversion independently. Fail-closed: a missing script, a nonzero exit, or
+    unparseable output all raise — ``--rerun`` never silently falls back to
+    stale or absent data.
+
+    ``runner`` is injected in tests; it returns ``(returncode, stdout, stderr)``.
+    """
+    name = validate_benchmark_name(name)
+    benchmark_dir = Path(benchmarks_root) / name
+    if not benchmark_dir.exists():
+        raise BenchmarkNotFound(
+            f"benchmark not adopted: {benchmark_dir} — run "
+            f"`bench agent create {name}` first"
+        )
+    script = benchmark_dir / "parity_test.py"
+    if not script.exists():
+        raise ParityRerunError(
+            f"no parity_test.py in {benchmark_dir} — cannot --rerun "
+            "(scaffold it with `bench agent create` and implement side-by-side)"
+        )
+    command = ["python", str(script), "--mode", "side-by-side"]
+    returncode, stdout, stderr = (runner or _run_parity_script)(command, benchmark_dir)
+    if returncode != 0:
+        raise ParityRerunError(
+            f"parity_test.py --mode side-by-side exited {returncode}: "
+            f"{(stderr or stdout).strip()[-2000:]}"
+        )
+    # Tolerate leading log lines: extract the JSON object the script prints.
+    try:
+        start = stdout.index("{")
+        end = stdout.rindex("}") + 1
+        return json.loads(stdout[start:end])
+    except (ValueError, json.JSONDecodeError) as exc:
+        raise ParityRerunError(
+            "could not parse parity_test.py --mode side-by-side output as JSON "
+            f"(expected the recorded parity_experiment.json shape): {exc}"
+        ) from exc
+
+
+def _run_parity_script(command: list[str], cwd: Path) -> tuple[int, str, str]:
+    import subprocess
+    import sys
+
+    # Use the interpreter running benchflow so parity_test.py imports resolve.
+    argv = [sys.executable, *command[1:]] if command[:1] == ["python"] else command
+    proc = subprocess.run(argv, cwd=str(cwd), capture_output=True, text=True)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
 def roundtrip_conformance_status(
     task_dir: Path,
     *,
@@ -571,17 +636,35 @@ def register_agent_router(agent_app: typer.Typer) -> None:
                 help="Also run the structural round-trip check on this task dir",
             ),
         ] = None,
+        rerun: Annotated[
+            bool,
+            typer.Option(
+                "--rerun",
+                help="Independently re-execute parity_test.py --mode side-by-side "
+                "and score its fresh output, instead of the recorded "
+                "parity_experiment.json",
+            ),
+        ] = False,
     ) -> None:
         """Run the parity gate for an adopted benchmark; emit a verdict."""
         root = benchmarks_dir or default_benchmarks_dir()
         try:
             name = validate_benchmark_name(name)
-            data: Any = load_parity_experiment(root, name)
+            if rerun:
+                console.print(
+                    "[dim]Re-executing parity_test.py --mode side-by-side…[/dim]"
+                )
+                data: Any = rerun_parity_experiment(root, name)
+            else:
+                data = load_parity_experiment(root, name)
         except InvalidBenchmarkName as exc:
             console.print(f"[red]{exc}[/red]")
             raise typer.Exit(1) from exc
         except BenchmarkNotFound as exc:
             console.print(f"[red]{exc}[/red]")
+            raise typer.Exit(1) from exc
+        except ParityRerunError as exc:
+            console.print(f"[red]--rerun failed: {exc}[/red]")
             raise typer.Exit(1) from exc
         except ParityExperimentMissing as exc:
             console.print(f"[yellow]{exc}[/yellow]")

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -485,19 +485,96 @@ def test_scaffolded_parity_file_is_insufficient_evidence() -> None:
 
 
 def _rerun(tmp_path: Path, runner) -> object:
-    create_benchmark("my-bench", tmp_path)  # ships parity_test.py
+    if not (tmp_path / "my-bench").exists():
+        create_benchmark("my-bench", tmp_path)  # ships parity_test.py
     return rerun_parity_experiment(tmp_path, "my-bench", runner=runner)
 
 
-def test_rerun_parses_fresh_side_by_side_json(tmp_path: Path) -> None:
-    """A clean side-by-side run's JSON is parsed (tolerating log noise around it)."""
-    payload = {"side_by_side": {"criteria_compared": 4, "agreed": 4}}
+def test_rerun_parses_scoreable_side_by_side_json(tmp_path: Path) -> None:
+    """A clean side-by-side run's scoreable JSON is parsed (tolerating log noise)."""
+    payload = _criteria_doc(("pass", "pass"), ("fail", "fail"))
 
     def runner(command: list[str], cwd: Path) -> tuple[int, str, str]:
         assert command[-2:] == ["--mode", "side-by-side"]
         return 0, f"running parity…\n{json.dumps(payload)}\n[done]", ""
 
     assert _rerun(tmp_path, runner) == payload
+
+
+def test_rerun_parses_top_level_array(tmp_path: Path) -> None:
+    """Robust parse handles a top-level JSON array (the harvey-lab shape) carrying
+    reward samples — not just a single ``{...}`` object."""
+    payload = [
+        {"metrics": [{"name": "pass_rate", "original": "1.0", "converted": "1.0"}]}
+    ]
+    assert _rerun(tmp_path, lambda c, w: (0, json.dumps(payload), "")) == payload
+
+
+def test_rerun_fail_closed_on_unscoreable_shape(tmp_path: Path) -> None:
+    """Parses cleanly but carries NO scoreable parity data → fail closed, instead
+    of silently feeding build_verify_report an insufficient-evidence verdict that
+    would FAIL the gate on a benchmark whose recorded JSON passes (gh #694)."""
+    payload = {"side_by_side": {"criteria_compared": 4, "agreed": 4}}
+    with pytest.raises(ParityRerunError, match="no scoreable parity data"):
+        _rerun(tmp_path, lambda c, w: (0, json.dumps(payload), ""))
+
+
+def test_rerun_output_scores_through_build_verify_report(tmp_path: Path) -> None:
+    """The load-bearing seam: rerun output must feed build_verify_report to a
+    USABLE verdict, agreeing and diverging as the fresh comparisons dictate."""
+    agree = _criteria_doc(("pass", "pass"), ("fail", "fail"))
+    data = _rerun(tmp_path, lambda c, w: (0, json.dumps(agree), ""))
+    report = build_verify_report("my-bench", data)
+    assert report.verdict == "parity-confirmed"
+    assert report.conversion.compared == 2
+
+    diverge = _criteria_doc(("pass", "pass"), ("pass", "fail"))
+    data2 = _rerun(tmp_path, lambda c, w: (0, json.dumps(diverge), ""))
+    assert build_verify_report("my-bench", data2).verdict == "parity-divergent"
+
+
+def test_run_parity_script_timeout_is_fail_closed(tmp_path: Path, monkeypatch) -> None:
+    """A hung parity_test.py raises ParityRerunError, never wedges the gate."""
+    import subprocess
+
+    from benchflow import agent_router
+
+    def boom(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="parity_test.py", timeout=1)
+
+    monkeypatch.setattr(subprocess, "run", boom)
+    with pytest.raises(ParityRerunError, match="timed out"):
+        agent_router._run_parity_script(
+            ["python", "x.py", "--mode", "side-by-side"], tmp_path, timeout_sec=1
+        )
+
+
+def test_verify_rerun_cli_end_to_end(tmp_path: Path) -> None:
+    """`bench agent verify <name> --rerun` exercises the REAL subprocess path: a
+    parity_test.py that prints scoreable JSON → parity-confirmed, exit 0."""
+    create_benchmark("my-bench", tmp_path)
+    payload = _criteria_doc(("pass", "pass"), ("fail", "fail"))
+    (tmp_path / "my-bench" / "parity_test.py").write_text(
+        "print('''" + json.dumps(payload) + "''')\n"
+    )
+    result = CliRunner().invoke(
+        app,
+        ["agent", "verify", "my-bench", "--rerun", "--benchmarks-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "parity-confirmed" in result.output
+
+
+def test_verify_rerun_cli_fails_closed_on_script_error(tmp_path: Path) -> None:
+    """`verify --rerun` exits 1 with a clear error when parity_test.py fails."""
+    create_benchmark("my-bench", tmp_path)
+    (tmp_path / "my-bench" / "parity_test.py").write_text("import sys\nsys.exit(3)\n")
+    result = CliRunner().invoke(
+        app,
+        ["agent", "verify", "my-bench", "--rerun", "--benchmarks-dir", str(tmp_path)],
+    )
+    assert result.exit_code == 1
+    assert "rerun" in result.output.lower()
 
 
 def test_rerun_fail_closed_on_nonzero_exit(tmp_path: Path) -> None:

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -18,6 +18,7 @@ from benchflow.agent_router import (
     CodexLaunchError,
     InvalidBenchmarkName,
     ParityExperimentMissing,
+    ParityRerunError,
     assemble_adoption_context,
     build_codex_launch_command,
     build_scaffold_files,
@@ -31,6 +32,7 @@ from benchflow.agent_router import (
     load_parity_experiment,
     prepare_adoption_launch,
     render_divergence_issue,
+    rerun_parity_experiment,
     roundtrip_conformance_status,
     run_agent_adoption,
     validate_benchmark_name,
@@ -446,6 +448,50 @@ def test_scaffolded_parity_file_is_insufficient_evidence() -> None:
     data = json.loads(build_scaffold_files("my-bench")["parity_experiment.json"])
     report = build_verify_report("my-bench", data)
     assert report.verdict == "insufficient-evidence"
+
+
+# verify --rerun: independently re-execute parity_test.py instead of trusting
+# the recorded parity_experiment.json (the conversion's self-report).
+
+
+def _rerun(tmp_path: Path, runner) -> object:
+    create_benchmark("my-bench", tmp_path)  # ships parity_test.py
+    return rerun_parity_experiment(tmp_path, "my-bench", runner=runner)
+
+
+def test_rerun_parses_fresh_side_by_side_json(tmp_path: Path) -> None:
+    """A clean side-by-side run's JSON is parsed (tolerating log noise around it)."""
+    payload = {"side_by_side": {"criteria_compared": 4, "agreed": 4}}
+
+    def runner(command: list[str], cwd: Path) -> tuple[int, str, str]:
+        assert command[-2:] == ["--mode", "side-by-side"]
+        return 0, f"running parity…\n{json.dumps(payload)}\n[done]", ""
+
+    assert _rerun(tmp_path, runner) == payload
+
+
+def test_rerun_fail_closed_on_nonzero_exit(tmp_path: Path) -> None:
+    with pytest.raises(ParityRerunError, match="exited 2"):
+        _rerun(tmp_path, lambda c, w: (2, "partial", "traceback boom"))
+
+
+def test_rerun_fail_closed_on_unparseable_output(tmp_path: Path) -> None:
+    with pytest.raises(ParityRerunError, match="could not parse"):
+        _rerun(tmp_path, lambda c, w: (0, "no json emitted", ""))
+
+
+def test_rerun_requires_parity_test_script(tmp_path: Path) -> None:
+    create_benchmark("my-bench", tmp_path)
+    (tmp_path / "my-bench" / "parity_test.py").unlink()
+    with pytest.raises(ParityRerunError, match=r"no parity_test\.py"):
+        rerun_parity_experiment(tmp_path, "my-bench", runner=lambda c, w: (0, "{}", ""))
+
+
+def test_rerun_unknown_benchmark_is_not_found(tmp_path: Path) -> None:
+    with pytest.raises(BenchmarkNotFound):
+        rerun_parity_experiment(
+            tmp_path, "never-adopted", runner=lambda c, w: (0, "{}", "")
+        )
 
 
 # An adopted benchmark (harvey-lab) ships a parity_experiment.json whose top


### PR DESCRIPTION
## Why

`bench agent verify` is the universal-adapter's confidence gate. By default it **scores the recorded `parity_experiment.json`** — an artifact the conversion produced *about itself*. A rosy or fabricated experiment file earns a `parity-confirmed` verdict with no independent check. For a "convert any benchmark, trust the verdict" adapter, that's the highest-value hardening gap.

## What

Adds `bench agent verify <name> --rerun`: instead of reading the recorded JSON, it runs `python <benchmark>/parity_test.py --mode side-by-side` (the `bench agent create` scaffold contract) and scores its **fresh** output.

- New `rerun_parity_experiment(benchmarks_root, name, *, runner=...)` helper — runs the script, tolerates leading log lines, extracts the JSON.
- **Fail-closed:** missing `parity_test.py`, nonzero exit, or unparseable output all raise `ParityRerunError` → `verify --rerun` exits 1. It never silently falls back to stale/absent data.
- `runner` seam keeps it unit-testable without a subprocess.

## How it was found

Exercising the **never-run live `bench agent run` path** end-to-end (HumanEval → `benchmarks/humaneval-live`): codex produced a complete, genuine adoption and `bench agent verify` reported `parity-confirmed, 10/10`. Adversarially re-running `parity_test.py` myself confirmed the parity was real — but it also made clear that `verify` was *trusting the artifact*, not re-checking it. `--rerun` closes that.

## Validation

- Live: `bench agent verify humaneval-live --rerun` → re-executes parity, `parity-confirmed, 10/10 criteria agree`.
- Unit: 5 new tests (fresh-parse with log noise; fail-closed on nonzero exit / unparseable output / missing script / unknown benchmark). Full `test_agent_router` green (78), ruff + ty clean.

## Notes

- Targets `release/v0.6.0`. Not merging — flagged for review.
- Default behavior unchanged (still scores the recorded experiment); `--rerun` is opt-in.
- Related dev-ex findings from the same live run (not in this PR): codex `--sandbox workspace-write` has no network so it can't fetch the source dataset (got a 5-task fixture); `bench agent run` exposes no codex `-c` config override.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the adoption parity gate with subprocess execution, but default verify is unchanged and failures are fail-closed rather than silent pass-through.
> 
> **Overview**
> Adds **`bench agent verify <name> --rerun`**, an opt-in path that re-runs `parity_test.py --mode side-by-side` and scores the **live stdout JSON** instead of the on-disk `parity_experiment.json`. Default verify is unchanged.
> 
> New **`rerun_parity_experiment`** runs the script (subprocess with timeout, current interpreter), parses JSON with log-noise tolerance, and requires output that **`build_verify_report`** can score. **Fail-closed** behavior raises **`ParityRerunError`** (CLI exit 1) for missing script, nonzero exit, bad JSON, unscoreable shape, or timeout—no fallback to the recorded file.
> 
> Unit and CLI tests cover parsing, unscoreable-shape rejection, timeouts, and end-to-end `--rerun`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 459c3284858b2aa6ae1998cf90ca2937998d2a84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->