### PR TITLE
fix(loop): None (not 0) per-round tokens when no trusted usage captured

### DIFF
--- a/src/benchflow/rollout/_user_loop.py
+++ b/src/benchflow/rollout/_user_loop.py
@@ -46,11 +46,27 @@ from benchflow.scenes import (
     scene_step_skills_dir,
 )
 from benchflow.trajectories.tree import Step
+from benchflow.usage_tracking import is_token_usage_available
 
 if TYPE_CHECKING:
     from benchflow.rollout import Rollout
 
 logger = logging.getLogger(__name__)
+
+
+def _round_tokens(rollout: Rollout) -> int | None:
+    """Cumulative native-ACP tokens spent so far, or ``None`` if untrusted.
+
+    ``_native_usage_metrics`` is initialized to a zeroed ``usage_unavailable()``
+    payload (``usage_source="unavailable"``, ``total_tokens=0``), so a bare read
+    can't tell "spent 0 tokens" apart from "no usage captured". Gating on the
+    trusted-source check keeps uninstrumented paths reporting ``None`` rather
+    than a spurious ``0`` — preserving the cost-curve's best-effort contract.
+    """
+    metrics = getattr(rollout, "_native_usage_metrics", None)
+    if not is_token_usage_available(metrics):
+        return None
+    return metrics.get("total_tokens")
 
 
 async def _export_generated_skills(rollout: Rollout) -> None:
@@ -391,11 +407,12 @@ async def _run_user_loop(rollout: Rollout) -> None:
                 "n_trajectory_events": len(round_trajectory),
                 "wall_sec": round(time.monotonic() - round_started, 1),
                 # Cumulative native-ACP tokens spent through this round — the
-                # cost-curve x-axis. Best-effort: None when usage is unavailable
-                # (e.g. a LiteLLM-proxied path that doesn't surface native usage).
-                "tokens": (getattr(rollout, "_native_usage_metrics", None) or {}).get(
-                    "total_tokens"
-                ),
+                # cost-curve x-axis. None (NOT 0) when no trusted usage was
+                # captured: _native_usage_metrics defaults to a zeroed
+                # usage_unavailable() payload, so a bare total_tokens read would
+                # report a spurious 0 on uninstrumented paths (e.g. a
+                # LiteLLM-proxied run that never surfaces native ACP usage).
+                "tokens": _round_tokens(rollout),
             }
             if isinstance(user, LoopStrategyUser):
                 entry["feedback_level"] = user.feedback_level.value

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -902,7 +902,8 @@ class TestLoopStrategyEngine:
             "iterations_run": 3,
             "stop_reason": "max_iterations",
             "reward_trajectory": [0.0, 0.0, 0.0],
-            "tokens_trajectory": [0, 0, 0],
+            # No trusted native usage on the mock trial → None, not a spurious 0.
+            "tokens_trajectory": [None, None, None],
             "first_pass_iteration": None,
             "tokens_to_pass": None,
         }
@@ -938,9 +939,9 @@ class TestLoopStrategyEngine:
             "iterations_run": 3,
             "stop_reason": "passed_bar",
             "reward_trajectory": [0.0, 0.0, 1.0],
-            "tokens_trajectory": [0, 0, 0],
+            "tokens_trajectory": [None, None, None],
             "first_pass_iteration": 2,
-            "tokens_to_pass": 0,
+            "tokens_to_pass": None,
         }
 
     @pytest.mark.asyncio
@@ -1020,9 +1021,9 @@ class TestLoopStrategyEngine:
             "iterations_run": 1,
             "stop_reason": "passed_bar",
             "reward_trajectory": [1.0],
-            "tokens_trajectory": [0],
+            "tokens_trajectory": [None],
             "first_pass_iteration": 0,
-            "tokens_to_pass": 0,
+            "tokens_to_pass": None,
         }
 
     @pytest.mark.asyncio
@@ -1047,6 +1048,41 @@ class TestLoopStrategyEngine:
 
         assert not (tmp_path / "loop").exists()
         assert trial._loop_strategy_metadata() is None
+
+
+class TestRoundTokens:
+    """Per-round token capture must distinguish 'spent 0' from 'no usage'."""
+
+    def test_returns_none_when_usage_unavailable(self):
+        from benchflow.rollout._usage import _zero_native_acp_usage_metrics
+        from benchflow.rollout._user_loop import _round_tokens
+
+        # The zeroed default carries usage_source="unavailable" + total_tokens=0.
+        rollout = type(
+            "R", (), {"_native_usage_metrics": _zero_native_acp_usage_metrics()}
+        )()
+        assert _round_tokens(rollout) is None
+
+    def test_returns_none_when_metrics_missing(self):
+        from benchflow.rollout._user_loop import _round_tokens
+
+        assert _round_tokens(type("R", (), {})()) is None
+
+    def test_returns_total_when_usage_trusted(self):
+        from benchflow.rollout._user_loop import _round_tokens
+        from benchflow.usage_tracking import USAGE_SOURCE_AGENT_NATIVE_ACP
+
+        rollout = type(
+            "R",
+            (),
+            {
+                "_native_usage_metrics": {
+                    "total_tokens": 4096,
+                    "usage_source": USAGE_SOURCE_AGENT_NATIVE_ACP,
+                }
+            },
+        )()
+        assert _round_tokens(rollout) == 4096
 
 
 class TestSoftVerify:


### PR DESCRIPTION
## Follow-up to #718 (Bugbot fix)

#718 merged before its Bugbot re-review landed. Bugbot flagged a **medium-severity spurious-zero** in the per-iteration token capture, and this PR lands the fix on `release/v0.6.0`.

### The bug

`_native_usage_metrics` is initialized to a zeroed `usage_unavailable()` payload (`usage_source="unavailable"`, `total_tokens=0`). The per-round capture in #718 read `total_tokens` directly, so an **uninstrumented path** (e.g. a LiteLLM-proxied run that never surfaces native ACP usage) recorded `tokens=0` instead of `None` — contradicting the best-effort contract and letting `tokens_to_pass` / `mean_tokens_to_converge` report a misleading `0`.

### The fix

Gate the capture on `is_token_usage_available()` via a small `_round_tokens()` helper: trusted source → `total_tokens`, otherwise `None`.

### Tests

- `TestRoundTokens`: trusted source → value; unavailable → `None`; missing metrics → `None`.
- Updated the mock-trial integration assertions in `test_user.py` to expect `None` (proving the contract end-to-end through `_run_user_loop`).
- `ruff` clean; 112 loop/user/summary tests pass.

Bugbot thread: https://github.com/benchflow-ai/benchflow/pull/718#discussion_r3407166774

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow telemetry fix in the user loop with no auth or scoring changes; behavior change is intentional for analytics metadata only.
> 
> **Overview**
> Fixes a **spurious-zero** in loop cost-curve telemetry: per-round `tokens` and derived `tokens_trajectory` / `tokens_to_pass` no longer read `total_tokens` from the default zeroed `usage_unavailable()` payload when native ACP usage was never captured.
> 
> Per-round capture now goes through **`_round_tokens()`**, which returns cumulative `total_tokens` only when `is_token_usage_available()` passes (trusted `usage_source`); otherwise it returns **`None`**, matching the best-effort contract for uninstrumented paths (e.g. LiteLLM-proxied runs).
> 
> Tests add **`TestRoundTokens`** for unavailable, missing, and trusted metrics, and loop-strategy integration expectations switch from `[0, …]` to `[None, …]` on mock rollouts without trusted usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69b3d54e5fe62e1bc977d50665b03f27df5e15a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->