### PR TITLE
feat(cli): live eval dashboard + UX hardening (v0.6 dogfood)

### DIFF
--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -1,4 +1,4 @@
-"""benchflow — ACP-native agent benchmarking framework.
+"""benchflow — the universal environment framework for agent benchmarks.
 
 Public API surface:
 - Sandbox protocol for isolated execution environments

--- a/src/benchflow/_utils/task_authoring/scaffolding.py
+++ b/src/benchflow/_utils/task_authoring/scaffolding.py
@@ -93,6 +93,22 @@ def scaffold_task(
         no_oracle = no_solution
     if task_format not in ("legacy", "task-md"):
         raise ValueError("task_format must be 'legacy' or 'task-md'")
+    # The name is a single directory segment under parent_dir, never a path. Reject
+    # separators / '..' / leading dots / whitespace so `init "../escape"` can't write
+    # outside parent_dir and names stay safe for HF/registry/shell tooling.
+    if (
+        not name
+        or name in (".", "..")
+        or "/" in name
+        or "\\" in name
+        or name != name.strip()
+        or name.startswith(".")
+        or any(c.isspace() for c in name)
+    ):
+        raise ValueError(
+            "task name must be a single path segment "
+            f"(no '/', '..', leading dot, or spaces); got {name!r}"
+        )
 
     task_dir = parent_dir / name
     if task_dir.exists():

--- a/src/benchflow/cli/_live_progress.py
+++ b/src/benchflow/cli/_live_progress.py
@@ -144,12 +144,23 @@ class LiveEvalProgress:
 
     # -- engine hooks -------------------------------------------------------
 
-    def on_plan(self, total: int, done: int, remaining: int) -> None:
+    def on_plan(
+        self,
+        total: int,
+        done: int,
+        remaining: int,
+        resumed_outcomes: tuple[int, int, int] = (0, 0, 0),
+    ) -> None:
+        # Seed the pass/fail/errored counters with the RESUMED tasks' outcomes so
+        # the counts row and pass-rate footer are correct over the whole job, not
+        # just this process's new tasks. resumed_outcomes = (passed, failed,
+        # errored). _completed stays this-run-only (drives the ETA rate).
         with self._lock:
             self._total = total
             self._resumed = done
             self._to_run = remaining
             self._run_start = time.monotonic()
+            self._passed, self._failed, self._errored = resumed_outcomes
 
     def on_task_start(self, name: str) -> None:
         with self._lock:
@@ -210,8 +221,9 @@ class LiveEvalProgress:
             completed, covered = self._completed, self._covered
             elapsed = time.monotonic() - self._run_start
 
-        finished = passed + failed + errored
-        done = resumed + finished
+        # passed/failed/errored already include the resumed-seeded outcomes, so
+        # "done" is their sum — adding `resumed` again would double-count.
+        done = passed + failed + errored
         queued = max(total - done - len(running), 0)
 
         header = Text()
@@ -225,8 +237,9 @@ class LiveEvalProgress:
         bar = Text()
         bar.append("━" * filled, style="green")
         bar.append("━" * (_BAR_WIDTH - filled), style="grey37")
-        rate = finished / elapsed if elapsed > 0 and finished else 0.0
-        eta = (to_run - finished) / rate if rate > 0 else None
+        # ETA from THIS run's finish rate (completed excludes instant resumed).
+        rate = completed / elapsed if elapsed > 0 and completed else 0.0
+        eta = (to_run - completed) / rate if rate > 0 else None
         bar.append(f"  {done}/{total}", style="bold")
         bar.append(f" · {frac * 100:.0f}%", style="dim")
         bar.append(f" · {_fmt_dur(elapsed)}", style="dim")

--- a/src/benchflow/cli/_live_progress.py
+++ b/src/benchflow/cli/_live_progress.py
@@ -1,0 +1,283 @@
+"""Live terminal dashboard for ``bench eval create`` runs.
+
+Renders a single Rich :class:`~rich.live.Live` panel — a progress bar with ETA,
+queued/running/passed/failed/errored counts, a "running now" table, and running
+token / cost / pass-rate totals — fed by the :class:`~benchflow.evaluation.Evaluation`
+engine's ``on_plan`` / ``on_task_start`` / ``on_result`` hooks.
+
+TTY-only by contract: the CLI keeps its plain ``logger.info`` lines when stdout
+isn't a terminal (CI, pipes, parity files), so machine-readable output is never
+polluted with cursor escapes. The display is purely additive — every mutator is
+cheap and lock-guarded, and the engine fires the hooks best-effort, so a render
+bug can never perturb or abort a run.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import os
+import threading
+import time
+from typing import TYPE_CHECKING
+
+from rich.console import Group
+from rich.live import Live
+from rich.table import Table
+from rich.text import Text
+
+from benchflow.usage_tracking import is_trusted_usage_source
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from rich.console import Console, RenderableType
+
+    from benchflow.models import RunResult
+
+_BAR_WIDTH = 30
+_MAX_RUNNING_ROWS = 12
+_DISABLE_ENV = "BENCHFLOW_NO_PROGRESS"
+
+
+def progress_enabled(console: Console) -> bool:
+    """Live dashboard only on a real TTY, and only when not opted out.
+
+    Non-terminal stdout (CI, pipes, parity files) keeps the plain ``logger.info``
+    stream so machine-readable output is never polluted with cursor escapes;
+    ``BENCHFLOW_NO_PROGRESS=1`` forces that path too.
+    """
+    if os.environ.get(_DISABLE_ENV, "").strip() not in ("", "0", "false", "False"):
+        return False
+    return bool(getattr(console, "is_terminal", False))
+
+
+@contextlib.contextmanager
+def quiet_root_logging() -> Iterator[None]:
+    """Silence root-logger output for the duration of a live display.
+
+    The engine streams ``logger.info`` lines to stderr during a run; a Live panel
+    repainting stdout would be shredded by them. Suppressing them keeps the
+    dashboard the single coherent view. Note this also drops per-task *error
+    detail* (tracebacks) from the live stream — the error counts still surface in
+    the dashboard and the categories in ``summary.json``, but a future refinement
+    could buffer WARNING+ records and flush them after the Live exits. Handlers
+    are restored on exit even if the run raises.
+    """
+    root = logging.getLogger()
+    saved = root.handlers[:]
+    root.handlers = [logging.NullHandler()]
+    try:
+        yield
+    finally:
+        root.handlers = saved
+
+
+@contextlib.contextmanager
+def live_session(live: LiveEvalProgress) -> Iterator[None]:
+    """Run a block under the live dashboard with logging quieted.
+
+    Combines :func:`quiet_root_logging` and the ``Live`` so callers have a single
+    context to wrap the blocking ``Evaluation.run()`` — and a single, non-
+    duplicated ``Evaluation(...)`` construction at the call site.
+    """
+    with quiet_root_logging(), live:
+        yield
+
+
+def _fmt_dur(seconds: float) -> str:
+    seconds = int(max(seconds, 0))
+    h, rem = divmod(seconds, 3600)
+    m, s = divmod(rem, 60)
+    return f"{h}:{m:02d}:{s:02d}" if h else f"{m}:{s:02d}"
+
+
+def _fmt_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.2f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+class LiveEvalProgress:
+    """A live ``Live``-rendered dashboard, driven by the engine's progress hooks.
+
+    Use as a context manager around the blocking ``Evaluation.run()`` call and
+    pass the three bound methods as the engine's ``on_plan`` / ``on_task_start`` /
+    ``on_result`` callbacks. The panel re-renders on a timer (so elapsed/ETA tick
+    between events) by reading lock-guarded state in :meth:`__rich__`.
+    """
+
+    def __init__(
+        self,
+        console: Console,
+        *,
+        label: str,
+        agent: str,
+        model: str | None,
+        sandbox: str,
+    ) -> None:
+        self._console = console
+        self._label = label
+        self._agent = agent
+        self._model = model or "(default)"
+        self._sandbox = sandbox
+        self._lock = threading.Lock()
+
+        self._total = 0
+        self._resumed = 0  # already-complete on resume; counted as done, not run
+        self._to_run = 0
+        self._run_start = time.monotonic()
+
+        self._passed = 0
+        self._failed = 0
+        self._errored = 0
+        self._running: dict[str, float] = {}  # name -> monotonic start
+
+        self._tokens = 0
+        self._cost = 0.0
+        self._completed = 0  # finished this run (for telemetry coverage)
+        self._covered = 0  # finished with trusted token telemetry
+
+        self._live: Live | None = None
+
+    # -- engine hooks -------------------------------------------------------
+
+    def on_plan(self, total: int, done: int, remaining: int) -> None:
+        with self._lock:
+            self._total = total
+            self._resumed = done
+            self._to_run = remaining
+            self._run_start = time.monotonic()
+
+    def on_task_start(self, name: str) -> None:
+        with self._lock:
+            self._running[name] = time.monotonic()
+
+    def on_result(self, name: str, result: RunResult) -> None:
+        with self._lock:
+            self._running.pop(name, None)
+            # Mirror Evaluation._log_and_report exactly: reward==1 -> PASS,
+            # reward not None -> FAIL, else ERR (no reward reached).
+            rewards = getattr(result, "rewards", None)
+            reward = rewards.get("reward") if rewards else None
+            if reward == 1:
+                self._passed += 1
+            elif reward is not None:
+                self._failed += 1
+            else:
+                self._errored += 1
+
+            self._completed += 1
+            tokens = getattr(result, "total_tokens", None)
+            cost = getattr(result, "cost_usd", None)
+            if is_trusted_usage_source(getattr(result, "usage_source", None)):
+                self._covered += 1
+                if tokens:
+                    self._tokens += int(tokens)
+                if cost:
+                    self._cost += float(cost)
+
+    # -- context manager ----------------------------------------------------
+
+    def __enter__(self) -> LiveEvalProgress:
+        self._live = Live(
+            self,
+            console=self._console,
+            auto_refresh=True,
+            refresh_per_second=4,
+            transient=False,
+        )
+        self._live.__enter__()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        if self._live is not None:
+            self._live.__exit__(*exc)
+            self._live = None
+
+    # -- rendering ----------------------------------------------------------
+
+    def __rich__(self) -> Group:
+        with self._lock:
+            total = self._total
+            resumed = self._resumed
+            to_run = self._to_run
+            passed, failed, errored = self._passed, self._failed, self._errored
+            running = dict(self._running)
+            tokens, cost = self._tokens, self._cost
+            completed, covered = self._completed, self._covered
+            elapsed = time.monotonic() - self._run_start
+
+        finished = passed + failed + errored
+        done = resumed + finished
+        queued = max(total - done - len(running), 0)
+
+        header = Text()
+        header.append("benchflow", style="bold cyan")
+        header.append(f"  ·  {self._label}  ·  {self._agent}", style="dim")
+        header.append(f"  ·  {self._model}  ·  {self._sandbox}", style="dim")
+
+        # Progress bar + ETA (computed from this run's finish rate).
+        frac = (done / total) if total else 0.0
+        filled = int(frac * _BAR_WIDTH)
+        bar = Text()
+        bar.append("━" * filled, style="green")
+        bar.append("━" * (_BAR_WIDTH - filled), style="grey37")
+        rate = finished / elapsed if elapsed > 0 and finished else 0.0
+        eta = (to_run - finished) / rate if rate > 0 else None
+        bar.append(f"  {done}/{total}", style="bold")
+        bar.append(f" · {frac * 100:.0f}%", style="dim")
+        bar.append(f" · {_fmt_dur(elapsed)}", style="dim")
+        if eta is not None:
+            bar.append(f" · ETA {_fmt_dur(eta)}", style="dim")
+        if resumed:
+            bar.append(f" · {resumed} resumed", style="dim")
+
+        counts = Text()
+        counts.append(f"✓ {passed} passed", style="green")
+        counts.append("   ")
+        counts.append(f"✗ {failed} failed", style="red" if failed else "dim")
+        counts.append("   ")
+        counts.append(f"⚠ {errored} errored", style="yellow" if errored else "dim")
+        counts.append("   ")
+        counts.append(f"◷ {len(running)} running", style="cyan")
+        counts.append("   ")
+        counts.append(f"⋯ {queued} queued", style="dim")
+
+        parts: list[RenderableType] = [header, bar, counts]
+
+        # "Running now" — cap rows so short terminals don't overflow.
+        if running:
+            tbl = Table(
+                show_edge=True, show_header=True, header_style="dim", expand=False
+            )
+            tbl.add_column("running now", no_wrap=True)
+            tbl.add_column("elapsed", justify="right")
+            now = time.monotonic()
+            for name in sorted(running, key=lambda n: running[n])[:_MAX_RUNNING_ROWS]:
+                tbl.add_row(name, _fmt_dur(now - running[name]))
+            extra = len(running) - _MAX_RUNNING_ROWS
+            if extra > 0:
+                tbl.add_row(f"… {extra} more", "")
+            parts.append(tbl)
+
+        # Footer: pass-rate (excl errors) + token/cost economics. Show "—" (not
+        # 0 / $0.00) when no trusted telemetry, so a coverage-0 run reads broken,
+        # not free — matching the summary.json contract.
+        footer = Text()
+        scored = passed + failed
+        if scored:
+            footer.append(f"pass-rate {passed / scored * 100:.1f}% (excl-err)", "bold")
+        else:
+            footer.append("pass-rate —", style="dim")
+        footer.append(" · ")
+        footer.append(f"{_fmt_tokens(tokens)} tokens" if covered else "— tokens", "dim")
+        footer.append(" · ")
+        footer.append(f"${cost:.2f}" if covered else "$—", style="dim")
+        if completed:
+            footer.append(f" · telemetry {covered / completed * 100:.0f}%", style="dim")
+        parts.append(footer)
+
+        return Group(*parts)

--- a/src/benchflow/cli/_shared.py
+++ b/src/benchflow/cli/_shared.py
@@ -18,6 +18,8 @@ import typer
 from rich.console import Console
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from benchflow.evaluation import EvaluationResult
 
 console = Console()
@@ -47,9 +49,38 @@ def _exit_if_evaluation_had_errors(result: object) -> None:
         raise typer.Exit(1)
 
 
-def _report_eval_result(result: EvaluationResult) -> None:
-    """Print the standard Score/errors summary line for an evaluation result."""
+def _report_eval_result(result: EvaluationResult, job_dir: Path | None = None) -> None:
+    """Print the Score/errors summary line, colored by outcome, plus artifacts.
+
+    A clean pass and a total failure used to look identical (both bold white);
+    now the line is green only on a full clean pass, red on a shutout, amber
+    otherwise, and ``errors=N`` is red when non-zero. When ``job_dir`` is given,
+    the result/summary paths are printed so testers know where to look (the
+    guide repeatedly says "read summary.json" but the CLI never said where).
+    """
+    errors = int(getattr(result, "errored", 0) or 0)
+    verifier_errors = int(getattr(result, "verifier_errored", 0) or 0)
+    total_errors = errors + verifier_errors
+    if result.total and result.passed == result.total and total_errors == 0:
+        style, mark = "bold green", "✓"
+    elif result.passed > 0:
+        style, mark = "bold yellow", "•"
+    else:
+        style, mark = "bold red", "✗"
+    # The displayed count must agree with the colour decision (which uses
+    # total_errors): a verifier-error-only run is NOT "errors=0". Break out the
+    # verifier bucket when present so the two error kinds stay legible.
+    if total_errors:
+        detail = f"errors={errors}"
+        if verifier_errors:
+            detail += f" verifier-errors={verifier_errors}"
+        err_part = f", [red]{detail}[/red]"
+    else:
+        err_part = ", errors=0"
     console.print(
-        f"\n[bold]Score: {result.passed}/{result.total} "
-        f"({result.score:.1%})[/bold], errors={result.errored}"
+        f"\n[{style}]{mark} Score: {result.passed}/{result.total} "
+        f"({result.score:.1%})[/{style}]{err_part}"
     )
+    if job_dir is not None:
+        console.print(f"[dim]Artifacts:[/dim] {job_dir}")
+        console.print(f"[dim]Summary:  [/dim] {job_dir}/summary.json")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -704,7 +704,9 @@ def _run_config_file_eval(plan: "EvalPlan") -> None:
     except (EmptyTaskSelectionError, ValueError) as e:
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1) from None
-    _report_eval_result(result)
+    job_name = getattr(result, "job_name", None)
+    job_dir = Path(j._jobs_dir) / job_name if job_name else None
+    _report_eval_result(result, job_dir)
     _exit_if_evaluation_had_errors(result)
 
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+from contextlib import AbstractContextManager, nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
@@ -27,6 +28,11 @@ from benchflow import __version__
 from benchflow._dotenv import load_dotenv_env
 from benchflow._utils.config import normalize_sandbox_user
 from benchflow.agents.registry import parse_agent_spec
+from benchflow.cli._live_progress import (
+    LiveEvalProgress,
+    live_session,
+    progress_enabled,
+)
 from benchflow.cli._options import AgentOption, ModelOption, SkillModeOption
 from benchflow.cli._shared import (
     _exit_if_evaluation_had_errors,
@@ -66,9 +72,11 @@ logging.basicConfig(
     format="%(message)s",
 )
 
+_TAGLINE = "The universal environment framework — run, author, and adopt agent benchmarks across any environment."
+
 app = typer.Typer(
     name="benchflow",
-    help="ACP-native agent benchmarking framework.",
+    help=_TAGLINE,
     no_args_is_help=True,
 )
 
@@ -91,7 +99,7 @@ def _cli_main(
         ),
     ] = None,
 ) -> None:
-    """ACP-native agent benchmarking framework."""
+    """The universal environment framework — run, author, and adopt agent benchmarks."""
 
 
 def _parse_agent_env(entries: list[str] | None) -> dict[str, str]:
@@ -563,6 +571,16 @@ def eval_create(
         raise typer.Exit(1)
 
 
+def _eval_label(plan: "EvalPlan", tasks_dir: Path) -> str:
+    """A short source descriptor for the live dashboard header."""
+    req = plan.request
+    for attr in ("source_repo", "dataset", "source_env"):
+        val = getattr(req, attr, None)
+        if val:
+            return str(val)
+    return tasks_dir.name
+
+
 def run_batch_eval(
     plan: "EvalPlan",
     resolved_tasks_dir: Path,
@@ -578,13 +596,34 @@ def run_batch_eval(
 
     try:
         if plan.request.worker_concurrency is None:
-            result = asyncio.run(
-                Evaluation(
-                    tasks_dir=str(resolved_tasks_dir),
-                    jobs_dir=plan.output_jobs_dir,
-                    config=eval_config,
-                ).run()
-            )
+            # One Evaluation construction; the live dashboard contributes hooks +
+            # a context manager on a TTY, and a null context + no hooks otherwise
+            # (CI/pipes keep the plain logger stream).
+            hooks: dict = {}
+            run_ctx: AbstractContextManager = nullcontext()
+            if progress_enabled(console):
+                live = LiveEvalProgress(
+                    console,
+                    label=_eval_label(plan, resolved_tasks_dir),
+                    agent=eval_config.agent,
+                    model=eval_config.model,
+                    sandbox=eval_config.environment,
+                )
+                hooks = {
+                    "on_plan": live.on_plan,
+                    "on_task_start": live.on_task_start,
+                    "on_result": live.on_result,
+                }
+                run_ctx = live_session(live)
+            with run_ctx:
+                result = asyncio.run(
+                    Evaluation(
+                        tasks_dir=str(resolved_tasks_dir),
+                        jobs_dir=plan.output_jobs_dir,
+                        config=eval_config,
+                        **hooks,
+                    ).run()
+                )
         else:
             from benchflow.eval_sharding import run_sharded_evaluation
 
@@ -606,7 +645,9 @@ def run_batch_eval(
         console.print(f"[red]{e}[/red]")
         raise typer.Exit(1) from None
 
-    _report_eval_result(result)
+    job_name = getattr(result, "job_name", None)
+    job_dir = Path(plan.output_jobs_dir) / job_name if job_name else None
+    _report_eval_result(result, job_dir)
     _exit_if_evaluation_had_errors(result)
     return result
 

--- a/src/benchflow/cli/monitor.py
+++ b/src/benchflow/cli/monitor.py
@@ -64,7 +64,7 @@ def register_monitor(app: typer.Typer) -> None:
             typer.Option("--run-name", help="Human-readable id for this monitor run."),
         ] = None,
     ) -> None:
-        """Score one trajectory under monitor semantics. **Not yet implemented (#386).**"""
+        """Score one trajectory under monitor semantics. [bold]Not yet implemented (#386).[/bold]"""
         del source, rubric, jobs_dir, run_name  # accepted for API stability
         _monitor_not_implemented()
 
@@ -76,7 +76,7 @@ def register_monitor(app: typer.Typer) -> None:
         ],
         jobs_dir: MonitorJobsDirOption = "jobs/monitor",
     ) -> None:
