### PR TITLE
fix(eval): surface provider failure cause and harden trajectory redaction

### DIFF
--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -129,6 +129,16 @@ def _usage_from_response(response: Any) -> Any:
     return None
 
 
+def _failure_detail(response_obj: Any, exception: Any) -> Any:
+    # On a deterministic provider reject (e.g. a context-window overflow,
+    # #830) litellm fires the failure hook with response_obj=None and the real
+    # cause in kwargs['exception']. Fall back to it so error.type/message carry
+    # the upstream reason instead of the literal 'NoneType'/'None'. A non-None
+    # response_obj still wins, so the existing success-shaped-failure path is
+    # unchanged; both None degrades gracefully to the old behavior.
+    return response_obj if response_obj is not None else exception
+
+
 class BenchFlowLiteLLMLogger(CustomLogger):
     def _write(self, payload: dict[str, Any]) -> None:
         path = os.environ.get("BENCHFLOW_LITELLM_LOG_PATH")
@@ -214,13 +224,14 @@ class BenchFlowLiteLLMLogger(CustomLogger):
 
     async def async_log_failure_event(self, kwargs, response_obj, start_time, end_time):
         record = self._base_record(kwargs, start_time, end_time)
+        detail = _failure_detail(response_obj, (kwargs or {}).get("exception"))
         record.update(
             {
                 "event": "failure",
                 "response": _jsonable(response_obj),
                 "error": {
-                    "type": type(response_obj).__name__,
-                    "message": str(response_obj),
+                    "type": type(detail).__name__,
+                    "message": str(detail),
                     "traceback": traceback.format_exc()[-2000:],
                 },
             }

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -173,15 +173,61 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
     )
 
 
-# Token families are redacted *whole* — prefix included — so the v0.5
-# secret-leak audit (which greps for raw prefixes like ``AIzaSy``/``dtn_``)
-# sees no live-key shape (#537/#585). Keeping the prefix (``AIzaSy***``) would
-# still trip that grep, so the entire matched token becomes ``***REDACTED***``.
+# Quote atom for the header/key-value carriers below: a run of 0-8 optional
+# backslashes followed by an optional quote. This makes every carrier fire on raw
+# text (``"k": "v"``), Python dict-repr (``'k': 'v'``), AND json.dumps-escaped
+# JSON at any nesting depth (``\"k\": \"v\"``, ``\\\"k\\\": …``) — the escaped
+# form is how a provider error body embedded in ``error.message`` reaches the
+# redactor after ``Trajectory.to_jsonl`` runs ``json.dumps`` over the record
+# before redacting it (#830). The ``{0,8}`` cap keeps it ReDoS-bounded.
+_ESCQ = r'\\{0,8}["\']?'
+# Secret value class for the carriers: stops at a quote (plain, or the backslash
+# of an escaped closing quote), whitespace, and the ``,`` ``}`` ``&`` delimiters
+# so a redacted value can never swallow a sibling JSON field or URL query param;
+# excludes ``*`` so an already-redacted value isn't re-matched.
+_SECVAL = r"[^\"'\s,}\\*&]+"
+# Name-prefix class for the env/JSON carriers, LENGTH-CAPPED. An uncapped
+# ``[A-Za-z0-9_]*`` before a required marker backtracks O(n²) on a long
+# alphanumeric run (e.g. a base64 image field), so a benign trajectory could
+# stall the redactor for tens of seconds. Real env-var/header names are short;
+# ``{0,64}`` makes each match attempt O(1) → overall O(n) (#830 ReDoS fix).
+_NAME = r"[A-Za-z0-9_]{0,64}"
+
 _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    # PEM private-key blocks (GCP/Vertex service-account JSON, RSA keys). Redact
