### PR TITLE
fix(litellm): honor Gemini provider base URL

### DIFF
--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -345,8 +345,17 @@ def resolve_litellm_route(model: str, env: dict[str, str]) -> LiteLLMRoute:
         required = ("OPENAI_API_KEY",)
 
     params: dict[str, str | int | float | bool] = {"model": upstream}
+    if upstream.lower().startswith("gemini/"):
+        explicit_api_base = (env.get("BENCHFLOW_PROVIDER_BASE_URL") or "").strip()
+        explicit_api_key = (env.get("BENCHFLOW_PROVIDER_API_KEY") or "").strip()
+        if explicit_api_base:
+            params["api_base"] = explicit_api_base
+            if explicit_api_key:
+                params["api_key"] = _env_ref("BENCHFLOW_PROVIDER_API_KEY")
+                required = ("BENCHFLOW_PROVIDER_API_KEY",)
+
     key = required[0] if required else None
-    if key:
+    if key and "api_key" not in params:
         params["api_key"] = _env_ref(key)
     return LiteLLMRoute(
         requested_model=model,

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -103,6 +103,53 @@ def test_registered_provider_route_honors_explicit_generic_proxy_env():
     assert route.required_env == ("BENCHFLOW_PROVIDER_API_KEY",)
 
 
+@pytest.mark.parametrize("model", ["gemini/gemini-2.5-flash", "gemini-2.5-flash"])
+def test_gemini_native_route_honors_explicit_base_url(model):
+    """Guards the fix from PR #881 for issue #672."""
+    route = resolve_litellm_route(
+        model,
+        {
+            "BENCHFLOW_PROVIDER_BASE_URL": "https://gemini-proxy.example.test/v1",
+            "GEMINI_API_KEY": "sk-gemini",
+        },
+    )
+
+    assert route.upstream_model == "gemini/gemini-2.5-flash"
+    assert route.provider_name == "native"
+    assert route.litellm_params["api_base"] == "https://gemini-proxy.example.test/v1"
+    assert route.litellm_params["api_key"] == "os.environ/GEMINI_API_KEY"
+    assert route.required_env == ("GEMINI_API_KEY",)
+
+
+def test_gemini_native_route_honors_generic_proxy_key():
+    """Guards the fix from PR #881 for issue #672."""
+    route = resolve_litellm_route(
+        "gemini/gemini-2.5-flash",
+        {
+            "BENCHFLOW_PROVIDER_BASE_URL": "https://gemini-proxy.example.test/v1",
+            "BENCHFLOW_PROVIDER_API_KEY": "sk-proxy",
+            "GEMINI_API_KEY": "sk-gemini",
+        },
+    )
+
+    assert route.litellm_params["api_base"] == "https://gemini-proxy.example.test/v1"
+    assert route.litellm_params["api_key"] == "os.environ/BENCHFLOW_PROVIDER_API_KEY"
+    assert route.required_env == ("BENCHFLOW_PROVIDER_API_KEY",)
+
+
+def test_gemini_native_route_without_explicit_base_url_is_unchanged():
+    """Guards the fix from PR #881 for issue #672."""
+    route = resolve_litellm_route(
+        "gemini/gemini-2.5-flash",
+        {"GEMINI_API_KEY": "sk-gemini"},
+    )
+
+    assert route.upstream_model == "gemini/gemini-2.5-flash"
+    assert "api_base" not in route.litellm_params
+    assert route.litellm_params["api_key"] == "os.environ/GEMINI_API_KEY"
+    assert route.required_env == ("GEMINI_API_KEY",)
+
+
 def test_openrouter_route_uses_openai_compatible_endpoint():
     route = resolve_litellm_route(
         "openrouter/qwen/qwen3.5-397b-a17b",


### PR DESCRIPTION
## Summary
- honor `BENCHFLOW_PROVIDER_BASE_URL` for native `gemini/*` and bare Gemini LiteLLM routes
- allow `BENCHFLOW_PROVIDER_API_KEY` to override `GEMINI_API_KEY` when routing through a custom Gemini proxy
- keep default Gemini routing unchanged when no explicit base URL is set

Refs #672 (lands the core native-route fix). Intentionally scoped to the GenerateContent (`gemini/`) route per the Protocol note below; the OpenAI-compatible-proxy protocol-prefix acceptance item on #672 remains, so #672 stays open with narrowed scope.

## Verification
- `uv run python -m pytest tests/test_litellm_config.py -q`
- `uv run ruff check src/benchflow/providers/litellm_config.py tests/test_litellm_config.py`
- `uv run ruff format --check src/benchflow/providers/litellm_config.py tests/test_litellm_config.py`
- `uv run ty check src/benchflow/providers/litellm_config.py`

## Protocol note
This only supplies `api_base` to LiteLLM's existing `gemini/` upstream, so it is intended for Gemini/GenerateContent-compatible endpoints. OpenAI-compatible proxies should continue using an OpenAI-compatible provider route such as `vllm`/registered provider routing.
