### PR TITLE
fix(self-gen): keep generated skills in agent workspace

### DIFF
--- a/src/benchflow/rollout/_skills.py
+++ b/src/benchflow/rollout/_skills.py
@@ -88,15 +88,33 @@ def _resolve_skill_creator_root(path: str | Path | None) -> tuple[Path, str]:
     )
 
 
+def _format_task_prompts(task_prompts: list[str]) -> str:
+    if len(task_prompts) == 1:
+        return task_prompts[0].strip()
+
+    blocks = []
+    for index, prompt in enumerate(task_prompts, start=1):
+        blocks.append(f'<prompt index="{index}">\n{prompt.strip()}\n</prompt>')
+    return "\n\n".join(blocks)
+
+
 def _self_gen_prompt(
-    task_path: Path, generated_skills_root: str, skill_creator_name: str
+    task_path: Path,
+    generated_skills_root: str,
+    skill_creator_name: str,
+    task_prompts: list[str],
 ) -> str:
     """Prompt the clean creator agent to use the mounted skill-creator skill."""
     skill_dir_name = f"{_safe_skill_name(task_path.name)}-skill"
     target_dir = f"{generated_skills_root}/{skill_dir_name}"
+    formatted_prompts = _format_task_prompts(task_prompts)
     return f"""Use the {skill_creator_name} skill exactly as provided.
 
-Read /instruction.md and inspect the task environment only as needed to understand the reusable workflow. Do not solve the task directly.
+Create reusable skills for the task prompts below. Inspect the task environment only as needed to understand the reusable workflow. Do not solve the task directly.
+
+<task-prompts>
+{formatted_prompts}
+</task-prompts>
 
 Create one or more complete Anthropic-standard skill packs as immediate child directories under:
 

--- a/src/benchflow/rollout/_user_loop.py
+++ b/src/benchflow/rollout/_user_loop.py
@@ -45,6 +45,7 @@ from benchflow.scenes import (
     scene_step_role,
     scene_step_skills_dir,
 )
+from benchflow.skill_policy import SKILL_MODE_SELF_GEN
 from benchflow.trajectories.tree import Step
 from benchflow.usage_tracking import is_token_usage_available
 
@@ -108,6 +109,14 @@ async def _export_generated_skills(rollout: Rollout) -> None:
     from benchflow.learner_skills import capture_skills
 
     rollout._evolved_skills = capture_skills(target)
+    if (
+        rollout._config.recorded_skill_mode == SKILL_MODE_SELF_GEN
+        and not rollout._evolved_skills
+    ):
+        raise RuntimeError(
+            "self-gen creator produced no generated skills; aborting empty "
+            "self-gen result"
+        )
 
 
 async def _activate_step_skills(rollout: Rollout, step: Step) -> None:

--- a/src/benchflow/self_gen.py
+++ b/src/benchflow/self_gen.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import shlex
 import shutil
 from dataclasses import replace
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from uuid import uuid4
 
 from benchflow.rollout import (
@@ -22,11 +22,17 @@ from benchflow.rollout import (
     _self_gen_prompt,
     _skill_frontmatter_name,
 )
+from benchflow.rollout._setup import (
+    _configured_task_workdir,
+    _resolve_prompts,
+    _validate_agent_workdir,
+)
+from benchflow.skill_policy import validate_container_mount_path
+from benchflow.task import Task
 
 
 def _normalize_sandbox_path(path: str) -> str:
-    normalized = PurePosixPath(path).as_posix().rstrip("/")
-    return normalized or "/"
+    return validate_container_mount_path(path, "generated_skills_root")
 
 
 def _find_skill_creator_dir(skills_root: Path, skill_name: str) -> Path:
@@ -67,9 +73,29 @@ def _self_gen_artifact_root(config: RolloutConfig) -> Path:
     )
 
 
+def _default_generated_skills_root(task_path: Path) -> str:
+    workspace = _configured_task_workdir(Task(task_path))
+    if workspace is None:
+        workspace = "/root"
+    else:
+        _validate_agent_workdir(workspace)
+        workspace = _normalize_sandbox_path(workspace)
+    return f"{workspace}/generated-skills"
+
+
+def _generated_skills_root(config: RolloutConfig) -> str:
+    configured = _normalize_sandbox_path(
+        config.generated_skills_root or GENERATED_SKILLS_ROOT
+    )
+    if configured == _normalize_sandbox_path(GENERATED_SKILLS_ROOT):
+        return _default_generated_skills_root(config.task_path)
+    return configured
+
+
 def _creator_scene(
     config: RolloutConfig, creator_skills_root: Path, skill_creator_name: str
 ) -> Scene:
+    task_prompts = _resolve_prompts(config.task_path, config.prompts)
     return Scene(
         name="self-gen-creator",
         roles=[Role("skill_creator", config.agent, config.model)],
@@ -80,6 +106,7 @@ def _creator_scene(
                     config.task_path,
                     config.generated_skills_root or GENERATED_SKILLS_ROOT,
                     skill_creator_name,
+                    task_prompts,
                 ),
             )
         ],
@@ -127,19 +154,22 @@ def _single_trial_config(
     skill_creator_name: str,
     artifact_root: Path,
 ) -> RolloutConfig:
+    generated_skills_root = _generated_skills_root(config)
+    scene_config = replace(config, generated_skills_root=generated_skills_root)
     return replace(
         config,
         scenes=[
-            _creator_scene(config, creator_skills_root, skill_creator_name),
-            _solver_scene(config),
+            _creator_scene(scene_config, creator_skills_root, skill_creator_name),
+            _solver_scene(scene_config),
         ],
         skills_dir=None,
         skill_mode=SKILL_MODE_NO_SKILL,
         artifact_skill_mode=config.artifact_skill_mode or SKILL_MODE_SELF_GEN,
         skill_creator_dir=None,
+        generated_skills_root=generated_skills_root,
         pre_agent_hooks=[
             *(config.pre_agent_hooks or []),
-            _ensure_generated_skills_hook(config),
+            _ensure_generated_skills_hook(scene_config),
         ],
         export_generated_skills_to=(
             config.export_generated_skills_to or artifact_root / "generated-skills"

--- a/tests/test_scene_outbox_trial.py
+++ b/tests/test_scene_outbox_trial.py
@@ -310,6 +310,7 @@ def test_self_gen_mode_uses_custom_creator_skill_name(tmp_path: Path) -> None:
         Path("tasks/fake"),
         "/app/generated-skills",
         skill_name,
+        ["solve the fake task"],
     )
 
     assert resolved_root == skills_root

--- a/tests/test_self_gen_export_failures.py
+++ b/tests/test_self_gen_export_failures.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from benchflow.rollout import Rollout, RolloutConfig
+from benchflow.skill_policy import SKILL_MODE_SELF_GEN
 
 
 def _bare_rollout(tmp_path: Path, export_target: Path | None) -> Rollout:
@@ -119,6 +120,25 @@ async def test_cleanup_successful_export_leaves_errors_empty(tmp_path):
     assert rollout._error is None
     assert rollout._export_error is None
     assert rollout._evolved_skills == {"skill-a": "# Skill A\n"}
+
+
+@pytest.mark.asyncio
+async def test_cleanup_self_gen_empty_export_is_not_success(tmp_path):
+    """Guards #533: self-gen cannot silently continue with zero generated skills."""
+    rollout = _bare_rollout(tmp_path, export_target=tmp_path / "exports")
+    rollout._config.artifact_skill_mode = SKILL_MODE_SELF_GEN
+
+    async def fake_download_dir(source_dir, target_dir):
+        Path(target_dir).mkdir(parents=True, exist_ok=True)
+
+    rollout._env.download_dir = fake_download_dir
+
+    await rollout.cleanup()
+
+    assert rollout._error is None
+    assert rollout._export_error is not None
+    assert "self-gen creator produced no generated skills" in rollout._export_error
+    assert rollout._evolved_skills is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_self_gen_orchestration.py
+++ b/tests/test_self_gen_orchestration.py
@@ -18,6 +18,7 @@ from benchflow.rollout import (
 )
 from benchflow.runtime import run as runtime_run
 from benchflow.sdk import SDK
