### PR TITLE
Registry-driven Claude subscription gate + zero-signal heuristic exemption (Anthropic OAuth unlock)

### DIFF
--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -414,7 +414,15 @@ def uses_native_subscription_auth(
             or check_subscription_auth(agent, required_key)
         )
 
-    if agent == "claude-agent-acp":
+    # Registry-driven Claude-CLI gate: any agent whose subscription_auth
+    # substitutes ANTHROPIC_API_KEY runs the Claude Code CLI and can take
+    # OAuth/subscription auth natively (claude-agent-acp, omnigent claude-*).
+    claude_cfg = AGENTS.get(agent)
+    if (
+        claude_cfg is not None
+        and claude_cfg.subscription_auth is not None
+        and claude_cfg.subscription_auth.replaces_env == "ANTHROPIC_API_KEY"
+    ):
         if agent_env.get("ANTHROPIC_API_KEY"):
             return False
         if model is not None:

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -2162,6 +2162,22 @@ class Rollout:
         # silent API failure.
         if not getattr(self, "_executed_prompts", None):
             return
+        # Native-subscription runs have NO usage channel: the LiteLLM proxy is
+        # deliberately skipped (Harbor-style split) and the CLI authenticates
+        # itself, so zero tokens + zero tool calls is the expected shape of a
+        # HEALTHY run for agents whose trajectory carries no tool telemetry
+        # (e.g. omnigent's flat session events). The zero-signal heuristic is
+        # meaningless there and would null verifier-granted rewards; real
+        # failures still surface via the agent error channels.
+        from benchflow.agents.env import uses_native_subscription_auth
+
+        config = getattr(self, "_config", None)
+        if config is not None and uses_native_subscription_auth(
+            config.agent,
+            config.model,
+            getattr(self, "_agent_env", None) or {},
+        ):
+            return
         # getattr-defensive: tests construct partial Rollout doubles that
         # bypass __init__ (same pattern as _task_skill_policy below).
         usage_metrics = getattr(self, "_usage_metrics", None) or {}

--- a/tests/test_api_error_capture.py
+++ b/tests/test_api_error_capture.py
@@ -264,3 +264,39 @@ class TestCircuitBreaker:
         for i in range(10):
             breaker.record(_api_result(f"t{i}"))
         assert not breaker.tripped
+
+
+class TestSubscriptionAuthExemption:
+    """Native-subscription runs (no proxy, no usage channel) must not be
+    zero-signal-flagged: zero tokens + zero tool calls is the expected shape
+    of a healthy run for flat-telemetry agents (e.g. omnigent sessions), and
+    the heuristic was nulling verifier-granted rewards there."""
+
+    def _rollout_double(self, agent_env):
+        from benchflow.rollout import Rollout
+
+        r = Rollout.__new__(Rollout)
+        r._error = None
+        r._executed_prompts = ["p"]
+        r._agent_env = agent_env
+        r._config = SimpleNamespace(
+            agent="claude-agent-acp", model="claude-haiku-4-5-20251001"
+        )
+        r._usage_metrics = {}
+        r._n_tool_calls = 0
+        r._api_failure_summary_cached = None
+        r._rewards = {"reward": 1.0}
+        r._diagnostics = SimpleNamespace(set=lambda d: None)
+        return r
+
+    def test_oauth_run_keeps_verifier_reward(self):
+        r = self._rollout_double({"CLAUDE_CODE_OAUTH_TOKEN": "oauth-token"})
+        r._maybe_classify_api_error()
+        assert r._rewards == {"reward": 1.0}
+        assert r._error is None
+
+    def test_proxy_run_still_flagged(self):
+        r = self._rollout_double({"BENCHFLOW_PROVIDER_NAME": "litellm"})
+        r._maybe_classify_api_error()
+        assert r._rewards is None
+        assert "suspected provider api error" in (r._error or "")

--- a/tests/test_api_error_capture.py
+++ b/tests/test_api_error_capture.py
@@ -267,7 +267,7 @@ class TestCircuitBreaker:
 
 
 class TestSubscriptionAuthExemption:
