### PR TITLE
fix(integration): make citation-check oracle deterministic

### DIFF
--- a/docs/examples/task-md/real-skillsbench/citation-check/oracle/solve.sh
+++ b/docs/examples/task-md/real-skillsbench/citation-check/oracle/solve.sh
@@ -38,6 +38,40 @@ from urllib.parse import quote
 
 WORKSPACE = Path(os.environ.get("BENCHFLOW_WORKSPACE", "/root"))
 
+# This oracle is used by BenchFlow's live integration gate. It must be
+# deterministic: external citation services may rate limit or intermittently
+# miss real ACL Anthology DOIs, but the ground truth for this fixture is fixed.
+KNOWN_FAKE_KEYS = {
+    "patel2023blockchain",
+    "smith2020ai",
+    "wilson2021neural",
+}
+KNOWN_REAL_KEYS = {
+    "Jumper2021",
+    "lila",
+    "Watson1953",
+    "joshi-etal-2017-triviaqa",
+    "Doudna2014",
+    "clue",
+    "cmmlu",
+    "chid",
+    "hellaswag",
+    "Alberts2014",
+    "Sambrook2001",
+    "Vaswani2017",
+    "He2016",
+    "jing-etal-2025-mcip",
+    "steg",
+    "adversarial",
+    "paraphraser",
+    "kaptchuk2021meteor",
+    "boolq",
+    "zhao-etal-2025-efficiently",
+    "wang-etal-2025-agentvigil",
+    "zhao-etal-2023-pre",
+    "gureja-etal-2025-rewardbench",
+}
+
 
 @dataclass
 class DetectionResult:
@@ -332,6 +366,32 @@ class FakeCitationDetector:
             doi = fields.get('doi', '')
             title = fields.get('title', '')
             author = fields.get('author', '')
+
+            if entry['key'] in KNOWN_FAKE_KEYS:
+                self.log("  FAKE: fixture ground truth")
+                results.append(DetectionResult(
+                    citation_key=entry['key'],
+                    entry_type=entry['type'],
+                    is_fake=True,
+                    confidence=1.0,
+                    reasons=["Known fake citation in this deterministic fixture"],
+                    verification_status="fake",
+                    metadata={'bibtex': fields, 'found': None},
+                ))
+                continue
+
+            if entry['key'] in KNOWN_REAL_KEYS:
+                self.log("  OK: fixture ground truth")
+                results.append(DetectionResult(
+                    citation_key=entry['key'],
+                    entry_type=entry['type'],
+                    is_fake=False,
+                    confidence=0.0,
+                    reasons=[],
+                    verification_status="verified",
+                    metadata={'bibtex': fields, 'found': {'source': 'fixture_ground_truth'}},
+                ))
+                continue
 
             # Strategy 1: If DOI exists, verify it
             if doi:

--- a/tests/test_task_check_eval_consistency.py
+++ b/tests/test_task_check_eval_consistency.py
@@ -10,7 +10,10 @@ None) so both commands return the same verdict.
 
 from __future__ import annotations
 
+import json
 import logging
+import os
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -38,6 +41,11 @@ REAL_SKILLSBENCH_TASK_MD_EXAMPLES = (
 USER_RUNTIME_TASK_MD_EXAMPLES = (
     Path("docs/examples/task-md/user-runtime/private-facts-nudges"),
 )
+EXPECTED_CITATION_CHECK_FAKES = [
+    "Advances in Artificial Intelligence for Natural Language Processing",
+    "Blockchain Applications in Supply Chain Management",
+    "Neural Networks in Deep Learning: A Comprehensive Review",
+]
 
 
 def _make_task_missing_agent(
@@ -86,6 +94,27 @@ def _make_malformed_task_md(parent: Path, name: str = "malformed-task-md") -> Pa
         "---\ntask:\n  name: [unclosed\n---\n\n## prompt\n\nhi\n"
     )
     return task
+
+
+def test_citation_check_oracle_uses_fixture_ground_truth(tmp_path: Path):
+    """Guards the PR #767 integration gate from live citation API flakiness."""
+    task = Path("docs/examples/task-md/real-skillsbench/citation-check")
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "test.bib").write_text((task / "environment" / "test.bib").read_text())
+
+    proc = subprocess.run(
+        ["bash", str(task / "oracle" / "solve.sh")],
+        cwd=Path.cwd(),
+        env={**os.environ, "BENCHFLOW_WORKSPACE": str(workspace)},
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr[-1000:]
+    answer = json.loads((workspace / "answer.json").read_text())
+    assert answer == {"fake_citations": EXPECTED_CITATION_CHECK_FAKES}
 
 
 def test_check_task_accepts_missing_agent(tmp_path):


### PR DESCRIPTION
## Summary

Fixes a live integration flake in the `citation-check` real SkillsBench fixture. The oracle was treating transient CrossRef/DOI lookup misses as fake citations, so a known-real entry such as `clue` could be reported as fake when external citation services hiccuped.

The oracle now uses explicit fixture ground truth for this fixed example task: the three intentionally fake entries remain fake, and known-real entries do not depend on live citation API availability.

## Evidence

Observed during batch PR validation:

- #767 `integration-eval` failed with `oracle did not self-score 1.0: {'citation-check': 0.0}` and docker/daytona parity mismatch.
- #679 later failed the same live scenario on `citation-check`.
- Artifact inspection showed the failure mode: `clue` was added to `fake_citations`, making the expected fake count 4 instead of 3.

Local/GCP validation:

- `uv run python -m pytest tests/test_task_check_eval_consistency.py::test_citation_check_oracle_uses_fixture_ground_truth tests/test_task_check_eval_consistency.py::test_eval_create_enumerates_real_skillsbench_native_examples -q` -> 2 passed.
- `uv run ruff check tests/test_task_check_eval_consistency.py` -> passed.
- `uv run ruff format --check tests/test_task_check_eval_consistency.py` -> passed.
- `bash -n docs/examples/task-md/real-skillsbench/citation-check/oracle/solve.sh` -> passed.
- On `benchflow-docker-runner-03`, after applying this patch to current `origin/main`: `uv run pytest tests/test_integration_suite.py::test_oracle_determinism_docker -m integration -p no:cacheprovider -v` -> 1 passed in 91.34s.

## Notes

This is intentionally scoped to the oracle fixture. It does not change runtime scoring logic or verifier behavior.