-        """Re-score a persisted rollout under monitor semantics. **Not yet implemented (#386).**"""
+        """Re-score a persisted rollout under monitor semantics. [bold]Not yet implemented (#386).[/bold]"""
         del trajectory_path, jobs_dir  # accepted for API stability
         _monitor_not_implemented()
 
@@ -90,6 +90,6 @@ def register_monitor(app: typer.Typer) -> None:
         ],
         jobs_dir: MonitorJobsDirOption = "jobs/monitor",
     ) -> None:
-        """Stream-score live production events. **Not yet implemented (#386).**"""
+        """Stream-score live production events. [bold]Not yet implemented (#386).[/bold]"""
         del source, jobs_dir  # accepted for API stability
         _monitor_not_implemented()

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -230,6 +230,22 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--ignore-bench-version requires --dataset")
     if request.tasks_dir and not Path(request.tasks_dir).exists():
         raise EvalPlanError(f"--tasks-dir not found: {request.tasks_dir}")
+    # Validate --config here so a typo'd / missing / non-file path becomes a clean
+    # CLI error instead of a raw FileNotFoundError/IsADirectoryError traceback from
+    # the bare open() in Evaluation.from_yaml.
+    if request.config_file and not Path(request.config_file).is_file():
+        raise EvalPlanError(f"--config not found: {request.config_file}")
+    # Validate the --source-repo shape up front (it's otherwise checked deep in
+    # resolve_source_with_metadata, after planning, where the ValueError escapes
+    # as a traceback). Match that resolver's semantics — split("/", 1) into two
+    # non-empty parts — so this guard never rejects a shape the resolver accepts.
+    if request.source_repo is not None:
+        parts = str(request.source_repo).split("/", 1)
+        if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+            raise EvalPlanError(
+                f"Invalid --source-repo {request.source_repo!r}; expected 'org/repo' "
+                "(e.g. benchflow-ai/skillsbench)"
+            )
     if request.worker_concurrency is not None and not (
         request.tasks_dir or request.source_repo
     ):
