### PR TITLE
refactor(sandbox): name Daytona retry-attempt budgets (#532)

### DIFF
--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -243,14 +243,21 @@ def _is_daytona_transient_retry_error(exc: BaseException) -> bool:
 
 _DAYTONA_TRANSIENT_RETRY: Any = retry_if_exception(_is_daytona_transient_retry_error)
 
+# Retry-attempt budgets for transient Daytona failures, named here so the
+# repeated ``3`` cannot silently drift between the idempotent-SDK policy and
+# sandbox creation (#532). ``_stop_sandbox`` deliberately uses a smaller budget.
+_DAYTONA_RETRY_ATTEMPTS = 3
+_DAYTONA_STOP_RETRY_ATTEMPTS = 2
+
 # Shared tenacity policy for the idempotent Daytona SDK calls — session-command
 # polling and filesystem up/download. Three attempts with exponential backoff,
 # re-raising the final failure. ``_create_sandbox`` and ``_stop_sandbox`` keep
-# their own policies (different attempt counts and backoff bounds), so they are
-# intentionally not folded in here. Reusing one ``retry(...)`` decorator across
-# methods is safe: tenacity builds a fresh controller per decorated function.
+# their own policies (different backoff bounds, and ``_stop_sandbox`` a smaller
+# attempt budget), so they are intentionally not folded in here. Reusing one
+# ``retry(...)`` decorator across methods is safe: tenacity builds a fresh
+# controller per decorated function.
 _SDK_RETRY = retry(
-    stop=stop_after_attempt(3),
+    stop=stop_after_attempt(_DAYTONA_RETRY_ATTEMPTS),
     wait=wait_exponential(multiplier=1, min=1, max=10),
     retry=_DAYTONA_TRANSIENT_RETRY,
     reraise=True,
@@ -428,7 +435,7 @@ class DaytonaSandbox(BaseSandbox):
         persist_sandbox_info(self, self.rollout_paths.rollout_dir)
 
     @retry(
-        stop=stop_after_attempt(3),
+        stop=stop_after_attempt(_DAYTONA_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=2, min=2, max=30),
         retry=_DAYTONA_TRANSIENT_RETRY,
         reraise=True,
@@ -488,7 +495,7 @@ class DaytonaSandbox(BaseSandbox):
             raise
 
     @retry(
-        stop=stop_after_attempt(2),
+        stop=stop_after_attempt(_DAYTONA_STOP_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1, max=10),
         retry=_DAYTONA_TRANSIENT_RETRY,
         reraise=True,


### PR DESCRIPTION
## Purpose
Fixes #532 — the Daytona transient-retry **attempt budget** was a bare integer literal repeated across call sites with no shared constant, so the value could silently drift between policies.

## What this does
Extracts two module-level constants in `src/benchflow/sandbox/daytona.py`:
- `_DAYTONA_RETRY_ATTEMPTS = 3` — used by `_SDK_RETRY` (idempotent SDK calls: session-command polling, filesystem up/download) **and** `_create_sandbox`.
- `_DAYTONA_STOP_RETRY_ATTEMPTS = 2` — used by `_stop_sandbox`, which deliberately keeps a smaller budget.

The exponential-backoff **bounds** are intentionally left per-site (they legitimately differ: `_create_sandbox` uses `multiplier=2, min=2, max=30`; the others `multiplier=1, min=1, max=10`). Only the attempt-count literal — the value the issue flagged as duplicated/drift-prone — is consolidated. The existing explanatory comment block was updated to match.

## Why
`#532`: "Daytona sandbox attempts=3 retry budget hardcoded at three call sites with no shared constant." This is a pure code-hygiene / drift-prevention refactor.

## Behavior change
**None.** All three sites resolve to the same attempt counts as before (3, 3, 2). This is a literal→named-constant substitution only.

## Validation
- `uv run ruff check src/benchflow/sandbox/daytona.py` → clean
- `uv run ruff format --check src/benchflow/sandbox/daytona.py` → already formatted
- `uv run python -m pytest tests/test_daytona_download.py tests/test_daytona_dind_compose_up.py tests/test_daytona_command_polling.py tests/test_daytona_poll_deadline.py tests/test_daytona_reap.py` → **75 passed**

No new test added: there is no behavior change, and the existing retry tests already exercise the transient-retry path. The tenacity `@retry` decorator does not expose its stop budget for post-hoc introspection in this version, so a constant-equality assertion would be circular.

Closes #532
