### PR TITLE
fix(integration): repair the full L0–L3 workflow + ready-to-merge codex auto-trigger

### DIFF
--- a/.github/workflows/integration-final-review.yml
+++ b/.github/workflows/integration-final-review.yml
@@ -5,12 +5,15 @@
 #     (build_integration_review_pack.py), the harness (scenarios), and the codex
 #     reviewer (codex_review.py) ALWAYS load from origin/main via sparse checkout.
 #     Only src/benchflow (the code-under-test) is overlaid from the PR head SHA.
-#   * NEVER on push / pull_request: this workflow is workflow_dispatch ONLY. The
-#     jobs run under the existing 'pypi-internal-preview' environment (which holds
-#     the provider + DAYTONA secrets). No separate protected env is created — the
-#     L3 golden truth is the HuggingFace leaderboard `main` runs (the deepseek-
-#     v4-flash baseline) compared against the PR vs the latest benchflow main.
-#     (To add a human-approval gate later, point these jobs at a protected env.)
+#   * TRIGGERS: workflow_dispatch (manual, any PR) OR a `pull_request` `labeled`
+#     event when the `ready-to-merge` label is added — the auto path: marking a PR
+#     ready to merge runs the FULL final review, codex included. NEVER on push and
+#     NEVER pull_request_target, so fork PRs receive no secrets; the plan job's
+#     resolve step additionally refuses any non-internal head repo, and only
+#     write-access users can apply labels. The jobs run under the existing
+#     'pypi-internal-preview' environment (provider + DAYTONA secrets). No separate
+#     protected env — the L3 golden truth is the HuggingFace leaderboard `main`
+#     runs (deepseek-v4-flash baseline) vs the PR and the latest benchflow main.
 #   * FAIL-CLOSED CODEX: at L3 codex_review.py is REQUIRED. A missing codex
 #     binary / codex auth (the repo OPENAI_API_KEY), or unparseable codex output, yields
 #     'not mergeable (codex unavailable)' and a red check. The published
@@ -54,9 +57,16 @@ on:
         type: boolean
         default: true
 
+  # Auto path: adding the `ready-to-merge` label to an INTERNAL PR runs the full
+  # final review (codex included). Plain pull_request (NEVER pull_request_target),
+  # so fork PRs receive no secrets; the plan job's resolve step additionally
+  # refuses any non-internal head repo, and only write-access users can label.
+  pull_request:
+    types: [labeled]
+
 # One final review per PR at a time; do NOT cancel an in-flight rollout.
 concurrency:
-  group: integration-final-review-${{ github.event.inputs.pr_number }}
+  group: integration-final-review-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
   cancel-in-progress: false
 
 permissions:
@@ -73,6 +83,13 @@ jobs:
   # ----------------------------------------------------------------------------
   plan:
     runs-on: ubuntu-latest
+    # Manual dispatch (any PR) OR the `ready-to-merge` auto-label trigger. Any
+    # OTHER label added to a PR is a no-op: this job — and the run-matrix /
+    # review-pack jobs that depend on its outputs — are skipped, so an unrelated
+    # label never spins up a rollout and the workflow stays green.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && github.event.label.name == 'ready-to-merge')
     # Run under the same env that run-matrix uses so the credential filter
     # below can see the real provider secrets (DEEPSEEK/GEMINI/OPENAI/Bedrock).
     environment: pypi-internal-preview
@@ -90,7 +107,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
         run: |
           set -euo pipefail
           json=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}")
@@ -139,7 +156,7 @@ jobs:
       - name: Plan final-review scope (trusted)
         id: plan
         env:
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
           BASE_REF: ${{ steps.resolve.outputs.base_ref }}
           HEAD_SHA: ${{ steps.resolve.outputs.head_sha }}
           SCOPE_INPUT: ${{ github.event.inputs.scope || 'auto' }}
@@ -528,7 +545,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.pull_request.number }}
           FINAL_VERDICT: ${{ steps.final.outputs.final_verdict }}
           MARKER: "<!-- integration-final-review -->"
         run: |

--- a/.github/workflows/integration-final-review.yml
+++ b/.github/workflows/integration-final-review.yml
@@ -109,9 +109,15 @@ jobs:
         with:
           ref: ${{ steps.resolve.outputs.base_ref }}
           fetch-depth: 0
+          # pyproject.toml + README.md + src so `uv pip install .` below can build
+          # benchflow (hatchling) for the credential filter — the planner itself
+          # is pure stdlib and needs only .github.
           sparse-checkout: |
             .github
             tests/integration
+            pyproject.toml
+            README.md
+            src
           sparse-checkout-cone-mode: false
 
       - name: Fetch PR head SHA for the diff
@@ -124,6 +130,11 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
 
       - name: Plan final-review scope (trusted)
         id: plan
@@ -161,7 +172,10 @@ jobs:
       # benchflow.agents.env. The planner above is pure (MiniYaml-safe) and
       # needs nothing; only this env-aware step needs the package.
       - name: Install benchflow (for the credential filter)
