### PR TITLE
feat(hub): flatten to bench hub list + browse Harbor (not just PrimeIntellect)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -495,25 +495,30 @@ to disable that automatic pass and rely on the manual command above.
 
 `bench environment` is a hidden **deprecated alias group**, removed in 0.7. The
 local lifecycle moved to [`bench sandbox`](#bench-sandbox) (`create`/`list`/`cleanup`)
-and hosted-provider browsing to [`bench hub env`](#bench-hub-env). The old
+and hosted-provider browsing to [`bench hub list`](#bench-hub). The old
 `bench environment create|list|cleanup` and `show|inspect` (plus `list
 --provider`/`--hub`) still work, each printing a one-line stderr notice.
 
 ## bench hub
 
-External environment hubs: compatibility checks (`check`) and browsing a hosted
-provider's environments (`env`).
+External environment hubs: browse a hub's environments (`list`/`show`/`inspect`)
+and check Harbor registry compatibility (`check`).
 
-### bench hub env
+### bench hub list / show / inspect
 
-Read-only browsing of a hosted provider's environments (PrimeIntellect
-"Environments"). To *run* one, use [`bench eval create --source-env`](#bench-eval-create).
+Read-only browsing of a hub's environments. `list` covers two hubs via
+`--provider`: `primeintellect` (hosted "Environments") and `harbor` (the
+benchmark registry). To *run* a hosted environment, use
+[`bench eval create --source-env`](#bench-eval-create).
 
 ```bash
-bench hub env list --provider primeintellect --owner primeintellect --search general-agent --limit 5
-bench hub env show primeintellect/general-agent --version 0.1.1
-bench hub env inspect primeintellect/general-agent --version 0.1.1 --path README.md
+bench hub list --provider primeintellect --owner primeintellect --search general-agent --limit 5
+bench hub list --provider harbor --search coding
+bench hub show primeintellect/general-agent --version 0.1.1
+bench hub inspect primeintellect/general-agent --version 0.1.1 --path README.md
 ```
+
+`bench hub env list|show|inspect` still resolves as a hidden back-compat alias.
 
 ### bench hub check
 

--- a/src/benchflow/cli/_hosted_env.py
+++ b/src/benchflow/cli/_hosted_env.py
@@ -1,6 +1,6 @@
 """Shared hosted-environment read commands.
 
-Canonically reached via ``bench hub env list|show|inspect`` (external
+Canonically reached via ``bench hub list|show|inspect`` (external
 environment-hub browsing). ``list`` browses multiple hubs — PrimeIntellect
 hosted "Environments" and the Harbor benchmark registry — dispatched on
 ``--provider``. ``show``/``inspect`` currently target the PrimeIntellect CLI.
@@ -21,7 +21,7 @@ from rich.table import Table
 
 from benchflow.cli._shared import console, print_error
 
-#: Hubs that ``bench hub env list`` can browse.
+#: Hubs that ``bench hub list`` can browse.
 LIST_PROVIDERS = ("primeintellect", "harbor")
 
 

--- a/src/benchflow/cli/_hosted_env.py
+++ b/src/benchflow/cli/_hosted_env.py
@@ -1,10 +1,14 @@
-"""Shared hosted-environment read commands (PrimeIntellect "Environments").
+"""Shared hosted-environment read commands.
 
 Canonically reached via ``bench hub env list|show|inspect`` (external
-environment-hub browsing); the deprecated ``bench environment list --provider``
-/ ``environment show`` / ``environment inspect`` aliases delegate here so there
-is exactly one copy of the logic. The actual API helpers live in
-``benchflow.hosted_env`` and are untouched.
+environment-hub browsing). ``list`` browses multiple hubs — PrimeIntellect
+hosted "Environments" and the Harbor benchmark registry — dispatched on
+``--provider``. ``show``/``inspect`` currently target the PrimeIntellect CLI.
+
+The deprecated ``bench environment list --provider`` / ``environment show`` /
+``environment inspect`` aliases delegate here so there is exactly one copy of
+the logic. The actual API/registry helpers live in ``benchflow.hosted_env`` and
+``benchflow.hub.harbor_registry`` and are untouched.
 """
 
 from __future__ import annotations
@@ -17,7 +21,8 @@ from rich.table import Table
 
 from benchflow.cli._shared import console, print_error
 
-_SUPPORTED_PROVIDER = "primeintellect"
+#: Hubs that ``bench hub env list`` can browse.
+LIST_PROVIDERS = ("primeintellect", "harbor")
 
 
 def hosted_env_list(
@@ -28,12 +33,26 @@ def hosted_env_list(
     limit: int | None,
     output_json: bool,
 ) -> None:
-    """List a hosted provider's environments (table, or raw JSON to stdout)."""
-    if provider != _SUPPORTED_PROVIDER:
+    """List a hub's environments (table, or raw JSON to stdout)."""
+    if provider == "primeintellect":
+        _list_primeintellect(
+            owner=owner, search=search, limit=limit, output_json=output_json
+        )
+    elif provider == "harbor":
+        if owner:
+            print_error("--owner is not supported for the harbor hub")
+            raise typer.Exit(1)
+        _list_harbor(search=search, limit=limit, output_json=output_json)
+    else:
         print_error(
-            f"Only --provider {_SUPPORTED_PROVIDER} is supported today (got {provider!r})"
+            f"Unknown --provider {provider!r}; supported: {', '.join(LIST_PROVIDERS)}"
         )
         raise typer.Exit(1)
+
+
+def _list_primeintellect(
+    *, owner: str | None, search: str | None, limit: int | None, output_json: bool
+) -> None:
     from benchflow.hosted_env import HostedEnvError, prime_env_list
 
     try:
@@ -44,9 +63,8 @@ def hosted_env_list(
     if output_json:
         # typer.echo, NOT console.print: Rich's console soft-wraps long lines to
         # the terminal width and injects a literal newline mid-string, which
-        # turns the upstream's valid JSON into unparseable output (raw control
-        # char inside a string). Write the payload verbatim so `--json | jq`
-        # works at any width.
+        # turns the upstream's valid JSON into unparseable output. Write the
+        # payload verbatim so `--json | jq` works at any width.
         typer.echo(raw)
         return
     data = json.loads(raw)
@@ -85,6 +103,61 @@ def hosted_env_list(
     console.print(
         f"[dim]Showing {len(rows)}{suffix} environment(s). Refine with "
         "--search/--owner, raise --limit, or use --json for the full payload.[/dim]"
+    )
+
+
+def _list_harbor(*, search: str | None, limit: int | None, output_json: bool) -> None:
+    from benchflow.hub.harbor_registry import (
+        DEFAULT_HARBOR_REGISTRY_URL,
+        load_harbor_registry,
+    )
+
+    try:
+        datasets = load_harbor_registry(DEFAULT_HARBOR_REGISTRY_URL)
+    except (OSError, ValueError) as e:
+        # A network/file failure or malformed registry must not dump a traceback.
+        print_error(f"could not load the Harbor registry: {e}")
+        raise typer.Exit(1) from None
+
+    rows = datasets
+    if search:
+        q = search.lower()
+        rows = [
+            d
+            for d in rows
+            if q in str(d.get("name", "")).lower()
+            or q in str(d.get("description", "")).lower()
+        ]
+    matched = len(rows)
+    if limit:
+        rows = rows[:limit]
+
+    if output_json:
+        typer.echo(json.dumps(rows))
+        return
+
+    table = Table(title="Harbor Environments")
+    table.add_column("Environment", style="cyan")
+    table.add_column("Version", style="green")
+    table.add_column("Tasks", justify="right")
+    table.add_column("Description", style="dim")
+    for d in rows:
+        tasks = d.get("tasks") or []
+        n_tasks = str(len(tasks)) if isinstance(tasks, list) else "0"
+        desc = str(d.get("description", "") or "")
+        if len(desc) > 80:
+            desc = desc[:79] + "…"
+        table.add_row(
+            escape(str(d.get("name", ""))),
+            escape(str(d.get("version", "") or "")),
+            n_tasks,
+            escape(desc),
+        )
+    console.print(table)
+    suffix = f" of {matched}" if matched > len(rows) else ""
+    console.print(
+        f"[dim]Showing {len(rows)}{suffix} Harbor environment(s). Refine with "
+        "--search, raise --limit, or use --json for the full registry.[/dim]"
     )
 
 

--- a/src/benchflow/cli/_hosted_env.py
+++ b/src/benchflow/cli/_hosted_env.py
@@ -129,7 +129,7 @@ def _list_harbor(*, search: str | None, limit: int | None, output_json: bool) ->
             or q in str(d.get("description", "")).lower()
         ]
     matched = len(rows)
-    if limit:
+    if limit is not None:
         rows = rows[:limit]
 
     if output_json:

--- a/src/benchflow/cli/environment.py
+++ b/src/benchflow/cli/environment.py
@@ -38,7 +38,7 @@ def register_environment(app: typer.Typer) -> None:
     alone matches the ``adopt`` / ``agent`` alias families: exactly one
     once-per-process stderr notice, verbs hidden from help.
     """
-    env_app = typer.Typer(help="Deprecated; use `bench sandbox` / `bench hub env`.")
+    env_app = typer.Typer(help="Deprecated; use `bench sandbox` / `bench hub`.")
     app.add_typer(env_app, name="environment", hidden=True)
 
     @env_app.command("create", hidden=True)
@@ -60,14 +60,12 @@ def register_environment(app: typer.Typer) -> None:
         provider: Annotated[
             str | None,
             typer.Option(
-                "--provider", hidden=True, help="Deprecated; use `bench hub env list`"
+                "--provider", hidden=True, help="Deprecated; use `bench hub list`"
             ),
         ] = None,
         hub: Annotated[
             str | None,
-            typer.Option(
-                "--hub", hidden=True, help="Deprecated; use `bench hub env list`"
-            ),
+            typer.Option("--hub", hidden=True, help="Deprecated; use `bench hub list`"),
         ] = None,
         owner: Annotated[
             str | None,
@@ -88,11 +86,11 @@ def register_environment(app: typer.Typer) -> None:
             ),
         ] = False,
     ) -> None:
-        """Deprecated; use `bench sandbox list` (local) or `bench hub env list` (hosted)."""
+        """Deprecated; use `bench sandbox list` (local) or `bench hub list` (hosted)."""
         provider = provider or hub
         if provider:
             warn_deprecated(
-                "bench environment list --provider", "bench hub env list --provider"
+                "bench environment list --provider", "bench hub list --provider"
             )
             hosted_env_list(
                 provider=provider,
@@ -117,8 +115,8 @@ def register_environment(app: typer.Typer) -> None:
             str | None, typer.Option("--version", help="Hosted environment version")
         ] = None,
     ) -> None:
-        """Deprecated; use `bench hub env show`."""
-        warn_deprecated("bench environment show", "bench hub env show")
+        """Deprecated; use `bench hub show`."""
+        warn_deprecated("bench environment show", "bench hub show")
         hosted_env_show(source_env=source_env, version=version)
 
     @env_app.command("inspect", hidden=True)
@@ -137,8 +135,8 @@ def register_environment(app: typer.Typer) -> None:
             typer.Option("--path", help="File inside the hosted environment package"),
         ] = "README.md",
     ) -> None:
-        """Deprecated; use `bench hub env inspect`."""
-        warn_deprecated("bench environment inspect", "bench hub env inspect")
+        """Deprecated; use `bench hub inspect`."""
+        warn_deprecated("bench environment inspect", "bench hub inspect")
         hosted_env_inspect(source_env=source_env, version=version, path=path)
 
     @env_app.command("cleanup", hidden=True)

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -1,7 +1,10 @@
-"""``bench hub`` — compatibility checks for external environment hubs.
+"""``bench hub`` — browse external environment hubs + check compatibility.
 
-Registered onto the top-level app by :func:`register_hub`; ``cli/main.py``
-only wires the call.
+Registered onto the top-level app by :func:`register_hub`; ``cli/main.py`` only
+wires the call. The browsing verbs (``list``/``show``/``inspect``) live directly
+under ``hub`` — the old ``hub env`` nesting was redundant (the whole group is
+about environment hubs), so ``hub env *`` is kept only as a hidden back-compat
+alias.
 """
 
 from __future__ import annotations
@@ -26,12 +29,23 @@ def register_hub(app: typer.Typer) -> None:
     """Attach the ``hub`` command group to the top-level benchflow app."""
     hub_app = typer.Typer(
         help=(
-            "External environment hubs: compatibility checks (check) and browsing "
-            "hosted provider environments (env)."
+            "External environment hubs: browse a hub's environments "
+            "(list/show/inspect) and check Harbor compatibility (check)."
         )
     )
     app.add_typer(hub_app, name="hub", rich_help_panel="Environments")
-    _register_hub_env(hub_app)
+
+    # Canonical browsing verbs live directly under `hub` (the `env` level was
+    # redundant — `hub` already means environment hubs).
+    _register_env_verbs(hub_app)
+
+    # Back-compat: `bench hub env list|show|inspect` still resolves, as a hidden
+    # alias of the flattened commands.
+    env_alias = typer.Typer(
+        help="Alias of `bench hub` — use `bench hub list/show/inspect`."
+    )
+    hub_app.add_typer(env_alias, name="env", hidden=True)
+    _register_env_verbs(env_alias)
 
     @hub_app.command("check")
     def hub_check(
@@ -110,18 +124,15 @@ def register_hub(app: typer.Typer) -> None:
             console.print(f"[green]Wrote JSONL report:[/green] {escape(str(out))}")
 
 
-def _register_hub_env(hub_app: typer.Typer) -> None:
-    """Attach ``bench hub env`` — read-only browsing of a hosted provider's
-    environments (PrimeIntellect "Environments"). The canonical home for what
-    used to be ``bench environment list --provider`` / ``show`` / ``inspect``;
-    the run path stays on ``bench eval create --source-env``."""
-    env_app = typer.Typer(
-        help="Browse environments from an external hub (primeintellect or harbor)."
-    )
-    hub_app.add_typer(env_app, name="env")
+def _register_env_verbs(target: typer.Typer) -> None:
+    """Register the hub-environment browsing verbs (list/show/inspect) on ``target``.
 
-    @env_app.command("list")
-    def hub_env_list(
+    Called once for the canonical ``bench hub`` group and once for the hidden
+    ``bench hub env`` back-compat alias, so both expose identical commands.
+    """
+
+    @target.command("list")
+    def hub_list(
         provider: Annotated[
             str,
             typer.Option(
@@ -153,8 +164,8 @@ def _register_hub_env(hub_app: typer.Typer) -> None:
             output_json=output_json,
         )
 
-    @env_app.command("show")
-    def hub_env_show(
+    @target.command("show")
+    def hub_show(
         source_env: Annotated[
             str,
             typer.Argument(
@@ -165,11 +176,11 @@ def _register_hub_env(hub_app: typer.Typer) -> None:
             str | None, typer.Option("--version", help="Hosted environment version")
         ] = None,
     ) -> None:
-        """Show hosted environment metadata."""
+        """Show a hub environment's metadata."""
         hosted_env_show(source_env=source_env, version=version)
 
-    @env_app.command("inspect")
-    def hub_env_inspect(
+    @target.command("inspect")
+    def hub_inspect(
         source_env: Annotated[
             str,
             typer.Argument(
@@ -184,5 +195,5 @@ def _register_hub_env(hub_app: typer.Typer) -> None:
             typer.Option("--path", help="File inside the hosted environment package"),
         ] = "README.md",
     ) -> None:
-        """Inspect a file from a hosted environment package."""
+        """Inspect a file from a hub environment package."""
         hosted_env_inspect(source_env=source_env, version=version, path=path)

--- a/src/benchflow/cli/hub.py
+++ b/src/benchflow/cli/hub.py
@@ -116,7 +116,7 @@ def _register_hub_env(hub_app: typer.Typer) -> None:
     used to be ``bench environment list --provider`` / ``show`` / ``inspect``;
     the run path stays on ``bench eval create --source-env``."""
     env_app = typer.Typer(
-        help="Browse hosted environments from an external provider (e.g. primeintellect)."
+        help="Browse environments from an external hub (primeintellect or harbor)."
     )
     hub_app.add_typer(env_app, name="env")
 
@@ -124,10 +124,15 @@ def _register_hub_env(hub_app: typer.Typer) -> None:
     def hub_env_list(
         provider: Annotated[
             str,
-            typer.Option("--provider", help="Hosted environment provider"),
+            typer.Option(
+                "--provider",
+                help="Hub to browse: 'primeintellect' (hosted envs) or "
+                "'harbor' (benchmark registry)",
+            ),
         ] = "primeintellect",
         owner: Annotated[
-            str | None, typer.Option("--owner", help="Owner/namespace filter")
+            str | None,
+            typer.Option("--owner", help="Owner/namespace filter (primeintellect)"),
         ] = None,
         search: Annotated[
             str | None, typer.Option("--search", help="Search query")
@@ -139,7 +144,7 @@ def _register_hub_env(hub_app: typer.Typer) -> None:
             bool, typer.Option("--json", help="Emit raw JSON")
         ] = False,
     ) -> None:
-        """List a hosted provider's environments."""
+        """List a hub's environments (primeintellect or harbor)."""
         hosted_env_list(
             provider=provider,
             owner=owner,

--- a/src/benchflow/cli/sandbox.py
+++ b/src/benchflow/cli/sandbox.py
@@ -4,7 +4,7 @@ This is the local execution side of the framework: provision a task as a
 runnable environment on a docker/daytona/modal **sandbox** backend, list active
 sandboxes, and reap stale ones. It was previously ``bench environment``; that
 name now reads as a misnomer (hosted-environment browsing moved to
-``bench hub env``), so the group is renamed to ``sandbox`` — ``bench
+``bench hub``), so the group is renamed to ``sandbox`` — ``bench
 environment`` stays as a hidden deprecated alias group through 0.6.
 
 The command bodies live here as plain functions so the deprecated

--- a/tests/test_cli_adopt_aliases.py
+++ b/tests/test_cli_adopt_aliases.py
@@ -13,7 +13,7 @@ stderr notice that points at the new canonical shape:
 * the original ``bench agent create|run|verify``.
 
 ``--hub`` likewise remains the deprecated spelling of ``environment list
---provider`` (hosted browsing moved to ``bench hub env list``). These tests pin
+--provider`` (hosted browsing moved to ``bench hub list``). These tests pin
 the canonical surface and every back-compat path so the renames stay additive.
 """
 
@@ -307,7 +307,7 @@ def test_deprecation_fires_once_per_process(tmp_path) -> None:
 
 
 def test_environment_list_hosted_is_deprecated_json_stays_clean(monkeypatch) -> None:
-    # Hosted browsing moved to `bench hub env list`; `environment list
+    # Hosted browsing moved to `bench hub list`; `environment list
     # --provider`/`--hub` now warn (deprecated) but still work, and the warning
     # goes to stderr ONLY so `--json >out` consumers stay clean.
     import benchflow.hosted_env as hosted
@@ -319,6 +319,6 @@ def test_environment_list_hosted_is_deprecated_json_stays_clean(monkeypatch) -> 
             app, ["environment", "list", flag, "primeintellect", "--json"]
         )
         assert res.exit_code == 0
-        assert "deprecation" in res.stderr and "bench hub env list" in res.stderr
+        assert "deprecation" in res.stderr and "bench hub list" in res.stderr
         assert "environments" not in res.stderr  # JSON did not leak to stderr
         assert '{"environments": []}' in res.output  # JSON present on stdout

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -186,6 +186,10 @@ def test_documented_subcommands_exist() -> None:
         ["environment", "inspect"],
         ["environment", "cleanup"],
         ["hub", "check"],
+        ["hub", "list"],
+        ["hub", "show"],
+        ["hub", "inspect"],
+        # `hub env *` is a hidden back-compat alias of the flattened verbs.
         ["hub", "env", "list"],
         ["hub", "env", "show"],
         ["hub", "env", "inspect"],

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -326,7 +326,7 @@ def test_hub_env_list_json_is_valid_json_even_when_narrow(monkeypatch):
     payload = json.dumps({"environments": [{"name": "a/b", "description": long_desc}]})
     monkeypatch.setattr(hosted, "prime_env_list", lambda **kw: payload)
     monkeypatch.setenv("COLUMNS", "40")
-    res = runner.invoke(app, ["hub", "env", "list", "--json"])
+    res = runner.invoke(app, ["hub", "list", "--json"])
     assert res.exit_code == 0
     assert json.loads(res.stdout) == json.loads(payload)  # round-trips cleanly
 

--- a/tests/test_cli_hub_env.py
+++ b/tests/test_cli_hub_env.py
@@ -1,10 +1,11 @@
-"""`bench hub env` is the canonical home for hosted-provider environment reads.
+"""`bench hub list|show|inspect` is the canonical home for hosted-provider reads.
 
 The overloaded `bench environment` group (gap #5) was split: local sandbox
 lifecycle stays on `bench environment` (create/list/cleanup), and the read-only
-hosted-provider browsing moved to `bench hub env list|show|inspect`. The old
+hosted-provider browsing moved to `bench hub list|show|inspect`. The old
 `environment show`/`inspect` and `environment list --provider`/`--hub` remain as
-hidden deprecated aliases (stderr notice) through 0.6.
+hidden deprecated aliases (stderr notice) through 0.6. The `bench hub env *`
+nesting is itself a hidden back-compat alias of the flattened verbs.
 """
 
 from __future__ import annotations
@@ -36,19 +37,40 @@ _FAKE_HARBOR = [
 ]
 
 
-def test_hub_env_subgroup_exposes_list_show_inspect() -> None:
-    res = runner.invoke(app, ["hub", "env", "--help"])
+def test_hub_flattens_verbs_and_hides_env_alias() -> None:
+    """`list`/`show`/`inspect`/`check` are canonical under `bench hub`; the old
+    `env` nesting is hidden but still resolves for back-compat.
+
+    Asserts against the Click command registry (authoritative), not a regex over
+    rendered `--help` (which is ANSI/width-fragile and "env" also appears inside
+    the word "environments")."""
+    import typer
+
+    hub = typer.main.get_command(app).commands["hub"]
+    visible = {
+        name for name, sub in hub.commands.items() if not getattr(sub, "hidden", False)
+    }
+    assert {"list", "show", "inspect", "check"} <= visible
+    assert "env" not in visible  # the redundant nesting is hidden…
+    assert "env" in hub.commands  # …but still registered for back-compat
+    assert runner.invoke(app, ["hub", "env", "list", "--help"]).exit_code == 0
+
+
+def test_hub_env_alias_still_lists(monkeypatch) -> None:
+    """The flattened verbs still resolve under the hidden `bench hub env`."""
+    monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
+    res = runner.invoke(app, ["hub", "env", "list", "--provider", "harbor", "--json"])
     assert res.exit_code == 0
-    for verb in ("list", "show", "inspect"):
-        assert verb in res.output, f"`bench hub env` missing {verb!r}: {res.output}"
-    # and the subgroup is reachable from `bench hub`
-    assert "env" in runner.invoke(app, ["hub", "--help"]).output
+    assert [d["name"] for d in json.loads(res.output)] == [
+        "aider-polyglot",
+        "swe-bench",
+    ]
 
 
 def test_hub_env_list_is_canonical_and_silent(monkeypatch) -> None:
     monkeypatch.setattr(hosted, "prime_env_list", lambda **kw: '{"environments": []}')
     shared._DEPRECATION_WARNED.clear()
-    res = runner.invoke(app, ["hub", "env", "list", "--json"])  # defaults provider
+    res = runner.invoke(app, ["hub", "list", "--json"])  # defaults provider
     assert res.exit_code == 0
     assert res.output.strip() == '{"environments": []}'
     assert "deprecation" not in res.stderr  # canonical surface never warns
@@ -57,7 +79,7 @@ def test_hub_env_list_is_canonical_and_silent(monkeypatch) -> None:
 def test_hub_env_show_delegates(monkeypatch) -> None:
     monkeypatch.setattr(hosted, "prime_env_info", lambda ref: "META: general-agent")
     shared._DEPRECATION_WARNED.clear()
-    res = runner.invoke(app, ["hub", "env", "show", "primeintellect/general-agent"])
+    res = runner.invoke(app, ["hub", "show", "primeintellect/general-agent"])
     assert res.exit_code == 0
     assert "META: general-agent" in res.output
     assert "deprecation" not in res.stderr
@@ -69,7 +91,7 @@ def test_environment_show_is_deprecated_alias_of_hub_env_show(monkeypatch) -> No
     res = runner.invoke(app, ["environment", "show", "primeintellect/general-agent"])
     assert res.exit_code == 0
     assert "META: general-agent" in res.output  # behavior identical
-    assert "deprecation" in res.stderr and "bench hub env show" in res.stderr
+    assert "deprecation" in res.stderr and "bench hub show" in res.stderr
 
 
 def test_environment_inspect_is_deprecated_alias(monkeypatch) -> None:
@@ -78,7 +100,7 @@ def test_environment_inspect_is_deprecated_alias(monkeypatch) -> None:
     res = runner.invoke(app, ["environment", "inspect", "primeintellect/general-agent"])
     assert res.exit_code == 0
     assert "FILE:README.md" in res.output
-    assert "deprecation" in res.stderr and "bench hub env inspect" in res.stderr
+    assert "deprecation" in res.stderr and "bench hub inspect" in res.stderr
 
 
 def test_environment_group_is_hidden_but_still_resolves() -> None:
@@ -101,13 +123,13 @@ def test_environment_group_is_hidden_but_still_resolves() -> None:
     assert runner.invoke(app, ["environment", "create", "--help"]).exit_code == 0
 
 
-# ── multi-hub: `bench hub env list` browses harbor too, not just primeintellect ─
+# ── multi-hub: `bench hub list` browses harbor too, not just primeintellect ─
 
 
 def test_hub_env_list_harbor_renders_registry(monkeypatch) -> None:
     """`hub env list --provider harbor` lists the Harbor benchmark registry."""
     monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
-    res = runner.invoke(app, ["hub", "env", "list", "--provider", "harbor"])
+    res = runner.invoke(app, ["hub", "list", "--provider", "harbor"])
     assert res.exit_code == 0, res.output
     assert res.exception is None
     assert "Harbor" in res.output  # title/footer name the hub
@@ -115,7 +137,7 @@ def test_hub_env_list_harbor_renders_registry(monkeypatch) -> None:
 
 def test_hub_env_list_harbor_json_is_the_registry(monkeypatch) -> None:
     monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
-    res = runner.invoke(app, ["hub", "env", "list", "--provider", "harbor", "--json"])
+    res = runner.invoke(app, ["hub", "list", "--provider", "harbor", "--json"])
     assert res.exit_code == 0
     assert [d["name"] for d in json.loads(res.output)] == [
         "aider-polyglot",
@@ -127,7 +149,7 @@ def test_hub_env_list_harbor_search_filters(monkeypatch) -> None:
     monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
     res = runner.invoke(
         app,
-        ["hub", "env", "list", "--provider", "harbor", "--search", "coding", "--json"],
+        ["hub", "list", "--provider", "harbor", "--search", "coding", "--json"],
     )
     assert res.exit_code == 0
     assert [d["name"] for d in json.loads(res.output)] == ["aider-polyglot"]
@@ -136,22 +158,20 @@ def test_hub_env_list_harbor_search_filters(monkeypatch) -> None:
 def test_hub_env_list_harbor_limit(monkeypatch) -> None:
     monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
     res = runner.invoke(
-        app, ["hub", "env", "list", "--provider", "harbor", "--limit", "1", "--json"]
+        app, ["hub", "list", "--provider", "harbor", "--limit", "1", "--json"]
     )
     assert res.exit_code == 0
     assert len(json.loads(res.output)) == 1
 
 
 def test_hub_env_list_unknown_provider_errors() -> None:
-    res = runner.invoke(app, ["hub", "env", "list", "--provider", "bogus"])
+    res = runner.invoke(app, ["hub", "list", "--provider", "bogus"])
     assert res.exit_code == 1
     assert "Unknown --provider" in res.output
 
 
 def test_hub_env_list_harbor_rejects_owner(monkeypatch) -> None:
     monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
-    res = runner.invoke(
-        app, ["hub", "env", "list", "--provider", "harbor", "--owner", "x"]
-    )
+    res = runner.invoke(app, ["hub", "list", "--provider", "harbor", "--owner", "x"])
     assert res.exit_code == 1
     assert "owner" in res.output.lower()

--- a/tests/test_cli_hub_env.py
+++ b/tests/test_cli_hub_env.py
@@ -9,13 +9,31 @@ hidden deprecated aliases (stderr notice) through 0.6.
 
 from __future__ import annotations
 
+import json
+
 from typer.testing import CliRunner
 
 import benchflow.cli._shared as shared
 import benchflow.hosted_env as hosted
+import benchflow.hub.harbor_registry as harbor
 from benchflow.cli.main import app
 
 runner = CliRunner()
+
+_FAKE_HARBOR = [
+    {
+        "name": "aider-polyglot",
+        "version": "1.0",
+        "description": "a coding benchmark",
+        "tasks": [{"name": "t1"}, {"name": "t2"}],
+    },
+    {
+        "name": "swe-bench",
+        "version": "2.0",
+        "description": "issue fixing",
+        "tasks": [{"name": "a"}],
+    },
+]
 
 
 def test_hub_env_subgroup_exposes_list_show_inspect() -> None:
@@ -81,3 +99,59 @@ def test_environment_group_is_hidden_but_still_resolves() -> None:
     assert "environment" not in visible  # deprecated alias group is hidden
     assert "environment" in cmd.commands  # …but still registered for back-compat
     assert runner.invoke(app, ["environment", "create", "--help"]).exit_code == 0
+
+
+# ── multi-hub: `bench hub env list` browses harbor too, not just primeintellect ─
+
+
+def test_hub_env_list_harbor_renders_registry(monkeypatch) -> None:
+    """`hub env list --provider harbor` lists the Harbor benchmark registry."""
+    monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
+    res = runner.invoke(app, ["hub", "env", "list", "--provider", "harbor"])
+    assert res.exit_code == 0, res.output
+    assert res.exception is None
+    assert "Harbor" in res.output  # title/footer name the hub
+
+
+def test_hub_env_list_harbor_json_is_the_registry(monkeypatch) -> None:
+    monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
+    res = runner.invoke(app, ["hub", "env", "list", "--provider", "harbor", "--json"])
+    assert res.exit_code == 0
+    assert [d["name"] for d in json.loads(res.output)] == [
+        "aider-polyglot",
+        "swe-bench",
+    ]
+
+
+def test_hub_env_list_harbor_search_filters(monkeypatch) -> None:
+    monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
+    res = runner.invoke(
+        app,
+        ["hub", "env", "list", "--provider", "harbor", "--search", "coding", "--json"],
+    )
+    assert res.exit_code == 0
+    assert [d["name"] for d in json.loads(res.output)] == ["aider-polyglot"]
+
+
+def test_hub_env_list_harbor_limit(monkeypatch) -> None:
+    monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
+    res = runner.invoke(
+        app, ["hub", "env", "list", "--provider", "harbor", "--limit", "1", "--json"]
+    )
+    assert res.exit_code == 0
+    assert len(json.loads(res.output)) == 1
+
+
+def test_hub_env_list_unknown_provider_errors() -> None:
+    res = runner.invoke(app, ["hub", "env", "list", "--provider", "bogus"])
+    assert res.exit_code == 1
+    assert "Unknown --provider" in res.output
+
+
+def test_hub_env_list_harbor_rejects_owner(monkeypatch) -> None:
+    monkeypatch.setattr(harbor, "load_harbor_registry", lambda src: _FAKE_HARBOR)
+    res = runner.invoke(
+        app, ["hub", "env", "list", "--provider", "harbor", "--owner", "x"]
+    )
+    assert res.exit_code == 1
+    assert "owner" in res.output.lower()


### PR DESCRIPTION
## Summary

Two changes to the `bench hub` environment-browsing surface.

### 1. Flatten `hub env` → `hub` (the `env` level was redundant)

`hub` already means *environment hubs*, so `hub env list` was one level too deep. The browsing verbs now sit directly under `hub`:

| Before | Now |
|--------|-----|
| `bench hub env list` | `bench hub list` |
| `bench hub env show` | `bench hub show` |
| `bench hub env inspect` | `bench hub inspect` |

`bench hub env *` still resolves as a **hidden back-compat alias**, so existing scripts keep working. `bench hub check` is unchanged.

### 2. Multi-hub: `hub list` browses Harbor too, not just PrimeIntellect

`hub list` was hard-gated to `--provider primeintellect`. It's now a clean dispatch:
- `--provider primeintellect` — hosted environments (unchanged)
- `--provider harbor` — the Harbor benchmark registry, listing its **80 datasets** (name / version / task-count / description)

```
bench hub list                            # PrimeIntellect (default) — 1,280 envs
bench hub list --provider harbor          # Harbor — 80 datasets
bench hub list --provider harbor --search coding
bench hub list --provider harbor --limit 10 --json | jq length
```

`--search` / `--limit` / `--json` work for both hubs. `--owner` is PrimeIntellect-only (rejected cleanly for Harbor). An unknown `--provider` gives a clean error naming the supported hubs. `show` / `inspect` stay PrimeIntellect for now.

## Tests & docs
`test_cli_hub_env.py` — harbor render/json/search/limit, unknown-provider, owner-rejection, the flatten + hidden-alias back-compat. `test_cli_docs_drift.py` covers `hub list/show/inspect` **and** the `hub env *` aliases. `docs/reference/cli.md` updated. Full unit suite green.
