### PR TITLE
fix(docs): wrap literal braces in inline code — Mintlify MDX/acorn parse failure

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ BenchFlow is the **environment-and-rollout engine for agentic RL** — it turns 
 
 **One engine, three modes.** There is one thing — a *scored rollout*. **Eval** = score it and stop. **Train** = score it and hand the trajectory to a trainer. **Monitor** = score it in production. (Han Lee: *"evaluation, reward and monitoring … it's really all the same thing under different circumstances."*)
 
-**The bet.** A complete RL environment is **E = {T, H, V, S, C}** — Tasks, Harness, Verifier, **State**, Config (Han Lee, *RL Environments for LLM Agents*). BenchFlow targets the complete E. **State management** — stateful, multi-service environments that can **roll out, roll back, and branch** — is the frontier of agentic RL and the surface BenchFlow is built around.
+**The bet.** A complete RL environment is **E = `{T, H, V, S, C}`** — Tasks, Harness, Verifier, **State**, Config (Han Lee, *RL Environments for LLM Agents*). BenchFlow targets the complete E. **State management** — stateful, multi-service environments that can **roll out, roll back, and branch** — is the frontier of agentic RL and the surface BenchFlow is built around.
 
 **The boundary.** BenchFlow owns **environment + rollout + reward**. Trainers own **weights + gradients + optimizer**. The **trajectory is the seam** — every RL trainer can consume BenchFlow output without coupling.
 

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -367,7 +367,7 @@ bench eval create \
 ## SkillsBench skill-toggle matrix (Opus-4.8 + Gemini) on Daytona
 
 A self-contained recipe for the four-cell matrix of
-**{Opus-4.8 via Bedrock, Gemini-3.5-flash} × {with-skills, without-skills}**,
+**`{Opus-4.8 via Bedrock, Gemini-3.5-flash}` × `{with-skills, without-skills}`**,
 agent `openhands`, sandbox `daytona`. Each cell produces a complete trajectory
 (`trajectory/{acp,llm}_trajectory.jsonl`) plus a verifier reward — but treat a
 cell as done only after the audit in [Verifying the batch](#verifying-the-batch)


### PR DESCRIPTION
Mintlify deploys `docs/` as MDX, where bare `{…}` in prose is parsed as a JSX expression and fails with *"Could not parse page content … Could not parse expression with acorn"*. This surfaced on the v0.6.0 release PR (#665) the first time a deploy targeted `running-benchmarks.md`; the same two lines exist on main, so main's docs deploys are equally broken.

Two lines, both wrapped in inline code so the braces render verbatim:
- `docs/running-benchmarks.md`: the skill-toggle matrix `{Opus-4.8 via Bedrock, Gemini-3.5-flash} × {with-skills, without-skills}`
- `docs/architecture.md`: `E = {T, H, V, S, C}`

Already applied to `release/v0.6.0` as `113f3507` (same patch — future syncs merge clean). Remaining flagged spots from a full-docs scan are inside multi-line inline-code spans (safe) or under `docs/examples/` (not in the Mintlify nav).