### PR TITLE
chore: purge verified-dead code smells (mechanical, no behavior change)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+### Removed
+- Dead-code purge (no public-API impact unless noted): removed the unused
+  `job_config_from_yaml` helper, the nominal `TASK_REPOS` back-compat dict
+  (use `TASK_ALIASES`), the `_looks_like_verifier_dep_install_error` shim
+  (use `contains_verifier_dep_install_marker`), the unused `parse_binary_verdict`
+  reward helper (use `parse_verdict`), the dead `SandboxBackend` type alias,
+  an unused `StdioTransport._read_buffer` field, and 12 redundant `rollout`
+  package re-export aliases (submodule definitions unchanged).
+- Removed the deprecated, hidden `benchflow skills install` CLI command. The
+  SDK function `benchflow.skills.install_skill` is unchanged.
+- Removed the dead 0.3-era legacy CLI commands `job`, `agents`, and the legacy
+  `eval` (shadowed by the `eval` subgroup). The `metrics`, `view`, and
+  `cleanup` legacy commands are retained.
+
 ## 0.6.0 — 2026-06-10
 
 ### Added

--- a/src/benchflow/_utils/benchmark_repos.py
+++ b/src/benchflow/_utils/benchmark_repos.py
@@ -495,16 +495,6 @@ TASK_ALIASES: dict[str, tuple[str, str | None, str | None]] = {
     "harvey-lab": ("benchflow-ai/benchmarks", "main", "datasets/harvey-lab/tasks"),
 }
 
-# Old dict shape kept for imports that reference TASK_REPOS.
-TASK_REPOS = {
-    name: {
-        "repo": f"https://github.com/{org_repo}.git",
-        **({"ref": branch} if branch else {}),
-        **({"subdir": subdir} if subdir else {}),
-    }
-    for name, (org_repo, branch, subdir) in TASK_ALIASES.items()
-}
-
 
 def ensure_tasks(benchmark: str) -> Path:
     """Clone task repo if not present. Supports aliases and org/repo strings."""

--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -151,11 +151,6 @@ def contains_verifier_dep_install_marker(text: str) -> bool:
     return any(marker in lower for marker in VERIFIER_DEP_INSTALL_MARKERS)
 
 
-def _looks_like_verifier_dep_install_error(error: str) -> bool:
-    """Backward-compatible internal alias for dep-install marker matching."""
-    return contains_verifier_dep_install_marker(error)
-
-
 def _looks_like_verifier_infra_error(error: str) -> bool:
     return any(
         marker in error

--- a/src/benchflow/_utils/yaml_loader.py
+++ b/src/benchflow/_utils/yaml_loader.py
@@ -168,23 +168,3 @@ def _parse_turn(raw: dict) -> Turn:
         role=raw["role"],
         prompt=raw.get("prompt"),
     )
-
-
-def job_config_from_yaml(path: str | Path) -> dict:
-    """Parse a YAML file and return both job-level and trial-level config.
-
-    Returns a dict with keys: task_dir, concurrency, max_retries,
-    trial_config (RolloutConfig), and any other job-level fields.
-    """
-    raw = load_rollout_yaml(path)
-    task_dir = Path(raw.get("task_dir", raw.get("tasks_dir", ".")))
-    concurrency = raw.get("concurrency", 4)
-    max_retries = raw.get("max_retries", 2)
-
-    return {
-        "task_dir": task_dir,
-        "concurrency": concurrency,
-        "max_retries": max_retries,
-        "trial_config": rollout_config_from_dict(raw, task_path=task_dir),
-        "raw": raw,
-    }

--- a/src/benchflow/acp/transport.py
+++ b/src/benchflow/acp/transport.py
@@ -72,7 +72,6 @@ class StdioTransport(Transport):
         self._env = env
         self._cwd = cwd
         self._process: asyncio.subprocess.Process | None = None
-        self._read_buffer = ""
 
     async def start(self) -> None:
         import os

--- a/src/benchflow/cli/legacy.py
+++ b/src/benchflow/cli/legacy.py
@@ -12,7 +12,6 @@ only wires the call. ``cleanup`` resolves the Daytona helpers through the
 
 from __future__ import annotations
 
-import asyncio
 import json
 from pathlib import Path
 from typing import Annotated
