### PR TITLE
Add session-factory agent contract fields

### DIFF
--- a/src/benchflow/agents/protocol.py
+++ b/src/benchflow/agents/protocol.py
@@ -20,6 +20,7 @@ adapter that makes ``ACPClient`` honour the ``Session`` contract.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
@@ -111,7 +112,12 @@ class Session(Protocol):
     turn, registers an ``on_ask_user`` handler for agent-initiated
     branches, and reads ``steps`` for the session's contribution to the
     trajectory.
+
+    ``on_change`` is an assignable streaming hook the rollout kernel wires
+    after connect. Implementations call it after appending trajectory events.
     """
+
+    on_change: Callable[[Session], None] | None
 
     async def prompt(self, text: str) -> StopReason:
         """Send the task instruction or a nudge; block until the turn ends.
@@ -187,6 +193,27 @@ class ACPSessionAdapter:
     def __init__(self, client: ACPClient) -> None:
         self._client = client
         self._ask_user_handler: AskUserHandler | None = None
+        self._on_change_handler: Callable[[Session], None] | None = None
+
+    @property
+    def on_change(self) -> Callable[[Session], None] | None:
+        """Assignable streaming hook, bridged onto the current ACP session."""
+        return self._on_change_handler
+
+    @on_change.setter
+    def on_change(self, handler: Callable[[Session], None] | None) -> None:
+        self._on_change_handler = handler
+        session = getattr(self._client, "session", None)
+        if session is None:
+            return
+        if handler is None:
+            session.on_change = None
+            return
+
+        def _bridge(_session: Any) -> None:
+            handler(self)
+
+        session.on_change = _bridge
 
     async def prompt(self, text: str) -> StopReason:
         """Send the task instruction or a nudge; return the stop reason.

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -15,7 +15,10 @@ Required fields
 
 Common optional fields
 ----------------------
-- ``protocol``           "acp" (default) or "cli". Almost always "acp".
+- ``protocol``           "acp" (default), "cli", or "session-factory".
+                         Almost always "acp".
+- ``session_factory``    Non-ACP "module:callable" entrypoint used only when
+                         ``protocol="session-factory"``.
 - ``requires_env``       List of env var names the SDK must propagate into the
                          sandbox (e.g. ``["ANTHROPIC_API_KEY"]``). Validated at
                          run start; missing keys raise before the container
@@ -259,7 +262,10 @@ class AgentConfig:
     name: str
     install_cmd: str
     launch_cmd: str
-    protocol: str = "acp"  # "acp" or "cli"
+    protocol: str = "acp"  # "acp", "cli", or "session-factory"
+    session_factory: str = ""
+    # Non-ACP only. When protocol == "session-factory", this is a
+    # "module:callable" entrypoint that builds an Agent Protocol object.
     requires_env: list[str] = field(default_factory=list)
     description: str = ""
     skill_paths: list[str] = field(default_factory=list)
@@ -767,7 +773,7 @@ AGENT_ALIASES: dict[str, str] = {
     "deepagents": "deepagents",
 }
 
-VALID_PROTOCOLS = {"acp", "acpx"}
+VALID_PROTOCOLS = {"acp", "acpx", "session-factory"}
 
 # ---------------------------------------------------------------------------
 # The ``acpx:`` runtime-key namespace
@@ -855,6 +861,7 @@ def _acpx_wrap(config: AgentConfig) -> AgentConfig:
             f'export PATH="{_JS_AGENT_PATH}" && acpx {acpx_agent_name} --approve-all'
         ),
         protocol="acp",
+        session_factory=config.session_factory,
         requires_env=config.requires_env,
         description=f"{config.description} (via acpx)",
         skill_paths=config.skill_paths,
@@ -961,6 +968,7 @@ def register_agent(
     launch_cmd: str,
     *,
     protocol: str = "acp",
+    session_factory: str = "",
     requires_env: list[str] | None = None,
     description: str = "",
     skill_paths: list[str] | None = None,
@@ -999,6 +1007,7 @@ def register_agent(
         install_cmd=install_cmd,
         launch_cmd=launch_cmd,
         protocol=protocol,
+        session_factory=session_factory,
         requires_env=requires_env or [],
         description=description,
         skill_paths=skill_paths or [],

--- a/tests/agents/test_protocol.py
+++ b/tests/agents/test_protocol.py
@@ -15,6 +15,8 @@ def test_session_is_runtime_checkable_protocol():
     """Tracer bullet — a trivial class structurally satisfies ``Session``."""
 
     class Dummy:
+        on_change = None
+
         async def prompt(self, text): ...
         async def cancel(self): ...
         def on_ask_user(self, handler): ...
@@ -156,6 +158,30 @@ def test_adapter_steps_empty_without_session():
     client._session = None
     adapter = ACPSessionAdapter(client)
     assert adapter.steps == []
+
+
+def test_adapter_on_change_bridges_to_acp_session():
+    """Guards PR #753: ``Session.on_change`` remains true for ACP adapters."""
+    from benchflow.acp.client import ACPClient
+    from benchflow.acp.session import ACPSession
+
+    client = ACPClient.__new__(ACPClient)
+    acp_session = ACPSession("s1")
+    client._session = acp_session
+    adapter = ACPSessionAdapter(client)
+    seen: list[Session] = []
+
+    def handler(session: Session) -> None:
+        seen.append(session)
+
+    adapter.on_change = handler
+    assert adapter.on_change is handler
+
+    acp_session.record_user_prompt("first instruction")
+    assert seen == [adapter]
+
+    adapter.on_change = None
+    assert acp_session.on_change is None
 
 
 def test_adapter_on_ask_user_stores_and_forwards_handler():

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -252,6 +252,7 @@ class TestRegisterAgent:
         )
         assert cfg.default_model == ""
         assert cfg.api_protocol == ""
