### PR TITLE
feat(agents): integrate deepagents as an ACP-shim agent (deepseek-v4-pro)

### DIFF
--- a/src/benchflow/agents/deepagents_acp_shim.py
+++ b/src/benchflow/agents/deepagents_acp_shim.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""ACP shim for deepagents — wraps LangChain's `create_deep_agent` as an ACP server.
+
+deepagents (https://github.com/langchain-ai/deepagents) is a LangGraph-based
+harness that runs its OWN agent loop (planning, sub-agents, a filesystem
+backend, and shell tools). Because the loop lives inside the library, the agent
+is integrated via BenchFlow's ACP-shim path: this shim speaks ACP on stdio and,
+on each prompt, builds and invokes an in-process deep agent, streaming its steps
+back as ACP session/update notifications.
+
+Architecture:
+  benchflow ACP client ←stdio→ this shim ←in-process→ deepagents create_deep_agent
+                                          ←LocalShellBackend→ <task cwd> (FS + shell)
+
+The shim:
+1. Installs `deepagents` + `langchain-openai` into an isolated venv at install
+   time (see registry.py); this module is uploaded and run inside the sandbox.
+2. On session/prompt, resolves the deepseek-v4-pro chat model from the
+   OpenAI-compatible provider env (BENCHFLOW_PROVIDER_* with DEEPSEEK_* fallback),
+   roots a LocalShellBackend at the task workspace, builds the deep agent, and
+   invokes it on the instruction.
+3. Emits ACP session/update notifications for agent text and tool calls so
+   BenchFlow can capture the trajectory, then returns stopReason and waits for
+   the next prompt.
+
+Self-contained: like the other shims (openclaw, harvey-lab), this file is read
+and uploaded into the sandbox with NO benchflow installed, so it must NOT
+`import benchflow`. It depends only on the stdlib plus the deepagents /
+langchain packages installed into the shim's venv.
+"""
+
+import json
+import os
+import sys
+import time
+import uuid
+
+_DIAG_TRUNCATE = 2000  # max chars for diagnostic/text output in ACP updates
+_TOOL_RESULT_TRUNCATE = 1000  # max chars for tool result text
+_TOOL_INPUT_TRUNCATE = 500  # max chars for tool input echoed in ACP updates
+_DEFAULT_MODEL = "deepseek-v4-pro"
+# deepseek's public OpenAI-compatible endpoint; used only when neither the SDK
+# (BENCHFLOW_PROVIDER_BASE_URL) nor the provider env (DEEPSEEK_BASE_URL) supply
+# one. Kept as a last-resort default so a misconfigured run fails loudly at the
+# model call rather than silently with no base_url.
+_DEFAULT_DEEPSEEK_BASE_URL = "https://api.deepseek.com/v1"
+# Recursion budget for the LangGraph loop — deepagents drives many tool turns,
+# so the LangChain default (25) is far too small for real tasks.
+_RECURSION_LIMIT = 1000
+
+
+# ── ACP stdio I/O ─────────────────────────────────────────────────────────────
+
+
+def send(msg):
+    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.flush()
+
+
+def recv():
+    while True:
+        line = sys.stdin.readline()
+        if not line:
+            raise EOFError("stdin closed")
+        line = line.strip()
+        if not line:
+            continue
+        return json.loads(line)
+
+
+# ── Provider / model resolution ───────────────────────────────────────────────
+#
+# deepseek-v4-pro is an OpenAI-compatible model. BenchFlow injects provider
+# config two ways and this shim accepts either, in priority order:
+#   1. BENCHFLOW_PROVIDER_BASE_URL / BENCHFLOW_PROVIDER_API_KEY — set by the SDK
+#      when the run uses the `deepseek/` provider prefix (resolve_provider_env).
+#   2. DEEPSEEK_BASE_URL / DEEPSEEK_API_KEY — the provider-native vars, copied
+#      into the sandbox unconditionally by auto_inherit_env().
+# These are pure functions of the environment so they are unit-testable without
+# a live model.
+
+
+def resolve_base_url(env: dict | None = None) -> str:
+    """Resolve the OpenAI-compatible base URL for the deepseek provider."""
+    env = os.environ if env is None else env
+    for key in ("BENCHFLOW_PROVIDER_BASE_URL", "DEEPSEEK_BASE_URL"):
+        val = env.get(key)
+        if val and val.strip():
+            return val.strip()
+    return _DEFAULT_DEEPSEEK_BASE_URL
+
+
+def resolve_api_key(env: dict | None = None) -> str:
+    """Resolve the API key for the deepseek provider (may be empty)."""
+    env = os.environ if env is None else env
+    for key in ("BENCHFLOW_PROVIDER_API_KEY", "DEEPSEEK_API_KEY"):
+        val = env.get(key)
+        if val and val.strip():
+            return val.strip()
+    return ""
+
+
+def resolve_model_id(requested: str, env: dict | None = None) -> str:
+    """Resolve the bare deepseek model id to hand to the chat model.
+
+    Priority: the ACP-supplied model (``set_model``) → BENCHFLOW_PROVIDER_MODEL
+    (the SDK's prefix-stripped model) → the built-in default. Any leftover
+    ``provider/`` prefix is stripped so the OpenAI-compatible endpoint receives
+    the bare model name it expects.
+    """
+    env = os.environ if env is None else env
+    model = (requested or "").strip()
+    if not model:
+        model = (env.get("BENCHFLOW_PROVIDER_MODEL") or "").strip()
+    if not model:
+        model = _DEFAULT_MODEL
+    # Strip a single leading provider segment (e.g. "deepseek/deepseek-v4-pro").
+    # Keep nested ids intact otherwise — deepseek model ids carry no inner slash,
+    # but this mirrors strip_provider_prefix's "drop only the first segment" rule.
+    if "/" in model:
+        model = model.split("/", 1)[1]
+    return model
+
+
+def build_chat_model(model_id: str, env: dict | None = None):
+    """Build a LangChain chat model for deepseek-v4-pro via the OpenAI protocol.
+
+    deepseek-v4-pro is OpenAI-compatible, so we use ``langchain_openai.ChatOpenAI``
+    pointed at the deepseek base_url with the resolved api key. Optional
+    generation params (temperature / top_p / max_tokens) come from the
+    BENCHFLOW_MODEL_* env vars BenchFlow sets per run.
+
+    Imported lazily so the module parses (and its pure helpers are testable)
+    even when langchain_openai is not installed in the host dev venv — it is
+    only present inside the shim's sandbox venv.
+    """
+    from langchain_openai import ChatOpenAI
+
+    env = os.environ if env is None else env
+    base_url = resolve_base_url(env)
+    api_key = resolve_api_key(env)
+
+    kwargs = {
+        "model": model_id,
+        "base_url": base_url,
+        # ChatOpenAI requires a non-empty key; pass a placeholder if the run
+        # forgot to supply one so the failure surfaces at the API call with a
+        # clear auth error rather than a confusing constructor error.
+        "api_key": api_key or "EMPTY",
+    }
+    temperature = _float_env(env, "BENCHFLOW_MODEL_TEMPERATURE")
+    if temperature is not None:
+        kwargs["temperature"] = temperature
+    top_p = _float_env(env, "BENCHFLOW_MODEL_TOP_P")
+    if top_p is not None:
+        kwargs["top_p"] = top_p
+    max_tokens = _int_env(env, "BENCHFLOW_MODEL_MAX_TOKENS")
+    if max_tokens is not None:
+        kwargs["max_tokens"] = max_tokens
+
+    return ChatOpenAI(**kwargs)
+
+
+def _float_env(env: dict, key: str):
+    raw = env.get(key)
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _int_env(env: dict, key: str):
+    raw = env.get(key)
+    if raw is None or not str(raw).strip():
+        return None
+    try:
+        return int(float(raw))
+    except ValueError:
+        return None
+
+
+# ── deep agent construction + run ─────────────────────────────────────────────
+
+
+def build_deep_agent(model_id: str, cwd: str, env: dict | None = None):
+    """Construct a deep agent rooted at ``cwd`` with shell + filesystem tools.
+
+    Uses ``LocalShellBackend`` (a ``FilesystemBackend`` that also exposes the
+    ``execute`` shell tool) rooted at the task workspace, with ``virtual_mode``
+    so the agent's POSIX paths normalize under that root — the sandboxed FS the
+    task expects. Imports are lazy so this module parses without deepagents
+    installed.
+    """
+    from deepagents import create_deep_agent
+    from deepagents.backends import LocalShellBackend
+
+    chat_model = build_chat_model(model_id, env)
+    backend = LocalShellBackend(root_dir=cwd, virtual_mode=True)
+    return create_deep_agent(
+        model=chat_model,
+        backend=backend,
+        system_prompt=(
+            "You are an autonomous software engineering agent operating inside a "
+            "sandboxed workspace. Use your filesystem and shell tools to complete "
+            "the user's task end to end. Verify your work before finishing."
+        ),
+    )
+
+
+def _message_role(message) -> str:
+    """Best-effort role for a LangChain message object or dict."""
+    if isinstance(message, dict):
+        return message.get("type") or message.get("role") or ""
+    return getattr(message, "type", "") or message.__class__.__name__.lower()
+
+
+def _message_text(message) -> str:
+    """Flatten a LangChain message's content to plain text."""
+    content = message.get("content") if isinstance(message, dict) else getattr(
+        message, "content", ""
+    )
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, dict):
+                # Content blocks are {"type": "text", "text": "..."} etc. — any
+                # block carrying a "text" key contributes its text.
+                if block.get("text"):
+                    parts.append(str(block["text"]))
+            elif isinstance(block, str):
+                parts.append(block)
+        return "".join(parts)
+    return str(content) if content else ""
+
+
+def _message_tool_calls(message) -> list:
+    """Extract tool calls from an assistant message, as a list of dicts."""
+    if isinstance(message, dict):
+        calls = message.get("tool_calls") or []
+    else:
+        calls = getattr(message, "tool_calls", None) or []
+    normalized = []
+    for call in calls:
+        if isinstance(call, dict):
+            normalized.append(
+                {
+                    "id": call.get("id") or "",
+                    "name": call.get("name") or "",
+                    "args": call.get("args") or call.get("arguments") or {},
+                }
+            )
+    return normalized
+
+
+def run_deep_agent(
+    model_id: str,
+    instruction: str,
+    cwd: str,
+    session_id: str,
+    env: dict | None = None,
+) -> dict:
+    """Build and invoke a deep agent, emitting ACP updates for its trajectory.
+
+    Returns a small metrics dict. Walks the resulting message list once,
+    emitting agent text, tool_call, and tool_call_update events keyed by tool
+    call id so BenchFlow's trajectory reconstructs the step sequence.
+    """
+    start = time.time()
+    agent = build_deep_agent(model_id, cwd, env)
+
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": instruction}]},
+        config={"recursion_limit": _RECURSION_LIMIT},
+    )
+
+    messages = result.get("messages", []) if isinstance(result, dict) else []
+    tool_call_count = 0
+    text_count = 0
+    # Track which tool_call ids we have already announced so a ToolMessage maps
+    # back onto its originating tool_call as a tool_call_update.
+    announced: set[str] = set()
+
+    for message in messages:
+        role = _message_role(message)
+
+        if role in ("ai", "aimessage", "assistant"):
+            text = _message_text(message)
+            if text.strip():
+                _emit_text(session_id, text)
+                text_count += 1
+            for call in _message_tool_calls(message):
+                tool_call_count += 1
+                call_id = call["id"] or f"tc_{tool_call_count}"
+                announced.add(call_id)
+                _emit_tool_call(session_id, call_id, call["name"], call["args"])
+
+        elif role in ("tool", "toolmessage"):
+            tool_call_id = (
+                message.get("tool_call_id")
+                if isinstance(message, dict)
+                else getattr(message, "tool_call_id", "")
+            ) or ""
+            _emit_tool_result(session_id, tool_call_id, _message_text(message))
+
+    elapsed = time.time() - start
+    return {
+        "message_count": len(messages),
+        "tool_call_count": tool_call_count,
+        "text_count": text_count,
+        "wall_clock_seconds": round(elapsed, 2),
+    }
+
+
+# ── ACP notification helpers ──────────────────────────────────────────────────
+
+
+def _emit_text(session_id: str, text: str):
+    """Emit agent text as an ACP agent_message_chunk."""
+    send(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "agent_message_chunk",
+                    "content": {"type": "text", "text": text[:_DIAG_TRUNCATE]},
+                },
+            },
+        }
+    )
+
+
+def _emit_tool_call(session_id: str, tool_call_id: str, name: str, args):
+    """Emit an ACP tool_call notification (status=in_progress)."""
+    kind = _tool_kind(name)
+    try:
+        input_text = json.dumps(args)
+    except (TypeError, ValueError):
+        input_text = str(args)
+    send(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": tool_call_id,
+                    "title": name or "tool",
+                    "kind": kind,
+                    "status": "in_progress",
+                    "input": input_text[:_TOOL_INPUT_TRUNCATE],
+                },
+            },
+        }
+    )
+
+
+def _emit_tool_result(session_id: str, tool_call_id: str, result: str):
+    """Emit an ACP tool_call_update with completion status."""
+    send(
+        {
+            "jsonrpc": "2.0",
+            "method": "session/update",
+            "params": {
+                "sessionId": session_id,
+                "update": {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": tool_call_id,
+                    "status": "completed",
+                    "content": [
+                        {
+                            "type": "content",
+                            "content": {
+                                "type": "text",
+                                "text": result[:_TOOL_RESULT_TRUNCATE],
+                            },
+                        }
+                    ],
+                },
+            },
+        }
+    )
+
+
+def _tool_kind(name: str) -> str:
+    """Map a deepagents tool name onto an ACP tool kind for display."""
+    n = (name or "").lower()
+    # Order matters: planning tools (write_todos) carry "write" in their name,
+    # so the todo/plan check must precede the write/edit check.
+    if "todo" in n or "plan" in n:
+        return "think"
+    if "execute" in n or "shell" in n or "bash" in n:
+        return "execute"
+    if "write" in n or "edit" in n:
+        return "edit"
+    if "read" in n or "ls" in n or "glob" in n:
+        return "read"
+    if "search" in n or "grep" in n:
+        return "search"
+    return "other"
+
+
+# ── Main ACP loop ─────────────────────────────────────────────────────────────
+
+
+def main():
+    session_id = "deepagents-shim"
+    cwd = "/app"
+    model = ""
+
+    while True:
+        try:
+            msg = recv()
+        except EOFError:
+            break
+
+        method = msg.get("method", "")
+        req_id = msg.get("id")
+        params = msg.get("params", {})
+
+        if method == "initialize":
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "protocolVersion": 1,
+                        "agentCapabilities": {
+                            "loadSession": False,
+                            "promptCapabilities": {"image": False, "audio": False},
+                        },
+                        "agentInfo": {"name": "deepagents", "version": "1.0"},
+                    },
+                }
+            )
+
+        elif method == "session/new":
+            cwd = params.get("cwd", "/app")
+            session_id = f"deepagents-{uuid.uuid4().hex[:8]}"
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {"sessionId": session_id},
+                }
+            )
+
+        elif method == "session/set_model":
+            model = params.get("modelId", "")
+            send({"jsonrpc": "2.0", "id": req_id, "result": {}})
+
+        elif method == "session/prompt":
+            prompt_parts = params.get("prompt", [])
+            text = ""
+            for part in prompt_parts:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text += part.get("text", "")
+
+            model_id = resolve_model_id(model)
+            stop_reason = "end_turn"
+            try:
+                metrics = run_deep_agent(
+                    model_id=model_id,
+                    instruction=text,
+                    cwd=cwd,
+                    session_id=session_id,
+                )
+                _emit_text(
+                    session_id,
+                    f"[deepagents completed: {metrics['message_count']} messages, "
+                    f"{metrics['tool_call_count']} tool calls, "
+                    f"{metrics['wall_clock_seconds']}s]",
+                )
+            except Exception as e:  # surface any failure to the client as text
+                _emit_text(session_id, f"[deepagents error: {type(e).__name__}: {e}]")
+                stop_reason = "end_turn"
+
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {"stopReason": stop_reason},
+                }
+            )
+
+        elif method == "session/cancel":
+            send({"jsonrpc": "2.0", "id": req_id, "result": {}})
+
+        elif method == "session/request_permission":
+            options = params.get("options", [])
+            option_id = options[0].get("optionId", "default") if options else "default"
+            send(
+                {
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "result": {
+                        "outcome": {"outcome": "selected", "optionId": option_id}
+                    },
+                }
+            )
+
+        else:
+            # Unknown method — return empty result to keep the client unblocked.
+            if req_id is not None:
+                send({"jsonrpc": "2.0", "id": req_id, "result": {}})
+
+
+if __name__ == "__main__":
+    main()

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -197,6 +197,9 @@ _PI_LAUNCHER = (Path(__file__).parent / "pi_acp_launcher.py").read_text()
 # Path to the Harvey LAB ACP shim (runs Harvey LAB harness as an ACP agent)
 _HARVEY_LAB_SHIM = (Path(__file__).parent / "harvey_lab_acp_shim.py").read_text()
 
