### PR TITLE
Package local Prime SFT JSONL for Prime-RL

### DIFF
--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import tomllib
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from math import ceil
 from pathlib import Path
 from threading import Thread
@@ -77,6 +77,26 @@ class PrimeRlSftExposurePlan:
             "sync_scheduler_to_max_steps": self.sync_scheduler_to_max_steps,
             "pack_function": self.pack_function,
             "generated_overrides": list(self.generated_overrides),
+        }
+
+
+@dataclass(frozen=True)
+class PrimeRlSftDatasetPlan:
+    source_data: str
+    resolved_data: str
+    kind: str
+    dataset_dir: str | None = None
+    train_jsonl: str | None = None
+    validation: dict[str, Any] | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "source_data": self.source_data,
+            "resolved_data": self.resolved_data,
+            "kind": self.kind,
+            "dataset_dir": self.dataset_dir,
+            "train_jsonl": self.train_jsonl,
+            "validation": self.validation,
         }
 
 
@@ -270,11 +290,76 @@ def _copy_stream(stream: TextIO, handle: TextIO, *, echo: bool) -> None:
             print(line, end="", flush=True)
 
 
+def _local_data_path(data: str) -> Path | None:
+    path = Path(data).expanduser()
+    if path.exists():
+        return path.resolve()
+    if path.suffix == ".jsonl":
+        raise ValueError(f"--data JSONL file not found: {data}")
+    return None
+
+
+def _prepare_prime_rl_data(
+    spec: PrimeRlSftSpec, work_dir: Path
+) -> tuple[PrimeRlSftSpec, PrimeRlSftDatasetPlan | None]:
+    """Make local BenchFlow JSONL usable by Prime-RL's ``load_dataset`` path."""
+    if not spec.data:
+        return spec, None
+
+    source_path = _local_data_path(spec.data)
+    if source_path is None:
+        return spec, None
+
+    if source_path.is_dir():
+        train_jsonl = source_path / "train.jsonl"
+        validation = None
+        if train_jsonl.is_file():
+            from benchflow.trajectories.export_prime_sft import (
+                validate_prime_sft_jsonl,
+            )
+
+            validation = validate_prime_sft_jsonl(train_jsonl)
+        resolved_spec = replace(spec, data=str(source_path))
+        return resolved_spec, PrimeRlSftDatasetPlan(
+            source_data=spec.data,
+            resolved_data=str(source_path),
+            kind="local_dataset_dir",
+            dataset_dir=str(source_path),
+            train_jsonl=str(train_jsonl) if train_jsonl.is_file() else None,
+            validation=validation,
+        )
+
+    if source_path.suffix != ".jsonl":
+        raise ValueError(
+            f"--data local files must be Prime-SFT JSONL files, got {source_path}"
+        )
+
+    from benchflow.trajectories.export_prime_sft import validate_prime_sft_jsonl
+
+    validation = validate_prime_sft_jsonl(source_path)
+    dataset_dir = work_dir / "prime-rl-dataset"
+    if dataset_dir.exists():
+        shutil.rmtree(dataset_dir)
+    dataset_dir.mkdir(parents=True)
+    train_jsonl = dataset_dir / "train.jsonl"
+    shutil.copy2(source_path, train_jsonl)
+    resolved_spec = replace(spec, data=str(dataset_dir))
+    return resolved_spec, PrimeRlSftDatasetPlan(
+        source_data=spec.data,
+        resolved_data=str(dataset_dir),
+        kind="local_jsonl_packaged",
+        dataset_dir=str(dataset_dir),
+        train_jsonl=str(train_jsonl),
+        validation=validation,
+    )
+
+
 def _initial_manifest(
     spec: PrimeRlSftSpec,
     argv: list[str],
     logs: list[str],
     exposure_plan: PrimeRlSftExposurePlan | None = None,
+    dataset_plan: PrimeRlSftDatasetPlan | None = None,
 ) -> TrainRunManifest:
     work_dir = spec.work_dir.resolve()
     output_dir = (
@@ -310,6 +395,8 @@ def _initial_manifest(
     )
     if exposure_plan is not None:
         manifest.extra["prime_rl_sft_exposure_plan"] = exposure_plan.to_dict()
+    if dataset_plan is not None:
+        manifest.extra["prime_rl_sft_dataset"] = dataset_plan.to_dict()
     return manifest
 
 
@@ -333,17 +420,19 @@ def run_prime_rl_sft(spec: PrimeRlSftSpec) -> PrimeRlSftResult:
     stderr_path = log_dir / "stderr.log"
     command_path = work_dir / "command.txt"
 
-    launch = build_prime_rl_sft_launch(spec)
+    launch_spec, dataset_plan = _prepare_prime_rl_data(spec, work_dir)
+    launch = build_prime_rl_sft_launch(launch_spec)
     argv = launch.argv
     command_path.write_text(_shell_quote(argv) + "\n", encoding="utf-8")
     manifest = _initial_manifest(
-        spec,
+        launch_spec,
         argv,
         [
             str(stdout_path.relative_to(work_dir)),
             str(stderr_path.relative_to(work_dir)),
         ],
         launch.exposure_plan,
+        dataset_plan,
     )
     manifest.overall_status = "running"
     manifest.components[0].status = "running"

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -480,6 +480,143 @@ def test_train_run_sft_prime_rl_records_manifest(tmp_path: Path, monkeypatch) ->
     assert (work_dir / "prime-rl" / "stdout.log").read_text() == "trainer ok\n"
 
 
+def test_train_run_sft_prime_rl_packages_local_jsonl_data(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Prime-RL load_dataset accepts local dataset dirs, not raw JSONL paths."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            captured["argv"] = argv
+            captured["cwd"] = kwargs["cwd"]
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    source = tmp_path / "prime-sft.jsonl"
+    source.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "do it"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "finish",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "ok",
+                    },
+                    {"role": "assistant", "content": "done"},
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "finish",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--data",
+            str(source),
+            "--work-dir",
+            str(work_dir),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    dataset_dir = work_dir / "prime-rl-dataset"
+    train_jsonl = dataset_dir / "train.jsonl"
+    assert train_jsonl.read_text(encoding="utf-8") == source.read_text(encoding="utf-8")
+    assert captured["argv"] == [
+        "uv",
+        "run",
+        "sft",
+        "@",
+        str(config),
+        "--data.name",
+        str(dataset_dir.resolve()),
+        "--output-dir",
+        str(work_dir / "prime-rl-output"),
+    ]
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["extra"]["prime_rl_sft_dataset"] == {
+        "dataset_dir": str(dataset_dir.resolve()),
+        "kind": "local_jsonl_packaged",
+        "resolved_data": str(dataset_dir.resolve()),
+        "source_data": str(source),
+        "train_jsonl": str(train_jsonl),
+        "validation": {"ok": True, "rows": 1, "rows_with_tool_calls": 1},
+    }
+
+
+def test_train_run_sft_prime_rl_rejects_missing_local_jsonl_data(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+    missing = tmp_path / "missing.jsonl"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--data",
+            str(missing),
+            "--work-dir",
+            str(tmp_path / "train-run"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--data JSONL file not found" in result.output
+
+
 def test_train_run_sft_prime_rl_target_examples_derives_exposure(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary
- package local Prime-SFT JSONL paths into a run-local dataset directory before launching Prime-RL
- validate packaged JSONL with BenchFlow's Prime-SFT validator and record dataset evidence in train-run.json
- keep HF dataset IDs and existing local dataset directories as pass-through data names

## Why
Prime-RL calls datasets.load_dataset(data.name, split="train"). Under Prime-RL's current datasets==4.6.1 stack, a bare JSONL file path is not accepted, and the current HF-published mobile300 dataset fails with Feature type 'Json' not found. A local directory containing train.jsonl loads correctly and preserves messages as list[dict].

## Validation
- uv run pytest tests/test_train_cli.py tests/trajectories/test_export_prime_sft.py -q
- uv run ruff check src/benchflow/training/backends/prime_rl.py tests/test_train_cli.py tests/trajectories/test_export_prime_sft.py
- uv run ruff format --check src/benchflow/training/backends/prime_rl.py tests/test_train_cli.py tests/trajectories/test_export_prime_sft.py
- H100 remote dry run: bench train run sft --data /home/ubuntu/work/mobile300-fixed/datasets/local_mobile300/train.jsonl ... --dry-run --target-examples 300 --pack-function stack
- H100 Prime-RL loader check: load_dataset('/home/ubuntu/work/mobile300-fixed/train-runs/wrapper-jsonl-dry-run/prime-rl-dataset', split='train') loaded 300 rows with messages as list[dict]