+        assert cfg.session_factory == ""
         assert cfg.disallow_web_tools_setup_cmd == ""
         assert cfg.disallow_web_tools_launch_suffix == ""
 
@@ -261,11 +262,15 @@ class TestRegisterAgent:
             name="rt-full-agent",
             install_cmd="install rt",
             launch_cmd="launch rt",
+            protocol="session-factory",
+            session_factory="my_agent.factory:create_agent",
             default_model="rt-model-1",
             api_protocol="openai-completions",
             disallow_web_tools_setup_cmd="printf 'no web' > /tmp/policy",
             disallow_web_tools_launch_suffix=" --no-web",
         )
+        assert cfg.protocol == "session-factory"
+        assert cfg.session_factory == "my_agent.factory:create_agent"
         assert cfg.default_model == "rt-model-1"
         assert cfg.api_protocol == "openai-completions"
         assert cfg.disallow_web_tools_setup_cmd == "printf 'no web' > /tmp/policy"
@@ -273,6 +278,8 @@ class TestRegisterAgent:
 
         # And the registered entry reflects them.
         registered = AGENTS["rt-full-agent"]
+        assert registered.protocol == "session-factory"
+        assert registered.session_factory == "my_agent.factory:create_agent"
         assert registered.default_model == "rt-model-1"
         assert registered.api_protocol == "openai-completions"
         assert registered.disallow_web_tools_launch_suffix == " --no-web"

--- a/tests/test_agent_spec.py
+++ b/tests/test_agent_spec.py
@@ -99,6 +99,7 @@ class TestResolveAgent:
         assert wrapped.acp_model_config_id == underlying.acp_model_config_id
         assert wrapped.acp_effort_config_id == underlying.acp_effort_config_id
         assert wrapped.install_timeout == underlying.install_timeout
+        assert wrapped.session_factory == underlying.session_factory
         assert (
             wrapped.disallow_web_tools_setup_cmd
             == underlying.disallow_web_tools_setup_cmd

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -29,7 +29,7 @@ from benchflow.agents.registry import (
     _js_agent_install,
 )
 
-VALID_AGENT_PROTOCOLS = {"acp", "cli"}
+VALID_AGENT_PROTOCOLS = {"acp", "cli", "session-factory"}
 # Empty api_protocol is valid for agents (they infer from the model name at
 # runtime); providers must always declare an explicit protocol.
 VALID_API_PROTOCOLS = {


### PR DESCRIPTION
## Summary

Rebuilds the safe first slice of #753 on current `main`.

This PR only lands the protocol/registry contract needed for future non-ACP session-factory agents:
- declares `Session.on_change` as part of the runtime-checkable `Session` protocol
- bridges `ACPSessionAdapter.on_change` onto the underlying `ACPSession.on_change` callback so existing ACP sessions still satisfy the expanded contract
- adds `AgentConfig.session_factory` and allows `protocol=\"session-factory\"` in registration/spec validation
- passes `session_factory` through `register_agent()` and ACPX wrapping so runtime-registered agents do not silently drop the field

It intentionally does **not** port #753's rollout engine changes. Those should land as a separate narrower PR after this contract slice is green.

## Validation

- `uv run python -m pytest tests/agents/test_protocol.py tests/test_agent_registry.py tests/test_registry_invariants.py tests/test_agent_spec.py -q` -> 238 passed
- `uv run ruff check src/benchflow/agents/protocol.py src/benchflow/agents/registry.py tests/agents/test_protocol.py tests/test_agent_registry.py tests/test_registry_invariants.py tests/test_agent_spec.py`
- `uv run ruff format --check src/benchflow/agents/protocol.py src/benchflow/agents/registry.py tests/agents/test_protocol.py tests/test_agent_registry.py tests/test_registry_invariants.py tests/test_agent_spec.py`
- `uv run ty check src/benchflow/agents/protocol.py src/benchflow/agents/registry.py`

## Follow-up

Supersedes the protocol/registry portion of #753. The rollout execution path and a real session-factory e2e should be rebuilt in a follow-up PR.