### PR TITLE
fix(litellm-proxy): label Responses-API turns /v1/responses in llm_trajectory

### DIFF
--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -114,6 +114,23 @@ def _usage_from_response(response: Any) -> Any:
     return None
 
 
+# litellm ``CallTypes`` for the OpenAI Responses API. The proxy serves it under
+# ``/v1/responses`` (routed natively by litellm 1.89), so a Responses call is
+# captured by this callback just like chat/completions + messages — it must only
+# be LABELLED with the right wire path (else a codex/Responses turn is recorded
+# as ``/v1/chat/completions``, misleading trajectory review + replay).
+_RESPONSES_CALL_TYPES = frozenset({"responses", "aresponses", "_aresponses_websocket"})
+
+
+def _request_path_for_call_type(call_type):
+    # Map a litellm call_type to the OpenAI-compatible wire path we proxied.
+    if call_type == "anthropic_messages":
+        return "/v1/messages"
+    if call_type in _RESPONSES_CALL_TYPES:
+        return "/v1/responses"
+    return "/v1/chat/completions"
+
+
 class BenchFlowLiteLLMLogger(CustomLogger):
     def _write(self, payload: dict[str, Any]) -> None:
         path = os.environ.get("BENCHFLOW_LITELLM_LOG_PATH")
@@ -156,7 +173,7 @@ class BenchFlowLiteLLMLogger(CustomLogger):
             },
             "request": {
                 "method": "POST",
-                "path": "/v1/messages" if kwargs.get("call_type") == "anthropic_messages" else "/v1/chat/completions",
+                "path": _request_path_for_call_type(kwargs.get("call_type")),
                 "body": request_body,
             },
             "start_time": _iso(start_time),

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -195,3 +195,49 @@ def test_responses_api_record_becomes_exchange_with_usage():
     )
     assert usage["usage_source"] == "provider_response"
     assert usage["total_tokens"] == 16
+
+
+def test_responses_call_types_stay_in_sync_with_litellm():
+    # Solid-for-all-model-paths guard: the callback's hardcoded responses call_type
+    # set must equal litellm's actual Responses-API family. If litellm adds/renames
+    # a responses call_type, this fails loudly — otherwise that wire would silently
+    # regress to /v1/chat/completions in every codex/Responses trajectory.
+    from litellm.types.utils import CallTypes
+
+    namespace: dict = {}
+    exec(callback_module_source(), namespace)
+    hardcoded = set(namespace["_RESPONSES_CALL_TYPES"])
+    litellm_responses = {c.value for c in CallTypes if "response" in c.value.lower()}
+    assert hardcoded == litellm_responses, (
+        f"responses call_type drift: litellm={litellm_responses} callback={hardcoded}"
+    )
+
+
+def test_callback_labels_every_agent_wire_correctly():
+    # Solid-for-all-agents spec: each agent family's litellm call_type maps to its
+    # true wire path. Verified empirically against real trajectories — chat agents
+    # (pi-acp/openhands/opencode/mimo/ai-sdk/omnigent-pi/omnigent-openai-agents) ->
+    # chat; claude (claude-agent-acp/omnigent-claude) -> messages; codex on a
+    # Responses-capable provider -> responses. A strict refinement of the original
+    # mapping: only the responses family moved out of the chat default.
+    namespace: dict = {}
+    exec(callback_module_source(), namespace)
+    path_for = namespace["_request_path_for_call_type"]
+
+    for ct in ("completion", "acompletion"):
+        assert path_for(ct) == "/v1/chat/completions", ct
+    assert path_for("anthropic_messages") == "/v1/messages"
+    for ct in ("responses", "aresponses", "_aresponses_websocket"):
+        assert path_for(ct) == "/v1/responses", ct
+
+    # Non-generation / unknown call_types must fall back to the historical default
+    # (chat), never crash or misroute — no regression for any current agent.
+    for ct in ("embedding", "atext_completion", "moderation", None, "future_unknown"):
+        assert path_for(ct) == "/v1/chat/completions", ct
+
+    # Deferred gap (out of scope for the Responses PR): Google GenerateContent
+    # (gemini / omnigent-antigravity) still falls back to the chat default — the
+    # proxy does not serve that wire yet. Documented so the gemini follow-up
+    # updates this deliberately.
+    assert path_for("generate_content") == "/v1/chat/completions"
+    assert path_for("agenerate_content") == "/v1/chat/completions"

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -119,3 +119,79 @@ def test_litellm_failure_records_become_error_exchanges():
     assert trajectory.exchanges[0].response.body["error"]["message"] == "bad key"
     usage = extract_usage_from_trajectory(trajectory, fallback_model="openai/gpt-4")
     assert usage["usage_source"] == "unavailable"
