### PR TITLE
chore(release): version 0.6.0rc6 → 0.6.0.dev0 (internal-preview channel)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.0rc6"
+version = "0.6.0.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.0rc6"
+version = "0.6.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Switches `release/v0.6.0` from the RC line (`0.6.0rc6`) to a plain **`.dev`** version so the **internal-preview** PyPI channel can publish it.

**Why:** `internal-preview-release.yml` (fires on a green `test` push to `main`) computes the version via `tools/release_version.py internal-preview`, which **only publishes a plain `.dev` base** — it *rejects* `rc`/final. With this, merging `release → main` (#665) auto-publishes **`0.6.0.dev<run_number>`** to PyPI → `pip install --pre --upgrade benchflow`.

**Not the public release:** plain `pip install benchflow` still resolves 0.5.x; the public `0.6.0` only happens on a `v0.6.0` tag (`public-release.yml`).

**Minimal diff:** `pyproject` `[project].version` + the matching `uv.lock` self-version (2 lines). `uv sync --locked` validates; `bench --version` → `0.6.0.dev0`; `test_dataset_registry` 32 pass (already covers `0.6.0.dev3` → in-range for the bench_version gate).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-line version metadata change only; no application logic, security, or dependency updates beyond the self-version in the lockfile.
> 
> **Overview**
> Bumps the package version on the `0.6.0` release line from **`0.6.0rc6`** to **`0.6.0.dev0`** in `pyproject.toml`, with the matching **`benchflow`** entry in `uv.lock`.
> 
> This aligns the branch with the **internal-preview** publish path: after a green `test` run on `main`, `internal-preview-release.yml` uses `tools/release_version.py internal-preview`, which only accepts a plain **`.dev`** base (not `rc`/final), then publishes versions like **`0.6.0.dev<run_number>`** via `pip install --pre`. The public **`0.6.0`** release remains tag-driven (`public-release.yml`); this change does not alter runtime or API behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01948923926c866006edbb99b977303e418ed4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->