### PR TITLE
fix(harvey): map provider env to the OpenAI-compatible adapter

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -721,9 +721,21 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd=f"HARVEY_LABS_ROOT=/opt/harvey-labs /opt/benchflow/harvey-lab-venv/bin/python {_BENCHFLOW_BIN_PREFIX}/harvey-lab-acp-shim",
         protocol="acp",
         requires_env=[],  # inferred from model at runtime (ANTHROPIC_API_KEY, etc.)
-        # env_mapping intentionally empty — Harvey LAB adapters read
-        # provider-specific env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY,
-        # GOOGLE_API_KEY) directly; auto_inherit_env propagates these.
+        # Harvey LAB's Anthropic/Gemini adapters read ANTHROPIC_API_KEY /
+        # GOOGLE_API_KEY directly (auto_inherit_env propagates a host key). But
+        # the OpenAI-compatible adapter — the one that serves every proxied
+        # provider (deepseek, the azure gpt-5.4-mini gateway, the benchflow-*
+        # aliases) — reads OPENAI_BASE_URL/OPENAI_API_KEY, which only exist as
+        # BENCHFLOW_PROVIDER_* on the proxy path. Without this mapping the
+        # adapter had no base URL/key, hit api.openai.com unauthenticated, and
+        # the harness loop ended on turn 0 with zero LLM activity
+        # (suspected_api_error). Mapping them points the adapter at the gateway;
+        # a direct ANTHROPIC/GEMINI run is unaffected (those adapters ignore
+        # OPENAI_*).
+        env_mapping={
+            "BENCHFLOW_PROVIDER_BASE_URL": "OPENAI_BASE_URL",
+            "BENCHFLOW_PROVIDER_API_KEY": "OPENAI_API_KEY",
+        },
     ),
     "deepagents": AgentConfig(
         name="deepagents",

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -481,3 +481,17 @@ def test_resolve_auth_env_matches_provider_auth_type():
             assert result is None, (
                 f"{name!r} ({cfg.auth_type}): resolve_auth_env should return None, got {result!r}"
             )
+
+
+def test_harvey_maps_provider_env_to_openai_compatible_adapter():
+    """Harvey LAB's OpenAI-compatible adapter reads OPENAI_BASE_URL/OPENAI_API_KEY;
+    on the proxy path those only exist as BENCHFLOW_PROVIDER_*. Without this
+    mapping the adapter had no endpoint/key and the harness loop ended on turn 0
+    with zero LLM activity. Guard the mapping so deepseek / gpt-5.4-mini-gateway /
+    every benchflow-* alias can route.
+    """
+    from benchflow.agents.registry import AGENTS
+
+    em = AGENTS["harvey-lab-harness"].env_mapping
+    assert em.get("BENCHFLOW_PROVIDER_BASE_URL") == "OPENAI_BASE_URL", em
+    assert em.get("BENCHFLOW_PROVIDER_API_KEY") == "OPENAI_API_KEY", em


### PR DESCRIPTION
## What

`harvey-lab-harness` ended every proxied run on **turn 0 with zero LLM activity** (`suspected_api_error`). Root cause: its `env_mapping` was empty, but Harvey LAB's **OpenAI-compatible adapter** — the one that serves every proxied provider (deepseek, the azure gpt-5.4-mini gateway, the `benchflow-*` proxy aliases) — reads `OPENAI_BASE_URL` / `OPENAI_API_KEY`, which only exist as `BENCHFLOW_PROVIDER_*` on the proxy path. With neither set, the adapter hit `api.openai.com` unauthenticated and the harness loop made zero calls.

Map `BENCHFLOW_PROVIDER_BASE_URL → OPENAI_BASE_URL` and `BENCHFLOW_PROVIDER_API_KEY → OPENAI_API_KEY` so the adapter points at the gateway. Direct `ANTHROPIC`/`GEMINI` runs are unaffected (those adapters read `ANTHROPIC_API_KEY`/`GOOGLE_API_KEY` directly and ignore `OPENAI_*`).

## Verification (daytona, deepseek)

harvey now **routes and issues requests** (`total_requests >= 1`) — previously `total_requests == 0` / zero activity. This corrects the long-standing "harvey is a harness-level zero-activity defect" classification: it was an unwired adapter, not a broken harness. The remaining HTTP 500s in the run are transient upstream provider errors (benchflow retries them), orthogonal to this fix.

## Tests

`test_registry_invariants.py`: new `test_harvey_maps_provider_env_to_openai_compatible_adapter` guards the mapping. 184 pass; ruff clean.