### PR TITLE
feat(cli): move `continue` under `bench eval continue` (keep deprecated top-level alias)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+- **`bench continue` is now `bench eval continue`.** The command (and its
+  `continue-batch` companion) moved under the `eval` group, where it is now
+  discoverable in `bench eval --help` alongside `run`/`adopt`. The original
+  top-level `bench continue` / `bench continue-batch` remain as hidden,
+  deprecated aliases (they print a deprecation notice) so existing scripts keep
+  working.
+
 ## 0.6.3 — 2026-06-16
 
 ### Changed

--- a/docs/continue-runs.md
+++ b/docs/continue-runs.md
@@ -1,12 +1,15 @@
-# Continuing timed-out runs (`benchflow continue`)
+# Continuing timed-out runs (`bench eval continue`)
 
-`benchflow continue` resumes a previous, **unfinished** (timed-out) agent run to
+`bench eval continue` resumes a previous, **unfinished** (timed-out) agent run to
 completion. It is a standalone tool — it does **not** modify benchflow's normal
 `eval`/run path — and currently targets the **`openhands`** agent.
 
 The goal is a *transparent* resume: the continued run behaves as if the original
 timeout had simply been larger. The agent keeps its exact context and
 environment and continues its own loop with **no injected prompt**.
+
+> The command lives under the `eval` group (`bench eval continue`). The original
+> top-level `bench continue` still works as a hidden, deprecated alias.
 
 ## The problem it solves
 
@@ -15,12 +18,12 @@ What survives on disk is the run folder: `config.json`, `result.json`,
 `prompts.json`, and `trajectory/llm_trajectory.jsonl`. So a historical timeout
 has only its *trajectory* + the *task*; there is no saved container to restore.
 
-`benchflow continue` reconstructs the missing state from the trajectory.
+`bench eval continue` reconstructs the missing state from the trajectory.
 
 ## How it works — record-replay
 
 The recorded `llm_trajectory.jsonl` is the exact sequence of LLM
-request/response pairs from the original run. `benchflow continue`:
+request/response pairs from the original run. `bench eval continue`:
 
 1. **Loads** the original run folder and the recorded exchanges.
 2. **Boots a fresh, pristine sandbox** from the same base image.
@@ -41,7 +44,7 @@ continuous run rather than a fresh agent on a warm filesystem.
 ## Usage
 
 ```bash
-benchflow continue path/to/original/run-folder \
+bench eval continue path/to/original/run-folder \
   --tasks-dir path/to/tasks          # where the task source (verifier) lives
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -597,15 +597,17 @@ scenes:
 
 ---
 
-## bench continue
+## bench eval continue
 
 Resume a previous, unfinished (timed-out) `openhands` run to completion via
 record-replay. Standalone — it does not touch the normal run path. See
 [Continuing timed-out runs](../continue-runs.md) for the full guide.
 
 ```bash
-bench continue path/to/original/run-folder --tasks-dir path/to/tasks
+bench eval continue path/to/original/run-folder --tasks-dir path/to/tasks
 ```
+
+The original top-level `bench continue` still works as a hidden, deprecated alias.
 
 Key options: `--model` (override the live-continuation model; defaults to the
 original run's model), `--timeout`, `--output`, `--require-timeout`,
@@ -614,7 +616,7 @@ cut-point — no live model or API key needed), and `--proxy-mode` (replay
 proxy placement: `auto`, `host`, or `sandbox`; default `auto` uses
 sandbox-local replay for Daytona/Modal and host replay for Docker).
 
-### bench continue-batch
+### bench eval continue-batch
 
 Continue all timed-out OpenHands runs found under a directory tree. Discovers
 run folders (`config.json` + `trajectory/llm_trajectory.jsonl`) recursively,
@@ -622,7 +624,7 @@ continues each, and prints a JSON batch summary (exits 1 if any continuation
 failed).
 
 ```bash
