### PR TITLE
fix(cli): round-2 error-path & edge-case hardening from the v0.6 sweep

### DIFF
--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -38,6 +38,7 @@ from pathlib import Path
 from typing import Annotated, Any
 
 import typer
+from rich.markup import escape
 
 # The parity gate (parsers, scoring, verdict) lives in agent_router_parity to
 # keep this module focused on create/run/verify CLI wiring. Re-exported here
@@ -395,7 +396,17 @@ ExecFn = Callable[..., int]
 def _subprocess_exec(command: list[str], *, cwd: str, env: Mapping[str, str]) -> int:
     import subprocess
 
-    return subprocess.run(command, cwd=cwd, env=dict(env)).returncode
+    try:
+        return subprocess.run(command, cwd=cwd, env=dict(env)).returncode
+    except FileNotFoundError as exc:
+        # Missing codex binary (default ``codex`` not on PATH, or a bad
+        # --codex-bin) raises FileNotFoundError here; re-raise as the
+        # already-handled launch error so the CLI prints a clean hint instead
+        # of a raw traceback on every fresh/CI machine.
+        raise CodexLaunchError(
+            f"codex binary not found: {command[0]!r} — install codex or pass "
+            "--codex-bin with the path to the binary"
+        ) from exc
 
 
 def run_agent_adoption(
@@ -697,7 +708,10 @@ def register_agent_router(agent_app: typer.Typer) -> None:
                 config_overrides=overrides,
             )
         except (InvalidBenchmarkName, CodexLaunchError) as exc:
-            console.print(f"[red]{exc}[/red]")
+            # escape(): CodexLaunchError embeds the user-supplied --codex-bin
+            # and InvalidBenchmarkName the benchmark name — either can contain
+            # Rich markup that would make this handler itself raise MarkupError.
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise typer.Exit(1) from exc
         raise typer.Exit(code)
 

--- a/src/benchflow/cli/_live_progress.py
+++ b/src/benchflow/cli/_live_progress.py
@@ -290,7 +290,12 @@ class LiveEvalProgress:
             tbl.add_column("elapsed", justify="right")
             now = time.monotonic()
             for name in sorted(running, key=lambda n: running[n])[:_MAX_RUNNING_ROWS]:
-                tbl.add_row(name, _fmt_dur(now - running[name]))
+                # Text() so a task name containing Rich markup (`[` is legal in
+                # SkillsBench dir names) is rendered literally, not parsed as
+                # markup — a MarkupError here escapes __rich__ and aborts the
+                # CLI on live-context exit, violating this module's "a render
+                # bug can never perturb a run" contract.
+                tbl.add_row(Text(name), _fmt_dur(now - running[name]))
             extra = len(running) - _MAX_RUNNING_ROWS
             if extra > 0:
                 tbl.add_row(f"… {extra} more", "")

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -139,6 +139,11 @@ def register_continue(app: typer.Typer) -> None:
             typer.echo(f"  rewards: {result.rewards}")
         if result.error:
             typer.secho(f"  agent error: {result.error}", fg=typer.colors.YELLOW)
+            # A failed continuation must report failure to $? — matches
+            # `continue-batch` (exits 1 if any continuation failed) and the
+            # `eval create` run-error contract. Without this a scripted caller
+            # reads the green ✓ + exit 0 as success.
+            raise typer.Exit(1)
 
     @app.command("continue-batch", hidden=True)
     def continue_batch_cmd(
@@ -175,6 +180,7 @@ def register_continue(app: typer.Typer) -> None:
             typer.Option(
                 "--concurrency",
                 help="Maximum number of continuation runs in flight.",
+                min=1,
             ),
         ] = 100,
         limit: Annotated[

--- a/src/benchflow/cli/environment.py
+++ b/src/benchflow/cli/environment.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.markup import escape
 from rich.table import Table
 
 from benchflow.cli._options import SandboxOption
@@ -44,9 +45,19 @@ def register_environment(app: typer.Typer) -> None:
         from benchflow.runtime import Environment
 
         if not task_dir.is_dir():
-            console.print(f"[red]Not a directory: {task_dir}[/red]")
+            console.print(f"[red]Not a directory: {escape(str(task_dir))}[/red]")
             raise typer.Exit(1)
-        env = Environment.from_task(task_dir, sandbox=sandbox)
+        try:
+            env = Environment.from_task(task_dir, sandbox=sandbox)
+        except (FileNotFoundError, NotADirectoryError, ValueError) as e:
+            # An existing dir with no task document reaches Task.__init__'s
+            # unguarded read_text() — surface a clean error instead of a raw
+            # FileNotFoundError traceback ending at instruction.md/task.md.
+            console.print(
+                f"[red]Not a valid task directory {escape(str(task_dir))}:[/red] "
+                f"{escape(str(e))}"
+            )
+            raise typer.Exit(1) from None
         console.print(f"[green]Environment created:[/green] {env}")
         console.print(f"  Task:    {env.task_path}")
         console.print(f"  Sandbox: {env.sandbox}")
@@ -91,7 +102,7 @@ def register_environment(app: typer.Typer) -> None:
             try:
                 raw = prime_env_list(owner=owner, search=search, limit=limit)
             except HostedEnvError as e:
-                console.print(f"[red]{e}[/red]")
+                console.print(f"[red]{escape(str(e))}[/red]")
                 raise typer.Exit(1) from None
             if output_json:
                 console.print(raw)
@@ -167,7 +178,7 @@ def register_environment(app: typer.Typer) -> None:
             ref = HostedEnvRef.parse(source_env, version=version)
             console.print(prime_env_info(ref))
         except HostedEnvError as e:
-            console.print(f"[red]{e}[/red]")
+            console.print(f"[red]{escape(str(e))}[/red]")
             raise typer.Exit(1) from None
 
     @env_app.command("inspect")
@@ -198,7 +209,7 @@ def register_environment(app: typer.Typer) -> None:
             ref = HostedEnvRef.parse(source_env, version=version)
             console.print(prime_env_inspect(ref, path=path))
         except HostedEnvError as e:
-            console.print(f"[red]{e}[/red]")
+            console.print(f"[red]{escape(str(e))}[/red]")
             raise typer.Exit(1) from None
 
     @env_app.command("cleanup")

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.markup import escape
 
 from benchflow.cli._shared import console
 from benchflow.hub.harbor_registry import DEFAULT_HARBOR_REGISTRY_URL
@@ -73,7 +74,12 @@ def register_hub(app: typer.Typer) -> None:
                 limit=limit,
             )
         except Exception as exc:
