### PR TITLE
fix(litellm): bridge /v1/responses→chat for chat-only OpenAI upstreams

### DIFF
--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -383,6 +383,30 @@ def litellm_proxy_config(
             model_list.append(
                 {"model_name": model_name, "litellm_params": dict(params)}
             )
+
+    # Responses-API bridge entries. A responses-only client (e.g. the codex CLI,
+    # which dropped the chat wire) hits /v1/responses, but a chat-only OpenAI-
+    # compatible backend (deepseek, vllm) has no /responses endpoint — LiteLLM's
+    # native responses path then 404s the model. Register the same model under an
+    # ``openai/chat_completions/<name>`` model_name whose UPSTREAM carries that
+    # prefix; LiteLLM strips it and bridges responses→chat_completions
+    # (use_chat_completions_api), so /v1/responses reaches the chat backend. Only
+    # for openai/-prefixed upstreams (chat-only); native-responses providers are
+    # untouched, and the bridge names are never sent on the /chat route.
+    upstream = str(params.get("model", ""))
+    if upstream.startswith("openai/") and bare_requested:
+        bridge_params = {**params, "model": f"openai/chat_completions/{bare_requested}"}
+        existing = {entry["model_name"] for entry in model_list}
+        # Non-slashed bridge model_names (the codex CLI mis-parses a slashed model
+        # id and then sends no request); the prefix that triggers the bridge lives
+        # on the UPSTREAM (bridge_params["model"]), not the client-facing name.
+        for name in (route.model_alias, bare_requested):
+            bridge_name = f"{name}-responses-bridge"
+            if bridge_name not in existing:
+                existing.add(bridge_name)
+                model_list.append(
+                    {"model_name": bridge_name, "litellm_params": dict(bridge_params)}
+                )
     return {
         "model_list": model_list,
         "general_settings": {"master_key": master_key},

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -206,6 +206,28 @@ class BenchFlowLiteLLMLogger(CustomLogger):
             "duration_ms": max((getattr(end_time, "timestamp", lambda: time.time())() - getattr(start_time, "timestamp", lambda: time.time())()) * 1000, 0),
         }
 
+    async def async_pre_call_hook(
+        self, user_api_key_dict, cache, data, call_type
+    ):
+        # Drop non-"function" tools before they reach a chat-only backend. A
+        # responses-API client (codex) sends tools the Responses wire allows but
+        # chat completions does not, e.g. a {"type": "namespace"} tool. When the
+        # proxy bridges /v1/responses to /chat/completions for a chat-only backend
+        # (deepseek, vllm), that stray tool makes the backend reject the whole
+        # request ("unknown variant namespace, expected function"). The dropped
+        # tools cannot be represented on the chat wire anyway; the function tools
+        # (shell, file IO, ...) survive untouched.
+        tools = data.get("tools") if isinstance(data, dict) else None
+        if isinstance(tools, list):
+            kept = [
+                t
+                for t in tools
+                if not isinstance(t, dict) or t.get("type", "function") == "function"
+            ]
+            if len(kept) != len(tools):
+                data["tools"] = kept
+        return data
+
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         record = self._base_record(kwargs, start_time, end_time)
         response = _jsonable(response_obj)

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -209,6 +209,18 @@ class BenchFlowLiteLLMLogger(CustomLogger):
     async def async_pre_call_hook(
         self, user_api_key_dict, cache, data, call_type
     ):
+        if not isinstance(data, dict):
+            return None
+
+        cleaned = data
+
+        # Chat-completions backends reject the Responses-compatible ``input``
+        # mirror when ``messages`` is already present. Copy before changing so
+        # LiteLLM callers do not observe in-place mutation.
+        if data.get("messages") is not None and data.get("input") is not None:
+            cleaned = dict(cleaned)
+            cleaned.pop("input", None)
+
         # Drop non-"function" tools before they reach a chat-only backend. A
         # responses-API client (codex) sends tools the Responses wire allows but
         # chat completions does not, e.g. a {"type": "namespace"} tool. When the
@@ -217,7 +229,7 @@ class BenchFlowLiteLLMLogger(CustomLogger):
         # request ("unknown variant namespace, expected function"). The dropped
         # tools cannot be represented on the chat wire anyway; the function tools
         # (shell, file IO, ...) survive untouched.
-        tools = data.get("tools") if isinstance(data, dict) else None
+        tools = cleaned.get("tools")
         if isinstance(tools, list):
             kept = [
                 t
@@ -225,8 +237,12 @@ class BenchFlowLiteLLMLogger(CustomLogger):
                 if not isinstance(t, dict) or t.get("type", "function") == "function"
             ]
             if len(kept) != len(tools):
-                data["tools"] = kept
-        return data
+                if cleaned is data:
+                    cleaned = dict(data)
+                cleaned["tools"] = kept
+        if cleaned is data:
+            return None
+        return cleaned
 
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         record = self._base_record(kwargs, start_time, end_time)

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -163,3 +163,38 @@ def test_proxy_config_registers_requested_bare_model_name():
     names = [entry["model_name"] for entry in config["model_list"]]
     assert "gpt-5.4-mini" in names
     assert "openai/gpt-5.4-mini" in names
+
+
+def test_proxy_config_registers_responses_bridge_for_openai_upstream():
+    """A responses-only CLI (codex) hits /v1/responses; a chat-only OpenAI-
+    compatible backend has no /responses endpoint, so the proxy must expose a
+    bridge deployment named ``<model>-responses-bridge`` whose upstream carries
+    the ``openai/chat_completions/`` prefix (LiteLLM strips it and bridges
+    responses→chat). The bridge name is non-slashed (codex mis-parses a slashed
+    model id and then sends no request)."""
+    route = resolve_litellm_route("openai/gpt-5.4-mini", {"OPENAI_API_KEY": "key"})
+    config = litellm_proxy_config(route, master_key="sk-local")
+
+    by_name = {e["model_name"]: e for e in config["model_list"]}
+    bridge_name = "gpt-5.4-mini-responses-bridge"
+    assert bridge_name in by_name
+    assert f"{route.model_alias}-responses-bridge" in by_name
+    # the bridge entry's UPSTREAM carries the chat-completions prefix
+    assert (
+        by_name[bridge_name]["litellm_params"]["model"]
+        == "openai/chat_completions/gpt-5.4-mini"
+    )
+    # never slashed (would break codex's model parsing)
+    assert "/" not in bridge_name
+
+
+def test_proxy_config_no_responses_bridge_for_non_openai_upstream():
+    """The bridge is openai/-upstream only; native-responses/anthropic/bedrock
+    providers are untouched."""
+    route = resolve_litellm_route(
+        "aws-bedrock/us.anthropic.claude-opus-4-8",
+        {"AWS_BEARER_TOKEN_BEDROCK": "token", "AWS_REGION": "us-west-2"},
+    )
+    config = litellm_proxy_config(route, master_key="sk-local")
+    names = [entry["model_name"] for entry in config["model_list"]]
+    assert not any(n.endswith("-responses-bridge") for n in names)

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 from benchflow.providers.litellm_logging import (
@@ -7,6 +8,50 @@ from benchflow.providers.litellm_logging import (
     extract_usage_from_trajectory,
     trajectory_from_litellm_callback_log,
 )
+
+
+def test_pre_call_hook_drops_non_function_tools_for_chat_backend():
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [
+            {"type": "function", "function": {"name": "shell"}},
+            {"type": "namespace", "namespace": {"name": "codex"}},
+        ],
+    }
+
+    cleaned = asyncio.run(logger.async_pre_call_hook(None, None, data, "completion"))
+
+    # The Responses-only {"type": "namespace"} tool is stripped; the function
+    # tool a chat-completions backend accepts survives.
+    assert cleaned is not None
+    assert [t["type"] for t in cleaned["tools"]] == ["function"]
+    # The caller's dict is not mutated in place.
+    assert [t["type"] for t in data["tools"]] == ["function", "namespace"]
+
+
+def test_pre_call_hook_strips_responses_input_mirror_when_messages_present():
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {"messages": [{"role": "user", "content": "hi"}], "input": "hi"}
+
+    cleaned = asyncio.run(logger.async_pre_call_hook(None, None, data, "completion"))
+
+    assert cleaned is not None
+    assert "input" not in cleaned
+    assert "input" in data  # no in-place mutation
+
+
+def test_pre_call_hook_is_noop_for_pure_function_tools():
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "shell"}}],
+    }
+
+    # Nothing to strip -> returns None so LiteLLM keeps the original payload.
+    assert (
+        asyncio.run(logger.async_pre_call_hook(None, None, data, "completion")) is None
+    )
 
 
 def test_callback_module_source_exposes_proxy_handler_instance():


