### PR TITLE
fix(deps): pin stable litellm 1.89.0 so `uv tool install benchflow` works by default

### DIFF
--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -42,13 +42,11 @@ STEP 0 — Preflight
 STEP 1 — Install benchflow
 This prompt requires benchflow 0.6.0 or newer (the task.md authoring CLI and
 trainer artifacts shipped in 0.6.0). Install it from PyPI:
-    uv tool install --prerelease allow benchflow
-The `--prerelease allow` flag is REQUIRED: benchflow pins a litellm release
-candidate (litellm[proxy]==1.88.0rc1), and uv refuses prerelease transitive
-dependencies without it — 0.6.0 itself is a final release. If uv reports
+    uv tool install benchflow
+benchflow pins a stable litellm (no `--prerelease` flag needed). If uv reports
 "Executables already exist: bench, benchflow", rerun the same command with
 `--force`. Confirm with `bench --version` after install.
-and check `bench --version`. If the installed version is still older than
+If the installed version is still older than
 0.6.0, CONTINUE anyway in degraded mode: steps 0–6 work on 0.5.x too. Tell
 the user which version you got, then (a) in step 6, expect only
 `trainer/verifiers.jsonl` (the `atif.json`/`adp.jsonl` trainer artifacts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.0"
+version = "0.6.1"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -14,7 +14,7 @@ dependencies = [
     "rich>=13.0",
     # Dataset registry bench_version checks (PEP 440 specifier sets).
     "packaging>=24",
-    "litellm[proxy]==1.88.0rc1",
+    "litellm[proxy]==1.89.0",
     "tomli-w>=1.0",
     "typer>=0.9",
 ]

--- a/src/benchflow/providers/litellm_bedrock_patch.py
+++ b/src/benchflow/providers/litellm_bedrock_patch.py
@@ -1,6 +1,6 @@
 """LiteLLM startup patch for Bedrock Claude 4.8+ adaptive thinking.
 
-LiteLLM 1.88.0rc1 knows the direct Anthropic Claude 4.8+ IDs, but Bedrock
+LiteLLM 1.89.0 knows the direct Anthropic Claude 4.8+ IDs, but Bedrock
 inference-profile IDs such as ``us.anthropic.claude-opus-4-8`` still need to be
 classified as adaptive-thinking models before the Bedrock Converse transform is
 called. This module is loaded inside the LiteLLM proxy process via

--- a/src/benchflow/providers/litellm_bedrock_preflight.py
+++ b/src/benchflow/providers/litellm_bedrock_preflight.py
@@ -24,7 +24,7 @@ class BedrockPatchPreflightError(RuntimeError):
 BEDROCK_PATCH_PREFLIGHT_SOURCE = """\
 import sys
 
-# Probe with versioned/profile-shaped Bedrock IDs: stock litellm 1.88.0rc1
+# Probe with versioned/profile-shaped Bedrock IDs: stock litellm 1.89.0
 # resolves the Opus bare alias through its cost map, so only the versioned form
 # discriminates patched from stock (#602). Fable 5 is profile-shaped today.
 PROBES = [

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -53,7 +53,7 @@ from benchflow.usage_tracking import UsageTrackingConfig, usage_unavailable
 
 logger = logging.getLogger(__name__)
 
-LITELLM_VERSION_SPEC = "litellm[proxy]==1.88.0rc1"
+LITELLM_VERSION_SPEC = "litellm[proxy]==1.89.0"
 LITELLM_SANDBOX_ROOT = "/tmp/benchflow-litellm"
 _CALLBACK_MODULE = "benchflow_litellm_callback"
 _PATCH_MODULE = "benchflow_litellm_bedrock_patch"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -343,7 +343,7 @@ requires-dist = [
     { name = "google-genai", marker = "extra == 'judge'", specifier = ">=1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain-openai", marker = "extra == 'deepagents'", specifier = ">=0.2" },
-    { name = "litellm", extras = ["proxy"], specifier = "==1.88.0rc1" },
+    { name = "litellm", extras = ["proxy"], specifier = "==1.89.0" },
     { name = "modal", marker = "extra == 'sandbox-modal'", specifier = ">=0.73" },
     { name = "openai", marker = "extra == 'judge'", specifier = ">=1.40" },
     { name = "packaging", specifier = ">=24" },
@@ -1674,7 +1674,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.88.0rc1"
+version = "1.89.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1690,9 +1690,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/d9/ff399e95a4dd0b11d356736cc248213f89b90e18350218f28ea88dc06f1d/litellm-1.88.0rc1.tar.gz", hash = "sha256:79d5c792505092ca5ae1fbad8176204726112251689f0443da2ff59ab0bbdbb1", size = 13885858, upload-time = "2026-05-31T04:12:21.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/4b/15d4cb75f054933c1f19bcfd5683e139cdf792099b995ae55916b26094dc/litellm-1.89.0.tar.gz", hash = "sha256:eb1910a23497044b4375a0500c65f4c60d291a575d7b679c7566a5df9b9a5fcb", size = 14062606, upload-time = "2026-06-13T23:45:53.723Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/17/3852e5c11231c7a656d6e53d337e50c4f1bfabda38eb0f141f24c46b6b5b/litellm-1.88.0rc1-py3-none-any.whl", hash = "sha256:4f4dfe9f5967b668761f64a48f9602472f26426cef1e500804572b543d285b69", size = 15275196, upload-time = "2026-05-31T04:12:18.154Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/86/49cf94af8c51cacc15fd9bff1e6f9de1fb07ab10b8bb09961675ab389af4/litellm-1.89.0-py3-none-any.whl", hash = "sha256:63b33e2de386ab2a83fed7ed852c755e59d461a21b16c79fc17993f1b8c3d154", size = 15475805, upload-time = "2026-06-13T23:45:46.037Z" },
 ]
 
 [package.optional-dependencies]
@@ -1739,11 +1739,11 @@ wheels = [
 
 [[package]]
 name = "litellm-proxy-extras"
-version = "0.4.73"
+version = "0.4.74"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/37/bed736f8a623b7891e9ff272fd60c2f08fc4a8fed372885f5df9ec09b769/litellm_proxy_extras-0.4.73.tar.gz", hash = "sha256:d4fb1238fb56cdaa21aef6b1d7683c2c0fe3a148ecd423f8bf4cef3c3d07bd36", size = 43599, upload-time = "2026-05-20T00:00:05.495Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2a/10/a8231bbc381569fb9484e29b6d6463c79908b500322c2f498a7c46edfd0b/litellm_proxy_extras-0.4.74.tar.gz", hash = "sha256:af1df564126451c45635c331451504ea02dc092d68c211201ac4876e7af149c2", size = 44395, upload-time = "2026-06-06T22:20:20.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/64/7e85f5f47495ebb0bb5f30a4f4b54b64277a40a14be79c34052df97ac7ab/litellm_proxy_extras-0.4.73-py3-none-any.whl", hash = "sha256:a4f460d15dd01a095dadb26f7660a259fa2a8757a9e27dee68c159a872b8db7e", size = 118593, upload-time = "2026-05-20T00:00:04.017Z" },
+    { url = "https://files.pythonhosted.org/packages/39/fb/a5f7cc9a091c528a473d1cbfedc55c15828b8f2a49f7e3804b2dffce4ea4/litellm_proxy_extras-0.4.74-py3-none-any.whl", hash = "sha256:d4b82d4f994cb0a9954e02337455e822dc35e28a33bfe29a13d4ca2bbf0e2c76", size = 121647, upload-time = "2026-06-06T22:20:18.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

benchflow `0.6.0` is a *final* release, but it depends on a **prerelease**: `litellm[proxy]==1.88.0rc1`. uv refuses transitive prereleases by default, so `uv tool install benchflow` / `uv pip install benchflow` silently **backtrack to `0.4.0`** (the newest release with no prerelease dependency) instead of erroring — users get an ancient CLI with no litellm and a missing `--version`. (`pip` happened to honor the explicit `==…rc1` pin, which masked this.)

A version bump alone does **not** fix it — any release still depending on the rc is rejected by uv the same way. The fix is to remove the prerelease dependency.

## Fix

litellm shipped a **stable `1.89.0`** after that rc, so repin to it:

- `pyproject.toml`: `litellm[proxy]==1.88.0rc1` → `==1.89.0`; version `0.6.0` → `0.6.1`
- `litellm_runtime.py`: `LITELLM_VERSION_SPEC` → `1.89.0` (in-sandbox installs carried the same prerelease risk)
- `litellm_bedrock_patch.py` / `litellm_bedrock_preflight.py`: version refs in comments → `1.89.0`
- `docs/agent-quickstart.md`: drop the now-unneeded `--prerelease allow` workaround
- `uv.lock`: relocked to `litellm 1.89.0`

## Validation (against litellm 1.89.0)

- `uv pip compile pyproject.toml` with **no `--prerelease` flag** → `litellm==1.89.0`, exit 0 ✅ (the core fix)
- Bedrock monkeypatch targets intact (`AnthropicConfig._is_adaptive_thinking_model`, `AmazonConverseConfig._handle_reasoning_effort_parameter`, `model_cost`); patch applies in-proxy ✅
- 140 unit tests pass (bedrock/config/logging/smoke/hardening/runtime), 5 live-gated skips ✅
- Real litellm 1.89.0 proxy boots healthy (`/health/liveliness → 200`) with benchflow's generated config + callback + bedrock patch ✅

## Release

Tag `v0.6.1` on the merge commit to publish to PyPI via `public-release.yml`. This becomes the version `uv tool install benchflow` resolves by default.