@@ -22,111 +21,14 @@ from rich.table import Table
 
 from benchflow.cli._options import (
     AgentOption,
-    ConcurrencyOption,
-    JobsDirOption,
-    ModelOption,
-    SandboxOption,
-    SkillModeOption,
 )
 from benchflow.cli._shared import (
-    _REQUIRES_AUTH_NOTE,
-    _format_requires,
-    _report_eval_result,
     console,
 )
-from benchflow.evaluation import DEFAULT_AGENT, effective_model
-from benchflow.skill_policy import SKILL_MODE_NO_SKILL
 
 
 def register_legacy(app: typer.Typer) -> None:
     """Attach the deprecated top-level commands to the benchflow app."""
-
-    @app.command(hidden=True, deprecated=True)
-    def job(
-        tasks_dir: Annotated[
-            Path | None,
-            typer.Option("--tasks-dir", help="Directory of tasks to run"),
-        ] = None,
-        config_file: Annotated[
-            Path | None,
-            typer.Option(
-                "--config", help="YAML config file (benchflow or legacy format)"
-            ),
-        ] = None,
-        agent: Annotated[
-            str,
-            typer.Option("--agent", help="Agent name from registry"),
-        ] = DEFAULT_AGENT,
-        model: Annotated[
-            str | None,
-            typer.Option("--model", help="Model to use"),
-        ] = None,
-        environment: SandboxOption = "docker",
-        concurrency: ConcurrencyOption = 4,
-        max_retries: Annotated[
-            int,
-            typer.Option("--retries", help="Max retries per task"),
-        ] = 0,
-        jobs_dir: JobsDirOption = "jobs",
-        skills_dir: Annotated[
-            Path | None,
-            typer.Option(
-                "--skills-dir", help="Skills directory to deploy into sandbox"
-            ),
-        ] = None,
-        skill_mode: SkillModeOption = SKILL_MODE_NO_SKILL,
-    ) -> None:
-        """Run all tasks in a directory with concurrency and retries.
-
-        Use --config for YAML config, or --tasks-dir for direct invocation.
-        """
-        from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
-
-        if config_file:
-            j = Evaluation.from_yaml(config_file)
-        elif tasks_dir:
-            j = Evaluation(
-                tasks_dir=str(tasks_dir),
-                jobs_dir=jobs_dir,
-                config=EvaluationConfig(
-                    agent=agent,
-                    model=effective_model(agent, model),
-                    environment=environment,
-                    concurrency=concurrency,
-                    retry=RetryConfig(max_retries=max_retries),
-                    skills_dir=str(skills_dir) if skills_dir else None,
-                    skill_mode=skill_mode,
-                ),
-            )
-        else:
-            console.print("[red]Either --tasks-dir or --config is required[/red]")
-            raise typer.Exit(1)
-
-        result = asyncio.run(j.run())
-
-        _report_eval_result(result)
-
-    @app.command(hidden=True, deprecated=True)
-    def agents() -> None:
-        """List available agents."""
-        from benchflow.agents.registry import list_agents
-
-        table = Table(title="Registered Agents")
-        table.add_column("Name", style="cyan")
-        table.add_column("Description")
-        table.add_column("Protocol", style="green")
-        table.add_column("Requires", style="yellow")
-
-        for agent in list_agents():
-            table.add_row(
-                agent.name,
-                agent.description,
-                agent.protocol,
-                _format_requires(agent),
-            )
-
-        console.print(table)
-        console.print(f"[dim]{_REQUIRES_AUTH_NOTE}[/dim]")
 
     @app.command(hidden=True, deprecated=True)
     def metrics(
@@ -206,75 +108,6 @@ def register_legacy(app: typer.Typer) -> None:
         from benchflow.trajectories.viewer import serve
 
         serve(str(rollout_dir), port)
-
-    @app.command(hidden=True, deprecated=True)
-    def eval(
-        tasks_dir: Annotated[
-            Path,
-            typer.Option("--tasks-dir", help="Directory of tasks"),
-        ],
-        skill: Annotated[
-            Path | None,
-            typer.Option(
-                "--skill", help="Path to SKILL.md (parent dir used as skills_dir)"
-            ),
-        ] = None,
-        skills_dir: Annotated[
-            Path | None,
-            typer.Option("--skills-dir", help="Skills directory for agent discovery"),
-        ] = None,
-        agent: AgentOption = DEFAULT_AGENT,
-        model: ModelOption = None,
-        environment: SandboxOption = "docker",
-        concurrency: ConcurrencyOption = 4,
-        jobs_dir: Annotated[
-            str,
-            typer.Option("--jobs-dir", help="Output directory"),
-        ] = "jobs",
-        skill_mode: SkillModeOption = SKILL_MODE_NO_SKILL,
-    ) -> None:
-        """Evaluate a skill against multiple tasks.
-
-        Runs all tasks in --tasks-dir with the given skill and produces a summary.
-        Simpler than `benchflow job` — designed for skill evaluation workflows.
-
-        Examples:
-            benchflow eval --tasks-dir tasks/ --skill skills/gws/SKILL.md --agent claude-agent-acp --sandbox daytona
-            benchflow eval --tasks-dir tasks/ --skills-dir skills/ --agent gemini --sandbox daytona --concurrency 64
-        """
-        from benchflow.evaluation import Evaluation, EvaluationConfig
-
-        # Use --skill as skills_dir if --skills-dir not provided
-        effective_skills = (
-            str(skills_dir) if skills_dir else (str(skill.parent) if skill else None)
-        )
-
-        j = Evaluation(
-            tasks_dir=str(tasks_dir),
-            jobs_dir=jobs_dir,
-            config=EvaluationConfig(
-                agent=agent,
-                model=effective_model(agent, model),
-                environment=environment,
-                concurrency=concurrency,
-                skills_dir=effective_skills,
-                skill_mode=skill_mode,
-            ),
-        )
-
-        result = asyncio.run(j.run())
-
-        # Summary
-        console.print("\n[bold]Skill Eval Results[/bold]")
-        if skill:
-            console.print(f"  Skill: {skill}")
-        if skills_dir:
-            console.print(f"  Skills dir: {skills_dir}")
-        console.print(
-            f"  Score: [bold]{result.passed}/{result.total} "
-            f"({result.score:.1%})[/bold], errors={result.errored}"
-        )
-        console.print(f"  Elapsed: {result.elapsed_sec:.0f}s")
 
     @app.command(hidden=True, deprecated=True)
     def cleanup(

--- a/src/benchflow/cli/legacy.py
+++ b/src/benchflow/cli/legacy.py
@@ -1,9 +1,8 @@
 """Deprecated top-level benchflow commands (hidden in ``--help``).
 
 These predate the 0.3 resource-verb subgroups (``eval``/``environment``/
-``agent``) and are kept for backwards compatibility only: ``job``, ``agents``,
-``metrics``, ``view``, ``eval`` (legacy skill eval), and ``cleanup``. Each is
-``hidden=True, deprecated=True``.
+``agent``) and are kept for backwards compatibility only: ``metrics``,
+``view``, and ``cleanup``. Each is ``hidden=True, deprecated=True``.
 
 Registered onto the top-level app by :func:`register_legacy`; ``cli/main.py``
 only wires the call. ``cleanup`` resolves the Daytona helpers through the

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -44,7 +44,7 @@ def register_skills(app: typer.Typer) -> None:
         found = discover_skills(*search_dirs)
         if not found:
             console.print(
-                "No skills found. Install with: benchflow skills install owner/repo@skill-name"
+                "No skills found. Add skill directories under .claude/skills/ or skills/."
             )
             return
 
@@ -58,28 +58,6 @@ def register_skills(app: typer.Typer) -> None:
             table.add_row(s.name, s.version or "-", s.description[:60], str(s.path))
 
         console.print(table)
-
-    @skills_app.command("install", hidden=True, deprecated=True)
-    def skills_install(
-        spec: Annotated[
-            str,
-            typer.Argument(help="Skill spec (e.g. anthropics/skills@find-skills)"),
-        ],
-        directory: Annotated[
-            Path | None,
-            typer.Option("--dir", help="Target directory"),
-        ] = None,
-    ) -> None:
-        """Install a skill from the registry."""
-        from benchflow.skills import DEFAULT_SKILLS_DIR, install_skill
-
-        target = directory or DEFAULT_SKILLS_DIR
-        result = install_skill(spec, target_dir=target)
-        if result:
-            console.print(f"[green]Installed:[/green] {result}")
-        else:
-            console.print(f"[red]Failed to install {spec}[/red]")
-            raise typer.Exit(1)
 
     @skills_app.command("eval")
     def skills_eval(

--- a/src/benchflow/rewards/llm.py
+++ b/src/benchflow/rewards/llm.py
@@ -70,12 +70,6 @@ def parse_verdict(text: str) -> dict[str, Any]:
     raise ValueError(f"Could not parse verdict from: {text[:300]}")
 
 
-def parse_binary_verdict(text: str) -> bool:
-    """Coerce common LLM outputs to a boolean pass/fail."""
-    lowered = text.strip().lower()
-    return lowered in {"yes", "true", "1", "pass", "passed"}
-
-
 # Provider routing
 
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -83,39 +83,23 @@ from benchflow.diagnostics import (
 from benchflow.models import RolloutResult, TrajectorySource
 from benchflow.rollout._config import GENERATED_SKILLS_ROOT as GENERATED_SKILLS_ROOT
 from benchflow.rollout._config import RolloutConfig as RolloutConfig
-from benchflow.rollout._config import _task_document_scenes as _task_document_scenes
-from benchflow.rollout._config import (
-    _task_document_user_runtime as _task_document_user_runtime,
-)
 from benchflow.rollout._results import _DIAG_TRUNCATE as _DIAG_TRUNCATE
 from benchflow.rollout._results import _build_rollout_result as _build_rollout_result
 from benchflow.rollout._results import (
-    _compose_scene_user_prompt as _compose_scene_user_prompt,
-)
-from benchflow.rollout._results import (
     _environment_manifest_metadata as _environment_manifest_metadata,
 )
-from benchflow.rollout._results import _is_document_user as _is_document_user
 from benchflow.rollout._results import _is_secret_env_key as _is_secret_env_key
-from benchflow.rollout._results import _is_secret_env_value as _is_secret_env_value
 from benchflow.rollout._results import (
     _least_permissive_option_id as _least_permissive_option_id,
-)
-from benchflow.rollout._results import _role_metadata as _role_metadata
-from benchflow.rollout._results import _scene_metadata as _scene_metadata
-from benchflow.rollout._results import (
-    _should_record_env_entry as _should_record_env_entry,
 )
 from benchflow.rollout._results import (
     _user_confirmation_policy as _user_confirmation_policy,
 )
-from benchflow.rollout._results import _user_handoff_kind as _user_handoff_kind
 from benchflow.rollout._results import _write_config as _write_config
 from benchflow.rollout._results import _write_rewards_jsonl as _write_rewards_jsonl
 from benchflow.rollout._results import (
     _write_trainer_artifact as _write_trainer_artifact,
 )
-from benchflow.rollout._setup import _DISALLOW_WEB_TOOLS_ENV as _DISALLOW_WEB_TOOLS_ENV
 from benchflow.rollout._setup import (
     _agent_launch_with_web_policy as _agent_launch_with_web_policy,
 )
@@ -138,7 +122,6 @@ from benchflow.rollout._setup import _install_docker_compat as _install_docker_c
 from benchflow.rollout._setup import (
     _publish_trajectory_for_verifier as _publish_trajectory_for_verifier,
 )
-from benchflow.rollout._setup import _read_task_instruction as _read_task_instruction
 from benchflow.rollout._setup import _resolve_agent_cwd as _resolve_agent_cwd
 from benchflow.rollout._setup import _resolve_prompts as _resolve_prompts
 from benchflow.rollout._setup import _run_oracle as _run_oracle
@@ -147,7 +130,6 @@ from benchflow.rollout._setup import _start_env_and_upload as _start_env_and_upl
 from benchflow.rollout._setup import (
     _task_disallows_internet as _task_disallows_internet,
 )
-from benchflow.rollout._setup import _validate_agent_workdir as _validate_agent_workdir
 from benchflow.rollout._setup import _verify_rollout as _verify_rollout
 from benchflow.rollout._skills import (
     _resolve_skill_creator_root as _resolve_skill_creator_root,

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -12,7 +12,7 @@ import hashlib
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
-from typing import Literal, cast
+from typing import cast
 
 from benchflow.rewards.rubric_config import criteria_aggregate_policy_from_rubric
 from benchflow.task.config import (
@@ -30,7 +30,6 @@ from benchflow.task.prompts import (
 )
 from benchflow.task.verifier_document import load_verifier_document
 
-SandboxBackend = Literal["docker", "daytona", "modal"]
 SUPPORTED_SANDBOX_BACKENDS = {"docker", "daytona", "modal"}
 
 


### PR DESCRIPTION
Deep code-smell inspection of all ~245 source files (16-agent fan-out → adversarial purge-safety verification → synthesis + completeness critic). **Only the verified-dead, zero-behavior-change removals are in this PR**; everything that turned out to be load-bearing is documented below and the genuine product decisions are split out (see the PR comment).

## What's removed (each confirmed 0-reference repo-wide, or removable-redundant)
| File | Symbol | Why safe |
|---|---|---|
| `_utils/yaml_loader.py` | `job_config_from_yaml` | 0 refs; `load_rollout_yaml`/`rollout_config_from_yaml` survive |
| `_utils/benchmark_repos.py` | `TASK_REPOS` | nominal back-compat dict, 0 readers; `TASK_ALIASES` is the live data |
| `_utils/scoring.py` | `_looks_like_verifier_dep_install_error` | shim, 0 callers; use `contains_verifier_dep_install_marker` |
| `rewards/llm.py` | `parse_binary_verdict` | 0 refs; `parse_verdict` is the live parser |
| `acp/transport.py` | `StdioTransport._read_buffer` | field written once, never read |
| `task/runtime_capabilities.py` | `SandboxBackend` (+ orphaned `Literal` import) | dead type alias, 0 refs |
| `cli/skills.py` | `skills install` command | deprecated+hidden, 0 test/doc use; SDK `install_skill` unchanged |
| `cli/legacy.py` | `job`, `agents`, legacy `eval` | 0.3-era dead / shadowed by the `eval` subgroup |
| `rollout/__init__.py` | 12 `X as X` re-export aliases | import-only, never bare-name-used, 0 refs outside the package |

`cli/legacy.py` keeps `register_legacy` + `metrics`/`view`/`cleanup` (live tests / no replacement); 12 now-unused imports were ruff-trimmed.

## Verification
- **Full unit suite: 3839 passed, 12 skipped** (`pytest tests/ --ignore=tests/integration`).
- Import smoke across all touched packages; ruff clean.
- The 12 rollout aliases were selected by an **AST-equivalent filter** (symbol appears exactly once in `__init__.py` AND nowhere outside `rollout/`), not grep — this correctly *kept* lookalikes the discovery pass mislabeled (`_as_nonnegative_int`, `_native_acp_usage_delta`, `_zero_native_acp_usage_metrics`, `_user_confirmation_policy`, … are bare-name-used inside `__init__.py`).

## Deliberately NOT purged — verified load-bearing despite looking like smells
The two maintainer-named targets both turned out to be live:
- **`adapters/terminal_bench.py`** — it is the return value of `detect_adapter()` (`inbound.py:334`) for bare `task.yaml` dirs; handles the genuinely different flat Terminal-Bench format, documented, ~37 test assertions. The "superseded by Harbor" premise is false. Dropping it is a documented-format removal → product decision, not a purge.
- **`cli/legacy.py` (whole-file) / `cli/compat.py`** — `register_legacy`/`register_compat` are wired in `main.py`; `compat` is a tested public group; `metrics`/`view`/`cleanup` have no resource-verb replacement and live guard tests.

Other verified-keeps: the `*_acp_shim` send/recv "duplication" (each shim's source is read+b64'd+exec'd in a container with no benchflow installed — a shared import would ImportError), the bedrock patch self-containment (shipped into an isolated proxy venv), and `continue_run/sandbox_proxy.py` remote-exec duplication.

Follow-up product decisions (terminal_bench fate, retiring legacy metrics/view/cleanup, the monitor #386 scaffold, `experimental.mcp`, de-dup refactors) are enumerated in a comment for separate PRs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletions only affect unreferenced symbols and hidden deprecated CLI; supported paths (`TASK_ALIASES`, `parse_verdict`, `bench eval`, SDK install) are unchanged.
> 
> **Overview**
> Mechanical dead-code removal with **no intended behavior change**. Unused helpers and aliases are dropped (`job_config_from_yaml`, `TASK_REPOS`, verifier-dep shim, `parse_binary_verdict`, `SandboxBackend`, `StdioTransport._read_buffer`), and **12 redundant `rollout` package re-exports** are trimmed while submodule definitions stay the same.
> 
> **CLI surface shrinks:** deprecated hidden **`benchflow skills install`** is removed (SDK `install_skill` unchanged), and legacy top-level **`job`**, **`agents`**, and shadowed **`eval`** are removed; **`metrics`**, **`view`**, and **`cleanup`** remain. Changelog and `skills list` empty-state copy are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0116fce9581bc564401ec76c0b6431d3b83426a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->