### PR TITLE
fix(eval): expose context-root on eval run

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -240,6 +240,7 @@ bench eval run -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lite-p
 | `--jobs-dir` | `jobs` | Output directory |
 | `--sandbox-user` | `agent` | Sandbox user (null for root) |
 | `--sandbox-setup-timeout` | `120` | Timeout in seconds for sandbox user setup |
+| `--context-root` | — | Repo/build-context root used to stage Dockerfile `COPY` sources for monorepo-authored local tasks |
 | `--skills-dir` | — | Advanced custom skills directory; valid only with `--skill-mode with-skill`. Omit it to use each task's `environment/skills`. |
 | `--skill-mode` | `no-skill` | Skill mode: `no-skill`, `with-skill`, or `self-gen` |
 | `--skill-creator-dir` | — | Path to a `skill-creator` directory (or a skills root containing it); used when `--skill-mode self-gen` |

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -399,6 +399,16 @@ def eval_run(
             help="Timeout (seconds) for sandbox user setup inside the environment.",
         ),
     ] = 120,
+    context_root: Annotated[
+        Path | None,
+        typer.Option(
+            "--context-root",
+            help=(
+                "Repo/build-context root used to stage Dockerfile COPY sources "
+                "for monorepo-authored local tasks."
+            ),
+        ),
+    ] = None,
     skills_dir: Annotated[
         Path | None,
         typer.Option("--skills-dir", help="Skills directory to deploy"),
@@ -505,6 +515,7 @@ def eval_run(
         jobs_dir=jobs_dir,
         sandbox_user=sandbox_user,
         sandbox_setup_timeout=sandbox_setup_timeout,
+        context_root=context_root,
         skills_dir=skills_dir,
         skill_mode=skill_mode,
         skill_creator_dir=skill_creator_dir,

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -241,6 +241,8 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--ignore-bench-version requires --dataset")
     if request.tasks_dir and not Path(request.tasks_dir).exists():
         raise EvalPlanError(f"--tasks-dir not found: {request.tasks_dir}")
+    if request.context_root and not Path(request.context_root).is_dir():
+        raise EvalPlanError(f"--context-root not found: {request.context_root}")
     # Validate --config here so a typo'd / missing / non-file path becomes a clean
     # CLI error instead of a raw FileNotFoundError/IsADirectoryError traceback from
     # the bare open() in Evaluation.from_yaml.

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -100,6 +100,7 @@ class EvalCreateRequest:
     jobs_dir: str | None = None
     sandbox_user: str | None = "agent"
     sandbox_setup_timeout: int = 120
+    context_root: Path | None = None
     skills_dir: Path | None = None
     skill_mode: str = SKILL_MODE_NO_SKILL
     skill_creator_dir: Path | None = None
@@ -175,6 +176,7 @@ class EvalPlan:
             agent_env=self.parsed_env,
             sandbox_user=self.sandbox_user,
             sandbox_setup_timeout=req.sandbox_setup_timeout,
+            context_root=str(req.context_root) if req.context_root else None,
             skills_dir=str(req.skills_dir) if req.skills_dir else None,
             skill_mode=req.skill_mode,
             skill_creator_dir=(

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -140,6 +140,28 @@ def test_eval_run_context_root_threads_to_evaluation_config(tmp_path: Path):
     assert captured["context_root"] == str(context_root)
 
 
+def test_eval_run_context_root_missing_clean_error(tmp_path: Path):
+    """Guards PR #816 against typoed --context-root paths failing in rollout."""
+    task = _task_dir(tmp_path)
+    with patch.object(Evaluation, "run", new=_fake_run_pass):
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "run",
+                "--tasks-dir",
+                str(task),
+                "--agent",
+                "oracle",
+                "--context-root",
+                str(tmp_path / "does-not-exist"),
+            ],
+        )
+    assert result.exit_code == 1
+    assert "--context-root not found" in result.stderr
+    assert "Traceback (most recent call last)" not in result.output
+
+
 def test_agent_without_default_model_clean_error(tmp_path: Path):
     # codex has no default model; omitting --model must report cleanly, not crash.
     result = _invoke(tmp_path, "--agent", "codex", "--sandbox", "docker")

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -4,6 +4,7 @@ These lock in the v0.6.0 stress-test fixes: invalid arguments must fail fast
 with a clean message (no deadlock, no raw traceback) before any rollout starts.
 """
 
+import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -107,6 +108,38 @@ def test_tasks_dir_missing_clean_error(tmp_path: Path):
     assert "Traceback (most recent call last)" not in result.output
 
 
+def test_eval_run_context_root_threads_to_evaluation_config(tmp_path: Path):
+    """Guards issue #674: --context-root reaches Dockerfile staging config."""
+    task = _task_dir(tmp_path)
+    context_root = tmp_path / "repo"
+    context_root.mkdir()
+    captured: dict[str, str | None] = {}
+
+    async def capture_context_root(self):
+        captured["context_root"] = self._config.context_root
+        return SimpleNamespace(
+            passed=1, total=1, score=1.0, errored=0, verifier_errored=0
+        )
+
+    with patch.object(Evaluation, "run", new=capture_context_root):
+        result = CliRunner().invoke(
+            app,
+            [
+                "eval",
+                "run",
+                "--tasks-dir",
+                str(task),
+                "--agent",
+                "oracle",
+                "--context-root",
+                str(context_root),
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert captured["context_root"] == str(context_root)
+
+
 def test_agent_without_default_model_clean_error(tmp_path: Path):
     # codex has no default model; omitting --model must report cleanly, not crash.
     result = _invoke(tmp_path, "--agent", "codex", "--sandbox", "docker")
@@ -116,7 +149,7 @@ def test_agent_without_default_model_clean_error(tmp_path: Path):
 
 
 @pytest.mark.skipif(
-    __import__("importlib").util.find_spec("modal") is not None,
+    importlib.util.find_spec("modal") is not None,
     reason="modal extra installed; missing-extra preflight does not fire",
 )
 def test_sandbox_modal_without_extra_fails_fast(tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes #674.

This exposes the existing `EvaluationConfig.context_root` plumbing on the public `bench eval run` CLI as `--context-root`, so local monorepo-authored tasks can pass their repo/build-context root into Dockerfile COPY-source staging. The rollout path already knew how to stage Dockerfile deps from `context_root`; the missing piece was the CLI flag and plan-threading.

## Changes

- Add `--context-root` to `bench eval run`.
- Thread it through `EvalCreateRequest` / `EvalPlan.make_eval_config()` into `EvaluationConfig.context_root`.
- Document the flag in `docs/reference/cli.md`.
- Add a regression test naming issue #674 that verifies the CLI flag reaches `EvaluationConfig`.

## Validation

- `uv sync --extra dev --extra sandbox-daytona --locked`
- `uv run python -m pytest tests/test_cli_arg_validation.py::test_eval_run_context_root_threads_to_evaluation_config tests/test_rollout_config_path_coercion.py -q`
- `uv run python -m pytest tests/test_cli_arg_validation.py tests/test_build_context_stage.py -q`
- `uv run ruff check src/benchflow/cli/main.py src/benchflow/eval_plan.py tests/test_cli_arg_validation.py`
- `uv run ruff format --check src/benchflow/cli/main.py src/benchflow/eval_plan.py tests/test_cli_arg_validation.py`
- `uv run ty check src/benchflow/cli/main.py src/benchflow/eval_plan.py tests/test_cli_arg_validation.py`
- `uv run bench eval run --help | rg -- --context-root`

## Notes

No merge taken from automation. This still needs CI and human review before merge under repo policy.