### PR TITLE
Repair Prime SFT conversion from results JSONL

### DIFF
--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Iterator
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -62,6 +63,8 @@ class PrimeSftExportStats:
     skipped_no_assistant: int = 0
     skipped_missing_tool_defs: int = 0
     skipped_invalid: int = 0
+    tool_call_ids_rewritten: int = 0
+    tool_messages_merged: int = 0
     sources: list[str] = field(default_factory=list)
 
     def as_dict(self) -> dict[str, Any]:
@@ -78,6 +81,8 @@ class PrimeSftExportStats:
             "skipped_no_assistant": self.skipped_no_assistant,
             "skipped_missing_tool_defs": self.skipped_missing_tool_defs,
             "skipped_invalid": self.skipped_invalid,
+            "tool_call_ids_rewritten": self.tool_call_ids_rewritten,
+            "tool_messages_merged": self.tool_messages_merged,
             "sources": self.sources,
         }
 
@@ -601,6 +606,124 @@ def _sanitize_prime_sft_row_tool_call_arguments(row: dict[str, Any]) -> dict[str
     return out
 
 
+def _row_message_segments(
+    row: dict[str, Any],
+) -> list[tuple[Literal["messages", "prompt", "completion"], Any]]:
+    messages = row.get("messages")
+    if isinstance(messages, list) and messages:
+        return [("messages", message) for message in messages]
+    prompt = row.get("prompt")
+    completion = row.get("completion")
+    if isinstance(prompt, list) and isinstance(completion, list):
+        return [("prompt", message) for message in prompt] + [
+            ("completion", message) for message in completion
+        ]
+    return []
+
+
+def _content_join(left: Any, right: Any) -> str:
+    return "\n".join(
+        part for part in (_content_to_text(left), _content_to_text(right)) if part
+    )
+
+
+def _align_legacy_tool_call_ids(
+    segments: list[tuple[Literal["messages", "prompt", "completion"], Any]],
+) -> tuple[
+    list[tuple[Literal["messages", "prompt", "completion"], Any]], dict[str, int]
+]:
+    """Repair legacy BenchFlow rows whose provider call ids drifted.
+
+    Some historical ``results.jsonl`` artifacts preserved assistant tool-call ids
+    from one provider layer (``fc_*``) while the following tool messages used the
+    OpenAI-compatible ``call_*`` ids that the runtime sent back on the next turn.
+    Pair by message order and rewrite only when a pending assistant call exists;
+    true orphan tool outputs still fail validation.
+    """
+    out: list[tuple[Literal["messages", "prompt", "completion"], Any]] = []
+    pending: list[dict[str, Any]] = []
+    stats = {"tool_call_ids_rewritten": 0, "tool_messages_merged": 0}
+
+    for segment, raw_message in segments:
+        message = deepcopy(raw_message)
+        if not isinstance(message, dict):
+            out.append((segment, message))
+            continue
+
+        tool_calls = message.get("tool_calls")
+        if message.get("role") == "assistant" and isinstance(tool_calls, list):
+            pending.extend(
+                tool_call for tool_call in tool_calls if isinstance(tool_call, dict)
+            )
+
+        if message.get("role") == "tool":
+            tool_call_id = message.get("tool_call_id")
+            if (
+                out
+                and isinstance(out[-1][1], dict)
+                and out[-1][1].get("role") == "tool"
+                and out[-1][1].get("tool_call_id") == tool_call_id
+            ):
+                out[-1][1]["content"] = _content_join(
+                    out[-1][1].get("content"),
+                    message.get("content"),
+                )
+                stats["tool_messages_merged"] += 1
+                continue
+
+            match_index = next(
+                (
+                    idx
+                    for idx, tool_call in enumerate(pending)
+                    if tool_call.get("id") == tool_call_id
+                ),
+                None,
+            )
+            if match_index is not None:
+                pending.pop(match_index)
+            elif pending and tool_call_id:
+                tool_call = pending.pop(0)
+                if tool_call.get("id") != tool_call_id:
+                    tool_call["id"] = tool_call_id
+                    stats["tool_call_ids_rewritten"] += 1
+
+        out.append((segment, message))
+
+    return out, stats
+
+
+def _canonicalize_existing_prime_sft_row(
+    row: dict[str, Any],
+    row_num: int,
+    *,
+    sanitize_tool_call_arguments: bool = False,
+) -> tuple[dict[str, Any], dict[str, int]]:
+    out = (
+        _sanitize_prime_sft_row_tool_call_arguments(row)
+        if sanitize_tool_call_arguments
+        else dict(row)
+    )
+    segments = _row_message_segments(out)
+    if not segments:
+        validate_prime_sft_row(out, row_num)
+        return out, {"tool_call_ids_rewritten": 0, "tool_messages_merged": 0}
+
+    repaired, stats = _align_legacy_tool_call_ids(segments)
+    segment_names = {segment for segment, _ in repaired}
+    if segment_names == {"messages"}:
+        out["messages"] = [message for _, message in repaired]
+    else:
+        out.pop("messages", None)
+        out["prompt"] = [
+            message for segment, message in repaired if segment == "prompt"
+        ]
+        out["completion"] = [
+            message for segment, message in repaired if segment == "completion"
+        ]
+    validate_prime_sft_row(out, row_num)
+    return out, stats
+
+
 def validate_prime_sft_row(row: dict[str, Any], row_num: int = 1) -> None:
     leaked = sorted(BANNED_ROW_KEYS.intersection(row))
     if leaked:
@@ -744,7 +867,7 @@ def validate_prime_sft_jsonl(
 
 def _iter_prime_sft_jsonl_rows(
     path: Path, *, sanitize_tool_call_arguments: bool = False
-) -> Iterator[tuple[int, dict[str, Any]]]:
+) -> Iterator[tuple[int, dict[str, Any], dict[str, int]]]:
     with path.open("r", encoding="utf-8") as handle:
         for row_num, line in enumerate(handle, start=1):
             if not line.strip():
@@ -755,10 +878,12 @@ def _iter_prime_sft_jsonl_rows(
                 raise ValueError(f"row {row_num}: invalid JSON: {exc}") from exc
             if not isinstance(row, dict):
                 raise ValueError(f"row {row_num}: top-level row must be object")
-            if sanitize_tool_call_arguments:
-                row = _sanitize_prime_sft_row_tool_call_arguments(row)
-            validate_prime_sft_row(row, row_num)
-            yield row_num, row
+            row, repair_stats = _canonicalize_existing_prime_sft_row(
+                row,
+                row_num,
+                sanitize_tool_call_arguments=sanitize_tool_call_arguments,
+            )
+            yield row_num, row, repair_stats
 
 
 def _row_reward(row: dict[str, Any]) -> float | None:
@@ -768,15 +893,72 @@ def _row_reward(row: dict[str, Any]) -> float | None:
     return None
 
 
+def _compact_existing_prime_sft_row(
+    row: dict[str, Any],
+    *,
+    row_num: int,
+    source: Path,
+) -> dict[str, Any]:
+    """Emit a compact trainer row from a validated existing JSONL row."""
+    messages = [
+        message for message in _row_messages(row, row_num) if isinstance(message, dict)
+    ]
+    out: dict[str, Any] = {"messages": messages}
+
+    tools = row.get("tool_defs", row.get("tools"))
+    if tools is not None:
+        out["tool_defs"] = tools
+
+    reward = _row_reward(row)
+    if reward is not None:
+        out["reward"] = reward
+
+    raw_info = row.get("info")
+    info: dict[str, Any] = (
+        cast(dict[str, Any], raw_info) if isinstance(raw_info, dict) else {}
+    )
+    task_id = (
+        row.get("task_id")
+        or row.get("task_name")
+        or info.get("task_id")
+        or info.get("task_name")
+    )
+    if task_id:
+        out["task_id"] = str(task_id)
+    task_name = row.get("task_name") or info.get("task_name") or task_id
+    if task_name:
+        out["task_name"] = str(task_name)
+    if isinstance(row.get("model"), str):
+        out["model"] = row["model"]
+    elif isinstance(info.get("model"), str):
+        out["model"] = info["model"]
+    if isinstance(row.get("agent"), str):
+        out["agent"] = row["agent"]
+    elif isinstance(info.get("agent"), str):
+        out["agent"] = info["agent"]
+    if isinstance(row.get("example_id"), int):
+        out["source_example_id"] = row["example_id"]
+    if isinstance(info.get("rollout_dir"), str):
+        out["source_rollout_dir"] = info["rollout_dir"]
+    if row.get("chat_template_kwargs") is not None:
+        out["chat_template_kwargs"] = row["chat_template_kwargs"]
+    out["source_path"] = str(source)
+    out["source_index"] = row_num - 1
+    out["source_format"] = "benchflow-results-jsonl"
+    return out
+
+
 def _existing_prime_sft_jsonl_stats(
     path: Path,
     *,
     min_reward: float | None,
 ) -> PrimeSftExportStats:
     stats = PrimeSftExportStats(sources=[str(path)])
-    for row_num, row in _iter_prime_sft_jsonl_rows(
+    for row_num, row, repair_stats in _iter_prime_sft_jsonl_rows(
         path, sanitize_tool_call_arguments=True
     ):
+        stats.tool_call_ids_rewritten += repair_stats["tool_call_ids_rewritten"]
+        stats.tool_messages_merged += repair_stats["tool_messages_merged"]
         stats.rollouts_seen += 1
         reward = _row_reward(row)
         if min_reward is not None and (reward is None or reward < min_reward):
@@ -798,14 +980,20 @@ def _copy_existing_prime_sft_jsonl(
 ) -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w", encoding="utf-8") as handle:
-        for _, row in _iter_prime_sft_jsonl_rows(
+        for row_num, row, _ in _iter_prime_sft_jsonl_rows(
             source, sanitize_tool_call_arguments=True
         ):
             if min_reward is not None:
                 reward = _row_reward(row)
                 if reward is None or reward < min_reward:
                     continue
-            handle.write(_json_line(row) + "\n")
+            compact = _compact_existing_prime_sft_row(
+                row,
+                row_num=row_num,
+                source=source,
+            )
+            validate_prime_sft_row(compact, row_num)
+            handle.write(_json_line(compact) + "\n")
 
 
 def normalize_prime_sft_exchange(

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -221,10 +221,79 @@ def test_train_convert_sanitizes_malformed_tool_call_arguments(
 
     assert result.exit_code == 0, result.output
     row = json.loads(out.read_text())
-    arguments = row["completion"][0]["tool_calls"][0]["function"]["arguments"]
+    arguments = row["messages"][1]["tool_calls"][0]["function"]["arguments"]
     assert json.loads(arguments) == {
         "_malformed_json_arguments": '{"command":"python - <<\'PY\'\nunterminated'
     }
+    result = runner.invoke(app, ["train", "validate", str(out), "--expected-rows", "1"])
+    assert result.exit_code == 0, result.output
+
+
+def test_train_convert_repairs_legacy_results_tool_call_ids(tmp_path: Path) -> None:
+    source = tmp_path / "results.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "Inspect the app."}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "fc_legacy_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_runtime_1",
+                        "content": "ok",
+                    },
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    out = tmp_path / "prime-sft.jsonl"
+    manifest = tmp_path / "manifest.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "convert",
+            str(source),
+            "--out",
+            str(out),
+            "--expected-rows",
+            "1",
+            "--manifest",
+            str(manifest),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    row = json.loads(out.read_text())
+    assert "trajectory" not in row
+    assert row["messages"][1]["tool_calls"][0]["id"] == "call_runtime_1"
+    assert json.loads(manifest.read_text())["tool_call_ids_rewritten"] == 1
     result = runner.invoke(app, ["train", "validate", str(out), "--expected-rows", "1"])
     assert result.exit_code == 0, result.output
 

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -404,12 +404,90 @@ def test_export_accepts_existing_prime_sft_jsonl_input(tmp_path: Path) -> None:
     assert stats.rollouts_seen == 2
     assert stats.rows_written == 1
     assert stats.skipped_reward == 1
+    row = json.loads(out.read_text())
+    assert "messages" in row
+    assert "prompt" not in row
+    assert "completion" not in row
     assert validate_prime_sft_jsonl(out, expected_rows=1) == {
         "ok": True,
         "rows": 1,
         "rows_with_tool_calls": 1,
     }
     assert json.loads(manifest.read_text())["sources"] == [str(source)]
+
+
+def test_export_repairs_legacy_results_tool_call_ids(tmp_path: Path) -> None:
+    """Guards historical BenchFlow results rows whose assistant/tool ids drifted."""
+    source = tmp_path / "results.jsonl"
+    out = tmp_path / "prime-sft.jsonl"
+    manifest = tmp_path / "manifest.json"
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "Inspect the app."}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "fc_legacy_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_runtime_1",
+                        "content": "first chunk",
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_runtime_1",
+                        "content": "second chunk",
+                    },
+                    {"role": "assistant", "content": "Done."},
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stats = export_prime_sft_jsonl(source, out, expected_rows=1, manifest=manifest)
+
+    row = json.loads(out.read_text())
+    assert stats.tool_call_ids_rewritten == 1
+    assert stats.tool_messages_merged == 1
+    assert "trajectory" not in row
+    assert row["messages"][1]["tool_calls"][0]["id"] == "call_runtime_1"
+    assert row["messages"][2] == {
+        "role": "tool",
+        "tool_call_id": "call_runtime_1",
+        "content": "first chunk\nsecond chunk",
+    }
+    assert validate_prime_sft_jsonl(out, expected_rows=1) == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
+    manifest_payload = json.loads(manifest.read_text())
+    assert manifest_payload["tool_call_ids_rewritten"] == 1
+    assert manifest_payload["tool_messages_merged"] == 1
 
 
 def test_validate_rejects_tool_calls_without_tool_defs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- repair legacy BenchFlow `results.jsonl` rows whose assistant tool-call IDs (`fc_*`) do not match following tool result IDs (`call_*`) during `bench train convert`
- merge duplicate adjacent tool-result fragments with the same `tool_call_id`
- emit compact trainer rows from existing JSONL sources instead of copying bulky audit fields like `trajectory`
- expose repair counts in the conversion manifest and add CLI/library regressions

## Real-data validation

Using the PR828 mobile300 artifact:

```bash
uv run --extra dev bench train convert \
  /Users/bingran_you/.codex/worktrees/1c88/env-0-experiment/.local/env0-mobile-prime-sft-pr828/source/results.jsonl \
  --out .local/mobile300-prime-sft-patched/prime-sft.jsonl \
  --manifest .local/mobile300-prime-sft-patched/manifest.json \
  --expected-rows 300
uv run --extra dev bench train validate .local/mobile300-prime-sft-patched/prime-sft.jsonl --expected-rows 300
```

Result:

- validate: `{"ok": true, "rows": 300, "rows_with_tool_calls": 175}`
- manifest: `tool_call_ids_rewritten=2040`, `tool_messages_merged=26`, `rows_written=300`
- output size: `13M` vs source `results.jsonl` `202M`

Raw `bench train validate results.jsonl` still fails closed on the archived legacy file (`row 1: tool message references unknown tool_call_id`); this PR intentionally fixes the conversion path rather than weakening strict validation.

## Tests

```bash
uv run ruff format --check src/benchflow/trajectories/export_prime_sft.py tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py
uv run ruff check src/benchflow/trajectories/export_prime_sft.py tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py
uv run ty check src/benchflow/trajectories/export_prime_sft.py
uv run pytest tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py -q
```
