### PR TITLE
Filter Daytona retries to transient errors

### DIFF
--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -19,6 +19,7 @@ from uuid import uuid4
 try:
     from tenacity import (
         retry,
+        retry_if_exception,
         stop_after_attempt,
         wait_exponential,
     )
@@ -32,6 +33,9 @@ except ImportError:  # base install without ``sandbox-daytona`` extras (#358)
             return fn
 
         return _decorator
+
+    def retry_if_exception(*_args: Any, **_kwargs: Any) -> None:
+        return None
 
     def stop_after_attempt(*_args: Any, **_kwargs: Any) -> Any:
         return None
@@ -218,6 +222,26 @@ _STARTUP_HARD_TIMEOUT_BUFFER_SEC = 120
 # (``None``, or a non-positive value — both previously meant "no deadline");
 # an explicit positive ``timeout_sec`` is honored byte-for-byte as before.
 _DAYTONA_EXEC_HARD_CAP_SEC = 3600
+_DAYTONA_TRANSIENT_RETRY_CLASS_NAMES = frozenset(
+    {
+        "DaytonaConnectionError",
+        "DaytonaRateLimitError",
+        "DaytonaTimeoutError",
+    }
+)
+
+
+def _is_daytona_transient_retry_error(exc: BaseException) -> bool:
+    if isinstance(exc, (ConnectionError, TimeoutError)):
+        return True
+    exc_type = type(exc)
+    return (
+        exc_type.__module__.startswith("daytona.")
+        and exc_type.__name__ in _DAYTONA_TRANSIENT_RETRY_CLASS_NAMES
+    )
+
+
+_DAYTONA_TRANSIENT_RETRY: Any = retry_if_exception(_is_daytona_transient_retry_error)
 
 # Shared tenacity policy for the idempotent Daytona SDK calls — session-command
 # polling and filesystem up/download. Three attempts with exponential backoff,
@@ -228,6 +252,7 @@ _DAYTONA_EXEC_HARD_CAP_SEC = 3600
 _SDK_RETRY = retry(
     stop=stop_after_attempt(3),
     wait=wait_exponential(multiplier=1, min=1, max=10),
+    retry=_DAYTONA_TRANSIENT_RETRY,
     reraise=True,
 )
 
@@ -405,6 +430,7 @@ class DaytonaSandbox(BaseSandbox):
     @retry(
         stop=stop_after_attempt(3),
         wait=wait_exponential(multiplier=2, min=2, max=30),
+        retry=_DAYTONA_TRANSIENT_RETRY,
         reraise=True,
     )
     async def _create_sandbox(
@@ -464,6 +490,7 @@ class DaytonaSandbox(BaseSandbox):
     @retry(
         stop=stop_after_attempt(2),
         wait=wait_exponential(multiplier=1, min=1, max=10),
+        retry=_DAYTONA_TRANSIENT_RETRY,
         reraise=True,
     )
     async def _stop_sandbox(self) -> None:

--- a/tests/test_daytona_download.py
+++ b/tests/test_daytona_download.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from tenacity import retry, stop_after_attempt, wait_none
 
 import benchflow.sandbox.daytona as daytona_mod
 from benchflow.sandbox._base import ExecResult
@@ -65,11 +66,59 @@ class _FakeMissingFs(_FakeFs):
         raise FileNotFoundError(source)
 
 
+_FakeDaytonaConnectionError = type(
+    "DaytonaConnectionError",
+    (Exception,),
+    {"__module__": "daytona.common.errors"},
+)
+
+
 def _fake_daytona_sandbox(fake_fs):
     sandbox = object.__new__(DaytonaSandbox)
     sandbox._sandbox = SimpleNamespace(fs=fake_fs)
     sandbox.logger = logging.getLogger("test.daytona")
     return sandbox
+
+
+def _retry_with_daytona_policy(fn):
+    return retry(
+        stop=stop_after_attempt(3),
+        wait=wait_none(),
+        retry=daytona_mod._DAYTONA_TRANSIENT_RETRY,
+        reraise=True,
+    )(fn)
+
+
+def test_daytona_retry_filter_does_not_retry_permanent_errors() -> None:
+    """Guards issue #538: permanent SDK/file errors fail immediately."""
+    calls = 0
+
+    @_retry_with_daytona_policy
+    def fail_permanently() -> None:
+        nonlocal calls
+        calls += 1
+        raise FileNotFoundError("/logs/missing")
+
+    with pytest.raises(FileNotFoundError):
+        fail_permanently()
+
+    assert calls == 1
+
+
+def test_daytona_retry_filter_retries_transient_daytona_errors() -> None:
+    """Guards issue #538: transient Daytona SDK errors still retry."""
+    calls = 0
+
+    @_retry_with_daytona_policy
+    def fail_transiently() -> None:
+        nonlocal calls
+        calls += 1
+        raise _FakeDaytonaConnectionError("temporary Daytona connection failure")
+
+    with pytest.raises(_FakeDaytonaConnectionError):
+        fail_transiently()
+
+    assert calls == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a shared Daytona transient retry predicate for connection/rate-limit/timeout failures
- apply it to _SDK_RETRY, _create_sandbox, and _stop_sandbox
- add regression tests proving permanent FileNotFoundError is not retried while transient Daytona connection errors are retried

Fixes #538.

## Validation
- uv run python -m pytest tests/test_daytona_download.py -q
- uv run ruff check src/benchflow/sandbox/daytona.py tests/test_daytona_download.py
- uv run ty check src/
- uv run python -m pytest tests/
- uv run ruff check .