### PR TITLE
Preserve private Prime-SFT tool argument tokens

### DIFF
--- a/src/benchflow/cli/train.py
+++ b/src/benchflow/cli/train.py
@@ -71,6 +71,17 @@ def register_train(app: typer.Typer) -> None:
                 help="Restrict conversion to rows selected by canonical-selection.json",
             ),
         ] = None,
+        redact: Annotated[
+            bool,
+            typer.Option(
+                "--redact/--no-redact",
+                help=(
+                    "Redact secrets while exporting trainer JSONL. Use --no-redact "
+                    "only for private local SFT data when preserving exact tool-call "
+                    "argument tokens is required."
+                ),
+            ),
+        ] = True,
     ) -> None:
         """Convert BenchFlow rollout artifacts into trainer-ready data."""
         _ensure_prime_sft(format_name)
@@ -85,6 +96,7 @@ def register_train(app: typer.Typer) -> None:
                 expected_rows=expected_rows,
                 manifest=manifest,
                 canonical_selection=canonical_selection,
+                redact=redact,
             )
         except ValueError as exc:
             print_error(str(exc))

--- a/src/benchflow/trajectories/export_prime_sft.py
+++ b/src/benchflow/trajectories/export_prime_sft.py
@@ -99,13 +99,15 @@ class PrimeSftTrajectoryJsonlError(ValueError):
     """Raised when an LLM trajectory JSONL file is not parseable."""
 
 
-def _json_line(record: dict[str, Any]) -> str:
+def _json_line(record: dict[str, Any], *, redact: bool = True) -> str:
     # Redact secrets in the record's string values BEFORE serializing so the
     # emitted SFT row is always valid JSON; redacting the serialized text could
     # split a backslash escape next to a secret and corrupt the line.
-    redacted = redact_trajectory_obj(scrub_non_finite(record))
-    redacted = _sanitize_prime_sft_row_tool_call_arguments(redacted)
-    return dumps_finite(redacted, default=str)
+    clean = scrub_non_finite(record)
+    if redact:
+        clean = redact_trajectory_obj(clean)
+    clean = _sanitize_prime_sft_row_tool_call_arguments(clean, redact=redact)
+    return dumps_finite(clean, default=str)
 
 
 def _load_json(path: Path) -> dict[str, Any] | None:
@@ -245,7 +247,7 @@ def _normalize_role(role: Any) -> str:
     return str(role or "user")
 
 
-def _json_tool_call_arguments(arguments: Any) -> str:
+def _json_tool_call_arguments(arguments: Any, *, redact: bool = True) -> str:
     if isinstance(arguments, str):
         try:
             parsed = json.loads(arguments)
@@ -254,16 +256,24 @@ def _json_tool_call_arguments(arguments: Any) -> str:
         else:
             if not isinstance(parsed, dict):
                 parsed = {"_non_object_json_arguments": parsed}
+            else:
+                clean = redact_trajectory_obj(parsed) if redact else parsed
+                if clean == parsed:
+                    return arguments
+                return dumps_finite(clean, sort_keys=False, default=str)
     elif isinstance(arguments, dict):
         parsed = arguments
     elif arguments is None:
         parsed = {}
     else:
         parsed = {"_non_object_arguments": arguments}
-    return dumps_finite(redact_trajectory_obj(parsed), sort_keys=True, default=str)
+    clean = redact_trajectory_obj(parsed) if redact else parsed
+    return dumps_finite(clean, sort_keys=False, default=str)
 
 
-def _normalize_tool_call(call: dict[str, Any], index: int = 0) -> dict[str, Any]:
+def _normalize_tool_call(
+    call: dict[str, Any], index: int = 0, *, redact: bool = True
+) -> dict[str, Any]:
     function = call.get("function")
     if not isinstance(function, dict):
         function = {}
@@ -274,12 +284,14 @@ def _normalize_tool_call(call: dict[str, Any], index: int = 0) -> dict[str, Any]
         "type": "function",
         "function": {
             "name": str(name),
-            "arguments": _json_tool_call_arguments(arguments),
+            "arguments": _json_tool_call_arguments(arguments, redact=redact),
         },
     }
 
 
-def _normalize_message(message: dict[str, Any], index: int) -> dict[str, Any]:
+def _normalize_message(
+    message: dict[str, Any], index: int, *, redact: bool = True
+) -> dict[str, Any]:
     message_type = message.get("type")
     if message_type == "function_call":
         return {
@@ -296,6 +308,7 @@ def _normalize_message(message: dict[str, Any], index: int) -> dict[str, Any]:
                         },
                     },
                     index,
