### PR TITLE
feat(loop): per-iteration token capture for the cost-curve x-axis

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -175,6 +175,17 @@ def loop_summary(results: dict[str, dict]) -> dict[str, Any]:
     for loop in looped:
         sr = loop.get("stop_reason") or "unknown"
         stop_reasons[sr] = stop_reasons.get(sr, 0) + 1
+    # Cost-to-converge economics (the cost-curve money axis), over the converged
+    # tasks that actually captured token usage. None when nothing converged with
+    # usage data (e.g. a LiteLLM path that doesn't surface native tokens).
+    tokens_to_pass = [
+        loop["tokens_to_pass"]
+        for loop in looped
+        if loop.get("tokens_to_pass") is not None
+    ]
+    mean_tokens_to_converge = (
+        round(sum(tokens_to_pass) / len(tokens_to_pass), 1) if tokens_to_pass else None
+    )
 
     return {
         "loop_summary": {
@@ -185,6 +196,7 @@ def loop_summary(results: dict[str, dict]) -> dict[str, Any]:
                 round(sum(first_pass) / len(first_pass), 4) if first_pass else None
             ),
             "mean_iterations_run": round(sum(iters_run) / n, 4),
+            "mean_tokens_to_converge": mean_tokens_to_converge,
             "pass_at_iteration": [round(p, 4) for p in pass_at_iteration],
             "stop_reasons": stop_reasons,
         }

