### PR TITLE
feat(integration): codex reviewer on DeepSeek-v4-pro via Moon Bridge

### DIFF
--- a/.github/integration/moonbridge-config.yml
+++ b/.github/integration/moonbridge-config.yml
@@ -1,0 +1,41 @@
+# Moon Bridge config for the L3 codex equivalence reviewer on DeepSeek-v4-pro.
+#
+# codex (OpenAI's CLI) speaks ONLY the OpenAI Responses API; DeepSeek does not
+# serve it. Moon Bridge (https://github.com/ZhiYi-R/moon-bridge) is a local
+# forwarding proxy that exposes an OpenAI-Responses-compatible endpoint and
+# translates to DeepSeek's /anthropic surface — the integration method from
+# https://github.com/deepseek-ai/awesome-deepseek-agent docs/codex.md.
+#
+# DEEPSEEK_API_KEY_PLACEHOLDER is replaced with $DEEPSEEK_API_KEY by
+# setup_codex_deepseek_bridge.sh at runtime (the key is never committed).
+mode: "Transform"
+server:
+  addr: "127.0.0.1:38440"
+models:
+  deepseek-v4-pro:
+    context_window: 1000000
+    max_output_tokens: 384000
+    default_reasoning_level: "high"
+    supported_reasoning_levels:
+      - effort: "high"
+        description: "High reasoning effort"
+      - effort: "xhigh"
+        description: "Extra high reasoning effort"
+    supports_reasoning_summaries: true
+    default_reasoning_summary: "auto"
+    extensions:
+      deepseek_v4:
+        enabled: true
+providers:
+  deepseek:
+    base_url: "https://api.deepseek.com/anthropic"
+    api_key: "DEEPSEEK_API_KEY_PLACEHOLDER"
+    offers:
+      - model: deepseek-v4-pro
+routes:
+  moonbridge:
+    model: deepseek-v4-pro
+    provider: deepseek
+defaults:
+  model: moonbridge
+  max_tokens: 65536

--- a/.github/scripts/setup_codex_deepseek_bridge.sh
+++ b/.github/scripts/setup_codex_deepseek_bridge.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Set up Moon Bridge so the L3/L2 codex equivalence reviewer can run on
+# DeepSeek-v4-pro. codex speaks ONLY the OpenAI Responses API; Moon Bridge is a
+# local proxy that exposes a Responses-compatible endpoint and forwards to
+# DeepSeek's /anthropic surface (validated end-to-end). Method:
+# https://github.com/deepseek-ai/awesome-deepseek-agent docs/codex.md
+#
+# Starts the bridge in the BACKGROUND (it must stay alive for the later codex
+# step) and writes codex's config.toml into $CODEX_HOME so `codex exec` routes to
+# DeepSeek. Requires $DEEPSEEK_API_KEY in the env. Idempotent-ish; fail-closed.
+set -euo pipefail
+
+: "${DEEPSEEK_API_KEY:?DEEPSEEK_API_KEY required for the codex DeepSeek bridge}"
+GO_VERSION="${GO_VERSION:-go1.25.0}"
+BRIDGE_ADDR="${BRIDGE_ADDR:-127.0.0.1:38440}"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_TEMPLATE="${HERE}/../integration/moonbridge-config.yml"
+
+# 1. Go toolchain (Moon Bridge needs >= 1.25).
+if ! command -v go >/dev/null 2>&1 || ! go version | grep -qE 'go1\.(2[5-9]|[3-9][0-9])'; then
+  echo "installing ${GO_VERSION}..."
+  curl -fsSL "https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" | tar -C /tmp -xz
+  export PATH="/tmp/go/bin:${PATH}"
+fi
+export GOPATH="${GOPATH:-/tmp/gopath}" GOCACHE="${GOCACHE:-/tmp/gocache}"
+
+# 2. Build Moon Bridge.
+rm -rf /tmp/moon-bridge
+git clone --depth 1 https://github.com/ZhiYi-R/moon-bridge.git /tmp/moon-bridge
+( cd /tmp/moon-bridge && go build -o /tmp/moonbridge ./cmd/moonbridge )
+
+# 3. config.yml with the live DeepSeek key (placeholder -> $DEEPSEEK_API_KEY).
+sed "s|DEEPSEEK_API_KEY_PLACEHOLDER|${DEEPSEEK_API_KEY}|" \
+  "${CONFIG_TEMPLATE}" > /tmp/mb_config.yml
+
+# 4. Start the bridge in the background; wait until it accepts connections.
+nohup /tmp/moonbridge -config /tmp/mb_config.yml > /tmp/moonbridge.log 2>&1 &
+for _ in $(seq 1 30); do
+  curl -sf "http://${BRIDGE_ADDR}/console/" >/dev/null 2>&1 && break
+  sleep 1
+done
+if ! curl -sf "http://${BRIDGE_ADDR}/console/" >/dev/null 2>&1; then
+  echo "::error::Moon Bridge did not start"
+  tail -30 /tmp/moonbridge.log || true
+  exit 1
+fi
+
+# 5. Generate codex config.toml (provider=moonbridge, wire_api=responses) into
+#    $CODEX_HOME so `codex exec --model moonbridge` routes through the bridge.
+CODEX_HOME="${CODEX_HOME:-${HOME}/.codex}"
+mkdir -p "${CODEX_HOME}"
+MODEL="$(/tmp/moonbridge -config /tmp/mb_config.yml -print-codex-model)"
+/tmp/moonbridge -config /tmp/mb_config.yml -print-codex-config "${MODEL}" \
+  -codex-base-url "http://${BRIDGE_ADDR}/v1" -codex-home "${CODEX_HOME}" \
+  > "${CODEX_HOME}/config.toml"
+# The deepwiki MCP server the generator adds is unused by the read-only reviewer
+# and only adds startup latency — drop it.
+if grep -q '\[mcp_servers' "${CODEX_HOME}/config.toml"; then
+  sed -i '/^\[mcp_servers/,/^$/d' "${CODEX_HOME}/config.toml"
+fi
+echo "codex-deepseek bridge ready: codex model=${MODEL} -> deepseek-v4-pro"

