### PR TITLE
fix(integration): install codex CLI + isolate codex auth from the deepseek judge

### DIFF
--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -262,6 +262,25 @@ def has_codex_auth(env: Mapping[str, str], auth_path: Path | None) -> bool:
     return (_codex_config_dir(env) / "auth.json").exists()
 
 
+def _codex_env(env: Mapping[str, str]) -> dict[str, str]:
+    """Env for the host ``codex exec`` CLI (Pass 2), isolated from the judge.
+
+    The review-pack job points OPENAI_API_KEY / OPENAI_BASE_URL at the DeepSeek
+    endpoint so the cheap per-rollout judge (Pass 1) runs on deepseek-v4-flash.
+    The codex CLI needs the REAL OpenAI credential instead. When ``CODEX_API_KEY``
+    is set it becomes the codex ``OPENAI_API_KEY`` and the DeepSeek ``OPENAI_BASE_URL``
+    is dropped so codex falls back to the default OpenAI endpoint. With
+    ``CODEX_API_KEY`` unset the env is unchanged (a host where ``OPENAI_API_KEY``
+    is already the real key). Pass 1 keeps using the original ``env``.
+    """
+    out = dict(env)
+    codex_key = env.get("CODEX_API_KEY")
+    if codex_key:
+        out["OPENAI_API_KEY"] = codex_key
+        out.pop("OPENAI_BASE_URL", None)
+    return out
+
+
 def build_codex_command(
     prompt: str,
     *,
@@ -514,9 +533,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.findings_out:
         args.findings_out.write_text(json.dumps(findings, indent=2), encoding="utf-8")
 
-    # Pass 2: host codex exec. Fail closed if codex cannot authenticate.
-    auth_path = write_codex_auth(env)
-    if not has_codex_auth(env, auth_path):
+    # Pass 2: host codex exec. Fail closed if codex cannot authenticate. The
+    # codex CLI runs under an isolated env (real OpenAI key via CODEX_API_KEY,
+    # default OpenAI endpoint) so the DeepSeek judge clobber does not leak in.
+    codex_env = _codex_env(env)
+    auth_path = write_codex_auth(codex_env)
+    if not has_codex_auth(codex_env, auth_path):
         print("::error::codex auth.json / API key missing — failing closed")
         final = worst(deterministic, VERDICT_CODEX_UNAVAILABLE)
         print(f"codex_verdict={VERDICT_CODEX_UNAVAILABLE}")
@@ -537,7 +559,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         codex_bin=args.codex_bin,
         model=args.codex_model,
         config_overrides=args.config_overrides,
-        env=env,
+        env=codex_env,
     )
     if args.codex_out:
         args.codex_out.write_text(raw, encoding="utf-8")

--- a/.github/workflows/integration-final-review.yml
+++ b/.github/workflows/integration-final-review.yml
@@ -494,15 +494,26 @@ jobs:
           echo "deterministic_verdict=$DET" >> "$GITHUB_OUTPUT"
           echo "deterministic verdict: $DET (pack exit $rc)"
 
+      # The host codex CLI (`codex exec`) the equivalence reviewer drives.
+      # continue-on-error so a failed install reaches the codex step, which then
+      # fail-closes to 'not mergeable (codex unavailable)' with a verdict, rather
+      # than dying as a raw step error.
+      - name: Install codex CLI
+        if: ${{ github.event.inputs.codex_review != 'false' }}
+        continue-on-error: true
+        run: npm install -g @openai/codex@0.141.0
+
       # REQUIRED at L3 (fail-closed). A dead/absent codex key => not mergeable.
       - name: Codex equivalence review (REQUIRED, fail-closed)
         id: codex
         if: ${{ github.event.inputs.codex_review != 'false' }}
         env:
-          # Codex auth = OPENAI_API_KEY from the job env (codex_review.py writes
-          # it as an apikey auth.json). BENCHFLOW_JUDGE_MODEL is already in the
-          # job env (provider-select wrote it to $GITHUB_ENV) for the cheap
-          # deepseek per-rollout pass.
+          # The per-rollout judge (Pass 1) uses the DeepSeek OPENAI_* that
+          # provider-select wrote to $GITHUB_ENV. The host `codex exec` (Pass 2)
+          # needs the REAL OpenAI key — passed via CODEX_API_KEY, which
+          # codex_review.py uses for the CLI (dropping the DeepSeek base URL) so
+          # the judge clobber never leaks into codex auth.
+          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DETERMINISTIC_VERDICT: ${{ steps.pack.outputs.deterministic_verdict }}
         run: |
           set +e