-            console.print(f"[red]Harbor compatibility check failed:[/red] {exc}")
+            # escape(): the message echoes the user-supplied --registry path,
+            # which can contain Rich markup (`[`, `[/red]`) — an unescaped
+            # interpolation makes the error handler itself raise MarkupError.
+            console.print(
+                f"[red]Harbor compatibility check failed:[/red] {escape(str(exc))}"
+            )
             raise typer.Exit(1) from exc
 
         summary = records_summary(records)

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated
 
 import typer
+from rich.markup import escape
 from rich.table import Table
 
 from benchflow import __version__
@@ -659,6 +660,8 @@ def run_batch_eval(
 
 def _run_config_file_eval(plan: "EvalPlan") -> None:
     """Apply CLI overrides onto a YAML-loaded Evaluation, then run and report it."""
+    import yaml
+
     from benchflow.evaluation import EmptyTaskSelectionError, Evaluation
 
     req = plan.request
@@ -666,44 +669,61 @@ def _run_config_file_eval(plan: "EvalPlan") -> None:
     assert (
         config_file is not None
     )  # config-file source: build_eval_plan guarantees this
-    j = Evaluation.from_yaml(config_file)
-    if req.agent is not None:
-        j._config.agent = plan.eval_agent
-    else:
-        j._config.agent = _normalize_eval_agent_or_exit(j._config.agent)
-    if req.model is not None:
-        j._config.model = effective_model(j._config.agent, req.model)
-    else:
-        j._config.model = effective_model(j._config.agent, j._config.model)
-    if req.reasoning_effort is not None:
-        j._config.reasoning_effort = plan.eval_reasoning_effort
-    if req.environment is not None:
-        j._config.environment = plan.eval_environment
-    j._config.agent_env = {**j._config.agent_env, **plan.parsed_env}
-    j._config.sandbox_user = normalize_sandbox_user(j._config.sandbox_user)
-    if req.jobs_dir is not None:
-        j._jobs_dir = Path(req.jobs_dir)
-    if req.concurrency is not None:
-        j._config.concurrency = req.concurrency
-    if req.build_concurrency is not None:
-        j._config.build_concurrency = req.build_concurrency
-    if req.prompt is not None:
-        j._config.prompts = plan.eval_prompts
-    if req.agent_idle_timeout is not None:
-        j._config.agent_idle_timeout = plan.eval_agent_idle_timeout
-    if plan.usage_tracking_overridden:
-        j._config.usage_tracking = j._config.usage_tracking.overlay(
-            plan.eval_usage_tracking
+    # from_yaml + the override overlay run BEFORE j.run(); a malformed config
+    # surfaces here (bad YAML, missing source.repo, a list where a mapping is
+    # expected, a non-existent/invalid environment_manifest, …). Guard the
+    # whole block so the CLI prints one clean error instead of ~10 distinct raw
+    # tracebacks. The exception type is kept in the message for diagnosability.
+    try:
+        j = Evaluation.from_yaml(config_file)
+        if req.agent is not None:
+            j._config.agent = plan.eval_agent
+        else:
+            j._config.agent = _normalize_eval_agent_or_exit(j._config.agent)
+        if req.model is not None:
+            j._config.model = effective_model(j._config.agent, req.model)
+        else:
+            j._config.model = effective_model(j._config.agent, j._config.model)
+        if req.reasoning_effort is not None:
+            j._config.reasoning_effort = plan.eval_reasoning_effort
+        if req.environment is not None:
+            j._config.environment = plan.eval_environment
+        j._config.agent_env = {**j._config.agent_env, **plan.parsed_env}
+        j._config.sandbox_user = normalize_sandbox_user(j._config.sandbox_user)
+        if req.jobs_dir is not None:
+            j._jobs_dir = Path(req.jobs_dir)
+        if req.concurrency is not None:
+            j._config.concurrency = req.concurrency
+        if req.build_concurrency is not None:
+            j._config.build_concurrency = req.build_concurrency
+        if req.prompt is not None:
+            j._config.prompts = plan.eval_prompts
+        if req.agent_idle_timeout is not None:
+            j._config.agent_idle_timeout = plan.eval_agent_idle_timeout
+        if plan.usage_tracking_overridden:
+            j._config.usage_tracking = j._config.usage_tracking.overlay(
+                plan.eval_usage_tracking
+            )
+        if plan.include_tasks:
+            j._config.include_tasks = plan.include_tasks
+        if plan.exclude_tasks:
+            j._config.exclude_tasks = plan.exclude_tasks
+        # CLI --environment-manifest wins over whatever the YAML carried
+        # so an operator can override a baseline manifest without editing
+        # the config file.
+        if plan.eval_env_manifest is not None:
+            j._config.environment_manifest = plan.eval_env_manifest
+    except (yaml.YAMLError, ValueError, TypeError, LookupError, OSError) as e:
+        # LookupError covers missing source.repo (KeyError) and empty legacy
+        # agents:/datasets: lists (IndexError). Type-mismatch cases (e.g. a
+        # non-string source.repo) are converted to ValueError at the parse
+        # source rather than catching AttributeError here, which would mask
+        # genuine bugs.
+        console.print(
+            f"[red]Invalid eval config {escape(str(config_file))}:[/red] "
+            f"{type(e).__name__}: {escape(str(e))}"
         )
-    if plan.include_tasks:
-        j._config.include_tasks = plan.include_tasks
-    if plan.exclude_tasks:
-        j._config.exclude_tasks = plan.exclude_tasks
-    # CLI --environment-manifest wins over whatever the YAML carried
-    # so an operator can override a baseline manifest without editing
-    # the config file.
-    if plan.eval_env_manifest is not None:
-        j._config.environment_manifest = plan.eval_env_manifest
+        raise typer.Exit(1) from None
     try:
         result = asyncio.run(j.run())
     except (EmptyTaskSelectionError, ValueError) as e:
@@ -819,6 +839,10 @@ def eval_list(
     if not jobs_dir.exists():
         console.print(f"[yellow]No jobs directory: {jobs_dir}[/yellow]")
         return
+    if not jobs_dir.is_dir():
+        # exists() is True for a file; iterdir() below would NotADirectoryError.
+        console.print(f"[red]Not a directory: {escape(str(jobs_dir))}[/red]")
+        raise typer.Exit(1)
 
     table = Table(title="Evaluations")
     table.add_column("Evaluation", style="cyan")
@@ -830,15 +854,28 @@ def eval_list(
         score = data.get("memory_score")
         return f"{score:.1%}" if isinstance(score, int | float) else "—"
 
-    root_summary = jobs_dir / "summary.json"
-    if root_summary.exists():
-        data = json.loads(root_summary.read_text())
+    def add_summary_row(label: str, summary_path: Path) -> None:
+        # A corrupt / truncated / non-object summary.json must not abort the
+        # whole listing — degrade that one row, mirroring the "no summary"
+        # fallback (and matching collect_metrics / _get_completed_tasks, which
+        # both skip-guard).
+        try:
+            data = json.loads(summary_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            data = None
+        if not isinstance(data, dict):
+            table.add_row(label, "?", "[dim]corrupt summary[/dim]", "—")
+            return
         table.add_row(
-            jobs_dir.name,
+            label,
             str(data.get("total", "?")),
             f"{data.get('passed', '?')}/{data.get('total', '?')} ({data.get('score', '?')})",
             memory_label(data),
         )
+
+    root_summary = jobs_dir / "summary.json"
+    if root_summary.exists():
+        add_summary_row(jobs_dir.name, root_summary)
         console.print(table)
         return
 
@@ -847,13 +884,7 @@ def eval_list(
             continue
         summary = d / "summary.json"
         if summary.exists():
-            data = json.loads(summary.read_text())
-            table.add_row(
-                d.name,
-                str(data.get("total", "?")),
-                f"{data.get('passed', '?')}/{data.get('total', '?')} ({data.get('score', '?')})",
-                memory_label(data),
-            )
+            add_summary_row(d.name, summary)
         else:
             sub_count = sum(1 for s in d.iterdir() if s.is_dir())
             table.add_row(d.name, str(sub_count), "[dim]no summary[/dim]", "—")

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Annotated, Literal, cast
 
 import typer
+from rich.markup import escape
 
 from benchflow.cli._shared import console
 from benchflow.cli.trace_import import register_tasks_generate
@@ -64,8 +65,13 @@ def register_tasks(app: typer.Typer) -> None:
             # which `bench tasks check` validates).
             for rel in result.files:
                 console.print(f"  {rel}")
-        except (FileExistsError, ValueError) as e:
-            console.print(f"[red]{e}[/red]")
+        except (OSError, ValueError) as e:
+            # OSError covers FileExistsError plus the NotADirectoryError /
+            # PermissionError that mkdir() raises for `--dir <file>` or a
+            # read-only parent — siblings (migrate/normalize/export) already
+            # degrade gracefully; init was the outlier that dumped a traceback.
+            # escape(): the OSError message echoes the user-supplied path.
+            console.print(f"[red]{escape(str(e))}[/red]")
             raise typer.Exit(1) from None
 
     @tasks_app.command("check")
@@ -118,8 +124,6 @@ def register_tasks(app: typer.Typer) -> None:
         ] = False,
     ) -> None:
         """Validate a task directory structure."""
-        from rich.markup import escape
-
         from benchflow._utils.task_authoring import check_task
 
         issues = check_task(

--- a/src/benchflow/cli/trace_import.py
+++ b/src/benchflow/cli/trace_import.py
@@ -324,6 +324,13 @@ def _detect_format(path: Path) -> str:
     except json.JSONDecodeError:
         return "claude-code"
 
+    # A non-dict first line (list / bare scalar) is not any known trace shape;
+    # the membership tests and `.get` below assume a mapping. Route to the
+    # claude-code loader, which returns [] for unrecognized rows so the caller
+    # surfaces the clean "No traces found" message instead of a raw traceback.
+    if not isinstance(data, dict):
+        return "claude-code"
+
     if "schema_version" in data or ("agent" in data and "steps" in data):
         return "opentraces"
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -727,6 +727,18 @@ class Evaluation:
         with open(path) as f:
             raw = yaml.safe_load(f)
 
+        # A non-mapping document (empty file → None, or a top-level list/scalar)
+        # is not a valid config. Reject it up front: the membership tests below
+        # would otherwise TypeError on None, or silently substring-match a scalar
+        # string that happens to contain "agents"/"datasets" and mis-route to
+        # the legacy parser.
+        if not isinstance(raw, dict):
+            raise ValueError(
+                f"Eval config {path} must be a YAML mapping with 'source' or "
+                f"'tasks_dir' (or legacy 'agents'/'datasets'); got "
+                f"{type(raw).__name__}."
+            )
+
         # Detect format: legacy uses "agents" + "datasets", benchflow uses "agent"
         if "agents" in raw or "datasets" in raw:
             return cls._from_legacy_yaml(raw, **kwargs)
@@ -745,8 +757,18 @@ class Evaluation:
         source_provenance = None
         if "source" in raw:
             src = raw["source"]
+            if not isinstance(src, dict):
+                raise ValueError(
+                    f"YAML 'source' must be a mapping with a 'repo' key; got "
+                    f"{type(src).__name__}."
+                )
+            repo = src.get("repo")
+            if not isinstance(repo, str) or not repo:
+                raise ValueError(
+                    "YAML 'source.repo' must be a non-empty string (e.g. 'org/repo')."
+                )
             resolved = resolve_source_with_metadata(
-                repo=src["repo"],
+                repo=repo,
                 path=src.get("path"),
                 ref=src.get("ref"),
             )
@@ -763,8 +785,13 @@ class Evaluation:
 
         jobs_dir = Path(raw.get("jobs_dir", "jobs"))
 
-        # Parse prompts — YAML null becomes Python None
-        prompts = raw.get("prompts")
+        # Parse prompts — YAML null becomes Python None. A bare string must be
+        # wrapped: otherwise Scene.single iterates it character-by-character into
+        # one garbage turn per character (mirrors the SDK YAML loader).
+        raw_prompts = raw.get("prompts")
+        prompts: list[str | None] | None = (
+            [raw_prompts] if isinstance(raw_prompts, str) else raw_prompts
+        )
 
         agent_env_raw = raw.get("agent_env", {})
         exclude = set(raw.get("exclude", []))

--- a/src/benchflow/skills.py
+++ b/src/benchflow/skills.py
@@ -62,13 +62,21 @@ def parse_skill(skill_md: Path) -> SkillInfo | None:
         frontmatter = yaml.safe_load(text[3:end])
         if not isinstance(frontmatter, dict):
             return None
+
+        def _text(value: object, default: str = "") -> str:
+            # YAML leaves unquoted scalars as int/float/bool/None; the str-typed
+            # fields (and the `description[:60]` slice + the Rich table cell)
+            # need real strings. A present-but-null key must fall back to the
+            # default, which ``.get(key, default)`` does NOT do.
+            return default if value is None else str(value)
+
         return SkillInfo(
-            name=frontmatter.get("name", skill_md.parent.name),
-            description=frontmatter.get("description", ""),
-            version=frontmatter.get("version", ""),
+            name=_text(frontmatter.get("name"), skill_md.parent.name),
+            description=_text(frontmatter.get("description")),
+            version=_text(frontmatter.get("version")),
             path=skill_md.parent,
-            compatibility=frontmatter.get("compatibility", ""),
-            metadata=frontmatter.get("metadata", {}),
+            compatibility=_text(frontmatter.get("compatibility")),
+            metadata=frontmatter.get("metadata") or {},
         )
     except Exception as e:
         logger.debug(f"Failed to parse {skill_md}: {e}")

--- a/src/benchflow/traces/parsers.py
+++ b/src/benchflow/traces/parsers.py
@@ -94,10 +94,14 @@ def parse_claude_code_session(
         if not line:
             continue
         try:
-            entries.append(json.loads(line))
+            row = json.loads(line)
         except json.JSONDecodeError:
             logger.debug("Skipping malformed JSONL line in %s", path)
             continue
+        if isinstance(row, dict):
+            entries.append(row)
+        else:
+            logger.debug("Skipping non-object JSONL entry in %s", path)
 
     if not entries:
         raise ValueError(f"No valid entries in {path}")
@@ -260,13 +264,21 @@ def parse_claude_code_file(path: Path) -> list[ParsedTrace]:
         if not line:
             continue
         try:
-            entries.append(json.loads(line))
+            row = json.loads(line)
         except json.JSONDecodeError:
             logger.debug("Skipping malformed JSONL line in %s", path)
             continue
+        if isinstance(row, dict):
+            entries.append(row)
+        else:
+            logger.debug("Skipping non-object JSONL entry in %s", path)
 
     if not entries:
-        raise ValueError(f"No valid entries in {path}")
+        # Empty / all-malformed / non-object file → no traces. Returning []
+        # lets the CLI surface its clean "No traces found" message + exit 1
+        # instead of a raw ValueError/AttributeError traceback. (The
+        # single-session parser keeps its "No valid entries" contract.)
+        return []
 
     # Group entries by sessionId
     session_groups: dict[str, list[dict[str, Any]]] = {}
@@ -278,9 +290,11 @@ def parse_claude_code_file(path: Path) -> list[ParsedTrace]:
         else:
             no_session_id.append(entry)
 
-    # If no sessionId found at all, treat as single session
+    # If no sessionId found at all, treat as single session. Reuse the entries
+    # already read + dict-filtered above rather than re-reading the file — a
+    # re-read skips the non-dict filtering and would crash on a list/scalar line.
     if not session_groups:
-        return [parse_claude_code_session(path)]
+        return [_parse_claude_entries(entries, source_path=path)]
 
     # Append ungrouped entries to the first session (context lines, etc.)
     if no_session_id and session_groups:

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -1,0 +1,277 @@
+"""Regression tests for the v0.6 edge-case + UX sweep (round-2 hardening).
+
+Each test pins one confirmed bug from the sweep: a raw traceback / wrong exit
+code / silent corruption on a malformed-but-plausible input. They are grouped
+by the command surface they protect.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from rich.console import Console
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+runner = CliRunner()
+
+
+# ── continue: exit code (H1/H2) + concurrency floor (M4) ──────────────────────
+
+
+def test_continue_exits_1_on_agent_error(tmp_path, monkeypatch):
+    # H1/H2: a failed continuation must report failure to $? (it printed a green
+    # ✓ then a yellow warning and exited 0, so scripts read it as success).
+    import benchflow.continue_run.orchestrator as orch
+
+    async def fake_continue_run(*args, **kwargs):
+        return SimpleNamespace(
+            rollout_dir=tmp_path / "r",
+            n_recorded=1,
+            n_live=0,
+            divergences=0,
+            rewards=None,
+            error="agent boom",
+        )
+
+    monkeypatch.setattr(orch, "continue_run", fake_continue_run)
+    res = runner.invoke(app, ["continue", str(tmp_path)])
+    assert res.exit_code == 1
+    assert "agent error" in res.output
+
+
+def test_continue_exits_0_when_no_error(tmp_path, monkeypatch):
+    # The success path must still exit 0 (guard against over-correcting H1).
+    import benchflow.continue_run.orchestrator as orch
+
+    async def fake_continue_run(*args, **kwargs):
+        return SimpleNamespace(
+            rollout_dir=tmp_path / "r",
+            n_recorded=1,
+            n_live=2,
+            divergences=0,
+            rewards={"reward": 1.0},
+            error=None,
+        )
+
+    monkeypatch.setattr(orch, "continue_run", fake_continue_run)
+    res = runner.invoke(app, ["continue", str(tmp_path)])
+    assert res.exit_code == 0
+
+
+def test_continue_batch_rejects_zero_concurrency(tmp_path):
+    # M4: --concurrency 0 reached an unguarded asyncio.run -> raw ValueError.
+    res = runner.invoke(app, ["continue-batch", str(tmp_path), "--concurrency", "0"])
+    assert res.exit_code != 0
+    assert not isinstance(res.exception, ValueError)  # typer rejects it, not a crash
+
+
+# ── agent run: missing codex binary (H3) ─────────────────────────────────────
+
+
+def test_subprocess_exec_missing_binary_raises_launch_error():
+    # H3: a missing codex binary raised a raw FileNotFoundError that the CLI's
+    # except (InvalidBenchmarkName, CodexLaunchError) did not catch.
+    from benchflow.agent_router import CodexLaunchError, _subprocess_exec
+
+    with pytest.raises(CodexLaunchError, match="codex binary not found"):
+        _subprocess_exec(["/nonexistent/codex-xyz", "--help"], cwd=".", env={})
+
+
+# ── tasks init: bad --dir (H4) ────────────────────────────────────────────────
+
+
+def test_tasks_init_into_file_dir_exits_clean(tmp_path):
+    # H4: `--dir <a file>` -> mkdir NotADirectoryError; init was the only
+    # task subcommand that did not catch it.
+    afile = tmp_path / "afile"
+    afile.write_text("x")
+    res = runner.invoke(app, ["tasks", "init", "mytask", "--dir", str(afile)])
+    assert res.exit_code == 1
+    assert isinstance(res.exception, SystemExit)  # clean Exit, not a raw traceback
+
+
+# ── tasks generate --from-file: malformed trace files (H5) ────────────────────
+
+
+def test_parse_claude_code_file_empty_returns_empty(tmp_path):
+    from benchflow.traces.parsers import parse_claude_code_file
+
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    assert parse_claude_code_file(p) == []
+
+
+def test_parse_claude_code_file_non_object_lines_return_empty(tmp_path):
+    # H5: list / scalar JSONL lines hit `entry.get(...)` -> AttributeError.
+    from benchflow.traces.parsers import parse_claude_code_file
+
+    p = tmp_path / "garbage.jsonl"
+    p.write_text("[1, 2, 3]\n42\n")
+    assert parse_claude_code_file(p) == []
+
+
+def test_detect_format_non_dict_first_line(tmp_path):
+    from benchflow.cli.trace_import import _detect_format
+
+    p = tmp_path / "x.jsonl"
+    p.write_text("[1, 2, 3]\n")
+    assert _detect_format(p) == "claude-code"
+
+
+# ── skills list: numeric / null frontmatter (H6) ─────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "frontmatter, field, expected",
+    [
+        ("name: 123", "name", "123"),
+        ("version: 1.0", "version", "1.0"),
+        ("description: 42", "description", "42"),
+        ("description: null", "description", ""),
+    ],
+)
+def test_parse_skill_coerces_scalar_frontmatter(tmp_path, frontmatter, field, expected):
+    # H6: unquoted numeric / explicit-null frontmatter rendered as non-strings
+    # and crashed the whole `skills list` table (NotRenderableError / slicing).
+    from benchflow.skills import parse_skill
+
+    sk = tmp_path / "SKILL.md"
+    sk.write_text(f"---\nname: ok\n{frontmatter}\n---\nbody")
+    info = parse_skill(sk)
+    assert info is not None
+    assert getattr(info, field) == expected
+    # The crash site was `description[:60]` — all fields must be sliceable str.
+    assert info.description[:60] == info.description[:60]
+
+
+# ── eval create --config: malformed YAML (H7) + prompts string-split (H8) ─────
+
+
+def test_from_yaml_rejects_non_mapping(tmp_path):
+    from benchflow.evaluation import Evaluation
+
+    p = tmp_path / "c.yaml"
+    p.write_text("- a\n- b\n")
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        Evaluation.from_yaml(p)
+
+
+def test_from_yaml_rejects_empty_file(tmp_path):
+    from benchflow.evaluation import Evaluation
+
+    p = tmp_path / "e.yaml"
+    p.write_text("")
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        Evaluation.from_yaml(p)
+
+
+def test_from_yaml_rejects_non_string_repo(tmp_path):
+    from benchflow.evaluation import Evaluation
+
+    p = tmp_path / "r.yaml"
+    p.write_text("source:\n  repo: 12345\n")
+    with pytest.raises(ValueError, match=r"source\.repo"):
+        Evaluation.from_yaml(p)
+
+
+def test_yaml_string_prompts_are_wrapped_in_a_list(tmp_path):
+    # H8: a bare `prompts: do the thing` string was iterated char-by-char into
+    # one turn per character. It must be wrapped to a single-element list.
+    from benchflow.evaluation import Evaluation
+
+    tdir = tmp_path / "tasks"
+    tdir.mkdir()
+    p = tmp_path / "c.yaml"
+    p.write_text(f"tasks_dir: {tdir}\nagent: gemini\nprompts: do the thing\n")
+    ev = Evaluation.from_yaml(p)
+    assert ev._config.prompts == ["do the thing"]
+
+
+# ── markup in user input crashes error handlers (H10/M13) ─────────────────────
+
+
+def test_hub_check_markup_registry_does_not_crash_handler(monkeypatch):
+    import benchflow.hub.harbor_registry as hr
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("bad registry /tmp/[/red]x.json")
+
+    monkeypatch.setattr(hr, "check_harbor_registry", boom)
+    res = runner.invoke(app, ["hub", "check", "--registry", "/tmp/[/red]x.json"])
+    assert res.exit_code == 1
+    # If the [red] markup were not escaped, the handler's own console.print
+    # would raise MarkupError instead of exiting cleanly.
+    assert isinstance(res.exception, SystemExit)
+    assert "Harbor compatibility check failed" in res.output
+
+
+# ── environment create: existing non-task dir (H11) ──────────────────────────
+
+
+def test_environment_create_non_task_dir_exits_clean(tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    res = runner.invoke(
+        app, ["environment", "create", str(empty), "--sandbox", "docker"]
+    )
+    assert res.exit_code == 1
+    assert "Not a valid task directory" in res.output
+
+
+# ── live dashboard: markup in task names (H12/M11) ───────────────────────────
+
+
+def test_dashboard_render_survives_markup_task_name():
+    from benchflow.cli._live_progress import LiveEvalProgress
+
+    d = LiveEvalProgress(Console(), label="x", agent="a", model="m", sandbox="docker")
+    d.on_plan(total=1, done=0, remaining=1)
+    d.on_task_start("task-[red]danger[/red]")
+    d.__rich__()  # must not raise MarkupError
+
+
+# ── eval list: corrupt summary.json (M1) + non-dir arg (M2) ──────────────────
+
+
+def test_eval_list_corrupt_summary_does_not_crash(tmp_path):
+    (tmp_path / "summary.json").write_text("{ not valid json")
+    res = runner.invoke(app, ["eval", "list", str(tmp_path)])
+    assert res.exit_code == 0
+    assert "corrupt summary" in res.output
+
+
+def test_eval_list_non_directory_exits_clean(tmp_path):
+    afile = tmp_path / "afile"
+    afile.write_text("x")
+    res = runner.invoke(app, ["eval", "list", str(afile)])
+    assert res.exit_code == 1
+    assert "Not a directory" in res.output
+
+
+# ── error handlers must escape user input echoed in their own message ─────────
+# (review follow-up: the handlers this PR added/touched were themselves
+# vulnerable to the MarkupError crash the PR fixes elsewhere)
+
+
+def test_eval_config_handler_escapes_markup_in_path(tmp_path):
+    # A --config path containing Rich markup + a non-mapping body: the
+    # "Invalid eval config" handler must escape the path, not crash on it.
+    bad = tmp_path / "[bad].yaml"
+    bad.write_text("- a\n- b\n")
+    res = runner.invoke(app, ["eval", "create", "--config", str(bad)])
+    assert res.exit_code == 1
+    assert isinstance(res.exception, SystemExit)  # not a MarkupError
+    assert "Invalid eval config" in res.output
+
+
+def test_tasks_init_handler_escapes_markup_in_path(tmp_path):
+    # --dir is a file whose name contains markup → mkdir OSError whose message
+    # echoes the path; the handler must escape it.
+    afile = tmp_path / "[x].txt"
+    afile.write_text("x")
+    res = runner.invoke(app, ["tasks", "init", "mytask", "--dir", str(afile)])
+    assert res.exit_code == 1
+    assert isinstance(res.exception, SystemExit)  # not a MarkupError

--- a/tests/test_skill_eval_integration.py
+++ b/tests/test_skill_eval_integration.py
@@ -351,4 +351,6 @@ class TestSkillEvalCLI:
         assert result.exit_code == 0
         assert "eval" in result.output
         assert "list" in result.output
-        assert "install" in result.output
+        # No "install" assertion: `bench skills` exposes only list + eval — there
+        # is no install command, and the misleading "installation" wording was
+        # removed from the group help (sweep finding D10).


### PR DESCRIPTION
Round-2 of the prerelease hardening. A 21-agent edge-case + UX sweep walked every command × flag × malformed-input and adversarially confirmed these (all `real: true`, none refuted) — **distinct** from the B1–B11 shipped in #730. Each was a **raw traceback**, a **wrong exit code**, or **silent corruption** on a malformed-but-plausible input.

### HIGH
| # | Command | Bug | Fix |
|---|---------|-----|-----|
| H1/H2 | `continue` | failed continuation printed green ✓ and **exited 0** (scripts read success) | raise `Exit(1)` on `result.error`, matching `continue-batch` |
| H3 | `agent run` | missing codex binary → raw `FileNotFoundError` (hits every fresh/CI machine on default `--codex-bin codex`) | re-raise as `CodexLaunchError` with an install hint |
| H4 | `tasks init` | `--dir <file>` / read-only parent → `NotADirectoryError`/`PermissionError` (only task subcmd not catching `OSError`) | broaden the except to `OSError` |
| H5 | `tasks generate --from-file` | empty / non-JSONL / list / scalar → 4 distinct tracebacks | `_detect_format` rejects non-dict first line; claude-code parser filters non-objects + returns `[]` |
| H6 | `skills list` | unquoted numeric / null frontmatter (`version: 1.0`, `name: 123`, `description: null`) crashed the whole table | coerce scalar fields to `str` at the parse source |
| H7 | `eval create --config` | ~10 malformed-YAML shapes → raw tracebacks (`from_yaml`+overlay ran outside any try) | guard the block; reject non-mapping doc + non-string `source.repo` at the source |
| H8 | `eval create --config` | bare `prompts:` string iterated **char-by-char** into one garbage turn per char | wrap a `str` into a single-element list |
| H10/M13 | hub / environment / (new handlers) | error handlers interpolated raw user input → markup in it made the **handler itself** raise `MarkupError` | `escape()` the interpolations |
| H11 | `environment create` | existing-but-non-task dir → raw `FileNotFoundError` from `Task.__init__` | catch + clean error |
| H12/M11 | live dashboard | task name with `[` (legal in SkillsBench dirs) → `MarkupError` inside `__rich__`, crashing the CLI on live-context exit (violates the module's own contract) | render name as `Text()` |

### MEDIUM
- **M1/M2** `eval list`: corrupt/truncated/non-object `summary.json` crashed the whole listing; a non-dir arg dumped `NotADirectoryError`. → degrade row to "corrupt summary" + `is_dir` guard.
- **M4** `continue-batch --concurrency 0` → unguarded `asyncio.run` → raw `ValueError`. → `min=1`.

### Review
A thermo-nuclear structural+correctness review caught that **three handlers this PR added/touched** (the new `eval --config`, `tasks init`, and `agent run` error handlers) shipped with the *same* unescaped-markup crash the PR fixes elsewhere — now escaped, with 2 added regression tests. It verified the broadened excepts don't mask bugs or swallow `typer.Exit`, and that `parse_claude_code_file` returning `[]` breaks no caller.

### Verification
- New `tests/test_cli_edge_case_hardening.py` — **23 regression tests**, one per finding (+2 for the handler-escape review fixes).
- Updated `test_skills_help` to drop its assertion of the removed "installation" wording (no install command exists — D10).
- **Full suite: 4021 passed**, 49 skipped. `ruff` / `ruff format --check` / `ty` clean on every touched file.

### Deferred (follow-up)
- A single shared `print_error()` helper to escape all ~14 CLI error sites (this PR escapes only the handlers it touched).
- Remaining MEDIUM/LOW + UX items from the sweep (M3, M5–M10, U1–U9) — incl. the `eval create` help-panel grouping (U1) and source-mode docstring (U2).
- Full sweep synthesis saved at `~/benchflow-context/cli-design/EDGE-CASE-SWEEP-2026-06-13.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are defensive (error handling, validation, display); no auth or core eval scoring paths altered beyond safer YAML parsing.
> 
> **Overview**
> Hardens CLI and parsing **error paths** so malformed or adversarial inputs yield clean messages and correct exit codes instead of tracebacks, wrong `$?`, or silent corruption.
> 
> **Exit codes & subprocess:** `bench continue` now exits **1** when the continuation reports an agent error (aligned with `continue-batch`). `continue-batch` rejects `--concurrency` below 1. Missing **codex** on `agent run` is raised as `CodexLaunchError` with an install hint.
> 
> **Rich markup:** User-supplied paths and names in error output and the live eval dashboard are **escaped** or rendered as `Text()` so `[`-heavy strings cannot crash handlers or `__rich__` on dashboard exit.
> 
> **Eval & YAML:** `eval create --config` wraps `from_yaml` plus CLI overrides in one try/except with escaped config paths. `Evaluation.from_yaml` rejects non-mapping roots, validates `source.repo`, and wraps a bare string `prompts` value in a list. `eval list` guards non-directory args and degrades corrupt `summary.json` rows.
> 
> **Tasks, traces, skills:** `tasks init` catches `OSError` and escapes paths. Trace **JSONL** loaders skip non-object lines; multi-session claude parsing returns `[]` for empty/garbage files; format auto-detect ignores non-dict first lines. `skills list` coerces numeric/null YAML frontmatter to strings. `environment create` surfaces invalid task directories cleanly.
> 
> Adds **`tests/test_cli_edge_case_hardening.py`** (regressions per sweep finding) and adjusts `test_skills_help` for removed install wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c35d4f02c18585c4e247cf4eeca7ab833bb63a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->