### PR TITLE
fix(test): collapse rich line-wrap in malformed-JSON verify test (unblocks #665 CI)

### DIFF
--- a/tests/test_agent_router.py
+++ b/tests/test_agent_router.py
@@ -848,7 +848,11 @@ def test_cli_verify_malformed_json_prints_clean_message(tmp_path: Path) -> None:
     result = CliRunner().invoke(
         app, ["agent", "verify", "my-bench", "--benchmarks-dir", str(tmp_path)]
     )
-    out = click.unstyle(result.output)
+    # Collapse rich's line-wrapping before substring checks: CI's long tmp path
+    # pushes the message wide enough that "not valid JSON" wraps across a newline
+    # ("is not\nvalid JSON"), which broke the contiguous-substring assert in CI
+    # while passing locally on shorter paths.
+    out = " ".join(click.unstyle(result.output).split())
     # Fail-closed: a clean actionable message, no uncaught JSONDecodeError.
     assert "not valid JSON" in out
     assert "JSONDecodeError" not in out


### PR DESCRIPTION
## The CI failure

`#665`'s `test` job was **red** on `release/v0.6.0` — sole failure:

```
FAILED tests/test_agent_router.py::test_cli_verify_malformed_json_prints_clean_message
AssertionError: assert 'not valid JSON' in '...is not \nvalid JS...'
```

`test_cli_verify_malformed_json_prints_clean_message` asserts the contiguous substring `not valid JSON` on Rich console output. In CI the long tmp path (`/tmp/pytest-of-runner/pytest-0/test_cli_verify_malformed_json0/my-bench`) pushes the error message wide enough that Rich wraps `not valid JSON` across a newline (`is not\nvalid JSON`), so the assert fails — in CI only; it passes locally on shorter tmp paths. This is purely a test-fragility issue (the CLI message is correct and unchanged).

## Fix

Whitespace-collapse the output before the substring check:
```python
out = " ".join(click.unstyle(result.output).split())
```
This matches the pattern **already** used two tests below (`test_cli_verify_nonexistent_roundtrip_task_no_traceback` — "Collapse rich's line-wrapping before substring checks"), making the assert robust to wrapping regardless of path length / console width.

## Why it matters

This was the only thing keeping `#665` (the v0.6 release → main) from a green `test` gate. With it fixed, the release CI goes green and the release is ready to cut.

Targets `release/v0.6.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change; no production or CLI behavior changes.
> 
> **Overview**
> Fixes a **CI-only flake** in `test_cli_verify_malformed_json_prints_clean_message`: the verify CLI still prints the same malformed-JSON message, but Rich can wrap `not valid JSON` across a newline when the pytest tmp path is long, so a contiguous substring assert failed in CI.
> 
> The test now **whitespace-collapses** Rich output (`" ".join(click.unstyle(result.output).split())`) before checking for `not valid JSON`, matching the approach already used in `test_cli_verify_nonexistent_roundtrip_task_no_traceback`. Comments document why the collapse is needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce917d5a4b7bf399cd735810a1aca907a4be64c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->