### PR TITLE
feat(agents): core manifest consumer loader (decoupling contract, gated off)

### DIFF
--- a/src/benchflow/agents/manifest.py
+++ b/src/benchflow/agents/manifest.py
@@ -1,0 +1,296 @@
+"""Thin agent-manifest loader — the consumer half of the decoupling contract.
+
+An agent declares itself in a ``manifest.toml`` (see the agents repo's
+``contract/manifest_schema.json`` for the authoritative, strict schema). Core
+*consumes* that declaration here, turning it into the ``AgentConfig`` the rest
+of BenchFlow already understands — so a new agent can ship as data (a manifest)
+instead of a hand-edited entry in ``registry.AGENTS`` (design decision #4), and
+a directory of manifests can be merged into the registry at opt-in (#7).
+
+Authoring vs. consuming, on purpose:
+
+* The agents-repo JSON Schema is the *author's* contract — ``additionalProperties:
+  false``, every field type-checked. It fails an author loudly for a typo.
+* This loader is the *consumer's* contract — it enforces only the major-version
+  gate and the four required keys, then maps the declared fields onto
+  AgentConfig and **ignores unknown keys**. A v1.x manifest that carries a field
+  added in a later minor still loads on this v1 loader (SemVer: a minor bump is a
+  backward-compatible addition). The AgentConfig fields outside the contract are
+  the shim/credential set (session_factory, credential_files, subscription_auth,
+  acp_model_config_id, acp_effort_config_id, disallow_web_tools_*); they keep
+  their AgentConfig defaults because they are logic the shim owns, not data
+  (see _SHIM_ONLY and the partition test).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import tomllib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchflow.agents.registry import AgentConfig
+
+# This loader speaks contract major version 1. A manifest declaring a different
+# major is rejected (its shape may be incompatible); a different minor/patch is
+# accepted (additive-only within a major).
+SUPPORTED_CONTRACT_MAJOR = 1
+
+# The contract is acp-only ("one protocol", ADR-0001 §1; author schema enum:["acp"]).
+# The consumer re-enforces it because the BENCHFLOW_AGENTS_DIR dev override bypasses
+# the author-side jsonschema, and register_manifest_agents writes AGENTS directly,
+# skipping registry.VALID_PROTOCOLS — so this loader is the last protocol gate.
+_SUPPORTED_PROTOCOLS = frozenset({"acp"})
+
+# Directory env override for opt-in filesystem discovery (decision #7).
+MANIFEST_DIR_ENV = "BENCHFLOW_AGENTS_DIR"
+
+_REQUIRED = ("contract_version", "name", "install_cmd", "launch_cmd")
+_VERSION_RE = re.compile(r"^\d+\.\d+(\.\d+)?$")
+
+# manifest key -> AgentConfig field: the contract's data fields (the PR #14 schema
+# minus the meta keys contract_version/aliases). The consumer must cover EVERY
+# schema data field with an AgentConfig home; _SHIM_ONLY below holds the rest.
+# A test asserts _FIELD_MAP.values() | _SHIM_ONLY partitions AgentConfig exactly,
+# so a new field can never be silently dropped (it was, for the bottom three).
+_FIELD_MAP = {
+    "name": "name",
+    "description": "description",
+    "install_cmd": "install_cmd",
+    "launch_cmd": "launch_cmd",
+    "protocol": "protocol",
+    "api_protocol": "api_protocol",
+    "acp_model_format": "acp_model_format",
+    "supports_acp_set_model": "supports_acp_set_model",
+    "requires_env": "requires_env",
+    "install_timeout": "install_timeout",
+    "env_mapping": "env_mapping",
+    "default_model": "default_model",
+    "skill_paths": "skill_paths",
+    "home_dirs": "home_dirs",
+}
+
+# AgentConfig fields the contract deliberately does NOT carry: logic/credential
+# concerns the SHIM owns (credential-file emission, subscription auth, config-file
+# writing, web-tool toggles), never expressed as manifest data. The PR #14 schema
+# excludes them via additionalProperties:false; here they keep AgentConfig
+# defaults. Together with _FIELD_MAP's values these partition AgentConfig exactly.
+_SHIM_ONLY = frozenset(
+    {
+        # Non-ACP "module:callable" seam, only meaningful when
+        # protocol="session-factory"; the acp-only contract can never carry it.
+        "session_factory",
+        "credential_files",
+        "subscription_auth",
+        "acp_model_config_id",
+        "acp_effort_config_id",
+        "disallow_web_tools_setup_cmd",
+        "disallow_web_tools_owned_paths",
+        "disallow_web_tools_launch_suffix",
+    }
+)
+
+
+class AgentManifestError(ValueError):
+    """A manifest.toml is unreadable, missing a required field, declares an
+    unsupported contract major version, or collides with an existing agent."""
+
+
+@dataclass(frozen=True)
+class LoadedManifest:
+    """A manifest resolved into the registry's vocabulary: the AgentConfig plus
+    the alias names the agent answers to (registered separately from the config,
+    which has no alias field)."""
+
+    config: AgentConfig
+    aliases: tuple[str, ...]
+
+
+def _check_contract_version(raw: object) -> None:
+    if not isinstance(raw, str) or not _VERSION_RE.match(raw):
+        raise AgentManifestError(
+            f"contract_version must look like MAJOR.MINOR[.PATCH]; got {raw!r}"
+        )
+    major = int(raw.split(".", 1)[0])
+    if major != SUPPORTED_CONTRACT_MAJOR:
+        raise AgentManifestError(
+            f"contract_version {raw!r} declares major {major}; this loader speaks "
+            f"contract {SUPPORTED_CONTRACT_MAJOR}.x"
+        )
+
+
+def load_agent_manifest(path: str | Path) -> LoadedManifest:
+    """Parse + validate one ``manifest.toml`` and return its LoadedManifest.
+
+    Raises AgentManifestError on an unreadable/malformed file, a missing required
+    field, or an unsupported contract major version.
+    """
+    path = Path(path)
+    try:
+        data = tomllib.loads(path.read_text())
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise AgentManifestError(f"cannot read manifest {path}: {exc}") from exc
+
+    for key in _REQUIRED:
+        if key not in data:
+            raise AgentManifestError(f"manifest {path} is missing required {key!r}")
+    _check_contract_version(data["contract_version"])
+
+    protocol = data.get("protocol", "acp")
+    if protocol not in _SUPPORTED_PROTOCOLS:
+        raise AgentManifestError(
+            f"manifest {path}: protocol {protocol!r} is not supported; the contract "
+            f"is acp-only ({sorted(_SUPPORTED_PROTOCOLS)}). Non-ACP platforms must "
+            "ship an ACP-over-stdio shim and declare protocol='acp'."
+        )
+
+    kwargs = {field: data[key] for key, field in _FIELD_MAP.items() if key in data}
+    if "install_timeout" in kwargs:
+        # TOML has no int/float distinction guarantee across writers; AgentConfig
+        # wants seconds as an int.
+        kwargs["install_timeout"] = int(kwargs["install_timeout"])
+
+    aliases = tuple(data.get("aliases", ()))
+    return LoadedManifest(config=AgentConfig(**kwargs), aliases=aliases)
+
+
+# Directories never scanned for manifests: build/vendor/VCS noise that could
+# otherwise surface a fixture manifest or shadow a real agent.
+_DISCOVERY_SKIP_DIRS = frozenset(
+    {
+        "node_modules",
+        ".git",
+        ".venv",
+        "venv",
+        "__pycache__",
+        "dist",
+        "build",
+        "site-packages",
+        ".tox",
+        ".mypy_cache",
+        ".pytest_cache",
+    }
+)
+
+
+def discover_manifests(root: str | Path) -> list[Path]:
+    """Return the sorted manifest.toml paths under *root*, RECURSIVELY (eve-style:
+    each agent is a self-contained directory, and families nest — e.g.
+    ``ai-sdk/acp/manifest.toml`` alongside ``mimo-acp/manifest.toml``). A
+    manifest directly at *root* is ignored (the discovery root holds agent
+    SUBdirectories, not an agent itself), as are paths under build/vendor/VCS
+    dirs (_DISCOVERY_SKIP_DIRS). A missing root yields ``[]``."""
+    root = Path(root)
+    if not root.is_dir():
+        return []
+    out: list[Path] = []
+    for path in root.rglob("manifest.toml"):
+        rel = path.relative_to(root)
+        if len(rel.parts) < 2:
+            continue  # a bare root/manifest.toml is not an agent directory
+        if any(part in _DISCOVERY_SKIP_DIRS for part in rel.parts):
+            continue
+        out.append(path)
+    return sorted(out)
+
+
+def load_agents_from_dir(root: str | Path) -> dict[str, LoadedManifest]:
+    """Load every manifest under *root*, keyed by the agent's DECLARED name — not
+    the directory name, which may differ (e.g. ``mimo-acp/`` declares ``mimo``).
+    Raises AgentManifestError on a duplicate declared name."""
+    out: dict[str, LoadedManifest] = {}
+    for path in discover_manifests(root):
+        loaded = load_agent_manifest(path)
+        name = loaded.config.name
+        if name in out:
+            raise AgentManifestError(
+                f"duplicate agent name {name!r} (second declaration at {path})"
+            )
+        out[name] = loaded
+    return out
+
+
+def register_manifest_agents(
+    loaded: Mapping[str, LoadedManifest],
+    *,
+    agents: dict[str, AgentConfig],
+    aliases: dict[str, str],
+    installers: dict[str, str],
+    launch: dict[str, str],
+    override: bool = False,
+) -> None:
+    """Merge *loaded* manifests into the registry maps in place.
+
+    Writes all four name-keyed maps the registry keeps in lockstep — ``agents``
+    (AGENTS), ``installers`` (AGENT_INSTALLERS), ``launch`` (AGENT_LAUNCH), and
+    ``aliases`` (AGENT_ALIASES) — because per-agent lookups in install.py and
+    rollout_planes.py read the installer/launch projections, not AGENTS. Omitting
+    them would leave a manifest agent uninstallable / unlaunchable.
+
+    Fail-loud on collision (an agent name or alias that already exists is an
+    ambiguous source of truth, not a silent shadow) unless ``override=True``.
+    Collisions are checked across the whole batch BEFORE any mutation, so a
+    rejected batch leaves every map untouched (all-or-nothing)."""
+    if not override:
+        for name, lm in loaded.items():
+            if name in agents:
+                raise AgentManifestError(
+                    f"agent {name!r} already in the registry; ship its manifest as "
+                    "the sole source or pass override=True"
+                )
+            for alias in lm.aliases:
+                if alias in aliases:
+                    raise AgentManifestError(
+                        f"alias {alias!r} (for {name!r}) already maps to "
+                        f"{aliases[alias]!r}"
+                    )
+                if alias in agents:
+                    raise AgentManifestError(
+                        f"alias {alias!r} (for {name!r}) collides with an existing "
+                        "agent name"
+                    )
+    for name, lm in loaded.items():
+        agents[name] = lm.config
+        installers[name] = lm.config.install_cmd
+        launch[name] = lm.config.launch_cmd
+        for alias in lm.aliases:
+            aliases[alias] = name
+
+
+def register_env_manifest_agents(
+    *,
+    agents: dict[str, AgentConfig] | None = None,
+    aliases: dict[str, str] | None = None,
+    installers: dict[str, str] | None = None,
+    launch: dict[str, str] | None = None,
+) -> list[str]:
+    """Register agents from the directory named by ``$BENCHFLOW_AGENTS_DIR`` into
+    the registry; return the sorted names registered.
+
+    A no-op returning ``[]`` when the env var is unset — so a default import of
+    core is unchanged and the dual-source registry only activates on explicit
+    opt-in. The four maps default to the live ``registry`` globals (resolved
+    lazily to avoid an import cycle); tests pass throwaway dicts to stay
+    hermetic."""
+    root = os.environ.get(MANIFEST_DIR_ENV)
+    if not root:
+        return []
+    if None in (agents, aliases, installers, launch):
+        from benchflow.agents.registry import (
+            AGENT_ALIASES,
+            AGENT_INSTALLERS,
+            AGENT_LAUNCH,
+            AGENTS,
+        )
+
+        agents = AGENTS if agents is None else agents
+        aliases = AGENT_ALIASES if aliases is None else aliases
+        installers = AGENT_INSTALLERS if installers is None else installers
+        launch = AGENT_LAUNCH if launch is None else launch
+    loaded = load_agents_from_dir(root)
+    register_manifest_agents(
+        loaded, agents=agents, aliases=aliases, installers=installers, launch=launch
+    )
+    return sorted(loaded)

--- a/src/benchflow/agents/manifest.py
+++ b/src/benchflow/agents/manifest.py
@@ -233,12 +233,33 @@ def register_manifest_agents(
     ambiguous source of truth, not a silent shadow) unless ``override=True``.
     Collisions are checked across the whole batch BEFORE any mutation, so a
     rejected batch leaves every map untouched (all-or-nothing)."""
