### PR TITLE
Add MLE-bench adapter

### DIFF
--- a/benchmarks/mle-bench/README.md
+++ b/benchmarks/mle-bench/README.md
@@ -1,0 +1,159 @@
+# BenchFlow x MLE-bench
+
+Adopts [openai/mle-bench](https://github.com/openai/mle-bench) into BenchFlow as
+one task per MLE-bench competition.
+
+## Routing
+
+```text
+Source: openai/mle-bench
+Observed format: Python package with mlebench/competitions/*/config.yaml, prepare.py, grade.py, leaderboard.csv
+Original runner: run_agent.py launches competition containers over prepared Kaggle data
+Original verifier/scorer: mlebench.grade.grade_csv / grade-sample
+Task unit: Kaggle competition
+Oracle availability: none
+Proposed layer: L2
+Reason: structured task collection with reusable metadata and deterministic graders
+Parity evidence required: side-by-side grade_csv vs converted verifier on identical submissions
+```
+
+## Convert
+
+Prepare MLE-bench data first:
+
+```bash
+git clone https://github.com/openai/mle-bench.git /path/to/mle-bench
+cd /path/to/mle-bench
+pip install -e .
+mlebench prepare --lite --data-dir /path/to/mle-data
+```
+
+Then generate BenchFlow tasks:
+
+```bash
+python benchmarks/mle-bench/main.py \
+  --source-dir /path/to/mle-bench \
+  --data-dir /path/to/mle-data \
+  --output-dir benchmarks/mle-bench/tasks \
+  --split low \
+  --overwrite
+```
+
+Useful subsets:
+
+```bash
+python benchmarks/mle-bench/main.py --source-dir /path/to/mle-bench --data-dir /path/to/mle-data --output-dir /tmp/mle-tasks --limit 3
+python benchmarks/mle-bench/main.py --source-dir /path/to/mle-bench --data-dir /path/to/mle-data --output-dir /tmp/mle-tasks --task-ids spaceship-titanic,AI4Code
+```
+
+`--metadata-only` writes task structure without prepared data. Those tasks are
+not runnable; it is for adapter inspection only.
+
+## Task Contract
+
+Agents see:
+
+- `/home/data/` with prepared public competition data
+- `/home/data/description.md`
+- `/home/data/sample_submission.csv` when upstream provides one
+- `/home/validate_submission.sh` for a lightweight CSV-shape check
+
+Agents must write:
+
+- `/home/submission/submission.csv`
+
+The verifier keeps private data under `tests/private-data`, imports the
+upstream MLE-bench grader, writes the full report to
+`/logs/verifier/grading_report.json`, and writes `reward.txt` as:
+
+- `1.0` if `any_medal` is true
+- `0.0` otherwise
+
+## Parity
+
+Structural checks can run locally:
+
+```bash
+python benchmarks/mle-bench/parity_test.py --tasks-dir benchmarks/mle-bench/tasks --mode full
+```
+
+Side-by-side parity compares the original upstream `grade_csv` path with the
+converted BenchFlow verifier on the same CSV submission. By default it uses each
+task's copied sample submission:
+
+```bash
+python benchmarks/mle-bench/parity_test.py \
+  --tasks-dir benchmarks/mle-bench/tasks \
+  --mode side-by-side \
+  --record
+```
+
+For stronger evidence, place paired submissions in a directory as either
+`<competition-id>.csv`, `<slug>.csv`, `<competition-id>/submission.csv`, or
+`<slug>/submission.csv`, then run:
+
+```bash
+python benchmarks/mle-bench/parity_test.py \
+  --tasks-dir benchmarks/mle-bench/tasks \
+  --submissions-dir /path/to/submissions \
+  --mode side-by-side \
+  --record
+```
+
+Full parity still requires prepared MLE-bench data and real paired submissions.
+Do not claim `parity-confirmed` until `bench eval adopt mle-bench --verify` has
+scoreable side-by-side reward evidence in `parity_experiment.json`.
+
+Current recorded evidence uses real Kaggle-prepared data and upstream sample
+submissions for `aerial-cactus-identification`, `denoising-dirty-documents`,
+`nomad2018-predict-transparent-conductors`, `random-acts-of-pizza`,
+`spaceship-titanic`, and `spooky-author-identification`. The converted verifier
+matched upstream `grade_csv` on all 48 compared fields with reward delta `0.0`.
+
+## BenchFlow Runtime Smoke
+
+A converted `spaceship-titanic` task has also been run through BenchFlow's Docker
+sandbox with a temporary oracle fixture:
+
+```bash
+uv run bench eval create \
+  --tasks-dir /tmp/mle-bench-benchflow-smoke-task/spaceship-titanic \
+  --agent oracle \
+  --sandbox docker \
+  --jobs-dir /tmp/mle-bench-benchflow-smoke-jobs-default-user \
+  --concurrency 1
+```
+
+The fixture copied `/home/data/sample_submission.csv` to
+`/home/submission/submission.csv`. The run reached the verifier, emitted
+`valid_submission: 1.0`, and completed with `verifier_errored: 0`. The scalar
+reward was `0.0`, which is expected for the sample submission and does not
+indicate a runtime failure.
+
+Do not add `--sandbox-user root` for this smoke test. BenchFlow verifier
+hardening can terminate the root-owned main service before verification starts.
+
+## Live Agent Smoke
+
+A converted `spaceship-titanic` task has also been run with a real ACP agent,
+not just the oracle harness:
+
+```bash
+uv run bench eval create \
+  --tasks-dir /tmp/mle-bench-agent-smoke-task/spaceship-titanic \
+  --agent codex \
+  --model openai/gpt-5.4-mini \
+  --sandbox docker \
+  --jobs-dir /tmp/mle-bench-agent-smoke-jobs-codex-gpt54 \
+  --concurrency 1 \
+  --usage-tracking off \
+  --agent-idle-timeout 180 \
+  --prompt 'Runtime smoke only. Inspect /home/data, create /home/submission/submission.csv by copying /home/data/sample_submission.csv, then finish. Do not train a model or download anything.'
+```
+
+The run connected `codex-acp`, selected `gpt-5.4-mini[medium]`, executed 3 tool
+calls, reached the verifier, emitted `valid_submission: 1.0`, and completed with
+`errored: 0`, `verifier_errored: 0`, and `idle_timeout: 0`.
+
+For this Codex ACP smoke, avoid `--model gpt-4.1-mini`; that failed during
+`session/set_model` before the task prompt ran.

--- a/benchmarks/mle-bench/README.md
+++ b/benchmarks/mle-bench/README.md
@@ -19,13 +19,13 @@ Parity evidence required: side-by-side grade_csv vs converted verifier on identi
 
 ## Convert
 
-Prepare MLE-bench data first:
+Prepare MLE-bench data for the default `split75` task set first:
 
 ```bash
 git clone https://github.com/openai/mle-bench.git /path/to/mle-bench
 cd /path/to/mle-bench
 pip install -e .
-mlebench prepare --lite --data-dir /path/to/mle-data
+mlebench prepare --all --data-dir /path/to/mle-data
 ```
 
 Then generate BenchFlow tasks:
@@ -35,13 +35,15 @@ python benchmarks/mle-bench/main.py \
   --source-dir /path/to/mle-bench \
   --data-dir /path/to/mle-data \
   --output-dir benchmarks/mle-bench/tasks \
-  --split low \
+  --split split75 \
   --overwrite
 ```
 
 Useful subsets:
 
 ```bash
+cd /path/to/mle-bench && mlebench prepare --lite --data-dir /path/to/mle-data
+python benchmarks/mle-bench/main.py --source-dir /path/to/mle-bench --data-dir /path/to/mle-data --output-dir /tmp/mle-tasks --split low
 python benchmarks/mle-bench/main.py --source-dir /path/to/mle-bench --data-dir /path/to/mle-data --output-dir /tmp/mle-tasks --limit 3
 python benchmarks/mle-bench/main.py --source-dir /path/to/mle-bench --data-dir /path/to/mle-data --output-dir /tmp/mle-tasks --task-ids spaceship-titanic,AI4Code
 ```
@@ -68,6 +70,11 @@ upstream MLE-bench grader, writes the full report to
 
 - `1.0` if `any_medal` is true
 - `0.0` otherwise
+
+By design, the verifier runs as `root` and executes the vendored upstream
+per-competition `grade.py` only inside the verifier container. Agents can read
+and write only the task environment and final submission path; they do not
+control the verifier package or private grading data.
 
 ## Parity
 
@@ -116,7 +123,7 @@ A converted `spaceship-titanic` task has also been run through BenchFlow's Docke
 sandbox with a temporary oracle fixture:
 
 ```bash
-uv run bench eval create \
+uv run bench eval run \
   --tasks-dir /tmp/mle-bench-benchflow-smoke-task/spaceship-titanic \
   --agent oracle \
   --sandbox docker \
@@ -139,7 +146,7 @@ A converted `spaceship-titanic` task has also been run with a real ACP agent,
 not just the oracle harness:
 
 ```bash
-uv run bench eval create \
+uv run bench eval run \
   --tasks-dir /tmp/mle-bench-agent-smoke-task/spaceship-titanic \
   --agent codex \
   --model openai/gpt-5.4-mini \

--- a/benchmarks/mle-bench/benchflow.py
+++ b/benchmarks/mle-bench/benchflow.py
@@ -261,17 +261,19 @@ def _private_dir(data_dir: Path, competition: MLEBenchCompetition) -> Path:
     return data_dir / competition.competition_id / "prepared" / "private"
 
 
-def _answers_path(data_dir: Path, competition: MLEBenchCompetition) -> Path:
-    return data_dir / competition.dataset["answers"]
+def _safe_dataset_relpath(value: str, *, label: str) -> Path:
+    """Validate an upstream dataset path stays a contained relative subpath.
 
-
-def _sample_submission_path(
-    data_dir: Path, competition: MLEBenchCompetition
-) -> Path | None:
-    sample = competition.dataset.get("sample_submission")
-    if not sample:
-        return None
-    return data_dir / sample
+    These strings come from upstream ``config.yaml``. Rejecting absolute paths
+    and ``..`` keeps every copy inside the task's data/answer roots instead of
+    letting a malformed config escape them.
+    """
+    rel = Path(value)
+    if rel.is_absolute() or ".." in rel.parts:
+        raise ValueError(
+            f"MLE-bench {label} path must be a relative subpath, got {value!r}"
+        )
+    return rel
 
 
 def _copy_prepared_data(
@@ -291,9 +293,10 @@ def _copy_prepared_data(
         )
         return
 
+    answers_rel = _safe_dataset_relpath(competition.dataset["answers"], label="answers")
     public_src = _public_dir(data_dir, competition)
     private_src = _private_dir(data_dir, competition)
-    answers_src = _answers_path(data_dir, competition)
+    answers_src = data_dir / answers_rel
 
     if not public_src.is_dir():
         raise FileNotFoundError(
@@ -315,16 +318,21 @@ def _copy_prepared_data(
         (public_dst / "description.md").write_text(
             competition.description, encoding="utf-8"
         )
-    sample_src = _sample_submission_path(data_dir, competition)
-    if sample_src is not None and sample_src.is_file():
+    # Expose a canonical sample_submission.csv to the agent only when the
+    # upstream sample lives in the public tree (already copied above). Some
+    # competitions declare the sample under prepared/private/; those must never
+    # reach the agent-visible environment, so we source strictly from public.
+    sample = competition.dataset.get("sample_submission")
+    if sample:
+        public_sample = public_dst / Path(sample).name
         canonical_sample = public_dst / "sample_submission.csv"
-        if sample_src.name != canonical_sample.name:
-            shutil.copy2(sample_src, canonical_sample)
+        if public_sample.is_file() and public_sample != canonical_sample:
+            shutil.copy2(public_sample, canonical_sample)
 
     private_dst = private_root / competition.competition_id / "prepared" / "private"
     _copytree(private_src, private_dst)
 
-    answers_dst = private_root / competition.dataset["answers"]
+    answers_dst = private_root / answers_rel
     answers_dst.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(answers_src, answers_dst)
 

--- a/benchmarks/mle-bench/benchflow.py
+++ b/benchmarks/mle-bench/benchflow.py
@@ -74,7 +74,9 @@ def _toml_list(values: list[str]) -> str:
 def _copytree(src: Path, dst: Path) -> None:
     if dst.exists():
         shutil.rmtree(dst)
-    shutil.copytree(src, dst, symlinks=False, ignore=shutil.ignore_patterns(".git", "__pycache__"))
+    shutil.copytree(
+        src, dst, symlinks=False, ignore=shutil.ignore_patterns(".git", "__pycache__")
+    )
 
 
 def _resolve_source_dir(source_dir: Path | None) -> Path:
@@ -133,7 +135,11 @@ def _load_splits(source_dir: Path) -> dict[str, set[str]]:
 
     splits: dict[str, set[str]] = {}
     for path in sorted(splits_dir.glob("*.txt")):
-        ids = {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+        ids = {
+            line.strip()
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
         splits[path.stem] = ids
     return splits
 
@@ -183,7 +189,9 @@ def load_competitions(source_dir: Path | None = None) -> list[MLEBenchCompetitio
         dataset = {str(k): str(v) for k, v in dict(config.get("dataset", {})).items()}
         grader = dict(config.get("grader", {}))
         meta = category_meta.get(competition_id, {})
-        splits = sorted(name for name, ids in split_map.items() if competition_id in ids)
+        splits = sorted(
+            name for name, ids in split_map.items() if competition_id in ids
+        )
         complexity = meta.get("complexity") or _infer_complexity_from_splits(splits)
 
         competitions.append(
@@ -233,8 +241,12 @@ def _select_competitions(
         split_map = _load_splits(source_dir)
         if split not in split_map:
             valid = ", ".join(["all", *sorted(split_map)])
-            raise ValueError(f"Unknown MLE-bench split {split!r}; expected one of: {valid}")
-        selected = [task for task in selected if task.competition_id in split_map[split]]
+            raise ValueError(
+                f"Unknown MLE-bench split {split!r}; expected one of: {valid}"
+            )
+        selected = [
+            task for task in selected if task.competition_id in split_map[split]
+        ]
 
     if limit is not None:
         selected = selected[:limit]
@@ -253,7 +265,9 @@ def _answers_path(data_dir: Path, competition: MLEBenchCompetition) -> Path:
     return data_dir / competition.dataset["answers"]
 
 
-def _sample_submission_path(data_dir: Path, competition: MLEBenchCompetition) -> Path | None:
+def _sample_submission_path(
+    data_dir: Path, competition: MLEBenchCompetition
+) -> Path | None:
     sample = competition.dataset.get("sample_submission")
     if not sample:
         return None
@@ -272,7 +286,9 @@ def _copy_prepared_data(
 
     if not include_data:
         public_dst.mkdir(parents=True, exist_ok=True)
-        (public_dst / "description.md").write_text(competition.description, encoding="utf-8")
+        (public_dst / "description.md").write_text(
+            competition.description, encoding="utf-8"
+        )
         return
 
     public_src = _public_dir(data_dir, competition)
@@ -296,7 +312,9 @@ def _copy_prepared_data(
 
     _copytree(public_src, public_dst)
     if not (public_dst / "description.md").is_file():
-        (public_dst / "description.md").write_text(competition.description, encoding="utf-8")
+        (public_dst / "description.md").write_text(
+            competition.description, encoding="utf-8"
+        )
     sample_src = _sample_submission_path(data_dir, competition)
     if sample_src is not None and sample_src.is_file():
         canonical_sample = public_dst / "sample_submission.csv"
@@ -322,17 +340,24 @@ def _copy_mlebench_package(
 
     for filename in _CORE_MLEBENCH_FILES:
         src = src_pkg / filename
-        if src.is_file():
-            shutil.copy2(src, dst_pkg / filename)
+        if not src.is_file():
+            raise FileNotFoundError(f"Required MLE-bench core file missing: {src}")
+        shutil.copy2(src, dst_pkg / filename)
 
     competitions_dst = dst_pkg / "competitions"
     competitions_dst.mkdir(exist_ok=True)
     init = src_pkg / "competitions" / "__init__.py"
-    if init.is_file():
-        shutil.copy2(init, competitions_dst / "__init__.py")
+    if not init.is_file():
+        raise FileNotFoundError(
+            f"Required MLE-bench competitions package file missing: {init}"
+        )
+    shutil.copy2(init, competitions_dst / "__init__.py")
     utils = src_pkg / "competitions" / "utils.py"
-    if utils.is_file():
-        shutil.copy2(utils, competitions_dst / "utils.py")
+    if not utils.is_file():
+        raise FileNotFoundError(
+            f"Required MLE-bench competitions utility file missing: {utils}"
+        )
+    shutil.copy2(utils, competitions_dst / "utils.py")
 
     comp_src = src_pkg / "competitions" / competition.competition_id
     if not comp_src.is_dir():
@@ -557,7 +582,8 @@ def _render_validate_submission_sh() -> str:
 
 def _render_test_sh(competition: MLEBenchCompetition) -> str:
     return Template(
-        """\
+        textwrap.dedent(
+            """\
         #!/bin/bash
         set -euo pipefail
 
@@ -571,6 +597,7 @@ def _render_test_sh(competition: MLEBenchCompetition) -> str:
           --reward-json /logs/verifier/reward.json \\
           --report-file /logs/verifier/grading_report.json
         """
+        )
     ).substitute(competition_id=competition.competition_id)
 
 
@@ -582,7 +609,6 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-import traceback
 from pathlib import Path
 
 
@@ -595,6 +621,8 @@ def _write_outputs(
     report_file: Path,
 ) -> None:
     reward_file.parent.mkdir(parents=True, exist_ok=True)
+    reward_json.parent.mkdir(parents=True, exist_ok=True)
+    report_file.parent.mkdir(parents=True, exist_ok=True)
     reward_file.write_text(f"{reward:.6f}\\n")
     report_file.write_text(json.dumps(report, indent=2, sort_keys=True))
     reward_json.write_text(
@@ -626,30 +654,14 @@ def main() -> None:
 
     sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-    try:
-        from mlebench.grade import grade_csv
-        from mlebench.registry import registry
+    from mlebench.grade import grade_csv
+    from mlebench.registry import registry
 
-        competition = registry.set_data_dir(args.data_dir).get_competition(
-            args.competition_id
-        )
-        report = grade_csv(args.submission, competition).to_dict()
-        reward = 1.0 if report.get("any_medal") else 0.0
-    except Exception as exc:
-        report = {
-            "competition_id": args.competition_id,
-            "submission_path": str(args.submission),
-            "submission_exists": args.submission.is_file(),
-            "valid_submission": False,
-            "any_medal": False,
-            "gold_medal": False,
-            "silver_medal": False,
-            "bronze_medal": False,
-            "above_median": False,
-            "error": str(exc),
-            "traceback": traceback.format_exc(),
-        }
-        reward = 0.0
+    competition = registry.set_data_dir(args.data_dir).get_competition(
+        args.competition_id
+    )
+    report = grade_csv(args.submission, competition).to_dict()
+    reward = 1.0 if report.get("any_medal") else 0.0
 
     _write_outputs(
         reward=reward,
@@ -723,9 +735,15 @@ def convert(
     )
     _copy_mlebench_package(root, task_dir, competition)
 
-    (task_dir / "task.toml").write_text(_render_task_toml(competition), encoding="utf-8")
-    (task_dir / "instruction.md").write_text(_render_instruction(competition), encoding="utf-8")
-    (task_dir / "environment" / "Dockerfile").write_text(_render_dockerfile(), encoding="utf-8")
+    (task_dir / "task.toml").write_text(
+        _render_task_toml(competition), encoding="utf-8"
+    )
+    (task_dir / "instruction.md").write_text(
+        _render_instruction(competition), encoding="utf-8"
+    )
+    (task_dir / "environment" / "Dockerfile").write_text(
+        _render_dockerfile(), encoding="utf-8"
+    )
     (task_dir / "environment" / "instructions.txt").write_text(
         _render_environment_instructions(),
         encoding="utf-8",
@@ -791,7 +809,9 @@ def _parse_task_ids(raw: str | None) -> list[str] | None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Convert OpenAI MLE-bench to BenchFlow.")
+    parser = argparse.ArgumentParser(
+        description="Convert OpenAI MLE-bench to BenchFlow."
+    )
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--source-dir", type=Path, default=None)
     parser.add_argument(
@@ -807,7 +827,9 @@ def main() -> None:
     )
     parser.add_argument("--limit", type=int, default=None)
     parser.add_argument("--overwrite", action="store_true")
-    parser.add_argument("--task-ids", default=None, help="Comma-separated competition IDs or slugs")
+    parser.add_argument(
+        "--task-ids", default=None, help="Comma-separated competition IDs or slugs"
+    )
     parser.add_argument(
         "--metadata-only",
         action="store_true",

--- a/benchmarks/mle-bench/benchflow.py
+++ b/benchmarks/mle-bench/benchflow.py
@@ -1,0 +1,832 @@
+"""Convert OpenAI MLE-bench competitions into BenchFlow task dirs.
+
+MLE-bench is a collection of Kaggle competitions with its own preparation and
+grading code. This adapter keeps one competition as one BenchFlow task, exposes
+only the prepared public data to the agent, and runs the upstream grader from
+``tests/`` against the agent's ``/home/submission/submission.csv``.
+
+The converter expects a local checkout of ``openai/mle-bench`` and a prepared
+data directory produced by ``mlebench prepare``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import logging
+import os
+import re
+import shutil
+import textwrap
+from dataclasses import dataclass
+from pathlib import Path
+from string import Template
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+_SCRIPT_DIR = Path(__file__).resolve().parent
+_DEFAULT_SPLIT = "split75"
+_CORE_MLEBENCH_FILES = (
+    "__init__.py",
+    "data.py",
+    "grade.py",
+    "grade_helpers.py",
+    "metrics.py",
+    "registry.py",
+    "utils.py",
+)
+
+
+@dataclass(frozen=True)
+class MLEBenchCompetition:
+    competition_id: str
+    slug: str
+    name: str
+    description: str
+    competition_type: str
+    grader_name: str
+    grade_fn: str
+    dataset: dict[str, str]
+    category: str
+    complexity: str
+    dataset_size_gb: float | None
+    splits: list[str]
+
+
+def _sanitize_id(raw: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", raw.lower()).strip("-")
+    if not slug:
+        raise ValueError(f"Cannot derive task slug from {raw!r}")
+    return slug
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def _toml_list(values: list[str]) -> str:
+    return "[" + ", ".join(_toml_string(v) for v in values) + "]"
+
+
+def _copytree(src: Path, dst: Path) -> None:
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst, symlinks=False, ignore=shutil.ignore_patterns(".git", "__pycache__"))
+
+
+def _resolve_source_dir(source_dir: Path | None) -> Path:
+    candidates = []
+    if source_dir is not None:
+        candidates.append(source_dir)
+    else:
+        candidates.extend(
+            [
+                _SCRIPT_DIR / "source",
+                Path.cwd() / "mle-bench",
+                Path.cwd() / "mle-bench-upstream",
+                Path.home() / "mle-bench",
+                Path("/tmp/mle-bench-upstream"),
+            ]
+        )
+
+    for candidate in candidates:
+        root = candidate.resolve()
+        if (root / "mlebench" / "competitions").is_dir():
+            return root
+        if root.name == "mlebench" and (root / "competitions").is_dir():
+            return root.parent
+
+    searched = ", ".join(str(p) for p in candidates)
+    raise FileNotFoundError(
+        "Cannot find an MLE-bench checkout. Pass --source-dir /path/to/mle-bench. "
+        f"Searched: {searched}"
+    )
+
+
+def _resolve_data_dir(data_dir: Path | None, source_dir: Path) -> Path:
+    if data_dir is not None:
+        return data_dir.resolve()
+    for env_name in ("MLE_BENCH_DATA_DIR", "MLEBENCH_DATA_DIR"):
+        env_value = os.environ.get(env_name)
+        if env_value:
+            return Path(env_value).expanduser().resolve()
+    if (source_dir / "data").is_dir():
+        return (source_dir / "data").resolve()
+    return (Path.home() / ".cache" / "mle-bench" / "data").resolve()
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        data = yaml.safe_load(handle) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected mapping in {path}")
+    return data
+
+
+def _load_splits(source_dir: Path) -> dict[str, set[str]]:
+    splits_dir = source_dir / "experiments" / "splits"
+    if not splits_dir.is_dir():
+        return {}
+
+    splits: dict[str, set[str]] = {}
+    for path in sorted(splits_dir.glob("*.txt")):
+        ids = {line.strip() for line in path.read_text(encoding="utf-8").splitlines() if line.strip()}
+        splits[path.stem] = ids
+    return splits
+
+
+def _load_category_metadata(source_dir: Path) -> dict[str, dict[str, str]]:
+    path = source_dir / "experiments" / "competition_categories.csv"
+    if not path.is_file():
+        return {}
+
+    out: dict[str, dict[str, str]] = {}
+    with path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            competition_id = (row.get("competition_id") or "").strip()
+            if not competition_id:
+                continue
+            out[competition_id] = {
+                "category": (row.get("category") or "").strip(),
+                "complexity": (row.get("Complexity") or "").strip().lower(),
+                "dataset_size_GB": (row.get("dataset_size_GB") or "").strip(),
+            }
+    return out
+
+
+def _dataset_size(meta: dict[str, str]) -> float | None:
+    raw = meta.get("dataset_size_GB", "")
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def load_competitions(source_dir: Path | None = None) -> list[MLEBenchCompetition]:
+    """Load competition metadata from a local MLE-bench checkout."""
+    root = _resolve_source_dir(source_dir)
+    split_map = _load_splits(root)
+    category_meta = _load_category_metadata(root)
+    competitions_dir = root / "mlebench" / "competitions"
+
+    competitions: list[MLEBenchCompetition] = []
+    for config_path in sorted(competitions_dir.glob("*/config.yaml")):
+        config = _load_yaml(config_path)
+        competition_id = str(config.get("id") or config_path.parent.name)
+        slug = _sanitize_id(competition_id)
+        description_path = root / str(config["description"])
+        description = description_path.read_text(encoding="utf-8")
+        dataset = {str(k): str(v) for k, v in dict(config.get("dataset", {})).items()}
+        grader = dict(config.get("grader", {}))
+        meta = category_meta.get(competition_id, {})
+        splits = sorted(name for name, ids in split_map.items() if competition_id in ids)
+        complexity = meta.get("complexity") or _infer_complexity_from_splits(splits)
+
+        competitions.append(
+            MLEBenchCompetition(
+                competition_id=competition_id,
+                slug=slug,
+                name=str(config.get("name") or competition_id),
+                description=description,
+                competition_type=str(config.get("competition_type") or "unknown"),
+                grader_name=str(grader.get("name") or "unknown"),
+                grade_fn=str(grader.get("grade_fn") or ""),
+                dataset=dataset,
+                category=meta.get("category") or "machine-learning",
+                complexity=complexity,
+                dataset_size_gb=_dataset_size(meta),
+                splits=splits,
+            )
+        )
+    return competitions
+
+
+def _infer_complexity_from_splits(splits: list[str]) -> str:
+    for name in ("low", "medium", "high"):
+        if name in splits:
+            return name
+    return "medium"
+
+
+def _select_competitions(
+    competitions: list[MLEBenchCompetition],
+    *,
+    source_dir: Path,
+    split: str | None,
+    task_ids: list[str] | None,
+    limit: int | None,
+) -> list[MLEBenchCompetition]:
+    selected = competitions
+    if task_ids:
+        wanted = {item.strip() for item in task_ids if item.strip()}
+        wanted |= {_sanitize_id(item) for item in wanted}
+        selected = [
+            task
+            for task in selected
+            if task.competition_id in wanted or task.slug in wanted
+        ]
+    elif split and split != "all":
+        split_map = _load_splits(source_dir)
+        if split not in split_map:
+            valid = ", ".join(["all", *sorted(split_map)])
+            raise ValueError(f"Unknown MLE-bench split {split!r}; expected one of: {valid}")
+        selected = [task for task in selected if task.competition_id in split_map[split]]
+
+    if limit is not None:
+        selected = selected[:limit]
+    return selected
+
+
+def _public_dir(data_dir: Path, competition: MLEBenchCompetition) -> Path:
+    return data_dir / competition.competition_id / "prepared" / "public"
+
+
+def _private_dir(data_dir: Path, competition: MLEBenchCompetition) -> Path:
+    return data_dir / competition.competition_id / "prepared" / "private"
+
+
+def _answers_path(data_dir: Path, competition: MLEBenchCompetition) -> Path:
+    return data_dir / competition.dataset["answers"]
+
+
+def _sample_submission_path(data_dir: Path, competition: MLEBenchCompetition) -> Path | None:
+    sample = competition.dataset.get("sample_submission")
+    if not sample:
+        return None
+    return data_dir / sample
+
+
+def _copy_prepared_data(
+    competition: MLEBenchCompetition,
+    *,
+    data_dir: Path,
+    task_dir: Path,
+    include_data: bool,
+) -> None:
+    public_dst = task_dir / "environment" / "data"
+    private_root = task_dir / "tests" / "private-data"
+
+    if not include_data:
+        public_dst.mkdir(parents=True, exist_ok=True)
+        (public_dst / "description.md").write_text(competition.description, encoding="utf-8")
+        return
+
+    public_src = _public_dir(data_dir, competition)
+    private_src = _private_dir(data_dir, competition)
+    answers_src = _answers_path(data_dir, competition)
+
+    if not public_src.is_dir():
+        raise FileNotFoundError(
+            f"Prepared public data missing for {competition.competition_id}: {public_src}. "
+            f"Run `mlebench prepare -c {competition.competition_id} --data-dir {data_dir}` first."
+        )
+    if not private_src.is_dir():
+        raise FileNotFoundError(
+            f"Prepared private data missing for {competition.competition_id}: {private_src}. "
+            f"Run `mlebench prepare -c {competition.competition_id} --data-dir {data_dir}` first."
+        )
+    if not answers_src.is_file():
+        raise FileNotFoundError(
+            f"Prepared answer file missing for {competition.competition_id}: {answers_src}"
+        )
+
+    _copytree(public_src, public_dst)
+    if not (public_dst / "description.md").is_file():
+        (public_dst / "description.md").write_text(competition.description, encoding="utf-8")
+    sample_src = _sample_submission_path(data_dir, competition)
+    if sample_src is not None and sample_src.is_file():
+        canonical_sample = public_dst / "sample_submission.csv"
+        if sample_src.name != canonical_sample.name:
+            shutil.copy2(sample_src, canonical_sample)
+
+    private_dst = private_root / competition.competition_id / "prepared" / "private"
+    _copytree(private_src, private_dst)
+
+    answers_dst = private_root / competition.dataset["answers"]
+    answers_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(answers_src, answers_dst)
+
+
+def _copy_mlebench_package(
+    source_dir: Path,
+    task_dir: Path,
+    competition: MLEBenchCompetition,
+) -> None:
+    src_pkg = source_dir / "mlebench"
+    dst_pkg = task_dir / "tests" / "mlebench"
+    dst_pkg.mkdir(parents=True, exist_ok=True)
+
+    for filename in _CORE_MLEBENCH_FILES:
+        src = src_pkg / filename
+        if src.is_file():
+            shutil.copy2(src, dst_pkg / filename)
+
+    competitions_dst = dst_pkg / "competitions"
+    competitions_dst.mkdir(exist_ok=True)
+    init = src_pkg / "competitions" / "__init__.py"
+    if init.is_file():
+        shutil.copy2(init, competitions_dst / "__init__.py")
+    utils = src_pkg / "competitions" / "utils.py"
+    if utils.is_file():
+        shutil.copy2(utils, competitions_dst / "utils.py")
+
+    comp_src = src_pkg / "competitions" / competition.competition_id
+    if not comp_src.is_dir():
+        raise FileNotFoundError(f"MLE-bench competition package missing: {comp_src}")
+    _copytree(comp_src, competitions_dst / competition.competition_id)
+
+
+def _render_task_toml(competition: MLEBenchCompetition) -> str:
+    tags = [
+        "mle-bench",
+        _sanitize_id(competition.category),
+        competition.complexity,
+        competition.grader_name,
+    ]
+    dataset_size = (
+        str(competition.dataset_size_gb)
+        if competition.dataset_size_gb is not None
+        else "0.0"
+    )
+    split_list = _toml_list(competition.splits)
+    return textwrap.dedent(
+        f"""\
+        version = "1.0"
+
+        [task]
+        name = {_toml_string(f"mle-bench/{competition.slug}")}
+
+        [metadata]
+        author_name = "OpenAI"
+        difficulty = {_toml_string(competition.complexity)}
+        category = {_toml_string(competition.category)}
+        tags = {_toml_list(tags)}
+
+        [metadata.mle_bench]
+        competition_id = {_toml_string(competition.competition_id)}
+        competition_type = {_toml_string(competition.competition_type)}
+        grader = {_toml_string(competition.grader_name)}
+        grade_fn = {_toml_string(competition.grade_fn)}
+        dataset_size_gb = {dataset_size}
+        splits = {split_list}
+        reward = "any_medal"
+
+        [agent]
+        timeout_sec = 86400
+
+        [verifier]
+        timeout_sec = 3600
+        user = "root"
+
+        [environment]
+        build_timeout_sec = 3600
+        cpus = 4
+        memory_mb = 16384
+        storage_mb = 10240
+        allow_internet = false
+        workdir = "/home"
+        """
+    )
+
+
+def _render_instruction(competition: MLEBenchCompetition) -> str:
+    size_note = (
+        f"{competition.dataset_size_gb:g} GB"
+        if competition.dataset_size_gb is not None
+        else "unknown size"
+    )
+    splits = ", ".join(competition.splits) if competition.splits else "unlisted"
+    return textwrap.dedent(
+        f"""\
+        # MLE-bench: {competition.name}
+
+        You are solving an offline MLE-bench competition adapted to BenchFlow.
+        Train or otherwise construct a model using the prepared public data and
+        produce a Kaggle-style CSV submission.
+
+        ## Required Output
+
+        Write your final submission to:
+
+        `/home/submission/submission.csv`
+
+        The verifier only grades that file. If it is missing, malformed, or not
+        a CSV, the reward is `0`.
+
+        ## Data
+
+        - Public competition data is in `/home/data/`.
+        - The competition description is also available at `/home/data/description.md`.
+        - The sample submission file, when provided upstream, is in `/home/data/sample_submission.csv`.
+        - A lightweight CSV-shape check is available as `/home/validate_submission.sh`.
+
+        ## Scoring
+
+        BenchFlow runs the upstream MLE-bench grader for `{competition.competition_id}`.
+        The scalar reward is `1.0` when the submission earns any Kaggle medal
+        under MLE-bench thresholds, otherwise `0.0`. The full grading report is
+        saved to `/logs/verifier/grading_report.json`.
+
+        ## Metadata
+
+        - Competition ID: `{competition.competition_id}`
+        - Category: {competition.category}
+        - Complexity: {competition.complexity}
+        - Split membership: {splits}
+        - Dataset size: {size_note}
+        - Grader: `{competition.grader_name}`
+
+        ## Competition Description
+
+        {competition.description.strip()}
+        """
+    )
+
+
+def _render_dockerfile() -> str:
+    return textwrap.dedent(
+        """\
+        FROM python:3.11-slim
+
+        ENV DEBIAN_FRONTEND=noninteractive
+
+        RUN apt-get update -qq && apt-get install -y -qq \\
+            build-essential \\
+            curl \\
+            ffmpeg \\
+            git \\
+            libgl1 \\
+            libglib2.0-0 \\
+            p7zip-full \\
+            unzip \\
+            zip \\
+            && rm -rf /var/lib/apt/lists/*
+
+        RUN pip install --no-cache-dir \\
+            appdirs \\
+            diskcache \\
+            levenshtein \\
+            numpy \\
+            pandas \\
+            pillow \\
+            py7zr \\
+            pycocotools \\
+            pyquaternion \\
+            pyyaml \\
+            scikit-learn \\
+            scipy \\
+            shapely \\
+            tenacity \\
+            tqdm
+
+        WORKDIR /home
+
+        COPY data/ /home/data/
+        COPY instructions.txt /home/instructions.txt
+        COPY validate_submission.sh /home/validate_submission.sh
+
+        RUN mkdir -p /home/submission /workspace /logs/verifier /logs/agent /logs/artifacts \\
+            && chmod +x /home/validate_submission.sh \\
+            && chmod -R a+rwX /home/submission /workspace /logs
+
+        CMD ["sleep", "infinity"]
+        """
+    )
+
+
+def _render_environment_instructions() -> str:
+    return textwrap.dedent(
+        """\
+        You are participating in MLE-bench, an offline adaptation of Kaggle
+        competitions for evaluating machine learning engineering agents.
+
+        Use the data in /home/data/ and write your final submission CSV to
+        /home/submission/submission.csv. The BenchFlow verifier grades only that
+        file using the upstream MLE-bench grader.
+        """
+    )
+
+
+def _render_validate_submission_sh() -> str:
+    return textwrap.dedent(
+        """\
+        #!/bin/bash
+        set -euo pipefail
+
+        SUBMISSION="${1:-/home/submission/submission.csv}"
+        SAMPLE="/home/data/sample_submission.csv"
+
+        if [ ! -f "$SUBMISSION" ]; then
+            echo "Submission invalid: $SUBMISSION does not exist."
+            exit 1
+        fi
+
+        python3 - "$SUBMISSION" "$SAMPLE" <<'PY'
+        import sys
+        from pathlib import Path
+
+        import pandas as pd
+
+        submission = Path(sys.argv[1])
+        sample = Path(sys.argv[2])
+
+        try:
+            submission_df = pd.read_csv(submission)
+        except Exception as exc:
+            print(f"Submission invalid: could not read CSV: {exc}")
+            raise SystemExit(1)
+
+        if sample.is_file():
+            sample_df = pd.read_csv(sample, nrows=0)
+            if list(submission_df.columns) != list(sample_df.columns):
+                print(
+                    "Submission invalid: columns differ from sample_submission.csv. "
+                    f"Expected {list(sample_df.columns)}, got {list(submission_df.columns)}."
+                )
+                raise SystemExit(1)
+
+        print("Submission shape looks valid. Final grading runs after the task.")
+        PY
+        """
+    )
+
+
+def _render_test_sh(competition: MLEBenchCompetition) -> str:
+    return Template(
+        """\
+        #!/bin/bash
+        set -euo pipefail
+
+        mkdir -p /logs/verifier /logs/artifacts
+
+        python3 /tests/verify.py \\
+          --competition-id "$competition_id" \\
+          --submission /home/submission/submission.csv \\
+          --data-dir /tests/private-data \\
+          --reward-file /logs/verifier/reward.txt \\
+          --reward-json /logs/verifier/reward.json \\
+          --report-file /logs/verifier/grading_report.json
+        """
+    ).substitute(competition_id=competition.competition_id)
+
+
+VERIFY_PY = '''\
+"""BenchFlow verifier for one converted MLE-bench competition."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import traceback
+from pathlib import Path
+
+
+def _write_outputs(
+    *,
+    reward: float,
+    report: dict,
+    reward_file: Path,
+    reward_json: Path,
+    report_file: Path,
+) -> None:
+    reward_file.parent.mkdir(parents=True, exist_ok=True)
+    reward_file.write_text(f"{reward:.6f}\\n")
+    report_file.write_text(json.dumps(report, indent=2, sort_keys=True))
+    reward_json.write_text(
+        json.dumps(
+            {
+                "reward": reward,
+                "any_medal": 1.0 if report.get("any_medal") else 0.0,
+                "gold_medal": 1.0 if report.get("gold_medal") else 0.0,
+                "silver_medal": 1.0 if report.get("silver_medal") else 0.0,
+                "bronze_medal": 1.0 if report.get("bronze_medal") else 0.0,
+                "above_median": 1.0 if report.get("above_median") else 0.0,
+                "valid_submission": 1.0 if report.get("valid_submission") else 0.0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--competition-id", required=True)
+    parser.add_argument("--submission", required=True, type=Path)
+    parser.add_argument("--data-dir", required=True, type=Path)
+    parser.add_argument("--reward-file", required=True, type=Path)
+    parser.add_argument("--reward-json", required=True, type=Path)
+    parser.add_argument("--report-file", required=True, type=Path)
+    args = parser.parse_args()
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+    try:
+        from mlebench.grade import grade_csv
+        from mlebench.registry import registry
+
+        competition = registry.set_data_dir(args.data_dir).get_competition(
+            args.competition_id
+        )
+        report = grade_csv(args.submission, competition).to_dict()
+        reward = 1.0 if report.get("any_medal") else 0.0
+    except Exception as exc:
+        report = {
+            "competition_id": args.competition_id,
+            "submission_path": str(args.submission),
+            "submission_exists": args.submission.is_file(),
+            "valid_submission": False,
+            "any_medal": False,
+            "gold_medal": False,
+            "silver_medal": False,
+            "bronze_medal": False,
+            "above_median": False,
+            "error": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        reward = 0.0
+
+    _write_outputs(
+        reward=reward,
+        report=report,
+        reward_file=args.reward_file,
+        reward_json=args.reward_json,
+        report_file=args.report_file,
+    )
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def _write_metadata(task_dir: Path, competition: MLEBenchCompetition) -> None:
+    metadata = {
+        "benchmark": "mle-bench",
+        "upstream_repo": "https://github.com/openai/mle-bench",
+        "competition_id": competition.competition_id,
+        "slug": competition.slug,
+        "name": competition.name,
+        "competition_type": competition.competition_type,
+        "category": competition.category,
+        "complexity": competition.complexity,
+        "dataset_size_gb": competition.dataset_size_gb,
+        "splits": competition.splits,
+        "grader_name": competition.grader_name,
+        "grade_fn": competition.grade_fn,
+        "dataset": competition.dataset,
+        "reward": "1.0 for any medal, otherwise 0.0",
+    }
+    (task_dir / "tests" / "mlebench_task.json").write_text(
+        json.dumps(metadata, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def convert(
+    source_instance: MLEBenchCompetition,
+    output_dir: Path,
+    *,
+    overwrite: bool = False,
+    source_dir: Path | None = None,
+    data_dir: Path | None = None,
+    include_data: bool = True,
+) -> Path:
+    """Convert one MLE-bench competition into one BenchFlow task directory."""
+    if not isinstance(source_instance, MLEBenchCompetition):
+        raise TypeError("source_instance must be an MLEBenchCompetition")
+
+    root = _resolve_source_dir(source_dir)
+    data_root = _resolve_data_dir(data_dir, root)
+    competition = source_instance
+    task_dir = output_dir / competition.slug
+
+    if task_dir.exists():
+        if not overwrite:
+            logger.debug("Skipping existing task %s", task_dir)
+            return task_dir
+        shutil.rmtree(task_dir)
+
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "tests").mkdir()
+
+    _copy_prepared_data(
+        competition,
+        data_dir=data_root,
+        task_dir=task_dir,
+        include_data=include_data,
+    )
+    _copy_mlebench_package(root, task_dir, competition)
+
+    (task_dir / "task.toml").write_text(_render_task_toml(competition), encoding="utf-8")
+    (task_dir / "instruction.md").write_text(_render_instruction(competition), encoding="utf-8")
+    (task_dir / "environment" / "Dockerfile").write_text(_render_dockerfile(), encoding="utf-8")
+    (task_dir / "environment" / "instructions.txt").write_text(
+        _render_environment_instructions(),
+        encoding="utf-8",
+    )
+    validate_sh = task_dir / "environment" / "validate_submission.sh"
+    validate_sh.write_text(_render_validate_submission_sh(), encoding="utf-8")
+    validate_sh.chmod(0o755)
+
+    test_sh = task_dir / "tests" / "test.sh"
+    test_sh.write_text(_render_test_sh(competition), encoding="utf-8")
+    test_sh.chmod(0o755)
+    (task_dir / "tests" / "verify.py").write_text(VERIFY_PY, encoding="utf-8")
+    _write_metadata(task_dir, competition)
+
+    return task_dir
+
+
+def convert_all(
+    source_dir: Path | None,
+    output_dir: Path,
+    *,
+    overwrite: bool = False,
+    limit: int | None = None,
+    task_ids: list[str] | None = None,
+    data_dir: Path | None = None,
+    split: str | None = _DEFAULT_SPLIT,
+    include_data: bool = True,
+) -> list[Path]:
+    """Convert selected MLE-bench competitions into BenchFlow task dirs."""
+    root = _resolve_source_dir(source_dir)
+    competitions = load_competitions(root)
+    selected = _select_competitions(
+        competitions,
+        source_dir=root,
+        split=split,
+        task_ids=task_ids,
+        limit=limit,
+    )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    generated: list[Path] = []
+    for competition in selected:
+        generated.append(
+            convert(
+                competition,
+                output_dir,
+                overwrite=overwrite,
+                source_dir=root,
+                data_dir=data_dir,
+                include_data=include_data,
+            )
+        )
+        logger.info("Generated %s", competition.competition_id)
+
+    logger.info("Generated %d MLE-bench tasks in %s", len(generated), output_dir)
+    return generated
+
+
+def _parse_task_ids(raw: str | None) -> list[str] | None:
+    if not raw:
+        return None
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert OpenAI MLE-bench to BenchFlow.")
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--source-dir", type=Path, default=None)
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        help="Prepared MLE-bench data dir; defaults to MLE_BENCH_DATA_DIR or ~/.cache/mle-bench/data.",
+    )
+    parser.add_argument(
+        "--split",
+        default=_DEFAULT_SPLIT,
+        help="MLE-bench split to convert (default: split75). Use 'all' for every config.",
+    )
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--task-ids", default=None, help="Comma-separated competition IDs or slugs")
+    parser.add_argument(
+        "--metadata-only",
+        action="store_true",
+        help="Do not copy prepared data; generated tasks document structure but are not runnable.",
+    )
+    args = parser.parse_args()
+
+    generated = convert_all(
+        args.source_dir,
+        args.output_dir,
+        overwrite=args.overwrite,
+        limit=args.limit,
+        task_ids=_parse_task_ids(args.task_ids),
+        data_dir=args.data_dir,
+        split=args.split,
+        include_data=not args.metadata_only,
+    )
+    logger.info("Generated %d mle-bench tasks in %s", len(generated), args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mle-bench/benchmark.yaml
+++ b/benchmarks/mle-bench/benchmark.yaml
@@ -9,6 +9,7 @@ converted_by: BenchFlow
 
 tasks:
   count: 75
+  count_note: "Upstream split75 universe; parity evidence below covers the six real-data sample tasks listed under parity.side_by_side.evidence_tasks."
   task_unit: Kaggle competition
   splits:
     split75: 75
@@ -45,6 +46,13 @@ verification:
   aggregation: any_medal
   test_source: "openai/mle-bench grade_csv"
   private_data_agent_visible: false
+  verifier_user: root
+  verifier_design_note: >
+    Converted tasks vendor upstream per-competition grade.py under tests/mlebench
+    and execute it only inside the verifier container with private data mounted
+    under tests/private-data. Agents see environment/data and write
+    /home/submission/submission.csv; they do not control verifier code or
+    private grading data.
   benchflow_runtime_smoke:
     task: spaceship-titanic
     sandbox: docker
@@ -55,7 +63,7 @@ verification:
     reward: 0.0
     verifier_errored: 0
     notes: >
-      Recorded with `bench eval create --agent oracle --sandbox docker`.
+      Recorded with `bench eval run --agent oracle --sandbox docker`.
       Reward 0.0 is expected for the sample submission; the runtime evidence is
       that Docker build/start, oracle execution, and verifier grading completed
       without verifier errors.
@@ -73,7 +81,7 @@ verification:
     tool_calls: 3
     jobs_dir: /tmp/mle-bench-agent-smoke-jobs-codex-gpt54/2026-06-16__08-08-30
     notes: >
-      Recorded with `bench eval create --agent codex --model openai/gpt-5.4-mini
+      Recorded with `bench eval run --agent codex --model openai/gpt-5.4-mini
       --sandbox docker --usage-tracking off`. Reward 0.0 is expected for the
       sample submission; the runtime evidence is that a live ACP agent connected,
       executed tools, produced a valid submission, and the verifier completed.

--- a/benchmarks/mle-bench/benchmark.yaml
+++ b/benchmarks/mle-bench/benchmark.yaml
@@ -1,0 +1,119 @@
+# benchmark.yaml — standard benchmark descriptor for BenchFlow.
+name: mle-bench
+description: "OpenAI MLE-bench — Kaggle-style machine-learning engineering competitions converted one competition per BenchFlow task"
+url: https://github.com/openai/mle-bench
+paper: https://arxiv.org/abs/2410.07095
+repo: https://github.com/openai/mle-bench
+author: OpenAI
+converted_by: BenchFlow
+
+tasks:
+  count: 75
+  task_unit: Kaggle competition
+  splits:
+    split75: 75
+    low: 22
+    medium: 38
+    high: 15
+    dev: 7
+  categories:
+    - audio-classification
+    - image-classification
+    - image-regression
+    - image-segmentation
+    - image-to-image
+    - image-to-text
+    - tabular
+    - text-classification
+    - training-llms
+  tags: [mle-bench, kaggle, machine-learning, data-science]
+
+conversion:
+  script: benchflow.py
+  generator: main.py
+  source_format: "MLE-bench repo: mlebench/competitions/*/config.yaml + prepared data"
+  default_split: split75
+  has_oracle_solutions: false
+  data_requirement: >
+    Requires a local openai/mle-bench checkout and prepared data from
+    `mlebench prepare`. The converter copies prepared public data into
+    environment/data and private grading data into tests/private-data.
+
+verification:
+  method: deterministic_upstream_grader
+  reward: binary_any_medal
+  aggregation: any_medal
+  test_source: "openai/mle-bench grade_csv"
+  private_data_agent_visible: false
+  benchflow_runtime_smoke:
+    task: spaceship-titanic
+    sandbox: docker
+    agent: oracle
+    fixture: "temporary solution/solve.sh copied /home/data/sample_submission.csv to /home/submission/submission.csv"
+    result: verifier-completed
+    valid_submission: 1.0
+    reward: 0.0
+    verifier_errored: 0
+    notes: >
+      Recorded with `bench eval create --agent oracle --sandbox docker`.
+      Reward 0.0 is expected for the sample submission; the runtime evidence is
+      that Docker build/start, oracle execution, and verifier grading completed
+      without verifier errors.
+  live_agent_smoke:
+    task: spaceship-titanic
+    sandbox: docker
+    agent: codex-acp
+    model: openai/gpt-5.4-mini
+    prompt: "copy /home/data/sample_submission.csv to /home/submission/submission.csv"
+    result: verifier-completed
+    valid_submission: 1.0
+    reward: 0.0
+    verifier_errored: 0
+    idle_timeout: 0
+    tool_calls: 3
+    jobs_dir: /tmp/mle-bench-agent-smoke-jobs-codex-gpt54/2026-06-16__08-08-30
+    notes: >
+      Recorded with `bench eval create --agent codex --model openai/gpt-5.4-mini
+      --sandbox docker --usage-tracking off`. Reward 0.0 is expected for the
+      sample submission; the runtime evidence is that a live ACP agent connected,
+      executed tools, produced a valid submission, and the verifier completed.
+
+environment:
+  workdir: /home
+  output_file: /home/submission/submission.csv
+  public_data: /home/data
+  verifier_private_data: /tests/private-data
+  upstream_recommended_runtime_hours: 24
+  upstream_recommended_compute: "36 vCPUs, 440GB RAM, one 24GB A10 GPU"
+  benchflow_default_runtime:
+    cpus: 4
+    memory_mb: 16384
+    storage_mb: 10240
+    allow_internet: false
+
+parity:
+  routing_layer: L2
+  status: parity-confirmed-real-data-sample-6-tasks
+  structural:
+    description: "Generated task package contract, public/private data boundary, and verifier package checks."
+    tasks_tested: 6
+    passed: 6
+  eval_pipeline:
+    description: "Verifier imports upstream grade_csv and maps any_medal to reward.txt."
+    tasks_tested: 6
+    passed: 6
+  side_by_side:
+    harness: "parity_test.py --mode side-by-side"
+    compared_paths: "direct mlebench.grade.grade_csv vs tests/verify.py wrapper"
+    criteria_compared: 48
+    agreed: 48
+    agreement_rate: 1.0
+    reward_max_abs_delta: 0.0
+    evidence_tasks:
+      - aerial-cactus-identification
+      - denoising-dirty-documents
+      - nomad2018-predict-transparent-conductors
+      - random-acts-of-pizza
+      - spaceship-titanic
+      - spooky-author-identification
+    notes: "Recorded on real Kaggle-prepared MLE-bench data using upstream sample submissions."

--- a/benchmarks/mle-bench/main.py
+++ b/benchmarks/mle-bench/main.py
@@ -1,0 +1,13 @@
+"""Run the Mle Bench converter CLI.
+
+Thin delegator so ``python benchmarks/mle-bench/main.py --output-dir ...`` keeps
+working while ``benchflow.py`` stays the single source of truth.
+"""
+
+from __future__ import annotations
+
+import runpy
+from pathlib import Path
+
+if __name__ == "__main__":
+    runpy.run_path(str(Path(__file__).with_name("benchflow.py")), run_name="__main__")

--- a/benchmarks/mle-bench/mle-bench.yaml
+++ b/benchmarks/mle-bench/mle-bench.yaml
@@ -1,0 +1,8 @@
+# BenchFlow job config — how to *run* Mle Bench (separate from benchmark.yaml).
+tasks_dir: benchmarks/mle-bench/tasks
+jobs_dir: jobs/mle-bench
+agent: claude-agent-acp
+model: ""
+environment: docker
+concurrency: 4
+max_retries: 1

--- a/benchmarks/mle-bench/parity_experiment.json
+++ b/benchmarks/mle-bench/parity_experiment.json
@@ -1,0 +1,392 @@
+{
+  "benchmark": "mle-bench",
+  "conversion_parity": {
+    "description": "Direct upstream grade_csv vs converted BenchFlow verifier on identical CSV submissions.",
+    "tasks": [
+      {
+        "criteria_results": [
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "submission_exists",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "valid_submission",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "any_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "gold_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "silver_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "bronze_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "above_median",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "0.5",
+            "agreement": true,
+            "criterion_id": "score",
+            "original_verdict": "0.5"
+          }
+        ],
+        "n_criteria": 8,
+        "submission": "/tmp/mle-bench-real-tasks/aerial-cactus-identification/environment/data/sample_submission.csv",
+        "task_id": "aerial-cactus-identification"
+      },
+      {
+        "criteria_results": [
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "submission_exists",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "valid_submission",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "any_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "gold_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "silver_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "bronze_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "above_median",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "0.28616",
+            "agreement": true,
+            "criterion_id": "score",
+            "original_verdict": "0.28616"
+          }
+        ],
+        "n_criteria": 8,
+        "submission": "/tmp/mle-bench-real-tasks/denoising-dirty-documents/environment/data/sampleSubmission.csv",
+        "task_id": "denoising-dirty-documents"
+      },
+      {
+        "criteria_results": [
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "submission_exists",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "valid_submission",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "any_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "gold_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "silver_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "bronze_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "above_median",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "0.21174",
+            "agreement": true,
+            "criterion_id": "score",
+            "original_verdict": "0.21174"
+          }
+        ],
+        "n_criteria": 8,
+        "submission": "/tmp/mle-bench-real-tasks/nomad2018-predict-transparent-conductors/environment/data/sample_submission.csv",
+        "task_id": "nomad2018-predict-transparent-conductors"
+      },
+      {
+        "criteria_results": [
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "submission_exists",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "valid_submission",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "any_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "gold_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "silver_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "bronze_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "above_median",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "0.5",
+            "agreement": true,
+            "criterion_id": "score",
+            "original_verdict": "0.5"
+          }
+        ],
+        "n_criteria": 8,
+        "submission": "/tmp/mle-bench-real-tasks/random-acts-of-pizza/environment/data/sampleSubmission.csv",
+        "task_id": "random-acts-of-pizza"
+      },
+      {
+        "criteria_results": [
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "submission_exists",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "valid_submission",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "any_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "gold_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "silver_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "bronze_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "above_median",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "0.50345",
+            "agreement": true,
+            "criterion_id": "score",
+            "original_verdict": "0.50345"
+          }
+        ],
+        "n_criteria": 8,
+        "submission": "/tmp/mle-bench-real-tasks/spaceship-titanic/environment/data/sample_submission.csv",
+        "task_id": "spaceship-titanic"
+      },
+      {
+        "criteria_results": [
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "submission_exists",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "True",
+            "agreement": true,
+            "criterion_id": "valid_submission",
+            "original_verdict": "True"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "any_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "gold_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "silver_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "bronze_medal",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "False",
+            "agreement": true,
+            "criterion_id": "above_median",
+            "original_verdict": "False"
+          },
+          {
+            "adapted_verdict": "1.08468",
+            "agreement": true,
+            "criterion_id": "score",
+            "original_verdict": "1.08468"
+          }
+        ],
+        "n_criteria": 8,
+        "submission": "/tmp/mle-bench-real-tasks/spooky-author-identification/environment/data/sample_submission.csv",
+        "task_id": "spooky-author-identification"
+      }
+    ]
+  },
+  "eval_parity": {
+    "failed": 0,
+    "issues": [],
+    "passed": 6,
+    "tasks_tested": 6
+  },
+  "reward_distribution_parity": {
+    "description": "Reward is 1.0 for any_medal and 0.0 otherwise.",
+    "samples": [
+      {
+        "converted_reward": 0.0,
+        "legacy_reward": 0.0,
+        "reward_delta": 0.0,
+        "task_id": "aerial-cactus-identification"
+      },
+      {
+        "converted_reward": 0.0,
+        "legacy_reward": 0.0,
+        "reward_delta": 0.0,
+        "task_id": "denoising-dirty-documents"
+      },
+      {
+        "converted_reward": 0.0,
+        "legacy_reward": 0.0,
+        "reward_delta": 0.0,
+        "task_id": "nomad2018-predict-transparent-conductors"
+      },
+      {
+        "converted_reward": 0.0,
+        "legacy_reward": 0.0,
+        "reward_delta": 0.0,
+        "task_id": "random-acts-of-pizza"
+      },
+      {
+        "converted_reward": 0.0,
+        "legacy_reward": 0.0,
+        "reward_delta": 0.0,
+        "task_id": "spaceship-titanic"
+      },
+      {
+        "converted_reward": 0.0,
+        "legacy_reward": 0.0,
+        "reward_delta": 0.0,
+        "task_id": "spooky-author-identification"
+      }
+    ]
+  },
+  "side_by_side_status": "recorded",
+  "structural_parity": {
+    "failed": 0,
+    "issues": [],
+    "passed": 6,
+    "tasks_tested": 6
+  }
+}

