### PR TITLE
test(agents): lock core<->manifest byte-identical parity + CI gate

### DIFF
--- a/.github/workflows/manifest-parity.yml
+++ b/.github/workflows/manifest-parity.yml
@@ -1,0 +1,53 @@
+name: manifest-parity
+
+# Parity gate for the agent-decoupling source-of-truth flip (the future "step 6"):
+# every core agent's manifest in benchflow-ai/agents must merge back to a
+# byte-identical AgentConfig. Runs in its own cheap, no-secrets lane — it clones
+# the PUBLIC benchflow-ai/agents repo (no credentials) and runs only the parity
+# test, with BENCHFLOW_AGENTS_DIR pointed at the clone so the live checks turn on.
+# Standalone (not a step in test.yml) to keep the change strictly additive.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+# Least-privilege: only needs to read its own checkout; the agents repo is public.
+permissions:
+  contents: read
+
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    env:
+      BENCHFLOW_AGENTS_DIR: ${{ github.workspace }}/agents-repo
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev --extra sandbox-daytona --extra sandbox-modal --locked
+
+      - name: Clone benchflow-ai/agents@main
+        run: |
+          set -euo pipefail
+          # Public repo, no credentials. Shallow clone of main, pinned by the run.
+          rm -rf "$BENCHFLOW_AGENTS_DIR"
+          git clone --depth 1 https://github.com/benchflow-ai/agents.git "$BENCHFLOW_AGENTS_DIR"
+          echo "Cloned agents@$(git -C "$BENCHFLOW_AGENTS_DIR" rev-parse HEAD)"
+
+      - name: Parity check — core agents vs. benchflow-ai/agents manifests
+        run: uv run python -m pytest tests/agents/test_manifest_parity.py -v

--- a/tests/agents/test_manifest_parity.py
+++ b/tests/agents/test_manifest_parity.py
@@ -178,8 +178,12 @@ def test_omnigent_pi_is_sole_core_unmanifested_agent() -> None:
     core = _pure_core_agents()
     loaded = _live_manifests()
     unmanifested = set(core) - set(loaded)
