### PR TITLE
docs+test(prerelease): fix copy-paste/CLI/skill drift + bidirectional drift guard

### DIFF
--- a/.claude/skills/benchflow/SKILL.md
+++ b/.claude/skills/benchflow/SKILL.md
@@ -25,7 +25,7 @@ Arguments passed: `$ARGUMENTS`
 1. Check if benchflow is installed: `uv tool list | grep benchflow`
 2. Check if API keys are set (GEMINI_API_KEY, ANTHROPIC_API_KEY, etc.)
 3. Check available agents: `bench agent list`
-4. Show recent eval results if any exist in `evaluations/` or `jobs/`
+4. Show recent eval results if any exist under `jobs/` (the default `--jobs-dir`)
 5. Point to next action based on state
 
 ### `run <task-path>` — run a single task
@@ -94,12 +94,13 @@ max_retries: 1
 ### `metrics <jobs-dir>` — analyze results
 
 ```bash
-bench eval list jobs/
+bench eval metrics jobs/      # aggregate pass-rate / tokens / cost (add --json to pipe)
+bench eval list jobs/         # per-rollout table
 ```
 
 ### `view <rollout-dir>` — view a trajectory
 
-Results are in `evaluations/<eval-name>/<rollout-name>/` or `jobs/<job-name>/<rollout-name>/`:
+Results land under `jobs/<job-name>/<rollout-name>/` (the default `--jobs-dir` is `jobs/`):
 ```
 rollout-dir/
 ├── result.json              # rewards, agent, timing
@@ -114,20 +115,38 @@ rollout-dir/
 ### `create-task` — create a new benchmark task
 
 ```bash
-bench tasks init my-task
-bench tasks init my-task --no-pytest --no-solution
+bench tasks init my-task                       # native task.md format (default)
+bench tasks init my-task --no-pytest --no-oracle
+bench tasks check tasks/my-task                # structural validation
 ```
 
-Quick structure:
+Quick structure (native `task.md` format, the default):
 ```
 my-task/
-├── task.toml          # timeouts, resources, metadata
-├── instruction.md     # what the agent should do
+├── task.md            # YAML frontmatter (config) + prompt body
 ├── environment/
 │   └── Dockerfile     # sandbox setup
-├── tests/
-│   └── test.sh        # verifier -> writes to /logs/verifier/reward.txt
-└── solution/          # optional reference solution
+├── verifier/
+│   ├── test.sh        # verifier entrypoint -> writes /logs/verifier/reward.txt
+│   └── test_outputs.py
+└── oracle/            # optional reference solution (solve.sh)
+```
+
+`--format legacy` instead scaffolds the older split layout (`task.toml` +
+`instruction.md` + `tests/` + `solution/`).
+
+### `skills` — discover and evaluate agent skills
+
+```bash
+bench skills list                                   # discover skills on disk
+bench skills eval skills/citation-management \
+  --agent claude-agent-acp                          # score a skill against its evals/evals.json
+```
+
+### `hub` — check external-environment-hub compatibility
+
+```bash
+bench hub check          # inventory/structurally-check representative Harbor-registry tasks
 ```
 
 ### `agents` — list available agents
@@ -155,15 +174,19 @@ The underlying agent's install, env vars, credentials, and skill paths are prese
 
 ### `compare` — multi-agent comparison
 
+Compare by running one config per agent (the `agent:` key lives in each YAML)
+and printing the aggregate scores:
 ```python
 import asyncio
 from benchflow.evaluation import Evaluation
 
 async def main():
-    for agent_name in ["claude-agent-acp", "gemini", "opencode"]:
-        eval_obj = Evaluation.from_yaml("benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml")
-        result = await eval_obj.run()
-        print(f"{agent_name}: {result.passed}/{result.total} ({result.score:.1%})")
+    for config_path in [
+        "benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml",
+        "benchmarks/harvey-lab/harvey-lab-harness-parity.yaml",
+    ]:
+        result = await Evaluation.from_yaml(config_path).run()
+        print(f"{config_path}: {result.passed}/{result.total} ({result.score:.1%})")
 
 asyncio.run(main())
 ```
@@ -173,7 +196,10 @@ asyncio.run(main())
 ## Setup
 
 ```bash
