### PR TITLE
Fix idle timeout last_activity_at semantics

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -671,6 +671,7 @@ async def _prompt_with_idle_watchdog(
 
     prompt_task = asyncio.create_task(acp_client.prompt(prompt))
     last_progress = asyncio.get_event_loop().time()
+    last_activity_at = datetime.now(UTC)
     last_count = _activity_count()
     # poll_interval considers BOTH idle_timeout and wall-clock timeout so that
     # short overall budgets don't overshoot (e.g. timeout=30s with default
@@ -695,6 +696,7 @@ async def _prompt_with_idle_watchdog(
             cur_count = _activity_count()
             if cur_count > last_count:
                 last_progress = now
+                last_activity_at = datetime.now(UTC)
                 last_count = cur_count
             # An in-flight tool call means the agent is actively executing a tool
             # (e.g. a long build/test/solver shell command), not hung. Those tools
@@ -706,6 +708,7 @@ async def _prompt_with_idle_watchdog(
             # tool_call_update), so it still trips the idle path.
             elif session.pending_tool_call_ids():
                 last_progress = now
+                last_activity_at = datetime.now(UTC)
             if now - last_progress >= idle_timeout:
                 diag = IdleTimeoutDiagnostic(
                     idle_timeout_sec=idle_timeout,
@@ -714,7 +717,7 @@ async def _prompt_with_idle_watchdog(
                     n_tool_calls=len(session.tool_calls),
                     n_message_chunks=len(session.message_chunks),
                     n_thought_chunks=len(session.thought_chunks),
-                    last_activity_at=datetime.now(UTC).isoformat(),
+                    last_activity_at=last_activity_at.isoformat(),
                 )
                 raise IdleTimeoutError(
                     f"Agent idle for {idle_timeout}s with no new tool call, "

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -688,6 +689,40 @@ class TestIdleTimeoutDiagnostics:
             )
         info = exc_info.value.diagnostic.to_dict()
         assert info["n_tool_calls"] == 1
+
+    @pytest.mark.asyncio
+    async def test_idle_timeout_last_activity_reports_progress_time(self) -> None:
+        """Guards issue #525: last_activity_at is last progress, not timeout fire."""
+        from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+
+        class OneMessageThenHang:
+            def __init__(self, session):
+                self._session = session
+                self._called = False
+
+            async def prompt(self, _prompt: str):
+                if not self._called:
+                    self._called = True
+                    self._session.message_chunks.append("working")
+                    await asyncio.sleep(0.1)
+                await asyncio.Future()
+
+        session = ACPSession("diag-last-activity")
+        client = OneMessageThenHang(session)
+        with pytest.raises(IdleTimeoutError) as exc_info:
+            await execute_prompts(
+                client,  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=30,
+                idle_timeout=1,
+            )
+        finished_at = datetime.now(UTC)
+        info = exc_info.value.diagnostic.to_dict()
+        last_activity_at = datetime.fromisoformat(info["last_activity_at"])
+
+        assert info["n_message_chunks"] == 1
+        assert (finished_at - last_activity_at).total_seconds() >= 0.75
 
     @pytest.mark.asyncio
     async def test_in_flight_tool_call_defers_idle_to_wall_clock(self) -> None:


### PR DESCRIPTION
## Summary
- track a wall-clock timestamp whenever the idle watchdog records progress
- emit that stored progress timestamp as idle_timeout_info.last_activity_at instead of timeout-fire time
- add a regression test for issue #525

Fixes #525.

## Validation
- uv run python -m pytest tests/test_acp.py::TestIdleTimeoutDiagnostics -q
- uv run python -m pytest tests/test_acp.py -q
- uv run ruff check src/benchflow/acp/runtime.py tests/test_acp.py
- uv run ty check src/benchflow/acp/runtime.py
- uv run python -m pytest tests/
- uv run ty check src/
- uv run ruff check .