--- a/src/benchflow/loop_strategies.py
+++ b/src/benchflow/loop_strategies.py
@@ -406,11 +406,23 @@ def collect_loop_metadata(
     result-build time when the error state is final.
     """
     trajectory = [_soft_reward(record.get("rewards")) for record in rounds_log]
+    # Cumulative native-ACP tokens through each round — the cost-curve x-axis.
+    # Best-effort: entries are None when usage isn't captured for the run.
+    tokens_trajectory = [record.get("tokens") for record in rounds_log]
     first_pass = next(
         (
             record["round"]
             for record, reward in zip(rounds_log, trajectory, strict=True)
             if reward is not None and reward >= user.pass_threshold
+        ),
+        None,
+    )
+    # Cost-to-converge: cumulative tokens at the first passing round.
+    tokens_to_pass = next(
+        (
+            record.get("tokens")
+            for record in rounds_log
+            if record.get("round") == first_pass
         ),
         None,
     )
@@ -429,5 +441,7 @@ def collect_loop_metadata(
         "iterations_run": len(rounds_log),
         "stop_reason": stop_reason,
         "reward_trajectory": trajectory,
+        "tokens_trajectory": tokens_trajectory,
         "first_pass_iteration": first_pass,
+        "tokens_to_pass": tokens_to_pass,
     }

--- a/src/benchflow/rollout/_user_loop.py
+++ b/src/benchflow/rollout/_user_loop.py
@@ -185,6 +185,7 @@ _ITERATION_RECORD_KEYS = (
     "verifier_error",
     "feedback_level",
     "wall_sec",
+    "tokens",
 )
 
 
@@ -389,6 +390,12 @@ async def _run_user_loop(rollout: Rollout) -> None:
                 "n_tool_calls": round_tools,
                 "n_trajectory_events": len(round_trajectory),
                 "wall_sec": round(time.monotonic() - round_started, 1),
+                # Cumulative native-ACP tokens spent through this round — the
+                # cost-curve x-axis. Best-effort: None when usage is unavailable
+                # (e.g. a LiteLLM-proxied path that doesn't surface native usage).
+                "tokens": (getattr(rollout, "_native_usage_metrics", None) or {}).get(
+                    "total_tokens"
+                ),
             }
             if isinstance(user, LoopStrategyUser):
                 entry["feedback_level"] = user.feedback_level.value

--- a/tests/test_loop_strategies.py
+++ b/tests/test_loop_strategies.py
@@ -257,7 +257,9 @@ class TestCollectLoopMetadata:
             "iterations_run": 3,
             "stop_reason": "passed_bar",
             "reward_trajectory": [0.0, 0.0, 1.0],
+            "tokens_trajectory": [None, None, None],
             "first_pass_iteration": 2,
+            "tokens_to_pass": None,
         }
 
     def test_exhausted_budget_is_max_iterations(self):
@@ -275,8 +277,24 @@ class TestCollectLoopMetadata:
             "iterations_run": 1,
             "stop_reason": "error",
             "reward_trajectory": [0.0],
+            "tokens_trajectory": [None],
             "first_pass_iteration": None,
+            "tokens_to_pass": None,
         }
+
+    def test_token_trajectory_and_cost_to_pass(self):
+        """Cumulative tokens per round form the cost-curve x-axis; tokens_to_pass
+        is the cumulative spend at the first passing round."""
+        rounds = [
+            {"round": 0, "rewards": {"reward": 0.0}, "tokens": 1000},
+            {"round": 1, "rewards": {"reward": 1.0}, "tokens": 2500},
+        ]
+        meta = collect_loop_metadata(
+            VerifyRetryUser(k=2), rounds, max_rounds=3, error=None
+        )
+        assert meta["tokens_trajectory"] == [1000, 2500]
+        assert meta["first_pass_iteration"] == 1
+        assert meta["tokens_to_pass"] == 2500
 
     def test_unscored_rounds_keep_none_in_trajectory(self):
         meta = collect_loop_metadata(
@@ -476,7 +494,9 @@ class TestRolloutConfigLoopStrategy:
     def test_bad_loop_strategy_type_raises(self, tmp_path):
         from benchflow.rollout import RolloutConfig
 
-        with pytest.raises(ValueError, match="spec string, mapping, or LoopStrategySpec"):
+        with pytest.raises(
+            ValueError, match="spec string, mapping, or LoopStrategySpec"
+        ):
             RolloutConfig(task_path=tmp_path, loop_strategy=5)
 
 
@@ -501,7 +521,9 @@ class TestEvaluationConfigLoopStrategy:
     def test_bad_type_raises(self):
         from benchflow.evaluation import EvaluationConfig
 
-        with pytest.raises(ValueError, match="spec string, mapping, or LoopStrategySpec"):
+        with pytest.raises(
+            ValueError, match="spec string, mapping, or LoopStrategySpec"
+        ):
             EvaluationConfig(loop_strategy=5)
 
 

--- a/tests/test_loop_summary.py
+++ b/tests/test_loop_summary.py
@@ -98,3 +98,56 @@ def test_ignores_single_shot_rows_in_a_mixed_job():
     s = loop_summary(results)["loop_summary"]
     assert s["n_tasks"] == 1  # single-shot row excluded
     assert s["fraction_converged"] == 1.0
+
+
+def test_mean_tokens_to_converge_over_captured_converged_tasks():
+    """Cost-to-converge (the cost-curve money axis): mean ``tokens_to_pass``
+    over converged tasks that captured usage; tasks with no token data are
+    excluded so a single uninstrumented path can't drag the mean to zero."""
+    results = {
+        "t1": _r(
+            {
+                "strategy": "verify-retry",
+                "first_pass_iteration": 1,
+                "iterations_run": 2,
+                "stop_reason": "passed_bar",
+                "tokens_to_pass": 2000,
+            }
+        ),
+        "t2": _r(
+            {
+                "strategy": "verify-retry",
+                "first_pass_iteration": 0,
+                "iterations_run": 1,
+                "stop_reason": "passed_bar",
+                "tokens_to_pass": 1000,
+            }
+        ),
+        "t3": _r(
+            {
+                "strategy": "verify-retry",
+                "first_pass_iteration": None,
+                "iterations_run": 1,
+                "stop_reason": "max_iterations",
+                "tokens_to_pass": None,
+            }
+        ),
+    }
+    s = loop_summary(results)["loop_summary"]
+    assert s["mean_tokens_to_converge"] == 1500.0  # (2000 + 1000) / 2
+
+
+def test_mean_tokens_to_converge_none_when_no_usage_captured():
+    """A LiteLLM-style path that surfaces no native tokens yields None, not 0."""
+    results = {
+        "t1": _r(
+            {
+                "strategy": "verify-retry",
+                "first_pass_iteration": 0,
+                "iterations_run": 1,
+                "stop_reason": "passed_bar",
+                "tokens_to_pass": None,
+            }
+        ),
+    }
+    assert loop_summary(results)["loop_summary"]["mean_tokens_to_converge"] is None

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -846,8 +846,9 @@ class TestLoopStrategyEngine:
                 trial,
                 "soft_verify",
                 new=AsyncMock(
-                    side_effect=lambda: verifies.append(1)
-                    or ({"reward": 0.0}, None, None)
+                    side_effect=lambda: (
+                        verifies.append(1) or ({"reward": 0.0}, None, None)
+                    )
                 ),
             ),
             patch.object(trial._planes, "lockdown_paths", new_callable=AsyncMock),
@@ -858,15 +859,14 @@ class TestLoopStrategyEngine:
                     side_effect=RuntimeError('service "main" is not running')
                 ),
             ),
+            caplog.at_level("WARNING"),
         ):
