### PR TITLE
fix(cli): error-path hardening (stress sweep round r9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,35 @@
 - `bench metrics` → `bench eval metrics` and `bench view` → `bench eval view`
   (the deprecated hidden top-level forms are gone; use the `eval` subgroup).
 
+### Fixed
+- **CLI errors now go to stderr.** `print_error` (the single CLI error sink) wrote
+  to stdout, so a `bench … --json | jq` pipeline could get a non-JSON error line on
+  the JSON channel. All CLI errors (and the dataset bench-version remediation hint)
+  now route to stderr; exit codes are unchanged, so failures stay detectable.
+- **`bench hub env list --json` now emits valid JSON at any width.** The raw
+  payload was printed through Rich's console, which soft-wrapped long strings and
+  injected literal newlines mid-value (unparseable JSON when piped). It is now
+  written verbatim.
+- **No more raw tracebacks on bad input.** Hardened the unguarded front doors a
+  stress sweep surfaced: `eval create --source-repo` clone failures and
+  `--tasks-dir <file>`; `eval view` on corrupt/partial trajectory artifacts
+  (`prompts.json`, a bad `acp_trajectory.jsonl` line, `result.json`, a null
+  `session_id`); `sandbox create` with an unknown `--sandbox` backend or a missing
+  optional sandbox dependency; `tasks digest` on an unreadable file (single = clean
+  error, batch = warn-and-skip); and `hub check` with a malformed/missing
+  `--registry` (now a user-meaningful message, not a raw `JSONDecodeError`/`OSError`).
+- **Markup-safe output.** User/author-controlled strings that look like Rich markup
+  no longer crash or silently garble output: `eval list` job names, `eval metrics`
+  title, `skills list` cells, and `tasks init`'s reported path are now escaped.
+- **`skills eval` schema errors** no longer leak pydantic internals (private model
+  name, `[type=…]` tags, the pydantic.dev URL) — just the actionable per-field text.
+- **`bench environment` deprecation notice** now fires exactly once (one line,
+  once per process) instead of doubling up with Typer's generic
+  `DeprecationWarning`, and its aliased verbs are hidden from `--help`, matching the
+  `agent` / `eval adopt` alias families.
+- `benchmarks/CONVERT.md` now references the canonical `bench eval adopt verify`
+  (was the deprecated `bench agent verify`) in the conversion prompt.
+
 ## 0.6.0 — 2026-06-10
 
 ### Added

--- a/benchmarks/CONVERT.md
+++ b/benchmarks/CONVERT.md
@@ -118,7 +118,7 @@ Save parity experiment results to `parity_experiment.json`:
 }
 ```
 
-`bench agent verify` reads this `tasks[].criteria_results` schema as the
+`bench eval adopt verify` reads this `tasks[].criteria_results` schema as the
 deterministic floor, and also accepts the equivalent pass/total summary blocks
 some benchmarks record instead — `structural_parity` / `eval_parity` /
 `live_parity` / `e2e_parity` / `pipeline_parity` / `security_parity` (or a bare

--- a/src/benchflow/cli/_hosted_env.py
+++ b/src/benchflow/cli/_hosted_env.py
@@ -42,7 +42,12 @@ def hosted_env_list(
         print_error(str(e))
         raise typer.Exit(1) from None
     if output_json:
-        console.print(raw)
+        # typer.echo, NOT console.print: Rich's console soft-wraps long lines to
+        # the terminal width and injects a literal newline mid-string, which
+        # turns the upstream's valid JSON into unparseable output (raw control
+        # char inside a string). Write the payload verbatim so `--json | jq`
+        # works at any width.
+        typer.echo(raw)
         return
     data = json.loads(raw)
     rows = (

--- a/src/benchflow/cli/_shared.py
+++ b/src/benchflow/cli/_shared.py
@@ -31,17 +31,22 @@ err_console = Console(stderr=True)
 
 
 def print_error(message: str) -> None:
-    """Print a red error line, escaping Rich markup in ``message``.
+    """Print a red error line to **stderr**, escaping Rich markup in ``message``.
 
-    The single safe sink for CLI error messages: error text routinely
-    interpolates user-supplied values (a task path, an agent name, a config
-    error echoing a field) that can contain ``[`` / ``[/x]`` tokens. An
-    unescaped ``console.print(f"[red]{value}[/red]")`` then makes Rich itself
-    raise ``MarkupError`` — turning a clean error into a raw traceback. Route
-    every such message through here. (Messages with NO user input escape to a
-    no-op, so it is always safe.)
+    The single safe sink for CLI error messages. Two jobs:
+
+    1. *Escape* — error text routinely interpolates user-supplied values (a task
+       path, an agent name, a config error echoing a field) that can contain
+       ``[`` / ``[/x]`` tokens. An unescaped ``console.print(f"[red]{value}[/red]")``
+       then makes Rich itself raise ``MarkupError`` — turning a clean error into a
+       raw traceback. (Messages with NO user input escape to a no-op, so it is
+       always safe.)
+    2. *Stream* — write to ``err_console`` (stderr), not stdout. Errors on stdout
+       corrupt ``--json`` consumers (a ``bench … --json | jq`` pipeline gets a
+       non-JSON line on the JSON channel); the same stderr rule the deprecation
+       notices follow. Exit codes are unchanged, so failures stay detectable.
     """
-    console.print(f"[red]{escape(str(message))}[/red]")
+    err_console.print(f"[red]{escape(str(message))}[/red]")
 
 
 _DEPRECATION_WARNED: set[str] = set()

--- a/src/benchflow/cli/environment.py
+++ b/src/benchflow/cli/environment.py
@@ -28,11 +28,20 @@ from benchflow.cli.sandbox import sandbox_cleanup, sandbox_create, sandbox_list_
 
 
 def register_environment(app: typer.Typer) -> None:
-    """Attach the deprecated ``environment`` alias group (hidden from help)."""
+    """Attach the deprecated ``environment`` alias group (hidden from help).
+
+    Each command uses ``hidden=True`` only — NOT Typer's ``deprecated=True``.
+    ``deprecated=True`` would (a) print its own generic ``DeprecationWarning: The
+    command 'X' is deprecated.`` line that omits the canonical replacement and
+    re-fires every invocation, doubling up with our ``warn_deprecated`` one-liner,
+    and (b) surface the aliased verbs in ``environment --help``. ``hidden=True``
+    alone matches the ``adopt`` / ``agent`` alias families: exactly one
+    once-per-process stderr notice, verbs hidden from help.
+    """
     env_app = typer.Typer(help="Deprecated; use `bench sandbox` / `bench hub env`.")
     app.add_typer(env_app, name="environment", hidden=True)
 
-    @env_app.command("create", deprecated=True)
+    @env_app.command("create", hidden=True)
     def environment_create(
         task_dir: Annotated[
             Path,
@@ -46,7 +55,7 @@ def register_environment(app: typer.Typer) -> None:
         warn_deprecated("bench environment create", "bench sandbox create")
         sandbox_create(task_dir, sandbox)
 
-    @env_app.command("list", deprecated=True)
+    @env_app.command("list", hidden=True)
     def environment_list(
         provider: Annotated[
             str | None,
@@ -96,7 +105,7 @@ def register_environment(app: typer.Typer) -> None:
         warn_deprecated("bench environment list", "bench sandbox list")
         sandbox_list_local()
 
-    @env_app.command("show", deprecated=True)
+    @env_app.command("show", hidden=True)
     def environment_show(
         source_env: Annotated[
             str,
@@ -112,7 +121,7 @@ def register_environment(app: typer.Typer) -> None:
         warn_deprecated("bench environment show", "bench hub env show")
         hosted_env_show(source_env=source_env, version=version)
 
-    @env_app.command("inspect", deprecated=True)
+    @env_app.command("inspect", hidden=True)
     def environment_inspect(
         source_env: Annotated[
             str,
@@ -132,7 +141,7 @@ def register_environment(app: typer.Typer) -> None:
         warn_deprecated("bench environment inspect", "bench hub env inspect")
         hosted_env_inspect(source_env=source_env, version=version, path=path)
 
-    @env_app.command("cleanup", deprecated=True)
+    @env_app.command("cleanup", hidden=True)
     def environment_cleanup(
         dry_run: Annotated[
             bool, typer.Option("--dry-run", help="List sandboxes without deleting")

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -6,6 +6,7 @@ only wires the call.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Annotated
 
@@ -17,7 +18,7 @@ from benchflow.cli._hosted_env import (
     hosted_env_list,
     hosted_env_show,
 )
-from benchflow.cli._shared import console
+from benchflow.cli._shared import console, print_error
 from benchflow.hub.harbor_registry import DEFAULT_HARBOR_REGISTRY_URL
 
 
@@ -84,13 +85,18 @@ def register_hub(app: typer.Typer) -> None:
                 cache_dir=cache_dir,
                 limit=limit,
             )
+        # Surface a user-meaningful message instead of a raw stdlib repr: a bad
+        # --registry otherwise leaks `Expecting value: line 1 column 1 (char 0)`
+        # (JSONDecodeError) or `[Errno 2] ...` (OSError). print_error escapes the
+        # path + routes to stderr.
+        except json.JSONDecodeError:
+            print_error(f"--registry {registry} is not valid JSON")
+            raise typer.Exit(1) from None
+        except OSError as exc:
+            print_error(f"--registry {registry}: {exc.strerror or exc}")
+            raise typer.Exit(1) from None
         except Exception as exc:
-            # escape(): the message echoes the user-supplied --registry path,
-            # which can contain Rich markup (`[`, `[/red]`) — an unescaped
-            # interpolation makes the error handler itself raise MarkupError.
-            console.print(
-                f"[red]Harbor compatibility check failed:[/red] {escape(str(exc))}"
-            )
+            print_error(f"Harbor compatibility check failed: {exc}")
             raise typer.Exit(1) from exc
 
         summary = records_summary(records)

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -39,6 +39,7 @@ from benchflow.cli._shared import (
     _exit_if_evaluation_had_errors,
     _report_eval_result,
     console,
+    err_console,
     print_error,
 )
 from benchflow.cli.adopt import register_adopt_deprecated, register_eval_adopt
@@ -485,7 +486,7 @@ def eval_create(
     # --source-path/--source-ref only apply to --source-repo; otherwise they're
     # silently ignored (e.g. `--dataset X --source-ref abc` drops the ref).
     if (source_path or source_ref) and not source_repo:
-        console.print("[red]--source-path/--source-ref require --source-repo[/red]")
+        print_error("--source-path/--source-ref require --source-repo")
         raise typer.Exit(1)
     try:
         plan = build_eval_plan(request)
@@ -507,11 +508,20 @@ def eval_create(
             source_env_sampling_arg=source_env_sampling_arg,
         )
     elif source_repo:
+        import subprocess
+
         from benchflow._utils.benchmark_repos import resolve_source_with_metadata
 
-        resolved = resolve_source_with_metadata(
-            source_repo, path=source_path, ref=source_ref
-        )
+        try:
+            resolved = resolve_source_with_metadata(
+                source_repo, path=source_path, ref=source_ref
+            )
+        except (subprocess.CalledProcessError, OSError, ValueError, RuntimeError) as e:
+            # A clone failure (missing/private repo, bad --source-ref, auth,
+            # network) otherwise escapes as a raw traceback — unlike the sibling
+            # config/source-env/dataset branches which all map to a clean error.
+            print_error(f"Could not resolve --source-repo {source_repo!r}: {e}")
+            raise typer.Exit(1) from None
         run_batch_eval(
             plan,
             resolved.path,
@@ -522,6 +532,11 @@ def eval_create(
         # handles both layouts (Evaluation._get_task_dirs detects when
         # tasks_dir itself contains task.toml) and applies include/exclude
         # filters uniformly (#400, #401, #407).
+        if not Path(tasks_dir).is_dir():
+            # Without this guard a file (or missing path) reaches iterdir() and
+            # dumps a raw NotADirectoryError, unlike sandbox create / eval metrics.
+            print_error(f"Not a directory: {tasks_dir}")
+            raise typer.Exit(1)
         run_batch_eval(plan, tasks_dir, plan.make_eval_config())
     elif dataset:
         from benchflow._utils.dataset_registry import (
@@ -544,7 +559,9 @@ def eval_create(
             # dataset version was validated against. The escape hatch keeps
             # local experimentation possible without weakening the default.
             print_error(f"{version_issue}")
-            console.print(
+            # The remediation hint is part of the error — keep it on stderr too so
+            # a `--json` consumer's stdout stays clean.
+            err_console.print(
                 "Pick a dataset version validated for this harness, or re-run "
                 "with --ignore-bench-version to proceed anyway."
             )
@@ -871,10 +888,10 @@ def eval_list(
         except (json.JSONDecodeError, OSError):
             data = None
         if not isinstance(data, dict):
-            table.add_row(label, "?", "[dim]corrupt summary[/dim]", "—")
+            table.add_row(escape(label), "?", "[dim]corrupt summary[/dim]", "—")
             return
         table.add_row(
-            label,
+            escape(label),
             str(data.get("total", "?")),
             f"{data.get('passed', '?')}/{data.get('total', '?')} ({data.get('score', '?')})",
             memory_label(data),
@@ -894,7 +911,7 @@ def eval_list(
             add_summary_row(d.name, summary)
         else:
             sub_count = sum(1 for s in d.iterdir() if s.is_dir())
-            table.add_row(d.name, str(sub_count), "[dim]no summary[/dim]", "—")
+            table.add_row(escape(d.name), str(sub_count), "[dim]no summary[/dim]", "—")
 
     console.print(table)
 
@@ -934,7 +951,7 @@ def eval_metrics(
         console.print(json.dumps(summary, indent=2))
         return
 
-    table = Table(title=f"Results: {jobs_dir}")
+    table = Table(title=f"Results: {escape(str(jobs_dir))}")
     table.add_column("Metric", style="cyan")
     table.add_column("Value", style="bold")
 

--- a/src/benchflow/cli/sandbox.py
+++ b/src/benchflow/cli/sandbox.py
@@ -24,7 +24,7 @@ from rich.markup import escape
 from rich.table import Table
 
 from benchflow.cli._options import SandboxOption
-from benchflow.cli._shared import console
+from benchflow.cli._shared import console, print_error
 
 
 def sandbox_create(task_dir: Path, sandbox: str) -> None:
@@ -32,17 +32,21 @@ def sandbox_create(task_dir: Path, sandbox: str) -> None:
     from benchflow.runtime import Environment
 
     if not task_dir.is_dir():
-        console.print(f"[red]Not a directory: {escape(str(task_dir))}[/red]")
+        print_error(f"Not a directory: {task_dir}")
         raise typer.Exit(1)
     try:
         env = Environment.from_task(task_dir, sandbox=sandbox)
     except (FileNotFoundError, NotADirectoryError, ValueError) as e:
         # An existing dir with no task document reaches Task.__init__'s unguarded
         # read_text() — surface a clean error instead of a raw traceback.
-        console.print(
-            f"[red]Not a valid task directory {escape(str(task_dir))}:[/red] "
-            f"{escape(str(e))}"
-        )
+        print_error(f"Not a valid task directory {task_dir}: {e}")
+        raise typer.Exit(1) from None
+    except RuntimeError as e:
+        # An unknown --sandbox backend (UnsupportedTaskFeatureError, a RuntimeError
+        # subclass) and a missing optional sandbox dependency both raise a
+        # RuntimeError carrying a clean, user-facing message. Surface it without a
+        # traceback, matching how `sandbox list`/`cleanup` handle the same cases.
+        print_error(str(e))
         raise typer.Exit(1) from None
     console.print(f"[green]Environment created:[/green] {escape(str(env))}")
     console.print(f"  Task:    {env.task_path}")

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -58,7 +58,15 @@ def register_skills(app: typer.Typer) -> None:
         table.add_column("Path", style="dim")
 
         for s in found:
-            table.add_row(s.name, s.version or "-", s.description[:60], str(s.path))
+            # escape(): SKILL.md metadata is author/third-party controlled (e.g.
+            # a description mentioning "[/INST]") and would otherwise raise a Rich
+            # MarkupError that crashes the listing — matching `skills eval`.
+            table.add_row(
+                escape(s.name),
+                escape(s.version or "-"),
+                escape(s.description[:60]),
+                escape(str(s.path)),
+            )
 
         console.print(table)
 

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -14,7 +14,7 @@ from typing import Annotated, Literal, cast
 import typer
 from rich.markup import escape
 
-from benchflow.cli._shared import console, print_error
+from benchflow.cli._shared import console, err_console, print_error
 from benchflow.cli.trace_import import register_tasks_generate
 from benchflow.sandbox.providers import providers_phrase
 
@@ -59,7 +59,7 @@ def register_tasks(app: typer.Typer) -> None:
                 no_oracle=no_oracle,
                 task_format=cast(Literal["legacy", "task-md"], task_format),
             )
-            console.print(f"[green]Created:[/green] {result.task_dir}/")
+            console.print(f"[green]Created:[/green] {escape(str(result.task_dir))}/")
             # List every file actually written, derived from the scaffold itself
             # so the summary can never under-report (e.g. omit
             # verifier/test_outputs.py or verifier/rubrics/verifier.toml, both of
@@ -257,7 +257,7 @@ def register_tasks(app: typer.Typer) -> None:
         )
 
         if target not in {"harbor", "pier"}:
-            console.print("[red]target must be 'harbor' or 'pier'[/red]")
+            print_error("target must be 'harbor' or 'pier'")
             raise typer.Exit(1)
 
         try:
@@ -324,7 +324,13 @@ def register_tasks(app: typer.Typer) -> None:
         if _is_task_dir(path):
             # typer.echo, not console.print: Rich wraps lines at terminal width,
             # which would corrupt piped machine-readable output.
-            typer.echo(task_digest(path))
+            try:
+                digest = task_digest(path)
+            except OSError as e:
+                # An unreadable file (permissions) otherwise dumps a raw traceback.
+                print_error(f"Cannot read task files under {path}: {e}")
+                raise typer.Exit(1) from None
+            typer.echo(digest)
             return
 
         task_dirs = sorted(d for d in path.iterdir() if d.is_dir() and _is_task_dir(d))
@@ -335,4 +341,13 @@ def register_tasks(app: typer.Typer) -> None:
             )
             raise typer.Exit(1)
         for task_dir in task_dirs:
-            typer.echo(f"{task_dir.name} {task_digest(task_dir)}")
+            # Batch: warn-and-skip an unreadable task (to stderr so the digest
+            # lines on stdout stay machine-readable) instead of aborting the run.
+            try:
+                digest = task_digest(task_dir)
+            except OSError as e:
+                err_console.print(
+                    f"[yellow]Skipping[/yellow] {escape(task_dir.name)}: {escape(str(e))}"
+                )
+                continue
+            typer.echo(f"{task_dir.name} {digest}")

--- a/src/benchflow/cli/trace_import.py
+++ b/src/benchflow/cli/trace_import.py
@@ -17,8 +17,9 @@ from typing import Annotated, Literal, cast
 
 import typer
 from rich.console import Console
-from rich.markup import escape
 from rich.table import Table
+
+from benchflow.cli._shared import print_error
 
 console = Console()
 
@@ -131,12 +132,10 @@ def register_tasks_generate(tasks_app: typer.Typer) -> None:
         """
         sources = sum([from_local, from_file is not None, from_hf is not None])
         if sources == 0:
-            console.print(
-                "[red]Specify a source: --from-local, --from-file, or --from-hf[/red]"
-            )
+            print_error("Specify a source: --from-local, --from-file, or --from-hf")
             raise typer.Exit(1)
         if sources > 1:
-            console.print("[red]Only one source allowed at a time[/red]")
+            print_error("Only one source allowed at a time")
             raise typer.Exit(1)
 
         if from_local:
@@ -180,7 +179,7 @@ def register_tasks_generate(tasks_app: typer.Typer) -> None:
         from benchflow.traces.task_gen import generate_tasks_from_traces
 
         if task_format not in ("task-md", "legacy"):
-            console.print("[red]--task-format must be task-md or legacy[/red]")
+            print_error("--task-format must be task-md or legacy")
             raise typer.Exit(1)
 
         results = generate_tasks_from_traces(
@@ -248,7 +247,7 @@ def _load_file(path: Path, format: str) -> list:
     )
 
     if not path.exists():
-        console.print(f"[red]File not found: {escape(str(path))}[/red]")
+        print_error(f"File not found: {path}")
         raise typer.Exit(1)
 
     detected_format = format
@@ -263,7 +262,7 @@ def _load_file(path: Path, format: str) -> list:
     elif detected_format == "claude-messages":
         return _parse_hf_messages_file(path)
     else:
-        console.print(f"[red]Unknown format: {escape(str(detected_format))}[/red]")
+        print_error(f"Unknown format: {detected_format}")
         raise typer.Exit(1)
 
 

--- a/src/benchflow/skill_eval/schema.py
+++ b/src/benchflow/skill_eval/schema.py
@@ -150,4 +150,12 @@ def validate_evals_json(data: object) -> _EvalsJsonModel:
     try:
         return _EvalsJsonModel.model_validate(data)
     except ValidationError as e:
-        raise ValueError(f"evals.json failed schema validation: {e}") from e
+        # Surface the actionable per-field messages only — not pydantic's raw
+        # str() (which leaks the private _EvalsJsonModel class name, the
+        # [type=..., input_value=..., input_type=...] plumbing, and an
+        # errors.pydantic.dev URL) to the CLI user.
+        details = "; ".join(
+            f"{'.'.join(str(p) for p in err['loc']) or '<root>'}: {err['msg']}"
+            for err in e.errors()
+        )
+        raise ValueError(f"evals.json failed schema validation: {details}") from e

--- a/src/benchflow/trajectories/viewer.py
+++ b/src/benchflow/trajectories/viewer.py
@@ -142,9 +142,14 @@ def render_rollout(rollout_dir: Path, prompts: list[str] | None = None) -> str:
     - trajectory/acp_trajectory.jsonl → ACP session events
     - prompts.json → used for prompt labels if available
     """
-    # Try loading prompts from prompts.json if not provided
+    # Try loading prompts from prompts.json if not provided. A corrupt file is
+    # auxiliary (it only supplies prompt labels) — degrade to default labels
+    # rather than crashing the whole view with a raw JSONDecodeError traceback.
     if prompts is None and (rollout_dir / "prompts.json").exists():
-        prompts = json.loads((rollout_dir / "prompts.json").read_text())
+        try:
+            prompts = json.loads((rollout_dir / "prompts.json").read_text())
+        except (json.JSONDecodeError, OSError):
+            prompts = None
 
     # Auto-detect format
     turn_files = sorted(rollout_dir.glob("turn*.txt"))
@@ -193,9 +198,12 @@ def render_rollout(rollout_dir: Path, prompts: list[str] | None = None) -> str:
                 total_cost += e.get("total_cost_usd", 0)
                 total_turns_count += e.get("num_turns", 0)
 
-    session_id = sys_event.get("session_id", "?")
-    model = sys_event.get("model", "?")
-    version = sys_event.get("claude_code_version", "?")
+    # `or "?"` (not just a .get default): a present-but-null value in the
+    # stream-json (e.g. "session_id": null) bypasses the default and would crash
+    # html.escape() / the [:16] slice below with a raw TypeError.
+    session_id = str(sys_event.get("session_id") or "?")
+    model = str(sys_event.get("model") or "?")
+    version = str(sys_event.get("claude_code_version") or "?")
 
     return f"""<!DOCTYPE html>
 <html>
@@ -248,15 +256,26 @@ def _render_acp_trajectory(
     rollout_dir: Path, acp_path: Path, prompts: list[str] | None
 ) -> str:
     """Render an ACP trajectory JSONL file as HTML."""
-    events = [
-        json.loads(line) for line in acp_path.read_text().splitlines() if line.strip()
-    ]
+    # Skip malformed/truncated lines (mirroring _parse_jsonl for turn files) so a
+    # single bad line does not abort the view with a raw JSONDecodeError.
+    events = []
+    for line in acp_path.read_text().splitlines():
+        if not line.strip():
+            continue
+        try:
+            events.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
 
-    # Load result.json for metadata
+    # Load result.json for metadata; a corrupt file degrades to no metadata
+    # rather than crashing.
     result_data = {}
     result_path = rollout_dir / "result.json"
     if result_path.exists():
-        result_data = json.loads(result_path.read_text())
+        try:
+            result_data = json.loads(result_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            result_data = {}
 
     blocks = []
 

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -46,8 +46,8 @@ def test_concurrency_zero_rejected_not_deadlocked(tmp_path: Path):
     # Semaphore(0) would deadlock; the CLI must reject it up front instead.
     result = _invoke(tmp_path, "--sandbox", "docker", "--concurrency", "0")
     assert result.exit_code == 1
-    assert "--concurrency must be >= 1" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "--concurrency must be >= 1" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_build_concurrency_zero_rejected(tmp_path: Path):
@@ -61,14 +61,14 @@ def test_build_concurrency_zero_rejected(tmp_path: Path):
         "0",
     )
     assert result.exit_code == 1
-    assert "--build-concurrency must be >= 1" in result.stdout
+    assert "--build-concurrency must be >= 1" in result.stderr
 
 
 def test_skill_mode_bogus_clean_error(tmp_path: Path):
     result = _invoke(tmp_path, "--sandbox", "docker", "--skill-mode", "bogus")
     assert result.exit_code == 1
-    assert "Invalid --skill-mode" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "Invalid --skill-mode" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_sandbox_bogus_clean_error(tmp_path: Path):
@@ -76,15 +76,15 @@ def test_sandbox_bogus_clean_error(tmp_path: Path):
     # per-task traceback once the rollout starts.
     result = _invoke(tmp_path, "--sandbox", "nope")
     assert result.exit_code == 1
-    assert "Invalid --sandbox" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "Invalid --sandbox" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_reasoning_effort_bogus_clean_error(tmp_path: Path):
     result = _invoke(tmp_path, "--sandbox", "docker", "--reasoning-effort", "banana")
     assert result.exit_code == 1
-    assert "reasoning_effort must be one of" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "reasoning_effort must be one of" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_tasks_dir_missing_clean_error(tmp_path: Path):
@@ -103,16 +103,16 @@ def test_tasks_dir_missing_clean_error(tmp_path: Path):
             ],
         )
     assert result.exit_code == 1
-    assert "--tasks-dir not found" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "--tasks-dir not found" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_agent_without_default_model_clean_error(tmp_path: Path):
     # codex has no default model; omitting --model must report cleanly, not crash.
     result = _invoke(tmp_path, "--agent", "codex", "--sandbox", "docker")
     assert result.exit_code == 1
-    assert "no default model" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "no default model" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 @pytest.mark.skipif(
@@ -122,15 +122,15 @@ def test_agent_without_default_model_clean_error(tmp_path: Path):
 def test_sandbox_modal_without_extra_fails_fast(tmp_path: Path):
     result = _invoke(tmp_path, "--sandbox", "modal")
     assert result.exit_code == 1
-    assert "sandbox-modal" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "sandbox-modal" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_loop_strategy_bad_spec_clean_error(tmp_path: Path):
     result = _invoke(tmp_path, "--sandbox", "docker", "--loop-strategy", "bogus")
     assert result.exit_code == 1
-    assert "Invalid --loop-strategy" in result.stdout
-    assert "Traceback (most recent call last)" not in result.stdout
+    assert "Invalid --loop-strategy" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
 
 
 def test_loop_strategy_k_out_of_range_rejected(tmp_path: Path):
@@ -138,7 +138,7 @@ def test_loop_strategy_k_out_of_range_rejected(tmp_path: Path):
         tmp_path, "--sandbox", "docker", "--loop-strategy", "verify-retry:k=99"
     )
     assert result.exit_code == 1
-    assert "k must be between 1 and 10" in result.stdout
+    assert "k must be between 1 and 10" in result.stderr
 
 
 def test_loop_strategy_conflicts_with_self_gen(tmp_path: Path):
@@ -152,7 +152,7 @@ def test_loop_strategy_conflicts_with_self_gen(tmp_path: Path):
         "verify-retry",
     )
     assert result.exit_code == 1
-    assert "not supported with --skill-mode self-gen" in result.stdout
+    assert "not supported with --skill-mode self-gen" in result.stderr
 
 
 def test_loop_strategy_conflicts_with_multiple_prompts(tmp_path: Path):
@@ -168,7 +168,7 @@ def test_loop_strategy_conflicts_with_multiple_prompts(tmp_path: Path):
         "verify-retry",
     )
     assert result.exit_code == 1
-    assert "conflicts with multiple" in result.stdout
+    assert "conflicts with multiple" in result.stderr
 
 
 def test_loop_strategy_accepted_and_plumbed(tmp_path: Path):

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -7,6 +7,7 @@ by the command surface they protect.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -275,3 +276,150 @@ def test_tasks_init_handler_escapes_markup_in_path(tmp_path):
     res = runner.invoke(app, ["tasks", "init", "mytask", "--dir", str(afile)])
     assert res.exit_code == 1
     assert isinstance(res.exception, SystemExit)  # not a MarkupError
+
+
+# ── round-9 stress sweep: error stream, raw-traceback, markup, deprecation ────
+
+
+def test_cli_errors_go_to_stderr_not_stdout(tmp_path):
+    # print_error is the single CLI error sink; it must write to stderr so a
+    # `bench … --json | jq` pipeline never gets a non-JSON line on stdout.
+    res = runner.invoke(app, ["eval", "metrics", str(tmp_path / "nope"), "--json"])
+    assert res.exit_code == 1
+    assert res.stdout == ""  # JSON channel stays clean
+    assert "Not a directory" in res.stderr
+
+
+def test_eval_create_bad_source_repo_no_raw_traceback(monkeypatch):
+    # A clone failure used to escape as a raw CalledProcessError traceback.
+    import subprocess
+
+    import benchflow._utils.benchmark_repos as br
+
+    def boom(*a, **k):
+        raise subprocess.CalledProcessError(128, ["git", "clone"])
+
+    monkeypatch.setattr(br, "resolve_source_with_metadata", boom)
+    res = runner.invoke(app, ["eval", "create", "--source-repo", "x/y"])
+    assert res.exit_code == 1
+    assert "Traceback (most recent call last)" not in res.output
+    assert "Could not resolve --source-repo" in res.stderr
+
+
+def test_eval_create_tasks_dir_is_a_file_clean_error(tmp_path):
+    afile = tmp_path / "notadir.txt"
+    afile.write_text("x")
+    res = runner.invoke(
+        app, ["eval", "create", "--tasks-dir", str(afile), "--agent", "oracle"]
+    )
+    assert res.exit_code == 1
+    assert "Traceback (most recent call last)" not in res.output
+    assert "Not a directory" in res.stderr
+
+
+def test_hub_env_list_json_is_valid_json_even_when_narrow(monkeypatch):
+    # The raw payload must be emitted verbatim, not through Rich's console (which
+    # soft-wraps long strings and injects newlines mid-value → unparseable JSON).
+    import benchflow.hosted_env as hosted
+
+    long_desc = "calibration-as-action. " + "a cheap base model " * 30
+    payload = json.dumps({"environments": [{"name": "a/b", "description": long_desc}]})
+    monkeypatch.setattr(hosted, "prime_env_list", lambda **kw: payload)
+    monkeypatch.setenv("COLUMNS", "40")
+    res = runner.invoke(app, ["hub", "env", "list", "--json"])
+    assert res.exit_code == 0
+    assert json.loads(res.stdout) == json.loads(payload)  # round-trips cleanly
+
+
+def test_eval_metrics_markup_in_path_does_not_crash(tmp_path):
+    # The full path string spans a closing-tag-shaped substring ("[/red]");
+    # interpolated unescaped into the Rich Table title it raised MarkupError.
+    d = tmp_path / "done[" / "red]"
+    d.mkdir(parents=True)
+    res = runner.invoke(app, ["eval", "metrics", str(d)])
+    assert res.exit_code == 0
+    assert "MarkupError" not in res.output
+    assert "Traceback (most recent call last)" not in res.output
+
+
+def test_skills_list_markup_in_metadata_does_not_crash(tmp_path):
+    skill = tmp_path / "llm"
+    skill.mkdir()
+    (skill / "SKILL.md").write_text(
+        "---\nname: prompt-helper\n"
+        'description: "Wraps user text in [INST] ... [/INST] blocks"\n'
+        'version: "1.0"\n---\nbody\n'
+    )
+    res = runner.invoke(app, ["skills", "list", "--dir", str(tmp_path)])
+    assert res.exit_code == 0
+    assert "MarkupError" not in res.output
+    assert "Traceback (most recent call last)" not in res.output
+
+
+def test_environment_alias_emits_exactly_one_deprecation_line():
+    import benchflow.cli._shared as shared
+
+    shared._DEPRECATION_WARNED.clear()
+    res = runner.invoke(app, ["environment", "list"])
+    # Exactly one project notice; NOT also Typer's generic per-call line.
+    assert res.stderr.count("deprecation:") == 1
+    assert "DeprecationWarning: The command" not in res.stderr
+
+
+def test_environment_help_hides_aliased_verbs():
+    res = runner.invoke(app, ["environment", "--help"])
+    assert res.exit_code == 0
+    assert "(deprecated)" not in res.output  # verbs hidden, like agent/eval adopt
+
+
+def test_skills_eval_schema_error_hides_pydantic_internals(tmp_path):
+    evals = tmp_path / "evals"
+    evals.mkdir()
+    (evals / "evals.json").write_text('{"cases": []}')
+    res = runner.invoke(app, ["skills", "eval", str(tmp_path)])
+    assert res.exit_code == 1
+    assert "_EvalsJsonModel" not in res.output  # no private model class name
+    assert "pydantic.dev" not in res.output  # no docs URL
+    assert "cases" in res.output  # actionable per-field text kept
+
+
+def test_viewer_renders_corrupt_artifacts_without_raising(tmp_path):
+    # eval view's render must degrade, not dump a raw traceback, on partial data.
+    from benchflow.trajectories.viewer import render_rollout
+
+    # null session_id + a corrupt prompts.json (auxiliary → degrade to defaults)
+    (tmp_path / "turn1.txt").write_text(
+        '{"type":"system","session_id":null,"model":"m"}\n'
+    )
+    (tmp_path / "prompts.json").write_text("not json{{{")
+    html = render_rollout(tmp_path)
+    assert "<!DOCTYPE html>" in html
+
+    # a truncated ACP trajectory line must be skipped, not crash
+    acp = tmp_path / "acp"
+    (acp / "trajectory").mkdir(parents=True)
+    (acp / "trajectory" / "acp_trajectory.jsonl").write_text(
+        '{"type":"user_message","text":"hi"}\nTRUNCATED-NOT-JSON'
+    )
+    (acp / "result.json").write_text("garbage{")  # corrupt → degrade to no metadata
+    html2 = render_rollout(acp)
+    assert isinstance(html2, str) and html2
+
+
+@pytest.mark.parametrize(
+    "argv, needle",
+    [
+        (["tasks", "generate"], "Specify a source"),
+        (
+            ["eval", "create", "--source-ref", "abc", "--tasks-dir", "."],
+            "require --source-repo",
+        ),
+    ],
+)
+def test_arg_validation_errors_route_to_stderr(argv, needle):
+    # The print_error sink is uniform: sibling arg-validation guards (not just the
+    # ones the sweep happened to hit) put their error on stderr, leaving stdout clean.
+    res = runner.invoke(app, argv)
+    assert res.exit_code == 1
+    assert needle in res.stderr
+    assert needle not in res.stdout

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -316,7 +316,7 @@ class TestEvalCreateDatasetCli:
             ],
         )
         assert result.exit_code == 1
-        assert "only one source" in result.stdout
+        assert "only one source" in result.stderr
 
     def test_registry_requires_dataset(self, tmp_path):
         result = CliRunner().invoke(
@@ -324,7 +324,7 @@ class TestEvalCreateDatasetCli:
             ["eval", "create", "--registry", str(tmp_path / "r.json")],
         )
         assert result.exit_code == 1
-        assert "--registry requires --dataset" in result.stdout
+        assert "--registry requires --dataset" in result.stderr
 
     def test_out_of_range_bench_version_blocks(self, tmp_path, snapshot, monkeypatch):
         """The bench_version range is a hard gate for dataset runs; the
@@ -356,8 +356,8 @@ class TestEvalCreateDatasetCli:
             ],
         )
         assert result.exit_code == 1
-        assert "outside the range" in result.stdout
-        assert "--ignore-bench-version" in result.stdout
+        assert "outside the range" in result.stderr
+        assert "--ignore-bench-version" in result.stderr
         assert not ran
 
     def test_ignore_bench_version_overrides_gate(self, tmp_path, snapshot, monkeypatch):
@@ -398,7 +398,7 @@ class TestEvalCreateDatasetCli:
             ["eval", "create", "--ignore-bench-version", "--tasks-dir", str(tmp_path)],
         )
         assert result.exit_code == 1
-        assert "--ignore-bench-version requires --dataset" in result.stdout
+        assert "--ignore-bench-version requires --dataset" in result.stderr
 
     def test_resolution_error_exits_cleanly(self, tmp_path, snapshot):
         registry = _write_registry(tmp_path, snapshot.tasks_parent)
@@ -414,7 +414,7 @@ class TestEvalCreateDatasetCli:
             ],
         )
         assert result.exit_code == 1
-        assert "not found in registry" in result.stdout
+        assert "not found in registry" in result.stderr
 
 
 class TestDatasetStamping:

--- a/tests/test_eval_zero_task_guard.py
+++ b/tests/test_eval_zero_task_guard.py
@@ -105,8 +105,8 @@ def test_cli_zero_task_selection_exits_nonzero_no_summary(tmp_path):
         ],
     )
 
-    assert result.exit_code == 1, result.stdout
-    assert "No tasks selected" in result.stdout
+    assert result.exit_code == 1, result.output
+    assert "No tasks selected" in result.stderr
     # Critically: no 0/0 summary.json must exist.
     assert not (jobs_dir / "summary.json").exists(), (
         "zero-task selection must not publish a 0/0 summary.json — that "

--- a/tests/test_oracle_chokepoint.py
+++ b/tests/test_oracle_chokepoint.py
@@ -286,7 +286,7 @@ class TestEvalCreateRouting:
         result = CliRunner().invoke(app, ["eval", "create", "--config", str(config)])
 
         assert result.exit_code == 1
-        assert "Unsupported eval agent protocol: openai" in result.stdout
+        assert "Unsupported eval agent protocol: openai" in result.stderr
 
     def test_eval_create_config_recomputes_model_after_agent_normalization(
         self, tmp_path: Path


### PR DESCRIPTION
## What

A multi-agent **stress sweep** of the integrated 0.6 release HEAD (post #742) drove every CLI surface with normal + malformed/edge inputs and adversarially verified each finding: **27 confirmed defects**, deduped to the fix groups below. All in-lane; **no breaking changes** (zero command/flag renames or default-behavior changes).

## Fixes by class

**Errors → stderr (keystone).** `print_error` — the single CLI error sink — wrote to **stdout**, so a `bench … --json | jq` pipeline could get a non-JSON error line on the JSON channel. It now routes to stderr (exit codes unchanged, so failures stay detectable). Applied uniformly: the dataset bench-version remediation hint, and the sibling validation guards in `trace_import` / `main` / `tasks` that still printed to stdout — so the sink is *actually* single.

**`hub env list --json` emitted invalid JSON by default** (high-severity). The raw payload went through Rich's console, which soft-wrapped long strings and injected literal newlines mid-value (unparseable when piped at any normal width). Now written verbatim via `typer.echo`.

**No raw tracebacks on bad input.** `eval create --source-repo` clone failures and `--tasks-dir <file>`; `eval view` on corrupt `prompts.json` / a bad `acp_trajectory.jsonl` line / corrupt `result.json` / null `session_id`; `sandbox create` with an unknown `--sandbox` backend or a missing optional sandbox dep; `tasks digest` on an unreadable file (single = clean error, batch = warn-and-skip); `hub check` with a malformed/missing `--registry` (friendly message, not raw `JSONDecodeError`/`OSError`).

**Markup-safe output.** Escape user/author-controlled strings before Rich so they can't crash (`MarkupError`) or silently garble: `eval list` job names, `eval metrics` title, `skills list` cells, `tasks init`'s reported path.

**`skills eval` schema errors** no longer leak pydantic internals (private `_EvalsJsonModel` name, `[type=…]` tags, the `pydantic.dev` URL) — just the actionable per-field text.

**`bench environment` deprecation hygiene.** Dropped Typer's `deprecated=True` (kept `hidden=True`) on the 5 aliases, so exactly one once-per-process stderr notice fires (was doubling with Typer's generic `DeprecationWarning`) and the verbs are hidden from `--help` — matching the `agent` / `eval adopt` alias families.

**Doc drift.** `benchmarks/CONVERT.md` now references the canonical `bench eval adopt verify` in the conversion prompt (was the deprecated `bench agent verify`).

## Verification

- Full suite **4069 passed, 49 skipped**; `ruff check` / `ruff format --check` / `ty check` clean.
- 14 new regression tests in `tests/test_cli_edge_case_hardening.py`; ~20 assertions that pinned the old stdout stream updated to stderr/output.
- Live dogfooded each fix (clean errors, valid JSON, single deprecation line, hidden verbs).
- Adversarial dev-ex review + thermo-nuclear structural review (**APPROVE-WITH-NITS**) — the one **major** finding (sibling error sites still on stdout) is folded into this PR; nits addressed.

Methodology mirrors the prior hardening rounds (#730, #732, #738): find → adversarially verify → fix the root-cause class, not the single instance.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX and error-handling only across CLI and trajectory viewer; exit codes and public commands unchanged. Broad touch surface but low blast radius for production eval runs.
> 
> **Overview**
> This PR hardens **CLI error and output behavior** after a stress sweep of malformed inputs—**no command renames or default behavior changes**.
> 
> **stderr for errors.** `print_error` and related validation paths now write to **stderr** instead of stdout, so `bench … --json | jq` keeps a clean JSON channel; exit codes are unchanged. The dataset `bench_version` remediation hint follows the same rule.
> 
> **Machine-readable output.** `bench hub env list --json` emits the upstream payload with **`typer.echo`** (verbatim), avoiding Rich line-wrapping that broke JSON at narrow terminals.
> 
> **Graceful failures** replace raw tracebacks for bad `--source-repo` clones, `--tasks-dir` pointing at a file, corrupt `eval view` artifacts, `sandbox create` backend/dependency issues, `tasks digest` read errors, and malformed `hub check --registry` input.
> 
> **Markup safety** via Rich `escape()` on user-controlled strings in `eval list`, `eval metrics`, `skills list`, and `tasks init`.
> 
> **Cleaner messages:** `skills eval` schema errors drop pydantic internals; **`bench environment`** aliases use `hidden=True` only (not Typer `deprecated=True`) for a single deprecation line and hidden help verbs. **`benchmarks/CONVERT.md`** points at `bench eval adopt verify`.
> 
> Tests assert stderr routing, valid JSON, no tracebacks, and viewer degradation on corrupt artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a25b97f7b3873d3d691ac4cd60ae132cbd14d23c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->