### PR TITLE
Honor eval YAML skip_install

### DIFF
--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -462,6 +462,7 @@ class EvaluationConfig:
     sandbox_user: str | None = "agent"
     sandbox_locked_paths: list[str] | None = None
     sandbox_setup_timeout: int = 120
+    skip_agent_install: bool = False
     agent_idle_timeout: int | None = 600
     context_root: str | None = None
     exclude_tasks: set[str] = field(default_factory=set)
@@ -833,6 +834,7 @@ class Evaluation:
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
+            skip_agent_install=bool(raw.get("skip_install", False)),
             agent_idle_timeout=raw.get(
                 "agent_idle_timeout_sec", raw.get("agent_idle_timeout", 600)
             ),
@@ -925,6 +927,7 @@ class Evaluation:
             sandbox_user=sandbox_user,
             sandbox_locked_paths=sandbox_locked_paths,
             sandbox_setup_timeout=sandbox_setup_timeout,
+            skip_agent_install=bool(agent_cfg.get("skip_install", False)),
             agent_idle_timeout=raw.get(
                 "agent_idle_timeout_sec", raw.get("agent_idle_timeout", 600)
             ),
@@ -1183,6 +1186,7 @@ class Evaluation:
             sandbox_user=cfg.sandbox_user,
             sandbox_locked_paths=cfg.sandbox_locked_paths,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+            skip_agent_install=cfg.skip_agent_install,
             agent_idle_timeout=cfg.agent_idle_timeout,
             context_root=cfg.context_root,
             skill_mode=skill_mode,

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -578,6 +578,7 @@ class Rollout:
             context_root=cfg.context_root,
             sandbox_locked_paths=self._effective_locked,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+            skip_agent_install=cfg.skip_agent_install,
             timeout=self._timeout,
             started_at=self._started_at,
             agent_env=self._agent_env,
@@ -687,12 +688,15 @@ class Rollout:
             return
 
         agent_name = cfg.primary_agent
-        self._agent_cfg = await self._planes.install_agent(
-            self._env,
-            agent_name,
-            rollout_dir,
-            sandbox_setup_timeout=cfg.sandbox_setup_timeout,
-        )
+        if cfg.skip_agent_install:
+            self._agent_cfg = None
+        else:
+            self._agent_cfg = await self._planes.install_agent(
+                self._env,
+                agent_name,
+                rollout_dir,
+                sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+            )
         if cfg.sandbox_user:
             self._agent_cwd = await self._planes.setup_sandbox_user(
                 self._env,
@@ -1638,12 +1642,15 @@ class Rollout:
             role_agent_differs or role.model != cfg.primary_model or bool(role.env)
         )
         if role_agent_differs:
-            agent_cfg = await self._planes.install_agent(
-                self._env,
-                role.agent,
-                rollout_dir,
-                sandbox_setup_timeout=cfg.sandbox_setup_timeout,
-            )
+            if cfg.skip_agent_install:
+                agent_cfg = None
+            else:
+                agent_cfg = await self._planes.install_agent(
+                    self._env,
+                    role.agent,
+                    rollout_dir,
+                    sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+                )
         else:
             agent_cfg = getattr(self, "_agent_cfg", None)
         if needs_role_credentials:

--- a/src/benchflow/rollout/_config.py
+++ b/src/benchflow/rollout/_config.py
@@ -101,6 +101,7 @@ class RolloutConfig:
     sandbox_user: str | None = "agent"
     sandbox_locked_paths: list[str] | None = None
     sandbox_setup_timeout: int = 120
+    skip_agent_install: bool = False
     services: list[str] | None = None
     job_name: str | None = None
     rollout_name: str | None = None

