### PR TITLE
feat(agents): namespace shorthand + manifest auto-load (#876)

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -1110,6 +1110,21 @@ def resolve_agent(spec: str) -> AgentConfig:
         if shorthand is not None:
             return _acpx_wrap(shorthand) if protocol == "acpx" else shorthand
 
+        # Miss-driven manifest auto-load (#876 Phase 2a): fetch DECLARATIVE
+        # manifest agents from the pinned agents source (data only — their
+        # install/launch strings run in the sandbox, same trust as task
+        # sources) and retry. One-shot per process; local names always win.
+        from benchflow.agents import remote_manifests
+
+        if remote_manifests.autoload_remote_manifest_agents():
+            name = AGENT_ALIASES.get(name, name)
+            if name in AGENTS:
+                config = AGENTS[name]
+                return _acpx_wrap(config) if protocol == "acpx" else config
+            shorthand = _resolve_namespace_shorthand(name)
+            if shorthand is not None:
+                return _acpx_wrap(shorthand) if protocol == "acpx" else shorthand
+
         from difflib import get_close_matches
 
         # Breadcrumb: if agent plugin packages failed to load at import time
@@ -1123,6 +1138,8 @@ def resolve_agent(spec: str) -> AgentConfig:
                 f" Note: agent plugin(s) failed to load at startup: {failed} "
                 "(see the startup warning for details)."
             )
+        if remote_manifests.last_source_description:
+            plugin_hint += f" ({remote_manifests.last_source_description} consulted)"
         close = get_close_matches(name, list(AGENTS.keys()), n=1, cutoff=0.6)
         if close:
             raise KeyError(

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -1050,10 +1050,46 @@ def _acpx_wrap(config: AgentConfig) -> AgentConfig:
     )
 
 
+# Namespace shorthand — harbor-style "<ns>:<id>" agent specs (design: #876).
+# The namespace names the adaptation path; resolution is a deterministic
+# name-candidate mapping onto the existing flat names (the naming law: the
+# native/ACP path owns bare names, every other path prefixes "<path>-"). No new
+# config fields, no ambiguity machinery — exact registered names and aliases
+# always win (checked before this), so "acpx:" runtime keys are unaffected.
+# Phase 2 (#876) keys the registry-backed agent auto-fetch on these same
+# namespaces (mirroring harbor's `--agent acp:<id>[@version]`).
+def _resolve_namespace_shorthand(name: str) -> AgentConfig | None:
+    """Resolve "<ns>:<id>" (e.g. "omnigent:pi", "acp:mimo", "ai-sdk:codex").
+
+    Candidates per namespace: ``acp:<id>`` tries the bare id then ``<id>-acp``
+    (so ``acp:mimo`` → ``mimo``, ``acp:pi`` → ``pi-acp``, ``acp:claude`` →
+    alias ``claude`` → ``claude-agent-acp``); ``ai-sdk:<id>`` /
+    ``omnigent:<id>`` try the ``<ns>-<id>`` prefix form. Every candidate goes
+    through AGENT_ALIASES, so alias-only names resolve too. Returns ``None``
+    when nothing matches (callers fall through to the unknown-agent error).
+    """
+    ns, sep, ident = name.partition(":")
+    if not sep or not ident:
+        return None
+    if ns == "acp":
+        candidates = [ident, f"{ident}-acp"]
+    elif ns in ("ai-sdk", "omnigent"):
+        candidates = [f"{ns}-{ident}"]
+    else:
+        return None
+    for candidate in candidates:
+        candidate = AGENT_ALIASES.get(candidate, candidate)
+        if candidate in AGENTS:
+            return AGENTS[candidate]
+    return None
+
+
 def resolve_agent(spec: str) -> AgentConfig:
     """Resolve an agent spec to an AgentConfig.
 
-    Supports: bare name, alias, protocol/name, acpx/name.
+    Supports: bare name, alias, protocol/name, acpx/name, and the namespace
+    shorthand "<ns>:<id>" for ns in {acp, ai-sdk, omnigent} — e.g.
+    "omnigent:pi" → omnigent-pi, "acp:pi" → pi-acp (see #876).
     Raises KeyError with suggestions for unknown agents.
     """
     protocol, name = parse_agent_spec(spec)
