### PR TITLE
feat(cli)!: rename bench compat → bench hub (env-hub compatibility)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -484,21 +484,22 @@ an idle-activity guard means concurrent live runs are never reaped). Set
 `BENCHFLOW_DAYTONA_AUTO_REAP` to any of `0`/`false`/`no`/`off` (case-insensitive)
 to disable that automatic pass and rely on the manual command above.
 
-## bench compat
+## bench hub
 
-Third-party framework compatibility checks.
+Compatibility checks for external environment hubs (Harbor today; built to
+extend to other hubs).
 
-### bench compat harbor-registry
+### bench hub check
 
-Inventory or structurally check representative Harbor registry tasks. Defaults
-to running an inventory pass against the public Harbor registry JSON.
+Inventory or structurally check representative tasks from an environment hub's
+registry. Defaults to an inventory pass against the public Harbor registry JSON.
 
 ```bash
-# Inventory the public Harbor registry
-bench compat harbor-registry
+# Inventory the public Harbor hub registry
+bench hub check
 
 # Structural check, two tasks per dataset, JSONL output
-bench compat harbor-registry --level check --tasks-per-dataset 2 --out compat.jsonl
+bench hub check --level check --tasks-per-dataset 2 --out hub.jsonl
 ```
 
 | Flag | Default | Description |

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -1,6 +1,6 @@
 """``bench compat`` — third-party framework compatibility checks.
 
-Registered onto the top-level app by :func:`register_compat`; ``cli/main.py``
+Registered onto the top-level app by :func:`register_hub`; ``cli/main.py``
 only wires the call.
 """
 
@@ -14,13 +14,13 @@ import typer
 from benchflow.cli._shared import console
 
 
-def register_compat(app: typer.Typer) -> None:
-    """Attach the ``compat`` command group to the top-level benchflow app."""
-    compat_app = typer.Typer(help="Third-party framework compatibility checks.")
-    app.add_typer(compat_app, name="compat", rich_help_panel="Environments")
+def register_hub(app: typer.Typer) -> None:
+    """Attach the ``hub`` command group to the top-level benchflow app."""
+    hub_app = typer.Typer(help="Compatibility checks for external environment hubs.")
+    app.add_typer(hub_app, name="hub", rich_help_panel="Environments")
 
