### PR TITLE
feat(loop): {model x loop} sweep → pass-rate-vs-tokens cost-curve matrix

### DIFF
--- a/src/benchflow/loop_sweep.py
+++ b/src/benchflow/loop_sweep.py
@@ -376,10 +376,13 @@ async def run_sweep(
 
     Cells run sequentially — each :class:`Evaluation` already parallelizes its
     own tasks (``config.concurrency``), and sequential cells keep the shared
-    sandbox-concurrency budget predictable. Each cell's job dir is named by
-    :attr:`SweepCell.job_name` so reruns are addressable; the assembled matrix is
-    written as ``{matrix_prefix}-matrix.json`` and ``-matrix.md`` under
-    ``jobs_dir``. The matrix dict is also returned.
+    sandbox-concurrency budget predictable. Each cell gets its **own** jobs_dir
+    (``jobs_dir/<cell.job_name>/``), so cells never collide on shared-root files
+    — notably ``Evaluation``'s backward-compat ``jobs_dir/summary.json`` copy,
+    which N cells writing into one jobs_dir would otherwise clobber to the last
+    cell's. The assembled matrix is written as ``{matrix_prefix}-matrix.json`` /
+    ``-matrix.md`` under the top ``jobs_dir``, which now holds only the per-cell
+    subdirs plus those two artifacts. The matrix dict is also returned.
     """
     tasks_dir = Path(tasks_dir)
     jobs_dir = Path(jobs_dir)
@@ -389,15 +392,17 @@ async def run_sweep(
     results: list[CellResult] = []
     for cell in cells:
         cfg = replace(base_config, model=cell.model, loop_strategy=cell.loop)
+        cell_dir = jobs_dir / cell.job_name
         evaluation = Evaluation(
             tasks_dir=tasks_dir,
-            jobs_dir=jobs_dir,
+            jobs_dir=cell_dir,
             config=cfg,
             job_name=cell.job_name,
         )
         await evaluation.run()
-        summary_path = jobs_dir / cell.job_name / "summary.json"
-        summary = json.loads(summary_path.read_text())
+        # Read the per-cell top-level summary.json (Evaluation writes it under
+        # this cell's isolated jobs_dir, so no cross-cell clobber).
+        summary = json.loads((cell_dir / "summary.json").read_text())
         results.append(cell_result_from_summary(cell.model, cell.loop_label, summary))
 
     matrix = build_cost_curve_matrix(

--- a/src/benchflow/loop_sweep.py
+++ b/src/benchflow/loop_sweep.py
@@ -215,6 +215,30 @@ def _cross_over_verdict(
     }
 
 
+def _resolve_baseline_cell(
+    cells: list[CellResult], baseline: tuple[str, str] | None
+) -> CellResult | None:
+    """Find the cell matching ``baseline`` by model + *canonical* loop identity.
+
+    Cells store the first-seen loop spelling, but the grid dedupes on a parsed
+    canonical key — so an exact label match would miss a baseline spelled
+    differently (``""`` vs ``"single-shot"``, default-vs-explicit params). Match
+    on the canonical key instead, mirroring :func:`expand_sweep_grid`.
+    """
+    if not baseline:
+        return None
+    base_model, base_loop = baseline
+    base_canon = _canonical_loop_key(base_loop)
+    return next(
+        (
+            c
+            for c in cells
+            if c.model == base_model and _canonical_loop_key(c.loop) == base_canon
+        ),
+        None,
+    )
+
+
 def build_cost_curve_matrix(
     cells: list[CellResult],
     *,
@@ -223,12 +247,14 @@ def build_cost_curve_matrix(
 ) -> dict[str, Any]:
     """Assemble the pass-rate-vs-tokens matrix + per-cell cross-over verdicts.
 
-    ``baseline`` is a ``(model, loop_label)`` pair naming the reference cell —
-    typically the expensive model's single-shot run. When given (and found among
-    ``cells``), each *other* cell gets a cross-over verdict against it. When
-    omitted or not found, the matrix carries no ``cross_over`` section.
+    ``baseline`` is a ``(model, loop)`` pair naming the reference cell —
+    typically the expensive model's single-shot run. Its loop is matched by the
+    same **canonical identity** the grid dedupes on, so the baseline resolves
+    even when spelled differently from the cell's stored label (``""`` vs
+    ``"single-shot"``, explicit-vs-default params, reordered params). When given
+    (and resolved), each *other* cell gets a cross-over verdict against it; when
+    omitted or unresolved, the matrix carries no ``cross_over`` section.
     """
-    by_key = {(c.model, c.loop): c for c in cells}
     # Preserve first-seen order for both axes so the matrix reads grid-stable.
     models: list[str] = []
     loops: list[str] = []
@@ -244,7 +270,7 @@ def build_cost_curve_matrix(
         "cells": [c.to_dict() for c in cells],
     }
 
-    baseline_cell = by_key.get(baseline) if baseline else None
+    baseline_cell = _resolve_baseline_cell(cells, baseline)
     if baseline_cell is not None:
         matrix["baseline"] = {
             "model": baseline_cell.model,

--- a/src/benchflow/loop_sweep.py
+++ b/src/benchflow/loop_sweep.py
@@ -24,6 +24,7 @@ thin :func:`run_sweep` orchestrator is the only part that drives a real
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
@@ -80,10 +81,23 @@ class SweepCell:
 
     @property
     def job_name(self) -> str:
-        """Filesystem-safe per-cell job name (one job dir per cell)."""
+        """Per-cell job dir name: a readable ``{model, loop}`` prefix plus a short
+        deterministic hash of the *exact* ``(model, loop)`` identity.
+
+        The hash is load-bearing for correctness, not decoration: sanitizing the
+        prefix is lossy ("/" → "_", ":"/"," → "_", "=" dropped), so distinct
+        cells like ``foo/bar`` vs ``foo_bar`` would otherwise share a job dir —
+        the second cell would resume into the first's results and the matrix
+        would misattribute one model's rollouts to another. The hash makes the
+        dir injective; it's stable across reruns so resume still addresses the
+        same cell.
+        """
         safe_loop = self.loop_label.replace(":", "_").replace(",", "_").replace("=", "")
         safe_model = self.model.replace("/", "_")
-        return f"model={safe_model}__loop={safe_loop}"
+        digest = hashlib.sha256(
+            f"{self.model}\x00{self.loop_label}".encode()
+        ).hexdigest()[:8]
+        return f"model={safe_model}__loop={safe_loop}__{digest}"
 
 
 def expand_sweep_grid(models: list[str], loops: list[str | None]) -> list[SweepCell]:
@@ -149,14 +163,18 @@ def cell_result_from_summary(
     - ``score`` is a formatted percentage string ("70.0%"), so pass-rate is
       recomputed from the integer ``passed`` / ``total`` counts instead.
 
-    Token totals are read only when usage telemetry was actually captured
-    (``telemetry_coverage > 0``); otherwise ``total_tokens`` / ``total_cost_usd``
-    stay ``None`` so a fully-uninstrumented job doesn't masquerade as a
-    zero-cost one on the matrix's cost axis.
+    Token totals are read only when usage telemetry is **complete**
+    (``telemetry_coverage == 1.0``); otherwise ``total_tokens`` /
+    ``total_cost_usd`` stay ``None``. Partial coverage (``0 < cov < 1``) means
+    ``usage_summary`` summed tokens for only *some* trials, so that partial total
+    is NOT the cell's full spend — treating it as such could make a cell look
+    falsely cheaper and even spuriously cross over. The honest answer for a
+    partially- or un-instrumented cell is an undecidable cost axis (``None``),
+    not a misleading number.
     """
     loop_block = summary.get("loop_summary") or {}
     coverage = summary.get("telemetry_coverage")