+from benchflow.self_gen import run_self_gen
 
 
 def _make_task(tmp_path: Path) -> Path:
@@ -28,6 +29,14 @@ def _make_task(tmp_path: Path) -> Path:
     task_skills = task / "environment" / "skills" / "task-bundled"
     task_skills.mkdir(parents=True)
     (task_skills / "SKILL.md").write_text("# Task bundled\n")
+    return task
+
+
+def _make_task_with_workdir(tmp_path: Path, workdir: str) -> Path:
+    task = _make_task(tmp_path)
+    (task / "task.toml").write_text(
+        f'schema_version = "1.1"\n\n[environment]\nworkdir = "{workdir}"\n'
+    )
     return task
 
 
@@ -148,11 +157,11 @@ async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_
     await trial_cfg.pre_agent_hooks[0](FakeEnv())
     assert env_commands == [
         (
-            "mkdir -p /app/generated-skills && chmod 777 /app/generated-skills",
+            "mkdir -p /root/generated-skills && chmod 777 /root/generated-skills",
             {"timeout_sec": 10},
         )
     ]
-    assert all("/root/generated-skills" not in cmd for cmd, _ in env_commands)
+    assert all("/home/worker/generated-skills" not in cmd for cmd, _ in env_commands)
     assert all("/root/skills" not in cmd for cmd, _ in env_commands)
     assert all("/app/workspace/generated-skills" not in cmd for cmd, _ in env_commands)
 
