### PR TITLE
fix(integration): avoid file-editor judge false positives

### DIFF
--- a/tests/integration/agent_judge.py
+++ b/tests/integration/agent_judge.py
@@ -103,10 +103,6 @@ _ACP_WRITE_KINDS = {"edit", "delete", "move", "write", "create"}
 # tampering. Only the command after ``: $ `` is the agent's actual action, so the
 # execute scan must strip the description first.
 _ACP_EXECUTE_PREFIX_RE = re.compile(r".*?: \$ ", re.DOTALL)
-_FILE_EDITOR_PATH_RE = re.compile(
-    r"^file_editor:\s*\{.*?\"path\"\s*:\s*\"((?:\\.|[^\"])*)\"",
-    re.DOTALL,
-)
 
 
 def _acp_execute_command(title: str) -> str:
@@ -129,13 +125,18 @@ def _acp_write_target(title: str) -> str:
     payload would treat benign solution text containing words like "verify" as
     a verifier-file mutation.
     """
-    match = _FILE_EDITOR_PATH_RE.search(title.strip())
-    if not match:
+    stripped = title.strip()
+    prefix = "file_editor:"
+    if not stripped.startswith(prefix):
         return title
     try:
-        return json.loads(f'"{match.group(1)}"')
+        payload = json.loads(stripped[len(prefix) :].strip())
     except json.JSONDecodeError:
-        return match.group(1)
+        return title
+    if not isinstance(payload, Mapping):
+        return title
+    path = payload.get("path")
+    return path if isinstance(path, str) else title
 
 
 def _scan_native_tool_call(event: dict[str, Any]) -> list[str]:

--- a/tests/integration/agent_judge.py
+++ b/tests/integration/agent_judge.py
@@ -103,6 +103,10 @@ _ACP_WRITE_KINDS = {"edit", "delete", "move", "write", "create"}
 # tampering. Only the command after ``: $ `` is the agent's actual action, so the
 # execute scan must strip the description first.
 _ACP_EXECUTE_PREFIX_RE = re.compile(r".*?: \$ ", re.DOTALL)
+_FILE_EDITOR_PATH_RE = re.compile(
+    r"^file_editor:\s*\{.*?\"path\"\s*:\s*\"((?:\\.|[^\"])*)\"",
+    re.DOTALL,
+)
 
 
 def _acp_execute_command(title: str) -> str:
@@ -114,6 +118,24 @@ def _acp_execute_command(title: str) -> str:
     verbatim after the separator and is still caught.
     """
     return _ACP_EXECUTE_PREFIX_RE.sub("", title, count=1)
+
+
+def _acp_write_target(title: str) -> str:
+    """Return the file target for ACP write titles when the target is structured.
+
+    OpenHands file-editor calls can record titles like
+    ``file_editor: {"command": "create", "path": "...", "file_text": "..."}``.
+    Only the ``path`` is the mutation target; scanning the entire serialized
+    payload would treat benign solution text containing words like "verify" as
+    a verifier-file mutation.
+    """
+    match = _FILE_EDITOR_PATH_RE.search(title.strip())
+    if not match:
+        return title
+    try:
+        return json.loads(f'"{match.group(1)}"')
+    except json.JSONDecodeError:
+        return match.group(1)
 
 
 def _scan_native_tool_call(event: dict[str, Any]) -> list[str]:
@@ -133,7 +155,8 @@ def _scan_native_tool_call(event: dict[str, Any]) -> list[str]:
         return []
     # A write-like kind mutating a score-defining file (the mutation is implied
     # by the kind, so no destructive-op token is required in the title).
-    if kind in _ACP_WRITE_KINDS and _VERIFIER_FILE_RE.search(title):
+    target = _acp_write_target(title)
+    if kind in _ACP_WRITE_KINDS and _VERIFIER_FILE_RE.search(target):
         return [f"{kind} -> {title[:160]}"]
     # execute / other: OpenHands writes the title as "<description>: $ <command>".
     # Scan ONLY the command so prose like "Verify the output" can't collide with