--- a/benchmarks/mle-bench/parity_test.py
+++ b/benchmarks/mle-bench/parity_test.py
@@ -1,0 +1,513 @@
+"""Parity helpers for the MLE-bench -> BenchFlow conversion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+_HERE = Path(__file__).resolve().parent
+PARITY_EXPERIMENT = _HERE / "parity_experiment.json"
+
+_REQUIRED_FILES = (
+    "task.toml",
+    "instruction.md",
+    "environment/Dockerfile",
+    "environment/instructions.txt",
+    "environment/validate_submission.sh",
+    "tests/test.sh",
+    "tests/verify.py",
+    "tests/mlebench_task.json",
+)
+
+
+def _task_dirs(tasks_dir: Path) -> list[Path]:
+    if not tasks_dir.is_dir():
+        return []
+    return sorted(path for path in tasks_dir.iterdir() if path.is_dir())
+
+
+def _summary(name: str, tasks_tested: int, issues: list[dict]) -> dict:
+    passed = tasks_tested - len({issue["task_id"] for issue in issues})
+    return {
+        name: {
+            "tasks_tested": tasks_tested,
+            "passed": passed,
+            "failed": tasks_tested - passed,
+            "issues": issues,
+        }
+    }
+
+
+def structural_parity(tasks_dir: Path) -> dict:
+    """Check generated tasks preserve the expected BenchFlow file contract."""
+    issues: list[dict] = []
+    tasks = _task_dirs(tasks_dir)
+
+    for task_dir in tasks:
+        for rel in _REQUIRED_FILES:
+            if not (task_dir / rel).is_file():
+                issues.append(
+                    {
+                        "task_id": task_dir.name,
+                        "path": rel,
+                        "issue": "missing required file",
+                    }
+                )
+
+        metadata_path = task_dir / "tests" / "mlebench_task.json"
+        if metadata_path.is_file():
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            if metadata.get("slug") != task_dir.name:
+                issues.append(
+                    {
+                        "task_id": task_dir.name,
+                        "path": "tests/mlebench_task.json",
+                        "issue": "metadata slug does not match task directory",
+                    }
+                )
+
+        if (task_dir / "environment" / "private-data").exists():
+            issues.append(
+                {
+                    "task_id": task_dir.name,
+                    "path": "environment/private-data",
+                    "issue": "private grading data must not be agent-visible",
+                }
+            )
+
+    return {
+        "benchmark": "mle-bench",
+        **_summary("structural_parity", len(tasks), issues),
+    }
+
+
+def eval_parity(tasks_dir: Path) -> dict:
+    """Check the verifier-side files needed for upstream grading are present."""
+    issues: list[dict] = []
+    tasks = _task_dirs(tasks_dir)
+
+    for task_dir in tasks:
+        private_data = task_dir / "tests" / "private-data"
+        mlebench_pkg = task_dir / "tests" / "mlebench"
+        verify_py = task_dir / "tests" / "verify.py"
+        if not private_data.exists():
+            issues.append(
+                {
+                    "task_id": task_dir.name,
+                    "path": "tests/private-data",
+                    "issue": "missing verifier-only prepared private data",
+                }
+            )
+        if not (mlebench_pkg / "grade.py").is_file():
+            issues.append(
+                {
+                    "task_id": task_dir.name,
+                    "path": "tests/mlebench/grade.py",
+                    "issue": "missing upstream grading module",
+                }
+            )
+        if verify_py.is_file():
+            content = verify_py.read_text(encoding="utf-8")
+            if "grade_csv" not in content or "any_medal" not in content:
+                issues.append(
+                    {
+                        "task_id": task_dir.name,
+                        "path": "tests/verify.py",
+                        "issue": "verifier does not call upstream grade_csv any-medal path",
+                    }
+                )
+
+    return {
+        "benchmark": "mle-bench",
+        **_summary("eval_parity", len(tasks), issues),
+    }
+
+
+def _load_metadata(task_dir: Path) -> dict[str, Any]:
+    path = task_dir / "tests" / "mlebench_task.json"
+    if not path.is_file():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _candidate_submission_paths(
+    task_dir: Path,
+    metadata: dict[str, Any],
+    submissions_dir: Path | None,
+) -> list[Path]:
+    competition_id = str(metadata.get("competition_id") or task_dir.name)
+    slug = str(metadata.get("slug") or task_dir.name)
+    candidates: list[Path] = []
+    if submissions_dir is not None:
+        candidates.extend(
+            [
+                submissions_dir / f"{competition_id}.csv",
+                submissions_dir / f"{slug}.csv",
+                submissions_dir / competition_id / "submission.csv",
+                submissions_dir / slug / "submission.csv",
+            ]
+        )
+    dataset = metadata.get("dataset")
+    if isinstance(dataset, dict):
+        sample_submission = dataset.get("sample_submission")
+        if sample_submission:
+            candidates.append(
+                task_dir / "environment" / "data" / Path(str(sample_submission)).name
+            )
+    candidates.extend(
+        [
+            task_dir / "environment" / "data" / "sample_submission.csv",
+            task_dir / "environment" / "data" / "sampleSubmission.csv",
+        ]
+    )
+    unique_candidates: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate not in seen:
+            unique_candidates.append(candidate)
+            seen.add(candidate)
+    return unique_candidates
+
+
+def _find_submission(
+    task_dir: Path,
+    metadata: dict[str, Any],
+    submissions_dir: Path | None,
+) -> Path | None:
+    for candidate in _candidate_submission_paths(task_dir, metadata, submissions_dir):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _run_json_subprocess(code: str, args: list[str], *, cwd: Path) -> dict[str, Any]:
+    proc = subprocess.run(
+        [sys.executable, "-c", code, *args],
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "error": (proc.stderr or proc.stdout).strip()[-4000:],
+        }
+    try:
+        return {"ok": True, "report": json.loads(proc.stdout)}
+    except json.JSONDecodeError as exc:
+        return {
+            "ok": False,
+            "error": f"could not parse JSON from subprocess: {exc}; stdout={proc.stdout[-1000:]}",
+        }
+
+
+def _run_original_grade(
+    task_dir: Path,
+    *,
+    competition_id: str,
+    submission: Path,
+) -> dict[str, Any]:
+    code = r"""
+import json
+import sys
+from pathlib import Path
+
+tests_dir = Path(sys.argv[1])
+competition_id = sys.argv[2]
+submission = Path(sys.argv[3])
+data_dir = tests_dir / "private-data"
+sys.path.insert(0, str(tests_dir))
+
+from mlebench.grade import grade_csv
+from mlebench.registry import registry
+
+competition = registry.set_data_dir(data_dir).get_competition(competition_id)
+print(json.dumps(grade_csv(submission, competition).to_dict(), sort_keys=True))
+"""
+    return _run_json_subprocess(
+        code,
+        [str(task_dir / "tests"), competition_id, str(submission)],
+        cwd=task_dir,
+    )
+
+
+def _run_converted_verifier(
+    task_dir: Path,
+    *,
+    competition_id: str,
+    submission: Path,
+) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="mle-bench-parity-") as tmp:
+        tmp_path = Path(tmp)
+        reward_file = tmp_path / "reward.txt"
+        reward_json = tmp_path / "reward.json"
+        report_file = tmp_path / "grading_report.json"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(task_dir / "tests" / "verify.py"),
+                "--competition-id",
+                competition_id,
+                "--submission",
+                str(submission),
+                "--data-dir",
+                str(task_dir / "tests" / "private-data"),
+                "--reward-file",
+                str(reward_file),
+                "--reward-json",
+                str(reward_json),
+                "--report-file",
+                str(report_file),
+            ],
+            cwd=str(task_dir),
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        if proc.returncode != 0:
+            return {
+                "ok": False,
+                "error": (proc.stderr or proc.stdout).strip()[-4000:],
+            }
+        if not report_file.is_file() or not reward_file.is_file():
+            return {"ok": False, "error": "converted verifier produced no report/reward"}
+        try:
+            return {
+                "ok": True,
+                "report": json.loads(report_file.read_text(encoding="utf-8")),
+                "reward": float(reward_file.read_text(encoding="utf-8")),
+            }
+        except (ValueError, json.JSONDecodeError) as exc:
+            return {"ok": False, "error": f"converted output parse error: {exc}"}
+
+
+def _verdict(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, float):
+        if math.isnan(value):
+            return "nan"
+        return f"{value:.10g}"
+    return str(value)
+
+
+def _criteria_for_reports(
+    original: dict[str, Any],
+    converted: dict[str, Any],
+) -> list[dict[str, Any]]:
+    criteria: list[dict[str, Any]] = []
+    for field in (
+        "submission_exists",
+        "valid_submission",
+        "any_medal",
+        "gold_medal",
+        "silver_medal",
+        "bronze_medal",
+        "above_median",
+        "score",
+    ):
+        original_value = original.get(field)
+        converted_value = converted.get(field)
+        if isinstance(original_value, (float, int)) and isinstance(converted_value, (float, int)):
+            agreement = math.isclose(float(original_value), float(converted_value), abs_tol=1e-9)
+        else:
+            agreement = original_value == converted_value
+        criteria.append(
+            {
+                "criterion_id": field,
+                "original_verdict": _verdict(original_value),
+                "adapted_verdict": _verdict(converted_value),
+                "agreement": agreement,
+            }
+        )
+    return criteria
+
+
+def _reward_from_report(report: dict[str, Any]) -> float:
+    return 1.0 if report.get("any_medal") else 0.0
+
+
+def side_by_side_parity(
+    tasks_dir: Path,
+    *,
+    submissions_dir: Path | None = None,
+    limit: int | None = None,
+) -> dict:
+    """Run direct grade_csv and the converted verifier on identical submissions.
+
+    By default this uses each task's copied sample submission. For a stronger
+    parity run, pass ``--submissions-dir`` with paired agent/oracle
+    submissions named ``<competition-id>.csv`` or ``<slug>.csv``.
+    """
+    tasks = _task_dirs(tasks_dir)
+    if limit is not None:
+        tasks = tasks[:limit]
+
+    parity_tasks: list[dict[str, Any]] = []
+    reward_samples: list[dict[str, Any]] = []
+    skipped: list[dict[str, str]] = []
+
+    for task_dir in tasks:
+        metadata = _load_metadata(task_dir)
+        competition_id = str(metadata.get("competition_id") or task_dir.name)
+        submission = _find_submission(task_dir, metadata, submissions_dir)
+        private_data = task_dir / "tests" / "private-data"
+        if submission is None:
+            skipped.append(
+                {
+                    "task_id": task_dir.name,
+                    "reason": "no submission found",
+                }
+            )
+            continue
+        if not private_data.exists():
+            skipped.append(
+                {
+                    "task_id": task_dir.name,
+                    "reason": "missing tests/private-data",
+                }
+            )
+            continue
+
+        original = _run_original_grade(
+            task_dir,
+            competition_id=competition_id,
+            submission=submission,
+        )
+        converted = _run_converted_verifier(
+            task_dir,
+            competition_id=competition_id,
+            submission=submission,
+        )
+        if not original.get("ok") or not converted.get("ok"):
+            parity_tasks.append(
+                {
+                    "task_id": task_dir.name,
+                    "n_criteria": 1,
+                    "criteria_results": [
+                        {
+                            "criterion_id": "grader-execution",
+                            "original_verdict": original.get("error", "ok"),
+                            "adapted_verdict": converted.get("error", "ok"),
+                            "agreement": False,
+                        }
+                    ],
+                }
+            )
+            continue
+
+        original_report = original["report"]
+        converted_report = converted["report"]
+        criteria = _criteria_for_reports(original_report, converted_report)
+        parity_tasks.append(
+            {
+                "task_id": task_dir.name,
+                "submission": str(submission),
+                "n_criteria": len(criteria),
+                "criteria_results": criteria,
+            }
+        )
+
+        legacy_reward = _reward_from_report(original_report)
+        converted_reward = float(converted["reward"])
+        reward_samples.append(
+            {
+                "task_id": task_dir.name,
+                "legacy_reward": legacy_reward,
+                "converted_reward": converted_reward,
+                "reward_delta": abs(converted_reward - legacy_reward),
+            }
+        )
+
+    status = "recorded" if parity_tasks or reward_samples else "insufficient-evidence"
+    return {
+        "experiment": "side-by-side-parity",
+        "benchmark": "mle-bench",
+        "status": status,
+        "tasks_dir": str(tasks_dir),
+        "conversion_parity": {
+            "description": "Direct upstream grade_csv vs converted BenchFlow verifier on identical CSV submissions.",
+            "tasks": parity_tasks,
+        },
+        "reward_distribution_parity": {
+            "description": "Reward is 1.0 for any_medal and 0.0 otherwise.",
+            "samples": reward_samples,
+        },
+        "skipped": skipped,
+    }
+
+
+def full_parity(
+    tasks_dir: Path,
+    *,
+    submissions_dir: Path | None = None,
+    limit: int | None = None,
+) -> dict:
+    structural = structural_parity(tasks_dir)["structural_parity"]
+    eval_result = eval_parity(tasks_dir)["eval_parity"]
+    side_by_side = side_by_side_parity(
+        tasks_dir,
+        submissions_dir=submissions_dir,
+        limit=limit,
+    )
+    return {
+        "benchmark": "mle-bench",
+        "structural_parity": structural,
+        "eval_parity": eval_result,
+        "side_by_side_status": side_by_side.get("status", "recorded"),
+        "conversion_parity": side_by_side.get("conversion_parity", {"tasks": []}),
+        "reward_distribution_parity": side_by_side.get(
+            "reward_distribution_parity",
+            {"samples": []},
+        ),
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="MLE-bench parity checks")
+    parser.add_argument(
+        "--mode",
+        choices=["full", "eval-parity", "side-by-side"],
+        default="full",
+    )
+    parser.add_argument("--tasks-dir", type=Path, default=_HERE / "tasks")
+    parser.add_argument("--submissions-dir", type=Path, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument(
+        "--record",
+        action="store_true",
+        help="Write the parity payload to parity_experiment.json.",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "eval-parity":
+        result = eval_parity(args.tasks_dir)
+    elif args.mode == "side-by-side":
+        result = side_by_side_parity(
+            args.tasks_dir,
+            submissions_dir=args.submissions_dir,
+            limit=args.limit,
+        )
+    else:
+        result = full_parity(
+            args.tasks_dir,
+            submissions_dir=args.submissions_dir,
+            limit=args.limit,
+        )
+    if args.record and args.mode in {"full", "side-by-side"}:
+        PARITY_EXPERIMENT.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/mle-bench/parity_test.py
+++ b/benchmarks/mle-bench/parity_test.py
@@ -277,7 +277,10 @@ def _run_converted_verifier(
                 "error": (proc.stderr or proc.stdout).strip()[-4000:],
             }
         if not report_file.is_file() or not reward_file.is_file():
-            return {"ok": False, "error": "converted verifier produced no report/reward"}
+            return {
+                "ok": False,
+                "error": "converted verifier produced no report/reward",
+            }
         try:
             return {
                 "ok": True,
@@ -315,8 +318,12 @@ def _criteria_for_reports(
     ):
         original_value = original.get(field)
         converted_value = converted.get(field)
-        if isinstance(original_value, (float, int)) and isinstance(converted_value, (float, int)):
-            agreement = math.isclose(float(original_value), float(converted_value), abs_tol=1e-9)
+        if isinstance(original_value, (float, int)) and isinstance(
+            converted_value, (float, int)
+        ):
+            agreement = math.isclose(
+                float(original_value), float(converted_value), abs_tol=1e-9
+            )
         else:
             agreement = original_value == converted_value
         criteria.append(

--- a/benchmarks/mle-bench/run_mle_bench.py
+++ b/benchmarks/mle-bench/run_mle_bench.py
@@ -25,6 +25,20 @@ def _load_converter():
     return module
 
 
+def _normalize_task_ids(raw: list[str] | None) -> list[str] | None:
+    """Accept both space-separated and comma-separated ``--task-ids`` values.
+
+    The converter CLI and the README document the comma-separated form
+    (``--task-ids a,b``); splitting here keeps that idiom working when the
+    runner collects values via ``nargs="*"`` instead of silently treating
+    ``"a,b"`` as one unmatched id.
+    """
+    if not raw:
+        return None
+    ids = [tid.strip() for token in raw for tid in token.split(",") if tid.strip()]
+    return ids or None
+
+
 def ensure_converted_tasks(args: argparse.Namespace) -> Path:
     """Convert the source benchmark into BenchFlow tasks under ``tasks/``."""
     converter = _load_converter()
@@ -34,7 +48,7 @@ def ensure_converted_tasks(args: argparse.Namespace) -> Path:
         output_dir,
         overwrite=args.overwrite,
         limit=args.limit,
-        task_ids=args.task_ids,
+        task_ids=_normalize_task_ids(args.task_ids),
         data_dir=args.data_dir,
         split=args.split,
         include_data=not args.metadata_only,

--- a/benchmarks/mle-bench/run_mle_bench.py
+++ b/benchmarks/mle-bench/run_mle_bench.py
@@ -6,7 +6,10 @@ import argparse
 import asyncio
 import importlib.util
 import sys
+import tempfile
 from pathlib import Path
+
+import yaml
 
 _HERE = Path(__file__).resolve().parent
 
@@ -43,9 +46,14 @@ async def run(args: argparse.Namespace) -> None:
     from benchflow.evaluation import Evaluation
 
     tasks_dir = ensure_converted_tasks(args)
-    job = Evaluation.from_yaml(str(_HERE / "mle-bench.yaml"))
-    job._tasks_dir = tasks_dir  # type: ignore[attr-defined]
-    result = await job.run()
+    config = yaml.safe_load((_HERE / "mle-bench.yaml").read_text(encoding="utf-8"))
+    if not isinstance(config, dict):
+        raise ValueError("mle-bench.yaml must contain a YAML mapping")
+    config["tasks_dir"] = str(tasks_dir)
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml", encoding="utf-8") as handle:
+        yaml.safe_dump(config, handle, sort_keys=False)
+        handle.flush()
+        result = await Evaluation.from_yaml(handle.name).run()
     print(f"Score: {result.passed}/{result.total} ({result.score:.1%})")
 
 

--- a/benchmarks/mle-bench/run_mle_bench.py
+++ b/benchmarks/mle-bench/run_mle_bench.py
@@ -1,0 +1,67 @@
+"""Convert MLE-bench tasks if needed, then run them through BenchFlow."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _load_converter():
+    spec = importlib.util.spec_from_file_location(
+        "benchflow_mle_bench_converter", _HERE / "benchflow.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def ensure_converted_tasks(args: argparse.Namespace) -> Path:
+    """Convert the source benchmark into BenchFlow tasks under ``tasks/``."""
+    converter = _load_converter()
+    output_dir = args.output_dir or (_HERE / "tasks")
+    converter.convert_all(
+        args.source_dir,
+        output_dir,
+        overwrite=args.overwrite,
+        limit=args.limit,
+        task_ids=args.task_ids,
+        data_dir=args.data_dir,
+        split=args.split,
+        include_data=not args.metadata_only,
+    )
+    return output_dir
+
+
+async def run(args: argparse.Namespace) -> None:
+    from benchflow.evaluation import Evaluation
+
+    tasks_dir = ensure_converted_tasks(args)
+    job = Evaluation.from_yaml(str(_HERE / "mle-bench.yaml"))
+    job._tasks_dir = tasks_dir  # type: ignore[attr-defined]
+    result = await job.run()
+    print(f"Score: {result.passed}/{result.total} ({result.score:.1%})")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run MLE-bench via BenchFlow.")
+    parser.add_argument("--source-dir", type=Path, default=None)
+    parser.add_argument("--data-dir", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--split", default="split75")
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--task-ids", nargs="*", default=None)
+    parser.add_argument("--metadata-only", action="store_true")
+    args = parser.parse_args()
+    asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_adapter_scripts.py
+++ b/tests/test_adapter_scripts.py
@@ -56,6 +56,21 @@ def test_opaquetoolsbench_run_script_help_works():
     assert "Run OpaqueToolsBench via BenchFlow" in result.stdout
 
 
+def test_mle_bench_run_script_help_works():
+    """Guards MLE-bench run script invokability by path."""
+    repo = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        [sys.executable, "benchmarks/mle-bench/run_mle_bench.py", "--help"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Run MLE-bench via BenchFlow" in result.stdout
+
+
 def test_opaquetoolsbench_converter_emits_oracle_solution(tmp_path):
     """Guards ENG-101: converted tasks can run with oracle evidence."""
     repo = Path(__file__).resolve().parents[1]
@@ -129,6 +144,7 @@ _BENCHMARKS_WITH_DESCRIPTOR_CLI = [
     "harvey-lab",
     "hilbench",
     "continuallearningbench",
+    "mle-bench",
 ]
 
 

--- a/tests/test_mle_bench_adapter.py
+++ b/tests/test_mle_bench_adapter.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+from benchflow.task.config import TaskConfig
+
+
+def _load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_converter():
+    return _load_module(
+        Path("benchmarks/mle-bench/benchflow.py").resolve(),
+        "mle_bench_converter_under_test",
+    )
+
+
+def _load_parity():
+    return _load_module(
+        Path("benchmarks/mle-bench/parity_test.py").resolve(),
+        "mle_bench_parity_under_test",
+    )
+
+
+def _write_fake_source(tmp_path: Path) -> tuple[Path, Path]:
+    source = tmp_path / "mle-bench"
+    data = tmp_path / "mle-data"
+    comp_id = "Fake-Kaggle"
+    comp_dir = source / "mlebench" / "competitions" / comp_id
+    comp_dir.mkdir(parents=True)
+    (source / "mlebench" / "__init__.py").write_text("")
+    (source / "mlebench" / "utils.py").write_text(
+        """
+import importlib
+import logging
+from pathlib import Path
+
+import pandas as pd
+import yaml
+
+
+def get_logger(name):
+    return logging.getLogger(name)
+
+
+def get_module_dir():
+    return Path(__file__).parent.resolve()
+
+
+def get_repo_dir():
+    return get_module_dir().parent
+
+
+def import_fn(import_string):
+    module_name, fn_name = import_string.split(":")
+    module = importlib.import_module(module_name)
+    return getattr(module, fn_name)
+
+
+def load_yaml(path):
+    return yaml.safe_load(Path(path).read_text())
+
+
+def read_csv(path, **kwargs):
+    return pd.read_csv(path, **kwargs)
+
+
+def load_answers(path):
+    return read_csv(path)
+""".lstrip()
+    )
+    (source / "mlebench" / "grade_helpers.py").write_text(
+        """
+from dataclasses import dataclass
+from datetime import datetime
+
+from mlebench.utils import import_fn
+
+
+class InvalidSubmissionError(Exception):
+    pass
+
+
+class Grader:
+    def __init__(self, name, grade_fn):
+        self.name = name
+        self.grade_fn = import_fn(grade_fn)
+
+    @staticmethod
+    def from_dict(data):
+        return Grader(**data)
+
+    def __call__(self, submission, answers):
+        return round(float(self.grade_fn(submission, answers)), 5)
+
+    def rank_score(self, score, leaderboard):
+        return {
+            "gold_threshold": 0.5,
+            "silver_threshold": 0.5,
+            "bronze_threshold": 0.5,
+            "median_threshold": 0.5,
+            "gold_medal": bool(score is not None and score >= 0.5),
+            "silver_medal": False,
+            "bronze_medal": False,
+            "above_median": bool(score is not None and score >= 0.5),
+        }
+
+    def is_lower_better(self, leaderboard):
+        return False
+
+
+@dataclass(frozen=True)
+class CompetitionReport:
+    competition_id: str
+    score: float | None
+    gold_threshold: float
+    silver_threshold: float
+    bronze_threshold: float
+    median_threshold: float
+    any_medal: bool
+    gold_medal: bool
+    silver_medal: bool
+    bronze_medal: bool
+    above_median: bool
+    submission_exists: bool
+    valid_submission: bool
+    is_lower_better: bool
+    created_at: datetime
+    submission_path: str
+
+    def to_dict(self):
+        return {
+            "competition_id": self.competition_id,
+            "score": self.score,
+            "gold_threshold": self.gold_threshold,
+            "silver_threshold": self.silver_threshold,
+            "bronze_threshold": self.bronze_threshold,
+            "median_threshold": self.median_threshold,
+            "any_medal": self.any_medal,
+            "gold_medal": self.gold_medal,
+            "silver_medal": self.silver_medal,
+            "bronze_medal": self.bronze_medal,
+            "above_median": self.above_median,
+            "submission_exists": self.submission_exists,
+            "valid_submission": self.valid_submission,
+            "is_lower_better": self.is_lower_better,
+            "created_at": self.created_at.isoformat(),
+            "submission_path": self.submission_path,
+        }
+""".lstrip()
+    )
+    (source / "mlebench" / "registry.py").write_text(
+        """
+from dataclasses import dataclass
+from pathlib import Path
+
+from mlebench.grade_helpers import Grader
+from mlebench.utils import get_module_dir, get_repo_dir, load_yaml
+
+
+@dataclass(frozen=True)
+class Competition:
+    id: str
+    name: str
+    description: str
+    grader: Grader
+    answers: Path
+    sample_submission: Path
+    leaderboard: Path
+
+
+class Registry:
+    def __init__(self, data_dir=Path(".")):
+        self._data_dir = Path(data_dir)
+
+    def set_data_dir(self, new_data_dir):
+        return Registry(Path(new_data_dir))
+
+    def get_competitions_dir(self):
+        return get_module_dir() / "competitions"
+
+    def get_competition(self, competition_id):
+        config_path = self.get_competitions_dir() / competition_id / "config.yaml"
+        config = load_yaml(config_path)
+        description = (get_repo_dir() / config["description"]).read_text()
+        dataset = config["dataset"]
+        return Competition(
+            id=config["id"],
+            name=config["name"],
+            description=description,
+            grader=Grader.from_dict(config["grader"]),
+            answers=self._data_dir / dataset["answers"],
+            sample_submission=self._data_dir / dataset["sample_submission"],
+            leaderboard=self.get_competitions_dir() / competition_id / "leaderboard.csv",
+        )
+
+
+registry = Registry()
+""".lstrip()
+    )
+    (source / "mlebench" / "grade.py").write_text(
+        """
+from datetime import datetime
+from pathlib import Path
+
+from mlebench.grade_helpers import CompetitionReport
+from mlebench.utils import load_answers, read_csv
+
+
+def grade_csv(path_to_submission, competition):
+    submission_path = Path(path_to_submission)
+    submission_exists = submission_path.is_file() and submission_path.suffix == ".csv"
+    score = None
+    if submission_exists:
+        score = competition.grader(read_csv(submission_path), load_answers(competition.answers))
+    rank_info = competition.grader.rank_score(score, read_csv(competition.leaderboard))
+    return CompetitionReport(
+        competition_id=competition.id,
+        score=score,
+        gold_threshold=rank_info["gold_threshold"],
+        silver_threshold=rank_info["silver_threshold"],
+        bronze_threshold=rank_info["bronze_threshold"],
+        median_threshold=rank_info["median_threshold"],
+        any_medal=rank_info["gold_medal"] or rank_info["silver_medal"] or rank_info["bronze_medal"],
+        gold_medal=rank_info["gold_medal"],
+        silver_medal=rank_info["silver_medal"],
+        bronze_medal=rank_info["bronze_medal"],
+        above_median=rank_info["above_median"],
+        submission_exists=submission_exists,
+        valid_submission=score is not None,
+        is_lower_better=False,
+        created_at=datetime.now(),
+        submission_path=str(submission_path),
+    )
+""".lstrip()
+    )
+    for filename in ("data.py", "metrics.py"):
+        (source / "mlebench" / filename).write_text("# fake mlebench core\n")
+    (source / "mlebench" / "competitions" / "__init__.py").write_text("")
+    (source / "mlebench" / "competitions" / "utils.py").write_text("")
+    (comp_dir / "description.md").write_text("Predict the fake label.\n")
+    (comp_dir / "grade.py").write_text("def grade(submission, answers):\n    return 1.0\n")
+    (comp_dir / "leaderboard.csv").write_text("team,score\nwinner,1.0\n")
+    (comp_dir / "config.yaml").write_text(
+        """
+id: Fake-Kaggle
+name: Fake Kaggle
+competition_type: simple
+description: mlebench/competitions/Fake-Kaggle/description.md
+dataset:
+  answers: Fake-Kaggle/prepared/private/test.csv
+  sample_submission: Fake-Kaggle/prepared/public/sampleSubmission.csv
+grader:
+  name: accuracy
+  grade_fn: mlebench.competitions.Fake-Kaggle.grade:grade
+preparer: mlebench.competitions.Fake-Kaggle.prepare:prepare
+""".lstrip()
+    )
+
+    splits = source / "experiments" / "splits"
+    splits.mkdir(parents=True)
+    (splits / "split75.txt").write_text(f"{comp_id}\n")
+    (splits / "low.txt").write_text(f"{comp_id}\n")
+    (source / "experiments" / "competition_categories.csv").write_text(
+        "competition_id,category,dataset_size_GB,EnabledDate,DeadlineDate,Complexity\n"
+        "Fake-Kaggle,Tabular,0.001,1/1/2024,1/2/2024,Low\n"
+    )
+
+    public = data / comp_id / "prepared" / "public"
+    private = data / comp_id / "prepared" / "private"
+    public.mkdir(parents=True)
+    private.mkdir(parents=True)
+    (public / "train.csv").write_text("id,label\n1,0\n")
+    (public / "sampleSubmission.csv").write_text("id,label\n2,0\n")
+    (private / "test.csv").write_text("id,label\n2,1\n")
+    return source, data
+
+
+def test_mle_bench_converter_keeps_private_data_out_of_environment(tmp_path: Path):
+    converter = _load_converter()
+    source, data = _write_fake_source(tmp_path)
+
+    generated = converter.convert_all(
+        source,
+        tmp_path / "out",
+        data_dir=data,
+        split="split75",
+        overwrite=True,
+    )
+
+    assert len(generated) == 1
+    task_dir = generated[0]
+    assert task_dir.name == "fake-kaggle"
+    assert (task_dir / "environment" / "data" / "train.csv").is_file()
+    assert (task_dir / "environment" / "data" / "sample_submission.csv").is_file()
+    assert (task_dir / "environment" / "data" / "sampleSubmission.csv").is_file()
+    assert not (task_dir / "environment" / "private-data").exists()
+    assert (
+        task_dir / "tests" / "private-data" / "Fake-Kaggle" / "prepared" / "private" / "test.csv"
+    ).is_file()
+
+    metadata = json.loads((task_dir / "tests" / "mlebench_task.json").read_text())
+    assert metadata["competition_id"] == "Fake-Kaggle"
+    assert metadata["slug"] == "fake-kaggle"
+    assert metadata["reward"] == "1.0 for any medal, otherwise 0.0"
+
+    config = TaskConfig.model_validate_toml((task_dir / "task.toml").read_text())
+    assert config.task is not None
+    assert config.task.name == "mle-bench/fake-kaggle"
+    assert config.environment.allow_internet is False
+
+    dockerfile = (task_dir / "environment" / "Dockerfile").read_text()
+    assert 'CMD ["sleep", "infinity"]' in dockerfile
+
+
+def test_mle_bench_converter_accepts_sanitized_task_ids(tmp_path: Path):
+    converter = _load_converter()
+    source, data = _write_fake_source(tmp_path)
+
+    generated = converter.convert_all(
+        source,
+        tmp_path / "out",
+        data_dir=data,
+        task_ids=["fake-kaggle"],
+        overwrite=True,
+    )
+
+    assert [path.name for path in generated] == ["fake-kaggle"]
+
+
+def test_mle_bench_parity_checks_generated_subset(tmp_path: Path):
+    converter = _load_converter()
+    parity = _load_parity()
+    source, data = _write_fake_source(tmp_path)
+    out = tmp_path / "out"
+    converter.convert_all(source, out, data_dir=data, split="low", overwrite=True)
+
+    result = parity.full_parity(out)
+
+    assert result["structural_parity"]["tasks_tested"] == 1
+    assert result["structural_parity"]["passed"] == 1
+    assert result["eval_parity"]["tasks_tested"] == 1
+    assert result["eval_parity"]["passed"] == 1
+    assert result["side_by_side_status"] == "recorded"
+    assert len(result["conversion_parity"]["tasks"]) == 1
+    assert len(result["reward_distribution_parity"]["samples"]) == 1
+    assert result["reward_distribution_parity"]["samples"][0]["reward_delta"] == 0.0

--- a/tests/test_mle_bench_adapter.py
+++ b/tests/test_mle_bench_adapter.py
@@ -249,7 +249,9 @@ def grade_csv(path_to_submission, competition):
     (source / "mlebench" / "competitions" / "__init__.py").write_text("")
     (source / "mlebench" / "competitions" / "utils.py").write_text("")
     (comp_dir / "description.md").write_text("Predict the fake label.\n")
-    (comp_dir / "grade.py").write_text("def grade(submission, answers):\n    return 1.0\n")
+    (comp_dir / "grade.py").write_text(
+        "def grade(submission, answers):\n    return 1.0\n"
+    )
     (comp_dir / "leaderboard.csv").write_text("team,score\nwinner,1.0\n")
     (comp_dir / "config.yaml").write_text(
         """
@@ -306,7 +308,13 @@ def test_mle_bench_converter_keeps_private_data_out_of_environment(tmp_path: Pat
     assert (task_dir / "environment" / "data" / "sampleSubmission.csv").is_file()
     assert not (task_dir / "environment" / "private-data").exists()
     assert (
-        task_dir / "tests" / "private-data" / "Fake-Kaggle" / "prepared" / "private" / "test.csv"
+        task_dir
+        / "tests"
+        / "private-data"
+        / "Fake-Kaggle"
+        / "prepared"
+        / "private"
+        / "test.csv"
     ).is_file()
 
     metadata = json.loads((task_dir / "tests" / "mlebench_task.json").read_text())

--- a/tests/test_mle_bench_adapter.py
+++ b/tests/test_mle_bench_adapter.py
@@ -418,6 +418,88 @@ def test_mle_bench_converter_accepts_sanitized_task_ids(tmp_path: Path):
     assert [path.name for path in generated] == ["fake-kaggle"]
 
 
+def _point_sample_submission(source: Path, data: Path, rel: str) -> None:
+    """Repoint Fake-Kaggle's sample_submission at ``rel`` (relative to data dir)."""
+    comp_id = "Fake-Kaggle"
+    (source / "mlebench" / "competitions" / comp_id / "config.yaml").write_text(
+        f"""
+id: Fake-Kaggle
+name: Fake Kaggle
+competition_type: simple
+description: mlebench/competitions/Fake-Kaggle/description.md
+dataset:
+  answers: Fake-Kaggle/prepared/private/test.csv
+  sample_submission: {rel}
+grader:
+  name: accuracy
+  grade_fn: mlebench.competitions.Fake-Kaggle.grade:grade
+preparer: mlebench.competitions.Fake-Kaggle.prepare:prepare
+""".lstrip()
+    )
+
+
+def test_mle_bench_converter_never_exposes_private_sample_submission(tmp_path: Path):
+    """A sample_submission declared under prepared/private/ must not reach the agent.
+
+    Five real upstream competitions (e.g. statoil-iceberg-classifier-challenge)
+    declare their sample under prepared/private/; exposing it would leak
+    verifier-side data into the agent-visible environment.
+    """
+    converter = _load_converter()
+    source, data = _write_fake_source(tmp_path)
+    comp_id = "Fake-Kaggle"
+    _point_sample_submission(
+        source, data, f"{comp_id}/prepared/private/secretSample.csv"
+    )
+    # The only sample now lives in private with a secret marker; no public sample.
+    (data / comp_id / "prepared" / "public" / "sampleSubmission.csv").unlink()
+    (data / comp_id / "prepared" / "private" / "secretSample.csv").write_text(
+        "id,label\n2,SECRET_PRIVATE_LABEL\n"
+    )
+
+    task_dir = converter.convert_all(
+        source, tmp_path / "out", data_dir=data, split="split75", overwrite=True
+    )[0]
+
+    env_data = task_dir / "environment" / "data"
+    assert not (env_data / "secretSample.csv").exists()
+    assert not (env_data / "sample_submission.csv").exists()
+    for path in env_data.rglob("*"):
+        if path.is_file():
+            assert "SECRET_PRIVATE_LABEL" not in path.read_text(errors="ignore")
+
+
+def test_mle_bench_converter_rejects_answers_path_traversal(tmp_path: Path):
+    """A dataset.answers path that escapes the data dir must be rejected."""
+    converter = _load_converter()
+    source, data = _write_fake_source(tmp_path)
+    comp_id = "Fake-Kaggle"
+    (source / "mlebench" / "competitions" / comp_id / "config.yaml").write_text(
+        """
+id: Fake-Kaggle
+name: Fake Kaggle
+competition_type: simple
+description: mlebench/competitions/Fake-Kaggle/description.md
+dataset:
+  answers: ../../escape/test.csv
+  sample_submission: Fake-Kaggle/prepared/public/sampleSubmission.csv
+grader:
+  name: accuracy
+  grade_fn: mlebench.competitions.Fake-Kaggle.grade:grade
+preparer: mlebench.competitions.Fake-Kaggle.prepare:prepare
+""".lstrip()
+    )
+
+    try:
+        converter.convert_all(
+            source, tmp_path / "out", data_dir=data, split="split75", overwrite=True
+        )
+    except ValueError as exc:
+        assert "must be a relative subpath" in str(exc)
+    else:
+        raise AssertionError("answers path traversal should be rejected")
+
+
 def test_mle_bench_parity_checks_generated_subset(tmp_path: Path):
     converter = _load_converter()
     parity = _load_parity()

--- a/tests/test_mle_bench_adapter.py
+++ b/tests/test_mle_bench_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -43,9 +44,9 @@ def _write_fake_source(tmp_path: Path) -> tuple[Path, Path]:
         """
 import importlib
 import logging
+import csv
 from pathlib import Path
 
-import pandas as pd
 import yaml
 
 
@@ -72,7 +73,9 @@ def load_yaml(path):
 
 
 def read_csv(path, **kwargs):
-    return pd.read_csv(path, **kwargs)
+    del kwargs
+    with open(path, newline="") as handle:
+        return list(csv.DictReader(handle))
 
 
 def load_answers(path):
@@ -329,6 +332,75 @@ def test_mle_bench_converter_keeps_private_data_out_of_environment(tmp_path: Pat
 
     dockerfile = (task_dir / "environment" / "Dockerfile").read_text()
     assert 'CMD ["sleep", "infinity"]' in dockerfile
+
+    test_sh = (task_dir / "tests" / "test.sh").read_text()
+    assert test_sh.startswith("#!/bin/bash\n")
+    assert (
+        subprocess.run(
+            ["bash", "-n", str(task_dir / "tests" / "test.sh")],
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def test_mle_bench_converter_fails_when_core_package_file_is_missing(tmp_path: Path):
+    converter = _load_converter()
+    source, data = _write_fake_source(tmp_path)
+    (source / "mlebench" / "grade.py").unlink()
+
+    try:
+        converter.convert_all(
+            source,
+            tmp_path / "out",
+            data_dir=data,
+            split="split75",
+            overwrite=True,
+        )
+    except FileNotFoundError as exc:
+        assert "Required MLE-bench core file missing" in str(exc)
+    else:
+        raise AssertionError("missing MLE-bench core file should fail conversion")
+
+
+def test_mle_bench_verifier_fails_loudly_when_grader_package_is_broken(tmp_path: Path):
+    converter = _load_converter()
+    source, data = _write_fake_source(tmp_path)
+    task_dir = converter.convert_all(
+        source,
+        tmp_path / "out",
+        data_dir=data,
+        split="split75",
+        overwrite=True,
+    )[0]
+    (task_dir / "tests" / "mlebench" / "grade.py").unlink()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(task_dir / "tests" / "verify.py"),
+            "--competition-id",
+            "Fake-Kaggle",
+            "--submission",
+            str(task_dir / "environment" / "data" / "sample_submission.csv"),
+            "--data-dir",
+            str(task_dir / "tests" / "private-data"),
+            "--reward-file",
+            str(tmp_path / "reward.txt"),
+            "--reward-json",
+            str(tmp_path / "reward.json"),
+            "--report-file",
+            str(tmp_path / "grading_report.json"),
+        ],
+        cwd=task_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert not (tmp_path / "reward.txt").exists()
+    assert "mlebench.grade" in result.stderr
 
 
 def test_mle_bench_converter_accepts_sanitized_task_ids(tmp_path: Path):


### PR DESCRIPTION
Adds an MLE-bench adapter that converts OpenAI MLE-bench Kaggle competitions into BenchFlow tasks, preserving public/private data boundaries and using the upstream mlebench.grade.grade_csv verifier.

Validation included:

6 real Kaggle-prepared tasks converted successfully
48/48 side-by-side grading criteria matched upstream with reward delta 0.0
BenchFlow Docker oracle smoke completed
Live codex-acp agent smoke completed with valid submission and verifier success
Focused adapter tests, Ruff, Ty, and bench eval adopt mle-bench --verify pass