### PR TITLE
fix(cli): 0.6.1 dogfood fixes — skills-eval exit code + migrate wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+- `bench skills eval` now exits non-zero when any eval case errors (e.g. missing
+  credentials), matching `bench eval create`. A 100%-error run printed `0/1`
+  but exited `0`, so CI/scripts read a total failure as success.
+- The "task.md already exists" migrate error now names both surfaces
+  (`--overwrite` for the CLI, `overwrite=True` for the Python API) instead of
+  only the API kwarg.
+
 ## 0.6.0 — 2026-06-13
 
 ### Added

--- a/src/benchflow/_utils/task_authoring/scaffolding.py
+++ b/src/benchflow/_utils/task_authoring/scaffolding.py
@@ -236,7 +236,8 @@ def migrate_task_to_task_md(
         )
     if task_md.exists() and not overwrite:
         raise FileExistsError(
-            f"{task_md} already exists; pass overwrite=True to replace it"
+            f"{task_md} already exists; pass --overwrite (CLI) / overwrite=True "
+            "(API) to replace it"
         )
 
     legacy_config = import_task_config_toml(

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -185,3 +185,14 @@ def register_skills(app: typer.Typer) -> None:
             console.print(
                 f"[green]GEPA traces exported to {escape(str(gepa_dir))}[/green]"
             )
+
+        # Match `eval create`'s _exit_if_evaluation_had_errors: a run with any
+        # errored case is a failure for CI/scripting — exit non-zero so a
+        # 100%-error run (e.g. missing credentials) is not reported as success.
+        errored = sum(1 for c in result.case_results if c.error)
+        if errored:
+            print_error(
+                f"{errored}/{len(result.case_results)} eval case(s) errored — "
+                "the eval did not complete cleanly."
+            )
+            raise typer.Exit(1)

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -423,3 +423,39 @@ def test_arg_validation_errors_route_to_stderr(argv, needle):
     assert res.exit_code == 1
     assert needle in res.stderr
     assert needle not in res.stdout
+
+
+def test_skills_eval_exits_nonzero_when_cases_error(tmp_path, monkeypatch):
+    # A run where cases errored (e.g. missing credentials) must exit non-zero,
+    # matching `eval create` — a 100%-error run printed `0/1` but exited 0, so CI
+    # read a total failure as success.
+    from benchflow.skill_eval._core import CaseResult, SkillEvalResult, SkillEvaluator
+
+    evals = tmp_path / "evals"
+    evals.mkdir()
+    (evals / "evals.json").write_text(
+        '{"skill_name":"s","cases":[{"id":"c","question":"q",'
+        '"ground_truth":"g","expected_behavior":["x"]}]}'
+    )
+
+    async def fake_run(self, **kwargs):
+        return SkillEvalResult(
+            skill_name="s",
+            n_cases=1,
+            agents=["oracle"],
+            case_results=[
+                CaseResult(
+                    case_id="c",
+                    agent="oracle",
+                    model="",
+                    with_skill=True,
+                    reward=None,
+                    error="boom",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(SkillEvaluator, "run", fake_run)
+    res = runner.invoke(app, ["skills", "eval", str(tmp_path), "--agent", "oracle"])
+    assert res.exit_code == 1
+    assert "errored" in res.stderr


### PR DESCRIPTION
First batch of the 0.6.0 dogfood fast-follow (targets `main` for 0.6.1).

- **`bench skills eval` exits non-zero on errored cases** (the one *confirmed bug* from the dogfood). Per your call, it matches `eval create`'s contract: **any** errored case → exit 1. A 100%-error run printed `0/1 (0.0%), errors=1` but exited `0`, so CI/scripts read a total failure as success. Now counts `CaseResult.error` and exits 1 with a clear stderr line. Regression test added.
- **Migrate "already exists" wording** — `scaffolding.py` told CLI users to "pass `overwrite=True`" (the Python kwarg); now names both `--overwrite` (CLI) / `overwrite=True` (API).

Full suite **4069 passed**; ruff/format/ty clean.

### Still in the 0.6.1 backlog (next batches)
The more involved dogfood papercuts: scaffold's no-op verifier (test.sh writes 0.0 without running test_outputs.py), `migrate`→publication-grade dead-end, the skills-eval missing-creds traceback, `eval view <job_dir>` not descending into rollout subdirs, and `hub env list`'s "20 of 1270" with no footer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI/UX fixes with a targeted regression test; no auth, data, or core eval execution changes beyond post-run exit semantics.
> 
> **Overview**
> **`bench skills eval`** now **exits with code 1** when any eval case records an error (e.g. missing credentials), aligned with **`bench eval create`**. Previously a run could show errored cases but still exit `0`, so CI/scripts treated a total failure as success. After results are printed, the command counts `CaseResult.error`, writes a short message to stderr via `print_error`, and raises `typer.Exit(1)`.
> 
> The **task migrate** path updates the `task.md` already-exists error so it documents both **`--overwrite`** (CLI) and **`overwrite=True`** (Python API), not only the API kwarg.
> 
> CHANGELOG documents both fixes; a regression test stubs a 100%-error skill eval run and asserts exit code 1 and stderr mentioning errored cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee2c284ac8cd8c9756462768edb5a7dba638bf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->