-uv tool install benchflow    # or: uv sync --extra dev --locked (from source)
+# 0.6 is pre-release — not yet on PyPI. Install the RC wheel from GitHub releases:
+uv tool install --prerelease allow \
+  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
+# (replace rc.6 with the newest 0.6.0-rc.* release; or from source: uv sync --extra dev --locked)
 export GEMINI_API_KEY=...     # or ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
 export DAYTONA_API_KEY=...    # for cloud sandboxes
 ```

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -48,14 +48,14 @@ resolve yet. To get the real 0.6 flow TODAY, install the latest 0.6.0
 release-candidate WHEEL from the GitHub prerelease page.
   1. Open https://github.com/benchflow-ai/benchflow/releases and find the
      NEWEST `0.6.0-rc.*` prerelease (highest rc number — do not assume a
-     specific rc; rc.3 may already be superseded by rc.4 or later).
+     specific rc; rc.6 may already be superseded by rc.7 or later).
   2. Copy the download URL of that release's `.whl` asset (named like
      `benchflow-0.6.0rcN-py3-none-any.whl`). The tag and the filename share
      the same rc number — tag `0.6.0-rc.N`, file `benchflow-0.6.0rcN`.
-  3. Install it with the URL you copied, e.g. (this example pins rc.3; replace
-     `rc.3`/`rc3` with the actual newest rc you found):
+  3. Install it with the URL you copied, e.g. (this example pins rc.6; replace
+     `rc.6`/`rc6` with the actual newest rc you found):
     uv tool install --prerelease allow \
-      'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.3/benchflow-0.6.0rc3-py3-none-any.whl'
+      'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
 Any `0.6.0-rc.*` is a valid full-0.6 build. If `gh` is available, you can
 resolve the newest tag without opening a browser:
     gh release list --repo benchflow-ai/benchflow --limit 20 | grep '0.6.0-rc'

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,10 +18,10 @@ open it, pick the newest `0.6.0-rc.*` prerelease, and install its `.whl` asset:
 
 ```bash
 uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.3/benchflow-0.6.0rc3-py3-none-any.whl'
+  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
 ```
 
-The URL pins `0.6.0-rc.3` (newest at time of writing); if a later `0.6.0-rc.*`
+The URL pins `0.6.0-rc.6` (newest at time of writing); if a later `0.6.0-rc.*`
 prerelease exists, use that tag and filename instead. The `--prerelease allow`
 flag is required for BenchFlow's pinned LiteLLM release-candidate dependency. If
 `uv` reports `Executables already exist: bench, benchflow`, rerun the same

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -222,6 +222,8 @@ bench eval create -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lit
 | `--agent-env` | — | Agent environment variable as `KEY=VALUE`; repeatable |
 | `--include` | — | Only run these task names; repeatable (e.g. `--include jax-computing-basics --include data-to-d3`) |
 | `--exclude` | — | Skip these task names; repeatable (e.g. `--exclude quantum-numerical-simulation`) |
+| `--loop-strategy` | — | Wrap each rollout in a loop, e.g. `verify-retry:k=3,feedback=names` or `self-review:k=3` (omit for single-shot) |
+| `--ignore-bench-version` | `false` | With `--dataset`, skip the dataset's `bench_version` compatibility gate |
 
 When mounting skills, the recommended docs default is
 `--agent-env BENCHFLOW_SKILL_NUDGE=name`. See
@@ -508,7 +510,7 @@ bench hub check --level check --tasks-per-dataset 2 --out hub.jsonl
 | `--tasks-per-dataset` | `2` | Representative tasks selected per dataset |
 | `--level` | `inventory` | Compatibility level: `inventory` or `check` |
 | `--out` | — | Optional JSONL output path |
-| `--cache-dir` | `.cache/compat/harbor` | Cache directory for sparse clones |
+| `--cache-dir` | `.cache/hub/harbor` | Cache directory for sparse clones |
 | `--limit` | — | Optional cap on selected task refs |
 
 ## YAML Config Format

--- a/docs/release.md
+++ b/docs/release.md
@@ -27,10 +27,10 @@ open it, pick the newest `0.6.0-rc.*` prerelease, and install its `.whl` asset:
 
 ```bash
 uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.3/benchflow-0.6.0rc3-py3-none-any.whl'
