### PR TITLE
fix(acp): avoid empty agent log placeholders

### DIFF
--- a/src/benchflow/acp/container_transport.py
+++ b/src/benchflow/acp/container_transport.py
@@ -39,6 +39,13 @@ class ContainerTransport(Transport):
         """Start the agent process inside the sandbox."""
         if self._agent_log_path:
             self._agent_log_path.parent.mkdir(parents=True, exist_ok=True)
+            # Clear any stale log from a previous connect attempt. _connect_acp_session
+            # reuses the same agent/<agent>.txt path across retries (runtime.py), so a
+            # failed attempt that logged a non-protocol warning before raising would
+            # otherwise leave stale text behind when a later JSON-RPC-only retry succeeds
+            # (which never re-opens the file). Unlink rather than truncating so we keep
+            # the lazy-open contract: no empty placeholder for protocol-only runs.
+            self._agent_log_path.unlink(missing_ok=True)
         await self._cp.start(
             command=self._command,
             env=self._env,

--- a/src/benchflow/acp/container_transport.py
+++ b/src/benchflow/acp/container_transport.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from benchflow.sandbox.process import LiveProcess
 
@@ -33,14 +33,12 @@ class ContainerTransport(Transport):
         self._env = env or {}
         self._cwd = cwd
         self._agent_log_path = agent_log_path
-        self._agent_log_file = None
+        self._agent_log_file: TextIO | None = None
 
     async def start(self) -> None:
         """Start the agent process inside the sandbox."""
         if self._agent_log_path:
             self._agent_log_path.parent.mkdir(parents=True, exist_ok=True)
-            # File handle outlives this method — closed in stop(). noqa: SIM115
-            self._agent_log_file = open(self._agent_log_path, "w")  # noqa: SIM115
         await self._cp.start(
             command=self._command,
             env=self._env,
@@ -64,7 +62,9 @@ class ContainerTransport(Transport):
             if message is not None:
                 return message
             # Capture non-protocol output (agent debug logs, errors, warnings).
-            if self._agent_log_file:
+            if self._agent_log_path:
+                if self._agent_log_file is None:
+                    self._agent_log_file = self._agent_log_path.open("w")
                 self._agent_log_file.write(text + "\n")
                 self._agent_log_file.flush()
             logger.debug(f"Non-JSON-RPC from container agent: {text[:200]}")

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -513,6 +513,58 @@ class TestTransportProtocolFiltering:
         assert not agent_log.exists()
 
     @pytest.mark.asyncio
+    async def test_container_transport_clears_stale_log_on_retry(
+        self, tmp_path
+    ) -> None:
+        """Guards #535/PR#832: a failed connect attempt that logged a warning must
+        not leave stale text behind when a later JSON-RPC-only retry succeeds.
+
+        _connect_acp_session reuses the same agent/<agent>.txt path across retry
+        attempts, so start() must clear any stale log from a prior attempt.
+        """
+        agent_log = tmp_path / "agent" / "gemini.txt"
+
+        # Attempt 0: agent emits a non-protocol warning (captured to the log),
+        # then the connection "fails" (the caller discards the transport).
+        first_process = AsyncMock()
+        first_process.readline = AsyncMock(
+            side_effect=[
+                b"WARNING: provider hiccup\n",
+                b'{"jsonrpc": "2.0", "id": 1, "result": {"ok": true}}\n',
+            ]
+        )
+        first = ContainerTransport(
+            container_process=first_process,
+            command="agent acp",
+            agent_log_path=agent_log,
+        )
+        await first.start()
+        await asyncio.wait_for(first.receive(), timeout=5)
+        await first.close()
+        assert "provider hiccup" in agent_log.read_text()
+
+        # Attempt 1: a fresh transport on the SAME path, JSON-RPC only (no
+        # non-protocol output). start() must wipe the stale log.
+        second_process = AsyncMock()
+        second_process.readline = AsyncMock(
+            return_value=b'{"jsonrpc": "2.0", "id": 2, "result": {"ok": true}}\n'
+        )
+        second = ContainerTransport(
+            container_process=second_process,
+            command="agent acp",
+            agent_log_path=agent_log,
+        )
+        await second.start()
+        assert not agent_log.exists()
+        try:
+            msg = await asyncio.wait_for(second.receive(), timeout=5)
+        finally:
+            await second.close()
+        assert msg == {"jsonrpc": "2.0", "id": 2, "result": {"ok": True}}
+        # The successful retry never logged non-protocol output, so no stale text.
+        assert not agent_log.exists()
+
+    @pytest.mark.asyncio
     async def test_stdio_transport_skips_structured_json_logs(self) -> None:
         """Guards PR #236 against treating JSON object logs as ACP responses."""
         reader = asyncio.StreamReader()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -486,6 +486,33 @@ class TestTransportProtocolFiltering:
         assert '["debug", "list"]' in log_text
 
     @pytest.mark.asyncio
+    async def test_container_transport_does_not_create_empty_agent_log(
+        self, tmp_path
+    ) -> None:
+        """Guards PR #832's fix for issue #535 against empty ACP agent logs."""
+        fake_process = AsyncMock()
+        fake_process.readline = AsyncMock(
+            return_value=b'{"jsonrpc": "2.0", "id": 2, "result": {"ok": true}}\n'
+        )
+        agent_log = tmp_path / "agent" / "gemini.txt"
+        transport = ContainerTransport(
+            container_process=fake_process,
+            command="agent acp",
+            agent_log_path=agent_log,
+        )
+
+        await transport.start()
+        assert not agent_log.exists()
+
+        try:
+            msg = await asyncio.wait_for(transport.receive(), timeout=5)
+        finally:
+            await transport.close()
+
+        assert msg == {"jsonrpc": "2.0", "id": 2, "result": {"ok": True}}
+        assert not agent_log.exists()
+
+    @pytest.mark.asyncio
     async def test_stdio_transport_skips_structured_json_logs(self) -> None:
         """Guards PR #236 against treating JSON object logs as ACP responses."""
         reader = asyncio.StreamReader()


### PR DESCRIPTION
## Summary

Fixes #535.

ACP container transport used to create `<rollout>/agent/<agent>.txt` as soon as the agent process started, before seeing any non-protocol output. Normal ACP agents can communicate entirely through JSON-RPC, so runs like `gemini` produced a zero-byte `agent/gemini.txt` that looked like missing capture even though the structured ACP trajectory was healthy.

This change keeps the parent `agent/` directory creation, but opens the per-agent text log lazily only when `ContainerTransport.receive()` sees non-JSON/non-ACP output that actually needs to be captured. Existing debug/stderr capture behavior is preserved for non-protocol lines.

## Validation

```text
uv sync --extra dev --extra sandbox-daytona --locked
uv run python -m pytest tests/test_acp.py::TestTransportProtocolFiltering::test_container_transport_skips_json_scalars tests/test_acp.py::TestTransportProtocolFiltering::test_container_transport_does_not_create_empty_agent_log tests/test_acp.py::TestTransportProtocolFiltering::test_container_transport_logs_structured_json_logs -q
# 3 passed
uv run python -m pytest tests/test_acp.py -q
# 76 passed
uv run ruff check src/benchflow/acp/container_transport.py tests/test_acp.py
uv run ruff format --check src/benchflow/acp/container_transport.py tests/test_acp.py
uv run ty check src/benchflow/acp/container_transport.py
```
