### PR TITLE
feat(cli): split overloaded `bench environment` — hosted reads → `bench hub env`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@
   convert`, `bench agent verify` → `bench adopt verify`. `bench agent` now means
   agent management only (`list` / `show`). The old `bench agent create|run|verify`
   still work as hidden aliases and print a one-line deprecation notice (stderr).
-- `bench environment list --hub` → `--provider` (the value is a hosted-env
-  provider, e.g. `primeintellect`). `--hub` remains as a hidden deprecated alias.
+- Hosted-environment browsing moved out of the overloaded `bench environment`
+  group into `bench hub env {list,show,inspect}` (`bench environment` is now
+  local sandbox lifecycle only: `create`/`list`/`cleanup`). The old
+  `bench environment show`/`inspect` and `bench environment list --provider`/`--hub`
+  still work as hidden deprecated aliases (one-line stderr notice; removed in 0.7).
+  The hosted *run* path stays on `bench eval create --source-env`.
 
 ### Removed
 - Dead-code purge (no public-API impact unless noted): removed the unused

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -457,28 +457,16 @@ bench environment create tasks/my-task --sandbox daytona
 
 ### bench environment list
 
-List active Daytona sandboxes, or list a hosted hub.
+List active local (Daytona) sandboxes.
 
 ```bash
 bench environment list
