### PR TITLE
feat(rewards): task-declared reward_range widens the [0,1] contract

### DIFF
--- a/src/benchflow/rewards/validation.py
+++ b/src/benchflow/rewards/validation.py
@@ -10,6 +10,12 @@ from typing import Any
 
 RewardValue = float | int
 RewardMap = dict[str, Any]
+RewardRange = tuple[float, float]
+
+# BenchFlow's canonical reward contract. A task may WIDEN it (never narrow or
+# shift it) by declaring ``[verifier] reward_range`` — see
+# :func:`validate_declared_reward_range`.
+DEFAULT_REWARD_RANGE: RewardRange = (0.0, 1.0)
 
 # Operator toggle for the lenient reward-map path. Default (unset/empty/``0``)
 # keeps the strict contract; any truthy value opts the classic
@@ -43,14 +49,77 @@ _STRUCTURED_REWARD_KEYS = {
 }
 
 
-def is_valid_reward_number(value: Any) -> bool:
-    """Return True for finite scalar rewards in BenchFlow's [0, 1] range."""
+def is_valid_reward_number(
+    value: Any,
+    *,
+    reward_range: RewardRange | None = None,
+) -> bool:
+    """Return True for finite scalar rewards within the task's reward range.
+
+    The default range is BenchFlow's canonical [0, 1]; a task that declares
+    ``[verifier] reward_range`` (validated at config parse by
+    :func:`validate_declared_reward_range`) widens the accepted bounds.
+    """
+    lo, hi = reward_range or DEFAULT_REWARD_RANGE
     return (
         isinstance(value, int | float)
         and not isinstance(value, bool)
         and math.isfinite(float(value))
-        and 0.0 <= float(value) <= 1.0
+        and lo <= float(value) <= hi
     )
+
+
+def validate_declared_reward_range(value: Any) -> RewardRange:
+    """Validate a task-declared ``[verifier] reward_range`` at config parse.
+
+    A declared range may only WIDEN the canonical [0, 1] contract: it must be
+    a ``[lo, hi]`` pair of finite numbers with ``lo < hi``, ``lo <= 0.0`` and
+    ``hi >= 1.0``. Widen-only keeps the canonical anchors meaningful for every
+    task — 0 ("did nothing") and 1 ("solved") stay valid rewards, so no-op and
+    oracle baselines keep scoring and a range can never silently shift or
+    narrow the contract. Safety-floor benchmarks, whose deliberate-violation
+    floor sits *below* doing nothing, declare ``reward_range = [-1.0, 1.0]``.
+    """
+    if (
+        not isinstance(value, list | tuple)
+        or len(value) != 2
+        or any(
+            isinstance(item, bool) or not isinstance(item, int | float)
+            for item in value
+        )
+    ):
+        raise ValueError("reward_range must be a [lo, hi] pair of numbers")
+    lo, hi = float(value[0]), float(value[1])
+    if not (math.isfinite(lo) and math.isfinite(hi)) or lo >= hi:
+        raise ValueError("reward_range must be finite with lo < hi")
+    if lo > 0.0 or hi < 1.0:
+        raise ValueError(
+            "reward_range may only widen the canonical [0.0, 1.0] contract "
+            "(lo <= 0.0 and hi >= 1.0)"
+        )
+    return (lo, hi)
+
+
+def reward_range_phrase(reward_range: RewardRange | None) -> str:
+    """Render the accepted bounds for error messages (default: canonical)."""
+    lo, hi = reward_range or DEFAULT_REWARD_RANGE
+    return f"between {lo} and {hi}"
+
+
+def declared_reward_range(task: Any) -> RewardRange | None:
+    """Return ``task.config.verifier.reward_range`` as a tuple, or None.
+
+    The config layer (``VerifierConfig.reward_range``) already validated a
+    real task's declaration via :func:`validate_declared_reward_range`; this
+    accessor only recognizes that validated 2-sequence shape, so Any-typed
+    task fakes (e.g. MagicMock in tests) and legacy task objects without the
+    field read as "undeclared" → the canonical [0, 1] contract.
+    """
+    verifier = getattr(getattr(task, "config", None), "verifier", None)
+    raw = getattr(verifier, "reward_range", None)
+    if isinstance(raw, list | tuple) and len(raw) == 2:
+        return (float(raw[0]), float(raw[1]))
+    return None
 
 
 def reward_lenient_from_env() -> bool:
@@ -68,10 +137,16 @@ def reward_lenient_from_env() -> bool:
     return os.environ.get(_REWARD_LENIENT_ENV, "").strip().lower() in _TRUTHY
 
 
