### PR TITLE
Strip OpenHands chat input field before LiteLLM upstream calls

### DIFF
--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -157,6 +157,13 @@ def _failure_traceback(detail: Any) -> str:
 
 
 class BenchFlowLiteLLMLogger(CustomLogger):
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        if isinstance(data, dict) and data.get("messages") is not None and "input" in data:
+            cleaned = dict(data)
+            cleaned.pop("input", None)
+            return cleaned
+        return None
+
     def _write(self, payload: dict[str, Any]) -> None:
         path = os.environ.get("BENCHFLOW_LITELLM_LOG_PATH")
         if not path:

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from benchflow.providers.litellm_logging import (
     callback_module_source,
     extract_usage_from_trajectory,
@@ -14,6 +16,38 @@ def test_callback_module_source_exposes_proxy_handler_instance():
 
     assert "class BenchFlowLiteLLMLogger" in source
     assert "proxy_handler_instance = BenchFlowLiteLLMLogger()" in source
+
+
+@pytest.mark.asyncio
+async def test_callback_pre_call_hook_strips_chat_input_compat_field():
+    namespace: dict[str, object] = {}
+    exec(callback_module_source(), namespace)
+    logger = namespace["proxy_handler_instance"]
+
+    data = {
+        "model": "accounts/example/deployments/qwen",
+        "messages": [{"role": "user", "content": "hi"}],
+        "input": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }
+
+    cleaned = await logger.async_pre_call_hook(None, None, data, "completion")
+
+    assert cleaned is not data
+    assert "input" not in cleaned
+    assert cleaned["messages"] == data["messages"]
+    assert cleaned["stream"] is True
+
+
+@pytest.mark.asyncio
+async def test_callback_pre_call_hook_preserves_input_only_requests():
+    namespace: dict[str, object] = {}
+    exec(callback_module_source(), namespace)
+    logger = namespace["proxy_handler_instance"]
+
+    data = {"model": "responses-model", "input": "hello"}
+
+    assert await logger.async_pre_call_hook(None, None, data, "responses") is None
 
 
 def test_litellm_callback_jsonl_imports_usage_and_cost():


### PR DESCRIPTION
## Summary
- strip the OpenHands compatibility `input` field from LiteLLM proxy requests when `messages` is present
- keep input-only/Responses-style requests unchanged
- add embedded callback tests for both paths

## Why
Fireworks/OpenAI-compatible chat-completions rejects requests that include both `messages` and `input`. In the env-0 Prime-RL SFT eval canary, the extra field prevented streamed tool-call handling from reaching OpenHands reliably. Removing it at the proxy pre-call hook preserves the chat-completions contract before forwarding upstream.

## Validation
- `uv run --extra dev pytest tests/test_litellm_logging.py tests/test_litellm_config.py -q`
- `uv run --extra dev pytest tests/test_litellm_logging.py tests/test_litellm_config.py tests/test_litellm_hardening.py tests/test_litellm_runtime.py -q`
- manual local LiteLLM proxy replay of the Fireworks/OpenHands streamed request with both `messages` and `input`: returns `finish=tool_calls` with structured `terminal` tool deltas after the hook