-bench environment list --provider primeintellect --owner primeintellect --search general-agent --limit 5
 ```
 
-### bench environment show
-
-Show hosted environment metadata.
-
-```bash
-bench environment show primeintellect/general-agent --version 0.1.1
-```
-
-### bench environment inspect
-
-Inspect a file from a hosted environment package.
-
-```bash
-bench environment inspect primeintellect/general-agent --version 0.1.1 --path README.md
-```
+> Browsing a hosted provider's environments moved to [`bench hub env`](#bench-hub-env). The
+> old `bench environment list --provider`/`--hub`, `bench environment show`, and `bench
+> environment inspect` still work as **deprecated aliases** through 0.6 (one-line stderr
+> notice; removed in 0.7).
 
 ### bench environment cleanup
 
@@ -497,8 +485,19 @@ to disable that automatic pass and rely on the manual command above.
 
 ## bench hub
 
-Compatibility checks for external environment hubs (Harbor today; built to
-extend to other hubs).
+External environment hubs: compatibility checks (`check`) and browsing a hosted
+provider's environments (`env`).
+
+### bench hub env
+
+Read-only browsing of a hosted provider's environments (PrimeIntellect
+"Environments"). To *run* one, use [`bench eval create --source-env`](#bench-eval-create).
+
+```bash
+bench hub env list --provider primeintellect --owner primeintellect --search general-agent --limit 5
+bench hub env show primeintellect/general-agent --version 0.1.1
+bench hub env inspect primeintellect/general-agent --version 0.1.1 --path README.md
+```
 
 ### bench hub check
 

--- a/src/benchflow/cli/_hosted_env.py
+++ b/src/benchflow/cli/_hosted_env.py
@@ -1,0 +1,97 @@
+"""Shared hosted-environment read commands (PrimeIntellect "Environments").
+
+Canonically reached via ``bench hub env list|show|inspect`` (external
+environment-hub browsing); the deprecated ``bench environment list --provider``
+/ ``environment show`` / ``environment inspect`` aliases delegate here so there
+is exactly one copy of the logic. The actual API helpers live in
+``benchflow.hosted_env`` and are untouched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import typer
+from rich.markup import escape
+from rich.table import Table
+
+from benchflow.cli._shared import console, print_error
+
+_SUPPORTED_PROVIDER = "primeintellect"
+
+
+def hosted_env_list(
+    *,
+    provider: str,
+    owner: str | None,
+    search: str | None,
+    limit: int | None,
+    output_json: bool,
+) -> None:
+    """List a hosted provider's environments (table, or raw JSON to stdout)."""
+    if provider != _SUPPORTED_PROVIDER:
+        print_error(
+            f"Only --provider {_SUPPORTED_PROVIDER} is supported today (got {provider!r})"
+        )
+        raise typer.Exit(1)
+    from benchflow.hosted_env import HostedEnvError, prime_env_list
+
+    try:
+        raw = prime_env_list(owner=owner, search=search, limit=limit)
+    except HostedEnvError as e:
+        print_error(str(e))
+        raise typer.Exit(1) from None
+    if output_json:
+        console.print(raw)
+        return
+    data = json.loads(raw)
+    rows = (
+        data
+        if isinstance(data, list)
+        else data.get("environments", data.get("items", []))
+    )
+    table = Table(title="PrimeIntellect Environments")
+    table.add_column("Environment", style="cyan")
+    table.add_column("Version", style="green")
+    table.add_column("Visibility")
+    table.add_column("Updated", style="dim")
+    for item in rows:
+        name = (
+            item.get("environment")
+            or item.get("fullName")
+            or item.get("name")
+            or item.get("id")
+            or ""
+        )
+        version = str(item.get("version") or item.get("latestVersion") or "")
+        visibility = str(item.get("visibility") or item.get("private") or "")
+        updated = str(item.get("updated_at") or item.get("updatedAt") or "")
+        # escape(): cells are external-API strings that may contain Rich markup.
+        table.add_row(
+            escape(str(name)), escape(version), escape(visibility), escape(updated)
+        )
+    console.print(table)
+
+
+def hosted_env_show(*, source_env: str, version: str | None) -> None:
+    """Show hosted environment metadata."""
+    from benchflow.hosted_env import HostedEnvError, HostedEnvRef, prime_env_info
+
+    try:
+        ref = HostedEnvRef.parse(source_env, version=version)
+        console.print(prime_env_info(ref))
+    except HostedEnvError as e:
+        print_error(str(e))
+        raise typer.Exit(1) from None
+
+
+def hosted_env_inspect(*, source_env: str, version: str | None, path: str) -> None:
+    """Inspect a file from a hosted environment package."""
+    from benchflow.hosted_env import HostedEnvError, HostedEnvRef, prime_env_inspect
+
+    try:
+        ref = HostedEnvRef.parse(source_env, version=version)
+        console.print(prime_env_inspect(ref, path=path))
+    except HostedEnvError as e:
+        print_error(str(e))
+        raise typer.Exit(1) from None

--- a/src/benchflow/cli/environment.py
+++ b/src/benchflow/cli/environment.py
@@ -1,7 +1,9 @@
-"""``bench environment`` — environment management commands.
+"""``bench environment`` — local sandbox lifecycle (create / list / cleanup).
 
-Covers local Daytona sandbox lifecycle (create / list / cleanup) and the
-read-only hosted-environment hub views (list / show / inspect).
+Read-only browsing of hosted external-provider environments moved to
+``bench hub env list|show|inspect`` (see :mod:`benchflow.cli._hosted_env`); the
+old ``environment show|inspect`` and ``environment list --provider`` remain as
+hidden deprecated aliases through 0.6.
 
 Registered onto the top-level app by :func:`register_environment`;
 ``cli/main.py`` only wires the call. The Daytona client + cleanup helpers
@@ -13,7 +15,6 @@ deliberately live in ``cli/main.py`` (``_daytona_client_or_exit`` /
 
 from __future__ import annotations
 
-import json
 from datetime import UTC
 from pathlib import Path
 from typing import Annotated
@@ -22,6 +23,11 @@ import typer
 from rich.markup import escape
 from rich.table import Table
 
+from benchflow.cli._hosted_env import (
+    hosted_env_inspect,
+    hosted_env_list,
+    hosted_env_show,
+)
 from benchflow.cli._options import SandboxOption
 from benchflow.cli._shared import console, warn_deprecated
 
@@ -71,83 +77,61 @@ def register_environment(app: typer.Typer) -> None:
             str | None,
             typer.Option(
                 "--provider",
-                help="Hosted environment provider to list (e.g. primeintellect)",
+                hidden=True,
+                help="[deprecated] use `bench hub env list --provider`",
             ),
         ] = None,
         hub: Annotated[
             str | None,
-            typer.Option("--hub", hidden=True, help="[deprecated] use --provider"),
+            typer.Option(
+                "--hub", hidden=True, help="[deprecated] use `bench hub env list`"
+            ),
         ] = None,
         owner: Annotated[
             str | None,
-            typer.Option("--owner", help="Hosted provider owner/namespace filter"),
+            typer.Option("--owner", hidden=True, help="Hosted provider owner filter"),
         ] = None,
         search: Annotated[
             str | None,
-            typer.Option("--search", help="Hosted provider search query"),
+            typer.Option("--search", hidden=True, help="Hosted provider search query"),
         ] = None,
         limit: Annotated[
             int | None,
-            typer.Option("--limit", help="Maximum hosted provider results"),
+            typer.Option(
+                "--limit", hidden=True, help="Maximum hosted provider results"
+            ),
         ] = None,
         output_json: Annotated[
             bool,
-            typer.Option("--json", help="Emit raw JSON for hosted provider results"),
+            typer.Option(
+                "--json", hidden=True, help="Emit raw JSON for hosted results"
+            ),
         ] = False,
     ) -> None:
-        """List active Daytona sandboxes or hosted provider environments."""
+        """List active local sandboxes.
+
+        (Hosted-provider browsing moved to ``bench hub env list``; the
+        ``--provider``/``--hub`` options here are deprecated aliases.)
+        """
         from datetime import datetime
 
         from benchflow.cli import main as cli_main
 
-        # --hub is the deprecated spelling of --provider (kept through 0.6).
-        if hub is not None:
-            warn_deprecated(
-                "bench environment list --hub", "bench environment list --provider"
-            )
-            if provider is None:
-                provider = hub
-
+        # Hosted browsing moved to `bench hub env list`. --provider/--hub stay
+        # as deprecated aliases (one stderr nudge) that delegate to the same
+        # logic, so existing scripts keep working through 0.6.
+        provider = provider or hub
         if provider:
-            if provider != "primeintellect":
-                console.print(
-                    "[red]Only --provider primeintellect is supported today[/red]"
-                )
-                raise typer.Exit(1)
-            from benchflow.hosted_env import HostedEnvError, prime_env_list
-
-            try:
-                raw = prime_env_list(owner=owner, search=search, limit=limit)
-            except HostedEnvError as e:
-                console.print(f"[red]{escape(str(e))}[/red]")
-                raise typer.Exit(1) from None
-            if output_json:
-                console.print(raw)
-                return
-            data = json.loads(raw)
-            rows = (
-                data
-                if isinstance(data, list)
-                else data.get("environments", data.get("items", []))
+            warn_deprecated(
+                "bench environment list --provider", "bench hub env list --provider"
             )
-            table = Table(title="PrimeIntellect Environments")
-            table.add_column("Environment", style="cyan")
-            table.add_column("Version", style="green")
-            table.add_column("Visibility")
-            table.add_column("Updated", style="dim")
-            for item in rows:
-                name = (
-                    item.get("environment")
-                    or item.get("fullName")
-                    or item.get("name")
-                    or item.get("id")
-                    or ""
-                )
-                version = str(item.get("version") or item.get("latestVersion") or "")
-                visibility = str(item.get("visibility") or item.get("private") or "")
-                updated = str(item.get("updated_at") or item.get("updatedAt") or "")
-                table.add_row(name, version, visibility, updated)
-            console.print(table)
+            hosted_env_list(
+                provider=provider,
+                owner=owner,
+                search=search,
+                limit=limit,
+                output_json=output_json,
+            )
             return
 
         d = cli_main._daytona_client_or_exit()
@@ -175,7 +159,7 @@ def register_environment(app: typer.Typer) -> None:
         console.print(table)
         console.print(f"\n[bold]{total} sandbox(es)[/bold]")
 
-    @env_app.command("show")
+    @env_app.command("show", hidden=True, deprecated=True)
     def environment_show(
         source_env: Annotated[
             str,
@@ -188,17 +172,11 @@ def register_environment(app: typer.Typer) -> None:
             typer.Option("--version", help="Hosted environment version"),
         ] = None,
     ) -> None:
-        """Show hosted environment metadata."""
-        from benchflow.hosted_env import HostedEnvError, HostedEnvRef, prime_env_info
+        """[deprecated] Show hosted environment metadata — use `bench hub env show`."""
+        warn_deprecated("bench environment show", "bench hub env show")
+        hosted_env_show(source_env=source_env, version=version)
 
-        try:
-            ref = HostedEnvRef.parse(source_env, version=version)
-            console.print(prime_env_info(ref))
-        except HostedEnvError as e:
-            console.print(f"[red]{escape(str(e))}[/red]")
-            raise typer.Exit(1) from None
-
-    @env_app.command("inspect")
+    @env_app.command("inspect", hidden=True, deprecated=True)
     def environment_inspect(
         source_env: Annotated[
             str,
@@ -215,19 +193,9 @@ def register_environment(app: typer.Typer) -> None:
             typer.Option("--path", help="File inside the hosted environment package"),
         ] = "README.md",
     ) -> None:
-        """Inspect a file from a hosted environment package."""
-        from benchflow.hosted_env import (
-            HostedEnvError,
-            HostedEnvRef,
-            prime_env_inspect,
-        )
-
-        try:
-            ref = HostedEnvRef.parse(source_env, version=version)
-            console.print(prime_env_inspect(ref, path=path))
-        except HostedEnvError as e:
-            console.print(f"[red]{escape(str(e))}[/red]")
-            raise typer.Exit(1) from None
+        """[deprecated] Inspect a hosted environment file — use `bench hub env inspect`."""
+        warn_deprecated("bench environment inspect", "bench hub env inspect")
+        hosted_env_inspect(source_env=source_env, version=version, path=path)
 
     @env_app.command("cleanup")
     def environment_cleanup(

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -12,6 +12,11 @@ from typing import Annotated
 import typer
 from rich.markup import escape
 
+from benchflow.cli._hosted_env import (
+    hosted_env_inspect,
+    hosted_env_list,
+    hosted_env_show,
+)
 from benchflow.cli._shared import console
 from benchflow.hub.harbor_registry import DEFAULT_HARBOR_REGISTRY_URL
 
@@ -20,6 +25,7 @@ def register_hub(app: typer.Typer) -> None:
     """Attach the ``hub`` command group to the top-level benchflow app."""
     hub_app = typer.Typer(help="Compatibility checks for external environment hubs.")
     app.add_typer(hub_app, name="hub", rich_help_panel="Environments")
+    _register_hub_env(hub_app)
 
     @hub_app.command("check")
     def hub_check(
@@ -91,3 +97,76 @@ def register_hub(app: typer.Typer) -> None:
         )
         if out is not None:
             console.print(f"[green]Wrote JSONL report:[/green] {escape(str(out))}")
+
+
+def _register_hub_env(hub_app: typer.Typer) -> None:
+    """Attach ``bench hub env`` — read-only browsing of a hosted provider's
+    environments (PrimeIntellect "Environments"). The canonical home for what
+    used to be ``bench environment list --provider`` / ``show`` / ``inspect``;
+    the run path stays on ``bench eval create --source-env``."""
+    env_app = typer.Typer(
+        help="Browse hosted environments from an external provider (e.g. primeintellect)."
+    )
+    hub_app.add_typer(env_app, name="env")
+
+    @env_app.command("list")
+    def hub_env_list(
+        provider: Annotated[
+            str,
+            typer.Option("--provider", help="Hosted environment provider"),
+        ] = "primeintellect",
+        owner: Annotated[
+            str | None, typer.Option("--owner", help="Owner/namespace filter")
+        ] = None,
+        search: Annotated[
+            str | None, typer.Option("--search", help="Search query")
+        ] = None,
+        limit: Annotated[
+            int | None, typer.Option("--limit", help="Maximum results")
+        ] = None,
+        output_json: Annotated[
+            bool, typer.Option("--json", help="Emit raw JSON")
+        ] = False,
+    ) -> None:
+        """List a hosted provider's environments."""
+        hosted_env_list(
+            provider=provider,
+            owner=owner,
+            search=search,
+            limit=limit,
+            output_json=output_json,
+        )
+
+    @env_app.command("show")
+    def hub_env_show(
+        source_env: Annotated[
+            str,
+            typer.Argument(
+                help="Hosted environment (e.g. primeintellect/general-agent)"
+            ),
+        ],
+        version: Annotated[
+            str | None, typer.Option("--version", help="Hosted environment version")
+        ] = None,
+    ) -> None:
+        """Show hosted environment metadata."""
+        hosted_env_show(source_env=source_env, version=version)
+
+    @env_app.command("inspect")
+    def hub_env_inspect(
+        source_env: Annotated[
+            str,
+            typer.Argument(
+                help="Hosted environment (e.g. primeintellect/general-agent)"
+            ),
+        ],
+        version: Annotated[
+            str | None, typer.Option("--version", help="Hosted environment version")
+        ] = None,
+        path: Annotated[
+            str,
+            typer.Option("--path", help="File inside the hosted environment package"),
+        ] = "README.md",
+    ) -> None:
+        """Inspect a file from a hosted environment package."""
+        hosted_env_inspect(source_env=source_env, version=version, path=path)

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -23,7 +23,12 @@ from benchflow.hub.harbor_registry import DEFAULT_HARBOR_REGISTRY_URL
 
 def register_hub(app: typer.Typer) -> None:
     """Attach the ``hub`` command group to the top-level benchflow app."""
-    hub_app = typer.Typer(help="Compatibility checks for external environment hubs.")
+    hub_app = typer.Typer(
+        help=(
+            "External environment hubs: compatibility checks (check) and browsing "
+            "hosted provider environments (env)."
+        )
+    )
     app.add_typer(hub_app, name="hub", rich_help_panel="Environments")
     _register_hub_env(hub_app)
 

--- a/tests/test_cli_adopt_aliases.py
+++ b/tests/test_cli_adopt_aliases.py
@@ -69,29 +69,19 @@ def test_deprecation_fires_once_per_process(tmp_path) -> None:
     assert "deprecation" not in second.stderr  # already warned this process
 
 
-def test_environment_list_provider_replaces_hub_json_stays_clean(monkeypatch) -> None:
+def test_environment_list_hosted_is_deprecated_json_stays_clean(monkeypatch) -> None:
+    # Hosted browsing moved to `bench hub env list`; `environment list
+    # --provider`/`--hub` now warn (deprecated) but still work, and the warning
+    # goes to stderr ONLY so `--json >out` consumers stay clean.
     import benchflow.hosted_env as hosted
 
     monkeypatch.setattr(hosted, "prime_env_list", lambda **kw: '{"environments": []}')
