### PR TITLE
fix(agents): route OpenCode-family + pi-acp agents through the LLM usage proxy

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -156,6 +156,14 @@ def _format_acp_model(model: str, agent: str) -> str:
     bare = strip_provider_prefix(model)
     agent_cfg = AGENTS.get(agent)
     if agent_cfg and agent_cfg.acp_model_format == "registered-provider/model":
+        # Proxy mode: BenchFlow's LiteLLM proxy serves the model under the alias
+        # "benchflow-…", which the pi-acp launcher registers under the "litellm"
+        # provider (BENCHFLOW_PROVIDER_NAME) in models.json. The alias carries no
+        # provider prefix, so sending it bare leaves Pi unable to resolve it — the
+        # model calls then bypass the proxy and no llm_trajectory.jsonl is written.
+        # Send the registered-provider-qualified id so Pi hits the gateway route.
+        if model.startswith("benchflow-"):
+            return f"litellm/{model}"
         return model if find_provider(model) else bare
     if not agent_cfg or agent_cfg.acp_model_format != "provider/model":
         return bare

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -32,7 +32,7 @@ from benchflow.agents.providers import (
     find_provider_for_bare_model,
     strip_provider_prefix,
 )
-from benchflow.agents.registry import AGENTS
+from benchflow.agents.registry import AGENTS, OPENCODE_PROXY_PROVIDER_ID
 from benchflow.diagnostics import (
     AgentPromptTimeoutDiagnostic,
     AgentPromptTimeoutError,
@@ -170,12 +170,14 @@ def _format_acp_model(model: str, agent: str) -> str:
     # Already has a slash — assume it's provider/model already
     if "/" in bare:
         return bare
-    # BenchFlow's LiteLLM proxy registers every model under "openai/<alias>"
-    # (aliases are always "benchflow-…"). Send that so provider/model agents
-    # (e.g. opencode) hit a registered route instead of a guessed provider that
-    # the proxy never serves (the heuristic would default to anthropic/).
+    # BenchFlow's ``<binary>-proxy`` wrapper registers the gateway alias under a
+    # dedicated provider id (OPENCODE_PROXY_PROVIDER_ID) that OpenCode routes
+    # through the chat-completions path. It must NOT be the built-in ``openai``
+    # id: OpenCode hard-codes the Responses API there (``provider.responses(id)``)
+    # which the gateway/DeepSeek cannot serve (the model call then crashes or
+    # 404s with zero tool calls). Aliases are always "benchflow-…".
     if bare.startswith("benchflow-"):
-        return f"openai/{bare}"
+        return f"{OPENCODE_PROXY_PROVIDER_ID}/{bare}"
     # Provider ownership lives in the registry: if a ProviderConfig claims this
     # bare model family via its declared model_prefixes, route through it
     # (e.g. mimo-v2.5 -> xiaomi, deepseek-v4-flash -> deepseek). This keeps

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -235,6 +235,7 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
     (preserves existing config); no-op outside proxy mode.
     """
     real = f"{_BENCHFLOW_BIN_PREFIX}/{binary}"
+    agent_bin = f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin/{binary}"
     target = f"{_BENCHFLOW_BIN_PREFIX}/{binary}-proxy"
     register_py = "\n".join(
         [
@@ -259,7 +260,15 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
         f"{register_py}\n"
         "PYEOF\n"
         "fi\n"
-        f'exec {real} "$@"\n'
+        # Exec the agent. A node-shim bin (shebang) goes through the isolated node
+        # launcher; a native binary (e.g. opencode-ai 1.17.x ships its bin as a
+        # native ELF, bin/opencode.exe) must run DIRECTLY — running it via `node`
+        # parses the ELF as JS and crashes at startup with a SyntaxError.
+        f'if [ "$(head -c2 {agent_bin} 2>/dev/null)" = "#!" ]; then\n'
+        f'  exec {real} "$@"\n'
+        "else\n"
+        f'  PATH="{_BENCHFLOW_NODE_PREFIX}/bin:$PATH" exec {agent_bin} "$@"\n'
+        "fi\n"
     )
     b64 = base64.b64encode(wrapper.encode()).decode()
     return f"printf '%s' '{b64}' | base64 -d > {target} && chmod +x {target}"

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -272,7 +272,7 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
             # Responses API the built-in ``openai`` id is hard-coded to.
             f'    prov = d.setdefault("provider", {{}}).setdefault({provider_id!r}, {{}})',
             '    prov["npm"] = "@ai-sdk/openai-compatible"',
-            f'    prov.setdefault("name", "BenchFlow Gateway")',
+            '    prov.setdefault("name", "BenchFlow Gateway")',
             '    opts = prov.setdefault("options", {})',
             '    base = os.environ.get("OPENAI_BASE_URL", "").strip()',
             "    if base:",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -109,6 +109,14 @@ def _apt_install(*packages: str) -> str:
 _BENCHFLOW_NODE_PREFIX = "/opt/benchflow/node"
 _BENCHFLOW_JS_AGENT_PREFIX = "/opt/benchflow/js-agents"
 _BENCHFLOW_BIN_PREFIX = "/opt/benchflow/bin"
+
+# OpenCode-family proxy provider id. OpenCode hard-codes the OpenAI *Responses*
+# API for the built-in ``openai`` provider id (its ``getModel`` calls
+# ``provider.responses(id)``), which the LiteLLM gateway/DeepSeek cannot serve —
+# so the gateway alias must be registered under a *separate* provider id that
+# OpenCode routes through the chat-completions path. Shared with
+# ``benchflow.acp.runtime._format_acp_model`` so set_model targets the same id.
+OPENCODE_PROXY_PROVIDER_ID = "benchflow"
 _OPENHANDS_CLI_GIT_REV = "3ca17446c5d9c1e35e054803478a3501ec251ecf"
 _OPENHANDS_SDK_VERSION = "1.22.1"
 _OPENHANDS_TOOLS_VERSION = "1.22.1"
@@ -230,13 +238,28 @@ def _json_settings_merge(path: str, mutator: str) -> str:
 # routes through the proxy.
 def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str:
     """Install ``/opt/benchflow/bin/<binary>-proxy``: a thin wrapper that, in
-    proxy mode, registers the LiteLLM gateway alias under the OpenCode-family
-    agent's ``openai`` provider, then execs the isolated agent binary. Idempotent
+    proxy mode, registers the LiteLLM gateway alias under a dedicated
+    OpenCode provider, then execs the isolated agent binary. Idempotent
     (preserves existing config); no-op outside proxy mode.
+
+    The gateway alias is registered under the ``{OPENCODE_PROXY_PROVIDER_ID}``
+    provider using ``@ai-sdk/openai-compatible`` — NOT the built-in ``openai``
+    provider. OpenCode-family agents hard-code the OpenAI **Responses API** for
+    the ``openai`` provider id (``getModel`` calls ``provider.responses(id)``);
+    BenchFlow's LiteLLM gateway — and the OpenAI-completions upstreams it fronts
+    (e.g. DeepSeek) — only serve **chat completions**, so a Responses-API call
+    404s/500s and the agent idles with zero tool calls. Overriding the ``openai``
+    provider's ``npm`` does not help: OpenCode still calls ``.responses()`` and
+    crashes with ``provider.responses is not a function``. A *separate* provider
+    id routes through the chat-completions path, which is what the gateway
+    expects. ``small_model`` is pinned to the same alias so OpenCode's
+    title/summary helper stops falling back to its hard-coded ``gpt-5-nano``
+    (which the gateway cannot serve either).
     """
     real = f"{_BENCHFLOW_BIN_PREFIX}/{binary}"
     agent_bin = f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin/{binary}"
     target = f"{_BENCHFLOW_BIN_PREFIX}/{binary}-proxy"
+    provider_id = OPENCODE_PROXY_PROVIDER_ID
     register_py = "\n".join(
         [
             "import json, os, pathlib",
@@ -245,11 +268,20 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
             f"    p = pathlib.Path(os.path.expanduser({config_path!r}))",
             "    p.parent.mkdir(parents=True, exist_ok=True)",
             "    d = json.loads(p.read_text()) if p.exists() and p.read_text().strip() else {}",
-            '    prov = d.setdefault("provider", {}).setdefault("openai", {})',
+            # Dedicated provider id (see docstring) → chat completions, not the
+            # Responses API the built-in ``openai`` id is hard-coded to.
+            f'    prov = d.setdefault("provider", {{}}).setdefault({provider_id!r}, {{}})',
+            '    prov["npm"] = "@ai-sdk/openai-compatible"',
+            f'    prov.setdefault("name", "BenchFlow Gateway")',
+            '    opts = prov.setdefault("options", {})',
             '    base = os.environ.get("OPENAI_BASE_URL", "").strip()',
             "    if base:",
-            '        prov.setdefault("options", {})["baseURL"] = base',
+            '        opts["baseURL"] = base',
+            '    key = os.environ.get("OPENAI_API_KEY", "").strip()',
+            "    if key:",
+            '        opts["apiKey"] = key',
             '    prov.setdefault("models", {}).setdefault(alias, {"name": alias})',
+            f'    d["small_model"] = "{provider_id}/" + alias',
             '    p.write_text(json.dumps(d, indent=2) + "\\n")',
         ]
     )

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -220,6 +220,51 @@ def _json_settings_merge(path: str, mutator: str) -> str:
     return f"python3 -c {shlex.quote(py)}"
 
 
+# OpenCode-family proxy fix: OpenCode and its MiMo fork validate provider/model
+# ids against the models.dev catalog and reject the synthetic
+# ``openai/benchflow-<alias>`` that BenchFlow's LiteLLM proxy serves the model
+# under (ProviderModelNotFoundError -> zero requests -> no
+# ``trajectory/llm_trajectory.jsonl``, which ``benchflow-experiment-review``
+# requires). Registering the alias under ``provider.openai.models`` (with the
+# gateway baseURL) bypasses that catalog check so the agent accepts the id and
+# routes through the proxy.
+def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str:
+    """Install ``/opt/benchflow/bin/<binary>-proxy``: a thin wrapper that, in
+    proxy mode, registers the LiteLLM gateway alias under the OpenCode-family
+    agent's ``openai`` provider, then execs the isolated agent binary. Idempotent
+    (preserves existing config); no-op outside proxy mode.
+    """
+    real = f"{_BENCHFLOW_BIN_PREFIX}/{binary}"
+    target = f"{_BENCHFLOW_BIN_PREFIX}/{binary}-proxy"
+    register_py = "\n".join(
+        [
+            "import json, os, pathlib",
+            'alias = os.environ.get("BENCHFLOW_LITELLM_MODEL_ALIAS", "").strip()',
+            "if alias:",
+            f"    p = pathlib.Path(os.path.expanduser({config_path!r}))",
+            "    p.parent.mkdir(parents=True, exist_ok=True)",
+            "    d = json.loads(p.read_text()) if p.exists() and p.read_text().strip() else {}",
+            '    prov = d.setdefault("provider", {}).setdefault("openai", {})',
+            '    base = os.environ.get("OPENAI_BASE_URL", "").strip()',
+            "    if base:",
+            '        prov.setdefault("options", {})["baseURL"] = base',
+            '    prov.setdefault("models", {}).setdefault(alias, {"name": alias})',
+            '    p.write_text(json.dumps(d, indent=2) + "\\n")',
+        ]
+    )
+    wrapper = (
+        "#!/bin/sh\n"
+        'if [ -n "$BENCHFLOW_LITELLM_MODEL_ALIAS" ]; then\n'
+        "python3 - <<'PYEOF' || true\n"
+        f"{register_py}\n"
+        "PYEOF\n"
+        "fi\n"
+        f'exec {real} "$@"\n'
+    )
+    b64 = base64.b64encode(wrapper.encode()).decode()
+    return f"printf '%s' '{b64}' | base64 -d > {target} && chmod +x {target}"
+
+
 @dataclass
 class CredentialFile:
     """A file to write inside the container before agent launch."""
@@ -501,8 +546,14 @@ AGENTS: dict[str, AgentConfig] = {
         description="OpenCode via ACP — open-source coding agent (TypeScript)",
         skill_paths=["$HOME/.opencode/skills"],
         home_dirs=[".opencode"],
-        install_cmd=_js_agent_install("opencode", "opencode-ai"),
-        launch_cmd=_js_agent_launch("opencode", "acp"),
+        install_cmd=(
+            _js_agent_install("opencode", "opencode-ai")
+            + " && "
+            + _opencode_family_proxy_wrapper_install(
+                "opencode", "~/.config/opencode/opencode.json"
+            )
+        ),
+        launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/opencode-proxy acp",
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         acp_model_format="provider/model",
@@ -523,8 +574,14 @@ AGENTS: dict[str, AgentConfig] = {
         description="MiMo Code via ACP — Xiaomi's OpenCode fork (TypeScript)",
         skill_paths=["$HOME/.mimocode/skills"],
         home_dirs=[".mimocode", ".config/mimocode"],
-        install_cmd=_js_agent_install("mimo", "@mimo-ai/cli@0.1.0"),
-        launch_cmd=_js_agent_launch("mimo", "acp"),
+        install_cmd=(
+            _js_agent_install("mimo", "@mimo-ai/cli@0.1.0")
+            + " && "
+            + _opencode_family_proxy_wrapper_install(
+                "mimo", "~/.config/mimocode/mimocode.json"
+            )
+        ),
+        launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/mimo-proxy acp",
         protocol="acp",
         requires_env=[],  # inferred from --model at runtime
         # MiMo Code ships a fixed endpoint for its native models.dev "xiaomi"

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -260,12 +260,18 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
     agent_bin = f"{_BENCHFLOW_JS_AGENT_PREFIX}/bin/{binary}"
     target = f"{_BENCHFLOW_BIN_PREFIX}/{binary}-proxy"
     provider_id = OPENCODE_PROXY_PROVIDER_ID
+    # ``config_relpath`` is resolved against ``$BENCHFLOW_AGENT_HOME`` at launch
+    # time — the same home the agent's ``disallow_web_tools_setup_cmd`` and
+    # ``credential_files`` write to — so all writers target one config file even
+    # when the sandbox home differs from ``$HOME``. Falls back to ``~``.
+    config_relpath = config_path.lstrip("/")
     register_py = "\n".join(
         [
             "import json, os, pathlib",
             'alias = os.environ.get("BENCHFLOW_LITELLM_MODEL_ALIAS", "").strip()',
             "if alias:",
-            f"    p = pathlib.Path(os.path.expanduser({config_path!r}))",
+            '    home = os.environ.get("BENCHFLOW_AGENT_HOME", "").strip() or os.path.expanduser("~")',
+            f"    p = pathlib.Path(home) / {config_relpath!r}",
             "    p.parent.mkdir(parents=True, exist_ok=True)",
             "    d = json.loads(p.read_text()) if p.exists() and p.read_text().strip() else {}",
             # Dedicated provider id (see docstring) → chat completions, not the
@@ -287,10 +293,20 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
     )
     wrapper = (
         "#!/bin/sh\n"
+        # Proxy mode only. Fail LOUD: if registration errors (malformed existing
+        # config, unwritable path), do NOT launch — the agent would otherwise get
+        # set_model "<provider>/<alias>" for a model now missing from its config
+        # and hit ProviderModelNotFoundError with nothing explaining why. A hard
+        # exit surfaces the cause instead of a silent broken proxy path.
         'if [ -n "$BENCHFLOW_LITELLM_MODEL_ALIAS" ]; then\n'
-        "python3 - <<'PYEOF' || true\n"
+        "  if ! python3 - <<'PYEOF'\n"
         f"{register_py}\n"
         "PYEOF\n"
+        "  then\n"
+        f'    echo "benchflow {binary}-proxy: gateway alias registration failed; '
+        'refusing to launch in proxy mode" >&2\n'
+        "    exit 1\n"
+        "  fi\n"
         "fi\n"
         # Exec the agent. A node-shim bin (shebang) goes through the isolated node
         # launcher; a native binary (e.g. opencode-ai 1.17.x ships its bin as a
@@ -591,7 +607,7 @@ AGENTS: dict[str, AgentConfig] = {
             _js_agent_install("opencode", "opencode-ai")
             + " && "
             + _opencode_family_proxy_wrapper_install(
-                "opencode", "~/.config/opencode/opencode.json"
+                "opencode", ".config/opencode/opencode.json"
             )
         ),
         launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/opencode-proxy acp",
@@ -619,7 +635,7 @@ AGENTS: dict[str, AgentConfig] = {
             _js_agent_install("mimo", "@mimo-ai/cli@0.1.0")
             + " && "
             + _opencode_family_proxy_wrapper_install(
-                "mimo", "~/.config/mimocode/mimocode.json"
+                "mimo", ".config/mimocode/mimocode.json"
             )
         ),
         launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/mimo-proxy acp",
@@ -644,9 +660,12 @@ AGENTS: dict[str, AgentConfig] = {
         acp_model_format="provider/model",
         # MiMo Code is an OpenCode fork: `mimo acp` reports agentInfo.name="OpenCode"
         # and uses models.dev "provider/model" ids, so set_model must send e.g.
-        # "openai/benchflow-<alias>" in proxy mode, or "xiaomi/mimo-v2.5" in
-        # non-proxy mode via the registered xiaomi provider (the ("mimo","xiaomi")
-        # models.dev heuristic in acp/runtime.py keeps that prefix intact).
+        # "benchflow/benchflow-<alias>" in proxy mode (the dedicated
+        # OPENCODE_PROXY_PROVIDER_ID chat-completions provider the -proxy wrapper
+        # registers — NOT the built-in "openai" id, whose Responses-API hard-coding
+        # the gateway cannot serve), or "xiaomi/mimo-v2.5" in non-proxy mode via the
+        # registered xiaomi provider (the ("mimo","xiaomi") models.dev heuristic in
+        # acp/runtime.py keeps that prefix intact).
         env_mapping={
             # Map BOTH base_url and api_key (codex-acp precedent) so the non-proxy
             # path wires the key without an `if agent == "mimo"` core edit.

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -61,13 +61,16 @@ def test_needs_litellm_runtime_excludes_native_protocol_agents(agent, model, exp
     assert runtime_mod.needs_litellm_runtime(agent, model) is expected
 
 
-def test_opencode_litellm_alias_formats_to_registered_openai_route():
+def test_opencode_litellm_alias_formats_to_dedicated_provider_route():
     from benchflow.acp.runtime import _format_acp_model
+    from benchflow.agents.registry import OPENCODE_PROXY_PROVIDER_ID
 
-    # The proxy registers only "<alias>" and "openai/<alias>"; provider/model
-    # agents must send the openai/ form, not a guessed anthropic/ provider.
+    # The <binary>-proxy wrapper registers the gateway alias under a dedicated
+    # provider id (NOT the built-in "openai" id, whose Responses-API hard-coding
+    # the gateway cannot serve). provider/model agents must send that id.
     out = _format_acp_model("benchflow-minimax-MiniMax-M3", "opencode")
-    assert out == "openai/benchflow-minimax-MiniMax-M3"
+    assert out == f"{OPENCODE_PROXY_PROVIDER_ID}/benchflow-minimax-MiniMax-M3"
+    assert not out.startswith("openai/")
 
 
 def test_format_acp_model_passes_through_existing_provider_prefix():
@@ -105,15 +108,15 @@ def test_format_acp_model_routes_via_provider_registry_not_runtime_branches():
     assert "xiaomi" not in {provider for _, provider in _MODELSDEV_PROVIDER_HEURISTICS}
 
 
-def test_mimo_litellm_alias_formats_to_registered_openai_route():
+def test_mimo_litellm_alias_formats_to_dedicated_provider_route():
     from benchflow.acp.runtime import _format_acp_model
+    from benchflow.agents.registry import OPENCODE_PROXY_PROVIDER_ID
 
-    # Proxy mode is untouched by the heuristic: aliases still route to the
-    # proxy-registered "openai/<alias>" form.
-    assert (
-        _format_acp_model("benchflow-deepseek-deepseek-v4-flash", "mimo")
-        == "openai/benchflow-deepseek-deepseek-v4-flash"
-    )
+    # Proxy-mode aliases route to the dedicated chat-completions provider id,
+    # not the built-in "openai" id (Responses-API crash) nor a guessed provider.
+    out = _format_acp_model("benchflow-deepseek-deepseek-v4-flash", "mimo")
+    assert out == f"{OPENCODE_PROXY_PROVIDER_ID}/benchflow-deepseek-deepseek-v4-flash"
+    assert not out.startswith("openai/")
 
 
 def test_vllm_route_honors_runtime_supplied_base_url():

--- a/tests/test_opencode_family_proxy_tracking.py
+++ b/tests/test_opencode_family_proxy_tracking.py
@@ -1,13 +1,14 @@
 """Regression: OpenCode-family agents (opencode + its MiMo fork) support
 LLM-proxy trajectory tracking.
 
-These agents use acp_model_format="provider/model" and validate model ids
-against the models.dev catalog, so they reject BenchFlow's synthetic gateway
-model ``openai/benchflow-<alias>`` (ProviderModelNotFoundError) and never route
-through the LiteLLM usage proxy — producing no ``trajectory/llm_trajectory.jsonl``
-(which ``benchflow-experiment-review`` requires). The fix installs a ``-proxy``
-wrapper under ``/opt/benchflow/bin`` that, in proxy mode, registers the gateway
-alias under the agent's ``openai`` provider before exec'ing the isolated binary.
+These agents use acp_model_format="provider/model" and hard-code the OpenAI
+Responses API for the built-in ``openai`` provider id, which the LiteLLM gateway
+(chat-completions only) cannot serve — so the gateway alias never routes through
+the usage proxy and no ``trajectory/llm_trajectory.jsonl`` is written (which
+``benchflow-experiment-review`` requires). The fix installs a ``-proxy`` wrapper
+under ``/opt/benchflow/bin`` that, in proxy mode, registers the gateway alias
+under a dedicated ``@ai-sdk/openai-compatible`` provider id
+(``OPENCODE_PROXY_PROVIDER_ID``) before exec'ing the isolated binary.
 """
 
 import base64
@@ -76,8 +77,7 @@ def test_format_acp_model_routes_proxy_alias_to_dedicated_provider():
     alias = "benchflow-deepseek-deepseek-v4-flash"
     for agent in ("opencode", "mimo"):
         assert (
-            _format_acp_model(alias, agent)
-            == f"{OPENCODE_PROXY_PROVIDER_ID}/{alias}"
+            _format_acp_model(alias, agent) == f"{OPENCODE_PROXY_PROVIDER_ID}/{alias}"
         )
         assert _format_acp_model(alias, agent).split("/")[0] != "openai"
 
@@ -91,7 +91,9 @@ def test_proxy_wrapper_pins_small_model_to_gateway_alias(agent, wrapper_bin, cfg
 
 
 @pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
-def test_proxy_wrapper_is_conditional_and_execs_isolated_binary(agent, wrapper_bin, cfg):
+def test_proxy_wrapper_is_conditional_and_execs_isolated_binary(
+    agent, wrapper_bin, cfg
+):
     w = _wrapper_script(agent, wrapper_bin)
     assert '[ -n "$BENCHFLOW_LITELLM_MODEL_ALIAS" ]' in w  # no-op without alias
     base = wrapper_bin[: -len("-proxy")]

--- a/tests/test_opencode_family_proxy_tracking.py
+++ b/tests/test_opencode_family_proxy_tracking.py
@@ -1,0 +1,69 @@
+"""Regression: OpenCode-family agents (opencode + its MiMo fork) support
+LLM-proxy trajectory tracking.
+
+These agents use acp_model_format="provider/model" and validate model ids
+against the models.dev catalog, so they reject BenchFlow's synthetic gateway
+model ``openai/benchflow-<alias>`` (ProviderModelNotFoundError) and never route
+through the LiteLLM usage proxy — producing no ``trajectory/llm_trajectory.jsonl``
+(which ``benchflow-experiment-review`` requires). The fix installs a ``-proxy``
+wrapper under ``/opt/benchflow/bin`` that, in proxy mode, registers the gateway
+alias under the agent's ``openai`` provider before exec'ing the isolated binary.
+"""
+
+import base64
+import re
+
+import pytest
+
+from benchflow.agents.registry import AGENTS
+
+# (agent name, proxy wrapper binary, agent config filename)
+CASES = [
+    ("opencode", "opencode-proxy", "opencode.json"),
+    ("mimo", "mimo-proxy", "mimocode.json"),
+]
+
+
+def _wrapper_script(agent: str, wrapper_bin: str) -> str:
+    ic = AGENTS[agent].install_cmd
+    m = re.search(
+        r"printf '%s' '([A-Za-z0-9+/=]+)' \| base64 -d > \S*/" + re.escape(wrapper_bin),
+        ic,
+    )
+    assert m, f"{wrapper_bin} wrapper install snippet not found in {agent} install_cmd"
+    return base64.b64decode(m.group(1)).decode()
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_registers_gateway_alias_under_openai_provider(
+    agent, wrapper_bin, cfg
+):
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "BENCHFLOW_LITELLM_MODEL_ALIAS" in w  # gated on proxy mode
+    assert cfg in w  # writes the agent's config
+    for token in ("provider", "openai", "models"):
+        assert token in w, f"{agent} wrapper missing {token!r}"
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_wires_gateway_base_url(agent, wrapper_bin, cfg):
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "OPENAI_BASE_URL" in w
+    assert "baseURL" in w
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_is_conditional_and_execs_isolated_binary(agent, wrapper_bin, cfg):
+    w = _wrapper_script(agent, wrapper_bin)
+    assert '[ -n "$BENCHFLOW_LITELLM_MODEL_ALIAS" ]' in w  # no-op without alias
+    base = wrapper_bin[: -len("-proxy")]
+    assert f"exec /opt/benchflow/bin/{base} " in w  # execs the isolated binary
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_launch_entrypoint_stays_under_isolated_bin(agent, wrapper_bin, cfg):
+    lc = AGENTS[agent].launch_cmd
+    # keeps the JS-ACP isolated-runtime invariant (launch entrypoint under
+    # /opt/benchflow/bin)
+    assert lc.split()[0] == f"/opt/benchflow/bin/{wrapper_bin}"
+    assert "acp" in lc

--- a/tests/test_opencode_family_proxy_tracking.py
+++ b/tests/test_opencode_family_proxy_tracking.py
@@ -91,6 +91,28 @@ def test_proxy_wrapper_pins_small_model_to_gateway_alias(agent, wrapper_bin, cfg
 
 
 @pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_fails_loud_on_registration_error(agent, wrapper_bin, cfg):
+    """In proxy mode a registration failure must abort the launch (exit 1), not
+    be swallowed by ``|| true`` — otherwise the agent launches with the alias
+    missing from its config and hits ProviderModelNotFoundError silently."""
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "|| true" not in w
+    assert "exit 1" in w
+    assert "if ! python3" in w
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_resolves_config_under_agent_home(agent, wrapper_bin, cfg):
+    """The config file is resolved against ``$BENCHFLOW_AGENT_HOME`` (the same
+    home ``disallow_web_tools_setup_cmd``/``credential_files`` use) so all
+    writers target one file even when the sandbox home differs from ``$HOME``."""
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "BENCHFLOW_AGENT_HOME" in w
+    # relative config path joined onto the resolved home, not a baked ~ expansion
+    assert cfg in w
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
 def test_proxy_wrapper_is_conditional_and_execs_isolated_binary(
     agent, wrapper_bin, cfg
 ):

--- a/tests/test_opencode_family_proxy_tracking.py
+++ b/tests/test_opencode_family_proxy_tracking.py
@@ -15,7 +15,7 @@ import re
 
 import pytest
 
-from benchflow.agents.registry import AGENTS
+from benchflow.agents.registry import AGENTS, OPENCODE_PROXY_PROVIDER_ID
 
 # (agent name, proxy wrapper binary, agent config filename)
 CASES = [
@@ -35,14 +35,17 @@ def _wrapper_script(agent: str, wrapper_bin: str) -> str:
 
 
 @pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
-def test_proxy_wrapper_registers_gateway_alias_under_openai_provider(
+def test_proxy_wrapper_registers_gateway_alias_under_dedicated_provider(
     agent, wrapper_bin, cfg
 ):
     w = _wrapper_script(agent, wrapper_bin)
     assert "BENCHFLOW_LITELLM_MODEL_ALIAS" in w  # gated on proxy mode
     assert cfg in w  # writes the agent's config
-    for token in ("provider", "openai", "models"):
+    for token in ("provider", OPENCODE_PROXY_PROVIDER_ID, "models"):
         assert token in w, f"{agent} wrapper missing {token!r}"
+    # Must NOT touch the built-in ``openai`` provider id — OpenCode hard-codes
+    # the Responses API there, which the gateway cannot serve.
+    assert '"openai"' not in w and "'openai'" not in w
 
 
 @pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
@@ -50,6 +53,41 @@ def test_proxy_wrapper_wires_gateway_base_url(agent, wrapper_bin, cfg):
     w = _wrapper_script(agent, wrapper_bin)
     assert "OPENAI_BASE_URL" in w
     assert "baseURL" in w
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_forces_chat_completions_sdk(agent, wrapper_bin, cfg):
+    """The dedicated provider must use ``@ai-sdk/openai-compatible`` (chat
+    completions) so OpenCode does not call ``provider.responses()`` (which the
+    gateway/DeepSeek do not serve), and forward the gateway master key as
+    ``apiKey``."""
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "@ai-sdk/openai-compatible" in w  # chat completions, not Responses API
+    assert '"npm"' in w
+    assert "OPENAI_API_KEY" in w and "apiKey" in w
+
+
+def test_format_acp_model_routes_proxy_alias_to_dedicated_provider():
+    """In proxy mode the gateway alias (``benchflow-…``) must be sent to
+    set_model as ``<OPENCODE_PROXY_PROVIDER_ID>/<alias>`` for provider/model
+    agents — NOT ``openai/<alias>`` (which crashes OpenCode's Responses path)."""
+    from benchflow.acp.runtime import _format_acp_model
+
+    alias = "benchflow-deepseek-deepseek-v4-flash"
+    for agent in ("opencode", "mimo"):
+        assert (
+            _format_acp_model(alias, agent)
+            == f"{OPENCODE_PROXY_PROVIDER_ID}/{alias}"
+        )
+        assert _format_acp_model(alias, agent).split("/")[0] != "openai"
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_pins_small_model_to_gateway_alias(agent, wrapper_bin, cfg):
+    """The title/summary helper must not fall back to the hard-coded
+    ``gpt-5-nano`` (unservable by the gateway) — it is pinned to the alias."""
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "small_model" in w
 
 
 @pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)

--- a/tests/test_opencode_family_proxy_tracking.py
+++ b/tests/test_opencode_family_proxy_tracking.py
@@ -67,3 +67,12 @@ def test_launch_entrypoint_stays_under_isolated_bin(agent, wrapper_bin, cfg):
     # /opt/benchflow/bin)
     assert lc.split()[0] == f"/opt/benchflow/bin/{wrapper_bin}"
     assert "acp" in lc
+
+
+def test_wrapper_runs_native_binary_directly_not_via_node():
+    """opencode-ai ships its bin as a native ELF (bin/opencode.exe); the wrapper
+    must detect non-shebang bins and exec them directly (running an ELF via
+    `node` crashes with a SyntaxError at startup)."""
+    w = _wrapper_script("opencode", "opencode-proxy")
+    assert "head -c2" in w  # detect shebang vs native
+    assert "/opt/benchflow/js-agents/bin/opencode" in w  # direct native-exec path

--- a/tests/test_pi_acp_proxy_routing.py
+++ b/tests/test_pi_acp_proxy_routing.py
@@ -19,7 +19,9 @@ _PROXY = {
 
 
 def _final_id(agent, model, env):
-    return _select_acp_model_id(_resolve_acp_model_input(agent, model, env), agent, None)
+    return _select_acp_model_id(
+        _resolve_acp_model_input(agent, model, env), agent, None
+    )
 
 
 def test_pi_acp_proxy_alias_is_litellm_provider_qualified():

--- a/tests/test_pi_acp_proxy_routing.py
+++ b/tests/test_pi_acp_proxy_routing.py
@@ -1,0 +1,43 @@
+"""Regression: pi-acp (acp_model_format="registered-provider/model") must route
+through the LiteLLM usage proxy in proxy mode.
+
+In proxy mode BenchFlow serves the model under the alias `benchflow-<...>` and the
+pi-acp launcher registers it under the `litellm` provider (BENCHFLOW_PROVIDER_NAME)
+in `~/.pi/agent/models.json`. If `session/set_model` sends the *bare* alias (no
+provider prefix), Pi cannot resolve it to that provider and the model calls
+**bypass the proxy** — completing the task (tool calls happen) but capturing no
+`trajectory/llm_trajectory.jsonl` (usage_source=unavailable). The fix sends the
+registered-provider-qualified id `litellm/<alias>`.
+"""
+
+from benchflow.acp.runtime import _resolve_acp_model_input, _select_acp_model_id
+
+_PROXY = {
+    "BENCHFLOW_LITELLM_MODEL_ALIAS": "benchflow-deepseek-deepseek-v4-flash",
+    "BENCHFLOW_PROVIDER_NAME": "litellm",
+}
+
+
+def _final_id(agent, model, env):
+    return _select_acp_model_id(_resolve_acp_model_input(agent, model, env), agent, None)
+
+
+def test_pi_acp_proxy_alias_is_litellm_provider_qualified():
+    assert (
+        _final_id("pi-acp", "deepseek/deepseek-v4-flash", _PROXY)
+        == "litellm/benchflow-deepseek-deepseek-v4-flash"
+    )
+
+
+def test_pi_acp_non_proxy_keeps_registered_provider_behavior():
+    # No alias → not proxy mode → must NOT be litellm-prefixed.
+    out = _final_id("pi-acp", "anthropic/claude-sonnet-4-6", {})
+    assert not out.startswith("litellm/")
+
+
+def test_provider_model_agents_unaffected_by_pi_acp_fix():
+    # opencode (provider/model) still routes via openai/<alias>, not litellm/.
+    assert (
+        _final_id("opencode", "deepseek/deepseek-v4-flash", _PROXY)
+        == "openai/benchflow-deepseek-deepseek-v4-flash"
+    )

--- a/tests/test_pi_acp_proxy_routing.py
+++ b/tests/test_pi_acp_proxy_routing.py
@@ -36,8 +36,9 @@ def test_pi_acp_non_proxy_keeps_registered_provider_behavior():
 
 
 def test_provider_model_agents_unaffected_by_pi_acp_fix():
-    # opencode (provider/model) still routes via openai/<alias>, not litellm/.
-    assert (
-        _final_id("opencode", "deepseek/deepseek-v4-flash", _PROXY)
-        == "openai/benchflow-deepseek-deepseek-v4-flash"
-    )
+    # opencode (provider/model) routes via the dedicated OpenCode gateway
+    # provider id, NOT litellm/ (pi-acp) and NOT openai/ (Responses-API crash).
+    out = _final_id("opencode", "deepseek/deepseek-v4-flash", _PROXY)
+    assert out == "benchflow/benchflow-deepseek-deepseek-v4-flash"
+    assert not out.startswith("litellm/")
+    assert not out.startswith("openai/")


### PR DESCRIPTION
## Problem

BenchFlow's `benchflow-experiment-review` skill audits a run from
`trajectory/llm_trajectory.jsonl` — raw request bodies, per-request token usage,
and timestamps the LiteLLM **usage proxy** writes only when the agent routes its
model calls through the gateway. Three ACP agents were not producing it:

- **opencode** and its **mimo** fork (`acp_model_format="provider/model"`)
- **pi-acp** (`acp_model_format="registered-provider/model"`)

So a reviewer got only the agent-native ACP aggregate — no auditable raw LLM
trajectory.

## Root cause

**OpenCode family.** OpenCode hard-codes the OpenAI **Responses API** for the
built-in `openai` provider id — its `getModel` calls `provider.responses(id)`.
The LiteLLM gateway and the openai-completions upstreams it fronts (e.g.
DeepSeek) only serve **chat completions**, so the gateway alias never produced a
usable request:

| Attempt | Result |
|---|---|
| alias registered bare under `openai` | Responses API → 404/500, agent idles, 0 tool calls |
| `openai.npm` overridden to `@ai-sdk/openai-compatible` | OpenCode still calls `.responses()` → `TypeError: provider.responses is not a function` → **0 requests** |

Captured live in an ACP debug session:
```
level=ERROR message=process error="Z.responses is not a function ... at getModel"
```

**pi-acp.** The launcher registers the gateway model under the `litellm`
provider (`BENCHFLOW_PROVIDER_NAME`) in `~/.pi/agent/models.json`, but set_model
received the bare `benchflow-<alias>` (no provider prefix) → Pi could not resolve
it → the model calls bypassed the proxy.

## Fix

- **OpenCode family** — register the gateway alias under a **dedicated provider
  id** (`benchflow`) using `@ai-sdk/openai-compatible`, which OpenCode routes
  through the chat-completions path (NOT the built-in `openai` id). `set_model`
  now sends `benchflow/<alias>` for `provider/model` agents in proxy mode. The
  `<binary>-proxy` wrapper writes this config in proxy mode only, forwards the
  gateway master key as `options.apiKey`, and pins `small_model` to the alias so
  the title/summary helper stops hitting the hard-coded `gpt-5-nano`. The wrapper
  also execs native-ELF agent bins directly (opencode-ai 1.17.x ships
  `bin/opencode.exe`) instead of via `node`.
- **pi-acp** — in proxy mode, send `litellm/<alias>` so Pi hits the registered
  gateway route.

## Validation (docker, citation-check, deepseek-v4-flash)

Bar: `reward != None` ∧ `tool_calls > 0` ∧ every LLM request carries real
`provider_response` usage, via `/v1/chat/completions`.

| Agent | Reward | Tool calls | LLM reqs (all w/ real usage) |
|---|---|---|---|
| pi-acp | 1.0 | 8 | 9 / 9 |
| opencode | 1.0 | 11 | 37 / 37 |
| mimo | 1.0 | 14 | 9 / 9 |

`trajectory/llm_trajectory.jsonl` now carries raw request bodies + per-request
tokens + timestamps for all three — exactly what `benchflow-experiment-review`
needs.

## Tests

`tests/test_opencode_family_proxy_tracking.py` and
`tests/test_pi_acp_proxy_routing.py` assert: dedicated-provider registration
(and that the wrapper never touches `openai`), `@ai-sdk/openai-compatible`,
master-key forwarding, `small_model` pin, native-binary direct exec, and
`_format_acp_model` → `benchflow/<alias>` for opencode/mimo vs `litellm/<alias>`
for pi-acp. Full agents/acp/registry/launcher suites green (no regressions).
