### PR TITLE
fix(cli): 0.6.1 dogfood papercuts batch 2 (eval view, hub footer, check hint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 - The "task.md already exists" migrate error now names both surfaces
   (`--overwrite` for the CLI, `overwrite=True` for the Python API) instead of
   only the API kwarg.
+- `bench eval view <job-dir>` no longer shows a blank "No trajectory files
+  found" when given a job directory (the natural value from `eval create`'s
+  "Artifacts:" line) — it now indexes the rollout subdirectories to drill into.
+- `bench hub env list` prints a footer (`Showing N…`) with how to refine
+  (`--search`/`--owner`/`--limit`/`--json`), so a small page of a large catalog
+  no longer reads as "the provider only has N environments".
+- `bench tasks check --level publication-grade` errors for a missing verifier
+  package now include a remediation hint (author `verifier/verifier.md`; note
+  that `bench tasks migrate` does not generate it), instead of a dead-end.
 
 ## 0.6.0 — 2026-06-13
 

--- a/src/benchflow/_utils/task_authoring/structural_checks.py
+++ b/src/benchflow/_utils/task_authoring/structural_checks.py
@@ -223,7 +223,12 @@ def _check_publication_grade(task_dir: Path) -> list[str]:
 
     verifier_dir = paths.verifier_source_dir
     if not verifier_dir.is_dir():