+  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
 ```
 
-The URL pins `0.6.0-rc.3` (newest at time of writing); use a later
+The URL pins `0.6.0-rc.6` (newest at time of writing); use a later
 `0.6.0-rc.*` tag and filename if one exists. Confirm with `bench --version`.
 
 ## Install and Upgrade Commands (once 0.6.0 ships to PyPI)

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -376,47 +376,6 @@ evolve the skill text based on failure patterns.
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-## Real-World Example: Benchmark Hallucination Audit
-
-The `benchmark-hallucination-audit` skill teaches agents to verify claims
-in benchmark comparison tables by checking papers, GitHub, and HuggingFace.
-Its eval cases use findings from a real audit of AlphaEval (arXiv:2604.12162).
-
-```
-benchmark-hallucination-audit/
-├── skill.md                     # 5-round layered subagent methodology
-└── evals/
-    └── evals.json               # 8 cases from real AlphaEval audit
-```
-
-Sample case — detecting a Cross-Domain overclaim:
-```json
-{
-  "id": "overclaim-xdom-agentbench",
-  "question": "AlphaEval Table 1 marks AgentBench with Cross-Domain=✓. The definition is: 'spans 3+ distinct PROFESSIONAL domains'. AgentBench has 8 environments: OS, Database, Knowledge Graph, Card Game, Puzzles, ALFWorld, WebShop, Web Browsing. Is this correct or an overclaim?",
-  "ground_truth": "OVERCLAIM. The 8 environments are TASK TYPES, not 3+ professional domains like healthcare, finance, or law.",
-  "expected_behavior": [
-    "The agent fetched the AgentBench paper (arXiv:2308.03688)",
-    "The agent compared environments against the strict definition",
-    "The agent concluded task types ≠ professional domains"
-  ]
-}
-```
-
-Other cases test: missing Multi-Modal marks (MLE-bench), missing Dynamic
-marks (Gaia2 — title literally says "Dynamic"), correct Production marks
-(SWE-Lancer — $1M real Upwork payouts), and self-audit overclaims
-(AlphaEval's own Dynamic=✓ is aspirational, not mechanism-backed).
-
-Run it:
-```bash
-bench skills eval ./benchmark-hallucination-audit/ --agent claude-agent-acp --agent codex-acp
-```
-
-This is a good template for **research skills** — where the eval cases
-have verified ground truth from manual expert analysis, and the skill
-teaches a systematic methodology.
-
 ## For Skill Developers (Jon Snow Adapter Pattern)
 
 If you maintain skills and want CI-integrated eval:

--- a/docs/task-authoring-task-md.md
+++ b/docs/task-authoring-task-md.md
@@ -124,8 +124,12 @@ the entire body is the instruction the agent receives.
 
 Four reserved headings are recognized for compatibility imports: `## prompt`,
 `## role:<name>`, `## scene:<name>`, and `## user-persona`. Repeating the same
-section heading is a parse error. New tasks should not use them;
-multi-prompt material belongs in sidecar files under `prompts/`:
+section heading is a parse error. `bench tasks init` scaffolds a single
+`## prompt` section as a starting point — for a single-prompt task that is
+equivalent to a bare body, so keep it or drop the heading as you prefer. The
+multi-prompt headings (`## role:`, `## scene:`, `## user-persona`) are for
+compatibility imports only; new multi-prompt material belongs in sidecar files
+under `prompts/`:
 
 | File | Meaning |
 |---|---|

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -322,6 +322,16 @@ def test_number():  assert _load()(7) == "7"
 ```
 
 ```bash