-def _lenient_reward_alias(rewards: Mapping[str, Any]) -> str | None:
+def _lenient_reward_alias(
+    rewards: Mapping[str, Any],
+    *,
+    reward_range: RewardRange | None,
+) -> str | None:
     """Return the first legacy alias key holding a usable scalar reward."""
     for alias in _LENIENT_REWARD_ALIASES:
-        if alias in rewards and is_valid_reward_number(rewards[alias]):
+        if alias in rewards and is_valid_reward_number(
+            rewards[alias], reward_range=reward_range
+        ):
             return alias
     return None
 
@@ -106,6 +181,7 @@ def validate_reward_map(
     source: str = "verifier",
     aggregate_policy: Mapping[str, Any] | None = None,
     lenient: bool = False,
+    reward_range: RewardRange | None = None,
 ) -> RewardMap:
     """Validate and normalize a verifier reward mapping.
 
@@ -128,6 +204,13 @@ def validate_reward_map(
     ``score``/``rewards`` alias, otherwise from numeric metrics plus a declared
     aggregate policy. The operator opts in via ``BENCHFLOW_REWARD_LENIENT=1``
     (see :func:`reward_lenient_from_env`).
+
+    ``reward_range`` is the task's declared reward contract (see
+    :func:`validate_declared_reward_range`); ``None`` keeps the canonical
+    strict [0, 1]. The range applies to every reward-valued number in the map
+    — the scalar ``reward``, top-level numeric metrics, and ``metrics``
+    entries — but NOT to ``rubric`` item scores, which are normalized
+    judge-criterion scores and always stay in [0, 1].
     """
     if rewards is None:
         raise ValueError(f"{source} returned no rewards")
