### PR TITLE
fix: litellm-proxy health + ACP shims survive parallel/deepseek runs

### DIFF
--- a/src/benchflow/agents/harvey_lab_acp_shim.py
+++ b/src/benchflow/agents/harvey_lab_acp_shim.py
@@ -379,13 +379,13 @@ def _create_adapter(
     if model_id.startswith("gemini"):
         mod = importlib.import_module("harness.adapters.google")
         return mod.GoogleAdapter(**kwargs)
-    # Default to the OpenAI adapter for gpt/o-series AND every other model id.
-    # Under BenchFlow every provider is served through the OpenAI-compatible
-    # LiteLLM proxy (the adapter reads OPENAI_BASE_URL/OPENAI_API_KEY), so any
-    # non-anthropic/gemini id — deepseek-v4-flash, qwen, the ``benchflow-*``
-    # proxy alias, ... — speaks the OpenAI chat API. Previously this raised, so a
-    # deepseek (or any non-gpt) model ended the turn with zero LLM calls
-    # (suspected_api_error).
+    # Default to the OpenAI adapter for gpt/o-series AND every id not special-cased
+    # above. BenchFlow serves those remaining providers over the proxy's
+    # OpenAI-compatible chat surface (the adapter reads OPENAI_BASE_URL/
+    # OPENAI_API_KEY), so any non-anthropic/gemini id — deepseek-v4-flash, qwen, the
+    # ``benchflow-*`` proxy alias, ... — speaks the OpenAI chat API here. Previously
+    # this raised, so a deepseek (or any non-gpt) model ended the turn with zero LLM
+    # calls (suspected_api_error).
     mod = importlib.import_module("harness.adapters.openai")
     return mod.OpenAIAdapter(**kwargs)
 

--- a/src/benchflow/agents/harvey_lab_acp_shim.py
+++ b/src/benchflow/agents/harvey_lab_acp_shim.py
@@ -376,17 +376,18 @@ def _create_adapter(
     if model_id.startswith("claude"):
         mod = importlib.import_module("harness.adapters.anthropic")
         return mod.AnthropicAdapter(**kwargs)
-    elif model_id.startswith(("gpt", "o1", "o3", "o4")):
-        mod = importlib.import_module("harness.adapters.openai")
-        return mod.OpenAIAdapter(**kwargs)
-    elif model_id.startswith("gemini"):
+    if model_id.startswith("gemini"):
         mod = importlib.import_module("harness.adapters.google")
         return mod.GoogleAdapter(**kwargs)
-    else:
-        raise ValueError(
-            f"Can't determine provider for model: {model}. "
-            "Model name should start with claude, gpt, o1/o3/o4, or gemini."
-        )
+    # Default to the OpenAI adapter for gpt/o-series AND every other model id.
+    # Under BenchFlow every provider is served through the OpenAI-compatible
+    # LiteLLM proxy (the adapter reads OPENAI_BASE_URL/OPENAI_API_KEY), so any
+    # non-anthropic/gemini id — deepseek-v4-flash, qwen, the ``benchflow-*``
+    # proxy alias, ... — speaks the OpenAI chat API. Previously this raised, so a
+    # deepseek (or any non-gpt) model ended the turn with zero LLM calls
+    # (suspected_api_error).
+    mod = importlib.import_module("harness.adapters.openai")
+    return mod.OpenAIAdapter(**kwargs)
 
 
 def _run_harvey_lab_agent(

--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -671,46 +671,58 @@ def main():
 
         elif method == "session/set_model":
             model = params.get("modelId", "")
-            if model:
-                # The SDK strips provider prefixes before set_model and passes
-                # the original provider name via BENCHFLOW_PROVIDER_NAME env var.
-                #
-                # Openclaw natively supports google-vertex/ and anthropic/ prefixes
-                # (via the google plugin enabled at startup). Custom providers like
-                # zai/ and other custom providers need explicit registration via openclaw.json.
-                provider_name = os.environ.get("BENCHFLOW_PROVIDER_NAME", "")
+            # A provider-resolution / config-write failure here must NOT crash the
+            # shim: an unhandled exception exits rc=1, which benchflow sees as the
+            # ACP transport dying mid-set_model ("Process closed stdout (rc=1)") —
+            # the observed openclaw-on-docker failure. Catch, log the real cause,
+            # and still ACK so the run proceeds with the model config that exists.
+            try:
+                if model:
+                    # The SDK strips provider prefixes before set_model and passes
+                    # the original provider name via BENCHFLOW_PROVIDER_NAME env var.
+                    #
+                    # Openclaw natively supports google-vertex/ and anthropic/ prefixes
+                    # (via the google plugin enabled at startup). Custom providers like
+                    # zai/ and other custom providers need explicit registration via openclaw.json.
+                    provider_name = os.environ.get("BENCHFLOW_PROVIDER_NAME", "")
 
-                # Native Vertex providers — openclaw handles these via google plugin
-                if provider_name in ("google-vertex", "anthropic-vertex"):
-                    # Reconstruct the full model name openclaw expects
-                    if "/" not in model:
-                        model = f"{provider_name}/{model}"
-                # Custom providers — register in openclaw.json
-                elif provider_name:
-                    _provider_name = _find_and_setup_provider(model)
-                    if _provider_name and "/" not in model:
-                        model = f"{_provider_name}/{model}"
-                # No provider env var — resolve the bare id: registry-specific
-                # setup, then the generic BENCHFLOW_PROVIDER_* env fallback,
-                # then prefix heuristics (see _resolve_bare_model_prefix).
-                elif "/" not in model:
-                    model = f"{_resolve_bare_model_prefix(model)}/{model}"
+                    # Native Vertex providers — openclaw handles these via google plugin
+                    if provider_name in ("google-vertex", "anthropic-vertex"):
+                        # Reconstruct the full model name openclaw expects
+                        if "/" not in model:
+                            model = f"{provider_name}/{model}"
+                    # Custom providers — register in openclaw.json
+                    elif provider_name:
+                        _provider_name = _find_and_setup_provider(model)
+                        if _provider_name and "/" not in model:
+                            model = f"{_provider_name}/{model}"
+                    # No provider env var — resolve the bare id: registry-specific
+                    # setup, then the generic BENCHFLOW_PROVIDER_* env fallback,
+                    # then prefix heuristics (see _resolve_bare_model_prefix).
+                    elif "/" not in model:
+                        model = f"{_resolve_bare_model_prefix(model)}/{model}"
 
-                subprocess.run(
-                    [_OPENCLAW_BIN, "config", "set", "agents.defaults.model", model],
-                    capture_output=True,
-                    timeout=10,
-                )
-
-            # Apply model generation parameters from env vars
-            for env_key, config_path in _PARAM_MAP.items():
-                val = os.environ.get(env_key)
-                if val:
                     subprocess.run(
-                        [_OPENCLAW_BIN, "config", "set", config_path, val],
+                        [_OPENCLAW_BIN, "config", "set", "agents.defaults.model", model],
                         capture_output=True,
                         timeout=10,
                     )
+
+                # Apply model generation parameters from env vars
+                for env_key, config_path in _PARAM_MAP.items():
+                    val = os.environ.get(env_key)
+                    if val:
+                        subprocess.run(
+                            [_OPENCLAW_BIN, "config", "set", config_path, val],
+                            capture_output=True,
+                            timeout=10,
+                        )
+            except Exception as exc:
+                print(
+                    f"[openclaw-acp-shim] set_model setup failed, continuing: {exc!r}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
             send({"jsonrpc": "2.0", "id": req_id, "result": {}})
 

--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -674,8 +674,9 @@ def main():
             # A provider-resolution / config-write failure here must NOT crash the
             # shim: an unhandled exception exits rc=1, which benchflow sees as the
             # ACP transport dying mid-set_model ("Process closed stdout (rc=1)") —
-            # the observed openclaw-on-docker failure. Catch, log the real cause,
-            # and still ACK so the run proceeds with the model config that exists.
+            # the observed openclaw-on-docker failure. Catch, surface the real cause
+            # on the trajectory (agent_thought) and stderr, and still ACK so the run
+            # proceeds with the model config that exists.
             try:
                 if model:
                     # The SDK strips provider prefixes before set_model and passes
@@ -711,6 +712,7 @@ def main():
                             model,
                         ],
                         capture_output=True,
+                        check=True,
                         timeout=10,
                     )
 
@@ -721,13 +723,29 @@ def main():
                         subprocess.run(
                             [_OPENCLAW_BIN, "config", "set", config_path, val],
                             capture_output=True,
+                            check=True,
                             timeout=10,
                         )
             except Exception as exc:
-                print(
-                    f"[openclaw-acp-shim] set_model setup failed, continuing: {exc!r}",
-                    file=sys.stderr,
-                    flush=True,
+                diag = (
+                    f"[openclaw-acp-shim] set_model setup failed, continuing: {exc!r}"
+                )
+                print(diag, file=sys.stderr, flush=True)
+                # Surface the real cause on the trajectory too: without this, a
+                # set_model config failure is indistinguishable downstream from a
+                # genuine provider outage (both read as an opaque suspected_api_error).
+                send(
+                    {
+                        "jsonrpc": "2.0",
+                        "method": "session/update",
+                        "params": {
+                            "sessionId": session_id,
+                            "update": {
+                                "sessionUpdate": "agent_thought",
+                                "text": diag[:_DIAG_TRUNCATE],
+                            },
+                        },
+                    }
                 )
 
             send({"jsonrpc": "2.0", "id": req_id, "result": {}})

--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -703,7 +703,13 @@ def main():
                         model = f"{_resolve_bare_model_prefix(model)}/{model}"
 
                     subprocess.run(
-                        [_OPENCLAW_BIN, "config", "set", "agents.defaults.model", model],
+                        [
+                            _OPENCLAW_BIN,
+                            "config",
+                            "set",
+                            "agents.defaults.model",
+                            model,
+                        ],
                         capture_output=True,
                         timeout=10,
                     )

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -639,7 +639,7 @@ AGENTS: dict[str, AgentConfig] = {
         skill_paths=["$HOME/.mimocode/skills"],
         home_dirs=[".mimocode", ".config/mimocode"],
         install_cmd=(
-            _js_agent_install("mimo", "@mimo-ai/cli@0.1.0")
+            _js_agent_install("mimo", "@mimo-ai/cli@0.1.4")
             + " && "
             + _opencode_family_proxy_wrapper_install(
                 "mimo", ".config/mimocode/mimocode.json"

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -452,7 +452,7 @@ async def _poll_host_health(
     process: HostLiteLLMProcess, deadline_s: float = _HEALTH_DEADLINE_SEC
 ) -> None:
     last_error = ""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     start = loop.time()
     while loop.time() - start < deadline_s:
         if process.process.poll() is not None:

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -420,9 +420,26 @@ def _write_runtime_files(
     return config_path, callback_path, patch_path
 
 
-async def _poll_host_health(process: HostLiteLLMProcess) -> None:
+# How long to wait for a per-run LiteLLM proxy to become healthy. litellm's cold
+# start is ~35s, and when many runs launch in parallel (max-parallel sweeps) the
+# proxies cold-start simultaneously and contend for CPU, pushing well past a
+# fixed ~30s budget — the old ``range(120)`` x 0.25s. That surfaced as "LiteLLM
+# did not become healthy: All connection attempts failed" for otherwise-fine
+# agents on Docker under load. Use a generous, time-based, env-tunable deadline
+# so a slow-but-fine proxy is not killed; a genuine crash still fails fast via
+# the process-exit check below.
+_HEALTH_DEADLINE_SEC = float(
+    os.environ.get("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "180")
+)
+
+
+async def _poll_host_health(
+    process: HostLiteLLMProcess, deadline_s: float = _HEALTH_DEADLINE_SEC
+) -> None:
     last_error = ""
-    for _ in range(120):
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    while loop.time() - start < deadline_s:
         if process.process.poll() is not None:
             raise RuntimeError(
                 "LiteLLM exited before becoming healthy.\n" + process.log_tail()
@@ -437,7 +454,8 @@ async def _poll_host_health(process: HostLiteLLMProcess) -> None:
             last_error = str(exc)
         await asyncio.sleep(0.25)
     raise RuntimeError(
-        f"LiteLLM did not become healthy: {last_error}\n{process.log_tail()}"
+        f"LiteLLM did not become healthy after {deadline_s:.0f}s: "
+        f"{last_error}\n{process.log_tail()}"
     )
 
 

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -420,17 +420,32 @@ def _write_runtime_files(
     return config_path, callback_path, patch_path
 
 
-# How long to wait for a per-run LiteLLM proxy to become healthy. litellm's cold
-# start is ~35s, and when many runs launch in parallel (max-parallel sweeps) the
-# proxies cold-start simultaneously and contend for CPU, pushing well past a
-# fixed ~30s budget — the old ``range(120)`` x 0.25s. That surfaced as "LiteLLM
-# did not become healthy: All connection attempts failed" for otherwise-fine
-# agents on Docker under load. Use a generous, time-based, env-tunable deadline
-# so a slow-but-fine proxy is not killed; a genuine crash still fails fast via
-# the process-exit check below.
-_HEALTH_DEADLINE_SEC = float(
-    os.environ.get("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "180")
-)
+# How long to wait for the *host* per-run LiteLLM proxy to become healthy.
+# litellm's cold start runs tens of seconds, and when many runs launch in parallel
+# (max-parallel sweeps) the proxies cold-start simultaneously and contend for CPU,
+# pushing well past a fixed ~30s budget — the old ``range(120)`` x 0.25s. That
+# surfaced as "LiteLLM did not become healthy: All connection attempts failed" for
+# otherwise-fine agents on Docker under load. Use a generous, time-based, env-tunable
+# deadline so a slow-but-fine proxy is not killed; a genuine crash still fails fast
+# via the process-exit check below.
+#
+# Scope: this deadline covers only ``_poll_host_health``. The in-sandbox proxy
+# pollers (``_wait_for_sandbox_state`` / ``_poll_sandbox_health``) keep their own
+# ``range(120)`` loop, where each iteration is bounded by a ``sandbox.exec`` round
+# trip rather than a fixed 0.25s sleep — so they already wait far longer than 30s
+# and are deliberately not governed by this budget.
+def _health_deadline_sec() -> float:
+    # Parse defensively: a malformed BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC must not
+    # crash ``import benchflow``. Floor at one poll cycle so a 0/negative value still
+    # checks process liveness and attempts health once instead of raising immediately.
+    try:
+        deadline = float(os.environ.get("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "180"))
+    except (TypeError, ValueError):
+        deadline = 180.0
+    return max(deadline, 1.0)
+
+
+_HEALTH_DEADLINE_SEC = _health_deadline_sec()
 
 
 async def _poll_host_health(

--- a/src/benchflow/sandbox/_compose.py
+++ b/src/benchflow/sandbox/_compose.py
@@ -12,8 +12,11 @@ COMPOSE_NO_NETWORK_PATH = COMPOSE_DIR / "docker-compose-no-network.yaml"
 
 # Back-off delays for retrying a `compose up` that hit a daemon-side network
 # create/attach race. Shared by the host docker.py path and the Daytona DinD
-# path so a fresh-daemon race is retried identically on both.
-COMPOSE_UP_RETRY_DELAYS_SEC = (2.0, 5.0)
+# path so a fresh-daemon race is retried identically on both. Extended past the
+# original (2.0, 5.0): under max-parallel sweeps many `compose up` calls race on
+# the daemon's network create/attach at once, and two short retries were not
+# enough (observed "network <project>_default not found" surviving both).
+COMPOSE_UP_RETRY_DELAYS_SEC = (2.0, 5.0, 10.0, 20.0)
 # Daemon-side create/attach race seen on Docker 29.x: `compose up` prints
 # "Network ... Created" but the container create/start that follows fails with
 # "network <project>_default not found". Older daemons emit the same race

--- a/tests/test_bare_model_provider.py
+++ b/tests/test_bare_model_provider.py
@@ -289,3 +289,54 @@ class TestResolveBareModelPrefix:
         """Without generic envs, builtin/unknown ids resolve exactly as before."""
         assert _resolve_bare_model_prefix(model) == expected
         assert setup_spy == []
+
+
+def test_set_model_failure_acks_and_emits_thought_without_crashing(monkeypatch):
+    # Contract for PR #871's openclaw set_model swallow: a provider-resolution /
+    # config-write failure must NOT crash the shim (rc=1). It must still ACK the
+    # request AND surface the real cause on the trajectory (agent_thought) so the
+    # failure is not indistinguishable downstream from a genuine provider outage.
+    import benchflow.agents.openclaw_acp_shim as shim
+
+    monkeypatch.setattr(shim, "setup_openai_auth", lambda: None)
+    monkeypatch.setattr(shim, "setup_gcloud_adc", lambda: None)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("config set exploded")
+
+    monkeypatch.setattr(shim.subprocess, "run", _boom)
+
+    inbox = iter(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "session/set_model",
+                "params": {"modelId": "deepseek/deepseek-v4-flash"},
+            }
+        ]
+    )
+
+    def _fake_recv():
+        try:
+            return next(inbox)
+        except StopIteration:
+            raise EOFError from None
+
+    sent: list = []
+    monkeypatch.setattr(shim, "recv", _fake_recv)
+    monkeypatch.setattr(shim, "send", sent.append)
+
+    shim.main()  # must return normally — no rc=1 crash
+
+    acks = [m for m in sent if m.get("id") == 7 and "result" in m]
+    assert acks == [{"jsonrpc": "2.0", "id": 7, "result": {}}]
+    assert not any(m.get("id") == 7 and "error" in m for m in sent)
+
+    thoughts = [
+        m
+        for m in sent
+        if m.get("method") == "session/update"
+        and m["params"]["update"].get("sessionUpdate") == "agent_thought"
+    ]
+    assert any("config set exploded" in t["params"]["update"]["text"] for t in thoughts)

--- a/tests/test_harvey_lab_shim.py
+++ b/tests/test_harvey_lab_shim.py
@@ -44,3 +44,50 @@ def test_direct_sandbox_rewrites_harvey_absolute_paths(tmp_path: Path):
     assert str(documents / "source.docx") in command
     assert f"ls {output}" in command
     assert str(workspace / "answer.md") in command
+
+
+def test_create_adapter_defaults_unknown_models_to_openai(monkeypatch):
+    # PR #871: _create_adapter must default any non-claude/non-gemini id (deepseek,
+    # qwen, the benchflow-* proxy alias, ...) to the OpenAI-compatible adapter
+    # instead of raising — a raise ended the turn with zero LLM calls
+    # (suspected_api_error, reward 0). claude/gemini still route to their adapters.
+    import sys
+    import types
+
+    import benchflow.agents.harvey_lab_acp_shim as shim
+
+    def _fake_mod(mod_name, cls_name):
+        module = types.ModuleType(mod_name)
+
+        class _Adapter:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+
+        _Adapter.__name__ = cls_name
+        setattr(module, cls_name, _Adapter)
+        return module, _Adapter
+
+    openai_mod, OpenAIAdapter = _fake_mod("harness.adapters.openai", "OpenAIAdapter")
+    anthropic_mod, AnthropicAdapter = _fake_mod(
+        "harness.adapters.anthropic", "AnthropicAdapter"
+    )
+    google_mod, GoogleAdapter = _fake_mod("harness.adapters.google", "GoogleAdapter")
+
+    for name, module in [
+        ("harness", types.ModuleType("harness")),
+        ("harness.adapters", types.ModuleType("harness.adapters")),
+        ("harness.adapters.openai", openai_mod),
+        ("harness.adapters.anthropic", anthropic_mod),
+        ("harness.adapters.google", google_mod),
+    ]:
+        monkeypatch.setitem(sys.modules, name, module)
+
+    assert isinstance(shim._create_adapter("deepseek-v4-flash"), OpenAIAdapter)
+    assert isinstance(shim._create_adapter("qwen-3-max"), OpenAIAdapter)
+    assert isinstance(
+        shim._create_adapter("benchflow-openai-gpt-5.4-mini"), OpenAIAdapter
+    )
+    assert isinstance(shim._create_adapter("claude-opus-4-5"), AnthropicAdapter)
+    assert isinstance(shim._create_adapter("gemini-3-flash"), GoogleAdapter)
+    # a provider-qualified id is stripped to the bare model before dispatch
+    assert isinstance(shim._create_adapter("deepseek/deepseek-v4-flash"), OpenAIAdapter)

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -884,3 +884,66 @@ async def test_callback_records_unpriced_cost_as_null(tmp_path, monkeypatch):
     assert usage["n_input_tokens"] == 1000
     assert usage["cost_usd"] is None
     assert usage["price_source"] is None
+
+
+def test_poll_host_health_fails_fast_when_process_exited():
+    # PR #871's extended deadline leans on the process-exit check: a crashed proxy
+    # must fail fast, not wait out the full budget.
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    from benchflow.providers.litellm_runtime import _poll_host_health
+
+    process = MagicMock()
+    process.process.poll.return_value = 1  # already exited
+    process.log_tail.return_value = "(tail)"
+
+    with pytest.raises(RuntimeError, match="exited before becoming healthy"):
+        asyncio.run(_poll_host_health(process, deadline_s=30.0))
+    process.process.poll.assert_called()  # checked liveness, did not wait out 30s
+
+
+def test_poll_host_health_bails_at_deadline_when_never_healthy(monkeypatch):
+    import asyncio
+    from unittest.mock import MagicMock
+
+    import pytest
+
+    import benchflow.providers.litellm_runtime as rt
+
+    class _FailingClient:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url):
+            raise ConnectionError("refused")
+
+    monkeypatch.setattr(rt.httpx, "AsyncClient", _FailingClient)
+    process = MagicMock()
+    process.process.poll.return_value = None  # alive but never healthy
+    process.endpoint.local_base_url = "http://127.0.0.1:9/"
+    process.log_tail.return_value = "(tail)"
+
+    with pytest.raises(RuntimeError, match="did not become healthy"):
+        asyncio.run(rt._poll_host_health(process, deadline_s=0.3))
+
+
+def test_health_deadline_env_parse_is_defensive(monkeypatch):
+    # A malformed BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC must not crash import; a
+    # 0/negative value is floored so the poll still runs at least once.
+    import benchflow.providers.litellm_runtime as rt
+
+    monkeypatch.setenv("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "not-a-number")
+    assert rt._health_deadline_sec() == 180.0
+    monkeypatch.setenv("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "0")
+    assert rt._health_deadline_sec() >= 1.0
+    monkeypatch.setenv("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "240")
+    assert rt._health_deadline_sec() == 240.0

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -443,8 +443,9 @@ class TestDockerComposeUpNetworkRaceRetry:
 
     @pytest.mark.asyncio
     async def test_compose_up_retry_is_bounded(self, monkeypatch):
-        """A persistent race signature re-raises after the configured backoffs."""
+        """Guards PR #871's compose-up retries from outliving configured backoffs."""
         from benchflow.sandbox import docker as docker_module
+        from benchflow.sandbox._compose import COMPOSE_UP_RETRY_DELAYS_SEC
         from benchflow.sandbox.docker import DockerSandbox
 
         sandbox = DockerSandbox.__new__(DockerSandbox)
@@ -471,8 +472,10 @@ class TestDockerComposeUpNetworkRaceRetry:
         with pytest.raises(RuntimeError, match="not found"):
             await sandbox._run_docker_compose_up()
 
-        assert calls == [["up", "--detach", "--wait"]] * 3
-        assert sleeps == [2.0, 5.0]
+        assert calls == [["up", "--detach", "--wait"]] * (
+            len(COMPOSE_UP_RETRY_DELAYS_SEC) + 1
+        )
+        assert sleeps == list(COMPOSE_UP_RETRY_DELAYS_SEC)
 
     def test_network_race_signature_matching(self):
         """The race matcher stays anchored to the daemon network-not-found error."""

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -443,7 +443,7 @@ class TestDockerComposeUpNetworkRaceRetry:
 
     @pytest.mark.asyncio
     async def test_compose_up_retry_is_bounded(self, monkeypatch):
-        """Guards PR #871's compose-up retries from outliving configured backoffs."""
+        """A persistent network-race signature re-raises after exactly the configured backoffs (bounded, not infinite)."""
         from benchflow.sandbox import docker as docker_module
         from benchflow.sandbox._compose import COMPOSE_UP_RETRY_DELAYS_SEC
         from benchflow.sandbox.docker import DockerSandbox
@@ -476,6 +476,12 @@ class TestDockerComposeUpNetworkRaceRetry:
             len(COMPOSE_UP_RETRY_DELAYS_SEC) + 1
         )
         assert sleeps == list(COMPOSE_UP_RETRY_DELAYS_SEC)
+        # Concrete anti-revert guard: the assertions above derive from the constant
+        # and would move with it, so a silent truncation back to the old two short
+        # delays (2.0, 5.0) — the regression this bound exists to prevent — must
+        # trip here independently.
+        assert COMPOSE_UP_RETRY_DELAYS_SEC[-1] >= 10.0
+        assert len(COMPOSE_UP_RETRY_DELAYS_SEC) >= 4
 
     def test_network_race_signature_matching(self):
         """The race matcher stays anchored to the daemon network-not-found error."""


### PR DESCRIPTION
Surgical fixes so every litellm-proxy (openai-completions) agent produces a healthy citation-check run on **both** docker and daytona under max-parallel sweeps. Found while verifying the 3 agent paths on `deepseek/deepseek-v4-flash`.

## Common fixes (help whole classes of agents)
- **`litellm_runtime._poll_host_health`**: the per-run proxy health check only allowed **~30s** (`range(120)` × 0.25s). litellm cold-start is ~35s, and when many runs launch at once the proxies contend and start slower — so otherwise-fine agents (opencode, pi-acp, openhands) failed on Docker with `LiteLLM did not become healthy: All connection attempts failed`. Now a **time-based deadline, default 180s** (`BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC`); a real crash still fails fast via the process-exit check.
- **`_compose`**: extend the compose-up network-race retry `(2,5)→(2,5,10,20)s` (mimo hit `network <project>_default not found` under parallel `compose up`).

## ACP-shim robustness
- **`openclaw_acp_shim`**: wrap `session/set_model` provider-resolution + config writes in try/except. An exception there exited the shim `rc=1`, which benchflow saw as the ACP transport dying mid-set_model (`Process closed stdout (rc=1)`) — the openclaw-on-docker failure. Catch, log, still ACK.
- **`harvey_lab_acp_shim`**: default unrecognized models to the OpenAI adapter (benchflow proxies everything as OpenAI-compatible) instead of raising `Can't determine provider`.

## Per-agent forced
- **`registry` (mimo)**: `@mimo-ai/cli` `0.1.0 → 0.1.4` — 0.1.0/0.1.1 were **unpublished** from npm (`npm error notarget`).

## Verified
All 10 chat/openai-completions-compatible agents — `omnigent-pi/claude/openai-agents`, `ai-sdk`, `deepagents`, `mimo`, `opencode`, `pi-acp`, `openclaw`, `openhands` — now produce a healthy run (ACP + raw-LLM trajectory present) on **both** sandboxes with `deepseek/deepseek-v4-flash`, reviewed with `benchflow-experiment-review`. (`harvey-lab-harness` remains Responses-wire-limited — its harness `OpenAIAdapter` uses `client.responses.create`, which the gateway doesn't serve for deepseek; same category as codex.)