+# tests/test.sh — verifier entrypoint; runs the pytest module, writes the reward
+#!/bin/bash
+curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh
+source $HOME/.local/bin/env
+
+uvx --with pytest==8.4.1 pytest /tests/test_outputs.py -rA
+if [ $? -eq 0 ]; then echo 1; else echo 0; fi > /logs/verifier/reward.txt
+```
+
+```bash
 # solution/solve.sh
 cat > /app/fizzbuzz.py << 'EOF'
 def fizzbuzz(n: int) -> str:

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -69,6 +69,7 @@ scenes:
 
 ```python
 from pathlib import Path
+import benchflow as bf
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 
 config = RolloutConfig(
@@ -146,6 +147,7 @@ For stronger isolation, use the MCP reviewer server pattern. The reviewer runs a
 from pathlib import Path
 
 from benchflow.experimental.mcp.hooks import mcp_reviewer_hook
+import benchflow as bf
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 
 config = RolloutConfig(
@@ -226,6 +228,7 @@ scenes:
 
 ```python
 from pathlib import Path
+import benchflow as bf
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 
 config = RolloutConfig(
@@ -287,6 +290,7 @@ scenes:
 
 ```python
 from pathlib import Path
+import benchflow as bf
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 
 config = RolloutConfig(
@@ -357,6 +361,7 @@ scenes:
 
 ```python
 from pathlib import Path
+import benchflow as bf
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 
 config = RolloutConfig(
@@ -401,6 +406,7 @@ Tasks that require agents to interact with live services -- Gmail, Calendar, Doc
 
 ```python
 from pathlib import Path
+import benchflow as bf
 from benchflow.rollout import RolloutConfig, Scene, Role, Turn
 from benchflow import SERVICES, build_service_hooks
 

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -1,4 +1,4 @@
-"""``bench compat`` — third-party framework compatibility checks.
+"""``bench hub`` — compatibility checks for external environment hubs.
 
 Registered onto the top-level app by :func:`register_hub`; ``cli/main.py``
 only wires the call.
@@ -12,6 +12,7 @@ from typing import Annotated
 import typer
 
 from benchflow.cli._shared import console
+from benchflow.hub.harbor_registry import DEFAULT_HARBOR_REGISTRY_URL
 
 
 def register_hub(app: typer.Typer) -> None:
@@ -27,7 +28,7 @@ def register_hub(app: typer.Typer) -> None:
                 "--registry",
                 help="Harbor registry JSON URL or local file.",
             ),
-        ] = "https://raw.githubusercontent.com/harbor-framework/harbor/main/registry.json",
+        ] = DEFAULT_HARBOR_REGISTRY_URL,
         tasks_per_dataset: Annotated[
             int,
             typer.Option(

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -1,4 +1,4 @@
-"""``bench skills`` — skill discovery, installation, and evaluation.
+"""``bench skills`` — skill discovery and evaluation.
 
 Registered onto the top-level app by :func:`register_skills`; ``cli/main.py``
 only wires the call.
@@ -23,7 +23,7 @@ from benchflow.cli._shared import console
 
 def register_skills(app: typer.Typer) -> None:
     """Attach the ``skills`` command group to the top-level benchflow app."""
-    skills_app = typer.Typer(help="Skill discovery, installation, and evaluation.")
+    skills_app = typer.Typer(help="Skill discovery and evaluation.")
     app.add_typer(skills_app, name="skills", rich_help_panel="Core")
 
     @skills_app.command("list")

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -9,7 +9,11 @@ live Typer parser so doc rot is caught in CI.
 from __future__ import annotations
 
 import re
+from pathlib import Path
+from typing import cast
 
+import click
+import typer
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
@@ -17,6 +21,41 @@ from benchflow.cli.main import app
 runner = CliRunner()
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+_CLI_MD = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
+
+
+def _click_command(path: list[str]) -> click.Command:
+    """Resolve a subcommand from the live Typer app (authoritative, untruncated)."""
+    cmd = typer.main.get_command(app)
+    for seg in path:
+        cmd = cast("click.Group", cmd).commands[seg]
+    return cmd
+
+
+def _cli_long_flags(path: list[str]) -> set[str]:
+    """Every ``--long`` option the parser actually accepts for ``path`` (minus --help)."""
+    flags = {
+        opt
+        for param in _click_command(path).params
+        for opt in getattr(param, "opts", [])
+        if opt.startswith("--")
+    }
+    flags.discard("--help")
+    return flags
+
+
+def _doc_section(header: str) -> str:
+    """The cli.md block from ``header`` up to the next ``### `` heading."""
+    doc = _CLI_MD.read_text()
+    i = doc.index(header)
+    nxt = doc.find("\n### ", i + len(header))
+    return doc[i : nxt if nxt != -1 else len(doc)]
+
+
+def _doc_flags(header: str) -> set[str]:
+    """Backtick-wrapped ``--flags`` documented under a cli.md heading."""
+    return set(re.findall(r"`(--[a-z0-9-]+)`", _doc_section(header)))
 
 
 def _help(args: list[str]) -> str:
@@ -54,49 +93,46 @@ def test_top_level_help_lists_public_groups() -> None:
         )
 
 
-def test_eval_create_help_lists_all_documented_flags() -> None:
-    """docs/reference/cli.md's bench eval create flag table must stay in sync.
+def test_eval_create_flags_match_cli_md_bidirectional() -> None:
+    """`bench eval create`'s flags and its cli.md table must be set-equal.
 
-    Typer truncates long flag names with '…' in --help, so we match against a
-    prefix of each documented flag — long enough to disambiguate from
-    sibling flags but short enough to survive Click's right-column truncation.
+    The old guard only checked doc→CLI (a hand-maintained list of documented
+    flags must exist in --help). It could not catch the *reverse* — a new CLI
+    flag landing undocumented — which is exactly how ``--loop-strategy`` and
+    ``--ignore-bench-version`` rotted out of the docs (#731). Deriving both
+    sides from ground truth (the live parser + the doc table) drops the
+    hand-maintained list and closes both directions.
     """
-    out = _help(["eval", "create"])
-    documented_flag_prefixes = [
-        "--config",
-        "--tasks-dir",
-        "--source-repo",
-        "--source-path",
-        "--source-ref",
-        "--source-env",
-        "--source-env-version",
-        "--source-env-arg",
-        "--source-env-num-examp",
-        "--source-env-rollouts-",
-        "--source-env-max-tokens",
-        "--source-env-temperatu",
-        "--source-env-sampling-",
-        "--agent",
-        "--model",
-        "--sandbox",
-        "--environment-manifest",
-        "--prompt",
-        "--concurrency",
-        "--agent-idle-timeout",
-        "--jobs-dir",
-        "--sandbox-user",
-        "--sandbox-setup-timeout",
-        "--skills-dir",
-        "--skill-mode",
-        "--skill-creator-dir",
-        "--self-gen-no-internet",
-        "--agent-env",
-        "--include",
-        "--exclude",
+    cli = _cli_long_flags(["eval", "create"])
+    doc = _doc_flags("### bench eval create")
+    assert cli == doc, (
+        "bench eval create CLI↔cli.md flag drift:\n"
+        f"  in CLI but UNDOCUMENTED: {sorted(cli - doc)}\n"
+        f"  documented but NOT in CLI: {sorted(doc - cli)}"
+    )
+
+
+def test_documented_defaults_match_cli() -> None:
+    """Documented default *values* must match the live param defaults.
+
+    The name-only guard happily passed while ``bench hub check --cache-dir``
+    documented the pre-rename ``.cache/compat/harbor`` (the CLI moved to
+    ``.cache/hub/harbor``). Pin the defaults that have drift history so a
+    stale value in either the code or the doc fails CI.
+    """
+    checks = [
+        (["hub", "check"], "--cache-dir", "### bench hub check", ".cache/hub/harbor"),
     ]
-    for flag in documented_flag_prefixes:
-        assert flag in out, (
-            f"documented flag prefix {flag!r} missing from `bench eval create --help`: {out}"
+    for path, flag, header, expected in checks:
+        param = next(
+            p for p in _click_command(path).params if flag in getattr(p, "opts", [])
+        )
+        assert expected in str(param.default), (
+            f"`bench {' '.join(path)} {flag}` default is {param.default!r}, "
+            f"expected to contain {expected!r}"
+        )
+        assert expected in _doc_section(header), (
+            f"cli.md {header!r} no longer documents the {flag} default {expected!r}"
         )
 
 


### PR DESCRIPTION
Prerelease accuracy sweep — fix every place the docs, the CLI help, and the agent-facing skill drifted from what 0.6 actually does, plus the recurrence-guard that keeps the CLI↔doc contract honest. Each item either **breaks on copy-paste**, **contradicts the CLI**, or (the skill) **actively misleads an agent**.

### Docs drift
| # | File | Drift | Fix |
|---|------|-------|-----|
| D1 | `use-cases.md` | All 6 Python examples call `bf.run(config)` with no `import benchflow as bf` → `NameError` on paste | Prepend the import |
| D2 | `task-authoring.md` | write-fizzbuzz example ships `tests/test_outputs.py` but no `tests/test.sh` — doc says it's "called by test.sh" but never shows it, so the task never scores | Add the `tests/test.sh` verifier entrypoint |
| D3 | `skill-eval.md` | "Benchmark Hallucination Audit" example cites a skill, a benchmark, 8 eval cases, and arXiv:2604.12162 that **exist nowhere in the repo** | Remove the fabricated section; `citation-management` is the real worked example |
| D4 | `reference/cli.md` | `eval create` flag table omits `--loop-strategy` and `--ignore-bench-version` | Add both rows |
| D5 | `cli/hub.py` + `reference/cli.md` | Post-`compat`→`hub` rename: stale docstring, duplicated registry URL literal, `.cache/compat/harbor` path | Align docstring, de-dup onto `DEFAULT_HARBOR_REGISTRY_URL`, fix cache path |
| D6/D7 | `getting-started` / `release` / `agent-quickstart` | RC-wheel install pinned at `rc.3` while README is `rc.6` | Align to `rc.6` |
| D9 | `task-authoring-task-md.md` | "new tasks should not use `## prompt`" contradicts `bench tasks init`, which scaffolds one | Reconcile the advice with the scaffold |
| D10 | `cli/skills.py` | `bench skills` help says "installation" but the group only exposes `list` + `eval` | Drop the word |

### Skills — regenerate the user-invocable `benchflow` skill against 0.6
`.claude/skills/benchflow/SKILL.md` triggers on "benchmark an agent / run a suite" — it *is* the agent-facing usage path — but had drifted enough to mislead: `bench eval list` shown as the metrics command; legacy `task.toml`/`instruction.md` scaffold layout instead of native `task.md`/`verifier/`/`oracle/`; `uv tool install benchflow` (fails — not on PyPI); no mention of `bench skills`/`bench hub`; stale `evaluations/` dir; and a `compare` example that looped without using the loop var and referenced a nonexistent YAML. Every command/flag/import/path re-verified against the live 0.6 CLI + repo.

### Drift guard (prevents recurrence)
- **Bidirectional flag check**: `test_cli_docs_drift` now derives both sides from ground truth — the live Click parser vs the cli.md table — and asserts set-equality. The old guard only checked doc→CLI against a hand-maintained list, which is exactly how D4's flags rotted out undocumented. Drops the list to maintain.
- **Default-value check**: pins `bench hub check --cache-dir` = `.cache/hub/harbor` in *both* parser and doc — the name-only guard passed while D5's stale `.cache/compat/harbor` sat in the doc.

**Verified:** `ruff` / `ruff format --check` / `ty` clean on every touched source file; `test_cli_docs_drift` (5), `test_hub_harbor_registry`, `test_cli_arg_validation`, `test_skills`, `test_skill_eval` all pass.

Investigated, **not** changed:
- **D8** (getting-started fetch/run order) — the `--source-repo` section is already correctly ordered.
- **§5 S1–S7** (source-model unification) — breaking/architectural; queued for product decision, not auto-implemented here.