### PR TITLE
ci: avoid canceling integration eval gates

### DIFF
--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -30,10 +30,13 @@ permissions:
   contents: read
   models: read
 
-# One in-flight integration run at a time; newer dispatches supersede older.
+# One in-flight integration run at a time. Do not cancel an in-progress gate:
+# delayed workflow_run events can otherwise interrupt a real rollout after it
+# has already passed the rollout and judge steps, leaving a cancelled check on
+# the tested commit.
 concurrency:
   group: integration-eval-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   eval-and-judge:


### PR DESCRIPTION
## Summary
- keep integration-eval serialized by branch
- stop newer workflow_run events from canceling an already-running real rollout/judge gate
- document why delayed workflow_run events should queue/skip instead of interrupting the gate

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/integration-eval.yml"); puts "yaml ok"'