### PR TITLE
fix: fully detach manifest service starts so Daytona evals don't wedge (#676)

### DIFF
--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -109,8 +109,19 @@ class ManifestEnvironment:
                 if probe.return_code != 0:
                     continue  # binary missing or its package absent — skip
                 log = f"/tmp/benchflow-env-{svc.name}.log"
+                # Full fd detachment (#676). On Daytona, ``exec`` is a *session*
+                # command that only reports an exit code once nothing holds the
+                # session's streams. A backgrounded service that inherits the
+                # session's stdin/stdout/stderr keeps the call "running" until
+                # the hard timeout cap (#670), so a manifest eval wedges instead
+                # of starting. Redirect ALL THREE fds — ``</dev/null`` for stdin
+                # was the missing one; ``>log 2>&1`` only covered stdout/stderr —
+                # and ``nohup`` to detach from the session's SIGHUP. No
+                # ``disown``: it is a bash/zsh builtin and the Daytona DinD shell
+                # is ``sh``/dash. Docker is unaffected (``communicate()`` returns
+                # when the foreground shell exits), so this only bites on Daytona.
                 await self._sandbox.exec(
-                    f"{svc.command} > {log} 2>&1 &",
+                    f"nohup {svc.command} </dev/null >{shlex.quote(log)} 2>&1 &",
                     timeout_sec=15,
                 )
                 self._started.append(svc)

--- a/tests/environment/test_manifest_env.py
+++ b/tests/environment/test_manifest_env.py
@@ -122,6 +122,31 @@ async def test_provision_starts_present_services():
     assert all(c.rstrip().endswith("&") for c in starts)
 
 
+async def test_provision_fully_detaches_service_fds():
+    """Guards #676: manifest services must start with ALL THREE fds redirected
+    (``</dev/null`` + ``>log 2>&1``) and ``nohup``, never ``disown``.
+
+    On Daytona, ``exec`` is a session command that only returns once nothing
+    holds the session's streams; a service inheriting stdin/stdout/stderr keeps
+    the call running until the timeout cap (#670), wedging the eval. Docker
+    hides this, so only an explicit shape assertion catches the regression.
+    """
+    sandbox = FakeSandbox()
+    env = ManifestEnvironment(CLAWS, sandbox=sandbox)
+    await env.provision(ctx=None)
+    starts = [c for c in sandbox.exec_calls if "serve" in c]
+    assert starts, "expected at least one service start"
+    for cmd in starts:
+        assert cmd.startswith("nohup "), f"service start must use nohup: {cmd!r}"
+        assert "</dev/null" in cmd, f"stdin not redirected (the #676 bug): {cmd!r}"
+        assert ">/tmp/benchflow-env-" in cmd and "2>&1" in cmd, (
+            f"stdout/stderr not redirected to the per-service log: {cmd!r}"
+        )
+        assert cmd.rstrip().endswith("&"), f"service must be backgrounded: {cmd!r}"
+        # `disown` is bash/zsh-only and breaks under the Daytona DinD `sh`/dash.
+        assert "disown" not in cmd, f"disown is not sh/dash-safe: {cmd!r}"
+
+
 async def test_provision_skips_absent_service_binary():
     sandbox = FakeSandbox(absent_binaries={"claw-gcal"})
     env = ManifestEnvironment(CLAWS, sandbox=sandbox)


### PR DESCRIPTION
## Summary

`ManifestEnvironment.provision()` started declared services with `{cmd} > {log} 2>&1 &` — stdout/stderr redirected, but **stdin left attached and no `nohup`**.

On Daytona, `exec` runs as a *session* command that only reports an exit code once nothing holds the session's streams (the failure class root-caused in smolclaws#85). A backgrounded service that inherits the session's stdin/stdout/stderr keeps the call "running" until the hard timeout cap (#670) → a manifest-driven eval **wedges (~1h) instead of starting**.

Docker is unaffected — `communicate()` returns when the foreground shell exits — so the bug is invisible in local runs and CI, and only bites on Daytona.

## Fix

Start services with full detachment:

```sh
nohup {cmd} </dev/null >/tmp/benchflow-env-<svc>.log 2>&1 &
```

- all three fds redirected — **the missing `</dev/null` (stdin) is the operative change**; the old form only covered stdout/stderr
- `nohup` to detach from the session's SIGHUP
- **no `disown`** — it is a bash/zsh builtin and the Daytona DinD shell is `sh`/dash
- per-service logs stay retrievable at `/tmp/benchflow-env-<svc>.log`

Mirrors the fix that resolved the identical wedge downstream.

## Test plan

- [x] `test_provision_fully_detaches_service_fds` — asserts `nohup` + all three fd redirections + backgrounded + **no `disown`**; **verified to fail on the old `> {log} 2>&1 &` form** (fail-then-pass). The pre-existing test only checked the command ended with `&`, which is exactly why the missing stdin redirect slipped through.
- [x] `tests/environment/` + manifest inbound suite: 75 passed
- [x] ruff check + format, ty clean

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)