### PR TITLE
Resolve Prime-RL SFT configs from checkout

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -369,7 +369,7 @@ that were present are recorded.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--backend` | `prime-rl` | Training backend. Currently only `prime-rl` is supported |
-| `--config` | required | Prime-RL SFT TOML config |
+| `--config` | required | Prime-RL SFT TOML config. Relative paths are resolved from the current directory first, then from `--prime-rl-dir` when set |
 | `--data` | — | Optional dataset override passed through as `--data.name` |
 | `--output-dir` | `<work-dir>/prime-rl-output` | Prime-RL trainer output directory |
 | `--work-dir` | `train-runs/sft` | BenchFlow training run directory |

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -62,8 +62,18 @@ def _parse_overrides(overrides: Iterable[str]) -> list[str]:
     return argv
 
 
+def _resolve_config_path(config: Path, cwd: Path | None) -> Path:
+    if config.is_file():
+        return config.resolve()
+    if cwd is not None and not config.is_absolute():
+        candidate = cwd / config
+        if candidate.is_file():
+            return candidate.resolve()
+    raise ValueError(f"--config not found: {config}")
+
+
 def build_prime_rl_sft_argv(spec: PrimeRlSftSpec) -> list[str]:
-    config = spec.config.resolve()
+    config = _resolve_config_path(spec.config, spec.cwd)
     work_dir = spec.work_dir.resolve()
     output_dir = (
         spec.output_dir.resolve() if spec.output_dir else work_dir / "prime-rl-output"
@@ -124,7 +134,7 @@ def _initial_manifest(
         schema_version=1,
         run_type="sft",
         backend="prime-rl",
-        config=str(spec.config.resolve()),
+        config=str(_resolve_config_path(spec.config, spec.cwd)),
         work_dir=str(work_dir),
         output_dir=str(output_dir),
         dry_run=spec.dry_run,
@@ -137,10 +147,9 @@ def _initial_manifest(
 
 
 def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
-    if not spec.config.is_file():
-        raise ValueError(f"--config not found: {spec.config}")
     if spec.cwd is not None and not spec.cwd.is_dir():
         raise ValueError(f"--prime-rl-dir not found: {spec.cwd}")
+    _resolve_config_path(spec.config, spec.cwd)
     work_dir = spec.work_dir.resolve()
     manifest_path = work_dir / "train-run.json"
     if manifest_path.exists() and not spec.force:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -260,3 +260,51 @@ def test_train_run_sft_prime_rl_failure_updates_manifest(
     assert manifest["components"][0]["status"] == "failed"
     assert manifest["components"][0]["extra"] == {"returncode": 7}
     assert (work_dir / "prime-rl" / "stderr.log").read_text() == "boom\n"
+
+
+def test_train_run_sft_resolves_config_relative_to_prime_rl_dir(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Guards the Prime-RL wrapper's native-checkout config path handling."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del kwargs
+            captured["argv"] = argv
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    prime_rl_dir = tmp_path / "prime-rl"
+    config = prime_rl_dir / "examples" / "reverse_text" / "sft.toml"
+    config.parent.mkdir(parents=True)
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            "examples/reverse_text/sft.toml",
+            "--prime-rl-dir",
+            str(prime_rl_dir),
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["argv"][4] == str(config.resolve())
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["config"] == str(config.resolve())


### PR DESCRIPTION
## Goal
Make `bench train run sft --prime-rl-dir <checkout>` work with native Prime-RL config paths such as `examples/reverse_text/sft.toml`, without requiring callers to rewrite them as absolute paths from the BenchFlow caller directory.

## What changed
- Added config resolution that first checks the caller-provided path, then checks the path relative to `--prime-rl-dir` when that option is set.
- Stored the resolved config path in both the launched Prime-RL argv and `train-run.json`.
- Documented the relative-path behavior for `--config`.
- Added a regression test for config paths that only exist inside the Prime-RL checkout.

## Validation
- `uv run ruff check src/benchflow/training/backends/prime_rl.py tests/test_train_cli.py`
- `uv run ruff format --check src/benchflow/training/backends/prime_rl.py tests/test_train_cli.py`
- `uv run ty check src/benchflow/training/backends/prime_rl.py`
- `uv run pytest tests/test_train_cli.py -q`