### PR TITLE
fix(cli): validate skills eval model cardinality (#550)

### DIFF
--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -115,6 +115,12 @@ def register_skills(app: typer.Typer) -> None:
             raise typer.Exit(1)
         if agent is None:
             agent = ["claude-agent-acp"]
+        if model is not None and len(model) not in {1, len(agent)}:
+            print_error(
+                "--model may be provided once for all agents or once per --agent; "
+                f"got {len(model)} models for {len(agent)} agents"
+            )
+            raise typer.Exit(1)
         if not (skill_dir / "evals" / "evals.json").exists():
             print_error(
                 f"No evals/evals.json found in {skill_dir}\n"

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -461,6 +461,43 @@ def test_skills_eval_exits_nonzero_when_cases_error(tmp_path, monkeypatch):
     assert "errored" in res.stderr
 
 
+def test_skills_eval_rejects_model_agent_length_mismatch_before_header(tmp_path):
+    """Guards PR #650 against #550's raw model/agent cardinality failure."""
+    evals = tmp_path / "evals"
+    evals.mkdir()
+    (evals / "evals.json").write_text(
+        '{"skill_name":"citation-management",'
+        '"cases":[{"id":"case-1","question":"Q?","ground_truth":"A"}]}'
+    )
+
+    res = runner.invoke(
+        app,
+        [
+            "skills",
+            "eval",
+            str(tmp_path),
+            "--agent",
+            "gemini",
+            "--model",
+            "gemini-2.5-flash",
+            "--model",
+            "extra-model",
+            "--no-baseline",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+        ],
+    )
+
+    assert res.exit_code == 1
+    assert (
+        "--model may be provided once for all agents or once per --agent" in res.stderr
+    )
+    assert "got 2 models" in res.stderr
+    assert "for 1 agents" in res.stderr
+    assert "Skill eval:" not in res.stdout
+    assert "Traceback" not in res.output
+
+
 def test_viewer_job_dir_indexes_rollout_subdirs(tmp_path):
     # `eval view <job_dir>` used to render a blank "No trajectory files found"
     # (the natural value from create's "Artifacts:" line); now it indexes the


### PR DESCRIPTION
## Summary

Closes #550 by validating `bench skills eval --model` cardinality before constructing and running the skill evaluator.

The older fork PR #650 targeted the pre-split CLI implementation and added a now-stale `tests/test_skill_eval_cli.py`; this replacement applies the same user-facing fix to the current `src/benchflow/cli/skills.py` surface and the existing CLI edge-case test suite.

## Validation

- `uv run python -m pytest tests/test_cli_edge_case_hardening.py tests/test_skill_eval_integration.py -q` passed: 52 passed.
- `uv run ruff check src/benchflow/cli/skills.py tests/test_cli_edge_case_hardening.py` passed.
- `uv run ty check src/benchflow/cli/skills.py` passed.

## Notes

The error is emitted through the shared `print_error` path before the `Skill eval:` header, so users see a clean validation error rather than a late evaluator failure or traceback.
