### PR TITLE
fix(diagnostics): classify core error markers case-insensitively

### DIFF
--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -119,7 +119,7 @@ def classify_error(error: str | None) -> str | None:
     lower = error.lower()
     if "agent idle for" in lower:
         return IDLE_TIMEOUT
-    if "install failed" in error:
+    if "install failed" in lower:
         return INSTALL_FAILED
     if "closed stdout" in lower:
         return PIPE_CLOSED
@@ -129,7 +129,7 @@ def classify_error(error: str | None) -> str | None:
         return SUSPECTED_API_ERROR
     if "provider api error" in lower:
         return API_ERROR
-    if "ACP error" in error or "was rejected as invalid" in error:
+    if "acp error" in lower or "was rejected as invalid" in lower:
         if any(m in lower for m in _PROVIDER_AUTH_MARKERS):
             return PROVIDER_AUTH
         if any(m in lower for m in _PROVIDER_RATE_LIMIT_MARKERS):

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -190,6 +190,11 @@ class TestClassifyError:
         """'install' alone should NOT match — only 'install failed'."""
         assert classify_error("installing dependencies") == "other"
 
+    def test_error_classification_is_case_insensitive_for_core_markers(self):
+        """Guards the fix from PR #880 for issue #541."""
+        assert classify_error("Agent Install failed (rc=1)") == "install_failure"
+        assert classify_error("acp error -32000: connection refused") == "acp_error"
+
 
 class TestClassifyResultOutcome:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- make `classify_error()` use the already-normalized lowercase error string for `install failed` and `ACP error` markers
- add regression coverage for capitalized install failures and lowercase ACP errors

Fixes #541.

## Verification
- `uv sync --extra dev --locked`
- `uv run python -m pytest tests/test_scoring.py -q`
- `uv run ruff check src/benchflow/_utils/scoring.py tests/test_scoring.py`
- `uv run ruff format --check src/benchflow/_utils/scoring.py tests/test_scoring.py`
- `uv run ty check src/benchflow/_utils/scoring.py`