### PR TITLE
Sync Mobile300 Prime-RL checkpoint step

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -430,6 +430,7 @@ that were present are recorded.
 | `--target-examples` | — | Derive Prime-RL `max_steps` from target sample exposure and effective `data.batch_size`, rounding up |
 | `--target-micro-steps` | — | Derive Prime-RL `max_steps` from custom-trainer batch-size-1 microsteps, dropping the final partial accumulation |
 | `--sync-scheduler-to-max-steps` / `--no-sync-scheduler-to-max-steps` | `true` | When `--target-examples` or `--target-micro-steps` is set, also derive `scheduler.decay_steps` |
+| `--sync-ckpt-to-max-steps` / `--no-sync-ckpt-to-max-steps` | `false` | When deriving `max_steps`, also derive `ckpt.interval` and `ckpt.keep_interval` |
 | `--pack-function` | — | First-class Prime-RL `data.pack_function` override: `cat` or `stack` |
 | `--loss-mask` | — | First-class Prime-RL `data.loss_mask` override: `assistant`, `all`, or comma-separated roles from `system,user,assistant,tool` |
 | `--model-attn` | — | First-class Prime-RL `model.attn` override, e.g. `sdpa` |

--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -309,6 +309,16 @@ def register_train(app: typer.Typer) -> None:
                 ),
             ),
         ] = True,
+        sync_ckpt_to_max_steps: Annotated[
+            bool,
+            typer.Option(
+                "--sync-ckpt-to-max-steps/--no-sync-ckpt-to-max-steps",
+                help=(
+                    "When deriving max_steps, also derive ckpt.interval and "
+                    "ckpt.keep_interval from the computed max_steps"
+                ),
+            ),
+        ] = False,
         pack_function: Annotated[
             str | None,
             typer.Option(
@@ -451,6 +461,7 @@ def register_train(app: typer.Typer) -> None:
                     target_examples=target_examples,
                     target_micro_steps=target_micro_steps,
                     sync_scheduler_to_max_steps=sync_scheduler_to_max_steps,
+                    sync_ckpt_to_max_steps=sync_ckpt_to_max_steps,
                     pack_function=pack_function,
                     loss_mask=loss_mask,
                     model_attn=model_attn,

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -47,6 +47,7 @@ class PrimeRlSftSpec:
     target_examples: int | None = None
     target_micro_steps: int | None = None
     sync_scheduler_to_max_steps: bool = True
+    sync_ckpt_to_max_steps: bool = False
     pack_function: str | None = None
     loss_mask: str | None = None
     model_attn: str | None = None
@@ -81,6 +82,7 @@ class PrimeRlSftExposurePlan:
     effective_train_examples: int | None = None
     unapplied_micro_steps: int | None = None
     sync_scheduler_to_max_steps: bool = False
+    sync_ckpt_to_max_steps: bool = False
     pack_function: str | None = None
     loss_mask: str | None = None
     model_attn: str | None = None
@@ -96,6 +98,7 @@ class PrimeRlSftExposurePlan:
             "effective_train_examples": self.effective_train_examples,
             "unapplied_micro_steps": self.unapplied_micro_steps,
             "sync_scheduler_to_max_steps": self.sync_scheduler_to_max_steps,
+            "sync_ckpt_to_max_steps": self.sync_ckpt_to_max_steps,
             "pack_function": self.pack_function,
             "loss_mask": self.loss_mask,
             "model_attn": self.model_attn,
@@ -429,6 +432,7 @@ def _apply_compat_profile(spec: PrimeRlSftSpec) -> PrimeRlSftSpec:
                 profile=profile,
             )
         ),
