### PR TITLE
feat(agents): autoload agent plugin packages via benchflow.agents entry points

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -1213,3 +1213,41 @@ from benchflow.agents.manifest import (  # noqa: E402
 )
 
 _register_env_manifest_agents()
+
+
+# --- Agent plugin packages (entry-point autoload) ------------------------------
+# Out-of-core agent packages (benchflow-ai/agents: omnigent, mimo-acp,
+# mini-swe-acp, ...) register their agents as an import side effect. Without
+# discovery, `bench eval run --agent omnigent-pi` only works if something in the
+# process happened to `import omnigent` first — in practice a hand-planted
+# sitecustomize/.pth hack. Standard plugin pattern instead: any installed
+# distribution may declare
+#
+#     [project.entry-points."benchflow.agents"]
+#     omnigent = "omnigent"
+#
+# and its module is imported here (after the core + manifest registries are
+# built, so `register_agent` overwrite-by-name semantics apply). `pip install
+# benchflow <agent-pkg>` is then sufficient for `--agent <name>` to resolve.
+# Guarded per-plugin: a broken plugin logs a warning, never breaks the CLI.
+def _load_agent_plugin_packages() -> None:
+    import logging
+    from importlib.metadata import entry_points
+
+    try:
+        eps = entry_points(group="benchflow.agents")
+    except Exception:  # pragma: no cover - metadata backend quirks
+        return
+    for ep in eps:
+        try:
+            ep.load()
+        except Exception as exc:
+            logging.getLogger(__name__).warning(
+                "benchflow.agents plugin %r failed to load (agents from it will "
+                "be unavailable): %s",
+                ep.name,
+                exc,
+            )
+
+
+_load_agent_plugin_packages()

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -1072,11 +1072,25 @@ def resolve_agent(spec: str) -> AgentConfig:
     if name not in AGENTS:
         from difflib import get_close_matches
 
+        # Breadcrumb: if agent plugin packages failed to load at import time
+        # (see FAILED_AGENT_PLUGINS / _load_agent_plugin_packages), the missing
+        # name is very likely one of theirs — connect the two events here, at
+        # the point the user actually sees a failure.
+        plugin_hint = ""
+        if FAILED_AGENT_PLUGINS:
+            failed = ", ".join(sorted(FAILED_AGENT_PLUGINS))
+            plugin_hint = (
+                f" Note: agent plugin(s) failed to load at startup: {failed} "
+                "(see the startup warning for details)."
+            )
         close = get_close_matches(name, list(AGENTS.keys()), n=1, cutoff=0.6)
         if close:
-            raise KeyError(f"Unknown agent: {name!r}. Did you mean: {close[0]!r}?")
+            raise KeyError(
+                f"Unknown agent: {name!r}. Did you mean: {close[0]!r}?{plugin_hint}"
+            )
         raise KeyError(
-            f"Unknown agent: {name!r}. Available: {', '.join(sorted(AGENTS.keys()))}"
+            f"Unknown agent: {name!r}. Available: "
+            f"{', '.join(sorted(AGENTS.keys()))}{plugin_hint}"
         )
 
     config = AGENTS[name]
@@ -1104,6 +1118,20 @@ def resolve_agent_key(spec: str) -> str:
     try:
         config = resolve_agent(spec)
     except KeyError:
+        # The raw-command fallback bypasses resolve_agent's error entirely (the
+        # spec is later exec'd verbatim in the sandbox), so surface the failed-
+        # plugin breadcrumb HERE too — otherwise a plugin load failure manifests
+        # only as a deep, minutes-later "command not found" in the rollout.
+        if FAILED_AGENT_PLUGINS:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                "Agent spec %r is not a registered agent and will be treated as "
+                "a raw command; note that agent plugin(s) failed to load at "
+                "startup: %s",
+                spec,
+                ", ".join(sorted(FAILED_AGENT_PLUGINS)),
+            )
         return spec
     if config.name not in AGENTS:
         AGENTS[config.name] = config
@@ -1216,31 +1244,52 @@ _register_env_manifest_agents()
 
 
 # --- Agent plugin packages (entry-point autoload) ------------------------------
