### PR TITLE
fix(task): port guard fixes from #651 — schema_version major gate, judge empty-inputs, network-mode contradiction

### DIFF
--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -13,7 +13,7 @@ import re
 import tomllib
 import warnings
 from enum import StrEnum
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from pydantic import (
     AliasChoices,
@@ -546,10 +546,29 @@ class SandboxConfig(TaskConfigModel):
             )
             self.storage_mb = self._parse_size_to_mb(storage)
             self.storage = None
+        # Reconcile the deprecated allow_internet flag with network_mode.
+        # The new field is authoritative: when network_mode was explicitly
+        # provided, allow_internet must not silently override it. An explicit
+        # contradiction (e.g. network_mode='allowlist' + allow_internet=False)
+        # is a hard error rather than a silent downgrade to no-network.
+        network_mode_explicit = "network_mode" in self.model_fields_set
         if self.allow_internet is False:
-            self.network_mode = NetworkMode.NO_NETWORK
+            if network_mode_explicit:
+                if self.network_mode != NetworkMode.NO_NETWORK:
+                    raise ValueError(
+                        "allow_internet=False contradicts the explicit "
+                        f"network_mode={self.network_mode.value!r}; "
+                        "drop the deprecated allow_internet field and rely on "
+                        "network_mode (use network_mode='no-network' to "
+                        "disable networking)."
+                    )
+            else:
+                self.network_mode = NetworkMode.NO_NETWORK
         if self.network_mode == NetworkMode.NO_NETWORK:
             self.allow_internet = False
+        # Reconciliation must never leave the object in a state that
+        # _validate_network_policy_fields itself rejects.
+        _validate_network_policy_fields(self.network_mode, self.allowed_hosts)
         return self
 
 
@@ -651,6 +670,8 @@ class TaskConfig(TaskConfigModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
+    _SUPPORTED_SCHEMA_MAJORS: ClassVar[frozenset[int]] = frozenset({1})
+
     @model_validator(mode="before")
     @classmethod
     def handle_version_rename(cls, data: Any) -> Any:
@@ -664,6 +685,30 @@ class TaskConfig(TaskConfigModel):
             if "version" in data:
                 data.setdefault("schema_version", data.pop("version"))
         return data
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: str) -> str:
+        """Reject unknown/unparseable schema majors; stay permissive on minor.
+
+        The schema version is ``MAJOR.MINOR``; only majors the loader knows how
+        to interpret are accepted. Unknown majors or non-numeric versions are a
+        hard error rather than a value silently carried through.
+        """
+        major_part = value.split(".", 1)[0]
+        try:
+            major = int(major_part)
+        except ValueError:
+            raise ValueError(
+                f"schema_version {value!r} is not a valid MAJOR.MINOR version"
+            ) from None
+        if major not in cls._SUPPORTED_SCHEMA_MAJORS:
+            supported = ", ".join(str(m) for m in sorted(cls._SUPPORTED_SCHEMA_MAJORS))
+            raise ValueError(
+                f"Unsupported schema_version major {major} (from {value!r}); "
+                f"supported major version(s): {supported}"
+            )
+        return value
 
     @classmethod
     def model_validate_toml(cls, toml_data: str) -> TaskConfig:

--- a/src/benchflow/task/verifier_core.py
+++ b/src/benchflow/task/verifier_core.py
@@ -1148,6 +1148,10 @@ class Verifier:
         self,
         strategy: VerifierStrategy,
     ) -> list[dict[str, Any]]:
+        if not strategy.inputs:
+            raise AgentJudgeInputError(
+                f"agent-judge strategy {strategy.name!r} must declare inputs"
+            )
         inputs_dir = self._rollout_paths.verifier_dir / "agent-judge-inputs"
         if inputs_dir.exists():
             if inputs_dir.is_dir() and not inputs_dir.is_symlink():

--- a/src/benchflow/task/verifier_document.py
+++ b/src/benchflow/task/verifier_document.py
@@ -323,16 +323,20 @@ def _validate_strategy(
                 f"{prefix}.isolation must be 'verifier-only'"
             )
         inputs = config.get("inputs")
