### PR TITLE
Add reproducible eval and SFT artifact CLI hooks

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -182,6 +182,19 @@ bench eval run \
 # From local directory
 bench eval run --tasks-dir ./tasks --agent gemini --model gemini-3.1-flash-lite-preview
 
+# Emit reproducible training/eval artifacts and publish them to Hugging Face
+bench eval run \
+  --tasks-dir ./tasks \
+  --agent openhands \
+  --model openai/gpt-5.4-mini \
+  --sandbox daytona \
+  --task-manifest-out task-manifest.json \
+  --health-summary-out health.json \
+  --canonicalize one-healthy-per-task \
+  --canonical-selection-out canonical-selection.json \
+  --publish-hf benchflow/env0-experiment-trajectories \
+  --hf-prefix experiments/my-run
+
 # From a hosted PrimeIntellect / Verifiers environment
 bench eval run \
   --source-env primeintellect/general-agent \
@@ -202,6 +215,9 @@ bench eval run \
 # Pinned registry dataset: resolves skillsbench@1.1, verifies task digests,
 # and stamps dataset identity into every result.json/config.json
 bench eval run -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lite-preview
+
+# Matrix eval over multiple models/trials
+bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 ```
 
 | Flag | Default | Description |
@@ -250,6 +266,21 @@ bench eval run -d skillsbench@1.1 --agent gemini --model gemini-3.1-flash-lite-p
 | `--exclude` | — | Skip these task names; repeatable (e.g. `--exclude quantum-numerical-simulation`) |
 | `--loop-strategy` | — | Wrap each rollout in a loop, e.g. `verify-retry:k=3,feedback=names` or `self-review:k=3` (omit for single-shot) |
 | `--ignore-bench-version` | `false` | With `--dataset`, skip the dataset's `bench_version` compatibility gate |
+| `--task-manifest-out` | — | Write selected task-set manifest JSON with task ids, paths, digests, and source provenance |
+| `--run-config-out` | — | Write a redacted normalized run config JSON |
+| `--health-summary-out` | — | Write trajectory health summary JSON for the completed job |
+| `--expected-tasks` | — | Fail unless the selected task count, and canonical selected count when used, matches this value |
+| `--canonicalize` | `none` | Canonicalization policy: `none` or `one-healthy-per-task` |
+| `--canonical-selection-out` | — | Write canonical rollout-selection JSON |
+| `--canonical-jobs-dir` | — | Materialize selected rollout directories for trainer conversion |
+| `--retry-policy` | `default` | Retry policy label for reproducible eval artifacts: `default` or `unscored-only` |
+| `--retry-attempts` | — | Override retry attempts for the eval run |
+| `--retry-concurrency` | — | Reserved retry concurrency setting recorded in run config |
+| `--publish-hf` | — | Upload final eval artifacts to this Hugging Face dataset repo |
+| `--hf-prefix` | — | Path prefix inside the Hugging Face repo; requires `--publish-hf` |
+| `--hf-public-read-check` | `false` | Verify public Hugging Face reads after upload |
+| `--matrix` | — | YAML model matrix for repeated evals; currently requires `--tasks-dir` |
+| `--trials` | `1` | Number of trials for `--matrix` |
 
 When mounting skills, the recommended docs default is
 `--agent-env BENCHFLOW_SKILL_NUDGE=name`. See
@@ -312,6 +343,7 @@ OpenAI-compatible `messages` plus `tool_defs`.
 ```bash
 bench train convert jobs/run-001 --out train.jsonl
 bench train convert jobs/run-001 --out train.jsonl --min-reward 1.0
+bench train convert jobs/run-001 --out train.jsonl --canonical-selection canonical-selection.json
 ```
 
 | Flag | Default | Description |
@@ -322,6 +354,7 @@ bench train convert jobs/run-001 --out train.jsonl --min-reward 1.0
 | `--row-mode` | `rollout` | `rollout` writes one row per rollout; `exchange` writes one row per LLM exchange |
 | `--manifest` | — | Optional conversion stats JSON path |
 | `--expected-rows` | — | Fail before writing unless exactly this many rows would be exported |
+| `--canonical-selection` | — | Restrict conversion to rows selected by `canonical-selection.json` |
 
 ### bench train validate
 
@@ -330,12 +363,21 @@ Validate Prime-RL SFT JSONL before upload or training.
 ```bash
 bench train validate train.jsonl
 bench train validate train.jsonl --expected-rows 4417
+bench train validate train.jsonl \
+  --source-jobs jobs/run-001 \
+  --require-llm-trajectory \
+  --require-tool-calls
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--format` | `prime-sft` | Trainer format |
 | `--expected-rows` | — | Fail unless this many rows are present |
+| `--source-jobs` | — | Source BenchFlow jobs directory to audit alongside trainer JSONL |
+| `--source-canonical-selection` | — | Canonical selection JSON used for this trainer data |
+| `--task-manifest` | — | Task manifest for source rows |
+| `--require-llm-trajectory` | `false` | Fail unless source selected rows have valid `llm_trajectory.jsonl` |
+| `--require-tool-calls` | `false` | Fail unless trainer rows and source rows include tool calls |
 
 ### bench train run sft
 
@@ -350,6 +392,9 @@ bench train run sft \
   --data benchflow/env0-prime-sft \
   --prime-rl-dir .local/prime-rl \
   --work-dir train-runs/qwen35-env0-sft \
+  --publish-model benchflow/benchflow-qwen35-9b \
+  --publish-artifacts benchflow/env0-experiment-trajectories \
+  --hf-prefix experiments/env0-mobile-pr828/training \
   --follow
 ```
 
@@ -379,6 +424,12 @@ that were present are recorded.
 | `--uv-no-sync` | `false` | Run Prime-RL as `uv run --no-sync sft ...`, useful after backend post-install steps such as `flash-attn` |
 | `--override` | — | Prime-RL override as `KEY=VALUE`; repeatable, emitted as `--KEY VALUE` |
 | `--force` | `false` | Overwrite an existing `<work-dir>/train-run.json` manifest |
+| `--publish-model` | — | Upload trainer output to this Hugging Face model repo |
+| `--model-tag` | — | Path prefix/tag for the model upload |
+| `--model-card` | — | Model card mode; currently accepts `auto` |
+| `--publish-artifacts` | — | Upload BenchFlow train run artifacts to this Hugging Face dataset repo |
+| `--hf-prefix` | — | Path prefix for `--publish-artifacts` |
+| `--hf-public-read-check` | `false` | Verify public Hugging Face reads after upload |
 
 ## bench skills
 
