### PR TITLE
feat(loop): job-level convergence report (loop_summary / pass@iteration)

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -133,6 +133,64 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
     }
 
 
+def loop_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate per-rollout ``loop`` blocks into a job-level convergence report.
+
+    The headline loopbench artifact: the **pass@iteration curve** (cumulative
+    fraction of tasks passed by each loop iteration) plus convergence rates and
+    iteration economics. Returns ``{}`` when no result carries a real
+    (non-single-shot) loop strategy, so ordinary jobs never gain empty keys.
+    """
+    looped = [
+        loop
+        for r in results.values()
+        if isinstance((loop := r.get("loop")), dict)
+        and loop.get("strategy") not in (None, "single-shot")
+    ]
+    if not looped:
+        return {}
+
+    n = len(looped)
+    first_pass = [
+        loop["first_pass_iteration"]
+        for loop in looped
+        if loop.get("first_pass_iteration") is not None
+    ]
+    iters_run = [loop.get("iterations_run") or 0 for loop in looped]
+    max_iter = max(
+        (len(loop.get("reward_trajectory") or []) for loop in looped), default=0
+    )
+    # pass@iteration: cumulative fraction of tasks passed BY iteration i.
+    pass_at_iteration = [
+        sum(
+            1
+            for loop in looped
+            if loop.get("first_pass_iteration") is not None
+            and loop["first_pass_iteration"] <= i
+        )
+        / n
+        for i in range(max_iter)
+    ]
+    stop_reasons: dict[str, int] = {}
+    for loop in looped:
+        sr = loop.get("stop_reason") or "unknown"
+        stop_reasons[sr] = stop_reasons.get(sr, 0) + 1
+
+    return {
+        "loop_summary": {
+            "strategy": looped[0].get("strategy"),
+            "n_tasks": n,
+            "fraction_converged": len(first_pass) / n,
+            "mean_iterations_to_converge": (
+                round(sum(first_pass) / len(first_pass), 4) if first_pass else None
+            ),
+            "mean_iterations_run": round(sum(iters_run) / n, 4),
+            "pass_at_iteration": [round(p, 4) for p in pass_at_iteration],
+            "stop_reasons": stop_reasons,
+        }
+    }
+
+
 def trajectory_step_summary(results: dict[str, dict]) -> dict[str, Any]:
     """Aggregate Harbor-style trajectory step counts for summary.json."""
     summaries: list[dict[str, Any]] = []

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -27,6 +27,7 @@ from typing import Any
 import yaml
 
 from benchflow._utils.evaluation_results import (
+    loop_summary,
     phase_timing_summary,
     rollout_result_payload,
     skill_invocation_summary,
@@ -1627,6 +1628,7 @@ class Evaluation:
             "memory_scores": memory_scores,
             **skill_invocation_summary(all_results),
             **usage_summary(all_results),
+            **loop_summary(all_results),
             **tool_call_summary(all_results),
             **trajectory_step_summary(all_results),
             **phase_timing_summary(all_results),

--- a/tests/test_loop_summary.py
+++ b/tests/test_loop_summary.py
@@ -1,0 +1,100 @@
+"""Tests for the job-level loop convergence report (loop_summary)."""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow._utils.evaluation_results import loop_summary
+
+
+def _r(loop: dict | None) -> dict:
+    return {"loop": loop} if loop is not None else {}
+
+
+def test_empty_when_no_real_loop():
+    assert loop_summary({}) == {}
+    assert loop_summary({"a": _r(None)}) == {}
+    assert loop_summary({"a": _r({"strategy": "single-shot"})}) == {}
+    assert loop_summary({"a": _r({"strategy": None})}) == {}
+
+
+def test_pass_at_iteration_curve_and_convergence():
+    results = {
+        "t1": _r(
+            {
+                "strategy": "verify-retry",
+                "reward_trajectory": [0.0, 1.0],
+                "first_pass_iteration": 1,
+                "iterations_run": 2,
+                "stop_reason": "passed_bar",
+            }
+        ),
+        "t2": _r(
+            {
+                "strategy": "verify-retry",
+                "reward_trajectory": [1.0],
+                "first_pass_iteration": 0,
+                "iterations_run": 1,
+                "stop_reason": "passed_bar",
+            }
+        ),
+        "t3": _r(
+            {
+                "strategy": "verify-retry",
+                "reward_trajectory": [0.0, 0.0, 0.0],
+                "first_pass_iteration": None,
+                "iterations_run": 3,
+                "stop_reason": "max_iterations",
+            }
+        ),
+    }
+    s = loop_summary(results)["loop_summary"]
+    assert s["strategy"] == "verify-retry"
+    assert s["n_tasks"] == 3
+    assert s["fraction_converged"] == pytest.approx(2 / 3)
+    # t2 passes @0, t1 @1, t3 never → cumulative pass@iteration over 3 slots.
+    # (values are rounded to 4 decimals in the report)
+    assert s["pass_at_iteration"] == [
+        pytest.approx(1 / 3, abs=1e-3),
+        pytest.approx(2 / 3, abs=1e-3),
+        pytest.approx(2 / 3, abs=1e-3),
+    ]
+    assert s["mean_iterations_to_converge"] == pytest.approx(0.5)  # (1 + 0) / 2
+    assert s["mean_iterations_run"] == pytest.approx(2.0)  # (2 + 1 + 3) / 3
+    assert s["stop_reasons"] == {"passed_bar": 2, "max_iterations": 1}
+
+
+def test_none_converged_curve_is_flat_zero():
+    results = {
+        "t1": _r(
+            {
+                "strategy": "verify-retry",
+                "reward_trajectory": [0.0, 0.0],
+                "first_pass_iteration": None,
+                "iterations_run": 2,
+                "stop_reason": "max_iterations",
+            }
+        ),
+    }
+    s = loop_summary(results)["loop_summary"]
+    assert s["fraction_converged"] == 0.0
+    assert s["mean_iterations_to_converge"] is None
+    assert s["pass_at_iteration"] == [0.0, 0.0]
+
+
+def test_ignores_single_shot_rows_in_a_mixed_job():
+    results = {
+        "loop": _r(
+            {
+                "strategy": "verify-retry",
+                "reward_trajectory": [1.0],
+                "first_pass_iteration": 0,
+                "iterations_run": 1,
+                "stop_reason": "passed_bar",
+            }
+        ),
+        "baseline": _r({"strategy": "single-shot"}),
+    }
+    s = loop_summary(results)["loop_summary"]
+    assert s["n_tasks"] == 1  # single-shot row excluded
+    assert s["fraction_converged"] == 1.0


### PR DESCRIPTION
Builds on #713. Adds the headline **loopbench** artifact: a job-level convergence report aggregated into `summary.json`.

`loop_summary(all_results)` (beside `usage_summary`) emits, when a job ran a real (non-single-shot) loop strategy:
- **`pass_at_iteration`** — the cumulative fraction of tasks passed by each loop iteration (the convergence curve).
- `fraction_converged`, `mean_iterations_to_converge`, `mean_iterations_run`, and the `stop_reasons` breakdown.

Returns `{}` for ordinary jobs so they never gain empty keys.

**Validated on the real converged run** (deepseek-v4-pro + deepagents + verify-retry from #713): `pass_at_iteration [0.0, 1.0]`, `fraction_converged 1.0`, `mean_iterations_to_converge 1.0`. 4 new unit tests (empty/single-shot guard, the pass@iteration curve, none-converged flat-zero, mixed-job single-shot exclusion); ruff clean; no regression.

Next toward the cost curve: a `{model × loop}` sweep emits one `loop_summary` per cell → the pass-rate-vs-tokens matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only aggregation for summary.json with no changes to rollout execution or scoring; empty dict when loops are absent limits blast radius.
> 
> **Overview**
> Adds a **loopbench** job-level convergence report to `summary.json` by aggregating per-rollout `loop` metadata from completed results.
> 
> New `loop_summary(all_results)` in `evaluation_results.py` (alongside `usage_summary`) only emits when at least one rollout used a real loop strategy (not `single-shot` / missing strategy); otherwise it returns `{}` so normal jobs do not get empty keys. When present, the nested **`loop_summary`** block includes **`pass_at_iteration`** (cumulative fraction of tasks that passed by each iteration index), **`fraction_converged`**, **`mean_iterations_to_converge`**, **`mean_iterations_run`**, **`stop_reasons`**, plus **`strategy`** and **`n_tasks`**.
> 
> `evaluation.py` merges `**loop_summary(all_results)` into the job summary payload. Unit tests cover empty/single-shot guards, the pass@iteration curve, all-fail flat curves, and excluding single-shot rows in mixed jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3dae4ad78575a8991e6d758e24623e26bc95d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->