-        issues.append("publication-grade validation requires native verifier/")
+        issues.append(
+            "publication-grade validation requires native verifier/ — `bench tasks "
+            "migrate` produces the native layout but not the verifier package; "
+            "author verifier/ (verifier.md + rubrics/) per "
+            "docs/task-authoring-task-md.md, then re-run check"
+        )
         return issues
     if paths.legacy_tests_dir.exists():
         issues.append(
@@ -233,7 +238,11 @@ def _check_publication_grade(task_dir: Path) -> list[str]:
 
     verifier_md = verifier_dir / VERIFIER_DOCUMENT_FILENAME
     if not verifier_md.exists():
-        issues.append("publication-grade validation requires verifier/verifier.md")
+        issues.append(
+            "publication-grade validation requires verifier/verifier.md — author "
+            "the verifier strategy document (see docs/task-authoring-task-md.md); "
+            "`bench tasks migrate` does not generate it"
+        )
         return issues
 
     try:

--- a/src/benchflow/cli/_hosted_env.py
+++ b/src/benchflow/cli/_hosted_env.py
@@ -76,6 +76,16 @@ def hosted_env_list(
             escape(str(name)), escape(version), escape(visibility), escape(updated)
         )
     console.print(table)
+    # The table is a (often small) page of a much larger catalog; without this
+    # footer a user reasonably concludes the provider has only these few.
+    total = (
+        data.get("total") or data.get("totalCount") if isinstance(data, dict) else None
+    )
+    suffix = f" of {total}" if isinstance(total, int) and total > len(rows) else ""
+    console.print(
+        f"[dim]Showing {len(rows)}{suffix} environment(s). Refine with "
+        "--search/--owner, raise --limit, or use --json for the full payload.[/dim]"
+    )
 
 
 def hosted_env_show(*, source_env: str, version: str | None) -> None:

--- a/src/benchflow/trajectories/viewer.py
+++ b/src/benchflow/trajectories/viewer.py
@@ -159,6 +159,29 @@ def render_rollout(rollout_dir: Path, prompts: list[str] | None = None) -> str:
         return _render_acp_trajectory(rollout_dir, acp_traj, prompts)
 
     if not turn_files:
+        # The given dir has no trajectory of its own. If it's a job directory
+        # (the natural value from `eval create`'s "Artifacts:" line), point at its
+        # rollout subdirectories instead of showing a blank page.
+        try:
+            rollouts = sorted(
+                d.name
+                for d in rollout_dir.iterdir()
+                if d.is_dir()
+                and (
+                    any(d.glob("turn*.txt"))
+                    or (d / "trajectory" / "acp_trajectory.jsonl").exists()
+                )
+            )
+        except OSError:
+            rollouts = []
+        if rollouts:
+            items = "".join(f"<li><code>{html.escape(r)}</code></li>" for r in rollouts)
+            return (
+                f"<p>No trajectory here — <code>{html.escape(rollout_dir.name)}</code> "
+                f"looks like a job directory with {len(rollouts)} rollout(s). "
+                f"View one with <code>bench eval view {html.escape(rollout_dir.name)}/"
+                f"&lt;rollout&gt;</code>:</p><ul>{items}</ul>"
+            )
         return "<p>No trajectory files found</p>"
 
     # Default prompts

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -459,3 +459,20 @@ def test_skills_eval_exits_nonzero_when_cases_error(tmp_path, monkeypatch):
     res = runner.invoke(app, ["skills", "eval", str(tmp_path), "--agent", "oracle"])
     assert res.exit_code == 1
     assert "errored" in res.stderr
+
+
+def test_viewer_job_dir_indexes_rollout_subdirs(tmp_path):
+    # `eval view <job_dir>` used to render a blank "No trajectory files found"
+    # (the natural value from create's "Artifacts:" line); now it indexes the
+    # rollout subdirectories so the user knows to drill in.
+    from benchflow.trajectories.viewer import render_rollout
+
+    rollout = tmp_path / "task-a__trial-1"
+    rollout.mkdir()
+    (rollout / "turn1.txt").write_text(
+        '{"type":"system","session_id":"s","model":"m"}\n'
+    )
+    html_out = render_rollout(tmp_path)
+    assert "job directory" in html_out
+    assert "task-a__trial-1" in html_out
+    assert "No trajectory files found" not in html_out


### PR DESCRIPTION
Second batch of 0.6.0 dogfood fast-follow papercuts (targets `main`).

- **`eval view <job-dir>`** no longer shows a blank "No trajectory files found" — `render_rollout` now indexes the job dir's rollout subdirectories so you know to drill in. (Regression test added.)
- **`hub env list`** prints a `Showing N of M…` footer with how to refine (`--search`/`--owner`/`--limit`/`--json`) — a 20-row page of a 1270-env catalog previously read as "the provider only has 20".
- **`tasks check --level publication-grade`** verifier-missing errors now include a remediation hint (author `verifier/verifier.md`; `tasks migrate` doesn't generate it) instead of a dead-end.

Full suite **4070 passed**; ruff/format/ty clean.

### Deferred — the scaffold no-op verifier (needs your design call)
The highest-value papercut isn't a quick patch: `verifier.md` wires `command: ./test.sh` (script strategy), `test.sh` writes `0.0`, and a separate `test_outputs.py` is **orphaned**. Connecting them is a verifier-model decision:
1. **`test.sh` runs `pytest test_outputs.py`** — requires pytest in the *task's own* Dockerfile (a real constraint on every scaffolded task).
2. **Switch `verifier.md` to a pytest strategy** on `test_outputs.py` — benchflow's harness runs pytest, no task-Dockerfile dependency (cleaner, if a pytest strategy exists).
3. **Drop the orphaned `test_outputs.py`** — author edits `test.sh` only (smallest change, removes the pytest option).

Which model do you want? I'll implement it once you pick.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing CLI messaging and HTML viewer behavior only; no changes to eval execution, auth, or data handling.
> 
> **Overview**
> Three small CLI/UX fixes from 0.6.0 dogfood follow-ups.
> 
> **`bench eval view`** on a **job directory** (typical path from `eval create` artifacts) no longer shows an empty “No trajectory files found” page. **`render_rollout`** scans child dirs for `turn*.txt` or ACP trajectory files and returns HTML that lists rollout names and how to open `bench eval view <job>/<rollout>`.
> 
> **`bench hub env list`** adds a dim footer: **Showing N** (optionally **of total** when the API returns it) plus pointers to `--search`, `--owner`, `--limit`, and `--json`, so a short page is not mistaken for the full catalog.
> 
> **`bench tasks check --level publication-grade`** expands missing **`verifier/`** and **`verifier/verifier.md`** errors with remediation text (author per docs; **`bench tasks migrate`** does not create the verifier package). **CHANGELOG** documents these; a regression test covers job-dir indexing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6295c8ef641ef9db6202795fd435f1e999ace556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->