### PR TITLE
Make task.md the native v0.6.2 authoring path

### DIFF
--- a/.claude/skills/benchflow/SKILL.md
+++ b/.claude/skills/benchflow/SKILL.md
@@ -132,8 +132,9 @@ my-task/
 └── oracle/            # optional reference solution (solve.sh)
 ```
 
-`--format legacy` instead scaffolds the older split layout (`task.toml` +
-`instruction.md` + `tests/` + `solution/`).
+`--format legacy` is retired in v0.6.2: `bench tasks init` always scaffolds a
+native `task.md` package. To bring an existing split-layout task forward, run
+`bench tasks migrate <dir> --remove-legacy`.
 
 ### `skills` — discover and evaluate agent skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+- **`task.md` is now the sole task authoring format.** `bench tasks init`
+  scaffolds a native `task.md` package (`task.md` + `environment/` + `oracle/` +
+  `verifier/`). `bench tasks init --format legacy` is retired and now exits with
+  an error pointing at `bench tasks migrate <dir> --remove-legacy`. Existing
+  split-layout packages remain readable, and `bench tasks migrate` /
+  `bench tasks export` continue to cover the migration and compatibility paths.
+  Authoring docs now lead with `task.md`; the split layout is documented only as
+  a migration/export target.
+
 ### Fixed
 - `bench skills eval` now exits non-zero when any eval case errors (e.g. missing
   credentials), matching `bench eval create`. A 100%-error run printed `0/1`

--- a/README.md
+++ b/README.md
@@ -139,8 +139,8 @@ the authoring lifecycle:
 ```bash
 bench tasks init my-task                 # scaffold a task.md package under tasks/
 bench tasks check tasks/my-task          # validate (default --level structural)
-bench tasks migrate legacy-task/         # convert task.toml + instruction.md → task.md
-bench tasks export tasks/my-task out/    # write a Harbor/Pier split layout + loss report
+bench tasks migrate legacy-task/ --remove-legacy  # convert old split packages to task.md
+bench tasks export tasks/my-task out/             # write a compatibility export + loss report
 ```
 
 See [Native task.md authoring](./docs/task-authoring-task-md.md) and the

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -197,7 +197,7 @@ Trajectories are written to `<jobs_dir>/<job_name>/<rollout_name>/trajectory/acp
 
 - [Getting started](./getting-started.md) — install, run your first eval.
 - [Task authoring (native task.md)](./task-authoring-task-md.md) — write a task as a single `task.md` document plus `environment/` and `verifier/`.