@@ -505,6 +556,24 @@ bench tasks digest tasks/                  # one "<name> sha256:<hex>" line per 
 ```
 
 Arguments: `PATH` (a task directory, or a directory of task directories).
+
+### bench tasks overlap
+
+Compare two task manifests, typically one emitted by a training-data collection
+run and one emitted by an evaluation run.
+
+```bash
+bench tasks overlap train-task-manifest.json eval-task-manifest.json
+bench tasks overlap train-task-manifest.json eval-task-manifest.json --out overlap.json
+```
+
+The command reports exact task-id overlap and exact digest overlap. A zero
+overlap result means the task ids/digests are disjoint; it does not prove domain
+or generator-family disjointness.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--out`, `-o` | — | Optional JSON output path |
 
 ### bench tasks generate
 

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -1,0 +1,289 @@
+"""CLI-side artifact handling for ``bench eval run``."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal, cast
+
+import typer
+from rich.markup import escape
+
+from benchflow.cli._shared import console, print_error
+
+if TYPE_CHECKING:
+    from benchflow.eval_plan import EvalPlan
+    from benchflow.evaluation import EvaluationConfig, EvaluationResult
+
+
+def _write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _redacted_eval_config(eval_config: EvaluationConfig) -> dict:
+    return {
+        "agent": eval_config.agent,
+        "model": eval_config.model,
+        "reasoning_effort": eval_config.reasoning_effort,
+        "environment": eval_config.environment,
+        "concurrency": eval_config.concurrency,
+        "build_concurrency": eval_config.build_concurrency,
+        "skill_mode": eval_config.skill_mode,
+        "skills_dir": eval_config.skills_dir,
+        "usage_tracking": eval_config.usage_tracking.to_config_artifact(),
+        "agent_env_keys": sorted(eval_config.agent_env),
+        "include_tasks": sorted(eval_config.include_tasks),
+        "exclude_tasks": sorted(eval_config.exclude_tasks),
+        "source_provenance": eval_config.source_provenance,
+        "dataset_name": eval_config.dataset_name,
+        "dataset_version": eval_config.dataset_version,
+    }
+
+
+def postprocess_eval_artifacts(
+    plan: EvalPlan,
+    resolved_tasks_dir: Path,
+    eval_config: EvaluationConfig,
+    job_dir: Path | None,
+) -> None:
+    req = plan.request
+    if job_dir is None:
+        return
+    from benchflow.eval_artifacts import (
+        TaskManifestOptions,
+        materialize_canonical_job,
+        write_canonical_selection,
+        write_health_summary,
+        write_task_manifest,
+    )
+
+    if req.task_manifest_out is not None:
+        manifest = write_task_manifest(
+            req.task_manifest_out,
+            TaskManifestOptions(
+                tasks_dir=resolved_tasks_dir,
+                include_tasks=eval_config.include_tasks,
+                exclude_tasks=eval_config.exclude_tasks,
+                source_provenance=eval_config.source_provenance,
+                dataset_name=eval_config.dataset_name,
+                dataset_version=eval_config.dataset_version,
+                dataset_task_digests=eval_config.dataset_task_digests,
+            ),
+        )
+        if req.expected_tasks is not None and manifest["total"] != req.expected_tasks:
+            print_error(
+                f"selected task count {manifest['total']} != expected {req.expected_tasks}"
+            )
+            raise typer.Exit(1)
+        console.print(
+            f"[green]Task manifest:[/green] {escape(str(req.task_manifest_out))}"
+        )
+    if req.run_config_out is not None:
+        _write_json(
+            req.run_config_out,
+            {
+                "schema_version": 1,
+                "jobs_dir": str(job_dir),
+                "eval": _redacted_eval_config(eval_config),
+                "retry_policy": req.retry_policy,
+                "retry_attempts": req.retry_attempts,
+                "retry_concurrency": req.retry_concurrency,
+            },
+        )
+        console.print(f"[green]Run config:[/green] {escape(str(req.run_config_out))}")
+    if req.health_summary_out is not None:
+        write_health_summary(req.health_summary_out, job_dir)
+        console.print(
+            f"[green]Health summary:[/green] {escape(str(req.health_summary_out))}"
+        )
+    if req.canonicalize != "none" and req.canonical_selection_out is not None:
+        try:
+            policy = cast(Literal["one-healthy-per-task"], req.canonicalize)
+            write_canonical_selection(
+                req.canonical_selection_out,
+                job_dir,
+                policy=policy,
+                expected_tasks=req.expected_tasks,
+            )
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+        console.print(
+            "[green]Canonical selection:[/green] "
+            f"{escape(str(req.canonical_selection_out))}"
+        )
+        if req.canonical_jobs_dir is not None:
+            try:
+                materialize_canonical_job(
+                    req.canonical_selection_out, req.canonical_jobs_dir
+                )
+            except ValueError as exc:
+                print_error(str(exc))
+                raise typer.Exit(1) from None
+            console.print(
+                f"[green]Canonical jobs:[/green] {escape(str(req.canonical_jobs_dir))}"
+            )
+    if req.publish_hf is not None:
+        from benchflow.publish.huggingface import publish_folder_to_hf
+
+        prefix = req.hf_prefix or job_dir.name
+        try:
+            published = publish_folder_to_hf(
+                job_dir,
+                repo_id=req.publish_hf,
+                path_in_repo=prefix,
+                repo_type="dataset",
+                public_read_check=req.hf_public_read_check,
+            )
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+        console.print(f"[green]Published HF artifacts:[/green] {escape(published.url)}")
+
+
+def _load_eval_matrix(path: Path) -> dict[str, dict]:
+    import yaml
+
+    data = yaml.safe_load(path.read_text())
+    if not isinstance(data, dict) or not isinstance(data.get("models"), dict):
+        raise ValueError("--matrix must be a YAML mapping with a models: mapping")
+    models = {}
+    for alias, raw in data["models"].items():
+        if isinstance(raw, str):
+            models[str(alias)] = {"model": raw}
+        elif isinstance(raw, dict) and raw.get("model"):
+            models[str(alias)] = dict(raw)
+        else:
+            raise ValueError(
+                f"matrix model {alias!r} must be a string or model mapping"
+            )
+    return models
+
+
+def _matrix_agent_env(raw: object) -> dict[str, str]:
+    if raw is None:
+        return {}
+    if isinstance(raw, dict):
+        return {str(key): str(value) for key, value in raw.items()}
+    raise ValueError("matrix agent_env must be a mapping")
+
+
+def _matrix_file_path(path: Path | None, alias: str, trial: int) -> Path | None:
+    if path is None:
+        return None
+    return path.parent / alias / f"trial-{trial:02d}" / path.name
+
+
+def _matrix_dir_path(path: Path | None, alias: str, trial: int) -> Path | None:
+    if path is None:
+        return None
+    return path / alias / f"trial-{trial:02d}"
+
+
+def _write_matrix_task_manifest(
+    plan: EvalPlan, resolved_tasks_dir: Path, eval_config: EvaluationConfig
+) -> None:
+    req = plan.request
+    if req.task_manifest_out is None:
+        return
+    from benchflow.eval_artifacts import TaskManifestOptions, write_task_manifest
+
+    manifest = write_task_manifest(
+        req.task_manifest_out,
+        TaskManifestOptions(
+            tasks_dir=resolved_tasks_dir,
+            include_tasks=eval_config.include_tasks,
+            exclude_tasks=eval_config.exclude_tasks,
+            source_provenance=eval_config.source_provenance,
+            dataset_name=eval_config.dataset_name,
+            dataset_version=eval_config.dataset_version,
+            dataset_task_digests=eval_config.dataset_task_digests,
+        ),
+    )
+    if req.expected_tasks is not None and manifest["total"] != req.expected_tasks:
+        print_error(
+            f"selected task count {manifest['total']} != expected {req.expected_tasks}"
+        )
+        raise typer.Exit(1)
+    console.print(f"[green]Task manifest:[/green] {escape(str(req.task_manifest_out))}")
+
+
+def run_matrix_eval(
+    plan: EvalPlan,
+    resolved_tasks_dir: Path,
+    run_batch_eval: Callable[[EvalPlan, Path, EvaluationConfig], EvaluationResult],
+) -> None:
+    req = plan.request
+    assert req.matrix is not None
+    try:
+        models = _load_eval_matrix(req.matrix)
+    except (OSError, ValueError) as exc:
+        print_error(str(exc))
+        raise typer.Exit(1) from None
+    root = Path(plan.output_jobs_dir)
+    _write_matrix_task_manifest(plan, resolved_tasks_dir, plan.make_eval_config())
+    matrix_runs = []
+    for alias, raw in models.items():
+        for trial in range(1, req.trials + 1):
+            trial_dir = root / alias / f"trial-{trial:02d}"
+            trial_prefix = (
+                f"{req.hf_prefix.rstrip('/')}/{alias}/trial-{trial:02d}"
+                if req.hf_prefix
+                else None
+            )
+            trial_request = replace(
+                req,
+                hf_prefix=trial_prefix,
+                task_manifest_out=None,
+                run_config_out=_matrix_file_path(req.run_config_out, alias, trial),
+                health_summary_out=_matrix_file_path(
+                    req.health_summary_out, alias, trial
+                ),
+                canonical_selection_out=_matrix_file_path(
+                    req.canonical_selection_out, alias, trial
+                ),
+                canonical_jobs_dir=_matrix_dir_path(
+                    req.canonical_jobs_dir, alias, trial
+                ),
+                matrix=None,
+            )
+            trial_plan = replace(
+                plan,
+                request=trial_request,
+                output_jobs_dir=str(trial_dir),
+                parsed_env={
+                    **plan.parsed_env,
+                    **_matrix_agent_env(raw.get("agent_env")),
+                },
+            )
+            eval_config = trial_plan.make_eval_config()
+            eval_config.model = str(raw["model"])
+            if raw.get("agent"):
+                eval_config.agent = str(raw["agent"])
+            result = run_batch_eval(trial_plan, resolved_tasks_dir, eval_config)
+            matrix_runs.append(
+                {
+                    "alias": alias,
+                    "trial": trial,
+                    "jobs_dir": str(trial_dir),
+                    "passed": result.passed,
+                    "failed": result.failed,
+                    "errored": result.errored,
+                    "verifier_errored": result.verifier_errored,
+                    "total": result.total,
+                }
+            )
+    summary_path = root / "matrix-summary.json"
+    _write_json(
+        summary_path,
+        {
+            "schema_version": 1,
+            "matrix": str(req.matrix),
+            "trials": req.trials,
+            "runs": matrix_runs,
+        },
+    )
+    console.print(f"[green]Matrix summary:[/green] {escape(str(summary_path))}")

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -47,6 +47,7 @@ from benchflow.cli.adopt import register_adopt_deprecated, register_eval_adopt
 from benchflow.cli.agent import register_agent
 from benchflow.cli.continue_cmd import register_continue
 from benchflow.cli.environment import register_environment
+from benchflow.cli.eval_artifacts import postprocess_eval_artifacts, run_matrix_eval
 from benchflow.cli.hub import register_hub
 from benchflow.cli.monitor import register_monitor
 from benchflow.cli.sandbox import register_sandbox
@@ -491,6 +492,87 @@ def eval_run(
             "range it was validated against. Only valid with --dataset.",
         ),
     ] = False,
+    task_manifest_out: Annotated[
+        Path | None,
+        typer.Option(
+            "--task-manifest-out", help="Write selected task-set manifest JSON"
+        ),
+    ] = None,
+    run_config_out: Annotated[
+        Path | None,
+        typer.Option(
+            "--run-config-out", help="Write redacted normalized run config JSON"
+        ),
+    ] = None,
+    health_summary_out: Annotated[
+        Path | None,
+        typer.Option(
+            "--health-summary-out", help="Write trajectory health summary JSON"
+        ),
+    ] = None,
+    expected_tasks: Annotated[
+        int | None,
+        typer.Option(
+            "--expected-tasks", help="Fail unless the selected task count matches"
+        ),
+    ] = None,
+    canonicalize: Annotated[
+        str,
+        typer.Option(
+            "--canonicalize",
+            help="Canonicalization policy: none or one-healthy-per-task",
+        ),
+    ] = "none",
+    canonical_selection_out: Annotated[
+        Path | None,
+        typer.Option(
+            "--canonical-selection-out",
+            help="Write canonical rollout-selection JSON",
+        ),
+    ] = None,
+    canonical_jobs_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--canonical-jobs-dir",
+            help="Materialize selected rollout dirs for trainer conversion",
+        ),
+    ] = None,
+    retry_policy: Annotated[
+        str,
+        typer.Option("--retry-policy", help="Retry policy: default or unscored-only"),
+    ] = "default",
+    retry_attempts: Annotated[
+        int | None,
+        typer.Option("--retry-attempts", help="Reserved retry-attempt override"),
+    ] = None,
+    retry_concurrency: Annotated[
+        int | None,
+        typer.Option("--retry-concurrency", help="Reserved retry concurrency"),
+    ] = None,
+    publish_hf: Annotated[
+        str | None,
+        typer.Option(
+            "--publish-hf", help="Upload final eval artifacts to a HF dataset repo"
+        ),
+    ] = None,
+    hf_prefix: Annotated[
+        str | None,
+        typer.Option("--hf-prefix", help="Path prefix in the HF repo"),
+    ] = None,
+    hf_public_read_check: Annotated[
+        bool,
+        typer.Option(
+            "--hf-public-read-check", help="Verify public HF reads after upload"
+        ),
+    ] = False,
+    matrix: Annotated[
+        Path | None,
+        typer.Option("--matrix", help="YAML model matrix for repeated evals"),
+    ] = None,
+    trials: Annotated[
+        int,
+        typer.Option("--trials", help="Number of trials for --matrix"),
+    ] = 1,
 ) -> None:
     """Run an evaluation — single task or batch.
 
