### PR TITLE
Fix Mobile300 Prime-RL chat-template profile

### DIFF
--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -343,6 +343,17 @@ def register_train(app: typer.Typer) -> None:
                 ),
             ),
         ] = "preserve",
+        chat_template_kwarg: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--chat-template-kwarg",
+                help=(
+                    "Apply KEY=VALUE to every local Prime-SFT row's "
+                    "chat_template_kwargs before Prime-RL loads it; repeatable. "
+                    "Values are parsed as JSON literals when possible."
+                ),
+            ),
+        ] = None,
         allow_unsafe_stack_flash_attn: Annotated[
             bool,
             typer.Option(
@@ -422,6 +433,7 @@ def register_train(app: typer.Typer) -> None:
                     model_attn=model_attn,
                     renderer_mode=renderer_mode,
                     tool_defs_mode=tool_defs_mode,
+                    chat_template_kwargs=tuple(chat_template_kwarg or ()),
                     allow_unsafe_stack_flash_attn=allow_unsafe_stack_flash_attn,
                     force=force,
                     cwd=prime_rl_dir,

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -291,7 +291,9 @@ def _parse_chat_template_kwargs(raw: Iterable[str]) -> dict[str, Any]:
         key, value = item.split("=", 1)
         key = key.strip()
         if not key:
-            raise ValueError(f"--chat-template-kwarg must have a non-empty key: {item!r}")
+            raise ValueError(
+                f"--chat-template-kwarg must have a non-empty key: {item!r}"
+            )
         values[key] = _parse_chat_template_value(value)
     return values
 

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -49,6 +49,7 @@ class PrimeRlSftSpec:
     model_attn: str | None = None
     renderer_mode: str | None = None
     tool_defs_mode: str = "preserve"
+    chat_template_kwargs: tuple[str, ...] = ()
     allow_unsafe_stack_flash_attn: bool = False
     force: bool = False
     cwd: Path | None = None
@@ -102,6 +103,8 @@ class PrimeRlSftDatasetPlan:
     train_jsonl: str | None = None
     tool_defs_mode: str = "preserve"
     tool_defs_removed_rows: int | None = None
+    chat_template_kwargs: dict[str, Any] | None = None
+    chat_template_kwargs_rows: int | None = None
     validation: dict[str, Any] | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -113,6 +116,8 @@ class PrimeRlSftDatasetPlan:
             "train_jsonl": self.train_jsonl,
             "tool_defs_mode": self.tool_defs_mode,
             "tool_defs_removed_rows": self.tool_defs_removed_rows,
+            "chat_template_kwargs": self.chat_template_kwargs,
+            "chat_template_kwargs_rows": self.chat_template_kwargs_rows,
             "validation": self.validation,
         }
 
@@ -268,6 +273,50 @@ def _normalize_tool_defs_mode(raw: str) -> str:
     return value
 
 
+def _parse_chat_template_value(raw: str) -> Any:
+    value = raw.strip()
+    if value.lower() in {"true", "false", "null"}:
+        value = value.lower()
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return raw
+
+
+def _parse_chat_template_kwargs(raw: Iterable[str]) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for item in raw:
+        if "=" not in item:
+            raise ValueError(f"--chat-template-kwarg must be KEY=VALUE, got {item!r}")
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"--chat-template-kwarg must have a non-empty key: {item!r}")
+        values[key] = _parse_chat_template_value(value)
+    return values
+
+
+def _profile_chat_template_kwargs(
+    raw: tuple[str, ...],
+    defaults: Mapping[str, Any],
+    *,
+    profile: str,
+) -> tuple[str, ...]:
+    values = _parse_chat_template_kwargs(raw)
+    generated: list[str] = []
+    for key, required in defaults.items():
+        if key in values:
+            if values[key] != required:
+                rendered = json.dumps(required, sort_keys=True)
+                raise ValueError(
+                    f"--compat-profile {profile} requires "
+                    f"--chat-template-kwarg {key}={rendered}; got {values[key]!r}"
+                )
+            continue
+        generated.append(f"{key}={json.dumps(required, sort_keys=True)}")
+    return (*raw, *generated)
+
+
 def _normalize_compat_profile(raw: str | None) -> str | None:
     if raw is None:
         return None