--- a/.github/workflows/integration-scope.yml
+++ b/.github/workflows/integration-scope.yml
@@ -488,13 +488,20 @@ jobs:
       # ADVISORY-ONLY at L2: codex can make the verdict stricter but is NOT
       # required (no fail-closed). A missing reviewer key just yields no codex
       # signal here.
+      # The host codex CLI (`codex exec`) the advisory reviewer drives.
+      - name: Install codex CLI
+        continue-on-error: true
+        run: npm install -g @openai/codex@0.141.0
+
       - name: Codex equivalence review (advisory)
         id: codex
         continue-on-error: true
         env:
-          # Codex auth = OPENAI_API_KEY (apikey auth.json). BENCHFLOW_JUDGE_MODEL
-          # is already in the job env (provider-select wrote it to $GITHUB_ENV).
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Pass 1 judge uses the DeepSeek OPENAI_* (provider-select wrote it to
+          # $GITHUB_ENV). The host `codex exec` (Pass 2) gets the REAL OpenAI key
+          # via CODEX_API_KEY — codex_review.py isolates the CLI env (real key +
+          # default OpenAI base) so the judge clobber never leaks into codex auth.
+          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set +e
           uv run python .github/scripts/codex_review.py \

--- a/tests/test_codex_review.py
+++ b/tests/test_codex_review.py
@@ -41,6 +41,35 @@ cr = _load_module()
 
 
 # ------------------------------------------------------------------
+# _codex_env — isolate the codex CLI auth from the DeepSeek judge clobber
+# ------------------------------------------------------------------
+
+
+def test_codex_env_prefers_codex_api_key_and_drops_deepseek_base():
+    # The review-pack job points OPENAI_* at DeepSeek for the Pass-1 judge; the
+    # host codex CLI must instead use the REAL OpenAI key (CODEX_API_KEY) and the
+    # default OpenAI endpoint (DeepSeek base URL dropped). The judge model stays.
+    out = cr._codex_env(
+        {
+            "OPENAI_API_KEY": "ds-key",
+            "OPENAI_BASE_URL": "https://api.deepseek.com",
+            "CODEX_API_KEY": "real-openai-key",
+            "BENCHFLOW_JUDGE_MODEL": "openai/deepseek-v4-flash",
+        }
+    )
+    assert out["OPENAI_API_KEY"] == "real-openai-key"
+    assert "OPENAI_BASE_URL" not in out
+    assert out["BENCHFLOW_JUDGE_MODEL"] == "openai/deepseek-v4-flash"
+
+
+def test_codex_env_unchanged_without_codex_api_key():
+    # Backward compatible: with no CODEX_API_KEY (host where OPENAI_API_KEY is
+    # already the real key), the env is returned untouched.
+    src = {"OPENAI_API_KEY": "x", "OPENAI_BASE_URL": "y"}
+    assert cr._codex_env(src) == src
+
+
+# ------------------------------------------------------------------
 # worst() — advisory-stricter-only composition
 # ------------------------------------------------------------------
 def test_worst_codex_can_downgrade():


### PR DESCRIPTION
Third follow-up to #806/#807 to get the **full L3 review** green. The first full run on #803 reached `review-pack` with **plan ✓ + all 10 rollouts ✓ + deterministic grader ✓** — only codex failed.

## Root causes
1. **`codex binary not found: 'codex'`** — the review-pack job never installed the codex CLI.
2. **codex auth clobbered to DeepSeek** — `provider-select` exports `OPENAI_*`=DeepSeek for the cheap Pass-1 judge; `codex_review.py` then wrote the codex `auth.json` from that key and ran `codex exec` against the DeepSeek base.

## Fix
- **Install `@openai/codex@0.141.0`** in both review-pack jobs (L2 advisory, L3 required), `continue-on-error` so a failed install still hits codex's fail-closed verdict.
- **`_codex_env` in codex_review.py** isolates the host `codex exec`: real OpenAI key via `CODEX_API_KEY` + DeepSeek `OPENAI_BASE_URL` dropped (default OpenAI endpoint). The Pass-1 deepseek judge keeps the original env. Workflows pass `CODEX_API_KEY: secrets.OPENAI_API_KEY` (L2 also drops its `OPENAI_API_KEY` override, which paired the real key with the deepseek base).

## Test plan
- [x] ruff + YAML valid; `_codex_env` unit test (real-key isolation + backward-compat) green
- [ ] Re-dispatch L3 on #803 → review-pack runs codex against the real OpenAI endpoint → real verdict (not 'codex unavailable')