-            with caplog.at_level("WARNING"):
-                await trial._run_user_loop()  # must NOT raise
+            await trial._run_user_loop()  # must NOT raise
 
         # k=1 → round 0 + 1 retry; both ran despite the clear failing each round.
         assert len(verifies) == 2
         assert any(
-            "Mid-loop verifier isolation skipped" in r.message
-            for r in caplog.records
+            "Mid-loop verifier isolation skipped" in r.message for r in caplog.records
         )
 
     @pytest.mark.asyncio
@@ -902,7 +902,9 @@ class TestLoopStrategyEngine:
             "iterations_run": 3,
             "stop_reason": "max_iterations",
             "reward_trajectory": [0.0, 0.0, 0.0],
+            "tokens_trajectory": [0, 0, 0],
             "first_pass_iteration": None,
+            "tokens_to_pass": None,
         }
 
     @pytest.mark.asyncio
@@ -936,7 +938,9 @@ class TestLoopStrategyEngine:
             "iterations_run": 3,
             "stop_reason": "passed_bar",
             "reward_trajectory": [0.0, 0.0, 1.0],
+            "tokens_trajectory": [0, 0, 0],
             "first_pass_iteration": 2,
+            "tokens_to_pass": 0,
         }
 
     @pytest.mark.asyncio
@@ -1016,7 +1020,9 @@ class TestLoopStrategyEngine:
             "iterations_run": 1,
             "stop_reason": "passed_bar",
             "reward_trajectory": [1.0],
+            "tokens_trajectory": [0],
             "first_pass_iteration": 0,
+            "tokens_to_pass": 0,
         }
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

Captures **per-iteration token spend** across loop rounds — the missing x-axis for the loopbench pass-rate-vs-tokens cross-over curve. Per-round *reward* was already captured (#713/#716); this adds per-round *cost*.

## Changes

- **`rollout/_user_loop.py`** — each loop round entry now records `tokens` = cumulative native-ACP `total_tokens` through that round (`_native_usage_metrics["total_tokens"]`). Added `"tokens"` to `_ITERATION_RECORD_KEYS` so it's persisted to `iterations.jsonl`.
- **`loop_strategies.py`** — `collect_loop_metadata` now emits two new fields in the result.json `loop` block:
  - `tokens_trajectory` — cumulative tokens at each round (index-aligned with `reward_trajectory`).
  - `tokens_to_pass` — cumulative tokens at the first passing round (the cost-to-converge scalar). `None` when the task never converged.
- **`_utils/evaluation_results.py`** — `loop_summary` rolls these up as `mean_tokens_to_converge` (mean `tokens_to_pass` over converged tasks that captured usage), surfaced in `summary.json` alongside the existing pass@iteration curve.

## Best-effort by design

Every new field is `None` when a run's harness doesn't surface native usage (e.g. a LiteLLM-proxied path). Non-loop jobs and uninstrumented paths gain **no spurious zeros** — `mean_tokens_to_converge` is `None`, not `0`, when no usage was captured.

## Tests

- Updated the exact-dict assertions in `test_loop_strategies.py` / `test_user.py` for the two new keys.
- Added `test_token_trajectory_and_cost_to_pass` (collect_loop_metadata).
- Added `test_mean_tokens_to_converge_over_captured_converged_tasks` + `test_mean_tokens_to_converge_none_when_no_usage_captured` (loop_summary).
- `ruff check` + `ruff format` clean; 109 loop/user/summary tests + 15 eval tests pass.

## Why

The loopbench thesis — *can a cheap model + loops match an expensive model single-shot at equal token spend?* — needs cost on the x-axis. With this merged, a `{model × loop}` sweep can produce the cross-over curve directly from `summary.json`.

Follows #713 (verify-retry), #715 (deepagents), #716 (loop_summary), #717 (self-review).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive telemetry and summary fields on loop artifacts; behavior is best-effort and does not change scoring, auth, or verifier paths.
> 
> **Overview**
> Adds **per-round cumulative token spend** alongside existing reward trajectories so loopbench jobs can plot pass rate vs. total tokens.
> 
> Each user-loop round now records **`tokens`** from native ACP `total_tokens` (via `_native_usage_metrics`), persisted in `user_rounds.jsonl` and `loop/iterations.jsonl`. **`collect_loop_metadata`** exposes **`tokens_trajectory`** and **`tokens_to_pass`** (tokens at first passing round) on each rollout’s `loop` block. **`loop_summary`** aggregates **`mean_tokens_to_converge`** into `summary.json`, averaging `tokens_to_pass` only over converged tasks that actually captured usage.
> 
> Missing usage stays **`None`** end-to-end (no fake zeros), including when paths like LiteLLM don’t surface native tokens. Tests cover metadata derivation, job-level aggregation, and updated loop integration expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd01dc2413078ea8378d9397ab41a530c219fb81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->