### PR TITLE
Match Mobile300 custom trainer microstep semantics

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -427,8 +427,9 @@ that were present are recorded.
 | `--follow` | `false` | Stream trainer stdout while writing logs |
 | `--uv-no-sync` | `false` | Run Prime-RL as `uv run --no-sync sft ...`, useful after backend post-install steps such as `flash-attn` |
 | `--override` | — | Prime-RL override as `KEY=VALUE`; repeatable, emitted as `--KEY VALUE` |
-| `--target-examples` | — | Derive Prime-RL `max_steps` from target sample exposure and effective `data.batch_size` |
-| `--sync-scheduler-to-max-steps` / `--no-sync-scheduler-to-max-steps` | `true` | When `--target-examples` is set, also derive `scheduler.decay_steps` |
+| `--target-examples` | — | Derive Prime-RL `max_steps` from target sample exposure and effective `data.batch_size`, rounding up |
+| `--target-micro-steps` | — | Derive Prime-RL `max_steps` from custom-trainer batch-size-1 microsteps, dropping the final partial accumulation |
+| `--sync-scheduler-to-max-steps` / `--no-sync-scheduler-to-max-steps` | `true` | When `--target-examples` or `--target-micro-steps` is set, also derive `scheduler.decay_steps` |
 | `--pack-function` | — | First-class Prime-RL `data.pack_function` override: `cat` or `stack` |
 | `--loss-mask` | — | First-class Prime-RL `data.loss_mask` override: `assistant`, `all`, or comma-separated roles from `system,user,assistant,tool` |
 | `--model-attn` | — | First-class Prime-RL `model.attn` override, e.g. `sdpa` |

--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -285,7 +285,17 @@ def register_train(app: typer.Typer) -> None:
                 "--target-examples",
                 help=(
                     "Derive Prime-RL max_steps from a target number of training "
-                    "examples using data.batch_size"
+                    "examples using data.batch_size, rounding up"
+                ),
+            ),
+        ] = None,
+        target_micro_steps: Annotated[
+            int | None,
+            typer.Option(
+                "--target-micro-steps",
+                help=(
+                    "Derive Prime-RL max_steps from custom-trainer batch-size-1 "
+                    "microsteps, dropping the final partial accumulation"
                 ),
             ),
         ] = None,
@@ -294,8 +304,8 @@ def register_train(app: typer.Typer) -> None:
             typer.Option(
                 "--sync-scheduler-to-max-steps/--no-sync-scheduler-to-max-steps",
                 help=(
-                    "When --target-examples is set, also derive "
-                    "scheduler.decay_steps from the computed max_steps"
+                    "When --target-examples or --target-micro-steps is set, "
+                    "also derive scheduler.decay_steps from the computed max_steps"
                 ),
             ),
         ] = True,
@@ -439,6 +449,7 @@ def register_train(app: typer.Typer) -> None:
                     uv_no_sync=uv_no_sync,
                     overrides=tuple(override or ()),
                     target_examples=target_examples,
+                    target_micro_steps=target_micro_steps,
                     sync_scheduler_to_max_steps=sync_scheduler_to_max_steps,
                     pack_function=pack_function,
                     loss_mask=loss_mask,

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -45,6 +45,7 @@ class PrimeRlSftSpec:
     uv_no_sync: bool = False
     overrides: tuple[str, ...] = ()
     target_examples: int | None = None
+    target_micro_steps: int | None = None
     sync_scheduler_to_max_steps: bool = True
     pack_function: str | None = None
     loss_mask: str | None = None
@@ -74,8 +75,11 @@ class PrimeRlSftResult:
 @dataclass(frozen=True)
 class PrimeRlSftExposurePlan:
     target_examples: int | None = None
+    target_micro_steps: int | None = None
     data_batch_size: int | None = None
     derived_max_steps: int | None = None
+    effective_train_examples: int | None = None
+    unapplied_micro_steps: int | None = None
     sync_scheduler_to_max_steps: bool = False
     pack_function: str | None = None
     loss_mask: str | None = None
