### PR TITLE
feat(cli): rename `bench eval create` to `bench eval run` (keep deprecated alias)

### DIFF
--- a/.agents/skills/benchflow/SKILL.md
+++ b/.agents/skills/benchflow/SKILL.md
@@ -31,7 +31,7 @@ Arguments passed: `$ARGUMENTS`
 ### `run <task-path>` — run a single task
 
 ```bash
-bench eval create \
+bench eval run \
   --tasks-dir <task-path> \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
@@ -65,7 +65,7 @@ API keys are auto-inherited from `os.environ` into the sandbox.
 ### `eval <tasks-dir>` — run a benchmark suite
 
 ```bash
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks \
   --agent gemini \
@@ -76,7 +76,7 @@ bench eval create \
 
 Or via YAML config:
 ```bash
-bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
+bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 ```
 
 YAML format:
@@ -167,7 +167,7 @@ bench agent list
 
 Any agent can be prefixed with `acpx/` to run via ACPX (https://acpx.sh/):
 ```bash
-bench eval create --tasks-dir tasks/edit-pdf --agent acpx/gemini --model gemini-3.1-flash-lite-preview --sandbox daytona
+bench eval run --tasks-dir tasks/edit-pdf --agent acpx/gemini --model gemini-3.1-flash-lite-preview --sandbox daytona
 ```
 
 ACPX is a headless ACP client with persistent sessions and crash recovery.
@@ -225,7 +225,7 @@ COPY skills /root/.claude/skills
 
 ### Runtime deployment via `--skills-dir`
 ```bash
-bench eval create \
+bench eval run \
   --tasks-dir task-dir \
   --agent claude-agent-acp \
   --sandbox daytona \

--- a/.agents/skills/benchflow/references/create-task.md
+++ b/.agents/skills/benchflow/references/create-task.md
@@ -143,7 +143,7 @@ fi
 
 ```bash
 # Run with benchflow
-bench eval create --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
+bench eval run --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
 
 # Or with SDK
 python -c "

--- a/.agents/skills/benchflow/references/review-and-test.md
+++ b/.agents/skills/benchflow/references/review-and-test.md
@@ -57,9 +57,9 @@ After fixes pass unit tests, run a real smoke test:
 source .env
 
 # Pick 5 diverse tasks (cross-env if available)
-bench eval create --tasks-dir benchflow-ai/skillsbench/task-1 --agent claude-agent-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
-bench eval create --tasks-dir benchflow-ai/skillsbench/task-2 --agent pi-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
-bench eval create --tasks-dir benchflow-ai/skillsbench/task-3 --agent openclaw --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
+bench eval run --tasks-dir benchflow-ai/skillsbench/task-1 --agent claude-agent-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
+bench eval run --tasks-dir benchflow-ai/skillsbench/task-2 --agent pi-acp --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
+bench eval run --tasks-dir benchflow-ai/skillsbench/task-3 --agent openclaw --sandbox daytona --skills-dir skills/ --model claude-haiku-4-5-20251001
 ```
 
 Verify for each agent:

--- a/.agents/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/SKILL.md
+++ b/.agents/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/SKILL.md
@@ -29,11 +29,11 @@ Arguments passed: `$ARGUMENTS`
 4. Show recent job results if any exist in `jobs/`
 5. Point to next action based on state
 
-### `eval create --tasks-dir <task-path>` — run a task
+### `eval run --tasks-dir <task-path>` — run a task
 
 ```bash
 source .env
-bench eval create --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
+bench eval run --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
 ```
 
 Or via SDK:

--- a/.agents/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/references/create-task.md
+++ b/.agents/skills/benchflow/tasks/benchflow-knowledge/environment/benchflow/references/create-task.md
@@ -143,7 +143,7 @@ fi
 
 ```bash
 # Run with benchflow
-bench eval create --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
+bench eval run --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
 
 # Or with SDK
 python -c "

--- a/.agents/skills/benchflow/tasks/create-simple-task/environment/benchflow/SKILL.md
+++ b/.agents/skills/benchflow/tasks/create-simple-task/environment/benchflow/SKILL.md
@@ -29,11 +29,11 @@ Arguments passed: `$ARGUMENTS`
 4. Show recent job results if any exist in `jobs/`
 5. Point to next action based on state
 
-### `eval create --tasks-dir <task-path>` — run a task
+### `eval run --tasks-dir <task-path>` — run a task
 
 ```bash
 source .env
-bench eval create --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
+bench eval run --tasks-dir <task-path> --agent claude-agent-acp --sandbox daytona --model claude-haiku-4-5-20251001
 ```
 
 Or via SDK:

--- a/.agents/skills/benchflow/tasks/create-simple-task/environment/benchflow/references/create-task.md
+++ b/.agents/skills/benchflow/tasks/create-simple-task/environment/benchflow/references/create-task.md
@@ -143,7 +143,7 @@ fi
 
 ```bash
 # Run with benchflow
-bench eval create --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
+bench eval run --tasks-dir my-task/ --agent claude-agent-acp --sandbox daytona
 
 # Or with SDK
 python -c "

--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -78,7 +78,7 @@ task/agent IDs. For each hit, verify it resolves in the current tree:
 - Function / class / decorator names (`register_agent`, `SDK`,
   `RunResult`, `detect_services_from_dockerfile`, …) → `Grep` in
   `src/benchflow/` and the `__init__.py` re-exports.
-- CLI commands (`bench eval create`, `bench eval list`, `bench skills list`, …) →
+- CLI commands (`bench eval run`, `bench eval list`, `bench skills list`, …) →
   check the Typer app in `src/benchflow/cli/`.
 - Task IDs referenced in examples → check `examples/` and
   `fixtures/`.

--- a/.agents/skills/release-manager/SKILL.md
+++ b/.agents/skills/release-manager/SKILL.md
@@ -105,7 +105,7 @@ patch, the CI gate + a smoke may suffice.
   `uv lock --check`. Run pytest with `env -u FORCE_COLOR -u COLORTERM` — a set
   `FORCE_COLOR` leaks ANSI into Rich-output assertions and shows false failures.
 - **e2e live smoke** — a real Docker eval on the release branch
-  (`bench eval create --sandbox docker …`); confirm it's REAL (tool calls > 0,
+  (`bench eval run --sandbox docker …`); confirm it's REAL (tool calls > 0,
   tokens > 0, reward written) and the expected artifacts emit.
 - **Structural / adversarial audit** — for a big release, fan out reviewers over
   the `vLAST..HEAD` diff (correctness, security/secrets, claims-vs-code,

--- a/.github/workflows/integration-eval.yml
+++ b/.github/workflows/integration-eval.yml
@@ -1,6 +1,6 @@
 # BenchFlow integration eval: one real rollout, gated by BenchFlow's own
 # agent-as-judge check. This workflow runs a single small task end to end
-# through `bench eval create` on Docker, then has BenchFlow's agent judge
+# through `bench eval run` on Docker, then has BenchFlow's agent judge
 # (tests/integration/agent_judge.py) grade the resulting rollout. The job
 # fails if the run is not REAL (no tool calls / no tokens / null reward) or
 # if the judge fails the trajectory. It is kept to one task so the check
@@ -102,7 +102,7 @@ jobs:
 
       - name: Run one real rollout on Docker
         run: |
-          uv run bench eval create \
+          uv run bench eval run \
             --source-repo benchflow-ai/skillsbench \
             --source-path tasks \
             --source-ref main \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Changed
+- **`bench eval create` renamed to `bench eval run`.** The verb now matches what
+  the command does (it runs an evaluation, single task or batch). `bench eval
+  create` stays as a deprecated alias that prints a deprecation notice on use, so
+  existing scripts, YAML configs, and downstream repos (e.g.
+  `benchflow-ai/skillsbench`) keep working unchanged. Switch to `bench eval run`.
 - **`task.md` is now the sole task authoring format.** `bench tasks init`
   scaffolds a native `task.md` package (`task.md` + `environment/` + `oracle/` +
   `verifier/`). `bench tasks init --format legacy` is retired and now exits with
@@ -14,13 +19,13 @@
 
 ### Fixed
 - `bench skills eval` now exits non-zero when any eval case errors (e.g. missing
-  credentials), matching `bench eval create`. A 100%-error run printed `0/1`
+  credentials), matching `bench eval run`. A 100%-error run printed `0/1`
   but exited `0`, so CI/scripts read a total failure as success.
 - The "task.md already exists" migrate error now names both surfaces
   (`--overwrite` for the CLI, `overwrite=True` for the Python API) instead of
   only the API kwarg.
 - `bench eval view <job-dir>` no longer shows a blank "No trajectory files
-  found" when given a job directory (the natural value from `eval create`'s
+  found" when given a job directory (the natural value from `eval run`'s
   "Artifacts:" line) — it now indexes the rollout subdirectories to drill into.
 - `bench hub env list` prints a footer (`Showing N…`) with how to refine
   (`--search`/`--owner`/`--limit`/`--json`), so a small page of a large catalog

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ uv tool install benchflow
 
 # Run a benchmark: any task source, any ACP agent, any sandbox
 export GEMINI_API_KEY=...            # or claude login / codex --login for subscription auth
-bench eval create \
+bench eval run \
     --source-repo benchflow-ai/skillsbench --source-path tasks \
     --agent gemini --model gemini-3.1-flash-lite-preview \
     --sandbox docker
@@ -105,10 +105,10 @@ Run any benchmark via the CLI:
 
 ```bash
 # From a YAML config (shipped with the repo)
-bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
+bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
 # Inline — mirrors the YAML source fields
-bench eval create \
+bench eval run \
     --source-repo benchflow-ai/skillsbench --source-path tasks \
     --agent gemini --model gemini-3.1-flash-lite-preview --sandbox daytona --concurrency 64
 ```
@@ -121,7 +121,7 @@ own native harness — BenchFlow preserves the hosted identity (`env_uid`,
 `hub_url`) and still writes the shared rollout output contract:
 
 ```bash
-bench eval create \
+bench eval run \
     --source-env primeintellect/general-agent \
     --source-env-version 0.1.1 \
     --model google/gemini-2.5-flash-lite

--- a/benchmarks/chi-bench/README.md
+++ b/benchmarks/chi-bench/README.md
@@ -37,7 +37,7 @@ framework's readiness gate probes the same `:8023/health` endpoint.
 ## Run it
 
 ```bash
-bench eval create --tasks-dir benchmarks/chi-bench/tasks/<task> \
+bench eval run --tasks-dir benchmarks/chi-bench/tasks/<task> \
   --environment-manifest benchmarks/chi-bench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 ```

--- a/benchmarks/clawsbench/README.md
+++ b/benchmarks/clawsbench/README.md
@@ -21,7 +21,7 @@ for the hard-coded `SERVICES` dict in `benchflow/sandbox/services.py`.
 ## Run it
 
 ```bash
-bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 ```

--- a/benchmarks/clawsbench/tasks/archive-amazon-shipping/README.md
+++ b/benchmarks/clawsbench/tasks/archive-amazon-shipping/README.md
@@ -25,7 +25,7 @@ build-time message id is baked in.
 ## Run it
 
 ```bash
-bench eval create --tasks-dir benchmarks/clawsbench/tasks/archive-amazon-shipping \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks/archive-amazon-shipping \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent gemini --model gemini-3.1-flash-lite-preview \
   --sandbox daytona
@@ -34,6 +34,6 @@ bench eval create --tasks-dir benchmarks/clawsbench/tasks/archive-amazon-shippin
 Confirm the task is solvable with the oracle:
 
 ```bash
-bench eval create --tasks-dir benchmarks/clawsbench/tasks/archive-amazon-shipping \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks/archive-amazon-shipping \
   --agent oracle --sandbox docker
 ```

--- a/benchmarks/harvey-lab/README.md
+++ b/benchmarks/harvey-lab/README.md
@@ -71,7 +71,7 @@ python benchmarks/harvey-lab/run_harvey_lab.py
 
 # Harvey LAB harness smoke test: runs Harvey LAB's own agent loop via ACP.
 # Requires GEMINI_API_KEY for the agent and ANTHROPIC_API_KEY for the verifier.
-uv run bench eval create \
+uv run bench eval run \
   --source-repo benchflow-ai/benchmarks \
   --source-path datasets/harvey-lab/tasks/corporate-ma-analyze-cim-deal-teaser-scenario-01 \
   --agent harvey-lab-harness \

--- a/benchmarks/harvey-lab/run_harvey_lab.py
+++ b/benchmarks/harvey-lab/run_harvey_lab.py
@@ -4,7 +4,7 @@ Usage:
     python benchmarks/harvey-lab/run_harvey_lab.py                # default config
     python benchmarks/harvey-lab/run_harvey_lab.py path/to/config.yaml
 
-Prefer using `bench eval create --config` with a YAML config that has tasks_dir
+Prefer using `bench eval run --config` with a YAML config that has tasks_dir
 pointing to already-converted tasks if you've pre-converted them.
 """
 

--- a/benchmarks/hilbench/run_hilbench.py
+++ b/benchmarks/hilbench/run_hilbench.py
@@ -233,7 +233,7 @@ async def main():
 
     if not args.config:
         logger.info("No config specified; tasks generated at %s", tasks_dir)
-        logger.info("Use: bench eval create -f <config.yaml> to run evaluations")
+        logger.info("Use: bench eval run -f <config.yaml> to run evaluations")
         return
 
     from benchflow.evaluation import Evaluation

--- a/docs/agent-quickstart.md
+++ b/docs/agent-quickstart.md
@@ -19,7 +19,7 @@ GUARDRAILS (apply to every step):
 - Never print, echo, log, or commit API keys. Never write keys into any file
   except a local .env (if the working directory is a git repo, confirm .env
   is gitignored; never commit it anywhere).
-- Every `bench eval create` invocation — including retries — must use a FRESH
+- Every `bench eval run` invocation — including retries — must use a FRESH
   --jobs-dir. Reusing a jobs dir triggers resume logic and skips the run.
 - A `[FAIL]` line with a fractional reward (e.g. reward 0.4, Score: 0/1) means
   the pipeline is HEALTHY: the agent ran and the verifier scored it below the
@@ -92,7 +92,7 @@ settings automatically.
 STEP 4 — Run the eval in a Docker sandbox
 Use a fresh, timestamped jobs dir and concurrency 1:
     JOBS_DIR="jobs/quickstart-$(date +%Y%m%d-%H%M%S)"
-    bench eval create \
+    bench eval run \
       --tasks-dir skillsbench/tasks/tictoc-unnecessary-abort-detection \
       --agent openhands \
       --model <provider>/<model> \
@@ -178,7 +178,7 @@ Fix anything it flags (it rejects unreplaced [REPLACE: ...] placeholders).
 Then run the task with the built-in oracle agent — it executes
 oracle/solve.sh directly, needs no model or API key, and proves the task +
 verifier loop:
-    bench eval create \
+    bench eval run \
       --tasks-dir tasks/my-first-task \
       --agent oracle \
       --sandbox docker \

--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -160,17 +160,17 @@ reaches them on `localhost`. During a rollout:
 3. `Rollout.cleanup()` tears the environment down.
 
 Run one task or a task directory against an environment manifest with
-`bench eval create --tasks-dir ...`. `--environment-manifest` applies the
+`bench eval run --tasks-dir ...`. `--environment-manifest` applies the
 Environment-plane manifest to every rollout in the Job pipeline.
 
 ```bash
 # one task
-bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 
 # task directory
-bench eval create --tasks-dir benchmarks/clawsbench/tasks \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 ```

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -5,10 +5,10 @@ They live under `docs/examples/` so examples and docs move together.
 
 ## Single Task
 
-Use `bench eval create` for one task:
+Use `bench eval run` for one task:
 
 ```bash
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks/edit-pdf \
   --agent gemini \
@@ -24,7 +24,7 @@ When an example or task has a skills directory, mount it and pass the skill
 nudge. The docs use `BENCHFLOW_SKILL_NUDGE=name` as the default recommendation:
 
 ```bash
-bench eval create \
+bench eval run \
   --tasks-dir tasks/my-task \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \

--- a/docs/examples/task-md/README.md
+++ b/docs/examples/task-md/README.md
@@ -13,7 +13,7 @@ uv run --extra dev bench tasks check docs/examples/task-md/nudgebench-team --lev
 ```
 
 Those fixtures are not runnable eval tasks. Default structural validation, and
-`bench eval create`, require runtime assets such as `environment/` and
+`bench eval run`, require runtime assets such as `environment/` and
 `verifier/` or legacy `tests/`.
 
 Use default structural validation for runnable examples:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,7 +112,7 @@ and never reaches the `bench` process. The portable pattern for a `.env` file:
 
 ```bash
 set -a; source .env; set +a
-bench eval create ...
+bench eval run ...
 ```
 
 (benchflow also picks up well-known credential keys from a `.env` file in the
@@ -131,14 +131,14 @@ option, unset the higher one in your shell before running.
 
 ```bash
 # Single task from a local directory
-GEMINI_API_KEY=... bench eval create \
+GEMINI_API_KEY=... bench eval run \
   --tasks-dir tasks/edit-pdf \
   --agent gemini \
   --model gemini-3.1-pro-preview \
   --sandbox docker
 
 # Single task with mounted skills
-GEMINI_API_KEY=... bench eval create \
+GEMINI_API_KEY=... bench eval run \
   --tasks-dir tasks/edit-pdf \
   --agent gemini \
   --model gemini-3.1-pro-preview \
@@ -148,10 +148,10 @@ GEMINI_API_KEY=... bench eval create \
   --agent-env BENCHFLOW_SKILL_NUDGE=name
 
 # A whole batch from YAML config
-bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
+bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
 # Batch over a local tasks directory with concurrency
-GEMINI_API_KEY=... bench eval create \
+GEMINI_API_KEY=... bench eval run \
     --tasks-dir tasks \
     --agent gemini --model gemini-3.1-pro-preview --sandbox daytona --concurrency 32
 
@@ -159,7 +159,7 @@ GEMINI_API_KEY=... bench eval create \
 bench agent list
 ```
 
-`bench eval create` is the primary command for running evaluations — it works for
+`bench eval run` is the primary command for running evaluations — it works for
 single tasks, batch runs, and remote repos. Use `--tasks-dir <dir>` for a local
 directory or `--config <config.yaml>` for a YAML config.
 
@@ -173,7 +173,7 @@ use a sparse checkout and point `--tasks-dir` at it:
 ```bash
 git clone --depth 1 --filter=blob:none --sparse https://github.com/benchflow-ai/skillsbench
 cd skillsbench && git sparse-checkout set tasks/edit-pdf
-bench eval create --tasks-dir tasks/edit-pdf --agent gemini --model gemini-3.1-pro-preview
+bench eval run --tasks-dir tasks/edit-pdf --agent gemini --model gemini-3.1-pro-preview
 ```
 
 When you mount skills, use `BENCHFLOW_SKILL_NUDGE=name` as the default docs
@@ -220,7 +220,7 @@ errors. CLI usage errors (bad flags) exit 2.
 
 The Docker sandbox needs the Docker daemon running. There is no up-front
 check — if the daemon is down the run fails partway through rather than at
-startup, so start Docker before `bench eval create --sandbox docker`.
+startup, so start Docker before `bench eval run --sandbox docker`.
 
 ## Run from Python
 

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -44,7 +44,7 @@ BENCHFLOW_INTEGRATION_CONCURRENCY=100 tests/integration/run.sh gemini
 ## What It Does
 
 1. **Resolves tasks** — downloads the full SkillsBench task set, then creates a symlinked subset of 9 selected tasks.
-2. **Launches agents in parallel** — each agent is started as a background process running `bench eval create` with concurrency=64 by default. Set `BENCHFLOW_INTEGRATION_CONCURRENCY=100` for the large post-migration validation run.
+2. **Launches agents in parallel** — each agent is started as a background process running `bench eval run` with concurrency=64 by default. Set `BENCHFLOW_INTEGRATION_CONCURRENCY=100` for the large post-migration validation run.
 3. **Waits and reports** — as each agent finishes, prints its score line. After all complete, runs `check_results.py` to validate output schema and print the results table.
 
 ## Release Readiness Coverage
@@ -55,11 +55,11 @@ Before cutting a trial-ready release, every current release blocker must pass. I
 |---|---|---|
 | SkillsBench agent matrix | Validates the full agent × task pipeline on Daytona | 9 selected tasks across all credentialed agents produce valid `result.json`, trajectory output, and summary schema |
 | Adapter release set | Validates merged and open benchmark adapters preserve source-suite semantics | Each benchmark listed in [Running Adapted Benchmarks](./running-benchmarks.md#available-benchmarks), plus each open benchmark-adapter PR targeted at the release, has at least one representative smoke or parity run with verifier execution and reward schema validation |
-| Terminal-Bench smoke | Validates Terminal-Bench-style task packaging and shell verifier behavior | At least one representative task runs through `bench eval create`, verifier executes from the task tests, and sandbox hardening does not break normal task execution |
-| Trace-to-task | Validates `bench tasks generate` can turn real traces into runnable benchmark tasks | Generate from at least one local or JSONL trace and one HuggingFace/opentraces source, then run the generated task through `bench eval create` and validate the verifier outcome |
+| Terminal-Bench smoke | Validates Terminal-Bench-style task packaging and shell verifier behavior | At least one representative task runs through `bench eval run`, verifier executes from the task tests, and sandbox hardening does not break normal task execution |
+| Trace-to-task | Validates `bench tasks generate` can turn real traces into runnable benchmark tasks | Generate from at least one local or JSONL trace and one HuggingFace/opentraces source, then run the generated task through `bench eval run` and validate the verifier outcome |
 | Agent decoupling | Validates agents are pluggable runtime targets rather than core-coupled implementations | Core import and task validation work without optional agent packages; at least two non-oracle agents run the same representative task through the same Rollout path |
 | Sandbox decoupling | Validates sandbox backends are pluggable and optional dependencies remain isolated | Core `import benchflow` works without optional sandbox extras; Docker and Daytona smoke runs use the same task contract; missing optional sandbox deps produce clear install guidance |
-| Release-gated sandbox support | Validates the release-quality sandbox backends in the current release gate | Docker and Daytona can run a representative task via `bench eval create --sandbox docker` and `--sandbox daytona` without special user intervention beyond each backend's documented auth; Modal remains optional follow-up evidence, not a release blocker |
+| Release-gated sandbox support | Validates the release-quality sandbox backends in the current release gate | Docker and Daytona can run a representative task via `bench eval run --sandbox docker` and `--sandbox daytona` without special user intervention beyond each backend's documented auth; Modal remains optional follow-up evidence, not a release blocker |
 
 These blockers test benchmark-suite portability, not backward compatibility with old BenchFlow names. Public docs and new configs should use Rollout/Sandbox terminology.
 
@@ -226,7 +226,7 @@ Adapter coverage should stay intentionally small in the near-term profile: one r
 
 | Lane | Axis slice | Promote when |
 |---|---|---|
-| Security DinD smoke | `harbor:termigen-environments/docker_escape_privileged_container_medium@dc329464161db64b0c670f46fa39b62e4719dddd` × Firecracker/K8s | `bench eval create --sandbox firecracker` and `bench eval create --sandbox k8s` run the task without questions, Docker-in-Docker-style service/container operations work inside both sandboxes, and the verifier executes after sandbox hardening |
+| Security DinD smoke | `harbor:termigen-environments/docker_escape_privileged_container_medium@dc329464161db64b0c670f46fa39b62e4719dddd` × Firecracker/K8s | `bench eval run --sandbox firecracker` and `bench eval run --sandbox k8s` run the task without questions, Docker-in-Docker-style service/container operations work inside both sandboxes, and the verifier executes after sandbox hardening |
 
 ### Coverage Policy
 
@@ -306,10 +306,10 @@ models use `AZURE_API_KEY` plus `AZURE_API_ENDPOINT`.
 
 ## Standalone YAML Configs
 
-Each agent has a YAML config in `configs/` with an `include` list restricting to the 9 selected tasks. These can be used directly with `bench eval create --config`:
+Each agent has a YAML config in `configs/` with an `include` list restricting to the 9 selected tasks. These can be used directly with `bench eval run --config`:
 
 ```bash
-uv run bench eval create --config tests/integration/configs/gemini.yaml
+uv run bench eval run --config tests/integration/configs/gemini.yaml
 ```
 
 `run.sh` uses CLI arguments instead of these configs for parallel execution, but both approaches run the same 9 tasks at the active-dev concurrency of 64. The shell runner can be temporarily raised with `BENCHFLOW_INTEGRATION_CONCURRENCY=100` for the larger validation set.
@@ -351,7 +351,7 @@ uv run python tests/integration/agent_judge.py jobs/integration-eval --json
 ```
 
 The lightweight `.github/workflows/integration-eval.yml` workflow runs one
-small task through `bench eval create --agent openhands --model
+small task through `bench eval run --agent openhands --model
 deepseek/deepseek-v4-flash --sandbox docker`, then runs the agent judge over
 the rollout and fails the job if the run is not REAL or the judge fails. It
 triggers on `workflow_dispatch` and nightly, and is capped at one task to keep

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -146,17 +146,20 @@ bench eval adopt my-bench --verify --rerun   # re-run parity_test.py, score fres
 
 ## bench eval
 
-### bench eval create
+### bench eval run
 
-Create and run an evaluation. Use it for YAML configs and batch runs; it also
-accepts a single task directory.
+Run an evaluation — single task or batch. Use it for YAML configs and batch
+runs; it also accepts a single task directory.
+
+> **Renamed from `bench eval create`.** The old name still works as a deprecated
+> alias and prints a deprecation notice; switch to `bench eval run`.
 
 ```bash
 # From YAML config
-bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
+bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
 # From remote repo (fast Daytona batch; token usage may be unavailable)
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks \
   --agent gemini \
@@ -166,7 +169,7 @@ bench eval create \
   --sandbox-setup-timeout 300
 
 # From remote repo with required token usage telemetry
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks \
   --agent gemini \
@@ -177,10 +180,10 @@ bench eval create \
   --sandbox-setup-timeout 300
 
 # From local directory
-bench eval create --tasks-dir ./tasks --agent gemini --model gemini-3.1-flash-lite-preview
+bench eval run --tasks-dir ./tasks --agent gemini --model gemini-3.1-flash-lite-preview
 
 # From a hosted PrimeIntellect / Verifiers environment
-bench eval create \
+bench eval run \
   --source-env primeintellect/general-agent \
   --source-env-version 0.1.1 \
   --source-env-arg task=calendar_scheduling_t0 \
@@ -188,7 +191,7 @@ bench eval create \
   --model google/gemini-2.5-flash-lite
 
 # Single task with mounted skills and the recommended skill nudge
-bench eval create \
+bench eval run \
   --tasks-dir tasks/pdf-fix \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
@@ -198,7 +201,7 @@ bench eval create \
 
 # Pinned registry dataset: resolves skillsbench@1.1, verifies task digests,
 # and stamps dataset identity into every result.json/config.json
-bench eval create -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lite-preview
+bench eval run -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lite-preview
 ```
 
 | Flag | Default | Description |
@@ -403,7 +406,7 @@ Arguments: `TASK_DIR` (task directory to export) and optional `OUTPUT_DIR`
 ### bench tasks digest
 
 Compute the content digest that pins a task's files, independent of git — the
-sha256 the dataset registry keys on (matches the digests `bench eval create -d`
+sha256 the dataset registry keys on (matches the digests `bench eval run -d`
 verifies and the `task_digest` stamped into every `result.json`). Recognizes
 both legacy `task.toml` tasks and native `task.md` tasks. Given a single task
 directory it prints the digest; given a directory of tasks it prints one
@@ -509,7 +512,7 @@ and check Harbor registry compatibility (`check`).
 Read-only browsing of a hub's environments. `list` covers two hubs via
 `--provider`: `primeintellect` (hosted "Environments") and `harbor` (the
 benchmark registry). To *run* a hosted environment, use
-[`bench eval create --source-env`](#bench-eval-create).
+[`bench eval run --source-env`](#bench-eval-run).
 
 ```bash
 bench hub list --provider primeintellect --owner primeintellect --search general-agent --limit 5
@@ -564,7 +567,7 @@ max_retries: 2
 
 ### Multi-scene (BYOS skill generation)
 
-Use the Python API for multi-scene experiments. `bench eval create --config` is for
+Use the Python API for multi-scene experiments. `bench eval run --config` is for
 batch job configs; scene configs are loaded with `benchflow._utils.yaml_loader` or built
 directly in Python.
 

--- a/docs/running-any-benchmark.md
+++ b/docs/running-any-benchmark.md
@@ -54,7 +54,7 @@ their native Verifiers execution surface and preserves their hosted identity
 [`src/benchflow/hosted_env.py`](../src/benchflow/hosted_env.py):
 
 ```bash
-bench eval create \
+bench eval run \
     --source-env primeintellect/general-agent \
     --source-env-version 0.1.1 \
     --model google/gemini-2.5-flash-lite

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -46,15 +46,15 @@ See [Running a benchmark with an Environment manifest](#running-a-benchmark-with
 
 ## Quick start
 
-### Option 1: YAML config (`bench eval create --config`)
+### Option 1: YAML config (`bench eval run --config`)
 
 The simplest path. Point at a YAML config that specifies the benchmark source,
 agent, and model:
 
 ```bash
-GEMINI_API_KEY=... bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
-GEMINI_API_KEY=... bench eval create --config benchmarks/programbench/programbench-gemini-flash-lite.yaml
-bench eval create --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
+GEMINI_API_KEY=... bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
+GEMINI_API_KEY=... bench eval run --config benchmarks/programbench/programbench-gemini-flash-lite.yaml
+bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 ```
 
 The config handles everything — downloads/generates tasks, resolves the task path,
@@ -66,14 +66,14 @@ Use CLI flags for ad-hoc runs without a config file:
 
 ```bash
 # Harvey LAB — single pre-converted task
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/benchmarks \
   --source-path datasets/harvey-lab/tasks/corporate-ma-analyze-cim-deal-teaser-scenario-01 \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 
 # Harvey LAB harness adapter smoke test.
 # Requires GEMINI_API_KEY for the agent and ANTHROPIC_API_KEY for the verifier.
-uv run bench eval create \
+uv run bench eval run \
   --source-repo benchflow-ai/benchmarks \
   --source-path datasets/harvey-lab/tasks/corporate-ma-analyze-cim-deal-teaser-scenario-01 \
   --agent harvey-lab-harness \
@@ -83,25 +83,25 @@ uv run bench eval create \
   --jobs-dir jobs/smoke-test/harvey-harness
 
 # Harvey LAB — all pre-converted tasks
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/benchmarks \
   --source-path datasets/harvey-lab/tasks \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker --concurrency 4
 
 # SkillsBench
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks/edit-pdf \
   --agent gemini --model gemini-3.1-flash-lite-preview
 
 # ProgramBench — single task (tasks are generated at runtime by the converter;
 # see "Running ProgramBench" below for the generation step)
-bench eval create \
+bench eval run \
   --tasks-dir benchmarks/programbench/tasks/abishekvashok__cmatrix.5c082c6 \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 
 # Claude Code on Daytona
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks \
   --agent claude-agent-acp --model anthropic/claude-sonnet-4-6 --sandbox daytona --concurrency 32
@@ -156,12 +156,12 @@ set from a dataset registry instead of pointing at a directory or branch:
 ```bash
 # Resolve skillsbench@1.1 from the registry, verify every task's content
 # digest against the pinned snapshot, then run.
-bench eval create -d skillsbench@1.1 \
+bench eval run -d skillsbench@1.1 \
   --agent claude-agent-acp --model claude-haiku-4-5-20251001
 
 # Versions are immutable, so the version is always explicit — there is no
 # floating "latest". --include/--exclude filter the registry roster.
-bench eval create -d skillsbench@1.1 --include xlsx-recover-data ...
+bench eval run -d skillsbench@1.1 --include xlsx-recover-data ...
 ```
 
 A registry (`registry.json` at a dataset repo's root — see skillsbench's
@@ -197,26 +197,26 @@ digest for any task directory.
 ### Single task
 
 ```bash
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks/edit-pdf \
   --agent gemini --model gemini-3.1-flash-lite-preview
 
-bench eval create \
+bench eval run \
   --tasks-dir benchmarks/programbench/tasks/abishekvashok__cmatrix.5c082c6 \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 
-bench eval create \
+bench eval run \
   --tasks-dir .cache/harvey-lab-tasks/corporate-ma-review-data-room-red-flag-review \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 ```
 
 ### Batch with a tasks directory
 
-Point `bench eval create --tasks-dir` at a directory containing only the tasks you want:
+Point `bench eval run --tasks-dir` at a directory containing only the tasks you want:
 
 ```bash
-bench eval create --tasks-dir benchmarks/programbench/tasks \
+bench eval run --tasks-dir benchmarks/programbench/tasks \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker --concurrency 4
 ```
 
@@ -224,13 +224,13 @@ bench eval create --tasks-dir benchmarks/programbench/tasks \
 
 ```bash
 # SkillsBench single task
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks/edit-pdf \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 
 # Harvey LAB single task (pre-converted)
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/benchmarks \
   --source-path datasets/harvey-lab/tasks/corporate-ma-analyze-cim-deal-teaser-scenario-01 \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
@@ -271,13 +271,13 @@ python -m benchmarks.programbench.main \
 ### Run all tasks
 
 ```bash
-bench eval create --config benchmarks/programbench/programbench-gemini-flash-lite.yaml
+bench eval run --config benchmarks/programbench/programbench-gemini-flash-lite.yaml
 ```
 
 ### Run a single task (after generation)
 
 ```bash
-bench eval create \
+bench eval run \
   --tasks-dir benchmarks/programbench/tasks/abishekvashok__cmatrix.5c082c6 \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 ```
@@ -287,7 +287,7 @@ bench eval create \
 Verify a task is solvable using the gold solution (original source at commit):
 
 ```bash
-bench eval create \
+bench eval run \
   --tasks-dir benchmarks/programbench/tasks/abishekvashok__cmatrix.5c082c6 \
   --agent oracle --sandbox docker
 ```
@@ -327,7 +327,7 @@ as `azure-foundry-openai/gpt-5.5` or
 Any agent can also be run via [ACPX](https://acpx.sh/) by prefixing with `acpx/`:
 
 ```bash
-bench eval create --tasks-dir tasks/edit-pdf --agent acpx/gemini --model gemini-3.1-flash-lite-preview --sandbox daytona
+bench eval run --tasks-dir tasks/edit-pdf --agent acpx/gemini --model gemini-3.1-flash-lite-preview --sandbox daytona
 ```
 
 ACPX is a headless ACP client that adds persistent sessions and crash recovery.
@@ -350,7 +350,7 @@ The **Harvey LAB harness** agent is special — it runs Harvey LAB's own agent l
 For large-scale runs (100+ tasks), use Daytona or Modal with high concurrency:
 
 ```bash
-bench eval create \
+bench eval run \
   --source-repo benchflow-ai/skillsbench \
   --source-path tasks \
   --agent gemini --model gemini-3.1-flash-lite-preview --sandbox daytona --concurrency 64
@@ -415,19 +415,19 @@ COMMON="--tasks-dir $SKILLSBENCH/tasks --include $TASK --agent openhands \
   --sandbox daytona --concurrency 1 --usage-tracking required --agent-idle-timeout none"
 
 # (1) Opus-4.8 (MAX) — with skills
-bench eval create $COMMON --model aws-bedrock/us.anthropic.claude-opus-4-8 \
+bench eval run $COMMON --model aws-bedrock/us.anthropic.claude-opus-4-8 \
   --skill-mode with-skill --jobs-dir jobs/opus-skill
 
 # (2) Opus-4.8 (MAX) — without skills
-bench eval create $COMMON --model aws-bedrock/us.anthropic.claude-opus-4-8 \
+bench eval run $COMMON --model aws-bedrock/us.anthropic.claude-opus-4-8 \
   --skill-mode no-skill --jobs-dir jobs/opus-noskill
 
 # (3) Gemini-3.5-flash — with skills
-bench eval create $COMMON --model gemini-3.5-flash --agent-env LLM_CACHING_PROMPT=false \
+bench eval run $COMMON --model gemini-3.5-flash --agent-env LLM_CACHING_PROMPT=false \
   --skill-mode with-skill --jobs-dir jobs/gemini-skill
 
 # (4) Gemini-3.5-flash — without skills
-bench eval create $COMMON --model gemini-3.5-flash --agent-env LLM_CACHING_PROMPT=false \
+bench eval run $COMMON --model gemini-3.5-flash --agent-env LLM_CACHING_PROMPT=false \
   --skill-mode no-skill --jobs-dir jobs/gemini-noskill
 ```
 
@@ -481,22 +481,22 @@ Notes:
 A **stateful** benchmark — one with mock services, databases, or accounts the
 agent acts on — declares its world in an `environment.toml` manifest and runs
 on the [Environment plane](./environment-plane.md). Use
-`bench eval create --tasks-dir ...` for both single-task and batch
+`bench eval run --tasks-dir ...` for both single-task and batch
 manifest-backed evaluations; `--environment-manifest` applies the manifest to
 every rollout in the Job pipeline.
 
 ```bash
 # single task
-bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks/<task> \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 
-bench eval create --tasks-dir benchmarks/chi-bench/tasks/<task> \
+bench eval run --tasks-dir benchmarks/chi-bench/tasks/<task> \
   --environment-manifest benchmarks/chi-bench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 
 # batch via the Job API
-bench eval create --tasks-dir benchmarks/clawsbench/tasks \
+bench eval run --tasks-dir benchmarks/clawsbench/tasks \
   --environment-manifest benchmarks/clawsbench/environment.toml \
   --agent claude-agent-acp --model claude-haiku-4-5
 ```

--- a/docs/task-authoring-task-md.md
+++ b/docs/task-authoring-task-md.md
@@ -226,7 +226,7 @@ legacy alias; `oracle/` wins when both exist). Native oracles are uploaded to
 of an agent with `--agent oracle`:
 
 ```bash
-bench eval create --tasks-dir tasks/my-task --agent oracle --sandbox docker
+bench eval run --tasks-dir tasks/my-task --agent oracle --sandbox docker
 ```
 
 A correct task scores `1.0` on its oracle run before any model sees it.
@@ -331,7 +331,7 @@ migrating, validate the result:
 
 ```bash
 bench tasks check tasks/my-task
-bench eval create --tasks-dir tasks/my-task --agent oracle --sandbox docker
+bench eval run --tasks-dir tasks/my-task --agent oracle --sandbox docker
 ```
 
 ## Compatibility Export

--- a/src/benchflow/_utils/dataset_registry.py
+++ b/src/benchflow/_utils/dataset_registry.py
@@ -1,4 +1,4 @@
-"""Dataset registry resolution — `bench eval create -d skillsbench@1.1`.
+"""Dataset registry resolution — `bench eval run -d skillsbench@1.1`.
 
 Resolves a published dataset version from the skillsbench registry
 (``registry.json``, see ``docs/dataset-versioning.md`` in

--- a/src/benchflow/_utils/task_authoring/__init__.py
+++ b/src/benchflow/_utils/task_authoring/__init__.py
@@ -178,7 +178,7 @@ def check_task(
     # Note: [agent] and [agent].timeout_sec are optional at runtime
     # (AgentConfig defaults to timeout_sec=None → no wall-clock cap). We
     # only surface parse errors here so `bench tasks check` and
-    # `bench eval create` agree on what a "valid" task looks like.
+    # `bench eval run` agree on what a "valid" task looks like.
     # See #379.
     toml_path = task_dir / "task.toml"
     if toml_path.exists() and not has_task_md:

--- a/src/benchflow/_utils/task_authoring/scaffolding.py
+++ b/src/benchflow/_utils/task_authoring/scaffolding.py
@@ -191,7 +191,7 @@ def test_placeholder():
         sol_dir.mkdir()
         (sol_dir / "solve.sh").write_text(f"""#!/bin/bash
 # Oracle solution - demonstrates the task is solvable.
-# Used by: bench eval create --agent oracle --tasks-dir tasks/{name}
+# Used by: bench eval run --agent oracle --tasks-dir tasks/{name}
 
 # [REPLACE: implement the oracle solution. It must satisfy the verifier in
 # {verifier_dirname}/test.sh so that running solve.sh -> test.sh produces reward 1.0.]

--- a/src/benchflow/agent_router.py
+++ b/src/benchflow/agent_router.py
@@ -5,7 +5,7 @@ that adopts an upstream benchmark into a BenchFlow benchmark (canonically
 ``bench eval adopt``; the legacy ``bench agent create|run|verify`` and the
 intermediate ``bench adopt init|convert|verify`` remain as hidden deprecated
 aliases). It sits downstream of every environment framework: a benchmark is
-*routed* into the repo here, while ``bench eval create`` *runs* the tasks.
+*routed* into the repo here, while ``bench eval run`` *runs* the tasks.
 
 Three cohesive action bodies — module-level functions so the canonical command
 and the deprecated alias closures share one implementation:

--- a/src/benchflow/cli/_live_progress.py
+++ b/src/benchflow/cli/_live_progress.py
@@ -1,4 +1,4 @@
-"""Live terminal dashboard for ``bench eval create`` runs.
+"""Live terminal dashboard for ``bench eval run`` runs.
 
 Renders a single Rich :class:`~rich.live.Live` panel — a progress bar with ETA,
 queued/running/passed/failed/errored counts, a "running now" table, and running

--- a/src/benchflow/cli/adopt.py
+++ b/src/benchflow/cli/adopt.py
@@ -8,7 +8,7 @@
 * ``bench eval adopt <name> --verify`` — run the parity gate for the benchmark.
 
 It lives under ``eval`` because ``eval`` is the universal benchmark entry point
-(``eval create`` runs a benchmark; ``eval adopt`` is the manual path to make a
+(``eval run`` runs a benchmark; ``eval adopt`` is the manual path to make a
 foreign benchmark runnable). It previously was a subgroup with ``init`` /
 ``convert`` / ``verify`` subcommands, and before that ``bench agent
 create|run|verify`` (#735); both ``bench adopt init|convert|verify`` and ``bench

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -138,7 +138,7 @@ def register_continue(app: typer.Typer) -> None:
             typer.secho(f"  agent error: {result.error}", fg=typer.colors.YELLOW)
             # A failed continuation must report failure to $? — matches
             # `continue-batch` (exits 1 if any continuation failed) and the
-            # `eval create` run-error contract. Without this a scripted caller
+            # `eval run` run-error contract. Without this a scripted caller
             # reads the green ✓ + exit 0 as success.
             raise typer.Exit(1)
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1,9 +1,10 @@
 """benchflow CLI — agent benchmarking framework.
 
 This module owns the top-level Typer ``app``, the global callback/version flag,
-and the ``eval`` command group (``eval create`` / ``eval list``). ``eval create``
+and the ``eval`` command group (``eval run`` / ``eval list``). ``eval run``
 is defined here on purpose: tests pin its callback ``__module__`` to
 ``benchflow.cli.main`` and import it (plus the Daytona helpers) from here.
+(``eval create`` remains as a deprecated alias of ``eval run``.)
 
 Every other command group lives in a sibling ``cli/<group>.py`` module and is
 attached through a ``register_<group>(app)`` call below, mirroring the
@@ -69,7 +70,7 @@ __all__ = [
     "_daytona_client_or_exit",
     "app",
     "eval_app",
-    "eval_create",
+    "eval_run",
 ]
 
 # Show progress messages (logger.info) from benchflow internals by default.
@@ -193,8 +194,8 @@ app.add_typer(eval_app, name="eval", rich_help_panel="Core")
 register_eval_adopt(eval_app)
 
 
-@eval_app.command("create")
-def eval_create(
+@eval_app.command("run")
+def eval_run(
     config_file: Annotated[
         Path | None,
         typer.Option("--config", help="YAML config file"),
@@ -618,7 +619,7 @@ def run_batch_eval(
 ):
     """Run the source-repo / tasks-dir batch path and report its result.
 
-    Promoted from the ``eval_create`` ``_run_batch_eval`` closure: the worker /
+    Promoted from the ``eval_run`` ``_run_batch_eval`` closure: the worker /
     jobs-dir / manifest knobs it used to capture now ride in on ``plan``.
     """
     from benchflow.eval_sharding import ShardWorkerError
@@ -861,6 +862,13 @@ def _run_source_env_eval(
     if run_result.error:
         console.print(f"[red]Error:[/red] {escape(str(run_result.error))}")
         raise typer.Exit(1)
+
+
+# `bench eval create` was renamed to `bench eval run`. Keep the old name as a
+# visible, deprecated alias so existing scripts, configs, and downstream repos
+# (e.g. benchflow-ai/skillsbench) keep working; Click prints a deprecation
+# notice when the alias is invoked.
+eval_app.command("create", deprecated=True)(eval_run)
 
 
 @eval_app.command("list")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -71,6 +71,7 @@ __all__ = [
     "app",
     "eval_app",
     "eval_run",
+    "eval_create",  # deprecated import alias of eval_run
 ]
 
 # Show progress messages (logger.info) from benchflow internals by default.
@@ -869,6 +870,11 @@ def _run_source_env_eval(
 # (e.g. benchflow-ai/skillsbench) keep working; Click prints a deprecation
 # notice when the alias is invoked.
 eval_app.command("create", deprecated=True)(eval_run)
+
+# Back-compat for the Python symbol: `eval_create` was part of this module's
+# public surface (``__all__``). Keep it as an import alias of ``eval_run`` so any
+# `from benchflow.cli.main import eval_create` keeps resolving.
+eval_create = eval_run
 
 
 @eval_app.command("list")

--- a/src/benchflow/cli/sandbox.py
+++ b/src/benchflow/cli/sandbox.py
@@ -54,7 +54,7 @@ def sandbox_create(task_dir: Path, sandbox: str) -> None:
     console.print(f"  Task:    {env.task_path}")
     console.print(f"  Sandbox: {env.sandbox}")
     console.print(
-        "  Use [cyan]bench eval create[/cyan] for CLI runs, or pass to [cyan]bf.run()[/cyan]"
+        "  Use [cyan]bench eval run[/cyan] for CLI runs, or pass to [cyan]bf.run()[/cyan]"
     )
 
 

--- a/src/benchflow/cli/skills.py
+++ b/src/benchflow/cli/skills.py
@@ -194,7 +194,7 @@ def register_skills(app: typer.Typer) -> None:
                 f"[green]GEPA traces exported to {escape(str(gepa_dir))}[/green]"
             )
 
-        # Match `eval create`'s _exit_if_evaluation_had_errors: a run with any
+        # Match `eval run`'s _exit_if_evaluation_had_errors: a run with any
         # errored case is a failure for CI/scripting — exit non-zero so a
         # 100%-error run (e.g. missing credentials) is not reported as success.
         errored = sum(1 for c in result.case_results if c.error)

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -1,6 +1,6 @@
-"""Planning logic for ``bench eval create`` — the pure core of the CLI command.
+"""Planning logic for ``bench eval run`` — the pure core of the CLI command.
 
-``bench eval create`` (defined in :mod:`benchflow.cli.main`, pinned there by the
+``bench eval run`` (defined in :mod:`benchflow.cli.main`, pinned there by the
 oracle-chokepoint tests) is a thin parse → request → plan → run → report shell.
 This module owns the **plan** step: it takes an :class:`EvalCreateRequest` of raw
 CLI flags and turns them into an :class:`EvalPlan` — the disambiguated source,
@@ -60,7 +60,7 @@ __all__ = [
 
 
 class EvalPlanError(ValueError):
-    """A ``bench eval create`` validation failure.
+    """A ``bench eval run`` validation failure.
 
     Carries the operator-facing ``message`` exactly as the CLI used to print it
     (without Rich markup). The CLI shell renders it ``[red]...[/red]`` and exits
@@ -70,7 +70,7 @@ class EvalPlanError(ValueError):
 
 @dataclass
 class EvalCreateRequest:
-    """Raw ``bench eval create`` flags relevant to planning.
+    """Raw ``bench eval run`` flags relevant to planning.
 
     Mirrors the subset of ``eval_create`` parameters consumed by
     :func:`build_eval_plan`. Execution-only flags (the ``source_env_*`` hosted-run
@@ -113,7 +113,7 @@ class EvalCreateRequest:
 
 @dataclass
 class EvalPlan:
-    """Normalized, validated inputs for the ``bench eval create`` run step.
+    """Normalized, validated inputs for the ``bench eval run`` run step.
 
     Holds every value the CLI shell needs after planning: the normalized
     agent/timeout/effort, the resolved manifest, the parsed include/exclude sets,
@@ -207,7 +207,7 @@ def _normalize_eval_agent(agent_spec: str) -> str:
 
 
 def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
-    """Validate and normalize ``bench eval create`` flags into an :class:`EvalPlan`.
+    """Validate and normalize ``bench eval run`` flags into an :class:`EvalPlan`.
 
     Raises :class:`EvalPlanError` for any validation failure, carrying the exact
     operator-facing message (no Rich markup). Performs no console or process-exit

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -72,7 +72,7 @@ class EvalPlanError(ValueError):
 class EvalCreateRequest:
     """Raw ``bench eval run`` flags relevant to planning.
 
-    Mirrors the subset of ``eval_create`` parameters consumed by
+    Mirrors the subset of ``eval_run`` parameters consumed by
     :func:`build_eval_plan`. Execution-only flags (the ``source_env_*`` hosted-run
     knobs, ``source_path``/``source_ref``, and the worker run details) are passed
     straight through by the CLI and are not modeled here.

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -1,6 +1,6 @@
 """Subprocess worker for sharded evaluation runs.
 
-The public ``bench eval create`` command uses this module when the operator asks
+The public ``bench eval run`` command uses this module when the operator asks
 for worker-level isolation. A worker runs one normal :class:`Evaluation` over a
 small include set and exits zero when BenchFlow completed the shard, even if the
 benchmark tasks themselves failed. Non-zero exits are reserved for control-plane

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -489,7 +489,7 @@ class EvaluationConfig:
     self_gen_no_internet: bool = False
     job_mode: str = DEFAULT_JOB_MODE
     source_provenance: dict[str, Any] | None = None
-    # Registry dataset identity (`bench eval create -d name@version`). When
+    # Registry dataset identity (`bench eval run -d name@version`). When
     # set, every result.json/config.json is stamped with dataset_name,
     # dataset_version, and the task's registry content digest — see
     # docs/dataset-versioning.md in benchflow-ai/skillsbench.

--- a/src/benchflow/trajectories/viewer.py
+++ b/src/benchflow/trajectories/viewer.py
@@ -165,7 +165,7 @@ def render_rollout(rollout_dir: Path, prompts: list[str] | None = None) -> str:
 
     if not turn_files:
         # The given dir has no trajectory of its own. If it's a job directory
-        # (the natural value from `eval create`'s "Artifacts:" line), point at its
+        # (the natural value from `eval run`'s "Artifacts:" line), point at its
         # rollout subdirectories instead of showing a blank page.
         try:
             rollouts = sorted(

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -14,7 +14,7 @@ split files used by older conformance docs and tests.
 ## Run
 
 ```bash
-bench eval create --tasks-dir tests/conformance/acp_smoke --agent <agent-name> --model claude-haiku-4-5-20251001
+bench eval run --tasks-dir tests/conformance/acp_smoke --agent <agent-name> --model claude-haiku-4-5-20251001
 ```
 
 Every agent in the registry must return `reward=1` on the smoke task against the oracle solution, and must complete cleanly for Haiku 4.5 as the driving model.

--- a/tests/examples/test_claude.sh
+++ b/tests/examples/test_claude.sh
@@ -159,7 +159,7 @@ for label in "${SELECTED[@]}"; do
   extra="${EXTRA_ARGS[$label]:-}"
 
   # shellcheck disable=SC2086
-  if uv run bench eval create \
+  if uv run bench eval run \
     --tasks-dir "$TASK" \
     --agent "$AGENT" \
     --model "$model" \

--- a/tests/examples/test_codex.sh
+++ b/tests/examples/test_codex.sh
@@ -206,7 +206,7 @@ for label in "${SELECTED[@]}"; do
   extra="${EXTRA_ARGS[$label]:-}"
 
   # shellcheck disable=SC2086
-  if uv run bench eval create \
+  if uv run bench eval run \
     --tasks-dir "$TASK" \
     --agent "$AGENT" \
     --model "$model" \

--- a/tests/examples/test_codex_custom_provider.sh
+++ b/tests/examples/test_codex_custom_provider.sh
@@ -92,7 +92,7 @@ echo ""
 set +e
 env -u CODEX_ACCESS_TOKEN -u CODEX_API_KEY -u OPENAI_BASE_URL -u OPENAI_API_KEY \
   OPENAI_API_KEY="dummy-local-key" \
-  uv run bench eval create \
+  uv run bench eval run \
     --tasks-dir "$TASK" \
     --agent codex-acp \
     --model vllm/gpt-5.4 \

--- a/tests/examples/test_gemini.sh
+++ b/tests/examples/test_gemini.sh
@@ -160,7 +160,7 @@ for label in "${SELECTED[@]}"; do
   extra="${EXTRA_ARGS[$label]:-}"
 
   # shellcheck disable=SC2086
-  if uv run bench eval create \
+  if uv run bench eval run \
     --tasks-dir "$TASK" \
     --agent "$AGENT" \
     --model "$model" \

--- a/tests/examples/test_openclaw.sh
+++ b/tests/examples/test_openclaw.sh
@@ -159,7 +159,7 @@ for label in "${SELECTED[@]}"; do
   extra="${EXTRA_ARGS[$label]:-}"
 
   # shellcheck disable=SC2086
-  if uv run bench eval create \
+  if uv run bench eval run \
     --tasks-dir "$TASK" \
     --agent "$AGENT" \
     --model "$model" \

--- a/tests/integration/agent_judge.py
+++ b/tests/integration/agent_judge.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Agent-as-judge verification over a completed BenchFlow rollout.
 
-This is BenchFlow's own integration check: after a real ``bench eval create``
+This is BenchFlow's own integration check: after a real ``bench eval run``
 run, an LLM judge reads the recorded rollout and decides whether the run is a
 trustworthy measurement — the agent genuinely attempted the task, the
 trajectory is coherent, and the reward is not the product of obvious
@@ -572,7 +572,7 @@ def _find_rollout_dir(root: Path) -> Path:
     """Resolve a rollout directory from a path that may be a jobs root.
 
     Accepts either a rollout dir (contains ``result.json``) directly, or a
-    parent tree from one ``bench eval create`` run, in which case the most
+    parent tree from one ``bench eval run`` run, in which case the most
     recently modified rollout is judged.
     """
     if (root / "result.json").is_file():

--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -1,7 +1,7 @@
 """Review integration test results.
 
 Reads jobs/<agent>/*/result.json and summary.json files produced by
-``bench eval create`` and validates:
+``bench eval run`` and validates:
 
 1. Every expected agent produced a jobs directory
 2. Each trial has a valid result.json (schema check)
@@ -978,7 +978,7 @@ def check_agent(agent_dir: Path) -> dict:
             f"{', '.join(verifier_timeout_tasks)}"
         )
 
-    # Summary.json — bench eval create writes it at the agent_dir root
+    # Summary.json — bench eval run writes it at the agent_dir root
     if summary_error is None:
         assert summary is not None
         worker_sharded_summary = _is_worker_sharded_summary(summary)

--- a/tests/integration/check_trace_to_task_evidence.py
+++ b/tests/integration/check_trace_to_task_evidence.py
@@ -138,11 +138,11 @@ def _run_oracle_eval(task_dir: Path, jobs_dir: Path, sandbox: str) -> dict[str, 
         "status": "fail",
     }
     if completed.returncode != 0:
-        record["message"] = "bench eval create returned non-zero"
+        record["message"] = "bench eval run returned non-zero"
         _attach_failure_logs(record, completed)
         return record
     if result_path is None:
-        record["message"] = "bench eval create did not produce a fresh result.json"
+        record["message"] = "bench eval run did not produce a fresh result.json"
         _attach_failure_logs(record, completed)
         return record
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Integration test runner — drives bench eval create per agent.
+# Integration test runner — drives bench eval run per agent.
 #
 # All agents launch in parallel; each agent runs its 9 tasks concurrently
 # via Daytona (concurrency=64 by default). The script waits for every agent to finish,
@@ -164,7 +164,7 @@ if [ "$CHECK_ONLY" = false ]; then
     model="$(model_for_agent "$agent")"
     config_file="tests/integration/configs/$agent.yaml"
     echo "Launching $agent (model=$model, config=$config_file)..."
-    uv run bench eval create \
+    uv run bench eval run \
       --config "$config_file" \
       --jobs-dir "$JOBS_ROOT/$agent" \
       --concurrency "$INTEGRATION_CONCURRENCY" \
@@ -178,7 +178,7 @@ if [ "$CHECK_ONLY" = false ]; then
   echo ""
   CHECK_AGENTS=("${LAUNCHED[@]}")
 
-  # Wait for all and report as each finishes. bench eval create may exit
+  # Wait for all and report as each finishes. bench eval run may exit
   # non-zero when trials fail or verifiers reject agent output; audit anyway.
   EVAL_WARNINGS=0
   for i in "${!PIDS[@]}"; do

--- a/tests/integration/scenarios.py
+++ b/tests/integration/scenarios.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Reusable building blocks for BenchFlow's integration scenarios.
 
-These helpers layer on BenchFlow's own primitives — ``bench eval create``, the
+These helpers layer on BenchFlow's own primitives — ``bench eval run``, the
 :mod:`tests.integration.agent_judge` realness+judge gate, and the
 ``result.json`` / ATIF / ADP artifact contracts — so the integration suite
 (:mod:`tests.test_integration_suite`) reads as a set of end-to-end assertions
@@ -66,7 +66,7 @@ _SECRET_PATTERNS = (
 
 @dataclass(frozen=True)
 class EvalOutcome:
-    """The result of a ``bench eval create`` subprocess."""
+    """The result of a ``bench eval run`` subprocess."""
 
     returncode: int
     jobs_dir: Path
@@ -90,7 +90,7 @@ def run_eval(
     env: Mapping[str, str] | None = None,
     timeout: float = 1800.0,
 ) -> EvalOutcome:
-    """Run ``bench eval create`` and return its outcome.
+    """Run ``bench eval run`` and return its outcome.
 
     A thin, explicit wrapper so every scenario invokes the real CLI the same
     way a user would, with a per-batch ``jobs_dir`` (the resume trap: a reused
@@ -101,7 +101,7 @@ def run_eval(
         "run",
         "bench",
         "eval",
-        "create",
+        "run",
         "--agent",
         agent,
         "--sandbox",

--- a/tests/integration/suites/release.yaml
+++ b/tests/integration/suites/release.yaml
@@ -339,7 +339,7 @@ lanes:
       task_sets:
         - shared_sandbox_smoke
     acceptance:
-      - bench eval create succeeds on Docker and Daytona without special user intervention beyond each backend's documented auth.
+      - bench eval run succeeds on Docker and Daytona without special user intervention beyond each backend's documented auth.
       - result.json, trajectory output, and summary schema are valid.
 
   - id: security-dind-smoke
@@ -351,8 +351,8 @@ lanes:
       - Firecracker/K8s sandbox backends are not exposed by the current CLI.
       - Run evidence is blocked until those backends have runnable support.
     activation_criteria:
-      - bench eval create --sandbox firecracker runs the task without questions.
-      - bench eval create --sandbox k8s runs the task without questions.
+      - bench eval run --sandbox firecracker runs the task without questions.
+      - bench eval run --sandbox k8s runs the task without questions.
       - Docker-in-Docker-style service/container operations work inside both sandboxes.
     matrix:
       agents: cheap_representative
@@ -456,7 +456,7 @@ lanes:
     acceptance:
       - bench tasks generate emits valid task directories from both source classes.
       - Generated tasks pass bench tasks check.
-      - At least one generated task runs through bench eval create and validates verifier outcome.
+      - At least one generated task runs through bench eval run and validates verifier outcome.
 
   - id: decoupling-checks
     release_blocker: true

--- a/tests/test_agent_gemini_defaults.py
+++ b/tests/test_agent_gemini_defaults.py
@@ -57,7 +57,7 @@ class TestEffectiveModelHonorsAgentDefault:
 
     def test_default_agent_still_uses_global_default(self):
         """Backwards-compat: the DEFAULT_AGENT still falls back to DEFAULT_MODEL
-        so `benchflow eval create` with no flags keeps working."""
+        so `benchflow eval run` with no flags keeps working."""
         from benchflow.evaluation import DEFAULT_AGENT, DEFAULT_MODEL
 
         assert effective_model(DEFAULT_AGENT, None) == DEFAULT_MODEL

--- a/tests/test_agent_idle_timeout_cli.py
+++ b/tests/test_agent_idle_timeout_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the ``--agent-idle-timeout`` CLI flag on ``bench eval create``.
+"""Tests for the ``--agent-idle-timeout`` CLI flag on ``bench eval run``.
 
 Closes #338: long-running optimization tasks need to extend or disable the
 ACP idle watchdog without patching the installed source.
@@ -12,7 +12,7 @@ from unittest.mock import patch
 import typer
 from typer.testing import CliRunner
 
-from benchflow.cli.main import app, eval_create
+from benchflow.cli.main import app, eval_run
 from benchflow.evaluation import EvaluationResult
 
 
@@ -50,7 +50,7 @@ def test_eval_create_integer_idle_timeout_lands_in_config(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             tasks_dir=tasks,
             agent_idle_timeout="300",
             jobs_dir=str(tmp_path / "jobs"),
@@ -65,7 +65,7 @@ def test_eval_create_reasoning_effort_lands_in_config(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             tasks_dir=tasks,
             reasoning_effort="MAX",
             jobs_dir=str(tmp_path / "jobs"),
@@ -86,7 +86,7 @@ def test_eval_create_reasoning_effort_overrides_yaml_config(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             config_file=yaml_path,
             reasoning_effort="MAX",
             jobs_dir=str(tmp_path / "jobs"),
@@ -101,7 +101,7 @@ def test_eval_create_none_string_disables_idle_watchdog(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             tasks_dir=tasks,
             agent_idle_timeout="none",
             jobs_dir=str(tmp_path / "jobs"),
@@ -116,7 +116,7 @@ def test_eval_create_zero_string_disables_idle_watchdog(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             tasks_dir=tasks,
             agent_idle_timeout="0",
             jobs_dir=str(tmp_path / "jobs"),
@@ -131,7 +131,7 @@ def test_eval_create_default_idle_timeout_is_600(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             tasks_dir=tasks,
             jobs_dir=str(tmp_path / "jobs"),
         )
@@ -144,7 +144,7 @@ def test_eval_create_rejects_invalid_idle_timeout(tmp_path: Path):
     tasks = _make_tasks_dir(tmp_path)
 
     try:
-        eval_create(
+        eval_run(
             tasks_dir=tasks,
             agent_idle_timeout="forever",
             jobs_dir=str(tmp_path / "jobs"),
@@ -167,7 +167,7 @@ def test_eval_create_idle_timeout_overrides_yaml_config(tmp_path: Path):
     captured: dict = {}
 
     with _stub_evaluation_run(captured):
-        eval_create(
+        eval_run(
             config_file=yaml_path,
             agent_idle_timeout="none",
             jobs_dir=str(tmp_path / "jobs"),

--- a/tests/test_clawsbench_slice.py
+++ b/tests/test_clawsbench_slice.py
@@ -4,7 +4,7 @@ Verifiers/ORS export.
 The data-path test proves the thread with no Docker. A full live rollout is
 run manually:
 
-    bench eval create --tasks-dir benchmarks/clawsbench/tasks/<task> \\
+    bench eval run --tasks-dir benchmarks/clawsbench/tasks/<task> \\
       --environment-manifest benchmarks/clawsbench/environment.toml \\
       --agent claude-agent-acp --model claude-haiku-4-5
 """

--- a/tests/test_cli_adopt_aliases.py
+++ b/tests/test_cli_adopt_aliases.py
@@ -1,7 +1,7 @@
 """Benchmark adoption is canonically the single ``bench eval adopt`` command.
 
 Adoption lives under ``eval`` because ``eval`` is the universal benchmark entry
-point (``eval create`` runs a benchmark; ``eval adopt`` makes a foreign one
+point (``eval run`` runs a benchmark; ``eval adopt`` makes a foreign one
 runnable). ``bench eval adopt`` is one multi-mode command: ``<source>`` to
 scaffold+convert, ``<name> --scaffold-only`` to only scaffold, and
 ``<name> --verify`` to run the parity gate. Two prior spellings stay as hidden

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -16,7 +16,7 @@ import click
 import typer
 from typer.testing import CliRunner
 
-from benchflow.cli.main import app
+from benchflow.cli.main import app, eval_app
 
 runner = CliRunner()
 
@@ -105,8 +105,8 @@ def test_top_level_help_lists_public_groups() -> None:
         )
 
 
-def test_eval_create_flags_match_cli_md_bidirectional() -> None:
-    """`bench eval create`'s flags and its cli.md table must be set-equal.
+def test_eval_run_flags_match_cli_md_bidirectional() -> None:
+    """`bench eval run`'s flags and its cli.md table must be set-equal.
 
     The old guard only checked doc→CLI (a hand-maintained list of documented
     flags must exist in --help). It could not catch the *reverse* — a new CLI
@@ -115,10 +115,10 @@ def test_eval_create_flags_match_cli_md_bidirectional() -> None:
     sides from ground truth (the live parser + the doc table) drops the
     hand-maintained list and closes both directions.
     """
-    cli = _cli_long_flags(["eval", "create"])
-    doc = _doc_flags("### bench eval create")
+    cli = _cli_long_flags(["eval", "run"])
+    doc = _doc_flags("### bench eval run")
     assert cli == doc, (
-        "bench eval create CLI↔cli.md flag drift:\n"
+        "bench eval run CLI↔cli.md flag drift:\n"
         f"  in CLI but UNDOCUMENTED: {sorted(cli - doc)}\n"
         f"  documented but NOT in CLI: {sorted(doc - cli)}"
     )
@@ -148,17 +148,31 @@ def test_documented_defaults_match_cli() -> None:
         )
 
 
-def test_eval_create_accepts_environment_manifest() -> None:
-    """`bench eval create --environment-manifest` is the batch seam for
+def test_eval_run_accepts_environment_manifest() -> None:
+    """`bench eval run --environment-manifest` is the batch seam for
     Environment-plane rollouts (#398). Guard against silent removal so the
     docs and CLI stay in sync."""
-    out = _help(["eval", "create"])
+    out = _help(["eval", "run"])
     assert "--environment-manifest" in out
+
+
+def test_eval_create_is_deprecated_alias_of_run() -> None:
+    """`bench eval create` was renamed to `bench eval run`; the old name stays
+    as a deprecated alias so existing scripts and downstream repos keep working.
+    """
+    by_name = {c.name: c for c in eval_app.registered_commands}
+    assert "run" in by_name, "primary `bench eval run` command missing"
+    assert "create" in by_name, "deprecated `bench eval create` alias missing"
+    assert by_name["create"].deprecated, "`create` must be marked deprecated"
+    assert not by_name["run"].deprecated, "`run` must not be deprecated"
+    # Both names share the same callback so flags/behavior never drift apart.
+    assert by_name["run"].callback is by_name["create"].callback
 
 
 def test_documented_subcommands_exist() -> None:
     """Subcommands referenced in docs/reference/cli.md must resolve."""
     for cmd in (
+        ["eval", "run"],
         ["eval", "create"],
         ["eval", "list"],
         ["eval", "metrics"],

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -149,7 +149,7 @@ def test_parse_skill_coerces_scalar_frontmatter(tmp_path, frontmatter, field, ex
     assert info.description[:60] == info.description[:60]
 
 
-# ── eval create --config: malformed YAML (H7) + prompts string-split (H8) ─────
+# ── eval run --config: malformed YAML (H7) + prompts string-split (H8) ─────
 
 
 def test_from_yaml_rejects_non_mapping(tmp_path):
@@ -428,7 +428,7 @@ def test_arg_validation_errors_route_to_stderr(argv, needle):
 
 def test_skills_eval_exits_nonzero_when_cases_error(tmp_path, monkeypatch):
     # A run where cases errored (e.g. missing credentials) must exit non-zero,
-    # matching `eval create` — a 100%-error run printed `0/1` but exited 0, so CI
+    # matching `eval run` — a 100%-error run printed `0/1` but exited 0, so CI
     # read a total failure as success.
     from benchflow.skill_eval._core import CaseResult, SkillEvalResult, SkillEvaluator
 

--- a/tests/test_dataset_registry.py
+++ b/tests/test_dataset_registry.py
@@ -1,4 +1,4 @@
-"""Tests for registry dataset resolution (`bench eval create -d name@version`).
+"""Tests for registry dataset resolution (`bench eval run -d name@version`).
 
 Step 2 of the dataset-versioning plan (docs/dataset-versioning.md in
 benchflow-ai/skillsbench, registry added in skillsbench PR #922): resolving a

--- a/tests/test_eval_filters_applied.py
+++ b/tests/test_eval_filters_applied.py
@@ -1,4 +1,4 @@
-"""Single-task `bench eval create` must honor --include / --exclude (#401).
+"""Single-task `bench eval run` must honor --include / --exclude (#401).
 
 Before the fix the single-task branch called ``SDK().run`` directly and
 ignored the include/exclude sets that the batch path applied.

--- a/tests/test_eval_single_task_summary.py
+++ b/tests/test_eval_single_task_summary.py
@@ -1,4 +1,4 @@
-"""Single-task `bench eval create` must publish a summary.json (#400).
+"""Single-task `bench eval run` must publish a summary.json (#400).
 
 Single-task and batch must share the same orchestration path so that
 ``bench eval list`` can find a real score for both.  Before the fix the
@@ -61,7 +61,7 @@ async def test_evaluation_run_writes_summary_for_single_task(tmp_path):
 
 
 def test_cli_single_task_publishes_summary_for_eval_list(tmp_path, monkeypatch):
-    """CLI: `bench eval create --tasks-dir <task>` writes summary.json (#400).
+    """CLI: `bench eval run --tasks-dir <task>` writes summary.json (#400).
 
     With the unified path the single-task CLI invocation produces the same
     summary.json layout that `bench eval list` reads — fixing the

--- a/tests/test_eval_source_provenance.py
+++ b/tests/test_eval_source_provenance.py
@@ -288,7 +288,7 @@ def test_eval_create_single_task_applies_concurrency_override(monkeypatch, tmp_p
 
 
 def test_eval_create_single_task_passes_cli_prompts(monkeypatch, tmp_path):
-    """Guards PR #608 so eval create keeps custom CLI prompts."""
+    """Guards PR #608 so eval run keeps custom CLI prompts."""
     task_dir = tmp_path / "task-a"
     task_dir.mkdir()
     (task_dir / "task.toml").write_text("[task]\n")
@@ -388,7 +388,7 @@ def test_eval_create_config_allows_literal_jobs_dir_override(monkeypatch, tmp_pa
 
 
 def test_eval_create_config_prompt_overrides_yaml(monkeypatch, tmp_path):
-    """Guards PR #608 so bench eval create --prompt overrides YAML prompts."""
+    """Guards PR #608 so bench eval run --prompt overrides YAML prompts."""
     tasks_root = tmp_path / "tasks"
     tasks_root.mkdir()
     config = tmp_path / "eval.yaml"

--- a/tests/test_eval_zero_task_guard.py
+++ b/tests/test_eval_zero_task_guard.py
@@ -1,7 +1,7 @@
 """Zero-task selection must exit non-zero and never write a misleading
 summary.json (#407).
 
-Before the fix, ``bench eval create --include not-a-real-task`` exited 0
+Before the fix, ``bench eval run --include not-a-real-task`` exited 0
 and published a ``total: 0, passed: 0, score: "0.0%"`` artifact that
 downstream dashboards could ingest as evidence.
 """

--- a/tests/test_evaluation_environment_manifest.py
+++ b/tests/test_evaluation_environment_manifest.py
@@ -6,7 +6,7 @@ rollouts:
 * ``EvaluationConfig`` had no ``environment_manifest`` field;
 * ``Evaluation._run_single_task`` built ``RolloutConfig.from_legacy`` without
   one, so the manifest seam disappeared at the Job layer;
-* ``bench eval create`` exposed no ``--environment-manifest`` option.
+* ``bench eval run`` exposed no ``--environment-manifest`` option.
 
 These tests assert the full path: dataclass → CLI flag → YAML loader →
 ``RolloutConfig.environment_manifest``.
@@ -105,7 +105,7 @@ async def test_run_single_task_passes_manifest_to_rollout_config(
     assert captured["manifest"] is _MANIFEST
 
 
-# bench eval create --environment-manifest
+# bench eval run --environment-manifest
 
 
 def test_cli_eval_create_flag_loads_manifest_into_evaluation_config(

--- a/tests/test_integration_agent_judge.py
+++ b/tests/test_integration_agent_judge.py
@@ -54,7 +54,7 @@ def _write_rollout(
     result: dict | None = None,
     trajectory: list[dict] | None = None,
 ) -> Path:
-    """Materialize a rollout dir shaped like a real ``bench eval create`` one."""
+    """Materialize a rollout dir shaped like a real ``bench eval run`` one."""
     root.mkdir(parents=True, exist_ok=True)
     (root / "result.json").write_text(json.dumps(result or _REAL_RESULT))
     if trajectory is not None:

--- a/tests/test_integration_run_suite.py
+++ b/tests/test_integration_run_suite.py
@@ -235,7 +235,7 @@ def test_security_dind_lane_has_concrete_task_but_remains_blocked() -> None:
     assert lane["status"] == "backlog"
     assert lane["release_blocker"] is False
     assert "Firecracker/K8s" in lane["backlog_reason"]
-    assert "bench eval create --sandbox firecracker" in lane["activation_criteria"][0]
+    assert "bench eval run --sandbox firecracker" in lane["activation_criteria"][0]
     task_set = expanded["matrix"]["task_sets"][0]
     assert task_set["source"]["env_uid"] == (
         "harbor:termigen-environments/docker_escape_privileged_container_medium@"
@@ -310,7 +310,7 @@ def test_backlog_profile_tracks_security_dind_blocker(
         "harbor:termigen-environments/docker_escape_privileged_container_medium@"
         in captured.out
     )
-    assert "bench eval create --sandbox firecracker" in captured.out
+    assert "bench eval run --sandbox firecracker" in captured.out
     assert "unresolved TODOs or blocked lanes in selected lane(s):" in captured.err
     assert "security-dind-smoke (blocked: 2)" in captured.err
 

--- a/tests/test_no_cross_provider_fallback.py
+++ b/tests/test_no_cross_provider_fallback.py
@@ -67,7 +67,7 @@ class TestNoCrossProviderFallback:
 
     def test_default_agent_with_no_model_still_works(self):
         """Backwards-compat: the DEFAULT_AGENT keeps falling back to
-        DEFAULT_MODEL so `benchflow eval create` with no flags works."""
+        DEFAULT_MODEL so `benchflow eval run` with no flags works."""
         assert effective_model(DEFAULT_AGENT, None) == DEFAULT_MODEL
 
     def test_oracle_short_circuits_before_default_check(self):

--- a/tests/test_oracle_chokepoint.py
+++ b/tests/test_oracle_chokepoint.py
@@ -4,16 +4,16 @@ Pins the fix from this branch (post-PR #173 follow-up):
 
   Layer 1 — restore `agent != "oracle"` guard in resolve_agent_env so the
             chokepoint defends against any caller that forwards a model.
-  Layer 2 — keep `bench eval create` routed through the live CLI entry point.
+  Layer 2 — keep `bench eval run` routed through the live CLI entry point.
   Layer 3 — funnel all CLI/YAML-loader sites through effective_model() so
             oracle gets honest model=None end-to-end.
 
 The classes below pin each layer at the right altitude:
-- TestEvalCreateRouting   — proves `bench eval create` dispatches to
+- TestEvalCreateRouting   — proves `bench eval run` dispatches to
                             cli/main.py.
 - TestEffectiveModel      — unit tests for the helper.
 - TestOracleYamlLoaders   — Evaluation.from_yaml(oracle config) → model is None.
-- TestEvalCreateOracleCLI — end-to-end: invoke `bench eval create --agent oracle`
+- TestEvalCreateOracleCLI — end-to-end: invoke `bench eval run --agent oracle`
                             and assert no API-key validation error.
 """
 
@@ -35,7 +35,7 @@ def _plain_cli_output(output: str) -> str:
 
 
 class TestEvalCreateRouting:
-    """`bench eval create` must dispatch to cli/main.py:eval_create.
+    """`bench eval run` must dispatch to cli/main.py:eval_run.
 
     The pyproject.toml `bench`/`benchflow` scripts both resolve to
     `benchflow.cli.main:app`; these tests pin the live command callback.
@@ -54,7 +54,7 @@ class TestEvalCreateRouting:
         assert create_cmds[0].callback.__module__ == "benchflow.cli.main"
 
     def test_bench_eval_create_help_resolves(self):
-        """Smoke test: `bench eval create --help` reaches a real callback."""
+        """Smoke test: `bench eval run --help` reaches a real callback."""
         from benchflow.cli.main import app
 
         result = CliRunner().invoke(app, ["eval", "create", "--help"])
@@ -189,10 +189,10 @@ class TestEvalCreateRouting:
         assert not (task_dir / "task.md").exists()
 
     def test_eval_create_normalizes_agent_alias(self, tmp_path: Path):
-        """Guards ENG-86: eval create normalizes aliases before launch."""
+        """Guards ENG-86: eval run normalizes aliases before launch."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         task = tmp_path / "task"
@@ -208,7 +208,7 @@ class TestEvalCreateRouting:
             )
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(
+            eval_run(
                 config_file=None,
                 tasks_dir=task,
                 source_repo=None,
@@ -234,7 +234,7 @@ class TestEvalCreateRouting:
         """Guards ENG-91 P0 dogfood sandbox-user CLI regression."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         task = tmp_path / "task"
@@ -250,7 +250,7 @@ class TestEvalCreateRouting:
             )
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(
+            eval_run(
                 config_file=None,
                 tasks_dir=task,
                 source_repo=None,
@@ -294,7 +294,7 @@ class TestEvalCreateRouting:
         """Guards the ENG-86 fix from commit b69bdf4 for config-file agents."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         tasks = tmp_path / "tasks"
@@ -309,7 +309,7 @@ class TestEvalCreateRouting:
             return SimpleNamespace(passed=0, total=0, score=0.0, errored=0)
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(config_file=config)
+            eval_run(config_file=config)
 
         assert captured == {"agent": "oracle", "model": None}
 
@@ -319,7 +319,7 @@ class TestEvalCreateRouting:
         """Guards ENG-78: CLI runs inherit provider keys without --agent-env."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         task = tmp_path / "task"
@@ -343,7 +343,7 @@ class TestEvalCreateRouting:
             )
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(
+            eval_run(
                 config_file=None,
                 tasks_dir=task,
                 source_repo=None,
@@ -374,7 +374,7 @@ class TestEvalCreateRouting:
         import os
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         task = tmp_path / "task"
@@ -402,7 +402,7 @@ class TestEvalCreateRouting:
             )
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(
+            eval_run(
                 config_file=None,
                 tasks_dir=task,
                 source_repo=None,
@@ -583,7 +583,7 @@ class TestEvalCreateIncludeExclude:
         """Guards ENG-159: --include reaches EvaluationConfig for --tasks-dir batch runs."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         tasks = tmp_path / "tasks"
@@ -600,7 +600,7 @@ class TestEvalCreateIncludeExclude:
             return SimpleNamespace(passed=0, total=0, score=0.0, errored=0)
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(
+            eval_run(
                 config_file=None,
                 tasks_dir=tasks,
                 source_repo=None,
@@ -629,7 +629,7 @@ class TestEvalCreateIncludeExclude:
         """Guards ENG-159: CLI --include overrides YAML include list."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         tasks = tmp_path / "tasks"
@@ -645,7 +645,7 @@ class TestEvalCreateIncludeExclude:
             return SimpleNamespace(passed=0, total=0, score=0.0, errored=0)
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(config_file=config, include=["cli-task"])
+            eval_run(config_file=config, include=["cli-task"])
 
         assert captured["include"] == {"cli-task"}
 
@@ -653,7 +653,7 @@ class TestEvalCreateIncludeExclude:
         """Guards ENG-159: without CLI --include, YAML include list is preserved."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.evaluation import Evaluation
 
         tasks = tmp_path / "tasks"
@@ -669,7 +669,7 @@ class TestEvalCreateIncludeExclude:
             return SimpleNamespace(passed=0, total=0, score=0.0, errored=0)
 
         with patch.object(Evaluation, "run", new=fake_run):
-            eval_create(config_file=config)
+            eval_run(config_file=config)
 
         assert captured["include"] == {"yaml-task"}
 
@@ -971,10 +971,10 @@ class TestOracleYamlLoaders:
 
 
 class TestEvalCreateOracleCLI:
-    """End-to-end: `bench eval create --agent oracle` must not trip API key validation.
+    """End-to-end: `bench eval run --agent oracle` must not trip API key validation.
 
     This is the user-visible bug the chokepoint test guards against at the
-    unit level. Here we call the live handler (cli/main.py:eval_create)
+    unit level. Here we call the live handler (cli/main.py:eval_run)
     directly rather than through Typer's CliRunner; the handler still runs
     asyncio.run() internally, exercising the full
     CLI → effective_model → RolloutConfig → resolve_agent_env path the bug
@@ -1004,7 +1004,7 @@ class TestEvalCreateOracleCLI:
         """The bug: oracle + missing API key → ANTHROPIC_API_KEY ValueError."""
         from types import SimpleNamespace
 
-        from benchflow.cli.main import eval_create
+        from benchflow.cli.main import eval_run
         from benchflow.models import RunResult
 
         self._strip_api_keys(monkeypatch)
@@ -1033,7 +1033,7 @@ class TestEvalCreateOracleCLI:
             return trial
 
         with patch("benchflow.rollout.Rollout.create", new=fake_create):
-            eval_create(
+            eval_run(
                 config_file=None,
                 tasks_dir=task,
                 agent="oracle",

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -617,7 +617,7 @@ class TestResolveAgentEnvOracle:
     Regression for the PR #173 follow-up: commit 360c460 removed the
     `agent != "oracle"` guard from resolve_agent_env, betting that CLI callers
     would pass model=None for oracle. But cli/main.py:eval_create (the live
-    `bench eval create`) still passes `model or DEFAULT_MODEL`, so oracle
+    `bench eval run`) still passes `model or DEFAULT_MODEL`, so oracle
     reaches the chokepoint with a real model and triggers ANTHROPIC_API_KEY
     validation — breaking offline oracle runs that have no API key set.
     """

--- a/tests/test_self_gen_cli.py
+++ b/tests/test_self_gen_cli.py
@@ -15,8 +15,8 @@ def _make_task(tmp_path: Path) -> Path:
 
 
 def test_eval_create_single_task_self_gen_passes_trial_config(tmp_path: Path):
-    """`bench eval create --skill-mode self-gen` reaches strict self-gen orchestration."""
-    from benchflow.cli.main import eval_create
+    """`bench eval run --skill-mode self-gen` reaches strict self-gen orchestration."""
+    from benchflow.cli.main import eval_run
 
     task = _make_task(tmp_path)
     skill_creator = tmp_path / "skills" / "skill-creator"
@@ -36,7 +36,7 @@ def test_eval_create_single_task_self_gen_passes_trial_config(tmp_path: Path):
         )
 
     with patch("benchflow.self_gen.run_self_gen", new=fake_run_self_gen):
-        eval_create(
+        eval_run(
             config_file=None,
             tasks_dir=task,
             agent="claude-agent-acp",

--- a/tests/test_task_check_eval_consistency.py
+++ b/tests/test_task_check_eval_consistency.py
@@ -1,8 +1,8 @@
-"""Regression tests for #379 — `bench tasks check` and `bench eval create`
+"""Regression tests for #379 — `bench tasks check` and `bench eval run`
 must agree on the structural contract for task packages.
 
 The original bug: a task.toml without an [agent] section was rejected by
-`bench tasks check` but happily executed by `bench eval create`, producing
+`bench tasks check` but happily executed by `bench eval run`, producing
 recorded evidence for a "malformed" task. The fix aligns the structural
 checker with the runtime contract (AgentConfig.timeout_sec defaults to
 None) so both commands return the same verdict.
@@ -96,7 +96,7 @@ def test_check_task_accepts_missing_agent(tmp_path):
 
     Runtime AgentConfig.timeout_sec defaults to None (rollout treats this
     as "no wall-clock cap"). Rejecting it here would diverge from what
-    `bench eval create` actually executes.
+    `bench eval run` actually executes.
     """
     task = _make_task_missing_agent(tmp_path)
     issues = check_task(task)
@@ -117,7 +117,7 @@ def test_tasks_check_cli_accepts_missing_agent(tmp_path):
 
 
 def test_eval_create_enumerates_task_missing_agent(tmp_path):
-    """`bench eval create --tasks-dir <dir>` must enumerate the same
+    """`bench eval run --tasks-dir <dir>` must enumerate the same
     task that `bench tasks check` accepted — no structural filtering on
     missing [agent].
     """
@@ -129,7 +129,7 @@ def test_eval_create_enumerates_task_missing_agent(tmp_path):
     )
     task_dirs = ev._get_task_dirs()
     assert task_dirs == [task], (
-        f"`eval create` dropped a task that `tasks check` accepts: {task_dirs}"
+        f"`eval run` dropped a task that `tasks check` accepts: {task_dirs}"
     )
 
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -98,7 +98,7 @@ class TestCheckTask:
     def test_task_toml_missing_agent_section_is_allowed(self, tmp_path):
         """[agent] is optional — runtime AgentConfig defaults to no timeout.
 
-        Guards #379: bench tasks check and bench eval create must agree on
+        Guards #379: bench tasks check and bench eval run must agree on
         the missing-[agent] contract. The runtime accepts it, so check_task
         does too.
         """
@@ -421,7 +421,7 @@ class TestTaskMdScaffoldAgentNeutral:
     """The default task.md scaffold must not pin an agent (#dogfood-1).
 
     A scenes block with a role-pinned agent silently overrides --agent on
-    `bench eval create`, so the scaffold's own documented oracle smoke test
+    `bench eval run`, so the scaffold's own documented oracle smoke test
     (`--agent oracle`) ran claude-agent-acp instead and died on ACP auth.
     The scaffold stays bare prose; roles/scenes are opt-in via the authoring
     guide.


### PR DESCRIPTION
## What

Renames the primary evaluation command from `bench eval create` to **`bench eval run`**. The verb now matches what the command does — it *runs* an evaluation (single task or batch); `create` was always a slightly wrong verb.

`bench eval create` is kept as a **deprecated alias** so nothing breaks:

```
│ run       Run an evaluation — single task or batch.
│ create    Run an evaluation — single task or batch.   (deprecated)
```

- `bench eval run …` → runs normally, no warning.
- `bench eval create …` → still runs, prints `DeprecationWarning: The command 'create' is deprecated.` (Click's native deprecation notice).

## Why

`run` reads correctly and is what users expect. Keeping `create` as an alias means existing scripts, YAML configs, and **downstream repos (e.g. `benchflow-ai/skillsbench`)** keep working with zero changes — they can migrate at their own pace.

## How

- **`src/benchflow/cli/main.py`**: `@eval_app.command("run") / def eval_run`, plus `eval_app.command("create", deprecated=True)(eval_run)` for the alias (the idiomatic Typer pattern — same callback under two names).
- Python symbol `eval_create` → `eval_run` (incl. `__all__` and the 3 in-repo callers).
- **`tests/test_cli_docs_drift.py`**: bidirectional flag/doc check repointed to `run` + `### bench eval run`; new `test_eval_create_is_deprecated_alias_of_run` pins that `create` is deprecated and shares `run`'s callback (so flags can never drift between the two names).
- **`docs/reference/cli.md`**: header → `### bench eval run` + a deprecation note + fixed anchor link.
- Mechanical `eval create` → `eval run` sweep across live docs, `src/` docstrings/strings, the CI integration workflow, `benchmarks/` + `.agents/` docs, and a `CHANGELOG` entry. (Historical `CHANGELOG` 0.6.0 entries left as-is.)

## Tests

`4213 passed`. The only failures in the full run (`tests/test_trace_import_cli.py::test_tasks_generate_rejects_removed_short_options`, ×4) are **pre-existing on `main`** (verified: identical with this branch stashed) and are unrelated — they're in `bench tasks generate`.

> Test argv invocations that still pass `["eval", "create"]` are kept **intentionally**: they exercise the deprecated alias end-to-end (the back-compat guarantee this PR ships) and pass via the alias.

## Downstream

Paired skillsbench migration: opened separately. (skillsbench can keep running on the `create` alias until it picks up a benchflow release with `run`.)