### PR TITLE
fix(eval): bind resolved S-axis env + C-axis overlay on the sharded and run-config paths

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -699,7 +699,6 @@ def run_batch_eval(
                     worker_concurrency=plan.request.worker_concurrency,
                     worker_retries=plan.request.worker_retries,
                     worker_start_stagger_sec=plan.request.worker_start_stagger_sec,
-                    environment_manifest_path=plan.request.environment_manifest,
                 )
             )
     except EmptyTaskSelectionError as e:
@@ -773,6 +772,14 @@ def _run_config_file_eval(plan: "EvalPlan") -> None:
         # the config file.
         if plan.eval_env_manifest is not None:
             j._config.environment_manifest = plan.eval_env_manifest
+        # CLI --config / --config-override (the C axis) likewise wins over the
+        # YAML's own config_override. Parsed + allowlist-validated at plan time
+        # and applied per task at the rollout layer. Without this the
+        # file-config path silently dropped the overlay (it threaded every
+        # other override but never this one), so a --config-override on a
+        # run-config file was a no-op.
+        if plan.eval_config_override is not None:
+            j._config.config_override = plan.eval_config_override
     except subprocess.CalledProcessError as e:
         # A source.repo clone/fetch failure (git exits non-zero) otherwise escapes
         # as a raw traceback — it is not a config-parse error, so give it its own

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -103,7 +103,6 @@ def _config_payload(
     config: EvaluationConfig,
     *,
     shard: EvalShard,
-    environment_manifest_path: Path | None,
 ) -> dict[str, Any]:
     if config.loop_strategy is not None and not isinstance(
         config.loop_strategy, LoopStrategySpec
@@ -137,8 +136,17 @@ def _config_payload(
         "self_gen_no_internet": config.self_gen_no_internet,
         "job_mode": config.job_mode,
         "source_provenance": config.source_provenance,
-        "environment_manifest_path": (
-            str(environment_manifest_path) if environment_manifest_path else None
+        # Serialize the already-resolved manifest OBJECT (the S axis), not a
+        # path. The parent resolves --state / --environment-manifest /
+        # name@version into config.environment_manifest before sharding; a
+        # path-only payload dropped that binding entirely for --state runs
+        # (request.environment_manifest is None) and lost any inline tool
+        # subset from resolve_state. model_dump round-trips the filtered
+        # services so the worker boots the exact same world.
+        "environment_manifest": (
+            config.environment_manifest.model_dump(mode="json")
+            if config.environment_manifest is not None
+            else None
         ),
         "config_override": config.config_override,
         "loop_strategy": (
@@ -293,7 +301,6 @@ async def run_sharded_evaluation(
     worker_concurrency: int,
     worker_retries: int,
     worker_start_stagger_sec: float,
-    environment_manifest_path: Path | None = None,
 ) -> EvaluationResult:
     """Run a batch as isolated worker subprocesses and aggregate their summaries."""
     discovery = Evaluation(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config)
@@ -322,11 +329,7 @@ async def run_sharded_evaluation(
             "tasks_dir": str(tasks_dir),
             "jobs_dir": str(shard_dir / "jobs"),
             "result_path": str(result_path),
-            "config": _config_payload(
-                config,
-                shard=shard,
-                environment_manifest_path=environment_manifest_path,
-            ),
+            "config": _config_payload(config, shard=shard),
         }
         payload_path.write_text(json.dumps(payload, indent=2))
         log_path = shard_dir / "worker.log"

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -33,12 +33,21 @@ def _retry_config(raw: dict[str, Any]) -> RetryConfig:
 
 
 def _environment_manifest(raw: dict[str, Any]):
-    manifest_path = raw.get("environment_manifest_path")
-    if not manifest_path:
-        return None
-    from benchflow.environment.manifest import load_manifest
+    from benchflow.environment.manifest import EnvironmentManifest, load_manifest
 
-    return load_manifest(Path(manifest_path))
+    manifest = raw.get("environment_manifest")
+    if manifest is not None:
+        # The parent serialized the already-resolved manifest object (S axis),
+        # so rebuild it directly. This preserves an inline --state tool subset
+        # and needs no $BENCHFLOW_ENV_REGISTRY (or registry re-resolution) in
+        # the worker subprocess.
+        return EnvironmentManifest.model_validate(manifest)
+    # Back-compat: a pre-fix shard payload (e.g. one mid-flight across an
+    # upgrade, retried) carried only a path.
+    manifest_path = raw.get("environment_manifest_path")
+    if manifest_path:
+        return load_manifest(Path(manifest_path))
+    return None
 
 
 def _evaluation_config(raw: dict[str, Any]) -> EvaluationConfig:

--- a/tests/test_config_override.py
+++ b/tests/test_config_override.py
@@ -136,3 +136,57 @@ def test_apply_enforces_allowlist():
 def test_apply_revalidates_and_rejects_bad_value():
     with pytest.raises(ValidationError):
         apply_config_override(_cfg(), {"agent": {"timeout_sec": "nope"}})
+
+
+# ---- CLI threading: --config-override on the run-config-file path ----------
+
+
+def test_cli_config_override_applies_on_run_config_file_path(tmp_path):
+    """Guards against the PR #790 regression where the run-config-file path
+    silently dropped --config-override.
+
+    ``_run_config_file_eval`` threaded every other CLI override onto the
+    YAML-loaded Evaluation but never the C-axis overlay, so
+    ``bench eval create --config run.yaml --config-override '{...}'`` parsed and
+    validated the overlay (no error) and then ran every task with its original
+    config. The ``--tasks-dir`` path applied it correctly, which masked the gap.
+    """
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    from typer.testing import CliRunner
+
+    from benchflow.cli.main import app
+    from benchflow.evaluation import Evaluation
+
+    tasks = tmp_path / "tasks" / "task-a"
+    tasks.mkdir(parents=True)
+    (tasks / "task.toml").write_text('version = "1.0"\n')
+    (tasks / "instruction.md").write_text("Do something")
+
+    run_config = tmp_path / "run.yaml"
+    run_config.write_text("tasks_dir: tasks\njobs_dir: output\nagent: oracle\n")
+
+    captured: dict = {}
+
+    async def fake_run(self: Evaluation):
+        captured["config_override"] = self._config.config_override
+        return SimpleNamespace(
+            passed=1, total=1, score=1.0, errored=0, verifier_errored=0
+        )
+
+    with patch.object(Evaluation, "run", new=fake_run):
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "create",
+                "--config",
+                str(run_config),
+                "--config-override",
+                '{"agent":{"timeout_sec":30}}',
+            ],
+        )
+
+    assert result.exit_code == 0, result.stdout
+    assert captured["config_override"] == {"agent": {"timeout_sec": 30}}

--- a/tests/test_eval_sharding.py
+++ b/tests/test_eval_sharding.py
@@ -53,7 +53,7 @@ def test_worker_payload_round_trips_loop_strategy() -> None:
     config = EvaluationConfig(loop_strategy="verify-retry:k=2,feedback=raw")
     shard = EvalShard(index=0, task_names=("task-a",), concurrency=1)
 
-    payload = _config_payload(config, shard=shard, environment_manifest_path=None)
+    payload = _config_payload(config, shard=shard)
     restored = _evaluation_config(json.loads(json.dumps(payload)))
 
     assert restored.loop_strategy == config.loop_strategy
@@ -66,7 +66,7 @@ def test_worker_payload_without_loop_strategy_stays_none() -> None:
     config = EvaluationConfig()
     shard = EvalShard(index=0, task_names=("task-a",), concurrency=1)
 
-    payload = _config_payload(config, shard=shard, environment_manifest_path=None)
+    payload = _config_payload(config, shard=shard)
 
     assert payload["loop_strategy"] is None
     assert _evaluation_config(json.loads(json.dumps(payload))).loop_strategy is None
@@ -80,7 +80,55 @@ def test_worker_payload_rejects_unparsed_loop_strategy() -> None:
     shard = EvalShard(index=0, task_names=("task-a",), concurrency=1)
 
     with pytest.raises(TypeError, match="LoopStrategySpec"):
-        _config_payload(config, shard=shard, environment_manifest_path=None)
+        _config_payload(config, shard=shard)
+
+
+def test_worker_payload_round_trips_resolved_environment_manifest() -> None:
+    """Guards against the PR #790 regression where sharded workers lost the S axis.
+
+    PR #790 added ``--state`` but the sharded payload serialized only a manifest
+    *path* (``request.environment_manifest``), which is ``None`` for a ``--state``
+    run — so every worker booted with no Environment plane, and an inline tool
+    subset from ``resolve_state`` was dropped even when a path was present. The
+    fix serializes the already-resolved manifest object. This round-trips it
+    through the JSON payload boundary (exactly what the worker subprocess reads)
+    and asserts the filtered service subset survives.
+    """
+    from benchflow.environment.manifest import EnvironmentManifest, ServiceSpec
+
+    full = EnvironmentManifest(
+        name="clawsbench",
+        base_image="clawsbench/base:latest",
+        owns_lifecycle=False,
+        services=[
+            ServiceSpec(name="gmail", command="run-gmail", port=8001),
+            ServiceSpec(name="slack", command="run-slack", port=8002),
+        ],
+    )
+    # Mirror resolve_state's inline-JSON tool subset: keep only gmail.
+    subset = full.model_copy(update={"services": full.services[:1]})
+    config = EvaluationConfig(environment_manifest=subset)
+    shard = EvalShard(index=0, task_names=("task-a",), concurrency=1)
+
+    payload = _config_payload(config, shard=shard)
+    assert payload["environment_manifest"] is not None
+    # The path-only key is gone: the object is the single source of truth.
+    assert "environment_manifest_path" not in payload
+
+    restored = _evaluation_config(json.loads(json.dumps(payload)))
+    assert restored.environment_manifest == subset
+    assert [s.name for s in restored.environment_manifest.services] == ["gmail"]
+
+
+def test_worker_payload_environment_manifest_none_stays_none() -> None:
+    """A run with no S-axis binding must serialize a null manifest, not crash."""
+    payload = _config_payload(
+        EvaluationConfig(),
+        shard=EvalShard(index=0, task_names=("task-a",), concurrency=1),
+    )
+    assert payload["environment_manifest"] is None
+    restored = _evaluation_config(json.loads(json.dumps(payload)))
+    assert restored.environment_manifest is None
 
 
 def test_worker_sharded_summary_includes_numeric_score_ratios(tmp_path) -> None:

--- a/tests/test_usage_tracking.py
+++ b/tests/test_usage_tracking.py
@@ -118,7 +118,6 @@ def test_usage_tracking_shard_payload_preserves_implicit_env_mode(monkeypatch):
     payload = _config_payload(
         parent_config,
         shard=EvalShard(index=0, task_names=("task-a",), concurrency=1),
-        environment_manifest_path=None,
     )
     worker_config = _evaluation_config(payload)
 
@@ -142,7 +141,6 @@ def test_usage_tracking_shard_payload_uses_flat_yaml_shape():
     payload = _config_payload(
         parent_config,
         shard=EvalShard(index=0, task_names=("task-a",), concurrency=1),
-        environment_manifest_path=None,
     )
     worker_config = _evaluation_config(payload)
 


### PR DESCRIPTION
## What

Follow-up to **#790**, which added the `--state` (S) and `--config-override` (C) eval axes. Two delivery paths silently dropped the binding — **producing wrong eval results with no error**, the worst failure mode for a benchmarking pipeline. Found during a post-merge review of #790.

### 1. Sharded / `--worker-concurrency` runs dropped `--state` entirely
`run_sharded_evaluation` serialized only a manifest **path** (`request.environment_manifest`) into the worker payload. For a `--state` run that path is `None`, so every worker booted with **no Environment plane**; and an inline `resolve_state` tool subset (`{"name":"env0","tools":[...]}`) was lost even when a path *was* present (it lives only on the resolved object).

**Fix:** serialize the already-resolved `config.environment_manifest` object and rebuild it in the worker (`model_dump(mode="json")` ↔ `model_validate`), so the worker boots the exact world the parent resolved — including the filtered service subset, with no dependency on `$BENCHFLOW_ENV_REGISTRY` being present in the subprocess. Removes the now-redundant `environment_manifest_path` plumbing (worker keeps a back-compat fallback for in-flight pre-fix payloads).

### 2. The run-config-file path dropped `--config-override`
`_run_config_file_eval` threaded every CLI override onto the YAML-loaded `Evaluation` **except** `config_override`, so `bench eval create --config run.yaml --config-override '{...}'` validated the overlay (no error) then ran every task with its original config. The `--tasks-dir` path applied it correctly, which masked the gap.

**Fix:** apply `plan.eval_config_override`, mirroring the existing `--environment-manifest`-wins-over-YAML precedence right above it.

## Tests
- `test_worker_payload_round_trips_resolved_environment_manifest` — resolved manifest with a filtered service subset survives the JSON shard-payload boundary.
- `test_worker_payload_environment_manifest_none_stays_none` — no-S-axis run serializes a null manifest.
- `test_cli_config_override_applies_on_run_config_file_path` — `--config <yaml> --config-override` lands on `EvaluationConfig.config_override`.

Full unit suite green (**4293 passed, 12 skipped**); `ruff check`, `ruff format --check`, `ty check` all clean.

## Not in scope (from the same review, deferred)
- `build_context_stage.py` re-implements `sandbox/setup.py:stage_dockerfile_deps` and drops its symlink / path-escape guards (#363/#411).
- The C-axis allowlist permits the whole `sandbox` section (`network_mode`/`allowed_hosts`/resources), which the default shared verifier can depend on.
- Residual `_agent_process_kill_pattern` edges (flag-values not skipped; silent `None` → no teardown).