### PR TITLE
fix(dogfood): four harness-lane bugs surfaced by deepseek-v4-pro/deepagents run

### DIFF
--- a/src/benchflow/agents/deepagents_acp_shim.py
+++ b/src/benchflow/agents/deepagents_acp_shim.py
@@ -268,50 +268,62 @@ def run_deep_agent(
 ) -> dict:
     """Build and invoke a deep agent, emitting ACP updates for its trajectory.
 
-    Returns a small metrics dict. Walks the resulting message list once,
-    emitting agent text, tool_call, and tool_call_update events keyed by tool
-    call id so BenchFlow's trajectory reconstructs the step sequence.
+    Returns a small metrics dict. Streams the LangGraph trajectory, emitting
+    agent text, tool_call, and tool_call_update events keyed by tool call id as
+    each step happens so BenchFlow's trajectory reconstructs the step sequence
+    and its idle watchdog stays fed during long model turns.
     """
     start = time.time()
     agent = build_deep_agent(model_id, cwd, env)
 
-    result = agent.invoke(
-        {"messages": [{"role": "user", "content": instruction}]},
-        config={"recursion_limit": _RECURSION_LIMIT},
-    )
-
-    messages = result.get("messages", []) if isinstance(result, dict) else []
+    # Stream the LangGraph trajectory so ACP updates emit incrementally per step,
+    # NOT one blocking invoke() that stays silent until it returns. BenchFlow's
+    # idle watchdog counts ACP updates (tool calls + message/thought chunks), so a
+    # long-but-productive model turn under a single invoke() emits nothing for
+    # >600s and false-fires the idle timeout; streaming also preserves the
+    # trajectory if the run is cancelled mid-flight (it was discarded before).
+    message_count = 0
     tool_call_count = 0
     text_count = 0
     # Track which tool_call ids we have already announced so a ToolMessage maps
-    # back onto its originating tool_call as a tool_call_update.
+    # back onto its originating tool_call as a tool_call_update (and so a repeated
+    # streamed update does not double-count).
     announced: set[str] = set()
 
-    for message in messages:
-        role = _message_role(message)
+    for chunk in agent.stream(
+        {"messages": [{"role": "user", "content": instruction}]},
+        config={"recursion_limit": _RECURSION_LIMIT},
+        stream_mode="updates",
+    ):
+        for node_update in (chunk or {}).values():
+            for message in (node_update or {}).get("messages", []):
+                message_count += 1
+                role = _message_role(message)
 
-        if role in ("ai", "aimessage", "assistant"):
-            text = _message_text(message)
-            if text.strip():
-                _emit_text(session_id, text)
-                text_count += 1
-            for call in _message_tool_calls(message):
-                tool_call_count += 1
-                call_id = call["id"] or f"tc_{tool_call_count}"
-                announced.add(call_id)
-                _emit_tool_call(session_id, call_id, call["name"], call["args"])
+                if role in ("ai", "aimessage", "assistant"):
+                    text = _message_text(message)
+                    if text.strip():
+                        _emit_text(session_id, text)
+                        text_count += 1
+                    for call in _message_tool_calls(message):
+                        call_id = call["id"] or f"tc_{tool_call_count + 1}"
+                        if call_id in announced:
+                            continue
+                        tool_call_count += 1
+                        announced.add(call_id)
+                        _emit_tool_call(session_id, call_id, call["name"], call["args"])
 
