### PR TITLE
Harden Prime SFT tool-call validation

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -358,7 +358,9 @@ bench train convert jobs/run-001 --out train.jsonl --canonical-selection canonic
 
 ### bench train validate
 
-Validate Prime-RL SFT JSONL before upload or training.
+Validate Prime-RL SFT JSONL before upload or training. This fails closed on
+malformed tool-call arguments, undeclared tool names, orphan tool outputs, and
+row-count mismatches before Prime-RL can hit the bad row mid-training.
 
 ```bash
 bench train validate train.jsonl

--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -234,28 +234,36 @@ def _normalize_role(role: Any) -> str:
     return str(role or "user")
 
 
+def _json_tool_call_arguments(arguments: Any) -> str:
+    if isinstance(arguments, str):
+        try:
+            parsed = json.loads(arguments)
+        except json.JSONDecodeError:
+            parsed = {"_malformed_json_arguments": arguments}
+        else:
+            if not isinstance(parsed, dict):
+                parsed = {"_non_object_json_arguments": parsed}
+    elif isinstance(arguments, dict):
+        parsed = arguments
+    elif arguments is None:
+        parsed = {}
+    else:
+        parsed = {"_non_object_arguments": arguments}
+    return json.dumps(parsed, sort_keys=True)
+
+
 def _normalize_tool_call(call: dict[str, Any], index: int = 0) -> dict[str, Any]:
     function = call.get("function")
     if not isinstance(function, dict):
         function = {}
     name = function.get("name") or call.get("name") or "tool"
     arguments = function.get("arguments", call.get("arguments", {}))
-    if isinstance(arguments, str):
-        try:
-            json.loads(arguments)
-        except json.JSONDecodeError:
-            arguments = json.dumps(
-                {"_malformed_json_arguments": arguments},
-                sort_keys=True,
-            )
-    else:
-        arguments = json.dumps(arguments or {}, sort_keys=True)
     return {
         "id": str(call.get("id") or call.get("tool_call_id") or f"call_{index:06d}"),
         "type": "function",
         "function": {
             "name": str(name),
-            "arguments": arguments,
+            "arguments": _json_tool_call_arguments(arguments),
         },
     }
 
@@ -534,6 +542,18 @@ def _normalize_tools_for_validation(
     return tools
 
 
+def _tool_names_for_validation(tools: list[Any] | None) -> set[str]:
+    names: set[str] = set()
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        name = function.get("name") if isinstance(function, dict) else tool.get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+    return names
+
+
 def _row_messages(row: dict[str, Any], row_num: int) -> list[Any]:
     messages = row.get("messages")
     if isinstance(messages, list) and messages:
@@ -589,6 +609,9 @@ def validate_prime_sft_row(row: dict[str, Any], row_num: int = 1) -> None:
         )
 
     messages = _row_messages(row, row_num)
+    tools = _normalize_tools_for_validation(row, row_num)
+    known_tool_names = _tool_names_for_validation(tools)
+    pending_tool_call_ids: set[str] = set()
 
     for idx, message in enumerate(messages):
         if not isinstance(message, dict):
@@ -610,43 +633,68 @@ def validate_prime_sft_row(row: dict[str, Any], row_num: int = 1) -> None:
             raise ValueError(
                 f"row {row_num}: messages[{idx}] needs content or tool_calls"
             )
-        if (
-            "tool_calls" in message
-            and message.get("tool_calls")
-            and role != "assistant"
-        ):
+        tool_calls = message.get("tool_calls")
+        if tool_calls and role != "assistant":
             raise ValueError(
                 f"row {row_num}: only assistant messages may contain tool_calls"
             )
         if role == "tool" and not message.get("tool_call_id"):
             raise ValueError(f"row {row_num}: tool message requires tool_call_id")
-        tool_calls = message.get("tool_calls")
+        if role == "tool" and message.get("tool_call_id") not in pending_tool_call_ids:
+            raise ValueError(
+                f"row {row_num}: tool message references unknown tool_call_id"
+            )
+        if role == "tool":
+            pending_tool_call_ids.discard(cast(str, message.get("tool_call_id")))
+        if tool_calls is not None and not isinstance(tool_calls, list):
+            raise ValueError(
+                f"row {row_num}: messages[{idx}].tool_calls must be a list"
+            )
         if isinstance(tool_calls, list):
             for tool_call_idx, tool_call in enumerate(tool_calls):
+                prefix = f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}]"
                 if not isinstance(tool_call, dict):
-                    raise ValueError(
-                        f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}] must be object"
-                    )
+                    raise ValueError(f"{prefix} must be object")
                 tool_call = cast(dict[str, Any], tool_call)
                 function = tool_call.get("function")
                 if not isinstance(function, dict):
+                    raise ValueError(f"{prefix}.function must be object")
+                tool_call_id = tool_call.get("id")
+                if not isinstance(tool_call_id, str) or not tool_call_id:
+                    raise ValueError(f"{prefix}.id must be a non-empty string")
+                if tool_call.get("type") != "function":
+                    raise ValueError(f"{prefix}.type must be 'function'")
+                name = function.get("name")
+                if not isinstance(name, str) or not name:
                     raise ValueError(
-                        f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}].function must be object"
+                        f"{prefix}.function.name must be a non-empty string"
+                    )
+                if known_tool_names and name not in known_tool_names:
+                    raise ValueError(
+                        f"{prefix}.function.name {name!r} not found in tool_defs/tools"
                     )
                 arguments = function.get("arguments")
                 if isinstance(arguments, str):
                     try:
-                        json.loads(arguments)
+                        parsed_arguments = json.loads(arguments)
                     except json.JSONDecodeError as exc:
                         raise ValueError(
-                            f"row {row_num}: messages[{idx}].tool_calls[{tool_call_idx}].function.arguments is not valid JSON: {exc}"
+                            f"{prefix}.function.arguments is not valid JSON: {exc}"
                         ) from exc
+                    if not isinstance(parsed_arguments, dict):
+                        raise ValueError(
+                            f"{prefix}.function.arguments must be a JSON object"
+                        )
+                elif not isinstance(arguments, dict):
+                    raise ValueError(
+                        f"{prefix}.function.arguments must be a JSON object or JSON-encoded object"
+                    )
+                pending_tool_call_ids.add(tool_call_id)
 
     if not any(isinstance(m, dict) and m.get("role") == "assistant" for m in messages):
         raise ValueError(f"row {row_num}: no assistant message")
 
     typed_messages = [m for m in messages if isinstance(m, dict)]
-    tools = _normalize_tools_for_validation(row, row_num)
     if _has_tool_calls(typed_messages) and not tools:
         raise ValueError(
             f"row {row_num}: assistant tool_calls require non-empty tool_defs/tools"
@@ -655,6 +703,14 @@ def validate_prime_sft_row(row: dict[str, Any], row_num: int = 1) -> None:
         for tool_idx, tool in enumerate(tools):
             if not isinstance(tool, dict):
                 raise ValueError(f"row {row_num}: tool_defs[{tool_idx}] must be object")
+            function = tool.get("function")
+            name = (
+                function.get("name") if isinstance(function, dict) else tool.get("name")
+            )
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    f"row {row_num}: tool_defs[{tool_idx}] missing function name"
+                )
 
 
 def validate_prime_sft_jsonl(

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -445,7 +445,7 @@ def test_validate_rejects_tool_calls_without_tool_defs(tmp_path: Path) -> None:
 
 
 def test_validate_rejects_malformed_tool_call_arguments(tmp_path: Path) -> None:
-    """Guards the 1703-row SFT crash: bad tool-call JSON fails before training."""
+    """Guards PR #848: bad tool-call JSON fails before training."""
     path = tmp_path / "bad-arguments.jsonl"
     path.write_text(
         json.dumps(
@@ -487,7 +487,7 @@ def test_validate_rejects_malformed_tool_call_arguments(tmp_path: Path) -> None:
 
 
 def test_validate_rejects_non_object_tool_call_arguments(tmp_path: Path) -> None:
-    """Prime-RL tool-call args must parse to a JSON object, not any JSON value."""
+    """Guards PR #848: tool-call args must parse to a JSON object."""
     path = tmp_path / "list-arguments.jsonl"
     path.write_text(
         json.dumps(
@@ -527,7 +527,7 @@ def test_validate_rejects_non_object_tool_call_arguments(tmp_path: Path) -> None
 def test_validate_rejects_unknown_tool_name_and_orphan_tool_output(
     tmp_path: Path,
 ) -> None:
-    """Tool calls must reference declared tools and tool outputs must link back."""
+    """Guards PR #848: tool calls must declare tools and linked outputs."""
     unknown_tool = tmp_path / "unknown-tool.jsonl"
     unknown_tool.write_text(
         json.dumps(

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -444,6 +444,141 @@ def test_validate_rejects_tool_calls_without_tool_defs(tmp_path: Path) -> None:
         validate_prime_sft_jsonl(path)
 
 
+def test_validate_rejects_malformed_tool_call_arguments(tmp_path: Path) -> None:
+    """Guards the 1703-row SFT crash: bad tool-call JSON fails before training."""
+    path = tmp_path / "bad-arguments.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "task_name": "gdoc-rebrand-juniper-cloud-to-umbra-software-69",
+                "messages": [
+                    {"role": "user", "content": "Replace the old brand."},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_588",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": '{"security_risk":"MEDIUM","summary":"Replace old brand"',
+                                },
+                            }
+                        ],
+                    },
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
+
+    with pytest.raises(ValueError, match=r"function\.arguments is not valid JSON"):
+        validate_prime_sft_jsonl(path, expected_rows=1)
+
+
+def test_validate_rejects_non_object_tool_call_arguments(tmp_path: Path) -> None:
+    """Prime-RL tool-call args must parse to a JSON object, not any JSON value."""
+    path = tmp_path / "list-arguments.jsonl"
+    path.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Call the tool."},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "finish", "arguments": "[]"},
+                            }
+                        ],
+                    },
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "finish",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
+
+    with pytest.raises(ValueError, match=r"function\.arguments must be a JSON object"):
+        validate_prime_sft_jsonl(path, expected_rows=1)
+
+
+def test_validate_rejects_unknown_tool_name_and_orphan_tool_output(
+    tmp_path: Path,
+) -> None:
+    """Tool calls must reference declared tools and tool outputs must link back."""
+    unknown_tool = tmp_path / "unknown-tool.jsonl"
+    unknown_tool.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Call the tool."},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "missing", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "finish",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n"
+    )
+    orphan_tool = tmp_path / "orphan-tool.jsonl"
+    orphan_tool.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "Call the tool."},
+                    {"role": "assistant", "content": "No tool call."},
+                    {"role": "tool", "tool_call_id": "call_missing", "content": "ok"},
+                ]
+            }
+        )
+        + "\n"
+    )
+
+    with pytest.raises(ValueError, match="not found in tool_defs/tools"):
+        validate_prime_sft_jsonl(unknown_tool, expected_rows=1)
+    with pytest.raises(ValueError, match="unknown tool_call_id"):
+        validate_prime_sft_jsonl(orphan_tool, expected_rows=1)
+
+
 def test_strict_llm_trajectory_loader_rejects_malformed_jsonl(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Story

The first full env-0 `tasks-train` SFT attempt over 1703 rows failed in the middle of training because one trainer row had malformed tool-call JSON. The bad row was not a GPU, W&B, Fireworks, Daytona, or model-stability failure. It was an `assistant.tool_calls[*].function.arguments` value that looked like a JSON object but was unterminated, so Prime-RL only crashed once the shuffled/packed dataloader reached that example around the middle of the run.

That failure mode is expensive because the launch can look healthy: model load succeeds, loss starts finite, usage telemetry exists, and the bad row may not be consumed until many optimizer steps later. The right fix is to make BenchFlow reject or normalize this trainer data before it ever reaches Prime-RL.

## What changed

- Hardened the canonical Prime SFT validation path used by `bench train validate`.
- Tool calls now fail closed unless they have:
  - `tool_calls` as a list on assistant messages only
  - non-empty tool-call `id`
  - `type == "function"`
  - object-shaped `function`
  - non-empty `function.name`
  - `function.arguments` that is either an object or a JSON-encoded object
  - a `function.name` declared in `tool_defs` / `tools` when tool definitions are available
  - matching prior assistant tool-call ids for `tool` messages
- Converter-side normalization now also turns malformed or non-object tool-call arguments into JSON-object sentinels, so converted BenchFlow rows stay Prime-RL-safe instead of passing through arbitrary argument shapes.
- Updated CLI docs to make `bench train validate` explicit as the pre-training gate for malformed tool-call arguments, undeclared tools, orphan tool outputs, and row-count mismatches.
- Added regression coverage for the 1703-row crash class, using the concrete `gdoc-rebrand-juniper-cloud-to-umbra-software-69` style malformed argument case.

## Design / quality notes

I kept this in `src/benchflow/trajectories/export_prime_sft.py` instead of creating a second validator. That is the canonical layer already used by both conversion and `bench train validate`, so the fix makes the existing boundary stricter rather than adding another path operators have to remember.

I also kept the main touched file below the 1k-line guardrail after the change. The validation block is still local and direct, with no new framework or indirection.

## Validation

- `uv run ruff check src/benchflow/trajectories/export_prime_sft.py tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py`
- `uv run ruff format --check src/benchflow/trajectories/export_prime_sft.py tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py`
- `uv run ty check src/benchflow/trajectories/export_prime_sft.py src/benchflow/cli/train.py`
- `uv run pytest tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py tests/test_cli_docs_drift.py -q`

## Out of scope

This PR prevents malformed Prime SFT rows from reaching training. It does not implement a full Prime-RL renderer dry-run or a scheduler/resume LR guard. Those are still useful follow-up gates, but this PR targets the data-shape crash directly.

## Merge note

Opening for review only. Do not merge yet per operator request.