-    has_usage = bool(coverage)
+    has_usage = coverage is not None and coverage >= 1.0
     passed = int(summary.get("passed") or 0)
     total = int(summary.get("total") or 0)
     return CellResult(

--- a/src/benchflow/loop_sweep.py
+++ b/src/benchflow/loop_sweep.py
@@ -1,0 +1,364 @@
+"""The loopbench cost-curve: sweep ``{model x loop-strategy}`` and assemble a
+pass-rate-vs-tokens matrix with cross-over detection.
+
+This is the money-shot artifact for the loopbench thesis — *can a cheap model
+plus loops match an expensive model single-shot at equal token spend?* The
+x-axis (per-iteration token capture) already lands in ``result.json``'s loop
+block and rolls up into ``summary.json``'s ``loop_summary`` / ``usage_summary``;
+this module runs one evaluation job per grid cell, reads each cell's
+``summary.json``, and assembles the cells into:
+
+- a **matrix** (rows = models, cols = loop strategies, value = pass-rate @
+  token spend), and
+- a **cross-over verdict** per non-baseline cell against a chosen baseline cell
+  (typically the strong model's single-shot run): does this cell match the
+  baseline pass-rate at *less-or-equal* token spend? That boolean is the thesis,
+  evaluated per cell.
+
+The pure assembly functions (``expand_sweep_grid``, ``cell_result_from_summary``,
+``build_cost_curve_matrix``, ``render_matrix_markdown``) carry no I/O and no live
+runs, so the matrix shape and the cross-over logic are fully unit-testable. The
+thin :func:`run_sweep` orchestrator is the only part that drives a real
+:class:`~benchflow.evaluation.Evaluation`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from benchflow.evaluation import Evaluation, EvaluationConfig
+from benchflow.loop_strategies import SINGLE_SHOT, parse_loop_strategy_spec
+
+# "single-shot", "", and None all denote the no-loop baseline path. The rollout
+# treats loop_strategy=None as single-shot, so we normalize these aliases to
+# None before handing them to the config and to "single-shot" for display.
+_BASELINE_LOOP_ALIASES = frozenset({"", SINGLE_SHOT})
+
+
+def _normalize_loop(loop: str | None) -> str | None:
+    """Map the baseline aliases ("", "single-shot") to None (the no-loop path)."""
+    if loop is None:
+        return None
+    text = loop.strip()
+    return None if text in _BASELINE_LOOP_ALIASES else text
+
+
+def _canonical_loop_key(loop: str | None) -> str | None:
+    """A canonical dedup identity for a loop spec — None for the single-shot path.
+
+    Two specs that mean the *same run* must collapse to one grid cell (one full
+    evaluation), else the matrix double-counts an evaluand and burns a redundant
+    run. Parsing fills the strategy's default params and ``to_mapping`` is
+    order-independent, so "verify-retry:k=3", "verify-retry:k=3,feedback=names"
+    (names being the default), and "verify-retry:feedback=names,k=3" all key
+    identically — the grid spawns one cell for the three.
+    """
+    norm = _normalize_loop(loop)
+    if norm is None:
+        return None
+    return json.dumps(parse_loop_strategy_spec(norm).to_mapping(), sort_keys=True)
+
+
+@dataclass(frozen=True)
+class SweepCell:
+    """One ``{model x loop}`` point in the sweep grid.
+
+    ``loop`` is normalized: ``None`` means the single-shot (no-loop) path, so the
+    cell can be fed straight to ``EvaluationConfig.loop_strategy`` without further
+    aliasing.
+    """
+
+    model: str
+    loop: str | None
+
+    @property
+    def loop_label(self) -> str:
+        return self.loop or SINGLE_SHOT
+
+    @property
+    def job_name(self) -> str:
+        """Filesystem-safe per-cell job name (one job dir per cell)."""
+        safe_loop = self.loop_label.replace(":", "_").replace(",", "_").replace("=", "")
+        safe_model = self.model.replace("/", "_")
+        return f"model={safe_model}__loop={safe_loop}"
+
+
+def expand_sweep_grid(models: list[str], loops: list[str | None]) -> list[SweepCell]:
+    """Cartesian product of ``models x loops``, de-duplicated and order-stable.
+
+    Order is model-major (all loops for model A, then model B …) so the rendered
+    matrix reads row-by-row. Cells are de-duplicated on their *canonical* loop
+    identity (see :func:`_canonical_loop_key`), so equivalent specs — including
+    the single-shot aliases and default-vs-explicit params — collapse to one
+    cell that keeps the first-seen spelling as its display label.
+    """
+    seen: set[tuple[str, str | None]] = set()
+    cells: list[SweepCell] = []
+    for model in models:
+        for loop in loops:
+            key = (model, _canonical_loop_key(loop))
+            if key in seen:
+                continue
+            seen.add(key)
+            cells.append(SweepCell(model=model, loop=_normalize_loop(loop)))
+    return cells
+
+
+@dataclass(frozen=True)
+class CellResult:
+    """A sweep cell's headline metrics, extracted from its ``summary.json``.
+
+    ``total_tokens`` / ``total_cost_usd`` are ``None`` when the job captured no
+    trusted usage telemetry (so the cost axis can be honestly absent rather than
+    a misleading zero). ``pass_at_iteration`` / ``mean_tokens_to_converge`` /
+    ``fraction_converged`` are ``None``/empty for single-shot cells, which carry
+    no ``loop_summary``.
+    """
+
+    model: str
+    loop: str
+    pass_rate: float
+    passed: int
+    total: int
+    total_tokens: int | None
+    total_cost_usd: float | None
+    mean_tokens_to_converge: float | None
+    pass_at_iteration: list[float]
+    fraction_converged: float | None
+    telemetry_coverage: float | None
+
+    def to_dict(self) -> dict[str, Any]:
+        # All fields are scalars/lists, so asdict is an exact, drift-proof mirror.
+        return asdict(self)
+
+
+def cell_result_from_summary(
+    model: str, loop: str, summary: dict[str, Any]
+) -> CellResult:
+    """Extract the matrix-relevant metrics from a written ``summary.json`` dict.
+
+    Mirrors the evaluation writer's layout (``evaluation.py`` summary assembly):
+
+    - ``usage_summary(...)`` is spread **flat**, so ``total_tokens`` /
+      ``total_cost_usd`` / ``telemetry_coverage`` are top-level keys (not nested).
+    - ``loop_summary(...)`` is spread too but is itself ``{"loop_summary": {...}}``,
+      so the convergence block lives at ``summary["loop_summary"]``.
+    - ``score`` is a formatted percentage string ("70.0%"), so pass-rate is
+      recomputed from the integer ``passed`` / ``total`` counts instead.
+
+    Token totals are read only when usage telemetry was actually captured
+    (``telemetry_coverage > 0``); otherwise ``total_tokens`` / ``total_cost_usd``
+    stay ``None`` so a fully-uninstrumented job doesn't masquerade as a
+    zero-cost one on the matrix's cost axis.
+    """
+    loop_block = summary.get("loop_summary") or {}
+    coverage = summary.get("telemetry_coverage")
+    has_usage = bool(coverage)
+    passed = int(summary.get("passed") or 0)
+    total = int(summary.get("total") or 0)
+    return CellResult(
+        model=model,
+        loop=loop,
+        pass_rate=(passed / total if total else 0.0),
+        passed=passed,
+        total=total,
+        total_tokens=(summary.get("total_tokens") if has_usage else None),
+        total_cost_usd=(summary.get("total_cost_usd") if has_usage else None),
+        mean_tokens_to_converge=loop_block.get("mean_tokens_to_converge"),
+        pass_at_iteration=list(loop_block.get("pass_at_iteration") or []),
+        fraction_converged=loop_block.get("fraction_converged"),
+        telemetry_coverage=coverage,
+    )
+
+
+def _cross_over_verdict(
+    candidate: CellResult, baseline: CellResult, *, pass_rate_tol: float
+) -> dict[str, Any]:
+    """Does ``candidate`` match the baseline pass-rate at ≤ its token spend?
+
+    The verdict is split into its two independent axes so a reader can see *why*
+    a cell does or doesn't cross over:
+
+    - ``matches_pass_rate`` — candidate pass-rate ≥ baseline − tolerance.
+    - ``at_lower_or_equal_cost`` — candidate token spend ≤ baseline's. ``None``
+      when either side lacks usage telemetry (the cost axis is undecidable, not
+      "free").
+
+    ``crosses_over`` is their conjunction, and is ``None`` (undecidable) whenever
+    the cost axis is ``None``.
+    """
+    matches = candidate.pass_rate >= baseline.pass_rate - pass_rate_tol
+    cand_tok = candidate.total_tokens
+    base_tok = baseline.total_tokens
+    if cand_tok is None or base_tok is None:
+        at_lower_cost: bool | None = None
+        token_ratio: float | None = None
+        crosses: bool | None = None
+    else:
+        at_lower_cost = cand_tok <= base_tok
+        token_ratio = round(cand_tok / base_tok, 4) if base_tok else None
+        crosses = bool(matches and at_lower_cost)
+    return {
+        "model": candidate.model,
+        "loop": candidate.loop,
+        "pass_rate": candidate.pass_rate,
+        "baseline_pass_rate": baseline.pass_rate,
+        "matches_pass_rate": matches,
+        "total_tokens": cand_tok,
+        "baseline_total_tokens": base_tok,
+        "token_ratio_vs_baseline": token_ratio,
+        "at_lower_or_equal_cost": at_lower_cost,
+        "crosses_over": crosses,
+    }
+
+
+def build_cost_curve_matrix(
+    cells: list[CellResult],
+    *,
+    baseline: tuple[str, str] | None = None,
+    pass_rate_tol: float = 0.0,
+) -> dict[str, Any]:
+    """Assemble the pass-rate-vs-tokens matrix + per-cell cross-over verdicts.
+
+    ``baseline`` is a ``(model, loop_label)`` pair naming the reference cell —
+    typically the expensive model's single-shot run. When given (and found among
+    ``cells``), each *other* cell gets a cross-over verdict against it. When
+    omitted or not found, the matrix carries no ``cross_over`` section.
+    """
+    by_key = {(c.model, c.loop): c for c in cells}
+    # Preserve first-seen order for both axes so the matrix reads grid-stable.
+    models: list[str] = []
+    loops: list[str] = []
+    for c in cells:
+        if c.model not in models:
+            models.append(c.model)
+        if c.loop not in loops:
+            loops.append(c.loop)
+
+    matrix: dict[str, Any] = {
+        "models": models,
+        "loops": loops,
+        "cells": [c.to_dict() for c in cells],
+    }
+
+    baseline_cell = by_key.get(baseline) if baseline else None
+    if baseline_cell is not None:
+        matrix["baseline"] = {
+            "model": baseline_cell.model,
+            "loop": baseline_cell.loop,
+        }
+        matrix["cross_over"] = [
+            _cross_over_verdict(c, baseline_cell, pass_rate_tol=pass_rate_tol)
+            for c in cells
+            if (c.model, c.loop) != (baseline_cell.model, baseline_cell.loop)
+        ]
+    return matrix
+
+
+def _fmt_tokens(tokens: int | None) -> str:
+    if tokens is None:
+        return "n/a"
+    if tokens >= 1000:
+        return f"{tokens / 1000:.0f}k"
+    return str(tokens)
+
+
+def render_matrix_markdown(matrix: dict[str, Any]) -> str:
+    """Render the matrix as a human-readable markdown table + cross-over notes.
+
+    Each cell shows ``pass-rate @ token-spend`` so the pass-rate/cost trade-off
+    is legible at a glance; the cross-over section calls out which cheap-model
+    loop cells match the baseline at lower cost (the thesis, per cell).
+    """
+    cells = {(c["model"], c["loop"]): c for c in matrix.get("cells", [])}
+    models = matrix.get("models", [])
+    loops = matrix.get("loops", [])
+
+    lines: list[str] = ["# Loop cost-curve: pass-rate @ tokens", ""]
+    header = "| model \\ loop | " + " | ".join(loops) + " |"
+    sep = "| --- | " + " | ".join("---" for _ in loops) + " |"
+    lines += [header, sep]
+    for model in models:
+        row = [f"`{model}`"]
+        for loop in loops:
+            cell = cells.get((model, loop))
+            if cell is None:
+                row.append("—")
+            else:
+                pr = f"{cell['pass_rate'] * 100:.0f}%"
+                row.append(f"{pr} @ {_fmt_tokens(cell['total_tokens'])}")
+        lines.append("| " + " | ".join(row) + " |")
+
+    cross_over = matrix.get("cross_over")
+    if cross_over:
+        base = matrix.get("baseline", {})
+        lines += [
+            "",
+            f"## Cross-over vs baseline `{base.get('model')}` / `{base.get('loop')}`",
+            "",
+        ]
+        for v in cross_over:
+            if v["crosses_over"] is True:
+                mark = "✅ crosses over"
+            elif v["crosses_over"] is False:
+                mark = "❌ no"
+            else:
+                mark = "❓ undecidable (no token telemetry)"
+            ratio = v["token_ratio_vs_baseline"]
+            ratio_str = f" ({ratio:.2f}x tokens)" if ratio is not None else ""
+            lines.append(
+                f"- `{v['model']}` / `{v['loop']}`: "
+                f"{v['pass_rate'] * 100:.0f}% vs "
+                f"{v['baseline_pass_rate'] * 100:.0f}% baseline{ratio_str} — {mark}"
+            )
+    return "\n".join(lines) + "\n"
+
+
+async def run_sweep(
+    *,
+    tasks_dir: str | Path,
+    jobs_dir: str | Path,
+    base_config: EvaluationConfig,
+    models: list[str],
+    loops: list[str | None],
+    baseline: tuple[str, str] | None = None,
+    pass_rate_tol: float = 0.0,
+    matrix_prefix: str = "sweep",
+) -> dict[str, Any]:
+    """Run one evaluation job per ``{model x loop}`` cell, then assemble the matrix.
+
+    Cells run sequentially — each :class:`Evaluation` already parallelizes its
+    own tasks (``config.concurrency``), and sequential cells keep the shared
+    sandbox-concurrency budget predictable. Each cell's job dir is named by
+    :attr:`SweepCell.job_name` so reruns are addressable; the assembled matrix is
+    written as ``{matrix_prefix}-matrix.json`` and ``-matrix.md`` under
+    ``jobs_dir``. The matrix dict is also returned.
+    """
+    tasks_dir = Path(tasks_dir)
+    jobs_dir = Path(jobs_dir)
+    jobs_dir.mkdir(parents=True, exist_ok=True)
+
+    cells = expand_sweep_grid(models, loops)
+    results: list[CellResult] = []
+    for cell in cells:
+        cfg = replace(base_config, model=cell.model, loop_strategy=cell.loop)
+        evaluation = Evaluation(
+            tasks_dir=tasks_dir,
+            jobs_dir=jobs_dir,
+            config=cfg,
+            job_name=cell.job_name,
+        )
+        await evaluation.run()
+        summary_path = jobs_dir / cell.job_name / "summary.json"
+        summary = json.loads(summary_path.read_text())
+        results.append(cell_result_from_summary(cell.model, cell.loop_label, summary))
+
+    matrix = build_cost_curve_matrix(
+        results, baseline=baseline, pass_rate_tol=pass_rate_tol
+    )
+    (jobs_dir / f"{matrix_prefix}-matrix.json").write_text(json.dumps(matrix, indent=2))
+    (jobs_dir / f"{matrix_prefix}-matrix.md").write_text(render_matrix_markdown(matrix))
+    return matrix

--- a/tests/test_loop_sweep.py
+++ b/tests/test_loop_sweep.py
@@ -69,7 +69,30 @@ def test_sweep_cell_labels_and_job_name_are_filesystem_safe():
     # the structural "model=" / "__loop=" separators (safe in filenames).
     for bad in ("/", ":", ","):
         assert bad not in cell.job_name
-    assert cell.job_name == "model=deepseek_v4-pro__loop=verify-retry_k3_feedbacknames"
+    assert cell.job_name.startswith(
+        "model=deepseek_v4-pro__loop=verify-retry_k3_feedbacknames__"
+    )
+    # ...followed by a short stable hex hash for injectivity.
+    suffix = cell.job_name.rsplit("__", 1)[1]
+    assert len(suffix) == 8 and all(ch in "0123456789abcdef" for ch in suffix)
+
+
+def test_job_name_injective_for_models_that_sanitize_alike():
+    # "foo/bar" and "foo_bar" both sanitize to "foo_bar" in the readable prefix,
+    # but the identity hash keeps their job dirs distinct — else the second cell
+    # resumes into the first's dir and the matrix misattributes results
+    # (Bugbot HIGH, #720).
+    a = SweepCell(model="foo/bar", loop=None).job_name
+    b = SweepCell(model="foo_bar", loop=None).job_name
+    assert a != b
+
+
+def test_job_name_stable_across_instances():
+    # Same identity -> same dir, so resume addresses the same cell across reruns.
+    assert (
+        SweepCell(model="m", loop="verify-retry:k=3").job_name
+        == SweepCell(model="m", loop="verify-retry:k=3").job_name
+    )
 
 
 def test_single_shot_cell_label():
@@ -142,6 +165,22 @@ def test_cell_from_summary_no_usage_yields_none_tokens_not_zero():
     assert cell.total_tokens is None
     assert cell.total_cost_usd is None
     assert cell.telemetry_coverage == 0.0
+
+
+def test_cell_from_summary_partial_coverage_is_undecidable_cost():
+    # 0 < coverage < 1: usage_summary summed only SOME trials, so the partial
+    # total is not the cell's full spend. Leave the cost axis undecidable rather
+    # than let a half-instrumented cell look falsely cheap (Bugbot P1, #720).
+    summary = _summary(
+        score=0.5,
+        passed=1,
+        total=2,
+        usage={"total_tokens": 500, "total_cost_usd": 0.1, "telemetry_coverage": 0.5},
+    )
+    cell = cell_result_from_summary("m", "single-shot", summary)
+    assert cell.total_tokens is None
+    assert cell.total_cost_usd is None
+    assert cell.telemetry_coverage == 0.5  # still surfaced for transparency
 
 
 def test_cell_from_summary_single_shot_has_empty_loop_fields():

--- a/tests/test_loop_sweep.py
+++ b/tests/test_loop_sweep.py
@@ -447,9 +447,13 @@ async def test_run_sweep_drives_one_job_per_cell_and_writes_matrix(
 
         async def run(self):
             summary = fake_summaries[(self._config.model, _full_label(self._config))]
+            # Mirror the real Evaluation: canonical copy under <job_name>/ plus a
+            # backward-compat copy at the (now per-cell) jobs_dir root.
             job_dir = self._jobs_dir / self._job_name
             job_dir.mkdir(parents=True, exist_ok=True)
-            (job_dir / "summary.json").write_text(json.dumps(summary))
+            text = json.dumps(summary)
+            (job_dir / "summary.json").write_text(text)
+            (self._jobs_dir / "summary.json").write_text(text)
 
     monkeypatch.setattr("benchflow.loop_sweep.Evaluation", FakeEvaluation)
 
@@ -476,6 +480,12 @@ async def test_run_sweep_drives_one_job_per_cell_and_writes_matrix(
     assert (jobs_dir / "sweep-matrix.md").exists()
     on_disk = json.loads((jobs_dir / "sweep-matrix.json").read_text())
     assert on_disk == matrix
+
+    # Cells are isolated: each writes under its own subdir, so the shared
+    # jobs_dir root is never clobbered with a single cell's summary (#720).
+    assert not (jobs_dir / "summary.json").exists()
+    cell_summaries = sorted(p.parent.name for p in jobs_dir.glob("*/summary.json"))
+    assert len(cell_summaries) == 4  # one isolated job dir per cell
 
     # 3 non-baseline verdicts; only cheap/verify-retry crosses over (matches the
     # 70% baseline at < its token spend). cheap/single-shot fails on pass-rate;

--- a/tests/test_loop_sweep.py
+++ b/tests/test_loop_sweep.py
@@ -1,0 +1,421 @@
+"""Tests for the loopbench cost-curve sweep (loop_sweep).
+
+Covers the pure assembly functions (grid expansion, summary→cell extraction,
+matrix + cross-over assembly, markdown render) and the thin orchestrator with a
+mocked Evaluation — no live runs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchflow.evaluation import EvaluationConfig
+from benchflow.loop_sweep import (
+    CellResult,
+    SweepCell,
+    build_cost_curve_matrix,
+    cell_result_from_summary,
+    expand_sweep_grid,
+    render_matrix_markdown,
+    run_sweep,
+)
+
+# --------------------------------------------------------------------------- #
+# expand_sweep_grid
+# --------------------------------------------------------------------------- #
+
+
+def test_expand_grid_is_model_major_and_normalizes_single_shot():
+    cells = expand_sweep_grid(["cheap", "pricey"], ["single-shot", "verify-retry:k=3"])
+    assert [(c.model, c.loop) for c in cells] == [
+        ("cheap", None),  # single-shot -> None
+        ("cheap", "verify-retry:k=3"),
+        ("pricey", None),
+        ("pricey", "verify-retry:k=3"),
+    ]
+
+
+def test_expand_grid_dedups_single_shot_aliases():
+    # "", "single-shot", and None all collapse to the one no-loop cell.
+    cells = expand_sweep_grid(["m"], ["single-shot", "", None, "self-review:k=2"])
+    assert [(c.model, c.loop) for c in cells] == [
+        ("m", None),
+        ("m", "self-review:k=2"),
+    ]
+
+
+def test_expand_grid_dedups_equivalent_loop_specs():
+    # Same evaluand spelled three ways (implicit vs explicit default, param
+    # order) collapses to ONE cell — keeping the first-seen spelling — so the
+    # matrix never double-counts or burns a redundant run.
+    cells = expand_sweep_grid(
+        ["m"],
+        [
+            "verify-retry:k=3",
+            "verify-retry:k=3,feedback=names",  # names is the default
+            "verify-retry:feedback=names,k=3",  # reordered params
+        ],
+    )
+    assert [(c.model, c.loop) for c in cells] == [("m", "verify-retry:k=3")]
+
+
+def test_sweep_cell_labels_and_job_name_are_filesystem_safe():
+    cell = SweepCell(model="deepseek/v4-pro", loop="verify-retry:k=3,feedback=names")
+    assert cell.loop_label == "verify-retry:k=3,feedback=names"
+    # Path-breaking chars are sanitized out of the spec; the only "=" left are
+    # the structural "model=" / "__loop=" separators (safe in filenames).
+    for bad in ("/", ":", ","):
+        assert bad not in cell.job_name
+    assert cell.job_name == "model=deepseek_v4-pro__loop=verify-retry_k3_feedbacknames"
+
+
+def test_single_shot_cell_label():
+    assert SweepCell(model="m", loop=None).loop_label == "single-shot"
+
+
+# --------------------------------------------------------------------------- #
+# cell_result_from_summary
+# --------------------------------------------------------------------------- #
+
+
+def _summary(
+    *,
+    score=0.0,
+    passed=0,
+    total=0,
+    usage=None,
+    loop_summary=None,
+):
+    """Build a summary.json-shaped dict matching the evaluation writer's layout:
+    score is a formatted "%"-string, usage_summary fields are spread flat at the
+    top level, and the loop block is nested under "loop_summary"."""
+    out = {"score": f"{score:.1%}", "passed": passed, "total": total}
+    if usage is not None:
+        out.update(usage)  # usage_summary(...) is spread flat in summary.json
+    if loop_summary is not None:
+        out["loop_summary"] = loop_summary
+    return out
+
+
+def test_cell_from_summary_extracts_full_loop_and_usage():
+    # The evaluation writer spreads loop_summary(results) into summary.json, so
+    # the block sits at summary["loop_summary"] directly.
+    summary = _summary(
+        score=0.72,
+        passed=36,
+        total=50,
+        usage={
+            "total_tokens": 1_200_000,
+            "total_cost_usd": 3.4,
+            "telemetry_coverage": 1.0,
+        },
+        loop_summary={
+            "mean_tokens_to_converge": 18_000.0,
+            "pass_at_iteration": [0.4, 0.6, 0.72],
+            "fraction_converged": 0.72,
+        },
+    )
+    cell = cell_result_from_summary("cheap", "verify-retry:k=3", summary)
+    assert cell.pass_rate == pytest.approx(0.72)
+    assert cell.passed == 36
+    assert cell.total == 50
+    assert cell.total_tokens == 1_200_000
+    assert cell.total_cost_usd == 3.4
+    assert cell.mean_tokens_to_converge == 18_000.0
+    assert cell.pass_at_iteration == [0.4, 0.6, 0.72]
+    assert cell.fraction_converged == 0.72
+    assert cell.telemetry_coverage == 1.0
+
+
+def test_cell_from_summary_no_usage_yields_none_tokens_not_zero():
+    # A job with zero telemetry coverage must not masquerade as zero-cost.
+    summary = _summary(
+        score=0.5,
+        passed=1,
+        total=2,
+        usage={"total_tokens": 0, "total_cost_usd": 0.0, "telemetry_coverage": 0.0},
+    )
+    cell = cell_result_from_summary("m", "single-shot", summary)
+    assert cell.total_tokens is None
+    assert cell.total_cost_usd is None
+    assert cell.telemetry_coverage == 0.0
+
+
+def test_cell_from_summary_single_shot_has_empty_loop_fields():
+    # single-shot jobs carry no loop_summary block.
+    summary = _summary(
+        score=0.6,
+        passed=3,
+        total=5,
+        usage={"total_tokens": 500, "total_cost_usd": 0.1, "telemetry_coverage": 1.0},
+    )
+    cell = cell_result_from_summary("m", "single-shot", summary)
+    assert cell.mean_tokens_to_converge is None
+    assert cell.pass_at_iteration == []
+    assert cell.fraction_converged is None
+
+
+# --------------------------------------------------------------------------- #
+# build_cost_curve_matrix + cross-over
+# --------------------------------------------------------------------------- #
+
+
+def _cell(model, loop, pass_rate, tokens):
+    return CellResult(
+        model=model,
+        loop=loop,
+        pass_rate=pass_rate,
+        passed=0,
+        total=0,
+        total_tokens=tokens,
+        total_cost_usd=None,
+        mean_tokens_to_converge=None,
+        pass_at_iteration=[],
+        fraction_converged=None,
+        telemetry_coverage=(1.0 if tokens is not None else 0.0),
+    )
+
+
+def test_matrix_axes_preserve_first_seen_order():
+    cells = [
+        _cell("cheap", "single-shot", 0.3, 100),
+        _cell("cheap", "verify-retry", 0.7, 300),
+        _cell("pricey", "single-shot", 0.7, 2000),
+    ]
+    matrix = build_cost_curve_matrix(cells)
+    assert matrix["models"] == ["cheap", "pricey"]
+    assert matrix["loops"] == ["single-shot", "verify-retry"]
+    assert "cross_over" not in matrix  # no baseline given
+
+
+def test_cross_over_true_cheap_loop_matches_baseline_at_lower_cost():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),  # baseline
+        _cell("cheap", "verify-retry", 0.72, 1200),  # matches @ < tokens
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    [verdict] = matrix["cross_over"]
+    assert verdict["model"] == "cheap"
+    assert verdict["matches_pass_rate"] is True
+    assert verdict["at_lower_or_equal_cost"] is True
+    assert verdict["crosses_over"] is True
+    assert verdict["token_ratio_vs_baseline"] == pytest.approx(0.48)
+
+
+def test_cross_over_false_when_pass_rate_below_baseline():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry", 0.60, 1200),  # cheaper but worse
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    [verdict] = matrix["cross_over"]
+    assert verdict["matches_pass_rate"] is False
+    assert verdict["at_lower_or_equal_cost"] is True
+    assert verdict["crosses_over"] is False
+
+
+def test_cross_over_false_when_more_expensive_even_if_better():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry", 0.80, 3000),  # better but pricier
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    [verdict] = matrix["cross_over"]
+    assert verdict["matches_pass_rate"] is True
+    assert verdict["at_lower_or_equal_cost"] is False
+    assert verdict["crosses_over"] is False
+
+
+def test_cross_over_undecidable_when_tokens_missing():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry", 0.72, None),  # no telemetry
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    [verdict] = matrix["cross_over"]
+    assert verdict["matches_pass_rate"] is True
+    assert verdict["at_lower_or_equal_cost"] is None
+    assert verdict["crosses_over"] is None
+    assert verdict["token_ratio_vs_baseline"] is None
+
+
+def test_cross_over_tolerance_allows_near_match():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry", 0.68, 1000),  # 2pt below
+    ]
+    matrix = build_cost_curve_matrix(
+        cells, baseline=("pricey", "single-shot"), pass_rate_tol=0.05
+    )
+    [verdict] = matrix["cross_over"]
+    assert verdict["matches_pass_rate"] is True  # within 5pt tolerance
+    assert verdict["crosses_over"] is True
+
+
+def test_cross_over_zero_baseline_tokens_guards_ratio_division():
+    # Baseline captured 0 tokens: the ratio is undefined (None) but the cost
+    # comparison and the verdict stay real booleans (cand 0 <= base 0).
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 0),
+        _cell("cheap", "verify-retry", 0.72, 0),
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    [verdict] = matrix["cross_over"]
+    assert verdict["token_ratio_vs_baseline"] is None  # no divide-by-zero
+    assert verdict["at_lower_or_equal_cost"] is True
+    assert verdict["crosses_over"] is True
+
+
+def test_unknown_baseline_omits_cross_over():
+    cells = [_cell("m", "single-shot", 0.5, 100)]
+    matrix = build_cost_curve_matrix(cells, baseline=("nope", "single-shot"))
+    assert "cross_over" not in matrix
+    assert "baseline" not in matrix
+
+
+# --------------------------------------------------------------------------- #
+# render_matrix_markdown
+# --------------------------------------------------------------------------- #
+
+
+def test_render_markdown_has_table_and_crossover_marks():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "single-shot", 0.30, 80),
+        _cell("cheap", "verify-retry", 0.72, 1200),
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    md = render_matrix_markdown(matrix)
+    assert "| model \\ loop | single-shot | verify-retry |" in md
+    assert "`cheap`" in md and "`pricey`" in md
+    assert "70% @ 2k" in md  # baseline cell formatting
+    assert "72% @ 1k" in md
+    assert "✅ crosses over" in md  # cheap/verify-retry crosses over
+    assert "Cross-over vs baseline" in md
+
+
+def test_render_markdown_marks_undecidable_cost():
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry", 0.72, None),
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", "single-shot"))
+    md = render_matrix_markdown(matrix)
+    assert "n/a" in md  # missing token spend
+    assert "undecidable" in md
+
+
+# --------------------------------------------------------------------------- #
+# run_sweep orchestrator (mocked Evaluation)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_run_sweep_drives_one_job_per_cell_and_writes_matrix(
+    tmp_path: Path, monkeypatch
+):
+    """Each cell runs an Evaluation with the right (model, loop_strategy), and the
+    assembled matrix.json/.md land under jobs_dir."""
+
+    def _usage(tok, cost):
+        return {
+            "total_tokens": tok,
+            "total_cost_usd": cost,
+            "telemetry_coverage": 1.0,
+        }
+
+    # Full 2x2 grid (the orchestrator visits every cell), keyed by
+    # (model, loop_label).
+    fake_summaries = {
+        ("pricey", "single-shot"): _summary(
+            score=0.70, passed=35, total=50, usage=_usage(2_500_000, 12.0)
+        ),
+        ("pricey", "verify-retry:k=3"): _summary(
+            score=0.74,
+            passed=37,
+            total=50,
+            usage=_usage(3_000_000, 14.0),
+            loop_summary={
+                "mean_tokens_to_converge": 40_000.0,
+                "pass_at_iteration": [0.6, 0.7, 0.74],
+                "fraction_converged": 0.74,
+            },
+        ),
+        ("cheap", "single-shot"): _summary(
+            score=0.30, passed=15, total=50, usage=_usage(80_000, 0.2)
+        ),
+        ("cheap", "verify-retry:k=3"): _summary(
+            score=0.72,
+            passed=36,
+            total=50,
+            usage=_usage(1_200_000, 3.0),
+            loop_summary={
+                "mean_tokens_to_converge": 18_000.0,
+                "pass_at_iteration": [0.5, 0.65, 0.72],
+                "fraction_converged": 0.72,
+            },
+        ),
+    }
+    captured: list[tuple[str | None, str]] = []
+
+    def _full_label(config) -> str:
+        # Reconstruct the grid's full spec string from the parsed LoopStrategySpec
+        # so it matches the matrix's cell.loop_label ("verify-retry:k=3"), not
+        # just the bare strategy name.
+        spec = config.loop_strategy
+        if spec is None:
+            return "single-shot"
+        if spec.params.get("k") is not None:
+            return f"{spec.name}:k={spec.params['k']}"
+        return spec.name
+
+    class FakeEvaluation:
+        def __init__(self, *, tasks_dir, jobs_dir, config, job_name):
+            self._jobs_dir = Path(jobs_dir)
+            self._config = config
+            self._job_name = job_name
+            # loop_strategy is a LoopStrategySpec | None after __post_init__.
+            captured.append((config.model, _full_label(config)))
+
+        async def run(self):
+            summary = fake_summaries[(self._config.model, _full_label(self._config))]
+            job_dir = self._jobs_dir / self._job_name
+            job_dir.mkdir(parents=True, exist_ok=True)
+            (job_dir / "summary.json").write_text(json.dumps(summary))
+
+    monkeypatch.setattr("benchflow.loop_sweep.Evaluation", FakeEvaluation)
+
+    jobs_dir = tmp_path / "jobs"
+    matrix = await run_sweep(
+        tasks_dir=tmp_path / "tasks",
+        jobs_dir=jobs_dir,
+        base_config=EvaluationConfig(concurrency=8),
+        models=["pricey", "cheap"],
+        loops=["single-shot", "verify-retry:k=3"],
+        baseline=("pricey", "single-shot"),
+    )
+
+    # All 4 cells drove a job, each with the right (model, loop) config.
+    assert captured == [
+        ("pricey", "single-shot"),
+        ("pricey", "verify-retry:k=3"),
+        ("cheap", "single-shot"),
+        ("cheap", "verify-retry:k=3"),
+    ]
+
+    # Matrix artifacts written and match the returned dict.
+    assert (jobs_dir / "sweep-matrix.json").exists()
+    assert (jobs_dir / "sweep-matrix.md").exists()
+    on_disk = json.loads((jobs_dir / "sweep-matrix.json").read_text())
+    assert on_disk == matrix
+
+    # 3 non-baseline verdicts; only cheap/verify-retry crosses over (matches the
+    # 70% baseline at < its token spend). cheap/single-shot fails on pass-rate;
+    # pricey/verify-retry fails on cost.
+    verdicts = {(v["model"], v["loop"]): v for v in matrix["cross_over"]}
+    assert verdicts[("cheap", "verify-retry:k=3")]["crosses_over"] is True
+    assert verdicts[("cheap", "single-shot")]["crosses_over"] is False
+    assert verdicts[("pricey", "verify-retry:k=3")]["crosses_over"] is False

