### PR TITLE
Preserve row-wise Prime-RL SFT exposure

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -415,11 +415,12 @@ not written to the manifest; only the names of recognized credential env vars
 that were present are recorded.
 
 For the Mobile300 PR828 reproduction, use `--compat-profile
-env0-mobile300-pr828`. That profile stages the historical custom-trainer token
-suffix, preserves row boundaries with `stack`, and enables `sample_mean` loss
-normalization through a run-local `sitecustomize.py` shim. The shim leaves
-Prime-RL package files untouched but fails closed if the Prime-RL SFT train loop
-source no longer matches the expected token-mean block.
+env0-mobile300-pr828`. That profile stages the historical custom-trainer
+pretokenized shifted-label rows, bypasses Prime-RL `stack`/`cat` packing for
+those staged rows so training sees one original trajectory per micro-batch, and
+enables `sample_mean` loss normalization through a run-local `sitecustomize.py`
+shim. The shim leaves Prime-RL package files untouched but fails closed if the
+Prime-RL SFT train loop or data module no longer exposes the expected hooks.
 
 | Flag | Default | Description |
 |------|---------|-------------|

--- a/src/benchflow/training/backends/prime_rl.py
+++ b/src/benchflow/training/backends/prime_rl.py
@@ -1074,6 +1074,50 @@ class _BenchFlowPretokenizedDataLoader(importlib.machinery.SourceFileLoader):
             return original_process(self, example)
 
         dataset_cls._process = benchflow_process
+        stateful_dataloader_cls = getattr(module, "StatefulDataLoader", None)
+        torch_mod = getattr(module, "torch", None)
+        if (
+            getattr(module, "setup_dataloader", None) is None
+            or stateful_dataloader_cls is None
+        ):
+            raise RuntimeError(
+                "BenchFlow Prime-RL pretokenized data shim could not find "
+                "setup_dataloader or StatefulDataLoader."
+            )
+
+        def benchflow_row_collate(samples):
+            if torch_mod is None:
+                raise RuntimeError(
+                    "BenchFlow row-wise pretokenized collate requires torch in "
+                    "prime_rl.trainer.sft.data."
+                )
+            if len(samples) != 1:
+                raise ValueError(
+                    "BenchFlow row-wise pretokenized dataloader expected one "
+                    f"sample per micro-batch, got {len(samples)}"
+                )
+            sample = samples[0]
+            return {
+                "input_ids": torch_mod.tensor(
+                    [sample["input_ids"]], dtype=torch_mod.long, device="cuda"
+                ),
+                "position_ids": torch_mod.tensor(
+                    [sample["position_ids"]], dtype=torch_mod.long, device="cuda"
+                ),
+                "target_ids": torch_mod.tensor(
+                    [sample["target_ids"]], dtype=torch_mod.long, device="cuda"
+                ),
+                "loss_mask": torch_mod.tensor(
+                    [sample["loss_mask"]], dtype=torch_mod.bool, device="cuda"
+                ),
+            }
+
+        def benchflow_setup_dataloader(dataset, config):
+            return stateful_dataloader_cls(
+                dataset, batch_size=1, collate_fn=benchflow_row_collate
+            )
+
+        module.setup_dataloader = benchflow_setup_dataloader
         sys.stderr.write("BenchFlow Prime-RL pretokenized SFT data shim enabled\\n")
 
 
@@ -1139,6 +1183,7 @@ def _write_prime_rl_sft_compat_shim(
             [
                 "Prime-RL SFTDataset must be source-backed",
                 "pretokenized rows must carry input_ids/target_ids/loss_mask/position_ids",
+                "pretokenized rows bypass Prime-RL stack/cat packing and train one original row per micro-batch",
             ]
         )
     if stub_flash_attn:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -1250,7 +1250,12 @@ def test_train_run_sft_prime_rl_mobile300_compat_profile(
     assert "if not torch.all(valid_sample_mask):" not in sitecustomize_text
     assert "_flash_attn_varlen_forward" in sitecustomize_text
     assert "flash-attn import stub enabled for SDPA" in sitecustomize_text
+    assert "def benchflow_setup_dataloader" in sitecustomize_text
     assert shim["name"] == "prime_rl_sft_compatibility"
+    assert (
+        "pretokenized rows bypass Prime-RL stack/cat packing and train one original "
+        "row per micro-batch"
+    ) in shim["guards"]
     assert manifest["extra"]["prime_rl_sft_compat_profile"]["name"] == (
         "env0-mobile300-pr828"
     )
@@ -1360,6 +1365,101 @@ def test_prime_rl_sft_flash_attn_stub_imports_and_fails_closed(tmp_path: Path) -
     assert "['flash-attn']" in completed.stdout
     assert "model.attn=sdpa" in completed.stdout
     assert "called unexpectedly" in completed.stdout
+
+
+def test_prime_rl_pretokenized_shim_uses_rowwise_dataloader(tmp_path: Path) -> None:
+    """Pretokenized rows bypass Prime-RL packers so exposure matches the old trainer."""
+    import benchflow.training.backends.prime_rl as prime_rl
+
+    fake_sft = tmp_path / "fake" / "prime_rl" / "trainer" / "sft"
+    fake_sft.mkdir(parents=True)
+    for package_dir in [
+        fake_sft.parent.parent,
+        fake_sft.parent,
+        fake_sft,
+    ]:
+        (package_dir / "__init__.py").write_text("", encoding="utf-8")
+    (fake_sft / "data.py").write_text(
+        "\n".join(
+            [
+                "class SFTDataset:",
+                "    def _process(self, example):",
+                "        return {'native': True, 'example': example}",
+                "",
+                "class StatefulDataLoader:",
+                "    def __init__(self, dataset, batch_size, collate_fn):",
+                "        self.dataset = dataset",
+                "        self.batch_size = batch_size",
+                "        self.collate_fn = collate_fn",
+                "",
+                "def setup_dataloader(dataset, config):",
+                "    return ('native', dataset, config)",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    plan = prime_rl._write_prime_rl_sft_compat_shim(
+        tmp_path,
+        sample_mean=False,
+        pretokenized_data=True,
+        stub_flash_attn=False,
+    )
+    env = os.environ.copy()
+    env.update(plan.env)
+    env["PYTHONPATH"] = os.pathsep.join(
+        (plan.env["PYTHONPATH"], str(tmp_path / "fake"))
+    )
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "\n".join(
+                [
+                    "import json",
+                    "import prime_rl.trainer.sft.data as data",
+                    "row = {",
+                    "    'benchflow_custom_trainer_pretokenized': True,",
+                    "    'benchflow_input_ids': [1, 2, 3],",
+                    "    'benchflow_target_ids': [2, 3, 4],",
+                    "    'benchflow_loss_mask': [True, False, True],",
+                    "    'benchflow_position_ids': [0, 1, 2],",
+                    "}",
+                    "processed = data.SFTDataset()._process(row)",
+                    "loader = data.setup_dataloader('dataset', 'config')",
+                    "native = data.SFTDataset()._process({'messages': []})",
+                    "print(json.dumps({",
+                    "    'processed': processed,",
+                    "    'loader_class': type(loader).__name__,",
+                    "    'loader_batch_size': loader.batch_size,",
+                    "    'loader_collate_callable': callable(loader.collate_fn),",
+                    "    'native': native,",
+                    "}, sort_keys=True))",
+                ]
+            ),
+        ],
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "BenchFlow Prime-RL pretokenized SFT data shim enabled" in completed.stderr
+    payload = json.loads(completed.stdout)
+    assert payload == {
+        "loader_batch_size": 1,
+        "loader_class": "StatefulDataLoader",
+        "loader_collate_callable": True,
+        "native": {"example": {"messages": []}, "native": True},
+        "processed": {
+            "input_ids": [1, 2, 3],
+            "loss_mask": [True, False, True],
+            "position_ids": [0, 1, 2],
+            "target_ids": [2, 3, 4],
+        },
+    }
 
 
 def test_prime_rl_custom_trainer_pretokenized_row_masks_last_assistant_only() -> None:


### PR DESCRIPTION
## Summary
- make the BenchFlow Prime-RL pretokenized SFT shim bypass Prime-RL stack/cat packing and yield one original staged row per micro-batch
- keep the existing custom-trainer pretokenized row and sample-mean shims, but close the remaining exposure gap where StackDataset could consume/reweight many rows per micro-batch
- add a regression test proving the import shim replaces Prime-RL setup_dataloader before training imports it
- update CLI docs for the Mobile300 PR828 compatibility profile

## Why
The latest env0 Mobile300 PR828 reproduction staged exact custom-trainer tensors, but W&B still showed progress/num_samples=680 for a 300-microstep-compatible run that should expose about 296 rows. The culprit is that Prime-RL stack packing still repacked the pretokenized rows. This patch keeps Prime-RL package files untouched while forcing row-wise exposure only when BENCHFLOW_PRIME_RL_PRETOKENIZED_SFT_DATA=1.

## Validation
- uv run pytest tests/test_train_cli.py -q
- uv run ruff check src/benchflow/training/backends/prime_rl.py tests/test_train_cli.py
- uv run ruff format --check src/benchflow/training/backends/prime_rl.py tests/test_train_cli.py
- uv run ty check src/benchflow/training/backends/prime_rl.py
- git diff --check

## Spendful validation
Not run yet in this PR. Next step is a Prime-RL trainer canary on the Mobile300 staged dataset to verify W&B progress/num_samples matches row-wise exposure instead of the previous stacked-packing count.