### PR TITLE
style: ruff-format tests/test_cli_hub_env.py (CI gate fix)

### DIFF
--- a/tests/test_cli_hub_env.py
+++ b/tests/test_cli_hub_env.py
@@ -75,9 +75,7 @@ def test_environment_group_is_hidden_but_still_resolves() -> None:
 
     cmd = typer.main.get_command(app)
     visible = {
-        name
-        for name, sub in cmd.commands.items()
-        if not getattr(sub, "hidden", False)
+        name for name, sub in cmd.commands.items() if not getattr(sub, "hidden", False)
     }
     assert "sandbox" in visible  # canonical local group is visible
     assert "environment" not in visible  # deprecated alias group is hidden


### PR DESCRIPTION
Follow-up to #750: that test rewrite passed `ruff check` but I hadn't run `ruff format --check`, which the CI `test` job runs as a gating step — it failed on `Would reformat: tests/test_cli_hub_env.py`. This applies `ruff format` (collapses the set comprehension to canonical form), no logic change. With this, #665's gate should go fully green (the ANSI test fix from #750 + this format fix were the only two failures). Verified locally: ruff format --check + ruff check + ty + the test all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only whitespace/formatting; no production or assertion changes.
> 
> **Overview**
> **CI-only formatting fix** for `tests/test_cli_hub_env.py`: `ruff format` collapses the `visible` set comprehension in `test_environment_group_is_hidden_but_still_resolves` to a single line. **No test logic or assertions change**—this unblocks the `ruff format --check` gate that failed after the prior test rewrite (#750).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6842565e95af50ac2c0ecbd62cd33c8b90c6ed0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->