### PR TITLE
fix: enable Bedrock max effort for Claude Fable 5

### DIFF
--- a/src/benchflow/providers/litellm_bedrock_patch.py
+++ b/src/benchflow/providers/litellm_bedrock_patch.py
@@ -15,7 +15,7 @@ from typing import Any
 
 BEDROCK_THINKING_EFFORT_ENV = "BENCHFLOW_BEDROCK_THINKING_EFFORT"
 BEDROCK_ADAPTIVE_THINKING_RE = re.compile(
-    r"claude-(?:opus|sonnet|haiku)-4-(?:8|9|1\d)(?!\d)"
+    r"claude-(?:(?:opus|sonnet|haiku)-4-(?:8|9|1\d)(?!\d)|fable-5(?!\d))"
 )
 
 _VALID_EFFORTS = {"minimal", "low", "medium", "high", "xhigh", "max"}

--- a/src/benchflow/providers/litellm_bedrock_preflight.py
+++ b/src/benchflow/providers/litellm_bedrock_preflight.py
@@ -24,20 +24,24 @@ class BedrockPatchPreflightError(RuntimeError):
 BEDROCK_PATCH_PREFLIGHT_SOURCE = """\
 import sys
 
-# Probe with a versioned Bedrock inference-profile ID: stock litellm 1.88.0rc1
-# resolves the bare alias through its cost map, so only the versioned form
-# discriminates patched from stock (#602).
-PROBE = "us.anthropic.claude-opus-4-8-20251101-v1:0"
+# Probe with versioned/profile-shaped Bedrock IDs: stock litellm 1.88.0rc1
+# resolves the Opus bare alias through its cost map, so only the versioned form
+# discriminates patched from stock (#602). Fable 5 is profile-shaped today.
+PROBES = [
+    "us.anthropic.claude-opus-4-8-20251101-v1:0",
+    "us.anthropic.claude-fable-5",
+]
 
 failures = []
 try:
     from litellm.llms.anthropic.chat.transformation import AnthropicConfig
 
-    if not AnthropicConfig._is_adaptive_thinking_model(PROBE):
-        failures.append(
-            "adaptive-thinking gate inactive: "
-            f"_is_adaptive_thinking_model({PROBE!r}) is False"
-        )
+    for probe in PROBES:
+        if not AnthropicConfig._is_adaptive_thinking_model(probe):
+            failures.append(
+                "adaptive-thinking gate inactive: "
+                f"_is_adaptive_thinking_model({probe!r}) is False"
+            )
 except Exception as exc:  # noqa: BLE001 - report any import/shape drift
     failures.append(f"anthropic transform unavailable: {exc}")
 try:

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -50,7 +50,8 @@ def custom_cost_per_token(model: str) -> tuple[float, float] | None:
 
 
 _BEDROCK_ADAPTIVE_THINKING_RE = re.compile(
-    r"claude-(?:opus|sonnet|haiku)-4-(?:8|9|1\d)(?!\d)", re.IGNORECASE
+    r"claude-(?:(?:opus|sonnet|haiku)-4-(?:8|9|1\d)(?!\d)|fable-5(?!\d))",
+    re.IGNORECASE,
 )
 _BEDROCK_THINKING_EFFORTS = {"minimal", "low", "medium", "high", "xhigh", "max"}
 

--- a/tests/test_bedrock_thinking.py
+++ b/tests/test_bedrock_thinking.py
@@ -15,6 +15,7 @@ from benchflow.providers.litellm_config import resolve_litellm_route
         "us.anthropic.claude-opus-4-8",
         "global.anthropic.claude-sonnet-4-9",
         "anthropic.claude-haiku-4-10",
+        "us.anthropic.claude-fable-5",
     ],
 )
 def test_provider_patch_matcher_covers_bedrock_claude_4_8_plus(model):
@@ -44,6 +45,20 @@ def test_bedrock_thinking_effort_is_threaded_into_route_params():
     )
 
     assert route.upstream_model == "bedrock/us.anthropic.claude-opus-4-8"
+    assert route.litellm_params["reasoning_effort"] == "max"
+
+
+def test_bedrock_fable5_thinking_effort_is_threaded_into_route_params():
+    route = resolve_litellm_route(
+        "aws-bedrock/us.anthropic.claude-fable-5",
+        {
+            "AWS_BEARER_TOKEN_BEDROCK": "token",
+            "AWS_REGION": "us-west-2",
+            BEDROCK_THINKING_EFFORT_ENV: "max",
+        },
+    )
+
+    assert route.upstream_model == "bedrock/us.anthropic.claude-fable-5"
     assert route.litellm_params["reasoning_effort"] == "max"
 
 

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -434,6 +434,7 @@ _BEDROCK_ENV = {"AWS_BEARER_TOKEN_BEDROCK": "tok", "AWS_REGION": "us-east-1"}
     [
         ("aws-bedrock/us.anthropic.claude-opus-4-8-20251101-v1:0", True),
         ("aws-bedrock/eu.anthropic.claude-sonnet-4-9-20260301-v1:0", True),
+        ("aws-bedrock/us.anthropic.claude-fable-5", True),
         ("aws-bedrock/us.anthropic.claude-opus-4-7-20251101-v1:0", False),
     ],
 )


### PR DESCRIPTION
## Summary
- Treat `claude-fable-5` Bedrock inference-profile IDs as adaptive-thinking models in LiteLLM route resolution.
- Extend the Bedrock startup patch/preflight probes so Fable 5 max-effort routes fail closed if the adaptive-thinking shim is not active.
- Add focused coverage for Fable 5 route params and patch gating.

## Validation
- `uv run python -m pytest tests/test_bedrock_thinking.py tests/test_litellm_hardening.py -q` -> 52 passed
- `uv run ruff check src/benchflow/providers/litellm_config.py src/benchflow/providers/litellm_bedrock_patch.py src/benchflow/providers/litellm_bedrock_preflight.py tests/test_bedrock_thinking.py tests/test_litellm_hardening.py`
- `uv run ty check src/benchflow/providers/litellm_config.py src/benchflow/providers/litellm_bedrock_patch.py src/benchflow/providers/litellm_bedrock_preflight.py`

## Live canary
- Raw Bedrock Converse call to `us.anthropic.claude-fable-5` succeeded.
- SkillsBench `citation-check` with `claude-agent-acp`, Docker, `--skill-mode with-skill`, `--reasoning-effort max`, and `BENCHFLOW_BEDROCK_THINKING_EFFORT=max` completed end-to-end: reward 1.0, CTRF 9/9 passed.
- `benchflow-experiment-review` audit confirmed `task_skills_loading: 1` for `citation-management`, complete timing/usage/trajectory metadata, and LLM trajectory requests carrying `reasoning_effort=max`, `thinking={type: adaptive}`, and `output_config={effort: max}`.

Note: a no-skill canary for the same task produced a Fable/Claude Code content-filter refusal after reading `test.bib`; audit showed no task-skill leakage (`task_skills_loading: 0`) but that cell is not publishable as benchmark data.