+                    redact=redact,
                 )
             ],
         }
@@ -318,7 +331,7 @@ def _normalize_message(message: dict[str, Any], index: int) -> dict[str, Any]:
         tool_calls = [message["function_call"]]
     if isinstance(tool_calls, list) and tool_calls:
         out["tool_calls"] = [
-            _normalize_tool_call(call, i)
+            _normalize_tool_call(call, i, redact=redact)
             for i, call in enumerate(tool_calls)
             if isinstance(call, dict)
         ]
@@ -361,7 +374,9 @@ def prime_sft_last_user_training_window(
     return None
 
 
-def _messages_from_chat_request(body: dict[str, Any]) -> list[dict[str, Any]]:
+def _messages_from_chat_request(
+    body: dict[str, Any], *, redact: bool = True
+) -> list[dict[str, Any]]:
     messages = body.get("messages")
     if not isinstance(messages, list):
         return []
@@ -372,11 +387,13 @@ def _messages_from_chat_request(body: dict[str, Any]) -> list[dict[str, Any]]:
         message = cast(dict[str, Any], message)
         if message.get("type") == "reasoning":
             continue
-        normalized.append(_normalize_message(message, idx))
+        normalized.append(_normalize_message(message, idx, redact=redact))
     return normalized
 
 
-def _messages_from_responses_request(body: dict[str, Any]) -> list[dict[str, Any]]:
+def _messages_from_responses_request(
+    body: dict[str, Any], *, redact: bool = True
+) -> list[dict[str, Any]]:
     messages: list[dict[str, Any]] = []
     instructions = body.get("instructions")
     if instructions:
@@ -390,7 +407,7 @@ def _messages_from_responses_request(body: dict[str, Any]) -> list[dict[str, Any
                 continue
             item = cast(dict[str, Any], item)
             if item.get("type") != "reasoning":
-                messages.append(_normalize_message(item, idx))
+                messages.append(_normalize_message(item, idx, redact=redact))
     return messages
 
 
@@ -420,7 +437,9 @@ def _tool_defs_from_body(body: dict[str, Any]) -> list[dict[str, Any]]:
     return tools
 
 
-def _assistant_from_anthropic_content(content: Any) -> dict[str, Any] | None:
+def _assistant_from_anthropic_content(
+    content: Any, *, redact: bool = True
+) -> dict[str, Any] | None:
     """Build an assistant row from Anthropic ``/v1/messages`` content blocks.
 
     Anthropic responses carry a list of typed blocks: ``text`` blocks hold the
@@ -450,33 +469,38 @@ def _assistant_from_anthropic_content(content: Any) -> dict[str, Any] | None:
     }
     if raw_tool_calls:
         message["tool_calls"] = [
-            _normalize_tool_call(call, i) for i, call in enumerate(raw_tool_calls)
+            _normalize_tool_call(call, i, redact=redact)
+            for i, call in enumerate(raw_tool_calls)
         ]
     return message
 
 
-def _assistant_from_chat_response(body: dict[str, Any]) -> dict[str, Any] | None:
+def _assistant_from_chat_response(
+    body: dict[str, Any], *, redact: bool = True
+) -> dict[str, Any] | None:
     choices = body.get("choices")
     if isinstance(choices, list) and choices:
         first = choices[0]
         if isinstance(first, dict) and isinstance(first.get("message"), dict):
-            return _normalize_message(first["message"], 0)
+            return _normalize_message(first["message"], 0, redact=redact)
     message = body.get("message")
     if isinstance(message, dict):
-        return _normalize_message(message, 0)
+        return _normalize_message(message, 0, redact=redact)
     content = body.get("content")
     if content:
-        assistant = _assistant_from_anthropic_content(content)
+        assistant = _assistant_from_anthropic_content(content, redact=redact)
         if assistant is not None:
             return assistant
         return {"role": "assistant", "content": _content_to_text(content)}
-    assistant = _assistant_from_responses_response(body)
+    assistant = _assistant_from_responses_response(body, redact=redact)
     if assistant is not None:
         return assistant
     return None
 
 
-def _assistant_from_responses_response(body: dict[str, Any]) -> dict[str, Any] | None:
+def _assistant_from_responses_response(
+    body: dict[str, Any], *, redact: bool = True
+) -> dict[str, Any] | None:
     output = body.get("output")
     if not isinstance(output, list):
         return None
@@ -507,13 +531,16 @@ def _assistant_from_responses_response(body: dict[str, Any]) -> dict[str, Any] |
     }
     if tool_calls:
         message["tool_calls"] = [
-            _normalize_tool_call(call, i) for i, call in enumerate(tool_calls)
+            _normalize_tool_call(call, i, redact=redact)
+            for i, call in enumerate(tool_calls)
         ]
     return message
 
 
 def _exchange_to_messages_and_tools(
     exchange: dict[str, Any],
+    *,
+    redact: bool = True,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]], str | None]:
     request = (
         cast(dict[str, Any], exchange.get("request"))
@@ -537,11 +564,11 @@ def _exchange_to_messages_and_tools(
     )
 
     if "messages" in request_body:
-        messages = _messages_from_chat_request(request_body)
-        assistant = _assistant_from_chat_response(response_body)
+        messages = _messages_from_chat_request(request_body, redact=redact)
+        assistant = _assistant_from_chat_response(response_body, redact=redact)
     else:
-        messages = _messages_from_responses_request(request_body)
-        assistant = _assistant_from_responses_response(response_body)
+        messages = _messages_from_responses_request(request_body, redact=redact)
+        assistant = _assistant_from_responses_response(response_body, redact=redact)
 
     if assistant is None:
         return [], [], "no_assistant"
@@ -602,7 +629,9 @@ def _row_messages(row: dict[str, Any], row_num: int) -> list[Any]:
     )
 
 
-def _sanitize_message_tool_call_arguments(messages: list[Any]) -> list[Any]:
+def _sanitize_message_tool_call_arguments(
+    messages: list[Any], *, redact: bool = True
+) -> list[Any]:
     sanitized: list[Any] = []
     for message in messages:
         if not isinstance(message, dict):
@@ -612,7 +641,9 @@ def _sanitize_message_tool_call_arguments(messages: list[Any]) -> list[Any]:
         tool_calls = out.get("tool_calls")
         if isinstance(tool_calls, list) and tool_calls:
             out["tool_calls"] = [
-                _normalize_tool_call(cast(dict[str, Any], tool_call), idx)
+                _normalize_tool_call(
+                    cast(dict[str, Any], tool_call), idx, redact=redact
+                )
                 for idx, tool_call in enumerate(tool_calls)
                 if isinstance(tool_call, dict)
             ]
@@ -620,17 +651,21 @@ def _sanitize_message_tool_call_arguments(messages: list[Any]) -> list[Any]:
     return sanitized
 
 
-def _sanitize_prime_sft_row_tool_call_arguments(row: dict[str, Any]) -> dict[str, Any]:
+def _sanitize_prime_sft_row_tool_call_arguments(
+    row: dict[str, Any], *, redact: bool = True
+) -> dict[str, Any]:
     out = dict(row)
     messages = out.get("messages")
     if isinstance(messages, list):
-        out["messages"] = _sanitize_message_tool_call_arguments(messages)
+        out["messages"] = _sanitize_message_tool_call_arguments(messages, redact=redact)
     prompt = out.get("prompt")
     if isinstance(prompt, list):
-        out["prompt"] = _sanitize_message_tool_call_arguments(prompt)
+        out["prompt"] = _sanitize_message_tool_call_arguments(prompt, redact=redact)
     completion = out.get("completion")
     if isinstance(completion, list):
-        out["completion"] = _sanitize_message_tool_call_arguments(completion)
+        out["completion"] = _sanitize_message_tool_call_arguments(
+            completion, redact=redact
+        )
     return out
 
 
@@ -725,9 +760,10 @@ def _canonicalize_existing_prime_sft_row(
     row_num: int,
     *,
     sanitize_tool_call_arguments: bool = False,
+    redact: bool = True,
 ) -> tuple[dict[str, Any], dict[str, int]]:
     out = (
-        _sanitize_prime_sft_row_tool_call_arguments(row)
+        _sanitize_prime_sft_row_tool_call_arguments(row, redact=redact)
         if sanitize_tool_call_arguments
         else dict(row)
     )
@@ -894,7 +930,10 @@ def validate_prime_sft_jsonl(
 
 
 def _iter_prime_sft_jsonl_rows(
-    path: Path, *, sanitize_tool_call_arguments: bool = False
+    path: Path,
+    *,
+    sanitize_tool_call_arguments: bool = False,
+    redact: bool = True,
 ) -> Iterator[tuple[int, dict[str, Any], dict[str, int]]]:
     with path.open("r", encoding="utf-8") as handle:
         for row_num, line in enumerate(handle, start=1):
@@ -910,6 +949,7 @@ def _iter_prime_sft_jsonl_rows(
                 row,
                 row_num,
                 sanitize_tool_call_arguments=sanitize_tool_call_arguments,
+                redact=redact,
             )
             yield row_num, row, repair_stats
 
@@ -1020,10 +1060,11 @@ def _existing_prime_sft_jsonl_stats(
     path: Path,
     *,
     min_reward: float | None,
+    redact: bool = True,
 ) -> PrimeSftExportStats:
     stats = PrimeSftExportStats(sources=[str(path)])
     for row_num, row, repair_stats in _iter_prime_sft_jsonl_rows(
-        path, sanitize_tool_call_arguments=True
+        path, sanitize_tool_call_arguments=True, redact=redact
     ):
         stats.tool_call_ids_rewritten += repair_stats["tool_call_ids_rewritten"]
         stats.tool_messages_merged += repair_stats["tool_messages_merged"]
@@ -1048,11 +1089,12 @@ def _copy_existing_prime_sft_jsonl(
     out: Path,
     *,
     min_reward: float | None,
+    redact: bool = True,
 ) -> None:
     out.parent.mkdir(parents=True, exist_ok=True)
     with out.open("w", encoding="utf-8") as handle:
         for row_num, row, _ in _iter_prime_sft_jsonl_rows(
-            source, sanitize_tool_call_arguments=True
+            source, sanitize_tool_call_arguments=True, redact=redact
         ):
             if _benchflow_row_training_skip_reason(row) is not None:
                 continue
@@ -1066,14 +1108,18 @@ def _copy_existing_prime_sft_jsonl(
                 source=source,
             )
             validate_prime_sft_row(compact, row_num)
-            handle.write(_json_line(compact) + "\n")
+            handle.write(_json_line(compact, redact=redact) + "\n")
 
 
 def normalize_prime_sft_exchange(
     exchange: dict[str, Any],
+    *,
+    redact: bool = True,
 ) -> tuple[PrimeSftExchangeData | None, str | None]:
     """Normalize one raw LLM exchange through the Prime-SFT validator path."""
-    messages, tool_defs, skip_reason = _exchange_to_messages_and_tools(exchange)
+    messages, tool_defs, skip_reason = _exchange_to_messages_and_tools(
+        exchange, redact=redact
+    )
     if skip_reason:
         return None, skip_reason
     if _has_tool_calls(messages) and not tool_defs:
@@ -1092,8 +1138,9 @@ def _row_from_exchange(
     result: dict[str, Any] | None,
     reward: float | None,
     exchange_idx: int,
+    redact: bool = True,
 ) -> tuple[dict[str, Any] | None, str | None]:
-    normalized, skip_reason = normalize_prime_sft_exchange(exchange)
+    normalized, skip_reason = normalize_prime_sft_exchange(exchange, redact=redact)
     if skip_reason:
         return None, skip_reason
     if normalized is None:
@@ -1127,6 +1174,7 @@ def convert_benchflow_rollouts_to_prime_sft_rows(
     min_reward: float | None = None,
     row_mode: PrimeSftRowMode = "rollout",
     canonical_selection: str | Path | None = None,
+    redact: bool = True,
 ) -> tuple[list[dict[str, Any]], PrimeSftExportStats]:
     stats = PrimeSftExportStats()
     rows: list[dict[str, Any]] = []
@@ -1174,6 +1222,7 @@ def convert_benchflow_rollouts_to_prime_sft_rows(
                 result=result,
                 reward=reward,
                 exchange_idx=idx,
+                redact=redact,
             )
             if skip_reason == "no_assistant":
                 stats.skipped_no_assistant += 1
@@ -1217,6 +1266,7 @@ def export_prime_sft_jsonl(
     expected_rows: int | None = None,
     manifest: str | Path | None = None,
     canonical_selection: str | Path | None = None,
+    redact: bool = True,
 ) -> PrimeSftExportStats:
     """Export BenchFlow rollouts to a Prime-RL SFT JSONL file.
 
@@ -1232,7 +1282,9 @@ def export_prime_sft_jsonl(
     if source_path.is_file() and source_path.suffix == ".jsonl":
         if source_path.resolve() == out_path.resolve():
             raise ValueError("--out must differ from the source JSONL path")
-        stats = _existing_prime_sft_jsonl_stats(source_path, min_reward=min_reward)
+        stats = _existing_prime_sft_jsonl_stats(
+            source_path, min_reward=min_reward, redact=redact
+        )
         if expected_rows is not None and stats.rows_written != expected_rows:
             raise ValueError(
                 f"row count {stats.rows_written} != expected {expected_rows}"
@@ -1241,6 +1293,7 @@ def export_prime_sft_jsonl(
             source_path,
             out_path,
             min_reward=min_reward,
+            redact=redact,
         )
         if manifest_path is not None:
             manifest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1254,6 +1307,7 @@ def export_prime_sft_jsonl(
         min_reward=min_reward,
         row_mode=row_mode,
         canonical_selection=canonical_selection,
+        redact=redact,
     )
     if expected_rows is not None and len(rows) != expected_rows:
         raise ValueError(f"row count {len(rows)} != expected {expected_rows}")
@@ -1261,7 +1315,7 @@ def export_prime_sft_jsonl(
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w", encoding="utf-8") as handle:
         for row in rows:
-            handle.write(_json_line(row) + "\n")
+            handle.write(_json_line(row, redact=redact) + "\n")
 
     if manifest_path is not None:
         manifest_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -394,7 +394,8 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(
             rf"(?<![A-Za-z0-9_-])({_ESCQ}authorization{_ESCQ}\s*[:=]\s*{_ESCQ})"
-            rf"(?!(?:Bearer|Token|Basic|ApiKey)\b){_SECVAL}",
+            rf"(?!(?:Bearer|Token|Basic|ApiKey)\b|[rRuUbBfF]{{1,3}}[\"'])"
+            rf"{_SECVAL}",
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -204,6 +204,70 @@ def test_train_convert_accepts_results_jsonl_cli(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
 
 
+def test_train_convert_no_redact_preserves_tool_argument_tokens(tmp_path: Path) -> None:
+    """Private SFT conversion should not mutate valid tool-call argument strings."""
+    source = tmp_path / "results.jsonl"
+    raw_arguments = json.dumps(
+        {
+            "command": "headers={'Authorization': f'Bearer {token}'}",
+            "summary": "use runtime token",
+        }
+    )
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "do it"}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": raw_arguments,
+                                },
+                            }
+                        ],
+                    }
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n"
+    )
+    out = tmp_path / "prime-sft.jsonl"
+
+    result = runner.invoke(
+        app,
+        [
+            "train",
+            "convert",
+            str(source),
+            "--out",
+            str(out),
+            "--expected-rows",
+            "1",
+            "--no-redact",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    row = json.loads(out.read_text())
+    assert row["messages"][1]["tool_calls"][0]["function"]["arguments"] == raw_arguments
+
+
 def test_train_convert_sanitizes_malformed_tool_call_arguments(
     tmp_path: Path,
 ) -> None:

--- a/tests/trajectories/test_export_prime_sft.py
+++ b/tests/trajectories/test_export_prime_sft.py
@@ -690,6 +690,148 @@ def test_export_repairs_legacy_results_tool_call_ids(tmp_path: Path) -> None:
     assert manifest_payload["tool_messages_merged"] == 1
 
 
+def test_export_preserves_valid_tool_call_argument_strings_during_repair(
+    tmp_path: Path,
+) -> None:
+    """SFT conversion must not rewrite valid argument text into a new token view."""
+    source = tmp_path / "results.jsonl"
+    out = tmp_path / "prime-sft.jsonl"
+    raw_arguments = (
+        '{"security_risk":"LOW","summary":"List files",'
+        '"command":"find /app -maxdepth 1","timeout":10}'
+    )
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "Inspect the app."}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "fc_legacy_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": raw_arguments,
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_runtime_1",
+                        "content": "ok",
+                    },
+                    {"role": "assistant", "content": "Done."},
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stats = export_prime_sft_jsonl(source, out, expected_rows=1)
+
+    row = json.loads(out.read_text())
+    tool_call = row["messages"][1]["tool_calls"][0]
+    assert stats.tool_call_ids_rewritten == 1
+    assert tool_call["id"] == "call_runtime_1"
+    assert tool_call["function"]["arguments"] == raw_arguments
+    assert validate_prime_sft_jsonl(out, expected_rows=1) == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
+
+
+def test_export_no_redact_preserves_private_tool_call_argument_strings(
+    tmp_path: Path,
+) -> None:
+    """Private SFT conversion can keep executable tool arguments byte-for-byte."""
+    source = tmp_path / "results.jsonl"
+    out = tmp_path / "prime-sft.jsonl"
+    raw_arguments = json.dumps(
+        {
+            "security_risk": "MEDIUM",
+            "summary": "Use auth header",
+            "command": (
+                "python3 - <<'PY'\n"
+                "headers={'Authorization': f'Bearer {token}'}\n"
+                "print('password=password123')\n"
+                "PY"
+            ),
+            "timeout": 10,
+        },
+        separators=(",", ":"),
+    )
+    source.write_text(
+        json.dumps(
+            {
+                "prompt": [{"role": "user", "content": "Inspect the app."}],
+                "completion": [
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "fc_legacy_1",
+                                "type": "function",
+                                "function": {
+                                    "name": "terminal",
+                                    "arguments": raw_arguments,
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_call_id": "call_runtime_1",
+                        "content": "ok",
+                    },
+                    {"role": "assistant", "content": "Done."},
+                ],
+                "tool_defs": [
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "parameters": {"type": "object", "properties": {}},
+                        },
+                    }
+                ],
+                "reward": 1.0,
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    stats = export_prime_sft_jsonl(source, out, expected_rows=1, redact=False)
+
+    row = json.loads(out.read_text())
+    tool_call = row["messages"][1]["tool_calls"][0]
+    assert stats.tool_call_ids_rewritten == 1
+    assert tool_call["id"] == "call_runtime_1"
+    assert tool_call["function"]["arguments"] == raw_arguments
+    assert validate_prime_sft_jsonl(out, expected_rows=1) == {
+        "ok": True,
+        "rows": 1,
+        "rows_with_tool_calls": 1,
+    }
+
+
 def test_validate_rejects_tool_calls_without_tool_defs(tmp_path: Path) -> None:
     """Guards PR #828 review: tool-using rows must carry tool_defs/tools."""
     path = tmp_path / "missing-tools.jsonl"

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -705,6 +705,13 @@ def test_redaction_preserves_json_when_code_mentions_token_label():
     assert "***REDACTED***" not in redacted
 
 
+def test_redaction_does_not_corrupt_python_authorization_fstrings():
+    """A Python f-string prefix after an Authorization key is syntax, not a secret."""
+    raw = "headers={'Authorization': f'Bearer {token}'}"
+
+    assert redact_trajectory_text(raw) == raw
+
+
 @pytest.mark.parametrize(
     "raw",
     [


### PR DESCRIPTION
## Summary

- add an explicit `bench train convert --no-redact` private-training path so Prime-SFT conversion can preserve valid assistant `tool_calls[].function.arguments` strings byte-for-byte
- thread the redaction policy through Prime-SFT normalization/copy/export instead of only the final JSONL writer
- stop the generic redactor from treating Python authorization f-string prefixes like `f'Bearer {token}'` as bare secret values
- keep the default conversion redacted for safe artifact export

## Why

The env-0 Mobile300 Prime-RL SFT reproduction regressed because the converted training view did not match the source trajectory token surface. In the PR828 300-row data, the previous conversion rewrote valid tool-call argument JSON strings. With `--no-redact`, the same source now validates as Prime-SFT while preserving all compared argument strings:

```json
{
  "rows_written": 300,
  "rows_with_tool_calls": 175,
  "tool_messages_merged": 26,
  "validation": {"ok": true, "rows": 300, "rows_with_tool_calls": 175},
  "message_count_diff_rows": 24,
  "total_argument_strings_compared": 2049,
  "changed_argument_strings": 0
}
```

The 24 message-count diffs are the existing duplicate tool-result merges; the supervised assistant tool-call argument strings are preserved.

## Validation

- `uv run pytest tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py tests/trajectories/test_redaction.py -q`
- `uv run ruff check src/benchflow/trajectories/export_prime_sft.py src/benchflow/cli/train.py src/benchflow/trajectories/types.py tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py tests/trajectories/test_redaction.py`
- `uv run ruff format --check src/benchflow/trajectories/export_prime_sft.py src/benchflow/cli/train.py src/benchflow/trajectories/types.py tests/trajectories/test_export_prime_sft.py tests/test_train_cli.py tests/trajectories/test_redaction.py`
- `uv run ty check src/benchflow/trajectories/export_prime_sft.py src/benchflow/cli/train.py src/benchflow/trajectories/types.py`
- real PR828 300-row smoke: `bench train convert ... --expected-rows 300 --no-redact` then `bench train validate ... --expected-rows 300`

## Security note

`--redact` remains the default. `--no-redact` is intended only for private local trainer data where exact trajectory token preservation is required.
