### PR TITLE
fix(cli): systemic markup-escape sweep + dataset-registry guards + doc install fixes

### DIFF
--- a/.claude/skills/benchflow/SKILL.md
+++ b/.claude/skills/benchflow/SKILL.md
@@ -230,10 +230,13 @@ bench eval create \
   --agent claude-agent-acp \
   --sandbox daytona \
   --skills-dir skills/ \
+  --skill-mode with-skill \
   --agent-env BENCHFLOW_SKILL_NUDGE=name
 ```
 
-Skills are uploaded to `/skills/` in the sandbox and symlinked to agent-specific paths.
+`--skill-mode with-skill` is required whenever you pass `--skills-dir` (omitting
+it errors). Skills are uploaded to `/skills/` in the sandbox and symlinked to
+agent-specific paths.
 
 ## Tips
 

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -4,7 +4,9 @@ Test whether your agent skill actually helps agents perform better.
 ## Install
 
 ```bash
-uv tool install --prerelease allow 'benchflow==0.6.0'
+uv tool install --prerelease allow \
+  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
+# 0.6.0 is not on PyPI yet — install the newest 0.6.0-rc.* wheel from GitHub releases (replace rc.6 with the latest).
 ```
 
 ## Overview
@@ -395,7 +397,9 @@ BenchFlow generates everything ephemeral — only results persist.
 **CI integration:**
 ```bash
 # In your skill's CI pipeline