+
+
+def test_callback_source_labels_responses_call_type_as_v1_responses():
+    # A Responses-API call (call_type responses/aresponses) must be recorded with
+    # the /v1/responses wire path and keep its `input`, so codex/Responses turns
+    # land in llm_trajectory.jsonl labelled correctly (not as /v1/chat/completions).
+    from datetime import datetime
+
+    namespace: dict = {}
+    exec(callback_module_source(), namespace)  # exercise the generated proxy module
+
+    path_for = namespace["_request_path_for_call_type"]
+    assert path_for("responses") == "/v1/responses"
+    assert path_for("aresponses") == "/v1/responses"
+    assert path_for("_aresponses_websocket") == "/v1/responses"
+    assert path_for("anthropic_messages") == "/v1/messages"
+    assert path_for("acompletion") == "/v1/chat/completions"
+    assert path_for(None) == "/v1/chat/completions"
+
+    logger = namespace["BenchFlowLiteLLMLogger"]()
+    record = logger._base_record(
+        {
+            "call_type": "aresponses",
+            "model": "benchflow-openai-gpt-5.4-mini",
+            "input": [{"role": "user", "content": "hi"}],
+        },
+        datetime(2026, 6, 4, 10, 0, 0),
+        datetime(2026, 6, 4, 10, 0, 1),
+    )
+    assert record["request"]["path"] == "/v1/responses"
+    assert record["input_shape"]["has_input"] is True
+    assert record["request"]["body"]["input"]
+
+
+def test_responses_api_record_becomes_exchange_with_usage():
+    # A /v1/responses success record (OpenAI Responses shape: `input` + a usage
+    # block with input_tokens/output_tokens) parses into a trajectory exchange
+    # with recoverable provider token usage — same as chat/completions + messages.
+    record = {
+        "event": "success",
+        "request_model": "benchflow-openai-gpt-5.4-mini",
+        "provider_model": "openai/gpt-5.4-mini",
+        "call_type": "aresponses",
+        "request": {
+            "method": "POST",
+            "path": "/v1/responses",
+            "body": {"model": "benchflow-openai-gpt-5.4-mini", "input": "hi"},
+        },
+        "response": {
+            "model": "gpt-5.4-mini",
+            "output": [
+                {
+                    "type": "message",
+                    "content": [{"type": "output_text", "text": "pong"}],
+                }
+            ],
+            "usage": {"input_tokens": 12, "output_tokens": 4, "total_tokens": 16},
+        },
+        "usage": {"input_tokens": 12, "output_tokens": 4, "total_tokens": 16},
+        "response_cost": 0.0001,
+        "start_time": "2026-06-04T10:00:00",
+        "end_time": "2026-06-04T10:00:01",
+        "duration_ms": 1000,
+    }
+    trajectory = trajectory_from_litellm_callback_log(
+        json.dumps(record), session_id="session", agent_name="codex-acp"
+    )
+    assert len(trajectory.exchanges) == 1
+    assert trajectory.total_input_tokens == 12
+    assert trajectory.total_output_tokens == 4
+
+    usage = extract_usage_from_trajectory(
+        trajectory, fallback_model="openai/gpt-5.4-mini"
+    )
+    assert usage["usage_source"] == "provider_response"
+    assert usage["total_tokens"] == 16


