### PR TITLE
ci: fix the 13 ty type-check errors blocking release CI (release-blocking)

### DIFF
--- a/src/benchflow/agents/deepagents_acp_shim.py
+++ b/src/benchflow/agents/deepagents_acp_shim.py
@@ -34,6 +34,7 @@ import os
 import sys
 import time
 import uuid
+from collections.abc import Mapping
 
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic/text output in ACP updates
 _TOOL_RESULT_TRUNCATE = 1000  # max chars for tool result text
@@ -80,7 +81,7 @@ def recv():
 # a live model.
 
 
-def resolve_base_url(env: dict | None = None) -> str:
+def resolve_base_url(env: Mapping[str, str] | None = None) -> str:
     """Resolve the OpenAI-compatible base URL for the deepseek provider."""
     env = os.environ if env is None else env
     for key in ("BENCHFLOW_PROVIDER_BASE_URL", "DEEPSEEK_BASE_URL"):
@@ -90,7 +91,7 @@ def resolve_base_url(env: dict | None = None) -> str:
     return _DEFAULT_DEEPSEEK_BASE_URL
 
 
-def resolve_api_key(env: dict | None = None) -> str:
+def resolve_api_key(env: Mapping[str, str] | None = None) -> str:
     """Resolve the API key for the deepseek provider (may be empty)."""
     env = os.environ if env is None else env
     for key in ("BENCHFLOW_PROVIDER_API_KEY", "DEEPSEEK_API_KEY"):
@@ -100,7 +101,7 @@ def resolve_api_key(env: dict | None = None) -> str:
     return ""
 
 
-def resolve_model_id(requested: str, env: dict | None = None) -> str:
+def resolve_model_id(requested: str, env: Mapping[str, str] | None = None) -> str:
     """Resolve the bare deepseek model id to hand to the chat model.
 
     Priority: the ACP-supplied model (``set_model``) → BENCHFLOW_PROVIDER_MODEL
@@ -122,7 +123,7 @@ def resolve_model_id(requested: str, env: dict | None = None) -> str:
     return model
 
 
-def build_chat_model(model_id: str, env: dict | None = None):
+def build_chat_model(model_id: str, env: Mapping[str, str] | None = None):
     """Build a LangChain chat model for deepseek-v4-pro via the OpenAI protocol.
 
     deepseek-v4-pro is OpenAI-compatible, so we use ``langchain_openai.ChatOpenAI``
@@ -161,7 +162,7 @@ def build_chat_model(model_id: str, env: dict | None = None):
     return ChatOpenAI(**kwargs)
 
 
-def _float_env(env: dict, key: str):
+def _float_env(env: Mapping[str, str], key: str):
     raw = env.get(key)
     if raw is None or not str(raw).strip():
         return None
@@ -171,7 +172,7 @@ def _float_env(env: dict, key: str):
         return None
 
 
-def _int_env(env: dict, key: str):
+def _int_env(env: Mapping[str, str], key: str):
     raw = env.get(key)
     if raw is None or not str(raw).strip():
         return None
@@ -184,7 +185,7 @@ def _int_env(env: dict, key: str):
 # ── deep agent construction + run ─────────────────────────────────────────────
 
 
-def build_deep_agent(model_id: str, cwd: str, env: dict | None = None):
+def build_deep_agent(model_id: str, cwd: str, env: Mapping[str, str] | None = None):
     """Construct a deep agent rooted at ``cwd`` with shell + filesystem tools.
 
     Uses ``LocalShellBackend`` (a ``FilesystemBackend`` that also exposes the
@@ -263,7 +264,7 @@ def run_deep_agent(
     instruction: str,
     cwd: str,
     session_id: str,
-    env: dict | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> dict:
     """Build and invoke a deep agent, emitting ACP updates for its trajectory.
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import yaml
 
@@ -456,7 +456,8 @@ class EvaluationConfig:
     environment_manifest: EnvironmentManifest | None = None
     # Harness loop strategy applied to every rollout (e.g.
     # "verify-retry:k=3,feedback=names"). Threaded to RolloutConfig.from_legacy
-    # and stamped in summary.json; None = single-shot.
+    # and stamped in summary.json; None = single-shot. A dict (the to_mapping()
+    # shape) is also accepted at runtime — __post_init__ materializes it.
     loop_strategy: LoopStrategySpec | str | None = None
 
     def __post_init__(self):
@@ -481,7 +482,11 @@ class EvaluationConfig:
             # through a --config YAML, or an SDK EvaluationConfig(loop_strategy={...}))
             # must materialize too — not silently fall through and mislabel the run
             # single-shot. Mirror the sharding guard's loud-failure stance.
-            self.loop_strategy = LoopStrategySpec.from_mapping(self.loop_strategy)
+            # cast: isinstance narrows to dict[Unknown, Unknown]; from_mapping
+            # validates the keys at runtime.
+            self.loop_strategy = LoopStrategySpec.from_mapping(
+                cast("dict[str, Any]", self.loop_strategy)
+            )
         elif self.loop_strategy is not None and not isinstance(
             self.loop_strategy, LoopStrategySpec
         ):