@@ -1070,6 +1106,10 @@ def resolve_agent(spec: str) -> AgentConfig:
         return AGENTS[name]
 
     if name not in AGENTS:
+        shorthand = _resolve_namespace_shorthand(name)
+        if shorthand is not None:
+            return _acpx_wrap(shorthand) if protocol == "acpx" else shorthand
+
         from difflib import get_close_matches
 
         # Breadcrumb: if agent plugin packages failed to load at import time

--- a/src/benchflow/agents/remote_manifests.py
+++ b/src/benchflow/agents/remote_manifests.py
@@ -1,0 +1,171 @@
+"""Miss-driven auto-load of DECLARATIVE agent manifests from a remote source.
+
+Design: #876 (Phase 2a). When ``--agent <name>`` does not resolve locally,
+benchflow fetches the pinned agents source (default: the first-party
+``benchflow-ai/agents`` repo, cloned+cached through the same
+``benchmark_repos`` machinery task sources use) and registers every
+``manifest.toml`` agent found there that does not collide with anything already
+registered — then resolution is retried.
+
+Why this is safe to do automatically, unlike installing agent packages: a
+manifest is **pure data**. Its ``install_cmd``/``launch_cmd`` strings execute
+inside the task sandbox — exactly the trust level of a task fetched with
+``--source-repo`` (and of harbor's ``acp:<id>`` registry auto-fetch, which also
+fetches data and executes it sandboxed). No remote code ever runs in the host
+process. Host-side *python* agent adapters (e.g. omnigent's session-factory)
+are deliberately NOT auto-loaded — those remain explicit installs.
+
+Semantics:
+
+* **Gap-fill only** — an agent name or alias that already exists locally
+  always wins; the remote manifest for it is skipped (never overwritten).
+* **One-shot per process** — the first resolution miss triggers at most one
+  fetch; later misses fail fast as before.
+* **Guarded** — a broken manifest (or an unreachable source) logs a warning
+  and never breaks agent resolution.
+* **Opt-out / re-point** — ``BENCHFLOW_AGENTS_SOURCE=off`` disables;
+  ``BENCHFLOW_AGENTS_SOURCE=owner/repo[@ref]`` re-pins; a local directory path
+  is also accepted (dev/tests).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from benchflow.agents.manifest import (
+    LoadedManifest,
+    discover_manifests,
+    load_agent_manifest,
+    register_manifest_agents,
+)
+
+logger = logging.getLogger(__name__)
+
+AGENTS_SOURCE_ENV = "BENCHFLOW_AGENTS_SOURCE"
+DEFAULT_AGENTS_SOURCE = "benchflow-ai/agents@main"
+_OFF_VALUES = frozenset({"off", "0", "none", "disabled", "false"})
+
+# One-shot latch: the first resolution miss triggers at most one fetch per
+# process. A human-readable description of what was consulted is kept for the
+# unknown-agent error path.
+_attempted = False
+last_source_description: str = ""
+
+
+def _source_root(spec: str) -> Path:
+    """Resolve the source spec to a local directory of manifests.
+
+    A local directory path is used verbatim (dev/tests); otherwise the spec is
+    ``owner/repo[@ref]`` and is cloned+cached via the task-source machinery
+    (data-only shallow clone, same cache as ``--source-repo``).
+    """
+    local = Path(spec).expanduser()
+    if local.is_dir():
+        return local
+    repo, _, ref = spec.partition("@")
+    from benchflow._utils.benchmark_repos import resolve_source
+
+    return resolve_source(repo, ref=ref or None)
+
+
+def _gap_fill(
+    manifests: list[LoadedManifest],
+    *,
+    agents: dict,
+    aliases: dict,
+) -> dict[str, LoadedManifest]:
+    """Keep only manifests (and aliases) that collide with nothing local.
+
+    Local always wins: an existing agent name, an existing alias, or a name
+    shadowed by an alias disqualifies the remote manifest; colliding aliases on
+    an otherwise-fresh manifest are stripped rather than fatal.
+    """
+    kept: dict[str, LoadedManifest] = {}
+    for lm in manifests:
+        name = lm.config.name
+        if name in agents or name in aliases or name in kept:
+            continue
+        fresh_aliases = tuple(
+            a
+            for a in lm.aliases
+            if a != name and a not in agents and a not in aliases and a not in kept
+        )
+        kept[name] = LoadedManifest(config=lm.config, aliases=fresh_aliases)
+    return kept
+
+
+def autoload_remote_manifest_agents() -> int:
+    """Fetch + register remote manifest agents once; return how many were added.
+
+    Called from ``resolve_agent``'s miss path. Never raises: any failure logs a
+    warning and returns 0 so the normal unknown-agent error still surfaces.
+    """
+    global _attempted, last_source_description
+    if _attempted:
+        return 0
+    _attempted = True
+
+    spec = os.environ.get(AGENTS_SOURCE_ENV, DEFAULT_AGENTS_SOURCE).strip()
+    if not spec or spec.lower() in _OFF_VALUES:
+        last_source_description = "agents source disabled"
+        return 0
+    last_source_description = f"agents source {spec!r}"
+
+    try:
+        root = _source_root(spec)
+    except Exception as exc:
+        logger.warning(
+            "Agent manifest auto-load: could not fetch %s (%s); remote agents "
+            "unavailable this run.",
+            spec,
+            exc,
+        )
+        return 0
+
+    manifests: list[LoadedManifest] = []
+    for path in discover_manifests(root):
+        try:
+            manifests.append(load_agent_manifest(path))
+        except Exception as exc:
+            logger.warning(
+                "Agent manifest auto-load: skipping unreadable manifest %s: %s",
+                path,
+                exc,
+            )
+
+    from benchflow.agents.registry import (
+        AGENT_ALIASES,
+        AGENT_INSTALLERS,
+        AGENT_LAUNCH,
+        AGENTS,
+    )
+
+    fresh = _gap_fill(manifests, agents=AGENTS, aliases=AGENT_ALIASES)
+    if not fresh:
+        logger.info(
+            "Agent manifest auto-load: %s had no agents beyond the local registry.",
+            spec,
+        )
+        return 0
+    register_manifest_agents(
+        fresh,
+        agents=AGENTS,
+        aliases=AGENT_ALIASES,
+        installers=AGENT_INSTALLERS,
+        launch=AGENT_LAUNCH,
+    )
+    logger.info(
+        "Agent manifest auto-load: registered %d agent(s) from %s: %s",
+        len(fresh),
+        spec,
+        ", ".join(sorted(fresh)),
+    )
+    return len(fresh)
+
+
+def _reset_for_tests() -> None:
+    global _attempted, last_source_description
+    _attempted = False
+    last_source_description = ""

--- a/tests/agents/test_namespace_shorthand.py
+++ b/tests/agents/test_namespace_shorthand.py
@@ -1,0 +1,82 @@
+"""Namespace-shorthand agent specs — "<ns>:<id>" (design: #876).
+
+Harbor-style colon prefixes over the existing flat names: the native/ACP path
+owns bare names, other paths use their "<path>-" prefix, and the shorthand is a
+deterministic candidate mapping onto those names (no new config fields).
+Exact registered names and aliases always win — including ``acpx:`` runtime
+keys, which share the colon and are exact-checked first.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow.agents import registry
+from benchflow.agents.registry import AgentConfig, resolve_agent
+
+
+def test_acp_shorthand_bare_name():
+    assert resolve_agent("acp:mimo").name == "mimo"
+
+
+def test_acp_shorthand_suffix_form():
+    # no agent literally named "pi"; the -acp suffix candidate matches.
+    assert resolve_agent("acp:pi").name == "pi-acp"
+
+
+def test_acp_shorthand_via_alias():
+    # "claude" is an alias for claude-agent-acp; candidates go through aliases.
+    assert resolve_agent("acp:claude").name == "claude-agent-acp"
+    assert resolve_agent("acp:codex").name == "codex-acp"
+
+
+def test_prefix_namespaces(monkeypatch):
+    fake = {
+        "omnigent-probe": AgentConfig(
+            name="omnigent-probe", install_cmd="true", launch_cmd="true"
+        ),
+        "ai-sdk-probe": AgentConfig(
+            name="ai-sdk-probe", install_cmd="true", launch_cmd="true"
+        ),
+    }
+    monkeypatch.setattr(registry, "AGENTS", {**registry.AGENTS, **fake})
+    assert resolve_agent("omnigent:probe").name == "omnigent-probe"
+    assert resolve_agent("ai-sdk:probe").name == "ai-sdk-probe"
+
+
+def test_prefix_namespace_alias_candidate(monkeypatch):
+    """A prefix candidate that is only an ALIAS still resolves (e.g. the
+    historical ai-sdk-harness kept as an alias after a canonical rename)."""
+    fake = {
+        "some-canonical": AgentConfig(
+            name="some-canonical", install_cmd="true", launch_cmd="true"
+        ),
+    }
+    monkeypatch.setattr(registry, "AGENTS", {**registry.AGENTS, **fake})
+    monkeypatch.setattr(
+        registry,
+        "AGENT_ALIASES",
+        {**registry.AGENT_ALIASES, "ai-sdk-legacy": "some-canonical"},
+    )
+    assert resolve_agent("ai-sdk:legacy").name == "some-canonical"
+
+
+def test_unknown_namespace_still_errors():
+    with pytest.raises(KeyError):
+        resolve_agent("zzz:mimo")
+
+
+def test_unknown_id_in_namespace_errors():
+    with pytest.raises(KeyError):
+        resolve_agent("omnigent:does-not-exist")
+
+
+def test_exact_names_and_bare_specs_unchanged():
+    assert resolve_agent("mimo").name == "mimo"
+    assert resolve_agent("pi-acp").name == "pi-acp"
+    assert resolve_agent("pi").name == "pi-acp"  # existing alias
+
+
+def test_acpx_protocol_composes_with_shorthand():
+    cfg = resolve_agent("acpx/acp:pi")
+    assert cfg.name.startswith("acpx:")

--- a/tests/agents/test_remote_manifest_autoload.py
+++ b/tests/agents/test_remote_manifest_autoload.py
@@ -1,0 +1,109 @@
+"""Miss-driven remote-manifest auto-load (#876 Phase 2a).
+
+Contract: an unknown ``--agent`` name triggers at most ONE fetch of the pinned
+agents source; only DECLARATIVE manifests register (gap-fill — local names and
+aliases always win); a broken manifest or unreachable source degrades to the
+normal unknown-agent error, never a crash. Tests use a local directory source
+(``BENCHFLOW_AGENTS_SOURCE=<dir>``) so nothing touches the network.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow.agents import registry, remote_manifests
+from benchflow.agents.registry import resolve_agent
+
+_MANIFEST = """\
+contract_version = "1.0"
+name = "{name}"
+description = "test agent"
+protocol = "acp"
+install_cmd = "true"
+launch_cmd = "true"
+{extra}
+"""
+
+
+def _write_manifest(root, dirname, name, extra=""):
+    d = root / dirname
+    d.mkdir(parents=True)
+    (d / "manifest.toml").write_text(_MANIFEST.format(name=name, extra=extra))
+
+
+@pytest.fixture()
+def source_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv(remote_manifests.AGENTS_SOURCE_ENV, str(tmp_path))
+    remote_manifests._reset_for_tests()
+    registered: list[str] = []
+    yield tmp_path, registered
+    remote_manifests._reset_for_tests()
+    for name in registered:
+        registry.AGENTS.pop(name, None)
+        registry.AGENT_INSTALLERS.pop(name, None)
+        registry.AGENT_LAUNCH.pop(name, None)
+    for alias, target in list(registry.AGENT_ALIASES.items()):
+        if target in registered:
+            registry.AGENT_ALIASES.pop(alias, None)
+
+
+def test_unknown_agent_triggers_autoload_and_resolves(source_dir):
+    root, registered = source_dir
+    _write_manifest(root, "probe-remote", "probe-remote")
+    registered.append("probe-remote")
+    assert resolve_agent("probe-remote").name == "probe-remote"
+
+
+def test_gap_fill_never_overwrites_local(source_dir):
+    root, registered = source_dir
+    # remote manifest reuses an existing core name with different commands.
+    _write_manifest(root, "mimo", "mimo")
+    _write_manifest(root, "probe-remote2", "probe-remote2")
+    registered.append("probe-remote2")
+    before = registry.AGENTS["mimo"]
+    resolve_agent("probe-remote2")  # triggers the load
+    assert registry.AGENTS["mimo"] is before  # untouched
+
+
+def test_colliding_alias_is_stripped_not_fatal(source_dir):
+    root, registered = source_dir
+    # alias "claude" already maps to claude-agent-acp locally.
+    _write_manifest(
+        root, "probe-remote3", "probe-remote3", extra='aliases = ["claude"]\n'
+    )
+    registered.append("probe-remote3")
+    assert resolve_agent("probe-remote3").name == "probe-remote3"
+    assert registry.AGENT_ALIASES["claude"] == "claude-agent-acp"
+
+
+def test_broken_manifest_skipped_others_load(source_dir, caplog):
+    root, registered = source_dir
+    (root / "broken").mkdir()
+    (root / "broken" / "manifest.toml").write_text("not toml [[[")
+    _write_manifest(root, "probe-remote4", "probe-remote4")
+    registered.append("probe-remote4")
+    assert resolve_agent("probe-remote4").name == "probe-remote4"
+
+
+def test_off_disables_and_error_mentions_source(source_dir, monkeypatch):
+    monkeypatch.setenv(remote_manifests.AGENTS_SOURCE_ENV, "off")
+    with pytest.raises(KeyError) as exc:
+        resolve_agent("agent-that-definitely-does-not-exist")
+    assert "disabled" in str(exc.value)
+
+
+def test_one_shot_per_process(source_dir, monkeypatch):
+    _root, _registered = source_dir
+    calls: list[int] = []
+    real = remote_manifests._source_root
+
+    def counting(spec):
+        calls.append(1)
+        return real(spec)
+
+    monkeypatch.setattr(remote_manifests, "_source_root", counting)
+    with pytest.raises(KeyError):
+        resolve_agent("nope-1")
+    with pytest.raises(KeyError):
+        resolve_agent("nope-2")
+    assert len(calls) == 1


### PR DESCRIPTION
Implements #876 (final design; harbor prior art): the namespace shorthand (Phase 1) **and** the manifest auto-load (Phase 2a — corrected design, see the issue update).

## 1. Namespace-shorthand specs — `<ns>:<id>`

Deterministic candidate mapping onto the existing flat names (naming law: native/ACP owns bare names; other paths use their `<path>-` prefix):

| spec | resolves to |
|---|---|
| `acp:mimo` / `acp:pi` / `acp:claude` | `mimo` / `pi-acp` / `claude-agent-acp` |
| `omnigent:pi` | `omnigent-pi` |
| `ai-sdk:codex` | `ai-sdk-codex` (alias-aware) |

No new `AgentConfig` fields; exact names/aliases always win; `acpx:` keys unaffected.

## 2. Miss-driven manifest auto-load — agents load like tasks

Unknown `--agent` ⇒ fetch the pinned agents source (default `benchflow-ai/agents@main`, same clone+cache as `--source-repo`) ⇒ register every **declarative `manifest.toml`** agent that collides with nothing local ⇒ retry (exact + alias + shorthand).

**Why this is safe automatically** (the key correction in #876): a manifest is *pure data* — its install/launch strings execute **in the sandbox**, the same trust level as task sources and as harbor's `acp:<id>` registry fetch. No remote code runs on the host. Host-side python adapters (omnigent) stay explicit installs by design.

- **Gap-fill only**: local always wins; colliding aliases stripped, not fatal.
- One-shot per process; broken manifests / unreachable source degrade to the normal unknown-agent error (which now names the source consulted).
- `BENCHFLOW_AGENTS_SOURCE=off` disables; `=owner/repo[@ref]` re-pins; local dir for dev/tests.

## Live e2e

A fresh process resolving `auggie` fetched the repo once and auto-registered **28 manifest agents** (cline, goose, qwen-code, stakpak, kilo, github-copilot-cli, …) — zero installs, zero env vars:

```
bench eval run -d skillsbench@1.1 --agent cline --model deepseek/deepseek-v4-flash --sandbox daytona
```

## Tests

15 new (9 shorthand + 6 auto-load, network-free via local-dir source); full `tests/agents/` suite green (70 passed).

Companion: benchflow-ai/agents#44 (naming law + `ai-sdk-pi` rename).