-bench continue-batch path/to/jobs-root --tasks-dir path/to/tasks
+bench eval continue-batch path/to/jobs-root --tasks-dir path/to/tasks
 ```
 
 | Flag | Default | Description |

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -133,7 +133,9 @@ def register_continue(
                 )
             )
         except RunFolderError as exc:
-            typer.secho(f"bench eval continue: {exc}", fg=typer.colors.RED, err=True)
+            # Command-agnostic prefix: the same callback backs both the canonical
+            # `bench eval continue` and the deprecated top-level `bench continue`.
+            typer.secho(f"benchflow: {exc}", fg=typer.colors.RED, err=True)
             raise typer.Exit(1) from exc
 
         typer.secho(
@@ -228,14 +230,14 @@ def register_continue(
         # which exits 1 on a non-directory folder.
         if not root.exists():
             typer.secho(
-                f"bench eval continue-batch: path does not exist: {root}",
+                f"benchflow: path does not exist: {root}",
                 fg=typer.colors.RED,
                 err=True,
             )
             raise typer.Exit(1)
         if not root.is_dir():
             typer.secho(
-                f"bench eval continue-batch: not a directory: {root}",
+                f"benchflow: not a directory: {root}",
                 fg=typer.colors.RED,
                 err=True,
             )

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -1,9 +1,13 @@
-"""``benchflow continue`` — resume a timed-out run to completion.
+"""``bench eval continue`` — resume a timed-out run to completion.
 
 Standalone command (does not touch the normal eval/run path): reconstruct a
 previous unfinished ``openhands`` run's exact env + memory from its recorded
 trajectory via record-replay, continue it live, and write a new HF-compatible
 folder linked to the parent. See :mod:`benchflow.continue_run`.
+
+Canonical home is the ``eval`` group (``bench eval continue``); the original
+top-level ``bench continue`` stays as a hidden, deprecated alias so existing
+scripts keep working.
 """
 
 from __future__ import annotations
@@ -23,10 +27,17 @@ def _load_env_defaults() -> None:
         os.environ.setdefault(key, value)
 
 
-def register_continue(app: typer.Typer) -> None:
-    """Attach the ``continue`` command to the top-level benchflow app."""
+def register_continue(
+    eval_app: typer.Typer, *, alias_app: typer.Typer | None = None
+) -> None:
+    """Attach ``continue`` / ``continue-batch`` to the ``eval`` group.
 
-    @app.command("continue", hidden=True)
+    ``eval_app`` is the canonical home (``bench eval continue``). When
+    ``alias_app`` is given, the same commands are also registered on it as
+    hidden, deprecated top-level aliases (``bench continue``) for backward
+    compatibility.
+    """
+
     def continue_cmd(
         folder: Annotated[
             Path,
@@ -122,7 +133,7 @@ def register_continue(app: typer.Typer) -> None:
                 )
             )
         except RunFolderError as exc:
-            typer.secho(f"benchflow continue: {exc}", fg=typer.colors.RED, err=True)
+            typer.secho(f"bench eval continue: {exc}", fg=typer.colors.RED, err=True)
             raise typer.Exit(1) from exc
 
         typer.secho(
@@ -137,12 +148,11 @@ def register_continue(app: typer.Typer) -> None:
         if result.error:
             typer.secho(f"  agent error: {result.error}", fg=typer.colors.YELLOW)
             # A failed continuation must report failure to $? — matches
-            # `continue-batch` (exits 1 if any continuation failed) and the
+            # `eval continue-batch` (exits 1 if any continuation failed) and the
             # `eval run` run-error contract. Without this a scripted caller
             # reads the green ✓ + exit 0 as success.
             raise typer.Exit(1)
 
-    @app.command("continue-batch", hidden=True)
     def continue_batch_cmd(
         root: Annotated[
             Path,
@@ -214,18 +224,18 @@ def register_continue(app: typer.Typer) -> None:
         _load_env_defaults()
         # Fail fast on a bad ROOT instead of treating a typo'd/nonexistent path as
         # an empty-but-valid tree — otherwise scripted callers read the exit-0
-        # "No timeout run folders found." as success. Matches `bench continue`,
+        # "No timeout run folders found." as success. Matches `bench eval continue`,
         # which exits 1 on a non-directory folder.
         if not root.exists():
             typer.secho(
-                f"benchflow continue-batch: path does not exist: {root}",
+                f"bench eval continue-batch: path does not exist: {root}",
                 fg=typer.colors.RED,
                 err=True,
             )
             raise typer.Exit(1)
         if not root.is_dir():
             typer.secho(
-                f"benchflow continue-batch: not a directory: {root}",
+                f"bench eval continue-batch: not a directory: {root}",
                 fg=typer.colors.RED,
                 err=True,
             )
@@ -255,3 +265,15 @@ def register_continue(app: typer.Typer) -> None:
         typer.echo(json.dumps(summary, indent=2))
         if summary["failed"]:
             raise typer.Exit(1)
+
+    # Canonical home: ``bench eval continue`` (visible) and
+    # ``bench eval continue-batch`` (hidden batch utility).
+    eval_app.command("continue")(continue_cmd)
+    eval_app.command("continue-batch", hidden=True)(continue_batch_cmd)
+
+    # Backward-compat: hidden, deprecated top-level ``bench continue`` aliases.
+    if alias_app is not None:
+        alias_app.command("continue", hidden=True, deprecated=True)(continue_cmd)
+        alias_app.command("continue-batch", hidden=True, deprecated=True)(
+            continue_batch_cmd
+        )

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1040,7 +1040,7 @@ def eval_view(
 # ``cli/<group>.py`` module, mirroring the existing ``register_continue`` /
 # ``register_tasks_generate`` / ``register_agent_router`` precedent. Order does
 # not affect behavior; it follows the historical top-level help ordering.
-register_continue(app)
+register_continue(eval_app, alias_app=app)
 register_skills(app)
 register_tasks(app)
 register_hub(app)

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -70,6 +70,22 @@ def test_continue_batch_rejects_zero_concurrency(tmp_path):
     assert not isinstance(res.exception, ValueError)  # typer rejects it, not a crash
 
 
+def test_continue_is_canonical_under_eval_group(tmp_path):
+    # `continue` is canonical under the `eval` group (`bench eval continue`);
+    # the original top-level `bench continue` stays as a hidden, deprecated
+    # alias so existing scripts keep working.
+    eval_help = runner.invoke(app, ["eval", "--help"])
+    assert eval_help.exit_code == 0
+    assert "continue" in eval_help.output  # visible under the eval group
+
+    # Both spellings resolve to the same command and fail the same way on an
+    # empty (config-less) run folder.
+    canonical = runner.invoke(app, ["eval", "continue", str(tmp_path)])
+    alias = runner.invoke(app, ["continue", str(tmp_path)])
+    assert canonical.exit_code == 1
+    assert alias.exit_code == 1
+
+
 # ── agent run: missing codex binary (H3) ─────────────────────────────────────
 
 

--- a/tests/test_cli_edge_case_hardening.py
+++ b/tests/test_cli_edge_case_hardening.py
@@ -23,9 +23,20 @@ runner = CliRunner()
 # ── continue: exit code (H1/H2) + concurrency floor (M4) ──────────────────────
 
 
-def test_continue_exits_1_on_agent_error(tmp_path, monkeypatch):
-    # H1/H2: a failed continuation must report failure to $? (it printed a green
-    # ✓ then a yellow warning and exited 0, so scripts read it as success).
+# Run the exit-code guards through BOTH spellings: the canonical
+# `bench eval continue` and the deprecated top-level `bench continue` alias.
+# Without the canonical case, a broken `eval_app` registration (PR #800) would
+# slip through because the alias path would still pass.
+_CONTINUE_SPELLINGS = pytest.mark.parametrize(
+    "invoke", [["eval", "continue"], ["continue"]], ids=["eval", "alias"]
+)
+
+
+@_CONTINUE_SPELLINGS
+def test_continue_exits_1_on_agent_error(invoke, tmp_path, monkeypatch):
+    """Guards the continue exit-code contract (H1/H2: a failed continuation must
+    report failure to $? — it printed a green ✓ then exited 0). Parametrized over
+    both spellings after PR #800 moved the command under `bench eval continue`."""
     import benchflow.continue_run.orchestrator as orch
 
     async def fake_continue_run(*args, **kwargs):
@@ -39,13 +50,16 @@ def test_continue_exits_1_on_agent_error(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(orch, "continue_run", fake_continue_run)
-    res = runner.invoke(app, ["continue", str(tmp_path)])
+    res = runner.invoke(app, [*invoke, str(tmp_path)])
     assert res.exit_code == 1
     assert "agent error" in res.output
 
 
-def test_continue_exits_0_when_no_error(tmp_path, monkeypatch):
-    # The success path must still exit 0 (guard against over-correcting H1).
+@_CONTINUE_SPELLINGS
+def test_continue_exits_0_when_no_error(invoke, tmp_path, monkeypatch):
+    """Guards the continue success path (must still exit 0, against over-correcting
+    H1), on both the canonical `bench eval continue` and the deprecated alias
+    after PR #800."""
     import benchflow.continue_run.orchestrator as orch
 
     async def fake_continue_run(*args, **kwargs):
@@ -59,21 +73,29 @@ def test_continue_exits_0_when_no_error(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(orch, "continue_run", fake_continue_run)
-    res = runner.invoke(app, ["continue", str(tmp_path)])
+    res = runner.invoke(app, [*invoke, str(tmp_path)])
     assert res.exit_code == 0
 
 
-def test_continue_batch_rejects_zero_concurrency(tmp_path):
-    # M4: --concurrency 0 reached an unguarded asyncio.run -> raw ValueError.
-    res = runner.invoke(app, ["continue-batch", str(tmp_path), "--concurrency", "0"])
+@pytest.mark.parametrize(
+    "invoke", [["eval", "continue-batch"], ["continue-batch"]], ids=["eval", "alias"]
+)
+def test_continue_batch_rejects_zero_concurrency(invoke, tmp_path):
+    """Guards the M4 concurrency floor (--concurrency 0 reached an unguarded
+    asyncio.run -> raw ValueError), on both the canonical `bench eval
+    continue-batch` and the deprecated alias after PR #800."""
+    res = runner.invoke(app, [*invoke, str(tmp_path), "--concurrency", "0"])
     assert res.exit_code != 0
     assert not isinstance(res.exception, ValueError)  # typer rejects it, not a crash
 
 
 def test_continue_is_canonical_under_eval_group(tmp_path):
-    # `continue` is canonical under the `eval` group (`bench eval continue`);
-    # the original top-level `bench continue` stays as a hidden, deprecated
-    # alias so existing scripts keep working.
+    """Guards PR #800: `continue` is canonical under the `eval` group.
+
+    `bench eval continue` is the canonical spelling (visible in `bench eval
+    --help`); the original top-level `bench continue` stays as a hidden,
+    deprecated alias so existing scripts keep working.
+    """
     eval_help = runner.invoke(app, ["eval", "--help"])
     assert eval_help.exit_code == 0
     assert "continue" in eval_help.output  # visible under the eval group


### PR DESCRIPTION
## What

`continue` (and `continue-batch`) now live under the `eval` group — canonical spelling is **`bench eval continue`**, discoverable in `bench eval --help` next to `run` and `adopt`. It reads more naturally: `continue` resumes an evaluation, so it belongs with the other eval verbs.

The original top-level **`bench continue` / `bench continue-batch` are kept as hidden, deprecated aliases** (they print `DeprecationWarning: The command 'continue' is deprecated.`), so existing scripts, docs, and the `continue-batch` callers keep working unchanged.

## Why

`continue` was registered on the top-level app as a standalone command. Grouping it under `eval` matches the rest of the CLI taxonomy (`eval run`, `eval adopt`, `eval view`, …) without breaking anyone.

## Changes
- `cli/continue_cmd.py`: `register_continue(eval_app, *, alias_app=None)` — registers the canonical commands on the `eval` group and the deprecated aliases on the top-level app.
- `cli/main.py`: call site `register_continue(eval_app, alias_app=app)`.
- Docs: `docs/continue-runs.md`, `docs/reference/cli.md` lead with `bench eval continue` (+ alias note).
- `CHANGELOG.md`: `[Unreleased]` entry.
- Test: `test_continue_is_canonical_under_eval_group` pins the eval location + alias.

## Verification
- `bench eval continue --help` / `bench eval continue-batch --help` resolve; `continue` shows in `bench eval --help`.
- `bench continue …` still works and prints the deprecation notice.
- `tests/test_cli_edge_case_hardening.py` (continue subset) and `tests/continue_run/` pass; `ruff` clean.