--- a/.github/workflows/integration-final-review.yml
+++ b/.github/workflows/integration-final-review.yml
@@ -503,23 +503,29 @@ jobs:
         continue-on-error: true
         run: npm install -g @openai/codex@0.141.0
 
+      # Route codex to DeepSeek-v4-pro via Moon Bridge (a local OpenAI-Responses
+      # <-> DeepSeek forwarding proxy) — codex speaks ONLY the Responses API and
+      # the OpenAI account quota is exhausted, so the reviewer runs on DeepSeek.
+      # Starts the bridge in the background + writes codex's config.toml. Method:
+      # github.com/deepseek-ai/awesome-deepseek-agent docs/codex.md.
+      - name: Set up codex DeepSeek bridge (Moon Bridge)
+        if: ${{ github.event.inputs.codex_review != 'false' }}
+        continue-on-error: true
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: bash .github/scripts/setup_codex_deepseek_bridge.sh
+
       # REQUIRED at L3 (fail-closed). A dead/absent codex key => not mergeable.
       - name: Codex equivalence review (REQUIRED, fail-closed)
         id: codex
         if: ${{ github.event.inputs.codex_review != 'false' }}
         env:
-          # The per-rollout judge (Pass 1) uses the DeepSeek OPENAI_* that
-          # provider-select wrote to $GITHUB_ENV. The host `codex exec` (Pass 2)
-          # needs the REAL OpenAI key — passed via CODEX_API_KEY, which
-          # codex_review.py uses for the CLI (dropping the DeepSeek base URL) so
-          # the judge clobber never leaks into codex auth.
+          # codex runs on DeepSeek-v4-pro through Moon Bridge (config.toml written
+          # by the setup step into ~/.codex, model `moonbridge` -> deepseek-v4-pro).
+          # CODEX_API_KEY is still set so has_codex_auth passes; the moonbridge
+          # provider is a local bridge and ignores it.
           CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # codex speaks ONLY the OpenAI Responses API — DeepSeek is impossible
-          # (codex removed chat-wire; DeepSeek doesn't serve Responses). So the
-          # composer runs on an OpenAI model: gpt-5.5 (full model — supports
-          # codex's tools, unlike gpt-5.4-nano which rejected `tool_search`) with
-          # xhigh reasoning effort for a thorough equivalence review.
-          CODEX_MODEL: gpt-5.5
+          CODEX_MODEL: moonbridge
           CODEX_REASONING_EFFORT: xhigh
           DETERMINISTIC_VERDICT: ${{ steps.pack.outputs.deterministic_verdict }}
         run: |

