### PR TITLE
fix(environment): detach manifest service starts for Daytona session execs

### DIFF
--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -41,6 +41,34 @@ from benchflow.environment.protocol import (
     StateSnapshot,
 )
 
+# Bounded guard for the detached-start exec. The start command backgrounds the
+# service and returns immediately, so this only bounds sandbox transport
+# stalls — readiness() owns how long the service may take to become healthy.
+_SERVICE_START_TIMEOUT_SEC = 15
+
+
+def service_log_path(service_name: str) -> str:
+    """In-sandbox path collecting a started service's stdout+stderr."""
+    return f"/tmp/benchflow-env-{service_name}.log"
+
+
+def service_start_command(svc: ServiceSpec) -> str:
+    """Render the fully detached background start for one manifest service.
+
+    Full fd detachment — ``nohup {cmd} </dev/null >{log} 2>&1 &`` — is
+    load-bearing on Daytona (BF-9, the same failure class as BF-6/W9):
+    Daytona runs each exec as a *session command*, and a backgrounded service
+    that inherits ANY of the session's std streams keeps the session command
+    "running", wedging the exec until its timeout — which the bounded start
+    timeout turns into a hard provision failure on Daytona while the same
+    manifest passes on Docker. The three redirections sever every inherited
+    stream and ``nohup`` survives the session's terminal HUP. No ``disown``:
+    that is a bash/zsh builtin, absent from the ``sh``/dash shell sandbox
+    execs run under. The manifest's ``command`` is a single command line and
+    is used verbatim, matching clawbench's ``_build_service_hooks`` shape.
+    """
+    return f"nohup {svc.command} </dev/null >{service_log_path(svc.name)} 2>&1 &"
+
 
 class EnvironmentSnapshotError(RuntimeError):
     """Raised when a snapshot or restore sandbox command fails (issue #387).
@@ -108,11 +136,7 @@ class ManifestEnvironment:
                 )
                 if probe.return_code != 0:
                     continue  # binary missing or its package absent — skip
-                log = f"/tmp/benchflow-env-{svc.name}.log"
-                await self._sandbox.exec(
-                    f"{svc.command} > {log} 2>&1 &",
-                    timeout_sec=15,
-                )
+                await self._start_service(svc)
                 self._started.append(svc)
         endpoints = {p: f"http://localhost:{p}" for p in m.all_ports}
         self._handle = EnvHandle(name=m.name, endpoints=endpoints)
@@ -122,6 +146,19 @@ class ManifestEnvironment:
         if m.state is not None:
             self._baseline = await self._capture_baseline()
         return self._handle
+
+    async def _start_service(self, svc: ServiceSpec) -> None:
+        """Start one service fully detached, logging to its per-service file.
+
+        Shared by ``provision`` and ``reset`` so the (Daytona-critical)
+        detachment shape lives in exactly one place — see
+        :func:`service_start_command`. The service's output is retrievable at
+        :func:`service_log_path` for its name.
+        """
+        await self._sandbox.exec(
+            service_start_command(svc),
+            timeout_sec=_SERVICE_START_TIMEOUT_SEC,
+        )
 
     async def readiness(self) -> ReadinessProbe:
         """Poll each service's health endpoint from inside the sandbox.
@@ -298,11 +335,8 @@ class ManifestEnvironment:
         if self._baseline is not None:
             await self.restore(self._baseline)
         # 3. Restart the same services we previously started, in the same
-        #    background-with-log shape provision() uses. owns_lifecycle = true
-        #    manifests reach this with an empty self._started — nothing to do.
+        #    detached background-with-log shape provision() uses.
+        #    owns_lifecycle = true manifests reach this with an empty
+        #    self._started — nothing to do.
         for svc in self._started:
-            log = f"/tmp/benchflow-env-{svc.name}.log"
-            await self._sandbox.exec(
-                f"{svc.command} > {log} 2>&1 &",
-                timeout_sec=15,
-            )
+            await self._start_service(svc)

--- a/tests/environment/test_manifest_env.py
+++ b/tests/environment/test_manifest_env.py
@@ -12,6 +12,8 @@ from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.environment.manifest_env import (
     EnvironmentSnapshotError,
     ManifestEnvironment,
+    service_log_path,
+    service_start_command,
 )
 from benchflow.environment.protocol import Environment, StateSnapshot
 from benchflow.sandbox.protocol import ExecResult
