### PR TITLE
Add Prime-RL custom trainer compatibility controls

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -430,6 +430,8 @@ that were present are recorded.
 | `--pack-function` | — | First-class Prime-RL `data.pack_function` override: `cat` or `stack` |
 | `--loss-mask` | — | First-class Prime-RL `data.loss_mask` override: `assistant`, `all`, or comma-separated roles from `system,user,assistant,tool` |
 | `--model-attn` | — | First-class Prime-RL `model.attn` override, e.g. `sdpa` |
+| `--renderer-mode` | — | Prime-RL renderer override. `none` emits `--renderer None`, making Prime-RL use tokenizer `apply_chat_template` tokenization |
+| `--tool-defs-mode` | `preserve` | For local JSONL or local dataset dirs, keep tool schemas (`preserve`) or remove `tool_defs`/`tools` from the temporary training copy (`omit`) |
 | `--allow-unsafe-stack-flash-attn` | `false` | Allow Qwen3.5 `stack` packing with flash attention despite the known Prime-RL varlen-kernel risk |
 | `--force` | `false` | Overwrite an existing `<work-dir>/train-run.json` manifest |
 | `--publish-model` | — | Upload trainer output to this Hugging Face model repo |
@@ -438,6 +440,12 @@ that were present are recorded.
 | `--publish-artifacts` | — | Upload BenchFlow train run artifacts to this Hugging Face dataset repo |
 | `--hf-prefix` | — | Path prefix for `--publish-artifacts` |
 | `--hf-public-read-check` | `false` | Verify public Hugging Face reads after upload |
+
+Local JSONL files are packaged automatically into a temporary Hugging Face
+dataset directory under `<work-dir>/prime-rl-dataset`, with source validation
+metadata recorded in the manifest. If `--tool-defs-mode omit` is set,
+BenchFlow validates the source JSONL first and then strips tool schema columns
+only from the temporary training copy.
 
 ## bench skills
 

--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -313,6 +313,26 @@ def register_train(app: typer.Typer) -> None:
                 help="Optional first-class Prime-RL model.attn override, e.g. sdpa",
             ),
         ] = None,
+        renderer_mode: Annotated[
+            str | None,
+            typer.Option(
+                "--renderer-mode",
+                help=(
+                    "Optional Prime-RL renderer mode override. Use 'none' to "
+                    "fall back to tokenizer.apply_chat_template tokenization."
+                ),
+            ),
+        ] = None,
+        tool_defs_mode: Annotated[
+            str,
+            typer.Option(
+                "--tool-defs-mode",
+                help=(
+                    "How local training JSONL exposes tool schemas to Prime-RL: "
+                    "preserve or omit"
+                ),
+            ),
+        ] = "preserve",
         allow_unsafe_stack_flash_attn: Annotated[
             bool,
             typer.Option(
@@ -389,6 +409,8 @@ def register_train(app: typer.Typer) -> None:
                     pack_function=pack_function,
                     loss_mask=loss_mask,
                     model_attn=model_attn,
+                    renderer_mode=renderer_mode,
+                    tool_defs_mode=tool_defs_mode,
                     allow_unsafe_stack_flash_attn=allow_unsafe_stack_flash_attn,
                     force=force,
                     cwd=prime_rl_dir,

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -45,6 +46,8 @@ class PrimeRlSftSpec:
     pack_function: str | None = None
     loss_mask: str | None = None
     model_attn: str | None = None
+    renderer_mode: str | None = None
+    tool_defs_mode: str = "preserve"
     allow_unsafe_stack_flash_attn: bool = False
     force: bool = False
     cwd: Path | None = None
@@ -72,6 +75,7 @@ class PrimeRlSftExposurePlan:
     pack_function: str | None = None
     loss_mask: str | None = None
     model_attn: str | None = None
+    renderer_mode: str | None = None
     generated_overrides: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
@@ -83,6 +87,7 @@ class PrimeRlSftExposurePlan:
             "pack_function": self.pack_function,
             "loss_mask": self.loss_mask,
             "model_attn": self.model_attn,
+            "renderer_mode": self.renderer_mode,
             "generated_overrides": list(self.generated_overrides),
         }
 
@@ -94,6 +99,8 @@ class PrimeRlSftDatasetPlan:
     kind: str
     dataset_dir: str | None = None
     train_jsonl: str | None = None
+    tool_defs_mode: str = "preserve"
+    tool_defs_removed_rows: int | None = None
     validation: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -103,6 +110,8 @@ class PrimeRlSftDatasetPlan:
             "kind": self.kind,
             "dataset_dir": self.dataset_dir,
             "train_jsonl": self.train_jsonl,
+            "tool_defs_mode": self.tool_defs_mode,
+            "tool_defs_removed_rows": self.tool_defs_removed_rows,
             "validation": self.validation,
         }
 
