### PR TITLE
fix(ci): gate preview releases on integration eval

### DIFF
--- a/.github/scripts/select_integration_provider.py
+++ b/.github/scripts/select_integration_provider.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Select a live model provider for the integration-eval workflow.
+
+The workflow needs a real LLM for both the rollout and the agent-as-judge
+gate. Repo secrets can drift independently from code, so this script probes the
+configured candidates with a tiny OpenAI-compatible request and exports the
+first usable one to ``GITHUB_ENV``. It prints only candidate names and HTTP
+status classes, never secret values or response bodies.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import ssl
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+ProbeFunc = Callable[["Candidate", Mapping[str, str]], tuple[bool, str]]
+
+
+@dataclass(frozen=True)
+class Candidate:
+    name: str
+    key_env: str
+    base_url: str
+    probe_model: str
+    rollout_agent: str
+    rollout_model: str
+    judge_model: str
+    exports: Mapping[str, str]
+    insecure_tls: bool = False
+
+
+def _append_github_env(values: Mapping[str, str], env: Mapping[str, str]) -> None:
+    path = env.get("GITHUB_ENV")
+    if not path:
+        return
+    marker = "__BENCHFLOW_ENV__"
+    with Path(path).open("a", encoding="utf-8") as fh:
+        for key, value in values.items():
+            fh.write(f"{key}<<{marker}\n{value}\n{marker}\n")
+
+
+def _chat_completions_url(base_url: str) -> str:
+    return f"{base_url.rstrip('/')}/chat/completions"
+
+
+def probe_candidate(candidate: Candidate, env: Mapping[str, str]) -> tuple[bool, str]:
+    key = env.get(candidate.key_env, "").strip()
+    if not key:
+        return False, f"missing {candidate.key_env}"
+
+    body = json.dumps(
+        {
+            "model": candidate.probe_model,
+            "messages": [{"role": "user", "content": "Return OK only."}],
+            "max_tokens": 8,
+        }
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        _chat_completions_url(candidate.base_url),
+        data=body,
+        headers={
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+    context = None
+    if candidate.insecure_tls:
+        context = ssl._create_unverified_context()
+    try:
+        with urllib.request.urlopen(request, timeout=25, context=context) as response:
+            if response.status < 400:
+                return True, f"HTTP {response.status}"
+            return False, f"HTTP {response.status}"
+    except urllib.error.HTTPError as exc:
+        return False, f"HTTP {exc.code}"
+    except urllib.error.URLError as exc:
+        reason = getattr(exc, "reason", exc)
+        return False, f"{type(reason).__name__}"
+    except TimeoutError:
+        return False, "timeout"
+
+
+def candidates(env: Mapping[str, str]) -> list[Candidate]:
+    deepseek_base = env.get("DEEPSEEK_BASE_URL") or "https://api.deepseek.com"
+    glm_base = env.get("GLM_BASE_URL") or "https://open.bigmodel.cn/api/paas/v4"
+    qwen_base = env.get("QWEN_BASE_URL") or (
+        "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    )
+    litellm_base = env.get("LITELLM_BASE_URL") or (
+        "http://llm-proxy.eval.all-hands.dev/v1"
+    )
+    github_base = "https://models.github.ai/inference"
+
+    return [
+        Candidate(
+            name="deepseek",
+            key_env="DEEPSEEK_API_KEY",
+            base_url=deepseek_base,
+            probe_model=env.get("DEEPSEEK_FLASH_MODEL") or "deepseek-v4-flash",
+            rollout_agent="openhands",
+            rollout_model="deepseek/deepseek-v4-flash",
+            judge_model="openai/deepseek-v4-flash",
+            exports={
+                "DEEPSEEK_API_KEY": env.get("DEEPSEEK_API_KEY", ""),
+                "DEEPSEEK_BASE_URL": deepseek_base,
+                "OPENAI_API_KEY": env.get("DEEPSEEK_API_KEY", ""),
+                "OPENAI_BASE_URL": deepseek_base,
+            },
+        ),
+        Candidate(
+            name="glm",
+            key_env="GLM_API_KEY",
+            base_url=glm_base,
+            probe_model=env.get("GLM_MODEL") or "glm-5.1",
+            rollout_agent="openhands",
+            rollout_model="glm/glm-5.1",
+            judge_model="openai/glm-5.1",
+            exports={
+                "GLM_API_KEY": env.get("GLM_API_KEY", ""),
+                "GLM_BASE_URL": glm_base,
+                "OPENAI_API_KEY": env.get("GLM_API_KEY", ""),
+                "OPENAI_BASE_URL": glm_base,
+            },
+        ),
+        Candidate(
+            name="qwen-dashscope",
+            key_env="QWEN_API_KEY",
+            base_url=qwen_base,
+            probe_model=env.get("QWEN_MAX_PREVIEW_MODEL") or "qwen3.6-max-preview",
+            rollout_agent="openhands",
+            rollout_model="qwen-dashscope/qwen3.6-max-preview",
+            judge_model="openai/qwen3.6-max-preview",
+            exports={
+                "QWEN_API_KEY": env.get("QWEN_API_KEY", ""),
+                "QWEN_BASE_URL": qwen_base,
+                "OPENAI_API_KEY": env.get("QWEN_API_KEY", ""),
+                "OPENAI_BASE_URL": qwen_base,
+            },
+        ),
+        Candidate(
+            name="litellm-proxy",
+            key_env="LITELLM_API_KEY",
+            base_url=litellm_base,
+            probe_model=env.get("LITELLM_MODEL") or "gpt-4.1-mini",
+            rollout_agent="openhands",
+            rollout_model=f"litellm/{env.get('LITELLM_MODEL') or 'gpt-4.1-mini'}",
+            judge_model=f"openai/{env.get('LITELLM_MODEL') or 'gpt-4.1-mini'}",
+            exports={
+                "LITELLM_API_KEY": env.get("LITELLM_API_KEY", ""),
+                "LITELLM_BASE_URL": litellm_base,
+                "OPENAI_API_KEY": env.get("LITELLM_API_KEY", ""),
+                "OPENAI_BASE_URL": litellm_base,
+            },
+        ),
+        Candidate(
+            name="openai",
+            key_env="OPENAI_API_KEY",
+            base_url=env.get("OPENAI_BASE_URL") or "https://api.openai.com/v1",
+            probe_model=env.get("OPENAI_MODEL") or "gpt-4o-mini",
+            rollout_agent="openhands",
+            rollout_model=f"openai/{env.get('OPENAI_MODEL') or 'gpt-4o-mini'}",
+            judge_model=f"openai/{env.get('OPENAI_MODEL') or 'gpt-4o-mini'}",
+            exports={
+                "OPENAI_API_KEY": env.get("OPENAI_API_KEY", ""),
+                "OPENAI_BASE_URL": env.get("OPENAI_BASE_URL")
+                or "https://api.openai.com/v1",
+            },
+        ),
+        Candidate(
+            name="github-models",
+            key_env="GITHUB_MODELS_TOKEN",
+            base_url=github_base,
+            probe_model=env.get("GITHUB_MODELS_MODEL") or "openai/gpt-4.1-mini",
+            rollout_agent="openhands",
+            rollout_model="github-models/openai/gpt-4.1-mini",
+            judge_model="openai/openai/gpt-4.1-mini",
+            exports={
+                "GITHUB_TOKEN": env.get("GITHUB_MODELS_TOKEN", ""),
+                "OPENAI_API_KEY": env.get("GITHUB_MODELS_TOKEN", ""),
+                "OPENAI_BASE_URL": github_base,
+            },
+        ),
+    ]
+
+
+def select_candidate(
+    pool: list[Candidate],
+    env: Mapping[str, str],
+    probe: ProbeFunc = probe_candidate,
+) -> tuple[Candidate | None, list[tuple[str, str]]]:
+    attempts: list[tuple[str, str]] = []
+    for candidate in pool:
+        ok, reason = probe(candidate, env)
+        attempts.append((candidate.name, reason))
+        print(f"Provider candidate {candidate.name}: {reason}")
+        if ok:
+            return candidate, attempts
+    return None, attempts
+
+
+def main() -> int:
+    env = os.environ
+    selected, attempts = select_candidate(candidates(env), env)
+    if selected is None:
+        summary = ", ".join(f"{name}={reason}" for name, reason in attempts)
+        print(f"::error::No usable integration LLM provider found ({summary})")
+        return 1
+
+    exports = {
+        "BENCHFLOW_INTEGRATION_PROVIDER": selected.name,
+        "BENCHFLOW_INTEGRATION_AGENT": selected.rollout_agent,
+        "BENCHFLOW_INTEGRATION_MODEL": selected.rollout_model,
+        "BENCHFLOW_JUDGE_MODEL": selected.judge_model,
+        **selected.exports,
+    }
+    _append_github_env(exports, env)
+    print(
+        "Selected integration provider "
+        f"{selected.name}: agent={selected.rollout_agent}, "
+        f"model={selected.rollout_model}, judge={selected.judge_model}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -4,16 +4,19 @@
 # (tests/integration/agent_judge.py) grade the resulting rollout. The job
 # fails if the run is not REAL (no tool calls / no tokens / null reward) or
 # if the judge fails the trajectory. It is kept to one task so the check
-# stays cheap; trigger it on demand or nightly.
+# stays cheap; trigger it after main CI succeeds, on demand, or nightly.
 name: integration-eval
 
 on:
+  workflow_run:
+    workflows: ["test"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       task:
         description: SkillsBench task to run.
         type: string
-        default: jax-computing-basics
+        default: dialogue-parser
   schedule:
     # Nightly at 07:00 UTC. Disabled automatically on forks by the job guard.
     - cron: "0 7 * * *"
@@ -32,21 +35,42 @@ jobs:
     runs-on: ubuntu-latest
     # Only run on the canonical repo. Forks lack the eval/judge secrets, so
     # the scheduled and dispatched runs would otherwise fail-closed there.
-    if: github.repository == 'benchflow-ai/benchflow'
+    if: >-
+      ${{
+        github.repository == 'benchflow-ai/benchflow' &&
+        (
+          github.event_name != 'workflow_run' ||
+          (
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.event == 'push' &&
+            github.event.workflow_run.head_branch == 'main'
+          )
+        )
+      }}
     timeout-minutes: 45
     env:
-      # Agent (run) model. Keys are referenced from repo secrets; their
-      # values never appear in logs or files.
-      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
-      DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
-      # Judge model key (gemini-3.1-flash-lite). call_judge reads GEMINI_API_KEY.
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      # Daytona key for the parity + reaper scenarios; scenarios that need it
-      # skip cleanly when it is absent.
+      # Agent and judge model key. Values never appear in logs or files.
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # Optional Daytona key for the parity + reaper scenarios.
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-      TASK: ${{ github.event.inputs.task || 'jax-computing-basics' }}
+      TASK: ${{ github.event.inputs.task || 'dialogue-parser' }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Check integration secrets
+        run: |
+          missing=()
+          for name in OPENAI_API_KEY; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -ne 0 ]; then
+            printf '::error::Missing required GitHub Actions secrets for integration-eval: %s\n' "${missing[*]}"
+            exit 1
+          fi
 
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
@@ -66,24 +90,24 @@ jobs:
             --source-path tasks \
             --source-ref main \
             --include "$TASK" \
-            --agent openhands \
-            --model deepseek/deepseek-v4-flash \
+            --agent codex-acp \
+            --model openai/gpt-5.4-nano \
             --sandbox docker \
             --concurrency 1 \
+            --agent-idle-timeout 240 \
             --jobs-dir jobs/integration-eval
 
       - name: Agent-judge the rollout and enforce the gate
         run: |
           uv run python tests/integration/agent_judge.py \
             jobs/integration-eval \
-            --model gemini-3.1-flash-lite \
+            --model openai/gpt-5.4-nano \
             --json
 
       - name: Run the live integration scenarios
         # Oracle determinism, docker<->daytona parity, and reaper safety. The
         # agent-rollout scenario is skipped here because the step above already
-        # runs a real agent + judge; scenarios needing a key absent from secrets
-        # skip cleanly.
+        # runs a real agent + judge.
         run: |
           uv run pytest tests/test_integration_suite.py \
             -m integration -k "not agent_rollout" \

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -24,9 +24,10 @@ on:
     # Nightly at 07:00 UTC. Disabled automatically on forks by the job guard.
     - cron: "0 7 * * *"
 
-# Least-privilege default. This job only reads the repo.
+# Least-privilege default. This job reads the repo and calls GitHub Models.
 permissions:
   contents: read
+  models: read
 
 # One in-flight integration run at a time; newer dispatches supersede older.
 concurrency:
@@ -58,8 +59,10 @@ jobs:
       }}
     timeout-minutes: 45
     env:
-      # Agent and judge model key. Values never appear in logs or files.
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      # GitHub Models uses the workflow-scoped token, not a repo secret.
+      GITHUB_TOKEN: ${{ github.token }}
+      OPENAI_API_KEY: ${{ github.token }}
+      OPENAI_BASE_URL: https://models.github.ai/inference
       # Optional Daytona key for the parity + reaper scenarios.
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
       TASK: ${{ github.event.inputs.task || 'dialogue-parser' }}
@@ -68,16 +71,16 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
 
-      - name: Check integration secrets
+      - name: Check integration auth
         run: |
           missing=()
-          for name in OPENAI_API_KEY; do
+          for name in GITHUB_TOKEN OPENAI_API_KEY OPENAI_BASE_URL; do
             if [ -z "${!name}" ]; then
               missing+=("$name")
             fi
           done
           if [ "${#missing[@]}" -ne 0 ]; then
-            printf '::error::Missing required GitHub Actions secrets for integration-eval: %s\n' "${missing[*]}"
+            printf '::error::Missing required GitHub Actions auth for integration-eval: %s\n' "${missing[*]}"
             exit 1
           fi
 
@@ -100,7 +103,7 @@ jobs:
             --source-ref main \
             --include "$TASK" \
             --agent openhands \
-            --model openai/gpt-4.1-mini \
+            --model github-models/openai/gpt-4.1-mini \
             --sandbox docker \
             --concurrency 1 \
             --agent-idle-timeout 240 \
@@ -110,7 +113,7 @@ jobs:
         run: |
           uv run python tests/integration/agent_judge.py \
             jobs/integration-eval \
-            --model openai/gpt-4.1-mini \
+            --model openai/openai/gpt-4.1-mini \
             --json
 
       - name: Run the live integration scenarios

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -99,8 +99,8 @@ jobs:
             --source-path tasks \
             --source-ref main \
             --include "$TASK" \
-            --agent codex-acp \
-            --model openai/gpt-5.4-mini \
+            --agent openhands \
+            --model openai/gpt-4.1-mini \
             --sandbox docker \
             --concurrency 1 \
             --agent-idle-timeout 240 \
@@ -110,7 +110,7 @@ jobs:
         run: |
           uv run python tests/integration/agent_judge.py \
             jobs/integration-eval \
-            --model openai/gpt-5.4-mini \
+            --model openai/gpt-4.1-mini \
             --json
 
       - name: Run the live integration scenarios

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -24,7 +24,8 @@ on:
     # Nightly at 07:00 UTC. Disabled automatically on forks by the job guard.
     - cron: "0 7 * * *"
 
-# Least-privilege default. This job reads the repo and calls GitHub Models.
+# Least-privilege default. This job reads the repo and can call GitHub Models
+# when a token with model access is configured.
 permissions:
   contents: read
   models: read
@@ -59,10 +60,18 @@ jobs:
       }}
     timeout-minutes: 45
     env:
-      # GitHub Models uses the workflow-scoped token, not a repo secret.
-      GITHUB_TOKEN: ${{ github.token }}
-      OPENAI_API_KEY: ${{ github.token }}
-      OPENAI_BASE_URL: https://models.github.ai/inference
+      # Provider candidates. The selector probes these in order and exports
+      # only the first usable provider to the rollout/judge steps.
+      DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+      DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
+      GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+      GLM_BASE_URL: ${{ secrets.GLM_BASE_URL }}
+      QWEN_API_KEY: ${{ secrets.QWEN_API_KEY }}
+      QWEN_BASE_URL: ${{ secrets.QWEN_BASE_URL }}
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY || secrets.BF_TOKEN }}
+      LITELLM_BASE_URL: ${{ secrets.LITELLM_BASE_URL || 'http://llm-proxy.eval.all-hands.dev/v1' }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GITHUB_MODELS_TOKEN: ${{ secrets.GITHUB_MODELS_TOKEN || github.token }}
       # Optional Daytona key for the parity + reaper scenarios.
       DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
       TASK: ${{ github.event.inputs.task || 'dialogue-parser' }}
@@ -71,18 +80,8 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
 
-      - name: Check integration auth
-        run: |
-          missing=()
-          for name in GITHUB_TOKEN OPENAI_API_KEY OPENAI_BASE_URL; do
-            if [ -z "${!name}" ]; then
-              missing+=("$name")
-            fi
-          done
-          if [ "${#missing[@]}" -ne 0 ]; then
-            printf '::error::Missing required GitHub Actions auth for integration-eval: %s\n' "${missing[*]}"
-            exit 1
-          fi
+      - name: Select integration provider
+        run: python .github/scripts/select_integration_provider.py
 
       - name: Install uv
         uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
@@ -102,8 +101,8 @@ jobs:
             --source-path tasks \
             --source-ref main \
             --include "$TASK" \
-            --agent openhands \
-            --model github-models/openai/gpt-4.1-mini \
+            --agent "$BENCHFLOW_INTEGRATION_AGENT" \
+            --model "$BENCHFLOW_INTEGRATION_MODEL" \
             --sandbox docker \
             --concurrency 1 \
             --agent-idle-timeout 240 \
@@ -113,7 +112,7 @@ jobs:
         run: |
           uv run python tests/integration/agent_judge.py \
             jobs/integration-eval \
-            --model openai/openai/gpt-4.1-mini \
+            --model "$BENCHFLOW_JUDGE_MODEL" \
             --json
 
       - name: Run the live integration scenarios

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -4,10 +4,13 @@
 # (tests/integration/agent_judge.py) grade the resulting rollout. The job
 # fails if the run is not REAL (no tool calls / no tokens / null reward) or
 # if the judge fails the trajectory. It is kept to one task so the check
-# stays cheap; trigger it after main CI succeeds, on demand, or nightly.
+# stays cheap; trigger it for internal PRs, after main CI succeeds, on demand,
+# or nightly.
 name: integration-eval
 
 on:
+  pull_request:
+    branches: [main]
   workflow_run:
     workflows: ["test"]
     types: [completed]
@@ -33,14 +36,20 @@ concurrency:
 jobs:
   eval-and-judge:
     runs-on: ubuntu-latest
-    # Only run on the canonical repo. Forks lack the eval/judge secrets, so
-    # the scheduled and dispatched runs would otherwise fail-closed there.
+    # Only run where integration secrets are available. Fork PRs lack secrets,
+    # while internal PRs should fail visibly when the real eval path breaks.
     if: >-
       ${{
         github.repository == 'benchflow-ai/benchflow' &&
         (
-          github.event_name != 'workflow_run' ||
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'schedule' ||
           (
+            github.event_name == 'pull_request' &&
+            github.event.pull_request.head.repo.full_name == 'benchflow-ai/benchflow'
+          ) ||
+          (
+            github.event_name == 'workflow_run' &&
             github.event.workflow_run.conclusion == 'success' &&
             github.event.workflow_run.event == 'push' &&
             github.event.workflow_run.head_branch == 'main'
@@ -57,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
 
       - name: Check integration secrets
         run: |
@@ -91,7 +100,7 @@ jobs:
             --source-ref main \
             --include "$TASK" \
             --agent codex-acp \
-            --model openai/gpt-5.4-nano \
+            --model openai/gpt-5.4-mini \
             --sandbox docker \
             --concurrency 1 \
             --agent-idle-timeout 240 \
@@ -101,7 +110,7 @@ jobs:
         run: |
           uv run python tests/integration/agent_judge.py \
             jobs/integration-eval \
-            --model openai/gpt-5.4-nano \
+            --model openai/gpt-5.4-mini \
             --json
 
       - name: Run the live integration scenarios

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -38,6 +38,9 @@ concurrency:
 jobs:
   eval-and-judge:
     runs-on: ubuntu-latest
+    # Provider credentials are stored as environment secrets so they can be
+    # rotated without requiring repo-admin access to Actions secrets.
+    environment: pypi-internal-preview
     # Only run where integration secrets are available. Fork PRs lack secrets,
     # while internal PRs should fail visibly when the real eval path breaks.
     if: >-

--- a/.github/workflows/internal-preview-release.yml
+++ b/.github/workflows/internal-preview-release.yml
@@ -2,7 +2,7 @@ name: internal-preview-release
 
 on:
   workflow_run:
-    workflows: ["test"]
+    workflows: ["integration-eval"]
     types: [completed]
 
 # PyPI Trusted Publishing uses OIDC, so no PyPI token is stored in GitHub.
@@ -16,7 +16,7 @@ jobs:
     if: >-
       ${{
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.event == 'workflow_run' &&
         github.event.workflow_run.head_branch == 'main'
       }}
     runs-on: ubuntu-latest
@@ -38,9 +38,10 @@ jobs:
 
       - name: Compute internal preview version
         id: version
-        env:
-          TEST_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
-        run: uv run --with packaging --no-project python tools/release_version.py internal-preview
+        run: >-
+          uv run --with packaging --no-project python tools/release_version.py
+          internal-preview
+          --run-number "${{ github.event.workflow_run.run_number }}"
 
       - name: Apply internal preview version
         if: steps.version.outputs.publish == 'true'

--- a/docs/release.md
+++ b/docs/release.md
@@ -109,6 +109,11 @@ Internal preview:
 4. `.github/workflows/internal-preview-release.yml` publishes to PyPI only if
    the integration gate passed.
 
+The integration gate uses GitHub Models through the workflow-scoped
+`GITHUB_TOKEN` with `models: read` permission, so it does not need provider API
+keys for the smoke rollout or judge. `DAYTONA_API_KEY` is optional and enables
+the Daytona parity and reaper checks.
+
 Public release:
 
 1. Update `pyproject.toml` from the next `.dev0` version to the final public

--- a/docs/release.md
+++ b/docs/release.md
@@ -109,10 +109,12 @@ Internal preview:
 4. `.github/workflows/internal-preview-release.yml` publishes to PyPI only if
    the integration gate passed.
 
-The integration gate uses GitHub Models through the workflow-scoped
-`GITHUB_TOKEN` with `models: read` permission, so it does not need provider API
-keys for the smoke rollout or judge. `DAYTONA_API_KEY` is optional and enables
-the Daytona parity and reaper checks.
+The integration gate selects the first configured live LLM provider that can
+answer a small probe request, then uses that same provider for the smoke rollout
+and agent judge. Configure at least one of `DEEPSEEK_API_KEY`, `GLM_API_KEY`,
+`QWEN_API_KEY`, `LITELLM_API_KEY`/`BF_TOKEN`, `OPENAI_API_KEY`, or
+`GITHUB_MODELS_TOKEN` in GitHub Actions secrets. `DAYTONA_API_KEY` is optional
+and enables the Daytona parity and reaper checks.
 
 Public release:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -113,8 +113,8 @@ The integration gate selects the first configured live LLM provider that can
 answer a small probe request, then uses that same provider for the smoke rollout
 and agent judge. Configure at least one of `DEEPSEEK_API_KEY`, `GLM_API_KEY`,
 `QWEN_API_KEY`, `LITELLM_API_KEY`/`BF_TOKEN`, `OPENAI_API_KEY`, or
-`GITHUB_MODELS_TOKEN` in GitHub Actions secrets. `DAYTONA_API_KEY` is optional
-and enables the Daytona parity and reaper checks.
+`GITHUB_MODELS_TOKEN` as GitHub Actions secrets for the job environment.
+`DAYTONA_API_KEY` is optional and enables the Daytona parity and reaper checks.
 
 Public release:
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -104,8 +104,10 @@ Internal preview:
 
 1. Merge a PR to `main`.
 2. `.github/workflows/test.yml` runs.
-3. `.github/workflows/internal-preview-release.yml` publishes to PyPI only if
-   the tested `main` commit passed.
+3. `.github/workflows/integration-eval.yml` runs a real rollout after the
+   tested `main` commit passes.
+4. `.github/workflows/internal-preview-release.yml` publishes to PyPI only if
+   the integration gate passed.
 
 Public release:
 

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -205,13 +205,14 @@ def _model_selection_owned_by_env(
     agent_cfg = AGENTS.get(agent)
     if not agent_cfg:
         return False
-    # LiteLLM routing: when the model is delivered purely through env
-    # (LLM_MODEL/ANTHROPIC_MODEL + BENCHFLOW_LITELLM_MODEL_VIA_ENV) the agent
-    # must not also receive ACP model config. An alias present WITHOUT VIA_ENV
-    # (e.g. opencode) means ACP model config still runs — _format_acp_model maps
-    # it to the proxy's registered openai/<alias> route.
+    # LiteLLM routing: when the model is delivered through an agent-native env
+    # var (e.g. LLM_MODEL/ANTHROPIC_MODEL + BENCHFLOW_LITELLM_MODEL_VIA_ENV)
+    # the agent must not also receive ACP model config. Agents without a native
+    # model env mapping (codex-acp) still need ACP configuration so they do not
+    # fall back to their own defaults.
     if agent_env.get("BENCHFLOW_LITELLM_MODEL_VIA_ENV") in {"1", "true", "True"}:
-        return True
+        mapped_model_env = agent_cfg.env_mapping.get("BENCHFLOW_PROVIDER_MODEL")
+        return bool(mapped_model_env and agent_env.get(mapped_model_env))
     if agent_env.get("BENCHFLOW_LITELLM_MODEL_ALIAS"):
         return False
     provider = find_provider(model)
@@ -234,7 +235,7 @@ def _model_selection_owned_by_env(
 def _resolve_acp_model_input(agent: str, model: str, agent_env: dict[str, str]) -> str:
     """Pick the model string that should be sent through ACP model config."""
     litellm_alias = agent_env.get("BENCHFLOW_LITELLM_MODEL_ALIAS")
-    if litellm_alias:
+    if litellm_alias and agent != "codex-acp":
         return litellm_alias
     agent_cfg = AGENTS.get(agent)
     if not agent_cfg:

--- a/src/benchflow/agents/codex_config.py
+++ b/src/benchflow/agents/codex_config.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 CODEX_CONFIG_ENV = "CODEX_CONFIG"
+CODEX_DEFAULT_AUTH_REQUEST_ENV = "DEFAULT_AUTH_REQUEST"
 CODEX_MODEL_PROVIDER_ENV = "MODEL_PROVIDER"
 
 _CODEX_PROVIDER_ID_PREFIX = "benchflow-"
@@ -66,3 +67,57 @@ def apply_codex_provider_config(
 
     agent_env[CODEX_MODEL_PROVIDER_ENV] = str(provider_id)
     agent_env[CODEX_CONFIG_ENV] = json.dumps(config, separators=(",", ":"))
+    _apply_codex_default_auth_request(
+        agent_env,
+        base_url=base_url,
+        provider_name=provider_name,
+    )
+
+
+def _apply_codex_default_auth_request(
+    agent_env: dict[str, str],
+    *,
+    base_url: str,
+    provider_name: str,
+) -> None:
+    """Provide non-interactive auth for codex-acp's authorization gate.
+
+    ``codex-acp@0.0.45`` checks account authorization before it sends the first
+    prompt. Supplying ``OPENAI_API_KEY`` and ``CODEX_CONFIG`` is not enough; the
+    wrapper needs a default ACP auth request to complete that gate without an
+    IDE round-trip.
+    """
+    api_key = agent_env.get("OPENAI_API_KEY")
+    if not api_key:
+        return
+
+    normalized = provider_name.strip().lower()
+    if normalized == "litellm":
+        # BenchFlow owns this local gateway. Authenticate as a gateway so the
+        # proxy master key is used only against the proxy, not as an OpenAI
+        # account login key.
+        request = {
+            "methodId": "gateway",
+            "_meta": {
+                "gateway": {
+                    "baseUrl": base_url,
+                    "providerName": "BenchFlow LiteLLM",
+                    "headers": {"Authorization": f"Bearer {api_key}"},
+                }
+            },
+        }
+        agent_env[CODEX_DEFAULT_AUTH_REQUEST_ENV] = json.dumps(
+            request,
+            separators=(",", ":"),
+        )
+        return
+
+    if normalized == "openai" and CODEX_DEFAULT_AUTH_REQUEST_ENV not in agent_env:
+        request = {
+            "methodId": "api-key",
+            "_meta": {"api-key": {"apiKey": api_key}},
+        }
+        agent_env[CODEX_DEFAULT_AUTH_REQUEST_ENV] = json.dumps(
+            request,
+            separators=(",", ":"),
+        )

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -192,6 +192,15 @@ PROVIDERS: dict[str, ProviderConfig] = {
             "openai-responses": "https://us.api.openai.com/v1",
         },
     ),
+    # GitHub Models exposes an OpenAI-compatible endpoint that GitHub Actions
+    # can call with the workflow-scoped GITHUB_TOKEN and `models: read`.
+    "github-models": ProviderConfig(
+        name="github-models",
+        base_url="https://models.github.ai/inference",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="GITHUB_TOKEN",
+    ),
     # TODO: add eu-openai (https://eu.api.openai.com/v1) when needed.
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -336,10 +336,18 @@ def litellm_proxy_config(
         params.setdefault("input_cost_per_token", cost[0])
         params.setdefault("output_cost_per_token", cost[1])
     openai_alias = f"openai/{route.model_alias}"
+    bare_requested = strip_provider_prefix(route.requested_model)
     model_list: list[dict[str, object]] = [
         {"model_name": route.model_alias, "litellm_params": dict(params)},
         {"model_name": openai_alias, "litellm_params": dict(params)},
     ]
+    for model_name in (bare_requested, f"openai/{bare_requested}"):
+        if model_name and model_name not in {
+            entry["model_name"] for entry in model_list
+        }:
+            model_list.append(
+                {"model_name": model_name, "litellm_params": dict(params)}
+            )
     return {
         "model_list": model_list,
         "general_settings": {"master_key": master_key},

--- a/tests/integration/agent_judge.py
+++ b/tests/integration/agent_judge.py
@@ -60,6 +60,7 @@ _JUDGE_ENV_KEYS = (
     "GOOGLE_API_KEY",
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
 )
 
 # Files whose contents define the score: tampering with these to force a pass is

--- a/tests/test_acp_model_config_dispatch.py
+++ b/tests/test_acp_model_config_dispatch.py
@@ -16,6 +16,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from benchflow.acp.client import ACPClient
+from benchflow.providers.litellm_config import (
+    LITELLM_MODEL_ALIAS_ENV,
+    LITELLM_MODEL_VIA_ENV,
+)
 
 
 def _make_mocks(config_options=None, model_state=None):
@@ -49,7 +53,9 @@ def _runtime_patches(mock_acp):
         yield
 
 
-async def _connect(mock_acp, *, agent, model, tmp_path, reasoning_effort=None):
+async def _connect(
+    mock_acp, *, agent, model, tmp_path, agent_env=None, reasoning_effort=None
+):
     from benchflow.acp.runtime import connect_acp
 
     with _runtime_patches(mock_acp):
@@ -57,7 +63,7 @@ async def _connect(mock_acp, *, agent, model, tmp_path, reasoning_effort=None):
             env=AsyncMock(),
             agent=agent,
             agent_launch=agent,
-            agent_env={},
+            agent_env={} if agent_env is None else agent_env,
             sandbox_user=None,
             model=model,
             rollout_dir=tmp_path,
@@ -75,6 +81,39 @@ async def test_codex_with_only_fastmode_option_uses_set_model(tmp_path):
     await _connect(mock_acp, agent="codex-acp", model="gpt-5.5", tmp_path=tmp_path)
 
     mock_acp.set_model.assert_awaited_once_with("gpt-5.5")
+    mock_acp.set_config_option.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_codex_litellm_alias_uses_bare_model_for_set_model(tmp_path):
+    """Codex validates set_model against its own model catalog, not proxy aliases.
+
+    This guards against a false-green CI path where BenchFlow recorded the
+    requested model but codex-acp fell back to its own default at request time.
+    """
+    mock_acp = _make_mocks(
+        config_options=[{"id": "fast-mode"}],
+        model_state={
+            "availableModels": [
+                {"modelId": "gpt-5.4-mini[low]"},
+                {"modelId": "gpt-5.4-mini[medium]"},
+            ],
+            "currentModelId": "gpt-5.5[medium]",
+        },
+    )
+    await _connect(
+        mock_acp,
+        agent="codex-acp",
+        model="openai/gpt-5.4-mini",
+        tmp_path=tmp_path,
+        agent_env={
+            "BENCHFLOW_PROVIDER_MODEL": "benchflow-openai-gpt-5.4-mini",
+            LITELLM_MODEL_ALIAS_ENV: "benchflow-openai-gpt-5.4-mini",
+            LITELLM_MODEL_VIA_ENV: "1",
+        },
+    )
+
+    mock_acp.set_model.assert_awaited_once_with("gpt-5.4-mini[medium]")
     mock_acp.set_config_option.assert_not_awaited()
 
 

--- a/tests/test_agent_model_decouple.py
+++ b/tests/test_agent_model_decouple.py
@@ -82,6 +82,11 @@ class TestInferEnvKey:
         """anthropic-vertex/ models use ADC, not API keys."""
         assert infer_env_key_for_model("anthropic-vertex/claude-sonnet-4-6") is None
 
+    def test_github_models_uses_github_token(self):
+        assert infer_env_key_for_model("github-models/openai/gpt-4.1-mini") == (
+            "GITHUB_TOKEN"
+        )
+
     def test_unknown_model_returns_none(self):
         assert infer_env_key_for_model("some-custom-model") is None
 

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -76,6 +76,24 @@ class TestEnvMappingField:
 
         assert env["LLM_MODEL"] == "openai/glm-5"
 
+    def test_openhands_normalizes_github_models_model(self):
+        env = {"GITHUB_TOKEN": "ghs_test_token"}
+        resolve_provider_env(
+            agent="openhands",
+            model="github-models/openai/gpt-4.1-mini",
+            agent_env=env,
+        )
+
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "github-models"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "openai/gpt-4.1-mini"
+        assert (
+            env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://models.github.ai/inference"
+        )
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "ghs_test_token"
+        assert env["LLM_BASE_URL"] == "https://models.github.ai/inference"
+        assert env["LLM_API_KEY"] == "ghs_test_token"
+        assert env["LLM_MODEL"] == "openai/openai/gpt-4.1-mini"
+
     def test_openhands_bedrock_initial_env_marks_registered_provider(self):
         """Guards the LiteLLM runtime refactor: Bedrock is detected before runtime rewrite."""
         env = {

--- a/tests/test_config_redaction.py
+++ b/tests/test_config_redaction.py
@@ -88,6 +88,9 @@ def test_write_config_drops_secret_env_vars(tmp_path: Path) -> None:
         "MY_AUTH_HEADER": "Bearer secret",
         "GITHUB_TOKEN": "ghp_secret",
         "OPENAI_API_KEY": "sk-secret",
+        "DEFAULT_AUTH_REQUEST": (
+            '{"methodId":"api-key","_meta":{"api-key":{"apiKey":"sk-secret"}}}'
+        ),
         # Should be preserved.
         "NORMAL_VAR": "keep-me",
         "PATH": "/usr/bin:/bin",
@@ -119,6 +122,7 @@ def test_write_config_drops_secret_env_vars(tmp_path: Path) -> None:
         ("MY_AUTH_HEADER", "Bearer secret"),
         ("GITHUB_TOKEN", "ghp_secret"),
         ("OPENAI_API_KEY", "sk-secret"),
+        ("DEFAULT_AUTH_REQUEST", "apiKey"),
     ):
         assert redacted_name not in recorded
         assert redacted_value not in raw

--- a/tests/test_integration_agent_judge.py
+++ b/tests/test_integration_agent_judge.py
@@ -297,6 +297,28 @@ class TestJudgeRollout:
         # Only judge-relevant keys are forwarded.
         assert await_args.kwargs["env"] == {"GEMINI_API_KEY": "k"}
 
+    async def test_openai_base_url_threaded_to_call_judge(self) -> None:
+        mock = AsyncMock(return_value='{"verdict": "pass", "reason": "ok"}')
+        with patch("tests.integration.agent_judge.call_judge", mock):
+            await judge_rollout(
+                _evidence(),
+                model="openai/openai/gpt-4.1-mini",
+                env={
+                    "OPENAI_API_KEY": "ghs_test_token",
+                    "OPENAI_BASE_URL": "https://models.github.ai/inference",
+                    "GITHUB_TOKEN": "ghs_test_token",
+                },
+            )
+
+        mock.assert_awaited_once()
+        await_args = mock.await_args
+        assert await_args is not None
+        assert await_args.args[0] == "openai/openai/gpt-4.1-mini"
+        assert await_args.kwargs["env"] == {
+            "OPENAI_API_KEY": "ghs_test_token",
+            "OPENAI_BASE_URL": "https://models.github.ai/inference",
+        }
+
 
 # ------------------------------------------------------------------
 # Combined gate: realness AND judge

--- a/tests/test_integration_provider_selection.py
+++ b/tests/test_integration_provider_selection.py
@@ -1,0 +1,57 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / ".github/scripts/select_integration_provider.py"
+)
+spec = importlib.util.spec_from_file_location("select_integration_provider", SCRIPT)
+assert spec is not None
+selector = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+sys.modules[spec.name] = selector
+spec.loader.exec_module(selector)
+
+
+def test_select_candidate_picks_first_successful_provider():
+    env = {"DEEPSEEK_API_KEY": "deepseek-key", "GLM_API_KEY": "glm-key"}
+    seen = []
+
+    def probe(candidate, _env):
+        seen.append(candidate.name)
+        return candidate.name == "glm", "ok" if candidate.name == "glm" else "nope"
+
+    selected, attempts = selector.select_candidate(selector.candidates(env), env, probe)
+
+    assert selected.name == "glm"
+    assert seen == ["deepseek", "glm"]
+    assert attempts == [("deepseek", "nope"), ("glm", "ok")]
+
+
+def test_deepseek_exports_openai_compatible_judge_env():
+    env = {
+        "DEEPSEEK_API_KEY": "deepseek-key",
+        "DEEPSEEK_BASE_URL": "https://api.deepseek.example",
+    }
+
+    candidate = selector.candidates(env)[0]
+
+    assert candidate.name == "deepseek"
+    assert candidate.rollout_model == "deepseek/deepseek-v4-flash"
+    assert candidate.judge_model == "openai/deepseek-v4-flash"
+    assert candidate.exports["DEEPSEEK_API_KEY"] == "deepseek-key"
+    assert candidate.exports["OPENAI_API_KEY"] == "deepseek-key"
+    assert candidate.exports["OPENAI_BASE_URL"] == "https://api.deepseek.example"
+
+
+def test_github_env_writer_uses_multiline_format(tmp_path, monkeypatch):
+    path = tmp_path / "github_env"
+    monkeypatch.setenv("GITHUB_ENV", str(path))
+
+    selector._append_github_env({"OPENAI_API_KEY": "secret\nvalue"}, os.environ)
+
+    assert path.read_text() == (
+        "OPENAI_API_KEY<<__BENCHFLOW_ENV__\nsecret\nvalue\n__BENCHFLOW_ENV__\n"
+    )

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -94,6 +94,18 @@ def test_proxy_config_registers_plain_and_openai_aliases():
     names = [entry["model_name"] for entry in config["model_list"]]
     assert route.model_alias in names
     assert f"openai/{route.model_alias}" in names
+    assert "us.anthropic.claude-opus-4-8" in names
+    assert "openai/us.anthropic.claude-opus-4-8" in names
     assert config["litellm_settings"]["callbacks"] == [
         "benchflow_litellm_callback.proxy_handler_instance"
     ]
+
+
+def test_proxy_config_registers_requested_bare_model_name():
+    """Codex ACP sends the bare selected model name to the proxy."""
+    route = resolve_litellm_route("openai/gpt-5.4-mini", {"OPENAI_API_KEY": "key"})
+    config = litellm_proxy_config(route, master_key="sk-local")
+
+    names = [entry["model_name"] for entry in config["model_list"]]
+    assert "gpt-5.4-mini" in names
+    assert "openai/gpt-5.4-mini" in names

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
 
+from benchflow.agents.codex_config import CODEX_DEFAULT_AUTH_REQUEST_ENV
 from benchflow.providers import litellm_runtime as runtime_mod
 from benchflow.providers.litellm_bedrock_preflight import BedrockPatchPreflightError
 from benchflow.providers.litellm_config import LITELLM_MODEL_ALIAS_ENV
@@ -44,6 +46,9 @@ async def test_host_litellm_rewrites_codex_env(monkeypatch):
         agent_env={
             "AWS_BEARER_TOKEN_BEDROCK": "token",
             "AWS_REGION": "us-west-2",
+            CODEX_DEFAULT_AUTH_REQUEST_ENV: json.dumps(
+                {"methodId": "api-key", "_meta": {"api-key": {"apiKey": "old"}}}
+            ),
         },
         model="aws-bedrock/us.anthropic.claude-opus-4-8",
         runtime=None,
@@ -64,6 +69,17 @@ async def test_host_litellm_rewrites_codex_env(monkeypatch):
         '"model":"benchflow-aws-bedrock-us.anthropic.claude-opus-4-8"'
         in updated["CODEX_CONFIG"]
     )
+    auth_request = json.loads(updated[CODEX_DEFAULT_AUTH_REQUEST_ENV])
+    assert auth_request == {
+        "methodId": "gateway",
+        "_meta": {
+            "gateway": {
+                "baseUrl": "http://host.docker.internal:32123/v1",
+                "providerName": "BenchFlow LiteLLM",
+                "headers": {"Authorization": f"Bearer {provider_runtime.master_key}"},
+            }
+        },
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -60,6 +60,12 @@ class TestStripProviderPrefix:
     def test_openai_prefix_stripped(self) -> None:
         assert _strip_provider_prefix("openai/gpt-4o") == "gpt-4o"
 
+    def test_nested_openai_model_keeps_inner_provider_for_github_models(self) -> None:
+        assert (
+            _strip_provider_prefix("openai/openai/gpt-4.1-mini")
+            == "openai/gpt-4.1-mini"
+        )
+
     def test_google_prefix_stripped(self) -> None:
         assert _strip_provider_prefix("google/gemini-2.0-flash") == "gemini-2.0-flash"
 
@@ -141,6 +147,24 @@ class TestCallJudgeProviderFallback:
         assert result == "ok from openai"
         # ImportError is not retried.
         assert anthropic_mock.await_count == 1
+
+    async def test_github_models_openai_spelling_routes_to_openai(self) -> None:
+        openai_mock = AsyncMock(return_value="ok from github models")
+        anthropic_mock = AsyncMock(return_value="should not be reached")
+        google_mock = AsyncMock(return_value="should not be reached")
+
+        with (
+            patch("benchflow.rewards.llm._call_openai", openai_mock),
+            patch("benchflow.rewards.llm._call_anthropic", anthropic_mock),
+            patch("benchflow.rewards.llm._call_google", google_mock),
+        ):
+            result = await call_judge("openai/openai/gpt-4.1-mini", "prompt")
+
+        assert result == "ok from github models"
+        openai_mock.assert_awaited_once()
+        assert openai_mock.await_args.args[0] == "openai/gpt-4.1-mini"
+        anthropic_mock.assert_not_awaited()
+        google_mock.assert_not_awaited()
 
     async def test_matched_provider_missing_sdk_raises_clear_error(self) -> None:
         """Dogfood bug (2): when the model name confidently selects a provider

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -60,6 +60,19 @@ class TestFindProvider:
         assert resolve_auth_env("us-openai/gpt-5.4-mini") == "OPENAI_API_KEY"
         assert strip_provider_prefix("us-openai/gpt-5.4-mini") == "gpt-5.4-mini"
 
+    def test_github_models_prefix(self):
+        name, cfg = find_provider("github-models/openai/gpt-4.1-mini")
+
+        assert name == "github-models"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "GITHUB_TOKEN"
+        assert cfg.base_url == "https://models.github.ai/inference"
+        assert resolve_auth_env("github-models/openai/gpt-4.1-mini") == "GITHUB_TOKEN"
+        assert (
+            strip_provider_prefix("github-models/openai/gpt-4.1-mini")
+            == "openai/gpt-4.1-mini"
+        )
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -451,6 +451,7 @@ def test_provider_model_prefixes_unique_and_resolvable():
         ("azure-foundry-openai/gpt-5.5", "azure-foundry-openai"),
         ("azure-foundry-anthropic/claude-opus-4-5", "azure-foundry-anthropic"),
         ("aws-bedrock/openai.gpt-oss-20b-1:0", "aws-bedrock"),
+        ("github-models/openai/gpt-4.1-mini", "github-models"),
         ("zai/glm-5", "zai"),
         ("vllm/local-model", "vllm"),
         ("kimi/kimi-k2.6", "kimi"),

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 import pytest
 
+from benchflow.agents.codex_config import CODEX_DEFAULT_AUTH_REQUEST_ENV
 from benchflow.agents.env import (
     auto_inherit_env,
     check_subscription_auth,
@@ -1037,6 +1038,10 @@ class TestResolveAgentEnvCodexOpenAIPrefix:
         )
         assert result["CODEX_API_KEY"] == "codex-key"
         assert result["OPENAI_API_KEY"] == "codex-key"
+        assert json.loads(result[CODEX_DEFAULT_AUTH_REQUEST_ENV]) == {
+            "methodId": "api-key",
+            "_meta": {"api-key": {"apiKey": "codex-key"}},
+        }
 
     def test_codex_access_token_works_for_openai_prefix(self, monkeypatch, tmp_path):
         self._patch_expanduser(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary
- run `integration-eval` on internal PRs so real rollout failures are visible during review
- run `integration-eval` automatically after the main `test` workflow succeeds on a push to `main`
- gate internal preview publishing on successful `integration-eval`, not just unit-test CI
- select the first live configured LLM provider for the integration smoke rollout and judge, instead of binding CI to one stale/over-quota token
- add `github-models/` provider routing and pass `OPENAI_BASE_URL` through the agent-judge path
- fix Codex ACP model/auth setup for noninteractive CI rollouts through the BenchFlow provider path
- update release docs to describe the new test -> integration -> preview flow

## Why
The latest `test` workflow was green because it only covered lint/type/unit tests. The real rollout path lived in a separate integration workflow and did not block PR review or internal preview publishing, so broken end-to-end execution could be hidden behind green unit CI.

This PR makes the release path exercise a real SkillsBench rollout, verifies the produced trajectory with the agent judge, and blocks preview publishing if that end-to-end path fails.

## Current Status
All PR checks are green and the PR is mergeable. The integration job reads provider and Daytona credentials from the existing preview environment, probes configured providers without printing secrets, and fail-closes if none are usable.

The latest remote `integration-eval` run selected DeepSeek, executed a real OpenHands rollout on the latest SkillsBench `main`, produced a complete trajectory, and passed the agent-judge realness gate with no realness issues. The rollout task reward was `0.833`, which is acceptable for this gate because the check verifies healthy real execution and trustworthy trajectory generation rather than requiring a perfect task score.

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/integration-eval.yml .github/workflows/internal-preview-release.yml .github/workflows/test.yml`
- `uv run ruff check .github/scripts/select_integration_provider.py tests/test_integration_provider_selection.py src/benchflow/agents/providers.py tests/test_providers.py tests/test_agent_registry.py tests/test_agent_model_decouple.py tests/test_integration_agent_judge.py tests/test_llm_judge.py`
- `uv run ruff format --check .github/scripts/select_integration_provider.py tests/test_integration_provider_selection.py`
- `uv run ty check`
- `uv run python -m pytest tests/` (`4090 passed, 49 skipped, 7 deselected`)
- local provider selector probe with `/Users/bingran_you/Downloads/GitHub/bingran-you/.env`: selected DeepSeek with HTTP 200
- remote PR checks: `integration-eval / eval-and-judge`, `test / test`, `test / pip-audit`, and Mintlify Deployment all passed
- remote live integration scenarios: Docker oracle determinism passed, Docker/Daytona sandbox parity passed, reaper dry-run safety passed