### PR TITLE
feat(agent-router): bench agent run -c codex config passthrough

### DIFF
--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -312,8 +312,15 @@ def build_codex_launch_command(
     codex_bin: str = "codex",
     model: str | None = None,
     sandbox: str = "workspace-write",
+    config_overrides: Sequence[str] = (),
 ) -> list[str]:
-    """Construct the host ``codex exec`` argv for the adoption run (pure)."""
+    """Construct the host ``codex exec`` argv for the adoption run (pure).
+
+    ``config_overrides`` are passed through as codex ``-c key=value`` flags, so
+    host ``~/.codex/config.toml`` drift can be worked around per-run without
+    editing the user's config (e.g. ``-c service_tier=flex`` when an installed
+    codex version rejects a stale value).
+    """
     command = [
         codex_bin,
         "exec",
@@ -323,6 +330,8 @@ def build_codex_launch_command(
         "--sandbox",
         sandbox,
     ]
+    for override in config_overrides:
+        command += ["-c", override]
     if model:
         command += ["--model", model]
     command.append(prompt)
@@ -347,6 +356,7 @@ def prepare_adoption_launch(
     codex_bin: str = "codex",
     model: str | None = None,
     sandbox: str = "workspace-write",
+    config_overrides: Sequence[str] = (),
 ) -> AdoptionLaunch:
     """Assemble context + build the codex command (no exec, no credentials)."""
     name = validate_benchmark_name(name)
@@ -357,7 +367,12 @@ def prepare_adoption_launch(
         source, name, convert_guide=convert_guide, skills=skills
     )
     command = build_codex_launch_command(
-        prompt, workdir=repo_root, codex_bin=codex_bin, model=model, sandbox=sandbox
+        prompt,
+        workdir=repo_root,
+        codex_bin=codex_bin,
+        model=model,
+        sandbox=sandbox,
+        config_overrides=config_overrides,
     )
     return AdoptionLaunch(command=command, cwd=str(repo_root), prompt=prompt)
 
@@ -390,6 +405,7 @@ def run_agent_adoption(
     codex_bin: str = "codex",
     model: str | None = None,
     sandbox: str = "workspace-write",
+    config_overrides: Sequence[str] = (),
 ) -> int:
     """Launch the host codex CLI to drive the adoption. Fail-closed on creds.
 
@@ -412,6 +428,7 @@ def run_agent_adoption(
         codex_bin=codex_bin,
         model=model,
         sandbox=sandbox,
+        config_overrides=config_overrides,
     )
     return exec_fn(launch.command, cwd=launch.cwd, env=resolved_env)
 
@@ -521,9 +538,20 @@ def register_agent_router(agent_app: typer.Typer) -> None:
         codex_bin: Annotated[
             str, typer.Option("--codex-bin", help="Host codex binary")
         ] = "codex",
+        codex_config: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--codex-config",
+                "-c",
+                help="Codex config override as key=value, passed to codex as "
+                "`-c key=value`; repeatable (e.g. -c service_tier=flex to work "
+                "around host ~/.codex/config.toml drift)",
+            ),
+        ] = None,
     ) -> None:
         """Drive the CONVERT.md workflow by launching the host codex CLI."""
         repo_root = default_repo_root()
+        overrides = tuple(codex_config or ())
         try:
             resolved = name or derive_name_from_source(source)
             if dry_run:
@@ -533,6 +561,7 @@ def register_agent_router(agent_app: typer.Typer) -> None:
                     repo_root=repo_root,
                     codex_bin=codex_bin,
                     model=model,
+                    config_overrides=overrides,
                 )
                 console.print(" ".join(shlex.quote(c) for c in launch.command))
                 return
@@ -543,6 +572,7 @@ def register_agent_router(agent_app: typer.Typer) -> None:
                 exec_fn=_subprocess_exec,
                 codex_bin=codex_bin,
                 model=model,
+                config_overrides=overrides,
             )
         except (InvalidBenchmarkName, CodexLaunchError) as exc:
             console.print(f"[red]{exc}[/red]")

--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -196,6 +196,36 @@ def test_build_launch_command_omits_model_when_absent() -> None:
     assert "--model" not in cmd
 
 
+def test_build_launch_command_injects_codex_config_overrides() -> None:
+    """`-c key=value` overrides let a run work around host codex config drift."""
+    cmd = build_codex_launch_command(
+        "PROMPT",
+        workdir="/repo",
+        config_overrides=["service_tier=flex", "model_reasoning_effort=high"],
+    )
+    assert cmd.count("-c") == 2
+    # each -c is immediately followed by its key=value, and all precede the prompt.
+    pairs = [(cmd[i], cmd[i + 1]) for i, c in enumerate(cmd) if c == "-c"]
+    assert pairs == [("-c", "service_tier=flex"), ("-c", "model_reasoning_effort=high")]
+    assert cmd[-1] == "PROMPT"
+    assert cmd.index("-c") < cmd.index("PROMPT")
+
+
+def test_build_launch_command_no_overrides_by_default() -> None:
+    assert "-c" not in build_codex_launch_command("P", workdir="/repo")
+
+
+def test_run_command_dry_run_passes_codex_config(tmp_path: Path) -> None:
+    """`bench agent run -c k=v --dry-run` surfaces the override in the command."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["agent", "run", "github.com/foo/bar", "-c", "service_tier=flex", "--dry-run"],
+    )
+    assert result.exit_code == 0, result.output
+    assert "-c service_tier=flex" in result.output
+
+
 def test_collect_adoption_skills_references_convert_guide(tmp_path: Path) -> None:
     skills = collect_adoption_skills()
     refs = {s.reference for s in skills}