-# Out-of-core agent packages (benchflow-ai/agents: omnigent, mimo-acp, the
-# ai-sdk family, acp-registry, ...) register their agents either as an import
-# side effect or via a zero-arg ``register()``. Without discovery,
-# `bench eval run --agent omnigent-pi` only works if something in the process
-# happened to import/call them first — in practice a hand-planted
-# sitecustomize/.pth hack. Standard plugin pattern instead: any installed
-# distribution may declare
+# Out-of-core agent packages (e.g. the benchflow-ai/agents packages) register
+# their agents either as an import side effect or via a zero-arg ``register()``.
+# Without discovery, `bench eval run --agent omnigent-pi` only works if
+# something in the process happened to import/call them first — in practice a
+# hand-planted sitecustomize/.pth hack. Standard plugin pattern instead: any
+# installed distribution may declare
 #
 #     [project.entry-points."benchflow.agents"]
-#     omnigent = "omnigent"                          # module: import registers
-#     ai-sdk-acp = "ai_sdk_acp.register:register"    # callable: it is invoked
+#     my-agents = "my_agents"                          # module: import registers
+#     # ...or:  my-agents = "my_agents.register:register"  (callable: invoked)
 #
 # and it is loaded here (after the core + manifest registries are built, so
-# `register_agent` overwrite-by-name semantics apply). A module-style value
-# registers by import; a callable-style value is additionally invoked with no
-# arguments. `uv pip install benchflow <agent-pkg>` (or `uv add`) is then
-# sufficient for `--agent <name>` to resolve. Guarded per-plugin: a broken
-# plugin logs a warning, never breaks the CLI.
+# `register_agent` overwrite-by-name semantics apply — though a plugin may still
+# choose not to overwrite, e.g. acp-registry skips names built-ins already own).
+# A module-style value registers by import; a callable-style value is
+# additionally invoked with no arguments. Installing the plugin distribution
+# alongside benchflow (PyPI, git-subdirectory URL, or path) is then sufficient
+# for `--agent <registered-name>` to resolve — note the DIST name, entry-point
+# name, and registered AGENT name may all differ (installing dist `mimo-acp`
+# registers agent `mimo`).
+#
+# Failure handling: each plugin is guarded (a broken plugin logs a warning with
+# traceback and is skipped — siblings still load, the CLI never crashes), and a
+# failed metadata scan disables discovery with a warning. Failures are recorded
+# in FAILED_AGENT_PLUGINS so the eventual "Unknown agent" / raw-command-fallback
+# paths can point back at the real cause.
+
+# entry-point name -> "ExcType: message" for plugins that failed to load; the
+# sentinel key "<entry-point-scan>" means discovery itself failed.
+FAILED_AGENT_PLUGINS: dict[str, str] = {}
+
+
 def _load_agent_plugin_packages() -> None:
     import logging
     from importlib.metadata import entry_points
 
     try:
         eps = entry_points(group="benchflow.agents")
-    except Exception:  # pragma: no cover - metadata backend quirks
+    except Exception as exc:  # pragma: no cover - metadata backend quirks
+        FAILED_AGENT_PLUGINS["<entry-point-scan>"] = f"{type(exc).__name__}: {exc}"
+        logging.getLogger(__name__).warning(
+            "benchflow.agents entry-point scan failed; ALL agent plugins are "
+            "disabled: %s",
+            exc,
+            exc_info=True,
+        )
         return
     for ep in eps:
         try:
@@ -1248,11 +1297,13 @@ def _load_agent_plugin_packages() -> None:
             if callable(loaded):
                 loaded()
         except Exception as exc:
+            FAILED_AGENT_PLUGINS[ep.name] = f"{type(exc).__name__}: {exc}"
             logging.getLogger(__name__).warning(
-                "benchflow.agents plugin %r failed to load (agents from it will "
-                "be unavailable): %s",
+                "benchflow.agents plugin %r failed to load (some or all of its "
+                "agents may be unavailable or partially registered): %s",
                 ep.name,
                 exc,
+                exc_info=True,
             )
 
 

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -1216,20 +1216,24 @@ _register_env_manifest_agents()
 
 
 # --- Agent plugin packages (entry-point autoload) ------------------------------