@@ -533,6 +615,21 @@ def eval_run(
         dataset=dataset,
         registry=registry,
         ignore_bench_version=ignore_bench_version,
+        task_manifest_out=task_manifest_out,
+        run_config_out=run_config_out,
+        health_summary_out=health_summary_out,
+        expected_tasks=expected_tasks,
+        canonicalize=canonicalize,
+        canonical_selection_out=canonical_selection_out,
+        canonical_jobs_dir=canonical_jobs_dir,
+        retry_policy=retry_policy,
+        retry_attempts=retry_attempts,
+        retry_concurrency=retry_concurrency,
+        publish_hf=publish_hf,
+        hf_prefix=hf_prefix,
+        hf_public_read_check=hf_public_read_check,
+        matrix=matrix,
+        trials=trials,
     )
     # --source-path/--source-ref only apply to --source-repo; otherwise they're
     # silently ignored (e.g. `--dataset X --source-ref abc` drops the ref).
@@ -588,7 +685,10 @@ def eval_run(
             # dumps a raw NotADirectoryError, unlike sandbox create / eval metrics.
             print_error(f"Not a directory: {tasks_dir}")
             raise typer.Exit(1)
-        run_batch_eval(plan, tasks_dir, plan.make_eval_config())
+        if matrix is not None:
+            run_matrix_eval(plan, tasks_dir, run_batch_eval)
+        else:
+            run_batch_eval(plan, tasks_dir, plan.make_eval_config())
     elif dataset:
         from benchflow._utils.dataset_registry import (
             DEFAULT_REGISTRY_SOURCE,
@@ -676,6 +776,8 @@ def run_batch_eval(
     from benchflow.evaluation import EmptyTaskSelectionError, Evaluation
 
     try:
+        if plan.request.retry_attempts is not None:
+            eval_config.retry.max_retries = plan.request.retry_attempts
         if plan.request.worker_concurrency is None:
             # One Evaluation construction; the live dashboard contributes hooks +
             # a context manager on a TTY, and a null context + no hooks otherwise
@@ -727,6 +829,7 @@ def run_batch_eval(
 
     job_name = getattr(result, "job_name", None)
     job_dir = Path(plan.output_jobs_dir) / job_name if job_name else None
+    postprocess_eval_artifacts(plan, resolved_tasks_dir, eval_config, job_dir)
     _report_eval_result(result, job_dir)
     _exit_if_evaluation_had_errors(result)
     return result

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -8,6 +8,7 @@ only wires the call.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Annotated, Literal, cast
 
@@ -161,6 +162,41 @@ def register_tasks(app: typer.Typer) -> None:
                 # render verbatim instead of being parsed as styling (#379).
                 console.print(f"  [yellow]→[/yellow] {escape(issue)}")
             raise typer.Exit(1)
+
+    @tasks_app.command("overlap")
+    def tasks_overlap(
+        left_manifest: Annotated[
+            Path,
+            typer.Argument(help="Left task manifest JSON"),
+        ],
+        right_manifest: Annotated[
+            Path,
+            typer.Argument(help="Right task manifest JSON"),
+        ],
+        output: Annotated[
+            Path | None,
+            typer.Option("--out", "-o", help="Optional JSON output path"),
+        ] = None,
+    ) -> None:
+        """Compare two task manifests for exact task-id and digest overlap."""
+        from benchflow.eval_artifacts import task_overlap
+
+        try:
+            result = task_overlap(left_manifest, right_manifest)
+        except (OSError, ValueError) as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+        if output is not None:
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+            console.print(f"[green]Wrote:[/green] {escape(str(output))}")
+        console.print(
+            "Task-id overlap: "
+            f"{result['task_id_overlap_count']} "
+            f"({result['left_count']} left, {result['right_count']} right)"
+        )
+        console.print(f"Digest overlap: {result['digest_overlap_count']}")
+        console.print(f"[dim]{escape(result['caveat'])}[/dim]")
 
     @tasks_app.command("migrate")
     def tasks_migrate(

--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -64,6 +64,13 @@ def register_train(app: typer.Typer) -> None:
                 ),
             ),
         ] = None,
+        canonical_selection: Annotated[
+            Path | None,
+            typer.Option(
+                "--canonical-selection",
+                help="Restrict conversion to rows selected by canonical-selection.json",
+            ),
+        ] = None,
     ) -> None:
         """Convert BenchFlow rollout artifacts into trainer-ready data."""
         _ensure_prime_sft(format_name)
@@ -77,6 +84,7 @@ def register_train(app: typer.Typer) -> None:
                 row_mode=row_mode,
                 expected_rows=expected_rows,
                 manifest=manifest,
+                canonical_selection=canonical_selection,
             )
         except ValueError as exc:
             print_error(str(exc))
@@ -105,6 +113,35 @@ def register_train(app: typer.Typer) -> None:
                 "--expected-rows", help="Fail unless this many rows are present"
             ),
         ] = None,
+        source_jobs: Annotated[
+            Path | None,
+            typer.Option("--source-jobs", help="Source BenchFlow jobs dir to audit"),
+        ] = None,
+        source_canonical_selection: Annotated[
+            Path | None,
+            typer.Option(
+                "--source-canonical-selection",
+                help="Canonical selection JSON used for this trainer data",
+            ),
+        ] = None,
+        task_manifest: Annotated[
+            Path | None,
+            typer.Option("--task-manifest", help="Task manifest for source rows"),
+        ] = None,
+        require_llm_trajectory: Annotated[
+            bool,
+            typer.Option(
+                "--require-llm-trajectory",
+                help="Fail unless source selected rows have valid llm_trajectory.jsonl",
+            ),
+        ] = False,
+        require_tool_calls: Annotated[
+            bool,
+            typer.Option(
+                "--require-tool-calls",
+                help="Fail unless trainer rows and source rows include tool calls",
+            ),
+        ] = False,
     ) -> None:
         """Validate trainer-ready data."""
         _ensure_prime_sft(format_name)
@@ -112,6 +149,61 @@ def register_train(app: typer.Typer) -> None:
 
         try:
             result = validate_prime_sft_jsonl(jsonl, expected_rows=expected_rows)
+            if require_tool_calls and result["rows_with_tool_calls"] != result["rows"]:
+                raise ValueError(
+                    "not all trainer rows contain tool calls: "
+                    f"{result['rows_with_tool_calls']} / {result['rows']}"
+                )
+            if source_jobs is not None:
+                from benchflow.eval_artifacts import build_health_summary
+
+                health = build_health_summary(
+                    source_jobs, canonical_selection=source_canonical_selection
+                )
+                if require_llm_trajectory and (
+                    health["missing_llm_trajectory"]
+                    or health["malformed_llm_trajectory"]
+                ):
+                    raise ValueError(
+                        "source jobs contain missing/malformed llm_trajectory.jsonl"
+                    )
+                if (
+                    require_tool_calls
+                    and health["rows_with_tool_calls"] != health["total_rows"]
+                ):
+                    raise ValueError(
+                        "not all source rows contain tool calls: "
+                        f"{health['rows_with_tool_calls']} / {health['total_rows']}"
+                    )
+                result["source_health"] = {
+                    key: health[key]
+                    for key in (
+                        "total_rows",
+                        "scored_rows",
+                        "unscored_rows",
+                        "rows_with_tool_calls",
+                        "missing_llm_trajectory",
+                        "malformed_llm_trajectory",
+                    )
+                }
+            if source_canonical_selection is not None:
+                data = json.loads(source_canonical_selection.read_text())
+                selected = (
+                    data.get("selected", data.get("selection"))
+                    if isinstance(data, dict)
+                    else None
+                )
+                if not isinstance(selected, list):
+                    raise ValueError(
+                        f"{source_canonical_selection}: selected or selection must be a list"
+                    )
+                result["canonical_selected_rows"] = len(selected)
+            if task_manifest is not None:
+                data = json.loads(task_manifest.read_text())
+                tasks = data.get("tasks") if isinstance(data, dict) else None
+                if not isinstance(tasks, list):
+                    raise ValueError(f"{task_manifest}: tasks must be a list")
+                result["task_manifest_rows"] = len(tasks)
         except (OSError, ValueError) as exc:
             print_error(str(exc))
             raise typer.Exit(1) from None
@@ -184,6 +276,41 @@ def register_train(app: typer.Typer) -> None:
                 help="Overwrite an existing <work-dir>/train-run.json manifest",
             ),
         ] = False,
+        publish_model: Annotated[
+            str | None,
+            typer.Option(
+                "--publish-model", help="Upload trainer output to this HF model repo"
+            ),
+        ] = None,
+        model_tag: Annotated[
+            str | None,
+            typer.Option(
+                "--model-tag", help="Path prefix/tag for --publish-model upload"
+            ),
+        ] = None,
+        model_card: Annotated[
+            str | None,
+            typer.Option(
+                "--model-card", help="Model card mode; currently accepts 'auto'"
+            ),
+        ] = None,
+        publish_artifacts: Annotated[
+            str | None,
+            typer.Option(
+                "--publish-artifacts",
+                help="Upload BenchFlow train run artifacts to this HF dataset repo",
+            ),
+        ] = None,
+        hf_prefix: Annotated[
+            str | None,
+            typer.Option("--hf-prefix", help="Path prefix for --publish-artifacts"),
+        ] = None,
+        hf_public_read_check: Annotated[
+            bool,
+            typer.Option(
+                "--hf-public-read-check", help="Verify public HF reads after upload"
+            ),
+        ] = False,
     ) -> None:
         """Run a Prime-RL SFT job and record a BenchFlow manifest."""
         del backend  # Typer validates the single supported backend for now.
@@ -205,6 +332,12 @@ def register_train(app: typer.Typer) -> None:
                     overrides=tuple(override or ()),
                     force=force,
                     cwd=prime_rl_dir,
+                    publish_model=publish_model,
+                    model_tag=model_tag,
+                    model_card=model_card,
+                    publish_artifacts=publish_artifacts,
+                    hf_prefix=hf_prefix,
+                    hf_public_read_check=hf_public_read_check,
                 )
             )
         except ValueError as exc:

