### PR TITLE
fix(eval): keep failure traceback consistent with surfaced error.message

### DIFF
--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -139,6 +139,23 @@ def _failure_detail(response_obj: Any, exception: Any) -> Any:
     return response_obj if response_obj is not None else exception
 
 
+def _failure_traceback(detail: Any) -> str:
+    # ``format_exc()`` reflects the exception that is CURRENTLY ACTIVE when the
+    # callback fires. For the #830 case (litellm calls the hook from inside its
+    # except block) that IS ``detail``, so the traceback agrees with the
+    # exception-derived error.message. But if litellm clears the exception
+    # context first, ``format_exc()`` returns the ``'NoneType: None'`` sentinel
+    # while ``detail`` (recovered from kwargs['exception']) still holds the real
+    # cause — format that exception directly so the traceback doesn't go blank
+    # under a meaningful error.message (#830).
+    tb = traceback.format_exc()
+    if isinstance(detail, BaseException) and tb.startswith("NoneType: None"):
+        tb = "".join(
+            traceback.format_exception(type(detail), detail, detail.__traceback__)
+        )
+    return tb[-2000:]
+
+
 class BenchFlowLiteLLMLogger(CustomLogger):
     def _write(self, payload: dict[str, Any]) -> None:
         path = os.environ.get("BENCHFLOW_LITELLM_LOG_PATH")
@@ -232,7 +249,7 @@ class BenchFlowLiteLLMLogger(CustomLogger):
                 "error": {
                     "type": type(detail).__name__,
                     "message": str(detail),
-                    "traceback": traceback.format_exc()[-2000:],
+                    "traceback": _failure_traceback(detail),
                 },
             }
         )

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -187,6 +187,38 @@ def test_failure_detail_none_when_both_missing():
     assert _failure_detail(None, None) is None
 
 
+def test_failure_traceback_falls_back_to_exception_without_active_exc():
+    """Greptile P2 / #830: when no exception is active (format_exc() is the
+    'NoneType: None' sentinel) but we recovered the cause from kwargs['exception'],
+    the traceback formats that exception so it doesn't go blank under a meaningful
+    error.message."""
+    _failure_traceback = _callback_namespace()["_failure_traceback"]
+    # Called OUTSIDE any except block → traceback.format_exc() == 'NoneType: None\n'.
+    tb = _failure_traceback(ValueError(_CONTEXT_CAUSE))
+    assert "ValueError" in tb
+    assert "16384 tokens" in tb
+    assert "NoneType: None" not in tb
+
+
+def test_failure_traceback_uses_active_exception():
+    """When an exception IS active, format_exc() (the real stack) is used as-is."""
+    _failure_traceback = _callback_namespace()["_failure_traceback"]
+    try:
+        raise RuntimeError("active boom")
+    except RuntimeError as exc:
+        tb = _failure_traceback(exc)
+    assert "RuntimeError" in tb
+    assert "active boom" in tb
+    assert "Traceback (most recent call last)" in tb
+
+
+def test_failure_traceback_non_exception_detail_keeps_sentinel():
+    """No active exception and a non-exception detail (both-None path) keeps the
+    old 'NoneType: None' behavior — no spurious formatting."""
+    _failure_traceback = _callback_namespace()["_failure_traceback"]
+    assert _failure_traceback(None).strip() == "NoneType: None"
+
+
 async def test_failure_event_records_exception_cause_when_response_none(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Follow-up to #834 addressing the Greptile **P2** on that PR.

`async_log_failure_event` records `traceback.format_exc()`, which reflects the **currently-active** exception. For the #830 path — litellm calls the failure hook from inside its `except` block — that agrees with the exception-derived `error.message` #834 added. But if litellm clears the exception context before invoking the (async) callback, `format_exc()` returns the `'NoneType: None'` sentinel while `error.message` (recovered from `kwargs['exception']`) still carries the real cause. The reader then sees a meaningful message next to a **blank traceback**.

This adds a `_failure_traceback(detail)` helper: when `format_exc()` is the None sentinel **and** `detail` is the recovered exception, it formats that exception directly so the two fields stay consistent. The active-exception path is unchanged; the both-`None` path still yields the old sentinel.

## Test plan

- [x] `pytest tests/test_litellm_logging.py` — 12 passed (3 new `_failure_traceback` cases: sentinel-fallback, active-exception-unchanged, non-exception-keeps-sentinel), exercised via the exec'd callback source
- [x] `ruff check` + `ruff format --check` + `ty check` clean

## Related

Follow-up to #834 (#830 fix #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