@@ -246,7 +262,11 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         if request.agent is not None
         else DEFAULT_AGENT
     )
-    eval_environment = request.environment or "docker"
+    # Only None means "unset" → default docker; an empty/whitespace --sandbox is a
+    # typo and must reach the Invalid-sandbox check below, not be swallowed.
+    eval_environment = (
+        request.environment if request.environment is not None else "docker"
+    )
     # --sandbox is ignored by hosted source-env runs (the hosted Verifiers
     # environment owns its harness), so only validate / preflight it for the
     # paths that actually use the local sandbox.

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -593,6 +593,8 @@ class Evaluation:
         config: EvaluationConfig | None = None,
         job_name: str | None = None,
         on_result: Callable[[str, RunResult], None] | None = None,
+        on_task_start: Callable[[str], None] | None = None,
+        on_plan: Callable[[int, int, int], None] | None = None,
     ):
         self._tasks_dir = Path(tasks_dir)
         self._jobs_dir = Path(jobs_dir)
@@ -600,6 +602,10 @@ class Evaluation:
         self._job_name = job_name or self._resolve_job_name(self._jobs_dir)
         self._explicit_job_name = job_name is not None
         self._on_result = on_result
+        # UI-progress hooks (the CLI live dashboard; None everywhere else). Fired
+        # best-effort via _fire_progress so a display bug never aborts a run.
+        self._on_task_start = on_task_start
+        self._on_plan = on_plan
         # Kept for test mocking compat; _run_task prefers Rollout
         from benchflow.sdk import SDK
 
