### PR TITLE
Redact trajectory secrets before serialization (fix prime-sft convert)

### DIFF
--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from benchflow._utils.json_safe import dumps_finite, scrub_non_finite
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import redact_trajectory_obj
 
 PrimeSftRowMode = Literal["rollout", "exchange"]
 
@@ -93,8 +93,11 @@ class PrimeSftTrajectoryJsonlError(ValueError):
 
 
 def _json_line(record: dict[str, Any]) -> str:
-    raw = dumps_finite(scrub_non_finite(record), default=str)
-    return redact_trajectory_text(raw)
+    # Redact secrets in the record's string values BEFORE serializing so the
+    # emitted SFT row is always valid JSON; redacting the serialized text could
+    # split a backslash escape next to a secret and corrupt the line.
+    redacted = redact_trajectory_obj(scrub_non_finite(record))
+    return dumps_finite(redacted, default=str)
 
 
 def _load_json(path: Path) -> dict[str, Any] | None:

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -177,9 +177,12 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
 # backslashes followed by an optional quote. This makes every carrier fire on raw
 # text (``"k": "v"``), Python dict-repr (``'k': 'v'``), AND json.dumps-escaped
 # JSON at any nesting depth (``\"k\": \"v\"``, ``\\\"k\\\": …``) — the escaped
-# form is how a provider error body embedded in ``error.message`` reaches the
-# redactor after ``Trajectory.to_jsonl`` runs ``json.dumps`` over the record
-# before redacting it (#830). The ``{0,8}`` cap keeps it ReDoS-bounded.
+# form still appears when a serialized artifact is redacted as text (the
+# ADP/ATIF exporters, ``results.py``), or when a provider error body embedded in
+# ``error.message`` is itself JSON (#830). (``Trajectory.to_jsonl`` and the ACP
+# writer now redact record *values* before ``json.dumps`` via
+# ``redact_trajectory_obj`` so they can never emit a corrupt escape.) The
+# ``{0,8}`` cap keeps it ReDoS-bounded.
 _ESCQ = r'(?:\\{0,8}["\']|)'
 # Secret value class for the carriers: stops at a quote (plain, or the backslash
 # of an escaped closing quote), whitespace, and the ``,`` ``}`` ``&`` delimiters
@@ -414,20 +417,45 @@ def redact_trajectory_text(text: str) -> str:
     return text
 
 
+def redact_trajectory_obj(obj: Any) -> Any:
+    """Recursively redact secrets in the string leaves of a JSON-serializable value.
+
+    Prefer this over running :func:`redact_trajectory_text` on an
+    already-``json.dumps``-ed record. Redacting the serialized *text* can split a
+    ``\\`` escape — a secret sitting next to one leaves a lone ``\\X`` — which
+    corrupts the JSON so the trajectory file no longer parses and
+    ``bench train convert`` fails. Redacting the *values* first and serializing
+    afterwards keeps escaping valid. Coverage is unchanged for captured
+    exchanges: secrets live in free-text string leaves (request/response bodies,
+    message content) where the token-family and ``name: value`` carriers still
+    fire; structured auth headers are not stored.
+    """
+    if isinstance(obj, str):
+        return redact_trajectory_text(obj)
+    if isinstance(obj, dict):
+        return {key: redact_trajectory_obj(value) for key, value in obj.items()}
+    if isinstance(obj, list):
+        return [redact_trajectory_obj(item) for item in obj]
+    return obj
+
+
 def redact_acp_trajectory_jsonl(trajectory: list[dict[str, Any]]) -> str:
     """Serialize an ACP trajectory list to redacted JSONL.
 
-    Each event is JSON-encoded and then run through ``redact_trajectory_text``
-    so secrets the agent echoed into ``acp_trajectory.jsonl`` (env dumps, curl
-    -v output, header logs) are stripped before the file is written or uploaded
-    (#537/#585). Returns the joined lines without a trailing newline; callers
-    that need one (e.g. uploaded copies) append it themselves.
+    Each event's string values are redacted (env dumps, curl -v output, header
+    logs the agent echoed into ``acp_trajectory.jsonl``) *before* serialization,
+    so secrets are stripped (#537/#585) without a post-serialization regex
+    corrupting backslash escapes. Events are normalized to JSON primitives first
+    (applying ``default=str``) so non-JSON leaves are covered too. Returns the
+    joined lines without a trailing newline; callers that need one append it.
     """
     import json
 