--- a/src/benchflow/eval_artifacts.py
+++ b/src/benchflow/eval_artifacts.py
@@ -1,0 +1,383 @@
+"""Evaluation artifact helpers for reproducible training/eval workflows."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from benchflow._utils.task_authoring import task_digest
+from benchflow.trajectories.export_prime_sft import (
+    PrimeSftTrajectoryJsonlError,
+    load_llm_trajectory_jsonl,
+)
+
+CanonicalizePolicy = Literal["none", "one-healthy-per-task"]
+RetryPolicy = Literal["default", "unscored-only"]
+
+
+@dataclass(frozen=True)
+class TaskManifestOptions:
+    tasks_dir: Path
+    include_tasks: set[str]
+    exclude_tasks: set[str]
+    source_provenance: dict[str, Any] | None = None
+    dataset_name: str | None = None
+    dataset_version: str | None = None
+    dataset_task_digests: dict[str, str] | None = None
+
+
+def _json_dump(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _read_json(path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _is_task_dir(path: Path) -> bool:
+    return (path / "task.md").is_file() or (path / "task.toml").is_file()
+
+
+def _selected_task_dirs(
+    tasks_dir: Path, include_tasks: set[str], exclude_tasks: set[str]
+) -> list[Path]:
+    if _is_task_dir(tasks_dir):
+        candidates = [tasks_dir]
+    else:
+        candidates = sorted(path for path in tasks_dir.iterdir() if path.is_dir())
+        candidates = [path for path in candidates if _is_task_dir(path)]
+    selected = []
+    for task_dir in candidates:
+        name = task_dir.name
+        if include_tasks and name not in include_tasks:
+            continue
+        if name in exclude_tasks:
+            continue
+        selected.append(task_dir)
+    return selected
+
+
+def build_task_manifest(options: TaskManifestOptions) -> dict[str, Any]:
+    tasks = []
+    dataset_digests = options.dataset_task_digests or {}
+    for task_dir in _selected_task_dirs(
+        options.tasks_dir, options.include_tasks, options.exclude_tasks
+    ):
+        digest = task_digest(task_dir)
+        entry: dict[str, Any] = {
+            "task_id": task_dir.name,
+            "path": str(task_dir),
+            "digest": digest,
+        }
+        registry_digest = dataset_digests.get(task_dir.name)
+        if registry_digest is not None:
+            entry["registry_digest"] = registry_digest
+            entry["registry_digest_match"] = registry_digest == digest
+        tasks.append(entry)
+    return {
+        "schema_version": 1,
+        "tasks_dir": str(options.tasks_dir),
+        "source": options.source_provenance,
+        "dataset_name": options.dataset_name,
+        "dataset_version": options.dataset_version,
+        "total": len(tasks),
+        "tasks": tasks,
+    }
+
+
+def write_task_manifest(path: Path, options: TaskManifestOptions) -> dict[str, Any]:
+    manifest = build_task_manifest(options)
+    _json_dump(path, manifest)
+    return manifest
+
+
+def _iter_rollouts(job_dir: Path) -> list[Path]:
+    if (job_dir / "result.json").is_file():
+        return [job_dir]
+    return sorted({path.parent for path in job_dir.rglob("result.json")})
+
+
+def _rollout_dir_from_selection_row(
+    row: dict[str, Any], *, job_dir: Path, selection_path: Path
+) -> Path:
+    rollout_dir = Path(str(row.get("rollout_dir") or ""))
+    if not rollout_dir.is_dir() and not rollout_dir.is_absolute():
+        rollout_dir = job_dir / rollout_dir
+    if not rollout_dir.is_dir() and isinstance(row.get("result_json"), str):
+        result_json = Path(row["result_json"])
+        if result_json.is_absolute() and not result_json.is_file():
+            marker = f"/{selection_path.parent.name}/"
+            _, sep, suffix = str(result_json).partition(marker)
+            if sep:
+                result_json = selection_path.parent / suffix
+        rollout_dir = result_json.parent
+    return rollout_dir
+
+
+def _iter_selected_rollouts(selection_path: Path) -> list[Path]:
+    selection = _read_json(selection_path)
+    if selection is None:
+        raise ValueError(f"invalid canonical selection JSON: {selection_path}")
+    job_dir = Path(str(selection.get("job_dir") or ""))
+    selected = selection.get("selected", selection.get("selection"))
+    if not isinstance(selected, list):
+        raise ValueError(f"{selection_path}: selected or selection must be a list")
+    rollouts = []
+    for row in selected:
+        if not isinstance(row, dict):
+            continue
+        rollout_dir = _rollout_dir_from_selection_row(
+            row, job_dir=job_dir, selection_path=selection_path
+        )
+        if not rollout_dir.is_dir():
+            raise ValueError(f"selected rollout dir not found: {rollout_dir}")
+        rollouts.append(rollout_dir)
+    return rollouts
+
+
+def _reward(result: dict[str, Any]) -> float | None:
+    rewards = result.get("rewards")
+    if isinstance(rewards, dict):
+        value = rewards.get("reward")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    value = result.get("reward")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _tool_call_count(result: dict[str, Any]) -> int:
+    value = result.get("n_tool_calls")
+    if isinstance(value, int) and value >= 0:
+        return value
+    agent_result = result.get("agent_result")
+    if isinstance(agent_result, dict):
+        value = agent_result.get("n_tool_calls")
+        if isinstance(value, int) and value >= 0:
+            return value
+    summary = result.get("trajectory_summary")
+    if isinstance(summary, dict):
+        value = summary.get("tool_call_steps")
+        if isinstance(value, int) and value >= 0:
+            return value
+    return 0
+
+
+def _llm_trajectory_status(rollout_dir: Path) -> tuple[bool, bool, int]:
+    path = rollout_dir / "trajectory" / "llm_trajectory.jsonl"
+    if not path.is_file():
+        return False, False, 0
+    try:
+        rows = load_llm_trajectory_jsonl(path, strict=True)
+    except PrimeSftTrajectoryJsonlError:
+        return True, False, 0
+    return True, True, len(rows)
+
+
+def build_health_summary(
+    job_dir: Path, *, canonical_selection: Path | None = None
+) -> dict[str, Any]:
+    rows = []
+    counts = {
+        "total_rows": 0,
+        "scored_rows": 0,
+        "unscored_rows": 0,
+        "rows_with_tool_calls": 0,
+        "zero_tool_rows": 0,
+        "missing_llm_trajectory": 0,
+        "malformed_llm_trajectory": 0,
+    }
+    rollout_dirs = (
+        _iter_selected_rollouts(canonical_selection)
+        if canonical_selection is not None
+        else _iter_rollouts(job_dir)
+    )
+    for rollout_dir in rollout_dirs:
+        result = _read_json(rollout_dir / "result.json")
+        if result is None:
+            continue
+        counts["total_rows"] += 1
+        reward = _reward(result)
+        scored = reward is not None
+        if scored:
+            counts["scored_rows"] += 1
+        else:
+            counts["unscored_rows"] += 1
+        tool_calls = _tool_call_count(result)
+        if tool_calls > 0:
+            counts["rows_with_tool_calls"] += 1
+        else:
+            counts["zero_tool_rows"] += 1
+        has_llm, valid_llm, llm_rows = _llm_trajectory_status(rollout_dir)
+        if not has_llm:
+            counts["missing_llm_trajectory"] += 1
+        elif not valid_llm:
+            counts["malformed_llm_trajectory"] += 1
+        rows.append(
+            {
+                "task_id": result.get("task_name") or rollout_dir.name,
+                "rollout_dir": str(rollout_dir),
+                "reward": reward,
+                "scored": scored,
+                "tool_calls": tool_calls,
+                "has_llm_trajectory": has_llm,
+                "valid_llm_trajectory": valid_llm,
+                "llm_trajectory_rows": llm_rows,
+                "error": result.get("error"),
+                "verifier_error": result.get("verifier_error"),
+                "error_category": result.get("error_category"),
+                "verifier_error_category": result.get("verifier_error_category"),
+            }
+        )
+    return {"schema_version": 1, "job_dir": str(job_dir), **counts, "rows": rows}
+
+
+def write_health_summary(path: Path, job_dir: Path) -> dict[str, Any]:
+    summary = build_health_summary(job_dir)
+    _json_dump(path, summary)
+    return summary
+
+
+def _canonical_score(row: dict[str, Any]) -> tuple[int, float, int]:
+    scored = 1 if row["scored"] else 0
+    reward = row["reward"] if isinstance(row["reward"], float) else float("-inf")
+    tool_calls = int(row.get("tool_calls") or 0)
+    return scored, reward, tool_calls
+
+
+def build_canonical_selection(
+    job_dir: Path,
+    *,
+    policy: CanonicalizePolicy,
+    expected_tasks: int | None = None,
+) -> dict[str, Any]:
+    if policy == "none":
+        raise ValueError("canonical selection requires a non-none policy")
+    if policy != "one-healthy-per-task":
+        raise ValueError(f"unknown canonicalization policy: {policy}")
+
+    health = build_health_summary(job_dir)
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in health["rows"]:
+        grouped.setdefault(str(row["task_id"]), []).append(row)
+    selected = []
+    rejected = []
+    for task_id, rows in sorted(grouped.items()):
+        ranked = sorted(rows, key=_canonical_score, reverse=True)
+        winner = ranked[0]
+        selected.append({**winner, "selection_reason": "best-scored-then-reward"})
+        rejected.extend({**row, "rejected_for_task_id": task_id} for row in ranked[1:])
+
+    if expected_tasks is not None and len(selected) != expected_tasks:
+        raise ValueError(
+            f"canonical selected task count {len(selected)} != expected {expected_tasks}"
+        )
+    return {
+        "schema_version": 1,
+        "job_dir": str(job_dir),
+        "policy": policy,
+        "selected_count": len(selected),
+        "rejected_count": len(rejected),
+        "selected": selected,
+        "rejected": rejected,
+    }
+
+
+def write_canonical_selection(
+    path: Path,
+    job_dir: Path,
+    *,
+    policy: CanonicalizePolicy,
+    expected_tasks: int | None = None,
+) -> dict[str, Any]:
+    selection = build_canonical_selection(
+        job_dir, policy=policy, expected_tasks=expected_tasks
+    )
+    _json_dump(path, selection)
+    return selection
+
+
+def materialize_canonical_job(selection_path: Path, output_dir: Path) -> None:
+    selection = _read_json(selection_path)
+    if selection is None:
+        raise ValueError(f"invalid canonical selection JSON: {selection_path}")
+    selected = selection.get("selected", selection.get("selection"))
+    if not isinstance(selected, list):
+        raise ValueError(f"{selection_path}: selected or selection must be a list")
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+    for row in selected:
+        if not isinstance(row, dict):
+            continue
+        rollout_dir = _rollout_dir_from_selection_row(
+            row,
+            job_dir=Path(str(selection.get("job_dir") or "")),
+            selection_path=selection_path,
+        )
+        if not rollout_dir.is_dir():
+            raise ValueError(f"selected rollout dir not found: {rollout_dir}")
+        dest = output_dir / rollout_dir.name
+        shutil.copytree(rollout_dir, dest)
+
+
+def task_overlap(left_manifest: Path, right_manifest: Path) -> dict[str, Any]:
+    left = _read_json(left_manifest)
+    right = _read_json(right_manifest)
+    if left is None:
+        raise ValueError(f"invalid task manifest: {left_manifest}")
+    if right is None:
+        raise ValueError(f"invalid task manifest: {right_manifest}")
+    left_tasks = {
+        str(row["task_id"]): row
+        for row in left.get("tasks", [])
+        if isinstance(row, dict) and row.get("task_id")
+    }
+    right_tasks = {
+        str(row["task_id"]): row
+        for row in right.get("tasks", [])
+        if isinstance(row, dict) and row.get("task_id")
+    }
+    task_id_overlap = sorted(set(left_tasks) & set(right_tasks))
+    left_digest_to_task = {
+        str(row.get("digest")): task_id
+        for task_id, row in left_tasks.items()
+        if row.get("digest")
+    }
+    right_digest_to_task = {
+        str(row.get("digest")): task_id
+        for task_id, row in right_tasks.items()
+        if row.get("digest")
+    }
+    digest_overlap = sorted(set(left_digest_to_task) & set(right_digest_to_task))
+    return {
+        "schema_version": 1,
+        "left": str(left_manifest),
+        "right": str(right_manifest),
+        "left_count": len(left_tasks),
+        "right_count": len(right_tasks),
+        "task_id_overlap_count": len(task_id_overlap),
+        "task_id_overlap": task_id_overlap,
+        "digest_overlap_count": len(digest_overlap),
+        "digest_overlap": [
+            {
+                "digest": digest,
+                "left_task_id": left_digest_to_task[digest],
+                "right_task_id": right_digest_to_task[digest],
+            }
+            for digest in digest_overlap
+        ],
+        "caveat": (
+            "Exact task-id/digest disjointness does not prove domain or "
+            "generator-family disjointness."
+        ),
+    }

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -112,6 +112,21 @@ class EvalCreateRequest:
     dataset: str | None = None
     registry: str | None = None
     ignore_bench_version: bool = False
+    task_manifest_out: Path | None = None
+    run_config_out: Path | None = None
+    health_summary_out: Path | None = None
+    expected_tasks: int | None = None
+    canonicalize: str = "none"
+    canonical_selection_out: Path | None = None
+    canonical_jobs_dir: Path | None = None
+    retry_policy: str = "default"
+    retry_attempts: int | None = None
+    retry_concurrency: int | None = None
+    publish_hf: str | None = None
+    hf_prefix: str | None = None
+    hf_public_read_check: bool = False
+    matrix: Path | None = None
+    trials: int = 1
 
 
 @dataclass
@@ -239,8 +254,30 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--registry requires --dataset")
     if request.ignore_bench_version and not request.dataset:
         raise EvalPlanError("--ignore-bench-version requires --dataset")
+    if request.matrix is not None and not request.tasks_dir:
+        raise EvalPlanError("--matrix currently requires --tasks-dir")
+    if request.trials < 1:
+        raise EvalPlanError("--trials must be >= 1")
+    if request.expected_tasks is not None and request.expected_tasks < 1:
+        raise EvalPlanError("--expected-tasks must be >= 1")
+    if request.canonicalize not in {"none", "one-healthy-per-task"}:
+        raise EvalPlanError("--canonicalize must be 'none' or 'one-healthy-per-task'")
+    if request.canonical_selection_out and request.canonicalize == "none":
+        raise EvalPlanError("--canonical-selection-out requires --canonicalize")
+    if request.canonical_jobs_dir and not request.canonical_selection_out:
+        raise EvalPlanError("--canonical-jobs-dir requires --canonical-selection-out")
+    if request.retry_policy not in {"default", "unscored-only"}:
+        raise EvalPlanError("--retry-policy must be 'default' or 'unscored-only'")
+    if request.retry_attempts is not None and request.retry_attempts < 0:
+        raise EvalPlanError("--retry-attempts must be >= 0")
+    if request.retry_concurrency is not None and request.retry_concurrency < 1:
+        raise EvalPlanError("--retry-concurrency must be >= 1")
+    if request.hf_prefix and not request.publish_hf:
+        raise EvalPlanError("--hf-prefix requires --publish-hf")
     if request.tasks_dir and not Path(request.tasks_dir).exists():
         raise EvalPlanError(f"--tasks-dir not found: {request.tasks_dir}")
+    if request.matrix is not None and not Path(request.matrix).is_file():
+        raise EvalPlanError(f"--matrix not found: {request.matrix}")
     if request.context_root and not Path(request.context_root).is_dir():
         raise EvalPlanError(f"--context-root not found: {request.context_root}")
     # Validate --config here so a typo'd / missing / non-file path becomes a clean

--- a/src/benchflow/publish/__init__.py
+++ b/src/benchflow/publish/__init__.py
@@ -1,0 +1,1 @@
+"""Publication helpers for BenchFlow artifacts."""

--- a/src/benchflow/publish/huggingface.py
+++ b/src/benchflow/publish/huggingface.py
@@ -1,0 +1,115 @@
+"""Hugging Face publishing helpers with optional read-after-write checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import httpx
+
+
+@dataclass(frozen=True)
+class HfPublishResult:
+    repo_id: str
+    repo_type: str
+    path_in_repo: str
+    url: str
+    commit_url: str | None = None
+
+
+def _require_hf_api():
+    try:
+        from huggingface_hub import HfApi
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
+        raise ValueError(
+            "huggingface_hub is required for --publish-hf/--publish-model"
+        ) from exc
+    return HfApi()
+
+
+def _tree_url(repo_id: str, repo_type: str, path_in_repo: str) -> str:
+    kind = "datasets/" if repo_type == "dataset" else ""
+    suffix = f"/tree/main/{path_in_repo.strip('/')}" if path_in_repo else "/tree/main"
+    return f"https://huggingface.co/{kind}{repo_id}{suffix}"
+
+
+def _resolve_url(repo_id: str, repo_type: str, path_in_repo: str) -> str:
+    kind = "datasets/" if repo_type == "dataset" else ""
+    return f"https://huggingface.co/{kind}{repo_id}/resolve/main/{path_in_repo}"
+
+
+def _check_public_files(repo_id: str, repo_type: str, path_in_repo: str) -> None:
+    index_url = _tree_url(repo_id, repo_type, path_in_repo)
+    response = httpx.get(index_url, follow_redirects=True, timeout=20)
+    if response.status_code >= 400:
+        raise ValueError(
+            f"HF public read check failed: {index_url} -> {response.status_code}"
+        )
+
+
+def publish_folder_to_hf(
+    folder: Path,
+    *,
+    repo_id: str,
+    path_in_repo: str,
+    repo_type: str = "dataset",
+    public_read_check: bool = False,
+    commit_message: str | None = None,
+) -> HfPublishResult:
+    if not folder.is_dir():
+        raise ValueError(f"publish source folder not found: {folder}")
+    api = _require_hf_api()
+    api.create_repo(repo_id, repo_type=repo_type, exist_ok=True)
+    commit = api.upload_folder(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        folder_path=str(folder),
+        path_in_repo=path_in_repo.strip("/"),
+        commit_message=commit_message
+        or f"Upload BenchFlow artifacts to {path_in_repo}",
+    )
+    if public_read_check:
+        _check_public_files(repo_id, repo_type, path_in_repo)
+    return HfPublishResult(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        path_in_repo=path_in_repo,
+        url=_tree_url(repo_id, repo_type, path_in_repo),
+        commit_url=getattr(commit, "commit_url", None),
+    )
+
+
+def publish_file_to_hf(
+    file_path: Path,
+    *,
+    repo_id: str,
+    path_in_repo: str,
+    repo_type: str = "dataset",
+    public_read_check: bool = False,
+    commit_message: str | None = None,
+) -> HfPublishResult:
+    if not file_path.is_file():
+        raise ValueError(f"publish source file not found: {file_path}")
+    api = _require_hf_api()
+    api.create_repo(repo_id, repo_type=repo_type, exist_ok=True)
+    commit = api.upload_file(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        path_or_fileobj=str(file_path),
+        path_in_repo=path_in_repo.strip("/"),
+        commit_message=commit_message or f"Upload BenchFlow artifact {path_in_repo}",
+    )
+    if public_read_check:
+        url = _resolve_url(repo_id, repo_type, path_in_repo.strip("/"))
+        response = httpx.head(url, follow_redirects=True, timeout=20)
+        if response.status_code >= 400:
+            raise ValueError(
+                f"HF public read check failed: {url} -> {response.status_code}"
+            )
+    return HfPublishResult(
+        repo_id=repo_id,
+        repo_type=repo_type,
+        path_in_repo=path_in_repo,
+        url=_tree_url(repo_id, repo_type, str(Path(path_in_repo).parent)),
+        commit_url=getattr(commit, "commit_url", None),
+    )

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -40,6 +40,12 @@ class PrimeRlSftSpec:
     overrides: tuple[str, ...] = ()
     force: bool = False
     cwd: Path | None = None