-uv tool install --prerelease allow 'benchflow==0.6.0'
+uv tool install --prerelease allow \
+  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
+# 0.6.0 is not on PyPI yet — install the newest 0.6.0-rc.* wheel from GitHub releases (replace rc.6 with the latest).
 bench skills eval . --agent claude-agent-acp --no-baseline
 ```
 

--- a/src/benchflow/_utils/dataset_registry.py
+++ b/src/benchflow/_utils/dataset_registry.py
@@ -12,7 +12,7 @@ import posixpath
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.request import urlopen
 
 from benchflow._utils import benchmark_repos
@@ -155,13 +155,20 @@ def resolve_dataset(
         (
             e
             for e in entries
-            if e.get("name") == name and str(e.get("version")) == version
+            if isinstance(e, dict)
+            and e.get("name") == name
+            and str(e.get("version")) == version
         ),
         None,
     )
     if entry is None:
         available = (
-            ", ".join(f"{e.get('name')}@{e.get('version')}" for e in entries) or "none"
+            ", ".join(
+                f"{e.get('name')}@{e.get('version')}"
+                for e in entries
+                if isinstance(e, dict)
+            )
+            or "none"
         )
         raise DatasetResolutionError(
             f"Dataset {spec!r} not found in registry (available: {available})"
@@ -170,7 +177,18 @@ def resolve_dataset(
     if not tasks:
         raise DatasetResolutionError(f"Dataset {spec!r} has no tasks in the registry")
 
-    snapshots = {(t["git_url"], t["git_commit_id"]) for t in tasks}
+    def _require(task: object, key: str) -> str:
+        # A registry written by hand / a stale tool can have task entries that
+        # are non-objects or miss a key; surface a clean DatasetResolutionError
+        # instead of a raw KeyError / TypeError ('string indices must be integers').
+        if not isinstance(task, dict) or key not in task:
+            raise DatasetResolutionError(
+                f"Dataset {spec!r} has a malformed task entry "
+                f"(expected an object with {key!r}): {task!r}"
+            )
+        return str(cast("dict[str, Any]", task)[key])
+
+    snapshots = {(_require(t, "git_url"), _require(t, "git_commit_id")) for t in tasks}
     if len(snapshots) != 1:
         raise DatasetResolutionError(
             f"Dataset {spec!r} spans {len(snapshots)} git snapshots — "
@@ -178,7 +196,7 @@ def resolve_dataset(
         )
     git_url, commit = next(iter(snapshots))
 
-    parents = {posixpath.dirname(t["path"].rstrip("/")) for t in tasks}
+    parents = {posixpath.dirname(_require(t, "path").rstrip("/")) for t in tasks}
     if len(parents) != 1:
         raise DatasetResolutionError(
             f"Dataset {spec!r} tasks live under {len(parents)} parent "
@@ -188,12 +206,12 @@ def resolve_dataset(
 
     task_digests: dict[str, str] = {}
     for t in tasks:
-        base = posixpath.basename(t["path"].rstrip("/"))
+        base = posixpath.basename(_require(t, "path").rstrip("/"))
         if base in task_digests:
             raise DatasetResolutionError(
                 f"Dataset {spec!r} has two tasks named {base!r}"
             )
-        task_digests[base] = t["digest"]
+        task_digests[base] = _require(t, "digest")
 
     repo = _github_org_repo(git_url)
     resolved = benchmark_repos.resolve_source_with_metadata(

--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -669,7 +669,7 @@ def register_agent_router(
         try:
             target, written = create_benchmark(name, root)
         except (InvalidBenchmarkName, BenchmarkExistsError) as exc:
-            console.print(f"[red]{exc}[/red]")
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise typer.Exit(1) from exc
         console.print(f"[green]Scaffolded[/green] {target}")
         for rel in written:
@@ -791,16 +791,16 @@ def register_agent_router(
             else:
                 data = load_parity_experiment(root, name)
         except InvalidBenchmarkName as exc:
-            console.print(f"[red]{exc}[/red]")
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise typer.Exit(1) from exc
         except BenchmarkNotFound as exc:
-            console.print(f"[red]{exc}[/red]")
+            console.print(f"[red]{escape(str(exc))}[/red]")
             raise typer.Exit(1) from exc
         except ParityRerunError as exc:
-            console.print(f"[red]--rerun failed: {exc}[/red]")
+            console.print(f"[red]--rerun failed: {escape(str(exc))}[/red]")
             raise typer.Exit(1) from exc
         except ParityExperimentMissing as exc:
-            console.print(f"[yellow]{exc}[/yellow]")
+            console.print(f"[yellow]{escape(str(exc))}[/yellow]")
             data = {}
 
         report = build_verify_report(name, data, tolerance=tolerance)
@@ -845,7 +845,7 @@ def register_agent_router(
         issue = render_divergence_issue(report)
         if issue_out is not None:
             Path(issue_out).write_text(issue)
-            console.print(f"[dim]Issue draft written to {issue_out}[/dim]")
+            console.print(f"[dim]Issue draft written to {escape(str(issue_out))}[/dim]")
         else:
             console.print(issue)
         raise typer.Exit(1)

--- a/src/benchflow/cli/_live_progress.py
+++ b/src/benchflow/cli/_live_progress.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 from rich.console import Group
 from rich.live import Live
+from rich.markup import escape
 from rich.table import Table
 from rich.text import Text
 
@@ -90,7 +91,13 @@ class _WarningBuffer(logging.Handler):
     def replay(self) -> None:
         for record in self._records:
             style = "red" if record.levelno >= logging.ERROR else "yellow"
-            console.print(f"[{style}]{record.getMessage()}[/{style}]")
+            # escape(): buffered warnings carry user-derived text (a malformed
+            # task dir name, a resume agent-mismatch from config.json) that can
+            # contain Rich markup — an unescaped replay raises MarkupError and
+            # crashes the CLI on live-context exit (and silently swallows
+            # balanced [tokens]), defeating the buffer's "warnings must survive
+            # the Live" purpose.
+            console.print(f"[{style}]{escape(record.getMessage())}[/{style}]")
 
 
 @contextlib.contextmanager

--- a/src/benchflow/cli/_shared.py
+++ b/src/benchflow/cli/_shared.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -27,6 +28,21 @@ console = Console()
 # stderr console for out-of-band notices (deprecations) so they never corrupt
 # stdout consumers like `--json` (e.g. `environment list --json`).
 err_console = Console(stderr=True)
+
+
+def print_error(message: str) -> None:
+    """Print a red error line, escaping Rich markup in ``message``.
+
+    The single safe sink for CLI error messages: error text routinely
+    interpolates user-supplied values (a task path, an agent name, a config
+    error echoing a field) that can contain ``[`` / ``[/x]`` tokens. An
+    unescaped ``console.print(f"[red]{value}[/red]")`` then makes Rich itself
+    raise ``MarkupError`` — turning a clean error into a raw traceback. Route
+    every such message through here. (Messages with NO user input escape to a
+    no-op, so it is always safe.)
+    """
+    console.print(f"[red]{escape(str(message))}[/red]")
+
 
 _DEPRECATION_WARNED: set[str] = set()
 
@@ -107,5 +123,5 @@ def _report_eval_result(result: EvaluationResult, job_dir: Path | None = None) -
         f"({result.score:.1%})[/{style}]{err_part}"
     )
     if job_dir is not None:
-        console.print(f"[dim]Artifacts:[/dim] {job_dir}")
-        console.print(f"[dim]Summary:  [/dim] {job_dir}/summary.json")
+        console.print(f"[dim]Artifacts:[/dim] {escape(str(job_dir))}")
+        console.print(f"[dim]Summary:  [/dim] {escape(str(job_dir))}/summary.json")

--- a/src/benchflow/cli/agent.py
+++ b/src/benchflow/cli/agent.py
@@ -22,6 +22,7 @@ from benchflow.cli._shared import (
     _REQUIRES_AUTH_NOTE,
     _format_requires,
     console,
+    print_error,
 )
 
 
@@ -70,7 +71,7 @@ def register_agent(app: typer.Typer) -> None:
         resolved = AGENT_ALIASES.get(name, name)
         cfg = AGENTS.get(resolved)
         if not cfg:
-            console.print(f"[red]Unknown agent: {name}[/red]")
+            print_error(f"Unknown agent: {name}")
             raise typer.Exit(1)
 
         # Collect aliases that point to this agent

--- a/src/benchflow/cli/environment.py
+++ b/src/benchflow/cli/environment.py
@@ -58,7 +58,7 @@ def register_environment(app: typer.Typer) -> None:
                 f"{escape(str(e))}"
             )
             raise typer.Exit(1) from None
-        console.print(f"[green]Environment created:[/green] {env}")
+        console.print(f"[green]Environment created:[/green] {escape(str(env))}")
         console.print(f"  Task:    {env.task_path}")
         console.print(f"  Sandbox: {env.sandbox}")
         console.print(

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -90,4 +90,4 @@ def register_hub(app: typer.Typer) -> None:
             f"{summary['blocked']} blocked"
         )
         if out is not None:
-            console.print(f"[green]Wrote JSONL report:[/green] {out}")
+            console.print(f"[green]Wrote JSONL report:[/green] {escape(str(out))}")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -39,6 +39,7 @@ from benchflow.cli._shared import (
     _exit_if_evaluation_had_errors,
     _report_eval_result,
     console,
+    print_error,
 )
 from benchflow.cli.adopt import register_adopt
 from benchflow.cli.agent import register_agent
@@ -109,7 +110,7 @@ def _parse_agent_env(entries: list[str] | None) -> dict[str, str]:
     parsed: dict[str, str] = {}
     for entry in entries or []:
         if "=" not in entry:
-            console.print(f"[red]Invalid env var: {entry}[/red]")
+            print_error(f"Invalid env var: {entry}")
             raise typer.Exit(1)
         key, value = entry.split("=", 1)
         parsed[key] = value
@@ -125,7 +126,7 @@ def _apply_dotenv_to_process_env() -> None:
 def _normalize_eval_agent_or_exit(agent_spec: str) -> str:
     protocol, canonical_agent = parse_agent_spec(agent_spec)
     if protocol not in ("acp", "acpx"):
-        console.print(f"[red]Unsupported eval agent protocol: {protocol}[/red]")
+        print_error(f"Unsupported eval agent protocol: {protocol}")
         raise typer.Exit(1)
     if protocol == "acpx":
         return f"acpx/{canonical_agent}"
@@ -146,10 +147,10 @@ def _daytona_client_or_exit():
                 "Install it with [cyan]uv sync --extra sandbox-daytona[/cyan]."
             )
         else:
-            console.print(f"[red]daytona SDK import failed: {exc}[/red]")
+            print_error(f"daytona SDK import failed: {exc}")
         raise typer.Exit(1) from None
     except Exception as exc:
-        console.print(f"[red]daytona SDK import failed: {exc}[/red]")
+        print_error(f"daytona SDK import failed: {exc}")
         raise typer.Exit(1) from None
 
 
@@ -485,7 +486,7 @@ def eval_create(
     try:
         plan = build_eval_plan(request)
     except EvalPlanError as exc:
-        console.print(f"[red]{exc}[/red]")
+        print_error(f"{exc}")
         raise typer.Exit(1) from None
 
     if config_file:
@@ -531,14 +532,14 @@ def eval_create(
             with console.status(f"Resolving dataset {dataset}…"):
                 resolved_dataset = resolve_dataset(dataset, registry=registry_source)
         except DatasetResolutionError as e:
-            console.print(f"[red]{e}[/red]")
+            print_error(f"{e}")
             raise typer.Exit(1) from None
         version_issue = bench_version_issue(resolved_dataset.bench_version)
         if version_issue and not ignore_bench_version:
             # Hard gate: published results must come from a harness the
             # dataset version was validated against. The escape hatch keeps
             # local experimentation possible without weakening the default.
-            console.print(f"[red]{version_issue}[/red]")
+            print_error(f"{version_issue}")
             console.print(
                 "Pick a dataset version validated for this harness, or re-run "
                 "with --ignore-bench-version to proceed anyway."
@@ -546,10 +547,10 @@ def eval_create(
             raise typer.Exit(1)
         if version_issue:
             console.print(
-                f"[yellow]Warning:[/yellow] {version_issue} (--ignore-bench-version)"
+                f"[yellow]Warning:[/yellow] {escape(str(version_issue))} (--ignore-bench-version)"
             )
         console.print(
-            f"[green]✓[/green] {resolved_dataset.spec}: "
+            f"[green]✓[/green] {escape(str(resolved_dataset.spec))}: "
             f"{len(resolved_dataset.task_names)} tasks, digests verified "
             f"({str(resolved_dataset.provenance.get('resolved_sha', ''))[:12]})"
         )
@@ -647,10 +648,10 @@ def run_batch_eval(
                 )
             )
     except EmptyTaskSelectionError as e:
-        console.print(f"[red]{e}[/red]")
+        print_error(f"{e}")
         raise typer.Exit(1) from None
     except (ValueError, RuntimeError, ShardWorkerError) as e:
-        console.print(f"[red]{e}[/red]")
+        print_error(f"{e}")
         raise typer.Exit(1) from None
 
     job_name = getattr(result, "job_name", None)
@@ -729,7 +730,7 @@ def _run_config_file_eval(plan: "EvalPlan") -> None:
     try:
         result = asyncio.run(j.run())
     except (EmptyTaskSelectionError, ValueError) as e:
-        console.print(f"[red]{e}[/red]")
+        print_error(f"{e}")
         raise typer.Exit(1) from None
     job_name = getattr(result, "job_name", None)
     job_dir = Path(j._jobs_dir) / job_name if job_name else None
@@ -765,12 +766,12 @@ def _run_source_env_eval(
         )
     if plan.eval_environment != "docker":
         console.print(
-            f"[yellow]--sandbox {plan.eval_environment!r} is not used by source-env runs; "
+            f"[yellow]--sandbox {escape(repr(plan.eval_environment))} is not used by source-env runs; "
             "the hosted Verifiers environment owns its harness/sandbox.[/yellow]"
         )
     if plan.eval_agent != DEFAULT_AGENT:
         console.print(
-            f"[dim]source-env records --agent {plan.eval_agent!r}, but executes the model endpoint through Verifiers.[/dim]"
+            f"[dim]source-env records --agent {escape(repr(plan.eval_agent))}, but executes the model endpoint through Verifiers.[/dim]"
         )
     if plan.eval_env_manifest is not None:
         console.print(
@@ -808,25 +809,25 @@ def _run_source_env_eval(
             )
         )
     except HostedEnvError as e:
-        console.print(f"[red]{e}[/red]")
+        print_error(f"{e}")
         raise typer.Exit(1) from None
 
     console.print(f"\n[bold]Environment:[/bold] {run_result.source_env.env_uid}")
-    console.print(f"[bold]Hub:[/bold] {run_result.source_env.hub_url}")
+    console.print(f"[bold]Hub:[/bold] {escape(str(run_result.source_env.hub_url))}")
     console.print(
-        f"[bold]Model:[/bold] {run_result.normalized_model}"
+        f"[bold]Model:[/bold] {escape(str(run_result.normalized_model))}"
         + (
             f" [dim](from {run_result.model})[/dim]"
             if run_result.normalized_model != run_result.model
             else ""
         )
     )
-    console.print(f"[bold]Run dir:[/bold] {run_result.run_dir}")
+    console.print(f"[bold]Run dir:[/bold] {escape(str(run_result.run_dir))}")
     console.print(f"[bold]Reward:[/bold] {run_result.reward}")
     if run_result.total_tool_calls is not None:
         console.print(f"[bold]Tool calls:[/bold] {run_result.total_tool_calls}")
     if run_result.error:
-        console.print(f"[red]Error:[/red] {run_result.error}")
+        console.print(f"[red]Error:[/red] {escape(str(run_result.error))}")
         raise typer.Exit(1)
 
 
@@ -839,7 +840,7 @@ def eval_list(
 ) -> None:
     """List completed evaluations."""
     if not jobs_dir.exists():
-        console.print(f"[yellow]No jobs directory: {jobs_dir}[/yellow]")
+        console.print(f"[yellow]No jobs directory: {escape(str(jobs_dir))}[/yellow]")
         return
     if not jobs_dir.is_dir():
         # exists() is True for a file; iterdir() below would NotADirectoryError.
@@ -920,7 +921,7 @@ def eval_metrics(
     if not Path(jobs_dir).is_dir():
         # Without this, collect_metrics rglobs nothing and reports a green
         # all-zeros table with exit 0 — a silent trap for scripted collectors.
-        console.print(f"[red]Not a directory: {jobs_dir}[/red]")
+        print_error(f"Not a directory: {jobs_dir}")
         raise typer.Exit(1)
     m = collect_metrics(str(jobs_dir), benchmark=benchmark, agent=agent, model=model)
     summary = m.summary()
@@ -950,11 +951,17 @@ def eval_metrics(
     console.print(table)
 
     if summary["passed_tasks"]:
-        console.print(f"\n[green]Passed:[/green] {', '.join(summary['passed_tasks'])}")
+        console.print(
+            f"\n[green]Passed:[/green] {escape(', '.join(summary['passed_tasks']))}"
+        )
     if summary["errored_tasks"]:
-        console.print(f"[yellow]Errors:[/yellow] {', '.join(summary['errored_tasks'])}")
+        console.print(
+            f"[yellow]Errors:[/yellow] {escape(', '.join(summary['errored_tasks']))}"
+        )
     if summary["error_breakdown"]:
-        console.print(f"[yellow]Error breakdown:[/yellow] {summary['error_breakdown']}")
+        console.print(
+            f"[yellow]Error breakdown:[/yellow] {escape(str(summary['error_breakdown']))}"
+        )
 
 
 @eval_app.command("view")

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from rich.markup import escape
 from rich.table import Table
 
 from benchflow.cli._options import (
@@ -19,7 +20,7 @@ from benchflow.cli._options import (
     JobsDirOption,
     SandboxOption,
 )
-from benchflow.cli._shared import console
+from benchflow.cli._shared import console, print_error
 from benchflow.sandbox.providers import is_known_provider, providers_phrase
 
 
@@ -100,17 +101,16 @@ def register_skills(app: typer.Typer) -> None:
         from benchflow.skill_eval import SkillEvaluator, export_gepa_traces
 
         if not is_known_provider(environment):
-            console.print(
-                f"[red]Invalid --sandbox {environment!r}: "
-                f"choose {providers_phrase()}[/red]"
+            print_error(
+                f"Invalid --sandbox {environment!r}: choose {providers_phrase()}"
             )
             raise typer.Exit(1)
         if agent is None:
             agent = ["claude-agent-acp"]
         if not (skill_dir / "evals" / "evals.json").exists():
-            console.print(
-                f"[red]No evals/evals.json found in {skill_dir}[/red]\n"
-                f"Create one with test cases. See: benchflow skills eval --help"
+            print_error(
+                f"No evals/evals.json found in {skill_dir}\n"
+                "Create one with test cases. See: benchflow skills eval --help"
             )
             raise typer.Exit(1)
 
@@ -122,10 +122,10 @@ def register_skills(app: typer.Typer) -> None:
             FileNotFoundError,
             NotADirectoryError,
         ) as e:
-            console.print(f"[red]{e}[/red]")
+            print_error(f"{e}")
             raise typer.Exit(1) from None
         console.print(
-            f"[bold]Skill eval:[/bold] {evaluator.dataset.skill_name} "
+            f"[bold]Skill eval:[/bold] {escape(str(evaluator.dataset.skill_name))} "
             f"({len(evaluator.dataset.cases)} cases)"
         )
         console.print(f"  Agents: {', '.join(agent)}")
@@ -150,7 +150,7 @@ def register_skills(app: typer.Typer) -> None:
             FileNotFoundError,
             NotADirectoryError,
         ) as e:
-            console.print(f"[red]{e}[/red]")
+            print_error(f"{e}")
             raise typer.Exit(1) from None
 
         # Display results
@@ -174,4 +174,6 @@ def register_skills(app: typer.Typer) -> None:
                 evaluator.dataset,
                 output_dir=f"{jobs_dir}/skill-eval/{result.skill_name}/gepa",
             )
-            console.print(f"[green]GEPA traces exported to {gepa_dir}[/green]")
+            console.print(
+                f"[green]GEPA traces exported to {escape(str(gepa_dir))}[/green]"
+            )

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -14,7 +14,7 @@ from typing import Annotated, Literal, cast
 import typer
 from rich.markup import escape
 
-from benchflow.cli._shared import console
+from benchflow.cli._shared import console, print_error
 from benchflow.cli.trace_import import register_tasks_generate
 from benchflow.sandbox.providers import providers_phrase
 
@@ -72,7 +72,7 @@ def register_tasks(app: typer.Typer) -> None:
             # read-only parent — siblings (migrate/normalize/export) already
             # degrade gracefully; init was the outlier that dumped a traceback.
             # escape(): the OSError message echoes the user-supplied path.
-            console.print(f"[red]{escape(str(e))}[/red]")
+            print_error(str(e))
             raise typer.Exit(1) from None
 
     @tasks_app.command("check")
@@ -136,10 +136,12 @@ def register_tasks(app: typer.Typer) -> None:
         )
         if not issues:
             console.print(
-                f"[green]✓[/green] {task_dir.name} — valid ({validation_level})"
+                f"[green]✓[/green] {escape(task_dir.name)} — valid ({validation_level})"
             )
         else:
-            console.print(f"[red]✗[/red] {task_dir.name} — {len(issues)} issue(s):")
+            console.print(
+                f"[red]✗[/red] {escape(task_dir.name)} — {len(issues)} issue(s):"
+            )
             for issue in issues:
                 # Escape Rich markup so literal section names like "[agent]"
                 # render verbatim instead of being parsed as styling (#379).
@@ -179,7 +181,7 @@ def register_tasks(app: typer.Typer) -> None:
             NotADirectoryError,
             ValueError,
         ) as e:
-            console.print(f"[red]{e}[/red]")
+            print_error(f"{e}")
             raise typer.Exit(1) from None
 
         console.print(f"[green]Created:[/green] {result.task_md}")
@@ -215,7 +217,7 @@ def register_tasks(app: typer.Typer) -> None:
         try:
             result = normalize_task_md(task_dir, output_path=output, write=write)
         except (FileNotFoundError, NotADirectoryError, ValueError) as e:
-            console.print(f"[red]{e}[/red]")
+            print_error(f"{e}")
             raise typer.Exit(1) from None
 
         if result.output_path is None:
@@ -283,10 +285,10 @@ def register_tasks(app: typer.Typer) -> None:
             NotADirectoryError,
             ValueError,
         ) as e:
-            console.print(f"[red]{e}[/red]")
+            print_error(f"{e}")
             raise typer.Exit(1) from None
 
-        console.print(f"[green]Exported:[/green] {output_dir}")
+        console.print(f"[green]Exported:[/green] {escape(str(output_dir))}")
         console.print(f"  target: {report.target}")
         console.print(f"  status: {report.status}")
         console.print(f"  losses: {len(report.losses)}")
@@ -316,7 +318,7 @@ def register_tasks(app: typer.Typer) -> None:
             return (p / "task.toml").is_file() or (p / "task.md").is_file()
 
         if not path.is_dir():
-            console.print(f"[red]Not a directory: {path}[/red]")
+            print_error(f"Not a directory: {path}")
             raise typer.Exit(1)
 
         if _is_task_dir(path):
@@ -327,9 +329,9 @@ def register_tasks(app: typer.Typer) -> None:
 
         task_dirs = sorted(d for d in path.iterdir() if d.is_dir() and _is_task_dir(d))
         if not task_dirs:
-            console.print(
-                f"[red]No tasks under {path} — expected task.toml or task.md "
-                f"in it or in its immediate subdirectories[/red]"
+            print_error(
+                f"No tasks under {path} — expected task.toml or task.md "
+                "in it or in its immediate subdirectories"
             )
             raise typer.Exit(1)
         for task_dir in task_dirs:

--- a/src/benchflow/cli/trace_import.py
+++ b/src/benchflow/cli/trace_import.py
@@ -17,6 +17,7 @@ from typing import Annotated, Literal, cast
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 from rich.table import Table
 
 console = Console()
@@ -247,7 +248,7 @@ def _load_file(path: Path, format: str) -> list:
     )
 
     if not path.exists():
-        console.print(f"[red]File not found: {path}[/red]")
+        console.print(f"[red]File not found: {escape(str(path))}[/red]")
         raise typer.Exit(1)
 
     detected_format = format
@@ -262,7 +263,7 @@ def _load_file(path: Path, format: str) -> list:
     elif detected_format == "claude-messages":
         return _parse_hf_messages_file(path)
     else:
-        console.print(f"[red]Unknown format: {detected_format}[/red]")
+        console.print(f"[red]Unknown format: {escape(str(detected_format))}[/red]")
         raise typer.Exit(1)
 
 

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -182,6 +182,7 @@ _INSTALL_URL_DOCS = (
     "docs/getting-started.md",
     "docs/release.md",
     "docs/agent-quickstart.md",
+    "docs/skill-eval.md",
     ".claude/skills/benchflow/SKILL.md",
 )
 # Matches only CONCRETE pins, e.g.

--- a/tests/test_release_hardening_r5.py
+++ b/tests/test_release_hardening_r5.py
@@ -1,0 +1,103 @@
+"""Round-5 hardening: the markup-escape class + dataset-registry guards.
+
+The stress sweep found that #732's markup-escaping was per-handler, not
+systemic — ~6 more `console.print(f"[red]{user_input}[/red]")` sites (and the
+#730 dashboard warning buffer, fed by #733's malformed-task warning) still
+raised MarkupError on a `[`-bearing value. The fix is one `print_error()` sink
+that escapes, routed everywhere. These tests pin the class closed and pin the
+dataset-registry structural guards (raw KeyError/TypeError → DatasetResolutionError).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+
+runner = CliRunner()
+
+# Rich markup that raises MarkupError if interpolated unescaped.
+_MARKUP = "[/x]"
+
+
+def test_print_error_escapes_markup() -> None:
+    from benchflow.cli._shared import print_error
+
+    # If print_error did not escape, console.print would raise MarkupError here.
+    print_error(f"Unknown agent: {_MARKUP} and [bold]unclosed")
+
+
+def test_warning_buffer_replay_escapes_markup() -> None:
+    # #730 B5 buffer replays WARNING+ after the Live; #733's malformed-task
+    # warning carries a user dir name that can contain markup.
+    from benchflow.cli._live_progress import _WarningBuffer
+
+    buf = _WarningBuffer()
+    rec = logging.LogRecord(
+        name="benchflow",
+        level=logging.WARNING,
+        pathname="f",
+        lineno=1,
+        msg="Skipping malformed task %r: boom",
+        args=("a-[/red]-b",),
+        exc_info=None,
+    )
+    buf.emit(rec)
+    buf.replay()  # must not raise MarkupError
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["agent", "show", _MARKUP],
+        ["eval", "metrics", f"/tmp/nope-{_MARKUP}-dir"],
+    ],
+)
+def test_markup_in_cli_args_exits_clean_not_markup_error(argv) -> None:
+    res = runner.invoke(app, argv)
+    assert res.exit_code != 0
+    # A clean typer.Exit becomes SystemExit; a MarkupError would surface as the
+    # uncaught exception instead.
+    assert isinstance(res.exception, SystemExit), (
+        f"{argv} raised {type(res.exception).__name__}: {res.exception}"
+    )
+
+
+def test_eval_create_invalid_agent_env_markup_does_not_crash() -> None:
+    res = runner.invoke(
+        app, ["eval", "create", "--tasks-dir", ".", "--agent-env", _MARKUP]
+    )
+    assert res.exit_code != 0
+    assert isinstance(res.exception, SystemExit)
+
+
+# ── dataset registry: malformed entries → DatasetResolutionError ──────────────
+
+
+@pytest.mark.parametrize(
+    "registry",
+    [
+        # task object missing git_url/git_commit_id
+        [{"name": "evil", "version": "1.0", "tasks": [{"path": "tasks/foo"}]}],
+        # tasks is a list of strings (string indices error)
+        [{"name": "evil", "version": "1.0", "tasks": ["foo"]}],
+        # top-level list of strings (e.get on a str)
+        ["evil"],
+    ],
+)
+def test_resolve_dataset_malformed_registry_raises_clean(tmp_path, registry) -> None:
+    from benchflow._utils.dataset_registry import (
+        DatasetResolutionError,
+        resolve_dataset,
+    )
+
+    reg = tmp_path / "registry.json"
+    reg.write_text(json.dumps(registry))
+    # Must be a clean DatasetResolutionError, never a raw KeyError / TypeError /
+    # AttributeError leaking from per-entry structural access.
+    with pytest.raises(DatasetResolutionError):
+        resolve_dataset("evil@1.0", str(reg))


### PR DESCRIPTION
The **stress + verify workflow** found my #732 markup-escaping was *per-handler, not systemic* — and that my #733 malformed-task warning crashes #730's dashboard buffer. This closes the whole class (re-grep clean across **all** colors), the single-`print_error()`-sink fix the round-2 review recommended.

### Markup-crash class — now closed
`console.print(f"[<style>]{user_value}[/<style>]")` raised a raw `MarkupError` whenever the value held `[`/`[/x]` — confirmed at ~15 sites across red **and** yellow/green/dim: `agent show`, `eval --agent-env`, `eval metrics`/`eval list` non-dir + task names, `eval create --include`, `--sandbox`/`--dataset` errors, `skills eval` path/validation, `tasks` migrate/normalize/export/check, the post-run **Artifacts/Summary** lines, and the source-env result block.

- New **`print_error(message)`** in `cli/_shared.py` — one error sink that escapes. Full-red shared-console sites route through it; mixed-style (`✗` / `Error:` / `Hub:`) and local-`Console()` sites (`trace_import`, `agent_router`) inline-escape only the user value so styling survives.
- **`_WarningBuffer.replay()`** escapes each buffered message — no more `MarkupError` on a malformed-task / resume-mismatch warning (and balanced `[tokens]` survive instead of vanishing).

### dataset_registry guards (completes B2)
`resolve_dataset` per-entry/per-task structural access is guarded — a malformed registry (missing key, task entries as strings, a top-level list of strings) raises `DatasetResolutionError`, never a raw `KeyError`/`TypeError`/`AttributeError`.

### Docs (copy-paste-breaking, found by the dogfood agent)
- `skill-eval.md` install was `benchflow==0.6.0` (**not on PyPI → unsatisfiable**) → the `0.6.0-rc.6` GitHub-release wheel, matching the other 4 install docs and **now in the install-URL drift guard**.
- `.claude/skills/benchflow/SKILL.md` `--skills-dir` example was missing the **required** `--skill-mode with-skill` (ValueError on copy-paste).

### Verification
- **Full suite 4048 passed**; `ruff` / `ruff format --check` / `ty` clean on src+tests+tools; re-grep finds **zero** remaining user-derived unescaped colored interpolations.
- New `tests/test_release_hardening_r5.py` (8): `print_error` + buffer escape, markup in `agent show` / `eval metrics` / `--agent-env` exits clean (not MarkupError), malformed-registry → `DatasetResolutionError`.
- **Adversarial review: APPROVE-WITH-NITS → addressed.** It caught a double-escape regression I'd introduced (`tasks init` printed a stray `\[`) and that I'd only swept *red*; both fixed, and the sweep extended to all colors.

Deferred (lower-severity, noted in commit): the #14/#15 drift-test regex edge cases and the `--config` clone-failure `CalledProcessError` wrap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are defensive (CLI display escaping, clearer registry errors, doc/install fixes) with no auth, data, or eval orchestration logic altered beyond error messaging.
> 
> **Overview**
> **Closes a class of CLI crashes** where user-supplied paths, agent names, or env values containing `[` / `[/x]` made Rich raise `MarkupError` instead of showing the intended error.
> 
> Adds **`print_error()`** in `cli/_shared.py` as the shared red-error sink and routes most eval/tasks/skills/agent error paths through it. Mixed-style output and local consoles still **`escape()`** only the user-derived fragments. **`_WarningBuffer.replay()`** escapes buffered WARNING+ lines so live-eval exit does not crash on markup in task-dir warnings.
> 
> **`resolve_dataset`** now validates registry entries and task objects (`_require`, `isinstance` checks) so malformed `registry.json` raises **`DatasetResolutionError`** instead of raw `KeyError` / `TypeError`.
> 
> **Docs:** `skill-eval.md` and CI snippets switch from unsatisfiable `benchflow==0.6.0` on PyPI to the GitHub **0.6.0-rc.6** wheel; `skill-eval.md` joins the install-URL drift guard. **`benchflow` SKILL.md** adds required **`--skill-mode with-skill`** to the `--skills-dir` example.
> 
> **Tests:** `tests/test_release_hardening_r5.py` pins markup-safe CLI exits and malformed-registry behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9702d1649ae257c6f05d2e17e4daff66e5ec8a55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->