### PR TITLE
chore: remove dead code + dead test helpers (adversarially verified)

### DIFF
--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -622,7 +622,6 @@ class Evaluation:
         self._jobs_dir = Path(jobs_dir)
         self._config = config or EvaluationConfig()
         self._job_name = job_name or self._resolve_job_name(self._jobs_dir)
-        self._explicit_job_name = job_name is not None
         self._on_result = on_result
         # UI-progress hooks (the CLI live dashboard; None everywhere else). Fired
         # best-effort via _fire_progress so a display bug never aborts a run.

--- a/src/benchflow/task/verifier_core.py
+++ b/src/benchflow/task/verifier_core.py
@@ -291,10 +291,6 @@ class Verifier:
             return await self._verify_llm_judge()
         return await self._verify_test_script()
 
-    def _selected_verifier_strategy(self) -> VerifierStrategy | None:
-        document = self._selected_verifier_document()
-        return None if document is None else document.selected_strategy
-
     def _selected_verifier_document(self) -> VerifierDocument | None:
         paths = getattr(self._task, "paths", None)
         verifier_dir = getattr(paths, "tests_dir", None)

--- a/src/benchflow/traces/models.py
+++ b/src/benchflow/traces/models.py
@@ -36,7 +36,6 @@ class GitContext:
     repo: str | None = None
     branch: str | None = None
     commit_before: str | None = None
-    commit_after: str | None = None
 
 
 @dataclass

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 UsageTrackingMode = Literal["auto", "required", "off"]
-UsageSource = Literal["provider_response", "agent_native_acp", "unavailable"]
 
 USAGE_TRACKING_ENV = "BENCHFLOW_USAGE_TRACKING"
 USAGE_SOURCE_PROVIDER_RESPONSE = "provider_response"

--- a/tests/integration/run_suite.py
+++ b/tests/integration/run_suite.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import argparse
 import sys
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -250,11 +250,6 @@ def collect_lane_blockers(lanes: list[Mapping[str, Any]]) -> dict[str, list[str]
             if blockers:
                 lane_blockers[lane["id"]] = blockers
     return lane_blockers
-
-
-def iter_lane_ids(suite: Mapping[str, Any]) -> Iterable[str]:
-    for lane in suite["lanes"]:
-        yield lane["id"]
 
 
 def print_lane_list(suite: Mapping[str, Any]) -> None:

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -38,7 +38,7 @@ import re
 import subprocess
 import sys
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -57,19 +57,6 @@ _SECRET_PATTERNS = (
     re.compile(r"AQ\.[A-Za-z0-9_\-]{16,}"),  # Google/Gemini AQ. keys
     re.compile(r"AKIA[0-9A-Z]{12,}"),  # AWS access key ids
 )
-
-
-@dataclass(frozen=True)
-class ScenarioResult:
-    """The outcome of one integration scenario."""
-
-    name: str
-    passed: bool
-    detail: str
-    evidence: dict[str, Any] = field(default_factory=dict)
-
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
 
 
 # ------------------------------------------------------------------

--- a/tests/test_sandbox_snapshot_contract.py
+++ b/tests/test_sandbox_snapshot_contract.py
@@ -133,14 +133,6 @@ class TestModalSnapshotCapability:
 # 3. Default fails closed with SandboxSnapshotNotSupported
 
 
-class _UnsupportedSandbox:
-    """Bare object exercising BaseSandbox's default snapshot/restore."""
-
-    # Inherit the methods directly off BaseSandbox so the default path is
-    # what's under test — without dragging the whole __init__ in.
-    pass
-
-
 async def test_base_sandbox_default_snapshot_raises_unsupported():
     """The default ``snapshot`` raises so naive new backends fail closed."""
     from benchflow.sandbox._base import BaseSandbox


### PR DESCRIPTION
## Dead-code purge — detection-workflow output, executed

A dead-code detection workflow ran `vulture` (234 src + 237 test candidates), then **per-area verification + an adversarial refute pass** (a second agent tried hard to find any use — Typer commands, pydantic/dataclass fields, ABC/Protocol methods, pytest fixtures, `__all__` re-exports, dynamic dispatch, back-compat API). Of the candidates, **7 were confirmed dead** (0 rescued); the `cli`, `agents`, and `contracts` areas were clean.

Removed (each verified unreferenced across src + tests + pyproject + docs):

| File | Symbol |
|------|--------|
| `evaluation.py` | `self._explicit_job_name` (assigned, never read) |
| `task/verifier_core.py` | `_selected_verifier_strategy()` (no caller; sibling `_selected_verifier_document` stays) |
| `traces/models.py` | `GitContext.commit_after` (unused; `commit_before` stays) |
| `usage_tracking.py` | `UsageSource` type alias (unused; the `USAGE_SOURCE_*` constants + `UsageTrackingMode` stay) |
| `tests/test_sandbox_snapshot_contract.py` | `_UnsupportedSandbox` (unused; the tests use a local `_Dummy`) |
| `tests/integration/scenarios.py` | `ScenarioResult` dataclass (never constructed) |
| `tests/integration/run_suite.py` | `iter_lane_ids()` (uncalled) |

Plus the now-unused imports `ruff` flagged after removal (`Iterable`, `asdict`, `field`).

**Pure deletion, zero behavior change.** Verification gate green: `ruff check` + `ruff format --check` + `ty check` clean, **full suite 4041 passed, 4 skipped**.

First step of a standing pre-release hardening pass (dead code → bad syntax → exhaustive edge-case verification).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime paths change; only unreferenced code and imports are removed.
> 
> **Overview**
> **Dead-code cleanup** after static analysis and manual verification: pure deletions only.
> 
> In **src**, removes an unused `Evaluation` flag (`_explicit_job_name`), an uncalled `Verifier._selected_verifier_strategy()` (dispatch still uses `_selected_verifier_document()`), unused `GitContext.commit_after`, and the unused `UsageSource` type alias in `usage_tracking` (string constants remain).
> 
> In **tests**, drops unused `ScenarioResult`, `iter_lane_ids()`, the `_UnsupportedSandbox` helper in the sandbox snapshot contract tests (tests still use `_Dummy`), and imports that became unnecessary (`Iterable`, `asdict`, `field`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84db0ee69003aa11a9f63b3a60ce7d43585fef51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->