### PR TITLE
fix(integration): clear residual greptile findings on the L3 gate

### DIFF
--- a/.github/scripts/build_integration_review_pack.py
+++ b/.github/scripts/build_integration_review_pack.py
@@ -373,6 +373,11 @@ def _classify_one(slot: Slot, expected_source_sha: str | None) -> None:
             slot.detail = f"deterministic reject: {non_outcome}"
         else:
             slot.status = "healthy"
+            # Demoted to healthy: clear the reject flag too, so the serialized
+            # agent_judge_summary does not tell codex this healthy slot still has a
+            # deterministic reject — a contradiction that can spuriously push the
+            # codex reviewer to downgrade the verdict.
+            slot.grade["deterministic_reject"] = False
             slot.grade["quarantines"] = [
                 *slot.grade.get("quarantines", []),
                 "R-OUTCOME: rollout produced no valid scored outcome "

--- a/.github/scripts/codex_review.py
+++ b/.github/scripts/codex_review.py
@@ -184,14 +184,17 @@ async def _gather_findings(
                     "error": f"deepseek pass failed: {type(exc).__name__}: {exc}",
                 }
         finding: dict = {"rollout": str(rollout), "raw": raw[:4000]}
-        match = re.search(r"\{.*\}", raw, re.DOTALL)
-        if match:
+        start = raw.find("{")
+        if start == -1:
+            finding["parse_error"] = "no JSON object in deepseek finding"
+        else:
             try:
-                finding["parsed"] = json.loads(match.group(0))
+                # raw_decode parses the FIRST complete JSON object and ignores any
+                # trailing prose the model appends. A greedy `{.*}` span would
+                # instead merge multiple objects into one invalid blob.
+                finding["parsed"], _ = json.JSONDecoder().raw_decode(raw[start:])
             except json.JSONDecodeError:
                 finding["parse_error"] = "deepseek finding JSON was unparseable"
-        else:
-            finding["parse_error"] = "no JSON object in deepseek finding"
         return finding
 
     return await asyncio.gather(*(one(r) for r in rollout_dirs))

--- a/.github/scripts/integration_matrix.py
+++ b/.github/scripts/integration_matrix.py
@@ -1111,13 +1111,21 @@ def build_plan(
 
 
 def _changed_files_from_git(base_ref: str, head_sha: str) -> list[str]:
-    out = subprocess.run(
-        ["git", "diff", "--name-only", f"{base_ref}...{head_sha}"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"{base_ref}...{head_sha}"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        # git diff fails when e.g. head_sha was never fetched (the workflow
+        # silences the fetch with `|| true`). Surface it through the ScopeError
+        # fail-closed handler in main() rather than as an uncaught traceback.
+        raise ScopeError(
+            f"git diff {base_ref}...{head_sha} failed: {exc.stderr.strip() or exc}"
+        ) from exc
     return [line.strip() for line in out.stdout.splitlines() if line.strip()]
 
 

--- a/tests/test_build_review_pack.py
+++ b/tests/test_build_review_pack.py
@@ -407,6 +407,41 @@ def test_review_pack_infra_timeout_is_capability_attributed_quarantine() -> None
         assert attribution["label"] == "experiment-fidelity"
 
 
+def test_r_outcome_only_demotion_clears_deterministic_reject() -> None:
+    # Regression (#810 greptile P1): an R-OUTCOME-ONLY reject is demoted to a
+    # healthy + quarantine slot, but the serialized grade must NOT keep
+    # deterministic_reject=True. agent_judge_summary serializes that field and
+    # codex reads it; a "healthy slot that still has a deterministic reject" is a
+    # contradiction that can spuriously push the codex reviewer to downgrade.
+    import rubric_checks as rc
+
+    original = rc.grade_rollout
+    rc.grade_rollout = lambda rollout: {  # type: ignore[assignment]
+        "deterministic_reject": True,
+        "gates": [
+            {"id": "R-OUTCOME", "status": "fail", "enforcement": "deterministic"},
+            {"id": "R-REAL", "status": "pass", "enforcement": "deterministic"},
+        ],
+        "quarantines": [],
+    }
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            rollout = Path(tmp) / "r"
+            rollout.mkdir()
+            (rollout / "result.json").write_text("{}")
+            slot = pack_mod.Slot(
+                cell=pack_mod.normalize_cell(_cell("weighted-gdp-calc", "openhands"))
+            )
+            slot.rollouts = [rollout]
+            pack_mod._classify_one(slot, None)
+    finally:
+        rc.grade_rollout = original
+
+    assert slot.status == "healthy"
+    assert slot.grade["deterministic_reject"] is False  # the bug: was left True
+    assert any("R-OUTCOME" in q for q in slot.grade["quarantines"])
+
+
 # ------------------------------------------------------------------
 # Full review-pack/ layout on disk + the CLI verdict contract.
 # ------------------------------------------------------------------


### PR DESCRIPTION
Cross-checked every greptile comment left **unaddressed** on the earlier integration PRs (#802–#810). Most were already fixed by later work or stale; this PR closes the genuine ones.

## Triage of the 9 unaddressed comments

| file:line | P | verdict |
|---|---|---|
| #806 integration-final-review.yml:195 (filter fail-open) | P1 | **FIXED** — `filter_matrix` catches import + per-cell exceptions (fail-open) |
| **#810 build_integration_review_pack.py (deterministic_reject left True)** | **P1** | **OPEN → fixed here** |
| #810 codex_review.py (`endswith('/v1')`) | P2 | STALE — heuristic gone (Moon Bridge) |
| #808 codex_review.py:281 (CODEX_API_KEY in env) | P2 | cosmetic/intentional — kept (codex ignores it; Moon Bridge routes via config.toml) |
| **#802 codex_review.py:191 (greedy `{.*}`)** | P2 | **OPEN → fixed here** |
| **#802 integration_matrix.py:1121 (CalledProcessError)** | P2 | **OPEN → fixed here** |
| #802 codex_review.py:163 (`[:8000]` cut) | P2 | cosmetic-accepted — fenced untrusted text the LLM reads as prose |
| #802 integration-scope.yml:265 (empty matrix) | P1 | **FIXED** — `has_cells` green-no-op guard |
| #802 integration-final-review.yml:430 (DeepSeek creds bleed into codex) | P1 | **FIXED** — `_codex_env` isolation |

## Fixes in this PR
1. **P1 — `deterministic_reject` left `True` after R-OUTCOME demotion.** When an R-OUTCOME-only reject is demoted to `healthy` + quarantine, the grade still serialized `deterministic_reject: True` into `agent_judge_summary.json`. codex reads that, and a "healthy slot with a deterministic reject" can spuriously push it to downgrade `mergeable → not mergeable` — directly undermining the gate calibration in #814. Now cleared on demotion. **+ regression test.**
2. **Greedy JSON regex** in the deepseek per-rollout finding parser → `json.JSONDecoder().raw_decode` of the first complete object (tolerant of trailing prose; a greedy `{.*}` merged two objects into one invalid blob, losing the finding).
3. **Uncaught `CalledProcessError`** from `git diff --check=True` → re-raised as `ScopeError` so a failed/absent `head_sha` fails closed cleanly instead of an uncaught traceback.

**Validation:** 112 tests pass (incl. the new regression); ruff clean.