### PR TITLE
test(cli): fix CI-fragile help-parse blocking the 0.6.0 release gate

### DIFF
--- a/tests/test_cli_hub_env.py
+++ b/tests/test_cli_hub_env.py
@@ -67,10 +67,19 @@ def test_environment_group_is_hidden_but_still_resolves() -> None:
     # The whole `environment` group is now a hidden deprecated alias (local
     # lifecycle → `bench sandbox`, hosted reads → `bench hub env`). It must not
     # appear in top-level `bench --help`, but must still resolve for back-compat.
-    import re
+    #
+    # Assert against the Click command registry (authoritative), NOT a regex over
+    # rendered `--help` rows: that text is environment-fragile (Rich emits ANSI
+    # color codes on CI that break a `│`-anchored match → empty set → false fail).
+    import typer
 
-    top = runner.invoke(app, ["--help"], terminal_width=200).output
-    rows = {m.group(1) for m in re.finditer(r"^\s*│\s+([A-Za-z][\w-]*)\s", top, re.M)}
-    assert "sandbox" in rows  # canonical local group is visible
-    assert "environment" not in rows  # deprecated alias group is hidden
+    cmd = typer.main.get_command(app)
+    visible = {
+        name
+        for name, sub in cmd.commands.items()
+        if not getattr(sub, "hidden", False)
+    }
+    assert "sandbox" in visible  # canonical local group is visible
+    assert "environment" not in visible  # deprecated alias group is hidden
+    assert "environment" in cmd.commands  # …but still registered for back-compat
     assert runner.invoke(app, ["environment", "create", "--help"]).exit_code == 0


### PR DESCRIPTION
## What

Fixes the **sole failure** on #665's `test` gate (1 failed / 4112 passed) that's blocking the 0.6.0 release→main merge.

`test_environment_group_is_hidden_but_still_resolves` (in `test_cli_hub_env.py`) matched `│`-anchored command rows in `bench --help` **raw output without stripping ANSI**. On CI, Rich emits color codes (`FORCE_COLOR`), so the `^\s*│` anchor matched nothing → `rows == set()` → `assert 'sandbox' in set()` failed. It passed locally only because there were no ANSI codes.

## Fix

Assert against the **Click command registry** (`typer.main.get_command(app)` + `.hidden`) instead of a regex over rendered help — authoritative and immune to ANSI/locale rendering differences. It still checks the exact contract: `sandbox` visible, `environment` hidden-but-registered, and `bench environment create` resolves.

## Proof

- Fixed test **passes under `FORCE_COLOR=1`** (reproduces CI's rendering); the old regex-on-raw-output yields `EMPTY SET` under `FORCE_COLOR=1` (exactly the CI failure).
- The two other help-row parsers (`test_cli_docs_drift`, `test_cli_adopt_aliases`) already strip ANSI, so they were unaffected — this was the only fragile one.

Once merged, #665's gate re-runs and should pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production CLI behavior; aligns with an existing pattern in `test_cli_docs_drift.py`.
> 
> **Overview**
> **Fixes a CI-only failure** in `test_environment_group_is_hidden_but_still_resolves` that was blocking the release gate.
> 
> The test used a `│`-anchored regex on raw `bench --help` text to decide which top-level commands are visible. On CI, Rich/ANSI color codes break that match, so the parsed command set was empty and `sandbox` assertions failed despite correct CLI behavior.
> 
> **The change** inspects the Typer/Click command tree via `typer.main.get_command(app)` and each subcommand’s `hidden` flag instead of parsing rendered help. The same contract is checked: `sandbox` is visible, `environment` is hidden but still registered, and `bench environment create` still resolves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c81f926d13de06bc715cb82c1afaa1a8aca81892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->