### PR TITLE
chore: dead-code purge round 2 (verified zero-reference)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@
   on `bench eval create --source-env`.
 
 ### Removed
+- Dead-code purge, round 2 (no public-API impact; each symbol adversarially
+  verified zero-reference with class context): removed seven unused `*_path`
+  `@property`s from `TaskPaths`/`RolloutPaths` (`readme_path`, `gitignore_path`,
+  `verifier_document_path`, `artifacts_manifest_path`, `result_path`,
+  `exception_message_path`, `log_path`), the vestigial `ModalSandbox.supports_gpus`
+  / `can_disable_internet` capability properties (not on the Sandbox Protocol),
+  an unused module-level `logger` in `cli/continue_cmd.py`, and the orphaned
+  `mcp_service_hooks_from_config` helper.
 - Dead-code purge (no public-API impact unless noted): removed the unused
   `job_config_from_yaml` helper, the nominal `TASK_REPOS` back-compat dict
   (use `TASK_ALIASES`), the `_looks_like_verifier_dep_install_error` shim

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -9,14 +9,11 @@ folder linked to the parent. See :mod:`benchflow.continue_run`.
 from __future__ import annotations
 
 import asyncio
-import logging
 import os
 from pathlib import Path
 from typing import Annotated
 
 import typer
-
-logger = logging.getLogger(__name__)
 
 
 def _load_env_defaults() -> None:

--- a/src/benchflow/experimental/mcp/hooks.py
+++ b/src/benchflow/experimental/mcp/hooks.py
@@ -50,25 +50,3 @@ def mcp_reviewer_hook(
             logger.warning(f"MCP reviewer server may not be ready on port {port}")
 
     return _start_reviewer
-
-
-def mcp_service_hooks_from_config(services: list[str] | None) -> list:
-    """Parse service declarations into pre_agent_hooks.
-
-    Format: "service-name:port" where service-name maps to a known MCP server.
-    """
-    if not services:
-        return []
-
-    hooks = []
-    for svc in services:
-        parts = svc.split(":")
-        name = parts[0]
-        port = int(parts[1]) if len(parts) > 1 else 8100
-
-        if name == "benchflow-reviewer":
-            hooks.append(mcp_reviewer_hook(port=port))
-        else:
-            logger.warning(f"Unknown MCP service: {name}")
-
-    return hooks

--- a/src/benchflow/sandbox/modal_impl.py
+++ b/src/benchflow/sandbox/modal_impl.py
@@ -38,14 +38,6 @@ class ModalSandbox(BaseSandbox):
         return False
 
     @property
-    def supports_gpus(self) -> bool:
-        return True
-
-    @property
-    def can_disable_internet(self) -> bool:
-        return True
-
-    @property
     def _environment_definition_path(self) -> Path:
         return self.environment_dir / "Dockerfile"
 

--- a/src/benchflow/task/paths.py
+++ b/src/benchflow/task/paths.py
@@ -64,14 +64,6 @@ class TaskPaths:
         return self.task_dir / self.DOCUMENT_FILENAME
 
     @property
-    def readme_path(self) -> Path:
-        return self.task_dir / "README.md"
-
-    @property
-    def gitignore_path(self) -> Path:
-        return self.task_dir / ".gitignore"
-
-    @property
     def config_path(self) -> Path:
         return self.task_dir / self.CONFIG_FILENAME
 
@@ -122,10 +114,6 @@ class TaskPaths:
     @property
     def test_path(self) -> Path:
         return self.tests_dir / "test.sh"
-
-    @property
-    def verifier_document_path(self) -> Path:
-        return self.tests_dir / "verifier.md"
 
     def has_verifier_entrypoint(self) -> bool:
         """Return whether the selected verifier package has something runnable.
@@ -353,10 +341,6 @@ class RolloutPaths:
         return self.rollout_dir / "artifacts"
 
     @property
-    def artifacts_manifest_path(self) -> Path:
-        return self.artifacts_dir / "manifest.json"
-
-    @property
     def verifier_dir(self) -> Path:
         return self.rollout_dir / "verifier"
 
@@ -383,18 +367,6 @@ class RolloutPaths:
     @property
     def reward_kit_manifest_path(self) -> Path:
         return self.verifier_dir / "reward-kit-manifest.json"
-
-    @property
-    def result_path(self) -> Path:
-        return self.rollout_dir / "result.json"
-
-    @property
-    def exception_message_path(self) -> Path:
-        return self.rollout_dir / "exception.txt"
-
-    @property
-    def log_path(self) -> Path:
-        return self.rollout_dir / "rollout.log"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
## What

A 92-agent dead-code audit of the release HEAD found 47 adversarially-verified dead/stale symbols. This PR removes the **high-confidence, pure-deletion subset** — re-verified zero-reference **with class context** before deletion:

- **`task/paths.py`** — 7 unused `*_path` `@property`s: `TaskPaths.{readme_path, gitignore_path, verifier_document_path}` and `RolloutPaths.{artifacts_manifest_path, result_path, exception_message_path, log_path}`. The files themselves are still written/read via inline `dir / "name"`; only the unused accessors go.
- **`sandbox/modal_impl.py`** — `ModalSandbox.{supports_gpus, can_disable_internet}`, vestigial capability properties not on the `Sandbox` Protocol (GPU config reads `task_env_config.gpus`; internet policy uses `SandboxConfig.allow_internet`).
- **`cli/continue_cmd.py`** — unused module-level `logger` + its `import logging`.
- **`experimental/mcp/hooks.py`** — orphaned `mcp_service_hooks_from_config` (unexported, no callers). `mcp_reviewer_hook` is kept (referenced in docs).

## Why context-verification matters

The audit's blanket signal flagged `RolloutPaths.log_path` as dead, but a naive grep showed 14 `.log_path` references — all on **unrelated classes** (`models.py`, `litellm_runtime`, test fixtures). Each symbol here was disambiguated against its real reference sites before removal, so the deletions are genuinely safe.

## Verification
- Full suite **4069 passed, 49 skipped**; `ruff check` / `ruff format --check` / `ty check` clean.
- No public API touched.

## Deferred (NOT in this PR)

Items that need per-site verification or an outward-facing decision are intentionally left for a follow-up:
- **Dataclass fields** with positional-construction risk (`AgentLift`, `JudgeConfig`, `ServiceConfig`, `ToolCall`, `SandboxReplayProxy`).
- **Back-compat aliases** requiring test repoints (`scoring.classify_result_dict`/`count_result_outcomes`, SDK pass-through wrappers, `RuntimeResult.to_run_result`).
- **Public-`__all__` / Protocol-surface** items (`OTelCollector`, dead ACP `types.py` models, the `Sandbox.read_file`/`write_file` `@runtime_checkable` isinstance-trap, `RoundResult.n_tool_calls`) — these are breaking and will be queued for a maintainer decision.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure deletions of unreferenced helpers and properties; no behavior or public API changes, with full test suite passing per PR description.
> 
> **Overview**
> Second dead-code cleanup with **no public API changes**: drops path helpers and other symbols that had **zero in-repo references** after class-context verification.
> 
> **`TaskPaths` / `RolloutPaths`** — removes seven unused `*_path` properties (`readme_path`, `gitignore_path`, `verifier_document_path`, `artifacts_manifest_path`, `result_path`, `exception_message_path`, `log_path`). Rollout/task files are still read and written via existing inline paths; only the unused accessors go.
> 
> **`ModalSandbox`** — removes `supports_gpus` and `can_disable_internet` (not on the `Sandbox` protocol; GPU and network policy already come from `SandboxConfig` / `task_env_config`).
> 
> **`cli/continue_cmd.py`** — drops an unused module-level `logger` and `import logging`.
> 
> **`experimental/mcp/hooks.py`** — removes orphaned `mcp_service_hooks_from_config`; **`mcp_reviewer_hook`** stays.
> 
> **`CHANGELOG.md`** documents the removals under **Removed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d398202979ca0973a7192dc195446cf05e37a4f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->