### PR TITLE
Fix internal preview deployment environment

### DIFF
--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -41,9 +41,10 @@ concurrency:
 jobs:
   eval-and-judge:
     runs-on: ubuntu-latest
-    # Provider credentials are stored as environment secrets so they can be
-    # rotated without requiring repo-admin access to Actions secrets.
-    environment: pypi-internal-preview
+    # Provider credentials are stored in a dedicated CI environment so they can
+    # be rotated without repo-admin access and without polluting PyPI preview
+    # deployment status in the GitHub Deployments sidebar.
+    environment: integration-eval-secrets
     # Only run where integration secrets are available. Fork PRs lack secrets,
     # while internal PRs should fail visibly when the real eval path breaks.
     if: >-

--- a/docs/release.md
+++ b/docs/release.md
@@ -12,9 +12,9 @@ Current release state:
 
 - `0.6.2` is the latest stable release **published on PyPI** (tag `v0.6.2`).
   Use the public install commands below.
-- `main` currently carries `0.6.2`. To resume internal-preview builds for the
-  next line, bump `main` to `0.6.3.dev0` — internal previews then publish as
-  `0.6.3.dev<N>` automatically after the `test` workflow passes on `main`.
+- `main` tracks the next preview line, currently `0.6.3.dev0`. Internal
+  previews publish as `0.6.3.dev<N>` automatically after the `test` workflow
+  and integration gate pass on `main`.
 
 ## Install and Upgrade Commands
 
@@ -143,6 +143,10 @@ Create matching GitHub environments:
 
 - `pypi-internal-preview`: used for automatic preview publishing from `main`.
 - `pypi-public`: used for tag-driven public releases.
+- `integration-eval-secrets`: used by the integration-eval gate for provider
+  credentials. Do not reuse `pypi-internal-preview` here, because every Actions
+  job environment creates a GitHub deployment record and can make the PyPI
+  preview environment appear stale or inactive.
 
 The workflows build with `uv build --no-sources`, check distributions with
 `twine check`, and publish with `uv publish`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.2"
+version = "0.6.3.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -288,7 +288,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.2"
+version = "0.6.3.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- bump main from the final 0.6.2 release version to the next preview line, 0.6.3.dev0
- move integration-eval provider secrets to a dedicated `integration-eval-secrets` environment so CI deployments stop polluting `pypi-internal-preview`
- document the separate GitHub environments and why integration eval must not reuse the PyPI preview environment

## Why
`pypi-internal-preview` was showing as inactive because integration-eval also used that environment. GitHub Actions creates deployment records for every job environment, so PR/main integration runs mixed with real PyPI preview deployments and could mark them inactive. The release workflow was also skipping publication because `main` still carried final version `0.6.2`; preview publication only resumes once main is on a plain `.dev` version.

## Validation
- `uv lock --check`
- `uv run python -m pytest tests/test_release_version.py -q`
- `uv run python tools/release_version.py internal-preview --run-number 123` -> `publish=true`, `version=0.6.3.dev123`
- `uv run ruff check tools/release_version.py tests/test_release_version.py`
- `uv run ty check tools/release_version.py tests/test_release_version.py`

## Follow-up
Repo admin should create `integration-eval-secrets` and copy the integration provider secrets there if GitHub Models fallback is not sufficient. The current token cannot create environments (`403 Must have admin rights`).