### PR TITLE
feat/Add OpenReward hosted env execution path-- OpenRewards PR 3/3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "rich>=13.0",
     "tomli-w>=1.0",
     "typer>=0.9",
+    "openreward>=0.1.126",
 ]
 authors = [
     { name = "Xiangyi Li", email = "xiangyi@benchflow.ai" },

--- a/src/benchflow/_utils/reward_events.py
+++ b/src/benchflow/_utils/reward_events.py
@@ -3,9 +3,72 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from datetime import datetime
 from typing import Any
 
 _EVENT_FIELDS = ("type", "reward", "source", "space", "granularity", "step")
+
+
+def build_rewards_jsonl_events(
+    rewards: Mapping[str, Any] | None,
+    finished_at: datetime,
+) -> list[dict[str, Any]]:
+    """Build the ``rewards.jsonl`` event list from a native-shape rewards dict.
+
+    Shared by the native rollout writer and the hosted-env writer so both tag
+    every record ``(space, granularity, value)`` identically: ``space`` and
+    ``granularity`` are first-class fields, promoted from any verifier-supplied
+    per-item dict and falling back to ``space="output"`` (``granularity="step"``
+    for rubric ``process`` events, ``"terminal"`` for the scalar reward).
+    Rubric items with a non-numeric ``score`` are skipped so an out-of-contract
+    or nulled value never becomes a process event.
+    """
+    if not rewards:
+        return []
+    ts = finished_at.isoformat()
+    events: list[dict[str, Any]] = []
+    rubric = rewards.get("rubric")
+    if isinstance(rubric, list):
+        for i, item in enumerate(rubric):
+            if not isinstance(item, dict):
+                continue
+            score = item.get("score")
+            if not isinstance(score, (int, float)) or isinstance(score, bool):
+                continue
+            events.append(
+                {
+                    "ts": ts,
+                    "type": "process",
+                    "source": "verifier_rubric",
+                    "value": score,
+                    "tag": item.get("name", f"rubric_{i}"),
+                    "step_index": i,
+                    "space": item.get("space", "output"),
+                    "granularity": item.get("granularity", "step"),
+                    "meta": {
+                        k: v
+                        for k, v in item.items()
+                        if k not in ("score", "name", "space", "granularity")
+                    },
+                }
+            )
+    scalar = rewards.get("reward")
+    if scalar is not None:
+        non_event_keys = {"reward", "rubric", "space", "granularity"}
+        events.append(
+            {
+                "ts": ts,
+                "type": "terminal",
+                "source": "verifier",
+                "value": scalar,
+                "tag": "reward",
+                "step_index": None,
+                "space": rewards.get("space", "output"),
+                "granularity": rewards.get("granularity", "terminal"),
+                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
+            }
+        )
+    return events
 
 
 def reward_event_to_dict(event: Any) -> dict[str, Any]:

--- a/src/benchflow/adapters/ors.py
+++ b/src/benchflow/adapters/ors.py
@@ -11,7 +11,9 @@ custom field mappings.
 
 from __future__ import annotations
 
+import json
 import math
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -93,7 +95,153 @@ class ORSAdapter:
         """Convert a single ``RewardEvent`` to ORS event format."""
         return _event_to_dict(event)
 
+    @staticmethod
+    def tool_outputs_to_reward_events(
+        outputs: list[dict[str, Any]],
+        *,
+        source: str = "ors-tool-output",
+    ) -> list[dict[str, Any]]:
+        """Normalize ORS-style tool outputs into verifier evidence records."""
+
+        records: list[dict[str, Any]] = []
+        for index, output in enumerate(outputs, start=1):
+            if not isinstance(output, dict):
+                raise ValueError("ORS tool output records must be JSON objects")
+            reward = _bounded_reward(_reward_value(output), path=f"outputs[{index}]")
+            finished = bool(
+                output.get("finished") is True or output.get("done") is True
+            )
+            explicit_type = (
+                str(output["type"]) if output.get("type") is not None else None
+            )
+            explicit_granularity = (
+                str(output["granularity"])
+                if output.get("granularity") is not None
+                else None
+            )
+            if finished:
+                if explicit_type is not None and explicit_type != "terminal":
+                    raise ValueError(
+                        f"outputs[{index}] is finished but has non-terminal "
+                        f"type {explicit_type!r}; a finished record is terminal"
+                    )
+                if (
+                    explicit_granularity is not None
+                    and explicit_granularity != "terminal"
+                ):
+                    raise ValueError(
+                        f"outputs[{index}] is finished but has non-terminal "
+                        f"granularity {explicit_granularity!r}; "
+                        "a finished record is terminal"
+                    )
+                record_type = "terminal"
+                granularity = "terminal"
+            else:
+                record_type = explicit_type or "dense"
+                granularity = explicit_granularity or "step"
+
+            record: dict[str, Any] = {
+                "type": record_type,
+                "reward": reward,
+                "source": str(
+                    output.get("source")
+                    or output.get("tool_name")
+                    or output.get("tool")
+                    or source
+                ),
+                "step": _step_value(output, fallback=index),
+                "space": str(
+                    output.get("space") or ("output" if finished else "action")
+                ),
+                "granularity": granularity,
+            }
+            timestamp = output.get("timestamp") or output.get("ts")
+            if timestamp is not None:
+                record["timestamp"] = str(timestamp)
+            tool_call_id = output.get("tool_call_id") or output.get("toolCallId")
+            if tool_call_id is not None:
+                record["tool_call_id"] = str(tool_call_id)
+            if finished:
+                record["finished"] = True
+            records.append(record)
+        return records
+
+    @staticmethod
+    def write_tool_outputs_jsonl(
+        outputs: list[dict[str, Any]],
+        path: str | Path,
+        *,
+        source: str = "ors-tool-output",
+    ) -> list[dict[str, Any]]:
+        """Write ORS tool-output rewards to ``trajectory/ors-rewards.jsonl``."""
+
+        records = ORSAdapter.tool_outputs_to_reward_events(outputs, source=source)
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        with out.open("w") as f:
+            for record in records:
+                f.write(json.dumps(record, allow_nan=False) + "\n")
+        return records
+
 
 def to_ors_reward(result: VerifyResult) -> dict[str, Any]:
     """Convenience function to convert ``VerifyResult`` to ORS format."""
     return ORSAdapter.verify_result_to_ors(result)
+
+
+def ors_tool_outputs_to_reward_events(
+    outputs: list[dict[str, Any]],
+    *,
+    source: str = "ors-tool-output",
+) -> list[dict[str, Any]]:
+    """Convenience function to normalize ORS tool-output rewards."""
+    return ORSAdapter.tool_outputs_to_reward_events(outputs, source=source)
+
+
+def write_ors_tool_outputs_jsonl(
+    outputs: list[dict[str, Any]],
+    path: str | Path,
+    *,
+    source: str = "ors-tool-output",
+) -> list[dict[str, Any]]:
+    """Convenience function to write ORS tool-output reward JSONL."""
+    return ORSAdapter.write_tool_outputs_jsonl(outputs, path, source=source)
+
+
+def _reward_value(output: dict[str, Any]) -> Any:
+    for key in ("reward", "score", "value"):
+        if key in output:
+            value = output[key]
+            if isinstance(value, dict):
+                for nested_key in ("reward", "score", "value"):
+                    if nested_key in value:
+                        return value[nested_key]
+            return value
+    result = output.get("result")
+    if isinstance(result, dict):
+        for key in ("reward", "score", "value"):
+            if key in result:
+                return result[key]
+    raise ValueError("ORS tool output is missing reward")
+
+
+def _bounded_reward(value: Any, *, path: str) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"{path}.reward must be a number in [0, 1]")
+    try:
+        reward = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{path}.reward must be a number in [0, 1]") from exc
+    if not math.isfinite(reward) or reward < 0.0 or reward > 1.0:
+        raise ValueError(f"{path}.reward must be a number in [0, 1]")
+    return reward
+
+
+def _step_value(output: dict[str, Any], *, fallback: int) -> int:
+    raw = output.get("step", fallback)
+    if isinstance(raw, bool):
+        return fallback
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return fallback

--- a/src/benchflow/hosted_env.py
+++ b/src/benchflow/hosted_env.py
@@ -25,10 +25,13 @@ import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 from uuid import uuid4
 
+from benchflow._utils.reward_events import build_rewards_jsonl_events
 from benchflow.diagnostics import RolloutDiagnostics
+from benchflow.rewards.validation import is_valid_reward_number
+from benchflow.trajectories.types import redact_acp_trajectory_jsonl
 
 logger = logging.getLogger(__name__)
 
@@ -214,6 +217,7 @@ class HostedEnvRunResult:
     reward: float | None = None
     total_tool_calls: int | None = None
     verifiers_error: str | None = None
+    raw_reward: float | None = None
 
     @property
     def error(self) -> str | None:
@@ -339,6 +343,33 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         check=False,
     )
     finished_at = datetime.now(UTC)
