### PR TITLE
fix(integration): add uv.lock to plan-job sparse-checkout (setup-uv cache)

### DIFF
--- a/.github/workflows/integration-final-review.yml
+++ b/.github/workflows/integration-final-review.yml
@@ -127,12 +127,14 @@ jobs:
           ref: ${{ steps.resolve.outputs.base_ref }}
           fetch-depth: 0
           # pyproject.toml + README.md + src so `uv pip install .` below can build
-          # benchflow (hatchling) for the credential filter — the planner itself
-          # is pure stdlib and needs only .github.
+          # benchflow (hatchling) for the credential filter; uv.lock so the
+          # setup-uv cache key resolves. The planner itself is pure stdlib and
+          # needs only .github.
           sparse-checkout: |
             .github
             tests/integration
             pyproject.toml
+            uv.lock
             README.md
             src
           sparse-checkout-cone-mode: false

--- a/.github/workflows/integration-scope.yml
+++ b/.github/workflows/integration-scope.yml
@@ -164,12 +164,14 @@ jobs:
           ref: ${{ needs.detect-scope.outputs.base_ref }}
           fetch-depth: 0
           # pyproject.toml + README.md + src so `uv pip install .` below can build
-          # benchflow (hatchling) for the credential filter — the planner itself
-          # is pure stdlib and needs only .github.
+          # benchflow (hatchling) for the credential filter; uv.lock so the
+          # setup-uv cache key resolves. The planner itself is pure stdlib and
+          # needs only .github.
           sparse-checkout: |
             .github
             tests/integration
             pyproject.toml
+            uv.lock
             README.md
             src
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
Follow-up to #806. The plan-job `setup-uv` step uses `enable-cache: true`, which needs a `uv.lock` to compute the cache key — but the plan job's sparse-checkout omitted it, so the **Install uv** step failed on the re-dispatched L3 run (`No file matched [**/uv.lock]`). Add `uv.lock` to the plan-job sparse-checkout in both L2 and L3.

The "Directory not installable" error from before #806 is **gone** (the run used the new workflow); this is the next error in the chain. run-matrix / review-pack already get `uv.lock` via their full checkout.

## Test plan
- [x] YAML valid; uv.lock present at repo root
- [ ] Re-dispatch L3 on #803 → plan job passes setup-uv + reaches the credential filter + emits the matrix