-
-    # --provider: canonical, no warning at all.
-    shared._DEPRECATION_WARNED.clear()
-    res = runner.invoke(
-        app, ["environment", "list", "--provider", "primeintellect", "--json"]
-    )
-    assert res.exit_code == 0
-    assert res.output.strip() == '{"environments": []}'
-    assert "deprecation" not in res.stderr
-
-    # --hub: deprecated alias — the notice goes to stderr ONLY; the JSON stays on
-    # stdout, so a `... --json >out` consumer is never corrupted. (res.output
-    # mixes streams; res.stderr is pure stderr — assert the JSON never leaks
-    # there and the warning never leaves it.)
-    shared._DEPRECATION_WARNED.clear()
-    res2 = runner.invoke(
-        app, ["environment", "list", "--hub", "primeintellect", "--json"]
-    )
-    assert res2.exit_code == 0
-    assert "deprecation" in res2.stderr and "--provider" in res2.stderr
-    assert "environments" not in res2.stderr  # JSON did not leak to stderr
-    assert '{"environments": []}' in res2.output  # JSON present on stdout
+    for flag in ("--provider", "--hub"):
+        shared._DEPRECATION_WARNED.clear()
+        res = runner.invoke(
+            app, ["environment", "list", flag, "primeintellect", "--json"]
+        )
+        assert res.exit_code == 0
+        assert "deprecation" in res.stderr and "bench hub env list" in res.stderr
+        assert "environments" not in res.stderr  # JSON did not leak to stderr
+        assert '{"environments": []}' in res.output  # JSON present on stdout

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -164,10 +164,13 @@ def test_documented_subcommands_exist() -> None:
         ["skills", "eval"],
         ["environment", "create"],
         ["environment", "list"],