@@ -167,12 +176,16 @@ async def test_sdk_self_gen_runs_creator_then_solver_in_one_trial_with_isolated_
     assert _skill_dir_names(Path(creator_scene.skills_dir)) == {"skill-creator"}
     assert creator_scene.turns[0].prompt is not None
     assert "skill-creator" in creator_scene.turns[0].prompt
-    assert "/instruction.md" in creator_scene.turns[0].prompt
+    assert "solve the task" in creator_scene.turns[0].prompt
+    assert "instruction.md" not in creator_scene.turns[0].prompt
+    assert "task.md" not in creator_scene.turns[0].prompt
+    assert "/instruction.md" not in creator_scene.turns[0].prompt
     assert "/app/instruction.md" not in creator_scene.turns[0].prompt
+    assert "/root/generated-skills" in creator_scene.turns[0].prompt
     assert str(original_skills) not in creator_scene.turns[0].prompt
 
     assert solver_scene.name == "self-gen-solver"
-    assert solver_scene.skills_dir == "/app/generated-skills"
+    assert solver_scene.skills_dir == "/root/generated-skills"
     assert solver_scene.turns[0].prompt is None
 
 
@@ -283,11 +296,51 @@ async def test_job_self_gen_uses_strict_orchestration(
     assert seen_configs[0].artifact_skill_mode == SKILL_MODE_SELF_GEN
     assert seen_configs[0].skills_dir is None
     assert len(seen_configs[0].pre_agent_hooks or []) == 1
+    assert seen_configs[0].generated_skills_root == "/root/generated-skills"
     assert [scene.name for scene in seen_configs[0].scenes] == [
         "self-gen-creator",
         "self-gen-solver",
     ]
-    assert seen_configs[0].scenes[1].skills_dir == "/app/generated-skills"
+    assert seen_configs[0].scenes[1].skills_dir == "/root/generated-skills"
+
+
+@pytest.mark.asyncio
+async def test_self_gen_default_root_uses_declared_task_workdir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Guards #533: generated skills stay inside the ACP workspace allowlist."""
+    task = _make_task_with_workdir(tmp_path, "/workspace")
+    skill_creator_root = _make_skill_creator_root(tmp_path)
+    seen_configs = []
+
+    class FakeTrial:
+        def __init__(self, config):
+            self._config = config
+
+        @classmethod
+        async def create(cls, config):
+            seen_configs.append(config)
+            return cls(config)
+
+        async def run(self):
+            return RunResult(task_name="task", rewards={"reward": 1.0})
+
+    monkeypatch.setattr("benchflow.self_gen.Rollout", FakeTrial)
+
+    await SDK().run(
+        task_path=task,
+        agent="opencode",
+        model="google/gemini-3.1-pro-preview",
+        jobs_dir=tmp_path / "jobs",
+        environment="daytona",
+        skill_mode="self-gen",
+        skill_creator_dir=skill_creator_root,
+    )
+
+    assert seen_configs[0].generated_skills_root == "/workspace/generated-skills"
+    assert seen_configs[0].scenes[0].turns[0].prompt is not None
+    assert "/workspace/generated-skills" in seen_configs[0].scenes[0].turns[0].prompt
+    assert seen_configs[0].scenes[1].skills_dir == "/workspace/generated-skills"
 
 
 @pytest.mark.asyncio
@@ -315,6 +368,24 @@ async def test_runtime_trial_config_self_gen_routes_to_orchestrator(
 
     assert result is expected
     assert captured["config"] is config
+
+
+@pytest.mark.asyncio
+async def test_self_gen_rejects_unsafe_generated_skills_root(tmp_path: Path) -> None:
+    """Guards #533/#427: self-gen generated-skill roots stay sandbox-local."""
+    task = _make_task(tmp_path)
+    skill_creator_root = _make_skill_creator_root(tmp_path)
+    config = RolloutConfig.from_legacy(
+        task_path=task,
+        agent="opencode",
+        model="google/gemini-3.1-pro-preview",
+        skill_mode="self-gen",
+        skill_creator_dir=skill_creator_root,
+        generated_skills_root="/tmp/../generated-skills",
+    )
+
+    with pytest.raises(ValueError, match="generated_skills_root"):
+        await run_self_gen(config)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #533.

This fixes self-gen runs that could silently produce zero generated skills because the creator prompt/root pointed outside the agent-visible workspace.

- resolve the default generated-skills root from the task agent workspace (`environment.workdir` when declared, otherwise `/root`) instead of the legacy `/app/generated-skills` default
- inline the resolved task prompt(s) into the self-gen creator prompt so creator scenes do not try to read `/instruction.md`, `/task.md`, or another cwd-dependent path
- validate explicit generated-skills roots through the existing container mount-path policy
- fail self-gen cleanup when the creator export contains no `SKILL.md` packs, so empty self-gen output is no longer reported as successful

## Validation

- `uv run python -m pytest tests/test_self_gen_orchestration.py tests/test_self_gen_cli.py tests/test_self_gen_export_failures.py tests/test_skill_policy.py tests/test_scene_outbox_trial.py tests/test_rollout_upload.py tests/test_learner_skills.py -q` -> `90 passed`
- `uv run ruff check src/benchflow/self_gen.py src/benchflow/rollout/_skills.py src/benchflow/rollout/_user_loop.py tests/test_self_gen_orchestration.py tests/test_self_gen_export_failures.py tests/test_scene_outbox_trial.py` -> pass
- `uv run ruff format --check src/benchflow/self_gen.py src/benchflow/rollout/_skills.py src/benchflow/rollout/_user_loop.py tests/test_self_gen_orchestration.py tests/test_self_gen_export_failures.py tests/test_scene_outbox_trial.py` -> pass
- `uv run ty check src/benchflow/self_gen.py src/benchflow/rollout/_skills.py src/benchflow/rollout/_user_loop.py` -> pass
- `uv run python -m pytest tests/` -> `4139 passed, 4 skipped, 7 deselected`
- `uv run ty check src/` -> pass
- `uv run ruff check .` -> pass

## E2E Canary

Using current BenchFlow from this branch plus current SkillsBench `main` at `87df9cbd82fcf07fcb0cab960a1f8435d0c415ee`, with Gemini raw preflight returning 200:

```bash
uv run bench eval create \
  --tasks-dir /tmp/benchflow-skillsbench-main/tasks \
  --include offer-letter-generator \
  --agent gemini --model gemini-2.5-flash \
  --sandbox daytona \
  --skill-mode self-gen \
  --skill-creator-dir /tmp/benchflow-skillsbench-main/.agents/skills/skill-creator \
  --jobs-dir /tmp/benchflow-533-selfgen-daytona-20260615-033626 \
  --concurrency 1 \
  --agent-idle-timeout 240
```

Result:

- run completed with `errors=0`, `idle_timeouts=0`, and verifier score `reward=0.0`
- `result.json`: `error=null`, `verifier_error=null`, `export_error=null`, timing present
- creator prompt and solver config both use `/root/generated-skills`
- exported generated skill pack exists at `_self_gen/offer-letter-generator-47544765/generated-skills/offer-letter-generator-skill/SKILL.md`
- no old `/app/generated-skills`, `/home/agent/generated-skills`, `/instruction.md`, or `/root/task.md` prompt-path failure in the final canary

Caveat: this canary validates BenchFlow self-gen path/export lifecycle, not a publishable benchmark slot. Gemini/Daytona native usage tracking reported unavailable, and the model failed the task due to its own tool/dependency limitations after loading the generated template skill.
