### PR TITLE
fix(dataset): bench RC/dev builds in-range for their release line (bench_version)

### DIFF
--- a/src/benchflow/_utils/dataset_registry.py
+++ b/src/benchflow/_utils/dataset_registry.py
@@ -105,7 +105,13 @@ def bench_version_issue(declared_range: str | None) -> str | None:
             f"cannot compare bench version {__version__!r} against the "
             f"dataset's validated range {declared_range!r}"
         )
-    if specifier.contains(current, prereleases=True):
+    # Compare on the BASE version (strip pre/post/dev) so a release candidate or
+    # dev build counts as in-range for a spec that includes its release line.
+    # PEP 440 orders 0.6.0rc6 < 0.6.0, so a bare `>=0.6` would otherwise flag the
+    # very release being validated (v0.6 ships as 0.6.0rcN) as out-of-range — and
+    # the planned bench_version hard-gate would then block every RC user from
+    # dataset runs. base_version maps 0.6.0rc6 -> 0.6.0, the line it belongs to.
+    if specifier.contains(Version(current.base_version), prereleases=True):
         return None
     return (
         f"bench {__version__} is outside the range this dataset was "

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -127,6 +127,22 @@ class TestBenchVersionIssue:
         issue = bench_version_issue("not-a-range")
         assert issue is not None and "unparseable" in issue
 
+    def test_prerelease_counts_as_in_range_for_its_own_line(self, monkeypatch):
+        """A shipping release candidate (v0.6 ships as 0.6.0rcN) must count as
+        in-range for a >=0.6 dataset. PEP 440 orders 0.6.0rc6 < 0.6.0, so the
+        naive `contains(current)` spuriously flagged the very release being
+        validated as out-of-range — and the planned hard-gate would then block
+        every RC user from dataset runs. The base-version comparison fixes it."""
+        monkeypatch.setattr("benchflow.__version__", "0.6.0rc6")
+        assert bench_version_issue(">=0.6,<0.7") is None
+        # dev builds map to their release line too
+        monkeypatch.setattr("benchflow.__version__", "0.6.0.dev3")
+        assert bench_version_issue(">=0.6,<0.7") is None
+        # but a genuinely-different line still warns (no false in-range)
+        monkeypatch.setattr("benchflow.__version__", "0.6.0rc6")
+        assert bench_version_issue(">=0.4,<0.5") is not None
+        assert bench_version_issue(">=0.5,<0.6") is not None
+
 
 class TestResolveDataset:
     def test_resolves_and_verifies_digests(self, tmp_path, snapshot):


### PR DESCRIPTION
## The bug

`bench_version_issue` (the `bench eval create -d` dataset compatibility check) compared the **full** running version against the dataset's validated `bench_version` range. PEP 440 orders `0.6.0rc6 < 0.6.0`, so a dataset declaring `>=0.6,<0.7` flags the **shipping v0.6 release candidate (`0.6.0rcN`) as "outside the range"** — even though it *is* the 0.6 line being validated.

Impact:
- Every v0.6 RC user gets a spurious "outside the range — results may not be comparable" warning on a correctly-0.6-targeted dataset.
- The planned **bench_version hard-gate (#692)** would turn this into a hard **block** — every RC user locked out of dataset runs.

## How it was found

Dogfooding the never-run-live `bench eval create -d` path: `resolve_dataset("skillsbench@1.1")` on `0.6.0rc6` resolved + verified all 87 task digests correctly, but `bench_version_issue(">=0.6,<0.7")` returned a false out-of-range.

## Fix

Compare on the **base version** (`Version(current.base_version)`, which strips pre/post/dev), so `0.6.0rc6 → 0.6.0` maps to its release line. Verified across cases:

| installed | range | before | after |
|---|---|---|---|
| 0.6.0rc6 | >=0.6,<0.7 | ❌ out (bug) | ✅ in |
| 0.6.0rc6 | >=0.4,<0.5 | out | out |
| 0.6.0rc6 | >=0.5,<0.6 | out | out |
| 0.6.0 | >=0.6,<0.7 | in | in |

## Notes

- Targets `release/v0.6.0`; not merging — flagged for review.
- **Coordinate with #692** (the bench_version hard-gate, open on main): it builds on this check — the gate must use this base-version comparison or it will re-introduce the RC lockout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to advisory version matching logic with targeted tests; no auth, data, or eval execution path changes beyond compatibility messaging.
> 
> **Overview**
> Fixes a false **out-of-range** warning (and future hard-block risk) in the dataset `bench_version` advisory check used on `bench eval create -d`.
> 
> **`bench_version_issue`** now tests the dataset’s validated range against **`Version(current.base_version)`** instead of the full installed version. That maps PEP 440 prerelease/dev builds (e.g. `0.6.0rc6`, `0.6.0.dev3`) onto their release line (`0.6.0`), so a spec like `>=0.6,<0.7` no longer treats the shipping RC as below `0.6`. Warnings for genuinely different lines are unchanged.
> 
> Adds **`test_prerelease_counts_as_in_range_for_its_own_line`** covering RC/dev in-range and adjacent-line still-out-of-range cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05ff000c7e05d54cb6fa687c80a287399d7e0603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->