### PR TITLE
docs(cli): document v0.6 adapter features (verify --rerun, run -c, eval -d, tasks digest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,13 @@
   the host `codex` CLI through the conversion workflow, and `verify` runs the
   parity gate (deterministic per-criterion conversion parity plus the
   agent-scale reward-distribution layer) and emits a confidence verdict, with a
-  drafted support issue on divergence.
+  drafted support issue on divergence. `bench agent verify --rerun` independently
+  re-executes the benchmark's `parity_test.py` and scores its fresh output
+  (instead of trusting the recorded `parity_experiment.json`), failing closed if
+  the output is not scoreable; `bench agent run -c key=value` passes codex config
+  overrides through to the host codex driver (e.g. to work around `~/.codex`
+  drift). `bench tasks digest` recognizes native `task.md` tasks as well as
+  legacy `task.toml`.
 - **ATIF and ADP trajectory artifacts** — every scored rollout now emits
   `trainer/atif.json` and `trainer/adp.jsonl` (alongside the existing
   `verifiers.jsonl`), with job-level ADP aggregation. One canonical raw

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -84,6 +84,7 @@ bench agent run ./vendor/some-benchmark --name my-bench --model o3
 | `--model` | codex default | Model for the codex driver |
 | `--dry-run` | `false` | Print the launch command, do not run |
 | `--codex-bin` | `codex` | Host codex binary |
+| `-c`, `--codex-config` | — | Codex config override as `key=value`, passed through to codex as `-c key=value`; repeatable. Use it to work around host `~/.codex/config.toml` drift without editing the file — e.g. `-c service_tier=flex` when an installed codex version rejects a stale value. |
 
 ### bench agent verify
 
@@ -102,10 +103,18 @@ a draft GitHub issue body for human support — printed to stdout, or written to
 to also run the structural round-trip conformance check on a concrete task
 directory.
 
+By default the gate **scores the recorded** `parity_experiment.json` — fast, but
+it trusts an artifact the conversion produced about itself. Pass `--rerun` to
+**independently re-execute** `parity_test.py --mode side-by-side` and score its
+fresh output instead. `--rerun` is fail-closed: a missing/failing `parity_test.py`,
+a timeout, or output that is not in the scoreable `parity_experiment.json` shape
+all exit non-zero (rather than silently reporting `insufficient-evidence`).
+
 ```bash
 bench agent verify my-bench
 bench agent verify my-bench --tolerance 0.05 --issue-out divergence.md
 bench agent verify my-bench --roundtrip-task benchmarks/my-bench/tasks/example
+bench agent verify my-bench --rerun   # re-run parity_test.py, score fresh output
 ```
 
 | Flag | Default | Description |
@@ -114,6 +123,7 @@ bench agent verify my-bench --roundtrip-task benchmarks/my-bench/tasks/example
 | `--tolerance` | `0.02` | Max abs reward delta (statistical layer) |
 | `--issue-out` | — | Write the divergence issue draft to this path instead of stdout |
 | `--roundtrip-task` | — | Also run the structural round-trip check on this task dir |
+| `--rerun` | `false` | Re-execute `parity_test.py --mode side-by-side` and score its fresh output instead of the recorded `parity_experiment.json` |
 
 ## bench eval
 
@@ -166,12 +176,18 @@ bench eval create \
   --sandbox daytona \
   --skill-mode with-skill \
   --agent-env BENCHFLOW_SKILL_NUDGE=name
+
+# Pinned registry dataset: resolves skillsbench@1.1, verifies task digests,
+# and stamps dataset identity into every result.json/config.json
+bench eval create -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lite-preview
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--config` | — | YAML config file |
 | `--tasks-dir` | — | Local task dir (single task with task.toml, or parent of many) |
+| `-d`, `--dataset` | — | Registry dataset to run as `<name>@<version>` (e.g. `skillsbench@1.1`). Resolves the pinned snapshot from the registry, clones tasks at their pinned commit, verifies each task's sha256 content digest, and checks the dataset's `bench_version` range against the installed benchflow. Each `result.json`/`config.json` is stamped with `dataset_name`, `dataset_version`, and the task's `task_digest`. |
+| `--registry` | skillsbench registry | Dataset registry JSON URL or local file. Only valid with `--dataset`. |
 | `--source-repo` | — | Remote repo as `org/repo` (e.g. `benchflow-ai/skillsbench`) |
 | `--source-path` | — | Subpath within the repo (e.g. `tasks`) |
 | `--source-ref` | — | Branch or tag to clone (e.g. `main`) |
@@ -343,6 +359,23 @@ Arguments: `TASK_DIR` (task directory to export) and optional `OUTPUT_DIR`
 | `--target` | `harbor` | Compatibility target: `harbor` or `pier` |
 | `--overwrite` | `false` | Replace an existing export directory |
 | `--report-only` | `false` | Print the compatibility loss report without writing files |
+
+### bench tasks digest
+
+Compute the content digest that pins a task's files, independent of git — the
+sha256 the dataset registry keys on (matches the digests `bench eval create -d`
+verifies and the `task_digest` stamped into every `result.json`). Recognizes
+both legacy `task.toml` tasks and native `task.md` tasks. Given a single task
+directory it prints the digest; given a directory of tasks it prints one
+`<name> <digest>` line per task. Output goes to stdout via `echo` (not Rich), so
+it is safe to pipe into machine-readable tooling.
+
+```bash
+bench tasks digest tasks/my-task          # -> sha256:<hex>
+bench tasks digest tasks/                  # one "<name> sha256:<hex>" line per task
+```
+
+Arguments: `PATH` (a task directory, or a directory of task directories).
 
 ### bench tasks generate
 


### PR DESCRIPTION
## What

The four new v0.6 universal-adapter CLI surfaces (now merged: #694, #695, #696/#689-#693, #697) had no user-facing docs — a gap a review flagged. This adds **additive** doc content (no Mintlify config / nav changes):

- **`docs/reference/cli.md`**
  - `bench agent verify --rerun` — flag row + paragraph (independent parity re-execution; fail-closed if output isn't scoreable).
  - `bench agent run -c/--codex-config` — flag row (codex config passthrough for host `~/.codex` drift).
  - `bench eval create -d/--dataset` + `--registry` — flag rows + a worked example (pinned registry snapshot, digest verification, dataset-identity stamping).
  - `bench tasks digest` — new subsection (recognizes both `task.md` and legacy `task.toml`).
- **`CHANGELOG.md`** — noted the new flags on the `bench agent` router entry.

## Validation

`test_cli_docs_drift` + `test_docs_examples` pass (the documented flags match the real CLI; examples are valid).

## Notes

- **@bingran-you** — flagging for your docs-lane review since you own `docs/`/Mintlify; this PR deliberately touches **only doc content** (no `docs.json`/Mintlify config). The secondary surfaces the gap report identified (README "task sources" block, `docs/running-any-benchmark.md` Layer-1 dataset path, `docs/benchmark-adoption.md` verify/run sections) are intentionally left for you to fold into the RC docs line as you see fit.
- Targets `release/v0.6.0`; not merging — for your review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no runtime, auth, or data-path behavior is modified.
> 
> **Overview**
> Documents v0.6 CLI surfaces that shipped without user-facing reference text.
> 
> **`docs/reference/cli.md`** adds `bench agent run` `-c`/`--codex-config` (repeatable `key=value` passthrough to codex for host `~/.codex` drift), expands **`bench agent verify`** with `--rerun` (re-run `parity_test.py` side-by-side and score fresh output; fail-closed when output is not scoreable), documents **`bench eval create`** `-d`/`--dataset` and `--registry` with a `skillsbench@1.1` example (pinned snapshot, digest checks, dataset fields on results), and introduces a **`bench tasks digest`** subsection for `task.md` and legacy `task.toml` digest output.
> 
> **`CHANGELOG.md`** extends the `bench agent` router bullet to mention `--rerun`, run `-c`, and `bench tasks digest` in the same release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad6931ed8778f2de4e8a34fb2783d1d68b8ce2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->