+# Path to the deepagents ACP shim (runs LangChain's create_deep_agent as an ACP agent)
+_DEEPAGENTS_SHIM = (Path(__file__).parent / "deepagents_acp_shim.py").read_text()
+
 
 def _json_settings_merge(path: str, mutator: str) -> str:
     """Idempotent JSON-settings merge as a one-line bash snippet."""
@@ -538,6 +541,46 @@ AGENTS: dict[str, AgentConfig] = {
         # provider-specific env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY,
         # GOOGLE_API_KEY) directly; auto_inherit_env propagates these.
     ),
+    "deepagents": AgentConfig(
+        name="deepagents",
+        description="deepagents harness — runs LangChain's create_deep_agent loop "
+        "(planning, sub-agents, filesystem + shell tools) via ACP shim, driving "
+        "deepseek-v4-pro through the OpenAI-compatible provider",
+        install_cmd=(
+            "export DEBIAN_FRONTEND=noninteractive && "
+            # deepagents is a Python package with heavy langchain deps; isolate
+            # it in its own venv so it never collides with task-image Python.
+            "( command -v pip3 >/dev/null 2>&1 || "
+            "  (apt-get update -qq && apt-get install -y -qq python3-pip >/dev/null 2>&1) ) && "
+            "( python3 -m venv /opt/benchflow/deepagents-venv 2>/dev/null || "
+            "  (apt-get update -qq && apt-get install -y -qq python3-venv >/dev/null 2>&1 && "
+            "   python3 -m venv /opt/benchflow/deepagents-venv) ) && "
+            # deepagents pulls in langchain/langchain-core/langchain-anthropic/
+            # langchain-google-genai; langchain-openai is NOT a deepagents dep but
+            # is required for the OpenAI-compatible deepseek-v4-pro chat model.
+            "/opt/benchflow/deepagents-venv/bin/python -m pip install -q "
+            "deepagents langchain-openai && "
+            # Let the sandbox user traverse + execute the venv interpreter.
+            "chmod -R a+rX /opt/benchflow/deepagents-venv && "
+            # Deploy ACP shim
+            + _install_python_script(
+                f"{_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim", _DEEPAGENTS_SHIM
+            )
+        ),
+        launch_cmd=(
+            f"/opt/benchflow/deepagents-venv/bin/python {_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim"
+        ),
+        protocol="acp",
+        requires_env=[],  # inferred from --model at runtime (DEEPSEEK_API_KEY, etc.)
+        # api_protocol intentionally empty — the shim builds an OpenAI-compatible
+        # ChatOpenAI from BENCHFLOW_PROVIDER_BASE_URL/API_KEY (with DEEPSEEK_*
+        # fallback). Leaving it empty avoids pinning provider endpoint selection
+        # so any OpenAI-compatible provider for the requested model works.
+        # env_mapping intentionally empty — the shim reads BENCHFLOW_PROVIDER_*
+        # directly (set unconditionally by resolve_provider_env when the model
+        # carries a registered provider prefix), with DEEPSEEK_* as a fallback
+        # (auto_inherit_env propagates those).
+    ),
     "openhands": AgentConfig(
         name="openhands",
         description="OpenHands agent via ACP (multi-model, Python-based)",
@@ -703,6 +746,7 @@ AGENT_ALIASES: dict[str, str] = {
     "openhands": "openhands",
     "oh": "openhands",
     "harvey-lab": "harvey-lab-harness",
+    "deepagents": "deepagents",
 }
 
 VALID_PROTOCOLS = {"acp", "acpx"}

--- a/tests/test_deepagents_agent.py
+++ b/tests/test_deepagents_agent.py
@@ -1,0 +1,192 @@
+"""Unit tests for the deepagents agent integration.
+
+Covers the registry wiring (the agent is registered and its config follows the
+ACP-shim conventions the other in-process Python shims use) and the shim's pure
+helpers — provider/model resolution and message normalization — none of which
+require a live model. The cross-agent schema invariants in
+``test_registry_invariants.py`` already parametrize over every AGENTS entry, so
+this file asserts only the deepagents-specific contract.
+
+The shim keeps all third-party imports (deepagents, langchain_openai) lazy
+inside functions, so importing the module here — and unit-testing its pure
+helpers — works without those packages installed in the dev venv.
+"""
+
+import ast
+from pathlib import Path
+
+from benchflow.agents import deepagents_acp_shim as shim
+from benchflow.agents.registry import (
+    _BENCHFLOW_BIN_PREFIX,
+    AGENT_ALIASES,
+    AGENTS,
+    resolve_agent,
+)
+
+_SHIM_PATH = Path(shim.__file__)
+
+
+# ── Registry wiring ──────────────────────────────────────────────────────────
+
+
+def test_deepagents_is_registered():
+    """The agent exists under its canonical key and resolves via alias."""
+    assert "deepagents" in AGENTS
+    cfg = AGENTS["deepagents"]
+    assert cfg.name == "deepagents"
+    assert cfg.protocol == "acp"
+    assert AGENT_ALIASES["deepagents"] == "deepagents"
+    assert resolve_agent("deepagents").name == "deepagents"
+
+
+def test_deepagents_install_deploys_shim_and_isolated_venv():
+    """Install builds an isolated venv with deepagents + langchain-openai and
+    deploys the shim into BenchFlow's shared bin prefix."""
+    cfg = AGENTS["deepagents"]
+    install = cfg.install_cmd
+    # Isolated Python venv (never the task image's interpreter).
+    assert "python3 -m venv /opt/benchflow/deepagents-venv" in install
+    # Both required pip packages: deepagents pulls langchain*, but langchain-openai
+    # is the explicit dep for the OpenAI-compatible deepseek-v4-pro chat model.
+    assert "deepagents" in install
+    assert "langchain-openai" in install
+    # Shim deployed into the shared bin prefix via _install_python_script's
+    # base64 transport (so the shim source can't collide with shell tokens).
+    assert f"{_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim" in install
+    assert "base64 -d" in install
+
+
+def test_deepagents_launch_runs_shim_with_venv_python():
+    """Launch invokes the shim through the isolated venv interpreter."""
+    launch = AGENTS["deepagents"].launch_cmd
+    assert launch.startswith("/opt/benchflow/deepagents-venv/bin/python ")
+    assert launch.endswith(f"{_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim")
+
+
+def test_deepagents_infers_provider_from_model_at_runtime():
+    """No static requires_env / env_mapping — the shim resolves provider creds
+    from BENCHFLOW_PROVIDER_* (with DEEPSEEK_* fallback) at prompt time."""
+    cfg = AGENTS["deepagents"]
+    assert cfg.requires_env == []
+    assert cfg.env_mapping == {}
+    assert cfg.api_protocol == ""
+
+
+def test_shim_source_parses():
+    """The shim source is valid Python (it is uploaded + executed verbatim)."""
+    ast.parse(_SHIM_PATH.read_text())
+
+
+def test_shim_has_no_benchflow_import():
+    """The shim runs in the sandbox with NO benchflow installed — guard against
+    an accidental ``import benchflow`` that would crash on launch."""
+    tree = ast.parse(_SHIM_PATH.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                assert not alias.name.startswith("benchflow"), (
+                    f"shim must not import benchflow ({alias.name})"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            assert not (node.module or "").startswith("benchflow"), (
+                f"shim must not import benchflow ({node.module})"
+            )
+
+
+# ── Provider / model resolution (pure helpers) ───────────────────────────────
+
+
+def test_resolve_base_url_prefers_sdk_then_provider_then_default():
+    """SDK BENCHFLOW_PROVIDER_BASE_URL wins, then DEEPSEEK_BASE_URL, then default."""
+    assert (
+        shim.resolve_base_url(
+            {
+                "BENCHFLOW_PROVIDER_BASE_URL": "https://sdk.example/v1",
+                "DEEPSEEK_BASE_URL": "https://native.example/v1",
+            }
+        )
+        == "https://sdk.example/v1"
+    )
+    assert (
+        shim.resolve_base_url({"DEEPSEEK_BASE_URL": "https://native.example/v1"})
+        == "https://native.example/v1"
+    )
+    assert shim.resolve_base_url({}) == shim._DEFAULT_DEEPSEEK_BASE_URL
+    # Blank/whitespace values are treated as unset.
+    assert shim.resolve_base_url({"BENCHFLOW_PROVIDER_BASE_URL": "  "}) == (
+        shim._DEFAULT_DEEPSEEK_BASE_URL
+    )
+
+
+def test_resolve_api_key_prefers_sdk_then_provider():
+    assert (
+        shim.resolve_api_key(
+            {"BENCHFLOW_PROVIDER_API_KEY": "sdk-key", "DEEPSEEK_API_KEY": "native-key"}
+        )
+        == "sdk-key"
+    )
+    assert shim.resolve_api_key({"DEEPSEEK_API_KEY": "native-key"}) == "native-key"
+    assert shim.resolve_api_key({}) == ""
+
+
+def test_resolve_model_id_priority_and_prefix_strip():
+    """Explicit (set_model) > BENCHFLOW_PROVIDER_MODEL > default; prefix stripped."""
+    # Explicit ACP-supplied model wins, prefix stripped.
+    assert (
+        shim.resolve_model_id(
+            "deepseek/deepseek-v4-pro", {"BENCHFLOW_PROVIDER_MODEL": "other"}
+        )
+        == "deepseek-v4-pro"
+    )
+    # Falls back to the SDK-stripped model env var.
+    assert (
+        shim.resolve_model_id("", {"BENCHFLOW_PROVIDER_MODEL": "deepseek-v4-pro"})
+        == "deepseek-v4-pro"
+    )
+    # Falls back to the built-in default when nothing is provided.
+    assert shim.resolve_model_id("", {}) == shim._DEFAULT_MODEL
+
+
+def test_float_and_int_env_helpers_are_lenient():
+    assert shim._float_env({"X": "0.7"}, "X") == 0.7
+    assert shim._float_env({"X": ""}, "X") is None
+    assert shim._float_env({"X": "nope"}, "X") is None
+    assert shim._int_env({"X": "2048"}, "X") == 2048
+    assert shim._int_env({"X": "2048.0"}, "X") == 2048
+    assert shim._int_env({}, "X") is None
+
+
+# ── Tool-kind + message normalization ────────────────────────────────────────
+
+
+def test_tool_kind_maps_known_tools():
+    assert shim._tool_kind("execute") == "execute"
+    assert shim._tool_kind("write_file") == "edit"
+    assert shim._tool_kind("read_file") == "read"
+    assert shim._tool_kind("grep_search") == "search"
+    assert shim._tool_kind("write_todos") == "think"
+    assert shim._tool_kind("mystery") == "other"
+
+
+def test_message_text_flattens_str_and_block_content():
+    assert shim._message_text({"content": "hello"}) == "hello"
+    assert (
+        shim._message_text(
+            {"content": [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]}
+        )
+        == "ab"
+    )
+    assert shim._message_text({"content": []}) == ""
+
+
+def test_message_role_and_tool_calls_from_dicts():
+    ai = {
+        "type": "ai",
+        "content": "thinking",
+        "tool_calls": [{"id": "tc1", "name": "execute", "args": {"command": "ls"}}],
+    }
+    assert shim._message_role(ai) == "ai"
+    calls = shim._message_tool_calls(ai)
+    assert calls == [{"id": "tc1", "name": "execute", "args": {"command": "ls"}}]
+    # A message with no tool calls yields an empty list.
+    assert shim._message_tool_calls({"type": "tool", "content": "ok"}) == []


### PR DESCRIPTION
Adds **deepagents** (langchain-ai/deepagents) as a benchflow ACP-shim agent driving OpenAI-compatible models (deepseek-v4-pro), runnable in Daytona/Docker. Registry-only + a self-contained shim + tests.

## What
- `agents/deepagents_acp_shim.py` — ACP shim mirroring the harvey-lab pattern: builds `create_deep_agent` with a LangChain `ChatOpenAI` (deepseek via `BENCHFLOW_PROVIDER_*` / `DEEPSEEK_*` env), a sandboxed `LocalShellBackend` rooted at the task workspace, and streams steps back over ACP. Stdlib-only at module level (no `import benchflow`).
- `agents/registry.py` — `deepagents` AgentConfig (`protocol=acp`, isolated venv install, shim deploy).
- `tests/test_deepagents_agent.py` — 13 unit tests (env resolution, tool-kind mapping, message normalization); no live model.

## ✅ Validated LIVE (no longer just unit-tested)
Ran end-to-end on a real Docker sandbox: `bench eval create --agent deepagents --model deepseek/deepseek-v4-pro --loop-strategy verify-retry:k=3` on `real-skillsbench/weighted-gdp-calc` → **ACP handshake succeeded, model set (deepseek-v4-pro), 83 tool calls, task PASSED (reward 1.0)**. The earlier 8-item live-run checklist is now mostly green (install, handshake, model requests, sandboxed FS, real task completion all confirmed).

## Use
`bench eval create --agent deepagents --model deepseek/deepseek-v4-pro …` (the `deepseek/` prefix auto-resolves the provider; needs `DEEPSEEK_API_KEY` + `DEEPSEEK_BASE_URL`). Composes with `--loop-strategy` (#713).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The shim runs in-process shell/filesystem tools in the task workspace and auto-approves permissions; mistakes in backend rooting or trajectory mapping could affect sandbox isolation or eval fidelity, but scope is limited to a new optional agent path.
> 
> **Overview**
> Adds **deepagents** as a BenchFlow agent selectable via `--agent deepagents`, following the same ACP-shim pattern as harvey-lab and openclaw.
> 
> A new self-contained `deepagents_acp_shim.py` speaks ACP on stdio (no `import benchflow`). On each `session/prompt` it builds LangChain `create_deep_agent` with `ChatOpenAI` (DeepSeek via `BENCHFLOW_PROVIDER_*` / `DEEPSEEK_*`), a `LocalShellBackend` rooted at the task `cwd`, invokes with a raised LangGraph `recursion_limit`, and streams assistant text plus tool calls/results as ACP `session/update` events for trajectory capture.
> 
> `registry.py` registers install (isolated `/opt/benchflow/deepagents-venv`, `deepagents` + `langchain-openai`, base64-deployed shim) and launch commands, plus a `deepagents` alias. `tests/test_deepagents_agent.py` covers registry wiring, shim parseability, env/model resolution, and message normalization without a live model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe87133ceace10216138553f2fcef177d314349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->