### PR TITLE
Fix OpenHands explicit LiteLLM proxy routing

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -628,6 +628,25 @@ def _drop_inherited_generic_provider_overrides(
         agent_env.pop(key, None)
 
 
+def _bridge_explicit_openhands_provider_env(
+    agent_env: dict[str, str],
+    explicit_agent_env_keys: set[str],
+) -> None:
+    """Let explicit OpenHands endpoint/key flags configure the provider route."""
+    if (
+        "LLM_BASE_URL" in explicit_agent_env_keys
+        and agent_env.get("LLM_BASE_URL")
+        and "BENCHFLOW_PROVIDER_BASE_URL" not in agent_env
+    ):
+        agent_env["BENCHFLOW_PROVIDER_BASE_URL"] = agent_env["LLM_BASE_URL"]
+    if (
+        "LLM_API_KEY" in explicit_agent_env_keys
+        and agent_env.get("LLM_API_KEY")
+        and "BENCHFLOW_PROVIDER_API_KEY" not in agent_env
+    ):
+        agent_env["BENCHFLOW_PROVIDER_API_KEY"] = agent_env["LLM_API_KEY"]
+
+
 def resolve_agent_env(
     agent: str,
     model: str | None,
@@ -652,6 +671,11 @@ def resolve_agent_env(
             model=model,
             explicit_agent_env_keys=explicit_agent_env_keys,
         )
+        if agent == "openhands":
+            _bridge_explicit_openhands_provider_env(
+                agent_env,
+                explicit_agent_env_keys,
+            )
         resolve_provider_env(agent_env, model, agent)
         from benchflow.agents.providers import find_provider
 
@@ -695,6 +719,15 @@ def resolve_agent_env(
             agent_env["BENCHFLOW_PROVIDER_API_KEY"] = pre_provider_env[
                 mapped_provider_key
             ]
+        has_explicit_generic_provider_key = bool(
+            required_key
+            and "BENCHFLOW_PROVIDER_API_KEY" in explicit_agent_env_keys
+            and agent_env.get("BENCHFLOW_PROVIDER_API_KEY")
+            and (
+                "BENCHFLOW_PROVIDER_BASE_URL" in explicit_agent_env_keys
+                or "LLM_BASE_URL" in explicit_agent_env_keys
+            )
+        )
         has_oauth = any(
             key in agent_env and _shares_auth_context(required_key, key)
             for key in (
@@ -720,6 +753,7 @@ def resolve_agent_env(
             and required_key not in agent_env
             and not has_oauth
             and not has_agent_native_bridge_key
+            and not has_explicit_generic_provider_key
             and not has_codex_access_token
             and not has_codex_auth_json
         ):

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -235,17 +235,22 @@ def _route_registered_provider(
         if "openai-completions" in provider_cfg.all_endpoints
         else provider_cfg.api_protocol
     )
-    try:
-        api_base = resolve_base_url(
-            provider_cfg,
-            env,
-            protocol=protocol,
-        )
-    except KeyError as exc:
-        missing = ", ".join(sorted(provider_cfg.url_params.values()))
-        raise ValueError(
-            f"Provider {provider_name!r} for model {model!r} requires {missing}."
-        ) from exc
+    explicit_api_base = (env.get("BENCHFLOW_PROVIDER_BASE_URL") or "").strip()
+    explicit_api_key = (env.get("BENCHFLOW_PROVIDER_API_KEY") or "").strip()
+    if explicit_api_base and explicit_api_key:
+        api_base = explicit_api_base
+    else:
+        try:
+            api_base = resolve_base_url(
+                provider_cfg,
+                env,
+                protocol=protocol,
+            )
+        except KeyError as exc:
+            missing = ", ".join(sorted(provider_cfg.url_params.values()))
+            raise ValueError(
+                f"Provider {provider_name!r} for model {model!r} requires {missing}."
+            ) from exc
 
     # User-supplied-base_url providers (e.g. vllm) carry an empty config base_url
     # and resolve to "". Honor the runtime-supplied BENCHFLOW_PROVIDER_BASE_URL
@@ -260,10 +265,16 @@ def _route_registered_provider(
     params = {"model": upstream}
     if api_base:
         params["api_base"] = api_base
-    api_key_ref = _registered_api_key_ref(provider_cfg)
+    api_key_ref = (
+        _env_ref("BENCHFLOW_PROVIDER_API_KEY")
+        if explicit_api_base and explicit_api_key
+        else _registered_api_key_ref(provider_cfg)
+    )
     if api_key_ref:
         params["api_key"] = api_key_ref
-        if provider_cfg.auth_env:
+        if api_key_ref == _env_ref("BENCHFLOW_PROVIDER_API_KEY"):
+            required_env.append("BENCHFLOW_PROVIDER_API_KEY")
+        elif provider_cfg.auth_env:
             required_env.append(provider_cfg.auth_env)
 
     return LiteLLMRoute(

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -83,6 +83,22 @@ def test_common_provider_routes(model, upstream, required_env):
     assert route.required_env == required_env
 
 
+def test_registered_provider_route_honors_explicit_generic_proxy_env():
+    """Guards PR #780: external LiteLLM proxies can back registered providers."""
+    route = resolve_litellm_route(
+        "deepseek/deepseek-v4-flash",
+        {
+            "BENCHFLOW_PROVIDER_BASE_URL": "https://llm-proxy.example.test/v1",
+            "BENCHFLOW_PROVIDER_API_KEY": "sk-proxy",
+        },
+    )
+
+    assert route.upstream_model == "openai/deepseek-v4-flash"
+    assert route.litellm_params["api_base"] == "https://llm-proxy.example.test/v1"
+    assert route.litellm_params["api_key"] == ("os.environ/BENCHFLOW_PROVIDER_API_KEY")
+    assert route.required_env == ("BENCHFLOW_PROVIDER_API_KEY",)
+
+
 def test_proxy_config_registers_plain_and_openai_aliases():
     route = resolve_litellm_route(
         "aws-bedrock/us.anthropic.claude-opus-4-8",

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -135,6 +135,42 @@ async def test_daytona_uses_sandbox_local_litellm(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_openhands_registered_provider_can_route_via_explicit_proxy(monkeypatch):
+    """Guards PR #780: OpenHands keeps BenchFlow tracking over explicit proxy env."""
+    starts = []
+
+    async def fake_start(**kwargs):
+        starts.append(kwargs)
+        return FakeLiteLLMServer("http://172.17.0.1:45678", kwargs["route"])
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fake_start)
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="openhands",
+        agent_env={
+            "BENCHFLOW_PROVIDER_BASE_URL": "https://llm-proxy.example.test/v1",
+            "BENCHFLOW_PROVIDER_API_KEY": "sk-proxy",
+        },
+        model="deepseek/deepseek-v4-flash",
+        runtime=None,
+        environment="docker",
+        session_id="run-1",
+        usage_tracking="required",
+    )
+
+    assert provider_runtime is not None
+    route = starts[0]["route"]
+    assert route.litellm_params["api_base"] == "https://llm-proxy.example.test/v1"
+    assert route.litellm_params["api_key"] == ("os.environ/BENCHFLOW_PROVIDER_API_KEY")
+    assert updated["LLM_BASE_URL"] == "http://172.17.0.1:45678/v1"
+    assert updated["LLM_API_KEY"] == provider_runtime.master_key
+    assert updated["LLM_MODEL"] == "openai/benchflow-deepseek-deepseek-v4-flash"
+    assert updated["BENCHFLOW_PROVIDER_MODEL"] == (
+        "benchflow-deepseek-deepseek-v4-flash"
+    )
+
+
+@pytest.mark.asyncio
 async def test_runtime_reuse_and_stop(monkeypatch):
     created = []
 

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -820,6 +820,8 @@ class TestResolveAgentEnvHostProviderEndpoint:
         for k in (
             "BENCHFLOW_PROVIDER_BASE_URL",
             "BENCHFLOW_PROVIDER_API_KEY",
+            "DEEPSEEK_API_KEY",
+            "DEEPSEEK_BASE_URL",
             "GEMINI_API_KEY",
             "GOOGLE_API_KEY",
             "LLM_API_KEY",
@@ -916,6 +918,50 @@ class TestResolveAgentEnvHostProviderEndpoint:
         assert result["BENCHFLOW_PROVIDER_API_KEY"] == "sk-explicit-proxy"
         assert result["LLM_BASE_URL"] == "http://explicit-proxy:9000/v1"
         assert result["LLM_API_KEY"] == "sk-explicit-proxy"
+
+    def test_explicit_openhands_llm_env_can_override_registered_provider_without_native_key(
+        self,
+    ):
+        """Guards PR #780: OpenHands proxy flags must not require native DeepSeek env."""
+        result = resolve_agent_env(
+            "openhands",
+            "deepseek/deepseek-v4-flash",
+            {
+                "LLM_BASE_URL": "https://llm-proxy.example.test/v1",
+                "LLM_API_KEY": "sk-explicit-proxy",
+            },
+        )
+
+        assert (
+            result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://llm-proxy.example.test/v1"
+        )
+        assert result["BENCHFLOW_PROVIDER_API_KEY"] == "sk-explicit-proxy"
+        assert result["LLM_BASE_URL"] == "https://llm-proxy.example.test/v1"
+        assert result["LLM_API_KEY"] == "sk-explicit-proxy"
+        assert result["LLM_MODEL"] == "openai/deepseek-v4-flash"
+        assert "DEEPSEEK_API_KEY" not in result
+        assert "DEEPSEEK_BASE_URL" not in result
+
+    def test_explicit_generic_proxy_env_can_override_registered_provider_without_native_key(
+        self,
+    ):
+        """Guards PR #780: generic provider proxy env is a valid explicit route."""
+        result = resolve_agent_env(
+            "openhands",
+            "deepseek/deepseek-v4-flash",
+            {
+                "BENCHFLOW_PROVIDER_BASE_URL": "https://llm-proxy.example.test/v1",
+                "BENCHFLOW_PROVIDER_API_KEY": "sk-explicit-proxy",
+            },
+        )
+
+        assert (
+            result["BENCHFLOW_PROVIDER_BASE_URL"] == "https://llm-proxy.example.test/v1"
+        )
+        assert result["BENCHFLOW_PROVIDER_API_KEY"] == "sk-explicit-proxy"
+        assert result["LLM_BASE_URL"] == "https://llm-proxy.example.test/v1"
+        assert result["LLM_API_KEY"] == "sk-explicit-proxy"
+        assert "DEEPSEEK_API_KEY" not in result
 
     def test_no_host_override_keeps_resolved_provider_url(self, monkeypatch):
         """Sanity counterpart: without a host override zai's own endpoint is used."""


### PR DESCRIPTION
Fixes #571.

## What changed
- Treat explicit OpenHands `LLM_BASE_URL` / `LLM_API_KEY` as provider route inputs so operators can point registered-provider models at an external LiteLLM proxy without native provider env.
- Allow explicit `BENCHFLOW_PROVIDER_BASE_URL` / `BENCHFLOW_PROVIDER_API_KEY` to back registered provider LiteLLM routes.
- Keep BenchFlow usage tracking in front of the agent: OpenHands still receives the BenchFlow LiteLLM endpoint and alias model, while the runtime proxy routes upstream to the explicit endpoint.
- Added regression coverage for the #571 path and the existing direct-provider guardrails.

## Validation
- `uv run python -m pytest tests/test_resolve_env_helpers.py::TestResolveAgentEnvHostProviderEndpoint tests/test_litellm_config.py tests/test_litellm_runtime.py tests/test_litellm_hardening.py tests/test_usage_tracking.py`
- `uv run ruff format --check src tests tools`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/` -> 4140 passed, 4 skipped, 7 deselected

## Notes
Local Docker smoke was not possible on this workstation because the Docker daemon is not running. I will run the real Docker/Daytona proxy-path smoke from the GCP runner after the PR is available.