--- a/.github/workflows/integration-scope.yml
+++ b/.github/workflows/integration-scope.yml
@@ -493,18 +493,24 @@ jobs:
         continue-on-error: true
         run: npm install -g @openai/codex@0.141.0
 
+      # Route codex to DeepSeek-v4-pro via Moon Bridge (local Responses<->DeepSeek
+      # proxy) — codex speaks only the Responses API. Background bridge + codex
+      # config.toml. See setup_codex_deepseek_bridge.sh.
+      - name: Set up codex DeepSeek bridge (Moon Bridge)
+        continue-on-error: true
+        env:
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+        run: bash .github/scripts/setup_codex_deepseek_bridge.sh
+
       - name: Codex equivalence review (advisory)
         id: codex
         continue-on-error: true
         env:
-          # Pass 1 judge uses the DeepSeek OPENAI_* (provider-select wrote it to
-          # $GITHUB_ENV). The host `codex exec` (Pass 2) gets the REAL OpenAI key
-          # via CODEX_API_KEY — codex_review.py isolates the CLI env (real key +
-          # default OpenAI base) so the judge clobber never leaks into codex auth.
+          # codex runs on DeepSeek-v4-pro through Moon Bridge (config.toml in
+          # ~/.codex, model `moonbridge`). CODEX_API_KEY kept so has_codex_auth
+          # passes; the local bridge ignores it.
           CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          # codex requires the OpenAI Responses API (DeepSeek impossible): the
-          # composer runs on gpt-5.5 with xhigh reasoning effort.
-          CODEX_MODEL: gpt-5.5
+          CODEX_MODEL: moonbridge
           CODEX_REASONING_EFFORT: xhigh
         run: |
           set +e


### PR DESCRIPTION
Per your doc (deepseek-ai/awesome-deepseek-agent codex.md), route the L3 codex equivalence reviewer to **DeepSeek-v4-pro** through **Moon Bridge** — a local proxy that exposes an OpenAI-Responses endpoint and forwards to DeepSeek's `/anthropic` surface. This sidesteps the OpenAI quota (gpt-5.5 + xhigh hit `Quota exceeded`).

## Validated end-to-end LOCALLY
Installed Go + Moon Bridge, started the bridge with the DeepSeek key, generated codex's config, and ran `codex exec --model moonbridge`:
- codex **exit 0**, output `Verdict: mergeable`
- bridge log: `流式请求完成 ... actual_model=deepseek-v4-pro provider=deepseek input_total=12555 output_tokens=26` — confirmed the upstream DeepSeek call.
(First attempt failed only because `CODEX_HOME` was under `/tmp`, which made codex refuse to create helper binaries — a local artifact; CI uses `~/.codex`.)

## Changes
- `setup_codex_deepseek_bridge.sh` — install Go, build + background-start Moon Bridge with `$DEEPSEEK_API_KEY`, generate codex `config.toml` (`wire_api=responses`, `model=moonbridge`) into `~/.codex`, drop the unused deepwiki MCP.
- `moonbridge-config.yml` — bridge config template (key placeholder substituted at runtime).
- L3 + L2 review-pack: a bridge-setup step (continue-on-error) before the codex step; `CODEX_MODEL=moonbridge`, `CODEX_REASONING_EFFORT=xhigh`.

## Notes
- New external surface: the trusted-main review-pack job clones + builds Moon Bridge (a third-party Go tool). **Follow-up: pin the clone to a commit** (currently default HEAD).
- The rest of the pipeline is already green (plan → 10/10 rollouts → grader → parity + R-OUTCOME demotes = mergeable-with-quarantines deterministically).

## Test plan
- [x] Validated locally: codex → Moon Bridge → deepseek-v4-pro emits a parseable verdict
- [x] bash + YAML valid; no key committed
- [ ] Re-dispatch L3 on #803 → codex produces a real verdict on DeepSeek-v4-pro (no quota) → **mergeable / mergeable-with-quarantines**