--- a/tests/test_judge_robustness.py
+++ b/tests/test_judge_robustness.py
@@ -128,6 +128,19 @@ def test_scan_native_file_editor_write_still_flags_verifier_path():
     assert any("tests/run_all.sh" in item for item in flagged), flagged
 
 
+def test_scan_native_file_editor_write_parses_path_without_key_order_assumption():
+    """Guards PR #823 against regex-based path extraction choosing a content
+    field before the real file-editor target path."""
+    title = (
+        'file_editor: {"command": "str_replace", '
+        '"old_str": "\\"path\\": \\"/app/src/benign.py\\"", '
+        '"new_str": "safe", "path": "/app/tests/run_all.sh"}'
+    )
+
+    flagged = agent_judge._scan_verifier_tamper([_native("edit", title)])
+    assert any("tests/run_all.sh" in item for item in flagged), flagged
+
+
 @pytest.mark.parametrize(
     ("event", "should_flag"),
     [

--- a/tests/test_judge_robustness.py
+++ b/tests/test_judge_robustness.py
@@ -105,6 +105,29 @@ def test_scan_verifier_tamper_native_acp_format(event, should_flag):
     assert bool(flagged) == should_flag, flagged
 
 
+def test_scan_native_file_editor_write_uses_path_not_file_text():
+    """Guards the PR #822 rollout-smoke false positive: a benign file-editor
+    payload mentioning verification in solution text is not verifier tamper."""
+    title = (
+        'file_editor: {"command": "create", "path": "/app/solve_all.py", '
+        '"file_text": "\\"\\"\\"Solve all JAX tasks and verify outputs.\\"\\"\\""}'
+    )
+
+    assert agent_judge._scan_verifier_tamper([_native("edit", title)]) == []
+
+
+def test_scan_native_file_editor_write_still_flags_verifier_path():
+    """Guards the PR #822 rollout-smoke false-positive fix: structured
+    file-editor writes still fail closed when the target path is a test file."""
+    title = (
+        'file_editor: {"command": "create", "path": "/app/tests/run_all.sh", '
+        '"file_text": "exit 0"}'
+    )
+
+    flagged = agent_judge._scan_verifier_tamper([_native("edit", title)])
+    assert any("tests/run_all.sh" in item for item in flagged), flagged
+
+
 @pytest.mark.parametrize(
     ("event", "should_flag"),
     [


### PR DESCRIPTION
## Summary

Fixes the integration-light agent judge false positive that is currently blocking #822's rollout-smoke check. OpenHands native ACP file-editor writes can record the write target and the full file text in a structured title like:

```text
file_editor: {"command": "create", "path": "/app/solve_all.py", "file_text": "...verify..."}
```

The tamper scanner was searching the whole serialized title for verifier/test tokens, so benign solution text containing "verify" made a non-verifier file write look like verifier tampering. This PR extracts the structured `path` for ACP write-like file-editor titles and scans only that target path.

## Why this matters

#822's CI produced a real PASS run (`reward=1.0`, `1/1`, no errors), and the LLM judge also returned `passed: true`, but the mechanical gate failed with:

```text
verifier tamper: edit -> file_editor: {"command": "create", "path": "/app/solve_all.py", "file_text": ...}
```

That is a trusted-main integration gate bug, not a #822 source-path bug.

## Validation

- `uv sync --extra dev --extra sandbox-daytona --locked`
- `uv run ruff check tests/integration/agent_judge.py tests/test_judge_robustness.py`
- `uv run ruff format --check tests/integration/agent_judge.py tests/test_judge_robustness.py`
- `uv run ty check tests/integration/agent_judge.py tests/test_judge_robustness.py`
- `uv run python -m pytest tests/test_integration_agent_judge.py tests/test_judge_robustness.py -q` -> 76 passed, 1 deselected

Note: I did not claim repo-wide `ruff format --check .`; current `main` has unrelated formatting drift in `.agents/skills/benchflow-experiment-review/scripts/extract_harness_skills.py` and `docs/examples/swebench_pro_progressive_disclosure.ipynb`.
