### PR TITLE
test(agents): fix codex-acp custom-provider routing test

### DIFF
--- a/tests/examples/test_codex_custom_provider.sh
+++ b/tests/examples/test_codex_custom_provider.sh
@@ -5,6 +5,20 @@
 # to fail with a mocked 401. The test passes if codex-acp sends a request to
 # the local stub instead of api.openai.com.
 #
+# Two deliberate choices keep this a *direct* routing check:
+#   --usage-tracking off  — with the default (auto), benchflow stands up its
+#       own LiteLLM usage proxy in front of the agent (#587/#613). That proxy
+#       would intercept codex's call, fall back to codex's built-in default
+#       model, and 400 before forwarding upstream — so the stub would never
+#       see the request. Off sends provider traffic straight to the stub.
+#       (Usage-proxy forwarding for custom providers is a separate concern.)
+#   --model vllm/gpt-5.4  — codex-acp validates the model against its own
+#       catalog at session/set_model, so a synthetic id like "mock-model" is
+#       rejected with -32603 before any HTTP request. gpt-5.4 is a real catalog
+#       id that is accepted but is NOT codex's built-in default (gpt-5.5), so
+#       the model assertion below also proves codex sent the *configured* model
+#       rather than silently falling back. The stub returns a mocked 401.
+#
 # Usage:
 #   bash tests/examples/test_codex_custom_provider.sh
 #
@@ -42,12 +56,32 @@ python3 "$REPO_ROOT/tests/fixtures/mock_openai_responses_server.py" \
   >"$SERVER_LOG" 2>&1 &
 SERVER_PID=$!
 
+# Readiness guard. A plain "GET /health -> 200" check is not enough: if another
+# service is already bound to $PORT, our stub fails to bind and exits, yet the
+# squatter may answer /health 200 — codex would then be routed to the wrong
+# server and the test would fail confusingly (seen with a 403 from an unrelated
+# uvicorn app). So require BOTH that our process is still alive and that /health
+# returns the stub's sentinel body ({"ok": true}).
+ready=
 for _ in $(seq 1 50); do
-  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "FAIL: mock server exited — port ${PORT} is likely already in use."
+    echo "      Re-run with a free port, e.g. PORT=8770 bash $0"
+    cat "$SERVER_LOG"
+    exit 1
+  fi
+  if curl -fsS "http://127.0.0.1:${PORT}/health" 2>/dev/null | grep -q '"ok"'; then
+    ready=1
     break
   fi
   sleep 0.1
 done
+if [ -z "$ready" ]; then
+  echo "FAIL: mock server did not become ready on port ${PORT} (foreign service on this port?)."
+  echo "      Re-run with a free port, e.g. PORT=8770 bash $0"
+  cat "$SERVER_LOG"
+  exit 1
+fi
 
 echo "=== codex-acp custom provider routing check ==="
 echo "Stub URL:  $STUB_URL"
@@ -61,8 +95,9 @@ env -u CODEX_ACCESS_TOKEN -u CODEX_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_KEY 
   uv run bench eval create \
     --tasks-dir "$TASK" \
     --agent codex-acp \
-    --model vllm/mock-model \
+    --model vllm/gpt-5.4 \
     --sandbox docker \
+    --usage-tracking off \
     --jobs-dir "$JOBS_DIR" \
     --agent-env "BENCHFLOW_PROVIDER_BASE_URL=${STUB_URL}"
 RUN_RC=$?
@@ -85,6 +120,17 @@ fi
 if ! grep -q '"authorization": "Bearer dummy-local-key"' "$LOG_FILE" && \
    ! grep -q '"Authorization": "Bearer dummy-local-key"' "$LOG_FILE"; then
   echo "FAIL: Authorization header not observed at stub"
+  cat "$LOG_FILE"
+  exit 1
+fi
+
+# The configured model must reach the wire. If codex silently fell back to its
+# built-in default (gpt-5.5 — the failure mode when the usage proxy intercepts),
+# the request body's model field would not be gpt-5.4. Match the escaped model
+# field exactly; codex mentions "gpt-5.5" in its system prompt, so a loose grep
+# would give a false pass.
+if ! grep -q '\\"model\\":\\"gpt-5\.4\\"' "$LOG_FILE"; then
+  echo "FAIL: stub did not receive the configured model gpt-5.4 (codex may have fallen back to its default)"
   cat "$LOG_FILE"
   exit 1
 fi


### PR DESCRIPTION
## What

Fixes `tests/examples/test_codex_custom_provider.sh`, which had silently stopped exercising codex-acp's custom `/v1/responses` routing and failed with `FAIL: local stub did not receive any request`.

Surfaced while debugging [#642](https://github.com/benchflow-ai/benchflow/issues/642) (running Codex against a LiteLLM/Bedrock proxy).

## Root causes & fixes

1. **Usage proxy intercepts custom routing.** Default usage tracking now stands up benchflow's own LiteLLM proxy in front of the agent (#587/#613). It intercepts codex's call, codex falls back to its built-in default model, and the proxy `400`s before forwarding upstream — so the stub never receives a request. → Pass `--usage-tracking off` for a direct route. *(The usage-proxy-doesn't-forward-custom-providers gap is real but a separate concern — intentionally out of scope here.)*

2. **Model-catalog validation.** codex-acp validates the model against its own catalog at `session/set_model`, so the synthetic id `mock-model` was rejected with `-32603` before any HTTP request. → Use a real catalog id (`gpt-5.4`), deliberately **not** codex's built-in default (`gpt-5.5`), and add an assertion that this exact model reaches the wire — so a silent fallback can't pass.

3. **Port-collision robustness.** A foreign service squatting on the port answered `GET /health 200` and masked the stub's bind failure, routing codex to the wrong server (observed: `403 Cross-origin write blocked`). → Require our own process to stay alive **and** `/health` to return the stub's sentinel body, failing fast with a free-port hint.

## Verification (real codex-acp 0.0.45 in Docker)

| Scenario | Result |
|---|---|
| Free port | ✅ `PASS` — `Model set to: gpt-5.4`, `POST /v1/responses`, `401 mock-auth-failure`; all assertions (non-empty, `/v1/responses`, `Bearer`, `model=gpt-5.4`) hold |
| Occupied port | ✅ Fast, clear failure (no Docker) — `port ... already in use`, `Re-run with PORT=...` + bind traceback |

## Scope

Single file: `tests/examples/test_codex_custom_provider.sh`. `bash -n` and shellcheck clean. These `tests/examples/*.sh` are manual dev checks, not wired into CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates a manual example shell script and assertions; no production or CI behavior changes.
> 
> **Overview**
> Repairs the manual **codex-acp custom provider routing** example so it again proves traffic hits a local `/v1/responses` stub instead of failing with “stub did not receive any request.”
> 
> **`bench eval create`** now passes **`--usage-tracking off`** so the default LiteLLM usage proxy does not intercept codex and block the stub, and uses **`--model vllm/gpt-5.4`** (a real catalog id, not the built-in default) so `session/set_model` succeeds and the wire model can be asserted.
> 
> **Stub readiness** is stricter: the mock process must stay alive and `/health` must return the stub’s `{"ok": true}` sentinel, with clear failures when the port is taken.
> 
> A new check requires the stub log to contain **`"model":"gpt-5.4"`** so silent fallback to gpt-5.5 cannot pass. Header comments document why these flags matter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b01eb43edc19a391296e75c73ae710b08bc083fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->