### PR TITLE
fix(eval): reject .git and file --source-path with a clean error (#548)

### DIFF
--- a/src/benchflow/_utils/benchmark_repos.py
+++ b/src/benchflow/_utils/benchmark_repos.py
@@ -213,6 +213,12 @@ def _resolve_repo_path(root: Path, path: str, repo_label: str) -> Path:
         raise ValueError(
             f"Source path {path!r} escapes repository root for {repo_label}"
         )
+    git_metadata = root_resolved / ".git"
+    if target_resolved == git_metadata or target_resolved.is_relative_to(git_metadata):
+        raise ValueError(
+            f"Source path {path!r} must resolve to a task directory inside "
+            f"{repo_label}; .git is the clone metadata, not a task source"
+        )
     # A regular file (e.g. ``README.md``) exists and stays within the root, but a
     # task source must be a directory. Reject non-directories with a friendly
     # message rather than letting task resolution fail with zero hashes later.

--- a/src/benchflow/_utils/benchmark_repos.py
+++ b/src/benchflow/_utils/benchmark_repos.py
@@ -190,6 +190,15 @@ def _resolve_repo_path(root: Path, path: str, repo_label: str) -> Path:
         raise ValueError(
             f"Source path {path!r} must be relative to repository root for {repo_label}"
         )
+    # ``.git`` is the clone's VCS metadata, not a task source. It exists and is a
+    # directory inside the root, so it would otherwise pass the checks below and
+    # then resolve to zero task hashes downstream. Reject it (and anything under
+    # it) at the boundary with a clear message instead.
+    if ".git" in requested.parts:
+        raise ValueError(
+            f"Source path {path!r} must resolve to a task directory inside "
+            f"{repo_label}; .git is the clone metadata, not a task source"
+        )
     target = root / requested
     if not target.exists():
         raise FileNotFoundError(
@@ -203,6 +212,14 @@ def _resolve_repo_path(root: Path, path: str, repo_label: str) -> Path:
     ):
         raise ValueError(
             f"Source path {path!r} escapes repository root for {repo_label}"
+        )
+    # A regular file (e.g. ``README.md``) exists and stays within the root, but a
+    # task source must be a directory. Reject non-directories with a friendly
+    # message rather than letting task resolution fail with zero hashes later.
+    if not target_resolved.is_dir():
+        raise ValueError(
+            f"Source path {path!r} must resolve to a directory inside "
+            f"{repo_label}, not a file"
         )
     return target_resolved
 

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -485,6 +485,51 @@ def test_resolve_source_with_metadata_rejects_path_escape(tmp_path, monkeypatch)
         resolve_source_with_metadata("acme-org/benchmarks", path="../outside-task")
 
 
+def _clone_with(tmp_path, monkeypatch, *, populate):
+    """Install a fake ``git`` whose clone is populated by ``populate(clone_dir)``."""
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run(cmd, check=False, capture_output=False, text=False):
+        del capture_output, text
+        if cmd[:2] == ["git", "clone"]:
+            assert check is True
+            clone_dir = Path(cmd[-1])
+            (clone_dir / ".git").mkdir(parents=True)
+            populate(clone_dir)
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd[-2:] == ["rev-parse", "HEAD"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout="c65af83ae2c76fda3f1fd4d2fcf56563975e283e\n",
+                stderr="",
+            )
+        if cmd[-2:] == ["status", "--porcelain"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr(task_download.subprocess, "run", fake_run)
+
+
+def test_resolve_source_with_metadata_rejects_git_source_path(tmp_path, monkeypatch):
+    """Guards issue #548: --source-path .git is clone metadata, not a task source."""
+    _clone_with(tmp_path, monkeypatch, populate=lambda d: (d / "task-1").mkdir())
+
+    with pytest.raises(ValueError, match=r"\.git is the clone metadata"):
+        resolve_source_with_metadata("acme-org/benchmarks", path=".git")
+
+
+def test_resolve_source_with_metadata_rejects_file_source_path(tmp_path, monkeypatch):
+    """Guards issue #548: a file --source-path must report a clean validation error."""
+    _clone_with(
+        tmp_path,
+        monkeypatch,
+        populate=lambda d: (d / "README.md").write_text("# repo\n"),
+    )
+
+    with pytest.raises(ValueError, match="must resolve to a directory"):
+        resolve_source_with_metadata("acme-org/benchmarks", path="README.md")
+
+
 def test_resolve_source_without_path(tmp_path, monkeypatch):
     """resolve_source without path returns repo root."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -511,15 +511,29 @@ def _clone_with(tmp_path, monkeypatch, *, populate):
 
 
 def test_resolve_source_with_metadata_rejects_git_source_path(tmp_path, monkeypatch):
-    """Guards issue #548: --source-path .git is clone metadata, not a task source."""
+    """Guards PR #822: --source-path .git is clone metadata, not a task source."""
     _clone_with(tmp_path, monkeypatch, populate=lambda d: (d / "task-1").mkdir())
 
     with pytest.raises(ValueError, match=r"\.git is the clone metadata"):
         resolve_source_with_metadata("acme-org/benchmarks", path=".git")
 
 
+def test_resolve_source_with_metadata_rejects_symlink_to_git_path(
+    tmp_path, monkeypatch
+):
+    """Guards PR #822: a symlink into .git must not bypass source validation."""
+
+    def populate(clone_dir: Path) -> None:
+        (clone_dir / "git-link").symlink_to(".git", target_is_directory=True)
+
+    _clone_with(tmp_path, monkeypatch, populate=populate)
+
+    with pytest.raises(ValueError, match=r"\.git is the clone metadata"):
+        resolve_source_with_metadata("acme-org/benchmarks", path="git-link")
+
+
 def test_resolve_source_with_metadata_rejects_file_source_path(tmp_path, monkeypatch):
-    """Guards issue #548: a file --source-path must report a clean validation error."""
+    """Guards PR #822: a file --source-path must report a clean validation error."""
     _clone_with(
         tmp_path,
         monkeypatch,


### PR DESCRIPTION
Fixes #548.

## Summary

Closes the remaining half of #548. The `--tasks-dir <file>` crash was already fixed (clean `Not a directory` error); this PR handles the **source-resolver** path that issue #548 flagged as still unaddressed.

`_resolve_repo_path` validated absoluteness, existence, and root-escape — but never that the resolved target is a usable task **directory**. So:

- `--source-repo <org/repo> --source-path .git` resolved to the clone's VCS metadata (a real directory inside the root), passed every check, and produced **zero task hashes** downstream.
- a regular-file `--source-path` (e.g. `README.md`) passed the existence/escape checks and resolved to a non-directory that failed later.

## Fix

In `_resolve_repo_path` (`src/benchflow/_utils/benchmark_repos.py`):
- reject any path with a `.git` component (`.git` is clone metadata, not a task source);
- reject a resolved target that is not a directory.

Both raise a clear `ValueError`. The `eval create` CLI already wraps the resolver in `except (subprocess.CalledProcessError, OSError, ValueError, RuntimeError)` → `print_error("Could not resolve --source-repo ...")` + `typer.Exit(1)` (`cli/main.py`), so the user sees a clean validation error, **no traceback** — exactly the "Expected" behavior in #548.

## Validation
- `uv run python -m pytest tests/test_task_download.py -q` → 23 passed (2 new regression tests: `.git` and file cases, both naming #548)
- `uv run python -m pytest tests/test_eval_source_provenance.py tests/test_dataset_registry.py tests/test_cli_edge_case_hardening.py tests/test_cli_arg_validation.py -q` → 145 passed
- `uv run ruff check` + `ruff format --check` + `uv run ty check` → all clean

No merge taken from automation; needs CI + non-author human review under repo policy.
