### PR TITLE
fix(cli): bench tasks digest recognizes native task.md tasks

### DIFF
--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -299,28 +299,32 @@ def register_tasks(app: typer.Typer) -> None:
         """Compute the content digest that pins a task's files, independent of git.
 
         Matches the digests in the skillsbench dataset registry (registry.json).
-        Given a single task directory (contains task.toml), prints the digest;
-        given a directory of tasks, prints one "<name> <digest>" line per task.
+        Given a single task directory (a legacy ``task.toml`` or a native
+        ``task.md`` task), prints the digest; given a directory of tasks, prints
+        one "<name> <digest>" line per task.
         """
         from benchflow._utils.task_authoring import task_digest
+
+        # A task directory is either a legacy task.toml task or a native task.md
+        # task (the universal-adapter format) — recognize both, not just legacy.
+        def _is_task_dir(p: Path) -> bool:
+            return (p / "task.toml").is_file() or (p / "task.md").is_file()
 
         if not path.is_dir():
             console.print(f"[red]Not a directory: {path}[/red]")
             raise typer.Exit(1)
 
-        if (path / "task.toml").is_file():
+        if _is_task_dir(path):
             # typer.echo, not console.print: Rich wraps lines at terminal width,
             # which would corrupt piped machine-readable output.
             typer.echo(task_digest(path))
             return
 
-        task_dirs = sorted(
-            d for d in path.iterdir() if d.is_dir() and (d / "task.toml").is_file()
-        )
+        task_dirs = sorted(d for d in path.iterdir() if d.is_dir() and _is_task_dir(d))
         if not task_dirs:
             console.print(
-                f"[red]No tasks under {path} — expected task.toml in it "
-                f"or in its immediate subdirectories[/red]"
+                f"[red]No tasks under {path} — expected task.toml or task.md "
+                f"in it or in its immediate subdirectories[/red]"
             )
             raise typer.Exit(1)
         for task_dir in task_dirs:

--- a/tests/test_task_digest.py
+++ b/tests/test_task_digest.py
@@ -159,3 +159,27 @@ class TestTasksDigestCli:
         )
         assert result.exit_code == 1
         assert "No tasks under" in result.output
+
+    def test_recognizes_native_task_md_task(self, tmp_path):
+        """The universal-adapter native format is task.md (no task.toml). The
+        digest CLI must recognize it and emit the same digest the run-time
+        stamper uses, or `bench tasks digest` is unusable on converted tasks."""
+        task = tmp_path / "md-task"
+        task.mkdir()
+        (task / "task.md").write_text("# A native task\n")
+        (task / "input.txt").write_bytes(b"payload")
+        result = CliRunner().invoke(app, ["tasks", "digest", str(task)])
+        assert result.exit_code == 0, result.output
+        assert result.output.strip() == task_digest(task)
+
+    def test_directory_of_task_md_tasks(self, tmp_path):
+        for name in ("a-md", "b-md"):
+            t = tmp_path / name
+            t.mkdir()
+            (t / "task.md").write_text(f"# {name}\n")
+        result = CliRunner().invoke(app, ["tasks", "digest", str(tmp_path)])
+        assert result.exit_code == 0, result.output
+        assert [line.split()[0] for line in result.output.splitlines()] == [
+            "a-md",
+            "b-md",
+        ]


### PR DESCRIPTION
## The bug

`bench tasks digest` detected a task directory by checking for **`task.toml` only**. The universal adapter's *native* format is **`task.md`** (no `task.toml`), so the digest CLI rejected converted tasks with:

```
No tasks under <dir> — expected task.toml in it or in its immediate subdirectories
```

Meanwhile the **run-time digest stamper** (#691, `task_digest()`) digests task.md tasks fine — so the CLI and the stamper disagreed on what counts as a task. For a "convert any benchmark to task.md" adapter, the digest CLI being blind to task.md is a real dev-ex gap.

## How it was found

Dogfooding `bench tasks digest` on the family2 **task.md** tasks (which the #686 dogfood confirmed run on v0.6): the CLI said "expected task.toml," yet those same tasks had a stamped `task_digest` in their result.json.

## Fix

Recognize a task directory as `task.toml` **or** `task.md` (single-task and directory-scan modes). Verified the CLI digest of a task.md task now **equals** the run-time-stamped `task_digest` from a real rollout's result.json — closing the CLI↔stamp inconsistency (#689 ↔ #691).

## Validation

- `bench tasks digest <task.md dir>` → emits the digest, matching the stamped `sha256:…` exactly.
- 2 new tests (single task.md recognized + digest == `task_digest()`; directory of task.md tasks enumerated). Full `test_task_digest` green (14), ruff + ty clean.

Targets `release/v0.6.0`; not merging — flagged for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI detection change with tests; digest algorithm unchanged.
> 
> **Overview**
> **`bench tasks digest`** now treats a directory as a task when it contains **`task.md`** as well as **`task.toml`**, via a shared `_is_task_dir` helper used for single-path and batch enumeration.
> 
> This aligns the CLI with the run-time **`task_digest()`** stamper on universal-adapter native tasks (no `task.toml`), and updates the “no tasks found” message and docstring accordingly.
> 
> Two CLI tests cover a lone **`task.md`** task (output must match **`task_digest()`**) and a parent directory listing multiple **`task.md`** tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 926d4de837637a88957d9f92716cfae1939c5dc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->