-# Out-of-core agent packages (benchflow-ai/agents: omnigent, mimo-acp,
-# mini-swe-acp, ...) register their agents as an import side effect. Without
-# discovery, `bench eval run --agent omnigent-pi` only works if something in the
-# process happened to `import omnigent` first — in practice a hand-planted
+# Out-of-core agent packages (benchflow-ai/agents: omnigent, mimo-acp, the
+# ai-sdk family, acp-registry, ...) register their agents either as an import
+# side effect or via a zero-arg ``register()``. Without discovery,
+# `bench eval run --agent omnigent-pi` only works if something in the process
+# happened to import/call them first — in practice a hand-planted
 # sitecustomize/.pth hack. Standard plugin pattern instead: any installed
 # distribution may declare
 #
 #     [project.entry-points."benchflow.agents"]
-#     omnigent = "omnigent"
+#     omnigent = "omnigent"                          # module: import registers
+#     ai-sdk-acp = "ai_sdk_acp.register:register"    # callable: it is invoked
 #
-# and its module is imported here (after the core + manifest registries are
-# built, so `register_agent` overwrite-by-name semantics apply). `pip install
-# benchflow <agent-pkg>` is then sufficient for `--agent <name>` to resolve.
-# Guarded per-plugin: a broken plugin logs a warning, never breaks the CLI.
+# and it is loaded here (after the core + manifest registries are built, so
+# `register_agent` overwrite-by-name semantics apply). A module-style value
+# registers by import; a callable-style value is additionally invoked with no
+# arguments. `uv pip install benchflow <agent-pkg>` (or `uv add`) is then
+# sufficient for `--agent <name>` to resolve. Guarded per-plugin: a broken
+# plugin logs a warning, never breaks the CLI.
 def _load_agent_plugin_packages() -> None:
     import logging
     from importlib.metadata import entry_points
@@ -1240,7 +1244,9 @@ def _load_agent_plugin_packages() -> None:
         return
     for ep in eps:
         try:
-            ep.load()
+            loaded = ep.load()
+            if callable(loaded):
+                loaded()
         except Exception as exc:
             logging.getLogger(__name__).warning(
                 "benchflow.agents plugin %r failed to load (agents from it will "

--- a/tests/agents/test_plugin_entry_points.py
+++ b/tests/agents/test_plugin_entry_points.py
@@ -1,0 +1,98 @@
+"""Contract tests for the ``benchflow.agents`` entry-point autoloader.
+
+The loader (``registry._load_agent_plugin_packages``) runs at import time on
+every ``import benchflow``, so its failure modes are silent by nature — these
+lock the three behaviors that matter:
+
+* a callable-form entry point (``module:register``) is INVOKED, not just
+  loaded (the subtle branch: 7 of the 10 benchflow-ai/agents plugins are
+  callable-form, and a plain ``ep.load()`` would silently drop them all);
+* a module-form entry point registers via import side effect (exercised
+  through a real ``importlib.metadata.EntryPoint``);
+* a raising plugin is isolated — warning logged, recorded in
+  ``FAILED_AGENT_PLUGINS``, siblings still load, import never breaks — and the
+  eventual "Unknown agent" error carries the breadcrumb.
+
+The loader resolves ``entry_points`` from ``importlib.metadata`` at call time,
+so an ``importlib.metadata.entry_points`` monkeypatch reaches the real code
+path without any subprocess machinery.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from benchflow.agents import registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_failed_plugins(monkeypatch):
+    """Isolate FAILED_AGENT_PLUGINS per test (module-global breadcrumb dict)."""
+    monkeypatch.setattr(registry, "FAILED_AGENT_PLUGINS", {})
+
+
+def test_callable_entry_point_is_invoked(monkeypatch):
+    called = []
+    fake_ep = SimpleNamespace(name="p", load=lambda: lambda: called.append(1))
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda group: [fake_ep])
+    registry._load_agent_plugin_packages()
+    assert called == [1]
+
+
+def test_module_entry_point_registers_by_import(monkeypatch, tmp_path):
+    """Module-form value goes through a REAL EntryPoint.load() (an import), and
+    the module's import-side-effect registration lands in AGENTS. Also locks
+    that a non-callable load result is left alone (a module is not invoked)."""
+    from importlib.metadata import EntryPoint
+
+    (tmp_path / "bf_fake_plugin.py").write_text(
+        "from benchflow.agents.registry import register_agent\n"
+        "register_agent('probe-plugin', 'true', 'true')\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    ep = EntryPoint(name="fp", value="bf_fake_plugin", group="benchflow.agents")
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda group: [ep])
+    try:
+        registry._load_agent_plugin_packages()
+        assert "probe-plugin" in registry.AGENTS
+        assert not registry.FAILED_AGENT_PLUGINS
+    finally:
+        registry.AGENTS.pop("probe-plugin", None)
+        registry.AGENT_INSTALLERS.pop("probe-plugin", None)
+        registry.AGENT_LAUNCH.pop("probe-plugin", None)
+        sys.modules.pop("bf_fake_plugin", None)
+
+
+def test_broken_plugin_warns_records_and_does_not_block_others(monkeypatch, caplog):
+    def boom():
+        raise RuntimeError("kaput")
+
+    hits: dict[str, bool] = {}
+    eps = [
+        SimpleNamespace(name="bad", load=boom),
+        SimpleNamespace(
+            name="good", load=lambda: lambda: hits.setdefault("good", True)
+        ),
+    ]
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda group: eps)
+    with caplog.at_level(logging.WARNING, logger="benchflow.agents.registry"):
+        registry._load_agent_plugin_packages()
+
+    # broken plugin: warned + recorded; sibling still loaded; no exception.
+    assert "bad" in caplog.text
+    assert registry.FAILED_AGENT_PLUGINS.get("bad") == "RuntimeError: kaput"
+    assert hits.get("good")
+
+
+def test_unknown_agent_error_carries_failed_plugin_breadcrumb(monkeypatch):
+    monkeypatch.setattr(
+        registry, "FAILED_AGENT_PLUGINS", {"omnigent": "RuntimeError: kaput"}
+    )
+    with pytest.raises(KeyError) as exc:
+        registry.resolve_agent("agent-that-definitely-does-not-exist")
+    assert "failed to load" in str(exc.value)
+    assert "omnigent" in str(exc.value)


### PR DESCRIPTION
## Problem

Out-of-core agent packages (benchflow-ai/agents) register their agents either as an **import side effect** (`omnigent`, `mimo-acp`, `mini-swe-acp`) or via a **zero-arg `register()`** (the ai-sdk family, `acp-registry`) — but nothing imports/calls them. So `bench eval run --agent omnigent-pi` only resolves if the operator hand-plants a `sitecustomize`/`.pth` hack (found in the wild: `zzz_omnigent_autoload.pth` containing `import omnigent`). Without it the name falls through to the raw-command fallback and dies with `rc=127` ("omnigent-pi: command not found"). That's not a product UX.

## Fix (surgical, one mechanism for all 3 paths)

Standard plugin discovery. After the core + `BENCHFLOW_AGENTS_DIR` manifest registries are built, `registry.py` loads every installed distribution declaring a `benchflow.agents` entry point:

```toml
[project.entry-points."benchflow.agents"]
omnigent = "omnigent"                          # module form: import registers
ai-sdk-acp = "ai_sdk_acp.register:register"    # callable form: it is invoked
```

Now the product flow is just:

```bash
uv pip install benchflow omnigent-benchflow    # or: uv add benchflow omnigent-benchflow
bench eval run --agent omnigent-pi --model deepseek/deepseek-v4-flash --sandbox daytona ...
```

- Per-plugin guarded: a broken plugin logs a warning and is skipped — never breaks the CLI.
- Zero entry points installed ⇒ byte-for-byte unchanged registry (loader is a no-op).
- `register_agent` overwrite-by-name semantics unchanged.

Companion PR: benchflow-ai/agents#43 declares the group across **all 3 paths**: `omnigent` (omnigent), `mimo-acp`/`mini-swe-acp`/`acp-registry` (ACP), and `ai-sdk/{acp,harness-pi,harness-codex,harness-claude-code,harness-deepagents,harness-opencode}` (ai-sdk).

## Verified

benchflow **main** + agents main in a fresh venv, **no hacks, `BENCHFLOW_AGENTS_DIR` unset**:

```
[omnigent ] omnigent-pi  -> OK (omnigent.agent:build_omnigent_pi)   (22 omnigent agents)
[ai-sdk   ] ai-sdk       -> OK
[ACP      ] mimo         -> OK
```

plus a real citation-check run on daytona end-to-end.