--- a/src/benchflow/rollout/_config.py
+++ b/src/benchflow/rollout/_config.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from benchflow._types import Role, Scene
 from benchflow._utils.config import (
@@ -131,7 +131,8 @@ class RolloutConfig:
     # Harness-level loop strategy (``--loop-strategy``). Accepts a spec string
     # ("verify-retry:k=3,feedback=names") or a parsed LoopStrategySpec;
     # __post_init__ materializes it into user/max_user_rounds. Mutually
-    # exclusive with an explicit ``user``.
+    # exclusive with an explicit ``user``. A dict (the to_mapping() shape) is
+    # also accepted at runtime and materialized via from_mapping.
     loop_strategy: LoopStrategySpec | str | None = None
     # Whether a task.md-declared user may be adopted when neither an explicit
     # ``user`` nor a loop strategy materializes one. ``None`` (default)
@@ -192,7 +193,11 @@ class RolloutConfig:
         elif isinstance(self.loop_strategy, dict):
             # to_mapping() dict shape (round-tripped --config YAML / SDK kwargs)
             # must materialize, not fall through and mislabel single-shot.
-            self.loop_strategy = LoopStrategySpec.from_mapping(self.loop_strategy)
+            # cast: isinstance narrows to dict[Unknown, Unknown]; from_mapping
+            # validates the keys at runtime.
+            self.loop_strategy = LoopStrategySpec.from_mapping(
+                cast("dict[str, Any]", self.loop_strategy)
+            )
         elif self.loop_strategy is not None and not isinstance(
             self.loop_strategy, LoopStrategySpec
         ):

--- a/src/benchflow/rollout/_user_loop.py
+++ b/src/benchflow/rollout/_user_loop.py
@@ -64,9 +64,9 @@ def _round_tokens(rollout: Rollout) -> int | None:
     than a spurious ``0`` — preserving the cost-curve's best-effort contract.
     """
     metrics = getattr(rollout, "_native_usage_metrics", None)
-    if not is_token_usage_available(metrics):
-        return None
-    return metrics.get("total_tokens")
+    if metrics and is_token_usage_available(metrics):
+        return metrics.get("total_tokens")
+    return None
 
 
 async def _export_generated_skills(rollout: Rollout) -> None:


### PR DESCRIPTION
## The second release-CI gate: `ty check`

With the format gate fixed (#721), the `test` workflow advanced to its next step — **`uv run ty check`** — which surfaced **13 pre-existing type errors**. They slipped in because the loop-work PRs (#713/#715/#718/#719) merged while the format gate was *already* red, so the type-check step never gated them. All 13 are now green.

### Fixes

- **`deepagents_acp_shim.py` (8)** — env params were typed `dict | None`, then reassigned `env = os.environ if env is None else env`, widening to `_Environ[str] | dict` (not assignable back) and leaving `.get` on a possible `None`. Retyped as `Mapping[str, str]` (both `os.environ` and a passed `dict` satisfy it; `_float_env`/`_int_env` take the same).
- **`rollout/_user_loop._round_tokens` (1)** — `is_token_usage_available()` isn't a `TypeGuard`, so `ty` couldn't narrow `None` away before `.get`. Narrowed via a truthiness check — behavior identical (both `None` and `{}` return `None`).
- **`evaluation.py` + `rollout/_config.py` `from_mapping` (2)** — `isinstance(x, dict)` narrows the branch to `dict[Unknown, Unknown]`, not the `dict[str, Any]` `from_mapping` expects. `cast` at the callsite; `from_mapping` validates keys at runtime.

### Verification

`uv run ty check` → **All checks passed**; `ruff check` + `ruff format --check` clean; 149 loop/user/deepagents tests pass. **No behavior change.**

This is the last red gate I can see on the `test` workflow — it unblocks the v0.6 release and the `release → main` merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Annotation and narrow typing-only edits; runtime paths are unchanged per PR verification and existing tests.
> 
> **Overview**
> Unblocks **`uv run ty check`** in release CI by fixing 13 static typing issues with **no intended runtime behavior change**.
> 
> In **`deepagents_acp_shim.py`**, optional `env` parameters move from `dict | None` to **`Mapping[str, str] | None`** so assignments from `os.environ` type-check and `.get` is safe after the defaulting branch.
> 
> **`EvaluationConfig`** and **`RolloutConfig`** now **`cast`** `loop_strategy` dicts to `dict[str, Any]` before **`LoopStrategySpec.from_mapping`** (runtime validation unchanged). Docstrings note dict-shaped **`to_mapping()`** round-trips.
> 
> **`_round_tokens`** in **`rollout/_user_loop.py`** only calls **`.get("total_tokens")`** after a truthy metrics object passes **`is_token_usage_available`**, matching the prior guard logic for the type checker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ccfa3ce540e923c8100cb07dee1a72542e1fb30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->