### PR TITLE
Fix check_results invalidated retry dedup

### DIFF
--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -280,6 +280,7 @@ def _expected_config_concurrency(
     if expected_concurrency is _MISSING:
         return _MISSING
     if _is_worker_sharded_summary(summary):
+        assert summary is not None
         return summary["worker_concurrency"]
     return expected_concurrency
 
@@ -898,7 +899,7 @@ def check_agent(agent_dir: Path) -> dict:
 
     infra_errors: list[str] = []
     invalidated_by_category: dict[str, list[str]] = {}
-    for r in results:
+    for r in latest_results:
         err = r.get("error")
         cat = r.get("error_category") or (classify_error(str(err)) if err else None)
         if cat and cat in INFRA_ERROR_CATEGORIES:
@@ -923,7 +924,7 @@ def check_agent(agent_dir: Path) -> dict:
 
     # Verifier dependency install failures (ENG-151)
     dep_install_tasks: list[str] = []
-    for r in results:
+    for r in latest_results:
         verifier_err = r.get("verifier_error")
         vcat = r.get("verifier_error_category") or (
             classify_verifier_error(verifier_err) if verifier_err else None
@@ -950,7 +951,7 @@ def check_agent(agent_dir: Path) -> dict:
         d.category: d for d in DIAGNOSTIC_REGISTRY if d.channel == "verifier_error"
     }
     verifier_timeout_tasks: list[str] = []
-    for r in results:
+    for r in latest_results:
         verifier_err = r.get("verifier_error")
         vcat = classify_verifier_error(verifier_err) if verifier_err else None
         if vcat == "verifier_timeout":

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -2222,6 +2222,59 @@ def test_check_results_transport_error_without_info_still_flagged(
     )
 
 
+def test_check_results_invalidates_latest_retry_once_per_task(tmp_path: Path) -> None:
+    """Guards issue #526: retry rollout dirs do not duplicate invalidated tasks."""
+    agent_dir = tmp_path / "agentA"
+    run_root = agent_dir / "2026-05-18__00-00-00"
+    for retry in range(1, 4):
+        run_dir = run_root / f"task-a__retry{retry}"
+        run_dir.mkdir(parents=True)
+        (run_dir / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task-a",
+                    "agent": "agentA",
+                    "model": "test-model",
+                    "rewards": None,
+                    "error": "Agent idle timeout after 600s",
+                    "error_category": "idle_timeout",
+                    "verifier_error": None,
+                    "source": _source(),
+                }
+            )
+        )
+        _write_config(run_dir)
+    (agent_dir / "summary.json").write_text(
+        json.dumps(
+            {
+                "agent": "agentA",
+                "model": "test-model",
+                "environment": "daytona",
+                "concurrency": 64,
+                "agent_idle_timeout_sec": 600,
+                "total": 1,
+                "passed": 0,
+                "failed": 0,
+                "errored": 1,
+                "verifier_errored": 0,
+                "score": "0.0%",
+                "source": _source(),
+            }
+        )
+    )
+
+    findings = check_agent(agent_dir)
+
+    invalidated = [
+        issue
+        for issue in findings["issues"]
+        if issue.startswith("INVALIDATED:") and "idle timeout" in issue
+    ]
+    assert invalidated == [
+        "INVALIDATED: 1 task(s) hit idle timeout and should be rerun: task-a"
+    ]
+
+
 def test_check_results_flags_verifier_dep_install_failure(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- report invalidated infra/verifier categories from the latest result per task, matching summary reconciliation
- prevent retry rollout directories from inflating INVALIDATED task counts
- add a regression test for issue #526

Fixes #526.

## Validation
- uv run python -m pytest tests/test_integration_check_results.py -q
- uv run ruff check tests/integration/check_results.py tests/test_integration_check_results.py
- uv run ty check tests/integration/check_results.py
- uv run python -m pytest tests/
- uv run ty check src/
- uv run ruff check .