### PR TITLE
fix(diagnostics): type diagnostic and usage sources

### DIFF
--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -3,11 +3,13 @@
 from collections.abc import Iterable, Mapping
 from typing import Any, Literal
 
+from benchflow.diagnostics import DIAGNOSTIC_REASON_IDLE_TIMEOUT
+
 # Error category constants
 INSTALL_FAILED = "install_failure"
 PIPE_CLOSED = "pipe_closed"
 ACP_ERROR = "acp_error"
-IDLE_TIMEOUT = "idle_timeout"
+IDLE_TIMEOUT = DIAGNOSTIC_REASON_IDLE_TIMEOUT
 INFRA_ERROR = "infra_failure"
 SANDBOX_SETUP = "sandbox_setup"
 PROVIDER_AUTH = "provider_auth"

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -25,7 +25,19 @@ exceptions without pulling Daytona/Modal SDKs.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
+
+DIAGNOSTIC_REASON_IDLE_TIMEOUT = "idle_timeout"
+DIAGNOSTIC_REASON_WALL_CLOCK_TIMEOUT = "wall_clock_timeout"
+DIAGNOSTIC_REASON_SANDBOX_STARTUP_FAILED = "sandbox_startup_failed"
+DIAGNOSTIC_REASON_TRANSPORT_CLOSED = "transport_closed"
+
+DiagnosticReason = Literal[
+    "idle_timeout",
+    "wall_clock_timeout",
+    "sandbox_startup_failed",
+    "transport_closed",
+]
 
 # Diagnostic value objects
 
@@ -112,7 +124,7 @@ class Diagnostic:
 class IdleTimeoutDiagnostic(Diagnostic):
     """Agent went silent — no tool call, message, or thought arrived in time."""
 
-    reason: str = "idle_timeout"
+    reason: Literal["idle_timeout"] = DIAGNOSTIC_REASON_IDLE_TIMEOUT
     idle_timeout_sec: int = 0
     idle_duration_sec: int = 0
     wall_clock_elapsed_sec: int = 0
@@ -138,7 +150,7 @@ class IdleTimeoutDiagnostic(Diagnostic):
 class AgentPromptTimeoutDiagnostic(Diagnostic):
     """BenchFlow hit the prompt wall-clock budget and wrote timeout evidence."""
 
-    reason: str = "wall_clock_timeout"
+    reason: Literal["wall_clock_timeout"] = DIAGNOSTIC_REASON_WALL_CLOCK_TIMEOUT
     timeout_sec: float = 0.0
     n_tool_calls: int = 0
     pending_tool_call_ids: list[str] = field(default_factory=list)
@@ -163,7 +175,7 @@ class AgentPromptTimeoutDiagnostic(Diagnostic):
 class SandboxStartupDiagnostic(Diagnostic):
     """Sandbox creation failed before the rollout ever ran."""
 
-    reason: str = "sandbox_startup_failed"
+    reason: Literal["sandbox_startup_failed"] = DIAGNOSTIC_REASON_SANDBOX_STARTUP_FAILED
     sandbox_id: str | None = None
     sandbox_state: str | None = None
     attempts: int = 0
