### PR TITLE
fix(acp): derive model-via-env from registration data, not agent names

### DIFF
--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -1060,6 +1060,24 @@ def _wire_litellm_agent_env(
             LITELLM_MASTER_KEY_ENV: master_key,
         }
     )
+    # Generic model-via-env: an agent whose registration maps
+    # BENCHFLOW_PROVIDER_MODEL into an agent-native env var AND declares
+    # supports_acp_set_model=False states, in data, that launch/env config owns
+    # model selection. Set the via-env flag so the ACP layer
+    # (_model_selection_owned_by_env) skips driving set_model AND any
+    # capability-advertised model config option — several agents (qwen-code,
+    # kilo, dimcode, ...) validate foreign model ids against their own catalog
+    # and reject the gateway alias with -32603. This generalizes the hardcoded
+    # codex-acp/openhands/claude-agent-acp branches below to every agent that
+    # declares the env-owned-model shape (e.g. the benchflow-ai/agents
+    # manifests), instead of growing the special-case list per agent.
+    _cfg = AGENTS.get(agent)
+    if (
+        _cfg is not None
+        and not _cfg.supports_acp_set_model
+        and _cfg.env_mapping.get("BENCHFLOW_PROVIDER_MODEL")
+    ):
+        updated[LITELLM_MODEL_VIA_ENV] = "1"
     if agent == "codex-acp":
         updated["OPENAI_BASE_URL"] = openai_base_url
         updated["OPENAI_API_KEY"] = master_key

--- a/tests/test_acp_model_config_dispatch.py
+++ b/tests/test_acp_model_config_dispatch.py
@@ -171,3 +171,43 @@ async def test_effort_without_effort_config_id_fails_closed(tmp_path):
         )
 
     mock_acp.close.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_env_owned_model_skips_advertised_model_option(tmp_path):
+    """A manifest-shaped agent (supports_acp_set_model=False + a
+    BENCHFLOW_PROVIDER_MODEL env mapping) with the via-env flag set must get NO
+    ACP model configuration — several registry agents (qwen-code, kilo,
+    dimcode) advertise a ``model`` config option but validate values against
+    their own catalog and reject the gateway alias with -32603."""
+    from benchflow.agents.registry import AGENT_INSTALLERS, AGENT_LAUNCH, AGENTS
+    from benchflow.agents.registry import AgentConfig as _AC
+
+    AGENTS["env-owned-probe"] = _AC(
+        name="env-owned-probe",
+        install_cmd="true",
+        launch_cmd="true",
+        supports_acp_set_model=False,
+        env_mapping={"BENCHFLOW_PROVIDER_MODEL": "OPENAI_MODEL"},
+    )
+    try:
+        opt = MagicMock()
+        opt.id = "model"
+        mock_acp = _make_mocks(config_options=[opt])
+        await _connect(
+            mock_acp,
+            agent="env-owned-probe",
+            model="deepseek/deepseek-v4-flash",
+            tmp_path=tmp_path,
+            agent_env={
+                LITELLM_MODEL_VIA_ENV: "1",
+                LITELLM_MODEL_ALIAS_ENV: "benchflow-deepseek-deepseek-v4-flash",
+                "OPENAI_MODEL": "benchflow-deepseek-deepseek-v4-flash",
+            },
+        )
+        mock_acp.set_config_option.assert_not_awaited()
+        mock_acp.set_model.assert_not_awaited()
+    finally:
+        AGENTS.pop("env-owned-probe", None)
+        AGENT_INSTALLERS.pop("env-owned-probe", None)
+        AGENT_LAUNCH.pop("env-owned-probe", None)

