### PR TITLE
fix(agents): bump JS-agent Node pin 22.14.0 -> 22.20.0 for openclaw

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -113,10 +113,13 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_BIN_PREFIX}:{_BENCHFLOW_JS_AGENT_PREFIX}/bin:"
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
+# Node >=22.19 is required by current openclaw (the JS agents install
+# @latest); keep this pin at or above that floor or the openclaw ACP
+# bootstrap aborts at its runtime version check (BF-10).
 _NODE_INSTALL = (
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
-    "BF_NODE_VERSION=22.14.0; "
+    "BF_NODE_VERSION=22.20.0; "
     'if [ ! -x "$BF_NODE_DIR/bin/node" ]; then '
     "  if ! command -v curl >/dev/null 2>&1 || "
     "     ! command -v tar >/dev/null 2>&1 || "

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -128,7 +128,14 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
     launch_cmd = AGENTS[name].launch_cmd
 
     assert "/opt/benchflow/node" in install_cmd
-    assert "BF_NODE_VERSION=22.14.0" in install_cmd
+    # Node >=22.19 is required by current openclaw (JS agents install @latest);
+    # assert the floor, not a brittle exact pin (BF-10).
+    pin = re.search(r"BF_NODE_VERSION=(\d+)\.(\d+)\.\d+", install_cmd)
+    assert pin, "BF_NODE_VERSION pin missing from JS agent bootstrap"
+    major, minor = int(pin.group(1)), int(pin.group(2))
+    assert (major, minor) >= (22, 19), (
+        f"pinned node {pin.group(0)} is below openclaw's >=22.19 floor"
+    )
     assert "/opt/benchflow/js-agents" in install_cmd
     assert "/opt/benchflow/bin" in install_cmd
     assert "--prefix /opt/benchflow/js-agents" in install_cmd


### PR DESCRIPTION
## What

Bumps the private Node runtime pin in the JS-agent bootstrap
(`_NODE_INSTALL` in `agents/registry.py`) from `22.14.0` to `22.20.0`
(LTS, `>=22.19`).

## Why (a real bug, not a compat shim)

The JS-agent bootstrap installs an isolated Node runtime pinned
`BF_NODE_VERSION=22.14.0` into `/opt/benchflow/node`, then
`npm install -g openclaw@latest`. Current openclaw (2026.6.5+) requires
**Node `>=22.19`**, so it aborts at its own runtime version check:

```
openclaw: Node.js v22.19+ is required (current: v22.14.0)
```

The agent then produces **zero tool calls and every openclaw rollout silently
scores 0**, regardless of model or task. Because the agent uses its own isolated
runtime, the task image's Node version is irrelevant — this hits every openclaw
run.

## Fix

- Bump the pin to `22.20.0`.
- The invariant test now asserts the `>=22.19` **floor** instead of a brittle
  exact literal, so it tracks the real constraint rather than a specific patch
  release.

## Tests

- `pytest tests/test_registry_invariants.py` → **159 passed**
- `ruff check` / `ruff format --check` clean; import smoke confirms
  `BF_NODE_VERSION=22.20.0`.

## Use case

Verified live: `stripe-idempotent-no-double-charge` on
`--agent openclaw --model deepseek/deepseek-v4-flash --sandbox daytona` went
from the node-error abort (tools=0, reward 0) to **tools=4, reward 1.0** after
the bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small version bump in agent install bootstrap plus a looser test; no auth, data, or API surface changes.
> 
> **Overview**
> Raises the isolated Node runtime pin used by JS-agent sandbox bootstrap from **22.14.0** to **22.20.0**, with a comment that **openclaw** (installed via `@latest`) requires **Node ≥22.19** (BF-10).
> 
> The registry invariant test no longer asserts an exact `BF_NODE_VERSION` string; it parses the pin and enforces **(major, minor) ≥ (22, 19)** so future bumps stay aligned with openclaw’s floor without brittle exact-version checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68217400388e3fcc467de193609495810414af50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->