### PR TITLE
fix(eval): emit llm_trajectory.jsonl for streaming claude-agent-acp rollouts

### DIFF
--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -397,5 +397,12 @@ def litellm_proxy_config(
             "callbacks": [f"{callback_module}.proxy_handler_instance"],
             "drop_params": True,
             "set_verbose": False,
+            # Force the anthropic /v1/messages bridge onto /chat/completions.
+            # LiteLLM routes openai/-prefixed upstreams (e.g. the vllm
+            # provider) through its Responses-API adapter, whose *streaming*
+            # path never fires the success callback -- so streaming
+            # claude-agent-acp rollouts produced no llm_trajectory.jsonl
+            # (#833). /chat/completions logs success correctly.
+            "use_chat_completions_url_for_anthropic_messages": True,
         },
     }

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -125,6 +125,22 @@ def test_proxy_config_registers_plain_and_openai_aliases():
     }
 
 
+def test_proxy_config_forces_chat_completions_for_anthropic_messages():
+    """Streaming /v1/messages must bridge via /chat/completions so the
+    LiteLLM success callback fires and llm_trajectory.jsonl is written for
+    claude-agent-acp. LiteLLM's Responses-API streaming adapter (used for
+    openai/-prefixed upstreams such as the vllm provider) skips the success
+    callback; this flag opts out of it (#833).
+    """
+    route = resolve_litellm_route("openai/gpt-5.4-mini", {"OPENAI_API_KEY": "key"})
+    config = litellm_proxy_config(route, master_key="sk-local")
+
+    assert (
+        config["litellm_settings"]["use_chat_completions_url_for_anthropic_messages"]
+        is True
+    )
+
+
 def test_proxy_config_registers_requested_bare_model_name():
     """Codex ACP sends the bare selected model name to the proxy."""
     route = resolve_litellm_route("openai/gpt-5.4-mini", {"OPENAI_API_KEY": "key"})

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -141,6 +141,20 @@ def test_proxy_config_forces_chat_completions_for_anthropic_messages():
     )
 
 
+def test_litellm_exposes_anthropic_messages_chat_completions_flag():
+    """Guard against a LiteLLM upgrade silently dropping the flag.
+
+    litellm_proxy_config sets use_chat_completions_url_for_anthropic_messages
+    via LiteLLM's generic litellm_settings -> setattr(litellm, ...) path, which
+    does NOT raise on an unknown key. If a future LiteLLM renames or removes
+    this attribute the fix would become a silent no-op and regress #833, so
+    assert the attribute still exists.
+    """
+    import litellm
+
+    assert hasattr(litellm, "use_chat_completions_url_for_anthropic_messages")
+
+
 def test_proxy_config_registers_requested_bare_model_name():
     """Codex ACP sends the bare selected model name to the proxy."""
     route = resolve_litellm_route("openai/gpt-5.4-mini", {"OPENAI_API_KEY": "key"})


### PR DESCRIPTION
## Summary

`claude-agent-acp` did not write `trajectory/llm_trajectory.jsonl` for **successful** rollouts (0/50), while `pi` did (44/44) and claude-acp's *error* path did (11/17). This breaks trajectory parity and makes successful claude rollouts unusable for any LLM-trajectory consumer (export / RL training).

## Root cause

The per-rollout LiteLLM proxy captures the LLM trajectory from its `litellm_settings.callbacks` success/failure events. BenchFlow's `vllm/` provider maps the upstream to `openai/<model>`. For the anthropic `/v1/messages` route against an `openai/`-prefixed upstream, **LiteLLM 1.89 bridges through the OpenAI Responses API (`/responses`), and its Responses *streaming* adapter never invokes the success callback** — so streaming `/v1/messages` success produces zero callback records → empty `server.trajectory.exchanges` → `_write_llm_trajectory` early-returns and writes nothing.

- `claude-agent-acp` (Claude Code) **streams** `/v1/messages` → hits the gap (0/50 on success).
- `pi` calls `/v1/chat/completions` directly → streaming success logs fine (44/44).
- claude-acp **errors** go through `post_call_failure_hook` (failures *do* log) → that's the 11/17 on the error path.

## Fix

Set `litellm.use_chat_completions_url_for_anthropic_messages` via the proxy's `litellm_settings`, so the anthropic `/v1/messages` bridge uses `/chat/completions` — the universally-supported endpoint whose streaming path logs success correctly. Native `anthropic/` providers don't use the Responses bridge (unaffected); the proxy is BenchFlow-owned and per-rollout, so there is no external blast radius.

## Verification

Reproduced with a live-proxy harness (the real proxy started via the runtime + a mock OpenAI-compatible upstream), driving the exact `openai/` route the `vllm/` provider produces:

| case (openai/ route = #833 config) | upstream hit | success rec | exchanges | file |
|---|---|---|---|---|
| messages-stream (claude-acp) — **before** | `/responses` | 0 | 0 | ✗ |
| messages-stream (claude-acp) — **after** | `/chat/completions` | 1 | 1 | ✓ |
| chat-stream (pi) — after | `/chat/completions` | 1 | 1 | ✓ (unchanged) |

A regression test (`test_proxy_config_forces_chat_completions_for_anthropic_messages`) asserts the flag is present in the generated proxy config. `tests/test_litellm_config.py` + `tests/test_litellm_hardening.py` pass (57 passed).

Closes #833