### PR DESCRIPTION
## Problem

A **responses-only** client — notably the **codex CLI** (the OpenAI `chat` wire was removed) — calls `/v1/responses`. But a chat-only OpenAI-compatible backend (deepseek-v4-flash, vllm) has **no `/responses` endpoint**, so LiteLLM's native responses path **404s the model**:

```
POST <gateway>/v1/responses → 404
litellm.NotFoundError: Received Model Group=benchflow-deepseek-deepseek-v4-flash
```

…even though `/v1/chat/completions` serves the same model fine (which is why `omnigent-pi`/ACP agents work but `omnigent-codex` can't reach the model). This is what blocked codex on the gateway (benchflow-ai/agents#38).

## Fix

For openai/-prefixed upstreams, register an additional **responses-bridge deployment** named `<model>-responses-bridge` whose **upstream** carries LiteLLM's `openai/chat_completions/` prefix. LiteLLM strips that prefix and routes the request through its responses→chat_completions bridge (`use_chat_completions_api`), so a `/v1/responses` call reaches the backend's `/chat/completions`.

- **openai/-upstream only** — native-responses / anthropic / bedrock providers are untouched.
- **Non-slashed bridge name** — the codex CLI mis-parses a slashed model id and then sends no request; the prefix that triggers the bridge lives on the upstream, not the client-facing name.
- The bridge name is distinct, so the `/chat/completions` route for the normal model name is unchanged.

## Verification

In-sandbox `curl` to the bridge model returns **HTTP 200** with a real responses object:
```
POST <gateway>/v1/responses {"model":"benchflow-deepseek-deepseek-v4-flash-responses-bridge","input":"say PONG"}
→ 200 {"id":"resp_…","object":…}
```

## Test plan
- [x] `pytest tests/test_litellm_config.py` — 15 passed (2 new: bridge registered for openai upstream; not registered for bedrock/anthropic)
- [x] `ruff check` — clean
- [x] in-sandbox bridge probe → 200

## Note
The omnigent-codex adapter is updated to target the bridge (benchflow-ai/agents#37). The gateway side is now unblocked; a remaining, separate issue is that the codex CLI launched by omnigent's runner doesn't yet engage in-sandbox (opaque — omnigent surfaces no codex logs).