+        sync_ckpt_to_max_steps=True,
         pack_function=str(
             _profile_field(
                 spec.pack_function, "stack", field="--pack-function", profile=profile
@@ -573,6 +577,26 @@ def _build_generated_overrides(
                 )
             generated.append(f"scheduler.decay_steps={derived_max_steps}")
 
+    if spec.sync_ckpt_to_max_steps:
+        if derived_max_steps is None:
+            raise ValueError(
+                "--sync-ckpt-to-max-steps requires --target-examples or "
+                "--target-micro-steps"
+            )
+        ckpt_keys = ("ckpt.interval", "ckpt.keep_interval")
+        conflicting = sorted(key for key in ckpt_keys if key in overrides)
+        if conflicting:
+            raise ValueError(
+                "--sync-ckpt-to-max-steps cannot be combined with --override "
+                + ", ".join(f"{key}=..." for key in conflicting)
+            )
+        generated.extend(
+            [
+                f"ckpt.interval={derived_max_steps}",
+                f"ckpt.keep_interval={derived_max_steps}",
+            ]
+        )
+
     if spec.pack_function is not None:
         if spec.pack_function not in {"cat", "stack"}:
             raise ValueError("--pack-function must be either 'cat' or 'stack'")
@@ -638,6 +662,7 @@ def _build_generated_overrides(
             if target_examples is not None or target_micro_steps is not None
             else False
         ),
+        sync_ckpt_to_max_steps=bool(spec.sync_ckpt_to_max_steps),
         pack_function=pack_function,
         loss_mask=loss_mask,
         model_attn=model_attn,
@@ -1287,6 +1312,7 @@ def _initial_manifest(
                 "target_examples": spec.target_examples,
                 "target_micro_steps": spec.target_micro_steps,
                 "sync_scheduler_to_max_steps": spec.sync_scheduler_to_max_steps,
+                "sync_ckpt_to_max_steps": spec.sync_ckpt_to_max_steps,
                 "pack_function": spec.pack_function,
                 "loss_mask": spec.loss_mask,
                 "model_attn": spec.model_attn,

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -731,6 +731,7 @@ def test_train_run_sft_prime_rl_target_examples_derives_exposure(
         "model_attn": None,
         "pack_function": "stack",
         "renderer_mode": None,
+        "sync_ckpt_to_max_steps": False,
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
         "target_micro_steps": None,
@@ -853,6 +854,7 @@ def test_train_run_sft_prime_rl_target_micro_steps_drops_partial_accumulation(
         "model_attn": None,
         "pack_function": None,
         "renderer_mode": None,
+        "sync_ckpt_to_max_steps": False,
         "sync_scheduler_to_max_steps": True,
         "target_examples": None,
         "target_micro_steps": 300,
@@ -960,6 +962,7 @@ def test_train_run_sft_prime_rl_records_reproduction_semantics(
         "model_attn": "sdpa",
         "pack_function": "stack",
         "renderer_mode": None,
+        "sync_ckpt_to_max_steps": False,
         "sync_scheduler_to_max_steps": True,
         "target_examples": 300,
         "target_micro_steps": None,
@@ -1064,10 +1067,14 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
 
     assert result.exit_code == 0, result.output
     argv = captured["argv"]
-    assert argv[-18:] == [
+    assert argv[-22:] == [
         "--max_steps",
         "37",
         "--scheduler.decay_steps",
+        "37",
+        "--ckpt.interval",
+        "37",
+        "--ckpt.keep_interval",
         "37",
         "--data.pack_function",
         "stack",
@@ -1099,6 +1106,7 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
         "target_examples": None,
         "target_micro_steps": 300,
         "sync_scheduler_to_max_steps": True,
+        "sync_ckpt_to_max_steps": True,
         "pack_function": "stack",
         "loss_mask": "all",
         "model_attn": "sdpa",
@@ -1112,6 +1120,14 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
         == 296
     )
     assert manifest["extra"]["prime_rl_sft_exposure_plan"]["unapplied_micro_steps"] == 4
+    assert manifest["extra"]["prime_rl_sft_exposure_plan"]["generated_overrides"][
+        :4
+    ] == [
+        "max_steps=37",
+        "scheduler.decay_steps=37",
+        "ckpt.interval=37",
+        "ckpt.keep_interval=37",
+    ]
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_mode"] == "omit"
     assert manifest["extra"]["prime_rl_sft_dataset"]["tool_defs_removed_rows"] == 1
     assert manifest["extra"]["prime_rl_sft_dataset"]["chat_template_kwargs"] == {


### PR DESCRIPTION
## Summary

Follow-up to #862. The Mobile300 compatibility profile now derives `max_steps=37`, but the experiment config used by the H100 launcher still has checkpoint intervals from the previous 38-step run. If left unchanged, a 37-step run can miss the final adapter checkpoint expected by the eval/publish path.

Changes:
- Adds `--sync-ckpt-to-max-steps` to derive `ckpt.interval` and `ckpt.keep_interval` from the computed Prime-RL `max_steps`.
- Enables checkpoint sync automatically for `--compat-profile env0-mobile300-pr828`.
- Records `sync_ckpt_to_max_steps` in `prime_rl_sft_exposure_plan` and compat-profile manifest settings.
- Leaves generic `--target-examples` and `--target-micro-steps` checkpoint cadence unchanged unless the new flag is passed.

For Mobile300, the profile now emits:

```text
max_steps=37
scheduler.decay_steps=37
ckpt.interval=37
ckpt.keep_interval=37
```

## Validation

- `uv run pytest tests/test_train_cli.py -q` -> 27 passed
- `uv run ruff format --check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py tests/test_train_cli.py` -> 3 files already formatted
- `uv run ruff check` -> All checks passed
- `uv run ty check src/benchflow/training/backends/prime_rl.py src/benchflow/cli/train.py` -> All checks passed