+    publish_model: str | None = None
+    model_tag: str | None = None
+    model_card: str | None = None
+    publish_artifacts: str | None = None
+    hf_prefix: str | None = None
+    hf_public_read_check: bool = False
 
 
 @dataclass(frozen=True)
@@ -216,13 +222,81 @@ def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
     if returncode == 0:
         manifest.overall_status = "succeeded"
         manifest.components[0].status = "succeeded"
+        write_manifest(manifest_path, manifest)
+        try:
+            _publish_outputs(spec, manifest, manifest_path)
+        except ValueError as exc:
+            manifest.overall_status = "failed"
+            manifest.extra["publish_error"] = str(exc)
+            write_manifest(manifest_path, manifest)
+            raise
+        write_manifest(manifest_path, manifest)
     else:
         manifest.overall_status = "failed"
         manifest.components[0].status = "failed"
         manifest.components[0].extra["returncode"] = returncode
-    write_manifest(manifest_path, manifest)
+        write_manifest(manifest_path, manifest)
     return PrimeRlSftResult(
         manifest_path=manifest_path,
         command_path=command_path,
         returncode=returncode,
     )
+
+
+def _publish_outputs(
+    spec: PrimeRlSftSpec, manifest: TrainRunManifest, manifest_path: Path
+) -> None:
+    if spec.model_card not in {None, "auto"}:
+        raise ValueError("--model-card currently supports only 'auto'")
+    if not spec.publish_model and not spec.publish_artifacts:
+        return
+    from benchflow.publish.huggingface import publish_folder_to_hf
+
+    output_dir = (
+        spec.output_dir.resolve()
+        if spec.output_dir is not None
+        else spec.work_dir.resolve() / "prime-rl-output"
+    )
+    publishes: list[dict[str, str | None]] = []
+    if spec.publish_model:
+        model_prefix = spec.model_tag or ""
+        result = publish_folder_to_hf(
+            output_dir,
+            repo_id=spec.publish_model,
+            repo_type="model",
+            path_in_repo=model_prefix,
+            public_read_check=spec.hf_public_read_check,
+            commit_message="Upload BenchFlow SFT model artifacts",
+        )
+        manifest.artifacts["exported_models"].append(result.url)
+        publishes.append(
+            {
+                "type": "model",
+                "repo": spec.publish_model,
+                "path": model_prefix,
+                "url": result.url,
+                "commit_url": result.commit_url,
+            }
+        )
+        manifest.extra["published"] = publishes
+        write_manifest(manifest_path, manifest)
+    if spec.publish_artifacts:
+        artifact_prefix = spec.hf_prefix or Path(spec.work_dir).name
+        result = publish_folder_to_hf(
+            spec.work_dir.resolve(),
+            repo_id=spec.publish_artifacts,
+            repo_type="dataset",
+            path_in_repo=artifact_prefix,
+            public_read_check=spec.hf_public_read_check,
+            commit_message="Upload BenchFlow SFT training artifacts",
+        )
+        publishes.append(
+            {
+                "type": "dataset",
+                "repo": spec.publish_artifacts,
+                "path": artifact_prefix,
+                "url": result.url,
+                "commit_url": result.commit_url,
+            }
+        )
+    manifest.extra["published"] = publishes