@@ -76,6 +78,8 @@ paths = ["/data/gmail.db", "/data/gcal.db"]
 class FakeSandbox:
     """Minimal Sandbox stand-in recording exec calls.
 
+    ``exec_calls`` records commands; ``exec_detail`` additionally records
+    ``(command, timeout_sec)`` pairs for exec-boundary assertions.
     ``absent_binaries`` — the `<binary> --help` detection probe returns
     non-zero for these: the service's package is not installed in this
     per-task image (a bare PATH stub, or genuinely missing).
@@ -90,6 +94,7 @@ class FakeSandbox:
         fail_health_for: str | None = None,
     ) -> None:
         self.exec_calls: list[str] = []
+        self.exec_detail: list[tuple[str, int]] = []
         self._absent = absent_binaries or set()
         self._fail_health_for = fail_health_for
         self.host = "localhost"
@@ -99,6 +104,7 @@ class FakeSandbox:
         self, cmd: str, *, user: str = "root", timeout_sec: int = 30
     ) -> ExecResult:
         self.exec_calls.append(cmd)
+        self.exec_detail.append((cmd, timeout_sec))
         if "--help" in cmd:  # the service-detection probe: `<binary> --help`
             binary = cmd.split()[0]
             rc = 1 if binary in self._absent else 0
@@ -408,3 +414,52 @@ async def test_provision_baseline_capture_failure_surfaces():
     env = ManifestEnvironment(CLAWS_STATEFUL, sandbox=sandbox)
     with pytest.raises(EnvironmentSnapshotError):
         await env.provision(ctx=None)
+
+
+# BF-9 (benchflow-ai/benchflow#676): service starts must be fully detached.
+# On Daytona each exec is a session command — a backgrounded service that
+# inherits any of the session's std streams keeps the session "running" and
+# wedges the exec until its timeout (hard provision failure at the bounded
+# start timeout, while the same manifest passes on Docker).
+
+
+def test_service_start_command_fully_detaches():
+    svc = CLAWS.services[0]
+    cmd = service_start_command(svc)
+    assert cmd.startswith("nohup ")
+    assert svc.command in cmd
+    assert "</dev/null" in cmd
+    assert f">{service_log_path(svc.name)}" in cmd
+    assert "2>&1" in cmd
+    assert cmd.endswith("&")
+    assert "disown" not in cmd  # bash/zsh-only builtin; sandbox shell is sh/dash
+
+
+def test_service_log_path_is_per_service_and_retrievable():
+    assert service_log_path("gmail") == "/tmp/benchflow-env-gmail.log"
+    assert service_log_path("gmail") != service_log_path("gcal")
+
+
+async def test_provision_starts_services_detached_with_bounded_timeout():
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CLAWS, sandbox=sandbox)
+    await env.provision(ctx=None)
+    starts = [(c, t) for c, t in sandbox.exec_detail if "serve" in c]
+    assert [c for c, _ in starts] == [
+        service_start_command(CLAWS.services[0]),
+        service_start_command(CLAWS.services[1]),
+    ]
+    assert all(t == 15 for _, t in starts), "start exec must stay bounded"
+
+
+async def test_reset_restarts_services_with_the_same_detached_shape():
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CLAWS, sandbox=sandbox)
+    await env.provision(ctx=None)
+    provision_starts = [c for c in sandbox.exec_calls if c.startswith("nohup ")]
+    sandbox.exec_calls.clear()
+    sandbox.exec_detail.clear()
+    await env.reset()
+    restarts = [(c, t) for c, t in sandbox.exec_detail if c.startswith("nohup ")]
+    assert [c for c, _ in restarts] == provision_starts
+    assert all(t == 15 for _, t in restarts), "restart exec must stay bounded"


### PR DESCRIPTION
## What

`ManifestEnvironment.provision()` / `reset()` now start each
`[[environment.services]]` command **fully detached** —
`nohup {cmd} </dev/null >{log} 2>&1 &` — via one shared `service_start_command()`
helper used by both paths through a single `_start_service()` method.

## Why (a real bug, not a compat shim)

`provision`/`reset` previously started each service as `{cmd} > {log} 2>&1 &`:
stdout/stderr redirected, but **stdin inherited and no `nohup`**. On Daytona
each `sandbox.exec` runs as a *session command*, and a backgrounded service that
inherits any of the session's std streams keeps the session command "running",
wedging the exec until its timeout. The bounded 15s start timeout then turns the
wedge into a **hard provision failure on Daytona**, while the identical manifest
passes on Docker (whose `exec` returns as soon as the foreground `sh -c` exits,
regardless of orphaned background children). This is the same failure class as
the already-fixed unbounded Daytona-exec poll — every manifest environment that
backgrounds a service before the agent runs silently fails to provision on
Daytona.

## Fix

- One canonical detached start shape, `nohup {cmd} </dev/null >{log} 2>&1 &`,
  built by `service_start_command()` and launched via a single `_start_service()`
  helper shared by `provision` and `reset` (the duplicated inline shape is gone).
- The three redirections sever every inherited session stream and `nohup`
  survives the session's terminal HUP. **No `disown`** — it is a bash/zsh-only
  builtin, absent from the `sh`/dash shell the sandbox runs execs under.
- Start execs keep the explicit bounded `_SERVICE_START_TIMEOUT_SEC`;
  per-service logs stay retrievable via `service_log_path()`.

## Tests

`tests/environment/test_manifest_env.py` — exec-boundary coverage: the command
shape (nohup + three redirections + trailing `&`, no disown), that provision and
reset emit the *identical* detached shape, the bounded `timeout_sec` recorded at
the exec boundary, and the per-service log path.

- `pytest tests/environment/test_manifest_env.py` → **27 passed**
- `ruff check` / `ruff format --check` / `ty check` clean; import smoke OK.

## Use case

Surfaced running SkillsGym manifest environments directly on
`benchflow eval create --sandbox daytona`: a service backgrounded at provision
wedged the session exec and failed provision on Daytona while passing on Docker.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every framework-started manifest service is launched on all sandboxes; behavior is intentional for Daytona but alters process/session semantics at provision and reset.
> 
> **Overview**
> Fixes **Daytona provision failures** when manifest services are backgrounded inside `sandbox.exec`: starts now use a single detached shell shape — `nohup {cmd} </dev/null >{log} 2>&1 &` — instead of `{cmd} > {log} 2>&1 &`, which left stdin attached and could keep the Daytona session command open until the 15s start timeout.
> 
> **`ManifestEnvironment`** routes both **`provision`** and **`reset`** through new helpers **`service_start_command`**, **`service_log_path`**, and **`_start_service`**, so the detachment logic is not duplicated. Per-service logs stay at `/tmp/benchflow-env-{name}.log`; start execs remain bounded at 15s.
> 
> Tests assert the full command shape (including no `disown`), identical detached restarts on reset, and exec timeouts recorded on the fake sandbox.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654febfbbfce0fb19c69860c0261ea66f2751e32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->