### PR TITLE
fix(deps): require anyio>=4.10 so the daytona SDK imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,9 @@ keywords = ["benchmark", "llm-agents", "acp", "agent-evaluation", "multi-turn", 
 dependencies = [
     "agent-client-protocol>=0.10",
     "httpx>=0.27.0",
-    # httpx-ws (transitive via the daytona SDK) needs anyio>=4.9 for
-    # AsyncContextManagerMixin; anyio 4.8 makes the daytona SDK un-importable.
-    "anyio>=4.9",
+    # httpx-ws (transitive via the daytona SDK) needs anyio>=4.10 for
+    # AsyncContextManagerMixin; older anyio makes the daytona SDK un-importable.
+    "anyio>=4.10",
     "pydantic>=2.7",
     "pyyaml>=6.0",
     "rich>=13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,9 @@ keywords = ["benchmark", "llm-agents", "acp", "agent-evaluation", "multi-turn", 
 dependencies = [
     "agent-client-protocol>=0.10",
     "httpx>=0.27.0",
-    "anyio>=4.0",
+    # httpx-ws (transitive via the daytona SDK) needs anyio>=4.9 for
+    # AsyncContextManagerMixin; anyio 4.8 makes the daytona SDK un-importable.
+    "anyio>=4.9",
     "pydantic>=2.7",
     "pyyaml>=6.0",
     "rich>=13.0",

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ sandbox-modal = [
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.10" },
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
-    { name = "anyio", specifier = ">=4.9" },
+    { name = "anyio", specifier = ">=4.10" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40" },
     { name = "cua-sandbox", marker = "python_full_version < '3.14' and extra == 'sandbox-cua'", specifier = ">=0.1.16" },
     { name = "cua-train", marker = "extra == 'sandbox-cua-cloud'", specifier = ">=0.1.0", index = "https://wheels.cua.ai/simple/" },

--- a/uv.lock
+++ b/uv.lock
@@ -200,16 +200,15 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.8.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "idna" },
-    { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126, upload-time = "2025-01-05T13:13:11.095Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041, upload-time = "2025-01-05T13:13:07.985Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
 ]
 
 [[package]]
@@ -417,7 +416,7 @@ sandbox-modal = [
 requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.10" },
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
-    { name = "anyio", specifier = ">=4.0" },
+    { name = "anyio", specifier = ">=4.9" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40" },
     { name = "cua-sandbox", marker = "python_full_version < '3.14' and extra == 'sandbox-cua'", specifier = ">=0.1.16" },
     { name = "cua-train", marker = "extra == 'sandbox-cua-cloud'", specifier = ">=0.1.0", index = "https://wheels.cua.ai/simple/" },


### PR DESCRIPTION
## Problem
`httpx-ws` (a transitive dep of the **daytona SDK**) needs `anyio.AsyncContextManagerMixin`, which was added in **anyio 4.9**. The lock pinned **anyio 4.8.0**, so on `release/0.7`:

```
>>> from daytona import Daytona
AttributeError: module 'anyio' has no attribute 'AsyncContextManagerMixin'
```

This breaks **all live Daytona sandbox use** whenever the `sandbox-daytona` extra is installed — i.e. every Daytona-backed eval on `release/0.7`.

## Fix
- Bump the floor `anyio>=4.0` → `anyio>=4.9`.
- Refresh the lock surgically (`uv lock --upgrade-package anyio`): anyio **4.8.0 → 4.14.0** (also drops the now-unneeded `sniffio` sub-dep). No other packages move.

## Verification
With `sandbox-daytona` synced:
- `from daytona import Daytona` ✅
- `import benchflow` ✅

## Notes
- Diff is minimal: `pyproject.toml` (specifier) + `uv.lock` (anyio stanza only).
- `main` is affected identically (also locks anyio 4.8.0) and can cherry-pick this commit.
- Extracted from the unpushed `chore/0.7-strip-shapes` branch, where this fix was bundled inside a larger OSWorld-evaluator commit; split out here so it can land independently.