### PR DESCRIPTION
## Why

While exercising the live `bench agent run` path (HumanEval conversion), the host `~/.codex/config.toml` had `service_tier = "default"` — which **codex-cli 0.130.0 rejects** (it wants `fast`/`flex`), so codex wouldn't start at all. `bench agent run` exposed **no way to override codex config per-run**, so the only escape was editing the user's (sensitive) config file or building a `CODEX_HOME` shim. A "convert any benchmark" adapter shouldn't be wedged by host config drift.

## What

Adds `bench agent run <source> --codex-config key=value` (short `-c`, repeatable), passed straight through to `codex exec` as `-c key=value`:

```
bench agent run https://github.com/openai/human-eval -c service_tier=flex
```

Threaded through `build_codex_launch_command` → `prepare_adoption_launch` → `run_agent_adoption`. Overrides are emitted before the prompt positional. Default behavior unchanged (no `-c` when none given).

## Validation

- `bench agent run … -c service_tier=flex --dry-run` surfaces `-c service_tier=flex` in the launch command.
- 3 new unit tests (injection + ordering, none-by-default, CLI dry-run). Full `test_agent_router` green (76), ruff + ty clean.

## Notes

- Targets `release/v0.6.0`; not merging — flagged for review.
- Companion to the live-path findings: this is the CLI escape hatch for host codex config drift (the host `service_tier` itself is the user's to fix).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive CLI and argv plumbing with empty defaults; no changes to auth, parity, or scaffold paths.
> 
> **Overview**
> Adds **`bench agent run --codex-config key=value`** (short **`-c`**, repeatable) so adoption runs can pass codex **`exec`** config overrides without editing **`~/.codex/config.toml`**—e.g. **`-c service_tier=flex`** when the host config uses a value the installed codex CLI rejects.
> 
> The override list is threaded through **`build_codex_launch_command`**, **`prepare_adoption_launch`**, and **`run_agent_adoption`**, emitting each pair as **`-c`** flags before **`--model`** and the prompt. **Dry-run** and live launch both honor the same flags; when no overrides are given, behavior is unchanged (no **`-c`** in the argv). Unit tests cover argv ordering, the default, and CLI dry-run output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9740c6ea62c09987333f820d20d6149f2e27710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->