### PR TITLE
Guard Prime-RL SFT reproduction semantics

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -425,6 +425,12 @@ that were present are recorded.
 | `--follow` | `false` | Stream trainer stdout while writing logs |
 | `--uv-no-sync` | `false` | Run Prime-RL as `uv run --no-sync sft ...`, useful after backend post-install steps such as `flash-attn` |
 | `--override` | — | Prime-RL override as `KEY=VALUE`; repeatable, emitted as `--KEY VALUE` |
+| `--target-examples` | — | Derive Prime-RL `max_steps` from target sample exposure and effective `data.batch_size` |
+| `--sync-scheduler-to-max-steps` / `--no-sync-scheduler-to-max-steps` | `true` | When `--target-examples` is set, also derive `scheduler.decay_steps` |
+| `--pack-function` | — | First-class Prime-RL `data.pack_function` override: `cat` or `stack` |
+| `--loss-mask` | — | First-class Prime-RL `data.loss_mask` override: `assistant`, `all`, or comma-separated roles from `system,user,assistant,tool` |
+| `--model-attn` | — | First-class Prime-RL `model.attn` override, e.g. `sdpa` |
+| `--allow-unsafe-stack-flash-attn` | `false` | Allow Qwen3.5 `stack` packing with flash attention despite the known Prime-RL varlen-kernel risk |
 | `--force` | `false` | Overwrite an existing `<work-dir>/train-run.json` manifest |
 | `--publish-model` | — | Upload trainer output to this Hugging Face model repo |
 | `--model-tag` | — | Path prefix/tag for the model upload |

--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -296,6 +296,33 @@ def register_train(app: typer.Typer) -> None:
                 help="Optional first-class Prime-RL data.pack_function override: cat or stack",
             ),
         ] = None,