--- a/tests/test_loop_sweep.py
+++ b/tests/test_loop_sweep.py
@@ -276,6 +276,32 @@ def test_unknown_baseline_omits_cross_over():
     assert "baseline" not in matrix
 
 
+def test_baseline_single_shot_alias_resolves_by_canonical_identity():
+    # Baseline named with the "" alias still resolves to the single-shot cell.
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry:k=3", 0.72, 1200),
+    ]
+    matrix = build_cost_curve_matrix(cells, baseline=("pricey", ""))
+    assert matrix["baseline"] == {"model": "pricey", "loop": "single-shot"}
+    [verdict] = matrix["cross_over"]
+    assert verdict["model"] == "cheap"
+    assert verdict["crosses_over"] is True
+
+
+def test_baseline_resolves_explicit_and_reordered_params():
+    # Cell stores "verify-retry:k=3"; baseline names it with explicit-default +
+    # reordered params — canonical identity still resolves it (Bugbot #720).
+    cells = [
+        _cell("pricey", "single-shot", 0.70, 2500),
+        _cell("cheap", "verify-retry:k=3", 0.72, 1200),
+    ]
+    matrix = build_cost_curve_matrix(
+        cells, baseline=("cheap", "verify-retry:feedback=names,k=3")
+    )
+    assert matrix["baseline"] == {"model": "cheap", "loop": "verify-retry:k=3"}
+
+
 # --------------------------------------------------------------------------- #
 # render_matrix_markdown
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The loopbench money-shot