-        ["environment", "show"],
-        ["environment", "inspect"],
+        ["environment", "show"],  # hidden deprecated alias, still resolves
+        ["environment", "inspect"],  # hidden deprecated alias, still resolves
         ["environment", "cleanup"],
         ["hub", "check"],
+        ["hub", "env", "list"],
+        ["hub", "env", "show"],
+        ["hub", "env", "inspect"],
     ):
         out = _help(cmd)
         assert "Usage:" in out, f"bench {' '.join(cmd)} --help failed: {out}"

--- a/tests/test_cli_hub_env.py
+++ b/tests/test_cli_hub_env.py
@@ -1,0 +1,72 @@
+"""`bench hub env` is the canonical home for hosted-provider environment reads.
+
+The overloaded `bench environment` group (gap #5) was split: local sandbox
+lifecycle stays on `bench environment` (create/list/cleanup), and the read-only
+hosted-provider browsing moved to `bench hub env list|show|inspect`. The old
+`environment show`/`inspect` and `environment list --provider`/`--hub` remain as
+hidden deprecated aliases (stderr notice) through 0.6.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+import benchflow.cli._shared as shared
+import benchflow.hosted_env as hosted
+from benchflow.cli.main import app
+
+runner = CliRunner()
+
+
+def test_hub_env_subgroup_exposes_list_show_inspect() -> None:
+    res = runner.invoke(app, ["hub", "env", "--help"])
+    assert res.exit_code == 0
+    for verb in ("list", "show", "inspect"):
+        assert verb in res.output, f"`bench hub env` missing {verb!r}: {res.output}"
+    # and the subgroup is reachable from `bench hub`
+    assert "env" in runner.invoke(app, ["hub", "--help"]).output
+
+
+def test_hub_env_list_is_canonical_and_silent(monkeypatch) -> None:
+    monkeypatch.setattr(hosted, "prime_env_list", lambda **kw: '{"environments": []}')
+    shared._DEPRECATION_WARNED.clear()
+    res = runner.invoke(app, ["hub", "env", "list", "--json"])  # defaults provider
+    assert res.exit_code == 0
+    assert res.output.strip() == '{"environments": []}'
+    assert "deprecation" not in res.stderr  # canonical surface never warns
+
+
+def test_hub_env_show_delegates(monkeypatch) -> None:
+    monkeypatch.setattr(hosted, "prime_env_info", lambda ref: "META: general-agent")
+    shared._DEPRECATION_WARNED.clear()
+    res = runner.invoke(app, ["hub", "env", "show", "primeintellect/general-agent"])
+    assert res.exit_code == 0
+    assert "META: general-agent" in res.output
+    assert "deprecation" not in res.stderr
+
+
+def test_environment_show_is_deprecated_alias_of_hub_env_show(monkeypatch) -> None:
+    monkeypatch.setattr(hosted, "prime_env_info", lambda ref: "META: general-agent")
+    shared._DEPRECATION_WARNED.clear()
+    res = runner.invoke(app, ["environment", "show", "primeintellect/general-agent"])
+    assert res.exit_code == 0
+    assert "META: general-agent" in res.output  # behavior identical
+    assert "deprecation" in res.stderr and "bench hub env show" in res.stderr
+
+
+def test_environment_inspect_is_deprecated_alias(monkeypatch) -> None:
+    monkeypatch.setattr(hosted, "prime_env_inspect", lambda ref, path: f"FILE:{path}")
+    shared._DEPRECATION_WARNED.clear()
+    res = runner.invoke(app, ["environment", "inspect", "primeintellect/general-agent"])
+    assert res.exit_code == 0
+    assert "FILE:README.md" in res.output
+    assert "deprecation" in res.stderr and "bench hub env inspect" in res.stderr
+
+
+def test_environment_show_inspect_hidden_from_help() -> None:
+    out = runner.invoke(app, ["environment", "--help"]).output
+    assert "create" in out and "list" in out and "cleanup" in out
+    for hidden in ("show", "inspect"):
+        assert hidden not in out, (
+            f"deprecated {hidden!r} still shown in environment help"
+        )


### PR DESCRIPTION
Fixes the `bench environment` overload you flagged (self-audit **gap #5 / S5**). The group conflated two disjoint things; this splits them **additively** (deprecated aliases, no hard break).

### The split
| Concern | Home |
|---|---|
| **Local sandbox lifecycle** (provision a task on docker/daytona/modal, list active sandboxes, reap) | **`bench environment`** — `create` / `list` / `cleanup` (name kept — it genuinely provisions environments, fits the "universal environment framework" framing; **not** renamed to `sandbox`) |
| **Browse a hosted provider's environments** (PrimeIntellect "Environments", the env-0 style) | **`bench hub env`** ⭐ — `list --provider` / `show` / `inspect` (canonical; `bench hub` already = external environment hubs) |
| **Run** a hosted environment | unchanged — `bench eval create --source-env` |

### Why `hub env`, not `eval adopt` / `agent env`
You floated nesting under `eval`; I pushed back (running ≠ browsing — same category error as `agent create`). A design panel ran it; **note its "no `bench hub`/`adopt`/`warn_deprecated` exist" ground-truth was stale** (the agents read the primary worktree, not the release HEAD — those all shipped in #729/#735). Its `bench agent env` pivot rested on that false premise, so I implemented the conclusion the two *grounded* proposals shared: hosted reads belong under `bench hub`.

### Back-compat (no hard break)
- `bench environment show`/`inspect` → hidden + deprecated; `environment list --provider`/`--hub` keep working — all **delegate to one shared body** (`cli/_hosted_env.py`, no logic fork) and emit a one-line **stderr** notice via `warn_deprecated` (removed in 0.7). `environment list --json` stdout stays clean.
- Bare `bench environment list` is unchanged local-sandbox behavior, no warning.
- Table cells `escape()`'d (markup-class consistency with #738).

### Verification
- **Full suite 4054 passed**; `ruff` / `ruff format --check` / `ty` clean on src+tests+tools.
- `tests/test_cli_hub_env.py` (7): `hub env` canonical + silent; the three `environment` paths deprecated + **behavior-identical** + hidden from help; updated the #735 environment-list test for the new (now-deprecated) `--provider` semantics; added `hub env list/show/inspect` to the docs-drift resolution set.
- **Adversarial review: APPROVE-WITH-NITS** — verified the moved logic is byte-identical, error routing equivalent-or-better, stderr/once/local-path contracts hold, and there's exactly one copy of the logic. The one nit (the `bench hub` help string not mentioning `env`) is **fixed in this PR**.
- Docs: `reference/cli.md` (new `### bench hub env`, trimmed `## bench environment`), CHANGELOG.

Out of scope (noted): `--source-env` on `eval create` (the bigger S2 run-path decision) stays where it is; a pre-existing markup-escape asymmetry in `show`/`inspect` raw output (carried over verbatim, future ticket).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CLI routing and deprecation only; behavior is delegated to shared helpers with additive aliases and no changes to eval run paths or `hosted_env` APIs.
> 
> **Overview**
> Splits the overloaded **`bench environment`** group: **local sandbox lifecycle** (`create` / bare `list` / `cleanup`) stays there; **read-only hosted-provider browsing** (PrimeIntellect list/show/inspect) moves to **`bench hub env`**.
> 
> Hosted list/show/inspect logic is centralized in **`cli/_hosted_env.py`** and wired from both **`hub.py`** (canonical) and **`environment.py`** (hidden deprecated aliases). Old paths still work through 0.6 with a one-line **stderr** `warn_deprecated` notice (removed in 0.7); **`environment list --provider`/`--hub`** now warn too, while **`--json`** stdout stays clean. List table cells use Rich **`escape()`** for API strings.
> 
> Docs (**`cli.md`**, CHANGELOG) and tests (**`test_cli_hub_env.py`**, updated adopt-alias and docs-drift tests) reflect the new surface. **`bench eval create --source-env`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e3862c6e4b84275dbb4234682e9eb8f9da95050. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->