### PR TITLE
feat(loop): self-review-k strategy (feedback-source contrast to verify-retry)

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -374,10 +374,12 @@ def eval_create(
         typer.Option(
             "--loop-strategy",
             help=(
-                "Harness loop strategy, e.g. 'verify-retry:k=3,feedback=names' "
-                "or 'single-shot' (default). verify-retry re-prompts the agent "
-                "with filtered soft-verifier feedback until it passes or k "
-                "retries are spent."
+                "Harness loop strategy, e.g. 'verify-retry:k=3,feedback=names', "
+                "'self-review:k=3', or 'single-shot' (default). verify-retry "
+                "re-prompts with filtered soft-verifier feedback; self-review "
+                "re-prompts the agent to critique its OWN work (no verifier "
+                "signal) — both loop until the soft verifier passes or k retries "
+                "are spent."
             ),
         ),
     ] = None,

--- a/src/benchflow/loop_strategies.py
+++ b/src/benchflow/loop_strategies.py
@@ -25,7 +25,9 @@ __all__ = [
     "FeedbackLevel",
     "LoopStrategySpec",
     "LoopStrategyUser",
+    "SELF_REVIEW",
     "SINGLE_SHOT",
+    "SelfReviewUser",
     "VERIFY_RETRY",
     "VerifyRetryUser",
     "build_loop_user",
@@ -37,8 +39,10 @@ __all__ = [
 
 SINGLE_SHOT = "single-shot"
 VERIFY_RETRY = "verify-retry"
+SELF_REVIEW = "self-review"
 
 DEFAULT_VERIFY_RETRY_K = 3
+DEFAULT_SELF_REVIEW_K = 3
 DEFAULT_PASS_THRESHOLD = 1.0
 DEFAULT_MAX_FEEDBACK_CHARS = 4000
 
@@ -57,6 +61,18 @@ class FeedbackLevel(StrEnum):
     RAW = "raw"
 
 
+def _coerce_k(name: str, k: Any) -> int:
+    """Validate a retry-budget ``k`` (shared by retry-style strategies)."""
+    if isinstance(k, str):
+        try:
+            k = int(k)
+        except ValueError:
+            raise ValueError(f"{name} k must be an integer, got {k!r}") from None
+    if isinstance(k, bool) or not isinstance(k, int) or k < 1:
+        raise ValueError(f"{name} k must be a positive integer, got {k!r}")
+    return k
+
+
 def _normalized_params(name: str, params: dict[str, Any]) -> dict[str, Any]:
     """Validate and normalize strategy params, filling strategy defaults."""
     if name == SINGLE_SHOT:
@@ -69,16 +85,7 @@ def _normalized_params(name: str, params: dict[str, Any]) -> dict[str, Any]:
         unknown = set(params) - {"k", "feedback"}
         if unknown:
             raise ValueError(f"unknown verify-retry param(s): {sorted(unknown)}")
-        k = params.get("k", DEFAULT_VERIFY_RETRY_K)
-        if isinstance(k, str):
-            try:
-                k = int(k)
-            except ValueError:
-                raise ValueError(
-                    f"verify-retry k must be an integer, got {k!r}"
-                ) from None
-        if isinstance(k, bool) or not isinstance(k, int) or k < 1:
-            raise ValueError(f"verify-retry k must be a positive integer, got {k!r}")
+        k = _coerce_k(VERIFY_RETRY, params.get("k", DEFAULT_VERIFY_RETRY_K))
         feedback = params.get("feedback", FeedbackLevel.NAMES.value)
         if isinstance(feedback, FeedbackLevel):
             feedback = feedback.value
@@ -90,8 +97,16 @@ def _normalized_params(name: str, params: dict[str, Any]) -> dict[str, Any]:
                 f"verify-retry feedback must be one of {valid}, got {feedback!r}"
             ) from None
         return {"k": k, "feedback": feedback}
+    if name == SELF_REVIEW:
+        # No verifier feedback by design — self-review isolates self-critique as
+        # the feedback source, so its only param is the retry budget k.
+        unknown = set(params) - {"k"}
+        if unknown:
+            raise ValueError(f"unknown self-review param(s): {sorted(unknown)}")
+        return {"k": _coerce_k(SELF_REVIEW, params.get("k", DEFAULT_SELF_REVIEW_K))}
     raise ValueError(
-        f"unknown loop strategy {name!r} (expected {SINGLE_SHOT!r} or {VERIFY_RETRY!r})"
+        f"unknown loop strategy {name!r} "
+        f"(expected {SINGLE_SHOT!r}, {VERIFY_RETRY!r}, or {SELF_REVIEW!r})"
     )
 
 
@@ -313,6 +328,50 @@ class VerifyRetryUser(LoopStrategyUser):
         return "\n\n".join(lines)
 
 
+class SelfReviewUser(LoopStrategyUser):
+    """Retry by asking the agent to self-review its OWN work — no verifier
+    feedback at all.
+
+    The deliberate contrast to ``verify-retry``: it isolates *self-critique* as
+    the feedback source, so loopbench can measure how much weaker an agent
+    grading itself is than a verifier-grounded signal (loop-dev's "measurement
+    beats judgment" — in-thread self-review is the lowest-independence source).
+    The soft verifier still runs each round to record the trajectory, but its
+    output never reaches the agent; the retry prompt is pure self-review.
+    """
+
+    def __init__(
+        self,
+        *,
+        k: int = DEFAULT_SELF_REVIEW_K,
+        pass_threshold: float = DEFAULT_PASS_THRESHOLD,
+    ) -> None:
+        if k < 1:
+            raise ValueError(f"self-review k must be >= 1, got {k}")
+        # FeedbackLevel.NONE is load-bearing: no verifier output is ever piped
+        # back, so the only signal is the agent's own review.
+        super().__init__(pass_threshold=pass_threshold, feedback=FeedbackLevel.NONE)
+        self.k = k
+
+    async def run(
+        self,
+        round: int,
+        instruction: str,
+        round_result: RoundResult | None = None,
+    ) -> str | None:
+        if round == 0:
+            return instruction
+        reward = _soft_reward(round_result.rewards if round_result else None)
+        if reward is not None and reward >= self.pass_threshold:
+            return None
+        return (
+            "Critically review your previous solution in the workspace as if "
+            "reviewing an unfamiliar engineer's code: check correctness, edge "
+            "cases, and whether it fully satisfies the task. Identify any bugs "
+            "or missed requirements, then fix them."
+        )
+
+
 def build_loop_user(spec: LoopStrategySpec) -> tuple[LoopStrategyUser, int] | None:
     """Materialize the runtime user for *spec*.
 
@@ -325,6 +384,9 @@ def build_loop_user(spec: LoopStrategySpec) -> tuple[LoopStrategyUser, int] | No
         k = int(spec.params["k"])
         user = VerifyRetryUser(k=k, feedback=spec.params["feedback"])
         return user, k + 1
+    if spec.name == SELF_REVIEW:
+        k = int(spec.params["k"])
+        return SelfReviewUser(k=k), k + 1
     raise ValueError(f"unknown loop strategy {spec.name!r}")
 
 

--- a/tests/test_loop_strategies.py
+++ b/tests/test_loop_strategies.py
@@ -8,6 +8,7 @@ from benchflow.contracts import RoundResult
 from benchflow.loop_strategies import (
     FeedbackLevel,
     LoopStrategySpec,
+    SelfReviewUser,
     VerifyRetryUser,
     build_loop_user,
     collect_loop_metadata,
@@ -55,7 +56,7 @@ class TestParseLoopStrategySpec:
         "bad",
         [
             "",
-            "self-review",
+            "not-a-strategy",
             "verify-retry:k",
             "verify-retry:k=",
             "verify-retry:k=zero",
@@ -65,6 +66,8 @@ class TestParseLoopStrategySpec:
             "verify-retry:retries=3",
             "verify-retry:k=2,k=3",
             "single-shot:k=3",
+            "self-review:k=0",
+            "self-review:feedback=names",
         ],
     )
     def test_bad_specs_raise(self, bad: str):
@@ -205,6 +208,37 @@ class TestVerifyRetryUser:
             VerifyRetryUser(k=0)
 
 
+class TestSelfReviewUser:
+    @pytest.mark.asyncio
+    async def test_round0_instruction_then_self_review(self):
+        user = SelfReviewUser(k=2)
+        assert await user.run(0, "Fix the bug") == "Fix the bug"
+        prompt = await user.run(1, "Fix the bug", _failing_round(0))
+        assert prompt is not None
+        assert "review" in prompt.lower()
+
+    @pytest.mark.asyncio
+    async def test_self_review_never_leaks_verifier_output(self):
+        """The whole point: self-review uses NO verifier signal, so neither the
+        failing test names nor any ground truth may reach the agent."""
+        user = SelfReviewUser(k=2)
+        await user.run(0, "Fix the bug")
+        prompt = await user.run(1, "Fix the bug", _failing_round(0))
+        assert "tests/test_alpha.py::test_two" not in prompt
+        assert SECRET not in prompt
+        assert user.feedback_level is FeedbackLevel.NONE
+
+    @pytest.mark.asyncio
+    async def test_stops_when_soft_reward_passes(self):
+        user = SelfReviewUser(k=3)
+        passing = RoundResult(round=0, rewards={"reward": 1.0})
+        assert await user.run(1, "Fix the bug", passing) is None
+
+    def test_rejects_nonpositive_k(self):
+        with pytest.raises(ValueError, match="k must be >= 1"):
+            SelfReviewUser(k=0)
+
+
 def _rounds(*rewards: float | None) -> list[dict]:
     return [
         {"round": i, "rewards": None if r is None else {"reward": r}}
@@ -278,6 +312,23 @@ class TestBuildLoopUser:
         assert user.k == 2
         assert user.feedback_level is FeedbackLevel.NAMES
         assert max_rounds == 3
+
+    def test_self_review_materializes_user_and_rounds(self):
+        built = build_loop_user(parse_loop_strategy_spec("self-review:k=2"))
+        assert built is not None
+        user, max_rounds = built
+        assert isinstance(user, SelfReviewUser)
+        assert user.k == 2
+        assert user.feedback_level is FeedbackLevel.NONE
+        assert max_rounds == 3
+
+    def test_self_review_rejects_feedback_param(self):
+        with pytest.raises(ValueError, match="unknown self-review param"):
+            parse_loop_strategy_spec("self-review:feedback=names")
+
+    def test_self_review_round_trips(self):
+        spec = parse_loop_strategy_spec("self-review:k=4")
+        assert LoopStrategySpec.from_mapping(spec.to_mapping()) == spec
 
 
 class TestRolloutConfigLoopStrategy:


### PR DESCRIPTION
Builds on #713/#716. Adds the **self-review** loop strategy — `bench eval create --loop-strategy self-review:k=3`.

## What
On each retry the agent **critiques its own previous solution** (correctness, edge cases, completeness) and fixes issues — with **no verifier feedback** (`FeedbackLevel.NONE`, load-bearing). It's the deliberate contrast to `verify-retry`: it isolates *self-critique* as the feedback source.

## Why
This is the evaluand that lets **loopbench reproduce loop-dev's ranking with our own numbers**: run `self-review` vs `verify-retry` on the same {model, task} and measure whether a verifier-grounded signal converges better than an agent grading itself ("measurement beats judgment" — in-thread self-review is the lowest-independence feedback source).

## Scope
- `loop_strategies.py`: `SELF_REVIEW`, a shared `_coerce_k` validator (de-dups the k-validation), `SelfReviewUser`, parser + `build_loop_user` branches, `__all__`.
- `eval_plan` validation is already strategy-agnostic — covers self-review unchanged.
- CLI help advertises it.
- Tests: parse/build/round-trip, round behavior, the **no-verifier-leak** property (the whole point), k validation.

ruff clean; 170 loop/eval tests pass; full suite gate green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New opt-in eval harness behavior with isolated loop user logic; no changes to auth, scoring, or default single-shot runs.
> 
> **Overview**
> Adds **`self-review`** as a third harness loop strategy (e.g. `--loop-strategy self-review:k=3`), alongside `verify-retry` and `single-shot`.
> 
> On retries, **`SelfReviewUser`** re-prompts the agent to critique and fix its own workspace solution with **no verifier feedback** (`FeedbackLevel.NONE`); the soft verifier still runs for trajectory logging and stop-on-pass, same round budget model as `verify-retry` (`k` retries → `k+1` rounds). Shared **`_coerce_k`** centralizes `k` validation for retry-style strategies.
> 
> CLI **`--loop-strategy`** help documents `self-review` vs verifier-grounded `verify-retry`. Tests cover parsing, `build_loop_user`, round behavior, and the **no verifier leak** guarantee.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f04eeb6b9169a72c14afb1c0fed65d4748288c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->