### PR TITLE
test(loader): lock 3-path (acp/ ai-sdk/ omnigent/) manifest discovery

### DIFF
--- a/tests/agents/test_manifest_dirscan.py
+++ b/tests/agents/test_manifest_dirscan.py
@@ -220,3 +220,27 @@ def test_register_fails_loud_on_same_batch_name_alias_collision(tmp_path: Path):
     # collision detected before any mutation: nothing is registered.
     assert m["agents"] == {}
     assert m["installers"] == {}
+
+
+def test_discovery_walks_three_category_paths(tmp_path):
+    """A manifest dropped under each of the 3 category paths (acp/, ai-sdk/,
+    omnigent/) auto-registers. Discovery is recursive (rglob), so the eve-style
+    ``acp/<agent>/manifest.toml`` layout works exactly like a flat
+    ``<agent>/manifest.toml`` — adding a new agent is "drop it in the right path".
+    """
+    from benchflow.agents.manifest import load_agents_from_dir
+
+    def write(category: str, agent: str) -> None:
+        d = tmp_path / category / agent
+        d.mkdir(parents=True)
+        (d / "manifest.toml").write_text(
+            f'contract_version = "1.0"\nname = "{agent}"\n'
+            'install_cmd = "echo install"\nlaunch_cmd = "echo launch"\n'
+        )
+
+    write("acp", "cat-acp-agent")
+    write("ai-sdk", "cat-aisdk-agent")
+    write("omnigent", "cat-omnigent-agent")
+
+    loaded = load_agents_from_dir(tmp_path)
+    assert set(loaded) == {"cat-acp-agent", "cat-aisdk-agent", "cat-omnigent-agent"}


### PR DESCRIPTION
Step 3 of the agents decouple. The `BENCHFLOW_AGENTS_DIR` manifest scanner (`discover_manifests`) is **already recursive** (`root.rglob("manifest.toml")`), so the agents-repo category layout (`acp/<agent>/manifest.toml`, `ai-sdk/*`, `omnigent/*` — see benchflow-ai/agents#19) auto-registers without a scanner change. This adds a **load-bearing** test that drops a manifest under each of the 3 category paths and asserts all auto-register; proven load-bearing (making discovery non-recursive `rglob`->`glob` fails the test). Additive, no behaviour change — core registry stays the default source.