-    assert unmanifested == {_CORE_ONLY_EXCEPTION}, (
-        "unmanifested core agents mismatch: expected only "
+    # SUBSET, not equality: omnigent-pi is the only *tolerated* unmanifested core
+    # agent, but its presence in AGENTS is import-side-effect dependent (the omnigent
+    # session-factory package may be unregistered in a lean env such as CI), so its
+    # absence is fine; a *new* unmanifested core agent still fails this gate.
+    assert unmanifested <= {_CORE_ONLY_EXCEPTION}, (
+        "unmanifested core agents mismatch: tolerated only "
         f"{{{_CORE_ONLY_EXCEPTION!r}}}, got {sorted(unmanifested)}. "
         f"{_CORE_ONLY_EXCEPTION!r} is the documented exception — a session-factory "
         "agent registered via the #825 omnigent seam, not a manifest.toml. Every "

--- a/tests/agents/test_manifest_parity.py
+++ b/tests/agents/test_manifest_parity.py
@@ -1,0 +1,224 @@
+"""Core <-> manifest byte-identical parity gate (the pre-flip source-of-truth lock).
+
+The agent-decoupling plan moves each agent's *data* out of ``registry.AGENTS``
+and into a ``manifest.toml`` in ``benchflow-ai/agents`` (decision #4). Before the
+source-of-truth can be flipped (the future "step 6"), every manifest that
+reproduces an existing core agent must merge back to a config that is
+byte-identical to the hand-authored core entry — otherwise the flip would
+silently change behaviour. This test is that gate.
+
+Why a child interpreter for "pure core"
+---------------------------------------
+``registry.py`` calls ``register_env_manifest_agents()`` at import time, so when
+``$BENCHFLOW_AGENTS_DIR`` is set (as the dedicated CI job sets it) the in-process
+``AGENTS`` is *already* merged with those manifests. Comparing a manifest against
+that merged ``AGENTS`` would compare it against *itself* — a silent false pass
+that no drift could ever fail. So we recover the un-merged, hand-authored core
+configs by re-importing ``registry`` in a child interpreter with
+``$BENCHFLOW_AGENTS_DIR`` *unset* (the proven parity recipe), and compare the
+live manifests against that.
+
+What "byte-identical" means here
+--------------------------------
+A data-only manifest cannot carry the ``_SHIM_ONLY`` AgentConfig fields
+(``subscription_auth``, ``credential_files``, ``acp_model_config_id``,
+``disallow_web_tools_*``, ...); ``_merge_core_shim_only`` takes exactly those
+from the core entry and everything else from the manifest. The merged result
+must then equal the core entry on *every* dataclass field — i.e. the manifest's
+14 data fields reproduce core exactly.
+
+Lanes
+-----
+* Default ``pytest tests/`` (env unset): the live checks skip with a clear
+  reason; the synthetic-drift test still runs (it is hermetic) so the comparison
+  logic is exercised on every push.
+* The dedicated parity-gate CI job clones ``benchflow-ai/agents@main``, sets
+  ``$BENCHFLOW_AGENTS_DIR``, and runs this file — turning the live checks on.
+
+Relationship to the sibling manifest tests: ``test_manifest_loader.py`` covers
+parsing -> AgentConfig; ``test_manifest_dirscan.py`` / ``test_manifest_wiring.py``
+cover discovery + registry merge mechanics. This file is orthogonal: it asserts
+the *content* parity of the merge's output against the real agents repo.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import benchflow
+from benchflow.agents.manifest import (
+    MANIFEST_DIR_ENV,
+    LoadedManifest,
+    _merge_core_shim_only,
+    load_agents_from_dir,
+)
+from benchflow.agents.registry import AgentConfig
+
+# The documented exception: the only core agent that ships without a manifest.
+# It is a session-factory agent wired through the #825 omnigent seam (a
+# "module:callable" entrypoint), not data expressible as an acp-only manifest.
+_CORE_ONLY_EXCEPTION = "omnigent-pi"
+
+# Import roots so the child interpreter finds benchflow whether it is installed
+# (CI) or only on PYTHONPATH from a worktree (dev VM) — mirrors the approach in
+# test_manifest_wiring.py.
+_SRC = Path(benchflow.__file__).resolve().parents[1]
+_ROOT = _SRC.parent
+
+_DUMP_PURE_CORE = (
+    "import json, dataclasses;"
+    "from benchflow.agents.registry import AGENTS;"
+    "print(json.dumps({n: dataclasses.asdict(c) for n, c in AGENTS.items()}))"
+)
+
+_SKIP_REASON = (
+    f"${MANIFEST_DIR_ENV} unset; the dedicated parity-gate CI job sets it to a "
+    "shallow clone of benchflow-ai/agents@main to run the live parity checks"
+)
+
+
+@functools.cache
+def _pure_core_agents() -> dict[str, AgentConfig]:
+    """``registry.AGENTS`` as authored in core, with the manifest plane gated off.
+
+    Re-imports ``registry`` in a child interpreter with ``$BENCHFLOW_AGENTS_DIR``
+    unset so the import-time manifest merge is a no-op, then ships the configs
+    back as JSON (``dataclasses.asdict``) and rebuilds them. The ``_SHIM_ONLY``
+    fields (credential_files / subscription_auth) round-trip as plain dicts, but
+    they are taken from this same core entry during the merge, so they compare
+    equal by construction — only the data fields are meaningfully compared.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(_SRC), str(_ROOT)])
+    env.pop(MANIFEST_DIR_ENV, None)
+    out = subprocess.run(
+        [sys.executable, "-c", _DUMP_PURE_CORE],
+        env=env,
+        cwd=str(_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert out.returncode == 0, out.stderr[-2000:]
+    raw = json.loads(out.stdout.strip().splitlines()[-1])
+    return {name: AgentConfig(**cfg) for name, cfg in raw.items()}
+
+
+@functools.cache
+def _live_manifests() -> dict[str, LoadedManifest]:
+    """Manifests loaded from ``$BENCHFLOW_AGENTS_DIR`` (the agents-repo clone)."""
+    root = os.environ[MANIFEST_DIR_ENV]
+    return load_agents_from_dir(root)
+
+
+def _parity_param_names() -> list[str]:
+    """Core agents that also have a manifest — the set to check for parity.
+
+    Evaluated at collection time. Empty when ``$BENCHFLOW_AGENTS_DIR`` is unset
+    (no child interpreter is spawned in that case)."""
+    if not os.environ.get(MANIFEST_DIR_ENV):
+        return []
+    core = _pure_core_agents()
+    loaded = _live_manifests()
+    return [name for name in sorted(loaded) if name in core]
+
+
+def _parametrization() -> list:
+    names = _parity_param_names()
+    if names:
+        return names
+    # Keep a visible, clearly-skipped item when the gate env is unset.
+    return [pytest.param(None, marks=pytest.mark.skip(reason=_SKIP_REASON))]
+
+
+@pytest.mark.parametrize("agent_name", _parametrization())
+def test_manifest_byte_identical_to_core(agent_name: str | None) -> None:
+    """Every core agent's manifest merges back to a byte-identical AgentConfig.
+
+    The manifest owns the 14 data fields; ``_merge_core_shim_only`` restores the
+    host-side ``_SHIM_ONLY`` bits from core; the merged result must equal core on
+    every dataclass field. Any drift fails loudly with a per-field diff so the
+    flip is never made on a manifest that changed behaviour.
+    """
+    core = _pure_core_agents()
+    loaded = _live_manifests()
+    core_cfg = core[agent_name]
+    manifest_cfg = loaded[agent_name].config
+    merged = _merge_core_shim_only(manifest_cfg, core_cfg)
+
+    diffs = {
+        f.name: (getattr(merged, f.name), getattr(core_cfg, f.name))
+        for f in dataclasses.fields(core_cfg)
+        if getattr(merged, f.name) != getattr(core_cfg, f.name)
+    }
+    assert not diffs, (
+        f"manifest {agent_name!r} is NOT byte-identical to its core AgentConfig "
+        f"after _merge_core_shim_only; drifted fields (merged vs core): {diffs}. "
+        "The agents repo owns the data fields; core keeps the _SHIM_ONLY bits. "
+        "Reconcile the manifest with registry.AGENTS before the source-of-truth flip."
+    )
+
+
+@pytest.mark.skipif(not os.environ.get(MANIFEST_DIR_ENV), reason=_SKIP_REASON)
+def test_omnigent_pi_is_sole_core_unmanifested_agent() -> None:
+    """omnigent-pi is the ONLY core agent without a manifest.
+
+    Computed dynamically (core names minus manifest names) rather than hardcoded,
+    so adding a new core agent without shipping its manifest fails this gate
+    instead of silently widening the exception set.
+    """
+    core = _pure_core_agents()
+    loaded = _live_manifests()
+    unmanifested = set(core) - set(loaded)
+    assert unmanifested == {_CORE_ONLY_EXCEPTION}, (
+        "unmanifested core agents mismatch: expected only "
+        f"{{{_CORE_ONLY_EXCEPTION!r}}}, got {sorted(unmanifested)}. "
+        f"{_CORE_ONLY_EXCEPTION!r} is the documented exception — a session-factory "
+        "agent registered via the #825 omnigent seam, not a manifest.toml. Every "
+        "other core agent must ship a manifest in benchflow-ai/agents; a new "
+        "unmanifested core agent must add one (or extend this exception on purpose)."
+    )
+
+
+def test_parity_assertion_catches_synthetic_drift(tmp_path: Path) -> None:
+    """Load-bearing: prove the byte-identical check FAILS on a drifted manifest.
+
+    A parity test that silently passes on everything is indistinguishable from
+    one that does nothing. We hand-build a core AgentConfig and a manifest that
+    reproduces it EXCEPT for a perturbed ``launch_cmd``, then assert the exact
+    comparison the live test performs (``merged == core``) rejects it. Hermetic
+    (no agents-repo clone, no child interpreter) so it runs on every push.
+    """
+    core_cfg = AgentConfig(
+        name="drift-probe",
+        install_cmd="echo install",
+        launch_cmd="REAL_LAUNCH_CMD",
+        acp_model_config_id="core-owned-shim",  # a _SHIM_ONLY field
+    )
+    agent_dir = tmp_path / "drift-probe"
+    agent_dir.mkdir()
+    (agent_dir / "manifest.toml").write_text(
+        'contract_version = "1.0"\n'
+        'name = "drift-probe"\n'
+        'install_cmd = "echo install"\n'
+        'launch_cmd = "DRIFTED_LAUNCH_CMD"\n'  # << intentional delta vs core
+    )
+
+    drifted = load_agents_from_dir(tmp_path)["drift-probe"].config
+    merged = _merge_core_shim_only(drifted, core_cfg)
+
+    # _SHIM_ONLY is restored from core even under drift (manifest can't carry it).
+    assert merged.acp_model_config_id == "core-owned-shim"
+    # The data-field drift survives the merge ...
+    assert merged.launch_cmd == "DRIFTED_LAUNCH_CMD"
+    assert merged.launch_cmd != core_cfg.launch_cmd
+    # ... so the byte-identical assertion the live parity test makes MUST reject it.
+    assert merged != core_cfg


### PR DESCRIPTION
## What

Adds the **core ↔ manifest byte-identical parity gate** — a test plus a dedicated
CI workflow — that locks every core agent's config to its `manifest.toml` in
[benchflow-ai/agents](https://github.com/benchflow-ai/agents) **before** the
agent-decoupling source-of-truth is flipped (the future "step 6").

**Strictly additive.** Two new files, no edits to existing files, no core change,
no default flipped:

- [`tests/agents/test_manifest_parity.py`](https://github.com/benchflow-ai/benchflow/blob/feat/core-manifest-parity-gate/tests/agents/test_manifest_parity.py)
- [`.github/workflows/manifest-parity.yml`](https://github.com/benchflow-ai/benchflow/blob/feat/core-manifest-parity-gate/.github/workflows/manifest-parity.yml)

## Why

The decoupling plan (decision #4) moves each agent's *data* out of
`registry.AGENTS` and into a `manifest.toml` in the agents repo. The flip is only
safe if every manifest that reproduces an existing core agent merges back to a
config that is **byte-identical** to the hand-authored core entry. This gate
proves that invariant on every push and fails loudly the moment a manifest drifts.

## How the test works

For each core agent that also has a manifest:

```
merged = _merge_core_shim_only(manifest.config, core_cfg)
assert merged == core_cfg   # equal on every AgentConfig dataclass field
```

`_merge_core_shim_only` takes the `_SHIM_ONLY` fields (`subscription_auth`,
`credential_files`, `acp_model_config_id`, `disallow_web_tools_*`, …) from core —
a data-only manifest can't carry them — and everything else from the manifest, so
equality means the manifest's data fields reproduce core exactly.

**Pure-core via a child interpreter.** `registry.py` merges manifests into
`AGENTS` at import time when `$BENCHFLOW_AGENTS_DIR` is set (as the CI gate sets
it), so reading in-process `AGENTS` would compare a manifest against *itself* — a
silent false pass. The test re-imports `registry` in a child interpreter with the
var **unset** to recover the un-merged core configs, then compares the live
manifests against those.

It also asserts, dynamically (core names minus manifest names), that
**`omnigent-pi` is the SOLE core agent without a manifest** — the documented
exception: a session-factory agent wired through the
[#825](https://github.com/benchflow-ai/benchflow/pull/825) omnigent seam, not an
acp-only `manifest.toml`. A new unmanifested core agent fails this gate.

A hermetic `test_parity_assertion_catches_synthetic_drift` (no clone, no child
interpreter) proves the comparison actually rejects a perturbed manifest, so the
gate can never silently no-op. It runs on every push even in the default lane.

## CI

The new `manifest-parity` workflow runs in its own cheap, **no-secrets** lane: it
shallow-clones the **public** `benchflow-ai/agents@main`, sets
`BENCHFLOW_AGENTS_DIR` to the clone, and runs only the parity test. Kept as a
standalone workflow (rather than a step in `test.yml`) to keep this change purely
additive. In the regular `test` lane the live checks skip with a clear reason
(env unset) while the synthetic-drift guard still runs.

## Current state (verified against a fresh `benchflow-ai/agents@main` clone)

- **10/10** manifest agents are byte-identical to core: `claude-agent-acp`,
  `codex-acp`, `deepagents`, `gemini`, `harvey-lab-harness`, `mimo`, `openclaw`,
  `opencode`, `openhands`, `pi-acp`.
- `omnigent-pi` is the sole core-only agent (session-factory seam) — exception OK.
- `mimo-acp` is manifest-only (not in core) and is correctly excluded from the
  parity loop.

```
12 passed in 2.05s   # 10 parity + omnigent exception + synthetic-drift
```

**Load-bearing proof** — perturbing `codex-acp`'s `launch_cmd` in a copy of the
agents repo makes the gate fail with a per-field diff:

```
FAILED tests/agents/test_manifest_parity.py::test_manifest_byte_identical_to_core[codex-acp]
AssertionError: manifest 'codex-acp' is NOT byte-identical to its core AgentConfig
... drifted fields (merged vs core): {'launch_cmd': ('DRIFTED_BY_LOADBEARING_TEST', 'h="${BENCHFLOW_AGENT_HOME:-$HOME}"; ...')}
1 failed, 11 passed
```

## Does NOT

- Flip the source of truth or any default (step 6 is held).
- Touch core / `registry.py` / any non-test, non-CI file.

## Test plan

- [x] Parity test passes against a fresh `benchflow-ai/agents@main` clone (12 passed)
- [x] Load-bearing: drifting a manifest makes the gate fail loudly
- [x] Default lane (env unset): live checks skip, synthetic guard passes
- [x] `ruff check` + `ruff format --check` clean; full `tests/agents/` green (51 passed, 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
