### PR TITLE
Add Prime-RL SFT train wrapper

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -337,6 +337,49 @@ bench train validate train.jsonl --expected-rows 4417
 | `--format` | `prime-sft` | Trainer format |
 | `--expected-rows` | — | Fail unless this many rows are present |
 
+### bench train run sft
+
+Launch a supervised fine-tuning job and record BenchFlow launch metadata. The
+first supported backend is `prime-rl`; BenchFlow wraps the native Prime-RL SFT
+entrypoint instead of re-modeling trainer internals.
+
+```bash
+bench train run sft \
+  --backend prime-rl \
+  --config configs/qwen35-env0-sft.toml \
+  --data benchflow/env0-prime-sft \
+  --prime-rl-dir .local/prime-rl \
+  --work-dir train-runs/qwen35-env0-sft \
+  --follow
+```
+
+The wrapper runs:
+
+```bash
+uv run sft @ configs/qwen35-env0-sft.toml \
+  --data.name benchflow/env0-prime-sft \
+  --output-dir train-runs/qwen35-env0-sft/prime-rl-output
+```
+
+BenchFlow writes `<work-dir>/train-run.json`, `<work-dir>/command.txt`, and
+separate Prime-RL stdout/stderr logs under `<work-dir>/prime-rl/`. Secrets are
+not written to the manifest; only the names of recognized credential env vars
+that were present are recorded.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--backend` | `prime-rl` | Training backend. Currently only `prime-rl` is supported |
+| `--config` | required | Prime-RL SFT TOML config |
+| `--data` | — | Optional dataset override passed through as `--data.name` |
+| `--output-dir` | `<work-dir>/prime-rl-output` | Prime-RL trainer output directory |
+| `--work-dir` | `train-runs/sft` | BenchFlow training run directory |
+| `--prime-rl-dir` | current directory | Prime-RL checkout to run `uv run sft` from |
+| `--dry-run` | `false` | Pass `--dry-run` through to Prime-RL |
+| `--follow` | `false` | Stream trainer stdout while writing logs |
+| `--uv-no-sync` | `false` | Run Prime-RL as `uv run --no-sync sft ...`, useful after backend post-install steps such as `flash-attn` |
+| `--override` | — | Prime-RL override as `KEY=VALUE`; repeatable, emitted as `--KEY VALUE` |
+| `--force` | `false` | Overwrite an existing `<work-dir>/train-run.json` manifest |
+
 ## bench skills
 
 ### bench skills list

--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -22,6 +22,8 @@ def register_train(app: typer.Typer) -> None:
     """Attach the ``train`` command group to the top-level benchflow app."""
     train_app = typer.Typer(help="Training data commands.")
     app.add_typer(train_app, name="train", rich_help_panel="Core")
+    run_app = typer.Typer(help="Launch training jobs.")
+    train_app.add_typer(run_app, name="run")
 
     @train_app.command("convert")
     def train_convert(
@@ -114,3 +116,108 @@ def register_train(app: typer.Typer) -> None:
             print_error(str(exc))
             raise typer.Exit(1) from None
         console.print(json.dumps(result, sort_keys=True))
+
+    @run_app.command("sft")
+    def train_run_sft(
+        config: Annotated[
+            Path,
+            typer.Option("--config", help="Prime-RL SFT TOML config"),
+        ],
+        backend: Annotated[
+            Literal["prime-rl"],
+            typer.Option("--backend", help="Training backend"),
+        ] = "prime-rl",
+        data: Annotated[
+            str | None,
+            typer.Option(
+                "--data",
+                help="Optional dataset override passed to Prime-RL as --data.name",
+            ),
+        ] = None,
+        output_dir: Annotated[
+            Path | None,
+            typer.Option(
+                "--output-dir",
+                help="Prime-RL trainer output dir. Defaults to <work-dir>/prime-rl-output.",
+            ),
+        ] = None,
+        work_dir: Annotated[
+            Path,
+            typer.Option("--work-dir", help="BenchFlow training run directory"),
+        ] = Path("train-runs/sft"),
+        prime_rl_dir: Annotated[
+            Path | None,
+            typer.Option(
+                "--prime-rl-dir",
+                help="Prime-RL checkout to run uv from. Defaults to the current directory.",
+            ),
+        ] = None,
+        dry_run: Annotated[
+            bool,
+            typer.Option("--dry-run", help="Pass --dry-run through to Prime-RL"),
+        ] = False,
+        follow: Annotated[
+            bool,
+            typer.Option("--follow", help="Stream trainer stdout while writing logs"),
+        ] = False,
+        uv_no_sync: Annotated[
+            bool,
+            typer.Option(
+                "--uv-no-sync",
+                help=(
+                    "Run Prime-RL with `uv run --no-sync`, useful after backend "
+                    "post-install steps such as flash-attn."
+                ),
+            ),
+        ] = False,
+        override: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--override",
+                help="Prime-RL config override as KEY=VALUE; repeatable",
+            ),
+        ] = None,
+        force: Annotated[
+            bool,
+            typer.Option(
+                "--force",
+                help="Overwrite an existing <work-dir>/train-run.json manifest",
+            ),
+        ] = False,
+    ) -> None:
+        """Run a Prime-RL SFT job and record a BenchFlow manifest."""
+        del backend  # Typer validates the single supported backend for now.
+        from benchflow.training.backends.prime_rl import (
+            PrimeRlSftSpec,
+            run_prime_rl_sft,
+        )
+
+        try:
+            result = run_prime_rl_sft(
+                PrimeRlSftSpec(
+                    config=config,
+                    work_dir=work_dir,
+                    data=data,
+                    output_dir=output_dir,
+                    dry_run=dry_run,
+                    follow=follow,
+                    uv_no_sync=uv_no_sync,
+                    overrides=tuple(override or ()),
+                    force=force,
+                    cwd=prime_rl_dir,
+                )
+            )
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+
+        if result.returncode != 0:
+            print_error(
+                f"Prime-RL SFT failed with exit code {result.returncode}; "
+                f"see {result.manifest_path}"
+            )
+            raise typer.Exit(result.returncode)
+        console.print(
+            "[green]Prime-RL SFT completed[/green] "
+            f"(manifest: {escape(str(result.manifest_path))})"
+        )

--- a/src/benchflow/training/__init__.py
+++ b/src/benchflow/training/__init__.py
@@ -1,0 +1,1 @@
+"""Training launch helpers."""

--- a/src/benchflow/training/backends/__init__.py
+++ b/src/benchflow/training/backends/__init__.py
@@ -1,0 +1,1 @@
+"""Training backend implementations."""

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -1,0 +1,219 @@
+"""Prime-RL SFT launch wrapper."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Thread
+from typing import TextIO
+
+from benchflow.training.run_manifest import (
+    CommandRecord,
+    TrainComponent,
+    TrainRunManifest,
+    utc_now,
+    write_manifest,
+)
+
+_ENV_KEYS_TO_RECORD = (
+    "HF_TOKEN",
+    "HUGGINGFACE_HUB_TOKEN",
+    "PRIME_API_KEY",
+    "PRIMEINTELLECT_API_KEY",
+    "WANDB_API_KEY",
+)
+
+
+@dataclass(frozen=True)
+class PrimeRlSftSpec:
+    config: Path
+    work_dir: Path
+    data: str | None = None
+    output_dir: Path | None = None
+    dry_run: bool = False
+    follow: bool = False
+    uv_no_sync: bool = False
+    overrides: tuple[str, ...] = ()
+    force: bool = False
+    cwd: Path | None = None
+
+
+@dataclass(frozen=True)
+class PrimeRlSftResult:
+    manifest_path: Path
+    command_path: Path
+    returncode: int
+
+
+def _parse_overrides(overrides: Iterable[str]) -> list[str]:
+    argv: list[str] = []
+    for override in overrides:
+        if "=" not in override:
+            raise ValueError(f"--override must be KEY=VALUE, got {override!r}")
+        key, value = override.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"--override must have a non-empty key: {override!r}")
+        argv.extend([f"--{key}", value])
+    return argv
+
+
+def build_prime_rl_sft_argv(spec: PrimeRlSftSpec) -> list[str]:
+    config = spec.config.resolve()
+    work_dir = spec.work_dir.resolve()
+    output_dir = (
+        spec.output_dir.resolve() if spec.output_dir else work_dir / "prime-rl-output"
+    )
+    argv = ["uv", "run"]
+    if spec.uv_no_sync:
+        argv.append("--no-sync")
+    argv.extend(["sft", "@", str(config)])
+    if spec.data:
+        argv.extend(["--data.name", spec.data])
+    argv.extend(["--output-dir", str(output_dir)])
+    if spec.dry_run:
+        argv.append("--dry-run")
+    argv.extend(_parse_overrides(spec.overrides))
+    return argv
+
+
+def _recorded_env_keys() -> list[str]:
+    return sorted(key for key in _ENV_KEYS_TO_RECORD if os.environ.get(key))
+
+
+def _shell_quote(argv: list[str]) -> str:
+    import shlex
+
+    return " ".join(shlex.quote(arg) for arg in argv)
+
+
+def _copy_stream(stream: TextIO, handle: TextIO, *, echo: bool) -> None:
+    for line in stream:
+        handle.write(line)
+        handle.flush()
+        if echo:
+            print(line, end="", flush=True)
+
+
+def _initial_manifest(
+    spec: PrimeRlSftSpec, argv: list[str], logs: list[str]
+) -> TrainRunManifest:
+    work_dir = spec.work_dir.resolve()
+    output_dir = (
+        spec.output_dir.resolve() if spec.output_dir else work_dir / "prime-rl-output"
+    )
+    command = CommandRecord(
+        id="prime-rl-sft",
+        argv=argv,
+        cwd=str((spec.cwd or Path.cwd()).resolve()),
+        env_keys=_recorded_env_keys(),
+    )
+    component = TrainComponent(
+        name="trainer",
+        role="primary",
+        command_id=command.id,
+        status="pending",
+        logs=logs,
+    )
+    now = utc_now()
+    return TrainRunManifest(
+        schema_version=1,
+        run_type="sft",
+        backend="prime-rl",
+        config=str(spec.config.resolve()),
+        work_dir=str(work_dir),
+        output_dir=str(output_dir),
+        dry_run=spec.dry_run,
+        created_at=now,
+        updated_at=now,
+        overall_status="pending",
+        commands=[command],
+        components=[component],
+    )
+
+
+def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
+    if not spec.config.is_file():
+        raise ValueError(f"--config not found: {spec.config}")
+    if spec.cwd is not None and not spec.cwd.is_dir():
+        raise ValueError(f"--prime-rl-dir not found: {spec.cwd}")
+    work_dir = spec.work_dir.resolve()
+    manifest_path = work_dir / "train-run.json"
+    if manifest_path.exists() and not spec.force:
+        raise ValueError(f"{manifest_path} already exists; pass --force to overwrite")
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise ValueError("uv is required to launch Prime-RL SFT")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    log_dir = work_dir / "prime-rl"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = log_dir / "stdout.log"
+    stderr_path = log_dir / "stderr.log"
+    command_path = work_dir / "command.txt"
+
+    argv = build_prime_rl_sft_argv(spec)
+    command_path.write_text(_shell_quote(argv) + "\n", encoding="utf-8")
+    manifest = _initial_manifest(
+        spec,
+        argv,
+        [
+            str(stdout_path.relative_to(work_dir)),
+            str(stderr_path.relative_to(work_dir)),
+        ],
+    )
+    manifest.overall_status = "running"
+    manifest.components[0].status = "running"
+    write_manifest(manifest_path, manifest)
+
+    cwd = spec.cwd.resolve() if spec.cwd else Path.cwd()
+    with (
+        stdout_path.open("w", encoding="utf-8") as stdout_handle,
+        stderr_path.open("w", encoding="utf-8") as stderr_handle,
+    ):
+        process = subprocess.Popen(
+            argv,
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+        )
+        assert process.stdout is not None
+        assert process.stderr is not None
+        stdout_thread = Thread(
+            target=_copy_stream,
+            args=(process.stdout, stdout_handle),
+            kwargs={"echo": spec.follow},
+            daemon=True,
+        )
+        stderr_thread = Thread(
+            target=_copy_stream,
+            args=(process.stderr, stderr_handle),
+            kwargs={"echo": False},
+            daemon=True,
+        )
+        stdout_thread.start()
+        stderr_thread.start()
+        returncode = process.wait()
+        stdout_thread.join()
+        stderr_thread.join()
+
+    if returncode == 0:
+        manifest.overall_status = "succeeded"
+        manifest.components[0].status = "succeeded"
+    else:
+        manifest.overall_status = "failed"
+        manifest.components[0].status = "failed"
+        manifest.components[0].extra["returncode"] = returncode
+    write_manifest(manifest_path, manifest)
+    return PrimeRlSftResult(
+        manifest_path=manifest_path,
+        command_path=command_path,
+        returncode=returncode,
+    )

--- a/src/benchflow/training/run_manifest.py
+++ b/src/benchflow/training/run_manifest.py
@@ -1,0 +1,66 @@
+"""Manifest helpers for trainer launches."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal
+
+TrainComponentRole = Literal["primary", "service"]
+TrainComponentStatus = Literal["pending", "running", "succeeded", "failed"]
+TrainRunStatus = Literal["pending", "running", "succeeded", "failed"]
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat()
+
+
+@dataclass(frozen=True)
+class CommandRecord:
+    id: str
+    argv: list[str]
+    cwd: str
+    env_keys: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TrainComponent:
+    name: str
+    role: TrainComponentRole
+    command_id: str
+    status: TrainComponentStatus = "pending"
+    logs: list[str] = field(default_factory=list)
+    metrics: list[str] = field(default_factory=list)
+    checkpoints: list[str] = field(default_factory=list)
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class TrainRunManifest:
+    schema_version: int
+    run_type: str
+    backend: str
+    config: str
+    work_dir: str
+    output_dir: str
+    dry_run: bool
+    created_at: str
+    updated_at: str
+    overall_status: TrainRunStatus
+    commands: list[CommandRecord]
+    components: list[TrainComponent]
+    artifacts: dict[str, list[str]] = field(
+        default_factory=lambda: {"checkpoints": [], "exported_models": []}
+    )
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def write_manifest(path: Path, manifest: TrainRunManifest) -> None:
+    manifest.updated_at = utc_now()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(manifest.to_dict(), indent=2, sort_keys=True) + "\n")

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import json
 from pathlib import Path
+from typing import Any
 
 from typer.testing import CliRunner
 
@@ -123,3 +125,138 @@ def test_train_convert_rejects_malformed_llm_jsonl(tmp_path: Path) -> None:
     assert result.exit_code == 1
     assert "invalid JSON" in result.output
     assert not out.exists()
+
+
+def test_train_run_sft_prime_rl_records_manifest(tmp_path: Path, monkeypatch) -> None:
+    """Guards the Prime-RL SFT wrapper command against losing launch provenance."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            captured["argv"] = argv
+            captured["cwd"] = kwargs["cwd"]
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+    output_dir = tmp_path / "prime-output"
+    prime_rl_dir = tmp_path / "prime-rl-checkout"
+    prime_rl_dir.mkdir()
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--backend",
+            "prime-rl",
+            "--config",
+            str(config),
+            "--data",
+            "benchflow/env0-prime-sft",
+            "--output-dir",
+            str(output_dir),
+            "--work-dir",
+            str(work_dir),
+            "--prime-rl-dir",
+            str(prime_rl_dir),
+            "--dry-run",
+            "--uv-no-sync",
+            "--override",
+            "model.name=Qwen/Qwen3.5-9B",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Prime-RL SFT completed" in result.output
+    assert captured["argv"] == [
+        "uv",
+        "run",
+        "--no-sync",
+        "sft",
+        "@",
+        str(config),
+        "--data.name",
+        "benchflow/env0-prime-sft",
+        "--output-dir",
+        str(output_dir),
+        "--dry-run",
+        "--model.name",
+        "Qwen/Qwen3.5-9B",
+    ]
+    assert captured["cwd"] == str(prime_rl_dir.resolve())
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["overall_status"] == "succeeded"
+    assert manifest["run_type"] == "sft"
+    assert manifest["backend"] == "prime-rl"
+    assert manifest["commands"][0]["argv"] == captured["argv"]
+    assert manifest["commands"][0]["cwd"] == str(prime_rl_dir.resolve())
+    assert manifest["components"] == [
+        {
+            "checkpoints": [],
+            "command_id": "prime-rl-sft",
+            "extra": {},
+            "logs": ["prime-rl/stdout.log", "prime-rl/stderr.log"],
+            "metrics": [],
+            "name": "trainer",
+            "role": "primary",
+            "status": "succeeded",
+        }
+    ]
+    assert (work_dir / "command.txt").read_text().startswith("uv run --no-sync sft @")
+    assert (work_dir / "prime-rl" / "stdout.log").read_text() == "trainer ok\n"
+
+
+def test_train_run_sft_prime_rl_failure_updates_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Guards the Prime-RL SFT wrapper against reporting failed launches as done."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del argv, kwargs
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("boom\n")
+
+        def wait(self) -> int:
+            return 7
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 7
+    assert "Prime-RL SFT failed with exit code 7" in result.output
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["overall_status"] == "failed"
+    assert manifest["components"][0]["status"] == "failed"
+    assert manifest["components"][0]["extra"] == {"returncode": 7}
+    assert (work_dir / "prime-rl" / "stderr.log").read_text() == "boom\n"


### PR DESCRIPTION
## Summary
- Add `bench train run sft` with a Prime-RL backend wrapper around `uv run sft @ <config>`.
- Record `train-run.json`, `command.txt`, and split Prime-RL stdout/stderr logs under `--work-dir`.
- Add `--prime-rl-dir` for running from a separate Prime-RL checkout and `--uv-no-sync` for Prime-RL post-install workflows such as flash-attn.

## Validation
- `uv run ruff check src/benchflow/cli/train.py src/benchflow/training tests/test_train_cli.py`
- `uv run ruff format --check src/benchflow/cli/train.py src/benchflow/training tests/test_train_cli.py`
- `uv run ty check src/benchflow/cli/train.py src/benchflow/training`
- `uv run pytest tests/test_train_cli.py tests/test_train_mode_artifact_emission.py tests/trajectories/test_export_prime_sft.py tests/test_cli_docs_drift.py -q`

## Real SFT smoke
- Created `benchflow/env0-prime-sft-smoke10-arrow` from 10 rows of the env0-mobile PR828 300-row Prime-SFT dataset, using an explicit Arrow nested schema compatible with Prime-RL's `datasets` loader.
- Ran the latest BenchFlow wrapper on a Prime 1x H100 80GB pod:
  `bench train run sft --backend prime-rl --config /home/ubuntu/qwen35_env0_smoke_sft.toml --data benchflow/env0-prime-sft-smoke10-arrow --prime-rl-dir /home/ubuntu/prime-rl --work-dir /home/ubuntu/benchflow-sft-smoke2/train-arrow --output-dir /home/ubuntu/benchflow-sft-smoke2/train-arrow/prime-output --force --uv-no-sync --follow`.
- The run completed `max_steps=10` on `Qwen/Qwen3.5-9B` with LoRA rank 8. Final metrics included loss `0.62092`, peak memory `43.9 GiB`, and throughput about `2356 tokens/s`.
- Wrapper manifest ended with `overall_status=succeeded`; output included `weights/step_10/lora_adapters/adapter_model.safetensors` and full step-10 weights.
- W&B run: https://wandb.ai/benchflow-ai/benchflow-env0-sft-wrapper-smoke/runs/j6003i0y
- Prime pods were terminated after validation; `prime pods list` reported no active pods.

## Notes
- The successful smoke used Prime-RL's prebuilt `flash-attn` extra and required system build tools plus CUDA CCCL include path for TileLang runtime compilation on the base pod image. Those are backend environment requirements; the BenchFlow wrapper recorded failures clearly while we fixed them.