+        loss_mask: Annotated[
+            str | None,
+            typer.Option(
+                "--loss-mask",
+                help=(
+                    "Optional first-class Prime-RL data.loss_mask override: "
+                    "'assistant', 'all', or comma-separated roles"
+                ),
+            ),
+        ] = None,
+        model_attn: Annotated[
+            str | None,
+            typer.Option(
+                "--model-attn",
+                help="Optional first-class Prime-RL model.attn override, e.g. sdpa",
+            ),
+        ] = None,
+        allow_unsafe_stack_flash_attn: Annotated[
+            bool,
+            typer.Option(
+                "--allow-unsafe-stack-flash-attn",
+                help=(
+                    "Allow Qwen3.5 stack packing with flash attention despite "
+                    "known Prime-RL varlen-kernel risk"
+                ),
+            ),
+        ] = False,
         force: Annotated[
             bool,
             typer.Option(
@@ -360,6 +387,9 @@ def register_train(app: typer.Typer) -> None:
                     target_examples=target_examples,
                     sync_scheduler_to_max_steps=sync_scheduler_to_max_steps,
                     pack_function=pack_function,
+                    loss_mask=loss_mask,
+                    model_attn=model_attn,
+                    allow_unsafe_stack_flash_attn=allow_unsafe_stack_flash_attn,
                     force=force,
                     cwd=prime_rl_dir,
                     publish_model=publish_model,

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -43,6 +43,9 @@ class PrimeRlSftSpec:
     target_examples: int | None = None
     sync_scheduler_to_max_steps: bool = True
     pack_function: str | None = None
+    loss_mask: str | None = None
+    model_attn: str | None = None
+    allow_unsafe_stack_flash_attn: bool = False
     force: bool = False
     cwd: Path | None = None
     publish_model: str | None = None
@@ -67,6 +70,8 @@ class PrimeRlSftExposurePlan:
     derived_max_steps: int | None = None
     sync_scheduler_to_max_steps: bool = False
     pack_function: str | None = None
+    loss_mask: str | None = None
+    model_attn: str | None = None
     generated_overrides: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
@@ -76,6 +81,8 @@ class PrimeRlSftExposurePlan:
             "derived_max_steps": self.derived_max_steps,
             "sync_scheduler_to_max_steps": self.sync_scheduler_to_max_steps,
             "pack_function": self.pack_function,
+            "loss_mask": self.loss_mask,
+            "model_attn": self.model_attn,
             "generated_overrides": list(self.generated_overrides),
         }
 
@@ -188,6 +195,88 @@ def _resolve_data_batch_size(
     return _parse_positive_int(raw, key=source)
 
 
+def _loss_mask_overrides(raw: str) -> tuple[str, tuple[str, ...]]:
+    value = raw.strip().lower().replace("_", "-")
+    role_names = ("system", "user", "assistant", "tool")
+    role_set = set(role_names)
+    if value == "all":
+        enabled = role_set
+    elif value == "assistant":
+        enabled = {"assistant"}
+    else:
+        enabled = {part.strip().replace("_", "-") for part in value.split(",")}
+        if not enabled or any(not part for part in enabled):
+            raise ValueError(
+                "--loss-mask must be 'all', 'assistant', or comma-separated roles"
+            )
+        unknown = sorted(enabled - role_set)
+        if unknown:
+            raise ValueError(
+                "--loss-mask roles must be drawn from system,user,assistant,tool; "
+                f"got {','.join(unknown)}"
+            )
+    normalized = (
+        "all"
+        if enabled == role_set
+        else ",".join(role for role in role_names if role in enabled)
+    )
+    return normalized, tuple(
+        f"data.loss_mask.{role}={'true' if role in enabled else 'false'}"
+        for role in role_names
+    )
+
+
+def _resolve_effective_value(
+    config: Mapping[str, Any], overrides: Mapping[str, str], key: str
+) -> Any:
+    if key in overrides:
+        return overrides[key]
+    return _nested_config_value(config, key)
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    return str(value)
+
+
+def _is_qwen35_model(model_name: str | None) -> bool:
+    if model_name is None:
+        return False
+    normalized = model_name.lower().replace("_", "-")
+    return normalized.startswith("qwen/qwen3.5-")
+
+
+def _validate_prime_rl_mode(
+    spec: PrimeRlSftSpec,
+    config: Mapping[str, Any],
+    effective_overrides: Mapping[str, str],
+) -> None:
+    pack_function = _string_or_none(
+        _resolve_effective_value(config, effective_overrides, "data.pack_function")
+    )
+    model_name = _string_or_none(
+        _resolve_effective_value(config, effective_overrides, "model.name")
+    )
+    model_attn = _string_or_none(
+        _resolve_effective_value(config, effective_overrides, "model.attn")
+    )
+    if (
+        not spec.allow_unsafe_stack_flash_attn
+        and pack_function == "stack"
+        and _is_qwen35_model(model_name)
+        and model_attn in {"flash_attention_2", "flash_attention_3", "fa4"}
+    ):
+        raise ValueError(
+            "Prime-RL stack packing with Qwen/Qwen3.5-* and flash attention is "
+            "blocked because it can misinterpret padded position_ids as packed "
+            "sequence starts and fail inside Qwen3.5 varlen kernels. Use "
+            "--model-attn sdpa or --override model.attn=sdpa for the "
+            "custom-trainer-compatible stack path, or pass "
+            "--allow-unsafe-stack-flash-attn to run the native Prime-RL mode anyway."
+        )
+
+
 def _build_generated_overrides(
     spec: PrimeRlSftSpec, config: Mapping[str, Any]
 ) -> PrimeRlSftExposurePlan | None:
@@ -197,6 +286,8 @@ def _build_generated_overrides(
     data_batch_size: int | None = None
     derived_max_steps: int | None = None
     pack_function: str | None = None
+    loss_mask: str | None = None
+    model_attn: str | None = None
 
     if spec.target_examples is not None:
         if "max_steps" in overrides:
@@ -228,6 +319,32 @@ def _build_generated_overrides(
         pack_function = spec.pack_function
         generated.append(f"data.pack_function={pack_function}")
 
+    if spec.loss_mask is not None:
+        loss_keys = [
+            f"data.loss_mask.{role}" for role in ("system", "user", "assistant", "tool")
+        ]
+        conflicting = sorted(key for key in loss_keys if key in overrides)
+        if conflicting:
+            raise ValueError(
+                "--loss-mask cannot be combined with --override "
+                + ", ".join(f"{key}=..." for key in conflicting)
+            )
+        loss_mask, loss_overrides = _loss_mask_overrides(spec.loss_mask)
+        generated.extend(loss_overrides)
+
+    if spec.model_attn is not None:
+        model_attn = spec.model_attn.strip()
+        if not model_attn:
+            raise ValueError("--model-attn must be non-empty")
+        if "model.attn" in overrides:
+            raise ValueError(
+                "--model-attn cannot be combined with --override model.attn=..."
+            )
+        generated.append(f"model.attn={model_attn}")
+
+    effective_overrides = _override_map((*spec.overrides, *generated))
+    _validate_prime_rl_mode(spec, config, effective_overrides)
+
     if not generated:
         return None
     return PrimeRlSftExposurePlan(
@@ -240,6 +357,8 @@ def _build_generated_overrides(
             else False
         ),
         pack_function=pack_function,
+        loss_mask=loss_mask,
+        model_attn=model_attn,
         generated_overrides=tuple(generated),
     )
 

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -700,6 +700,8 @@ def test_train_run_sft_prime_rl_target_examples_derives_exposure(
             "scheduler.decay_steps=38",
             "data.pack_function=stack",
         ],
+        "loss_mask": None,
+        "model_attn": None,
         "pack_function": "stack",
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
@@ -756,6 +758,187 @@ def test_train_run_sft_prime_rl_target_examples_respects_batch_override(
         manifest["extra"]["prime_rl_sft_exposure_plan"]["sync_scheduler_to_max_steps"]
         is False
     )
+
+
+def test_train_run_sft_prime_rl_records_reproduction_semantics(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Guards explicit Prime-RL semantics for custom-trainer reproduction runs."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del kwargs
+            captured["argv"] = argv
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text(
+        "\n".join(
+            [
+                "max_steps = 300",
+                "[model]",
+                'name = "Qwen/Qwen3.5-9B"',
+                'attn = "flash_attention_2"',
+                "[data]",
+                "batch_size = 8",
+                'pack_function = "cat"',
+                "[scheduler]",
+                "decay_steps = 300",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(work_dir),
+            "--target-examples",
+            "300",
+            "--pack-function",
+            "stack",
+            "--loss-mask",
+            "all",
+            "--model-attn",
+            "sdpa",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["argv"][-16:] == [
+        "--max_steps",
+        "38",
+        "--scheduler.decay_steps",
+        "38",
+        "--data.pack_function",
+        "stack",
+        "--data.loss_mask.system",
+        "true",
+        "--data.loss_mask.user",
+        "true",
+        "--data.loss_mask.assistant",
+        "true",
+        "--data.loss_mask.tool",
+        "true",
+        "--model.attn",
+        "sdpa",
+    ]
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"] == {
+        "data_batch_size": 8,
+        "derived_max_steps": 38,
+        "generated_overrides": [
+            "max_steps=38",
+            "scheduler.decay_steps=38",
+            "data.pack_function=stack",
+            "data.loss_mask.system=true",
+            "data.loss_mask.user=true",
+            "data.loss_mask.assistant=true",
+            "data.loss_mask.tool=true",
+            "model.attn=sdpa",
+        ],
+        "loss_mask": "all",
+        "model_attn": "sdpa",
+        "pack_function": "stack",
+        "sync_scheduler_to_max_steps": True,
+        "target_examples": 300,
+    }
+
+
+def test_train_run_sft_prime_rl_rejects_qwen35_stack_flash_attn(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Fail closed on the Prime-RL Qwen3.5 stack/flash-attention path seen on H100."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    config = tmp_path / "sft.toml"
+    config.write_text(
+        "\n".join(
+            [
+                "[model]",
+                'name = "Qwen/Qwen3.5-9B"',
+                'attn = "flash_attention_2"',
+                "[data]",
+                "batch_size = 8",
+                'pack_function = "cat"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(tmp_path / "train-run"),
+            "--pack-function",
+            "stack",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert (
+        "stack packing with Qwen/Qwen3.5-* and flash attention is blocked"
+        in result.output
+    )
+    assert "--model-attn sdpa" in result.output
+
+
+def test_train_run_sft_prime_rl_loss_mask_rejects_override_conflict(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(tmp_path / "train-run"),
+            "--loss-mask",
+            "all",
+            "--override",
+            "data.loss_mask.user=false",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--loss-mask cannot be combined" in result.output
 
 
 def test_train_run_sft_prime_rl_target_examples_rejects_manual_max_steps(


### PR DESCRIPTION
## Summary

- add first-class `bench train run sft` controls for Prime-RL loss-mask and model-attention overrides
- fail closed on the known unsafe `Qwen/Qwen3.5-*` + `pack_function=stack` + flash-attention Prime-RL path unless explicitly overridden
- record loss-mask/model-attention semantics in `train-run.json` alongside the existing target-exposure plan
- document the new CLI flags

## Why

The env-0 Mobile300 SFT reproduction needs BenchFlow to own the Prime-RL wrapper contract without patching Prime-RL itself. The prior Prime-RL trainer-swap run diverged from the working custom trainer in sample exposure and loss semantics, and the `stack` + flash-attention path failed on H100 inside Qwen3.5 varlen kernels. This PR makes the required wrapper semantics explicit and reproducible from BenchFlow main.

## Validation

```bash
uv run pytest tests/test_train_cli.py tests/trajectories/test_export_prime_sft.py -q
uv run ruff check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py
uv run ruff format --check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py
```