-    return "\n".join(
-        redact_trajectory_text(json.dumps(event, default=str)) for event in trajectory
-    )
+    lines = []
+    for event in trajectory:
+        normalized = json.loads(json.dumps(event, default=str))
+        lines.append(json.dumps(redact_trajectory_obj(normalized)))
+    return "\n".join(lines)
 
 
 class LLMRequest(BaseModel):
@@ -528,14 +556,18 @@ class Trajectory(BaseModel):
         return msgs
 
     def to_jsonl(self, *, redact_keys: bool = True) -> str:
-        """Export as JSONL (one exchange per line)."""
+        """Export as JSONL (one exchange per line).
+
+        Redaction runs on the record's string *values* before ``json.dumps`` so
+        the emitted JSON is always valid — regexing the serialized text could
+        split a ``\\`` escape next to a secret and produce an unparseable line.
+        """
         import json
 
         lines = []
         for ex in self.exchanges:
             data = ex.model_dump(mode="json")
-            raw = json.dumps(data, default=str)
             if redact_keys:
-                raw = redact_trajectory_text(raw)
-            lines.append(raw)
+                data = redact_trajectory_obj(data)
+            lines.append(json.dumps(data, default=str))
         return "\n".join(lines)

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -424,19 +424,51 @@ def redact_trajectory_obj(obj: Any) -> Any:
     already-``json.dumps``-ed record. Redacting the serialized *text* can split a
     ``\\`` escape — a secret sitting next to one leaves a lone ``\\X`` — which
     corrupts the JSON so the trajectory file no longer parses and
