### PR TITLE
Accept provider total token usage in review gate

### DIFF
--- a/.agents/skills/benchflow-experiment-review/SKILL.md
+++ b/.agents/skills/benchflow-experiment-review/SKILL.md
@@ -61,8 +61,10 @@ usage-only without recoverable request/response evidence.
 a healthy model rollout it should contain a parseable row with
 `info.training_ready == true`, non-empty `prompt`, `completion`, and
 `trajectory`, positive token usage, reward/score metadata, task identity, and
-valid OpenAI-compatible message roles. If assistant `tool_calls` appear, the row
-must carry non-empty `tool_defs` or `tools`. Errored, verifier-failed, partial,
+valid OpenAI-compatible message roles. Token usage may be split into
+input/output fields or represented by a provider `total_tokens` value when the
+provider does not expose a split. If assistant `tool_calls` appear, the row must
+carry non-empty `tool_defs` or `tools`. Errored, verifier-failed, partial,
 malformed, or missing-LLM rollouts must fail closed with
 `training_ready == false` and an error/training-ready reason instead of being
 accepted as SFT-ready.
@@ -132,8 +134,8 @@ Reject or quarantine the trial if any of these appear:
 - `llm_trajectory.jsonl` has no real provider request bodies, no provider
   response bodies, or no provider token usage in response metadata.
 - `results.jsonl` lacks a Prime-RL-compatible row, marks an unhealthy rollout as
-  training-ready, misses prompt/completion/trajectory/token usage, or exposes
-  assistant tool calls without tool definitions.
+  training-ready, misses prompt/completion/trajectory/provider token usage, or
+  exposes assistant tool calls without tool definitions.
 - Empty transcript, agent never launched, or only setup logs.
 - Missing token usage/timing/tool usage metadata for newly generated data.
 - The agent lacked required task information, required skills, API keys,

--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -472,16 +472,17 @@ def validate_results_row(
         if not isinstance(token_usage, dict):
             issues.append(f"{row_path}: missing object token_usage")
         else:
-            if not (
-                positive_number(token_usage.get("final_input_tokens"))
-                or positive_number(token_usage.get("input_tokens"))
-            ):
-                issues.append(f"{row_path}: missing positive input token usage")
-            if not (
-                positive_number(token_usage.get("final_output_tokens"))
-                or positive_number(token_usage.get("output_tokens"))
-            ):
-                issues.append(f"{row_path}: missing positive output token usage")
+            has_total = positive_number(token_usage.get("total_tokens"))
+            has_input = positive_number(
+                token_usage.get("final_input_tokens")
+            ) or positive_number(token_usage.get("input_tokens"))
+            has_output = positive_number(
+                token_usage.get("final_output_tokens")
+            ) or positive_number(token_usage.get("output_tokens"))
+            if not (has_total or has_input):
+                issues.append(f"{row_path}: missing positive input/total token usage")
+            if not (has_total or has_output):
+                issues.append(f"{row_path}: missing positive output/total token usage")
         metrics = row.get("metrics")
         if not isinstance(metrics, dict):
             issues.append(f"{row_path}: missing object metrics")

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -133,6 +133,25 @@ def test_validator_accepts_training_ready_results_jsonl(tmp_path: Path) -> None:
     }
 
 
+def test_validator_accepts_provider_total_only_token_usage(tmp_path: Path) -> None:
+    """Some providers expose only total tokens; Prime-RL can still render the row."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    row = json.loads((rollout / "results.jsonl").read_text())
+    row["token_usage"] = {
+        "input_tokens": 17,
+        "output_tokens": 0,
+        "final_input_tokens": 17,
+        "final_output_tokens": 0,
+        "total_tokens": 17,
+    }
+    _write_jsonl(rollout / "results.jsonl", [row])
+
+    report = validator.validate_rollout(rollout)
+
+    assert report["healthy"] is True
+
+
 def test_validator_rejects_missing_results_jsonl(tmp_path: Path) -> None:
     """Guards PR #828: results.jsonl is part of the model-run health gate."""
     validator = _load_validator()


### PR DESCRIPTION
## Summary
- update `benchflow-experiment-review` so training-ready `results.jsonl` rows can satisfy token usage with provider `total_tokens` when a provider does not expose input/output split
- keep the gate fail-closed for rows with no token usage, malformed Prime-RL rows, missing trajectories, or missing tool definitions
- add regression coverage for provider-total-only rows

## Validation
- `uv run --extra dev --locked python -m pytest tests/test_benchflow_experiment_review_validator.py -q`
- `uv run --extra dev --locked ruff check .agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py tests/test_benchflow_experiment_review_validator.py`
- `uv run --extra dev --locked ruff format --check .agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py tests/test_benchflow_experiment_review_validator.py`

## Context
The MobileLite Daytona canary on BenchFlow #828 produced Prime-RL-valid `results.jsonl` rows and `bench train validate` passed, but Azure `gpt-5.4-mini` only exposed provider `total_tokens`. The review gate should accept that provider-total shape instead of requiring a split that the provider did not return.