@@ -1175,6 +1181,21 @@ class Evaluation:
         assert last_result is not None
         return last_result
 
+    @staticmethod
+    def _fire_progress(callback, *args) -> None:
+        """Invoke a UI-progress hook, swallowing any error.
+
+        A live-display callback must never abort or perturb the run, so failures
+        are logged at debug and ignored.
+        """
+        if callback is None:
+            return
+        try:
+            callback(*args)
+        except Exception as exc:
+            # Display is best-effort: a render bug must never abort the run.
+            logger.debug("progress callback failed: %s", exc)
+
     def _log_and_report(self, td: Path, result: RunResult) -> None:
         """Log one rollout's outcome and fire the on_result callback."""
         reward = result.rewards.get("reward") if result.rewards else None
@@ -1182,8 +1203,7 @@ class Evaluation:
         err_msg = result.error or result.verifier_error
         err = f" ({truncate_end(err_msg, 50)})" if err_msg else ""
         logger.info(f"[{status}] {td.name} (tools={result.n_tool_calls}){err}")
-        if self._on_result:
-            self._on_result(td.name, result)
+        self._fire_progress(self._on_result, td.name, result)
 
     async def _run_parallel_independent(
         self, remaining: list[Path]
@@ -1210,6 +1230,7 @@ class Evaluation:
                 if cfg.concurrency > 16:
                     jitter_max = max(cfg.concurrency / 2, 8.0)
                     await asyncio.sleep(random.uniform(0, jitter_max))
+                self._fire_progress(self._on_task_start, td.name)
                 result = await self._run_task(td)
                 breaker.record(result)
                 self._log_and_report(td, result)
@@ -1527,6 +1548,12 @@ class Evaluation:
         logger.info(
             f"Job: {len(task_dirs)} tasks, {len(completed)} done, "
             f"{len(remaining)} to run (concurrency={cfg.concurrency})"
+        )
+        # Hand the live dashboard an honest denominator: total / already-done /
+        # to-run. Resumed-complete tasks fold in below without a finish event, so
+        # a finish-event-only counter would mis-read the total on resume.
+        self._fire_progress(
+            self._on_plan, len(task_dirs), len(completed), len(remaining)
         )
 
         start = time.time()

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -379,6 +379,28 @@ def _warn_on_resume_mismatch(job_dir: Path, config: EvaluationConfig) -> None:
         )
 
 
