### PR TITLE
fix(pi): avoid context-window retry storms

### DIFF
--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -24,7 +24,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-
 TOKEN_KEYS = {
     "input_tokens",
     "output_tokens",
@@ -109,9 +108,12 @@ def has_token_usage(value: Any) -> bool:
     for obj in iter_dicts(value):
         for key in TOKEN_KEYS:
             token_value = obj.get(key)
-            if isinstance(token_value, (int, float)) and not isinstance(token_value, bool):
-                if token_value > 0:
-                    return True
+            if (
+                isinstance(token_value, (int, float))
+                and not isinstance(token_value, bool)
+                and token_value > 0
+            ):
+                return True
     return False
 
 

--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -22,6 +22,16 @@ PROVIDER_AUTH = "provider_auth"
 # self-surfacing throttle self-heals on backoff. The two paths track genuinely
 # different failure shapes, so the differing retry verdicts are intentional.
 PROVIDER_RATE_LIMIT = "provider_rate_limit"
+# A provider *rejected* the request (HTTP 400) and it surfaced as a *raised*
+# ``AgentProtocolError -32603`` sanitized at the ACP boundary
+# (``_classify_acp_error``). The canonical case is a context-window/token-budget
+# overflow (issue #830): the prompt + completion cap exceeds the model's context,
+# which is deterministic and futile to retry in-batch. Like ``provider_auth`` it
+# is permanent — no retry branch + listed in ``RetryConfig.exclude_categories``.
+# A 400 that instead surfaces post-rollout (every captured request failed, zero
+# tokens) is classified by ``_maybe_classify_api_error`` as
+# ``api_error[rejected_request/permanent]`` and is already non-retryable.
+PROVIDER_REJECTED = "provider_rejected"
 TIMED_OUT = "timeout"
 # Provider API failures detected post-rollout (rate limit, quota, rejected
 # request, 5xx). "api_error" is proxy-proven (every captured provider request
@@ -59,6 +69,13 @@ _PROVIDER_RATE_LIMIT_MARKERS = (
 _PROVIDER_UNAVAILABLE_MARKERS = (
     "provider unavailable",
     "http 503",
+)
+# Sanitized marker appended by ``_classify_acp_error`` when a raised ACP error
+# hides a provider request rejection (400) — most commonly a context-window
+# overflow (#830). Matched case-insensitively, same as the markers above.
+_PROVIDER_REJECTED_MARKERS = (
+    "provider rejected request",
+    "http 400",
 )
 
 # Verifier error category constants
@@ -117,6 +134,8 @@ def classify_error(error: str | None) -> str | None:
             return PROVIDER_RATE_LIMIT
         if any(m in lower for m in _PROVIDER_UNAVAILABLE_MARKERS):
             return INFRA_ERROR
+        if any(m in lower for m in _PROVIDER_REJECTED_MARKERS):
+            return PROVIDER_REJECTED
         return ACP_ERROR
     if "sandbox startup" in lower or "sandbox creation" in lower:
         return SANDBOX_SETUP

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -18,7 +18,7 @@ from pathlib import Path
 # Pi model-metadata defaults if neither the provider registry nor per-run
 # overrides supply values. Conservative — most modern models exceed these.
 _DEFAULT_CONTEXT_WINDOW = 128000
-_DEFAULT_MAX_TOKENS = 16384
+_DEFAULT_MAX_TOKENS_CAP = 4096
 _BENCHFLOW_BIN_DIR = "/opt/benchflow/bin"
 _PI_ACP_BIN = "/opt/benchflow/bin/pi-acp"
 
@@ -45,6 +45,27 @@ def _derive_provider_name(model: str) -> str:
     return f"benchflow-{model}" if model else "benchflow-custom"
 
 
+def _positive_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str | bytes | bytearray):
+        try:
+            parsed = int(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _default_max_tokens(context_window: object) -> int:
+    """Return a fallback completion cap that leaves prompt budget available."""
+    window = _positive_int(context_window) or _DEFAULT_CONTEXT_WINDOW
+    return max(1, min(_DEFAULT_MAX_TOKENS_CAP, window // 4))
+
+
 def setup_provider() -> None:
     """Configure Pi for the detected provider protocol."""
     protocol = os.environ.get("BENCHFLOW_PROVIDER_PROTOCOL", "")
@@ -66,6 +87,10 @@ def setup_provider() -> None:
         # Register the provider so Pi routes API calls through the OpenAI
         # Chat Completions wire format instead of Anthropic Messages.
         meta = _lookup_model_metadata(model)
+        context_window = meta.get("contextWindow", _DEFAULT_CONTEXT_WINDOW)
+        max_tokens = meta.get("maxTokens")
+        if max_tokens is None:
+            max_tokens = _default_max_tokens(context_window)
         config = {
             "providers": {
                 provider_name: {
@@ -78,10 +103,8 @@ def setup_provider() -> None:
                             "name": meta.get("name", model),
                             "reasoning": meta.get("reasoning", False),
                             "input": meta.get("input", ["text"]),
-                            "contextWindow": meta.get(
-                                "contextWindow", _DEFAULT_CONTEXT_WINDOW
-                            ),
-                            "maxTokens": meta.get("maxTokens", _DEFAULT_MAX_TOKENS),
+                            "contextWindow": context_window,
+                            "maxTokens": max_tokens,
                         }
                     ],
                 }

--- a/src/benchflow/agents/pi_acp_launcher.py
+++ b/src/benchflow/agents/pi_acp_launcher.py
@@ -50,6 +50,10 @@ def _positive_int(value: object) -> int | None:
         return None
     if isinstance(value, int):
         parsed = value
+    elif isinstance(value, float):
+        if not value.is_integer():
+            return None
+        parsed = int(value)
     elif isinstance(value, str | bytes | bytearray):
         try:
             parsed = int(value)

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -52,6 +52,7 @@ from benchflow._utils.scoring import (
     PIPE_CLOSED,
     PROVIDER_AUTH,
     PROVIDER_RATE_LIMIT,
+    PROVIDER_REJECTED,
     SUSPECTED_API_ERROR,
     VERIFIER_DEP_INSTALL,
     VERIFIER_INFRA,
@@ -195,7 +196,12 @@ class RetryConfig:
     min_wait_sec: float = 1.0
     max_wait_sec: float = 30.0
     exclude_categories: set[str] = field(
-        default_factory=lambda: {"timeout", PROVIDER_AUTH, PROVIDER_RATE_LIMIT}
+        default_factory=lambda: {
+            "timeout",
+            PROVIDER_AUTH,
+            PROVIDER_RATE_LIMIT,
+            PROVIDER_REJECTED,
+        }
     )
 
     @classmethod

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -386,6 +386,13 @@ def litellm_proxy_config(
     return {
         "model_list": model_list,
         "general_settings": {"master_key": master_key},
+        "router_settings": {
+            # BenchFlow owns task-level retry classification. Keep LiteLLM from
+            # multiplying deterministic provider rejects into proxy-local retry
+            # storms or deployment cooldown fast-fails (#830).
+            "num_retries": 0,
+            "disable_cooldowns": True,
+        },
         "litellm_settings": {
             "callbacks": [f"{callback_module}.proxy_handler_instance"],
             "drop_params": True,

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -16,7 +16,7 @@ from benchflow.trajectories.types import (
 from benchflow.usage_tracking import usage_unavailable
 
 _PROVIDER_AUTH_STATUS_CODES = (401, 403)
-_PROVIDER_FAILURE_STATUS_CODES = (*_PROVIDER_AUTH_STATUS_CODES, 429, 503)
+_PROVIDER_FAILURE_STATUS_CODES = (400, 401, 402, 403, 404, 408, 422, 429, 500, 503)
 _STATUS_KEYS = {
     "httpstatus",
     "httpstatuscode",
@@ -58,6 +58,18 @@ _PROVIDER_UNAVAILABLE_HINT_RE = re.compile(
     r"temporarily unavailable|"
     r"overloaded|"
     r"upstream unavailable"
+    r")\b",
+    re.IGNORECASE,
+)
+_CONTEXT_LIMIT_HINT_RE = re.compile(
+    r"\b("
+    r"context[-_ ]?(?:length|window)|"
+    r"context_length_exceeded|"
+    r"contextwindowexceeded|"
+    r"max(?:imum)?[_ -]?model[_ -]?len|"
+    r"prompt is too long|"
+    r"requested token count exceeds|"
+    r"maximum context"
     r")\b",
     re.IGNORECASE,
 )
@@ -300,7 +312,25 @@ def _flatten_failure_text(value: Any) -> str:
     return str(value)
 
 
+def _flatten_context_traceback_text(value: Any) -> str:
+    if isinstance(value, dict):
+        parts: list[str] = []
+        for key, nested in value.items():
+            if str(key).lower() == "traceback":
+                parts.append(str(nested))
+            else:
+                nested_text = _flatten_context_traceback_text(nested)
+                if nested_text:
+                    parts.append(nested_text)
+        return " ".join(parts)
+    if isinstance(value, list | tuple):
+        return " ".join(_flatten_context_traceback_text(item) for item in value)
+    return ""
+
+
 def _text_provider_failure_status(text: str) -> int | None:
+    if _CONTEXT_LIMIT_HINT_RE.search(text):
+        return 400
     match = _PROVIDER_FAILURE_STATUS_RE.search(text)
     status = int(match.group(1)) if match is not None else None
     if status in _PROVIDER_AUTH_STATUS_CODES:
@@ -324,11 +354,18 @@ def _provider_failure_status_from_failure_record(record: dict[str, Any]) -> int 
         "error": record.get("error"),
         "response": record.get("response"),
     }
+    text = _flatten_failure_text(failure_payload)
+    if _CONTEXT_LIMIT_HINT_RE.search(text):
+        return 400
+
+    traceback_text = _flatten_context_traceback_text(failure_payload)
+    if _CONTEXT_LIMIT_HINT_RE.search(traceback_text):
+        return 400
+
     status = _explicit_provider_failure_status(failure_payload)
     if status is not None:
         return status
 
-    text = _flatten_failure_text(failure_payload)
     return _text_provider_failure_status(text)
 
 

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -29,6 +29,9 @@ _STATUS_KEYS = {
     "response_status",
     "response_status_code",
 }
+# Keep free-text matching narrower than structured status-code handling. Broad
+# codes like 400 or 500 are too common in tracebacks and payload snippets to infer
+# provider failure unless they arrive through a real status field.
 _PROVIDER_FAILURE_STATUS_RE = re.compile(r"\b(401|403|429|503)\b")
 _PROVIDER_AUTH_HINT_RE = re.compile(
     r"\b("

--- a/src/benchflow/rollout/_usage.py
+++ b/src/benchflow/rollout/_usage.py
@@ -28,6 +28,7 @@ class ProviderFailure:
 
 
 _PROVIDER_FAILURES: dict[int, ProviderFailure] = {
+    400: ProviderFailure(400, "provider rejected request"),
     401: ProviderFailure(401, "provider auth failed"),
     403: ProviderFailure(403, "provider auth failed"),
     429: ProviderFailure(429, "provider rate limited"),

--- a/tests/test_api_error_capture.py
+++ b/tests/test_api_error_capture.py
@@ -78,6 +78,18 @@ class TestStatusSubcategory:
         assert _api_error_subcategory(400) == ("rejected_request", False)
         assert _api_error_subcategory(422) == ("rejected_request", False)
 
+    def test_context_length_imported_as_400_is_permanent(self):
+        """Guards issue #830: imported context-window rejects are not retried."""
+        summary = _provider_api_failure_summary_from_runtime(_runtime([400]))
+
+        assert summary is not None
+        assert summary["subcategory"] == "rejected_request"
+        assert summary["transient"] is False
+        assert summary["fingerprint"] == "rejected_request:400"
+        assert not api_error_is_transient(
+            "provider api error [rejected_request/permanent] HTTP 400"
+        )
+
 
 class TestFailureSummary:
     def test_none_without_exchanges(self):

--- a/tests/test_eval_worker_retry.py
+++ b/tests/test_eval_worker_retry.py
@@ -17,6 +17,17 @@ _PROVIDER_AUTH_ERROR = (
 _PROVIDER_RATE_LIMIT_ERROR = (
     "ACP error -32603: Internal error | provider rate limited (HTTP 429)"
 )
+_PROVIDER_REJECTED_ERROR = (
+    "ACP error -32603: Internal error | provider rejected request (HTTP 400)"
+)
+
+
+def test_from_mapping_omitted_exclude_excludes_provider_rejected():
+    """Guards #830: a context-window 400 raised as an ACP error must not retry,
+    even when the payload omits exclude_categories (falls back to defaults)."""
+    cfg = RetryConfig.from_mapping({"max_retries": 3})
+    assert not cfg.should_retry(_PROVIDER_REJECTED_ERROR)
+    assert "provider_rejected" in cfg.exclude_categories
 
 
 def test_from_mapping_omitted_exclude_keeps_provider_auth():

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -119,6 +119,10 @@ def test_proxy_config_registers_plain_and_openai_aliases():
     assert config["litellm_settings"]["callbacks"] == [
         "benchflow_litellm_callback.proxy_handler_instance"
     ]
+    assert config["router_settings"] == {
+        "num_retries": 0,
+        "disable_cooldowns": True,
+    }
 
 
 def test_proxy_config_registers_requested_bare_model_name():

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -119,3 +119,31 @@ def test_litellm_failure_records_become_error_exchanges():
     assert trajectory.exchanges[0].response.body["error"]["message"] == "bad key"
     usage = extract_usage_from_trajectory(trajectory, fallback_model="openai/gpt-4")
     assert usage["usage_source"] == "unavailable"
+
+
+def test_context_length_failure_imports_as_permanent_rejected_request():
+    """Guards issue #830: context-window failures must not look like 500s."""
+    record = {
+        "event": "failure",
+        "request_model": "benchflow-qwen",
+        "request": {"method": "POST", "path": "/v1/chat/completions", "body": {}},
+        "error": {
+            "type": "NoneType",
+            "message": "None",
+            "traceback": (
+                "litellm.exceptions.BadRequestError: OpenAIException - Requested "
+                "token count exceeds the model's maximum context length of "
+                "16384 tokens."
+            ),
+        },
+        "start_time": "2026-06-04T10:00:00",
+        "end_time": "2026-06-04T10:00:00",
+    }
+
+    trajectory = trajectory_from_litellm_callback_log(
+        json.dumps(record),
+        session_id="session",
+        agent_name="pi-acp",
+    )
+
+    assert trajectory.exchanges[0].response.status_code == 400

--- a/tests/test_pi_acp_launcher.py
+++ b/tests/test_pi_acp_launcher.py
@@ -255,6 +255,9 @@ class TestSetupProviderModelMetadata:
                 )
 
     def test_defaults_when_provider_models_absent(self, monkeypatch, tmp_path):
+        """Guards issue #829: unknown pi-acp models must not request the whole
+        completion budget of common 16k-context self-hosted models by default.
+        """
         monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
         monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost/v1")
         monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "mystery-model")
@@ -267,7 +270,29 @@ class TestSetupProviderModelMetadata:
         config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
         model_entry = config["providers"]["custom-vllm"]["models"][0]
         assert model_entry["contextWindow"] == 128000
-        assert model_entry["maxTokens"] == 16384
+        assert model_entry["maxTokens"] == 4096
+
+    def test_default_max_tokens_uses_context_window_when_metadata_lacks_cap(
+        self, monkeypatch, tmp_path
+    ):
+        """Guards issue #829: a 16k contextWindow fallback leaves prompt room."""
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_PROTOCOL", "openai-completions")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_BASE_URL", "http://localhost/v1")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_MODEL", "qwen35-2b-base")
+        monkeypatch.setenv("BENCHFLOW_PROVIDER_NAME", "vllm")
+        monkeypatch.setenv(
+            "BENCHFLOW_PROVIDER_MODELS",
+            json.dumps([{"id": "qwen35-2b-base", "contextWindow": 16384}]),
+        )
+
+        from benchflow.agents.pi_acp_launcher import setup_provider
+
+        setup_provider()
+
+        config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
+        model_entry = config["providers"]["vllm"]["models"][0]
+        assert model_entry["contextWindow"] == 16384
+        assert model_entry["maxTokens"] == 4096
 
     def test_lookup_model_metadata_corrupt_json_returns_empty(
         self, monkeypatch, tmp_path
@@ -286,7 +311,7 @@ class TestSetupProviderModelMetadata:
         config = json.loads((tmp_path / ".pi" / "agent" / "models.json").read_text())
         entry = config["providers"]["custom-vllm"]["models"][0]
         assert entry["contextWindow"] == 128000
-        assert entry["maxTokens"] == 16384
+        assert entry["maxTokens"] == 4096
 
 
 @pytest.mark.usefixtures("_pi_env")

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -64,6 +64,17 @@ def test_no_auth_status_when_all_ok():
     )
 
 
+def test_detects_400_rejected_in_trajectory():
+    """Guards #830: a provider 400 (context-window/token-budget reject) is
+    surfaced as a sanitized permanent failure, not an auth status."""
+    failure = _provider_failure_from_runtime(_runtime_with_statuses([200, 400]))
+    assert failure is not None
+    assert failure.status == 400
+    assert failure.marker == "provider rejected request"
+    # 400 is a rejection, not an auth failure — must not masquerade as 401/403.
+    assert _provider_auth_status_from_runtime(_runtime_with_statuses([400])) is None
+
+
 def test_missing_runtime_is_safe():
     """No proxy runtime (e.g. oracle runs) must not raise — returns None."""
     assert _provider_auth_status_from_runtime(None) is None

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -138,6 +138,16 @@ class TestClassifyError:
             == "infra_failure"
         )
 
+    def test_provider_rejected_marker_is_permanent(self):
+        """Guards #830: a context-window 400 surfaced as a raised ACP error
+        classifies as provider_rejected (permanent), not generic acp_error."""
+        assert (
+            classify_error(
+                "ACP error -32603: Internal error | provider rejected request (HTTP 400)"
+            )
+            == "provider_rejected"
+        )
+
     def test_generic_acp_internal_error_still_retryable(self):
         """Guards PR #564: a bare ACP internal error with no auth signal stays
         acp_error — only a real surfaced 401/403 should flip it to provider_auth."""


### PR DESCRIPTION
## Summary

Fixes #829.
Refs #830 (partial — implements suggested fix #1; preserving the proxy failure detail into `result.json` / keeping `stderr.log` on failure is intentionally left as a follow-up, so #830 stays open).

This patch handles the pi-acp/self-hosted 16k-context failure in two places:

1. pi-acp model metadata fallback no longer defaults unknown OpenAI-compatible models to `maxTokens=16384`. If provider metadata has no explicit `maxTokens`, BenchFlow now derives a conservative completion cap from `contextWindow` (`min(4096, contextWindow // 4)`), preserving any explicit registry/per-run value unchanged.
2. BenchFlow's LiteLLM proxy path no longer turns deterministic context-window rejects into transient retry storms. The generated proxy config sets `router_settings.num_retries=0` and `disable_cooldowns=true`, leaving retry ownership to BenchFlow's task-level classifier. The callback-log importer recognizes context-window/token-budget failures, including LiteLLM's `response_obj=None` traceback shape, as HTTP 400 `rejected_request/permanent` instead of fallback HTTP 500 `provider_error/transient`.

Also includes a lint-only cleanup in the checked-in `benchflow-experiment-review` validator so `ruff check .` stays green.

## Reproduction Before Fix

On clean `origin/main`:

```text
REPRO_829 {"contextWindow": 16384, "maxTokens": 16384, "overflows_16k": true, "prompt_plus_completion": 17964}
REPRO_830 {"fingerprint": "provider_error:500", "imported_status": 500, "subcategory": "provider_error", "transient": true}
```

## Verification After Fix

Patched repro:

```text
FIX_829 {"contextWindow": 16384, "maxTokens": 4096, "overflows_16k": false, "prompt_plus_completion": 5676}
FIX_830 {"fingerprint": "rejected_request:400", "imported_status": 400, "subcategory": "rejected_request", "transient": false}
```

Real local LiteLLM proxy e2e against a fake OpenAI-compatible upstream returning a context-length 400:

```text
E2E_LITELLM_CONTEXT_REJECT {
  "proxy_statuses": [400, 400],
  "upstream_post_hits": 2,
  "callback_exchanges": 2,
  "imported_statuses": [400, 400],
  "summary": {"fingerprint": "rejected_request:400", "subcategory": "rejected_request", "transient": false},
  "router_settings": {"disable_cooldowns": true, "num_retries": 0}
}
```

Local validation:

```text
uv sync --extra dev --extra sandbox-daytona --locked
uv run python -m pytest tests/test_pi_acp_launcher.py tests/test_litellm_logging.py tests/test_api_error_capture.py tests/test_litellm_config.py -q
# 62 passed
uv run python -m pytest tests/test_job.py tests/test_job_sequential_shared.py tests/test_litellm_runtime.py tests/test_litellm_hardening.py tests/test_provider_auth_detection.py -q
# 209 passed
uv run ruff check .
uv run ty check src
```

Note: local Docker daemon is not running on this Mac (`Cannot connect to the Docker daemon`), so the issue-specific e2e here uses the real local LiteLLM proxy and a fake OpenAI-compatible upstream rather than a Docker sandbox run.