@@ -305,11 +354,6 @@ def _apply_compat_profile(spec: PrimeRlSftSpec) -> PrimeRlSftSpec:
         return spec
     if profile != _MOBILE300_PROFILE:
         raise AssertionError(f"unhandled compat profile: {profile}")
-    if spec.renderer_mode is not None:
-        raise ValueError(
-            f"--compat-profile {profile} keeps the Prime-RL renderer enabled; "
-            "--renderer-mode cannot be set"
-        )
     if not spec.sync_scheduler_to_max_steps:
         raise ValueError(
             f"--compat-profile {profile} requires --sync-scheduler-to-max-steps"
@@ -335,7 +379,17 @@ def _apply_compat_profile(spec: PrimeRlSftSpec) -> PrimeRlSftSpec:
                 spec.model_attn, "sdpa", field="--model-attn", profile=profile
             )
         ),
+        renderer_mode=str(
+            _profile_field(
+                spec.renderer_mode, "none", field="--renderer-mode", profile=profile
+            )
+        ),
         tool_defs_mode="omit",
+        chat_template_kwargs=_profile_chat_template_kwargs(
+            spec.chat_template_kwargs,
+            {"enable_thinking": False},
+            profile=profile,
+        ),
     )
 
 
@@ -533,9 +587,22 @@ def _local_data_path(data: str) -> Path | None:
     return None
 
 
-def _copy_jsonl_omitting_tool_defs(source: Path, destination: Path) -> int:
-    """Copy JSONL while dropping tool schema columns from the training copy."""
+@dataclass(frozen=True)
+class _JsonlTransformStats:
+    tool_defs_removed_rows: int | None = None
+    chat_template_kwargs_rows: int | None = None
+
+
+def _copy_prime_rl_jsonl(
+    source: Path,
+    destination: Path,
+    *,
+    omit_tool_defs: bool,
+    chat_template_kwargs: Mapping[str, Any],
+) -> _JsonlTransformStats:
+    """Copy JSONL while applying BenchFlow-owned Prime-RL data transforms."""
     removed_rows = 0