-    ``bench train convert`` fails. Redacting the *values* first and serializing
-    afterwards keeps escaping valid. Coverage is unchanged for captured
-    exchanges: secrets live in free-text string leaves (request/response bodies,
-    message content) where the token-family and ``name: value`` carriers still
-    fire; structured auth headers are not stored.
+    ``bench train convert`` fails. Redacting the *values* before serializing keeps
+    escaping valid while preserving coverage: free-text leaves are scrubbed by the
+    token-family and inline ``name: value`` carriers, and structured fields (e.g.
+    a ``{"x-api-key": "<prefixless>"}`` header) are scrubbed in their key context
+    by :func:`_redact_field` so the carriers that key off a field name still fire.
     """
-    if isinstance(obj, str):
-        return redact_trajectory_text(obj)
     if isinstance(obj, dict):
-        return {key: redact_trajectory_obj(value) for key, value in obj.items()}
+        return {key: _redact_field(key, value) for key, value in obj.items()}
     if isinstance(obj, list):
         return [redact_trajectory_obj(item) for item in obj]
+    if isinstance(obj, str):
+        return redact_trajectory_text(obj)
     return obj
+
+
+def _redact_field(key: Any, value: Any) -> Any:
+    """Redact a dict field's *value*, keeping the field name as carrier context.
+
+    The ``name: value`` carriers (``x-api-key``, ``api_key``, ``authorization``,
+    ``*_TOKEN`` …) strip *prefixless* secret values only when they can see the
+    field name; in a parsed object the name and value are separate. So redact the
+    value inside a ``{"<key>": "<value>"}`` probe and read it back. The probe
+    round-trips through json so escaping stays valid; if redacting the serialized
+    probe would corrupt it (the escape hazard this module guards), fall back to
+    redacting the bare value, which still catches the prefixed token families.
+    """
+    if isinstance(value, (dict, list)):
+        return redact_trajectory_obj(value)
+    if not isinstance(value, str):
+        return value
+    if isinstance(key, str):
+        import json
+
+        probe = json.dumps({key: value})
+        redacted = redact_trajectory_text(probe)
+        if redacted == probe:
+            return value
+        try:
+            restored = json.loads(redacted)
+        except ValueError:
+            pass
+        else:
+            if isinstance(restored, dict) and isinstance(restored.get(key), str):
+                return restored[key]
+    return redact_trajectory_text(value)
 
 
 def redact_acp_trajectory_jsonl(trajectory: list[dict[str, Any]]) -> str:

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -694,3 +694,67 @@ def test_convert_openhands_responses_shape_preserves_tool_calls(tmp_path: Path) 
         "content": "File created.",
     }
     assert row["messages"][-1] == {"role": "assistant", "content": "Done."}
+
+
+def test_convert_succeeds_when_trajectory_written_via_to_jsonl_with_secrets(
+    tmp_path: Path,
+) -> None:
+    """End-to-end regression: a trajectory whose content carries a secret next to
+    a backslash escape must be written as valid JSON by ``Trajectory.to_jsonl``
+    and convert cleanly to a prime-sft row. Before the redactor was moved ahead of
+    serialization, the post-``json.dumps`` regex split the escape, producing an
+    unparseable ``llm_trajectory.jsonl`` and a hard ``Invalid \\escape`` failure.
+    """
+    from benchflow.trajectories.types import (
+        LLMExchange,
+        LLMRequest,
+        LLMResponse,
+        Trajectory,
+    )
+
+    secret = "sk-abc1234567defghijklmnop987654"
+    code = (
+        'token = form.get("token")\n'
+        "    if not token:\n"
+        f'        raise HTTPException(400, "invalid")  # {secret}\n'
+    )
+    messages = [
+        {"role": "system", "content": [{"type": "text", "text": "agent"}]},
+        {"role": "user", "content": "Edit the revoke handler."},
+    ]
+    traj = Trajectory(
+        session_id="s",
+        exchanges=[
+            LLMExchange(
+                request=LLMRequest(
+                    body={"model": "m", "messages": messages, "tools": []}
+                ),
+                response=LLMResponse(
+                    status_code=200,
+                    body={
+                        "choices": [{"message": {"role": "assistant", "content": code}}]
+                    },
+                ),
+            )
+        ],
+    )
+
+    rollout = tmp_path / "job" / "rollout-1"
+    (rollout / "trajectory").mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps({"task_name": "t", "agent": "openhands", "rewards": {"reward": 1.0}})
+    )
+    traj_path = rollout / "trajectory" / "llm_trajectory.jsonl"
+    traj_path.write_text(traj.to_jsonl(redact_keys=True) + "\n", encoding="utf-8")
+
+    # the written trajectory parses (the fix) ...
+    for line in traj_path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            json.loads(line)
+    # ... and converts to one valid prime-sft row with the secret redacted.
+    rows, stats = convert_benchflow_rollouts_to_prime_sft_rows(
+        tmp_path / "job", min_reward=1.0
+    )
+    assert stats.rows_written == 1
+    assert stats.skipped_invalid == 0
+    assert secret not in json.dumps(rows[0])

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -699,11 +699,12 @@ def test_convert_openhands_responses_shape_preserves_tool_calls(tmp_path: Path) 
 def test_convert_succeeds_when_trajectory_written_via_to_jsonl_with_secrets(
     tmp_path: Path,
 ) -> None:
-    """End-to-end regression: a trajectory whose content carries a secret next to
-    a backslash escape must be written as valid JSON by ``Trajectory.to_jsonl``
-    and convert cleanly to a prime-sft row. Before the redactor was moved ahead of
-    serialization, the post-``json.dumps`` regex split the escape, producing an
-    unparseable ``llm_trajectory.jsonl`` and a hard ``Invalid \\escape`` failure.
+    """PR #849 end-to-end regression: a trajectory whose content carries a secret
+    next to a backslash escape must be written as valid JSON by
+    ``Trajectory.to_jsonl`` and convert cleanly to a prime-sft row. Before the
+    redactor was moved ahead of serialization, the post-``json.dumps`` regex split
+    the escape, producing an unparseable ``llm_trajectory.jsonl`` and a hard
+    ``Invalid \\escape`` failure.
     """
     from benchflow.trajectories.types import (
         LLMExchange,

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -786,3 +786,91 @@ def test_redactor_no_redos(label, pathological):
     redact_trajectory_text(pathological)
     elapsed_ms = (time.perf_counter() - start) * 1000
     assert elapsed_ms < 750, f"possible ReDoS on {label}: {elapsed_ms:.0f} ms"
+
+
+# Regression: the redactor used to run over the already-serialized JSON
+# (``json.dumps`` then ``re.sub``). When a redacted secret sat next to a ``\``
+# escape, the substitution could split it and leave an invalid ``\X``, corrupting
+# llm_trajectory.jsonl / acp_trajectory.jsonl so they no longer parsed and
+# ``bench train convert`` hard-failed. The writers now redact string *values*
+# before serialization (``redact_trajectory_obj``), so output is always valid JSON.
+
+_ADVERSARIAL_CONTENTS = [
+    # secret immediately after a backslash
+    "auth header:\\" + "sk-abc1234567defghijklmnop987654",
+    # carrier-tripping code (``token =`` / ``if not token:``) with escaped quotes,
+    # newlines, and a secret in a comment — mirrors a real agent code edit that
+    # reproduced the corruption in the wild.
+    'token = form.get("token")\n'
+    "    if not token:\n"
+    '        raise HTTPException(400, "invalid")  '
+    "# key sk-abc1234567defghijklmnop987654\n",
+    # windows-style path backslashes adjacent to an AWS key
+    "C:\\Users\\app\\AKIAIOSFODNN7EXAMPLE",
+    # a JSON blob (escaped quotes once serialized) carrying a Google key
+    '{"x-api-key": "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"}',
+]
+
+_ADVERSARIAL_LEAKS = (
+    "abc1234567defghijklmnop987654",
+    "IOSFODNN7EXAMPLE",
+    "FORTESTSONLYxxxxxxxxxxxxxxx",
+)
+
+
+@pytest.mark.parametrize("content", _ADVERSARIAL_CONTENTS)
+def test_to_jsonl_emits_valid_json_with_secret_adjacent_escapes(content):
+    traj = Trajectory(
+        session_id="t",
+        exchanges=[
+            LLMExchange(
+                request=LLMRequest(
+                    body={"messages": [{"role": "user", "content": content}]}
+                ),
+                response=LLMResponse(
+                    status_code=200,
+                    body={
+                        "choices": [
+                            {"message": {"role": "assistant", "content": content}}
+                        ]
+                    },
+                ),
+            )
+        ],
+    )
+    jsonl = traj.to_jsonl(redact_keys=True)
+    for line in jsonl.splitlines():
+        json.loads(line)  # must round-trip — no corrupt escapes
+    for leaked in _ADVERSARIAL_LEAKS:
+        assert leaked not in jsonl
+
+
+@pytest.mark.parametrize("content", _ADVERSARIAL_CONTENTS)
+def test_acp_jsonl_emits_valid_json_with_secret_adjacent_escapes(content):
+    out = redact_acp_trajectory_jsonl(
+        [{"type": "agent_message", "content": content}, {"type": "tool_call"}]
+    )
+    lines = out.splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        json.loads(line)
+    for leaked in _ADVERSARIAL_LEAKS:
+        assert leaked not in out
+
+
+def test_redact_trajectory_obj_redacts_nested_string_leaves():
+    from benchflow.trajectories.types import redact_trajectory_obj
+
+    obj = {
+        "a": "sk-abc1234567defghijklmnop987654",
+        "b": ["plain", {"c": "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"}],
+        "n": 5,
+        "ok": True,
+    }
+    out = redact_trajectory_obj(obj)
+    dumped = json.dumps(out)  # re-serializes to valid JSON
+    for leaked in ("abc1234567defghijklmnop987654", "FORTESTSONLYxxxxxxxxxxxxxxx"):
+        assert leaked not in dumped
+    # non-string leaves and structure are preserved
+    assert out["n"] == 5 and out["ok"] is True
+    assert out["b"][0] == "plain"

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -788,7 +788,7 @@ def test_redactor_no_redos(label, pathological):
     assert elapsed_ms < 750, f"possible ReDoS on {label}: {elapsed_ms:.0f} ms"
 
 
-# Regression: the redactor used to run over the already-serialized JSON
+# Regression (PR #849): the redactor used to run over the already-serialized JSON
 # (``json.dumps`` then ``re.sub``). When a redacted secret sat next to a ``\``
 # escape, the substitution could split it and leave an invalid ``\X``, corrupting
 # llm_trajectory.jsonl / acp_trajectory.jsonl so they no longer parsed and
@@ -820,6 +820,8 @@ _ADVERSARIAL_LEAKS = (
 
 @pytest.mark.parametrize("content", _ADVERSARIAL_CONTENTS)
 def test_to_jsonl_emits_valid_json_with_secret_adjacent_escapes(content):
+    """PR #849: to_jsonl round-trips to valid JSON even when content puts a secret
+    next to a backslash escape, and still strips the secret."""
     traj = Trajectory(
         session_id="t",
         exchanges=[
@@ -847,6 +849,8 @@ def test_to_jsonl_emits_valid_json_with_secret_adjacent_escapes(content):
 
 @pytest.mark.parametrize("content", _ADVERSARIAL_CONTENTS)
 def test_acp_jsonl_emits_valid_json_with_secret_adjacent_escapes(content):
+    """PR #849: redact_acp_trajectory_jsonl emits valid JSON lines for the same
+    secret-adjacent-escape content."""
     out = redact_acp_trajectory_jsonl(
         [{"type": "agent_message", "content": content}, {"type": "tool_call"}]
     )
@@ -859,6 +863,8 @@ def test_acp_jsonl_emits_valid_json_with_secret_adjacent_escapes(content):
 
 
 def test_redact_trajectory_obj_redacts_nested_string_leaves():
+    """PR #849: redact_trajectory_obj scrubs string leaves at any depth, leaving
+    non-string values and structure intact."""
     from benchflow.trajectories.types import redact_trajectory_obj
 
     obj = {
@@ -874,3 +880,73 @@ def test_redact_trajectory_obj_redacts_nested_string_leaves():
     # non-string leaves and structure are preserved
     assert out["n"] == 5 and out["ok"] is True
     assert out["b"][0] == "plain"
+
+
+# PR #849 review (discussion_r3494557495): object-level redaction must keep the
+# field-name context, or the ``name: value`` carriers stop stripping *prefixless*
+# secrets held in structured fields (LLM request/response headers + body, ACP
+# structured events). A prefixless value has no token prefix and no inline
+# ``name: value`` text, so only key context can flag it.
+
+_PREFIXLESS_SECRET = "prefixlessSecretValue1234567890"
+
+
+def test_to_jsonl_redacts_prefixless_secret_in_structured_headers_and_body():
+    """PR #849 review: prefixless secrets in request/response headers or body must
+    still redact via key context, with valid-JSON output."""
+    traj = Trajectory(
+        session_id="t",
+        exchanges=[
+            LLMExchange(
+                request=LLMRequest(
+                    headers={"x-api-key": _PREFIXLESS_SECRET},
+                    body={
+                        "api_key": _PREFIXLESS_SECRET,
+                        "authorization": "Bearer " + _PREFIXLESS_SECRET,
+                    },
+                ),
+                response=LLMResponse(
+                    status_code=200,
+                    headers={"x-api-key": _PREFIXLESS_SECRET},
+                    body={
+                        "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+                    },
+                ),
+            )
+        ],
+    )
+    jsonl = traj.to_jsonl(redact_keys=True)
+    parsed = json.loads(jsonl)  # single exchange -> one valid line
+    assert _PREFIXLESS_SECRET not in jsonl
+    assert parsed["request"]["headers"]["x-api-key"] == "***REDACTED***"
+    assert parsed["request"]["body"]["api_key"] == "***REDACTED***"
+    assert parsed["request"]["body"]["authorization"] == "Bearer ***REDACTED***"
+    assert parsed["response"]["headers"]["x-api-key"] == "***REDACTED***"
+
+
+def test_acp_jsonl_redacts_prefixless_secret_in_structured_event():
+    """PR #849 review: a prefixless secret in a structured ACP event field (key
+    separate from value, possibly nested) must redact via key context."""
+    out = redact_acp_trajectory_jsonl(
+        [
+            {
+                "type": "tool_result",
+                "headers": {"authorization": _PREFIXLESS_SECRET},
+                "api_key": _PREFIXLESS_SECRET,
+            }
+        ]
+    )
+    event = json.loads(out)  # valid JSON
+    assert _PREFIXLESS_SECRET not in out
+    assert event["headers"]["authorization"] == "***REDACTED***"
+    assert event["api_key"] == "***REDACTED***"
+
+
+def test_redact_trajectory_obj_preserves_key_context_for_structured_secret():
+    """PR #849 review: object-level redaction keys off the field name (parity with
+    the prior serialized-text path) without touching non-secret fields."""
+    from benchflow.trajectories.types import redact_trajectory_obj
+
+    out = redact_trajectory_obj({"x-api-key": _PREFIXLESS_SECRET, "note": "plain text"})
+    assert out["x-api-key"] == "***REDACTED***"
+    assert out["note"] == "plain text"


### PR DESCRIPTION
## Problem
`bench train convert --format prime-sft` hard-fails with `Invalid \escape` on real rollouts — the captured `llm_trajectory.jsonl` isn't valid JSON.

**Root cause:** the trajectory writers serialize each record with `json.dumps` and **then** run secret-redaction (`re.sub` over `_REDACTION_PATTERNS`) on the serialized string. When a redacted secret sits next to a `\` escape, the substitution splits it into an invalid `\X`, corrupting the JSON. `build_health_summary` already surfaces these as `malformed_llm_trajectory`.

Reproduced on two independent runs (PrimeIntellect + OpenRouter) of env-0 `auth-revoke-overbroad-autoreplyer-2100036` with Qwen3.5-397B-A17B, both reward 1.0. The over-broad generic `*TOKEN`/`*SECRET` carrier also matches ordinary agent code (`token = form.get(...)`), which is what placed a redaction next to the escape.

## Fix
Redact string **values before** `json.dumps`, via a new `redact_trajectory_obj()` helper used by:
- `Trajectory.to_jsonl` → `llm_trajectory.jsonl`
- `redact_acp_trajectory_jsonl` → `acp_trajectory.jsonl`
- prime-sft `_json_line` → the SFT output rows (same bug on the write side)

Serializing after redaction keeps escaping valid. Coverage is unchanged: captured exchange headers are empty `{}` and secrets live in free-text string leaves where the token-family and `name: value` carriers still fire (the existing redaction suite still passes).

## Testing
- `ruff check` / `ruff format` / `ty` — clean
- **210 passed** (`tests/trajectories/` + `tests/test_train_cli.py`)
- New regression tests: writer + helper invariants (valid-JSON round-trip with secret-adjacent escapes) and an end-to-end `to_jsonl → convert` test
- CLI verified: `bench train convert` + `bench train validate` succeed on a fixed-writer rollout (secret redacted, 0 leaks)

## Scope / follow-up
Only the prime-sft pipeline writers are fixed here. The other exporters (`export.py`, `export_adp.py`, `export_atif.py`, `results.py`, `continue_run/orchestrator.py`) still redact serialized text and carry the same latent pattern — can sweep them onto `redact_trajectory_obj` in a follow-up.