+    # the whole armored block incl. the base64 body; the carriers below stop at
+    # the first space and would leave the key material. Lazy + length-capped body
+    # keeps it bounded (#830).
+    (
+        re.compile(
+            r"-----BEGIN [A-Z0-9 ]{0,40}PRIVATE KEY-----"
+            r"[\s\S]{0,8192}?"
+            r"-----END [A-Z0-9 ]{0,40}PRIVATE KEY-----"
+        ),
+        "***REDACTED***",
+    ),
+    # --- Token families: redacted WHOLE (prefix included) so the v0.5 leak audit
+    # greps (``AIzaSy``/``dtn_``…) see no live-key shape (#537/#585). ---
     # Anthropic: sk-ant-api03-...
     (re.compile(r"sk-ant-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
-    # OpenAI project key: sk-proj-...  (before generic sk- so it wins)
-    (re.compile(r"sk-proj-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
+    # BenchFlow proxy master key (sk-benchflow-<token_urlsafe(24)>), OpenAI service
+    # account (sk-svcacct-), OpenRouter (sk-or-v1-): rare labels that won't appear
+    # in a normal kebab slug, so the hyphen-permitting entropy class is safe here.
+    (
+        re.compile(r"sk-(?:benchflow|svcacct|or-v1)-[A-Za-z0-9_-]{12,}"),
+        "***REDACTED***",
+    ),
+    # OpenAI org-scoped sk-proj-/sk-admin-: `proj`/`admin` ARE common identifier
+    # words, so a bare hyphen class would redact kebab slugs like
+    # `sk-proj-refactor-auth`. Real keys are high-entropy base64url and always
+    # carry an uppercase char; gate on a lookahead for one so lowercase slugs
+    # survive (#830). Before generic sk- so it wins.
+    (
+        re.compile(
+            r"sk-(?:proj|admin)-(?=[A-Za-z0-9_-]{0,200}[A-Z])[A-Za-z0-9_-]{12,}"
+        ),
+        "***REDACTED***",
+    ),
     # OpenAI / generic sk- (alphanumeric only — widening to include `-` would
     # match common slugs like `task-sk-us-east-1-...`)
     (re.compile(r"sk-[a-zA-Z0-9]{12,}"), "***REDACTED***"),
@@ -199,43 +245,133 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "***REDACTED***"),
     # Slack tokens: bot/user/app/refresh/legacy (xoxb-/xoxp-/xoxa-/xoxr-/xoxs-).
     (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "***REDACTED***"),
-    # Header / key-value secret carriers, in BOTH JSON and raw-text forms
-    # (agents print env, curl -v, request logs into trajectories — #585).
-    # Matches: `"x-api-key": "v"`, `x-api-key: v`, `api-key=v`,
-    # `authorization: <scheme> v`, etc. The name is kept; the value is dropped.
-    # Hyphenated header names (x-api-key / api-key / x-goog-api-key). No leading
-    # boundary needed — the hyphen makes them safe from matching inside
-    # underscore variable names. Value excludes backslash so a literal
-    # JSON-escaped `\n` after one secret can't swallow the next header, and
-    # excludes `*` so an already-redacted value isn't re-matched.
+    # Other provider key families with distinctive prefixes — caught here for the
+    # bare-token-in-prose form that no NAME=value carrier sees (a provider
+    # exception that echoes the key). Groq gsk_, xAI xai-, Replicate r8_,
+    # HuggingFace hf_, Fireworks fw_. ≥20-char anchors avoid short ids (#830).
+    (re.compile(r"gsk_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"xai-[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"r8_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"hf_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"fw_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    # JSON Web Tokens (session/bearer creds): three base64url segments split by
+    # dots. The ``eyJ`` prefix is base64url of ``{"`` — a JWT header. The 3rd
+    # (signature) segment requires ≥20 chars (real HS256/RS256 sigs are 43+) so
+    # short dotted base64/method-chains that merely start ``eyJ`` aren't redacted;
+    # a left boundary keeps it from starting mid-identifier. Segment upper bounds
+    # keep it ReDoS-bounded (#830).
     (
         re.compile(
-            r'((?:"?(?:x-api-key|x-goog-api-key|api-key)"?)\s*[:=]\s*"?)'
-            r'[^"\s,}\\*]+',
+            r"(?<![A-Za-z0-9_-])"
+            r"eyJ[A-Za-z0-9_-]{10,512}\.[A-Za-z0-9_-]{6,512}\.[A-Za-z0-9_-]{20,512}"
+        ),
+        "***REDACTED***",
+    ),
+    # --- URL credentials ---
+    # Credentials in a URL's userinfo (scheme://user:pass@host) for KNOWN
+    # credential-bearing schemes (http/db/cache/mq) — a generic scheme class would
+    # scrub bespoke app deep-links (vscode://a:b@…). Drop the whole userinfo; keep
+    # scheme + host. The username class excludes `:` so it stops deterministically
+    # at the password separator (no catastrophic backtracking), both classes
+    # exclude `?`/`#` so the match can't span into a query string and grab an `@`
+    # from an email param, and the password may contain `@` so an un-encoded `@` in
+    # the password is fully scrubbed (greedy to the last `@`). Length caps keep it
+    # ReDoS-bounded. A plain host:port (no `@`) is untouched (#830).
+    (
+        re.compile(
+            r"((?:https?|ftp|ftps|postgres|postgresql|mysql|mongodb(?:\+srv)?|"
+            r"redis|rediss|amqp|amqps)://)"
+            r"[^\s/?#:@]{0,256}:[^\s/?#]{0,256}@"
+        ),
+        r"\1***REDACTED***@",
+    ),
+    # Secrets carried as URL query params. Curated EXACT param names (anchored to
+    # `?`/`&` with `=` right after the name) so non-secret params (`?page=`,
+    # `?key=name`, `?author=`, `?auth=basic`) are untouched; the value stops at
+    # `&` so sibling params survive. Bare `key`/`token`/`auth` are intentionally
+    # excluded (too often a non-secret field/mode); so are bare `sig`/`pwd` (a
+    # signature-scheme version / a working-directory path). A real key value under
+    # `?key=` is still caught by its token-family pattern above. Includes AWS
+    # SigV4 / Azure SAS / access-key names. Placed BEFORE the carriers below so the
+    # `*token*` carrier can't over-consume the rest of the query string past `&`.
+    (
+        re.compile(
+            r"([?&](?:"
+            r"api_?key|access_key|access_token|refresh_token|session_token|"
+            r"session_id|sessionid|client_secret|aws_secret_access_key|account_key|"
+            r"secret|password_hash|password|passwd|"
+            r"signature|x-amz-signature|x-amz-credential|x-amz-security-token|sas"
+            r")=)[^&\s\"']+",
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+    # Azure SAS `?sig=<token>` — bare `sig` is excluded from the curated list above
+    # (a `?sig=v2` scheme-version flag is a common non-secret), so gate on a
+    # high-entropy value length: a real SAS signature is a 40+ char base64 HMAC,
+    # while a version flag is short (#830).
+    (
+        re.compile(r"([?&]sig=)[^&\s\"']{16,}", re.IGNORECASE),
+        r"\1***REDACTED***",
+    ),
+    # --- Header / key-value secret carriers ---
+    # Match `name: value` / `name=value` in raw, JSON, Python dict-repr
+    # (single-quoted), AND json.dumps-escaped (`\"name\": \"value\"`) forms — see
+    # _ESCQ. The name is kept; only the value is dropped (#585/#830). No leading
+    # boundary on the hyphenated header names — the hyphen keeps them from matching
+    # inside underscore variable names.
+    (
+        re.compile(
+            rf"((?:{_ESCQ}(?:x-api-key|x-goog-api-key|api-key){_ESCQ})\s*[:=]\s*{_ESCQ})"
+            rf"{_SECVAL}",
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
     ),
     # Underscore form `api_key`. No leading boundary: namespaced env dumps like
-    # `GEMINI_API_KEY=secret` / `AZURE_OPENAI_API_KEY=...` and JSON keys such as
-    # `"openai_api_key"` must redact too (#585). The `\1` capture preserves the
-    # whole matched name+separator, so the key name (e.g. `GEMINI_API_KEY=`) is
-    # kept and only the value is dropped — no over-redaction of the name.
+    # `GEMINI_API_KEY=secret` / JSON keys such as `"openai_api_key"` must redact
+    # too (#585). The `\1` capture preserves the matched name+separator.
     (
         re.compile(
-            r'("?api_key"?\s*[:=]\s*"?)[^"\s,}\\*]+',
+            rf"({_ESCQ}api_key{_ESCQ}\s*[:=]\s*{_ESCQ}){_SECVAL}", re.IGNORECASE
+        ),
+        r"\1***REDACTED***",
+    ),
+    # `master_key`/`master-key` and `private_key`/`private-key` carriers — the
+    # BenchFlow proxy master key and GCP/Vertex service-account private-key field
+    # as labelled values (the PEM body itself is scrubbed by the block rule above).
+    (
+        re.compile(
+            rf"({_ESCQ}(?:master|private)[_-]key{_ESCQ}\s*[:=]\s*{_ESCQ}){_SECVAL}",
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
     ),
-    # Generic *TOKEN* / *SECRET* carriers (e.g. GITHUB_TOKEN=, SLACK_SECRET:),
-    # closing the name-coverage gap vs config.json's _SECRET_ENV_SUBSTRINGS. The
-    # name is kept, the value dropped. Value excludes backslash and `*` like the
-    # api_key/authorization carriers so an escaped `\n` can't swallow the next
-    # entry and an already-redacted value isn't re-matched.
+    # Bearer-token env vars whose NAME has BEARER_TOKEN in the MIDDLE, e.g.
+    # `AWS_BEARER_TOKEN_BEDROCK=` — the secret-suffix rule below anchors its marker
+    # at the name end, so a TOKEN in the middle slips through. `BEARER_TOKEN` is an
+    # unambiguous secret signal, safe as a substring (#830). Names length-capped.
     (
         re.compile(
-            r'("?[A-Za-z0-9_]*(?:TOKEN|SECRET)"?\s*[:=]\s*"?)[^"\s,}\\*]+',
+            rf"(?<![A-Za-z0-9])"
+            rf"({_ESCQ}{_NAME}BEARER_TOKEN{_NAME}{_ESCQ}\s*[:=]\s*{_ESCQ}){_SECVAL}",
+            re.IGNORECASE,
+        ),
+        r"\1***REDACTED***",
+    ),
+    # Generic secret-NAME-suffix carriers: names ending in TOKEN/SECRET/PASSWORD or
+    # a specific *secret* key suffix (ACCESS_KEY/SECRET_KEY/ACCOUNT_KEY/…). The KEY
+    # forms are spelled out (NOT a bare `_KEY`) so common non-secret identifiers
+    # like `primary_key`/`foreign_key`/`sort_key` are NOT redacted, while
+    # `AWS_SECRET_ACCESS_KEY`/`AZURE_STORAGE_ACCOUNT_KEY` are. TOKEN/SECRET at the
+    # name end stay safe from `TOKENIZER`/`SECRETARY` (marker not at the end).
+    (
+        re.compile(
+            rf"(?<![A-Za-z0-9])({_ESCQ}{_NAME}"
+            r"(?:TOKEN|SECRET|PASSWORD|PASSWD|"
+            r"ACCESS_KEY|SECRET_KEY|ACCOUNT_KEY|PRIVATE_KEY|ENCRYPTION_KEY|"
+            r"CREDENTIALS?)"
+            rf"{_ESCQ}\s*[:=]\s*{_ESCQ}){_SECVAL}",
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
@@ -243,22 +379,19 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     # authorization header WITH a scheme (Bearer/Token/Basic/…): keep scheme.
     (
         re.compile(
-            r"(?<![A-Za-z0-9_-])"
-            r'("?authorization"?\s*[:=]\s*"?(?:Bearer|Token|Basic|ApiKey)\s+)'
-            r'[^"\s,}\\*]+',
+            rf"(?<![A-Za-z0-9_-])({_ESCQ}authorization{_ESCQ}\s*[:=]\s*{_ESCQ}"
+            rf"(?:Bearer|Token|Basic|ApiKey)\s+){_SECVAL}",
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
     ),
-    # authorization header with a bare value (no recognized scheme). The
-    # negative lookahead skips scheme-prefixed values already handled above,
-    # so `Bearer <tok>` isn't double-redacted into `***REDACTED*** ***...`.
+    # authorization header with a bare value (no recognized scheme). The negative
+    # lookahead skips scheme-prefixed values already handled above, so
+    # `Bearer <tok>` isn't double-redacted into `***REDACTED*** ***...`.
     (
         re.compile(
-            r"(?<![A-Za-z0-9_-])"
-            r'("?authorization"?\s*[:=]\s*"?)'
-            r"(?!(?:Bearer|Token|Basic|ApiKey)\b)"
-            r'[^"\s,}\\*]+',
+            rf"(?<![A-Za-z0-9_-])({_ESCQ}authorization{_ESCQ}\s*[:=]\s*{_ESCQ})"
+            rf"(?!(?:Bearer|Token|Basic|ApiKey)\b){_SECVAL}",
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -147,3 +147,69 @@ def test_context_length_failure_imports_as_permanent_rejected_request():
     )
 
     assert trajectory.exchanges[0].response.status_code == 400
+
+
+def _callback_namespace() -> dict:
+    """Exec the embedded callback module source so its helpers/classes can be
+    exercised directly — the source ships as a string (runs inside the proxy
+    process) and cannot be imported, so exec is the only faithful seam."""
+    namespace: dict = {}
+    exec(callback_module_source(), namespace)
+    return namespace
+
+
+_CONTEXT_CAUSE = (
+    "litellm.ContextWindowExceededError: OpenAIException - Requested token "
+    "count exceeds the model's maximum context length of 16384 tokens. You "
+    "requested a total of 17964 tokens: 1580 input + 16384 completion."
+)
+
+
+def test_failure_detail_prefers_exception_when_response_none():
+    """Guards issue #830 fix#2: when litellm fires the failure hook with
+    response_obj=None, the real cause in kwargs['exception'] must drive
+    error.type/message — not the literal 'None'/'NoneType'."""
+    _failure_detail = _callback_namespace()["_failure_detail"]
+    detail = _failure_detail(None, ValueError(_CONTEXT_CAUSE))
+    assert type(detail).__name__ == "ValueError"
+    assert "16384 tokens" in str(detail)
+
+
+def test_failure_detail_uses_response_when_present():
+    """No behavior change on the existing path: a non-None response_obj wins."""
+    _failure_detail = _callback_namespace()["_failure_detail"]
+    assert _failure_detail("boom", ValueError("ignored")) == "boom"
+
+
+def test_failure_detail_none_when_both_missing():
+    """Graceful degradation: no response and no exception stays the old 'None'."""
+    _failure_detail = _callback_namespace()["_failure_detail"]
+    assert _failure_detail(None, None) is None
+
+
+async def test_failure_event_records_exception_cause_when_response_none(
+    tmp_path, monkeypatch
+):
+    """End-to-end through the real write path: a context-window reject
+    (response_obj=None, cause in kwargs['exception']) lands a USABLE
+    error.message in the callback record, not 'None' (issue #830 fix#2)."""
+    from datetime import datetime
+
+    namespace = _callback_namespace()
+    logger = namespace["BenchFlowLiteLLMLogger"]()
+    log_path = tmp_path / "callback.jsonl"
+    monkeypatch.setenv("BENCHFLOW_LITELLM_LOG_PATH", str(log_path))
+
+    now = datetime.now()
+    await logger.async_log_failure_event(
+        {"model": "benchflow-qwen", "exception": ValueError(_CONTEXT_CAUSE)},
+        None,
+        now,
+        now,
+    )
+
+    record = json.loads(log_path.read_text().splitlines()[-1])
+    assert record["event"] == "failure"
+    assert record["error"]["type"] == "ValueError"
+    assert "16384 tokens" in record["error"]["message"]
+    assert record["error"]["message"] != "None"

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -394,3 +394,367 @@ def test_redacts_namespaced_api_key_env_vars(raw, leaked, kept_name):
     assert leaked not in result
     # The key name itself must survive (over-redaction guard).
     assert kept_name in result
+
+
+# Issue #830 fix#2: surfacing the upstream provider cause (Option A) routes the
+# FULL provider exception string into error.message for ALL failure types, so
+# redact_trajectory_text must cover the credential shapes that appear in real
+# provider error bodies. These vectors were all verified leaking before this fix
+# (adversarial review), across URL userinfo, query params, hyphenated key
+# families, and the json.dumps-escaped JSON that to_jsonl produces.
+
+# Split literals so the verbatim secret never appears in source (push protection).
+_FAKE_MASTER_KEY = "sk-" + "benchflow-" + "FAKEmasterKEYvalue1234567890abcd"
+_FAKE_SVCACCT = "sk-" + "svcacct-" + "T3BlbkFJFAKEsvcacct0123456789ab"
+_FAKE_ADMIN = "sk-" + "admin-" + "T3BlbkFJFAKEadminkey0123456789ab"
+_FAKE_OPENROUTER = "sk-" + "or-v1-" + "0123fakeOPENROUTER456789abcdef0123456789"
+_FAKE_URL_PW = "s3cret" + "P4sswordVALUE"
+_FAKE_DB_PW = "Db" + "Pr0dPassValue123"
+_FAKE_BEARER_TOK = "bearersecret" + "value1234567890"
+_FAKE_QUERY_SECRET = "GENERICQUERY" + "SECRETvalue12345"
+_FAKE_BEDROCK = "bedrocksecret" + "value123456"
+_FAKE_GSK = "gsk_" + "FAKEgroq0123456789ABCDEF01234567"
+_FAKE_XAI = "xai-" + "FAKExai0123456789ABCDEF012345678"
+_FAKE_R8 = "r8_" + "FAKErepl0123456789ABCDEF01234567"
+_FAKE_HF = "hf_" + "FAKEhugg0123456789ABCDEF01234567"
+_FAKE_FW = "fw_" + "FAKEfire0123456789ABCDEF01234567"
+_FAKE_JWT = (
+    "eyJ"
+    + "hbGciOiJIUzI1NiJ9"
+    + "."
+    + "eyJzdWIiOiIxMjM0NTY3ODkwIn0"
+    + "."
+    + "dQw4w9WgXcQfakeSIGNATURE12"
+)
+
+
+@pytest.mark.parametrize(
+    "label,raw,leaked,kept",
+    [
+        pytest.param(
+            "https userinfo (user:pass@host)",
+            f"connecting to https://admin:{_FAKE_URL_PW}@proxy.internal/v1",
+            _FAKE_URL_PW,
+            "proxy.internal",
+            id="url-userinfo-https",
+        ),
+        pytest.param(
+            "postgres userinfo (DSN in a failure body)",
+            f"could not connect: postgres://litellm:{_FAKE_DB_PW}@db.internal:5432/x",
+            _FAKE_DB_PW,
+            "db.internal",
+            id="url-userinfo-postgres",
+        ),
+        pytest.param(
+            "redis userinfo, empty username (:pass@)",
+            f"ConnectionError redis://:{_FAKE_DB_PW}@cache.prod:6379/0",
+            _FAKE_DB_PW,
+            "cache.prod",
+            id="url-userinfo-redis-emptyuser",
+        ),
+        pytest.param(
+            "benchflow master key (sk-benchflow- family)",
+            f'{{"master_key": "{_FAKE_MASTER_KEY}"}}',
+            "FAKEmasterKEYvalue1234567890abcd",
+            None,
+            id="sk-benchflow",
+        ),
+        pytest.param(
+            "OpenAI service-account key (sk-svcacct-)",
+            f"Incorrect API key provided: {_FAKE_SVCACCT}",
+            "T3BlbkFJFAKEsvcacct0123456789ab",
+            None,
+            id="sk-svcacct",
+        ),
+        pytest.param(
+            "OpenAI admin key (sk-admin-)",
+            f"AuthenticationError: {_FAKE_ADMIN}",
+            "T3BlbkFJFAKEadminkey0123456789ab",
+            None,
+            id="sk-admin",
+        ),
+        pytest.param(
+            "OpenRouter key (sk-or-v1-)",
+            f"OpenrouterException - invalid api key {_FAKE_OPENROUTER}",
+            "0123fakeOPENROUTER456789abcdef0123456789",
+            None,
+            id="sk-or-v1",
+        ),
+        pytest.param(
+            "master key inside a Bearer header",
+            f"Authorization: Bearer {_FAKE_MASTER_KEY}",
+            "FAKEmasterKEYvalue1234567890abcd",
+            "Bearer",
+            id="master-key-bearer",
+        ),
+        pytest.param(
+            "AWS_BEARER_TOKEN_BEDROCK env dump (TOKEN not at name end)",
+            f"AWS_BEARER_TOKEN_BEDROCK={_FAKE_BEDROCK} set",
+            _FAKE_BEDROCK,
+            "AWS_BEARER_TOKEN_BEDROCK",
+            id="bedrock-bearer-token",
+        ),
+        pytest.param(
+            "Python dict-repr single-quoted Authorization",
+            f"headers={{'Authorization': 'Bearer {_FAKE_BEARER_TOK}'}}",
+            _FAKE_BEARER_TOK,
+            "Bearer",
+            id="dict-repr-authorization",
+        ),
+        pytest.param(
+            "Python dict-repr single-quoted x-api-key",
+            f"headers={{'x-api-key': '{_FAKE_BEARER_TOK}'}}",
+            _FAKE_BEARER_TOK,
+            None,
+            id="dict-repr-x-api-key",
+        ),
+        pytest.param(
+            "secret in URL query param (?apikey=)",
+            f"GET https://api/v1/x?apikey={_FAKE_QUERY_SECRET}&page=2",
+            _FAKE_QUERY_SECRET,
+            "page=2",
+            id="query-apikey",
+        ),
+        pytest.param(
+            "secret in URL query param (?access_token=)",
+            f"https://api/v1/x?access_token={_FAKE_QUERY_SECRET}&z=1",
+            _FAKE_QUERY_SECRET,
+            "z=1",
+            id="query-access-token",
+        ),
+        pytest.param(
+            "Azure SAS signature (?sig=)",
+            f"blob fetch failed https://acct.blob/c/f?sv=2023-01-01&sig={_FAKE_QUERY_SECRET}&se=x",
+            _FAKE_QUERY_SECRET,
+            "sv=2023-01-01",
+            id="query-sas-sig",
+        ),
+        pytest.param(
+            "session id in query (?sessionid=)",
+            f"https://api?sessionid={_FAKE_QUERY_SECRET}&b=2",
+            _FAKE_QUERY_SECRET,
+            "b=2",
+            id="query-sessionid",
+        ),
+        pytest.param(
+            "Groq key (gsk_)",
+            f"groq AuthenticationError: {_FAKE_GSK}",
+            "FAKEgroq0123456789ABCDEF01234567",
+            None,
+            id="provider-gsk",
+        ),
+        pytest.param(
+            "xAI key (xai-)",
+            f"xai exception: {_FAKE_XAI}",
+            "FAKExai0123456789ABCDEF012345678",
+            None,
+            id="provider-xai",
+        ),
+        pytest.param(
+            "Replicate token (r8_)",
+            f"replicate 401: {_FAKE_R8}",
+            "FAKErepl0123456789ABCDEF01234567",
+            None,
+            id="provider-r8",
+        ),
+        pytest.param(
+            "HuggingFace token (hf_)",
+            f"hf inference error {_FAKE_HF}",
+            "FAKEhugg0123456789ABCDEF01234567",
+            None,
+            id="provider-hf",
+        ),
+        pytest.param(
+            "Fireworks key (fw_)",
+            f"fireworks auth fail {_FAKE_FW}",
+            "FAKEfire0123456789ABCDEF01234567",
+            None,
+            id="provider-fw",
+        ),
+        pytest.param(
+            "JWT session/bearer token",
+            f"token expired: {_FAKE_JWT}",
+            "dQw4w9WgXcQfakeSIGNATURE12",
+            None,
+            id="jwt",
+        ),
+        pytest.param(
+            "AWS_SECRET_ACCESS_KEY (SECRET mid-name, ends ACCESS_KEY)",
+            "AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMIK7MDENGbPx" + "RfiCYsecretKEYval",
+            "wJalrXUtnFEMIK7MDENGbPx" + "RfiCYsecretKEYval",
+            "AWS_SECRET_ACCESS_KEY",
+            id="aws-secret-access-key",
+        ),
+        pytest.param(
+            "Azure storage account key (ends ACCOUNT_KEY)",
+            "AZURE_STORAGE_ACCOUNT_KEY=base64acct" + "AAAABBBBCCCCDDDDEEEE==",
+            "base64acct" + "AAAABBBBCCCCDDDDEEEE==",
+            "AZURE_STORAGE_ACCOUNT_KEY",
+            id="azure-account-key",
+        ),
+        pytest.param(
+            "GCP/Vertex service-account PEM private key block",
+            '{"private_key": "-----BEGIN PRIVATE KEY-----\\nMIIEvQIBADANBgkq'
+            + "PEMfakeSECRETmaterial12345"
+            + '\\n-----END PRIVATE KEY-----"}',
+            "PEMfakeSECRETmaterial12345",
+            None,
+            id="gcp-pem-private-key",
+        ),
+        pytest.param(
+            "URL password containing an un-encoded @",
+            "redis://admin:p@ss" + "w0rdSECRETval@cache.internal:6379/0",
+            "p@ss" + "w0rdSECRETval",
+            "cache.internal",
+            id="url-literal-at-password",
+        ),
+        pytest.param(
+            "OpenAI admin key with uppercase (sk-admin-)",
+            "AuthError: sk-" + "admin-" + "T3BlbkFJFAKEadminKEY0123456789ab",
+            "T3BlbkFJFAKEadminKEY0123456789ab",
+            None,
+            id="sk-admin-uppercase",
+        ),
+    ],
+)
+def test_redacts_proxy_failure_leak_vectors(label, raw, leaked, kept):
+    """Issue #830 fix#2: each input is a real leak shape from provider failure
+    text that survived redaction before this fix (adversarial review)."""
+    result = redact_trajectory_text(raw)
+    assert "***REDACTED***" in result, f"{label}: nothing redacted"
+    assert leaked not in result, f"{label}: secret survived"
+    if kept is not None:
+        assert kept in result, f"{label}: over-redacted (dropped {kept!r})"
+
+
+@pytest.mark.parametrize(
+    "carrier_json,leaked",
+    [
+        pytest.param(
+            'AzureException 401 - {"sent_headers": {"api-key": "AZ0123456789abcdefSECRET"}}',
+            "AZ0123456789abcdefSECRET",
+            id="escaped-api-key",
+        ),
+        pytest.param(
+            'OpenAIException {"request": {"headers": {"authorization": "Bearer ESCbearerSECRETtok123456"}}}',
+            "ESCbearerSECRETtok123456",
+            id="escaped-authorization",
+        ),
+        pytest.param(
+            'ProxyException {"master_key": "ESCmasterKEYnoprefixSECRET12"}',
+            "ESCmasterKEYnoprefixSECRET12",
+            id="escaped-master-key",
+        ),
+    ],
+)
+def test_redacts_escaped_json_provider_body(carrier_json, leaked):
+    """Issue #830 fix#2 (the central new surface): Option A surfaces the provider
+    error body into error.message; Trajectory.to_jsonl runs json.dumps over the
+    record (escaping inner quotes to \\") BEFORE redacting. The carriers must fire
+    on that backslash-escaped form, not just raw/JSON/dict-repr."""
+    import json
+
+    # Exactly what to_jsonl feeds redact_trajectory_text: json.dumps of a record
+    # whose error.message embeds the provider's JSON body.
+    serialized = json.dumps({"event": "failure", "error": {"message": carrier_json}})
+    assert leaked in serialized  # sanity: the secret is present pre-redaction
+    result = redact_trajectory_text(serialized)
+    assert "***REDACTED***" in result
+    assert leaked not in result, "escaped-JSON carrier bypass — secret survived"
+
+
+def test_redacts_double_escaped_json_carrier():
+    """Issue #830: a body that is json.dumps'd twice has THREE backslashes before
+    each quote; _ESCQ absorbs a run of backslashes, so even double-escaped carriers
+    redact (guards against a single-backslash-only escape atom)."""
+    import json
+
+    secret = "DBL" + "771b8b5e9f2a4c6d8e0f1a2b"
+    double = json.dumps(json.dumps(f'{{"api-key": "{secret}"}}'))
+    assert secret in double
+    out = redact_trajectory_text(double)
+    assert secret not in out
+    assert "***REDACTED***" in out
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # host:port in a URL has no userinfo — must not be touched.
+        '{"url": "https://example.com:8080/v1/chat"}',
+        "redis://cache.internal:6379/0",
+        # An email/'@' in a query param must not be mistaken for userinfo.
+        "https://localhost:8080?login_hint=user@example.com",
+        "GET https://auth.example.com:8443?login_hint=alice@corp.com&state=xyz",
+        "https://h:9000?a=1&b=2&c=x@d.com&keepme=yes",
+        # Non-secret query params keep their values (bare key/token/auth excluded).
+        "https://api/v1/list?page=2&limit=10&sortkey=name",
+        "https://api/search?monkey=banana&donkey=kong",
+        "https://api/v1?author=jane&keyboard=qwerty&pwd2=keepme",
+        "https://api/items?key=name&order=asc",
+        "https://api/login?auth=basic&user=bob",
+        "https://x.com/cb?sig=v2&id=42",  # short ?sig= is a scheme-version flag
+        # Names that merely CONTAIN token/secret/key but aren't secrets.
+        "TOKENIZER_PATH=/models/tokenizer.json",
+        '{"sortkey": "created_at", "pagekey": "next"}',
+        # Common non-secret *_key DB/ORM identifiers (NOT a secret key suffix).
+        "primary_key=id_column",
+        "{'foreign_key': 'user_id'}",
+        "sort_key=created_at",
+        # Words that merely CONTAIN a secret marker but don't end in one.
+        "SECRETARY_NAME=Jane",
+        "MONKEY=banana",
+        # Single-quoted non-secret dict reprs.
+        "{'role': 'user', 'content': 'hello world'}",
+        # sk-proj-/sk-admin- kebab slugs (lowercase → no uppercase → not a key).
+        "git checkout sk-proj-refactor-auth-module",
+        "kubectl create sa sk-admin-cluster-operator-prod",
+        # eyJ-prefixed identifiers / dotted base64 wire formats that aren't JWTs
+        # (3rd segment < 20 chars).
+        "result = eyJsonObject.parseColumns.getValuesFrom(input)",
+        "msg=eyJ0eXBlIjoiUElORyJ9.eyJzZXEiOjEwMDB9.eyJhY2siOnRydWV9",
+        # Bespoke app deep-link with :...@ that isn't a credential (scheme not in
+        # the credential-bearing allowlist).
+        "vscode://file:line@/path",
+    ],
+)
+def test_proxy_failure_vectors_do_not_over_redact(raw):
+    """The leak-vector patterns must not corrupt legitimate URLs, query params,
+    env names, or dict reprs that merely resemble a secret carrier."""
+    assert redact_trajectory_text(raw) == raw
+
+
+def test_carrier_value_stops_at_ampersand():
+    """A token-named query param redacts only its value, not the sibling params
+    after `&` (the *token* carrier value class excludes `&`)."""
+    out = redact_trajectory_text(
+        "https://h/v1?refresh_token=SEKRETvalue123456&model=gpt-4&n=2"
+    )
+    assert "SEKRETvalue123456" not in out
+    assert "model=gpt-4" in out
+    assert "n=2" in out
+
+
+@pytest.mark.parametrize(
+    "label,pathological",
+    [
+        # Long colon-rich, '@'-less URL — userinfo username class excludes ':'.
+        ("colon-rich-url", "https://" + "x:" * 4000),
+        # A large base64 image field is the realistic DoS: an uncapped name-prefix
+        # `[A-Za-z0-9_]*` before a marker backtracks O(n²) on it. The {0,64} cap
+        # plus the (?<![A-Za-z0-9]) left-anchor on the variable-prefix carriers
+        # keep it linear. (Pre-fix this stalled the redactor for ~45 s.)
+        ("base64-image", '{"image":"' + "iVBORw0KGgoAAAANSUhEUgAA" * 8000 + '"}'),
+        # A long contiguous alnum/underscore run (near-miss for the *TOKEN* carrier).
+        ("alnum-run", "Aa0_" * 4000),
+    ],
+)
+def test_redactor_no_redos(label, pathological):
+    """Guards ReDoS across the new/modified patterns: redaction of a large benign
+    blob must stay near-linear, not catastrophically backtrack."""
+    import time
+
+    start = time.perf_counter()
+    redact_trajectory_text(pathological)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    assert elapsed_ms < 750, f"possible ReDoS on {label}: {elapsed_ms:.0f} ms"


### PR DESCRIPTION
## Summary

Closes the remaining open half of #830 (**fix #2** — fix #1 landed in #831): durably surface the upstream provider error cause for triage, and keep it — plus every newly-surfaced failure body — free of leaked secrets.

### Provider failure cause (Option A)
The pi/litellm failure callback set `error.message = str(response_obj)`, but on a deterministic provider reject (context-window overflow, etc.) litellm fires the hook with `response_obj=None`, so the message became the literal `"None"` and the real cause was lost on teardown. It now falls back to `kwargs['exception']`, so `error.message` carries the real upstream reason. This rides the **existing** redacted `llm_trajectory.jsonl` pipeline; `result.json` stays status-code-only, so the #546/#564 secret posture is untouched.

### Redaction hardening
Option A now routes the **full provider error body into `error.message` for all failure types**, so `redact_trajectory_text` had to be hardened. Two adversarial verification passes drove these out (each empirically reproduced, then locked with a test):

- **Escaped-JSON bypass** (was leaking): carriers now fire on `json.dumps`-escaped JSON (`\"k\": \"v\"`) at any escape depth — the exact form `Trajectory.to_jsonl` produces — not just raw/dict-repr.
- **Catastrophic O(n²) ReDoS** (pre-existing, exposed here): a base64 image field stalled the redactor **~45 s** → now **<0.5 s**. Variable name prefixes are length-capped and the env/JSON carriers are left-anchored.
- **New coverage**: URL userinfo for credential-bearing schemes (incl. un-encoded `@` in passwords); `sk-benchflow/svcacct/admin/or-v1`, `gsk_`/`xai-`/`r8_`/`hf_`/`fw_`, and JWT key families; `AWS_SECRET_ACCESS_KEY` / `*_ACCOUNT_KEY`; GCP PEM private-key blocks; `master_key`/`private_key` carriers; AWS SigV4 / Azure SAS query params.
- **Over-redaction guards**: kebab slugs (`sk-proj-refactor-...`), `primary_key`/`foreign_key`, `?key=name`, short `?sig=<version>`, `vscode://` deep-links, `eyJ`-prefixed method chains.

## Reproduction → Verification

```text
# Before (issue #830): cause lost
error.message = "None"   (response_obj=None; real reason only in the deleted proxy stderr.log)

# After: cause preserved (redacted), result.json unchanged
error.message = "...Requested token count exceeds the model's maximum context length of 16384 tokens..."
```

## Test plan

- [x] `pytest tests/trajectories/test_redaction.py tests/test_litellm_logging.py` — 108 passed (incl. escaped-JSON, double-escape, ReDoS timing guards, AWS/GCP key vectors, over-redaction guards)
- [x] Full suite: 4528 passed (4 pre-existing unrelated failures, confirmed on the clean base)
- [x] `ruff check` + `ruff format --check` + `ty check` clean
- [x] Two adversarial verification passes (leak / over-redaction / ReDoS), all findings fixed + re-verified

## Related

Refs #830 (intentionally left open — a few LOW residuals noted below are deferred). fix #1: #831.

### Consciously deferred (LOW / noted)
- A secret value containing a literal `&` truncates at the `&` (query-sibling protection prioritized; real keys don't contain `&`).
- SigV4 `Signature=` inside an `Authorization` header (over-redaction risk on the common word "signature").
- Non-allowlisted credential URL schemes (e.g. `clickhouse://`, `kafka://`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