-        if not isinstance(inputs, list) or not all(
-            isinstance(item, str) and item for item in inputs
+        if (
+            not isinstance(inputs, list)
+            or not inputs
+            or not all(isinstance(item, str) and item for item in inputs)
         ):
             raise VerifierDocumentParseError(
                 f"{prefix}.inputs must be a non-empty list of strings"
             )
     elif strategy_type == "ors-episode":
         inputs = config.get("inputs")
-        if not isinstance(inputs, list) or not all(
-            isinstance(item, str) and item for item in inputs
+        if (
+            not isinstance(inputs, list)
+            or not inputs
+            or not all(isinstance(item, str) and item for item in inputs)
         ):
             raise VerifierDocumentParseError(
                 f"{prefix}.inputs must be a non-empty list of strings"

--- a/tests/test_v06_guard_ports.py
+++ b/tests/test_v06_guard_ports.py
@@ -1,0 +1,160 @@
+"""Guard ports from PR #651 (main): schema_version major gate, agent-judge
+empty-inputs backstop, verifier-document empty-list fix, and the explicit
+network-mode/allow_internet contradiction hard-error.
+
+Each test mirrors the source-PR test of the same guard, adapted to the v0.6
+module layout (``verifier_core`` behind the ``benchflow.task.verifier``
+façade).
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from benchflow.task import Verifier
+from benchflow.task.config import (
+    NetworkMode,
+    SandboxConfig,
+    TaskConfig,
+    _validate_network_policy_fields,
+)
+from benchflow.task.verifier import AgentJudgeInputError
+from benchflow.task.verifier_document import (
+    VerifierDocument,
+    VerifierDocumentParseError,
+    VerifierStrategy,
+)
+
+
+class TestExplicitNetworkModeContradiction:
+    def test_allowlist_with_allow_internet_false_raises(self):
+        with pytest.raises(ValueError):
+            SandboxConfig(
+                network_mode="allowlist",
+                allowed_hosts=["x.com"],
+                allow_internet=False,
+            )
+
+    def test_public_with_allow_internet_false_raises(self):
+        with pytest.raises(ValueError):
+            SandboxConfig(network_mode="public", allow_internet=False)
+
+
+class TestLegacyAllowInternetBackCompat:
+    def test_allow_internet_false_without_explicit_mode_resolves_no_network(self):
+        cfg = SandboxConfig(allow_internet=False)
+        assert cfg.network_mode == NetworkMode.NO_NETWORK
+        assert cfg.allowed_hosts is None
+        assert cfg.allow_internet is False
+
+    def test_explicit_no_network_with_allow_internet_false_is_consistent(self):
+        cfg = SandboxConfig(network_mode="no-network", allow_internet=False)
+        assert cfg.network_mode == NetworkMode.NO_NETWORK
+        assert cfg.allow_internet is False
+
+
+class TestPolicyInvariantAfterReconcile:
+    def test_no_network_with_stale_allowed_hosts_is_never_produced(self):
+        """The legacy override path must not yield no-network + allowed_hosts.
+
+        Reconciliation re-runs _validate_network_policy_fields at the end, so a
+        contradictory combination is rejected rather than silently produced.
+        """
+        with pytest.raises(ValueError):
+            SandboxConfig(
+                network_mode="allowlist",
+                allowed_hosts=["x.com"],
+                allow_internet=False,
+            )
+
+    def test_reconciled_object_satisfies_policy_validator(self):
+        cfg = SandboxConfig(allow_internet=False)
+        # Must not raise: the post-reconcile state is internally consistent.
+        _validate_network_policy_fields(cfg.network_mode, cfg.allowed_hosts)
+
+
+class TestSchemaVersionValidation:
+    def test_unknown_major_version_raises(self):
+        with pytest.raises(ValueError):
+            TaskConfig(schema_version="99.0")
+
+    def test_non_parseable_version_raises(self):
+        with pytest.raises(ValueError):
+            TaskConfig(schema_version="banana")
+
+    def test_explicit_supported_version_accepted(self):
+        cfg = TaskConfig(schema_version="1.0")
+        assert cfg.schema_version == "1.0"
+
+    def test_default_version_accepted(self):
+        cfg = TaskConfig()
+        assert cfg.schema_version == "1.3"
+
+
+def _agent_judge_doc(inputs_literal: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        ---
+        verifier:
+          name: demo
+          default_strategy: judge
+          strategies:
+            judge:
+              type: agent-judge
+              role: grader
+              isolation: verifier-only
+              inputs: {inputs_literal}
+        ---
+
+        ## role:grader
+
+        Grade the work.
+        """
+    )
+
+
+def _ors_episode_doc(inputs_literal: str) -> str:
+    return textwrap.dedent(
+        f"""\
+        ---
+        verifier:
+          name: demo
+          default_strategy: episode
+          strategies:
+            episode:
+              type: ors-episode
+              inputs: {inputs_literal}
+        ---
+        """
+    )
+
+
+def test_agent_judge_empty_inputs_rejected() -> None:
+    with pytest.raises(VerifierDocumentParseError, match="non-empty"):
+        VerifierDocument.from_text(_agent_judge_doc("[]"))
+
+
+def test_agent_judge_populated_inputs_accepted() -> None:
+    doc = VerifierDocument.from_text(_agent_judge_doc('["report.md"]'))
+    assert doc.strategies["judge"].inputs == ("report.md",)
+
+
+def test_ors_episode_empty_inputs_rejected() -> None:
+    with pytest.raises(VerifierDocumentParseError, match="non-empty"):
+        VerifierDocument.from_text(_ors_episode_doc("[]"))
+
+
+def test_ors_episode_populated_inputs_accepted() -> None:
+    doc = VerifierDocument.from_text(_ors_episode_doc('["episode.jsonl"]'))
+    assert doc.strategies["episode"].inputs == ("episode.jsonl",)
+
+
+async def test_collect_agent_judge_inputs_empty_raises() -> None:
+    """Runtime backstop mirroring _collect_ors_episode_inputs: an evidence-less
+    agent-judge strategy must not silently call the judge and grade a reward."""
+    strategy = VerifierStrategy(name="judge", type="agent-judge", config={"inputs": []})
+    verifier = Verifier(task=None, rollout_paths=None, sandbox=None)
+    with pytest.raises(AgentJudgeInputError):
+        await verifier._collect_agent_judge_inputs(strategy)


### PR DESCRIPTION
Ports four validation guards from PR #651 (main) onto `release/v0.6.0`. A code audit of 0.6.0-rc.6 on 2026-06-12 verified all four guards are absent on this branch; each was a real hole, not a refactor artifact.

## What each guard closes

### 1. `schema_version` major-version gate (`src/benchflow/task/config.py`)
v0.6 `TaskConfig.schema_version` accepted **any string** (`"banana"`, `"99.0"`) and carried it through silently. Ported `validate_schema_version` + `_SUPPORTED_SCHEMA_MAJORS = frozenset({1})`: non-numeric versions and majors outside `{1}` are now a hard `ValueError`. Minor versions stay permissive; the `"1.3"` default and existing `"1.0"`/`"1.x"` tasks are unaffected.

### 2. Agent-judge empty-inputs runtime backstop (`src/benchflow/task/verifier_core.py`)
`_collect_agent_judge_inputs` had no emptiness check, unlike its `_collect_ors_episode_inputs` sibling. **This is the silent-zero-evidence judge hole**: an `agent-judge` strategy whose `inputs` resolved empty would invoke the judge with *no evidence at all* and still produce a graded reward — a score backed by nothing, indistinguishable from a real one. Now raises `AgentJudgeInputError` (`"agent-judge strategy ... must declare inputs"`) before any judge call.

### 3. `verifier_document` empty-list fix (`src/benchflow/task/verifier_document.py`)
The parse-time checks for `agent-judge` and `ors-episode` `inputs` used `not isinstance(inputs, list) or not all(...)` — but `all([]) is True`, so an **empty list passed** a check whose error message says "must be a non-empty list of strings". Added `or not inputs` to both branches, making the document-level validation match its own contract (and backstopping guard 2 at parse time).

### 4. Network-mode contradiction hard-error (`src/benchflow/task/config.py`)
`SandboxConfig` silently coerced an **explicitly declared** `network_mode` (e.g. `allowlist` + `allowed_hosts`) down to `no-network` whenever the deprecated `allow_internet = false` was also present — a silent, surprising network downgrade. Ported the `model_fields_set`-based reconciliation: an explicit contradiction is now a hard `ValueError` directing authors to drop the deprecated flag, while the legacy path (`allow_internet = false` with **no** explicit `network_mode`) still coerces to `no-network` as before. Reconciliation also re-runs `_validate_network_policy_fields` at the end so it can never emit a self-contradictory config.

## Source
Reference implementation: PR #651 (`src/benchflow/task/config.py`, `src/benchflow/task/verifier.py`, `src/benchflow/task/verifier_document.py`), adapted to the v0.6 module layout (`verifier_core` behind the `benchflow.task.verifier` façade; `AgentJudgeInputError` from `verifier_errors`).

## Tests
- New `tests/test_v06_guard_ports.py` (15 tests) mirroring the #651 tests (`test_network_policy_reconcile.py`, `test_agent_judge_inputs.py`): contradiction raises, legacy back-compat coercion preserved, post-reconcile invariant, schema major gate (reject `99.0`/`banana`, accept `1.0`/default), document-level empty-`inputs` rejection for both strategy types, and the async runtime backstop on `_collect_agent_judge_inputs`.
- Directly-touched modules green: `test_task_config.py`, `test_verifier_document.py`, `test_internet_policy.py`, plus the verifier strategy/output/judge suites (126 passed).
- Full unit suite (`pytest tests/ --ignore=tests/integration`): **3834 passed, 49 skipped, 0 failures** — no existing fixture trips any guard, so no compatibility accommodations were needed.
- `ruff format` / `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)