### PR TITLE
docs: install benchflow 0.6.0 from PyPI (drop RC-wheel URLs)

### DIFF
--- a/.claude/skills/benchflow/SKILL.md
+++ b/.claude/skills/benchflow/SKILL.md
@@ -196,10 +196,9 @@ asyncio.run(main())
 ## Setup
 
 ```bash
-# 0.6 is pre-release — not yet on PyPI. Install the RC wheel from GitHub releases:
-uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
-# (replace rc.6 with the newest 0.6.0-rc.* release; or from source: uv sync --extra dev --locked)
+# Install benchflow 0.6.0 from PyPI (--prerelease allow is for the pinned LiteLLM rc dep):
+uv tool install --prerelease allow benchflow
+# (or from source: uv sync --extra dev --locked)
 export GEMINI_API_KEY=...     # or ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
 export DAYTONA_API_KEY=...    # for cloud sandboxes
 ```

--- a/README.md
+++ b/README.md
@@ -26,9 +26,8 @@ BenchFlow is a universal environment framework: it runs AI agents against task e
 ## Quickstart
 
 ```bash
-# Install the current 0.6 release candidate (see Install for why the wheel URL)
-uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
+# Install benchflow 0.6.0 from PyPI
+uv tool install --prerelease allow benchflow
 
 # Run a benchmark: any task source, any ACP agent, any sandbox
 export GEMINI_API_KEY=...            # or claude login / codex --login for subscription auth
@@ -42,17 +41,15 @@ Each run writes a per-task `result.json` (rewards + trajectory + token usage) an
 
 ## Install
 
-`0.6.0` is in **release-candidate** testing and is **not on PyPI yet** (the newest PyPI build is still `0.5.x`). Until it ships, install the latest `0.6.0-rc.*` wheel from the [GitHub releases page](https://github.com/benchflow-ai/benchflow/releases) — the Quickstart pins `0.6.0-rc.6`; if a newer `rc.*` exists, swap the tag and filename. Confirm with `bench --version`.
-
-- `--prerelease allow` is required for BenchFlow's pinned LiteLLM release-candidate dependency.
-- If you see `Executables already exist: bench, benchflow`, re-run with `--force` to replace stale entrypoints from an older install.
-
-**Once `0.6.0` ships to PyPI**, the plain commands resolve (until then they pick up only `0.5.x`):
+`0.6.0` is on PyPI. Install (or upgrade) with uv or pip:
 
 ```bash
-pip install --upgrade benchflow                                  # once 0.6.0 is on PyPI
-uv tool install --prerelease allow --upgrade 'benchflow==0.6.0'  # once 0.6.0 is on PyPI
+uv tool install --prerelease allow benchflow            # add --upgrade to refresh an existing install
+pip install --pre --upgrade benchflow                   # pip equivalent
 ```
+
+- `--prerelease allow` (uv) / `--pre` (pip) is required for BenchFlow's pinned LiteLLM release-candidate dependency, not for benchflow itself (`0.6.0` is a final release). Confirm with `bench --version`.
+- If you see `Executables already exist: bench, benchflow`, re-run with `--force` to replace stale entrypoints from an older install.
 
 Internal users wanting the newest preview from `main` install the [internal preview channel](./docs/release.md) (`uv tool install --prerelease allow --upgrade benchflow`).
 

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -41,35 +41,13 @@ STEP 0 — Preflight
 
 STEP 1 — Install benchflow
 This prompt requires benchflow 0.6.0 or newer (the task.md authoring CLI and
-trainer artifacts shipped in 0.6.0). While 0.6.0 is in RELEASE-CANDIDATE
-testing it is NOT yet on PyPI (the newest build published there is still
-0.5.x), so `uv tool install --prerelease allow 'benchflow==0.6.0'` cannot
-resolve yet. To get the real 0.6 flow TODAY, install the latest 0.6.0
-release-candidate WHEEL from the GitHub prerelease page.
-  1. Open https://github.com/benchflow-ai/benchflow/releases and find the
-     NEWEST `0.6.0-rc.*` prerelease (highest rc number — do not assume a
-     specific rc; rc.6 may already be superseded by rc.7 or later).
-  2. Copy the download URL of that release's `.whl` asset (named like
-     `benchflow-0.6.0rcN-py3-none-any.whl`). The tag and the filename share
-     the same rc number — tag `0.6.0-rc.N`, file `benchflow-0.6.0rcN`.
-  3. Install it with the URL you copied, e.g. (this example pins rc.6; replace
-     `rc.6`/`rc6` with the actual newest rc you found):
-    uv tool install --prerelease allow \
-      'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
-Any `0.6.0-rc.*` is a valid full-0.6 build. If `gh` is available, you can
-resolve the newest tag without opening a browser:
-    gh release list --repo benchflow-ai/benchflow --limit 20 | grep '0.6.0-rc'
-Confirm with `bench --version` after install.
-Once 0.6.0 ships to PyPI, the `uv tool install --prerelease allow
-'benchflow==0.6.0'` command is the one to use.
+trainer artifacts shipped in 0.6.0). Install it from PyPI:
+    uv tool install --prerelease allow benchflow
 The `--prerelease allow` flag is REQUIRED: benchflow pins a litellm release
 candidate (litellm[proxy]==1.88.0rc1), and uv refuses prerelease transitive
-dependencies without it. If uv reports "Executables already exist: bench,
-benchflow", rerun the same command with `--force`. If the resolver reports
-that no version of `benchflow==0.6.0` exists and you cannot use the RC wheel
-above, the release has not propagated to PyPI yet — as a last resort, fall
-back to:
-    uv tool install --prerelease allow --upgrade benchflow
+dependencies without it — 0.6.0 itself is a final release. If uv reports
+"Executables already exist: bench, benchflow", rerun the same command with
+`--force`. Confirm with `bench --version` after install.
 and check `bench --version`. If the installed version is still older than
 0.6.0, CONTINUE anyway in degraded mode: steps 0–6 work on 0.5.x too. Tell
 the user which version you got, then (a) in step 6, expect only

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,32 +10,19 @@ A 5-minute path from install to first eval.
 
 ## Install
 
-`0.6.0` is in **release-candidate** testing and is **not on PyPI yet** (the
-newest build there is still `0.5.x`). While 0.6 is RC, install the latest
-`0.6.0-rc.*` wheel from the
-[GitHub releases page](https://github.com/benchflow-ai/benchflow/releases) —
-open it, pick the newest `0.6.0-rc.*` prerelease, and install its `.whl` asset:
+`0.6.0` is on PyPI. Install (or upgrade) with uv or pip:
 
 ```bash
-uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
+uv tool install --prerelease allow benchflow            # add --upgrade to refresh
+pip install --pre --upgrade benchflow                   # pip equivalent
 ```
 
-The URL pins `0.6.0-rc.6` (newest at time of writing); if a later `0.6.0-rc.*`
-prerelease exists, use that tag and filename instead. The `--prerelease allow`
-flag is required for BenchFlow's pinned LiteLLM release-candidate dependency. If
-`uv` reports `Executables already exist: bench, benchflow`, rerun the same
-command with `--force` to replace older non-`uv` entrypoints.
-
-**Once `0.6.0` ships to PyPI**, the plain commands will work:
-
-```bash
-pip install --upgrade benchflow                                  # once 0.6.0 is on PyPI
-uv tool install --prerelease allow --upgrade 'benchflow==0.6.0'  # once 0.6.0 is on PyPI
-```
-
-Until then, `pip install --upgrade benchflow` resolves only to `0.5.x`. See
-[Release channels](./release.md) for the full command matrix.
+The `--prerelease allow` (uv) / `--pre` (pip) flag is required for BenchFlow's
+pinned LiteLLM release-candidate dependency, not for benchflow itself (`0.6.0`
+is a final release). If `uv` reports `Executables already exist: bench,
+benchflow`, rerun with `--force` to replace older non-`uv` entrypoints. Confirm
+with `bench --version`. See [Release channels](./release.md) for the full
+command matrix.
 
 This gives you the `benchflow` (alias `bench`) CLI plus the Python SDK. To install for editable development:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -10,35 +10,16 @@ BenchFlow uses two PyPI release channels with the same package name:
 
 Current release state:
 
-- `0.6.0` is in **release-candidate** testing. It is **not on PyPI yet** — the
-  newest PyPI build is still on the `0.5.x` line. The release candidates are
-  published as GitHub prereleases (`0.6.0-rc.*`) only.
-- The public PyPI `0.6.0` / tag `v0.6.0` step has **not happened yet**; the
-  commands below that pin `benchflow==0.6.0` from PyPI start working only after
-  that tag is cut.
-- After the public tag is cut, `main` should move to `0.6.1.dev0`, which
-  publishes internal preview builds as `0.6.1.dev<N>` after CI passes.
+- `0.6.0` is **published on PyPI** (tag `v0.6.0`). Use the public install
+  commands below.
+- `main` currently carries `0.6.0`. To resume internal-preview builds for the
+  next line, bump `main` to `0.6.1.dev0` — internal previews then publish as
+  `0.6.1.dev<N>` automatically after the `test` workflow passes on `main`.
 
-## Release-Candidate Install (current path)
-
-While `0.6.0` is RC, install the newest `0.6.0-rc.*` wheel from the
-[GitHub releases page](https://github.com/benchflow-ai/benchflow/releases) —
-open it, pick the newest `0.6.0-rc.*` prerelease, and install its `.whl` asset:
-
-```bash
-uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
-```
-
-The URL pins `0.6.0-rc.6` (newest at time of writing); use a later
-`0.6.0-rc.*` tag and filename if one exists. Confirm with `bench --version`.
-
-## Install and Upgrade Commands (once 0.6.0 ships to PyPI)
+## Install and Upgrade Commands
 
 Use the public channel by default. Opt into internal preview only when you want
-the newest build from `main` before the next public tag. The commands in this
-section that pin `benchflow==0.6.0` from PyPI only resolve **after** the public
-`v0.6.0` tag is cut — until then, use the Release-Candidate install above.
+the newest build from `main` before the next public tag.
 
 Public Python package users:
 

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -4,9 +4,8 @@ Test whether your agent skill actually helps agents perform better.
 ## Install
 
 ```bash
-uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
-# 0.6.0 is not on PyPI yet — install the newest 0.6.0-rc.* wheel from GitHub releases (replace rc.6 with the latest).
+uv tool install --prerelease allow benchflow
+# --prerelease allow is for the pinned LiteLLM rc dependency, not benchflow itself.
 ```
 
 ## Overview
@@ -397,9 +396,8 @@ BenchFlow generates everything ephemeral — only results persist.
 **CI integration:**
 ```bash
 # In your skill's CI pipeline
-uv tool install --prerelease allow \
-  'benchflow @ https://github.com/benchflow-ai/benchflow/releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl'
-# 0.6.0 is not on PyPI yet — install the newest 0.6.0-rc.* wheel from GitHub releases (replace rc.6 with the latest).
+uv tool install --prerelease allow benchflow
+# --prerelease allow is for the pinned LiteLLM rc dependency, not benchflow itself.
 bench skills eval . --agent claude-agent-acp --no-baseline
 ```
 

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -9,13 +9,11 @@ live Typer parser so doc rot is caught in CI.
 from __future__ import annotations
 
 import re
-import tomllib
 from pathlib import Path
 from typing import cast
 
 import click
 import typer
-from packaging.version import Version
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
@@ -196,10 +194,12 @@ def test_documented_subcommands_exist() -> None:
         assert "Usage:" in out, f"bench {' '.join(cmd)} --help failed: {out}"
 
 
-# ── install-wheel URL drift guard (dev-ex #15) ───────────────────────────────
+# ── install-doc guard: no regression to pinned GitHub-release RC wheels ───────
 
-# Docs that pin a concrete RC-wheel install URL. The hand-pinned tag drifts when
-# one doc is bumped and the others aren't; nothing previously caught that.
+# Install docs that used to pin a concrete RC-wheel URL before 0.6.0 shipped to
+# PyPI. They now install from PyPI (`uv tool install … benchflow`); a hand-pinned
+# `releases/download/<tag>/benchflow-…rcN.whl` goes stale the instant a newer
+# release lands, so this guards against re-introducing that pattern.
 _INSTALL_URL_DOCS = (
     "README.md",
     "docs/getting-started.md",
@@ -208,47 +208,22 @@ _INSTALL_URL_DOCS = (
     "docs/skill-eval.md",
     ".claude/skills/benchflow/SKILL.md",
 )
-# Matches only CONCRETE pins, e.g.
-# releases/download/0.6.0-rc.6/benchflow-0.6.0rc6-py3-none-any.whl
-# The \d+ deliberately skips agent-quickstart.md's `rc.N`/`rcN` placeholders.
-_WHEEL_URL_RE = re.compile(
-    r"releases/download/(?P<tag>\d+\.\d+\.\d+-rc\.\d+)/"
-    r"benchflow-(?P<whl>\d+\.\d+\.\d+rc\d+)-py3-none-any\.whl"
+_RC_WHEEL_URL_RE = re.compile(
+    r"releases/download/\d+\.\d+\.\d+-rc\.\d+/"
+    r"benchflow-\d+\.\d+\.\d+rc\d+-py3-none-any\.whl"
 )
 
 
-def test_install_wheel_url_consistent_across_docs() -> None:
-    """Every pinned RC-wheel install URL must be mutually consistent: one shared
-    rc tag, each URL's tag matching its own wheel filename, and the base version
-    matching pyproject. Offline-only (no network / freshness check)."""
-    matches: list[tuple[str, str, str]] = []  # (doc, tag, wheel)
-    missing: list[str] = []
-    for rel in _INSTALL_URL_DOCS:
-        text = (_REPO_ROOT / rel).read_text()
-        found = list(_WHEEL_URL_RE.finditer(text))
-        if not found:
-            missing.append(rel)
-        matches.extend((rel, m["tag"], m["whl"]) for m in found)
-
-    # A doc that dropped/renamed its pinned URL (e.g. a 404-shaped path) must
-    # fail loudly rather than silently pass with zero matches.
-    assert not missing, f"docs with no concrete pinned wheel URL: {missing}"
-
-    # Per-URL: the release tag and its own wheel filename share the rc number
-    # (PEP 440 normalizes 0.6.0-rc.6 and 0.6.0rc6 to the same Version).
-    for doc, tag, whl in matches:
-        assert Version(tag) == Version(whl), (
-            f"{doc}: release tag {tag!r} and wheel filename {whl!r} disagree"
-        )
-
-    # Cross-doc: all pinned rc tags identical (the core drift).
-    by_tag = {Version(tag): doc for doc, tag, _ in matches}
-    assert len(by_tag) == 1, "install-wheel rc pins drift across docs: " + ", ".join(
-        f"{doc}={tag}" for tag, doc in by_tag.items()
+def test_install_docs_use_pypi_not_pinned_rc_wheel() -> None:
+    """Install docs must install benchflow from PyPI, not a pinned GitHub-release
+    RC wheel (which goes stale on every release). Catches regressions to the
+    pre-0.6.0 `releases/download/…rcN.whl` pattern."""
+    offenders = [
+        rel
+        for rel in _INSTALL_URL_DOCS
+        if _RC_WHEEL_URL_RE.search((_REPO_ROOT / rel).read_text())
+    ]
+    assert not offenders, (
+        "install docs pin a stale GitHub-release RC wheel instead of installing "
+        f"from PyPI: {offenders}"
     )
-
-    # Base version ties to pyproject (0.6.0); NOT the rc number — pyproject
-    # carries no rc, so only the base is sensibly assertable.
-    pyproject = tomllib.loads((_REPO_ROOT / "pyproject.toml").read_text())
-    pin = next(iter(by_tag))
-    assert pin.base_version == Version(pyproject["project"]["version"]).base_version


### PR DESCRIPTION
## What

Now that **`benchflow==0.6.0` is live on public PyPI** (tag `v0.6.0`), the docs no longer need to point users at a pinned GitHub-release RC wheel. Every install snippet flips to the PyPI install:

```bash
uv tool install --prerelease allow benchflow
```

Updated: `README.md`, `docs/getting-started.md`, `docs/agent-quickstart.md`, `docs/skill-eval.md` (×2), `docs/release.md`, `.claude/skills/benchflow/SKILL.md`. Dropped the stale "not on PyPI yet / install the rc.6 wheel / once 0.6.0 ships" framing, and removed `release.md`'s now-obsolete RC-install section.

`--prerelease allow` (uv) / `--pre` (pip) **stays** — it's for the pinned LiteLLM RC dependency (`litellm[proxy]==1.88.0rc1`), not benchflow itself (0.6.0 is a final release). This also resolves the rc.6-vs-rc.3 pin drift the dogfood found (there are no pinned wheel URLs anymore).

## Test

Replaced `test_install_wheel_url_consistent_across_docs` (which *required* a pinned rc wheel in every doc — now inverted) with **`test_install_docs_use_pypi_not_pinned_rc_wheel`**, which fails if any install doc *regresses* to a stale `releases/download/…rcN.whl` URL.

Full suite **4068 passed**; ruff/format/ty clean. Targets `main` (post-release trunk).

## Note

`release.md` flags that `main` should bump to `0.6.1.dev0` to resume internal-preview builds — that's a separate one-line change for you when you open the 0.6.1 line.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and a drift guard test only; no runtime or packaging behavior changes.
> 
> **Overview**
> With **`benchflow==0.6.0` on public PyPI**, install guidance no longer points at pinned GitHub `0.6.0-rc.*` wheels. **README**, **getting-started**, **agent-quickstart**, **skill-eval**, **release.md**, and the **benchflow** skill now standardize on `uv tool install --prerelease allow benchflow` (plus pip equivalents where shown).
> 
> Removed the pre-release framing (“not on PyPI yet”, RC-only install sections, multi-step wheel URL discovery in the agent quickstart). **`--prerelease allow` / `--pre`** is documented as required for the pinned **LiteLLM** RC dependency, not because benchflow 0.6.0 is a prerelease. **release.md** states 0.6.0 is published and drops the obsolete RC-install block.
> 
> In **`tests/test_cli_docs_drift.py`**, **`test_install_wheel_url_consistent_across_docs`** is replaced by **`test_install_docs_use_pypi_not_pinned_rc_wheel`**, which fails if any listed install doc regresses to a `releases/download/…rcN.whl` URL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f2183c3df11b9c70478ba941834cadeac309629. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->