@@ -86,8 +90,11 @@ class PrimeRlSftExposurePlan:
     def to_dict(self) -> dict[str, Any]:
         return {
             "target_examples": self.target_examples,
+            "target_micro_steps": self.target_micro_steps,
             "data_batch_size": self.data_batch_size,
             "derived_max_steps": self.derived_max_steps,
+            "effective_train_examples": self.effective_train_examples,
+            "unapplied_micro_steps": self.unapplied_micro_steps,
             "sync_scheduler_to_max_steps": self.sync_scheduler_to_max_steps,
             "pack_function": self.pack_function,
             "loss_mask": self.loss_mask,
@@ -406,12 +413,20 @@ def _apply_compat_profile(spec: PrimeRlSftSpec) -> PrimeRlSftSpec:
         raise ValueError(
             f"--compat-profile {profile} requires --sync-scheduler-to-max-steps"
         )
+    if spec.target_examples is not None:
+        _profile_field(
+            spec.target_examples, 300, field="--target-examples", profile=profile
+        )
     return replace(
         spec,
         compat_profile=profile,
-        target_examples=int(
+        target_examples=None,
+        target_micro_steps=int(
             _profile_field(
-                spec.target_examples, 300, field="--target-examples", profile=profile
+                spec.target_micro_steps,
+                300,
+                field="--target-micro-steps",
+                profile=profile,
             )
         ),
         pack_function=str(
@@ -497,12 +512,20 @@ def _build_generated_overrides(
     overrides = _override_map(spec.overrides)
     generated: list[str] = []
     target_examples: int | None = None
+    target_micro_steps: int | None = None
     data_batch_size: int | None = None
     derived_max_steps: int | None = None
+    effective_train_examples: int | None = None
+    unapplied_micro_steps: int | None = None
     pack_function: str | None = None
     loss_mask: str | None = None
     model_attn: str | None = None
     renderer_mode: str | None = None
+
+    if spec.target_examples is not None and spec.target_micro_steps is not None:
+        raise ValueError(
+            "--target-examples and --target-micro-steps cannot be combined"
+        )
 
     if spec.target_examples is not None:
         if "max_steps" in overrides:
@@ -514,6 +537,33 @@ def _build_generated_overrides(
         )
         data_batch_size = _resolve_data_batch_size(config, overrides)
         derived_max_steps = ceil(target_examples / data_batch_size)
+        effective_train_examples = derived_max_steps * data_batch_size
+        generated.append(f"max_steps={derived_max_steps}")
+        if spec.sync_scheduler_to_max_steps:
+            if "scheduler.decay_steps" in overrides:
+                raise ValueError(
+                    "--sync-scheduler-to-max-steps cannot be combined with "
+                    "--override scheduler.decay_steps=..."
+                )
+            generated.append(f"scheduler.decay_steps={derived_max_steps}")
+
+    if spec.target_micro_steps is not None:
+        if "max_steps" in overrides:
+            raise ValueError(
+                "--target-micro-steps cannot be combined with --override max_steps=..."
+            )
+        target_micro_steps = _parse_positive_int(
+            spec.target_micro_steps, key="--target-micro-steps"
+        )
+        data_batch_size = _resolve_data_batch_size(config, overrides)
+        derived_max_steps = target_micro_steps // data_batch_size
+        if derived_max_steps <= 0:
+            raise ValueError(
+                "--target-micro-steps must cover at least one effective "
+                f"Prime-RL batch ({target_micro_steps} < {data_batch_size})"
+            )
+        effective_train_examples = derived_max_steps * data_batch_size
+        unapplied_micro_steps = target_micro_steps - effective_train_examples
         generated.append(f"max_steps={derived_max_steps}")
         if spec.sync_scheduler_to_max_steps:
             if "scheduler.decay_steps" in overrides:
@@ -578,11 +628,14 @@ def _build_generated_overrides(
         return None
     return PrimeRlSftExposurePlan(
         target_examples=target_examples,
+        target_micro_steps=target_micro_steps,
         data_batch_size=data_batch_size,
         derived_max_steps=derived_max_steps,
+        effective_train_examples=effective_train_examples,
+        unapplied_micro_steps=unapplied_micro_steps,
         sync_scheduler_to_max_steps=(
             bool(spec.sync_scheduler_to_max_steps)
-            if target_examples is not None
+            if target_examples is not None or target_micro_steps is not None
             else False
         ),
         pack_function=pack_function,
@@ -1227,11 +1280,12 @@ def _initial_manifest(
             "description": (
                 "BenchFlow Mobile300 PR828 Prime-RL wrapper settings that match "
                 "the historical custom-trainer run where Prime-SFT rows had "
-                "tool_defs but no tools and Qwen3.5 thinking was disabled in the "
-                "chat-template render."
+                "tool_defs but no tools and max_steps counted batch-size-1 "
+                "micro-batches before gradient accumulation."
             ),
             "resolved_settings": {
                 "target_examples": spec.target_examples,
+                "target_micro_steps": spec.target_micro_steps,
                 "sync_scheduler_to_max_steps": spec.sync_scheduler_to_max_steps,
                 "pack_function": spec.pack_function,
                 "loss_mask": spec.loss_mask,
@@ -1244,9 +1298,9 @@ def _initial_manifest(
                 "message_tail_truncation": spec.message_tail_truncation,
             },
             "known_prime_rl_gap": (
-                "Prime-RL still owns sequence packing; BenchFlow only stages "
-                "local rows to avoid known head truncation where possible and "
-                "does not patch Prime-RL internals."
+                "Prime-RL still owns token masking and sequence packing; "
+                "BenchFlow stages local rows to reduce known truncation and "
+                "tool-schema mismatches but does not patch Prime-RL internals."
             ),
         }
     return manifest

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -721,6 +721,7 @@ def test_train_run_sft_prime_rl_target_examples_derives_exposure(
     assert manifest["extra"]["prime_rl_sft_exposure_plan"] == {
         "data_batch_size": 8,
         "derived_max_steps": 38,
+        "effective_train_examples": 304,
         "generated_overrides": [
             "max_steps=38",
             "scheduler.decay_steps=38",
@@ -732,6 +733,8 @@ def test_train_run_sft_prime_rl_target_examples_derives_exposure(
         "renderer_mode": None,
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
+        "target_micro_steps": None,
+        "unapplied_micro_steps": None,
     }
 
 
@@ -785,6 +788,76 @@ def test_train_run_sft_prime_rl_target_examples_respects_batch_override(
         manifest["extra"]["prime_rl_sft_exposure_plan"]["sync_scheduler_to_max_steps"]
         is False
     )
+
+
+def test_train_run_sft_prime_rl_target_micro_steps_drops_partial_accumulation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Custom-trainer max_steps counted micro-batches, not optimizer updates."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    captured: dict[str, Any] = {}
+
+    class FakeProcess:
+        def __init__(self, argv: list[str], **kwargs: Any) -> None:
+            del kwargs
+            captured["argv"] = argv
+            self.stdout = io.StringIO("")
+            self.stderr = io.StringIO("")
+
+        def wait(self) -> int:
+            return 0
+
+    config = tmp_path / "sft.toml"
+    config.write_text(
+        "max_steps = 300\n[data]\nbatch_size = 8\n[scheduler]\ndecay_steps = 300\n",
+        encoding="utf-8",
+    )
+    work_dir = tmp_path / "train-run"
+
+    monkeypatch.setattr(prime_rl.shutil, "which", lambda name: "/usr/bin/uv")
+    monkeypatch.setattr(prime_rl.subprocess, "Popen", FakeProcess)
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "run",
+            "sft",
+            "--config",
+            str(config),
+            "--work-dir",
+            str(work_dir),
+            "--target-micro-steps",
+            "300",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["argv"][-4:] == [
+        "--max_steps",
+        "37",
+        "--scheduler.decay_steps",
+        "37",
+    ]
+    manifest = json.loads((work_dir / "train-run.json").read_text())
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"] == {
+        "data_batch_size": 8,
+        "derived_max_steps": 37,
+        "effective_train_examples": 296,
+        "generated_overrides": [
+            "max_steps=37",
+            "scheduler.decay_steps=37",
+        ],
+        "loss_mask": None,
+        "model_attn": None,
+        "pack_function": None,
+        "renderer_mode": None,
+        "sync_scheduler_to_max_steps": True,
+        "target_examples": None,
+        "target_micro_steps": 300,
+        "unapplied_micro_steps": 4,
+    }
 
 
 def test_train_run_sft_prime_rl_records_reproduction_semantics(
@@ -872,6 +945,7 @@ def test_train_run_sft_prime_rl_records_reproduction_semantics(
     assert manifest["extra"]["prime_rl_sft_exposure_plan"] == {
         "data_batch_size": 8,
         "derived_max_steps": 38,
+        "effective_train_examples": 304,
         "generated_overrides": [
             "max_steps=38",
             "scheduler.decay_steps=38",
@@ -888,6 +962,8 @@ def test_train_run_sft_prime_rl_records_reproduction_semantics(
         "renderer_mode": None,
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
+        "target_micro_steps": None,
+        "unapplied_micro_steps": None,
     }
 
 
@@ -990,9 +1066,9 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
     argv = captured["argv"]
     assert argv[-18:] == [
         "--max_steps",
-        "38",
+        "37",
         "--scheduler.decay_steps",
-        "38",
+        "37",
         "--data.pack_function",
         "stack",
         "--data.loss_mask.system",
@@ -1020,7 +1096,8 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
         "env0-mobile300-pr828"
     )
     assert manifest["extra"]["prime_rl_sft_compat_profile"]["resolved_settings"] == {
-        "target_examples": 300,
+        "target_examples": None,
+        "target_micro_steps": 300,
         "sync_scheduler_to_max_steps": True,
         "pack_function": "stack",
         "loss_mask": "all",
@@ -1030,6 +1107,11 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
         "chat_template_kwargs": {"enable_thinking": False},
         "message_tail_truncation": "keep-first-user",
     }
+    assert (
+        manifest["extra"]["prime_rl_sft_exposure_plan"]["effective_train_examples"]
+        == 296
+    )
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"]["unapplied_micro_steps"] == 4
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_mode"] == "omit"
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_removed_rows"] == 1
     assert manifest["extra"]["prime_rl_sft_dataset"]["chat_template_kwargs"] == {


### PR DESCRIPTION
## Summary

Fixes the BenchFlow Prime-RL SFT compatibility profile for the env-0 Mobile300 / PR828 reproduction path by matching the old custom PEFT trainer's step semantics.

The historical custom trainer counted `max_steps=300` as batch-size-1 micro-batches and only applied optimizer updates every 8 micro-batches. That means the saved adapter had 37 applied optimizer updates, with the final 4 micro-batches accumulated but not stepped. Prime-RL `max_steps` counts optimizer/trainer steps, so the previous `--target-examples 300` mapping generated `max_steps=38` and over-exposed the run relative to the source-of-truth custom trainer.

Changes:
- Adds `--target-micro-steps` to derive Prime-RL `max_steps` from custom-trainer micro-batch semantics.
- Updates `env0-mobile300-pr828` compat profile to use `target_micro_steps=300`, producing `max_steps=37` and `scheduler.decay_steps=37`.
- Records `effective_train_examples` and `unapplied_micro_steps` in the run manifest for auditability.
- Keeps generic `--target-examples` behavior unchanged: sample-exposure derivation still rounds up.
- Updates CLI docs and regression tests.

Known caveat: this is a BenchFlow wrapper/profile fix only. It does not patch Prime-RL internals. Remaining exact-equivalence gaps, if performance still does not recover, are likely deeper token/loss/truncation semantics inside Prime-RL rather than `results.jsonl` conversion or BenchFlow CLI command construction.

## Validation

- `uv run pytest tests/test_train_cli.py -q` -> 27 passed
- `uv run ruff format --check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py` -> 3 files already formatted
- `uv run ruff check` -> All checks passed
- `uv run ty check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py` -> All checks passed
- `uv run bench train run sft --help` -> exposes `--target-micro-steps`
- Full suite before final formatting: `uv run pytest -q` -> 4704 passed, 14 skipped, 7 deselected