-        run: pip install --quiet .
+        # uv pip install into the setup-python interpreter (--system). The filter
+        # is fail-open by design, so a failed install must NOT block the plan —
+        # warn and let the filter pass the matrix through unfiltered.
+        run: uv pip install --system --quiet . || echo "::warning::benchflow install failed; credential filter will fail-open (matrix unfiltered)"
 
       # Drop any planned cell whose agent+model credential is absent from this
       # environment BEFORE run-matrix consumes the matrix, so un-keyed agents

--- a/.github/workflows/integration-scope.yml
+++ b/.github/workflows/integration-scope.yml
@@ -163,9 +163,15 @@ jobs:
         with:
           ref: ${{ needs.detect-scope.outputs.base_ref }}
           fetch-depth: 0
+          # pyproject.toml + README.md + src so `uv pip install .` below can build
+          # benchflow (hatchling) for the credential filter — the planner itself
+          # is pure stdlib and needs only .github.
           sparse-checkout: |
             .github
             tests/integration
+            pyproject.toml
+            README.md
+            src
           sparse-checkout-cone-mode: false
 
       - name: Fetch PR head SHA for the diff
@@ -178,6 +184,11 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
 
       - name: Plan integration scope (trusted)
         id: plan
@@ -213,7 +224,10 @@ jobs:
       # benchflow.agents.env. The planner above is pure (MiniYaml-safe) and
       # needs nothing; only this env-aware step needs the package.
       - name: Install benchflow (for the credential filter)
-        run: pip install --quiet .
+        # uv pip install into the setup-python interpreter (--system). The filter
+        # is fail-open by design, so a failed install must NOT block the plan —
+        # warn and let the filter pass the matrix through unfiltered.
+        run: uv pip install --system --quiet . || echo "::warning::benchflow install failed; credential filter will fail-open (matrix unfiltered)"
 
       # Drop any planned cell whose agent+model credential is absent from this
       # environment BEFORE run-matrix consumes the matrix, so un-keyed agents


### PR DESCRIPTION
## Summary

Scope: **make the full integration test workflow actually runnable end-to-end**, plus add an automatic trigger for the codex final review. Two parts:

### 1. Fix the plan-job credential-filter install (the blocker)

The first live dispatch of L3 `integration-final-review` (against #803) **failed at the `plan` job**:

```
ERROR: Directory '.' is not installable. Neither 'setup.py' nor 'pyproject.toml' found.
```

The L2/L3 **plan** jobs sparse-checkout only `.github` + `tests/integration`, then `pip install .` to make `benchflow.agents.env` importable for the credential filter — but the sparse checkout omits `pyproject.toml`/`src`, so the build fails and the whole plan job goes red (→ `run-matrix` + `review-pack` skipped). It slipped past #802's own CI because that path was never exercised (L1 has no filter; L2 plan only runs on the `integration:medium` label; L3 is dispatch-only).

- Add `pyproject.toml` + `README.md` + `src` to the plan job's sparse-checkout so hatchling can build benchflow.
- **Switch `pip install .` → `uv pip install --system`** (`astral-sh/setup-uv`) — consistent with the rest of the workflows, no `pip`.
- Make the install **non-fatal** (`|| ::warning`) so the fail-open credential filter is never blocked by an install hiccup.

(The only remaining `pip install` is release-notes *text* in `internal-preview-release.yml`, not a CI step.)

### 2. Auto-trigger the codex final review on `ready-to-merge`

Today the codex equivalence reviewer runs **only** in L3, which is `workflow_dispatch`-only (manual). This adds a `pull_request: [labeled]` trigger so that applying the **`ready-to-merge`** label to an internal PR runs the **full** final review (plan → matrix → deterministic review pack + codex) automatically.

- plan job gated `if: workflow_dispatch OR (pull_request && label == 'ready-to-merge')`; **any other label is a no-op** (plan + dependent jobs skip, workflow stays green — no rollout spun up).
- PR resolved from `inputs.pr_number || pull_request.number` (resolve / plan / comment steps); concurrency keyed the same way (`cancel-in-progress: false`).
- **Security:** plain `pull_request` (never `pull_request_target`) → fork PRs get no secrets; the resolve step still refuses any non-internal head repo; only write-access users can apply labels. Codex stays **fail-closed** as the L3 gate, but **L3 is not a required status check**, so a red final-review *informs* without blocking the merge (mitigates the dead-`OPENAI_API_KEY` red-block concern).

The `ready-to-merge` label has been created in the repo.

## Test plan

- [x] YAML valid (both workflows); planner/filter unit suites pass
- [x] End-to-end: benchflow builds from `{pyproject.toml, README.md, src}` via `uv pip install .` and `resolve_agent_env` imports with real deps
- [x] Trigger wiring verified: `on` = {workflow_dispatch, pull_request[labeled]}, plan `if` gates on the label, PR resolved from both event shapes
- [ ] **After merge:** label a real internal PR `ready-to-merge` → L3 auto-runs (plan reaches the credential filter, matrix runs, review pack + codex verdict post)
- [ ] **After merge:** re-dispatch L3 on #803 to confirm the plan-install fix end-to-end