### PR TITLE
fix(acp): don't idle-timeout an agent while a tool call is in-flight

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -675,6 +675,11 @@ async def _prompt_with_idle_watchdog(
     # short overall budgets don't overshoot (e.g. timeout=30s with default
     # poll_interval=30s could overshoot 100%). Cap at 30s, floor at 1s.
     poll_interval = max(1, min(30, idle_timeout // 4, max(1, timeout // 4)))
+    # deadline is loop-INVARIANT (fixed at loop start), NOT re-derived from
+    # last_progress inside the loop. This is load-bearing: the idle branch below
+    # resets last_progress while a tool call is in-flight, so re-deriving the
+    # deadline from it would let an agent that emits a tool_call and then hangs
+    # forever push the wall-clock backstop out indefinitely. Keep this fixed.
     deadline = last_progress + timeout
 
     try:
@@ -690,6 +695,16 @@ async def _prompt_with_idle_watchdog(
             if cur_count > last_count:
                 last_progress = now
                 last_count = cur_count
+            # An in-flight tool call means the agent is actively executing a tool
+            # (e.g. a long build/test/solver shell command), not hung. Those tools
+            # emit no ACP updates until they return, so a >idle_timeout run would
+            # otherwise false-fire the watchdog and discard real work. Treat a
+            # pending tool call as progress and defer to the wall-clock `timeout`
+            # backstop below for a tool that never returns. A genuine model-side
+            # hang has no pending tool call (the prior tool already completed via
+            # tool_call_update), so it still trips the idle path.
+            elif session.pending_tool_call_ids():
+                last_progress = now
             if now - last_progress >= idle_timeout:
                 diag = IdleTimeoutDiagnostic(
                     idle_timeout_sec=idle_timeout,

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -690,6 +690,45 @@ class TestIdleTimeoutDiagnostics:
         assert info["n_tool_calls"] == 1
 
     @pytest.mark.asyncio
+    async def test_in_flight_tool_call_defers_idle_to_wall_clock(self) -> None:
+        """A pending/in-progress tool call (agent running a long shell command)
+        must NOT trip the idle watchdog: such tools emit no ACP updates until
+        they return, so the idle path would otherwise false-kill real work. The
+        agent is alive (executing a tool), so it defers to the wall-clock
+        backstop. Contrast test_idle_timeout_info_reflects_activity_counts, where
+        a *completed* tool that then hangs still idles out."""
+        from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts
+
+        class PendingToolThenHang:
+            def __init__(self, session: ACPSession):
+                self._session = session
+
+            async def prompt(self, _prompt: str):
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_long",
+                        "title": "long running build",
+                        "kind": "bash",
+                    }
+                )
+                await asyncio.Future()  # hang while the "tool" runs
+
+        session = ACPSession("pending-idle-session")
+        # idle_timeout(1) < wall-clock(3): without the in-flight exemption this
+        # would raise IdleTimeoutError at ~1s. With it, the pending tool defers
+        # idle and the wall-clock backstop fires (AgentPromptTimeoutError) instead.
+        with pytest.raises(AgentPromptTimeoutError):
+            await execute_prompts(
+                PendingToolThenHang(session),  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=3,
+                idle_timeout=1,
+            )
+        assert session.pending_tool_call_ids() == ["tc_long"]
+
+    @pytest.mark.asyncio
     async def test_wall_clock_timeout_records_terminal_diagnostic(self) -> None:
         """Wall-clock timeouts record runner-owned terminal timeout evidence."""
         from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts


### PR DESCRIPTION
## What

The ACP idle watchdog aborts a prompt when no `tool_call` / `agent_message_chunk` / `agent_thought_chunk` update arrives for `idle_timeout` seconds (default 600s). But a **long-running tool** — a build/test/solver shell `execute` — emits **no ACP updates until it returns**. So a tool that runs longer than `idle_timeout` false-fired the watchdog and discarded real work.

Surfaced in the deepseek-v4-pro / deepagents dogfood: the agent emitted a `tool_call` (status `pending`) for a shell command, the command ran >600s, and the watchdog killed a productive run (42 prior tool calls), which then needed a retry to recover.

## Fix

While a tool call is **in-flight** (`pending`/`in_progress`), treat the agent as active and reset the idle clock — deferring to the wall-clock `timeout` as the hard backstop for a tool that genuinely never returns.

```python
if cur_count > last_count:
    last_progress = now
    last_count = cur_count
elif session.pending_tool_call_ids():   # in-flight tool = working, not hung
    last_progress = now
```

**This does not weaken hang detection** (the watchdog's actual purpose):
- A genuine **model-side hang** has *no* pending tool call (the prior tool already completed via `tool_call_update`), so it still trips the idle path.
- A **completed-tool-then-hang** still idle-times-out — `test_idle_timeout_info_reflects_activity_counts` (uses a `COMPLETED` tool) is unchanged and passing.
- `deadline` is **loop-invariant** (fixed at loop start, never re-derived from `last_progress`), so the reset cannot push the wall-clock backstop out indefinitely. Added a load-bearing comment so a future refactor can't reintroduce that hang.

## Verification

- New regression test `test_in_flight_tool_call_defers_idle_to_wall_clock`: a pending tool that hangs raises the wall-clock `AgentPromptTimeoutError`, not `IdleTimeoutError`.
- Full suite **4072 passed**; `ruff check` / `ruff format --check` / `ty check` clean.
- Adversarial safety review (APPROVE-WITH-NITS): confirmed the deadline is loop-invariant, the model-hang path still fires, and there's no data race (single event loop, no threads).

## Note

A second item considered in the same investigation — an apparent summary "under-count" (8 rollouts reported as `total: 7`) — turned out **not to be a bug**: it's the retry mechanism (a task idle-timed-out, was retried, and the retry passed), and both the live summary and the post-hoc `metrics.py` aggregation correctly dedupe retries by `task_name`, keeping the best attempt. No change made there. This PR's fix also reduces *why* that retry was needed in the first place.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes rollout timeout behavior for all ACP runs with idle detection; misclassification of pending tools could weaken hang detection or allow stuck tools to run until wall-clock expiry.
> 
> **Overview**
> Fixes **false idle timeouts** during long-running shell tools: the ACP idle watchdog in `_prompt_with_idle_watchdog` now treats **pending/in-progress tool calls** as activity and refreshes the idle clock via `session.pending_tool_call_ids()`, since those tools often emit no ACP updates until they finish.
> 
> **Model-side hangs** after a completed tool are unchanged—the idle path still fires when there is no pending tool. The **wall-clock `timeout`** remains the hard cap (including tools that never return). Comments clarify that **`deadline` stays fixed at loop start** so resetting `last_progress` for in-flight tools cannot push the wall-clock backstop out indefinitely.
> 
> Adds regression test **`test_in_flight_tool_call_defers_idle_to_wall_clock`**: a pending tool that hangs hits `AgentPromptTimeoutError` at the wall-clock budget, not `IdleTimeoutError` at the shorter idle threshold.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7061a1f899f89bf3819ca09bb8856e5cda154d2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->