### PR TITLE
fix(agent): print dry-run codex command verbatim (no rich hard-wrap)

### DIFF
--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -678,7 +678,14 @@ def register_agent_router(agent_app: typer.Typer) -> None:
                     model=model,
                     config_overrides=overrides,
                 )
-                console.print(" ".join(shlex.quote(c) for c in launch.command))
+                # Verbatim, copy-pasteable command: no console-width hard
+                # wrapping (which would split tokens like the --cd path) and
+                # no rich-markup interpretation of the prompt text.
+                console.print(
+                    " ".join(shlex.quote(c) for c in launch.command),
+                    soft_wrap=True,
+                    markup=False,
+                )
                 return
             code = run_agent_adoption(
                 source,

--- a/tests/test_agent_router_cli_e2e.py
+++ b/tests/test_agent_router_cli_e2e.py
@@ -325,6 +325,12 @@ def test_cli_run_dry_run_prints_codex_command_with_context_markers(
     assert "CONVERT.md" in out
     assert "Benchmark adoption" in out
     assert "benchmarks/my-bench/" in out
+    # The command must be printed verbatim (soft_wrap): console-width hard
+    # wrapping would insert newlines mid-token (e.g. inside the --cd path),
+    # making the dry-run output non-copy-pasteable. The command head up to the
+    # prompt's first newline always exceeds 80 columns, so under hard wrapping
+    # this first physical line would be split wherever the repo path puts it.
+    assert out.splitlines()[0].endswith("'# Benchmark adoption: my-bench")
 
 
 def test_cli_run_live_path_fails_closed_without_credentials(


### PR DESCRIPTION
## Problem

`tests/test_agent_router_cli_e2e.py::test_cli_run_dry_run_prints_codex_command_with_context_markers` fails on `release/v0.6.0` — but only on machines with a long repo checkout path. The assertion `assert "Benchmark adoption" in out` trips even though the marker **is** emitted by `_adoption_prompt` (agent_router.py).

Root cause: the dry-run path prints the constructed codex command via rich `console.print(...)`, which **hard-wraps at console width** (80 in non-tty), inserting real newlines mid-token. Where the wrap lands depends on the length of the `--cd <repo_root>` path earlier on the line — on a long checkout path it lands exactly inside `# Benchmark adoption: my-bench`, splitting the phrase:

```
... --sandbox workspace-write '# Benchmark ⏎
adoption: my-bench
```

This is a real bug, not just a flaky test: `--dry-run`'s purpose is a copy-pasteable command, and hard-wrap splits the unquoted `--cd` path into two shell tokens on paste.

## Fix

- `console.print(..., soft_wrap=True, markup=False)` — no inserted newlines (terminal soft-wraps visually; copy-paste yields the intact command), and no rich-markup interpretation so a future CONVERT.md containing `[tag]`-like text can't be silently eaten.
- Deterministic regression guard in the test: the command head up to the prompt's first newline always exceeds 80 columns, so `out.splitlines()[0].endswith("'# Benchmark adoption: my-bench")` catches any hard-wrap on **every** machine — the original marker assert only caught it when the path length happened to put the wrap inside the phrase.

## Verification

- Previously-failing test now passes on a long-path checkout; full `test_agent_router_cli_e2e.py` + `test_agent_router.py` → **97 passed**.
- Mutation-tested: reverting the source fix makes the new guard (and on long paths the original assert) fail.
- `ruff check` / `ruff format --check` / `ty check` clean.