### PR TITLE
docs: fix Mintlify task standard parsing

### DIFF
--- a/.mintignore
+++ b/.mintignore
@@ -1,0 +1,3 @@
+.venv/
+tests/
+docs/examples/task-md/real-skillsbench/

--- a/docs/task-standard.md
+++ b/docs/task-standard.md
@@ -653,8 +653,8 @@ An interaction declares one **mode**. The modes form the Interaction axis:
 the exchange (by an assessor agent) rather than by a post-hoc verifier. It is
 declared in the schema so such tasks parse without loss; its runtime (an A2A bridge
 for the agent-under-test plus a concurrently-running assessor) is deferred to a
-later milestone (see *Open Primitives and Roadmap*). Note ACP (BenchFlow <-> agent)
-is not A2A (agent <-> agent); arena needs the A2A leg.
+later milestone (see *Open Primitives and Roadmap*). Note ACP (BenchFlow &lt;-&gt; agent)
+is not A2A (agent &lt;-&gt; agent); arena needs the A2A leg.
 
 The current executable slice is linear `scenes` that reference `agents.roles`.
 The first team handoff subset is intentionally narrow: a document-declared user


### PR DESCRIPTION
## Summary
- escape task-standard angle-bracket text that Mintlify parses as MDX
- add a .mintignore so local Mintlify validation ignores virtualenvs, test fixtures, and non-navigation task assets

## Validation
- git diff --check
- PATH=/Users/bingran_you/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH npx --yes mintlify@latest validate