-        elif role in ("tool", "toolmessage"):
-            tool_call_id = (
-                message.get("tool_call_id")
-                if isinstance(message, dict)
-                else getattr(message, "tool_call_id", "")
-            ) or ""
-            _emit_tool_result(session_id, tool_call_id, _message_text(message))
+                elif role in ("tool", "toolmessage"):
+                    tool_call_id = (
+                        message.get("tool_call_id")
+                        if isinstance(message, dict)
+                        else getattr(message, "tool_call_id", "")
+                    ) or ""
+                    _emit_tool_result(session_id, tool_call_id, _message_text(message))
 
     elapsed = time.time() - start
     return {
-        "message_count": len(messages),
+        "message_count": message_count,
         "tool_call_count": tool_call_count,
         "text_count": text_count,
         "wall_clock_seconds": round(elapsed, 2),

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -551,24 +551,39 @@ AGENTS: dict[str, AgentConfig] = {
         "deepseek-v4-pro through the OpenAI-compatible provider",
         install_cmd=(
             "export DEBIAN_FRONTEND=noninteractive && "
-            # deepagents is a Python package with heavy langchain deps; isolate
-            # it in its own venv so it never collides with task-image Python.
-            "( command -v pip3 >/dev/null 2>&1 || "
-            "  (apt-get update -qq && apt-get install -y -qq python3-pip >/dev/null 2>&1) ) && "
-            "( python3 -m venv /opt/benchflow/deepagents-venv 2>/dev/null || "
-            "  (apt-get update -qq && apt-get install -y -qq python3-venv >/dev/null 2>&1 && "
-            "   python3 -m venv /opt/benchflow/deepagents-venv) ) && "
+            # deepagents requires Python >=3.11, but task base images ship as low
+            # as 3.6/3.8 (ubuntu:20.04, cached CI images), so a system-python venv
+            # makes pip report "No matching distribution found for deepagents".
+            # Provision a pinned interpreter with uv (same pattern as the OpenHands
+            # install) so this works regardless of the base-image Python.
+            "( command -v curl >/dev/null 2>&1 || "
+            f"  {_apt_install('curl', 'ca-certificates')} ) && "
+            "( command -v uv >/dev/null 2>&1 || "
+            "  ( curl -LsSf https://astral.sh/uv/install.sh | sh >/dev/null 2>&1 ) ) && "
+            'export PATH="$HOME/.local/bin:$PATH" && '
+            "uv venv --python 3.12 /opt/benchflow/deepagents-venv && "
             # deepagents pulls in langchain/langchain-core/langchain-anthropic/
             # langchain-google-genai; langchain-openai is NOT a deepagents dep but
             # is required for the OpenAI-compatible deepseek-v4-pro chat model.
-            "/opt/benchflow/deepagents-venv/bin/python -m pip install -q "
+            "uv pip install -q --python /opt/benchflow/deepagents-venv/bin/python "
             "deepagents langchain-openai && "
-            # Let the sandbox user traverse + execute the venv interpreter.
+            # Let the sandbox user traverse + execute the venv interpreter and the
+            # uv-managed CPython it links to.
             "chmod -R a+rX /opt/benchflow/deepagents-venv && "
+            "chmod o+x /root /root/.local /root/.local/share "
+            "/root/.local/share/uv /root/.local/share/uv/python 2>/dev/null; "
             # Deploy ACP shim
             + _install_python_script(
                 f"{_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim", _DEEPAGENTS_SHIM
             )
+            # Verify deepagents actually imports through the pinned venv. Without
+            # this, install rc reflects only the shim-deploy's trailing `chmod +x`
+            # (the `;` above is intentionally non-fatal), so a failed `uv pip
+            # install deepagents` — the exact failure this block fixes — would
+            # report success and fail opaquely later at launch. Mirrors OpenHands'
+            # `command -v openhands` verification tail.
+            + " && /opt/benchflow/deepagents-venv/bin/python -c 'import deepagents' "
+            ">/dev/null 2>&1"
         ),
         launch_cmd=(
             f"/opt/benchflow/deepagents-venv/bin/python {_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim"

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -37,7 +37,22 @@ LITELLM_MASTER_KEY_ENV = "BENCHFLOW_LITELLM_MASTER_KEY"
 #
 # Example:
 #   "minimax-m3": (0.30e-6, 1.20e-6),   # $0.30 / $1.20 per 1M in/out — VERIFY
-MODEL_COST_PER_TOKEN: dict[str, tuple[float, float]] = {}
+MODEL_COST_PER_TOKEN: dict[str, tuple[float, float]] = {
+    # deepseek-v4 is not in LiteLLM's built-in price table (it tops out at
+    # deepseek-v3.2), so a deepseek-v4 run otherwise records $0/null cost.
+    # v4 list price is not yet published — these are v3-class PLACEHOLDERS;
+    # VERIFY against api-docs.deepseek.com/quick_start/pricing before relying on
+    # absolute cost figures. (Single flat input rate uses the cache-miss price,
+    # so cache-hit-heavy runs are slightly over-counted.)
+    "deepseek-v4-pro": (
+        0.28e-6,
+        0.42e-6,
+    ),  # $0.28 / $0.42 per 1M in/out — PLACEHOLDER, VERIFY
+    "deepseek-v4-flash": (
+        0.28e-6,
+        0.42e-6,
+    ),  # $0.28 / $0.42 per 1M in/out — PLACEHOLDER, VERIFY
+}
 
 
 def custom_cost_per_token(model: str) -> tuple[float, float] | None:

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1255,12 +1255,16 @@ class Rollout:
             # Purge agent-injected conftest/sitecustomize/.pth without
             # killing processes or restoring workspace.
             # Honor per-task [verifier.hardening] opt-outs from task config.
+            # No timeout_sec here: the conftest purge walks the rootfs and can be
+            # slow on network-backed FS (Daytona), so its budget is owned by
+            # lockdown.cleanup_verifier_python_hooks (VERIFIER_SETUP_TIMEOUT_SEC),
+            # shared with the scoring path in harden_before_verify. The except
+            # below keeps the step fail-closed.
             await self._planes.cleanup_verifier_python_hooks(
                 self._env,
                 getattr(self._task, "task_dir", None),
                 "Soft verifier setup failed: purging Python injection hooks",
                 user="root",
-                timeout_sec=10,
             )
         except Exception as e:
             verifier_error = f"soft verifier crashed: {e}"

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -744,6 +744,16 @@ async def _checked_exec(env: Any, command: str, label: str, **kwargs: Any) -> An
     return result
 
 
+# Verifier-setup commands that walk the full rootfs (notably the conftest purge)
+# run on the verifier sandbox, whose filesystem can be slow/network-backed
+# (Daytona). The find is pruned (see _build_cleanup_cmd) so it completes well
+# within this budget; the larger-than-default ceiling keeps a slow-but-valid
+# setup from false-erroring the verifier. Owned here so every call site — the
+# scoring path (harden_before_verify) and the soft-verify path (rollout, via
+# cleanup_verifier_python_hooks) — shares one value rather than scattering it.
+VERIFIER_SETUP_TIMEOUT_SEC = 60
+
+
 async def clear_verifier_output_dir(
     env: Any,
     label: str = "Verifier setup failed: clearing verifier output directory",
@@ -771,11 +781,20 @@ async def cleanup_verifier_python_hooks(
     env: Any,
     task_dir: "Path | str | None",
     label: str = "Verifier setup failed: purging Python injection hooks",
+    *,
+    timeout_sec: int = VERIFIER_SETUP_TIMEOUT_SEC,
     **kwargs: Any,
 ) -> Any:
-    """Purge agent-injected Python hook files using task hardening settings."""
+    """Purge agent-injected Python hook files using task hardening settings.
+
+    The conftest purge walks the full rootfs, so the timeout defaults to
+    VERIFIER_SETUP_TIMEOUT_SEC (the same budget the scoring path uses in
+    harden_before_verify) rather than the caller guessing a value.
+    """
     hardening = _read_hardening_config(task_dir)
-    return await _checked_exec(env, _build_cleanup_cmd(hardening), label, **kwargs)
+    return await _checked_exec(
+        env, _build_cleanup_cmd(hardening), label, timeout_sec=timeout_sec, **kwargs
+    )
 
 
 # Per-task hardening opt-outs. Tasks declare these in task config under
@@ -845,7 +864,11 @@ def _build_cleanup_cmd(hardening: dict[str, bool] | None = None) -> str:
     parts: list[str] = []
     if h.get("cleanup_conftests", True):
         parts.append(
-            "find / -name conftest.py "
+            # Prune virtual filesystems so the full-rootfs walk stays bounded and
+            # fast — an unpruned `find /` over a slow network-backed FS (Daytona)
+            # routinely exceeds the setup timeout and false-errors a valid verifier.
+            "find / -path /proc -prune -o -path /sys -prune -o -path /dev -prune -o "
+            "-name conftest.py "
             "-not -path '/verifier/*' -not -path '/tests/*' "
             "-delete 2>/dev/null"
         )
@@ -1109,9 +1132,16 @@ async def harden_before_verify(
     # 5. Purge symlinks + __pycache__, then chown the workspace to root.
     if workspace:
         await _freeze_workspace(env, workspace)
-    # 6. Remove injected conftest.py, sitecustomize.py, .pth files.
+    # 6. Remove injected conftest.py, sitecustomize.py, .pth files. The rootfs
+    #    conftest walk can be slow on network-backed FS, so use the shared
+    #    verifier-setup budget (not the default 10s) — same rationale as the
+    #    soft-verify path, on the path that actually scores.
     hardening = _read_hardening_config(getattr(task, "task_dir", None))
-    await env.exec(_build_cleanup_cmd(hardening), user="root", timeout_sec=10)
+    await env.exec(
+        _build_cleanup_cmd(hardening),
+        user="root",
+        timeout_sec=VERIFIER_SETUP_TIMEOUT_SEC,
+    )
     # 7. Merge trusted env vars into task.config.verifier.env.
     task.config.verifier.env = await _build_verifier_env(
         env, task, sandbox_user, workspace

--- a/tests/test_deepagents_agent.py
+++ b/tests/test_deepagents_agent.py
@@ -44,8 +44,15 @@ def test_deepagents_install_deploys_shim_and_isolated_venv():
     deploys the shim into BenchFlow's shared bin prefix."""
     cfg = AGENTS["deepagents"]
     install = cfg.install_cmd
-    # Isolated Python venv (never the task image's interpreter).
-    assert "python3 -m venv /opt/benchflow/deepagents-venv" in install
+    # Isolated venv on a uv-pinned interpreter (deepagents needs Python >=3.11,
+    # but task base images ship Python as old as 3.6/3.8, so a system-python venv
+    # would make pip report "No matching distribution found for deepagents").
+    assert "uv venv --python 3.12 /opt/benchflow/deepagents-venv" in install
+    # Packages are installed into that pinned venv via uv pip.
+    assert (
+        "uv pip install -q --python /opt/benchflow/deepagents-venv/bin/python"
+        in install
+    )
     # Both required pip packages: deepagents pulls langchain*, but langchain-openai
     # is the explicit dep for the OpenAI-compatible deepseek-v4-pro chat model.
     assert "deepagents" in install
@@ -54,6 +61,10 @@ def test_deepagents_install_deploys_shim_and_isolated_venv():
     # base64 transport (so the shim source can't collide with shell tokens).
     assert f"{_BENCHFLOW_BIN_PREFIX}/deepagents-acp-shim" in install
     assert "base64 -d" in install
+    # Install verifies deepagents imports through the pinned venv, so a failed
+    # `uv pip install` surfaces as rc!=0 instead of being masked by the
+    # non-fatal chmod / shim-deploy's trailing `chmod +x`.
+    assert "/opt/benchflow/deepagents-venv/bin/python -c 'import deepagents'" in install
 
 
 def test_deepagents_launch_runs_shim_with_venv_python():
@@ -190,3 +201,74 @@ def test_message_role_and_tool_calls_from_dicts():
     assert calls == [{"id": "tc1", "name": "execute", "args": {"command": "ls"}}]
     # A message with no tool calls yields an empty list.
     assert shim._message_tool_calls({"type": "tool", "content": "ok"}) == []
+
+
+# ── Streaming trajectory + dedup (run_deep_agent) ────────────────────────────
+
+
+class _FakeStreamingAgent:
+    """Stand-in LangGraph agent yielding pre-baked ``updates``-mode chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = chunks
+
+    def stream(self, _input, config=None, stream_mode=None):
+        # The shim must request incremental updates, not values/debug.
+        assert stream_mode == "updates"
+        yield from self._chunks
+
+
+def test_run_deep_agent_streams_and_dedups_tool_calls(monkeypatch):
+    """run_deep_agent emits ACP updates per streamed step and announces each
+    tool_call id exactly once even if a later chunk re-surfaces it (LangGraph
+    can re-emit accumulated state), so the idle watchdog is fed without
+    double-counting."""
+    ai_with_text = {
+        "type": "ai",
+        "content": "writing the file",
+        "tool_calls": [
+            {"id": "call_1", "name": "write_file", "args": {"path": "a.py"}}
+        ],
+    }
+    tool_result = {"type": "tool", "tool_call_id": "call_1", "content": "ok"}
+    # A later chunk re-surfaces call_1 (empty text so only the tool_call dedup is
+    # under test, not text emission), plus a genuinely new tool_call call_2.
+    ai_dup_plus_new = {
+        "type": "ai",
+        "content": "",
+        "tool_calls": [
+            {"id": "call_1", "name": "write_file", "args": {"path": "a.py"}},
+            {"id": "call_2", "name": "execute", "args": {"command": "pytest"}},
+        ],
+    }
+    chunks = [
+        {"agent": {"messages": [ai_with_text]}},
+        {"tools": {"messages": [tool_result]}},
+        {"agent": {"messages": [ai_dup_plus_new]}},
+    ]
+
+    monkeypatch.setattr(
+        shim, "build_deep_agent", lambda *a, **k: _FakeStreamingAgent(chunks)
+    )
+    sent: list[dict] = []
+    monkeypatch.setattr(shim, "send", lambda payload: sent.append(payload))
+
+    metrics = shim.run_deep_agent("deepseek-v4-pro", "do it", "/tmp", "sess-1", env={})
+
+    # call_1 announced once despite appearing in two chunks; call_2 added once.
+    assert metrics["tool_call_count"] == 2
+    # Only the first AI message carried text; the re-surfaced one was empty.
+    assert metrics["text_count"] == 1
+    assert metrics["message_count"] == 3
+
+    kinds = [p["params"]["update"]["sessionUpdate"] for p in sent]
+    tool_call_ids = [
+        p["params"]["update"]["toolCallId"]
+        for p in sent
+        if p["params"]["update"]["sessionUpdate"] == "tool_call"
+    ]
+    # Each tool_call id emitted exactly once, in first-seen order.
+    assert tool_call_ids == ["call_1", "call_2"]
+    # The tool result emitted as a completion update keyed to its originating call.
+    assert kinds.count("tool_call_update") == 1
+    assert kinds.count("agent_message_chunk") == 1

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -1678,7 +1678,10 @@ Use task.md as the canonical task entrypoint.
         from benchflow.sandbox.lockdown import _build_cleanup_cmd
 
         cmd = _build_cleanup_cmd()
-        assert "find / -name conftest.py" in cmd
+        # Rootfs conftest purge is present (pruning /proc /sys /dev to stay fast).
+        assert "-name conftest.py" in cmd
+        assert "-delete" in cmd
+        assert "-path /proc -prune" in cmd
         assert "find /tmp /var/tmp" in cmd
         assert "sitecustomize.py" in cmd
 


### PR DESCRIPTION
## What

A real-model dogfood (deepseek-v4-pro, **deepagents** agent, 50 real SkillsBench tasks on Daytona) surfaced four bugs in the **benchflow harness lane** — the tasks themselves were blameless. This PR fixes all four, with the fixes verified + re-dogfooded.

| # | Bug | Fix |
|---|-----|-----|
| 1 | deepagents install fails on base images shipping Python <3.11 (`No matching distribution found for deepagents`, 3/50) | Provision a **uv-pinned Python 3.12 venv** (mirrors the OpenHands install). Adds an `import deepagents` **verification tail** so a failed install surfaces as `rc!=0` instead of being masked by the shim-deploy's trailing `chmod +x`. |
| 2 | Idle watchdog false-fires at 600s on long-but-productive turns (9 `idle_timeout`s); trajectory lost on cancel | **Stream** the LangGraph trajectory (`agent.stream`, `updates` mode) emitting ACP updates per step instead of a blocking `invoke()`. Tool-call ids deduped across chunks. |
| 3 | `summary.json` records **$0** cost despite 41.4M deepseek tokens | Populate `MODEL_COST_PER_TOKEN` with deepseek-v4 entries (clearly-labeled v3-class **PLACEHOLDERS** to verify) — deepseek-v4 is absent from LiteLLM's built-in price table. |
| 4 | Rootfs conftest-purge `find /` exceeds a 10s timeout on slow network-backed FS → false-errors valid verifiers | **Prune** `/proc /sys /dev` from the find, and give the walk **one owned timeout** (`VERIFIER_SETUP_TIMEOUT_SEC`) shared by the scoring path (`harden_before_verify`) and the soft-verify path. Kept **fail-closed**. |

## Verification

- Full suite green: **4071 passed, 49 skipped**; `ruff check` / `ruff format --check` / `ty check` all clean.
- Adds a streaming/dedup unit test for the shim; updates the deepagents-install and conftest-purge assertions.
- Structural-quality (thermo-nuclear) review: **APPROVE** — two initial blockers (install-failure masking; the timeout bump reaching only one of two call sites + a scattered literal) were fixed and re-verified.
- `#4` keeps the conftest-purge **fail-closed** (a reward-hacking defense); pruning only skips descent into virtual filesystems where a planted conftest can't affect pytest collection.

## Notes

- The deepseek-v4 prices in `#3` are **PLACEHOLDERS** (v3-class) — flagged in-code to verify against published pricing before relying on absolute cost figures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches verifier hardening timeouts and rootfs find (fail-closed anti-tamper) plus agent streaming behavior; deepseek prices are unverified placeholders.
> 
> **Overview**
> Fixes four harness issues found during deepseek-v4-pro / **deepagents** dogfood on slow Daytona sandboxes.
> 
> **deepagents** install now provisions a **uv-managed Python 3.12** venv (package needs ≥3.11; old task images ship 3.6/3.8) and ends with an **`import deepagents`** check so a failed `uv pip install` fails install instead of masking behind shim deploy.
> 
> The deepagents ACP shim **streams** LangGraph (`agent.stream`, `updates`) and emits tool/text updates per step so the **600s idle watchdog** stays fed on long model turns; tool-call ids are **deduped** when chunks re-emit state.
> 
> **LiteLLM** custom pricing adds **deepseek-v4-pro/flash** placeholders so runs no longer record **$0** cost (v4 absent from built-in table).
> 
> Verifier **conftest purge** `find /` now **prunes `/proc`, `/sys`, `/dev`** and uses a shared **`VERIFIER_SETUP_TIMEOUT_SEC` (60s)** on both soft-verify and `harden_before_verify`, replacing scattered 10s limits that false-failed on network-backed FS.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eee4f8eec9ec38aacd976030b67f79d4fe3d4d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->