@@ -190,7 +202,7 @@ class TransportClosedDiagnostic(Diagnostic):
     reconstruct from the stringified ``ConnectionError`` (issue #504).
     """
 
-    reason: str = "transport_closed"
+    reason: Literal["transport_closed"] = DIAGNOSTIC_REASON_TRANSPORT_CLOSED
     raw_message: str = ""
     process_exit_code: int | None = None
     process_pid: int | None = None

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -20,7 +20,7 @@ from benchflow._utils.scoring import (
     pass_rate_excl_errors,
 )
 from benchflow.trajectories.metrics import result_skill_invocations
-from benchflow.usage_tracking import is_trusted_usage_source
+from benchflow.usage_tracking import UsageSource, is_trusted_usage_source
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class TaskMetrics:
     cache_creation_tokens: int | None = None
     total_tokens: int | None = None
     cost_usd: float | None = None
-    usage_source: str = "unavailable"
+    usage_source: UsageSource = "unavailable"
     memory_score: float | None = None
 
     @property

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Literal
 
+from benchflow.usage_tracking import UsageSource
+
 if TYPE_CHECKING:
     from benchflow.rewards.events import RewardEvent
 
@@ -138,7 +140,7 @@ class RolloutResult:
         n_cache_creation_tokens: int | None = None,
         total_tokens: int | None = None,
         cost_usd: float | None = None,
-        usage_source: str = "unavailable",
+        usage_source: UsageSource = "unavailable",
         price_source: str | None = None,
         usage_details: dict[str, Any] | None = None,
         error: str | None = None,

--- a/src/benchflow/rollout/_results.py
+++ b/src/benchflow/rollout/_results.py
@@ -44,7 +44,7 @@ from benchflow.skill_policy import (
 )
 from benchflow.trajectories._capture import TrajectoryWriter
 from benchflow.trajectories.metrics import count_skill_invocations
-from benchflow.usage_tracking import UsageTrackingConfig
+from benchflow.usage_tracking import UsageTrackingConfig, normalize_usage_source
 
 logger = logging.getLogger(__name__)
 
@@ -332,7 +332,7 @@ def _build_rollout_result(
         n_cache_creation_tokens=n_cache_creation_tokens,
         total_tokens=total_tokens,
         cost_usd=cost_usd,
-        usage_source=usage_source,
+        usage_source=normalize_usage_source(usage_source),
         price_source=price_source,
         usage_details=usage_details,
         error=error,

--- a/src/benchflow/usage_tracking.py
+++ b/src/benchflow/usage_tracking.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Literal, cast
 
 UsageTrackingMode = Literal["auto", "required", "off"]
+UsageSource = Literal["provider_response", "agent_native_acp", "unavailable"]
 
 USAGE_TRACKING_ENV = "BENCHFLOW_USAGE_TRACKING"
 USAGE_SOURCE_PROVIDER_RESPONSE = "provider_response"
@@ -17,6 +18,11 @@ TRUSTED_USAGE_SOURCES: frozenset[str] = frozenset(
 )
 
 _MODES: set[str] = {"auto", "required", "off"}
+_USAGE_SOURCES: set[str] = {
+    USAGE_SOURCE_PROVIDER_RESPONSE,
+    USAGE_SOURCE_AGENT_NATIVE_ACP,
+    USAGE_SOURCE_UNAVAILABLE,
+}
 _LEGACY_USAGE_PROXY_KEYS: frozenset[str] = frozenset(
     {
         "usage_proxy",
@@ -34,6 +40,13 @@ def normalize_usage_tracking_mode(value: str) -> UsageTrackingMode:
         expected = ", ".join(sorted(_MODES))
         raise ValueError(f"usage_tracking must be one of: {expected}")
     return cast(UsageTrackingMode, mode)
+
+
+def normalize_usage_source(value: str) -> UsageSource:
+    if value not in _USAGE_SOURCES:
+        expected = ", ".join(sorted(_USAGE_SOURCES))
+        raise ValueError(f"usage_source must be one of: {expected}")
+    return cast(UsageSource, value)
 
 
 def _optional_mode(value: Any) -> UsageTrackingMode | None:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1565,7 +1565,7 @@ class TestDiagnosticRegistry:
             assert empty[diag_cls.field] is None
 
     def test_diagnostic_reason_constants_share_scoring_source(self) -> None:
-        """Guards GitHub issue #531: diagnostic reasons use typed shared constants."""
+        """Guards the fix from PR #858 against diagnostic reasons drifting off the shared scoring source."""
         from typing import get_args, get_type_hints
 
         from benchflow._utils.scoring import IDLE_TIMEOUT

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1564,6 +1564,53 @@ class TestDiagnosticRegistry:
         for diag_cls in DIAGNOSTIC_REGISTRY:
             assert empty[diag_cls.field] is None
 
+    def test_diagnostic_reason_constants_share_scoring_source(self) -> None:
+        """Guards GitHub issue #531: diagnostic reasons use typed shared constants."""
+        from typing import get_args, get_type_hints
+
+        from benchflow._utils.scoring import IDLE_TIMEOUT
+        from benchflow.diagnostics import (
+            DIAGNOSTIC_REASON_IDLE_TIMEOUT,
+            DIAGNOSTIC_REASON_SANDBOX_STARTUP_FAILED,
+            DIAGNOSTIC_REASON_TRANSPORT_CLOSED,
+            DIAGNOSTIC_REASON_WALL_CLOCK_TIMEOUT,
+            AgentPromptTimeoutDiagnostic,
+            DiagnosticReason,
+            IdleTimeoutDiagnostic,
+            SandboxStartupDiagnostic,
+            TransportClosedDiagnostic,
+        )
+
+        assert IDLE_TIMEOUT == DIAGNOSTIC_REASON_IDLE_TIMEOUT
+        assert set(get_args(DiagnosticReason)) == {
+            DIAGNOSTIC_REASON_IDLE_TIMEOUT,
+            DIAGNOSTIC_REASON_WALL_CLOCK_TIMEOUT,
+            DIAGNOSTIC_REASON_SANDBOX_STARTUP_FAILED,
+            DIAGNOSTIC_REASON_TRANSPORT_CLOSED,
+        }
+
+        reason_hints = {
+            diag_cls.__name__: get_type_hints(diag_cls)["reason"]
+            for diag_cls in (
+                IdleTimeoutDiagnostic,
+                AgentPromptTimeoutDiagnostic,
+                SandboxStartupDiagnostic,
+                TransportClosedDiagnostic,
+            )
+        }
+        assert get_args(reason_hints["IdleTimeoutDiagnostic"]) == (
+            DIAGNOSTIC_REASON_IDLE_TIMEOUT,
+        )
+        assert get_args(reason_hints["AgentPromptTimeoutDiagnostic"]) == (
+            DIAGNOSTIC_REASON_WALL_CLOCK_TIMEOUT,
+        )
+        assert get_args(reason_hints["SandboxStartupDiagnostic"]) == (
+            DIAGNOSTIC_REASON_SANDBOX_STARTUP_FAILED,
+        )
+        assert get_args(reason_hints["TransportClosedDiagnostic"]) == (
+            DIAGNOSTIC_REASON_TRANSPORT_CLOSED,
+        )
+
     def test_summary_warning_uses_registry_metadata(self) -> None:
         """Summary warning text comes from the registry's
         ``summary_description``, not a per-call f-string in evaluation.py."""

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -426,7 +426,7 @@ def test_collect_metrics_usage_aggregation_mixed_telemetry(tmp_path):
 
 
 def test_usage_source_type_contract_tracks_trusted_sources():
-    """Guards GitHub issue #531: usage_source keeps a closed typed value set."""
+    """Guards the fix from PR #858 against usage_source_type drifting from the trusted source contract."""
     from typing import get_args
 
     from benchflow.usage_tracking import (

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -423,3 +423,32 @@ def test_collect_metrics_usage_aggregation_mixed_telemetry(tmp_path):
     assert summary["total_cost_usd"] == 0.003
     assert summary["avg_cost_per_trial_usd"] == 0.0015
     assert summary["telemetry_coverage"] == 2 / 3
+
+
+def test_usage_source_type_contract_tracks_trusted_sources():
+    """Guards GitHub issue #531: usage_source keeps a closed typed value set."""
+    from typing import get_args
+
+    from benchflow.usage_tracking import (
+        TRUSTED_USAGE_SOURCES,
+        USAGE_SOURCE_AGENT_NATIVE_ACP,
+        USAGE_SOURCE_PROVIDER_RESPONSE,
+        USAGE_SOURCE_UNAVAILABLE,
+        UsageSource,
+        normalize_usage_source,
+    )
+
+    assert set(get_args(UsageSource)) == {
+        USAGE_SOURCE_PROVIDER_RESPONSE,
+        USAGE_SOURCE_AGENT_NATIVE_ACP,
+        USAGE_SOURCE_UNAVAILABLE,
+    }
+    assert {
+        USAGE_SOURCE_PROVIDER_RESPONSE,
+        USAGE_SOURCE_AGENT_NATIVE_ACP,
+    } == TRUSTED_USAGE_SOURCES
+    assert normalize_usage_source(USAGE_SOURCE_AGENT_NATIVE_ACP) == (
+        USAGE_SOURCE_AGENT_NATIVE_ACP
+    )
+    with pytest.raises(ValueError, match="usage_source must be one of"):
+        normalize_usage_source("new_unregistered_source")


### PR DESCRIPTION
## Summary

Refs #531 (partial: parts A/B/C). This does **not** close #531 — part D (`Diagnostic.to_dict()` None-policy asymmetry) and the cross-subclass JSON-schema-stability test remain; #531 stays open with narrowed scope tracked in a follow-up comment.

This PR tightens the diagnostic and usage-source contracts without changing result JSON shape:

- adds shared diagnostic reason constants and a `DiagnosticReason` literal type in `benchflow.diagnostics`
- makes the single-value diagnostic dataclass `reason` fields typed as their exact literals
- reuses the diagnostic idle-timeout constant from `_utils.scoring` so the duplicate string no longer drifts independently
- adds a closed `UsageSource` literal type for `provider_response`, `agent_native_acp`, and `unavailable`
- normalizes `usage_source` at the rollout result construction boundary so future unregistered values fail explicitly
- adds regression coverage tied to GitHub issue #531 for diagnostic reason typing and usage-source typing

I intentionally did not change the existing `to_dict()` None-policy in this PR. That would alter serialized result shape across diagnostics and should be a separate compatibility decision.

## Validation

- `uv sync --extra dev --extra sandbox-daytona --locked`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check .`
- `uv run ty check src/`
- `uv run python -m pytest tests/test_acp.py tests/test_metrics.py -q` (`87 passed, 1 skipped`)
- `uv run python -m pytest tests/` (`4702 passed, 14 skipped, 7 deselected`)

## Notes

This is a narrow code-hygiene fix for the currently open `status:ready` diagnostics issue. It does not overlap the blocked sandbox/network PRs or release-branch PRs from the daily scan.

