### PR TITLE
Fix Claude no-skill home setup

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -319,6 +319,7 @@ AGENTS: dict[str, AgentConfig] = {
         name="claude-agent-acp",
         description="Claude Code via ACP (Anthropic's Agent Client Protocol)",
         skill_paths=["$HOME/.claude/skills"],
+        home_dirs=[".claude"],
         # Pinned to 0.40.0: the config-option wiring below (set_config_option +
         # the "model"/"effort" ids) targets this version's ACP protocol (sdk
         # 0.24, which dropped session/set_model). The option ids are coupled to

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -138,7 +138,8 @@ async def setup_sandbox_user(
         f"{_legacy_root_tool_link_cmd('/root/.local/bin', f'{home}/.local/bin')} && "
         f"{_legacy_root_tool_link_cmd('/root/.nvm', f'{home}/.nvm')} && "
         f"for d in {' '.join(home_dirs)}; do "
-        f"if [ -d /root/$d ]; then mkdir -p {home}/$d && "
+        f"mkdir -p {home}/$d && "
+        f"if [ -d /root/$d ]; then "
         f"cp -a /root/$d/. {home}/$d/ 2>/dev/null || true; fi; done && "
         f"chown -R {sandbox_user}:{sandbox_user} {home} && "
         f"chown -R {sandbox_user}:{sandbox_user} {shlex.quote(workspace)}",

--- a/tests/test_sandbox_setup.py
+++ b/tests/test_sandbox_setup.py
@@ -87,7 +87,19 @@ class TestSetupSandboxUser:
         )
         assert ".local" not in copy_loop_dirs
         assert "mkdir -p /home/agent/$d" in cmd
+        assert "mkdir -p /home/agent/$d && if [ -d /root/$d ]; then" in cmd
         assert "cp -a /root/$d/. /home/agent/$d/ 2>/dev/null || true" in cmd
+
+    @pytest.mark.asyncio
+    async def test_setup_command_creates_claude_home_for_no_skill_runs(self):
+        """Guards the fix from PR #777: no-skill Claude runs get writable ~/.claude."""
+        cmd, _ = await _run_setup_sandbox_user()
+
+        copy_loop_dirs = _get_copy_loop_dirs(cmd)
+
+        assert ".claude" in copy_loop_dirs
+        assert "mkdir -p /home/agent/$d && if [ -d /root/$d ]; then" in cmd
+        assert "chown -R agent:agent /home/agent" in cmd
 
     @pytest.mark.asyncio
     async def test_setup_command_does_not_copy_heavy_tool_trees_into_home(self):


### PR DESCRIPTION
## Summary
- register `.claude` as a Claude ACP sandbox home directory
- make sandbox user setup create registered home directories even when `/root/<dir>` does not exist
- keep root-to-user copies conditional so heavy or absent root tool trees are not copied

Fixes #584.

## Validation
- `uv run python -m pytest tests/test_sandbox_setup.py tests/test_agent_setup.py::test_deploy_skills_chowns_full_dir_chain_for_pi_acp_layout tests/test_agent_setup.py::test_apply_web_tool_policy_repairs_registry_policy_paths tests/test_subscription_auth.py::TestUploadSubscriptionAuth::test_subscription_auth_chowns_uploaded_home_file -q`
- `uv run ruff check src/benchflow/agents/registry.py src/benchflow/sandbox/lockdown.py tests/test_sandbox_setup.py`
- `uv run ruff format --check src/benchflow/agents/registry.py src/benchflow/sandbox/lockdown.py tests/test_sandbox_setup.py`
- `uv run ty check src/`
- `uv run ruff check .`
- `uv run ruff format --check src tests tools`
- `uv run python -m pytest tests/`