-    @compat_app.command("harbor-registry")
-    def compat_harbor_registry(
+    @hub_app.command("check")
+    def hub_check(
         registry: Annotated[
             str,
             typer.Option(
@@ -50,14 +50,14 @@ def register_compat(app: typer.Typer) -> None:
         cache_dir: Annotated[
             Path,
             typer.Option("--cache-dir", help="Cache directory for sparse clones."),
-        ] = Path(".cache/compat/harbor"),
+        ] = Path(".cache/hub/harbor"),
         limit: Annotated[
             int | None,
             typer.Option("--limit", help="Optional cap on selected task refs."),
         ] = None,
     ) -> None:
         """Inventory or structurally check representative Harbor registry tasks."""
-        from benchflow.compat.harbor_registry import (
+        from benchflow.hub.harbor_registry import (
             check_harbor_registry,
             records_summary,
         )

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -40,9 +40,9 @@ from benchflow.cli._shared import (
     console,
 )
 from benchflow.cli.agent import register_agent
-from benchflow.cli.compat import register_compat
 from benchflow.cli.continue_cmd import register_continue
 from benchflow.cli.environment import register_environment
+from benchflow.cli.hub import register_hub
 from benchflow.cli.monitor import register_monitor
 from benchflow.cli.skills import register_skills
 from benchflow.cli.tasks import register_tasks
@@ -937,7 +937,7 @@ def eval_view(
 register_continue(app)
 register_skills(app)
 register_tasks(app)
-register_compat(app)
+register_hub(app)
 register_agent(app)
 register_environment(app)
 register_monitor(app)

--- a/src/benchflow/hub/__init__.py
+++ b/src/benchflow/hub/__init__.py
@@ -1,6 +1,6 @@
 """Compatibility helpers for third-party benchmark frameworks."""
 
-from benchflow.compat.harbor_registry import (
+from benchflow.hub.harbor_registry import (
     DEFAULT_HARBOR_REGISTRY_URL,
     HarborTaskRef,
     check_harbor_registry,

--- a/src/benchflow/hub/harbor_registry.py
+++ b/src/benchflow/hub/harbor_registry.py
@@ -112,7 +112,7 @@ def check_harbor_registry(
     if limit is not None:
         refs = refs[:limit]
 
-    cache = cache_dir or Path(".cache") / "compat" / "harbor"
+    cache = cache_dir or Path(".cache") / "hub" / "harbor"
     records = [_record_for_ref(ref, level=level, cache_dir=cache) for ref in refs]
 
     if out is not None:

--- a/tests/integration/check_hosted_env_evidence.py
+++ b/tests/integration/check_hosted_env_evidence.py
@@ -16,7 +16,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
-from benchflow.compat.harbor_registry import (
+from benchflow.hub.harbor_registry import (
     check_harbor_registry,
     records_summary,
 )

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -45,7 +45,7 @@ def test_top_level_help_lists_public_groups() -> None:
     """Every public top-level group documented in cli.md is shown in --help."""
     out = _help([])
     commands = _help_command_names(out)
-    for group in ("eval", "skills", "tasks", "compat", "agent", "environment"):
+    for group in ("eval", "skills", "tasks", "hub", "agent", "environment"):
         assert group in commands, f"missing public group {group!r} in: {out}"
     # Deprecated, hidden, and removed commands must not show up in public help.
     for hidden in ("run", "job", "agents", "metrics", "view", "eval-batch"):
@@ -128,7 +128,7 @@ def test_documented_subcommands_exist() -> None:
         ["environment", "show"],
         ["environment", "inspect"],
         ["environment", "cleanup"],
-        ["compat", "harbor-registry"],
+        ["hub", "check"],
     ):
         out = _help(cmd)
         assert "Usage:" in out, f"bench {' '.join(cmd)} --help failed: {out}"

--- a/tests/test_hub_harbor_registry.py
+++ b/tests/test_hub_harbor_registry.py
@@ -6,8 +6,8 @@ import pytest
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
-from benchflow.compat import harbor_registry
-from benchflow.compat.harbor_registry import (
+from benchflow.hub import harbor_registry
+from benchflow.hub.harbor_registry import (
     HarborTaskRef,
     check_harbor_registry,
     dataclass_record,
@@ -310,8 +310,8 @@ def test_harbor_registry_cli_check_outputs_report(tmp_path: Path) -> None:
     result = CliRunner().invoke(
         app,
         [
-            "compat",
-            "harbor-registry",
+            "hub",
+            "check",
             "--registry",
             str(registry_path),
             "--level",


### PR DESCRIPTION
Per direction — *"compat seems a terrible word if we want to be compatible with all other env hubs"* → **`bench hub`** (short, hub-centric).

| Before | After |
|--------|-------|
| `bench compat harbor-registry` | `bench hub check` |
| `cli/compat.py` / `register_compat` | `cli/hub.py` / `register_hub` |
| `benchflow.compat` package | `benchflow.hub` package |
| `.cache/compat/harbor` | `.cache/hub/harbor` |

- The Harbor logic keeps its harbor-specific function names (no speculative abstraction — "shorter"); the group is built to extend to other hubs (`bench hub check --registry <other>`).
- Updated all importers (CLI, the integration evidence checker), the `test_cli_docs_drift` guard, and `docs/reference/cli.md`.
- **Left untouched:** the task.md frontmatter `benchflow.compat.*` namespace (provenance for compat-imported tasks in `task/_document_parse`/`export`/`imports`) — that's a *separate task-standard concept*, not this command. (A naive global rename would have broken the task format.)

Clean rename, no alias — `bench compat` is a v0.6-only command with no public users yet (`bench compat` now → "No such command"). Full suite **4041 passed**; `ruff` + `ty` clean.

Resolves the open `compat`-naming question from the pre-release hardening pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for any scripts using `bench compat`; behavior is otherwise the same Harbor check path with moved imports and cache defaults.
> 
> **Overview**
> **Breaking CLI rename:** the third-party environment-hub compatibility surface moves from **`bench compat`** to **`bench hub`**, with Harbor checks exposed as **`bench hub check`** instead of **`bench compat harbor-registry`**. There is no compatibility alias—old invocations fail as unknown commands.
> 
> The Python package **`benchflow.compat`** becomes **`benchflow.hub`** (Harbor registry logic unchanged aside from default cache under **`.cache/hub/harbor`**). Wiring updates **`register_hub`** in **`cli/main.py`**, integration evidence imports, harbor registry tests, and **`docs/reference/cli.md`**. **`test_cli_docs_drift`** now expects **`hub`** in top-level help and documents **`hub check`**.
> 
> **`benchflow.compat.*` task.md provenance** is explicitly out of scope and was not renamed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2defcd711b1338008179ed5500dd795d43b8ddd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->