--- a/src/benchflow/rollout/_results.py
+++ b/src/benchflow/rollout/_results.py
@@ -144,6 +144,7 @@ def _write_config(
     context_root: str | Path | None,
     sandbox_locked_paths: list[str] | None = None,
     sandbox_setup_timeout: int = 120,
+    skip_agent_install: bool = False,
     timeout: int,
     started_at: datetime,
     agent_env: dict[str, str],
@@ -175,9 +176,10 @@ def _write_config(
         "sandbox_user": sandbox_user,
         "sandbox_locked_paths": sandbox_locked_paths,
         "sandbox_setup_timeout": sandbox_setup_timeout,
-        "agent_install_timeout": effective_install_timeout(
-            agent, sandbox_setup_timeout
-        ),
+        "skip_install": skip_agent_install,
+        "agent_install_timeout": None
+        if skip_agent_install
+        else effective_install_timeout(agent, sandbox_setup_timeout),
         "context_root": str(context_root) if context_root else None,
         "timeout_sec": timeout,
         "concurrency": concurrency,

--- a/tests/test_trial_install_agent_timeout.py
+++ b/tests/test_trial_install_agent_timeout.py
@@ -16,13 +16,20 @@ from benchflow.skill_policy import (
 )
 
 
-def _make_trial(tmp_path, *, agent: str, sandbox_setup_timeout: int) -> Rollout:
+def _make_trial(
+    tmp_path,
+    *,
+    agent: str,
+    sandbox_setup_timeout: int,
+    skip_agent_install: bool = False,
+) -> Rollout:
     config = RolloutConfig.from_legacy(
         task_path=tmp_path / "task",
         agent=agent,
         prompts=[None],
         sandbox_user="agent",
         sandbox_setup_timeout=sandbox_setup_timeout,
+        skip_agent_install=skip_agent_install,
     )
     trial = Rollout(config)
     trial._env = MagicMock()
@@ -97,6 +104,44 @@ async def test_install_agent_forwards_sandbox_setup_timeout(
     snapshot_build_config_mock.assert_awaited_once()
     seed_verifier_workspace_mock.assert_awaited_once()
     lockdown_paths_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_install_agent_honors_skip_agent_install(tmp_path, monkeypatch):
+    """Guards #588: skip_install skips installer but keeps setup/credentials."""
+    trial = _make_trial(
+        tmp_path,
+        agent="claude-agent-acp",
+        sandbox_setup_timeout=41,
+        skip_agent_install=True,
+    )
+
+    install_agent_mock = AsyncMock(return_value=MagicMock())
+    write_credential_files_mock = AsyncMock()
+    deploy_skills_mock = AsyncMock()
+    setup_sandbox_user_mock = AsyncMock(return_value="/home/agent")
+
+    monkeypatch.setattr(trial._planes, "install_agent", install_agent_mock)
+    monkeypatch.setattr(
+        trial._planes, "write_credential_files", write_credential_files_mock
+    )
+    monkeypatch.setattr(trial._planes, "upload_subscription_auth", AsyncMock())
+    monkeypatch.setattr(trial._planes, "snapshot_build_config", AsyncMock())
+    monkeypatch.setattr(trial._planes, "seed_verifier_workspace", AsyncMock())
+    monkeypatch.setattr(trial._planes, "deploy_skills", deploy_skills_mock)
+    monkeypatch.setattr(trial._planes, "lockdown_paths", AsyncMock())
+    monkeypatch.setattr(trial._planes, "setup_sandbox_user", setup_sandbox_user_mock)
+    monkeypatch.setattr(trial._planes, "apply_web_tool_policy", AsyncMock())
+
+    await trial.install_agent()
+
+    install_agent_mock.assert_not_awaited()
+    setup_sandbox_user_mock.assert_awaited_once()
+    write_credential_files_mock.assert_awaited_once()
+    assert write_credential_files_mock.await_args.args[3] is None
+    deploy_skills_mock.assert_awaited_once()
+    assert trial._agent_cfg is None
+    assert trial._agent_cwd == "/home/agent"
 
 
 @pytest.mark.asyncio
@@ -240,6 +285,34 @@ def test_recorded_install_timeout_is_none_without_installer(tmp_path):
 
     assert config["agent_install_timeout"] is None
     assert config["sandbox_setup_timeout"] == 120
+
+
+def test_recorded_install_timeout_is_none_when_install_skipped(tmp_path):
+    rollout_dir = tmp_path / "rollout"
+    rollout_dir.mkdir(parents=True, exist_ok=True)
+    _write_config(
+        rollout_dir,
+        task_path=tmp_path / "task",
+        agent="claude-agent-acp",
+        model=None,
+        environment="daytona",
+        skill_policy=resolve_task_skill_policy(
+            task_path=tmp_path / "task",
+            skill_mode=SKILL_MODE_NO_SKILL,
+            runtime_skills_dir=None,
+            declared_sandbox_skills_dir=None,
+        ),
+        sandbox_user=None,
+        context_root=None,
+        sandbox_setup_timeout=41,
+        skip_agent_install=True,
+        timeout=300,
+        started_at=datetime(2026, 1, 1),
+        agent_env={},
+    )
+    config = json.loads((rollout_dir / "config.json").read_text())
+    assert config["skip_install"] is True
+    assert config["agent_install_timeout"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_yaml_config.py
+++ b/tests/test_yaml_config.py
@@ -83,6 +83,26 @@ def test_from_native_yaml(native_yaml):
     assert job._jobs_dir == Path("output")
 
 
+def test_native_yaml_reads_skip_install(tmp_path):
+    """Guards #588: native eval YAML skip_install reaches runtime config."""
+    tasks = tmp_path / "tasks" / "task-a"
+    tasks.mkdir(parents=True)
+    (tasks / "task.toml").write_text('version = "1.0"')
+    (tasks / "instruction.md").write_text("Do something")
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+tasks_dir: tasks
+agent: claude-agent-acp
+model: claude-haiku-4-5-20251001
+skip_install: true
+""")
+
+    job = Evaluation.from_yaml(config)
+
+    assert job._config.skip_agent_install is True
+
+
 def test_native_yaml_normalizes_agent_alias_and_root_sandbox_user(tmp_path):
     """Guards ENG-91 P0 dogfood config-boundary regression."""
     tasks = tmp_path / "tasks" / "task-a"
@@ -324,6 +344,27 @@ def test_from_legacy_yaml(legacy_yaml):
     assert cfg.sandbox_setup_timeout == 75
     assert job._tasks_dir == Path("tasks")
     assert job._jobs_dir == Path("output")
+
+
+def test_legacy_yaml_reads_agent_skip_install(tmp_path):
+    """Guards #588: legacy agents[].skip_install reaches runtime config."""
+    tasks = tmp_path / "tasks" / "task-a"
+    tasks.mkdir(parents=True)
+    (tasks / "task.toml").write_text('version = "1.0"')
+
+    config = tmp_path / "config.yaml"
+    config.write_text("""
+agents:
+  - name: claude-agent-acp
+    model_name: anthropic/claude-haiku-4-5-20251001
+    skip_install: true
+datasets:
+  - path: tasks
+""")
+
+    job = Evaluation.from_yaml(config)
+
+    assert job._config.skip_agent_install is True
 
 
 def test_legacy_yaml_preserves_provider_prefix(tmp_path):


### PR DESCRIPTION
## Summary
- Thread `skip_install` from native eval YAML and legacy `agents[].skip_install` into Evaluation/Rollout config.
- Skip only the registry agent installer while retaining sandbox user setup, credentials, skills deployment, verifier seeding, web policy, and lockdown.
- Record `skip_install` in rollout `config.json` and set `agent_install_timeout` to null when the installer is skipped.
- Add regression coverage for issue #588.

Fixes #588.

## Validation
- `uv run python -m pytest tests/test_yaml_config.py::test_native_yaml_reads_skip_install tests/test_yaml_config.py::test_legacy_yaml_reads_agent_skip_install tests/test_trial_install_agent_timeout.py::test_install_agent_honors_skip_agent_install tests/test_trial_install_agent_timeout.py::test_recorded_install_timeout_is_none_when_install_skipped -q`
- `uv run python -m pytest tests/test_yaml_config.py tests/test_trial_install_agent_timeout.py -q`
- `uv run ruff check src/benchflow/evaluation.py src/benchflow/rollout/_config.py src/benchflow/rollout/__init__.py src/benchflow/rollout/_results.py tests/test_yaml_config.py tests/test_trial_install_agent_timeout.py`
- `uv run ruff format --check src/benchflow/evaluation.py src/benchflow/rollout/_config.py src/benchflow/rollout/__init__.py src/benchflow/rollout/_results.py tests/test_yaml_config.py tests/test_trial_install_agent_timeout.py`
- `uv run ty check src/`
- `uv run ruff check .`
- `uv run ruff format --check src tests tools`
- `uv run python -m pytest tests/` (4140 passed, 4 skipped, 7 deselected, 16 warnings)