-    """Native-subscription runs (no proxy, no usage channel) must not be
+    """Guards the fix from PR #886: native-subscription runs must not be
     zero-signal-flagged: zero tokens + zero tool calls is the expected shape
     of a healthy run for flat-telemetry agents (e.g. omnigent sessions), and
     the heuristic was nulling verifier-granted rewards there."""

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -308,6 +308,44 @@ class TestResolveAgentEnvSubscription:
             },
         )
 
+    def test_anthropic_subscription_gate_is_registry_driven(self, monkeypatch):
+        """Any agent declaring ANTHROPIC subscription_auth gets the OAuth split.
+
+        The gate used to hardcode claude-agent-acp; decoupled Claude-CLI
+        agents (e.g. omnigent claude-*) opt in by declaring subscription_auth
+        in their registration. Agents without it must never skip the proxy.
+        """
+        from benchflow.agents.env import uses_native_subscription_auth
+        from benchflow.agents.registry import AGENTS, AgentConfig, SubscriptionAuth
+
+        cfg = AgentConfig(
+            name="fake-claude-cli",
+            install_cmd="",
+            launch_cmd="",
+            subscription_auth=SubscriptionAuth(
+                replaces_env="ANTHROPIC_API_KEY",
+                detect_file="~/.claude/.credentials.json",
+            ),
+        )
+        monkeypatch.setitem(AGENTS, "fake-claude-cli", cfg)
+
+        oauth_env = {"CLAUDE_CODE_OAUTH_TOKEN": "oauth-token"}
+        assert uses_native_subscription_auth(
+            "fake-claude-cli", "claude-haiku-4-5-20251001", oauth_env
+        )
+        # API key present → stays on the LiteLLM path.
+        assert not uses_native_subscription_auth(
+            "fake-claude-cli",
+            "claude-haiku-4-5-20251001",
+            {**oauth_env, "ANTHROPIC_API_KEY": "sk-ant"},
+        )
+        # No ANTHROPIC subscription_auth declared → never skips the proxy.
+        cfg_plain = AgentConfig(name="fake-plain-acp", install_cmd="", launch_cmd="")
+        monkeypatch.setitem(AGENTS, "fake-plain-acp", cfg_plain)
+        assert not uses_native_subscription_auth(
+            "fake-plain-acp", "claude-haiku-4-5-20251001", oauth_env
+        )
+
     def test_codex_api_key_auth_alias(self, monkeypatch, tmp_path):
         """Guards PR #296: CODEX_API_KEY works for native Codex auth."""
         for k in ("CODEX_ACCESS_TOKEN", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):

--- a/tests/test_subscription_auth.py
+++ b/tests/test_subscription_auth.py
@@ -309,7 +309,7 @@ class TestResolveAgentEnvSubscription:
         )
 
     def test_anthropic_subscription_gate_is_registry_driven(self, monkeypatch):
-        """Any agent declaring ANTHROPIC subscription_auth gets the OAuth split.
+        """Guards the fix from PR #886: ANTHROPIC subscription auth is registry-driven.
 
         The gate used to hardcode claude-agent-acp; decoupled Claude-CLI
         agents (e.g. omnigent claude-*) opt in by declaring subscription_auth


### PR DESCRIPTION
## What

Two changes that make Anthropic OAuth/subscription runs (`CLAUDE_CODE_OAUTH_TOKEN`, no `ANTHROPIC_API_KEY`) work beyond the single hardcoded agent:

1. **Registry-driven Claude subscription gate** (`agents/env.py`): `uses_native_subscription_auth` hardcoded `agent == "claude-agent-acp"` for the Anthropic split. Decoupled Claude-CLI agents (e.g. omnigent claude-sdk) could never opt in — with an OAuth token and no API key, the mandatory LiteLLM route failed with `requires ANTHROPIC_API_KEY` even though the Claude CLI authenticates itself. Now any agent whose `subscription_auth` declares `replaces_env == "ANTHROPIC_API_KEY"` takes the same Harbor-style split. `claude-agent-acp` keeps byte-identical behavior (its registry entry declares exactly that); agents without `subscription_auth` still never skip the proxy (regression-tested).

2. **Zero-signal heuristic exemption for subscription runs** (`rollout/__init__.py`): subscription runs skip the proxy by design, so they have **no usage channel** — zero tokens + zero tool calls is the expected shape of a *healthy* run for agents whose trajectory carries no tool telemetry (omnigent's flat session events). The `suspected_api_error` layer was nulling verifier-granted rewards there. Live repro: omnigent-claude + OAuth scored **1.0**, then got overridden to `reward=None / suspected_api_error`. The zero-signal layer is now skipped when `uses_native_subscription_auth` holds; the proxy-proven layer needs proxy evidence that cannot exist there, and real failures still surface via the agent error channels.

## Live verification (daytona, citation-check, with-skill, claude-sonnet-4-6)

- `claude-agent-acp` + `CLAUDE_CODE_OAUTH_TOKEN` → **reward 1.0** (acp 33 events, 17 tool calls)
- `omnigent-claude` + OAuth (with benchflow-ai/agents companion PR) → **reward 1.0, Score 1/1, errors=0**

## Tests

- `test_subscription_auth.py`: new `test_anthropic_subscription_gate_is_registry_driven` (opt-in agent honored; API-key still prefers LiteLLM; agents without subscription_auth never skip) — 31 pass
- `test_api_error_capture.py`: new `TestSubscriptionAuthExemption` (OAuth run keeps verifier reward; proxied run still flagged) — 30 pass
- Full unit sweep: 4735 passed; the 4 failures also fail on clean `main` in this environment (host `~/.claude` login poisons credential-gate fixtures) — pre-existing, unrelated.

Companion PR: benchflow-ai/agents (omnigent claude-sdk OAuth mode).