+    incoming_names = set(loaded)
+    incoming_aliases: dict[str, str] = {}
+    for name, lm in loaded.items():
+        for alias in lm.aliases:
+            if alias in incoming_names:
+                raise AgentManifestError(
+                    f"alias {alias!r} (for {name!r}) collides with an agent name "
+                    "in the same manifest batch"
+                )
+            previous_name = incoming_aliases.get(alias)
+            if previous_name is not None:
+                raise AgentManifestError(
+                    f"alias {alias!r} is declared by both {previous_name!r} and "
+                    f"{name!r}"
+                )
+            incoming_aliases[alias] = name
+
     if not override:
         for name, lm in loaded.items():
             if name in agents:
                 raise AgentManifestError(
                     f"agent {name!r} already in the registry; ship its manifest as "
                     "the sole source or pass override=True"
+                )
+            if name in aliases:
+                raise AgentManifestError(
+                    f"agent {name!r} collides with existing alias for {aliases[name]!r}"
                 )
             for alias in lm.aliases:
                 if alias in aliases:
@@ -277,7 +298,7 @@ def register_env_manifest_agents(
     root = os.environ.get(MANIFEST_DIR_ENV)
     if not root:
         return []
-    if None in (agents, aliases, installers, launch):
+    if agents is None or aliases is None or installers is None or launch is None:
         from benchflow.agents.registry import (
             AGENT_ALIASES,
             AGENT_INSTALLERS,

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -1191,3 +1191,18 @@ def register_agent(
     AGENT_INSTALLERS[name] = install_cmd
     AGENT_LAUNCH[name] = launch_cmd
     return config
+
+
+# --- Opt-in dual-source registry (agent-decoupling decision #7) ---------------
+# Merge agents declared as <dir>/manifest.toml files under $BENCHFLOW_AGENTS_DIR
+# into the registry. A NO-OP when the env var is unset, so a default import of
+# core is byte-for-byte unchanged; the manifest path only activates on explicit
+# opt-in. The import is deferred to here (end of module) on purpose: manifest.py
+# imports AgentConfig from this module, so a top-level import would be circular,
+# and the merge must run after AGENTS / AGENT_ALIASES / AGENT_INSTALLERS /
+# AGENT_LAUNCH are fully built above.
+from benchflow.agents.manifest import (  # noqa: E402
+    register_env_manifest_agents as _register_env_manifest_agents,
+)
+
+_register_env_manifest_agents()

--- a/tests/agents/test_manifest_dirscan.py
+++ b/tests/agents/test_manifest_dirscan.py
@@ -1,0 +1,140 @@
+"""Directory-scan registration: turn a tree of manifest.toml files into AGENTS
+entries (design decision #7, the eve-style filesystem discovery).
+
+The env-gated entry point ``register_env_manifest_agents`` is a no-op when
+``BENCHFLOW_AGENTS_DIR`` is unset — so importing core is unchanged by default;
+the dual-source registry only lights up when a developer opts in. Registration
+is fail-loud on collision (an agent or alias that already exists is an ambiguous
+source of truth, not a silent shadow) unless ``override=True``, and writes every
+name-keyed registry map (AGENTS / AGENT_INSTALLERS / AGENT_LAUNCH / AGENT_ALIASES)
+the install + rollout paths read from.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from benchflow.agents.manifest import (
+    AgentManifestError,
+    discover_manifests,
+    load_agents_from_dir,
+    register_env_manifest_agents,
+    register_manifest_agents,
+)
+from benchflow.agents.registry import AgentConfig
+
+_BODY = """contract_version = "1.0"
+name = "{name}"
+install_cmd = "echo install"
+launch_cmd = "echo launch"
+"""
+
+
+def _put(root: Path, subdir: str, name: str, extra: str = "") -> Path:
+    d = root / subdir
+    d.mkdir(parents=True)
+    (d / "manifest.toml").write_text(_BODY.format(name=name) + extra)
+    return d
+
+
+def _maps():
+    """Fresh throwaway copies of the four registry maps for hermetic tests."""
+    return {
+        "agents": {},
+        "aliases": {},
+        "installers": {},
+        "launch": {},
+    }
+
+
+def test_discover_finds_nested_manifests_only(tmp_path: Path):
+    _put(tmp_path, "alpha", "alpha")
+    _put(tmp_path, "beta", "beta")
+    (tmp_path / "manifest.toml").write_text("ignored = true\n")  # root-level: skip
+    (tmp_path / "gamma").mkdir()
+    (tmp_path / "gamma" / "notes.txt").write_text("no manifest here")
+    found = discover_manifests(tmp_path)
+    assert [p.parent.name for p in found] == ["alpha", "beta"]  # sorted, nested only
+
+
+def test_discover_missing_dir_returns_empty(tmp_path: Path):
+    assert discover_manifests(tmp_path / "nope") == []
+
+
+def test_load_dir_keys_by_agent_name_not_dirname(tmp_path: Path):
+    # eve-style: the directory ("mimo-acp") may differ from the agent ("mimo").
+    _put(tmp_path, "mimo-acp", "mimo")
+    loaded = load_agents_from_dir(tmp_path)
+    assert set(loaded) == {"mimo"}
+    assert loaded["mimo"].config.name == "mimo"
+
+
+def test_load_dir_rejects_duplicate_agent_name(tmp_path: Path):
+    _put(tmp_path, "one", "dup")
+    _put(tmp_path, "two", "dup")
+    with pytest.raises(AgentManifestError, match="dup"):
+        load_agents_from_dir(tmp_path)
+
+
+def test_register_writes_every_name_keyed_map(tmp_path: Path):
+    _put(tmp_path, "demo", "demo", extra='aliases = ["demo-code"]\n')
+    m = _maps()
+    register_manifest_agents(load_agents_from_dir(tmp_path), **m)
+    assert isinstance(m["agents"]["demo"], AgentConfig)
+    # The installer/launch projections the install + rollout paths read MUST be
+    # populated, not just AGENTS — else a manifest agent is uninstallable.
+    assert m["installers"]["demo"] == "echo install"
+    assert m["launch"]["demo"] == "echo launch"
+    assert m["aliases"] == {"demo-code": "demo"}
+
+
+def test_register_fails_loud_on_name_collision(tmp_path: Path):
+    _put(tmp_path, "demo", "demo")
+    m = _maps()
+    m["agents"]["demo"] = AgentConfig(name="demo", install_cmd="x", launch_cmd="y")
+    with pytest.raises(AgentManifestError, match="demo"):
+        register_manifest_agents(load_agents_from_dir(tmp_path), **m)
+    # collision is detected before any mutation: the batch is all-or-nothing.
+    assert m["agents"]["demo"].install_cmd == "x"
+    assert m["installers"] == {}
+
+
+def test_register_override_replaces(tmp_path: Path):
+    _put(tmp_path, "demo", "demo")
+    m = _maps()
+    m["agents"]["demo"] = AgentConfig(name="demo", install_cmd="OLD", launch_cmd="y")
+    register_manifest_agents(load_agents_from_dir(tmp_path), **m, override=True)
+    assert m["agents"]["demo"].install_cmd == "echo install"
+    assert m["installers"]["demo"] == "echo install"
+
+
+def test_register_fails_loud_on_alias_collision(tmp_path: Path):
+    _put(tmp_path, "demo", "demo", extra='aliases = ["taken"]\n')
+    m = _maps()
+    m["aliases"]["taken"] = "someone-else"
+    with pytest.raises(AgentManifestError, match="taken"):
+        register_manifest_agents(load_agents_from_dir(tmp_path), **m)
+
+
+def test_env_entry_is_noop_when_unset(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("BENCHFLOW_AGENTS_DIR", raising=False)
+    m = _maps()
+    registered = register_env_manifest_agents(**m)
+    assert registered == []
+    # importing core stays behavior-preserving: nothing touched.
+    assert all(d == {} for d in m.values())
+
+
+def test_env_entry_registers_when_set(tmp_path: Path, monkeypatch):
+    _put(tmp_path, "demo", "demo", extra='aliases = ["demo-code"]\n')
+    _put(tmp_path, "beta", "beta")
+    monkeypatch.setenv("BENCHFLOW_AGENTS_DIR", str(tmp_path))
+    m = _maps()
+    registered = register_env_manifest_agents(**m)
+    assert registered == ["beta", "demo"]
+    assert set(m["agents"]) == {"beta", "demo"}
+    assert set(m["installers"]) == {"beta", "demo"}
+    assert set(m["launch"]) == {"beta", "demo"}
+    assert m["aliases"] == {"demo-code": "demo"}

--- a/tests/agents/test_manifest_dirscan.py
+++ b/tests/agents/test_manifest_dirscan.py
@@ -118,6 +118,34 @@ def test_register_fails_loud_on_alias_collision(tmp_path: Path):
         register_manifest_agents(load_agents_from_dir(tmp_path), **m)
 
 
+def test_register_fails_loud_on_agent_name_existing_alias_collision(tmp_path: Path):
+    _put(tmp_path, "demo", "demo")
+    m = _maps()
+    m["aliases"]["demo"] = "someone-else"
+    with pytest.raises(AgentManifestError, match="existing alias"):
+        register_manifest_agents(load_agents_from_dir(tmp_path), **m)
+    assert m["agents"] == {}
+    assert m["installers"] == {}
+
+
+def test_register_fails_loud_on_same_batch_alias_collision(tmp_path: Path):
+    _put(tmp_path, "one", "one", extra='aliases = ["taken"]\n')
+    _put(tmp_path, "two", "two", extra='aliases = ["taken"]\n')
+    m = _maps()
+    with pytest.raises(AgentManifestError, match="both"):
+        register_manifest_agents(load_agents_from_dir(tmp_path), **m)
+    assert all(d == {} for d in m.values())
+
+
+def test_register_fails_loud_on_same_batch_alias_name_collision(tmp_path: Path):
+    _put(tmp_path, "one", "one", extra='aliases = ["two"]\n')
+    _put(tmp_path, "two", "two")
+    m = _maps()
+    with pytest.raises(AgentManifestError, match="same manifest batch"):
+        register_manifest_agents(load_agents_from_dir(tmp_path), **m)
+    assert all(d == {} for d in m.values())
+
+
 def test_env_entry_is_noop_when_unset(tmp_path: Path, monkeypatch):
     monkeypatch.delenv("BENCHFLOW_AGENTS_DIR", raising=False)
     m = _maps()

--- a/tests/agents/test_manifest_loader.py
+++ b/tests/agents/test_manifest_loader.py
@@ -1,0 +1,153 @@
+"""The consumer half of the agent-decoupling contract: parse one manifest.toml
+into the AgentConfig the registry already speaks (design decision #4).
+
+These pin the loader's *consumer* contract — distinct from the agents-repo JSON
+Schema, which is the stricter *author* contract. The loader enforces only the
+four required keys, the contract-major gate, and the acp-only protocol gate, then
+maps declared fields onto AgentConfig and ignores unknown keys (so a v1.x manifest
+carrying a field added in a later minor still loads here). The partition test is
+the drift guard: every AgentConfig field must be either declarable (_FIELD_MAP)
+or deliberately shim-owned (_SHIM_ONLY) — a new field can never be silently lost.
+"""
+
+from __future__ import annotations
+
+from dataclasses import fields
+from pathlib import Path
+
+import pytest
+
+from benchflow.agents.manifest import (
+    _FIELD_MAP,
+    _SHIM_ONLY,
+    AgentManifestError,
+    LoadedManifest,
+    load_agent_manifest,
+)
+from benchflow.agents.registry import AgentConfig
+
+_MINIMAL = """contract_version = "1.0"
+name = "demo"
+install_cmd = "echo install"
+launch_cmd = "echo launch"
+"""
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "manifest.toml"
+    p.write_text(body)
+    return p
+
+
+def test_loads_minimal_manifest(tmp_path: Path):
+    loaded = load_agent_manifest(_write(tmp_path, _MINIMAL))
+    assert isinstance(loaded, LoadedManifest)
+    assert loaded.config.name == "demo"
+    assert loaded.config.install_cmd == "echo install"
+    assert loaded.config.launch_cmd == "echo launch"
+    assert loaded.aliases == ()
+
+
+def test_maps_all_declared_data_fields(tmp_path: Path):
+    body = _MINIMAL + (
+        'description = "a demo agent"\n'
+        'protocol = "acp"\n'
+        'api_protocol = "openai-completions"\n'
+        'acp_model_format = "provider/model"\n'
+        "supports_acp_set_model = false\n"
+        'requires_env = ["OPENAI_API_KEY"]\n'
+        "install_timeout = 1200\n"
+        'default_model = "gpt-x"\n'
+        'skill_paths = ["$HOME/.demo/skills"]\n'
+        'home_dirs = [".demo"]\n'
+        'aliases = ["demo-code", "demo2"]\n'
+        "[env_mapping]\n"
+        'BENCHFLOW_PROVIDER_API_KEY = "OPENAI_API_KEY"\n'
+    )
+    c = load_agent_manifest(_write(tmp_path, body)).config
+    assert c.description == "a demo agent"
+    assert c.api_protocol == "openai-completions"
+    assert c.acp_model_format == "provider/model"
+    assert c.supports_acp_set_model is False
+    assert c.requires_env == ["OPENAI_API_KEY"]
+    assert c.install_timeout == 1200
+    assert c.default_model == "gpt-x"
+    assert c.skill_paths == ["$HOME/.demo/skills"]
+    assert c.home_dirs == [".demo"]
+    assert c.env_mapping == {"BENCHFLOW_PROVIDER_API_KEY": "OPENAI_API_KEY"}
+
+
+def test_aliases_parsed_separately_from_config(tmp_path: Path):
+    body = _MINIMAL + 'aliases = ["demo-code", "demo2"]\n'
+    assert load_agent_manifest(_write(tmp_path, body)).aliases == ("demo-code", "demo2")
+
+
+@pytest.mark.parametrize(
+    "missing", ["contract_version", "name", "install_cmd", "launch_cmd"]
+)
+def test_missing_required_key_is_loud(tmp_path: Path, missing: str):
+    body = "\n".join(
+        line for line in _MINIMAL.splitlines() if not line.startswith(missing + " ")
+    )
+    with pytest.raises(AgentManifestError, match=missing):
+        load_agent_manifest(_write(tmp_path, body))
+
+
+def test_unreadable_or_malformed_toml_is_loud(tmp_path: Path):
+    with pytest.raises(AgentManifestError):
+        load_agent_manifest(_write(tmp_path, "this is = = not toml"))
+    with pytest.raises(AgentManifestError):
+        load_agent_manifest(tmp_path / "does-not-exist.toml")
+
+
+def test_wrong_contract_major_is_rejected(tmp_path: Path):
+    body = _MINIMAL.replace('contract_version = "1.0"', 'contract_version = "2.0"')
+    with pytest.raises(AgentManifestError, match="major"):
+        load_agent_manifest(_write(tmp_path, body))
+
+
+def test_malformed_contract_version_is_rejected(tmp_path: Path):
+    body = _MINIMAL.replace('contract_version = "1.0"', 'contract_version = "v1"')
+    with pytest.raises(AgentManifestError, match="MAJOR"):
+        load_agent_manifest(_write(tmp_path, body))
+
+
+def test_higher_minor_is_accepted_additive(tmp_path: Path):
+    # SemVer: a minor bump within major 1 is a backward-compatible addition.
+    body = _MINIMAL.replace('contract_version = "1.0"', 'contract_version = "1.7.3"')
+    assert load_agent_manifest(_write(tmp_path, body)).config.name == "demo"
+
+
+def test_unknown_keys_are_ignored(tmp_path: Path):
+    # Forward compatibility: a field a later minor adds must not crash this loader.
+    body = _MINIMAL + 'some_future_field = "whatever"\n'
+    assert load_agent_manifest(_write(tmp_path, body)).config.name == "demo"
+
+
+def test_rejects_non_acp_protocol(tmp_path: Path):
+    # The contract is acp-only; non-ACP platforms ship an ACP-over-stdio shim.
+    body = _MINIMAL + 'protocol = "session-factory"\n'
+    with pytest.raises(AgentManifestError, match="acp"):
+        load_agent_manifest(_write(tmp_path, body))
+
+
+def test_install_timeout_coerced_to_int(tmp_path: Path):
+    body = _MINIMAL + "install_timeout = 900\n"
+    c = load_agent_manifest(_write(tmp_path, body)).config
+    assert c.install_timeout == 900
+    assert isinstance(c.install_timeout, int)
+
+
+def test_field_map_and_shim_only_partition_agentconfig():
+    """Drift guard: every AgentConfig field is either declarable in a manifest
+    (_FIELD_MAP) or deliberately shim-owned (_SHIM_ONLY) — never neither (a
+    silently dropped field) and never both (an ambiguous owner)."""
+    declarable = set(_FIELD_MAP.values())
+    shim = set(_SHIM_ONLY)
+    all_fields = {f.name for f in fields(AgentConfig)}
+    assert declarable & shim == set(), "a field is both declarable and shim-only"
+    assert declarable | shim == all_fields, (
+        "AgentConfig fields not partitioned: "
+        f"unowned={all_fields - declarable - shim}, "
+        f"stale={(declarable | shim) - all_fields}"
+    )

--- a/tests/agents/test_manifest_wiring.py
+++ b/tests/agents/test_manifest_wiring.py
@@ -1,0 +1,86 @@
+"""Import-time activation of the dual-source registry (decision #7 go-live).
+
+registry.py calls register_env_manifest_agents() at end-of-module. These tests
+spawn a *fresh* interpreter so the import-time merge runs cleanly (an in-process
+reload would mutate the shared registry the rest of the suite uses). They pin the
+gated-off guarantee — a default import is unchanged — and the opt-in behaviour —
+$BENCHFLOW_AGENTS_DIR merges a manifest agent into every name-keyed map.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import benchflow
+
+# Resolve absolute import roots so the spawned interpreter finds benchflow
+# whether it is installed (CI) or on PYTHONPATH from a worktree (dev VM).
+_SRC = Path(benchflow.__file__).resolve().parents[1]
+_ROOT = _SRC.parent
+
+_MANIFEST = """contract_version = "1.0"
+name = "probe-agent"
+install_cmd = "echo install"
+launch_cmd = "echo launch"
+aliases = ["probe-alias"]
+"""
+
+_PROBE = (
+    "import json;"
+    "from benchflow.agents.registry import ("
+    "AGENTS, AGENT_INSTALLERS, AGENT_LAUNCH, AGENT_ALIASES);"
+    "print(json.dumps({"
+    "'has': 'probe-agent' in AGENTS,"
+    "'installer': AGENT_INSTALLERS.get('probe-agent'),"
+    "'launch': AGENT_LAUNCH.get('probe-agent'),"
+    "'alias': AGENT_ALIASES.get('probe-alias'),"
+    "}))"
+)
+
+
+def _probe(manifest_root: Path, *, set_env: bool) -> dict:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(_SRC), str(_ROOT)])
+    if set_env:
+        env["BENCHFLOW_AGENTS_DIR"] = str(manifest_root)
+    else:
+        env.pop("BENCHFLOW_AGENTS_DIR", None)
+    out = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        env=env,
+        cwd=str(_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert out.returncode == 0, out.stderr[-2000:]
+    return json.loads(out.stdout.strip().splitlines()[-1])
+
+
+def _fixture(tmp_path: Path) -> Path:
+    d = tmp_path / "probe-agent-dir"  # dir name deliberately != agent name
+    d.mkdir()
+    (d / "manifest.toml").write_text(_MANIFEST)
+    return tmp_path
+
+
+def test_default_import_is_unchanged_when_env_unset(tmp_path: Path):
+    result = _probe(_fixture(tmp_path), set_env=False)
+    assert result == {
+        "has": False,
+        "installer": None,
+        "launch": None,
+        "alias": None,
+    }
+
+
+def test_import_merges_manifest_agent_when_env_set(tmp_path: Path):
+    result = _probe(_fixture(tmp_path), set_env=True)
+    assert result["has"] is True
+    assert result["installer"] == "echo install"
+    assert result["launch"] == "echo launch"
+    assert result["alias"] == "probe-agent"


### PR DESCRIPTION
## What

The **consumer half** of the agent-decoupling contract (ADR-0001): core reads an
agent's data-only `manifest.toml` and turns it into the `AgentConfig` the registry
already speaks. A new agent can then ship as **data** (a manifest in
`benchflow-ai/agents`) instead of a hand-edited entry in `registry.AGENTS`
(decision #4), and a directory of manifests merges into the registry on **explicit
opt-in** via `$BENCHFLOW_AGENTS_DIR` (decision #7).

This is the core-side counterpart to the author-side schema + reference loader
already in `benchflow-ai/agents` (`contract/manifest_schema.json`, PR #14).

## Gated OFF by default — zero behaviour change

`registry.py` calls the merge at end-of-module, but it is a **no-op when
`BENCHFLOW_AGENTS_DIR` is unset**, so a default `import benchflow.agents.registry`
is byte-for-byte unchanged (`AGENTS` count unchanged). The dual-source registry
only activates when a developer opts in.

## `src/benchflow/agents/manifest.py`

- **`load_agent_manifest(path) -> LoadedManifest{config, aliases}`** — the
  *consumer* contract (deliberately more lenient than the author-side JSON Schema):
  enforces the 4 required keys, the **contract-major gate** (`SUPPORTED_CONTRACT_MAJOR=1`;
  a v1.x manifest carrying a field added in a later minor still loads — SemVer
  forward-compat), and an **acp-only protocol gate** (the consumer re-enforces it
  because `$BENCHFLOW_AGENTS_DIR` bypasses the author-side jsonschema and
  `register_manifest_agents` writes `AGENTS` directly, skipping `VALID_PROTOCOLS` —
  so this loader is the last protocol gate). Maps the 14 contract data fields onto
  `AgentConfig`; ignores unknown keys.
- **`_FIELD_MAP` / `_SHIM_ONLY` partition `AgentConfig` exactly** — a test asserts
  it, so a field added to `AgentConfig` can never be **silently dropped** by the
  loader (it must be consciously routed to one set or the other). This guard already
  earned its keep: it caught `session_factory` (the non-ACP `module:callable` seam,
  re-added in #782) and pinned it as shim-only.
- **`discover_manifests`** — recursive, skips the root-level manifest and
  vendor/VCS dirs, so nested families (`ai-sdk/<variant>/manifest.toml` alongside
  `mimo-acp/manifest.toml`) are all found.
- **`register_manifest_agents` / `register_env_manifest_agents`** — fail-loud on
  name/alias collision (ambiguous source of truth, not a silent shadow),
  all-or-nothing, and write **every** name-keyed registry map
  (`AGENTS` / `AGENT_INSTALLERS` / `AGENT_LAUNCH` / `AGENT_ALIASES`) — `install.py`
  and `rollout_planes.py` read the installer/launch projections by name, so
  AGENTS-only would leave a manifest agent uninstallable.

## Test plan

- [x] `pytest tests/agents/test_manifest_loader.py test_manifest_dirscan.py test_manifest_wiring.py` — **27 passed**
  (loader 15 / dir-scan 10 / import-time wiring 2).
- [x] Partition guard green against current `AgentConfig` (22 fields = 14 declarable + 8 shim-only).
- [x] Default import unchanged when `BENCHFLOW_AGENTS_DIR` unset (wiring tests spawn a fresh interpreter to prove it).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] CI on this PR.

## Not in this PR

Authoring residents (`ai-sdk/*`, omnigent ACP-stdio server) and the real
standalone-platform parity fixture are follow-ups tracked in ADR-0003. This PR is
just the core seam, dark by default.
