### PR TITLE
ci: fix ruff format-check gate on release/v0.6.0 (release-blocking)

### DIFF
--- a/src/benchflow/agents/deepagents_acp_shim.py
+++ b/src/benchflow/agents/deepagents_acp_shim.py
@@ -218,8 +218,10 @@ def _message_role(message) -> str:
 
 def _message_text(message) -> str:
     """Flatten a LangChain message's content to plain text."""
-    content = message.get("content") if isinstance(message, dict) else getattr(
-        message, "content", ""
+    content = (
+        message.get("content")
+        if isinstance(message, dict)
+        else getattr(message, "content", "")
     )
     if isinstance(content, str):
         return content

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -866,13 +866,9 @@ def eval_metrics(
     if summary["passed_tasks"]:
         console.print(f"\n[green]Passed:[/green] {', '.join(summary['passed_tasks'])}")
     if summary["errored_tasks"]:
-        console.print(
-            f"[yellow]Errors:[/yellow] {', '.join(summary['errored_tasks'])}"
-        )
+        console.print(f"[yellow]Errors:[/yellow] {', '.join(summary['errored_tasks'])}")
     if summary["error_breakdown"]:
-        console.print(
-            f"[yellow]Error breakdown:[/yellow] {summary['error_breakdown']}"
-        )
+        console.print(f"[yellow]Error breakdown:[/yellow] {summary['error_breakdown']}")
 
 
 @eval_app.command("view")

--- a/tests/test_cli_misc.py
+++ b/tests/test_cli_misc.py
@@ -105,7 +105,9 @@ def test_benchflow_metrics_json_includes_memory_score_without_changing_score(tmp
         )
     )
 
-    result = CliRunner().invoke(app, ["eval", "metrics", str(tmp_path / "jobs"), "--json"])
+    result = CliRunner().invoke(
+        app, ["eval", "metrics", str(tmp_path / "jobs"), "--json"]
+    )
 
     assert result.exit_code == 0
     payload_start = result.output.index("{")

--- a/tests/test_inbound_adapters.py
+++ b/tests/test_inbound_adapters.py
@@ -56,6 +56,7 @@ cpus = 2
 memory_mb = 4096
 """
 
+
 def _write_harbor_task(root: Path) -> Path:
     """Create a Harbor-style task dir; return its path."""
     task_dir = root / "harbor-task"


### PR DESCRIPTION
## Release-blocking: CI `test` workflow is red on `release/v0.6.0`

The **Format check** step (`uv run ruff format --check src tests tools`) has been failing across recent release commits (`8a1f7ff6`, `d0d95e4f`, `6fd72e0e` …), which blocks the v0.6 release and any `release → main` merge.

Four files were last formatted under an older ruff and don't satisfy the **locked `ruff 0.15.12`**:
- `src/benchflow/agents/deepagents_acp_shim.py` — a re-wrapped `if/else` expression
- `src/benchflow/cli/main.py`
- `tests/test_cli_misc.py`
- `tests/test_inbound_adapters.py`

**Pure formatting, no logic change** — 10 insertions / 9 deletions, all whitespace/line-wrapping. After this, `ruff format --check` and `ruff check` both pass on `src tests tools` (449 files clean).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Whitespace-only formatting across shim, CLI, and tests; no functional or security impact.
> 
> **Overview**
> Unblocks the release **Format check** step (`ruff format --check`) by reformatting four files that were still laid out for an older Ruff.
> 
> Changes are **whitespace and line wrapping only**—no behavior edits: a multi-line ternary in `_message_text` in `deepagents_acp_shim.py`, single-line `console.print` calls in `eval metrics` error output in `cli/main.py`, a wrapped `CliRunner().invoke` in `test_cli_misc.py`, and a blank line before `_write_harbor_task` in `test_inbound_adapters.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110d803eb40a226af4cbc6155a269591cc532a3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->