+    parsed_reward = _extract_metric(proc.stdout, "reward")
+    verifiers_error = _extract_verifiers_error(proc.stdout + "\n" + proc.stderr)
+    reward = parsed_reward
+
+    # Fail closed so hosted evidence stays equivalent to native rollouts:
+    # 1. A headline reward outside the [0, 1] contract is recorded raw for
+    #    forensics but never persisted as a terminal reward (mirrors native
+    #    verifier_core / ors.ORSAdapter bounds enforcement).
+    if reward is not None and not is_valid_reward_number(reward):
+        verifiers_error = (
+            verifiers_error
+            or f"hosted reward out of [0,1] contract: {reward!r}"
+        )
+        reward = None
+    # 2. returncode 0 but no parseable reward and no abort marker means the
+    #    vf-eval summary format drifted — surface it as an error rather than a
+    #    clean run with no rewards artifact.
+    elif (
+        reward is None
+        and proc.returncode == 0
+        and not verifiers_error
+    ):
+        verifiers_error = (
+            "could not parse reward from vf-eval output "
+            "(vf-eval summary format may have changed)"
+        )
+
     result = HostedEnvRunResult(
         source_env=config.source_env,
         run_dir=run_dir,
@@ -348,9 +379,10 @@ def run_hosted_env(config: HostedEnvRunConfig) -> HostedEnvRunResult:
         stderr=proc.stderr,
         model=config.model,
         normalized_model=normalized_model,
-        reward=_extract_metric(proc.stdout, "reward"),
+        reward=reward,
         total_tool_calls=_extract_int_metric(proc.stdout, "total_tool_calls"),
-        verifiers_error=_extract_verifiers_error(proc.stdout + "\n" + proc.stderr),
+        verifiers_error=verifiers_error,
+        raw_reward=parsed_reward,
     )
     _write_run_artifacts(
         result,
@@ -612,7 +644,11 @@ def _write_run_artifacts(
         "normalized_model": result.normalized_model,
         "env_args": config.env_args,
         "returncode": result.returncode,
-        "rewards": {"reward": result.reward} if result.reward is not None else None,
+        "rewards": (
+            {"reward": result.reward}
+            if result.reward is not None and not result.verifiers_error
+            else None
+        ),
         "total_tool_calls": result.total_tool_calls,
         "verifiers_error": result.verifiers_error,
         "error": result.error,
@@ -634,8 +670,7 @@ def _write_run_artifacts(
     )
 
     (result.run_dir / "trajectory" / "acp_trajectory.jsonl").write_text(
-        "\n".join(json.dumps(e, default=str) for e in trajectory)
-        + ("\n" if trajectory else "")
+        redact_acp_trajectory_jsonl(trajectory) + ("\n" if trajectory else "")
     )
 
     result_payload = build_hosted_result_payload(
@@ -650,12 +685,9 @@ def _write_run_artifacts(
         agent_name="verifiers",
         trajectory_source="hosted_env",
         has_trajectory=bool(trajectory),
-        # vf-eval distinguishes a process crash (returncode != 0) from a
-        # verifier-level error: a clean run that reported a verifier error
-        # leaves ``error`` None and surfaces it under ``verifier_error``.
-        error=result.error
-        if result.returncode != 0 or not result.verifiers_error
-        else None,
+        # Surface aborts/parse-misses in top-level error so hosted errored
+        # rollouts match native errored-rollout semantics.
+        error=result.error,
         verifier_error=result.verifiers_error,
     )
     (result.run_dir / "result.json").write_text(json.dumps(result_payload, indent=2))
@@ -884,8 +916,14 @@ def _build_rewards_dict(
     Hosted runs report a single average reward from vf-eval's stdout
     summary, optionally augmented by per-example rubric items reconstructed
     from ``results.jsonl``.
+
+    Fails closed (returns ``None``) when the headline reward is absent or an
+    abort marker (``verifiers_error``) is set, so an aborted run is never
+    persisted as a legitimate 0.0-reward episode. Per-example rubric scores are
+    bounds-checked the same way the headline is, so an out-of-contract score
+    (e.g. ``1e9``) is never written as a process reward event.
     """
-    if result.reward is None:
+    if result.reward is None or result.verifiers_error:
         return None
     rubric: list[dict[str, Any]] = []
     results_path = _find_results_jsonl(output_dir)
@@ -903,13 +941,30 @@ def _build_rewards_dict(
                     if not isinstance(row, dict):
                         continue
                     reward = row.get("reward")
-                    if isinstance(reward, int | float):
-                        rubric.append(
-                            {
-                                "name": f"example_{example_idx}",
-                                "score": float(reward),
-                            }
-                        )
+                    if not is_valid_reward_number(reward):
+                        # Out-of-contract / non-numeric: keep the raw value for
+                        # forensics but do not write it as a rubric score.
+                        if isinstance(reward, int | float) and not isinstance(
+                            reward, bool
+                        ):
+                            rubric.append(
+                                {
+                                    "name": f"example_{example_idx}",
+                                    "score": None,
+                                    "raw_score": float(reward),
+                                }
+                            )
+                        continue
+                    item: dict[str, Any] = {
+                        "name": f"example_{example_idx}",
+                        "score": float(reward),
+                    }
+                    # Carry any verifier-supplied space/granularity through so the
+                    # writer can promote them to first-class rewards.jsonl fields.
+                    for tag in ("space", "granularity"):
+                        if isinstance(row.get(tag), str):
+                            item[tag] = row[tag]
+                    rubric.append(item)
         except OSError:
             pass
     payload: dict[str, Any] = {"reward": float(result.reward)}
@@ -925,43 +980,13 @@ def _write_hosted_rewards_jsonl(
 ) -> None:
     """Mirror ``rollout._write_rewards_jsonl`` for hosted-env rewards.
 
-    Kept in this module to avoid importing from ``benchflow.rollout`` (which
-    pulls heavy ACP/sandbox deps at import time).
+    Builds the events through the shared :func:`build_rewards_jsonl_events`
+    helper so hosted lines carry the same first-class ``space``/``granularity``
+    tags as native ones (Memory-space aggregation depends on them). The helper
+    lives in ``_utils.reward_events`` — a light module — so hosted_env still
+    avoids importing ``benchflow.rollout`` (heavy ACP/sandbox deps).
     """
-    events: list[dict[str, Any]] = []
-    rubric = rewards.get("rubric")
-    if isinstance(rubric, list):
-        for i, item in enumerate(rubric):
-            if not isinstance(item, dict):
-                continue
-            rubric_item = cast(dict[str, Any], item)
-            events.append(
-                {
-                    "ts": finished_at.isoformat(),
-                    "type": "process",
-                    "source": "verifier_rubric",
-                    "value": rubric_item.get("score", 0.0),
-                    "tag": rubric_item.get("name", f"rubric_{i}"),
-                    "step_index": i,
-                    "meta": {
-                        k: v for k, v in item.items() if k not in ("score", "name")
-                    },
-                }
-            )
-    scalar = rewards.get("reward")
-    if scalar is not None:
-        non_event_keys = {"reward", "rubric"}
-        events.append(
-            {
-                "ts": finished_at.isoformat(),
-                "type": "terminal",
-                "source": "verifier",
-                "value": scalar,
-                "tag": "reward",
-                "step_index": None,
-                "meta": {k: v for k, v in rewards.items() if k not in non_event_keys},
-            }
-        )
+    events = build_rewards_jsonl_events(rewards, finished_at)
     if events:
         path = rollout_dir / "rewards.jsonl"
         path.write_text("\n".join(json.dumps(e, default=str) for e in events) + "\n")

--- a/src/benchflow/openreward_env.py
+++ b/src/benchflow/openreward_env.py
@@ -15,8 +15,9 @@ Prime's hub, it drives an OpenReward environment directly through the
         # loop until out.finished; final reward is out.reward
 
 The reward of the loop is ``ToolOutput.reward`` (NOT a ``RunResult`` /
-``ToolResult``). ``client.rollout.create(...)`` is telemetry-only and is **not**
-used here — it is not the env-interaction handle.
+``ToolResult``). ``client.rollout.create(...)`` is telemetry/reporting, not the
+env-interaction handle; when a live OpenReward client is available we also
+create a rollout recording so the run appears in OpenReward's runs UI.
 
 The loop is driven by a :class:`Policy`. We ship a :class:`ScriptedPolicy`
 (schema-driven, no LLM) so the path is fully exercisable offline with a fake
@@ -42,6 +43,7 @@ import json
 import logging
 import os
 import re
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
@@ -101,6 +103,26 @@ class Policy(Protocol):
     ) -> tuple[str, dict[str, Any]] | None: ...
 
 
+@dataclass(frozen=True)
+class ToolAction:
+    """A model-selected OpenReward tool call."""
+
+    name: str
+    input: dict[str, Any]
+    call_id: str | None = None
+    raw_response: Any | None = None
+
+
+@dataclass(frozen=True)
+class OpenRewardSessionContext:
+    """Live OpenReward handles opened together for one hosted-env task."""
+
+    session: Any
+    client: Any | None = None
+    task: Any | None = None
+    environment: Any | None = None
+
+
 class ScriptedPolicy:
     """Deterministic, schema-driven policy — no LLM in the loop.
 
@@ -153,18 +175,30 @@ class ScriptedPolicy:
 
 
 class ModelPolicy:
-    """Seam for a real LLM-driven policy (PR3+).
+    """LLM-driven OpenReward policy.
 
-    Not implemented offline. A future change wires a BenchFlow agent / model
-    endpoint here: read ``prompt_text`` + ``tools`` (already provider-formatted
-    via ``session.list_tools(format=...)``), ask the model for a tool call, and
-    map its response to ``(tool_name, input)``. Kept as an explicit class so the
-    driver's policy seam is visible and the scripted path stays the only thing
-    shipped in PR2.
+    The policy owns model-side tool selection only. The driver still owns
+    environment execution: this class returns ``(tool_name, input)`` and the
+    run loop calls ``session.call_tool(...)``.
     """
 
-    def __init__(self, model: str) -> None:
+    def __init__(
+        self,
+        model: str,
+        *,
+        max_tokens: int = 1024,
+        temperature: float = 0.0,
+    ) -> None:
+        if not model:
+            raise HostedEnvError("--model is required for OpenReward ModelPolicy")
         self.model = model
+        self.max_tokens = max_tokens
+        self.temperature = temperature
+        self.tool_format = _tool_format_for_model(model)
+        self._transcript: list[str] = []
+        self._last_observation_step: int | None = None
+        self.last_action: ToolAction | None = None
+        self.last_model_response: Any | None = None
 
     def act(
         self,
@@ -173,10 +207,47 @@ class ModelPolicy:
         last_output: Any | None,
         step: int,
     ) -> tuple[str, dict[str, Any]] | None:
-        raise NotImplementedError(
-            "ModelPolicy is a seam for a real LLM agent and is not wired yet "
-            "(PR3+). Use ScriptedPolicy for offline runs."
+        if not tools:
+            return None
+        self._update_transcript(prompt_text, last_output, step)
+        action = _call_model_for_tool_action(
+            model=self.model,
+            prompt="\n\n".join(self._transcript),
+            tools=tools,
+            max_tokens=self.max_tokens,
+            temperature=self.temperature,
         )
+        self.last_action = action
+        self.last_model_response = action.raw_response
+        self._transcript.append(
+            f"Action {step + 1}: call {action.name} with "
+            f"{json.dumps(action.input, sort_keys=True)}"
+        )
+        return action.name, action.input
+
+    def _update_transcript(
+        self,
+        prompt_text: str,
+        last_output: Any | None,
+        step: int,
+    ) -> None:
+        if not self._transcript:
+            self._transcript.append(f"Task:\n{prompt_text}")
+            self._transcript.append(
+                "You are controlling an OpenReward environment. Select exactly "
+                "one available tool call for the next step. Do not answer in prose."
+            )
+        if last_output is None or self._last_observation_step == step:
+            return
+        observation = _tool_output_to_text(last_output)
+        reward = _read_attr(last_output, "reward")
+        finished = _read_attr(last_output, "finished", False)
+        self._transcript.append(
+            "Observation from previous tool call:\n"
+            f"{observation or '<no text output>'}\n"
+            f"reward={reward!r}, finished={finished!r}"
+        )
+        self._last_observation_step = step
 
 
 def _prompt_to_text(prompt: Any) -> str:
@@ -219,6 +290,399 @@ def _read_attr(obj: Any, name: str, default: Any = None) -> Any:
     return getattr(obj, name, default)
 
 
+def _strip_known_provider_prefix(model: str) -> str:
+    if "/" not in model:
+        return model
+    provider, bare = model.split("/", 1)
+    if provider in {"openai", "anthropic", "google", "gemini", "openrouter"}:
+        return bare
+    return model
+
+
+def _is_openai_model(model: str) -> bool:
+    return model.startswith(("openai/", "gpt-", "o1", "o3", "o4"))
+
+
+def _tool_format_for_model(model: str) -> str:
+    if _is_openai_model(model):
+        return "openai"
+    if model.startswith(("anthropic/", "claude-")):
+        raise HostedEnvError(
+            "OpenReward ModelPolicy currently supports OpenAI Responses models "
+            f"only; got {model!r}."
+        )
+    if model.startswith(("google/", "gemini/", "gemini")):
+        raise HostedEnvError(
+            "OpenReward ModelPolicy currently supports OpenAI Responses models "
+            f"only; got {model!r}."
+        )
+    raise HostedEnvError(
+        "OpenReward ModelPolicy could not infer a supported provider for "
+        f"model {model!r}; use an OpenAI model such as gpt-5.4-mini."
+    )
+
+
+def _openreward_tool_name(tool: Any) -> str:
+    if isinstance(tool, dict):
+        function = tool.get("function")
+        if isinstance(function, dict) and function.get("name") is not None:
+            return str(function["name"])
+        return str(tool.get("name") or "")
+    return str(getattr(tool, "name", ""))
+
+
+def _openreward_tool_description(tool: Any) -> str:
+    if isinstance(tool, dict):
+        function = tool.get("function")
+        if isinstance(function, dict) and function.get("description") is not None:
+            return str(function["description"])
+        return str(tool.get("description") or "")
+    return str(getattr(tool, "description", "") or "")
+
+
+def _openreward_tool_parameters(tool: Any) -> dict[str, Any]:
+    schema: Any
+    if isinstance(tool, dict):
+        function = tool.get("function")
+        if isinstance(function, dict):
+            schema = function.get("parameters") or function.get("input_schema")
+        else:
+            schema = tool.get("parameters") or tool.get("input_schema")
+    else:
+        schema = getattr(tool, "parameters", None) or getattr(tool, "input_schema", None)
+    if isinstance(schema, dict):
+        return schema
+    return {"type": "object", "properties": {}, "additionalProperties": True}
+
+
+def _tools_to_openai_responses(tools: list[Any]) -> list[dict[str, Any]]:
+    converted: list[dict[str, Any]] = []
+    for tool in tools:
+        name = _openreward_tool_name(tool)
+        if not name:
+            continue
+        converted.append(
+            {
+                "type": "function",
+                "name": name,
+                "description": _openreward_tool_description(tool),
+                "parameters": _openreward_tool_parameters(tool),
+            }
+        )
+    if not converted:
+        raise HostedEnvError("OpenReward environment did not expose any named tools")
+    return converted
+
+
+def _call_model_for_tool_action(
+    *,
+    model: str,
+    prompt: str,
+    tools: list[Any],
+    max_tokens: int,
+    temperature: float,
+) -> ToolAction:
+    if _is_openai_model(model):
+        return _call_openai_responses_tool_action(
+            model=model,
+            prompt=prompt,
+            tools=tools,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+    raise HostedEnvError(f"Unsupported OpenReward ModelPolicy model: {model}")
+
+
+def _call_openai_responses_tool_action(
+    *,
+    model: str,
+    prompt: str,
+    tools: list[Any],
+    max_tokens: int,
+    temperature: float,
+) -> ToolAction:
+    try:
+        import openai
+    except ImportError as exc:
+        raise HostedEnvError(
+            "OpenAI SDK is required for OpenReward ModelPolicy with "
+            f"model {model!r}. Install the OpenAI dependency."
+        ) from exc
+
+    client = openai.OpenAI()
+    response = client.responses.create(
+        model=_strip_known_provider_prefix(model),
+        instructions=(
+            "You are an agent inside an OpenReward environment. Use exactly one "
+            "tool call. Do not return a plain text answer."
+        ),
+        input=prompt,
+        tools=_tools_to_openai_responses(tools),
+        tool_choice="required",
+        max_output_tokens=max_tokens,
+        temperature=temperature,
+        parallel_tool_calls=False,
+    )
+    action = _parse_openai_responses_tool_action(response)
+    return ToolAction(
+        name=action.name,
+        input=action.input,
+        call_id=action.call_id,
+        raw_response=response,
+    )
+
+
+def _parse_openai_responses_tool_action(response: Any) -> ToolAction:
+    output = _read_attr(response, "output", [])
+    if not isinstance(output, list):
+        raise HostedEnvError("OpenAI response did not contain an output list")
+    for item in output:
+        item_type = _read_attr(item, "type")
+        if item_type != "function_call":
+            continue
+        name = _read_attr(item, "name")
+        raw_arguments = _read_attr(item, "arguments", "{}")
+        call_id = _read_attr(item, "call_id")
+        if not isinstance(name, str) or not name:
+            raise HostedEnvError("OpenAI function_call output is missing a tool name")
+        try:
+            arguments = json.loads(raw_arguments or "{}")
+        except json.JSONDecodeError as exc:
+            raise HostedEnvError(
+                f"OpenAI function_call arguments for {name!r} were not valid JSON"
+            ) from exc
+        if not isinstance(arguments, dict):
+            raise HostedEnvError(
+                f"OpenAI function_call arguments for {name!r} must be a JSON object"
+            )
+        return ToolAction(
+            name=name,
+            input=arguments,
+            call_id=str(call_id) if call_id else None,
+        )
+    raise HostedEnvError("OpenAI model did not return a function_call tool action")
+
+
+def _policy_tool_format(policy: Policy) -> str | None:
+    value = getattr(policy, "tool_format", None)
+    return str(value) if value else None
+
+
+class _NoopOpenRewardRolloutRecorder:
+    recording_info: dict[str, Any] | None = None
+
+    def log_prompt(self, prompt_text: str) -> None:
+        return
+
+    def log_model_response(self, response: Any, *, step: int) -> bool:
+        return False
+
+    def log_tool_call(
+        self,
+        *,
+        name: str,
+        tool_input: dict[str, Any],
+        call_id: str,
+        step: int,
+    ) -> None:
+        return
+
+    def log_tool_output(
+        self,
+        output: Any,
+        *,
+        call_id: str,
+        step: int,
+    ) -> None:
+        return
+
+
+class _OpenRewardRolloutRecorder:
+    """Best-effort mirror of the BenchFlow loop into OpenReward runs."""
+
+    def __init__(self, rollout: Any) -> None:
+        self._rollout = rollout
+        rollout_id = str(getattr(rollout, "event_id", "") or "")
+        web_base_url = str(getattr(rollout, "web_base_url", "") or "")
+        if not web_base_url:
+            web_base_url = "https://openreward.ai"
+        self.recording_info = {
+            "rollout_id": rollout_id or None,
+            "url": f"{web_base_url.rstrip('/')}/rollout/{rollout_id}"
+            if rollout_id
+            else None,
+        }
+
+    @classmethod
+    def create(
+        cls,
+        opened: Any,
+        *,
+        config: HostedEnvRunConfig,
+        run_dir: Path,
+        split: str,
+        index: int,
+        normalized_model: str,
+    ) -> _OpenRewardRolloutRecorder | _NoopOpenRewardRolloutRecorder:
+        client = getattr(opened, "client", None)
+        rollout_api = getattr(client, "rollout", None)
+        create = getattr(rollout_api, "create", None)
+        if not callable(create):
+            return _NoopOpenRewardRolloutRecorder()
+
+        run_info = _openreward_run_info(
+            normalized_model=normalized_model,
+            model=config.model,
+        )
+        metadata = {
+            "benchflow_run_dir": str(run_dir),
+            "benchflow_model": config.model,
+            "benchflow_normalized_model": normalized_model,
+            "benchflow_source_env": config.source_env.env_uid,
+            "benchflow_task_index": index,
+        }
+        rollout = create(
+            run_name=str(
+                config.env_args.get("openreward_run_name")
+                or config.env_args.get("run_name")
+                or "benchflow-openreward"
+            ),
+            rollout_name=str(config.env_args.get("rollout_name") or run_dir.name),
+            environment=config.source_env.env_id,
+            variant=_openreward_variant(config.source_env),
+            split=split,
+            metadata=metadata,
+            task_spec=_openreward_task_spec(getattr(opened, "task", None)),
+            run_info=run_info,
+            print_messages=True,
+        )
+        recorder = cls(rollout)
+        if getattr(rollout, "_rollouts_disabled", False):
+            logger.warning(
+                "openreward rollout recording is disabled; run may not appear in UI"
+            )
+        return recorder
+
+    def log_prompt(self, prompt_text: str) -> None:
+        if not prompt_text:
+            return
+        self._safe_log({"type": "user_message", "content": prompt_text})
+
+    def log_model_response(self, response: Any, *, step: int) -> bool:
+        if response is None:
+            return False
+        try:
+            self._rollout.log_openai_response(
+                response,
+                metadata={"benchflow_step": step, "benchflow_source": "model"},
+            )
+            return True
+        except Exception:
+            logger.warning("openreward rollout model log failed", exc_info=True)
+            return False
+
+    def log_tool_call(
+        self,
+        *,
+        name: str,
+        tool_input: dict[str, Any],
+        call_id: str,
+        step: int,
+    ) -> None:
+        self._safe_log(
+            {
+                "type": "tool_call",
+                "name": name,
+                "call_id": call_id,
+                "content": json.dumps(tool_input, sort_keys=True),
+            },
+            metadata={"benchflow_step": step, "benchflow_source": "benchflow"},
+        )
+
+    def log_tool_output(
+        self,
+        output: Any,
+        *,
+        call_id: str,
+        step: int,
+    ) -> None:
+        reward = _read_attr(output, "reward")
+        finished = bool(_read_attr(output, "finished", False))
+        payload = {
+            "text": _tool_output_to_text(output),
+            "reward": reward,
+            "finished": finished,
+        }
+        self._safe_log(
+            {
+                "type": "tool_result",
+                "call_id": call_id,
+                "content": json.dumps(payload, sort_keys=True),
+            },
+            reward=float(reward)
+            if isinstance(reward, (int, float)) and not isinstance(reward, bool)
+            else None,
+            is_finished=finished,
+            metadata={"benchflow_step": step, "benchflow_source": "openreward_env"},
+        )
+
+    def _safe_log(self, message: Any, **kwargs: Any) -> None:
+        try:
+            self._rollout.log(message, **kwargs)
+        except Exception:
+            logger.warning("openreward rollout log failed", exc_info=True)
+
+
+def _openreward_run_info(
+    *,
+    normalized_model: str,
+    model: str,
+) -> Any | None:
+    try:
+        from openreward.models import RunInfo
+    except ImportError:
+        return None
+    return RunInfo(
+        model_name=normalized_model or model,
+        run_type="eval",
+        framework="benchflow",
+    )
+
+
+def _openreward_variant(ref: Any) -> str | None:
+    version = getattr(ref, "version", None)
+    if version and version != "latest":
+        return str(version)
+    return None
+
+
+def _openreward_task_spec(task: Any) -> dict[str, Any] | None:
+    if task is None:
+        return None
+    if isinstance(task, dict):
+        candidate = task.get("task_spec") or task.get("spec") or task
+        return candidate if isinstance(candidate, dict) else None
+    for attr in ("task_spec", "spec", "data"):
+        candidate = getattr(task, attr, None)
+        if isinstance(candidate, dict):
+            return candidate
+    model_dump = getattr(task, "model_dump", None)
+    if callable(model_dump):
+        candidate = model_dump()
+        if isinstance(candidate, dict):
+            return candidate
+    return None
+
+
+def _opened_session(opened: Any) -> Any:
+    return getattr(opened, "session", opened)
+
+
+def _policy_last_action(policy: Any) -> ToolAction | None:
+    action = getattr(policy, "last_action", None)
+    return action if isinstance(action, ToolAction) else None
+
+
 def run_hosted_env_openreward(
     config: HostedEnvRunConfig,
     *,
@@ -257,7 +721,27 @@ def run_hosted_env_openreward(
             "name is rejected by the platform."
         )
 
-    policy = policy or ScriptedPolicy()
+    split = str(config.env_args.get("split", split))
+    try:
+        index = int(config.env_args.get("index", index))
+    except (TypeError, ValueError) as exc:
+        raise HostedEnvError(
+            f"OpenReward source-env arg 'index' must be an integer, got "
+            f"{config.env_args.get('index')!r}"
+        ) from exc
+
+    scripted_answer = config.env_args.get("answer")
+    if policy is None:
+        if scripted_answer is not None or config.env_args.get("policy") == "scripted":
+            policy = ScriptedPolicy(
+                answer=str(scripted_answer) if scripted_answer is not None else None
+            )
+        else:
+            policy = ModelPolicy(
+                config.model,
+                max_tokens=config.max_tokens,
+                temperature=config.temperature,
+            )
     run_dir = _make_run_dir(config)
     normalized_model = normalize_verifiers_model(config.model) if config.model else ""
 
@@ -267,14 +751,26 @@ def run_hosted_env_openreward(
     final_reward: float | None = None
     n_tool_calls = 0
     error: str | None = None
+    recording_info: dict[str, Any] | None = None
 
     factory = session_factory or _open_openreward_session
     try:
-        with factory(config, split, index) as session:
+        with factory(config, split, index) as opened:
+            session = _opened_session(opened)
+            recorder = _OpenRewardRolloutRecorder.create(
+                opened,
+                config=config,
+                run_dir=run_dir,
+                split=split,
+                index=index,
+                normalized_model=normalized_model,
+            )
+            recording_info = recorder.recording_info
             prompt = session.get_prompt()
             prompt_text = _prompt_to_text(prompt)
             if prompt_text:
                 prompts.append(prompt_text)
+                recorder.log_prompt(prompt_text)
                 trajectory.append(
                     {
                         "type": "user_message",
@@ -282,7 +778,7 @@ def run_hosted_env_openreward(
                         "content": prompt_text,
                     }
                 )
-            tools = list(session.list_tools())
+            tools = list(session.list_tools(format=_policy_tool_format(policy)))
 
             last_output: Any | None = None
             for step in range(max_steps):
@@ -290,9 +786,26 @@ def run_hosted_env_openreward(
                 if action is None:
                     break
                 tool_name, tool_input = action
+                last_action = _policy_last_action(policy)
+                call_id = (
+                    last_action.call_id
+                    if last_action is not None and last_action.call_id
+                    else f"benchflow-step-{step}"
+                )
+                if not recorder.log_model_response(
+                    getattr(policy, "last_model_response", None),
+                    step=step,
+                ):
+                    recorder.log_tool_call(
+                        name=tool_name,
+                        tool_input=tool_input,
+                        call_id=call_id,
+                        step=step,
+                    )
                 output = session.call_tool(tool_name, tool_input)
                 n_tool_calls += 1
                 last_output = output
+                recorder.log_tool_output(output, call_id=call_id, step=step)
 
                 ts = datetime.now(UTC).isoformat()
                 trajectory.append(
@@ -351,6 +864,7 @@ def run_hosted_env_openreward(
         split=split,
         index=index,
         error=error,
+        recording_info=recording_info,
     )
     return result
 
@@ -392,8 +906,10 @@ class _OpenRewardSessionCtx:
         self._index = index
         self._client: Any = None
         self._session_cm: Any = None
+        self._environment: Any = None
+        self._task: Any = None
 
-    def __enter__(self) -> Any:
+    def __enter__(self) -> OpenRewardSessionContext:
         import openreward
 
         api_key = next(
@@ -406,10 +922,17 @@ class _OpenRewardSessionCtx:
             )
         self._client = openreward.OpenReward(api_key=api_key)
         try:
-            env = self._client.environments.get(self._config.source_env.env_id)
-            task = env.get_task(self._split, self._index)
-            self._session_cm = env.session(task=task)
-            return self._session_cm.__enter__()
+            self._environment = self._client.environments.get(
+                self._config.source_env.env_id
+            )
+            self._task = self._environment.get_task(self._split, self._index)
+            self._session_cm = self._environment.session(task=self._task)
+            return OpenRewardSessionContext(
+                session=self._session_cm.__enter__(),
+                client=self._client,
+                task=self._task,
+                environment=self._environment,
+            )
         except Exception:
             self._close_client()
             raise
@@ -477,6 +1000,7 @@ def _write_openreward_artifacts(
     split: str,
     index: int,
     error: str | None,
+    recording_info: dict[str, Any] | None = None,
 ) -> None:
     """Write the BenchFlow rollout artifact contract for an openreward run.
 
@@ -547,6 +1071,10 @@ def _write_openreward_artifacts(
 
     if rewards:
         _write_hosted_rewards_jsonl(run_dir, rewards, finished_at)
+    if recording_info:
+        (run_dir / "artifacts" / "openreward_rollout.json").write_text(
+            json.dumps(recording_info, indent=2)
+        )
 
     # Canonical Reward-plane artifacts — reuse the shared writers so the schema
     # never drifts from native rollouts.

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -1,9 +1,76 @@
 """Trajectory types — raw LLM API request/response pairs captured by proxy."""
 
+import re
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+_REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"sk-ant-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
+    (re.compile(r"sk-proj-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
+    (re.compile(r"sk-[a-zA-Z0-9]{12,}"), "***REDACTED***"),
+    (re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"), "***REDACTED***"),
+    (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])"), "***REDACTED***"),
+    (re.compile(r"dtn_[A-Za-z0-9_]{16,}"), "***REDACTED***"),
+    (re.compile(r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "***REDACTED***"),
+    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "***REDACTED***"),
+    (
+        re.compile(
+            r'((?:"?(?:x-api-key|x-goog-api-key|api-key)"?)\s*[:=]\s*"?)'
+            r'[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+    (
+        re.compile(r'("?api_key"?\s*[:=]\s*"?)[^"\s,}\\*]+', re.IGNORECASE),
+        r"\1***REDACTED***",
+    ),
+    (
+        re.compile(
+            r'("?[A-Za-z0-9_]*(?:TOKEN|SECRET)"?\s*[:=]\s*"?)[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+    (
+        re.compile(
+            r"(?<![A-Za-z0-9_-])"
+            r'("?authorization"?\s*[:=]\s*"?(?:Bearer|Token|Basic|ApiKey)\s+)'
+            r'[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+    (
+        re.compile(
+            r"(?<![A-Za-z0-9_-])"
+            r'("?authorization"?\s*[:=]\s*"?)'
+            r"(?!(?:Bearer|Token|Basic|ApiKey)\b)"
+            r'[^"\s,}\\*]+',
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+]
+
+
+def redact_trajectory_text(text: str) -> str:
+    """Apply trajectory secret-redaction patterns to raw text."""
+    for pattern, replacement in _REDACTION_PATTERNS:
+        text = pattern.sub(replacement, text)
+    return text
+
+
+def redact_acp_trajectory_jsonl(trajectory: list[dict[str, Any]]) -> str:
+    """Serialize an ACP trajectory list to redacted JSONL."""
+    import json
+
+    return "\n".join(
+        redact_trajectory_text(json.dumps(event, default=str)) for event in trajectory
+    )
 
 
 class LLMRequest(BaseModel):
@@ -152,28 +219,12 @@ class Trajectory(BaseModel):
     def to_jsonl(self, *, redact_keys: bool = True) -> str:
         """Export as JSONL (one exchange per line)."""
         import json
-        import re
 
         lines = []
         for ex in self.exchanges:
             data = ex.model_dump(mode="json")
             raw = json.dumps(data, default=str)
             if redact_keys:
-                raw = re.sub(
-                    r"(sk-ant-[a-zA-Z0-9_-]{10})[a-zA-Z0-9_-]+",
-                    r"\1***REDACTED***",
-                    raw,
-                )
-                raw = re.sub(
-                    r"(sk-[a-zA-Z0-9]{10})[a-zA-Z0-9]+",
-                    r"\1***REDACTED***",
-                    raw,
-                )
-                raw = re.sub(
-                    r'("authorization"\s*:\s*"Bearer\s+)[^"]+(")',
-                    r"\1***REDACTED***\2",
-                    raw,
-                    flags=re.IGNORECASE,
-                )
+                raw = redact_trajectory_text(raw)
             lines.append(raw)
         return "\n".join(lines)

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -15,9 +15,16 @@ import json
 import math
 from pathlib import Path
 
+import pytest
+
 from benchflow._types import Role, Scene, Turn
 from benchflow.adapters.inspect_ai import InspectAdapter, to_inspect_task
-from benchflow.adapters.ors import ORSAdapter, to_ors_reward
+from benchflow.adapters.ors import (
+    ORSAdapter,
+    ors_tool_outputs_to_reward_events,
+    to_ors_reward,
+    write_ors_tool_outputs_jsonl,
+)
 from benchflow.rewards.events import RewardEvent
 from benchflow.rewards.protocol import VerifyResult
 from benchflow.rewards.rubric import Rubric
@@ -240,6 +247,121 @@ class TestORSAdapter:
             ("reasoning", "step"),
             ("memory", "step"),
         ]
+
+    def test_tool_outputs_to_reward_events(self) -> None:
+        """Guards PR #684: ORS tool rewards become verifier evidence records."""
+        records = ORSAdapter.tool_outputs_to_reward_events(
+            [
+                {
+                    "tool": "tool-call-check",
+                    "reward": 0.25,
+                    "step": 1,
+                    "tool_call_id": "call-1",
+                    "timestamp": "2026-06-05T00:00:00Z",
+                },
+                {
+                    "tool": "ors-terminal",
+                    "reward": {"reward": 0.88},
+                    "step": 2,
+                    "finished": True,
+                    "toolCallId": "call-2",
+                },
+            ]
+        )
+
+        assert records == [
+            {
+                "type": "dense",
+                "reward": 0.25,
+                "source": "tool-call-check",
+                "step": 1,
+                "space": "action",
+                "granularity": "step",
+                "timestamp": "2026-06-05T00:00:00Z",
+                "tool_call_id": "call-1",
+            },
+            {
+                "type": "terminal",
+                "reward": 0.88,
+                "source": "ors-terminal",
+                "step": 2,
+                "space": "output",
+                "granularity": "terminal",
+                "tool_call_id": "call-2",
+                "finished": True,
+            },
+        ]
+
+    def test_write_tool_outputs_jsonl(self, tmp_path: Path) -> None:
+        """Guards PR #684: runtime helper writes the ors-episode artifact."""
+        output_path = tmp_path / "trajectory" / "ors-rewards.jsonl"
+
+        records = write_ors_tool_outputs_jsonl(
+            [
+                {"tool": "search", "reward": 0.2},
+                {"tool": "submit", "reward": 0.8, "done": True},
+            ],
+            output_path,
+        )
+
+        assert output_path.exists()
+        assert [
+            json.loads(line) for line in output_path.read_text().splitlines()
+        ] == records
+        assert records[-1]["type"] == "terminal"
+        assert records[-1]["finished"] is True
+
+    def test_tool_outputs_reject_invalid_rewards(self) -> None:
+        """Guards PR #684: runtime ORS evidence fails closed."""
+        for output in (
+            {"reward": -0.1},
+            {"reward": 1.1},
+            {"reward": float("nan")},
+            {"reward": "not-a-number"},
+        ):
+            with pytest.raises(ValueError, match="reward"):
+                ORSAdapter.tool_outputs_to_reward_events([output])
+
+    def test_tool_output_convenience_function(self) -> None:
+        records = ors_tool_outputs_to_reward_events(
+            [{"tool": "submit", "result": {"reward": 0.7}, "finished": True}]
+        )
+        assert records == [
+            {
+                "type": "terminal",
+                "reward": 0.7,
+                "source": "submit",
+                "step": 1,
+                "space": "output",
+                "granularity": "terminal",
+                "finished": True,
+            }
+        ]
+
+    def test_finished_record_is_never_dense_terminal_contradiction(self) -> None:
+        """Guards PR #684: finished records are forced terminal/terminal."""
+        records = ORSAdapter.tool_outputs_to_reward_events(
+            [{"tool": "submit", "reward": 0.9, "finished": True}]
+        )
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["type"] == "terminal"
+        assert rec["granularity"] == "terminal"
+        assert not (rec["type"] == "dense" and rec["granularity"] == "terminal")
+
+    def test_finished_with_explicit_dense_type_is_rejected(self) -> None:
+        """Guards PR #684: finished records cannot be explicitly dense."""
+        with pytest.raises(ValueError, match=r"finished.*non-terminal type"):
+            ORSAdapter.tool_outputs_to_reward_events(
+                [{"tool": "submit", "reward": 0.9, "type": "dense", "finished": True}]
+            )
+
+    def test_finished_with_explicit_step_granularity_is_rejected(self) -> None:
+        """Guards PR #684: finished records cannot be explicitly step-level."""
+        with pytest.raises(ValueError, match=r"finished.*non-terminal granularity"):
+            ORSAdapter.tool_outputs_to_reward_events(
+                [{"tool": "submit", "reward": 0.9, "granularity": "step", "done": True}]
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_hosted_env_rollout_contract.py
+++ b/tests/test_hosted_env_rollout_contract.py
@@ -47,8 +47,38 @@ def _patch_run(monkeypatch: pytest.MonkeyPatch, *, results_jsonl: str = "") -> P
     return Path(captured.get("output_dir", Path()))
 
 
+def _patch_run_custom(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stdout: str,
+    stderr: str = "",
+    returncode: int = 0,
+    results_jsonl: str = "",
+) -> None:
+    """Patch shutil.which + subprocess.run with caller-controlled vf-eval output."""
+
+    def fake_which(binary: str) -> str:
+        return f"/bin/{binary}"
+
+    def fake_run(cmd, **kwargs):
+        if str(cmd[0]).endswith("vf-eval"):
+            output_dir = Path(cmd[cmd.index("--output-dir") + 1])
+            if results_jsonl:
+                output_dir.mkdir(parents=True, exist_ok=True)
+                (output_dir / "results.jsonl").write_text(results_jsonl)
+            return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("benchflow.hosted_env.shutil.which", fake_which)
+    monkeypatch.setattr("benchflow.hosted_env.subprocess.run", fake_run)
+
+
 def _run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results_jsonl: str = ""):
     _patch_run(monkeypatch, results_jsonl=results_jsonl)
+    return _invoke(tmp_path)
+
+
+def _invoke(tmp_path: Path):
     return run_hosted_env(
         HostedEnvRunConfig(
             source_env=HostedEnvRef.parse(
@@ -61,6 +91,13 @@ def _run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, results_jsonl: str = "
             num_examples=2,
         )
     )
+
+
+def _classify(result) -> str:
+    from benchflow._utils.scoring import classify_score_outcome
+
+    payload = json.loads((result.run_dir / "result.json").read_text())
+    return classify_score_outcome(payload)
 
 
 def test_hosted_env_writes_contract_result_json(tmp_path, monkeypatch):
@@ -195,3 +232,158 @@ def test_hosted_env_keeps_raw_evidence_for_forensics(tmp_path, monkeypatch):
     assert (hosted_dir / "hosted_run.json").exists()
     assert (hosted_dir / "stdout.log").exists()
     assert (hosted_dir / "stderr.log").exists()
+
+
+# ── HOE-1: reward bounds gate (hosted evidence == native contract) ────
+
+
+def test_hosted_env_out_of_range_headline_reward_is_not_persisted(
+    tmp_path, monkeypatch
+):
+    """A reward outside [0,1] must not land as a terminal reward (native parity)."""
+    _patch_run_custom(monkeypatch, stdout="reward: avg - 4.000\n")
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["rewards"] is None
+    assert payload["error"] and "out of [0,1]" in payload["error"]
+    # The raw value is kept for forensics but never as a terminal event.
+    assert result.raw_reward == 4.0
+    rewards_path = result.run_dir / "rewards.jsonl"
+    if rewards_path.exists():
+        values = [
+            json.loads(line)["value"]
+            for line in rewards_path.read_text().splitlines()
+            if line
+        ]
+        assert all(v is None or v <= 1.0 for v in values)
+
+
+def test_hosted_env_out_of_range_rubric_score_is_not_written(tmp_path, monkeypatch):
+    """An out-of-contract per-example score (1e9) must not become a process event."""
+    results_jsonl = json.dumps({"prompt": [], "completion": [], "reward": 1e9}) + "\n"
+    _patch_run_custom(
+        monkeypatch, stdout="reward: avg - 1.000\n", results_jsonl=results_jsonl
+    )
+    result = _invoke(tmp_path)
+    rewards_path = result.run_dir / "rewards.jsonl"
+    process_values = [
+        json.loads(line)["value"]
+        for line in rewards_path.read_text().splitlines()
+        if line and json.loads(line)["type"] == "process"
+    ]
+    assert all(v <= 1.0 for v in process_values), "out-of-range score leaked"
+
+
+# ── HOE-2: aborts fail closed (errored, not failed 0.0) ───────────────
+
+
+def test_hosted_env_aborted_run_is_errored_not_zero_reward(tmp_path, monkeypatch):
+    """An all-aborted vf-eval (reward 0.0 + abort + rc 0) must classify errored."""
+    _patch_run_custom(
+        monkeypatch,
+        stdout="reward: avg - 0.000\n",
+        stderr="Aborted rollout due to NotFoundError: model not found",
+        returncode=0,
+    )
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["rewards"] is None
+    assert payload["error"] and "NotFoundError" in payload["error"]
+    assert payload["verifier_error"] and "NotFoundError" in payload["verifier_error"]
+    # No misleading terminal reward=0.0 event.
+    rewards_path = result.run_dir / "rewards.jsonl"
+    assert not rewards_path.exists()
+    assert _classify(result) == "errored"
+
+
+def test_hosted_env_genuine_zero_reward_still_fails(tmp_path, monkeypatch):
+    """A genuine 0.0 episode (no abort) keeps its terminal reward and is 'failed'."""
+    _patch_run_custom(monkeypatch, stdout="reward: avg - 0.000\n", returncode=0)
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["rewards"] == {"reward": 0.0}
+    rewards_path = result.run_dir / "rewards.jsonl"
+    terminal = [
+        json.loads(line)
+        for line in rewards_path.read_text().splitlines()
+        if line and json.loads(line)["type"] == "terminal"
+    ]
+    assert terminal and terminal[0]["value"] == 0.0
+    assert _classify(result) == "failed"
+    # The abort path and the genuine-zero path must not collapse to one bucket.
+    assert _classify(result) != "errored"
+
+
+# ── HOE-3: unparseable vf-eval output fails closed ────────────────────
+
+
+def test_hosted_env_unparseable_reward_is_flagged_as_error(tmp_path, monkeypatch):
+    """rc 0 with no reward line and no abort marker must surface a parse error."""
+    _patch_run_custom(
+        monkeypatch,
+        stdout="some new summary format with no reward line\n",
+        returncode=0,
+    )
+    result = _invoke(tmp_path)
+    payload = json.loads((result.run_dir / "result.json").read_text())
+
+    assert payload["error"] is not None
+    assert "could not parse reward" in payload["error"]
+    assert payload["rewards"] is None
+    assert _classify(result) == "errored"
+
+
+# ── HOE-4: rewards.jsonl carries space/granularity ────────────────────
+
+
+def test_hosted_env_rewards_carry_space_and_granularity(tmp_path, monkeypatch):
+    """Hosted terminal/rubric events must carry the (space, granularity) tags."""
+    results_jsonl = json.dumps({"prompt": [], "completion": [], "reward": 0.5}) + "\n"
+    _patch_run_custom(
+        monkeypatch, stdout="reward: avg - 1.000\n", results_jsonl=results_jsonl
+    )
+    result = _invoke(tmp_path)
+    events = [
+        json.loads(line)
+        for line in (result.run_dir / "rewards.jsonl").read_text().splitlines()
+        if line
+    ]
+    terminal = next(e for e in events if e["type"] == "terminal")
+    assert terminal["space"] == "output"
+    assert terminal["granularity"] == "terminal"
+    rubric = [e for e in events if e["type"] == "process"]
+    assert rubric, "expected a per-example rubric process event"
+    assert all(e["space"] == "output" for e in rubric)
+    assert all(e["granularity"] == "step" for e in rubric)
+
+
+def test_hosted_env_promotes_verifier_supplied_space_out_of_meta(tmp_path, monkeypatch):
+    """A verifier-supplied space/granularity is promoted to first-class fields."""
+    results_jsonl = (
+        json.dumps(
+            {
+                "prompt": [],
+                "completion": [],
+                "reward": 0.5,
+                "space": "memory",
+                "granularity": "step",
+            }
+        )
+        + "\n"
+    )
+    _patch_run_custom(
+        monkeypatch, stdout="reward: avg - 1.000\n", results_jsonl=results_jsonl
+    )
+    result = _invoke(tmp_path)
+    process = [
+        json.loads(line)
+        for line in (result.run_dir / "rewards.jsonl").read_text().splitlines()
+        if line and json.loads(line)["type"] == "process"
+    ]
+    assert process, "expected a per-example rubric process event"
+    # The space tag is promoted onto the event, not buried in meta.
+    assert process[0]["space"] == "memory"
+    assert "space" not in process[0]["meta"]

--- a/tests/test_openreward_env.py
+++ b/tests/test_openreward_env.py
@@ -19,8 +19,13 @@ import pytest
 
 from benchflow.hosted_env import HostedEnvError, HostedEnvRef, HostedEnvRunConfig
 from benchflow.openreward_env import (
+    ModelPolicy,
+    OpenRewardSessionContext,
     ScriptedPolicy,
+    ToolAction,
+    _parse_openai_responses_tool_action,
     _prompt_to_text,
+    _tools_to_openai_responses,
     run_hosted_env_openreward,
 )
 
@@ -64,11 +69,13 @@ class FakeSession:
         self._outputs = outputs
         self._prompt = prompt
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.list_tool_formats: list[Any] = []
 
     def get_prompt(self) -> list[FakeBlock]:
         return [FakeBlock(text=self._prompt)]
 
     def list_tools(self, format: Any = None) -> list[FakeToolSpec]:
+        self.list_tool_formats.append(format)
         return list(self._tools)
 
     def call_tool(
@@ -77,6 +84,34 @@ class FakeSession:
         self.calls.append((tool_name, dict(input or {})))
         idx = min(len(self.calls) - 1, len(self._outputs) - 1)
         return self._outputs[idx]
+
+
+class FakeRollout:
+    def __init__(self) -> None:
+        self.event_id = "rollout-test-id"
+        self.logs: list[tuple[Any, dict[str, Any]]] = []
+        self.openai_responses: list[tuple[Any, dict[str, Any]]] = []
+
+    def log(self, message, **kwargs):
+        self.logs.append((message, kwargs))
+
+    def log_openai_response(self, response, **kwargs):
+        self.openai_responses.append((response, kwargs))
+
+
+class FakeRolloutAPI:
+    def __init__(self) -> None:
+        self.rollout = FakeRollout()
+        self.create_calls: list[dict[str, Any]] = []
+
+    def create(self, **kwargs):
+        self.create_calls.append(kwargs)
+        return self.rollout
+
+
+class FakeOpenRewardClient:
+    def __init__(self) -> None:
+        self.rollout = FakeRolloutAPI()
 
 
 def _factory(session: FakeSession):
@@ -93,6 +128,129 @@ def _config(tmp_path: Path) -> HostedEnvRunConfig:
         model="claude-haiku-4-5",
         jobs_dir=tmp_path,
     )
+
+
+def test_openai_tool_schema_normalizes_openreward_tools() -> None:
+    """Milestone 2: OpenReward tools become OpenAI Responses tools."""
+    tools = _tools_to_openai_responses(
+        [
+            FakeToolSpec(
+                name="submit_answer",
+                description="Submit a flag",
+                input_schema={
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                },
+            ),
+            {
+                "type": "function",
+                "function": {
+                    "name": "inspect_file",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"path": {"type": "string"}},
+                    },
+                },
+            },
+        ]
+    )
+
+    assert tools == [
+        {
+            "type": "function",
+            "name": "submit_answer",
+            "description": "Submit a flag",
+            "parameters": {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+        },
+        {
+            "type": "function",
+            "name": "inspect_file",
+            "description": "Read a file",
+            "parameters": {
+                "type": "object",
+                "properties": {"path": {"type": "string"}},
+            },
+        },
+    ]
+
+
+def test_parse_openai_responses_function_call() -> None:
+    """Milestone 2: OpenAI Responses function_call becomes a ToolAction."""
+
+    @dataclass
+    class FakeOutput:
+        type: str
+        name: str
+        arguments: str
+
+    @dataclass
+    class FakeResponse:
+        output: list[FakeOutput]
+
+    action = _parse_openai_responses_tool_action(
+        FakeResponse(
+            output=[
+                FakeOutput(
+                    type="function_call",
+                    name="submit_answer",
+                    arguments='{"answer": "flag{ok}"}',
+                )
+            ]
+        )
+    )
+
+    assert action == ToolAction("submit_answer", {"answer": "flag{ok}"})
+
+
+def test_parse_openai_responses_rejects_bad_arguments() -> None:
+    """Milestone 2: invalid model tool-call JSON is actionable."""
+
+    @dataclass
+    class FakeOutput:
+        type: str = "function_call"
+        name: str = "submit_answer"
+        arguments: str = "{not-json"
+
+    @dataclass
+    class FakeResponse:
+        output: list[FakeOutput]
+
+    with pytest.raises(HostedEnvError, match="not valid JSON"):
+        _parse_openai_responses_tool_action(FakeResponse(output=[FakeOutput()]))
+
+
+def test_model_policy_uses_model_action_helper(monkeypatch) -> None:
+    """Milestone 2: ModelPolicy returns the model-selected tool action."""
+    seen: dict[str, object] = {}
+
+    def fake_call_model_for_tool_action(**kwargs):
+        seen.update(kwargs)
+        return ToolAction("submit_answer", {"answer": "flag{model}"})
+
+    monkeypatch.setattr(
+        "benchflow.openreward_env._call_model_for_tool_action",
+        fake_call_model_for_tool_action,
+    )
+
+    policy = ModelPolicy("gpt-5.4-mini", max_tokens=17, temperature=0.2)
+    action = policy.act(
+        "Find the flag.",
+        [FakeToolSpec(name="submit_answer")],
+        None,
+        0,
+    )
+
+    assert action == ("submit_answer", {"answer": "flag{model}"})
+    assert seen["model"] == "gpt-5.4-mini"
+    assert seen["max_tokens"] == 17
+    assert seen["temperature"] == 0.2
+    assert "Find the flag." in str(seen["prompt"])
 
 
 def test_loop_drives_to_finished_and_maps_reward(tmp_path):
@@ -112,6 +270,129 @@ def test_loop_drives_to_finished_and_maps_reward(tmp_path):
     assert result.reward == 1.0
     assert result.total_tool_calls == 1
     assert result.error is None
+
+
+def test_env_args_can_drive_scripted_smoke_answer_and_task_selector(tmp_path):
+    session = FakeSession(
+        tools=[FakeToolSpec(name="submit_answer")],
+        outputs=[
+            FakeToolOutput(blocks=[FakeBlock("submitted")], reward=0.0, finished=True)
+        ],
+    )
+    seen: dict[str, object] = {}
+
+    @contextmanager
+    def factory(config, split, index):
+        seen["split"] = split
+        seen["index"] = index
+        yield session
+
+    config = _config(tmp_path)
+    config.env_args.update({"split": "validation", "index": 3, "answer": "dummy"})
+    result = run_hosted_env_openreward(config, session_factory=factory)
+
+    assert seen == {"split": "validation", "index": 3}
+    assert session.calls == [("submit_answer", {"answer": "dummy"})]
+    assert result.reward == 0.0
+
+
+def test_default_policy_is_model_policy_and_requests_openai_tools(
+    tmp_path, monkeypatch
+):
+    """Milestone 3: default OpenReward execution uses ModelPolicy."""
+    session = FakeSession(
+        tools=[FakeToolSpec(name="submit_answer")],
+        outputs=[
+            FakeToolOutput(blocks=[FakeBlock("submitted")], reward=1.0, finished=True)
+        ],
+    )
+
+    def fake_call_model_for_tool_action(**kwargs):
+        assert kwargs["model"] == "gpt-5.4-mini"
+        assert kwargs["tools"]
+        return ToolAction("submit_answer", {"answer": "flag{model}"})
+
+    monkeypatch.setattr(
+        "benchflow.openreward_env._call_model_for_tool_action",
+        fake_call_model_for_tool_action,
+    )
+    config = HostedEnvRunConfig(
+        source_env=HostedEnvRef.parse("openreward:GeneralReasoning/KellyBench"),
+        model="gpt-5.4-mini",
+        jobs_dir=tmp_path,
+    )
+
+    result = run_hosted_env_openreward(config, session_factory=_factory(session))
+
+    assert session.list_tool_formats == ["openai"]
+    assert session.calls == [("submit_answer", {"answer": "flag{model}"})]
+    assert result.reward == 1.0
+    assert result.total_tool_calls == 1
+
+
+def test_live_context_creates_openreward_rollout_recording(tmp_path, monkeypatch):
+    """Milestone 3: OpenReward platform rollout recording is created."""
+    session = FakeSession(
+        tools=[FakeToolSpec(name="submit_answer")],
+        outputs=[
+            FakeToolOutput(blocks=[FakeBlock("submitted")], reward=1.0, finished=True)
+        ],
+    )
+    client = FakeOpenRewardClient()
+
+    @dataclass
+    class FakeModelResponse:
+        output: list[Any] = field(default_factory=list)
+
+    response = FakeModelResponse()
+
+    def fake_call_model_for_tool_action(**kwargs):
+        return ToolAction(
+            "submit_answer",
+            {"answer": "flag{model}"},
+            call_id="call_123",
+            raw_response=response,
+        )
+
+    @contextmanager
+    def factory(config, split, index):
+        yield OpenRewardSessionContext(
+            session=session,
+            client=client,
+            task={"task_spec": {"id": "task-0"}},
+        )
+
+    monkeypatch.setattr(
+        "benchflow.openreward_env._call_model_for_tool_action",
+        fake_call_model_for_tool_action,
+    )
+    config = HostedEnvRunConfig(
+        source_env=HostedEnvRef.parse("openreward:GeneralReasoning/KellyBench"),
+        model="gpt-5.4-mini",
+        jobs_dir=tmp_path,
+    )
+
+    result = run_hosted_env_openreward(config, session_factory=factory)
+
+    assert result.reward == 1.0
+    assert client.rollout.create_calls
+    create_call = client.rollout.create_calls[0]
+    assert create_call["run_name"] == "benchflow-openreward"
+    assert create_call["environment"] == "GeneralReasoning/KellyBench"
+    assert create_call["split"] == "train"
+    assert create_call["task_spec"] == {"id": "task-0"}
+    assert client.rollout.rollout.openai_responses == [
+        (response, {"metadata": {"benchflow_step": 0, "benchflow_source": "model"}})
+    ]
+    assert any(
+        message.get("type") == "tool_result"
+        and message.get("call_id") == "call_123"
+        for message, _kwargs in client.rollout.rollout.logs
+    )
+    recording = json.loads(
+        (result.run_dir / "artifacts" / "openreward_rollout.json").read_text()
+    )
+    assert recording["rollout_id"] == "rollout-test-id"
 
 
 def test_loop_continues_until_finished(tmp_path):

--- a/tests/test_trajectory_redaction.py
+++ b/tests/test_trajectory_redaction.py
@@ -1,0 +1,46 @@
+"""Trajectory secret-redaction regressions."""
+
+from __future__ import annotations
+
+from benchflow.trajectories.types import (
+    redact_acp_trajectory_jsonl,
+    redact_trajectory_text,
+)
+
+
+def test_redact_trajectory_text_removes_token_shapes() -> None:
+    """Guards PR #684: trajectory text must not retain live token prefixes."""
+    raw = (
+        "OPENAI_API_KEY=sk-proj-abcdefghijklmnopqrstuvwxyz "
+        "authorization: Bearer ghp_abcdefghijklmnopqrstuvwxyz "
+        "x-api-key: AIzaSyabcdefghijklmnopqrstuvwxyz123456"
+    )
+
+    redacted = redact_trajectory_text(raw)
+
+    assert "sk-proj-" not in redacted
+    assert "ghp_" not in redacted
+    assert "AIzaSy" not in redacted
+    assert redacted.count("***REDACTED***") == 3
+
+
+def test_redact_acp_trajectory_jsonl_scrubs_serialized_events() -> None:
+    """Guards PR #684: hosted/acp trajectory JSONL is redacted after encoding."""
+    jsonl = redact_acp_trajectory_jsonl(
+        [
+            {
+                "type": "tool_call",
+                "content": [
+                    {
+                        "text": (
+                            "curl -H 'Authorization: Bearer "
+                            "sk-ant-abcdefghijklmnopqrstuvwxyz'"
+                        )
+                    }
+                ],
+            }
+        ]
+    )
+
+    assert "sk-ant-" not in jsonl
+    assert "***REDACTED***" in jsonl

--- a/uv.lock
+++ b/uv.lock
@@ -214,6 +214,7 @@ dependencies = [
     { name = "agent-client-protocol" },
     { name = "anyio" },
     { name = "httpx" },
+    { name = "openreward" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -257,6 +258,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "modal", marker = "extra == 'sandbox-modal'", specifier = ">=0.73" },
     { name = "openai", marker = "extra == 'judge'", specifier = ">=1.40" },
+    { name = "openreward", specifier = ">=0.1.126" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -692,6 +694,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
 ]
 
 [[package]]
@@ -1279,6 +1297,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload-time = "2026-05-21T21:23:39.636Z" },
+]
+
+[[package]]
+name = "openreward"
+version = "0.1.126"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "anthropic" },
+    { name = "click" },
+    { name = "fastapi" },
+    { name = "google-genai" },
+    { name = "openai" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "sse-starlette" },
+    { name = "structlog" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/ab/5f87589b0e8e4fdd586cd4610db7e31fce6cda48e726d3cb477149e8d7e7/openreward-0.1.126.tar.gz", hash = "sha256:11c9e983f2ca16f7ea57bc3036dc14bfafb48d4345a6936581bb6a700a814083", size = 139466, upload-time = "2026-06-04T11:12:36.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/c8/30c1fdd11684c8f34a1c78a5be8e00c52ea472a82aeeb4430f4190deeadd/openreward-0.1.126-py3-none-any.whl", hash = "sha256:3a01148f566839033845da8a9d966e501bf755ead18e59ae41ef63f8fbf869a2", size = 135826, upload-time = "2026-06-04T11:12:35.368Z" },
 ]
 
 [[package]]
@@ -1871,6 +1913,40 @@ wheels = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "2.3.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/f4/989bc70cb8091eda43a9034ef969b25145291f3601703b82766e5172dfed/sse_starlette-2.3.6.tar.gz", hash = "sha256:0382336f7d4ec30160cf9ca0518962905e1b69b72d6c1c995131e0a703b436e3", size = 18284, upload-time = "2025-05-30T13:34:12.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/05/78850ac6e79af5b9508f8841b0f26aa9fd329a1ba00bf65453c2d312bcc8/sse_starlette-2.3.6-py3-none-any.whl", hash = "sha256:d49a8285b182f6e2228e2609c350398b2ca2c36216c2675d875f81e93548f760", size = 10606, upload-time = "2025-05-30T13:34:11.703Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/37/cc24e33974e1439cf5ca62b0735b63026eabb768f472d8775f52d5851ed9/starlette-1.3.0.tar.gz", hash = "sha256:bb58cbb7a699da4ee4be9ed4cdfe4bc5b0390aa6dac1d1ac714ebebe8dc3c8df", size = 2702493, upload-time = "2026-06-11T06:27:41.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/42/56d31c5ee52dab0ad893d67d4f9c00f5ba2b4c5d87f392eca2c3fdce01cf/starlette-1.3.0-py3-none-any.whl", hash = "sha256:ff4ca1bc23de6a45cdfbbeb9b3caaea524c9221cdd8a6684ad7a4f651a83890b", size = 73492, upload-time = "2026-06-11T06:27:40.444Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+]
+
+[[package]]
 name = "synchronicity"
 version = "0.12.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2006,6 +2082,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.49.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This draft PR brings the OpenReward hosted-environment work into the `v0.5-integration` line.

It was prepared from the local `port-pr-684-to-v05` branch, using `v0.5-integration` as the integration base and cherry-picking/adapting the relevant OpenReward hosted-env changes from `release/v0.6.0`.

## What changed

- Added OpenReward as a first-class hosted environment execution path.
- Added OpenReward metadata/model-policy wiring for OpenAI Responses tool calls.
- Added OpenReward rollout recording so runs appear in the OpenReward runs UI.
- Added local rollout artifact metadata at `artifacts/openreward_rollout.json`.
- Added hosted-env reward event helpers and ORS/OpenReward adapter plumbing.
- Added trajectory redaction coverage and hosted-env artifact contract tests.
- Added the `openreward` dependency and updated the lockfile.

## Validation

- `uv run pytest tests/test_openreward_env.py -q`
  - `16 passed`
- `uv run pytest tests/test_openreward_env.py tests/test_hosted_env.py tests/test_hosted_env_rollout_contract.py tests/test_adapters.py tests/test_trajectory_redaction.py -q`
  - `74 passed`
- `uv run ruff check src/benchflow/openreward_env.py tests/test_openreward_env.py`
  - `All checks passed!`
- End-to-end OpenReward smoke test:

```bash
uv run bench eval create \
  --source-env openreward:GeneralReasoning/CTF \
  --source-env-arg split=train \
  --source-env-arg index=0 \
  --model gpt-5.4-mini \
  --jobs-dir /private/tmp/benchflow-openreward-pr3
```

Result:
<img width="1424" height="1570" alt="Screenshot 2026-06-13 at 00 16 31" src="https://github.com/user-attachments/assets/4be7a978-601a-4577-af3d-9b7518a6a7fc" />
<img width="1472" height="1586" alt="Screenshot 2026-06-13 at 00 16 38" src="https://github.com/user-attachments/assets/f650ebbf-d903-453b-a8b2-c4199dc8c91d" />
<img width="1440" height="1554" alt="Screenshot 2026-06-13 at 00 16 43" src="https://github.com/user-attachments/assets/7c08ca21-e6dc-4de8-acab-1b031f9ad9d5" />