### PR DESCRIPTION
## Problem

The LiteLLM usage proxy captures a raw LLM trajectory for every model call, but
`BenchFlowLiteLLMLogger._base_record` hardcoded the trajectory `request.path`:

```python
"path": "/v1/messages" if call_type == "anthropic_messages" else "/v1/chat/completions"
```

`codex-acp` is `api_protocol="openai-responses"` / `acp_model_format="bare"`, so it
sends **`/v1/responses`** straight to the proxy via `OPENAI_BASE_URL` (it is *not*
forced through the OpenCode chat-completions workaround — that path is OpenCode-family
only). litellm 1.89 already routes `/v1/responses` natively and the callback already
fires for it, so those turns were captured — but **mislabeled `/v1/chat/completions`**.
That corrupts trajectory replay/review: a Responses turn (`call_type=aresponses`) is a
different wire than chat/completions, so anything keying on `request.path` to
reconstruct the call replays it wrong.

## Fix

Map the litellm Responses call-types to the right wire path (passthrough only — no
responses↔chat translation):

```python
_RESPONSES_CALL_TYPES = frozenset({"responses", "aresponses", "_aresponses_websocket"})

def _request_path_for_call_type(call_type):
    if call_type == "anthropic_messages":  return "/v1/messages"
    if call_type in _RESPONSES_CALL_TYPES: return "/v1/responses"
    return "/v1/chat/completions"
```

Net effect: codex (and any Responses-wire harness) trajectory turns now land in
`trajectory/llm_trajectory.jsonl` labeled `/v1/responses`, the same way
chat/completions + messages already do.

## Verification (real loops, not just code reading)

- **Unit** — 2 new tests in `test_litellm_logging.py`: the generated callback labels
  responses/aresponses `/v1/responses`, and a Responses-shaped record parses into a
  usage-bearing exchange. `74` litellm tests pass; `ruff check` + `ruff format` clean.
- **Routing** — real BenchFlow proxy (deepseek route) + `POST /v1/responses`: proxy
  routes it, callback fires `event=failure call_type=aresponses path=/v1/responses`
  (deepseek is chat-only → 404 on the model, as expected).
- **Success capture** — real proxy + a mock OpenAI Responses upstream + the real
  callback + the real `trajectory.to_jsonl` (== `Rollout._write_llm_trajectory`):
  `POST /v1/responses` → 200 → `event=success call_type=aresponses path=/v1/responses`
  `usage_source=provider_response` → **non-empty `trajectory/llm_trajectory.jsonl`
  (1461 bytes, `exchange[0].request.path=/v1/responses`)**.

## Test plan

- [x] `test_litellm_logging.py` (74 pass), ruff check + format
- [x] proxy routes `/v1/responses` + callback captures it (live)
- [x] success payload → non-empty `llm_trajectory.jsonl` (live, mock upstream)
- [x] **Real codex smoke — PASSED** (Azure OpenAI `gpt-5.4-mini`, Responses wire, docker, with-skill): `bench eval run --source-repo benchflow-ai/skillsbench --source-path tasks --include citation-check --agent codex-acp --model openai/gpt-5.4-mini --sandbox docker --skill-mode with-skill` → **Score 1/1 (reward 1.0), 5 tool calls; `llm_trajectory.jsonl` = 5 records / 847 KB, all labeled `/v1/responses`, full usage captured.**

## Scope / follow-ups

- Passthrough only; **Gemini GenerateContent** (`/v1beta/...:generateContent`,
  gemini / omnigent-antigravity) is a separate untouched gap — needs its own passthrough.
- Enables codex trajectory capture on **openai/azure** (they serve `/v1/responses`);
  codex-on-**deepseek** stays legitimately blocked (chat-only, no `/responses`).
- `main` carries the same latent bug in a drifted form (this branch targets
  `feat/acp-decouple-all`) — worth a forward-port when the decouple line lands.
