### PR TITLE
Fix OpenRouter and Prime SFT results artifacts

### DIFF
--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -206,6 +206,16 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_type="api_key",
         auth_env="GITHUB_TOKEN",
     ),
+    # OpenRouter exposes hosted models through an OpenAI-compatible endpoint.
+    # Keep qwen-dashscope as the owner for bare qwen* models; callers choose
+    # OpenRouter explicitly with openrouter/<provider>/<model>.
+    "openrouter": ProviderConfig(
+        name="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="OPENROUTER_API_KEY",
+    ),
     # TODO: add eu-openai (https://eu.api.openai.com/v1) when needed.
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(

--- a/src/benchflow/eval_artifacts.py
+++ b/src/benchflow/eval_artifacts.py
@@ -102,7 +102,29 @@ def write_task_manifest(path: Path, options: TaskManifestOptions) -> dict[str, A
 def _iter_rollouts(job_dir: Path) -> list[Path]:
     if (job_dir / "result.json").is_file():
         return [job_dir]
-    return sorted({path.parent for path in job_dir.rglob("result.json")})
+    roots = [job_dir]
+    shard_root = _worker_shards_root(job_dir)
+    if shard_root is not None:
+        roots.append(shard_root)
+    return sorted(
+        {
+            path.parent
+            for root in roots
+            if root.is_dir()
+            for path in root.rglob("result.json")
+        }
+    )
+
+
+def _worker_shards_root(job_dir: Path) -> Path | None:
+    candidates = [
+        job_dir / "worker-shards",
+        job_dir.parent / "worker-shards",
+    ]
+    for candidate in candidates:
+        if (candidate / "plan.json").is_file():
+            return candidate
+    return None
 
 
 def _rollout_dir_from_selection_row(

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -289,7 +289,11 @@ def _aggregate_result(
         "shards": shard_results,
     }
     jobs_dir.mkdir(parents=True, exist_ok=True)
-    (jobs_dir / "summary.json").write_text(json.dumps(summary, indent=2))
+    summary_text = json.dumps(summary, indent=2)
+    (jobs_dir / "summary.json").write_text(summary_text)
+    aggregate_job_dir = jobs_dir / result.job_name
+    aggregate_job_dir.mkdir(parents=True, exist_ok=True)
+    (aggregate_job_dir / "summary.json").write_text(summary_text)
     return result
 
 

--- a/src/benchflow/trajectories/export.py
+++ b/src/benchflow/trajectories/export.py
@@ -33,7 +33,7 @@ from benchflow._utils.json_safe import scrub_non_finite
 from benchflow.adapters.ors import ORSAdapter
 from benchflow.rewards.protocol import VerifyResult
 from benchflow.trajectories._export_common import aggregate_rollout_jsonl
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import redact_trajectory_obj
 
 # Canonical artifact locations (see issue #385).
 ROLLOUT_ARTIFACT_RELPATH = "trainer/verifiers.jsonl"
@@ -92,9 +92,8 @@ def trajectory_to_verifiers_record(
 
 
 def _record_to_redacted_json_line(record: dict[str, Any]) -> str:
-    clean = scrub_non_finite(record)
-    raw = json.dumps(clean, default=str, allow_nan=False)
-    return redact_trajectory_text(raw)
+    clean = redact_trajectory_obj(scrub_non_finite(record))
+    return json.dumps(clean, default=str, allow_nan=False)
 
 
 def _redact_verifiers_record(record: dict[str, Any]) -> dict[str, Any]:

--- a/src/benchflow/trajectories/export_adp.py
+++ b/src/benchflow/trajectories/export_adp.py
@@ -50,7 +50,7 @@ from benchflow.trajectories._export_common import (
     aggregate_rollout_jsonl,
     content_blocks_to_text,
 )
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import redact_trajectory_obj
 
 logger = logging.getLogger(__name__)
 
@@ -210,8 +210,7 @@ def trajectory_to_adp_record(
 
 
 def _record_to_redacted_json_line(record: dict[str, Any]) -> str:
-    raw = dumps_finite(record, default=str)
-    return redact_trajectory_text(raw)
+    return dumps_finite(redact_trajectory_obj(record), default=str)
 
 
 def write_rollout_adp_jsonl(

--- a/src/benchflow/trajectories/export_atif.py
+++ b/src/benchflow/trajectories/export_atif.py
@@ -41,7 +41,7 @@ from typing import Any, cast
 
 from benchflow._utils.json_safe import dumps_finite
 from benchflow.trajectories._export_common import ThoughtBuffer, content_blocks_to_text
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import redact_trajectory_obj
 
 ATIF_SCHEMA_VERSION = "ATIF-v1.7"
 
@@ -183,8 +183,7 @@ def trajectory_to_atif_record(
 
 
 def _record_to_redacted_json(record: dict[str, Any]) -> str:
-    raw = dumps_finite(record, default=str, indent=2)
-    return redact_trajectory_text(raw)
+    return dumps_finite(redact_trajectory_obj(record), default=str, indent=2)
 
 
 def write_rollout_atif_json(

--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -62,6 +62,7 @@ class PrimeSftExportStats:
     skipped_exchanges_provider_error: int = 0
     skipped_no_assistant: int = 0
     skipped_missing_tool_defs: int = 0
+    skipped_terminal_error: int = 0
     skipped_invalid: int = 0
     tool_call_ids_rewritten: int = 0
     tool_messages_merged: int = 0
@@ -80,6 +81,7 @@ class PrimeSftExportStats:
             "skipped_exchanges_provider_error": self.skipped_exchanges_provider_error,
             "skipped_no_assistant": self.skipped_no_assistant,
             "skipped_missing_tool_defs": self.skipped_missing_tool_defs,
+            "skipped_terminal_error": self.skipped_terminal_error,
             "skipped_invalid": self.skipped_invalid,
             "tool_call_ids_rewritten": self.tool_call_ids_rewritten,
             "tool_messages_merged": self.tool_messages_merged,
@@ -994,6 +996,25 @@ def _is_benchflow_results_row(row: dict[str, Any]) -> bool:
     )
 
 
+def _benchflow_row_training_skip_reason(row: dict[str, Any]) -> str | None:
+    if not _is_benchflow_results_row(row):
+        return None
+    info = row.get("info")
+    if isinstance(info, dict) and info.get("training_ready") is False:
+        return "not_training_ready"
+    if row.get("error"):
+        return "terminal_error"
+    if row.get("is_truncated") is True:
+        return "partial_trajectory"
+    stop_condition = row.get("stop_condition")
+    if isinstance(stop_condition, str) and stop_condition not in {
+        "",
+        "agent_completed",
+    }:
+        return stop_condition
+    return None
+
+
 def _existing_prime_sft_jsonl_stats(
     path: Path,
     *,
@@ -1006,6 +1027,9 @@ def _existing_prime_sft_jsonl_stats(
         stats.tool_call_ids_rewritten += repair_stats["tool_call_ids_rewritten"]
         stats.tool_messages_merged += repair_stats["tool_messages_merged"]
         stats.rollouts_seen += 1
+        if _benchflow_row_training_skip_reason(row) is not None:
+            stats.skipped_terminal_error += 1
+            continue
         reward = _row_reward(row)
         if min_reward is not None and (reward is None or reward < min_reward):
             stats.skipped_reward += 1
@@ -1029,6 +1053,8 @@ def _copy_existing_prime_sft_jsonl(
         for row_num, row, _ in _iter_prime_sft_jsonl_rows(
             source, sanitize_tool_call_arguments=True
         ):
+            if _benchflow_row_training_skip_reason(row) is not None:
+                continue
             if min_reward is not None:
                 reward = _row_reward(row)
                 if reward is None or reward < min_reward:
@@ -1115,6 +1141,9 @@ def convert_benchflow_rollouts_to_prime_sft_rows(
         if result is None:
             stats.skipped_no_result += 1
             continue
+        if _result_training_skip_reason(result) is not None:
+            stats.skipped_terminal_error += 1
+            continue
         reward = _reward_from_result(result)
         if min_reward is not None and (reward is None or reward < min_reward):
             stats.skipped_reward += 1
@@ -1166,6 +1195,16 @@ def convert_benchflow_rollouts_to_prime_sft_rows(
             stats.sources.append(str(trajectory_path))
 
     return rows, stats
+
+
+def _result_training_skip_reason(result: dict[str, Any]) -> str | None:
+    if result.get("error"):
+        return "agent_error"
+    if result.get("verifier_error"):
+        return "verifier_error"
+    if result.get("partial_trajectory") is True:
+        return "partial_trajectory"
+    return None
 
 
 def export_prime_sft_jsonl(

--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -336,6 +336,28 @@ def _normalize_system_messages(messages: list[dict[str, Any]]) -> list[dict[str,
     return normalized
 
 
+def prime_sft_last_user_training_window(
+    messages: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]] | None:
+    """Return a compact prompt/completion window anchored at the last user turn.
+
+    OpenHands-style system prompts are large enough that a full conversation
+    prefix can push the first trainable assistant token beyond an 8k SFT
+    sequence. Prime-RL can then skip the row even though the JSONL is valid.
+    Keeping the latest user instruction plus the following assistant/tool turns
+    preserves the supervised action trace while moving trainable tokens into the
+    loaded context window.
+    """
+    for idx in range(len(messages) - 2, -1, -1):
+        message = messages[idx]
+        if message.get("role") != "user":
+            continue
+        completion = messages[idx + 1 :]
+        if any(item.get("role") == "assistant" for item in completion):
+            return [message], completion
+    return None
+
+
 def _messages_from_chat_request(body: dict[str, Any]) -> list[dict[str, Any]]:
     messages = body.get("messages")
     if not isinstance(messages, list):
@@ -906,6 +928,11 @@ def _compact_existing_prime_sft_row(
     messages = [
         message for message in _row_messages(row, row_num) if isinstance(message, dict)
     ]
+    if _is_benchflow_results_row(row):
+        window = prime_sft_last_user_training_window(messages)
+        if window is not None:
+            prompt, completion = window
+            messages = prompt + completion
     out: dict[str, Any] = {"messages": messages}
 
     tools = row.get("tool_defs", row.get("tools"))
@@ -949,6 +976,22 @@ def _compact_existing_prime_sft_row(
     out["source_index"] = row_num - 1
     out["source_format"] = "benchflow-results-jsonl"
     return out
+
+
+def _is_benchflow_results_row(row: dict[str, Any]) -> bool:
+    info = row.get("info")
+    if isinstance(info, dict) and info.get("source") == "benchflow":
+        return True
+    return any(
+        key in row
+        for key in (
+            "trajectory",
+            "stop_condition",
+            "token_usage",
+            "is_completed",
+            "is_truncated",
+        )
+    )
 
 
 def _existing_prime_sft_jsonl_stats(
@@ -1028,10 +1071,15 @@ def _row_from_exchange(
         return None, skip_reason
     if normalized is None:
         return None, "invalid_prime_sft_row"
+    messages = normalized.messages
+    window = prime_sft_last_user_training_window(messages)
+    if window is not None:
+        prompt, completion = window
+        messages = prompt + completion
 
     agent_result = result.get("agent_result") if isinstance(result, dict) else None
     row = {
-        "messages": normalized.messages,
+        "messages": messages,
         "tool_defs": normalized.tool_defs,
         "task_name": (result or {}).get("task_name") or rollout_dir.name,
         "source": "benchflow-llm-trajectory",

--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -104,6 +104,7 @@ def _json_line(record: dict[str, Any]) -> str:
     # emitted SFT row is always valid JSON; redacting the serialized text could
     # split a backslash escape next to a secret and corrupt the line.
     redacted = redact_trajectory_obj(scrub_non_finite(record))
+    redacted = _sanitize_prime_sft_row_tool_call_arguments(redacted)
     return dumps_finite(redacted, default=str)
 
 
@@ -259,7 +260,7 @@ def _json_tool_call_arguments(arguments: Any) -> str:
         parsed = {}
     else:
         parsed = {"_non_object_arguments": arguments}
-    return json.dumps(parsed, sort_keys=True)
+    return dumps_finite(redact_trajectory_obj(parsed), sort_keys=True, default=str)
 
 
 def _normalize_tool_call(call: dict[str, Any], index: int = 0) -> dict[str, Any]:

--- a/src/benchflow/trajectories/results.py
+++ b/src/benchflow/trajectories/results.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import suppress
 from pathlib import Path
 from typing import Any, cast
 
@@ -476,10 +477,8 @@ def _write_job_results_errors(
 ) -> None:
     out = job_path / JOB_RESULTS_ERRORS_FILENAME
     if not skipped_errors:
-        try:
+        with suppress(FileNotFoundError):
             out.unlink()
-        except FileNotFoundError:
-            pass
         return
     payload = {
         "schema_version": 1,

--- a/src/benchflow/trajectories/results.py
+++ b/src/benchflow/trajectories/results.py
@@ -25,19 +25,21 @@ from benchflow.trajectories.export_prime_sft import (
     PrimeSftTrajectoryJsonlError,
     load_llm_trajectory_jsonl,
     normalize_prime_sft_exchange,
+    prime_sft_last_user_training_window,
     validate_prime_sft_row,
 )
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import redact_trajectory_obj
 
 ROLLOUT_RESULTS_FILENAME = "results.jsonl"
 JOB_RESULTS_FILENAME = "results.jsonl"
+JOB_RESULTS_ERRORS_FILENAME = "results.errors.json"
 
 logger = logging.getLogger(__name__)
 
 
 def _record_to_redacted_json_line(record: dict[str, Any]) -> str:
-    raw = json.dumps(scrub_non_finite(record), default=str, allow_nan=False)
-    return redact_trajectory_text(raw)
+    redacted = redact_trajectory_obj(scrub_non_finite(record))
+    return json.dumps(redacted, default=str, allow_nan=False)
 
 
 def _reward_value(rewards: dict[str, Any] | None) -> float:
@@ -215,6 +217,12 @@ def _top_level_prompt_completion(
     full_messages = list(final_step.get("prompt") or []) + list(
         final_step.get("completion") or []
     )
+    typed_full_messages = [
+        message for message in full_messages if isinstance(message, dict)
+    ]
+    window = prime_sft_last_user_training_window(typed_full_messages)
+    if window is not None:
+        return window
     if prompt and len(full_messages) >= len(prompt):
         return prompt, full_messages[len(prompt) :]
     return prompt, list(final_step.get("completion") or [])
@@ -404,6 +412,7 @@ def write_job_results_jsonl(job_dir: str | Path) -> Path | None:
         return None
 
     example_ids: dict[str, int] = {}
+    skipped_errors: list[dict[str, Any]] = []
     out = job_path / JOB_RESULTS_FILENAME
     with out.open("w", encoding="utf-8") as handle:
         for src in rollout_files:
@@ -411,6 +420,13 @@ def write_job_results_jsonl(job_dir: str | Path) -> Path | None:
                 lines = src.read_text().splitlines()
             except OSError as exc:
                 logger.warning("Skipping unreadable results artifact %s: %s", src, exc)
+                skipped_errors.append(
+                    {
+                        "path": str(src),
+                        "error": "unreadable_results_artifact",
+                        "message": str(exc),
+                    }
+                )
                 continue
             for line_num, line in enumerate(lines, start=1):
                 if not line.strip():
@@ -424,6 +440,14 @@ def write_job_results_jsonl(job_dir: str | Path) -> Path | None:
                         line_num,
                         exc,
                     )
+                    skipped_errors.append(
+                        {
+                            "path": str(src),
+                            "line": line_num,
+                            "error": "invalid_results_artifact_json",
+                            "message": str(exc),
+                        }
+                    )
                     continue
                 if not isinstance(row, dict):
                     logger.warning(
@@ -431,11 +455,39 @@ def write_job_results_jsonl(job_dir: str | Path) -> Path | None:
                         src,
                         line_num,
                     )
+                    skipped_errors.append(
+                        {
+                            "path": str(src),
+                            "line": line_num,
+                            "error": "non_object_results_artifact_row",
+                        }
+                    )
                     continue
                 key = _job_example_key(row, src.parent)
                 row["example_id"] = example_ids.setdefault(key, len(example_ids))
                 handle.write(_record_to_redacted_json_line(row) + "\n")
+    _write_job_results_errors(job_path, skipped_errors)
     return out
+
+
+def _write_job_results_errors(
+    job_path: Path,
+    skipped_errors: list[dict[str, Any]],
+) -> None:
+    out = job_path / JOB_RESULTS_ERRORS_FILENAME
+    if not skipped_errors:
+        try:
+            out.unlink()
+        except FileNotFoundError:
+            pass
+        return
+    payload = {
+        "schema_version": 1,
+        "error": "skipped_results_artifact_rows",
+        "skipped_count": len(skipped_errors),
+        "skipped": skipped_errors,
+    }
+    out.write_text(_record_to_redacted_json_line(payload) + "\n")
 
 
 def _job_example_key(row: dict[str, Any], rollout_dir: Path) -> str:

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -94,6 +94,22 @@ class TestEnvMappingField:
         assert env["LLM_API_KEY"] == "ghs_test_token"
         assert env["LLM_MODEL"] == "openai/openai/gpt-4.1-mini"
 
+    def test_openhands_normalizes_openrouter_model(self):
+        env = {"OPENROUTER_API_KEY": "sk-openrouter"}
+        resolve_provider_env(
+            agent="openhands",
+            model="openrouter/qwen/qwen3.5-397b-a17b",
+            agent_env=env,
+        )
+
+        assert env["BENCHFLOW_PROVIDER_NAME"] == "openrouter"
+        assert env["BENCHFLOW_PROVIDER_MODEL"] == "qwen/qwen3.5-397b-a17b"
+        assert env["BENCHFLOW_PROVIDER_BASE_URL"] == "https://openrouter.ai/api/v1"
+        assert env["BENCHFLOW_PROVIDER_API_KEY"] == "sk-openrouter"
+        assert env["LLM_BASE_URL"] == "https://openrouter.ai/api/v1"
+        assert env["LLM_API_KEY"] == "sk-openrouter"
+        assert env["LLM_MODEL"] == "openai/qwen/qwen3.5-397b-a17b"
+
     def test_openhands_bedrock_initial_env_marks_registered_provider(self):
         """Guards the LiteLLM runtime refactor: Bedrock is detected before runtime rewrite."""
         env = {

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -146,11 +146,7 @@ def test_sharded_health_and_selection_discover_worker_shards(tmp_path: Path) -> 
     jobs_dir = tmp_path / "jobs"
     advertised_job_dir = jobs_dir / "worker-sharded"
     shard_job_dir = (
-        jobs_dir
-        / "worker-shards"
-        / "shard-000"
-        / "jobs"
-        / "2026-06-29__15-02-55"
+        jobs_dir / "worker-shards" / "shard-000" / "jobs" / "2026-06-29__15-02-55"
     )
     _write_rollout(shard_job_dir / "task-a__abc", "task-a")
     (jobs_dir / "worker-shards" / "plan.json").write_text(

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -10,6 +10,7 @@ from typing import Any
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
+from benchflow.eval_artifacts import build_canonical_selection, build_health_summary
 from benchflow.evaluation import Evaluation
 
 runner = CliRunner()
@@ -139,6 +140,41 @@ def test_eval_run_writes_manifest_health_and_canonical_artifacts(
     assert json.loads(health.read_text())["rows_with_tool_calls"] == 1
     assert json.loads(selection.read_text())["selected_count"] == 1
     assert (canonical_jobs / "task-a__abc" / "result.json").is_file()
+
+
+def test_sharded_health_and_selection_discover_worker_shards(tmp_path: Path) -> None:
+    jobs_dir = tmp_path / "jobs"
+    advertised_job_dir = jobs_dir / "worker-sharded"
+    shard_job_dir = (
+        jobs_dir
+        / "worker-shards"
+        / "shard-000"
+        / "jobs"
+        / "2026-06-29__15-02-55"
+    )
+    _write_rollout(shard_job_dir / "task-a__abc", "task-a")
+    (jobs_dir / "worker-shards" / "plan.json").write_text(
+        json.dumps(
+            {
+                "total_concurrency": 10,
+                "worker_concurrency": 2,
+                "shards": [{"index": 0, "concurrency": 2, "task_names": ["task-a"]}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    health = build_health_summary(advertised_job_dir)
+    selection = build_canonical_selection(
+        advertised_job_dir,
+        policy="one-healthy-per-task",
+        expected_tasks=1,
+    )
+
+    assert health["total_rows"] == 1
+    assert health["rows"][0]["task_id"] == "task-a"
+    assert selection["selected_count"] == 1
+    assert selection["selected"][0]["task_id"] == "task-a"
 
 
 def test_eval_run_matrix_runs_each_alias_and_trial(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_eval_sharding.py
+++ b/tests/test_eval_sharding.py
@@ -166,6 +166,10 @@ def test_worker_sharded_summary_includes_numeric_score_ratios(tmp_path) -> None:
     )
 
     summary = json.loads((tmp_path / "summary.json").read_text())
+    advertised_summary = json.loads(
+        (tmp_path / "worker-sharded" / "summary.json").read_text()
+    )
     assert result.score == pytest.approx(1 / 3)
     assert summary["score_ratio"] == pytest.approx(1 / 3)
     assert summary["score_excl_errors_ratio"] == pytest.approx(1 / 2)
+    assert advertised_summary == summary

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -103,6 +103,18 @@ def test_registered_provider_route_honors_explicit_generic_proxy_env():
     assert route.required_env == ("BENCHFLOW_PROVIDER_API_KEY",)
 
 
+def test_openrouter_route_uses_openai_compatible_endpoint():
+    route = resolve_litellm_route(
+        "openrouter/qwen/qwen3.5-397b-a17b",
+        {"OPENROUTER_API_KEY": "sk-openrouter"},
+    )
+
+    assert route.upstream_model == "openai/qwen/qwen3.5-397b-a17b"
+    assert route.litellm_params["api_base"] == "https://openrouter.ai/api/v1"
+    assert route.litellm_params["api_key"] == "os.environ/OPENROUTER_API_KEY"
+    assert route.required_env == ("OPENROUTER_API_KEY",)
+
+
 def test_proxy_config_registers_plain_and_openai_aliases():
     route = resolve_litellm_route(
         "aws-bedrock/us.anthropic.claude-opus-4-8",

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -73,6 +73,22 @@ class TestFindProvider:
             == "openai/gpt-4.1-mini"
         )
 
+    def test_openrouter_prefix(self):
+        name, cfg = find_provider("openrouter/qwen/qwen3.5-397b-a17b")
+
+        assert name == "openrouter"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "OPENROUTER_API_KEY"
+        assert cfg.base_url == "https://openrouter.ai/api/v1"
+        assert (
+            resolve_auth_env("openrouter/qwen/qwen3.5-397b-a17b")
+            == "OPENROUTER_API_KEY"
+        )
+        assert (
+            strip_provider_prefix("openrouter/qwen/qwen3.5-397b-a17b")
+            == "qwen/qwen3.5-397b-a17b"
+        )
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -26,7 +26,10 @@ from benchflow.trajectories.export import (
     write_rollout_verifiers_jsonl,
 )
 from benchflow.trajectories.export_prime_sft import validate_prime_sft_jsonl
-from benchflow.trajectories.results import write_job_results_jsonl
+from benchflow.trajectories.results import (
+    JOB_RESULTS_ERRORS_FILENAME,
+    write_job_results_jsonl,
+)
 
 _FAKE_GEMINI_KEY = "AIzaSyFAKEKEYFORTESTSONLYxxxxxxxxxxxxxxx"
 _FAKE_HEADER_SECRET = "plainSecretNoPrefix123"
@@ -436,10 +439,7 @@ def test_build_rollout_result_emits_verifiers_shaped_results_jsonl(tmp_path):
     artifact = rollout_dir / "results.jsonl"
     assert artifact.exists()
     row = json.loads(artifact.read_text())
-    assert row["prompt"] == [
-        {"role": "system", "content": "You are a tool-using agent."},
-        {"role": "user", "content": "List files."},
-    ]
+    assert row["prompt"] == [{"role": "user", "content": "List files."}]
     assert row["completion"][0]["tool_calls"][0]["function"]["name"] == "terminal"
     assert row["tool_defs"][0]["function"]["name"] == "terminal"
     assert row["info"]["training_ready"] is True
@@ -452,7 +452,10 @@ def test_build_rollout_result_emits_verifiers_shaped_results_jsonl(tmp_path):
     assert row["token_usage"]["final_output_tokens"] == 3.0
     assert row["token_usage"]["total_tokens"] == 13.0
     assert row["trajectory"][0]["tokens"] is None
-    assert row["trajectory"][0]["prompt"] == row["prompt"]
+    assert row["trajectory"][0]["prompt"] == [
+        {"role": "system", "content": "You are a tool-using agent."},
+        {"role": "user", "content": "List files."},
+    ]
     assert row["trajectory"][0]["completion"] == row["completion"]
     assert row["error"] is None
     assert row["is_completed"] is True
@@ -568,9 +571,49 @@ def test_results_jsonl_uses_canonical_prime_sft_normalization(tmp_path):
 
     artifact = rollout_dir / "results.jsonl"
     row = json.loads(artifact.read_text())
-    assert row["prompt"][0]["role"] == "system"
-    assert row["prompt"][1]["role"] == "user"
+    assert row["prompt"] == [{"role": "user", "content": "List files."}]
+    assert row["trajectory"][0]["prompt"][0]["role"] == "system"
+    assert row["trajectory"][0]["prompt"][1]["role"] == "user"
     assert row["info"]["training_ready"] is True
+    assert validate_prime_sft_jsonl(artifact, expected_rows=1)["ok"] is True
+
+
+def test_results_jsonl_redacts_without_corrupting_secret_named_booleans(tmp_path):
+    """Secret-carrier field names must not turn JSON booleans into bare tokens."""
+    rollout_dir = tmp_path / "rollout-redaction-bool"
+    rollout_dir.mkdir()
+    traj_dir = rollout_dir / "trajectory"
+    traj_dir.mkdir()
+    (traj_dir / "llm_trajectory.jsonl").write_text(json.dumps(_llm_exchange()) + "\n")
+
+    _build_rollout_result(
+        rollout_dir,
+        task_name="auth-phishing-token-exfil",
+        rollout_name="r1",
+        agent="openhands",
+        agent_name="OpenHands",
+        model="openai-compatible-model",
+        n_tool_calls=1,
+        prompts=["Check for leaked credentials."],
+        error=None,
+        verifier_error=None,
+        trajectory=_acp_trajectory(),
+        partial_trajectory=False,
+        trajectory_source="acp",
+        rewards={
+            "reward": 1.0,
+            "details": {"leaked_credentials": False, "leaked_kind": None},
+        },
+        started_at=datetime.now(),
+        timing={},
+    )
+
+    artifact = rollout_dir / "results.jsonl"
+    row = json.loads(artifact.read_text())
+    assert row["info"]["reward_details"] == {
+        "leaked_credentials": False,
+        "leaked_kind": None,
+    }
     assert validate_prime_sft_jsonl(artifact, expected_rows=1)["ok"] is True
 
 
@@ -733,6 +776,38 @@ def test_write_job_results_jsonl_groups_example_ids_by_task(tmp_path):
     rows = [json.loads(line) for line in out.read_text().splitlines()]
     assert [row["info"]["task_id"] for row in rows] == ["task-a", "task-a", "task-b"]
     assert [row["example_id"] for row in rows] == [0, 0, 1]
+    assert not (job_dir / JOB_RESULTS_ERRORS_FILENAME).exists()
+
+
+def test_write_job_results_jsonl_surfaces_skipped_malformed_rows(tmp_path):
+    job_dir = tmp_path / "job"
+    good = job_dir / "task-a__good"
+    bad = job_dir / "task-b__bad"
+    good.mkdir(parents=True)
+    bad.mkdir(parents=True)
+    (good / "results.jsonl").write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "do it"}],
+                "completion": [{"role": "assistant", "content": "done"}],
+                "reward": 1.0,
+                "info": {"task_id": "task-a"},
+            }
+        )
+        + "\n"
+    )
+    (bad / "results.jsonl").write_text(
+        '{"prompt": [], "completion": [], "leaked_credentials": ***REDACTED***}\n'
+    )
+
+    out = write_job_results_jsonl(job_dir)
+
+    assert out == job_dir / "results.jsonl"
+    assert len(out.read_text().splitlines()) == 1
+    errors = json.loads((job_dir / JOB_RESULTS_ERRORS_FILENAME).read_text())
+    assert errors["error"] == "skipped_results_artifact_rows"
+    assert errors["skipped_count"] == 1
+    assert errors["skipped"][0]["error"] == "invalid_results_artifact_json"
 
 
 def test_build_rollout_result_emits_atif_and_adp(tmp_path):

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -286,6 +286,35 @@ def test_write_rollout_verifiers_jsonl_redacts_trajectory_secrets(tmp_path):
     json.loads(text)
 
 
+def test_write_rollout_verifiers_jsonl_preserves_secret_named_booleans(tmp_path):
+    rollout_dir = tmp_path / "rollout-bool-redaction"
+    rollout_dir.mkdir()
+    record = write_rollout_verifiers_jsonl(
+        rollout_dir,
+        task_id="t-secret-bool",
+        prompts=["Inspect the security report."],
+        trajectory=[
+            {
+                "type": "tool_call",
+                "tool_call_id": "tc1",
+                "kind": "execute",
+                "title": "check report",
+                "status": "completed",
+                "content": [
+                    {"text": '{"leaked_credentials": false, "leaked_kind": null}'}
+                ],
+            }
+        ],
+        rewards={"reward": 1.0},
+        model="m",
+        environment="bench",
+    )
+
+    artifact = rollout_dir / ROLLOUT_ARTIFACT_RELPATH
+    parsed = json.loads(artifact.read_text())
+    assert parsed == record
+
+
 # job-level aggregation
 
 

--- a/tests/trajectories/test_export_adp.py
+++ b/tests/trajectories/test_export_adp.py
@@ -241,6 +241,33 @@ def test_write_redacts_secrets(tmp_path):
     assert "***REDACTED***" in observation["content"]
 
 
+def test_write_preserves_json_when_secret_named_boolean_appears_in_text(tmp_path):
+    events = [
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "check",
+            "status": "completed",
+            "content": [{"text": '{"leaked_credentials": false, "leaked_kind": null}'}],
+        }
+    ]
+
+    write_rollout_adp_jsonl(
+        tmp_path,
+        trajectory_id="r",
+        task_id="t",
+        prompts=None,
+        trajectory=events,
+        model=None,
+        environment="demo",
+    )
+
+    raw = (tmp_path / "trainer" / "adp.jsonl").read_text()
+    parsed = [json.loads(line) for line in raw.splitlines() if line.strip()]
+    assert len(parsed) == 1
+
+
 def test_write_job_adp_jsonl_aggregates_rollouts(tmp_path):
     for i in range(2):
         write_rollout_adp_jsonl(

--- a/tests/trajectories/test_export_atif.py
+++ b/tests/trajectories/test_export_atif.py
@@ -238,6 +238,30 @@ def test_write_redacts_secrets(tmp_path):
     assert "***REDACTED***" in content
 
 
+def test_write_preserves_json_when_secret_named_boolean_appears_in_text(tmp_path):
+    events = [
+        {
+            "type": "tool_call",
+            "tool_call_id": "tc1",
+            "kind": "execute",
+            "title": "check",
+            "status": "completed",
+            "content": [{"text": '{"leaked_credentials": false, "leaked_kind": null}'}],
+        }
+    ]
+
+    write_rollout_atif_json(
+        tmp_path,
+        session_id="s",
+        agent_name="a",
+        prompts=None,
+        trajectory=events,
+    )
+
+    parsed = json.loads((tmp_path / "trainer" / "atif.json").read_text())
+    assert parsed["steps"][0]["observation"]["results"][0]["content"]
+
+
 def test_write_scrubs_non_finite_cost(tmp_path):
     write_rollout_atif_json(
         tmp_path,

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -124,7 +124,7 @@ def test_convert_rollout_mode_uses_final_successful_exchange(tmp_path: Path) -> 
     assert row["source"] == "benchflow-llm-trajectory"
     assert row["reward"] == 1.0
     assert row["tool_defs"][0]["function"]["name"] == "bash"
-    assert row["messages"][0] == {"role": "system", "content": "You are an agent."}
+    assert row["messages"][0] == {"role": "user", "content": "List files."}
     assert any(message.get("role") == "tool" for message in row["messages"])
     assert row["messages"][-1] == {"role": "assistant", "content": "Done."}
 
@@ -206,8 +206,7 @@ def test_skipped_provider_error_counts_rollouts_not_exchanges(tmp_path: Path) ->
 
 
 def test_consecutive_leading_system_messages_not_dropped(tmp_path: Path) -> None:
-    """Guards #828 greptile P2: a row that starts with two system messages must
-    remap the second to 'user' instead of being silently dropped as invalid."""
+    """A valid row with leading system messages must still export cleanly."""
     exchange = _exchange(final=True)
     exchange["request"]["body"]["messages"] = [
         {"role": "system", "content": "Primary system prompt."},
@@ -221,8 +220,8 @@ def test_consecutive_leading_system_messages_not_dropped(tmp_path: Path) -> None
     assert stats.rows_written == 1
     assert stats.skipped_invalid == 0
     roles = [m["role"] for m in rows[0]["messages"]]
-    assert roles[0] == "system"
-    assert roles[1] == "user"  # second leading system remapped
+    assert roles[0] == "user"
+    assert "system" not in roles
 
 
 def test_exchange_mode_writes_one_row_per_successful_exchange(tmp_path: Path) -> None:
@@ -414,6 +413,73 @@ def test_export_accepts_existing_prime_sft_jsonl_input(tmp_path: Path) -> None:
         "rows_with_tool_calls": 1,
     }
     assert json.loads(manifest.read_text())["sources"] == [str(source)]
+
+
+def test_export_windows_benchflow_results_rows_for_prime_rl_8k(
+    tmp_path: Path,
+) -> None:
+    """BenchFlow results rows must not strand assistant tokens past 8k context."""
+    source = tmp_path / "results.jsonl"
+    out = tmp_path / "prime-sft.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [
+                    {"role": "system", "content": "system prompt\n" * 5000},
+                    {"role": "user", "content": "Solve the current task."},
+                ],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "ok",
+                    },
+                    {"role": "assistant", "content": "Done."},
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "info": {"source": "benchflow", "task_id": "task-a"},
+                "reward": 1.0,
+                "trajectory": [],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stats = export_prime_sft_jsonl(source, out, expected_rows=1)
+
+    assert stats.rows_written == 1
+    row = json.loads(out.read_text())
+    assert row["messages"][0] == {"role": "user", "content": "Solve the current task."}
+    assert all(message.get("role") != "system" for message in row["messages"])
+    assert row["messages"][1]["role"] == "assistant"
+    assert validate_prime_sft_jsonl(out, expected_rows=1) == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
 
 
 def test_export_repairs_legacy_results_tool_call_ids(tmp_path: Path) -> None:

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -284,6 +284,95 @@ def test_export_and_validate_prime_sft_jsonl(tmp_path: Path) -> None:
     assert json.loads(manifest.read_text())["rows_written"] == 1
 
 
+def test_export_redacts_malformed_tool_call_arguments_before_serializing(
+    tmp_path: Path,
+) -> None:
+    """Nested tool-call arguments are JSON strings; redact before encoding them."""
+    exchange = _exchange(final=False)
+    exchange["response"]["body"]["choices"][0]["message"] = {
+        "role": "assistant",
+        "content": "Let me request a token.",
+        "tool_calls": [
+            {
+                "id": "call_token",
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "arguments": (
+                        '{"command": "curl -d \\"password=sk-abc1234567890def"'
+                        ' | jq .", "summary": "request token"}'
+                    ),
+                },
+            }
+        ],
+    }
+    _write_rollout(tmp_path / "job" / "rollout-1", exchanges=[exchange])
+    out = tmp_path / "train.jsonl"
+
+    export_prime_sft_jsonl(tmp_path / "job", out, expected_rows=1)
+
+    assert validate_prime_sft_jsonl(out, expected_rows=1) == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
+    row = json.loads(out.read_text())
+    arguments = row["messages"][-1]["tool_calls"][0]["function"]["arguments"]
+    parsed_arguments = json.loads(arguments)
+    assert parsed_arguments == {
+        "_malformed_json_arguments": (
+            '{"command": "curl -d \\"password=***REDACTED***"'
+            ' | jq .", "summary": "request token"}'
+        )
+    }
+
+
+def test_export_keeps_already_redacted_tool_call_arguments_valid(
+    tmp_path: Path,
+) -> None:
+    """A later request can replay already-redacted malformed arguments."""
+    exchange = _exchange(final=False)
+    exchange["request"]["body"]["messages"] = [
+        {"role": "user", "content": "Request a token."},
+        {
+            "role": "assistant",
+            "content": "Let me request a token.",
+            "tool_calls": [
+                {
+                    "id": "call_token",
+                    "type": "function",
+                    "function": {
+                        "name": "bash",
+                        "arguments": json.dumps(
+                            {
+                                "_malformed_json_arguments": (
+                                    '{"command": "curl -d '
+                                    '\\"password=***REDACTED***" | jq ."}'
+                                )
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_token", "content": "ok"},
+    ]
+    _write_rollout(tmp_path / "job" / "rollout-1", exchanges=[exchange])
+    out = tmp_path / "train.jsonl"
+
+    export_prime_sft_jsonl(tmp_path / "job", out, expected_rows=1)
+
+    assert validate_prime_sft_jsonl(out, expected_rows=1) == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
+    row = json.loads(out.read_text())
+    arguments = row["messages"][1]["tool_calls"][0]["function"]["arguments"]
+    parsed_arguments = json.loads(arguments)
+    assert "_malformed_json_arguments" in parsed_arguments
+
+
 def test_validate_rejects_banned_message_keys(tmp_path: Path) -> None:
     """Guards this PR's leakage-key validation before Prime-RL ingestion."""
     path = tmp_path / "bad.jsonl"

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -21,17 +21,18 @@ def _write_rollout(
     *,
     reward: float = 1.0,
     exchanges: list[dict] | None = None,
+    result_overrides: dict | None = None,
 ) -> None:
     rollout_dir.mkdir(parents=True)
+    result = {
+        "task_name": "demo-task",
+        "agent": "openhands",
+        "rewards": {"reward": reward},
+        "agent_result": {"total_tokens": 123, "n_tool_calls": 1},
+    }
+    result.update(result_overrides or {})
     (rollout_dir / "result.json").write_text(
-        json.dumps(
-            {
-                "task_name": "demo-task",
-                "agent": "openhands",
-                "rewards": {"reward": reward},
-                "agent_result": {"total_tokens": 123, "n_tool_calls": 1},
-            }
-        )
+        json.dumps(result)
     )
     traj = rollout_dir / "trajectory"
     traj.mkdir()
@@ -248,6 +249,19 @@ def test_convert_filters_by_min_reward(tmp_path: Path) -> None:
 
     assert rows == []
     assert stats.skipped_reward == 1
+
+
+def test_convert_skips_terminal_errored_rollouts(tmp_path: Path) -> None:
+    _write_rollout(
+        tmp_path / "job" / "timeout",
+        result_overrides={"error": "Agent prompt exceeded wall-clock budget 600s"},
+    )
+
+    rows, stats = convert_benchflow_rollouts_to_prime_sft_rows(tmp_path / "job")
+
+    assert rows == []
+    assert stats.rows_written == 0
+    assert stats.skipped_terminal_error == 1
 
 
 def test_export_and_validate_prime_sft_jsonl(tmp_path: Path) -> None:
@@ -480,6 +494,39 @@ def test_export_windows_benchflow_results_rows_for_prime_rl_8k(
         "rows": 1,
         "rows_with_tool_calls": 1,
     }
+
+
+def test_export_skips_benchflow_results_rows_marked_not_training_ready(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "results.jsonl"
+    out = tmp_path / "prime-sft.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "do it"}],
+                "completion": [{"role": "assistant", "content": "done"}],
+                "info": {
+                    "source": "benchflow",
+                    "training_ready": False,
+                    "training_ready_reason": "agent_error",
+                },
+                "error": {
+                    "error": "agent_error",
+                    "error_chain_str": "timeout",
+                },
+                "reward": 0.7,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stats = export_prime_sft_jsonl(source, out, expected_rows=0)
+
+    assert out.read_text() == ""
+    assert stats.rows_written == 0
+    assert stats.skipped_terminal_error == 1
 
 
 def test_export_repairs_legacy_results_tool_call_ids(tmp_path: Path) -> None:

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -31,9 +31,7 @@ def _write_rollout(
         "agent_result": {"total_tokens": 123, "n_tool_calls": 1},
     }
     result.update(result_overrides or {})
-    (rollout_dir / "result.json").write_text(
-        json.dumps(result)
-    )
+    (rollout_dir / "result.json").write_text(json.dumps(result))
     traj = rollout_dir / "trajectory"
     traj.mkdir()
     records = (


### PR DESCRIPTION
## Summary
- add OpenRouter provider routing for openai-compatible OpenRouter models
- make BenchFlow trainer-facing results rows Prime-RL 8k usable by anchoring at the last user turn while preserving full raw trajectory audit data
- redact results JSONL at object level so secret-carrier field names cannot corrupt JSON booleans/nulls
- surface malformed aggregate rows through results.errors.json
- skip BenchFlow rows marked non-training-ready during Prime-SFT conversion
- make sharded health/canonical selection discover worker-shards and write the advertised worker-sharded summary path

## Validation
- uv run pytest tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py tests/test_train_mode_artifact_emission.py tests/test_eval_artifact_cli.py tests/test_eval_sharding.py tests/test_providers.py tests/test_litellm_config.py tests/test_agent_registry.py tests/test_registry_invariants.py -q
- 10-task Daytona/OpenHands/OpenRouter canary on env0 eval tasks: total=10, passed=8, failed=2, errored=0, verifier_errored=0
- canary health: total_rows=10, rows_with_tool_calls=10, missing_llm_trajectory=0, malformed_llm_trajectory=0
- bench train convert canonical canary -> 10 Prime-SFT rows, 10 rows_with_tool_calls, skipped_terminal_error=0
- bench train validate converted canary --expected-rows 10 --require-tool-calls
- Prime-RL SFTDataset + Qwen3.5 renderer at seq_len=8192 processed canary rows without skipped/no-trainable-token rows
