### PR TITLE
Sanitize host paths from eval artifacts

### DIFF
--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -12,6 +12,7 @@ from benchflow._utils.reward_events import (
     memory_score_from_events,
     reward_event_to_dict,
 )
+from benchflow._utils.source_provenance import artifact_source_provenance
 from benchflow.models import RolloutResult
 from benchflow.trajectories.metrics import (
     count_skill_invocations,
@@ -93,7 +94,7 @@ def rollout_result_payload(
             else {}
         ),
         **({"memory_score": memory_score} if memory_score is not None else {}),
-        **({"source": task_source} if task_source else {}),
+        **({"source": artifact_source_provenance(task_source)} if task_source else {}),
     }
 
 

--- a/src/benchflow/_utils/source_provenance.py
+++ b/src/benchflow/_utils/source_provenance.py
@@ -11,7 +11,6 @@ SOURCE_REQUIRED = {
     "requested_ref",
     "resolved_sha",
     "path",
-    "local_path",
     "dirty",
     "file_hashes",
 }
@@ -64,6 +63,11 @@ def source_issues(
     elif require_clean and dirty:
         issues.append(f"{label}: source.dirty must be false for validation evidence")
     file_hashes = source_dict.get("file_hashes")
+    local_path = source_dict.get("local_path")
+    if "local_path" in source_dict and (
+        not isinstance(local_path, str) or not local_path
+    ):
+        issues.append(f"{label}: source.local_path must be a string")
     if not isinstance(file_hashes, dict):
         issues.append(f"{label}: source.file_hashes must be an object")
     elif require_file_hashes and not file_hashes:
@@ -102,9 +106,12 @@ def source_matches_parent(
         return False
     parent_local = parent_source.get("local_path")
     result_local = result_source.get("local_path")
-    if isinstance(parent_local, str) and parent_local:
-        if not isinstance(result_local, str) or not result_local:
-            return False
+    if (
+        isinstance(parent_local, str)
+        and parent_local
+        and isinstance(result_local, str)
+        and result_local
+    ):
         parent_local_path = Path(parent_local).resolve(strict=False)
         result_local_path = Path(result_local).resolve(strict=False)
         if (
@@ -113,6 +120,24 @@ def source_matches_parent(
         ):
             return False
     return True
+
+
+def artifact_source_provenance(
+    source: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return source provenance safe for persisted, shareable artifacts.
+
+    ``local_path`` is useful while a run is live: validators can recompute file
+    hashes and git state from it. Persisted artifacts are commonly shared in PRs,
+    Hugging Face datasets, and review zips, where a host absolute path leaks user
+    identity and is not portable. The remaining repo/ref/path/hash fields carry
+    the stable provenance contract.
+    """
+    if source is None:
+        return None
+    artifact = dict(source)
+    artifact.pop("local_path", None)
+    return artifact
 
 
 def summary_source_fields(
@@ -128,4 +153,5 @@ def summary_source_fields(
     ]
     if mismatches:
         return {"source_mismatch_tasks": mismatches}
-    return {"source": parent_source}
+    artifact_source = artifact_source_provenance(parent_source)
+    return {"source": artifact_source} if artifact_source else {}

--- a/src/benchflow/rollout/_results.py
+++ b/src/benchflow/rollout/_results.py
@@ -27,6 +27,7 @@ from benchflow._utils.result_metadata import (
 )
 from benchflow._utils.reward_events import build_rewards_jsonl_events
 from benchflow._utils.scoring import classify_error, classify_verifier_error
+from benchflow._utils.source_provenance import artifact_source_provenance
 from benchflow.contracts import (
     BaseUser,
     DocumentNudgeUser,
@@ -161,11 +162,17 @@ def _write_config(
     """Write config.json to rollout_dir with secrets filtered out."""
     from benchflow.agents.install import effective_install_timeout
 
+    artifact_source = artifact_source_provenance(source_provenance)
+    recorded_task_path = (
+        str(artifact_source.get("path"))
+        if artifact_source and artifact_source.get("path")
+        else task_path.name
+    )
     recorded_env = {
         k: v for k, v in agent_env.items() if _should_record_env_entry(k, v)
     }
     config_data = {
-        "task_path": str(task_path),
+        "task_path": recorded_task_path,
         "agent": agent,
         "model": model,
         "reasoning_effort": reasoning_effort,
@@ -189,8 +196,8 @@ def _write_config(
     }
     if usage_tracking is not None:
         config_data["usage_tracking"] = usage_tracking.to_config_artifact()
-    if source_provenance is not None:
-        config_data["source"] = source_provenance
+    if artifact_source is not None:
+        config_data["source"] = artifact_source
     if dataset is not None:
         config_data["dataset_name"] = dataset.get("name")
         config_data["dataset_version"] = dataset.get("version")
@@ -387,7 +394,7 @@ def _build_rollout_result(
                 "scenes": _scene_metadata(scenes or []),
                 "loop": loop or loop_block(None),
                 **(
-                    {"source": source_provenance}
+                    {"source": artifact_source_provenance(source_provenance)}
                     if source_provenance is not None
                     else {}
                 ),

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -418,10 +418,12 @@ def _source_hash_truth_issues(source: object, label: str) -> list[str]:
     source_dict = cast(dict[str, Any], source)
     local_path_raw = source_dict.get("local_path")
     file_hashes = source_dict.get("file_hashes")
-    if not isinstance(local_path_raw, str):
-        return [f"{label}: source.local_path must be a string for hash audit"]
     if not isinstance(file_hashes, dict):
         return []
+    if local_path_raw is None:
+        return []
+    if not isinstance(local_path_raw, str):
+        return [f"{label}: source.local_path must be a string for hash audit"]
     local_path = Path(local_path_raw)
     if not local_path.exists():
         return [f"{label}: source.local_path does not exist for hash audit"]

--- a/tests/test_eval_source_provenance.py
+++ b/tests/test_eval_source_provenance.py
@@ -641,6 +641,33 @@ def test_eval_create_source_repo_writes_requested_concurrency_to_rollout_config(
     assert summary["agent_idle_timeout_sec"] == 45
 
 
+def test_summary_source_omits_host_local_path() -> None:
+    """Guards PR #779: summary.json source provenance is portable."""
+    from benchflow._utils.source_provenance import summary_source_fields
+
+    parent_source = {
+        "type": "github",
+        "repo": "acme/benchmarks",
+        "requested_ref": "main",
+        "resolved_sha": "0123456789abcdef0123456789abcdef01234567",
+        "path": "tasks",
+        "local_path": "/Users/dev/private/tasks",
+        "dirty": False,
+        "file_hashes": {},
+    }
+    result_source = {
+        **parent_source,
+        "path": "tasks/task-a",
+        "local_path": "/Users/dev/private/tasks/task-a",
+        "file_hashes": {"task.toml": "sha256:" + "0" * 64},
+    }
+
+    fields = summary_source_fields(parent_source, {"task-a": {"source": result_source}})
+
+    assert fields["source"]["path"] == "tasks"
+    assert "local_path" not in fields["source"]
+
+
 def test_evaluation_yaml_source_records_source_provenance(monkeypatch, tmp_path):
     """Guards v0.5-integration@cb8759e against YAML source provenance loss."""
     tasks_root = tmp_path / "tasks"

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -427,6 +427,7 @@ class TestWriteConfig:
             f"missing keys: {expected_keys - data.keys()}"
         )
         assert data["agent"] == "claude-agent-acp"
+        assert data["task_path"] == "foo"
         assert data["model"] == "claude-haiku-4-5-20251001"
         assert data["environment"] == "docker"
         assert data["skill_mode"] == "no-skill"
@@ -527,7 +528,7 @@ class TestWriteConfig:
         assert recorded["SAFE_VAR"] == "visible"
 
     def test_config_json_includes_source_provenance(self, tmp_path):
-        """Guards v0.5-integration@cb8759e against unaudited rollout config."""
+        """Guards PR #779: config artifacts keep portable source provenance."""
         source = {
             "type": "github",
             "repo": "acme/benchmarks",
@@ -557,7 +558,11 @@ class TestWriteConfig:
         )
 
         data = json.loads((tmp_path / "config.json").read_text())
-        assert data["source"] == source
+        assert data["task_path"] == "datasets/programbench/tasks/task-a"
+        assert data["source"] == {
+            key: value for key, value in source.items() if key != "local_path"
+        }
+        assert "/cache/acme" not in (tmp_path / "config.json").read_text()
 
     def test_config_json_records_agent_idle_timeout(self, tmp_path):
         """Guards v0.5-integration@219906c against unaudited ACP hang budgets."""
@@ -821,7 +826,7 @@ class TestBuildResult:
         assert "role-secret-value" not in text
 
     def test_result_json_includes_source_provenance(self, tmp_path):
-        """Guards v0.5-integration@cb8759e against split provenance artifacts."""
+        """Guards PR #779: result artifacts keep portable source provenance."""
         source = {
             "type": "github",
             "repo": "acme/benchmarks",
@@ -840,7 +845,10 @@ class TestBuildResult:
         result = self._build(tmp_path, source_provenance=source)
 
         data = json.loads((tmp_path / "result.json").read_text())
-        assert data["source"] == source
+        assert data["source"] == {
+            key: value for key, value in source.items() if key != "local_path"
+        }
+        assert "/cache/acme" not in (tmp_path / "result.json").read_text()
         assert result.source_provenance == source
 
     def test_timing_json_written(self, tmp_path):


### PR DESCRIPTION
## Summary
- add artifact-boundary source provenance sanitization that drops host `local_path` from persisted config/result/summary artifacts
- record portable `config.json.task_path` values from source path or task dir name instead of host absolute paths
- keep runtime/internal provenance unchanged so live validation can still recompute file hashes when local paths are available
- allow integration result checks to validate portable artifacts without `source.local_path` while retaining local-path truth checks when present

Fixes #524.

## Validation
- `uv run python -m pytest tests/test_sdk_internals.py::TestWriteConfig tests/test_sdk_internals.py::TestBuildResult::test_result_json_includes_source_provenance tests/test_eval_source_provenance.py tests/test_integration_check_results.py tests/test_task_download.py::test_task_source_provenance_derives_batch_task_path_and_hashes -q`
- `uv run python -m pytest tests/test_sdk_internals.py tests/test_eval_source_provenance.py tests/test_integration_check_results.py tests/test_task_download.py tests/test_check_skillsbench_harbor_parity.py -q`
- `uv run ruff format --check src tests tools`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/`