@@ -240,6 +249,15 @@ def _string_or_none(value: Any) -> str | None:
     return str(value)
 
 
+def _normalize_tool_defs_mode(raw: str) -> str:
+    value = raw.strip().lower().replace("_", "-")
+    aliases = {"keep": "preserve", "strip": "omit", "drop": "omit"}
+    value = aliases.get(value, value)
+    if value not in {"preserve", "omit"}:
+        raise ValueError("--tool-defs-mode must be either 'preserve' or 'omit'")
+    return value
+
+
 def _is_qwen35_model(model_name: str | None) -> bool:
     if model_name is None:
         return False
@@ -288,6 +306,7 @@ def _build_generated_overrides(
     pack_function: str | None = None
     loss_mask: str | None = None
     model_attn: str | None = None
+    renderer_mode: str | None = None
 
     if spec.target_examples is not None:
         if "max_steps" in overrides:
@@ -342,6 +361,20 @@ def _build_generated_overrides(
             )
         generated.append(f"model.attn={model_attn}")
 
+    if spec.renderer_mode is not None:
+        renderer_mode = spec.renderer_mode.strip().lower().replace("_", "-")
+        if renderer_mode != "none":
+            raise ValueError("--renderer-mode currently supports only 'none'")
+        conflicting = sorted(
+            key for key in overrides if key == "renderer" or key.startswith("renderer.")
+        )
+        if conflicting:
+            raise ValueError(
+                "--renderer-mode cannot be combined with --override "
+                + ", ".join(f"{key}=..." for key in conflicting)
+            )
+        generated.append("renderer=None")
+
     effective_overrides = _override_map((*spec.overrides, *generated))
     _validate_prime_rl_mode(spec, config, effective_overrides)
 
@@ -359,6 +392,7 @@ def _build_generated_overrides(
         pack_function=pack_function,
         loss_mask=loss_mask,
         model_attn=model_attn,
+        renderer_mode=renderer_mode,
         generated_overrides=tuple(generated),
     )
 
@@ -418,6 +452,28 @@ def _local_data_path(data: str) -> Path | None:
     return None
 
 
+def _copy_jsonl_omitting_tool_defs(source: Path, destination: Path) -> int:
+    """Copy JSONL while dropping tool schema columns from the training copy."""
+    removed_rows = 0
+    with (
+        source.open("r", encoding="utf-8") as src,
+        destination.open("w", encoding="utf-8") as dst,
+    ):
+        for line in src:
+            if not line.strip():
+                dst.write(line)
+                continue
+            row = json.loads(line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{source}: every JSONL row must be an object")
+            if "tool_defs" in row or "tools" in row:
+                removed_rows += 1
+            row.pop("tool_defs", None)
+            row.pop("tools", None)
+            dst.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+    return removed_rows
+
+
 def _prepare_prime_rl_data(
     spec: PrimeRlSftSpec, work_dir: Path
 ) -> tuple[PrimeRlSftSpec, PrimeRlSftDatasetPlan | None]:
@@ -425,8 +481,14 @@ def _prepare_prime_rl_data(
     if not spec.data:
         return spec, None
 
+    tool_defs_mode = _normalize_tool_defs_mode(spec.tool_defs_mode)
     source_path = _local_data_path(spec.data)
     if source_path is None:
+        if tool_defs_mode != "preserve":
+            raise ValueError(
+                "--tool-defs-mode omit requires --data to be a local JSONL file "
+                "or a local dataset directory"
+            )
         return spec, None
 
     if source_path.is_dir():
@@ -438,6 +500,30 @@ def _prepare_prime_rl_data(
             )
 
             validation = validate_prime_sft_jsonl(train_jsonl)
+        if tool_defs_mode == "omit":
+            if not train_jsonl.is_file():
+                raise ValueError(
+                    f"--tool-defs-mode omit requires {source_path} to contain train.jsonl"
+                )
+            dataset_dir = work_dir / "prime-rl-dataset"
+            if dataset_dir.exists():
+                shutil.rmtree(dataset_dir)
+            shutil.copytree(source_path, dataset_dir)
+            transformed_train_jsonl = dataset_dir / "train.jsonl"
+            removed_rows = _copy_jsonl_omitting_tool_defs(
+                train_jsonl, transformed_train_jsonl
+            )
+            resolved_spec = replace(spec, data=str(dataset_dir))
+            return resolved_spec, PrimeRlSftDatasetPlan(
+                source_data=spec.data,
+                resolved_data=str(dataset_dir),
+                kind="local_dataset_dir_transformed",
+                dataset_dir=str(dataset_dir),
+                train_jsonl=str(transformed_train_jsonl),
+                tool_defs_mode=tool_defs_mode,
+                tool_defs_removed_rows=removed_rows,
+                validation=validation,
+            )
         resolved_spec = replace(spec, data=str(source_path))
         return resolved_spec, PrimeRlSftDatasetPlan(
             source_data=spec.data,
@@ -445,6 +531,7 @@ def _prepare_prime_rl_data(
             kind="local_dataset_dir",
             dataset_dir=str(source_path),
             train_jsonl=str(train_jsonl) if train_jsonl.is_file() else None,
+            tool_defs_mode=tool_defs_mode,
             validation=validation,
         )
 
@@ -461,7 +548,11 @@ def _prepare_prime_rl_data(
         shutil.rmtree(dataset_dir)
     dataset_dir.mkdir(parents=True)
     train_jsonl = dataset_dir / "train.jsonl"
-    shutil.copy2(source_path, train_jsonl)
+    removed_rows = None
+    if tool_defs_mode == "omit":
+        removed_rows = _copy_jsonl_omitting_tool_defs(source_path, train_jsonl)
+    else:
+        shutil.copy2(source_path, train_jsonl)
     resolved_spec = replace(spec, data=str(dataset_dir))
     return resolved_spec, PrimeRlSftDatasetPlan(
         source_data=spec.data,
@@ -469,6 +560,8 @@ def _prepare_prime_rl_data(
         kind="local_jsonl_packaged",
         dataset_dir=str(dataset_dir),
         train_jsonl=str(train_jsonl),
+        tool_defs_mode=tool_defs_mode,
+        tool_defs_removed_rows=removed_rows,
         validation=validation,
     )
 

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -583,6 +583,8 @@ def test_train_run_sft_prime_rl_packages_local_jsonl_data(
         "resolved_data": str(dataset_dir.resolve()),
         "source_data": str(source),
         "train_jsonl": str(train_jsonl),
+        "tool_defs_mode": "preserve",
+        "tool_defs_removed_rows": None,
         "validation": {"ok": True, "rows": 1, "rows_with_tool_calls": 1},
     }
 
@@ -703,6 +705,7 @@ def test_train_run_sft_prime_rl_target_examples_derives_exposure(
         "loss_mask": None,
         "model_attn": None,
         "pack_function": "stack",
+        "renderer_mode": None,
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
     }
@@ -858,9 +861,174 @@ def test_train_run_sft_prime_rl_records_reproduction_semantics(
         "loss_mask": "all",
         "model_attn": "sdpa",
         "pack_function": "stack",
+        "renderer_mode": None,
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
     }
+
+
+def test_train_run_sft_prime_rl_custom_trainer_compatibility_mode(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Prime-RL can be launched against a custom-trainer-compatible data copy."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del kwargs
+            captured["argv"] = argv
+            self.stdout = io.StringIO("trainer ok\n")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text(
+        "\n".join(
+            [
+                "max_steps = 300",
+                "[renderer]",
+                'name = "qwen3.5"',
+                "[data]",
+                "batch_size = 8",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    source_jsonl = tmp_path / "prime-sft.jsonl"
+    source_jsonl.write_text(
+        json.dumps(
+            {
+                "messages": [
+                    {"role": "user", "content": "finish"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "finish",
+                                    "arguments": "{}",
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_1",
+                        "content": "ok",
+                    },
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "finish",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(work_dir),
+            "--data",
+            str(source_jsonl),
+            "--target-examples",
+            "300",
+            "--loss-mask",
+            "all",
+            "--renderer-mode",
+            "none",
+            "--tool-defs-mode",
+            "omit",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "--renderer" in captured["argv"]
+    renderer_idx = captured["argv"].index("--renderer")
+    assert captured["argv"][renderer_idx + 1] == "None"
+    assert "--data.name" in captured["argv"]
+    data_idx = captured["argv"].index("--data.name")
+    staged_dir = Path(captured["argv"][data_idx + 1])
+    staged_row = json.loads((staged_dir / "train.jsonl").read_text())
+    assert "tool_defs" not in staged_row
+    assert "tools" not in staged_row
+    assert "tool_defs" in json.loads(source_jsonl.read_text())
+
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"]["generated_overrides"] == [
+        "max_steps=38",
+        "scheduler.decay_steps=38",
+        "data.loss_mask.system=true",
+        "data.loss_mask.user=true",
+        "data.loss_mask.assistant=true",
+        "data.loss_mask.tool=true",
+        "renderer=None",
+    ]
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"]["renderer_mode"] == "none"
+    assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_mode"] == "omit"
+    assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_removed_rows"] == 1
+    assert manifest["extra"]["prime_rl_sft_dataset"]["validation"] == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
+
+
+def test_train_run_sft_prime_rl_rejects_tool_defs_omit_for_remote_data(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(tmp_path / "train-run"),
+            "--data",
+            "benchflow/remote-dataset",
+            "--tool-defs-mode",
+            "omit",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--tool-defs-mode omit requires --data to be a local JSONL" in result.output
 
 
 def test_train_run_sft_prime_rl_rejects_qwen35_stack_flash_attn(


### PR DESCRIPTION
## Summary

Adds explicit BenchFlow wrapper controls for reproducing the historical custom `train_lora_sft.py` data/rendering semantics while still launching native Prime-RL SFT:

- `--renderer-mode none` emits `--renderer None`, disabling Prime-RL's hand-coded renderer so SFT falls back to tokenizer `apply_chat_template` tokenization.
- `--tool-defs-mode omit` validates a local Prime-SFT source JSONL first, then removes `tool_defs` / `tools` only from BenchFlow's temporary training copy under `<work-dir>/prime-rl-dataset`.
- Records both choices in `train-run.json` so experiment artifacts preserve the exact compatibility semantics.
- Updates CLI docs and adds focused tests for the custom-trainer-compatible path and remote-dataset rejection.

## Experiment impact

This targets the remaining env-0 Mobile300 trainer-swap mismatch: the archived custom trainer consumed rows with `tool_defs` but no `tools`, so it rendered without tool schemas and trained full rendered sequences. Prime-RL with `[renderer] name="qwen3.5"` instead reads `tool_defs`, inserts tool schemas, and masks via renderer sampled-token semantics. These flags let BenchFlow run Prime-RL with the custom trainer's effective input contract without modifying Prime-RL.

## Validation

- `uv run pytest tests/test_train_cli.py -q`
- `uv run pytest tests/trajectories/test_export_prime_sft.py -q`
- `uv run pytest tests/test_train_cli.py tests/trajectories/test_export_prime_sft.py -q`
- `uv run ruff check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py`
- `uv run ruff format --check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py`
- `uv run ty check src/benchflow/training/backends/prime_rl.py`
- H100 Prime-RL parser check: `cli(SFTConfig, args=[..., "--renderer", "None", "--dry-run"])` resolved `renderer None`.
- `uv run bench train run sft --help`

## Spendful validation

No training rerun in this PR. The next env-0-experiment run should use:

```bash
TARGET_EXAMPLES=300 \
PACK_FUNCTION=stack \
LOSS_MASK=all \
MODEL_ATTN=sdpa \
RENDERER_MODE=none \
TOOL_DEFS_MODE=omit \
RUN_KIND=mobile300-custom-trainer-compatible-prime-rl \
bash experiments/env0-mobile-pr828-prime-rl-benchflow-cli/scripts/run_prime_rl_wandb_sft.sh
```