@@ -139,21 +222,25 @@ def validate_reward_map(
         # Operate on a copy so we can re-home a legacy alias onto ``reward``
         # and drop an unusable scalar without mutating the caller's mapping.
         mutable = dict(rewards)
-        if "reward" in mutable and not is_valid_reward_number(mutable["reward"]):
+        if "reward" in mutable and not is_valid_reward_number(
+            mutable["reward"], reward_range=reward_range
+        ):
             dropped.append("reward")
             del mutable["reward"]
         if "reward" not in mutable:
-            alias = _lenient_reward_alias(mutable)
+            alias = _lenient_reward_alias(mutable, reward_range=reward_range)
             if alias is not None:
                 mutable["reward"] = mutable.pop(alias)
         working = mutable
 
     reward = working.get("reward")
-    if "reward" in working and not is_valid_reward_number(reward):
+    if "reward" in working and not is_valid_reward_number(
+        reward, reward_range=reward_range
+    ):
         # Unreachable in lenient mode (an unusable ``reward`` is dropped above).
         raise ValueError(
             f"{source} returned rewards without numeric 'reward': "
-            "missing numeric 'reward' between 0.0 and 1.0"
+            f"missing numeric 'reward' {reward_range_phrase(reward_range)}"
         )
 
     parsed: RewardMap = {}
@@ -176,12 +263,16 @@ def validate_reward_map(
             continue
         if key == "metrics":
             if lenient:
-                metrics = _lenient_metrics(value, dropped=dropped)
+                metrics = _lenient_metrics(
+                    value, dropped=dropped, reward_range=reward_range
+                )
                 if metrics is not None:
                     parsed[key] = metrics
                     has_numeric_metric = has_numeric_metric or bool(metrics)
                 continue
-            parsed[key] = _validate_metrics(value, source=source)
+            parsed[key] = _validate_metrics(
+                value, source=source, reward_range=reward_range
+            )
             has_numeric_metric = bool(parsed[key])
             continue
         if key == "space":
@@ -220,7 +311,7 @@ def validate_reward_map(
         if key in _STRUCTURED_REWARD_KEYS:
             parsed[key] = value
             continue
-        if not is_valid_reward_number(value):
+        if not is_valid_reward_number(value, reward_range=reward_range):
             if lenient:
                 dropped.append(key)
                 continue
@@ -252,6 +343,7 @@ def _lenient_metrics(
     value: Any,
     *,
     dropped: list[str],
+    reward_range: RewardRange | None,
 ) -> dict[str, RewardValue] | None:
     """Prune a ``metrics`` mapping to numeric entries for lenient parsing.
 
@@ -265,7 +357,7 @@ def _lenient_metrics(
         return None
     kept: dict[str, RewardValue] = {}
     for key, metric in value.items():
-        if is_valid_reward_number(metric):
+        if is_valid_reward_number(metric, reward_range=reward_range):
             kept[str(key)] = metric
         else:
             dropped.append(f"metrics.{key}")
@@ -278,14 +370,20 @@ def apply_aggregate_policy(
     aggregate_policy: Mapping[str, Any] | None = None,
     source: str = "verifier",
     strict: bool = False,
+    reward_range: RewardRange | None = None,
 ) -> RewardMap:
-    """Compute canonical ``reward`` from metrics and a declared aggregate policy."""
+    """Compute canonical ``reward`` from metrics and a declared aggregate policy.
+
+    ``reward_range`` widens which metric values are aggregable and which
+    computed rewards are acceptable (default: canonical [0, 1]); see
+    :func:`validate_reward_map`.
+    """
 
     parsed = dict(rewards)
     if "reward" in parsed and not strict:
         return parsed
 
-    metrics = _aggregate_metrics(parsed)
+    metrics = _aggregate_metrics(parsed, reward_range=reward_range)
     if not metrics:
         raise ValueError(f"{source} has no metrics to aggregate into reward")
 
@@ -336,16 +434,16 @@ def apply_aggregate_policy(
         threshold=threshold,
         source=source,
     )
-    if not is_valid_reward_number(reward):
+    if not is_valid_reward_number(reward, reward_range=reward_range):
         raise ValueError(
             f"{source} aggregate policy produced invalid reward {reward!r}"
         )
     if "reward" in parsed and strict:
         existing = parsed["reward"]
-        if not is_valid_reward_number(existing):
+        if not is_valid_reward_number(existing, reward_range=reward_range):
             raise ValueError(
                 f"{source} returned rewards without numeric 'reward': "
-                "missing numeric 'reward' between 0.0 and 1.0"
+                f"missing numeric 'reward' {reward_range_phrase(reward_range)}"
             )
         if not math.isclose(float(existing), reward, abs_tol=1e-9):
             raise ValueError(
@@ -375,13 +473,18 @@ def _validate_rubric(value: Any, *, source: str) -> list[dict[str, Any]]:
     return parsed
 
 
-def _validate_metrics(value: Any, *, source: str) -> dict[str, RewardValue]:
+def _validate_metrics(
+    value: Any,
+    *,
+    source: str,
+    reward_range: RewardRange | None = None,
+) -> dict[str, RewardValue]:
     if not isinstance(value, Mapping):
         raise ValueError(f"{source} returned rewards with invalid value for 'metrics'")
 
     parsed: dict[str, RewardValue] = {}
     for key, metric in value.items():
-        if not is_valid_reward_number(metric):
+        if not is_valid_reward_number(metric, reward_range=reward_range):
             raise ValueError(
                 f"{source} returned rewards with invalid metric value for {str(key)!r}"
             )
@@ -428,19 +531,23 @@ def _validate_weight(value: Any, *, source: str, key: str) -> float | int:
     return value
 
 
-def _aggregate_metrics(rewards: Mapping[str, Any]) -> dict[str, RewardValue]:
+def _aggregate_metrics(
+    rewards: Mapping[str, Any],
+    *,
+    reward_range: RewardRange | None = None,
+) -> dict[str, RewardValue]:
     raw_metrics = rewards.get("metrics")
     if isinstance(raw_metrics, Mapping):
         return {
             str(key): metric
             for key, metric in raw_metrics.items()
-            if is_valid_reward_number(metric)
+            if is_valid_reward_number(metric, reward_range=reward_range)
         }
     metrics: dict[str, RewardValue] = {}
     for key, value in rewards.items():
         if key in {"aggregate", "reward"} | _STRUCTURED_REWARD_KEYS:
             continue
-        if is_valid_reward_number(value):
+        if is_valid_reward_number(value, reward_range=reward_range):
             metrics[str(key)] = value
     return metrics
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1192,7 +1192,9 @@ class Rollout:
                 verifier.verify(),
                 timeout=self._task.config.verifier.timeout_sec,
             )
-            rewards = _ensure_canonical_rewards(verifier_result.rewards)
+            rewards = _ensure_canonical_rewards(
+                verifier_result.rewards, task=self._task
+            )
             # Capture raw verifier output for the user
             cat = await self._env.exec(
                 "cat /logs/verifier/*.log 2>/dev/null || "

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -37,6 +37,7 @@ from benchflow.contracts import RolloutPlanes, default_rollout_planes
 from benchflow.diagnostics import VerifierTimeoutDiagnostic
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.rewards.validation import (
+    declared_reward_range,
     reward_lenient_from_env,
     validate_reward_map,
 )
@@ -428,7 +429,7 @@ async def _verify_rollout(
             timeout=timeout_budget,
         )
         timing["verifier"] = (datetime.now() - t0).total_seconds()
-        rewards = _ensure_canonical_rewards(verifier_result.rewards)
+        rewards = _ensure_canonical_rewards(verifier_result.rewards, task=task)
         logger.info(f"Rewards: {rewards}")
     except TimeoutError:
         elapsed = (datetime.now() - t0).total_seconds()
@@ -449,12 +450,16 @@ async def _verify_rollout(
     return rewards, verifier_error, verifier_timeout
 
 
-def _ensure_canonical_rewards(rewards: dict | None) -> dict:
-    # Honour the same BENCHFLOW_REWARD_LENIENT toggle as the reward.json parse
-    # path so the final canonicalization gate stays consistent with how the
-    # verifier accepted the map (no-op unless the operator opts in).
+def _ensure_canonical_rewards(rewards: dict | None, *, task: Any = None) -> dict:
+    # Honour the same BENCHFLOW_REWARD_LENIENT toggle and task-declared
+    # ``[verifier] reward_range`` (BF-8) as the reward.json parse path so the
+    # final canonicalization gate stays consistent with how the verifier
+    # accepted the map (no-op unless the operator/task opts in).
     return validate_reward_map(
-        rewards, source="verifier", lenient=reward_lenient_from_env()
+        rewards,
+        source="verifier",
+        lenient=reward_lenient_from_env(),
+        reward_range=declared_reward_range(task),
     )
 
 

--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -24,6 +24,8 @@ from pydantic import (
     model_validator,
 )
 
+from benchflow.rewards.validation import validate_declared_reward_range
+
 ORG_NAME_PATTERN = r"^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$"
 _NETWORK_HOST_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
 _ENV_VAR_NAME_PATTERN = re.compile(r"^[A-Z_][A-Z0-9_]*$")
@@ -250,6 +252,21 @@ class VerifierConfig(TaskConfigModel):
         "non-finite budgets are rejected at validation time.",
     )
     env: dict[str, str] = Field(default_factory=dict)
+    reward_range: tuple[float, float] | None = Field(
+        default=None,
+        description=(
+            "Declared [lo, hi] reward contract for this task. Omitted (None) "
+            "keeps BenchFlow's strict canonical [0.0, 1.0]. A declared range "
+            "may only WIDEN the canonical range — lo <= 0.0, hi >= 1.0, "
+            "lo < hi, both finite — so 0 ('did nothing') and 1 ('solved') "
+            "stay meaningful for every task; e.g. safety-floor benchmarks "
+            "declare reward_range = [-1.0, 1.0] to score deliberate "
+            "violations below doing nothing. Applies to the test-script "
+            "reward contract (reward.txt / reward.json scalar reward, "
+            "numeric metrics, aggregate results) and the final reward "
+            "canonicalization gate; LLM-judge rubric scores stay [0, 1]."
+        ),
+    )
     user: str | int | None = Field(
         default=None,
         description="Username or UID to run the verifier as.",
@@ -312,6 +329,15 @@ class VerifierConfig(TaskConfigModel):
     @classmethod
     def validate_allowed_hosts(cls, hosts: list[str] | None) -> list[str] | None:
         return _validate_allowed_hosts(hosts)
+
+    @field_validator("reward_range")
+    @classmethod
+    def validate_reward_range(
+        cls, value: tuple[float, float] | None
+    ) -> tuple[float, float] | None:
+        # Widen-only rule (lo <= 0.0 <= 1.0 <= hi, lo < hi, finite) lives with
+        # the reward contract in benchflow.rewards.validation.
+        return None if value is None else validate_declared_reward_range(value)
 
     @model_validator(mode="after")
     def validate_verifier_environment(self) -> VerifierConfig:

--- a/src/benchflow/task/verifier_core.py
+++ b/src/benchflow/task/verifier_core.py
@@ -27,8 +27,10 @@ from typing import Any
 
 from benchflow.rewards.validation import (
     apply_aggregate_policy,
+    declared_reward_range,
     is_valid_reward_number,
     reward_lenient_from_env,
+    reward_range_phrase,
     validate_reward_map,
 )
 from benchflow.sandbox.lockdown import _exec_return_code, clear_verifier_output_dir
@@ -108,6 +110,10 @@ class Verifier:
         self._rollout_paths = rollout_paths
         self._sandbox = sandbox
         self._logger = (_logger or logger).getChild("verifier")
+        # Task-declared ``[verifier] reward_range`` (BF-8); None keeps the
+        # canonical strict [0, 1]. Applies to the test-script reward contract
+        # (reward.txt / reward.json) — judge and ORS scores stay [0, 1].
+        self._reward_range = declared_reward_range(task)
 
     def _parse_reward_text(self) -> dict[str, float | int]:
         if self._rollout_paths.reward_text_path.stat().st_size == 0:
@@ -120,10 +126,11 @@ class Verifier:
             raise VerifierOutputParseError(
                 f"Failed to parse rewards from text file {self._rollout_paths.reward_text_path}"
             ) from e
-        if not is_valid_reward_number(reward):
+        if not is_valid_reward_number(reward, reward_range=self._reward_range):
             raise VerifierOutputParseError(
                 f"Reward text file {self._rollout_paths.reward_text_path} "
-                "must contain a finite numeric reward between 0.0 and 1.0"
+                "must contain a finite numeric reward "
+                f"{reward_range_phrase(self._reward_range)}"
             )
         return {"reward": reward}
 
@@ -155,6 +162,7 @@ class Verifier:
                 source="reward JSON",
                 aggregate_policy=aggregate_policy,
                 lenient=reward_lenient_from_env(),
+                reward_range=self._reward_range,
             )
         except ValueError as e:
             raise VerifierOutputParseError(
@@ -175,6 +183,7 @@ class Verifier:
                     aggregate_policy=aggregate_policy,
                     source="reward JSON",
                     strict=True,
+                    reward_range=self._reward_range,
                 )
             except ValueError as e:
                 raise VerifierOutputParseError(
@@ -191,6 +200,7 @@ class Verifier:
                         rewards,
                         aggregate_policy=aggregate_policy,
                         source="reward JSON",
+                        reward_range=self._reward_range,
                     )
                 except ValueError as e:
                     raise VerifierOutputParseError(
@@ -210,6 +220,7 @@ class Verifier:
                         rewards,
                         aggregate_policy=aggregate_policy,
                         source="reward JSON",
+                        reward_range=self._reward_range,
                     )
                 except ValueError as e:
                     raise VerifierOutputParseError(

--- a/tests/test_reward_range.py
+++ b/tests/test_reward_range.py
@@ -1,0 +1,284 @@
+"""Tests for BF-8: task-declared reward range (``[verifier] reward_range``).
+
+Guards the fix tracked as benchflow-ai/benchflow#675 (BF-8).
+
+skillsgym-style safety tasks floor reward at -1.0 — deliberately BELOW
+doing-nothing 0.0 — but BenchFlow's reward contract is hard-coded [0, 1] at
+every chokepoint, so unsafe runs become verifier ERRORS instead of scored
+-1.0. The fix is a task-config opt-in: ``[verifier] reward_range = [lo, hi]``
+may only WIDEN the canonical [0, 1] contract (lo <= 0.0, hi >= 1.0, lo < hi,
+finite). Undeclared tasks keep the strict [0, 1] contract byte-for-byte, and
+lenient mode (BF-3) never accepts negatives on its own.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from benchflow.rewards.validation import (
+    apply_aggregate_policy,
+    declared_reward_range,
+    validate_declared_reward_range,
+    validate_reward_map,
+)
+from benchflow.rollout import _ensure_canonical_rewards
+from benchflow.task import TaskConfig, TaskDocument
+from benchflow.task.verifier import Verifier, VerifierOutputParseError
+
+
+def _task_with_config(verifier: dict | None = None) -> MagicMock:
+    """A Verifier-shaped task fake carrying a REAL parsed TaskConfig."""
+    task = MagicMock()
+    task.config = TaskConfig.model_validate({"verifier": verifier or {}})
+    return task
+
+
+def _verifier(task: MagicMock, reward_text_path: Path) -> Verifier:
+    rollout_paths = MagicMock()
+    rollout_paths.reward_text_path = reward_text_path
+    return Verifier(task=task, rollout_paths=rollout_paths, sandbox=MagicMock())
+
+
+class TestValidateDeclaredRewardRange:
+    """The widen-only rule, enforced once at config parse."""
+
+    def test_accepts_safety_floor_range(self) -> None:
+        assert validate_declared_reward_range([-1.0, 1.0]) == (-1.0, 1.0)
+
+    def test_accepts_canonical_range_and_coerces_ints(self) -> None:
+        lo, hi = validate_declared_reward_range([0, 1])
+        assert (lo, hi) == (0.0, 1.0)
+        assert isinstance(lo, float) and isinstance(hi, float)
+
+    @pytest.mark.parametrize(
+        "value",
+        [[-1.0], [-1.0, 0.0, 1.0], "[-1.0, 1.0]", {"lo": -1.0, "hi": 1.0}, None],
+    )
+    def test_rejects_non_pair(self, value: object) -> None:
+        with pytest.raises(ValueError, match=r"\[lo, hi\] pair of numbers"):
+            validate_declared_reward_range(value)
+
+    @pytest.mark.parametrize("value", [[True, 1.0], [-1.0, "1.0"]])
+    def test_rejects_non_numeric_members(self, value: list) -> None:
+        with pytest.raises(ValueError, match=r"pair of numbers"):
+            validate_declared_reward_range(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [[float("-inf"), 1.0], [-1.0, float("nan")], [1.0, -1.0], [0.0, 0.0]],
+    )
+    def test_rejects_non_finite_or_inverted(self, value: list) -> None:
+        with pytest.raises(ValueError, match="finite with lo < hi"):
+            validate_declared_reward_range(value)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            [0.2, 0.8],  # narrowed: drops both anchors
+            [0.5, 2.0],  # shifted up: 0 ("did nothing") no longer scorable
+            [-2.0, 0.5],  # shifted down: 1 ("solved") no longer scorable
+        ],
+    )
+    def test_rejects_narrowing_or_shifting_the_contract(self, value: list) -> None:
+        with pytest.raises(ValueError, match="only widen"):
+            validate_declared_reward_range(value)
+
+
+class TestVerifierConfigParse:
+    """``reward_range`` enters via task.toml AND task.md frontmatter."""
+
+    def test_task_toml_round_trip(self) -> None:
+        config = TaskConfig.model_validate_toml(
+            "[verifier]\nreward_range = [-1.0, 1.0]\ntimeout_sec = 60\n"
+        )
+        assert config.verifier.reward_range == (-1.0, 1.0)
+        reparsed = TaskConfig.model_validate_toml(config.model_dump_toml())
+        assert reparsed.verifier.reward_range == (-1.0, 1.0)
+
+    def test_task_toml_undeclared_stays_none_and_is_not_serialized(self) -> None:
+        config = TaskConfig.model_validate_toml("[verifier]\ntimeout_sec = 60\n")
+        assert config.verifier.reward_range is None
+        assert "reward_range" not in config.model_dump_toml()
+
+    def test_task_md_frontmatter_round_trip(self) -> None:
+        document = TaskDocument.from_text(
+            "---\n"
+            "verifier:\n"
+            "  reward_range: [-1.0, 1.0]\n"
+            "---\n\n"
+            "## prompt\n\n"
+            "Do the thing safely.\n"
+        )
+        assert document.config.verifier.reward_range == (-1.0, 1.0)
+
+    @pytest.mark.parametrize(
+        "toml_range",
+        ["[0.2, 0.8]", "[1.0, -1.0]", "[-1.0]", "[-inf, 1.0]", '["a", 1.0]'],
+    )
+    def test_malformed_range_rejected_at_parse(self, toml_range: str) -> None:
+        with pytest.raises(ValidationError):
+            TaskConfig.model_validate_toml(f"[verifier]\nreward_range = {toml_range}\n")
+
+
+class TestValidateRewardMapRange:
+    def test_undeclared_still_rejects_negative_reward(self) -> None:
+        # The pre-BF-8 strict contract, byte-for-byte (message included).
+        with pytest.raises(ValueError, match=re.escape("between 0.0 and 1.0")):
+            validate_reward_map({"reward": -1.0}, source="reward JSON")
+
+    def test_declared_range_accepts_safety_floor(self) -> None:
+        parsed = validate_reward_map(
+            {"reward": -1.0}, source="reward JSON", reward_range=(-1.0, 1.0)
+        )
+        assert parsed == {"reward": -1.0}
+
+    def test_declared_range_still_rejects_below_floor(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("between -1.0 and 1.0")):
+            validate_reward_map(
+                {"reward": -1.5}, source="reward JSON", reward_range=(-1.0, 1.0)
+            )
+
+    def test_declared_range_widens_metrics(self) -> None:
+        with pytest.raises(ValueError, match="invalid metric value"):
+            validate_reward_map(
+                {"reward": 1.0, "metrics": {"safety_floor": -1.0}},
+                source="reward JSON",
+            )
+        parsed = validate_reward_map(
+            {"reward": -1.0, "metrics": {"safety_floor": -1.0}},
+            source="reward JSON",
+            reward_range=(-1.0, 1.0),
+        )
+        assert parsed["metrics"] == {"safety_floor": -1.0}
+
+    def test_lenient_alone_still_rejects_negative_reward(self) -> None:
+        # BF-3 lenient drops the out-of-range reward, then fails on the
+        # missing scalar — no silent contract erosion via lenient mode.
+        with pytest.raises(ValueError, match="missing numeric 'reward'"):
+            validate_reward_map({"reward": -1.0}, source="reward JSON", lenient=True)
+
+    def test_range_composes_with_lenient(self) -> None:
+        # skillsgym-shaped payload: floored reward plus a string safety
+        # verdict. Lenient drops the string key (warned, BF-3 semantics);
+        # the declared range keeps the -1.0 reward usable.
+        with pytest.warns(UserWarning, match="safety_gate"):
+            parsed = validate_reward_map(
+                {"reward": -1.0, "safety_gate": "blocked"},
+                source="reward JSON",
+                lenient=True,
+                reward_range=(-1.0, 1.0),
+            )
+        assert parsed == {"reward": -1.0}
+
+    def test_range_composes_with_lenient_alias_rehoming(self) -> None:
+        with pytest.warns(UserWarning, match="lenient mode"):
+            parsed = validate_reward_map(
+                {"score": -0.5, "done": True},
+                source="reward JSON",
+                lenient=True,
+                reward_range=(-1.0, 1.0),
+            )
+        assert parsed == {"reward": -0.5}
+
+    def test_string_safety_verdicts_survive_under_structured_keys(self) -> None:
+        # The strict-mode escape hatch for non-numeric verdicts: structured
+        # keys pass through untouched regardless of range.
+        parsed = validate_reward_map(
+            {"reward": -1.0, "details": {"safety_gate": "blocked"}},
+            source="reward JSON",
+            reward_range=(-1.0, 1.0),
+        )
+        assert parsed["details"] == {"safety_gate": "blocked"}
+
+
+class TestAggregatePolicyRange:
+    def test_aggregate_over_widened_metrics(self) -> None:
+        parsed = apply_aggregate_policy(
+            {"metrics": {"unsafe": -1.0, "safe": 1.0}},
+            aggregate_policy={"field": "reward", "method": "mean"},
+            source="reward JSON",
+            reward_range=(-1.0, 1.0),
+        )
+        assert parsed["reward"] == 0.0
+
+    def test_aggregate_without_range_filters_negative_metrics(self) -> None:
+        # Undeclared range: negative metrics are not aggregable, exactly as
+        # before BF-8.
+        with pytest.raises(ValueError):
+            apply_aggregate_policy(
+                {"metrics": {"unsafe": -1.0}},
+                aggregate_policy={"field": "reward", "method": "mean"},
+                source="reward JSON",
+            )
+
+    def test_strict_consistency_check_accepts_floored_reward(self) -> None:
+        parsed = apply_aggregate_policy(
+            {"reward": -1.0, "metrics": {"unsafe": -1.0}},
+            aggregate_policy={"field": "reward", "method": "mean"},
+            source="reward JSON",
+            strict=True,
+            reward_range=(-1.0, 1.0),
+        )
+        assert parsed["reward"] == -1.0
+
+
+class TestVerifierRewardText:
+    """The reward.txt chokepoint honors the task's declared range."""
+
+    def test_declared_range_accepts_floored_reward_txt(self, tmp_path: Path) -> None:
+        reward_txt = tmp_path / "reward.txt"
+        reward_txt.write_text("-1.0")
+        task = _task_with_config({"reward_range": [-1.0, 1.0]})
+        assert _verifier(task, reward_txt)._parse_reward_text() == {"reward": -1.0}
+
+    def test_undeclared_task_still_rejects_negative_reward_txt(
+        self, tmp_path: Path
+    ) -> None:
+        reward_txt = tmp_path / "reward.txt"
+        reward_txt.write_text("-1.0")
+        # MagicMock task: no usable declaration -> canonical [0, 1].
+        with pytest.raises(
+            VerifierOutputParseError, match=re.escape("between 0.0 and 1.0")
+        ):
+            _verifier(MagicMock(), reward_txt)._parse_reward_text()
+
+    def test_declared_range_still_bounds_reward_txt(self, tmp_path: Path) -> None:
+        reward_txt = tmp_path / "reward.txt"
+        reward_txt.write_text("-1.5")
+        task = _task_with_config({"reward_range": [-1.0, 1.0]})
+        with pytest.raises(
+            VerifierOutputParseError, match=re.escape("between -1.0 and 1.0")
+        ):
+            _verifier(task, reward_txt)._parse_reward_text()
+
+
+class TestDeclaredRewardRangeAccessor:
+    def test_real_config_task_reads_declared_range(self) -> None:
+        task = _task_with_config({"reward_range": [-1.0, 1.0]})
+        assert declared_reward_range(task) == (-1.0, 1.0)
+
+    def test_real_config_task_without_declaration_reads_none(self) -> None:
+        assert declared_reward_range(_task_with_config()) is None
+
+    @pytest.mark.parametrize("task", [None, MagicMock(), object()])
+    def test_unshaped_tasks_read_as_undeclared(self, task: object) -> None:
+        assert declared_reward_range(task) is None
+
+
+class TestRolloutFinalGate:
+    """``_ensure_canonical_rewards`` — the last chokepoint before scoring."""
+
+    def test_final_gate_honors_declared_range(self) -> None:
+        task = _task_with_config({"reward_range": [-1.0, 1.0]})
+        assert _ensure_canonical_rewards({"reward": -1.0}, task=task) == {
+            "reward": -1.0
+        }
+
+    def test_final_gate_default_stays_strict(self) -> None:
+        with pytest.raises(ValueError, match=re.escape("between 0.0 and 1.0")):
+            _ensure_canonical_rewards({"reward": -1.0})


### PR DESCRIPTION
## What

Adds an opt-in, **task-declared reward range** so a task can widen BenchFlow's
canonical `[0.0, 1.0]` reward contract:

```toml
[verifier]
reward_range = [-1.0, 1.0]
```

`VerifierConfig.reward_range` (default `None` = canonical strict `[0, 1]`)
parses from both `task.toml` and `task.md` frontmatter and threads through every
reward chokepoint.

## Why (a real framework feature, not a compat shim)

BenchFlow's reward contract is hard-coded `[0.0, 1.0]` in `is_valid_reward_number`
and enforced at every chokepoint — the verifier's `reward.txt`/`reward.json`
parse, `validate_reward_map`, `apply_aggregate_policy`, and rollout's final
`_ensure_canonical_rewards` gate. That is correct for accuracy-style benchmarks,
but **RL / safety benchmarks need sub-zero rewards**: a deliberate safety
violation should score *below* doing nothing (`0.0`), which is core to their
thesis. Today such a run becomes a verifier **ERROR** instead of a scored
negative reward, and the `[verifier]` table is `extra="forbid"` so a task cannot
even declare a wider range.

This is a general framework capability (RL/penalty benchmarks), not downstream
glue — the default is unchanged and strict.

## Design: widen-only, explicit, zero default change

- **Widen-only**, validated once at config parse by
  `validate_declared_reward_range`: `lo <= 0.0`, `hi >= 1.0`, `lo < hi`, both
  finite. This keeps the canonical anchors meaningful for *every* task — `0`
  ("did nothing") and `1` ("solved") stay valid rewards, so no-op and oracle
  baselines keep scoring and a range can never silently shift or narrow the
  contract.
- The range threads as an **explicit `reward_range` parameter** (resolved once
  per entry point via `declared_reward_range(task)`) through
  `is_valid_reward_number`, `validate_reward_map`, `apply_aggregate_policy`
  (incl. the strict consistency check), the three `Verifier` reward-parse paths,
  and rollout's `_ensure_canonical_rewards(..., task=...)` gate. No hidden
  global state; the contract is visible at every call site and consistent with
  how the existing `lenient` flag is threaded.
- **Defaults are byte-identical** — no behavior change unless a task declares a
  range. It composes with but does not imply lenient mode (lenient still never
  accepts negatives on its own). LLM-judge **rubric scores stay `[0, 1]`**
  (normalized criterion scores, not task rewards).

## Tests

`tests/test_reward_range.py` — 45 cases: declared range accepts `-1.0`;
undeclared still raises on a negative; malformed / narrowed / shifted ranges
rejected at parse; range composes with lenient and with the strict-aggregate
consistency check; `task.toml` + `task.md` round-trips; rollout final gate
honours the task-declared range.

- `pytest tests/test_reward_range.py` → **45 passed**
- sweep `-k "reward or verifier or validation or config or rollout"` →
  **1004 passed, 3 skipped**
- `ruff check` / `ruff format --check` / `ty check` clean; import smoke OK.

## Use case

Surfaced running SkillsGym's safety tasks directly on `benchflow eval create`:
they floor reward to `-1.0` on a safety violation (below doing-nothing `0.0`).
Without a declared range those runs become verifier errors instead of scored
`-1.0`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes reward validation on every verifier and rollout scoring path; default behavior is unchanged, but mis-declared ranges or edge cases in aggregate/lenient composition could affect benchmark scores for tasks that opt in.
> 
> **Overview**
> Adds an opt-in **`[verifier] reward_range`** on task config so benchmarks can **widen** BenchFlow’s default `[0, 1]` reward contract (e.g. `[-1.0, 1.0]` for safety floors below “did nothing”). Declarations are **widen-only** (`lo <= 0`, `hi >= 1`, finite, `lo < hi`), validated at parse in `VerifierConfig` via `validate_declared_reward_range`.
> 
> The declared range is threaded as an explicit `reward_range` argument through **`is_valid_reward_number`**, **`validate_reward_map`**, **`apply_aggregate_policy`**, verifier **`reward.txt` / `reward.json`** parsing, and rollout **`_ensure_canonical_rewards(..., task=...)`** (including `soft_verify`). **Undeclared tasks stay strict `[0, 1]`**; lenient mode alone still rejects negatives. **LLM-judge rubric scores remain `[0, 1]`.**
> 
> New coverage in **`tests/test_reward_range.py`** (parse round-trips, widen-only rejection, lenient composition, aggregate, final gate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b01ef283bf5cb53ffeb909c432356d40c845413. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->