### PR TITLE
fix(integration): audit summaryless result roots

### DIFF
--- a/tests/integration/check_results.py
+++ b/tests/integration/check_results.py
@@ -1173,9 +1173,19 @@ def check_agent(agent_dir: Path) -> dict:
 
 def _is_rollout_artifact_root(path: Path) -> bool:
     """Return True when *path* is one completed bench eval artifact root."""
-    if not (path / "summary.json").is_file():
+    if (path / "summary.json").is_file():
+        return any(path.rglob("result.json"))
+    # Failed/interrupted runs may have task rollout directories with result.json
+    # diagnostics but no summary.json. Treat that run directory as an artifact
+    # root so the existing result diagnostics are still audited; the missing
+    # summary remains a normal finding.
+    try:
+        return any(
+            child.is_dir() and (child / "result.json").is_file()
+            for child in path.iterdir()
+        )
+    except OSError:
         return False
-    return any(path.rglob("result.json"))
 
 
 def discover_agent_dirs(jobs_root: Path, agents: list[str] | None) -> list[Path]:

--- a/tests/test_integration_check_results.py
+++ b/tests/test_integration_check_results.py
@@ -1424,6 +1424,48 @@ def test_check_results_cli_accepts_single_rollout_artifact_root(
     assert findings["total"] == 1
 
 
+def test_check_results_audits_summaryless_run_root_with_result_diagnostics(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #824: summary-less failed run roots still surface result diagnostics."""
+    run_root = tmp_path / "2026-05-25__11-51-47"
+    task_dir = run_root / "weighted-gdp-calc__775466b0"
+    task_dir.mkdir(parents=True)
+    source = _source("weighted-gdp-calc")
+    (task_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "weighted-gdp-calc",
+                "agent": "opencode",
+                "model": "test-model",
+                "rewards": {"reward": None},
+                "error": "ACP transport closed",
+                "error_category": "pipe_closed",
+                "transport_error_info": {
+                    "reason": "transport_closed",
+                    "transport_diagnosis": "remote_session_killed",
+                    "sandbox_reachable": True,
+                    "sandbox_probe_rc": 0,
+                },
+                "verifier_error": None,
+                "source": source,
+            }
+        )
+    )
+    _write_config(task_dir, source, agent="opencode")
+    (run_root / "weighted-gdp-calc__80d7cd55").mkdir()
+
+    assert result_checker.discover_agent_dirs(run_root, None) == [run_root]
+
+    findings = check_agent(run_root)
+
+    assert findings["total"] == 1
+    assert findings["ok"] is False
+    assert any("summary.json not found" in issue for issue in findings["issues"])
+    assert any("lost ACP transport" in issue for issue in findings["issues"])
+    assert "no result.json files" not in findings["issues"]
+
+
 def test_check_results_cli_requires_expected_identity_for_artifact_root(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #556. `tests/integration/check_results.py` now treats a summary-less run directory as an artifact root when its immediate child task rollout directories contain `result.json` files.

Previously, a failed/interrupted timestamped run like:

```text
2026-05-25__11-51-47/
  weighted-gdp-calc__775466b0/result.json
  weighted-gdp-calc__80d7cd55/
```

was discovered as separate child "agent" directories, so the checker reported `no result.json files` and hid the useful `pipe_closed` / `transport_error_info` diagnostic already present in the result. With this change, the run root is audited directly, result diagnostics surface, and the missing `summary.json` is still reported as a normal issue.

## Validation

- `uv run python -m pytest tests/test_integration_check_results.py::test_check_results_audits_summaryless_run_root_with_result_diagnostics -q` -> 1 passed
- `uv run python -m pytest tests/test_integration_check_results.py -q` -> 63 passed
- `uv run ruff check tests/integration/check_results.py tests/test_integration_check_results.py`
- `uv run ruff format --check tests/integration/check_results.py tests/test_integration_check_results.py`
- `uv run ty check tests/integration/check_results.py`

Note: `ty check tests/test_integration_check_results.py` has a pre-existing helper annotation diagnostic unrelated to this change (`_write_config(model=...)` receives an object-typed test parameter). The touched production integration checker passes `ty`.
