### PR TITLE
fix(cli): round-3 dev-ex hardening — sandbox registry, install-URL guard, loud malformed-task.md

### DIFF
--- a/src/benchflow/_utils/task_authoring/__init__.py
+++ b/src/benchflow/_utils/task_authoring/__init__.py
@@ -84,6 +84,7 @@ from .structural_checks import (
     _check_unreplaced_verifier_placeholders,
     _logical_dir_label,
     _strategy_file_exists,
+    task_document_parse_error,
 )
 
 logger = logging.getLogger(__name__)
@@ -327,6 +328,7 @@ __all__ = [
     "_check_unreplaced_verifier_placeholders",
     "_logical_dir_label",
     "_strategy_file_exists",
+    "task_document_parse_error",
     # acceptance_evidence
     "_append_declared_evidence_path",
     "_check_acceptance_evidence",

--- a/src/benchflow/_utils/task_authoring/structural_checks.py
+++ b/src/benchflow/_utils/task_authoring/structural_checks.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Literal
 
 from benchflow.rewards.rubric_config import criteria_aggregate_policy_from_rubric
-from benchflow.task.document import TaskDocument, TaskDocumentParseError
+from benchflow.task.document import TaskDocument
 from benchflow.task.package import TaskPackage
 from benchflow.task.paths import TaskPaths, local_script_strategy_files
 from benchflow.task.verifier_document import (
@@ -142,14 +142,28 @@ def _check_partial_split_definition(paths: TaskPaths) -> list[str]:
     ]
 
 
+def task_document_parse_error(task_md: Path) -> str | None:
+    """Return a human-readable parse error if ``task_md`` fails to parse, else None.
+
+    The single source of truth for "does this task.md parse?" — used both by
+    ``check_task``'s structural validation and by eval task-discovery, so a
+    genuinely malformed task.md (a typo that would otherwise make the dir
+    silently vanish from a batch, #3) can be told apart from a dir that simply
+    isn't a task.
+    """
+    try:
+        TaskDocument.from_path(task_md)
+    except Exception as e:
+        return f"task.md parse error: {e}"
+    return None
+
+
 def _check_task_document(task_md: Path) -> list[str]:
     issues: list[str] = []
-    try:
-        document = TaskDocument.from_path(task_md)
-    except TaskDocumentParseError as e:
-        return [f"task.md parse error: {e}"]
-    except Exception as e:
-        return [f"task.md parse error: {e}"]
+    parse_error = task_document_parse_error(task_md)
+    if parse_error is not None:
+        return [parse_error]
+    document = TaskDocument.from_path(task_md)
 
     text = task_md.read_text()
     if not document.instruction.strip():

--- a/src/benchflow/cli/_options.py
+++ b/src/benchflow/cli/_options.py
@@ -11,10 +11,12 @@ from typing import Annotated
 
 import typer
 
+from benchflow.sandbox.providers import providers_phrase
+
 AgentOption = Annotated[str, typer.Option("--agent", help="Agent name")]
 ModelOption = Annotated[str | None, typer.Option("--model", help="Model")]
 SandboxOption = Annotated[
-    str, typer.Option("--sandbox", help="Sandbox: docker, daytona, or modal")
+    str, typer.Option("--sandbox", help=f"Sandbox: {providers_phrase()}")
 ]
 ConcurrencyOption = Annotated[
     int, typer.Option("--concurrency", help="Max concurrent tasks")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -49,6 +49,7 @@ from benchflow.cli.skills import register_skills
 from benchflow.cli.tasks import register_tasks
 from benchflow.eval_plan import EvalCreateRequest, EvalPlanError, build_eval_plan
 from benchflow.evaluation import DEFAULT_AGENT, effective_model
+from benchflow.sandbox.providers import providers_phrase
 from benchflow.skill_policy import SKILL_MODE_NO_SKILL
 
 if TYPE_CHECKING:
@@ -268,7 +269,7 @@ def eval_create(
     ] = None,
     environment: Annotated[
         str | None,
-        typer.Option("--sandbox", help="Sandbox: docker, daytona, or modal"),
+        typer.Option("--sandbox", help=f"Sandbox: {providers_phrase()}"),
     ] = None,
     usage_tracking: Annotated[
         str | None,

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -20,6 +20,7 @@ from benchflow.cli._options import (
     SandboxOption,
 )
 from benchflow.cli._shared import console
+from benchflow.sandbox.providers import is_known_provider, providers_phrase
 
 
 def register_skills(app: typer.Typer) -> None:
@@ -98,10 +99,10 @@ def register_skills(app: typer.Typer) -> None:
         """
         from benchflow.skill_eval import SkillEvaluator, export_gepa_traces
 
-        if environment not in ("docker", "daytona", "modal"):
+        if not is_known_provider(environment):
             console.print(
                 f"[red]Invalid --sandbox {environment!r}: "
-                "choose docker, daytona, or modal[/red]"
+                f"choose {providers_phrase()}[/red]"
             )
             raise typer.Exit(1)
         if agent is None:

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -16,6 +16,7 @@ from rich.markup import escape
 
 from benchflow.cli._shared import console
 from benchflow.cli.trace_import import register_tasks_generate
+from benchflow.sandbox.providers import providers_phrase
 
 
 def register_tasks(app: typer.Typer) -> None:
@@ -98,7 +99,7 @@ def register_tasks(app: typer.Typer) -> None:
             str | None,
             typer.Option(
                 "--sandbox",
-                help="Also validate parsed runtime semantics for docker, daytona, or modal",
+                help=f"Also validate parsed runtime semantics for {providers_phrase()}",
             ),
         ] = None,
         report_output: Annotated[

--- a/src/benchflow/continue_run/orchestrator.py
+++ b/src/benchflow/continue_run/orchestrator.py
@@ -37,6 +37,7 @@ from benchflow.continue_run.sandbox_proxy import (
     sandbox_replay_base_url,
 )
 from benchflow.contracts import AgentProtocolError, SandboxStartupFailure
+from benchflow.sandbox.providers import OFF_BOX_MODEL_PROVIDERS
 from benchflow.scenes import compile_scenes_to_steps
 from benchflow.trajectories.types import LLMExchange, redact_trajectory_text
 
@@ -48,7 +49,9 @@ logger = logging.getLogger(__name__)
 # OpenAI-compatible endpoint.
 _REPLAY_API_KEY = "sk-benchflow-replay"
 _REPLAY_MODEL = "openai/replay"
-_SANDBOX_LOCAL_REPLAY_ENVIRONMENTS = frozenset({"daytona", "modal"})
+# Off-box-model providers (≡ non-docker) — derived from the canonical registry
+# so this replay-routing subset can't drift from litellm_runtime's copy.
+_SANDBOX_LOCAL_REPLAY_ENVIRONMENTS = OFF_BOX_MODEL_PROVIDERS
 _PROXY_MODES = frozenset({"auto", "host", "sandbox"})
 
 

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -36,6 +36,11 @@ from benchflow.loop_strategies import (
     LoopStrategySpec,
     parse_loop_strategy_spec,
 )
+from benchflow.sandbox.providers import (
+    is_known_provider,
+    provider_extra,
+    providers_phrase,
+)
 from benchflow.skill_policy import (
     SKILL_MODE_NO_SKILL,
     SKILL_MODE_SELF_GEN,
@@ -271,12 +276,11 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
     # environment owns its harness), so only validate / preflight it for the
     # paths that actually use the local sandbox.
     if not request.source_env:
-        if eval_environment not in {"docker", "daytona", "modal"}:
+        if not is_known_provider(eval_environment):
             # Unknown sandbox values otherwise surface as a raw traceback per-task
             # once the rollout starts — reject them at planning instead.
             raise EvalPlanError(
-                f"Invalid --sandbox {eval_environment!r}: "
-                "choose docker, daytona, or modal"
+                f"Invalid --sandbox {eval_environment!r}: choose {providers_phrase()}"
             )
         if eval_environment == "modal":
             # Fail fast with the actionable extra hint instead of surfacing a raw
@@ -287,7 +291,7 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
             except ModuleNotFoundError as exc:
                 raise EvalPlanError(
                     "Missing optional dependency for 'modal' sandbox. "
-                    "Install it with `uv sync --extra sandbox-modal`."
+                    f"Install it with `uv sync --extra {provider_extra('modal')}`."
                 ) from exc
     eval_prompts = cast("list[str | None] | None", request.prompt)
     sandbox_user = normalize_sandbox_user(request.sandbox_user)

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -954,11 +954,7 @@ class Evaluation:
         """
         from benchflow._utils.task_authoring import task_document_parse_error
 
-        single_task_md = self._tasks_dir / "task.md"
-        if single_task_md.is_file():
-            parse_error = task_document_parse_error(single_task_md)
-            if parse_error is not None:
-                raise MalformedTaskError(f"{single_task_md}: {parse_error}")
+        # A valid task at the root → that IS the whole job (single-task input).
         if _is_task_dir(self._tasks_dir):
             if self._tasks_dir.name in self._config.exclude_tasks:
                 return []
@@ -969,6 +965,11 @@ class Evaluation:
                 return []
             return [self._tasks_dir]
 
+        # Batch input: collect valid child tasks; warn (don't silently drop) on
+        # any child whose task.md fails to PARSE. Selection filters are applied
+        # first, so excluded dirs are never warned about. A child task.md that
+        # PARSES but is structurally incomplete (schema-only fixture) keeps its
+        # silent skip.
         selected: list[Path] = []
         for d in sorted(self._tasks_dir.iterdir()):
             if not d.is_dir():
@@ -980,10 +981,6 @@ class Evaluation:
             if _is_task_dir(d):
                 selected.append(d)
                 continue
-            # Not a task per check_task — but if it carries a task.md that fails
-            # to PARSE, warn (naming the dir + error) instead of dropping it
-            # silently. Selection filters were applied above, so excluded dirs
-            # are never warned about.
             task_md = d / "task.md"
             if task_md.is_file():
                 parse_error = task_document_parse_error(task_md)
@@ -991,6 +988,24 @@ class Evaluation:
                     logger.warning(
                         "Skipping malformed task %r: %s", d.name, parse_error
                     )
+
+        # A malformed task.md at the tasks-dir ROOT is a hard error ONLY when no
+        # valid child tasks were found — i.e. the root was meant as a single
+        # task and it is broken. If the dir is a batch container that also
+        # happens to carry a stray broken root task.md, warn but still run the
+        # healthy children rather than aborting the whole batch.
+        root_task_md = self._tasks_dir / "task.md"
+        if root_task_md.is_file():
+            parse_error = task_document_parse_error(root_task_md)
+            if parse_error is not None:
+                if selected:
+                    logger.warning(
+                        "Ignoring malformed task.md at the tasks-dir root %r: %s",
+                        self._tasks_dir.name,
+                        parse_error,
+                    )
+                else:
+                    raise MalformedTaskError(f"{root_task_md}: {parse_error}")
         return selected
 
     def _get_completed_tasks(self) -> dict[str, dict]:

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -149,6 +149,15 @@ class EmptyTaskSelectionError(ValueError):
     """
 
 
+class MalformedTaskError(ValueError):
+    """A single-task input whose ``task.md`` exists but fails to parse (#3).
+
+    Subclasses ``ValueError`` so the CLI's existing run-error handlers surface it
+    as a clean red message + exit 1. The message names the offending file —
+    silently treating a typo'd task.md as "not a task" would make the task vanish.
+    """
+
+
 @dataclass
 class RetryConfig:
     """Configuration for retry behavior.
@@ -933,7 +942,23 @@ class Evaluation:
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
     def _get_task_dirs(self) -> list[Path]:
-        """Get all valid task directories."""
+        """Get all valid task directories.
+
+        A directory whose ``task.md`` *exists but fails to parse* is a malformed
+        task, not a non-task: in the single-task case that is a hard error (the
+        user named exactly one thing and it is broken); in the batch case it is
+        loudly warned and skipped (a typo must never make a task silently vanish
+        from a 50-task suite, #3) while the healthy tasks still run. A task.md
+        that PARSES but is structurally incomplete (e.g. a schema-only fixture)
+        keeps its existing silent skip.
+        """
+        from benchflow._utils.task_authoring import task_document_parse_error
+
+        single_task_md = self._tasks_dir / "task.md"
+        if single_task_md.is_file():
+            parse_error = task_document_parse_error(single_task_md)
+            if parse_error is not None:
+                raise MalformedTaskError(f"{single_task_md}: {parse_error}")
         if _is_task_dir(self._tasks_dir):
             if self._tasks_dir.name in self._config.exclude_tasks:
                 return []
@@ -943,14 +968,30 @@ class Evaluation:
             ):
                 return []
             return [self._tasks_dir]
-        return sorted(
-            d
-            for d in self._tasks_dir.iterdir()
-            if d.is_dir()
-            and _is_task_dir(d)
-            and d.name not in self._config.exclude_tasks
-            and (not self._config.include_tasks or d.name in self._config.include_tasks)
-        )
+
+        selected: list[Path] = []
+        for d in sorted(self._tasks_dir.iterdir()):
+            if not d.is_dir():
+                continue
+            if d.name in self._config.exclude_tasks:
+                continue
+            if self._config.include_tasks and d.name not in self._config.include_tasks:
+                continue
+            if _is_task_dir(d):
+                selected.append(d)
+                continue
+            # Not a task per check_task — but if it carries a task.md that fails
+            # to PARSE, warn (naming the dir + error) instead of dropping it
+            # silently. Selection filters were applied above, so excluded dirs
+            # are never warned about.
+            task_md = d / "task.md"
+            if task_md.is_file():
+                parse_error = task_document_parse_error(task_md)
+                if parse_error is not None:
+                    logger.warning(
+                        "Skipping malformed task %r: %s", d.name, parse_error
+                    )
+        return selected
 
     def _get_completed_tasks(self) -> dict[str, dict]:
         """Load tasks that already have results with rewards or verifier errors.

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -47,6 +47,7 @@ from benchflow.providers.litellm_logging import (
     extract_usage_from_trajectory,
     trajectory_from_litellm_callback_log,
 )
+from benchflow.sandbox.providers import OFF_BOX_MODEL_PROVIDERS
 from benchflow.trajectories.types import Trajectory
 from benchflow.usage_tracking import UsageTrackingConfig, usage_unavailable
 
@@ -63,7 +64,9 @@ _PATCH_MODULE = "benchflow_litellm_bedrock_patch"
 # GenerateContent format), so they talk to their provider directly and report
 # usage_source='unavailable'. ``oracle`` has no model at all.
 _NATIVE_PROTOCOL_AGENTS = frozenset({"oracle", "gemini"})
-_SANDBOX_LOCAL_ENVIRONMENTS = frozenset({"daytona", "modal"})
+# Providers whose model traffic exits the sandbox to the host proxy (≡ non-docker);
+# derived from the canonical registry so it can't drift from the provider set.
+_SANDBOX_LOCAL_ENVIRONMENTS = OFF_BOX_MODEL_PROVIDERS
 
 
 @dataclass(frozen=True)

--- a/src/benchflow/sandbox/providers.py
+++ b/src/benchflow/sandbox/providers.py
@@ -1,0 +1,76 @@
+"""Canonical registry of sandbox providers — the single source of truth.
+
+Before this module the provider set ``{docker, daytona, modal}`` was hand-copied
+across ~10 sites (typer ``--sandbox`` help strings, validation membership checks,
+error messages, the optional-extra map, and two ``{daytona, modal}`` "off-box
+model" subsets) with no registry and no drift test, so adding a provider meant
+editing every copy. All of those now derive from the tuple below; the drift test
+``tests/test_sandbox_provider_registry_drift.py`` fails if a literal set
+reappears elsewhere.
+
+Import-safe by design: stdlib only, so every caller (CLI options, eval planning,
+runtime capabilities, the litellm runtime, the replay orchestrator) can import it
+without a cycle. The provider→implementation dispatch deliberately stays in
+``sandbox/setup.py:_create_sandbox_environment`` (its per-branch lazy imports and
+daytona-only resource clamps make per-branch code the safer shape); it validates
+against this registry rather than re-listing the names.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SandboxProvider:
+    """One sandbox backend and the facts that were previously duplicated."""
+
+    name: str
+    extra: str | None  # pip/uv optional-dependency extra; None for built-in docker
+    off_box_model: bool  # model traffic exits the sandbox → host proxy (not docker)
+
+
+# Ordered, docker-first. This tuple is the ONLY place the set is spelled out.
+_PROVIDERS: tuple[SandboxProvider, ...] = (
+    SandboxProvider("docker", extra=None, off_box_model=False),
+    SandboxProvider("daytona", extra="sandbox-daytona", off_box_model=True),
+    SandboxProvider("modal", extra="sandbox-modal", off_box_model=True),
+)
+
+PROVIDERS_BY_NAME: dict[str, SandboxProvider] = {p.name: p for p in _PROVIDERS}
+
+#: Ordered provider names — use for help text / messages (stable order).
+SANDBOX_PROVIDERS: tuple[str, ...] = tuple(p.name for p in _PROVIDERS)
+#: O(1) membership set — use for validation.
+SANDBOX_PROVIDER_SET: frozenset[str] = frozenset(SANDBOX_PROVIDERS)
+#: provider → optional-dependency extra (only providers that need one).
+OPTIONAL_SANDBOX_EXTRAS: dict[str, str] = {
+    p.name: p.extra for p in _PROVIDERS if p.extra is not None
+}
+#: Providers whose model traffic must reach the host proxy off-box (≡ non-docker).
+OFF_BOX_MODEL_PROVIDERS: frozenset[str] = frozenset(
+    p.name for p in _PROVIDERS if p.off_box_model
+)
+
+
+def is_known_provider(name: str) -> bool:
+    """True if ``name`` is a registered sandbox provider."""
+    return name in SANDBOX_PROVIDER_SET
+
+
+def provider_extra(name: str) -> str | None:
+    """The optional-dependency extra for ``name`` (None for docker/unknown)."""
+    p = PROVIDERS_BY_NAME.get(name)
+    return p.extra if p else None
+
+
+def providers_phrase(*, quote: bool = False) -> str:
+    """Human list of providers, e.g. ``docker, daytona, or modal``.
+
+    Kept byte-identical to the strings it replaces so every help/error message
+    is unchanged. ``quote=True`` renders ``'docker', 'daytona', or 'modal'``.
+    """
+    items = [f"'{n}'" if quote else n for n in SANDBOX_PROVIDERS]
+    if len(items) == 1:
+        return items[0]
+    return ", ".join(items[:-1]) + ", or " + items[-1]

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -14,6 +14,7 @@ from typing import Any, NoReturn, cast
 
 from benchflow._paths import ignore_symlinks, is_safe_regular_file
 from benchflow.agents.registry import AGENTS
+from benchflow.sandbox.providers import OPTIONAL_SANDBOX_EXTRAS, providers_phrase
 from benchflow.skill_policy import validate_container_mount_path
 from benchflow.task import RolloutPaths, Task
 
@@ -55,17 +56,11 @@ def _stage_ignore(directory: str, contents: list[str]) -> list[str]:
 _HEREDOC_RE = re.compile(r"<<-?\s*['\"]?([A-Za-z0-9_.-]+)['\"]?")
 
 
-_OPTIONAL_SANDBOX_EXTRAS = {
-    "daytona": "sandbox-daytona",
-    "modal": "sandbox-modal",
-}
-
-
 def _raise_missing_optional_sandbox_dependency(
     sandbox_type: str,
     exc: ImportError,
 ) -> NoReturn:
-    extra = _OPTIONAL_SANDBOX_EXTRAS[sandbox_type]
+    extra = OPTIONAL_SANDBOX_EXTRAS[sandbox_type]
     raise RuntimeError(
         f"Missing optional dependency for {sandbox_type!r} sandbox. "
         f"Install it with `uv sync --extra {extra}` for local development, "
@@ -759,7 +754,7 @@ def _create_sandbox_environment(
         )
     else:
         raise ValueError(
-            f"Unknown sandbox_type: {sandbox_type!r} (use 'docker', 'daytona', or 'modal')"
+            f"Unknown sandbox_type: {sandbox_type!r} (use {providers_phrase(quote=True)})"
         )
 
 

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -15,6 +15,7 @@ from pathlib import Path, PurePosixPath
 from typing import cast
 
 from benchflow.rewards.rubric_config import criteria_aggregate_policy_from_rubric
+from benchflow.sandbox.providers import SANDBOX_PROVIDER_SET, providers_phrase
 from benchflow.task.config import (
     NetworkMode,
     TaskConfig,
@@ -30,7 +31,9 @@ from benchflow.task.prompts import (
 )
 from benchflow.task.verifier_document import load_verifier_document
 
-SUPPORTED_SANDBOX_BACKENDS = {"docker", "daytona", "modal"}
+# Back-compat name kept for this module's existing membership check; the
+# canonical set lives in benchflow.sandbox.providers.
+SUPPORTED_SANDBOX_BACKENDS = SANDBOX_PROVIDER_SET
 
 
 @dataclass(frozen=True)
@@ -76,7 +79,7 @@ def validate_task_runtime_support(
         _issue(
             unsupported,
             path="sandbox",
-            reason="unknown sandbox backend; use docker, daytona, or modal",
+            reason=f"unknown sandbox backend; use {providers_phrase()}",
             sandbox=sandbox,
         )
         return unsupported

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -9,11 +9,13 @@ live Typer parser so doc rot is caught in CI.
 from __future__ import annotations
 
 import re
+import tomllib
 from pathlib import Path
 from typing import cast
 
 import click
 import typer
+from packaging.version import Version
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
@@ -22,7 +24,8 @@ runner = CliRunner()
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
-_CLI_MD = Path(__file__).resolve().parents[1] / "docs" / "reference" / "cli.md"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_CLI_MD = _REPO_ROOT / "docs" / "reference" / "cli.md"
 
 
 def _click_command(path: list[str]) -> click.Command:
@@ -168,3 +171,60 @@ def test_documented_subcommands_exist() -> None:
     ):
         out = _help(cmd)
         assert "Usage:" in out, f"bench {' '.join(cmd)} --help failed: {out}"
+
+
+# ── install-wheel URL drift guard (dev-ex #15) ───────────────────────────────
+
+# Docs that pin a concrete RC-wheel install URL. The hand-pinned tag drifts when
+# one doc is bumped and the others aren't; nothing previously caught that.
+_INSTALL_URL_DOCS = (
+    "README.md",
+    "docs/getting-started.md",
+    "docs/release.md",
+    "docs/agent-quickstart.md",
+    ".claude/skills/benchflow/SKILL.md",
+)
+# Matches only CONCRETE pins, e.g.
+# releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl
+# The \d+ deliberately skips agent-quickstart.md's `rc.N`/`rcN` placeholders.
+_WHEEL_URL_RE = re.compile(
+    r"releases/download/(?P<tag>\d+\.\d+\.\d+-rc\.\d+)/"
+    r"benchflow-(?P<whl>\d+\.\d+\.\d+rc\d+)-py3-none-any\.whl"
+)
+
+
+def test_install_wheel_url_consistent_across_docs() -> None:
+    """Every pinned RC-wheel install URL must be mutually consistent: one shared
+    rc tag, each URL's tag matching its own wheel filename, and the base version
+    matching pyproject. Offline-only (no network / freshness check)."""
+    matches: list[tuple[str, str, str]] = []  # (doc, tag, wheel)
+    missing: list[str] = []
+    for rel in _INSTALL_URL_DOCS:
+        text = (_REPO_ROOT / rel).read_text()
+        found = list(_WHEEL_URL_RE.finditer(text))
+        if not found:
+            missing.append(rel)
+        matches.extend((rel, m["tag"], m["whl"]) for m in found)
+
+    # A doc that dropped/renamed its pinned URL (e.g. a 404-shaped path) must
+    # fail loudly rather than silently pass with zero matches.
+    assert not missing, f"docs with no concrete pinned wheel URL: {missing}"
+
+    # Per-URL: the release tag and its own wheel filename share the rc number
+    # (PEP 440 normalizes 0.6.0-rc.6 and 0.6.0rc6 to the same Version).
+    for doc, tag, whl in matches:
+        assert Version(tag) == Version(whl), (
+            f"{doc}: release tag {tag!r} and wheel filename {whl!r} disagree"
+        )
+
+    # Cross-doc: all pinned rc tags identical (the core drift).
+    by_tag = {Version(tag): doc for doc, tag, _ in matches}
+    assert len(by_tag) == 1, "install-wheel rc pins drift across docs: " + ", ".join(
+        f"{doc}={tag}" for tag, doc in by_tag.items()
+    )
+
+    # Base version ties to pyproject (0.6.0); NOT the rc number — pyproject is
+    # 0.6.0.dev0 and carries no rc, so only the base is sensibly assertable.
+    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
+    pin = next(iter(by_tag))
+    assert pin.base_version == Version(pyproject["project"]["version"]).base_version

--- a/tests/test_sandbox_provider_registry_drift.py
+++ b/tests/test_sandbox_provider_registry_drift.py
@@ -1,0 +1,97 @@
+"""Drift guard for the canonical sandbox-provider registry (dev-ex #14).
+
+Before ``benchflow.sandbox.providers`` the set ``{docker, daytona, modal}`` (and
+its ``{daytona, modal}`` off-box subset) was hand-copied across ~10 sites with no
+single source of truth. These tests fail if (a) a literal provider set reappears
+outside the registry, (b) the derived facts (phrase, extras, off-box subset) go
+stale, or (c) the registry and the dispatch table drift apart.
+"""
+
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+from benchflow.sandbox.providers import (
+    OFF_BOX_MODEL_PROVIDERS,
+    OPTIONAL_SANDBOX_EXTRAS,
+    SANDBOX_PROVIDER_SET,
+    SANDBOX_PROVIDERS,
+    providers_phrase,
+)
+
+_SRC = Path(__file__).resolve().parents[1] / "src" / "benchflow"
+_REGISTRY = _SRC / "sandbox" / "providers.py"
+
+
+def test_registry_is_the_single_source_of_truth() -> None:
+    # Locks the current set + docker-first order; adding a provider is then a
+    # deliberate edit here + a test update, never a silent scatter.
+    assert SANDBOX_PROVIDERS == ("docker", "daytona", "modal")
+    assert frozenset(SANDBOX_PROVIDERS) == SANDBOX_PROVIDER_SET
+
+
+def test_providers_phrase_is_byte_identical() -> None:
+    # The refactor must be behavior-preserving for every help/error string that
+    # used to hand-write this phrase.
+    assert providers_phrase() == "docker, daytona, or modal"
+    assert providers_phrase(quote=True) == "'docker', 'daytona', or 'modal'"
+
+
+def test_off_box_subset_is_exactly_the_non_docker_providers() -> None:
+    # The two former {daytona, modal} frozensets are now derived; this locks the
+    # property so a 4th provider can't silently miss the off-box routing.
+    assert SANDBOX_PROVIDER_SET - {"docker"} == OFF_BOX_MODEL_PROVIDERS
+
+
+def test_no_divergent_provider_set_literal_outside_the_registry() -> None:
+    """The core drift catcher: the literal provider set / off-box subset must
+    appear ONLY in providers.py. A reintroduced hand-rolled set fails here."""
+    # Ordered triple in any bracket form, e.g. {"docker", "daytona", "modal"} or
+    # ("docker", "daytona", "modal"); and the bare {"daytona", "modal"} subset.
+    triple = re.compile(
+        r'["\']docker["\']\s*,\s*["\']daytona["\']\s*,\s*["\']modal["\']'
+    )
+    off_box = re.compile(r'["\']daytona["\']\s*,\s*["\']modal["\']')
+    offenders: list[str] = []
+    for py in _SRC.rglob("*.py"):
+        if py.resolve() == _REGISTRY.resolve():
+            continue
+        text = py.read_text()
+        for rx, what in ((triple, "provider-set"), (off_box, "off-box-subset")):
+            for m in rx.finditer(text):
+                line = text[: m.start()].count("\n") + 1
+                offenders.append(
+                    f"{py.relative_to(_SRC.parent.parent)}:{line} ({what})"
+                )
+    assert not offenders, (
+        "Hardcoded sandbox-provider literal(s) found outside "
+        "benchflow.sandbox.providers — derive from the registry instead:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_optional_extras_match_pyproject() -> None:
+    # Every provider extra must be a real packaging extra; fails if an extra is
+    # renamed in pyproject without updating the registry.
+    pyproject = tomllib.loads((_SRC.parent.parent / "pyproject.toml").read_text())
+    declared = set(pyproject["project"]["optional-dependencies"])
+    assert set(OPTIONAL_SANDBOX_EXTRAS.values()) <= declared, (
+        f"registry extras {set(OPTIONAL_SANDBOX_EXTRAS.values())} not all declared "
+        f"in pyproject optional-dependencies {declared}"
+    )
+    # Every off-box provider needs an extra (docker is built in, needs none).
+    assert set(OPTIONAL_SANDBOX_EXTRAS) == SANDBOX_PROVIDER_SET - {"docker"}
+
+
+def test_every_registry_provider_has_a_dispatch_branch() -> None:
+    # Registry name with no branch in _create_sandbox_environment would fall to
+    # the "Unknown sandbox_type" ValueError — prove they can't drift apart.
+    setup_src = (_SRC / "sandbox" / "setup.py").read_text()
+    body = setup_src[setup_src.index("def _create_sandbox_environment") :]
+    for name in SANDBOX_PROVIDERS:
+        assert f'sandbox_type == "{name}"' in body, (
+            f"provider {name!r} is in the registry but has no dispatch branch in "
+            "_create_sandbox_environment"
+        )

--- a/tests/test_task_check_eval_consistency.py
+++ b/tests/test_task_check_eval_consistency.py
@@ -431,6 +431,29 @@ def test_malformed_excluded_task_md_is_not_warned(tmp_path, caplog):
     assert not any("broken-task" in r.message for r in caplog.records)
 
 
+def test_batch_with_broken_root_task_md_still_runs_children(tmp_path, caplog):
+    # Bugbot edge case: a batch tasks-dir that ALSO has a broken root task.md
+    # must warn + run the valid children, NOT abort the whole batch (the
+    # root-malformed hard-error is only for the single-task case).
+    runnable = _make_task_missing_agent(tmp_path, name="runnable-task")
+    (tmp_path / "task.md").write_text(
+        "---\ntask:\n  name: [unclosed\n---\n## prompt\nx\n"
+    )
+    ev = Evaluation(
+        tasks_dir=str(tmp_path),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle"),
+    )
+    with caplog.at_level(logging.WARNING):
+        dirs = ev._get_task_dirs()
+    assert dirs == [runnable]  # batch ran, did not abort
+    assert any(
+        "root" in r.message and "parse error" in r.message for r in caplog.records
+    ), (
+        f"no warning about the broken root task.md: {[r.message for r in caplog.records]}"
+    )
+
+
 def test_malformed_task_md_cli_exits_with_parse_error(tmp_path):
     # End-to-end: the CLI must exit non-zero with the file + parse error, not a
     # raw traceback and not a misleading empty-selection message.

--- a/tests/test_task_check_eval_consistency.py
+++ b/tests/test_task_check_eval_consistency.py
@@ -10,6 +10,7 @@ None) so both commands return the same verdict.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -17,7 +18,7 @@ from typer.testing import CliRunner
 
 from benchflow._utils.task_authoring import check_task
 from benchflow.cli.main import app
-from benchflow.evaluation import Evaluation, EvaluationConfig
+from benchflow.evaluation import Evaluation, EvaluationConfig, MalformedTaskError
 
 SCHEMA_ONLY_TASK_MD_EXAMPLES = (
     Path("docs/examples/task-md/harbor-parity"),
@@ -73,6 +74,16 @@ metadata:
 
 This fixture validates task.md authoring syntax only.
 """
+    )
+    return task
+
+
+def _make_malformed_task_md(parent: Path, name: str = "malformed-task-md") -> Path:
+    """Create a task dir whose task.md has broken YAML frontmatter (fails to parse)."""
+    task = parent / name
+    task.mkdir()
+    (task / "task.md").write_text(
+        "---\ntask:\n  name: [unclosed\n---\n\n## prompt\n\nhi\n"
     )
     return task
 
@@ -346,3 +357,89 @@ def test_tasks_check_escapes_rich_markup_in_diagnostic(tmp_path):
     assert result.exit_code == 1
     # Should mention the parse error literally, not swallow brackets.
     assert "parse error" in result.output
+
+
+# ── malformed task.md no longer vanishes silently (#3) ────────────────────────
+
+
+def test_malformed_task_md_single_task_aborts_with_parse_error(tmp_path):
+    # A single-task input whose task.md fails to parse must abort with a parse
+    # error naming the file — NOT be silently treated as "not a task" and then
+    # mislabeled as an empty-selection / filter miss.
+    task = _make_malformed_task_md(tmp_path)
+    ev = Evaluation(
+        tasks_dir=str(task),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle"),
+    )
+    with pytest.raises(MalformedTaskError) as ei:
+        ev._get_task_dirs()
+    msg = str(ei.value)
+    assert "task.md" in msg and "parse error" in msg
+    assert "No tasks" not in msg and "selected" not in msg
+
+
+def test_malformed_task_md_in_batch_is_warned_not_silently_dropped(tmp_path, caplog):
+    # The core #3 regression: a typo'd task.md in a batch must leave a trace
+    # (a WARNING naming the dir + parse error) while healthy tasks still run.
+    runnable = _make_task_missing_agent(tmp_path, name="runnable-task")
+    _make_malformed_task_md(tmp_path, name="broken-task")
+    ev = Evaluation(
+        tasks_dir=str(tmp_path),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle"),
+    )
+    with caplog.at_level(logging.WARNING):
+        dirs = ev._get_task_dirs()
+    assert runnable in dirs
+    assert all(d.name != "broken-task" for d in dirs)
+    assert any(
+        "broken-task" in r.message and "parse error" in r.message
+        for r in caplog.records
+    ), f"no warning naming the malformed task: {[r.message for r in caplog.records]}"
+
+
+def test_schema_only_task_md_is_still_silently_skipped(tmp_path, caplog):
+    # Regression guard: a parse-VALID but structurally-incomplete task.md must
+    # keep its silent skip — the fix must not make intentional fixtures noisy.
+    runnable = _make_task_missing_agent(tmp_path, name="runnable-task")
+    _make_schema_only_task(tmp_path)
+    ev = Evaluation(
+        tasks_dir=str(tmp_path),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle"),
+    )
+    with caplog.at_level(logging.WARNING):
+        dirs = ev._get_task_dirs()
+    assert runnable in dirs
+    assert not any("malformed" in r.message.lower() for r in caplog.records)
+
+
+def test_malformed_excluded_task_md_is_not_warned(tmp_path, caplog):
+    # Selection filtering wins: an excluded malformed dir wasn't going to run,
+    # so it must not produce a warning.
+    _make_malformed_task_md(tmp_path, name="broken-task")
+    runnable = _make_task_missing_agent(tmp_path, name="runnable-task")
+    ev = Evaluation(
+        tasks_dir=str(tmp_path),
+        jobs_dir=str(tmp_path / "jobs"),
+        config=EvaluationConfig(agent="oracle", exclude_tasks={"broken-task"}),
+    )
+    with caplog.at_level(logging.WARNING):
+        dirs = ev._get_task_dirs()
+    assert runnable in dirs
+    assert not any("broken-task" in r.message for r in caplog.records)
+
+
+def test_malformed_task_md_cli_exits_with_parse_error(tmp_path):
+    # End-to-end: the CLI must exit non-zero with the file + parse error, not a
+    # raw traceback and not a misleading empty-selection message.
+    task = _make_malformed_task_md(tmp_path)
+    result = CliRunner().invoke(
+        app,
+        ["eval", "create", "--tasks-dir", str(task), "--agent", "oracle"],
+    )
+    assert result.exit_code == 1
+    # Collapse Rich's line-wrapping before substring-matching the message.
+    out = " ".join(result.output.split())
+    assert "task.md" in out and "parse error" in out


### PR DESCRIPTION
The three **in-my-lane, non-breaking** findings from the 0.6 self-audit (the breaking source-model items S1–S7 remain queued for product). Each closes a "scattered duplication / silent drift / silent drop" gap.

### #14 — Sandbox-provider registry (kills `{docker, daytona, modal}`-in-8-places)
`{docker, daytona, modal}` was hand-copied across ~10 sites (typer `--sandbox` help, validation membership checks, error messages, the optional-extra map, and two `{daytona, modal}` "off-box model" subsets) with no registry and no drift test. New `benchflow/sandbox/providers.py` is the single source of truth — a frozen dataclass tuple holding `name` + pip-`extra` + `off_box_model` per provider; every site derives from it (`is_known_provider` / `providers_phrase` / `OPTIONAL_SANDBOX_EXTRAS` / `OFF_BOX_MODEL_PROVIDERS`).
- **Behavior-preserving**: `providers_phrase()` is byte-identical to the old `"docker, daytona, or modal"` (reviewer byte-verified all 7 rewritten strings). The provider→class dispatch stays the single point in `setup.py` (its lazy imports + daytona clamps are intentional); it just validates against the registry.
- **New `test_sandbox_provider_registry_drift.py`** fails if a literal set reappears outside the registry, if the phrase/extras/off-box subset go stale, or if a registry provider has no dispatch branch. The scan currently finds **zero** provider-set literals outside `providers.py` — proof the refactor is complete.

### #15 — Install-URL drift guard
The RC-wheel URL is hand-pinned across 5 docs (README + getting-started + release + agent-quickstart + the `benchflow` skill) with nothing catching drift. New offline test in `test_cli_docs_drift.py` asserts every doc yields a concrete pinned URL, each URL's tag matches its own wheel filename (PEP 440), all pinned rc tags are identical across docs, and the base version ties to pyproject. Catches "bumped one doc, forgot the others" / a 404-shaped URL. Freshness ("is rc.6 newest?") is explicitly left to a future network-marked check.

### #3 — A malformed `task.md` no longer vanishes silently
A dir whose `task.md` fails to **parse** was silently treated as "not a task" and dropped from discovery — a typo'd `task.md` = a task that silently disappears from a batch. New `task_document_parse_error()` helper (one source of truth, factored out of `_check_task_document`) lets `_get_task_dirs` tell a parse failure apart from a structurally-incomplete-but-valid dir:
- **single-task** input → `MalformedTaskError` (abort, names the file);
- **batch** → `logger.warning` naming the dir + parse error, skip it, **still run the healthy tasks** (an all-malformed batch still raises `EmptyTaskSelectionError`, never a silent 0/0);
- a parse-**valid** schema-only fixture keeps its silent skip. `_is_task_dir` stays a pure bool, so other callers are unaffected.

### Verification
- `ruff check` / `ruff format --check` / `ty` clean on **src + tests + tools** (CI-exact); **full suite 4033 passed**, 49 skipped.
- 12 new regression tests (6 registry-drift, 1 install-URL, 5 malformed-task).
- **Adversarial review**: APPROVE-WITH-NITS, no blockers — byte-verified the registry strings, confirmed no import cycle, proved the healthy-task selection set + off-box subset equivalences. The flagged nits (dead `requires_extra`/`DEFAULT_SANDBOX`, a false re-export comment) are fixed in this PR.

Known/out-of-scope: `evaluation.py` is >1000 lines (pre-existing, tracked as #536); two provider-phrase copies survive in docstrings (can't hold runtime f-strings) — the drift guard covers runtime strings, not docstrings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eval task discovery behavior changes for broken task.md (intentional, well-tested); sandbox validation is centralized but touches planning and rollout paths where wrong provider names would fail fast anyway.
> 
> **Overview**
> **Dev-ex hardening** in three areas: one canonical sandbox registry, offline doc consistency checks, and clearer handling when `task.md` does not parse.
> 
> **Sandbox providers** — New `benchflow.sandbox.providers` holds docker/daytona/modal (optional pip extras and off-box model routing). CLI help, `eval_plan`, `skills eval`, `runtime_capabilities`, `setup.py`, and LiteLLM/continue replay routing now use `is_known_provider`, `providers_phrase`, and `OFF_BOX_MODEL_PROVIDERS` instead of duplicated literals. `test_sandbox_provider_registry_drift.py` blocks reintroducing hand-rolled provider sets outside the registry.
> 
> **Malformed `task.md` (#3)** — Shared `task_document_parse_error()` feeds structural checks and `Evaluation._get_task_dirs`. Single-task runs raise `MalformedTaskError`; batch runs log a warning and skip the broken dir while still running healthy tasks; excluded dirs are not warned. Parse-valid but incomplete tasks keep silent skip.
> 
> **Docs** — `test_install_wheel_url_consistent_across_docs` ensures pinned RC wheel URLs agree across five docs and align with `pyproject.toml` (offline only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb919dc73f26af3eb7c46a8768fde1afb8014820. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->