### PR TITLE
Add Prime-RL SFT exposure controls

### DIFF
--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -269,6 +269,33 @@ def register_train(app: typer.Typer) -> None:
                 help="Prime-RL config override as KEY=VALUE; repeatable",
             ),
         ] = None,
+        target_examples: Annotated[
+            int | None,
+            typer.Option(
+                "--target-examples",
+                help=(
+                    "Derive Prime-RL max_steps from a target number of training "
+                    "examples using data.batch_size"
+                ),
+            ),
+        ] = None,
+        sync_scheduler_to_max_steps: Annotated[
+            bool,
+            typer.Option(
+                "--sync-scheduler-to-max-steps/--no-sync-scheduler-to-max-steps",
+                help=(
+                    "When --target-examples is set, also derive "
+                    "scheduler.decay_steps from the computed max_steps"
+                ),
+            ),
+        ] = True,
+        pack_function: Annotated[
+            str | None,
+            typer.Option(
+                "--pack-function",
+                help="Optional first-class Prime-RL data.pack_function override: cat or stack",
+            ),
+        ] = None,
         force: Annotated[
             bool,
             typer.Option(
@@ -330,6 +357,9 @@ def register_train(app: typer.Typer) -> None:
                     follow=follow,
                     uv_no_sync=uv_no_sync,
                     overrides=tuple(override or ()),
+                    target_examples=target_examples,
+                    sync_scheduler_to_max_steps=sync_scheduler_to_max_steps,
+                    pack_function=pack_function,
                     force=force,
                     cwd=prime_rl_dir,
                     publish_model=publish_model,

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
-from collections.abc import Iterable
+import tomllib
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from math import ceil
 from pathlib import Path
 from threading import Thread
-from typing import TextIO
+from typing import Any, TextIO
 
 from benchflow.training.run_manifest import (
     CommandRecord,
@@ -38,6 +40,9 @@ class PrimeRlSftSpec:
     follow: bool = False
     uv_no_sync: bool = False
     overrides: tuple[str, ...] = ()
+    target_examples: int | None = None
+    sync_scheduler_to_max_steps: bool = True
+    pack_function: str | None = None
     force: bool = False
     cwd: Path | None = None
     publish_model: str | None = None
@@ -55,6 +60,32 @@ class PrimeRlSftResult:
     returncode: int
 
 
+@dataclass(frozen=True)
+class PrimeRlSftExposurePlan:
+    target_examples: int | None = None
+    data_batch_size: int | None = None
+    derived_max_steps: int | None = None
+    sync_scheduler_to_max_steps: bool = False
+    pack_function: str | None = None
+    generated_overrides: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "target_examples": self.target_examples,
+            "data_batch_size": self.data_batch_size,
+            "derived_max_steps": self.derived_max_steps,
+            "sync_scheduler_to_max_steps": self.sync_scheduler_to_max_steps,
+            "pack_function": self.pack_function,
+            "generated_overrides": list(self.generated_overrides),
+        }
+
+
+@dataclass(frozen=True)
+class PrimeRlSftLaunch:
+    argv: list[str]
+    exposure_plan: PrimeRlSftExposurePlan | None = None
+
+
 def _parse_overrides(overrides: Iterable[str]) -> list[str]:
     argv: list[str] = []
     for override in overrides:
@@ -68,6 +99,19 @@ def _parse_overrides(overrides: Iterable[str]) -> list[str]:
     return argv
 
 
+def _override_map(overrides: Iterable[str]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for override in overrides:
+        if "=" not in override:
+            raise ValueError(f"--override must be KEY=VALUE, got {override!r}")
+        key, value = override.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"--override must have a non-empty key: {override!r}")
+        values[key] = value
+    return values
+
+
 def _resolve_config_path(config: Path, cwd: Path | None) -> Path:
     if config.is_file():
         return config.resolve()
@@ -78,11 +122,116 @@ def _resolve_config_path(config: Path, cwd: Path | None) -> Path:
     raise ValueError(f"--config not found: {config}")
 
 
-def build_prime_rl_sft_argv(spec: PrimeRlSftSpec) -> list[str]:
+def _load_toml(path: Path) -> Mapping[str, Any]:
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    return data if isinstance(data, Mapping) else {}
+
+
+def _nested_config_value(data: Mapping[str, Any], key: str) -> Any:
+    current: Any = data
+    for part in key.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _parse_positive_int(value: Any, *, key: str) -> int:
+    if isinstance(value, bool):
+        raise ValueError(f"{key} must be a positive integer, got {value!r}")
+    if isinstance(value, int):
+        parsed = value
+    elif isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+    else:
+        raise ValueError(f"{key} must be a positive integer, got {value!r}")
+    if parsed <= 0:
+        raise ValueError(f"{key} must be a positive integer, got {value!r}")
+    return parsed
+
+
+def _resolve_data_batch_size(
+    config: Mapping[str, Any], overrides: Mapping[str, str]
+) -> int:
+    raw = overrides.get("data.batch_size")
+    source = "--override data.batch_size" if raw is not None else "config data.batch_size"
+    if raw is None:
+        raw = _nested_config_value(config, "data.batch_size")
+    if raw is None:
+        raise ValueError(
+            "--target-examples requires data.batch_size in the Prime-RL config "
+            "or an explicit --override data.batch_size=..."
+        )
+    return _parse_positive_int(raw, key=source)
+
+
+def _build_generated_overrides(
+    spec: PrimeRlSftSpec, config: Mapping[str, Any]
+) -> PrimeRlSftExposurePlan | None:
+    overrides = _override_map(spec.overrides)
+    generated: list[str] = []
+    target_examples: int | None = None
+    data_batch_size: int | None = None
+    derived_max_steps: int | None = None
+    pack_function: str | None = None
+
+    if spec.target_examples is not None:
+        if "max_steps" in overrides:
+            raise ValueError(
+                "--target-examples cannot be combined with --override max_steps=..."
+            )
+        target_examples = _parse_positive_int(
+            spec.target_examples, key="--target-examples"
+        )
+        data_batch_size = _resolve_data_batch_size(config, overrides)
+        derived_max_steps = ceil(target_examples / data_batch_size)
+        generated.append(f"max_steps={derived_max_steps}")
+        if spec.sync_scheduler_to_max_steps:
+            if "scheduler.decay_steps" in overrides:
+                raise ValueError(
+                    "--sync-scheduler-to-max-steps cannot be combined with "
+                    "--override scheduler.decay_steps=..."
+                )
+            generated.append(f"scheduler.decay_steps={derived_max_steps}")
+
+    if spec.pack_function is not None:
+        if spec.pack_function not in {"cat", "stack"}:
+            raise ValueError("--pack-function must be either 'cat' or 'stack'")
+        if "data.pack_function" in overrides:
+            raise ValueError(
+                "--pack-function cannot be combined with "
+                "--override data.pack_function=..."
+            )
+        pack_function = spec.pack_function
+        generated.append(f"data.pack_function={pack_function}")
+
+    if not generated:
+        return None
+    return PrimeRlSftExposurePlan(
+        target_examples=target_examples,
+        data_batch_size=data_batch_size,
+        derived_max_steps=derived_max_steps,
+        sync_scheduler_to_max_steps=(
+            bool(spec.sync_scheduler_to_max_steps)
+            if target_examples is not None
+            else False
+        ),
+        pack_function=pack_function,
+        generated_overrides=tuple(generated),
+    )
+
+
+def build_prime_rl_sft_launch(spec: PrimeRlSftSpec) -> PrimeRlSftLaunch:
     config = _resolve_config_path(spec.config, spec.cwd)
+    config_data = _load_toml(config)
     work_dir = spec.work_dir.resolve()
     output_dir = (
         spec.output_dir.resolve() if spec.output_dir else work_dir / "prime-rl-output"
+    )
+    exposure_plan = _build_generated_overrides(spec, config_data)
+    effective_overrides = spec.overrides + (
+        exposure_plan.generated_overrides if exposure_plan is not None else ()
     )
     argv = ["uv", "run"]
     if spec.uv_no_sync:
@@ -93,8 +242,12 @@ def build_prime_rl_sft_argv(spec: PrimeRlSftSpec) -> list[str]:
     argv.extend(["--output-dir", str(output_dir)])
     if spec.dry_run:
         argv.append("--dry-run")
-    argv.extend(_parse_overrides(spec.overrides))
-    return argv
+    argv.extend(_parse_overrides(effective_overrides))
+    return PrimeRlSftLaunch(argv=argv, exposure_plan=exposure_plan)
+
+
+def build_prime_rl_sft_argv(spec: PrimeRlSftSpec) -> list[str]:
+    return build_prime_rl_sft_launch(spec).argv
 
 
 def _recorded_env_keys() -> list[str]:
@@ -116,7 +269,10 @@ def _copy_stream(stream: TextIO, handle: TextIO, *, echo: bool) -> None:
 
 
 def _initial_manifest(
-    spec: PrimeRlSftSpec, argv: list[str], logs: list[str]
+    spec: PrimeRlSftSpec,
+    argv: list[str],
+    logs: list[str],
+    exposure_plan: PrimeRlSftExposurePlan | None = None,
 ) -> TrainRunManifest:
     work_dir = spec.work_dir.resolve()
     output_dir = (
@@ -136,7 +292,7 @@ def _initial_manifest(
         logs=logs,
     )
     now = utc_now()
-    return TrainRunManifest(
+    manifest = TrainRunManifest(
         schema_version=1,
         run_type="sft",
         backend="prime-rl",
@@ -150,6 +306,9 @@ def _initial_manifest(
         commands=[command],
         components=[component],
     )
+    if exposure_plan is not None:
+        manifest.extra["prime_rl_sft_exposure_plan"] = exposure_plan.to_dict()
+    return manifest
 
 
 def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
@@ -172,7 +331,8 @@ def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
     stderr_path = log_dir / "stderr.log"
     command_path = work_dir / "command.txt"
 
-    argv = build_prime_rl_sft_argv(spec)
+    launch = build_prime_rl_sft_launch(spec)
+    argv = launch.argv
     command_path.write_text(_shell_quote(argv) + "\n", encoding="utf-8")
     manifest = _initial_manifest(
         spec,
@@ -181,6 +341,7 @@ def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
             str(stdout_path.relative_to(work_dir)),
             str(stderr_path.relative_to(work_dir)),
         ],
+        launch.exposure_plan,
     )
     manifest.overall_status = "running"
     manifest.components[0].status = "running"

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -155,7 +155,9 @@ def _resolve_data_batch_size(
     config: Mapping[str, Any], overrides: Mapping[str, str]
 ) -> int:
     raw = overrides.get("data.batch_size")
-    source = "--override data.batch_size" if raw is not None else "config data.batch_size"
+    source = (
+        "--override data.batch_size" if raw is not None else "config data.batch_size"
+    )
     if raw is None:
         raw = _nested_config_value(config, "data.batch_size")
     if raw is None:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -480,6 +480,178 @@ def test_train_run_sft_prime_rl_records_manifest(tmp_path: Path, monkeypatch) ->
     assert (work_dir / "prime-rl" / "stdout.log").read_text() == "trainer ok\n"
 
 
+def test_train_run_sft_prime_rl_target_examples_derives_exposure(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Guards sample-exposure parity for small BenchFlow SFT trajectory sets."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            captured["argv"] = argv
+            captured["cwd"] = kwargs["cwd"]
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text(
+        "\n".join(
+            [
+                "max_steps = 300",
+                "[data]",
+                "batch_size = 8",
+                'pack_function = "cat"',
+                "[scheduler]",
+                "decay_steps = 300",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "train-run"
+    output_dir = tmp_path / "prime-output"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--output-dir",
+            str(output_dir),
+            "--work-dir",
+            str(work_dir),
+            "--target-examples",
+            "300",
+            "--pack-function",
+            "stack",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["argv"] == [
+        "uv",
+        "run",
+        "sft",
+        "@",
+        str(config),
+        "--output-dir",
+        str(output_dir),
+        "--max_steps",
+        "38",
+        "--scheduler.decay_steps",
+        "38",
+        "--data.pack_function",
+        "stack",
+    ]
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"] == {
+        "data_batch_size": 8,
+        "derived_max_steps": 38,
+        "generated_overrides": [
+            "max_steps=38",
+            "scheduler.decay_steps=38",
+            "data.pack_function=stack",
+        ],
+        "pack_function": "stack",
+        "sync_scheduler_to_max_steps": True,
+        "target_examples": 300,
+    }
+
+
+def test_train_run_sft_prime_rl_target_examples_respects_batch_override(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del kwargs
+            captured["argv"] = argv
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 300\n[data]\nbatch_size = 1\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(work_dir),
+            "--target-examples",
+            "300",
+            "--no-sync-scheduler-to-max-steps",
+            "--override",
+            "data.batch_size=8",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--data.batch_size" in captured["argv"]
+    assert captured["argv"][-2:] == ["--max_steps", "38"]
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"][
+        "sync_scheduler_to_max_steps"
+    ] is False
+
+
+def test_train_run_sft_prime_rl_target_examples_rejects_manual_max_steps(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 300\n[data]\nbatch_size = 8\n", encoding="utf-8")
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(work_dir),
+            "--target-examples",
+            "300",
+            "--override",
+            "max_steps=300",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--target-examples cannot be combined" in result.output
+
+
 def test_train_run_sft_prime_rl_publish_flags_update_manifest(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -615,9 +615,10 @@ def test_train_run_sft_prime_rl_target_examples_respects_batch_override(
     assert "--data.batch_size" in captured["argv"]
     assert captured["argv"][-2:] == ["--max_steps", "38"]
     manifest = json.loads((work_dir / "train-run.json").read_text())
-    assert manifest["extra"]["prime_rl_sft_exposure_plan"][
-        "sync_scheduler_to_max_steps"
-    ] is False
+    assert (
+        manifest["extra"]["prime_rl_sft_exposure_plan"]["sync_scheduler_to_max_steps"]
+        is False
+    )
 
 
 def test_train_run_sft_prime_rl_target_examples_rejects_manual_max_steps(


### PR DESCRIPTION
## Summary
- add BenchFlow CLI `--target-examples` support for Prime-RL SFT, deriving `max_steps` from effective `data.batch_size`
- optionally sync `scheduler.decay_steps` and expose `--pack-function cat|stack` without touching Prime-RL
- record the derived exposure plan in `train-run.json` for reproducibility

## Why
The env-0 mobile300 Prime-RL rerun accidentally used `max_steps=300` as 300 Prime-RL optimizer steps at global batch 8, not the old custom trainer's ~300 micro-batches. This PR makes the intended sample exposure explicit in BenchFlow.

## Validation
- `uv run pytest tests/test_train_cli.py -q`
- `uv run pytest tests/test_train_cli.py tests/trajectories/test_export_prime_sft.py -q`
- `uv run ruff check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py`
- `uv run bench train run sft --help`