--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -148,6 +148,50 @@ def _iter_rollout_dirs(root: str | Path) -> list[Path]:
     return sorted({p.parent for p in path.rglob("result.json")})
 
 
+def _iter_selected_rollout_dirs(selection_path: str | Path) -> list[Path]:
+    path = Path(selection_path)
+    try:
+        selection = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid canonical selection JSON: {path}: {exc}") from exc
+    if not isinstance(selection, dict):
+        raise ValueError(f"canonical selection must be an object: {path}")
+    job_dir = Path(str(selection.get("job_dir") or ""))
+    selected = selection.get("selected", selection.get("selection"))
+    if not isinstance(selected, list):
+        raise ValueError(
+            f"canonical selection {path} must contain selected or selection list"
+        )
+    rollout_dirs = []
+    for idx, row in enumerate(selected, start=1):
+        if not isinstance(row, dict):
+            raise ValueError(f"canonical selection row {idx} must be an object")
+        row = cast(dict[str, Any], row)
+        raw_dir = row.get("rollout_dir")
+        if not isinstance(raw_dir, str) or not raw_dir:
+            raise ValueError(f"canonical selection row {idx} missing rollout_dir")
+        rollout_dir = Path(raw_dir)
+        if (
+            not (rollout_dir / "result.json").is_file()
+            and not rollout_dir.is_absolute()
+        ):
+            rollout_dir = job_dir / rollout_dir
+        if not (rollout_dir / "result.json").is_file() and isinstance(
+            row.get("result_json"), str
+        ):
+            result_json = Path(row["result_json"])
+            if result_json.is_absolute() and not result_json.is_file():
+                marker = f"/{path.parent.name}/"
+                _, sep, suffix = str(result_json).partition(marker)
+                if sep:
+                    result_json = path.parent / suffix
+            rollout_dir = result_json.parent
+        if not (rollout_dir / "result.json").is_file():
+            raise ValueError(f"selected rollout has no result.json: {rollout_dir}")
+        rollout_dirs.append(rollout_dir)
+    return rollout_dirs
+
+
 def _reward_from_result(result: dict[str, Any] | None) -> float | None:
     if not isinstance(result, dict):
         return None
@@ -196,7 +240,15 @@ def _normalize_tool_call(call: dict[str, Any], index: int = 0) -> dict[str, Any]
         function = {}
     name = function.get("name") or call.get("name") or "tool"
     arguments = function.get("arguments", call.get("arguments", {}))
-    if not isinstance(arguments, str):
+    if isinstance(arguments, str):
+        try:
+            json.loads(arguments)
+        except json.JSONDecodeError:
+            arguments = json.dumps(
+                {"_malformed_json_arguments": arguments},
+                sort_keys=True,
+            )
+    else:
         arguments = json.dumps(arguments or {}, sort_keys=True)
     return {
         "id": str(call.get("id") or call.get("tool_call_id") or f"call_{index:06d}"),
@@ -497,6 +549,38 @@ def _row_messages(row: dict[str, Any], row_num: int) -> list[Any]:
     )
 
 
+def _sanitize_message_tool_call_arguments(messages: list[Any]) -> list[Any]:
+    sanitized: list[Any] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            sanitized.append(message)
+            continue
+        out = dict(message)
+        tool_calls = out.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            out["tool_calls"] = [
+                _normalize_tool_call(cast(dict[str, Any], tool_call), idx)
+                for idx, tool_call in enumerate(tool_calls)
+                if isinstance(tool_call, dict)
+            ]
+        sanitized.append(out)
+    return sanitized
+
+
+def _sanitize_prime_sft_row_tool_call_arguments(row: dict[str, Any]) -> dict[str, Any]:
+    out = dict(row)
+    messages = out.get("messages")
+    if isinstance(messages, list):
+        out["messages"] = _sanitize_message_tool_call_arguments(messages)
+    prompt = out.get("prompt")
+    if isinstance(prompt, list):
+        out["prompt"] = _sanitize_message_tool_call_arguments(prompt)
+    completion = out.get("completion")
+    if isinstance(completion, list):
+        out["completion"] = _sanitize_message_tool_call_arguments(completion)
+    return out
+
+
 def validate_prime_sft_row(row: dict[str, Any], row_num: int = 1) -> None:
     leaked = sorted(BANNED_ROW_KEYS.intersection(row))
     if leaked:
@@ -536,6 +620,27 @@ def validate_prime_sft_row(row: dict[str, Any], row_num: int = 1) -> None:
             )
         if role == "tool" and not message.get("tool_call_id"):
             raise ValueError(f"row {row_num}: tool message requires tool_call_id")
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list):
+            for tool_call_idx, tool_call in enumerate(tool_calls):
+                if not isinstance(tool_call, dict):
+                    raise ValueError(
+                        f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}] must be object"
+                    )
+                tool_call = cast(dict[str, Any], tool_call)
+                function = tool_call.get("function")
+                if not isinstance(function, dict):
+                    raise ValueError(
+                        f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}].function must be object"
+                    )
+                arguments = function.get("arguments")
+                if isinstance(arguments, str):
+                    try:
+                        json.loads(arguments)
+                    except json.JSONDecodeError as exc:
+                        raise ValueError(
+                            f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}].function.arguments is not valid JSON: {exc}"
+                        ) from exc
 
     if not any(isinstance(m, dict) and m.get("role") == "assistant" for m in messages):
         raise ValueError(f"row {row_num}: no assistant message")