--- a/tests/test_litellm_model_via_env_generic.py
+++ b/tests/test_litellm_model_via_env_generic.py
@@ -1,0 +1,87 @@
+"""The via-env model flag is derived from registration data, not agent names.
+
+_wire_litellm_agent_env historically set BENCHFLOW_LITELLM_MODEL_VIA_ENV=1 only
+in hardcoded per-agent branches (codex-acp / openhands / claude-agent-acp), so
+generic manifest agents that deliver the model via env (supports_acp_set_model
+= false + a BENCHFLOW_PROVIDER_MODEL env mapping) never got it — and benchflow
+then drove their capability-advertised ``model`` config option, which agents
+like qwen-code reject (-32603). These lock the generic derivation.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchflow.agents.registry import AGENT_INSTALLERS, AGENT_LAUNCH, AGENTS
+from benchflow.agents.registry import AgentConfig as _AC
+from benchflow.providers.litellm_config import (
+    LITELLM_MODEL_VIA_ENV,
+    resolve_litellm_route,
+)
+from benchflow.providers.litellm_runtime import _wire_litellm_agent_env
+
+
+@pytest.fixture()
+def _route():
+    return resolve_litellm_route(
+        "deepseek/deepseek-v4-flash", {"DEEPSEEK_API_KEY": "k"}
+    )
+
+
+def _register(name: str, **kw):
+    AGENTS[name] = _AC(name=name, install_cmd="true", launch_cmd="true", **kw)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup():
+    yield
+    for n in ("via-env-probe", "acp-model-probe", "no-mapping-probe"):
+        AGENTS.pop(n, None)
+        AGENT_INSTALLERS.pop(n, None)
+        AGENT_LAUNCH.pop(n, None)
+
+
+def test_env_owned_registration_gets_via_env_flag(_route):
+    _register(
+        "via-env-probe",
+        supports_acp_set_model=False,
+        env_mapping={"BENCHFLOW_PROVIDER_MODEL": "OPENAI_MODEL"},
+    )
+    updated = _wire_litellm_agent_env(
+        agent="via-env-probe",
+        agent_env={},
+        route=_route,
+        base_url="http://127.0.0.1:4000",
+        master_key="sk-master",
+    )
+    assert updated[LITELLM_MODEL_VIA_ENV] == "1"
+
+
+def test_acp_configured_agent_does_not_get_flag(_route):
+    """supports_acp_set_model=True (default) keeps ACP-driven model config."""
+    _register(
+        "acp-model-probe",
+        env_mapping={"BENCHFLOW_PROVIDER_MODEL": "OPENAI_MODEL"},
+    )
+    updated = _wire_litellm_agent_env(
+        agent="acp-model-probe",
+        agent_env={},
+        route=_route,
+        base_url="http://127.0.0.1:4000",
+        master_key="sk-master",
+    )
+    assert LITELLM_MODEL_VIA_ENV not in updated
+
+
+def test_no_model_mapping_does_not_get_flag(_route):
+    """Without a model env mapping the agent cannot receive the model via env —
+    ACP configuration must stay on (else it falls back to its own default)."""
+    _register("no-mapping-probe", supports_acp_set_model=False)
+    updated = _wire_litellm_agent_env(
+        agent="no-mapping-probe",
+        agent_env={},
+        route=_route,
+        base_url="http://127.0.0.1:4000",
+        master_key="sk-master",
+    )
+    assert LITELLM_MODEL_VIA_ENV not in updated


### PR DESCRIPTION
Found by the 3-path clean-remote census (all agents × deepseek-v4-flash × citation-check): every registry-wired agent that **advertises an ACP `model` config option** failed identically —

```
ACP session/set_config_option failed agent=qwen-code config=model value=benchflow-deepseek-deepseek-v4-flash: -32603
```

(`qwen-code`, `kilo`, `dimcode`; their manifests even document the gap.)

## Root cause

`_model_selection_owned_by_env` only fires when `BENCHFLOW_LITELLM_MODEL_VIA_ENV=1` — and that flag was set **only in hardcoded per-agent branches** (`codex-acp`, `openhands`, `claude-agent-acp`) in `_wire_litellm_agent_env`. Generic manifest agents that deliver the model via env (`supports_acp_set_model = false` + a `BENCHFLOW_PROVIDER_MODEL` env mapping) never got it, so the capability-first dispatch drove their advertised `model` option — which these agents validate against their *own* model catalog and reject.

## Fix (surgical, common — no per-agent code)

Set the flag for **any** agent whose registration declares the env-owned-model shape:

```python
if cfg and not cfg.supports_acp_set_model and cfg.env_mapping.get("BENCHFLOW_PROVIDER_MODEL"):
    updated[LITELLM_MODEL_VIA_ENV] = "1"
```

The manifests already state this in data. Negative space preserved: agents with `supports_acp_set_model=true` or without a model mapping are untouched (they still need ACP model config so they don't fall back to their own defaults) — the hardcoded branches remain as-is.

## Tests

- generic flag derivation + 2 negative controls (`tests/test_litellm_model_via_env_generic.py`)
- end-to-end dispatch: a manifest-shaped agent advertising a `model` option gets **neither** `set_config_option` **nor** `set_model` (`tests/test_acp_model_config_dispatch.py`)

10 pass. Live verification on the census rerun to follow in the PR thread.