### PR TITLE
fix(agents): resolve bare model ids to their provider so harnesses route correctly

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -146,7 +146,11 @@ def _normalize_openhands_model(model: str) -> str:
     OpenHands expects provider-qualified model names for some providers even
     when benchflow uses bare model IDs or its own provider prefixes.
     """
-    from benchflow.agents.providers import find_provider, strip_provider_prefix
+    from benchflow.agents.providers import (
+        find_provider,
+        find_provider_for_bare_model,
+        strip_provider_prefix,
+    )
     from benchflow.agents.registry import is_vertex_model
 
     if model.startswith(("gemini/", "vertex_ai/", "openhands/")):
@@ -163,7 +167,7 @@ def _normalize_openhands_model(model: str) -> str:
         return f"vertex_ai/{stripped}"
     if "gemini" in lower:
         return f"gemini/{stripped}"
-    provider = find_provider(model)
+    provider = find_provider(model) or find_provider_for_bare_model(model)
     if provider is not None:
         _, cfg = provider
         if cfg.api_protocol == "openai-completions":
@@ -458,6 +462,7 @@ def resolve_provider_env(
     """Detect provider for model, inject BENCHFLOW_PROVIDER_* and env_mapping."""
     from benchflow.agents.providers import (
         find_provider,
+        find_provider_for_bare_model,
         resolve_base_url,
         strip_provider_prefix,
     )
@@ -467,7 +472,11 @@ def resolve_provider_env(
     # Agent-declared protocol takes precedence over provider's primary so
     # multi-endpoint providers (e.g. zai) route to the right URL.
     agent_protocol = agent_cfg.api_protocol if agent_cfg else ""
-    _prov = find_provider(model)
+    # Resolve bare family ids (e.g. "deepseek-v4-pro") too, not just explicit
+    # "provider/" prefixes — otherwise the provider env (NAME/BASE_URL/API_KEY)
+    # is never emitted and harnesses that rely on it misroute (openhands' litellm
+    # saw no provider; openclaw defaulted to anthropic/). Mirrors acp/runtime.py.
+    _prov = find_provider(model) or find_provider_for_bare_model(model)
     if _prov:
         _prov_name, _prov_cfg = _prov
         agent_env.setdefault("BENCHFLOW_PROVIDER_NAME", _prov_name)

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -74,6 +74,11 @@ class ProviderConfig:
     auth_type: str  # "api_key" | "adc" | "aws" | "none"
     auth_env: str | None = None  # env var holding the API key (None for ADC)
     url_params: dict[str, str] = field(default_factory=dict)  # {placeholder: ENV_VAR}
+    # Fallback value per url_params placeholder when its env var is unset, so a
+    # provider can ship a usable default endpoint while still honoring an
+    # explicit override (the env var wins). Empty => the env var is required
+    # (historical behavior).
+    url_param_defaults: dict[str, str] = field(default_factory=dict)
     models: list[dict] = field(default_factory=list)  # model metadata for agents
     # Bare-model-name family tokens this provider owns (e.g. ["deepseek"],
     # ["qwen"]). Used by find_provider_for_bare_model() to route a *prefix-less*
@@ -314,6 +319,10 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_type="api_key",
         auth_env="DEEPSEEK_API_KEY",
         url_params={"base_url": "DEEPSEEK_BASE_URL"},
+        # deepseek-v4-pro is served at deepseek's public OpenAI-compatible
+        # endpoint; default to it so bare ids resolve without DEEPSEEK_BASE_URL
+        # (matches the shim default), while DEEPSEEK_BASE_URL still overrides.
+        url_param_defaults={"base_url": "https://api.deepseek.com/v1"},
         model_prefixes=["deepseek"],
     ),
     "xiaomi": ProviderConfig(
@@ -455,7 +464,7 @@ def resolve_base_url(
         return url
     replacements = {}
     for placeholder, env_var in provider.url_params.items():
-        value = env.get(env_var)
+        value = env.get(env_var) or provider.url_param_defaults.get(placeholder)
         if not value:
             raise KeyError(
                 f"Provider {provider.name!r} requires {env_var} for "

--- a/tests/test_resolve_env_helpers.py
+++ b/tests/test_resolve_env_helpers.py
@@ -390,6 +390,52 @@ class TestResolveProviderEnv:
         assert env["BENCHFLOW_PROVIDER_MODEL"] == "claude-sonnet-4-6"
         assert env["ANTHROPIC_MODEL"] == "claude-sonnet-4-6"
 
+    def test_bare_deepseek_resolves_provider_for_openhands(self):
+        """Guards the harness-provider-resolution fix: a BARE deepseek id must
+        resolve the deepseek provider (NAME/BASE_URL/key) and litellm-qualify the
+        model, else OpenHands' litellm sees no provider ('LLM Provider NOT
+        provided … model=deepseek-v4-pro').
+
+        Before the fix, resolve_provider_env only matched an explicit 'deepseek/'
+        prefix via find_provider(), so 'deepseek-v4-pro' fell through to the
+        else branch and OpenHands got LLM_MODEL='deepseek-v4-pro' with no
+        base_url/key. The provider now also resolves bare family ids, and the
+        deepseek provider carries a default base_url so DEEPSEEK_BASE_URL is
+        optional (matching the shim default).
+        """
+        env = {"DEEPSEEK_API_KEY": "dk-test"}
+        resolve_provider_env(env, "deepseek-v4-pro", "openhands")
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "deepseek"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.deepseek.com/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "dk-test"
+        assert env["LLM_BASE_URL"] == "https://api.deepseek.com/v1"
+        assert env["LLM_API_KEY"] == "dk-test"
+        assert env["LLM_MODEL"] == "openai/deepseek-v4-pro"
+
+    def test_bare_deepseek_sets_provider_name_for_openclaw(self):
+        """Guards the harness-provider-resolution fix: openclaw must see
+        BENCHFLOW_PROVIDER_NAME=deepseek for a bare id, else its shim defaults the
+        provider to anthropic ('FailoverError: Unknown model:
+        anthropic/deepseek-v4-pro').
+        """
+        env = {"DEEPSEEK_API_KEY": "dk-test"}
+        resolve_provider_env(env, "deepseek-v4-pro", "openclaw")
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "deepseek"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://api.deepseek.com/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "dk-test"
+
+    def test_bare_deepseek_base_url_override_wins(self):
+        """An explicit DEEPSEEK_BASE_URL still overrides the provider default."""
+        env = {
+            "DEEPSEEK_API_KEY": "dk-test",
+            "DEEPSEEK_BASE_URL": "https://custom.deepseek.example/v1",
+        }
+        resolve_provider_env(env, "deepseek-v4-pro", "openhands")
+        assert (
+            env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://custom.deepseek.example/v1"
+        )
+        assert env["LLM_BASE_URL"] == "https://custom.deepseek.example/v1"
+
 
 # check_subscription_auth
 


### PR DESCRIPTION
## What

Found while dogfooding the harness coverage for #804: several agent harnesses errored with `--model deepseek-v4-pro` (a **bare** id, no `provider/` prefix) — the agent made **0 tool calls** because the model never resolved to a provider:

- **openhands** → `litellm.BadRequestError: LLM Provider NOT provided … model=deepseek-v4-pro`
- **openclaw** → `FailoverError: Unknown model: anthropic/deepseek-v4-pro` (its shim defaulted the provider to anthropic)

### Root cause
`resolve_provider_env` and `_normalize_openhands_model` (`agents/env.py`) only called `find_provider()`, which matches an **explicit `provider/` prefix**. A bare `deepseek-v4-pro` returned `None`, so `BENCHFLOW_PROVIDER_NAME/BASE_URL/API_KEY` were never emitted and provider-driven harnesses misrouted. The repo already has `find_provider_for_bare_model()` (used by `acp/runtime.py`) — it just wasn't wired into these two sites.

### Fix
1. Route bare family ids through `find_provider_for_bare_model()` in both sites.
2. Give the deepseek provider a **default base_url** via a new `ProviderConfig.url_param_defaults` field, so `resolve_base_url` no longer *requires* `DEEPSEEK_BASE_URL` (an explicit value still overrides). This matches the shims' hardcoded default (`https://api.deepseek.com/v1`) and is what prevents a regression: without it, routing bare deepseek into the strict branch would raise for the harnesses that work today (deepagents/pi-acp/opencode/mimo).

### Non-regression (verified)
- Every relevant agent declares `api_protocol=''`, so the protocol-compat check passes for all → no new raises.
- Prefixed ids (`deepseek/…`), non-deepseek models (`gpt-5`), and `DEEPSEEK_BASE_URL` override are all unchanged. 662 provider/env/registry/agent tests pass locally; ruff + ty clean.

### Tests
`test_bare_deepseek_resolves_provider_for_openhands`, `…_sets_provider_name_for_openclaw`, `…_base_url_override_wins`.

## Not in this PR
`harvey-lab-harness` needs a separate change — its `_create_adapter` only dispatches claude/gpt/o*/gemini, so deepseek raises inside the shim (a vendored-adapter routing issue, not provider resolution). Handled separately after e2e dogfood validation.