-- [Task authoring (legacy split layout)](./task-authoring.md) — write a task with `task.toml` + `tests/` + `solution/`.
+- [Migrating a legacy task](./task-authoring.md) — convert an existing `task.toml` + `instruction.md` split package to `task.md` (the split layout is no longer a first-class authoring path).
 - [LLM-as-judge](./llm-judge.md) — use an LLM to score subjective tasks against a rubric (see the [verifier file map](#verifier-file-map) for native vs legacy rubric paths).
 - [Progressive disclosure](./progressive-disclosure.md) — the User abstraction; SWE-bench Pro case study.
 - [Use cases](./use-cases.md) — multi-agent patterns (coder/reviewer, simulated user, BYOS, stateful environments).

--- a/docs/llm-judge.md
+++ b/docs/llm-judge.md
@@ -460,6 +460,6 @@ criterion, aggregates, and writes `reward.json` — no scripting required.
 ## Where to go next
 
 - [Concepts](./concepts.md) — the five primitives including Verifier
-- [Task authoring](./task-authoring.md) — `task.toml`, `tests/`, verifier contract
+- [Task authoring](./task-authoring-task-md.md) — `task.md` frontmatter, `verifier/`, verifier contract
 - [Running benchmarks](./running-benchmarks.md) — Harvey LAB uses LLM-as-judge
 - [Python API reference](./reference/python-api.md) — `LLMJudgeRewardFunc` and friends

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -315,16 +315,16 @@ Scaffold a new benchmark task.
 ```bash
 bench tasks init my-new-task
 bench tasks init my-new-task --dir tasks/
-bench tasks init my-new-task --format legacy
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--format` | `task-md` | Task format: `task-md` (native single-document) or `legacy` (split `task.toml` + `instruction.md` layout) |
+| `--format` | `task-md` | Task format. New tasks use `task-md`; the legacy scaffold path is retired in v0.6.2. |
 
 ### bench tasks check
 
-Validate a task directory (`task.md` or legacy `task.toml` + `instruction.md`, `environment/Dockerfile`, `verifier/` or legacy `tests/`).
+Validate a task directory. Native packages use `task.md`, `environment/`, and
+`verifier/`; older split packages should be migrated with `bench tasks migrate`.
 
 ```bash
 bench tasks check tasks/my-task
@@ -339,9 +339,9 @@ Evidence" section of `docs/task-standard.md`.
 
 ### bench tasks migrate
 
-Convert a legacy `task.toml` + `instruction.md` task into the unified
-`task.md` format. By default the legacy files are kept alongside the new
-`task.md`.
+Convert an older split task package into the unified `task.md` format. By
+default the old files are kept alongside the new `task.md`; for publication,
+use `--remove-legacy`.
 
 ```bash
 bench tasks migrate tasks/my-task
@@ -351,7 +351,7 @@ bench tasks migrate tasks/my-task --overwrite --remove-legacy
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--overwrite` | `false` | Replace an existing task.md |
-| `--remove-legacy` | `false` | Delete split files and promote tests/solution aliases after task.md is verified |
+| `--remove-legacy` | `false` | Delete split files and promote `tests/` to `verifier/` and `solution/` to `oracle/` after `task.md` is verified |
 
 ### bench tasks normalize
 
@@ -371,14 +371,14 @@ bench tasks normalize tasks/my-task -o normalized-task.md
 
 ### bench tasks export
 
-Export a `task.md` task to a Harbor/Pier-compatible split layout, with a
-compatibility loss report written to `compatibility/export-report.json` in
-the export directory.
+Export a `task.md` task to a compatibility split package, with a compatibility
+loss report written to `compatibility/export-report.json` in the export
+directory.
 
 ```bash
 bench tasks export tasks/my-task out/my-task-split
 bench tasks export tasks/my-task --report-only
-bench tasks export tasks/my-task out/my-task-split --target pier --overwrite
+bench tasks export tasks/my-task out/my-task-split --overwrite
 ```
 
 Arguments: `TASK_DIR` (task directory to export) and optional `OUTPUT_DIR`

--- a/docs/reports/2026-06-14-task-md-v062-cutover.md
+++ b/docs/reports/2026-06-14-task-md-v062-cutover.md
@@ -4,11 +4,14 @@ BenchFlow v0.6.2 makes native `task.md` packages the task authoring path:
 
 - `bench tasks init <name>` scaffolds `task.md`, `environment/`, `verifier/`,
   and `oracle/`.
-- The CLI no longer scaffolds new split-layout tasks.
+- `bench tasks init` no longer scaffolds new split-layout tasks; `--format
+  legacy` exits with a migration hint.
 - Existing split packages remain readable so they can be migrated in place with
   `bench tasks migrate <dir> --remove-legacy`.
 - Compatibility exports are produced from native packages with
   `bench tasks export`.
+- `bench tasks generate --task-format legacy` (trace import) still emits a split
+  package for trace-adoption compatibility; native `task-md` is its default.
 
 This keeps the migration path available without leaving two first-class
 authoring formats for contributors to choose between.

--- a/docs/reports/2026-06-14-task-md-v062-cutover.md
+++ b/docs/reports/2026-06-14-task-md-v062-cutover.md
@@ -1,0 +1,14 @@
+# BenchFlow v0.6.2 task.md cutover
+
+BenchFlow v0.6.2 makes native `task.md` packages the task authoring path:
+
+- `bench tasks init <name>` scaffolds `task.md`, `environment/`, `verifier/`,
+  and `oracle/`.
+- The CLI no longer scaffolds new split-layout tasks.
+- Existing split packages remain readable so they can be migrated in place with
+  `bench tasks migrate <dir> --remove-legacy`.
+- Compatibility exports are produced from native packages with
+  `bench tasks export`.
+
+This keeps the migration path available without leaving two first-class
+authoring formats for contributors to choose between.

--- a/docs/task-authoring-task-md.md
+++ b/docs/task-authoring-task-md.md
@@ -3,9 +3,7 @@
 A native BenchFlow task is one `task.md` document plus sidecar directories.
 The YAML frontmatter carries the task configuration; the markdown body **is**
 the prompt. This page teaches the native format hands-on. For the normative
-standard see [the task standard](./task-standard.md); for the legacy split
-layout (`task.toml` + `instruction.md` + `tests/` + `solution/`) see
-[Authoring tasks](./task-authoring.md).
+standard see [the task standard](./task-standard.md).
 
 When a directory contains both layouts, `task.md` is the authoritative task
 definition — the runtime selects it and ignores the split pair.
@@ -23,10 +21,9 @@ my-task/
     └── test.sh            # verifier entry point
 ```
 
-That is the complete runnable surface: structural validation requires a task
-definition (`task.md`, or the legacy `task.toml` + `instruction.md` pair), an
-`environment/` directory with a `Dockerfile`, and a verifier directory with a
-runnable entrypoint. An `oracle/` directory is optional.
+That is the complete runnable surface: structural validation requires
+`task.md`, an `environment/` directory with a `Dockerfile`, and a verifier
+directory with a runnable entrypoint. An `oracle/` directory is optional.
 
 ```markdown
 ---
@@ -68,7 +65,7 @@ bench tasks check tasks/my-task --level schema   # frontmatter + prompt parse on
 frontmatter must be a mapping — a document without it fails to parse. The keys
 fall into three classes.
 
-**Task config keys** are the Harbor-compatible config surface, validated as
+**Task config keys** are the BenchFlow task config surface, validated as
 `TaskConfig`. Unknown keys are **rejected** (the schema is `extra="forbid"`),
 so typos fail at parse time instead of becoming silently-ignored config:
 
@@ -81,7 +78,7 @@ so typos fail at parse time instead of becoming silently-ignored config:
 | `verifier` | Verifier run policy: `timeout_sec` (default 600), `env`, `user`, `service`, … |
 | `environment` | Sandbox: `docker_image`, `cpus`, `memory_mb`, `storage_mb`, `network_mode`, `env`, `workdir`, … |
 | `oracle` | Oracle run policy: `env`, `timeout_sec` (import alias: `solution`) |
-| `source`, `artifacts`, `steps`, `multi_step_reward_strategy`, `reward` | Provenance and Harbor-compatible extras |
+| `source`, `artifacts`, `steps`, `multi_step_reward_strategy`, `reward` | Provenance, artifact, and reward metadata |
 
 `agent.timeout_sec` is **strongly recommended**: it is optional and defaults
 to unset, and a task that omits it runs the agent with no wall-clock cap
@@ -163,18 +160,15 @@ including real converted SkillsBench packages.
 
 ## Verifier package and strategy declaration
 
-The native verifier directory is `verifier/` (`tests/` remains the legacy
-alias; when both exist, `verifier/` wins and there is no fallback to
-`tests/`). At verify time the directory is uploaded into the sandbox at
-`/verifier` (legacy `tests/` uploads to `/tests`), and the verifier must write
-its reward to `/logs/verifier/reward.txt` (and optionally
+The native verifier directory is `verifier/`. At verify time the directory is
+uploaded into the sandbox at `/verifier`, and the verifier must write its
+reward to `/logs/verifier/reward.txt` (and optionally
 `/logs/verifier/reward.json`).
 
 A plain `verifier/test.sh` is a complete verifier: with no other declaration,
-the runtime executes it directly. The same contract as the legacy layout
-applies — write a float `0.0`–`1.0` to `/logs/verifier/reward.txt`, then exit
-`0`; a nonzero exit means verifier infrastructure failure, not a scored task
-failure.
+the runtime executes it directly. Write a float `0.0`–`1.0` to
+`/logs/verifier/reward.txt`, then exit `0`; a nonzero exit means verifier
+infrastructure failure, not a scored task failure.
 
 To declare *how* the task is scored, add `verifier/verifier.md`. Its
 frontmatter must contain a `verifier:` mapping with at least one entry under
@@ -264,13 +258,13 @@ bench tasks check tasks/my-task
 bench eval create --tasks-dir tasks/my-task --agent oracle --sandbox docker
 ```
 
-## Exporting to the split layout
+## Compatibility Export
 
-To go the other way — produce a Harbor/Pier-compatible split layout from a
-`task.md` package — use `bench tasks export`:
+To produce a compatibility split package from a `task.md` package, use
+`bench tasks export`:
 
 ```bash
-bench tasks export tasks/my-task out/my-task-split            # harbor target
+bench tasks export tasks/my-task out/my-task-split
 bench tasks export tasks/my-task --report-only                # loss report only
 ```
 

--- a/docs/task-authoring-task-md.md
+++ b/docs/task-authoring-task-md.md
@@ -233,6 +233,82 @@ A correct task scores `1.0` on its oracle run before any model sees it.
 
 ---
 
+## Multi-container tasks
+
+A task may ship an `environment/docker-compose.yaml` alongside the
+`Dockerfile`. The agent always runs in the `main` service; any additional
+services you declare become sibling containers on the same Docker network.
+This supports vulhub-style CVE tasks where the agent attacks a separate target
+container over the network.
+
+> `environment/Dockerfile` is always required — `bench tasks check` rejects a
+> task that ships only a `docker-compose.yaml`. If your `main` service uses a
+> prebuilt `image:` and needs no build context, still include a minimal
+> `Dockerfile` (e.g. `FROM <same-image>`) so structural validation and other
+> tooling agree on the task package shape.
+
+```yaml
+# environment/docker-compose.yaml
+services:
+  main: {}            # agent container — BenchFlow injects build/image/limits
+  target:             # vulnerable service the agent must exploit
+    image: vulhub/struts2-s2-001:latest
+    expose: ["8080"]
+```
+
+`main` reaches `target` by service name (`http://target:8080`). The verifier
+can inspect *target-side* state — not just the agent's workspace — by passing a
+`service` argument when running commands:
+
+```python
+# In a Python-driven run or pre/post hook
+await env.exec_in_service("target", "test -f /tmp/exploit_proof.txt")
+await env.exec("cat /flag", service="target")          # equivalent form
+services = await env.inner.services()                  # ["main", "target"]
+```
+
+`exec(..., service=...)` works on the Docker sandbox and the Daytona DinD
+(compose) sandbox. Single-container backends (Modal, direct Daytona) raise a
+clear error for any non-`main` service. This lets a verifier check write-based
+oracles (`/tmp/exploit.txt` in the target), database modifications, or RCE
+markers without trusting the agent container.
+
+### Target-side verifier with `verifier.service`
+
+For tasks whose success oracle lives in a target container — an RCE marker
+file, a modified database row — point the `verifier/test.sh` verifier at that
+service with the `service` key under `verifier` in the frontmatter:
+
+```yaml
+verifier:
+  service: target     # run verifier/test.sh inside the `target` container
+```
+
+With this set, BenchFlow uploads the task's `verifier/` directory into the
+**target** container, runs `test.sh` there, and copies the resulting
+`reward.txt` / `reward.json` back to the host. `service` defaults to `"main"`
+(the agent container), so single-container tasks are unaffected.
+
+`verifier.service` is the declarative, task-schema way to do cross-container
+verification; the `env.exec_in_service(...)` Python API above is the imperative
+equivalent for hook-driven runs.
+
+> Use the same `service` name you declared in `docker-compose.yaml`. A
+> `test.sh` running in the target reaches `main` (and vice versa) by service
+> name over the Docker network, just like the agent does.
+
+### Hardening policy for multi-container tasks
+
+BenchFlow's pre-verification hardening — killing the sandbox user's processes,
+scrubbing `PATH`/`PYTHONPATH`, restoring build-config files — applies **only to
+the `main` (agent) container**. Target containers are deliberately left
+unhardened: a vulhub-style target is *meant* to be vulnerable, the agent never
+has a shell inside it, and hardening it would risk breaking the very
+vulnerability the task exercises. `verifier.service` selects where `test.sh`
+*runs*; it does not move hardening off `main`.
+
+---
+
 ## Migrating a legacy task
 
 `bench tasks migrate` converts a `task.toml` + `instruction.md` pair into

--- a/docs/task-authoring.md
+++ b/docs/task-authoring.md
@@ -1,343 +1,49 @@
-# Authoring tasks
-A BenchFlow task packages an instruction, a sandboxed environment, and a verifier into a directory that BenchFlow runs and scores automatically.
+# Authoring Tasks
 
-This page covers the Harbor-compatible split layout (`task.toml` + `instruction.md`). For the native single-document format, see [Authoring native task.md tasks](./task-authoring-task-md.md).
+BenchFlow v0.6.2 authors tasks in the native `task.md` package format.
+A task is one Markdown document with YAML frontmatter plus sidecar directories
+for the sandbox, verifier, and optional oracle.
 
----
-
-## Directory layout
-
-> [!NOTE]
-> BenchFlow will provide first-party support for hosted competition platforms, Verifiers, and OpenReward Standard.
-
-You can create [Harbor-format tasks](https://www.harborframework.com/docs/tasks) in BenchFlow with a `task.toml` config file, separate `instruction.md`, sandbox assets under `environment/`, verifier files under `tests/`, and an optional `solution/` oracle.
-
-```
-my-task/
-├── task.toml              # timeouts, resources, metadata
-├── instruction.md         # what the agent must do
+```text
+tasks/my-task/
+├── task.md
 ├── environment/
-│   └── Dockerfile         # sandbox image
-├── tests/
-│   └── test.sh            # verifier entry point
-└── solution/              # optional — reference/oracle solution
+│   └── Dockerfile
+├── verifier/
+│   ├── test.sh
+│   └── test_outputs.py
+└── oracle/
     └── solve.sh
 ```
 
-`tests/` may also include `test_outputs.py` (pytest module called by `test.sh`).
-
----
-
-## task.toml
-
-```toml
-version = "1.0"
-
-[metadata]                   # optional, freeform
-author_name = "alice"
-difficulty  = "easy"         # easy / medium / hard
-category    = "programming"
-tags        = ["bash", "files"]
-
-[agent]
-timeout_sec = 300            # strongly recommended — unset means no wall-clock cap
-# user = "agent"             # optional — run agent as this user/UID
-
-[verifier]
-timeout_sec = 120            # optional (default 600)
-
-[environment]
-cpus            = 1          # default 1
-memory_mb       = 2048       # default 2048
-storage_mb      = 10240      # default 10240
-allow_internet  = false      # default true
-env             = { OPENAI_API_KEY = "${OPENAI_API_KEY}" }  # host vars to inject
-```
-
-**Service-backed tasks** — BenchFlow ships a small service registry for task-local APIs such as Gmail, Slack, Calendar, Docs, and Drive. The runner does not auto-start services just because a Dockerfile references a binary. For Python-driven runs, start services explicitly with `pre_agent_hooks=build_service_hooks([...])`; for CLI-only task authoring, keep services inside the task's own Dockerfile/startup scripts until a dedicated service declaration is wired through the CLI.
-
-**Install tooling to shared prefixes, not `/root`** — when a task image ships Node.js, Python tools, or agent binaries that the sandbox user must execute, install them to `/usr/local/bin`, `/usr/local/lib`, or `/opt`, not `/root/.nvm` or `/root/.local/bin`. `setup_sandbox_user()` creates the non-root user, prepares small config/auth dirs, and chowns the workspace — it does not clone `/root` into the sandbox home. Legacy images that already install tools under `/root` still work via a narrow symlink fallback, but shared prefixes are the supported path. Pre-creating the sandbox user in the Dockerfile is an optional speedup, not a requirement.
-
----
-
-## Multi-container tasks
-
-A task may ship an `environment/docker-compose.yaml` alongside the
-`Dockerfile`. The agent always runs in the `main` service; any additional
-services you declare become sibling containers on the same Docker network.
-This supports vulhub-style CVE tasks where the agent attacks a separate target
-container over the network.
-
-> `environment/Dockerfile` is always required — `bench tasks check` rejects
-> a task that ships only a `docker-compose.yaml`. If your `main` service
-> uses a prebuilt `image:` and needs no build context, still include a
-> minimal `Dockerfile` (e.g. `FROM <same-image>`) so structural validation
-> and other tooling agree on the task package shape.
-
-```yaml
-# environment/docker-compose.yaml
-services:
-  main: {}            # agent container — BenchFlow injects build/image/limits
-  target:             # vulnerable service the agent must exploit
-    image: vulhub/struts2-s2-001:latest
-    expose: ["8080"]
-```
-
-`main` reaches `target` by service name (`http://target:8080`). The verifier
-can inspect *target-side* state — not just the agent's workspace — by passing
-a `service` argument when running commands:
-
-```python
-# In a Python-driven run or pre/post hook
-await env.exec_in_service("target", "test -f /tmp/exploit_proof.txt")
-await env.exec("cat /flag", service="target")          # equivalent form
-services = await env.inner.services()                  # ["main", "target"]
-```
-
-`exec(..., service=...)` works on the Docker sandbox and the Daytona DinD
-(compose) sandbox. Single-container backends (Modal, direct Daytona) raise a
-clear error for any non-`main` service. This lets a verifier check
-write-based oracles (`/tmp/exploit.txt` in the target), database modifications,
-or RCE markers without trusting the agent container.
-
-### Target-side `test.sh` verification
-
-For tasks whose success oracle lives in a target container — an RCE marker
-file, a modified database row — point the `test.sh` verifier at that service
-with `[verifier].service`:
-
-```toml
-[verifier]
-service = "target"     # run tests/test.sh inside the `target` container
-```
-
-With this set, BenchFlow uploads the task's `tests/` directory into the
-**target** container, runs `test.sh` there, and copies the resulting
-`reward.txt` / `reward.json` back to the host. `service` defaults to `"main"`
-(the agent container), so existing single-container tasks are unaffected.
-
-`[verifier].service` is the declarative, task-schema way to do cross-container
-verification; the `env.exec_in_service(...)` Python API above is the
-imperative equivalent for hook-driven runs.
-
-> Use the same `service` name you declared in `docker-compose.yaml`. A
-> `test.sh` running in the target reaches `main` (and vice versa) by service
-> name over the Docker network, just like the agent does.
-
-### Hardening policy for multi-container tasks
-
-BenchFlow's pre-verification hardening — killing the sandbox user's
-processes, scrubbing `PATH`/`PYTHONPATH`, restoring build-config files —
-applies **only to the `main` (agent) container**. Target containers are
-deliberately left unhardened: a vulhub-style target is *meant* to be
-vulnerable, the agent never has a shell inside it, and hardening it would
-risk breaking the very vulnerability the task exercises. `[verifier].service`
-selects where `test.sh` *runs*; it does not move hardening off `main`.
-
----
-
-## instruction.md
-
-The first prompt sent to the agent. Write it as you would for a skilled developer:
-
-- State the precise goal in the first sentence.
-- Name exact files or paths the agent must create or modify.
-- Specify constraints (no external libraries, must pass existing tests, etc.).
-- Don't mention the verifier or `reward.txt` — those are internal.
-
-**Multi-turn prompts** — use a Scene with multiple Turns. A `None` prompt means "use `instruction.md`":
-
-```python
-from benchflow.rollout import RolloutConfig, Scene, Role, Turn
-
-config = RolloutConfig(
-    task_path="tasks/my-task",
-    scenes=[Scene(
-        roles=[Role("agent", "gemini", "gemini-3.1-flash-lite-preview")],
-        turns=[
-            Turn("agent"),                                        # instruction.md
-            Turn("agent", "Review your solution and fix any test failures."),
-        ],
-    )],
-    environment="daytona",
-)
-result = await bf.run(config)
-```
-
----
-
-## Verifier contract (tests/test.sh)
-
-After the agent finishes, the BenchFlow runtime copies `tests/` to `/tests/` and runs `/tests/test.sh`. The working directory is the Dockerfile's `WORKDIR` (typically `/app/` in the example Dockerfile below).
-
-**Your script must write a single float (0.0–1.0) to `/logs/verifier/reward.txt`.** After writing the reward, exit `0`; a nonzero `test.sh` exit is treated as verifier infrastructure failure, not a scored task failure.
-
-| Path | Contents |
-|---|---|
-| `/app/` | Agent's working directory |
-| `/tests/` | Your `tests/` directory |
-| `/solution/` | `solution/` (oracle runs only) |
-| `/logs/verifier/` | Write `reward.txt` (and optionally `ctrf.json`) here |
-
-### Pure bash verifier
+Start every new task with the native scaffold:
 
 ```bash
-#!/bin/bash
-REWARD=0
-if [ -f /app/hello.txt ] && [ "$(cat /app/hello.txt | tr -d '\n')" = "Hello, world!" ]; then
-    REWARD=1
-fi
-echo "$REWARD" > /logs/verifier/reward.txt
+bench tasks init my-task
+bench tasks check tasks/my-task
 ```
 
-### pytest verifier
+The full authoring guide lives in
+[Authoring native task.md tasks](./task-authoring-task-md.md), and the
+normative schema lives in [Task standard](./task-standard.md).
+
+## Existing Split Packages
+
+BenchFlow can still read and migrate older split packages so existing datasets
+have a direct upgrade path. Do not start new tasks in that layout.
 
 ```bash
-#!/bin/bash
-curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh
-source $HOME/.local/bin/env
-
-uvx \
-  --with pytest==8.4.1 \
-  --with pytest-json-ctrf==0.3.5 \
-  pytest --ctrf /logs/verifier/ctrf.json /tests/test_outputs.py -rA
-
-if [ $? -eq 0 ]; then echo 1; else echo 0; fi > /logs/verifier/reward.txt
+bench tasks migrate tasks/old-task --remove-legacy
+bench tasks check tasks/old-task
 ```
 
-### Partial credit
+`--remove-legacy` promotes `tests/` to `verifier/`, promotes `solution/` to
+`oracle/`, and removes the old split entrypoint after the generated `task.md`
+round-trips successfully.
+
+If you need to publish a compatibility artifact for another runner, export from
+the native package instead of hand-authoring the old layout:
 
 ```bash
-python3 -c "print($PASSED / $TOTAL)" > /logs/verifier/reward.txt
-```
-
-**Security:** don't let the agent write to `/logs/verifier/reward.txt` or modify `/tests/test.sh`. For tasks running arbitrary code, use `allow_internet = false` and verify output files only. For LLM agent runs, BenchFlow preserves the network path needed for model APIs and agent startup, then disables supported agent web browsing/fetch tools through agent config or launch controls. Oracle runs still use the environment's network policy directly.
-
----
-
-## solution/ (optional)
-
-Include when you want to verify the task is solvable or provide a reference implementation. When BenchFlow runs with `--agent oracle`, it copies `solution/` to `/solution/` and runs `solution/solve.sh` instead of an ACP agent.
-
-`solve.sh` has the same filesystem access as the agent — write only to `/app/`, not to `/logs/verifier/`.
-
-```bash
-#!/bin/bash
-echo "Hello, world!" > /app/hello.txt
-```
-
----
-
-## CLI
-
-```bash
-# Scaffold a new task in this legacy split layout
-# (without --format legacy, init scaffolds the native task.md format)
-bench tasks init my-task --format legacy
-bench tasks init my-task --format legacy --no-pytest --no-solution
-
-# Generate tasks from agent traces (personal benchmark curation)
-bench tasks generate --from-local                          # from local Claude Code sessions
-bench tasks generate --from-file session.jsonl --dry-run    # from a JSONL trace file
-bench tasks generate --from-hf opentraces-test --limit 50   # from a HuggingFace dataset
-bench tasks list-sources                                    # list known HF trace datasets
-
-# Validate structure
-bench tasks check tasks/my-task/
-
-# Confirm oracle gets reward = 1.0
-bench eval create --tasks-dir tasks/my-task/ --agent oracle --sandbox docker
-
-# Run a real agent
-bench eval create --tasks-dir tasks/my-task/ --agent gemini --sandbox daytona
-
-# Run with task-local skills mounted
-bench eval create \
-  --tasks-dir tasks/my-task/ \
-  --agent gemini \
-  --sandbox daytona \
-  --skill-mode with-skill \
-  --agent-env BENCHFLOW_SKILL_NUDGE=name
-```
-
-Task-local skills are mounted through the selected agent's native skill paths.
-See [Architecture: skill loading](./architecture.md#skill-loading) for the
-canonical loading semantics and nudge modes.
-
-`bench tasks generate` converts agent traces (Claude Code sessions, opentraces records, or HuggingFace datasets) into task directories with `task.toml`, `instruction.md`, and a file-existence `test.sh`. Use `--dry-run` to preview traces before generating. See [CLI reference](./reference/cli.md#bench-tasks-generate) for all flags.
-
-`bench tasks check` validates task definition presence (`task.md` or legacy `task.toml` + `instruction.md`), a non-empty instruction, `environment/Dockerfile`, and a runnable verifier entrypoint (`verifier/` or legacy `tests/`). It surfaces `task.toml` parse errors but does not require `[agent].timeout_sec` (unset means no wall-clock cap). Exits with code 1 on failure (CI-friendly).
-
----
-
-## Worked example — write-fizzbuzz
-
-```toml
-# task.toml
-version = "1.0"
-[metadata]
-difficulty = "easy"
-tags = ["python"]
-[agent]
-timeout_sec = 180
-[verifier]
-timeout_sec = 60
-```
-
-```markdown
-# instruction.md
-Write a file `fizzbuzz.py` defining:
-
-    def fizzbuzz(n: int) -> str
-
-Return "FizzBuzz" / "Fizz" / "Buzz" / str(n) for divisibility by 15 / 3 / 5 / none.
-No __main__ block, no print statements.
-```
-
-```dockerfile
-# environment/Dockerfile
-FROM ubuntu:24.04
-RUN apt-get update -qq && apt-get install -y -qq python3 curl && rm -rf /var/lib/apt/lists/*
-WORKDIR /app
-RUN mkdir -p /logs/verifier /logs/agent /logs/artifacts
-```
-
-```python
-# tests/test_outputs.py
-import importlib.util
-from pathlib import Path
-
-def _load():
-    path = Path("/app/fizzbuzz.py")
-    assert path.exists()
-    spec = importlib.util.spec_from_file_location("fizzbuzz", path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod.fizzbuzz
-
-def test_fizz():    assert _load()(3) == "Fizz"
-def test_buzz():    assert _load()(5) == "Buzz"
-def test_fizzbuzz():assert _load()(15) == "FizzBuzz"
-def test_number():  assert _load()(7) == "7"
-```
-
-```bash
-# tests/test.sh — verifier entrypoint; runs the pytest module, writes the reward
-#!/bin/bash
-curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh
-source $HOME/.local/bin/env
-
-uvx --with pytest==8.4.1 pytest /tests/test_outputs.py -rA
-if [ $? -eq 0 ]; then echo 1; else echo 0; fi > /logs/verifier/reward.txt
-```
-
-```bash
-# solution/solve.sh
-cat > /app/fizzbuzz.py << 'EOF'
-def fizzbuzz(n: int) -> str:
-    if n % 15 == 0: return "FizzBuzz"
-    if n % 3 == 0:  return "Fizz"
-    if n % 5 == 0:  return "Buzz"
-    return str(n)
-EOF
+bench tasks export tasks/my-task exported/my-task
 ```

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -5,8 +5,8 @@ Status: v0.6 — shipped with BenchFlow 0.6.0 (2026-06-10)
 This document defines the direction for BenchFlow-native task packages. The
 short version: `task.md` is the native authoring entrypoint; `oracle/` and
 `verifier/` are the BenchFlow-native names for held-out reference behavior and
-reward checks. Harbor/Pier split names such as `solution/` and `tests/` remain
-compatibility names and export targets.
+reward checks. Split-layout names such as `solution/` and `tests/` remain
+compatibility names for migration and export only.
 
 The standard is intentionally split into three views:
 
@@ -14,7 +14,7 @@ The standard is intentionally split into three views:
 |---|---|---|
 | Authoring document | What humans and generators write: one `task.md` plus sidecar dirs | `TaskDocument` |
 | Runtime task view | What rollout, verifier, hardening, provenance, and trajectories consume | `TaskRuntimeView` plus first `TaskPackage` boundary |
-| Foreign adapter view | What Harbor, Pier, Terminal-Bench, SWE-bench, Inspect, and hosted envs import/export | adapters |
+| Foreign adapter view | What external benchmark formats and hosted environments import/export | adapters |
 
 Do not treat these as the same interface. A good authoring document can include
 more information than a foreign format can export, and a foreign import can
@@ -86,21 +86,22 @@ Within a BenchFlow-native package, selection is fail-closed:
 - duplicate alias trees must be byte-identical after normalized traversal or
   validation should report a collision
 
-This does not deprecate split layouts. Foreign adapters can still load and emit
-plain Harbor/Pier `task.toml` + `instruction.md` packages directly.
+As of v0.6.2, split layouts are compatibility inputs and export artifacts, not
+the native authoring surface. New BenchFlow tasks should publish `task.md` as
+the only authoritative entrypoint.
 
 ## Versioning
 
 There are two versions:
 
 ```yaml
-schema_version: "1.3"        # Harbor-compatible task config surface
+schema_version: "1.3"        # BenchFlow task config surface
 benchflow:
   document_version: "0.6"    # BenchFlow task.md document syntax
 ```
 
-`schema_version` is for the runtime config model shared with Harbor-style
-`task.toml`. `benchflow.document_version` is for document-only concepts such as
+`schema_version` is for the runtime config model shared with compatibility
+imports. `benchflow.document_version` is for document-only concepts such as
 teams, prompt composition, agent policy, runtime policy, private assets,
 provenance, evidence, nudges, and export policy.
 
@@ -108,7 +109,7 @@ provenance, evidence, nudges, and export policy.
 
 The root frontmatter has three classes of keys.
 
-Harbor-compatible config keys are modeled by `TaskConfig` and must be rejected
+BenchFlow config keys are modeled by `TaskConfig` and must be rejected
 when unknown in native authoring mode:
 
 - `schema_version` / `version`
@@ -240,7 +241,7 @@ The package has six planes. Keeping them separate is the core abstraction.
 | Oracle | held-out reference implementation and oracle-only env | tests/verifier code |
 | Evidence | validation runs, flake data, anti-cheat review, artifact hashes, leaderboard metadata | mutable task source |
 
-Harbor `steps` are verifier/runtime checkpoints. BenchFlow `scenes` are
+Imported `steps` are verifier/runtime checkpoints. BenchFlow `scenes` are
 interaction checkpoints. They are orthogonal. A task can have both, but a
 runtime must define how they compose before executing them.
 
@@ -358,7 +359,7 @@ Grade only the submitted artifact and declared evidence. Do not infer intent
 from private oracle files or hidden verifier fixtures.
 ```
 
-`test.sh` is the minimum executable strategy and the Harbor/Pier export target.
+`test.sh` is the minimum executable strategy and the compatibility export target.
 Reward Kit-style criteria, ORS-style episode rewards, and AgentBeats-style
 assessor agents are verifier strategies. Runtime adapters may write declared
 evidence artifacts such as `trajectory/ors-rewards.jsonl`, but the ORS-specific
@@ -437,10 +438,10 @@ only through declared artifact transfer paths.
 
 Target reward precedence:
 
-- `reward.txt` remains the Harbor-compatible scalar minimum
+- `reward.txt` remains the scalar compatibility minimum
 - when `reward.json` exists, it should be the authoritative rich reward artifact
-- `reward.json` may be an envelope with a numeric `reward`, or a Harbor Reward
-  Kit-style multi-metric map with `metrics` plus a declared `aggregate` policy
+- `reward.json` may be an envelope with a numeric `reward`, or a reward-kit
+  style multi-metric map with `metrics` plus a declared `aggregate` policy
 - if both files exist and `reward.json` has a scalar aggregate, the scalar must
   match `float(reward.txt)` or validation should fail closed
 - if `reward.json` is a multi-metric map without a scalar `reward`,
@@ -478,8 +479,8 @@ verifiers download it with the rest of `/logs/verifier`, and the built-in LLM
 judge emits criterion details there. Metrics-only `reward.json` maps can now
 use the verifier document's `outputs.aggregate_policy` or selected Reward Kit
 criteria policy to compute and persist the canonical `reward`. It still does
-not fully match the target: full Harbor
-Reward Kit parity, full OpenReward environment import/export, and AgentBeats
+not fully match the target: full Reward Kit parity, full OpenReward environment
+import/export, and AgentBeats
 assessor lifecycles are not yet first-class; selected unsupported strategies
 fail closed.
 
@@ -495,7 +496,7 @@ Compatibility `solution/` remains supported and is mounted at `/solution`.
 The naming change is semantic:
 
 - `oracle` means "held-out reference behavior used to prove solvability"
-- `solution` is a compatibility name for Harbor/Pier/Terminal-Bench exports
+- `solution` is a compatibility export name for older split layouts
 
 Proposed outbound exporters should map native `oracle/` to foreign
 `solution/`. Current runtime supports native and compatibility oracle paths, and
@@ -761,7 +762,7 @@ Target compatibility rules:
 1. Native authoring rejects unknown root config keys.
 2. Foreign adapter import preserves unknown `task.toml` keys outside native
    config. The first implementation is `import_task_config_toml()`: strict
-   native validation still fails on unknown keys, while Harbor import returns a
+   native validation still fails on unknown keys, while compatibility import returns a
    validated `TaskConfig` plus `InboundCompatibility.config_extra`.
 3. Legacy-to-native migration writes preserved foreign keys under
    `benchflow.compat.extra`:
@@ -793,11 +794,11 @@ Target compatibility rules:
    normalized prompt, and environment/solution/tests file-map hashes.
 6. Export emits a degraded-export report when the target format cannot express
    a native concept. The first implementation is
-   `src/benchflow/task/export.py`, which writes Harbor/Pier-style split layout
+   `src/benchflow/task/export.py`, which writes a compatibility split layout
    plus `compatibility/export-report.json`.
 7. Mixed native/legacy files are structurally invalid when task config,
    prompt, oracle/solution, or verifier/tests aliases drift.
-8. Harbor/Pier export should emit `task.toml`, `instruction.md`, `solution/`,
+8. Compatibility export should emit `task.toml`, `instruction.md`, `solution/`,
    and `tests/`.
 9. BenchFlow import should prefer `task.md` only when compatibility metadata
    proves the legacy files are equivalent.
@@ -833,7 +834,7 @@ Current implementation status:
 | native `oracle/` | yes | yes | keep |
 | verifier `script` strategy | yes | yes | keep |
 | verifier `llm-judge` strategy | yes | yes | keep |
-| verifier `reward-kit` strategy | yes | partial | safe relative `reward.py` runner executes; declared criteria parse before launch, emit a runtime manifest, require exact metrics, and compute/verify canonical reward; fuller Harbor Reward Kit parity remains target work |
+| verifier `reward-kit` strategy | yes | partial | safe relative `reward.py` runner executes; declared criteria parse before launch, emit a runtime manifest, require exact metrics, and compute/verify canonical reward; fuller Reward Kit parity remains target work |
 | verifier `agent-judge` strategy | yes | partial | verifier-scoped LLM judge over declared inputs; richer ACP-backed judge agents remain target work |
 | verifier `ors-episode` strategy | yes | partial | runtime helper writes ORS tool-output rewards to `trajectory/ors-rewards.jsonl`; declared reward responses/event streams normalize into `reward.json` and `reward-details.json`; fuller OpenReward environment import/export remains target work |
 | `agents.roles` | yes | partial | `TaskRuntimeView` carries parsed scenes; explicit sequential shared-workspace handoff can switch roles through the user loop |
@@ -841,7 +842,7 @@ Current implementation status:
 | `user` / `## user-persona` | yes | partial | `model: scripted` + string `private_facts` compiles to `DocumentNudgeUser`; bounded model-linear users compile to `ModelDocumentNudgeUser`; linear single- and multi-scene user loops execute when every scene is single-role, or when explicit multi-role turns opt into sequential shared-workspace team handoff; `confirmation_policy: human` gates ACP permissions fail-closed without an explicit handler; `branch_execution: option-kinds-preserved` preserves option IDs and kinds; forked branch execution, interactive approval UI, parallel teams, and rich handoff artifacts fail closed |
 | `benchflow.teams` | yes | partial | supports exactly one `handoff` with `mode: sequential`, `workspace_visibility: shared`, and `trajectory_visibility: none|metadata`; richer team keys fail closed |
 | `benchflow:` | raw | no | typed document schema after v0.3 stabilizes |
-| Harbor `steps` | yes | no/partial | fail closed per sandbox until implemented |
+| imported `steps` | yes | no/partial | fail closed per sandbox until implemented |
 | root/step artifacts | yes | no/partial | implement collection or fail closed |
 | network allowlist | yes | no/partial | per-sandbox capability check |
 | separate verifier env | yes | no/partial | materializer plus verifier runner support |
@@ -968,8 +969,7 @@ Start with `document_version`, `compatibility`, `provenance`, `assets`,
 
 P4: Extend exporters.
 
-The first `bench tasks export ... --target harbor|pier` path exports to
-Harbor/Pier-style split layout with explicit loss reports, backed by
-`export_task_to_split_layout()`. Extend the same reporting discipline to
-Terminal-Bench, Inspect, SWE-bench-style datasets, and same-format no-op
-exports.
+The first `bench tasks export` path exports to a compatibility split layout
+with explicit loss reports, backed by `export_task_to_split_layout()`. Extend
+the same reporting discipline to external benchmark datasets and same-format
+no-op exports.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.1"
+version = "0.6.2"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -45,13 +45,28 @@ def register_tasks(app: typer.Typer) -> None:
             ),
         ] = False,
         task_format: Annotated[
-            str, typer.Option("--format", help="Task format: legacy or task-md")
+            str,
+            typer.Option(
+                "--format",
+                help=(
+                    "Task format. New tasks use task-md; legacy scaffolding is "
+                    "retired in v0.6.2."
+                ),
+            ),
         ] = "task-md",
     ) -> None:
         """Scaffold a new benchmark task."""
         from benchflow._utils.task_authoring import scaffold_task
 
         try:
+            if task_format == "legacy":
+                print_error(
+                    "bench tasks init no longer scaffolds the legacy split layout. "
+                    "Use `bench tasks init <name>` for native task.md packages, or "
+                    "`bench tasks migrate <dir> --remove-legacy` for existing split tasks."
+                )
+                raise typer.Exit(1)
+
             result = scaffold_task(
                 name,
                 parent_dir=parent_dir,
@@ -250,7 +265,7 @@ def register_tasks(app: typer.Typer) -> None:
             ),
         ] = False,
     ) -> None:
-        """Export a task to a Harbor/Pier split layout with a loss report."""
+        """Export a task to a compatibility split layout with a loss report."""
         from benchflow.task import (
             build_compatibility_export_report,
             export_task_to_split_layout,

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -131,7 +131,16 @@ async def _resolve_agent_cwd(env: Any, task: Any) -> str:
     configured = _configured_task_workdir(task)
     if configured is None:
         cwd_result = await env.exec("pwd", timeout_sec=10)
-        return (cwd_result.stdout or "").strip() or "/app"
+        probed = (cwd_result.stdout or "").strip()
+        if probed and probed != "/":
+            return probed
+        fallback = "/root"
+        result = await env.exec(
+            f"mkdir -p {fallback} && cd {fallback} && pwd",
+            user="root",
+            timeout_sec=10,
+        )
+        return (getattr(result, "stdout", "") or "").strip() or fallback
 
     _validate_agent_workdir(configured)
     quoted = shlex.quote(configured)

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -89,6 +89,29 @@ async def test_resolve_agent_cwd_falls_back_to_container_pwd() -> None:
 
 
 @pytest.mark.asyncio
+async def test_resolve_agent_cwd_avoids_root_workspace() -> None:
+    """Prebuilt images without WORKDIR must not snapshot the entire rootfs."""
+    env = MagicMock()
+    env.exec = AsyncMock(
+        side_effect=[
+            MagicMock(stdout="/\n", stderr="", return_code=0),
+            MagicMock(stdout="/root\n", stderr="", return_code=0),
+        ]
+    )
+    task = SimpleNamespace(
+        config=SimpleNamespace(environment=SimpleNamespace(workdir=None))
+    )
+
+    agent_cwd = await _resolve_agent_cwd(env, task)
+
+    assert agent_cwd == "/root"
+    assert env.exec.await_args_list[0].args == ("pwd",)
+    assert env.exec.await_args_list[0].kwargs == {"timeout_sec": 10}
+    assert env.exec.await_args_list[1].args == ("mkdir -p /root && cd /root && pwd",)
+    assert env.exec.await_args_list[1].kwargs == {"user": "root", "timeout_sec": 10}
+
+
+@pytest.mark.asyncio
 async def test_start_env_does_not_upload_task_environment_skills(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -232,16 +232,25 @@ class TestScaffoldTaskReportedFiles:
         assert "verifier/test_outputs.py" in reported
         assert "verifier/rubrics/verifier.toml" in reported
 
+    def test_cli_init_rejects_legacy_scaffold(self, tmp_path):
+        from typer.testing import CliRunner
 
-class TestInitTaskLegacyScaffold:
-    """init_task(..., task_format="legacy") — the shipped legacy scaffold.
+        from benchflow.cli.main import app
 
-    `bench tasks init --format legacy` still ships on this release, and the
-    legacy code paths (render_task_md_from_legacy, the tests/ and solution/
-    aliases, legacy_solution_dir) remain in src/benchflow. These tests guard
-    the legacy split-scaffold contract — task.toml + instruction.md + tests/
-    + solution/ with fail-closed placeholder defaults — so the shipped path
-    can't silently regress while it is still reachable from the CLI.
+        out = CliRunner().invoke(
+            app, ["tasks", "init", "old", "--dir", str(tmp_path), "--format", "legacy"]
+        )
+        assert out.exit_code == 1
+        assert "no longer scaffolds the legacy split layout" in out.output
+        assert not (tmp_path / "old").exists()
+
+
+class TestLegacyScaffoldCompatibility:
+    """init_task(..., task_format="legacy") — compatibility scaffold coverage.
+
+    The CLI no longer creates new split-layout tasks in v0.6.2, but migration,
+    export, and adapter tests still depend on the compatibility scaffolder.
+    Keep these fail-closed defaults covered while the lower-level API remains.
     """
 
     def test_creates_complete_structure(self, tmp_path):
@@ -257,9 +266,9 @@ class TestInitTaskLegacyScaffold:
     def test_scaffold_fails_check_until_placeholders_replaced(self, tmp_path):
         """Freshly scaffolded legacy task must FAIL `bench tasks check` (#360).
 
-        Otherwise authors can `bench tasks init --format legacy foo &&
-        bench tasks check foo` and get a green check on a task that
-        auto-passes with reward 1.0 — silent false positives in eval sets.
+        Otherwise compatibility-generated fixtures can pass `bench tasks check`
+        before the placeholders are replaced, creating silent false positives in
+        eval sets.
         """
         task = init_task("scaffolded", parent_dir=tmp_path, task_format="legacy")
         issues = check_task(task)

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.1"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- bump BenchFlow to `0.6.2`
- make `task.md` the native task authoring path for `bench tasks init`
- reject new split-layout scaffolds through `bench tasks init --format legacy`
- keep export as an explicit compatibility path while default docs point contributors at `task.md`
- refresh CLI and task-authoring docs around `uv tool install benchflow`, `bench tasks check`, and `bench eval create`
- avoid using `/` as the inferred rollout workspace, so Docker verifier snapshots do not copy the whole root filesystem for prebuilt images without `WORKDIR`

## Validation
- CI `test` passed
- CI `pip-audit` passed
- `uv run --extra dev ruff check .`
- `uv run --extra dev pytest -q` -> 4074 passed, 49 skipped, 7 deselected
- targeted regression: `tests/test_rollout_upload.py::test_resolve_agent_cwd_avoids_root_workspace`
- verified via SkillsBench #929 VM Docker oracle canary on `daytona-orchestrator`

## Merge order
1. Merge this BenchFlow `0.6.2` PR.
2. Publish `benchflow==0.6.2` to PyPI.
3. Merge the SkillsBench native `task.md` corpus/docs PR.