+    chat_template_kwargs_rows = 0
     with (
         source.open("r", encoding="utf-8") as src,
         destination.open("w", encoding="utf-8") as dst,
@@ -547,12 +614,31 @@ def _copy_jsonl_omitting_tool_defs(source: Path, destination: Path) -> int:
             row = json.loads(line)
             if not isinstance(row, dict):
                 raise ValueError(f"{source}: every JSONL row must be an object")
-            if "tool_defs" in row or "tools" in row:
+            if omit_tool_defs and ("tool_defs" in row or "tools" in row):
                 removed_rows += 1
-            row.pop("tool_defs", None)
-            row.pop("tools", None)
+            if omit_tool_defs:
+                row.pop("tool_defs", None)
+                row.pop("tools", None)
+            if chat_template_kwargs:
+                existing = row.get("chat_template_kwargs")
+                if existing is None:
+                    existing = {}
+                if not isinstance(existing, dict):
+                    raise ValueError(
+                        f"{source}: chat_template_kwargs must be an object when present"
+                    )
+                row["chat_template_kwargs"] = {
+                    **existing,
+                    **dict(chat_template_kwargs),
+                }
+                chat_template_kwargs_rows += 1
             dst.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
-    return removed_rows
+    return _JsonlTransformStats(
+        tool_defs_removed_rows=removed_rows if omit_tool_defs else None,
+        chat_template_kwargs_rows=(
+            chat_template_kwargs_rows if chat_template_kwargs else None
+        ),
+    )
 
 
 def _prepare_prime_rl_data(
@@ -560,14 +646,22 @@ def _prepare_prime_rl_data(
 ) -> tuple[PrimeRlSftSpec, PrimeRlSftDatasetPlan | None]:
     """Make local BenchFlow JSONL usable by Prime-RL's ``load_dataset`` path."""
     if not spec.data:
+        if spec.chat_template_kwargs:
+            raise ValueError("--chat-template-kwarg requires --data")
         return spec, None
 
     tool_defs_mode = _normalize_tool_defs_mode(spec.tool_defs_mode)
+    chat_template_kwargs = _parse_chat_template_kwargs(spec.chat_template_kwargs)
     source_path = _local_data_path(spec.data)
     if source_path is None:
         if tool_defs_mode != "preserve":
             raise ValueError(
                 "--tool-defs-mode omit requires --data to be a local JSONL file "
+                "or a local dataset directory"
+            )
+        if chat_template_kwargs:
+            raise ValueError(
+                "--chat-template-kwarg requires --data to be a local JSONL file "
                 "or a local dataset directory"
             )
         return spec, None
@@ -581,18 +675,23 @@ def _prepare_prime_rl_data(
             )
 
             validation = validate_prime_sft_jsonl(train_jsonl)
-        if tool_defs_mode == "omit":
+        should_transform = tool_defs_mode == "omit" or bool(chat_template_kwargs)
+        if should_transform:
             if not train_jsonl.is_file():
                 raise ValueError(
-                    f"--tool-defs-mode omit requires {source_path} to contain train.jsonl"
+                    f"local Prime-RL data transforms require {source_path} "
+                    "to contain train.jsonl"
                 )
             dataset_dir = work_dir / "prime-rl-dataset"
             if dataset_dir.exists():
                 shutil.rmtree(dataset_dir)
             shutil.copytree(source_path, dataset_dir)
             transformed_train_jsonl = dataset_dir / "train.jsonl"
-            removed_rows = _copy_jsonl_omitting_tool_defs(
-                train_jsonl, transformed_train_jsonl
+            stats = _copy_prime_rl_jsonl(
+                train_jsonl,
+                transformed_train_jsonl,
+                omit_tool_defs=tool_defs_mode == "omit",
+                chat_template_kwargs=chat_template_kwargs,
             )
             resolved_spec = replace(spec, data=str(dataset_dir))
             return resolved_spec, PrimeRlSftDatasetPlan(
@@ -602,7 +701,11 @@ def _prepare_prime_rl_data(
                 dataset_dir=str(dataset_dir),
                 train_jsonl=str(transformed_train_jsonl),
                 tool_defs_mode=tool_defs_mode,
-                tool_defs_removed_rows=removed_rows,
+                tool_defs_removed_rows=stats.tool_defs_removed_rows,
+                chat_template_kwargs=(
+                    dict(chat_template_kwargs) if chat_template_kwargs else None
+                ),
+                chat_template_kwargs_rows=stats.chat_template_kwargs_rows,
                 validation=validation,
             )
         resolved_spec = replace(spec, data=str(source_path))
@@ -613,6 +716,9 @@ def _prepare_prime_rl_data(
             dataset_dir=str(source_path),
             train_jsonl=str(train_jsonl) if train_jsonl.is_file() else None,
             tool_defs_mode=tool_defs_mode,
+            chat_template_kwargs=(
+                dict(chat_template_kwargs) if chat_template_kwargs else None
+            ),
             validation=validation,
         )
 
@@ -629,9 +735,14 @@ def _prepare_prime_rl_data(
         shutil.rmtree(dataset_dir)
     dataset_dir.mkdir(parents=True)
     train_jsonl = dataset_dir / "train.jsonl"
-    removed_rows = None
-    if tool_defs_mode == "omit":
-        removed_rows = _copy_jsonl_omitting_tool_defs(source_path, train_jsonl)
+    stats = _JsonlTransformStats()
+    if tool_defs_mode == "omit" or chat_template_kwargs:
+        stats = _copy_prime_rl_jsonl(
+            source_path,
+            train_jsonl,
+            omit_tool_defs=tool_defs_mode == "omit",
+            chat_template_kwargs=chat_template_kwargs,
+        )
     else:
         shutil.copy2(source_path, train_jsonl)
     resolved_spec = replace(spec, data=str(dataset_dir))
@@ -642,7 +753,11 @@ def _prepare_prime_rl_data(
         dataset_dir=str(dataset_dir),
         train_jsonl=str(train_jsonl),
         tool_defs_mode=tool_defs_mode,
-        tool_defs_removed_rows=removed_rows,
+        tool_defs_removed_rows=stats.tool_defs_removed_rows,
+        chat_template_kwargs=(
+            dict(chat_template_kwargs) if chat_template_kwargs else None
+        ),
+        chat_template_kwargs_rows=stats.chat_template_kwargs_rows,
         validation=validation,
     )
 
@@ -696,7 +811,8 @@ def _initial_manifest(
             "description": (
                 "BenchFlow Mobile300 PR828 Prime-RL wrapper settings that match "
                 "the historical custom-trainer run where Prime-SFT rows had "
-                "tool_defs but no tools."
+                "tool_defs but no tools and Qwen3.5 thinking was disabled in the "
+                "chat-template render."
             ),
             "resolved_settings": {
                 "target_examples": spec.target_examples,
@@ -706,10 +822,13 @@ def _initial_manifest(
                 "model_attn": spec.model_attn,
                 "renderer_mode": spec.renderer_mode,
                 "tool_defs_mode": spec.tool_defs_mode,
+                "chat_template_kwargs": _parse_chat_template_kwargs(
+                    spec.chat_template_kwargs
+                ),
             },
             "known_prime_rl_gap": (
-                "Prime-RL still owns renderer tokenization and loss-mask "
-                "construction; BenchFlow does not patch Prime-RL internals."
+                "Prime-RL still owns sequence packing and truncation; BenchFlow "
+                "does not patch Prime-RL internals."
             ),
         }
     return manifest

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -585,6 +585,8 @@ def test_train_run_sft_prime_rl_packages_local_jsonl_data(
         "train_jsonl": str(train_jsonl),
         "tool_defs_mode": "preserve",
         "tool_defs_removed_rows": None,
+        "chat_template_kwargs": None,
+        "chat_template_kwargs_rows": None,
         "validation": {"ok": True, "rows": 1, "rows_with_tool_calls": 1},
     }
 
@@ -959,8 +961,7 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
 
     assert result.exit_code == 0, result.output
     argv = captured["argv"]
-    assert "--renderer" not in argv
-    assert argv[-16:] == [
+    assert argv[-18:] == [
         "--max_steps",
         "38",
         "--scheduler.decay_steps",
@@ -977,12 +978,15 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
         "true",
         "--model.attn",
         "sdpa",
+        "--renderer",
+        "None",
     ]
     data_idx = argv.index("--data.name")
     staged_dir = Path(argv[data_idx + 1])
     staged_row = json.loads((staged_dir / "train.jsonl").read_text())
     assert "tool_defs" not in staged_row
     assert "tools" not in staged_row
+    assert staged_row["chat_template_kwargs"] == {"enable_thinking": False}
 
     manifest = json.loads((work_dir / "train-run.json").read_text())
     assert manifest["extra"]["prime_rl_sft_compat_profile"]["name"] == (
@@ -994,11 +998,16 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
         "pack_function": "stack",
         "loss_mask": "all",
         "model_attn": "sdpa",
-        "renderer_mode": None,
+        "renderer_mode": "none",
         "tool_defs_mode": "omit",
+        "chat_template_kwargs": {"enable_thinking": False},
     }
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_mode"] == "omit"
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_removed_rows"] == 1
+    assert manifest["extra"]["prime_rl_sft_dataset"]["chat_template_kwargs"] == {
+        "enable_thinking": False
+    }
+    assert manifest["extra"]["prime_rl_sft_dataset"]["chat_template_kwargs_rows"] == 1
 
 
 def test_train_run_sft_prime_rl_custom_trainer_compatibility_mode(
@@ -1099,6 +1108,8 @@ def test_train_run_sft_prime_rl_custom_trainer_compatibility_mode(
             "none",
             "--tool-defs-mode",
             "omit",
+            "--chat-template-kwarg",
+            "enable_thinking=false",
         ],
     )
 
@@ -1112,6 +1123,7 @@ def test_train_run_sft_prime_rl_custom_trainer_compatibility_mode(
     staged_row = json.loads((staged_dir / "train.jsonl").read_text())
     assert "tool_defs" not in staged_row
     assert "tools" not in staged_row
+    assert staged_row["chat_template_kwargs"] == {"enable_thinking": False}
     assert "tool_defs" in json.loads(source_jsonl.read_text())
 
     manifest = json.loads((work_dir / "train-run.json").read_text())
@@ -1127,6 +1139,10 @@ def test_train_run_sft_prime_rl_custom_trainer_compatibility_mode(
     assert manifest["extra"]["prime_rl_sft_exposure_plan"]["renderer_mode"] == "none"
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_mode"] == "omit"
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_removed_rows"] == 1
+    assert manifest["extra"]["prime_rl_sft_dataset"]["chat_template_kwargs"] == {
+        "enable_thinking": False
+    }
+    assert manifest["extra"]["prime_rl_sft_dataset"]["chat_template_kwargs_rows"] == 1
     assert manifest["extra"]["prime_rl_sft_dataset"]["validation"] == {
         "ok": True,
         "rows": 1,
@@ -1163,6 +1179,37 @@ def test_train_run_sft_prime_rl_rejects_tool_defs_omit_for_remote_data(
 
     assert result.exit_code == 1
     assert "--tool-defs-mode omit requires --data to be a local JSONL" in result.output
+
+
+def test_train_run_sft_prime_rl_rejects_chat_template_kwargs_for_remote_data(
+    tmp_path: Path, monkeypatch
+) -> None:
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    config = tmp_path / "sft.toml"
+    config.write_text("max_steps = 1\n", encoding="utf-8")
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(tmp_path / "train-run"),
+            "--data",
+            "benchflow/remote-dataset",
+            "--chat-template-kwarg",
+            "enable_thinking=false",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "--chat-template-kwarg requires --data to be a local JSONL" in result.output
 
 
 def test_train_run_sft_prime_rl_rejects_qwen35_stack_flash_attn(


### PR DESCRIPTION
## Summary
- add repeatable `bench train run sft --chat-template-kwarg KEY=VALUE` for local Prime-SFT JSONL/data-dir packaging
- update the `env0-mobile300-pr828` compatibility profile to use `renderer=None` plus `chat_template_kwargs.enable_thinking=false`
- record chat-template transforms in the train-run manifest and guard remote-data misuse

## Why
The previous profile kept Prime-RL's Qwen3.5 renderer enabled. The latest H100 reproduction showed that `renderer=None` is usable for Qwen3.5 when every row carries `chat_template_kwargs={"enable_thinking": false}`; without that kwarg, Prime-RL's incremental tokenizer path fails. This is the closest BenchFlow-side match to the historical custom trainer's tokenizer path without changing Prime-RL internals.

## Validation
- `uv run pytest tests/test_train_cli.py -q` -> 24 passed
- `uv run ruff check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py` -> passed
- `git diff --check` -> passed
- `uv run pytest -q` -> 4701 passed, 14 skipped, 7 deselected

## Live experiment evidence
- H100 SFT completed with `renderer=None`, `enable_thinking=false`, `tool_defs_mode=omit`, `target_examples=300`, `pack_function=stack`, `loss_mask=all`, `model.attn=sdpa`
- training used 300 rows, 0 skipped examples, final loss 0.53054, adapter produced at step 38
- W&B: https://wandb.ai/benchflow-ai/env0-mobile-pr828-qwen35-prime-rl-sft-renderer-none-thinking-false-20260630/runs/mobile300_mobile300_renderer_none_thinking_false_prime_rl_main_20260630T083400Z
- Fireworks/Daytona vLLM-routed canary reached the model with no infra errors but remained 0/3: auth 0.0/16 tools, gcal 0.0/2 tools, slack 0.0/9 tools

## Remaining gap
This fixes BenchFlow's Prime-RL launch/data packaging semantics. It does not patch Prime-RL's head-truncation behavior for long sequences, which still differs from the historical custom trainer's tail-truncation behavior.