+def _classify_completed_outcomes(
+    completed: dict[str, dict],
+) -> tuple[int, int, int]:
+    """(passed, failed, errored) over already-complete (resumed) result payloads.
+
+    Mirrors ``_log_and_report``'s classification (reward==1 → passed, reward not
+    None → failed, else errored) so the live dashboard's resumed-seeded counts
+    match how this-run results are tallied.
+    """
+    passed = failed = errored = 0
+    for r in completed.values():
+        rewards = r.get("rewards") if isinstance(r, dict) else None
+        reward = rewards.get("reward") if rewards else None
+        if reward == 1:
+            passed += 1
+        elif reward is not None:
+            failed += 1
+        else:
+            errored += 1
+    return passed, failed, errored
+
+
 def effective_model(agent: str, model: str | None) -> str | None:
     """Resolve the model an agent should run with.
 
@@ -594,7 +616,7 @@ class Evaluation:
         job_name: str | None = None,
         on_result: Callable[[str, RunResult], None] | None = None,
         on_task_start: Callable[[str], None] | None = None,
-        on_plan: Callable[[int, int, int], None] | None = None,
+        on_plan: Callable[[int, int, int, tuple[int, int, int]], None] | None = None,
     ):
         self._tasks_dir = Path(tasks_dir)
         self._jobs_dir = Path(jobs_dir)
@@ -1249,12 +1271,12 @@ class Evaluation:
                     raise r
                 task_name = remaining[i].name
                 logger.error(f"[ERR] {task_name}: unexpected exception: {r}")
-                pairs.append(
-                    (
-                        task_name,
-                        RunResult(task_name=task_name, error=f"Unexpected: {r}"),
-                    )
-                )
+                err_result = RunResult(task_name=task_name, error=f"Unexpected: {r}")
+                # _run_task raised after on_task_start fired, so the live
+                # dashboard still has this task "running" — fire on_result to
+                # remove it and count it errored.
+                self._fire_progress(self._on_result, task_name, err_result)
+                pairs.append((task_name, err_result))
             else:
                 pairs.append(r)
         return pairs
@@ -1312,18 +1334,16 @@ class Evaluation:
                 self._learner_skills_dir = skills_dir
                 self._learner_export_dir = export_dir
 
+                self._fire_progress(self._on_task_start, td.name)
                 try:
                     result = await self._run_task(td)
                 except (asyncio.CancelledError, KeyboardInterrupt):
                     raise
                 except Exception as e:  # mirror the parallel path's catch
                     logger.error(f"[ERR] {td.name}: unexpected exception: {e}")
-                    pairs.append(
-                        (
-                            td.name,
-                            RunResult(task_name=td.name, error=f"Unexpected: {e}"),
-                        )
-                    )
+                    err_result = RunResult(task_name=td.name, error=f"Unexpected: {e}")
+                    self._fire_progress(self._on_result, td.name, err_result)
+                    pairs.append((td.name, err_result))
                     continue
                 finally:
                     self._learner_skills_dir = None
@@ -1551,9 +1571,15 @@ class Evaluation:
         )
         # Hand the live dashboard an honest denominator: total / already-done /
         # to-run. Resumed-complete tasks fold in below without a finish event, so
-        # a finish-event-only counter would mis-read the total on resume.
+        # a finish-event-only counter would mis-read the total on resume. Pass the
+        # resumed tasks' (passed, failed, errored) breakdown too, so the live
+        # counts + pass-rate cover the whole job, not just this process's tasks.
         self._fire_progress(
-            self._on_plan, len(task_dirs), len(completed), len(remaining)
+            self._on_plan,
+            len(task_dirs),
+            len(completed),
+            len(remaining),
+            _classify_completed_outcomes(completed),
         )
 
         start = time.time()

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -225,9 +225,9 @@ def test_agent_timeout_sec_rejects_nonpositive(bad):
 def test_config_file_with_no_default_model_agent_not_rejected(tmp_path: Path):
     # Regression: --config supplies the model from YAML, so build_eval_plan must
     # NOT pre-reject a no-default-model agent (e.g. codex) when --model is omitted.
-    plan = build_eval_plan(
-        EvalCreateRequest(config_file=tmp_path / "cfg.yaml", agent="codex")
-    )
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("model: some-model\n")  # must exist (B1 guard); content unused here
+    plan = build_eval_plan(EvalCreateRequest(config_file=cfg, agent="codex"))
     assert plan is not None
 
 
@@ -282,3 +282,45 @@ def test_source_env_skips_sandbox_preflight(monkeypatch):
 @pytest.mark.parametrize("ok", [None, 1, 900.0])
 def test_agent_timeout_sec_accepts_positive_or_none(ok):
     assert AgentConfig(timeout_sec=ok).timeout_sec == ok
+
+
+# --- v0.6 CLI-dogfood guards: clean fail-fast instead of raw tracebacks -------
+
+
+def test_config_missing_path_rejected_cleanly(tmp_path: Path):
+    # Was: a raw FileNotFoundError traceback from Evaluation.from_yaml's open().
+    with pytest.raises(EvalPlanError, match="--config not found"):
+        build_eval_plan(
+            EvalCreateRequest(config_file=tmp_path / "nope.yaml", agent="gemini")
+        )
+
+
+@pytest.mark.parametrize("bad", ["notaslash", "/leading", "trailing/", "org/"])
+def test_source_repo_bad_shape_rejected_cleanly(bad: str):
+    # Was: a raw ValueError traceback from resolve_source_with_metadata, after
+    # planning. Now caught at plan time with the org/repo guidance.
+    with pytest.raises(EvalPlanError, match="Invalid --source-repo"):
+        build_eval_plan(EvalCreateRequest(source_repo=bad, agent="gemini"))
+
+
+@pytest.mark.parametrize(
+    # "org/repo/subpath" must NOT be newly rejected — the canonical resolver
+    # splits "/" once and accepts a two-part shape, so the guard matches it.
+    "ok",
+    ["benchflow-ai/skillsbench", "benchflow-ai/repo/subpath"],
+)
+def test_source_repo_valid_shape_accepted(ok: str):
+    assert (
+        build_eval_plan(EvalCreateRequest(source_repo=ok, agent="gemini")) is not None
+    )
+
+
+def test_empty_sandbox_rejected_not_silently_defaulted(tmp_path: Path):
+    # "" is falsy: it used to slip past `or "docker"` and silently run docker,
+    # swallowing a typo'd --sandbox. It must hit the Invalid --sandbox check.
+    task = tmp_path / "t"
+    task.mkdir()
+    with pytest.raises(EvalPlanError, match="Invalid --sandbox"):
+        build_eval_plan(
+            EvalCreateRequest(tasks_dir=task, environment="", agent="gemini")
+        )

--- a/tests/test_cli_live_progress.py
+++ b/tests/test_cli_live_progress.py
@@ -1,0 +1,143 @@
+"""Unit tests for the eval live-progress dashboard (cli/_live_progress.py).
+
+State math + the TTY/quiet-logging gates are tested directly; the Rich render is
+exercised for "doesn't raise" rather than pixel-asserted.
+"""
+
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+from rich.console import Console
+
+from benchflow.cli._live_progress import (
+    LiveEvalProgress,
+    progress_enabled,
+    quiet_root_logging,
+)
+
+
+def _result(reward, *, tokens=0, cost=None, src="unavailable"):
+    return SimpleNamespace(
+        rewards={"reward": reward} if reward is not None else None,
+        total_tokens=tokens,
+        cost_usd=cost,
+        usage_source=src,
+    )
+
+
+def _dash() -> LiveEvalProgress:
+    return LiveEvalProgress(
+        Console(), label="skillsbench", agent="gemini", model="flash", sandbox="docker"
+    )
+
+
+def test_counts_classify_like_the_engine():
+    d = _dash()
+    d.on_plan(total=4, done=0, remaining=4)
+    for name in ("a", "b", "c", "d"):
+        d.on_task_start(name)
+    d.on_result("a", _result(1.0, tokens=1000, cost=0.02, src="agent_native_acp"))
+    d.on_result("b", _result(0.0))  # reward present but not 1 -> failed
+    d.on_result("c", _result(None))  # no reward -> errored
+    assert (d._passed, d._failed, d._errored) == (1, 1, 1)
+    assert len(d._running) == 1  # "d" still running
+    # render must not raise mid-run
+    d.__rich__()
+
+
+def test_resume_denominator_and_progress():
+    d = _dash()
+    d.on_plan(total=10, done=6, remaining=4)  # 6 resumed-complete
+    d.on_task_start("x")
+    d.on_result("x", _result(1.0))
+    # done = resumed(6) + finished(1) = 7 of 10; render reflects it
+    assert d._resumed == 6 and d._passed == 1
+    d.__rich__()
+
+
+def test_footer_no_telemetry_is_dash_not_zero():
+    # A coverage-0 run must read as undecidable ("—"), never "$0.00 / 0 tokens".
+    d = _dash()
+    d.on_plan(total=1, done=0, remaining=1)
+    d.on_result("a", _result(1.0, tokens=0, cost=None, src="unavailable"))
+    assert d._covered == 0 and d._tokens == 0
+    text = d.__rich__()  # builds the Group; tokens shown as "—"
+    assert text is not None
+
+
+def test_trusted_telemetry_accumulates():
+    d = _dash()
+    d.on_plan(total=2, done=0, remaining=2)
+    d.on_result("a", _result(1.0, tokens=1500, cost=0.03, src="agent_native_acp"))
+    d.on_result("b", _result(1.0, tokens=2500, cost=0.05, src="provider_response"))
+    assert d._tokens == 4000
+    assert round(d._cost, 2) == 0.08
+    assert d._covered == 2
+
+
+def test_progress_enabled_respects_tty_and_optout(monkeypatch):
+    tty = SimpleNamespace(is_terminal=True)
+    notty = SimpleNamespace(is_terminal=False)
+    monkeypatch.delenv("BENCHFLOW_NO_PROGRESS", raising=False)
+    assert progress_enabled(tty) is True
+    assert progress_enabled(notty) is False
+    monkeypatch.setenv("BENCHFLOW_NO_PROGRESS", "1")
+    assert progress_enabled(tty) is False
+
+
+def test_quiet_root_logging_restores_handlers():
+    root = logging.getLogger()
+    before = root.handlers[:]
+    with quiet_root_logging():
+        assert all(isinstance(h, logging.NullHandler) for h in root.handlers)
+    assert root.handlers == before
+
+
+def test_quiet_root_logging_restores_on_exception():
+    root = logging.getLogger()
+    before = root.handlers[:]
+    try:
+        with quiet_root_logging():
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+    assert root.handlers == before
+
+
+def test_report_eval_result_surfaces_verifier_errors(monkeypatch):
+    # B-1 regression: a verifier-error-only run is NOT "errors=0" — the displayed
+    # count must agree with the red colour (which keys off total errors).
+    import io
+
+    from rich.console import Console
+
+    import benchflow.cli._shared as shared
+
+    rec = Console(file=io.StringIO(), width=200)
+    monkeypatch.setattr(shared, "console", rec)
+    shared._report_eval_result(
+        SimpleNamespace(
+            passed=0, total=3, errored=0, verifier_errored=3, score=0.0, job_name="j"
+        )
+    )
+    out = rec.file.getvalue()
+    assert "errors=0 verifier-errors=3" in out
+    assert "Score: 0/3" in out
+
+
+def test_fire_progress_swallows_callback_errors():
+    # The feature's core safety contract: a raising display hook must never
+    # propagate out of the engine (a render bug can't abort a run).
+    from benchflow.evaluation import Evaluation
+
+    seen = []
+
+    def boom(*args):
+        seen.append(args)
+        raise RuntimeError("display bug")
+
+    Evaluation._fire_progress(boom, "task-x")  # must NOT raise
+    Evaluation._fire_progress(None)  # None callback is a no-op
+    assert seen == [("task-x",)]

--- a/tests/test_cli_live_progress.py
+++ b/tests/test_cli_live_progress.py
@@ -47,14 +47,29 @@ def test_counts_classify_like_the_engine():
     d.__rich__()
 
 
-def test_resume_denominator_and_progress():
+def test_resume_seeds_outcomes_so_counts_cover_whole_job():
+    # On resume the counts + pass-rate must include the resumed tasks' outcomes,
+    # not just this process's new tasks (Bugbot #726 medium).
     d = _dash()
-    d.on_plan(total=10, done=6, remaining=4)  # 6 resumed-complete
+    d.on_plan(total=10, done=6, remaining=4, resumed_outcomes=(5, 1, 0))
     d.on_task_start("x")
-    d.on_result("x", _result(1.0))
-    # done = resumed(6) + finished(1) = 7 of 10; render reflects it
-    assert d._resumed == 6 and d._passed == 1
+    d.on_result("x", _result(1.0))  # one new pass on top of the resumed 5/1/0
+    assert (d._passed, d._failed, d._errored) == (6, 1, 0)
+    assert d._resumed == 6
+    assert d._completed == 1  # this-run only — drives the ETA rate, not the bar
     d.__rich__()
+
+
+def test_classify_completed_outcomes_mirrors_engine():
+    from benchflow.evaluation import _classify_completed_outcomes
+
+    completed = {
+        "a": {"rewards": {"reward": 1.0}},
+        "b": {"rewards": {"reward": 0.0}},
+        "c": {"rewards": None, "verifier_error": "boom"},
+        "d": {},
+    }
+    assert _classify_completed_outcomes(completed) == (1, 1, 2)
 
 
 def test_footer_no_telemetry_is_dash_not_zero():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -146,6 +146,18 @@ class TestInitTask:
         with pytest.raises(FileExistsError):
             init_task("dupe", parent_dir=tmp_path)
 
+    @pytest.mark.parametrize(
+        "bad",
+        ["../escape", "foo/bar", "my task", "..", ".hidden", " lead", "back\\slash"],
+    )
+    def test_rejects_unsafe_task_names(self, tmp_path, bad):
+        # The name is a single dir segment under parent_dir; separators / '..' /
+        # leading dots / whitespace are rejected (path traversal + tooling safety).
+        with pytest.raises(ValueError, match="single path segment"):
+            init_task(bad, parent_dir=tmp_path)
+        # Nothing escaped the parent dir.
+        assert not (tmp_path.parent / "escape").exists()
+
     def test_creates_parent_dirs(self, tmp_path):
         task = init_task("deep", parent_dir=tmp_path / "nested" / "tasks")
         assert task.exists()


### PR DESCRIPTION
## The live eval experience, made pretty good

Dogfooding the v0.6 CLI (and a 10-agent review of it) surfaced that a multi-minute `bench eval create` run shows **dead air** — a flat stream of `logger.info` lines + a single final `Score:`. This PR replaces that with a **live dashboard** and fixes the worst first-impression bugs.

### Headline: `cli/_live_progress.py` — a Rich `Live` dashboard
```
benchflow · skillsbench · gemini · gemini-3.1-flash-lite · daytona
━━━━━━━━━━━━━━━━━ 4/20 · 20% · 0:02 · ETA 0:11
✓ 4 passed   ✗ 0 failed   ⚠ 0 errored   ◷ 5 running   ⋯ 11 queued
┌ running now ────────────┬─────────┐
│ weighted-gdp-calc       │   0:02  │  …
pass-rate 100.0% (excl-err) · 110.5k tokens · $0.12 · telemetry 100%
```
- Progress bar + ETA, **queued / running / passed / failed / errored** counts, a "running now" table, and a **tokens / cost / pass-rate** footer.
- Fed by three new, display-agnostic engine hooks — `on_plan` / `on_task_start` / `on_result` — fired **best-effort** (`_fire_progress`) so a render bug can never abort a run.
- **TTY-gated** (`console.is_terminal` + `BENCHFLOW_NO_PROGRESS`); CI / pipes / parity files keep the plain logger stream untouched.
- Telemetry-honest: shows `—`, not `$0.00`, when coverage is 0.

### UX hardening (ranked dogfood findings)
| | Fix |
|---|---|
| **B1/B2** | `--config` / `--source-repo` typos → clean `EvalPlanError`, not a raw traceback (source-repo guard matches the canonical resolver, so `org/repo/subpath` isn't newly rejected) |
| **B4** | `tasks init "../escape"` rejected — closes a path-traversal hole |
| **B5** | empty `--sandbox ''` no longer silently defaults to docker |
| **B7** | `monitor --help` renders bold, not literal `**...**` |
| **Q1/Q2** | final Score line colored by outcome + prints `Artifacts:` / `Summary:` paths; count agrees with the color (incl. verifier-errors) |
| **Q9** | tagline → *"the universal environment framework"* |

### Provenance & verification
- Findings from a 10-agent dogfood/UX workflow over the real `bench` binary.
- **Thermo-nuclear structural review: APPROVE-WITH-NITS** — all addressed: B-1 errors/color agreement (+ regression test), best-effort-swallow contract test (+ dropped the `# pragma: no cover`), source-repo↔resolver reconcile, and a code-judo single `Evaluation(...)` construction.
- **Full suite: 4040 passed, 4 skipped**; `ruff` + `ty` clean. Demo GIFs recorded (live dashboard + clean-error polish).

Scope: the dashboard wires the non-sharded `run_batch_eval` path (sharded workers run in subprocesses; follow-up). Longer-tail polish items (help panels, `bench agent` two-noun split, `env` alias, `agent list` truncation) are tracked for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch the core `Evaluation.run()` scheduling path and CLI batch entrypoint, but progress hooks are optional and errors are swallowed; main residual risk is UX/logging suppression during live runs and sharded eval still lacking the dashboard.
> 
> **Overview**
> **Live eval dashboard** on interactive terminals: `bench eval create` (non-sharded batch path) can show a Rich `Live` panel—progress/ETA, queued/running/passed/failed/errored, a “running now” table, and token/cost/pass-rate—driven by new optional `Evaluation` hooks (`on_plan`, `on_task_start`, `on_result`) invoked **best-effort** via `_fire_progress` so display bugs cannot abort runs. CI/pipes and `BENCHFLOW_NO_PROGRESS` keep the plain log stream; live mode quiets root logging during the panel.
> 
> **Evaluation** seeds resumed job totals into the dashboard (`_classify_completed_outcomes`), fires `on_task_start`/`on_result` on parallel and sequential schedules (including unexpected exceptions so “running” rows clear), and reports plan totals at job start.
> 
> **CLI polish**: final score line is color-coded by outcome, surfaces verifier-errors separately from agent errors, and prints `Artifacts:` / `summary.json` paths when `job_dir` is known. Tagline/help copy shifts to the “universal environment framework” positioning; `monitor` help uses Rich `[bold]` instead of literal `**`.
> 
> **Fail-fast guards** in `build_eval_plan`: missing `--config`, malformed `--source-repo`, and empty `--sandbox` (no silent docker default). **Task init** rejects unsafe single-segment names (`..`, slashes, leading dots, whitespace) to block path traversal.
> 
> Tests cover live-progress state/resume math, planning guards, unsafe task names, and `_fire_progress` swallowing callback errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ebe8f05221649720476267e04d8872749ad356b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->