### PR TITLE
Make LiteLLM proxy mandatory for routable agents (never bypass; always capture usage/cost/trajectory)

### DIFF
--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -288,7 +288,12 @@ def eval_run(
         str | None,
         typer.Option(
             "--usage-tracking",
-            help="Token usage tracking policy: auto, required, or off",
+            help=(
+                "Telemetry-enforcement policy: auto, required, or off. The "
+                "LiteLLM proxy is always used for routable agents (usage, cost, "
+                "and llm_trajectory.jsonl are always captured); this flag only "
+                "controls whether trusted telemetry is required."
+            ),
         ),
     ] = None,
     environment_manifest: Annotated[

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -866,7 +866,73 @@ def _provider_secret_env_names() -> set[str]:
     return names
 
 
+# Caller-supplied provider endpoints. If any of these survive in the agent env,
+# the agent could reach a provider directly and bypass the proxy (the exact way
+# an Azure ``LLM_BASE_URL`` leaked past the gateway before this hardening). They
+# are stripped before the proxy endpoint is wired in; the proxy process keeps
+# whatever upstream base_url it needs in its own env / baked config.
+_PROVIDER_ENDPOINT_ENV_NAMES = frozenset(
+    {
+        "LLM_BASE_URL",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+        "AZURE_API_ENDPOINT",
+        "AZURE_API_BASE",
+        "AZURE_OPENAI_ENDPOINT",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "GEMINI_BASE_URL",
+        "GOOGLE_GEMINI_BASE_URL",
+    }
+)
+
+
+def _assert_proxy_isolated(agent: str, env: dict[str, str], *, master_key: str) -> None:
+    """Fail closed if a *raw* provider secret would still reach the agent.
+
+    Invariant after wiring: a routable agent sees only the proxy endpoint and
+    the proxy master key — never an upstream provider credential. Some agents
+    legitimately carry the master key in a provider-named slot (codex/opencode
+    put it in ``OPENAI_API_KEY``, claude in ``ANTHROPIC_AUTH_TOKEN``), so a
+    provider-named var holding exactly ``master_key`` is the proxy credential and
+    is allowed; anything else in those slots is a raw upstream key. If one
+    survives (e.g. an agent registry ``env_mapping`` re-exposed it), refuse to
+    run so the agent cannot authenticate directly against a provider.
+    """
+    leaked = sorted(
+        name
+        for name in _provider_secret_env_names()
+        if env.get(name) and env.get(name) != master_key
+    )
+    if leaked:
+        raise RuntimeError(
+            f"LiteLLM proxy isolation breached for agent {agent!r}: raw provider "
+            f"secrets would reach the agent ({', '.join(leaked)}). Refusing to run "
+            "to prevent direct-to-provider traffic."
+        )
+
+
 def _apply_litellm_agent_env(
+    *,
+    agent: str,
+    agent_env: dict[str, str],
+    route: LiteLLMRoute,
+    base_url: str,
+    master_key: str,
+) -> dict[str, str]:
+    """Rewrite the agent env to talk only to the proxy, then verify isolation."""
+    updated = _wire_litellm_agent_env(
+        agent=agent,
+        agent_env=agent_env,
+        route=route,
+        base_url=base_url,
+        master_key=master_key,
+    )
+    _assert_proxy_isolated(agent, updated, master_key=master_key)
+    return updated
+
+
+def _wire_litellm_agent_env(
     *,
     agent: str,
     agent_env: dict[str, str],
@@ -876,12 +942,15 @@ def _apply_litellm_agent_env(
 ) -> dict[str, str]:
     updated = dict(agent_env)
     # Isolation: the agent must reach providers only through the proxy. Drop raw
-    # upstream provider secrets so a compromised or curious agent cannot bypass
-    # the gateway (and its usage metering) or read live keys. The proxy process
-    # holds them via its own env. (In sandbox-local mode the proxy shares the
-    # agent's sandbox, so this reduces — but cannot fully remove — key visibility.)
+    # upstream provider secrets AND endpoints so a compromised or curious agent
+    # cannot bypass the gateway (and its usage metering) or read live keys. The
+    # proxy process holds them via its own env. (In sandbox-local mode the proxy
+    # shares the agent's sandbox, so this reduces — but cannot fully remove — key
+    # visibility.)
     for secret_key in _provider_secret_env_names():
         updated.pop(secret_key, None)
+    for endpoint_key in _PROVIDER_ENDPOINT_ENV_NAMES:
+        updated.pop(endpoint_key, None)
     openai_base_url = f"{base_url.rstrip('/')}/v1"
     updated.update(
         {
@@ -957,21 +1026,22 @@ async def _skip_litellm_runtime(
     return agent_env, None
 
 
-async def _fallback_or_raise_for_unavailable_litellm(
+async def _raise_litellm_unavailable(
     *,
-    usage_cfg: UsageTrackingConfig,
-    agent_env: dict[str, str],
     runtime: Any | None,
-    required_error: str,
-    fallback_reason: str,
-) -> tuple[dict[str, str], Any | None]:
-    if usage_cfg.mode == "required":
-        raise RuntimeError(required_error)
-    return await _skip_litellm_runtime(
-        agent_env,
-        runtime,
-        reason=fallback_reason,
-    )
+    error: str,
+) -> None:
+    """Fail closed when a routable agent cannot be put behind the proxy.
+
+    BenchFlow always routes routable agents through the LiteLLM proxy so
+    provider traffic is metered and captured (``llm_trajectory.jsonl``).
+    Silently falling back to direct provider access would leak the raw key,
+    bypass usage/cost tracking, and lose the trainable trajectory — so any
+    proxy unavailability is fatal, independent of ``usage_tracking`` mode.
+    """
+    if runtime is not None:
+        await stop_litellm_runtime(runtime)
+    raise RuntimeError(error)
 
 
 async def ensure_litellm_runtime(
@@ -985,14 +1055,18 @@ async def ensure_litellm_runtime(
     usage_tracking: UsageTrackingConfig | dict[str, Any] | str | None = None,
     sandbox: Any | None = None,
 ) -> tuple[dict[str, str], Any | None]:
-    """Start/reuse LiteLLM and rewrite the agent env to talk to it."""
+    """Start/reuse LiteLLM and rewrite the agent env to talk to it.
+
+    Every LiteLLM-routable agent is *always* routed through the proxy so
+    provider traffic is metered and captured (``llm_trajectory.jsonl``) and the
+    raw provider key never reaches the agent. ``usage_tracking`` no longer gates
+    whether the proxy runs — it only governs whether trusted telemetry is
+    *required* (``required`` fails closed when usage cannot be captured at all).
+    The only agents that skip the proxy are those that physically cannot be
+    routed through it: ``oracle`` (no model), native-protocol agents (e.g.
+    ``gemini``), and native-subscription auth (no API key to proxy).
+    """
     usage_cfg = UsageTrackingConfig.coerce(usage_tracking).with_env_defaults()
-    if usage_cfg.mode == "off":
-        return await _skip_litellm_runtime(
-            agent_env,
-            runtime,
-            reason="usage_tracking=off leaves provider traffic untouched",
-        )
 
     if uses_native_subscription_auth(agent, model, agent_env):
         return await _skip_litellm_runtime(
@@ -1016,33 +1090,24 @@ async def ensure_litellm_runtime(
     try:
         route = resolve_litellm_route(model, agent_env)
     except ValueError as exc:
-        return await _fallback_or_raise_for_unavailable_litellm(
-            usage_cfg=usage_cfg,
-            agent_env=agent_env,
+        await _raise_litellm_unavailable(
             runtime=runtime,
-            required_error=(
-                "Token usage tracking is required, but LiteLLM cannot resolve "
-                f"model {model!r}: {exc}"
-            ),
-            fallback_reason=(
-                f"usage_tracking=auto could not resolve model {model!r}: {exc}"
+            error=(
+                "LiteLLM proxy is mandatory but cannot resolve "
+                f"model {model!r}: {exc}. BenchFlow never sends provider traffic "
+                "directly — register the provider/model or fix the route."
             ),
         )
     missing = _missing_required_env(route, agent_env)
     if missing:
         missing_text = ", ".join(missing)
-        required_error = (
-            f"LiteLLM route for model {model!r} requires {missing_text}. "
-            "Pass provider credentials via --agent-env/agent_env or define them in .env."
-        )
-        return await _fallback_or_raise_for_unavailable_litellm(
-            usage_cfg=usage_cfg,
-            agent_env=agent_env,
+        await _raise_litellm_unavailable(
             runtime=runtime,
-            required_error=required_error,
-            fallback_reason=(
-                f"usage_tracking=auto could not start LiteLLM for model {model!r}; "
-                f"missing provider credentials: {missing_text}"
+            error=(
+                f"LiteLLM route for model {model!r} requires {missing_text}. "
+                "Pass provider credentials via --agent-env/agent_env or define "
+                "them in .env (the proxy is mandatory; traffic is never sent "
+                "directly to the provider)."
             ),
         )
 
@@ -1090,16 +1155,11 @@ async def ensure_litellm_runtime(
     except BedrockPatchPreflightError:
         raise
     except Exception as exc:
-        return await _fallback_or_raise_for_unavailable_litellm(
-            usage_cfg=usage_cfg,
-            agent_env=agent_env,
+        await _raise_litellm_unavailable(
             runtime=None,
-            required_error=(
-                "Token usage tracking is required, but LiteLLM failed to start "
-                f"for model {model!r}: {exc}"
-            ),
-            fallback_reason=(
-                f"usage_tracking=auto could not start LiteLLM for model {model!r}: {exc}"
+            error=(
+                f"LiteLLM proxy failed to start for model {model!r}: {exc}. "
+                "BenchFlow never sends provider traffic directly, so this is fatal."
             ),
         )
 

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -58,6 +58,15 @@ LITELLM_SANDBOX_ROOT = "/tmp/benchflow-litellm"
 _CALLBACK_MODULE = "benchflow_litellm_callback"
 _PATCH_MODULE = "benchflow_litellm_bedrock_patch"
 
+# The proxy is an internal single-route gateway — it must never register the
+# FastAPI Swagger docs route. litellm's `_get_docs_url()` honours an inherited
+# `DOCS_URL` env *before* `NO_DOCS`, so a stray non-"/" `DOCS_URL` baked into a
+# sandbox base image makes litellm call `add_route(DOCS_URL, ...)` and crash with
+# `Routed paths must start with '/'` at startup. Force `DOCS_URL=""` (falsy, so
+# it's ignored) and `NO_DOCS=true` so the docs route is skipped regardless of the
+# inherited environment.
+_PROXY_DOCS_DISABLE_ENV = {"DOCS_URL": "", "NO_DOCS": "true"}
+
 # Agents that speak a provider-native wire protocol the LiteLLM proxy does not
 # expose on its OpenAI/Anthropic surfaces. Routing them through the proxy would
 # silently mis-wire the agent (e.g. the Gemini CLI speaks Google's
@@ -455,6 +464,7 @@ async def _start_host_litellm(
             "PYTHONPATH": f"{runtime_dir}{os.pathsep}{env.get('PYTHONPATH', '')}",
             "LITELLM_MASTER_KEY": master_key,
             "BENCHFLOW_LITELLM_LOG_PATH": str(log_path),
+            **_PROXY_DOCS_DISABLE_ENV,
         }
     )
     litellm_executable = _host_litellm_executable()
@@ -751,6 +761,7 @@ async def _start_sandbox_litellm(
             "PYTHONPATH": f"{runtime_dir}:{env.get('PYTHONPATH', '')}",
             "LITELLM_MASTER_KEY": master_key,
             "BENCHFLOW_LITELLM_LOG_PATH": paths["log"],
+            **_PROXY_DOCS_DISABLE_ENV,
         }
     )
     launch_config = {

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -18,7 +18,7 @@ import tempfile
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NoReturn, cast
 from uuid import uuid4
 
 import httpx
@@ -1030,7 +1030,7 @@ async def _raise_litellm_unavailable(
     *,
     runtime: Any | None,
     error: str,
-) -> None:
+) -> NoReturn:
     """Fail closed when a routable agent cannot be put behind the proxy.
 
     BenchFlow always routes routable agents through the LiteLLM proxy so

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -72,10 +72,15 @@ def usage_unavailable() -> dict[str, Any]:
 class UsageTrackingConfig:
     """User-facing token/cost telemetry policy.
 
-    ``mode`` is the operator contract:
+    ``mode`` is the operator *telemetry-enforcement* contract — it no longer
+    decides whether the LiteLLM proxy runs. Every routable agent is always
+    routed through the proxy (so usage, cost, and the raw LLM trajectory are
+    always captured and the provider key never reaches the agent); ``mode`` only
+    governs how hard BenchFlow insists on *trusted* telemetry:
     - ``auto`` records usage when LiteLLM or native ACP telemetry can be used.
     - ``required`` fails when no trusted token telemetry can be captured.
-    - ``off`` leaves provider traffic untouched.
+    - ``off`` still routes/captures, but does not *require* trusted telemetry
+      (it no longer leaves provider traffic untouched).
     """
 
     _mode: UsageTrackingMode | None
@@ -148,11 +153,16 @@ class UsageTrackingConfig:
         status: str,
         usage_source: str,
     ) -> dict[str, Any]:
+        # The proxy now always runs for routable agents, so the endpoint kind
+        # follows where telemetry actually came from rather than the mode: a
+        # live proxy reports host/sandbox, native-subscription agents report
+        # agent_native, and only a genuinely un-routable agent (no telemetry at
+        # all, e.g. a native-protocol agent) reports none.
         endpoint_kind = "sandbox" if environment == "daytona" else "host"
-        if self.mode == "off":
-            endpoint_kind = "none"
-        elif usage_source == USAGE_SOURCE_AGENT_NATIVE_ACP:
+        if usage_source == USAGE_SOURCE_AGENT_NATIVE_ACP:
             endpoint_kind = "agent_native"
+        elif usage_source == USAGE_SOURCE_UNAVAILABLE:
+            endpoint_kind = "none"
         return {
             "requested": self.mode,
             "status": status,

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -267,13 +267,14 @@ async def test_required_usage_skips_litellm_for_claude_subscription(monkeypatch)
 
 
 @pytest.mark.asyncio
-async def test_usage_tracking_off_leaves_provider_env_untouched(monkeypatch):
-    """Guards the follow-up to PR #613: off must not proxy provider traffic."""
+async def test_usage_tracking_off_still_routes_through_proxy(monkeypatch):
+    """off no longer disables the proxy: routable traffic is still captured and
+    the raw provider key never reaches the agent."""
 
-    async def fail_start(**_kwargs):
-        raise AssertionError("LiteLLM should not start when usage tracking is off")
+    async def fake_start(**kwargs):
+        return FakeLiteLLMServer("http://127.0.0.1:4000", kwargs["route"])
 
-    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fake_start)
     env = {"OPENAI_API_KEY": "sk-openai"}
 
     updated, provider_runtime = await ensure_litellm_runtime(
@@ -285,21 +286,30 @@ async def test_usage_tracking_off_leaves_provider_env_untouched(monkeypatch):
         usage_tracking="off",
     )
 
-    assert updated == env
-    assert provider_runtime is None
+    assert provider_runtime is not None
+    # Agent points at the proxy, holding the master key — not the raw provider key.
+    assert updated["OPENAI_BASE_URL"] == "http://127.0.0.1:4000/v1"
+    assert updated["OPENAI_API_KEY"] == provider_runtime.master_key
+    assert "sk-openai" not in updated.values()
 
 
 @pytest.mark.asyncio
-async def test_usage_tracking_off_stops_existing_litellm_runtime():
-    """Guards the follow-up to PR #613: off must clear stale LiteLLM routing."""
+async def test_usage_tracking_off_replaces_stale_litellm_runtime(monkeypatch):
+    """off with a stale runtime stops the old proxy and starts a fresh one
+    (it no longer tears the proxy down and goes direct)."""
 
-    server = FakeLiteLLMServer("http://127.0.0.1:4000", route=None)
+    old_server = FakeLiteLLMServer("http://127.0.0.1:4000", route=None)
     existing = ProviderRuntime(
         kind="litellm",
-        agent_base_url=server.base_url,
-        server=server,
+        agent_base_url=old_server.base_url,
+        server=old_server,
         config_key="old",
     )
+
+    async def fake_start(**kwargs):
+        return FakeLiteLLMServer("http://127.0.0.1:4001", kwargs["route"])
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fake_start)
 
     updated, provider_runtime = await ensure_litellm_runtime(
         agent="codex-acp",
@@ -310,36 +320,88 @@ async def test_usage_tracking_off_stops_existing_litellm_runtime():
         usage_tracking="off",
     )
 
-    assert updated == {"OPENAI_API_KEY": "sk-openai"}
-    assert provider_runtime is None
-    assert server.stopped is True
+    assert old_server.stopped is True
+    assert provider_runtime is not None
+    assert updated["OPENAI_BASE_URL"] == "http://127.0.0.1:4001/v1"
 
 
 @pytest.mark.asyncio
-async def test_auto_usage_falls_back_when_litellm_lacks_provider_key(monkeypatch):
-    """Guards the follow-up to PR #613: auto should not fail just to track usage."""
+async def test_openhands_azure_never_bypasses_proxy(monkeypatch):
+    """The bug this PR fixes: a caller-supplied Azure LLM_BASE_URL must never let
+    OpenHands reach Azure directly. The proxy is forced on even under off, the
+    raw Azure key and endpoints are stripped, and LLM_BASE_URL points at the proxy."""
+
+    async def fake_start(**kwargs):
+        return FakeLiteLLMServer("http://127.0.0.1:45678", kwargs["route"])
+
+    monkeypatch.setattr(runtime_mod, "_start_sandbox_litellm", fake_start)
+
+    updated, provider_runtime = await ensure_litellm_runtime(
+        agent="openhands",
+        agent_env={
+            "AZURE_API_KEY": "azure-secret",
+            "AZURE_API_ENDPOINT": "https://my-resource.openai.azure.com",
+            "AZURE_API_VERSION": "preview",
+            "LLM_BASE_URL": "https://my-resource.openai.azure.com/openai/v1",
+            "OPENAI_BASE_URL": "https://my-resource.openai.azure.com/openai/v1",
+        },
+        model="azure-foundry-openai/gpt-5.5",
+        runtime=None,
+        environment="daytona",
+        session_id="run-1",
+        usage_tracking="off",
+        sandbox=SimpleNamespace(),
+    )
+
+    assert provider_runtime is not None
+    assert updated["LLM_BASE_URL"] == "http://127.0.0.1:45678/v1"
+    assert updated["LLM_API_KEY"] == provider_runtime.master_key
+    assert "AZURE_API_KEY" not in updated
+    assert "OPENAI_BASE_URL" not in updated
+    assert not any("azure.com" in str(v) for v in updated.values())
+
+
+def test_proxy_isolation_guard_blocks_leaked_secret():
+    """The fail-closed guard refuses to run if a raw provider key would survive."""
+
+    with pytest.raises(RuntimeError, match="isolation breached"):
+        runtime_mod._assert_proxy_isolated(
+            "openhands", {"OPENAI_API_KEY": "sk-leak"}, master_key="sk-benchflow-x"
+        )
+
+    # Proxy master key in a provider slot + a non-secret var are fine.
+    runtime_mod._assert_proxy_isolated(
+        "codex-acp",
+        {"OPENAI_API_KEY": "sk-benchflow-x", "AZURE_API_VERSION": "preview"},
+        master_key="sk-benchflow-x",
+    )
+
+
+@pytest.mark.asyncio
+async def test_auto_usage_fails_closed_when_litellm_lacks_provider_key(monkeypatch):
+    """The proxy is mandatory: missing credentials are fatal, never a silent
+    fall back to direct provider access — even under auto."""
 
     async def fail_start(**_kwargs):
         raise AssertionError("LiteLLM should not start without provider credentials")
 
+    monkeypatch.setattr(runtime_mod, "uses_native_subscription_auth", lambda *_: False)
     monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
 
-    updated, provider_runtime = await ensure_litellm_runtime(
-        agent="codex-acp",
-        agent_env={},
-        model="openai/gpt-4.1-mini",
-        runtime=None,
-        environment="docker",
-        usage_tracking="auto",
-    )
-
-    assert updated == {}
-    assert provider_runtime is None
+    with pytest.raises(RuntimeError, match="requires OPENAI_API_KEY"):
+        await ensure_litellm_runtime(
+            agent="codex-acp",
+            agent_env={},
+            model="openai/gpt-4.1-mini",
+            runtime=None,
+            environment="docker",
+            usage_tracking="auto",
+        )
 
 
 @pytest.mark.asyncio
-async def test_auto_usage_falls_back_when_route_resolution_fails(monkeypatch):
-    """Guards the follow-up to PR #620: auto falls back on route failures."""
+async def test_auto_usage_fails_closed_when_route_resolution_fails(monkeypatch):
+    """Route resolution failure is fatal: BenchFlow never bypasses the proxy."""
 
     def fail_route(*_args, **_kwargs):
         raise ValueError("missing AZURE_RESOURCE")
@@ -349,42 +411,36 @@ async def test_auto_usage_falls_back_when_route_resolution_fails(monkeypatch):
 
     monkeypatch.setattr(runtime_mod, "resolve_litellm_route", fail_route)
     monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
-    env = {"AZURE_API_KEY": "azure-key"}
 
-    updated, provider_runtime = await ensure_litellm_runtime(
-        agent="codex-acp",
-        agent_env=env,
-        model="azure-foundry-openai/gpt-4.1-mini",
-        runtime=None,
-        environment="docker",
-        usage_tracking="auto",
-    )
-
-    assert updated == env
-    assert provider_runtime is None
+    with pytest.raises(RuntimeError, match="cannot resolve"):
+        await ensure_litellm_runtime(
+            agent="codex-acp",
+            agent_env={"AZURE_API_KEY": "azure-key"},
+            model="azure-foundry-openai/gpt-4.1-mini",
+            runtime=None,
+            environment="docker",
+            usage_tracking="auto",
+        )
 
 
 @pytest.mark.asyncio
-async def test_auto_usage_falls_back_when_litellm_start_fails(monkeypatch):
-    """Guards the follow-up to PR #613: auto should survive proxy startup errors."""
+async def test_auto_usage_fails_closed_when_litellm_start_fails(monkeypatch):
+    """Proxy startup failure is fatal under auto too (no direct-provider fallback)."""
 
     async def fail_start(**_kwargs):
         raise RuntimeError("proxy unavailable")
 
     monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
-    env = {"OPENAI_API_KEY": "sk-openai"}
 
-    updated, provider_runtime = await ensure_litellm_runtime(
-        agent="codex-acp",
-        agent_env=env,
-        model="openai/gpt-4.1-mini",
-        runtime=None,
-        environment="docker",
-        usage_tracking="auto",
-    )
-
-    assert updated == env
-    assert provider_runtime is None
+    with pytest.raises(RuntimeError, match="failed to start"):
+        await ensure_litellm_runtime(
+            agent="codex-acp",
+            agent_env={"OPENAI_API_KEY": "sk-openai"},
+            model="openai/gpt-4.1-mini",
+            runtime=None,
+            environment="docker",
+            usage_tracking="auto",
+        )
 
 
 @pytest.mark.asyncio
@@ -462,7 +518,7 @@ async def test_required_usage_propagates_litellm_start_failure(monkeypatch):
 
     monkeypatch.setattr(runtime_mod, "_start_host_litellm", fail_start)
 
-    with pytest.raises(RuntimeError, match="Token usage tracking is required"):
+    with pytest.raises(RuntimeError, match="failed to start"):
         await ensure_litellm_runtime(
             agent="codex-acp",
             agent_env={"OPENAI_API_KEY": "sk-openai"},

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -377,6 +377,22 @@ def test_proxy_isolation_guard_blocks_leaked_secret():
     )
 
 
+def test_proxy_docs_disable_env_neutralizes_stray_docs_url(monkeypatch):
+    """A stray DOCS_URL (e.g. baked into a sandbox base image) used to crash the
+    proxy at startup ('Routed paths must start with /'). The proxy launch env
+    must disable Swagger docs so litellm registers no docs route."""
+    from litellm.proxy.utils import _get_docs_url
+
+    # Reproduce the crash trigger: an inherited non-"/" DOCS_URL.
+    monkeypatch.setenv("DOCS_URL", "stray-without-leading-slash")
+    assert _get_docs_url() == "stray-without-leading-slash"  # would crash add_route
+
+    # Applying the proxy launch overrides makes litellm skip the docs route.
+    for key, value in runtime_mod._PROXY_DOCS_DISABLE_ENV.items():
+        monkeypatch.setenv(key, value)
+    assert _get_docs_url() is None
+
+
 @pytest.mark.asyncio
 async def test_auto_usage_fails_closed_when_litellm_lacks_provider_key(monkeypatch):
     """The proxy is mandatory: missing credentials are fatal, never a silent


### PR DESCRIPTION
## Problem

For any LiteLLM-routable agent, BenchFlow could end up talking to the provider **directly**, bypassing the proxy. When that happens:

- the raw provider key reaches the agent,
- token **usage / cost** is not metered, and
- **`trajectory/llm_trajectory.jsonl` is never written** (it is sourced from the proxy's captured exchanges).

Two paths caused the bypass:

1. `usage_tracking=off` returned early in `ensure_litellm_runtime`, so the proxy never started and the caller-supplied `LLM_BASE_URL` (e.g. an Azure endpoint) survived untouched — the agent hit the provider directly.
2. Under `auto`, route-resolution / missing-credential / proxy-start failures **silently fell back** to direct provider access.

Net effect for an Azure GPT-5.5 + OpenHands run: only the display-level ACP trajectory was captured; the wire-level `llm_trajectory.jsonl` (system prompt + tools schema + structured `tool_calls`) — the only trainable trajectory — was lost.

## Change

The LiteLLM proxy is now the **mandatory default** for every routable agent, independent of `usage_tracking`:

- Drop the `usage_tracking=off` skip in `ensure_litellm_runtime`.
- **Fail closed**: route-resolution / missing-credential / proxy-start failures now raise for routable agents instead of silently going direct (`_fallback_or_raise_for_unavailable_litellm` → `_raise_litellm_unavailable`).
- **Harden agent-env isolation**: strip caller-supplied provider endpoints (`LLM_BASE_URL`, `OPENAI_BASE_URL`, `AZURE_API_ENDPOINT`, …) before wiring the proxy, and add `_assert_proxy_isolated()` so no raw provider secret can reach the agent (the proxy master key in a provider slot, e.g. codex's `OPENAI_API_KEY`, is allowed).
- `usage_tracking` is now purely a **telemetry-enforcement** policy: `off` still routes and captures; only `required` fails when trusted telemetry is unavailable. Updated docstrings, CLI help, and result-metadata `endpoint_kind`.

Agents that physically cannot be proxied are unchanged and still skip: `oracle` (no model), native-protocol agents (e.g. `gemini`), and native-subscription auth.

## Tests

- Updated the `off` / `auto`-fallback expectations to the new fail-closed contract.
- Added `test_openhands_azure_never_bypasses_proxy` (a caller-supplied Azure `LLM_BASE_URL` is stripped and the agent points at the proxy) and `test_proxy_isolation_guard_blocks_leaked_secret`.
- Full non-live/non-integration suite green: **4461 passed, 4 skipped**.

## Compatibility note

This changes the observable behavior of `usage_tracking=off`/`auto` for routable agents (proxy is now always on; failures are fatal rather than silently direct). The flag is retained for config/CLI back-compat but no longer disables the proxy.