With per-iteration token capture landed (#718/#719 — the cost-curve **x-axis**), this adds the matrix that puts it to work: `loop_sweep` runs one evaluation job per `{model × loop-strategy}` grid cell, reads each cell's `summary.json`, and assembles a **pass-rate-vs-tokens matrix** with per-cell **cross-over verdicts**.

> *Does a cheap model + loops match an expensive model single-shot at ≤ its token spend?* That boolean — per cell, vs a chosen baseline — is the thesis.

## Shape

- **`expand_sweep_grid(models, loops)`** → cartesian grid of `SweepCell`s, de-duplicated on a **canonical** loop identity (parsed + default-filled), so `verify-retry:k=3`, `verify-retry:k=3,feedback=names` (names is the default), and the param-reordered spelling all collapse to one cell — never double-counting an evaluand or burning a redundant run.
- **`cell_result_from_summary(model, loop, summary)`** → extracts pass-rate + token spend + the loop convergence block, mirroring the real `summary.json` writer exactly (usage fields flat top-level; loop block nested at `summary["loop_summary"]`; pass-rate recomputed from `passed`/`total` since `score` is a `"%"`-string). `total_tokens` stays **`None`, not `0`**, when `telemetry_coverage == 0`, so an uninstrumented cell can't masquerade as zero-cost.
- **`build_cost_curve_matrix(cells, baseline=...)`** → the matrix + a `cross_over` verdict per non-baseline cell, split into its two axes (`matches_pass_rate`, `at_lower_or_equal_cost`) with honest **`None`** when the cost axis is undecidable (missing telemetry / zero-token baseline).
- **`render_matrix_markdown(matrix)`** → a `pass-rate @ tokens` table + ✅/❌/❓ cross-over notes.
- **`run_sweep(...)`** → the thin async orchestrator: one `Evaluation.run()` per cell (sequential — each Evaluation already parallelizes its own tasks via `concurrency`), then writes `sweep-matrix.json` + `sweep-matrix.md`.

Pure assembly functions carry no I/O and are fully unit-tested; only `run_sweep` touches a real `Evaluation`.

## Tests & review

- 19 unit tests: grid expansion + canonical dedup, summary→cell extraction (full / no-usage / single-shot), cross-over (match / pass-rate-fail / cost-fail / undecidable / tolerance / zero-baseline division-guard), markdown render, and a mocked-`Evaluation` end-to-end `run_sweep`.
- **Thermo-nuclear structural review: APPROVE-WITH-NITS** — summary.json extraction verified correct against the real writer; all nits addressed (canonical dedup, dead-helper removal, `asdict` mirror, division-guard test).
- `ruff` clean; 92 loop/eval tests green.

## Next

A real multi-cell live run (deepseek-v4-pro + loops vs a strong model single-shot on Daytona/Docker) to populate the curve, and CLI wiring (`bench eval` sweep YAML, per the locked "no new verb" decision).

Follows #718/#719 (token capture), #716 (loop_summary), #713/#717 (strategies).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive benchmark tooling with no changes to evaluation rollout paths; main risk is incorrect matrix assembly or job-dir collisions, which tests explicitly guard.
> 
> **Overview**
> Adds **`loop_sweep`**, which runs one evaluation per **model × loop-strategy** grid cell and builds a **pass-rate @ token spend** matrix plus optional **cross-over** verdicts against a baseline (match pass-rate at ≤ baseline tokens).
> 
> **Grid & isolation:** `expand_sweep_grid` builds a model-major cartesian grid with **canonical dedup** of loop specs (single-shot aliases, default params, param order) and **hash-suffixed per-cell job dirs** so sanitized model names cannot collide or resume into the wrong cell.
> 
> **Metrics honesty:** `cell_result_from_summary` mirrors real `summary.json` layout; token/cost fields stay **`None` unless `telemetry_coverage == 1.0`** so partial or missing usage cannot fake a cheaper cell or spurious cross-over.
> 
> **Orchestration:** `run_sweep` runs cells **sequentially** under isolated subdirs, then writes `{prefix}-matrix.json` and markdown; pure assembly/render paths stay I/O-free and are covered by **19 unit tests** including a mocked `Evaluation` end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e51dcb4efe827d8ca1539e77e721c08992bfdf29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->