@@ -581,7 +686,9 @@ def validate_prime_sft_jsonl(
     return {"ok": True, "rows": rows, "rows_with_tool_calls": rows_with_tool_calls}
 
 
-def _iter_prime_sft_jsonl_rows(path: Path) -> Iterator[tuple[int, dict[str, Any]]]:
+def _iter_prime_sft_jsonl_rows(
+    path: Path, *, sanitize_tool_call_arguments: bool = False
+) -> Iterator[tuple[int, dict[str, Any]]]:
     with path.open("r", encoding="utf-8") as handle:
         for row_num, line in enumerate(handle, start=1):
             if not line.strip():
@@ -592,6 +699,8 @@ def _iter_prime_sft_jsonl_rows(path: Path) -> Iterator[tuple[int, dict[str, Any]
                 raise ValueError(f"row {row_num}: invalid JSON: {exc}") from exc
             if not isinstance(row, dict):
                 raise ValueError(f"row {row_num}: top-level row must be object")
+            if sanitize_tool_call_arguments:
+                row = _sanitize_prime_sft_row_tool_call_arguments(row)
             validate_prime_sft_row(row, row_num)
             yield row_num, row
 
@@ -609,7 +718,9 @@ def _existing_prime_sft_jsonl_stats(
     min_reward: float | None,
 ) -> PrimeSftExportStats:
     stats = PrimeSftExportStats(sources=[str(path)])
-    for row_num, row in _iter_prime_sft_jsonl_rows(path):
+    for row_num, row in _iter_prime_sft_jsonl_rows(
+        path, sanitize_tool_call_arguments=True
+    ):
         stats.rollouts_seen += 1
         reward = _row_reward(row)
         if min_reward is not None and (reward is None or reward < min_reward):
@@ -630,20 +741,14 @@ def _copy_existing_prime_sft_jsonl(
     min_reward: float | None,
 ) -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
-    if min_reward is None:
-        with (
-            source.open("r", encoding="utf-8") as source_handle,
-            out.open("w", encoding="utf-8") as out_handle,
-        ):
-            for line in source_handle:
-                if line.strip():
-                    out_handle.write(line)
-        return
     with out.open("w", encoding="utf-8") as handle:
-        for _, row in _iter_prime_sft_jsonl_rows(source):
-            reward = _row_reward(row)
-            if reward is None or reward < min_reward:
-                continue
+        for _, row in _iter_prime_sft_jsonl_rows(
+            source, sanitize_tool_call_arguments=True
+        ):
+            if min_reward is not None:
+                reward = _row_reward(row)
+                if reward is None or reward < min_reward:
+                    continue
             handle.write(_json_line(row) + "\n")
 
 
@@ -699,11 +804,17 @@ def convert_benchflow_rollouts_to_prime_sft_rows(
     *,
     min_reward: float | None = None,
     row_mode: PrimeSftRowMode = "rollout",
+    canonical_selection: str | Path | None = None,
 ) -> tuple[list[dict[str, Any]], PrimeSftExportStats]:
     stats = PrimeSftExportStats()
     rows: list[dict[str, Any]] = []
 
-    for rollout_dir in _iter_rollout_dirs(jobs_dir):
+    rollout_dirs = (
+        _iter_selected_rollout_dirs(canonical_selection)
+        if canonical_selection is not None
+        else _iter_rollout_dirs(jobs_dir)
+    )
+    for rollout_dir in rollout_dirs:
         stats.rollouts_seen += 1
         result = _load_json(rollout_dir / "result.json")
         if result is None:
@@ -770,6 +881,7 @@ def export_prime_sft_jsonl(
     row_mode: PrimeSftRowMode = "rollout",
     expected_rows: int | None = None,
     manifest: str | Path | None = None,
+    canonical_selection: str | Path | None = None,
 ) -> PrimeSftExportStats:
     """Export BenchFlow rollouts to a Prime-RL SFT JSONL file.
 
@@ -787,7 +899,9 @@ def export_prime_sft_jsonl(
             raise ValueError("--out must differ from the source JSONL path")
         stats = _existing_prime_sft_jsonl_stats(source_path, min_reward=min_reward)
         if expected_rows is not None and stats.rows_written != expected_rows:
-            raise ValueError(f"row count {stats.rows_written} != expected {expected_rows}")
+            raise ValueError(
+                f"row count {stats.rows_written} != expected {expected_rows}"
+            )
         _copy_existing_prime_sft_jsonl(
             source_path,
             out_path,
@@ -804,6 +918,7 @@ def export_prime_sft_jsonl(
         jobs_dir,
         min_reward=min_reward,
         row_mode=row_mode,
+        canonical_selection=canonical_selection,
     )
     if expected_rows is not None and len(rows) != expected_rows:
         raise ValueError(f"row count {len(rows)} != expected {expected_rows}")

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -179,6 +179,8 @@ def test_documented_subcommands_exist() -> None:
         ["eval", "view"],
         ["train", "convert"],
         ["train", "validate"],
+        ["train", "run"],
+        ["train", "run", "sft"],
         # Adoption is canonically under `eval` (cli.md documents `bench eval adopt`).
         ["eval", "adopt", "init"],
         ["eval", "adopt", "convert"],
@@ -188,6 +190,7 @@ def test_documented_subcommands_exist() -> None:
         ["tasks", "init"],
         ["tasks", "check"],
         ["tasks", "generate"],
+        ["tasks", "overlap"],
         ["tasks", "list-sources"],
         ["skills", "list"],
         ["skills", "eval"],

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -1,0 +1,255 @@
+"""CLI coverage for eval/train artifact workflow surfaces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+from benchflow.evaluation import Evaluation
+
+runner = CliRunner()
+
+
+def _write_task(task_dir: Path) -> None:
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text('version = "1.0"\n', encoding="utf-8")
+
+
+def _write_llm_trajectory(rollout_dir: Path, *, tool_calls: bool = True) -> None:
+    trajectory = rollout_dir / "trajectory"
+    trajectory.mkdir(parents=True, exist_ok=True)
+    message: dict[str, Any] = {"role": "assistant", "content": "done"}
+    if tool_calls:
+        message = {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "finish", "arguments": "{}"},
+                }
+            ],
+        }
+    (trajectory / "llm_trajectory.jsonl").write_text(
+        json.dumps(
+            {
+                "request": {
+                    "body": {
+                        "model": "m",
+                        "messages": [{"role": "user", "content": "do it"}],
+                        "tools": [
+                            {
+                                "type": "function",
+                                "function": {
+                                    "name": "finish",
+                                    "parameters": {"type": "object", "properties": {}},
+                                },
+                            }
+                        ],
+                    }
+                },
+                "response": {
+                    "status_code": 200,
+                    "body": {"choices": [{"message": message}]},
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_rollout(rollout_dir: Path, task_name: str = "task-a") -> None:
+    rollout_dir.mkdir(parents=True)
+    (rollout_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": task_name,
+                "rewards": {"reward": 1.0},
+                "n_tool_calls": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    _write_llm_trajectory(rollout_dir)
+
+
+def test_eval_run_writes_manifest_health_and_canonical_artifacts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    tasks = tmp_path / "tasks"
+    _write_task(tasks / "task-a")
+
+    async def fake_run(self):
+        job_dir = self._jobs_dir / self._job_name
+        _write_rollout(job_dir / "task-a__abc", "task-a")
+        (job_dir / "summary.json").write_text(
+            json.dumps({"total": 1, "passed": 1}), encoding="utf-8"
+        )
+        return SimpleNamespace(
+            job_name=self._job_name,
+            passed=1,
+            failed=0,
+            errored=0,
+            verifier_errored=0,
+            total=1,
+            score=1.0,
+            score_excl_errors=1.0,
+        )
+
+    monkeypatch.setattr(Evaluation, "run", fake_run)
+    manifest = tmp_path / "task-manifest.json"
+    health = tmp_path / "health.json"
+    selection = tmp_path / "canonical-selection.json"
+    canonical_jobs = tmp_path / "canonical-jobs"
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "--tasks-dir",
+            str(tasks),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--task-manifest-out",
+            str(manifest),
+            "--health-summary-out",
+            str(health),
+            "--expected-tasks",
+            "1",
+            "--canonicalize",
+            "one-healthy-per-task",
+            "--canonical-selection-out",
+            str(selection),
+            "--canonical-jobs-dir",
+            str(canonical_jobs),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(manifest.read_text())["total"] == 1
+    assert json.loads(health.read_text())["rows_with_tool_calls"] == 1
+    assert json.loads(selection.read_text())["selected_count"] == 1
+    assert (canonical_jobs / "task-a__abc" / "result.json").is_file()
+
+
+def test_eval_run_matrix_runs_each_alias_and_trial(tmp_path: Path, monkeypatch) -> None:
+    tasks = tmp_path / "tasks"
+    _write_task(tasks / "task-a")
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        """
+models:
+  base: openai/base
+  sft:
+    model: openai/sft
+    agent_env:
+      OPENAI_BASE_URL: https://example.invalid/v1
+""",
+        encoding="utf-8",
+    )
+
+    async def fake_run(self):
+        job_dir = self._jobs_dir / self._job_name
+        _write_rollout(job_dir / "task-a__abc", "task-a")
+        return SimpleNamespace(
+            job_name=self._job_name,
+            passed=1,
+            failed=0,
+            errored=0,
+            verifier_errored=0,
+            total=1,
+            score=1.0,
+            score_excl_errors=1.0,
+        )
+
+    monkeypatch.setattr(Evaluation, "run", fake_run)
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "--tasks-dir",
+            str(tasks),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--matrix",
+            str(matrix),
+            "--trials",
+            "2",
+            "--task-manifest-out",
+            str(tmp_path / "task-manifest.json"),
+            "--run-config-out",
+            str(tmp_path / "run-config.json"),
+            "--health-summary-out",
+            str(tmp_path / "health.json"),
+            "--expected-tasks",
+            "1",
+            "--canonicalize",
+            "one-healthy-per-task",
+            "--canonical-selection-out",
+            str(tmp_path / "canonical-selection.json"),
+            "--canonical-jobs-dir",
+            str(tmp_path / "canonical-jobs"),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    summary = json.loads((tmp_path / "jobs" / "matrix-summary.json").read_text())
+    assert len(summary["runs"]) == 4
+    assert {row["alias"] for row in summary["runs"]} == {"base", "sft"}
+    assert json.loads((tmp_path / "task-manifest.json").read_text())["total"] == 1
+    assert (tmp_path / "base" / "trial-01" / "run-config.json").is_file()
+    assert (tmp_path / "base" / "trial-01" / "health.json").is_file()
+    assert (tmp_path / "base" / "trial-01" / "canonical-selection.json").is_file()
+    assert (
+        tmp_path
+        / "canonical-jobs"
+        / "base"
+        / "trial-01"
+        / "task-a__abc"
+        / "result.json"
+    ).is_file()
+
+
+def test_tasks_overlap_reports_exact_overlap(tmp_path: Path) -> None:
+    left = tmp_path / "left.json"
+    right = tmp_path / "right.json"
+    left.write_text(
+        json.dumps(
+            {
+                "tasks": [
+                    {"task_id": "a", "digest": "sha256:1"},
+                    {"task_id": "b", "digest": "sha256:2"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    right.write_text(
+        json.dumps(
+            {
+                "tasks": [
+                    {"task_id": "b", "digest": "sha256:2"},
+                    {"task_id": "c", "digest": "sha256:3"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = runner.invoke(app, ["tasks", "overlap", str(left), str(right)])
+
+    assert result.exit_code == 0, result.output
+    assert "Task-id overlap: 1" in result.output
+    assert "Digest overlap: 1" in result.output

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -17,7 +17,9 @@ runner = CliRunner()
 def _write_rollout(rollout_dir: Path) -> None:
     rollout_dir.mkdir(parents=True)
     (rollout_dir / "result.json").write_text(
-        json.dumps({"task_name": "task-a", "rewards": {"reward": 1.0}})
+        json.dumps(
+            {"task_name": "task-a", "rewards": {"reward": 1.0}, "n_tool_calls": 1}
+        )
     )
     traj = rollout_dir / "trajectory"
     traj.mkdir()
@@ -163,6 +165,139 @@ def test_train_convert_accepts_results_jsonl_cli(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
 
 
+def test_train_convert_sanitizes_malformed_tool_call_arguments(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "results.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "do it"}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": '{"command":"python - <<\'PY\'\nunterminated',
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "prime-sft.jsonl"
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "convert",
+            str(source),
+            "--out",
+            str(out),
+            "--expected-rows",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    row = json.loads(out.read_text())
+    arguments = row["completion"][0]["tool_calls"][0]["function"]["arguments"]
+    assert json.loads(arguments) == {
+        "_malformed_json_arguments": '{"command":"python - <<\'PY\'\nunterminated'
+    }
+    result = runner.invoke(app, ["train", "validate", str(out), "--expected-rows", "1"])
+    assert result.exit_code == 0, result.output
+
+
+def test_train_convert_accepts_canonical_selection(tmp_path: Path) -> None:
+    jobs = tmp_path / "jobs"
+    selected = jobs / "run" / "task-a__good"
+    ignored = jobs / "run" / "task-a__ignored"
+    _write_rollout(selected)
+    _write_rollout(ignored)
+    selection = tmp_path / "canonical-selection.json"
+    selection.write_text(
+        json.dumps(
+            {
+                "job_dir": str(jobs / "run"),
+                "selected": [{"task_id": "task-a", "rollout_dir": str(selected)}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "train.jsonl"
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "convert",
+            str(jobs),
+            "--out",
+            str(out),
+            "--canonical-selection",
+            str(selection),
+            "--expected-rows",
+            "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert sum(1 for _ in out.open()) == 1
+
+
+def test_train_validate_source_health_requirements(tmp_path: Path) -> None:
+    jobs = tmp_path / "jobs"
+    rollout = jobs / "run" / "task-a__abc123"
+    _write_rollout(rollout)
+    out = tmp_path / "train.jsonl"
+    result = runner.invoke(
+        app,
+        ["train", "convert", str(jobs), "--out", str(out), "--expected-rows", "1"],
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "validate",
+            str(out),
+            "--source-jobs",
+            str(jobs),
+            "--expected-rows",
+            "1",
+            "--require-llm-trajectory",
+            "--require-tool-calls",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["source_health"]["total_rows"] == 1
+    assert payload["source_health"]["rows_with_tool_calls"] == 1
+
+
 def test_train_convert_rejects_malformed_llm_jsonl(tmp_path: Path) -> None:
     """Guards PR #828 review: CLI conversion fails closed on corrupted LLM traces."""
     jobs = tmp_path / "jobs"
@@ -274,6 +409,140 @@ def test_train_run_sft_prime_rl_records_manifest(tmp_path: Path, monkeypatch) ->
     ]
     assert (work_dir / "command.txt").read_text().startswith("uv run --no-sync sft @")
     assert (work_dir / "prime-rl" / "stdout.log").read_text() == "trainer ok\n"
+
+
+def test_train_run_sft_prime_rl_publish_flags_update_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.publish.huggingface as hf_publish
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del argv, kwargs
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    class FakePublishResult:
+        def __init__(self, url: str) -> None:
+            self.url = url
+            self.commit_url = f"{url}/commit/abc"
+
+    published: list[tuple[str, str, str]] = []
+    dataset_manifest_seen: dict[str, Any] = {}
+
+    def fake_publish_folder_to_hf(
+        folder, *, repo_id, repo_type, path_in_repo, **kwargs
+    ):
+        del kwargs
+        if repo_type == "dataset":
+            dataset_manifest_seen.update(
+                json.loads((Path(folder) / "train-run.json").read_text())
+            )
+        published.append((repo_id, repo_type, path_in_repo))
+        return FakePublishResult(
+            f"https://huggingface.co/{repo_id}/tree/main/{path_in_repo}"
+        )
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+    output_dir = tmp_path / "prime-output"
+    output_dir.mkdir()
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(hf_publish, "publish_folder_to_hf", fake_publish_folder_to_hf)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+            "--work-dir",
+            str(work_dir),
+            "--publish-model",
+            "benchflow/model",
+            "--model-tag",
+            "env0-test",
+            "--model-card",
+            "auto",
+            "--publish-artifacts",
+            "benchflow/artifacts",
+            "--hf-prefix",
+            "experiments/run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert published == [
+        ("benchflow/model", "model", "env0-test"),
+        ("benchflow/artifacts", "dataset", "experiments/run"),
+    ]
+    assert dataset_manifest_seen["extra"]["published"][0]["type"] == "model"
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert len(manifest["extra"]["published"]) == 2
+
+
+def test_train_run_sft_prime_rl_publish_failure_updates_manifest(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.publish.huggingface as hf_publish
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del argv, kwargs
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    def fail_publish(*args, **kwargs):
+        del args, kwargs
+        raise ValueError("publish denied")
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+    output_dir = tmp_path / "prime-output"
+    output_dir.mkdir()
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+    monkeypatch.setattr(hf_publish, "publish_folder_to_hf", fail_publish)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+            "--work-dir",
+            str(work_dir),
+            "--publish-model",
+            "benchflow/model",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "publish denied" in result.output
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["overall_status"] == "failed"
+    assert manifest["extra"]["publish_error"] == "publish denied"
 
 
 def test_train_run_sft_prime_rl_failure_updates_manifest(


### PR DESCRIPTION
## Summary

Adds user-facing CLI hooks that keep the env-0 SFT workflow reproducible without adding a new recipe command:

- `bench eval run`
  - `--task-manifest-out`
  - `--run-config-out`
  - `--health-summary-out`
  - `--expected-tasks`
  - `--canonicalize one-healthy-per-task`
  - `--canonical-selection-out`
  - `--canonical-jobs-dir`
  - `--retry-policy`, `--retry-attempts`, `--retry-concurrency`
  - `--publish-hf`, `--hf-prefix`, `--hf-public-read-check`
  - `--matrix`, `--trials`
- `bench train convert`
  - `--canonical-selection`
- `bench train validate`
  - `--source-jobs`
  - `--source-canonical-selection`
  - `--task-manifest`
  - `--require-llm-trajectory`
  - `--require-tool-calls`
- `bench train run sft`
  - `--publish-model`
  - `--model-tag`
  - `--model-card auto`
  - `--publish-artifacts`
  - `--hf-prefix`
  - `--hf-public-read-check`
- `bench tasks overlap`

Implementation is split so the CLI stays thin:

- `benchflow.eval_artifacts` owns task manifests, health summaries, canonical selection/materialization, and task overlap.
- `benchflow.cli.eval_artifacts` owns eval-run CLI post-processing and matrix orchestration.
- `benchflow.publish.huggingface` owns HF upload/read-check helpers.

## Validation

Static/unit:

- `uv run ruff check .`
- `uv run ty check src/benchflow/eval_artifacts.py src/benchflow/cli/eval_artifacts.py src/benchflow/publish/huggingface.py src/benchflow/cli/train.py src/benchflow/training/backends/prime_rl.py`
- `uv run pytest tests/test_eval_artifact_cli.py tests/test_train_cli.py tests/test_cli_docs_drift.py tests/test_cli_arg_validation.py tests/test_cli_edge_case_hardening.py tests/test_eval_source_provenance.py tests/test_eval_filters_applied.py tests/test_eval_single_task_summary.py tests/test_eval_zero_task_guard.py tests/test_eval_sharding.py -q` -> `152 passed`
- `uv run pytest -q` -> `4635 passed, 14 skipped, 7 deselected`

Real data / task validation:

- Real SkillsBench Docker oracle run with new eval artifact flags:
  - task: `skillsbench/tasks/jax-computing-basics`
  - command used `--task-manifest-out`, `--run-config-out`, `--health-summary-out`, `--canonicalize one-healthy-per-task`, `--canonical-selection-out`, `--canonical-jobs-dir`
  - result: `1/1`, errors `0`
- Real SkillsBench matrix eval:
  - task: `skillsbench/tasks/weighted-gdp-calc`
  - command used `--matrix` with two model aliases and `--trials 1`
  - result: two runs, both `1/1`, matrix summary emitted
- Real HF trajectory data from `benchflow/env0-experiment-trajectories`:
  - downloaded one selected rollout from `experiments/env0-mobile-pr828/pr828-env0-mobile-full300-azure-openhands-daytona-20260625T041236Z`
  - `bench train convert ... --canonical-selection ... --expected-rows 1`
  - `bench train validate ... --source-jobs ... --source-canonical-selection ... --require-llm-trajectory --require-tool-calls`
  - result: `rows=1`, `rows_with_tool_calls=1`, source health clean
- Real task-overlap check:
  - `bench tasks overlap` on generated task manifests
  - emitted exact task-id and digest overlap counts
- Real Daytona smoke:
  - task: `skillsbench/tasks/weighted-gdp-calc`
  - `DAYTONA_TARGET=us bench eval run --sandbox daytona --agent oracle ...`
  - result: `1/1`, errors `0`

Prime-RL note:

- I cloned real upstream `PrimeIntellect-ai/prime-rl` and attempted a local `bench train run sft --dry-run` wrapper smoke.
- The wrapper produced a correct failed `train-run.json` manifest, but upstream `prime-rl` did not start locally because its current `pyproject.toml` / lock metadata fails under this macOS `uv` environment before the trainer entrypoint can run.
- Unit coverage verifies successful SFT launch, failed launch, successful HF publication, and publication-failure manifest state.

## Notes

- `bench eval run --retry-policy unscored-only` records the reproducibility policy and uses the existing eval retry semantics, which already retry error/unscored paths rather than scored model failures.
- Publication helpers dynamically import `huggingface_hub`; no dependency churn is introduced.
