### PR TITLE
feat(cli): group bench --help into panels; hide non-core verbs

### DIFF
--- a/src/benchflow/cli/agent.py
+++ b/src/benchflow/cli/agent.py
@@ -24,7 +24,7 @@ from benchflow.cli._shared import (
 def register_agent(app: typer.Typer) -> None:
     """Attach the ``agent`` command group to the top-level benchflow app."""
     agent_app = typer.Typer(help="Agent management commands.")
-    app.add_typer(agent_app, name="agent")
+    app.add_typer(agent_app, name="agent", rich_help_panel="Core")
     register_agent_router(agent_app)
 
     @agent_app.command("list")

--- a/src/benchflow/cli/compat.py
+++ b/src/benchflow/cli/compat.py
@@ -17,7 +17,7 @@ from benchflow.cli._shared import console
 def register_compat(app: typer.Typer) -> None:
     """Attach the ``compat`` command group to the top-level benchflow app."""
     compat_app = typer.Typer(help="Third-party framework compatibility checks.")
-    app.add_typer(compat_app, name="compat")
+    app.add_typer(compat_app, name="compat", rich_help_panel="Environments")
 
     @compat_app.command("harbor-registry")
     def compat_harbor_registry(

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -29,7 +29,7 @@ def _load_env_defaults() -> None:
 def register_continue(app: typer.Typer) -> None:
     """Attach the ``continue`` command to the top-level benchflow app."""
 
-    @app.command("continue")
+    @app.command("continue", hidden=True)
     def continue_cmd(
         folder: Annotated[
             Path,
@@ -140,7 +140,7 @@ def register_continue(app: typer.Typer) -> None:
         if result.error:
             typer.secho(f"  agent error: {result.error}", fg=typer.colors.YELLOW)
 
-    @app.command("continue-batch")
+    @app.command("continue-batch", hidden=True)
     def continue_batch_cmd(
         root: Annotated[
             Path,

--- a/src/benchflow/cli/environment.py
+++ b/src/benchflow/cli/environment.py
@@ -28,7 +28,7 @@ from benchflow.cli._shared import console
 def register_environment(app: typer.Typer) -> None:
     """Attach the ``environment`` command group to the top-level benchflow app."""
     env_app = typer.Typer(help="Environment management commands.")
-    app.add_typer(env_app, name="environment")
+    app.add_typer(env_app, name="environment", rich_help_panel="Environments")
 
     @env_app.command("create")
     def environment_create(

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -181,7 +181,7 @@ def _cleanup_daytona_sandboxes(dry_run: bool, max_age_minutes: int) -> None:
 
 
 eval_app = typer.Typer(help="Evaluation commands.")
-app.add_typer(eval_app, name="eval")
+app.add_typer(eval_app, name="eval", rich_help_panel="Core")
 
 
 @eval_app.command("create")

--- a/src/benchflow/cli/monitor.py
+++ b/src/benchflow/cli/monitor.py
@@ -42,7 +42,7 @@ def register_monitor(app: typer.Typer) -> None:
             "API surface scaffold; runtime not yet implemented."
         ),
     )
-    app.add_typer(monitor_app, name="monitor")
+    app.add_typer(monitor_app, name="monitor", hidden=True)
 
     @monitor_app.command("run")
     def monitor_run(

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -24,7 +24,7 @@ from benchflow.cli._shared import console
 def register_skills(app: typer.Typer) -> None:
     """Attach the ``skills`` command group to the top-level benchflow app."""
     skills_app = typer.Typer(help="Skill discovery, installation, and evaluation.")
-    app.add_typer(skills_app, name="skills")
+    app.add_typer(skills_app, name="skills", rich_help_panel="Core")
 
     @skills_app.command("list")
     def skills_list(

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -20,7 +20,7 @@ from benchflow.cli.trace_import import register_tasks_generate
 def register_tasks(app: typer.Typer) -> None:
     """Attach the ``tasks`` command group to the top-level benchflow app."""
     tasks_app = typer.Typer(help="Task authoring commands")
-    app.add_typer(tasks_app, name="tasks")
+    app.add_typer(tasks_app, name="tasks", rich_help_panel="Core")
 
     register_tasks_generate(tasks_app)
 

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -25,14 +25,31 @@ def _help(args: list[str]) -> str:
     return _ANSI_RE.sub("", result.output)
 
 
+def _help_command_names(out: str) -> set[str]:
+    """The command names listed in --help, from the panel rows only.
+
+    Rich renders each command as a panel row ``│ <name>   <description>``. Match
+    the first token of those rows so the check is robust to (a) the tagline prose
+    (which may contain words like "run") and (b) command-panel names (Core /
+    Environments / Recovery / the default "Commands").
+    """
+    names: set[str] = set()
+    for line in out.splitlines():
+        m = re.match(r"^\s*│\s+([A-Za-z][\w-]*)\s", line)
+        if m:
+            names.add(m.group(1))
+    return names
+
+
 def test_top_level_help_lists_public_groups() -> None:
     """Every public top-level group documented in cli.md is shown in --help."""
     out = _help([])
+    commands = _help_command_names(out)
     for group in ("eval", "skills", "tasks", "compat", "agent", "environment"):
-        assert group in out, f"missing public group {group!r} in: {out}"
+        assert group in commands, f"missing public group {group!r} in: {out}"
     # Deprecated, hidden, and removed commands must not show up in public help.
     for hidden in ("run", "job", "agents", "metrics", "view", "eval-batch"):
-        assert hidden not in out.split("Commands")[-1].split("─")[0], (
+        assert hidden not in commands, (
             f"hidden command {hidden!r} unexpectedly shown: {out}"
         )
 


### PR DESCRIPTION
## Cleaner `bench --help` (dogfood follow-up to #726)

The flat 9-command help led with OpenHands-specific `continue`/`continue-batch` and surfaced the *not-yet-implemented* `monitor` at the same level as `eval`. Now it's grouped and Core-first:

```
╭─ Core ─────────────────────────────────────────╮
│ eval     skills     tasks     agent             │
╰─────────────────────────────────────────────────╯
╭─ Environments ─────────────────────────────────╮
│ compat     environment                          │
╰─────────────────────────────────────────────────╯
```

- **Core** panel: `eval`, `tasks`, `agent`, `skills`
- **Environments** panel: `environment`, `compat`
- `continue` / `continue-batch` / `monitor` are **hidden from the top-level menu** but **fully runnable** (`bench continue --help`, `bench monitor run`, …) — they're niche recovery / not-yet-implemented verbs.

Core leads because Rich lists top-level commands before groups, so the niche recovery verbs would otherwise head the menu. Purely additive (`rich_help_panel=` / `hidden=`) — **no behavior change**.

Also fixes a brittle assertion in `test_cli_docs_drift` that scoped on the now-renamed "Commands" panel header and matched the word "run" in the v0.6 tagline — rewritten to match actual command-entry rows.

Verified: `ruff` + `ty` clean; CLI + drift + monitor-scaffold tests pass (`bench monitor`/`continue` still work). Follows #726 (Q5/Q6/Q7 from the dogfood synthesis).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Typer help options (`rich_help_panel`, `hidden`); no changes to command handlers or eval/runtime logic.
> 
> **Overview**
> **`bench --help`** is reorganized with Typer **`rich_help_panel`**: **Core** lists `eval`, `skills`, `tasks`, and `agent`; **Environments** lists `compat` and `environment`.
> 
> **`continue`**, **`continue-batch`**, and the **`monitor`** group are marked **`hidden=True`**, so they no longer appear in the top-level help but remain invokable with their own `--help`.
> 
> **`test_cli_docs_drift`** now parses command names from Rich panel rows (`│ <name> …`) instead of substring checks on the full help text, avoiding false matches on tagline prose and updated panel layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d287b1f6fe493f9de7878234f94fc1336af030e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->