### PR TITLE
Stabilize Toolathlon Daytona runtimes

### DIFF
--- a/src/benchflow/adapters/_toolathlon_container.py
+++ b/src/benchflow/adapters/_toolathlon_container.py
@@ -31,6 +31,7 @@ import importlib.machinery
 import importlib.util
 import os
 import re
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -114,6 +115,41 @@ def _resolve(value: str, variables: dict[str, str]) -> str:
     )
 
 
+def _looks_like_jsonrpc_stdout(line: bytes) -> bool:
+    """Return True for line-oriented MCP JSON-RPC stdout frames.
+
+    Several upstream Toolathlon MCP servers print human startup logs to stdout
+    before emitting real MCP JSON-RPC. MCP clients read stdout as protocol, so
+    those logs must be moved to stderr. The official servers used here emit
+    compact one-line JSON objects for protocol messages.
+    """
+    stripped = line.lstrip()
+    return stripped.startswith(b"{")
+
+
+def _run_stdio_server(argv: list[str], env: dict[str, str]) -> int:
+    proc = subprocess.Popen(
+        argv,
+        env=env,
+        stdin=sys.stdin,
+        stdout=subprocess.PIPE,
+        stderr=None,
+    )
+    assert proc.stdout is not None
+    try:
+        for line in iter(proc.stdout.readline, b""):
+            if _looks_like_jsonrpc_stdout(line):
+                sys.stdout.buffer.write(line)
+                sys.stdout.buffer.flush()
+            else:
+                sys.stderr.buffer.write(line)
+                sys.stderr.buffer.flush()
+        return proc.wait()
+    except KeyboardInterrupt:
+        proc.terminate()
+        return 130
+
+
 def _launch(argv: list[str]) -> int:
     if not argv:
         sys.stderr.write("toolathlon launch: no command given\n")
@@ -137,8 +173,7 @@ def _launch(argv: list[str]) -> int:
         resolved_env["PATH"] = (
             "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
         )
-    os.execvpe(resolved_argv[0], resolved_argv, resolved_env)
-    return 0  # unreachable when exec succeeds
+    return _run_stdio_server(resolved_argv, resolved_env)
 
 
 # --------------------------------------------------------------------------- #

--- a/src/benchflow/adapters/_toolathlon_fake_mail.py
+++ b/src/benchflow/adapters/_toolathlon_fake_mail.py
@@ -1,0 +1,398 @@
+"""Tiny SMTP/IMAP service for Toolathlon email tasks.
+
+The service intentionally implements only the protocol subset exercised by
+Toolathlon's ``emails-mcp`` package and verifier helpers:
+
+* SMTP/Submission accepts plaintext mail, optional AUTH, and DATA.
+* Delivered messages are copied to each recipient INBOX and the envelope
+  sender's Sent folder, matching the verifier's sender-outbox checks.
+* IMAP supports LOGIN, LIST, SELECT, APPEND, SEARCH ALL/FROM, FETCH RFC822,
+  STORE +FLAGS \\Deleted, EXPUNGE, CLOSE, NOOP, and LOGOUT.
+
+It is not a general mail server. It exists to avoid pulling the much larger
+poste.io appliance inside 10 GB Daytona DinD sandboxes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import email
+import http.server
+import re
+import socketserver
+import threading
+import time
+from pathlib import Path
+
+_ADDR_RE = re.compile(r"<([^>]+)>")
+_SAFE_RE = re.compile(r"[^A-Za-z0-9_.@+-]+")
+
+
+def _clean_mailbox(value: str | bytes | None) -> str:
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="replace")
+    value = (value or "unknown@mcp.com").strip().strip('"').strip("'")
+    match = _ADDR_RE.search(value)
+    if match:
+        value = match.group(1)
+    value = value.strip()
+    if not value:
+        value = "unknown@mcp.com"
+    return value.lower()
+
+
+def _safe_component(value: str) -> str:
+    return _SAFE_RE.sub("_", value)[:180] or "mailbox"
+
+
+def _dequote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        value = value[1:-1]
+    return value
+
+
+class MailStore:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self._lock = threading.Lock()
+        self._counter = 0
+
+    def _folder_path(self, mailbox: str, folder: str) -> Path:
+        mailbox_dir = self.root / _safe_component(mailbox)
+        folder_dir = mailbox_dir / ("Sent" if folder.lower() == "sent" else "INBOX")
+        folder_dir.mkdir(parents=True, exist_ok=True)
+        return folder_dir
+
+    def ensure_mailbox(self, mailbox: str) -> None:
+        self._folder_path(mailbox, "INBOX")
+        self._folder_path(mailbox, "Sent")
+
+    def append(self, mailbox: str, folder: str, raw: bytes) -> None:
+        mailbox = _clean_mailbox(mailbox)
+        with self._lock:
+            self._counter += 1
+            name = f"{time.time_ns()}_{self._counter:06d}.eml"
+            self._folder_path(mailbox, folder).joinpath(name).write_bytes(raw)
+
+    def deliver(self, sender: str, recipients: list[str], raw: bytes) -> None:
+        sender = _clean_mailbox(sender)
+        self.append(sender, "Sent", raw)
+        for recipient in recipients:
+            self.append(_clean_mailbox(recipient), "INBOX", raw)
+
+    def messages(self, mailbox: str, folder: str) -> list[Path]:
+        self.ensure_mailbox(mailbox)
+        folder_path = self._folder_path(mailbox, folder)
+        return [
+            path
+            for path in sorted(folder_path.glob("*.eml"))
+            if not path.with_suffix(path.suffix + ".deleted").exists()
+        ]
+
+    def mark_deleted(self, mailbox: str, folder: str, seqs: list[int]) -> None:
+        messages = self.messages(mailbox, folder)
+        with self._lock:
+            for seq in seqs:
+                if 1 <= seq <= len(messages):
+                    messages[seq - 1].with_suffix(
+                        messages[seq - 1].suffix + ".deleted"
+                    ).touch()
+
+    def expunge(self, mailbox: str, folder: str) -> list[int]:
+        self.ensure_mailbox(mailbox)
+        folder_path = self._folder_path(mailbox, folder)
+        deleted = sorted(folder_path.glob("*.eml.deleted"))
+        expunged: list[int] = []
+        with self._lock:
+            for marker in deleted:
+                message = marker.with_suffix("")
+                all_messages = sorted(folder_path.glob("*.eml"))
+                try:
+                    seq = all_messages.index(message) + 1
+                except ValueError:
+                    seq = 1
+                marker.unlink(missing_ok=True)
+                message.unlink(missing_ok=True)
+                expunged.append(seq)
+        return expunged
+
+
+class SMTPHandler(socketserver.StreamRequestHandler):
+    store: MailStore
+
+    def _line(self, text: str) -> None:
+        self.wfile.write(text.encode("utf-8") + b"\r\n")
+
+    def handle(self) -> None:
+        sender = ""
+        recipients: list[str] = []
+        self._line("220 toolathlon fake mail ready")
+        while True:
+            raw_line = self.rfile.readline(65536)
+            if not raw_line:
+                return
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            command, _, rest = line.partition(" ")
+            upper = command.upper()
+
+            if upper in {"EHLO", "HELO"}:
+                self._line("250-poste")
+                self._line("250-AUTH PLAIN LOGIN")
+                self._line("250 OK")
+            elif upper == "AUTH":
+                if rest.upper().startswith("LOGIN") and len(rest.split()) == 1:
+                    self._line("334 VXNlcm5hbWU6")
+                    self.rfile.readline(65536)
+                    self._line("334 UGFzc3dvcmQ6")
+                    self.rfile.readline(65536)
+                self._line("235 Authentication successful")
+            elif upper == "MAIL":
+                sender = _clean_mailbox(rest)
+                self._line("250 OK")
+            elif upper == "RCPT":
+                recipients.append(_clean_mailbox(rest))
+                self._line("250 OK")
+            elif upper == "DATA":
+                self._line("354 End data with <CR><LF>.<CR><LF>")
+                chunks: list[bytes] = []
+                while True:
+                    data_line = self.rfile.readline(65536)
+                    if not data_line:
+                        return
+                    if data_line in {b".\r\n", b".\n", b"."}:
+                        break
+                    if data_line.startswith(b".."):
+                        data_line = data_line[1:]
+                    chunks.append(data_line)
+                raw_message = b"".join(chunks)
+                self.store.deliver(sender, recipients, raw_message)
+                self._line("250 Queued")
+            elif upper == "RSET":
+                sender = ""
+                recipients = []
+                self._line("250 OK")
+            elif upper == "NOOP":
+                self._line("250 OK")
+            elif upper == "QUIT":
+                self._line("221 Bye")
+                return
+            else:
+                self._line("250 OK")
+
+
+class IMAPHandler(socketserver.StreamRequestHandler):
+    store: MailStore
+
+    def setup(self) -> None:
+        super().setup()
+        self.mailbox = "anonymous@mcp.com"
+        self.selected_folder: str | None = None
+
+    def _line(self, text: str) -> None:
+        self.wfile.write(text.encode("utf-8") + b"\r\n")
+
+    def _raw(self, data: bytes) -> None:
+        self.wfile.write(data)
+
+    def _tagged_ok(self, tag: str, text: str = "OK") -> None:
+        self._line(f"{tag} OK {text}")
+
+    def _parse_seqs(self, value: str) -> list[int]:
+        out: list[int] = []
+        for part in value.replace(",", " ").split():
+            if ":" in part:
+                start_s, end_s = part.split(":", 1)
+                try:
+                    start = int(start_s)
+                    end = len(self._selected_messages()) if end_s == "*" else int(end_s)
+                except ValueError:
+                    continue
+                out.extend(range(start, end + 1))
+            else:
+                try:
+                    out.append(int(part))
+                except ValueError:
+                    continue
+        return out
+
+    def _selected_messages(self) -> list[Path]:
+        folder = self.selected_folder or "INBOX"
+        return self.store.messages(self.mailbox, folder)
+
+    def _search(self, criteria: str) -> list[int]:
+        messages = self._selected_messages()
+        criteria_upper = criteria.upper().strip()
+        if not criteria_upper or criteria_upper == "ALL":
+            return list(range(1, len(messages) + 1))
+        from_match = re.search(r'FROM\s+"?([^")]+)"?', criteria, flags=re.IGNORECASE)
+        if from_match:
+            needle = from_match.group(1).lower()
+            hits: list[int] = []
+            for seq, path in enumerate(messages, start=1):
+                msg = email.message_from_bytes(path.read_bytes())
+                if needle in (msg.get("From") or "").lower():
+                    hits.append(seq)
+            return hits
+        return list(range(1, len(messages) + 1))
+
+    def _append(self, tag: str, rest: str) -> None:
+        mailbox, _, append_args = rest.partition(" ")
+        folder = _dequote(mailbox or "INBOX")
+        literal_match = re.search(r"\{(\d+)\}\s*$", append_args)
+        if not literal_match:
+            self._line(f"{tag} BAD APPEND expects literal data")
+            return
+
+        size = int(literal_match.group(1))
+        self._line("+ Ready for literal data")
+        raw = self.rfile.read(size)
+        # Consume the trailing command newline after the literal.
+        self.rfile.readline(65536)
+        self.store.append(self.mailbox, folder, raw)
+        self._tagged_ok(tag, "APPEND completed")
+
+    def handle(self) -> None:
+        self._line("* OK Toolathlon fake IMAP ready")
+        while True:
+            raw_line = self.rfile.readline(65536)
+            if not raw_line:
+                return
+            line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+            if not line:
+                continue
+            tag, _, remainder = line.partition(" ")
+            command, _, rest = remainder.partition(" ")
+            upper = command.upper()
+
+            if upper == "CAPABILITY":
+                self._line("* CAPABILITY IMAP4rev1 AUTH=PLAIN")
+                self._tagged_ok(tag, "CAPABILITY completed")
+            elif upper == "LOGIN":
+                username = rest.split(" ", 1)[0] if rest else self.mailbox
+                self.mailbox = _clean_mailbox(_dequote(username))
+                self.store.ensure_mailbox(self.mailbox)
+                self._tagged_ok(tag, "LOGIN completed.")
+            elif upper == "LIST":
+                self.store.ensure_mailbox(self.mailbox)
+                self._line('* LIST () "." "INBOX"')
+                self._line('* LIST () "." "Sent"')
+                self._tagged_ok(tag, "LIST completed")
+            elif upper in {"SELECT", "EXAMINE"}:
+                self.selected_folder = _dequote(rest or "INBOX")
+                messages = self._selected_messages()
+                self._line("* FLAGS (\\Seen \\Deleted)")
+                self._line("* OK [PERMANENTFLAGS (\\Seen \\Deleted)] flags permitted")
+                self._line(f"* {len(messages)} EXISTS")
+                self._line("* 0 RECENT")
+                self._tagged_ok(tag, "[READ-WRITE] SELECT completed")
+            elif upper == "SEARCH":
+                hits = " ".join(str(seq) for seq in self._search(rest))
+                self._line(f"* SEARCH {hits}".rstrip())
+                self._tagged_ok(tag, "SEARCH completed")
+            elif upper == "APPEND":
+                self._append(tag, rest)
+            elif upper == "FETCH":
+                seq_part, _, _fetch_spec = rest.partition(" ")
+                messages = self._selected_messages()
+                for seq in self._parse_seqs(seq_part):
+                    if 1 <= seq <= len(messages):
+                        raw = messages[seq - 1].read_bytes()
+                        self._raw(f"* {seq} FETCH (RFC822 {{{len(raw)}}}\r\n".encode())
+                        self._raw(raw)
+                        self._raw(b")\r\n")
+                self._tagged_ok(tag, "FETCH completed")
+            elif upper == "STORE":
+                seq_part, _, _flags = rest.partition(" ")
+                if self.selected_folder:
+                    self.store.mark_deleted(
+                        self.mailbox, self.selected_folder, self._parse_seqs(seq_part)
+                    )
+                self._tagged_ok(tag, "STORE completed")
+            elif upper == "EXPUNGE":
+                if self.selected_folder:
+                    for seq in self.store.expunge(self.mailbox, self.selected_folder):
+                        self._line(f"* {seq} EXPUNGE")
+                self._tagged_ok(tag, "EXPUNGE completed")
+            elif upper == "CLOSE":
+                if self.selected_folder:
+                    self.store.expunge(self.mailbox, self.selected_folder)
+                self.selected_folder = None
+                self._tagged_ok(tag, "CLOSE completed")
+            elif upper == "NOOP":
+                self._tagged_ok(tag, "NOOP completed")
+            elif upper == "LOGOUT":
+                self._line("* BYE LOGOUT requested")
+                self._tagged_ok(tag, "LOGOUT completed")
+                return
+            else:
+                self._line(f"{tag} BAD unsupported command")
+
+
+class HealthHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b"ok\n")
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+class ThreadingTCPServer(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+def _serve(server: ThreadingTCPServer) -> threading.Thread:
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return thread
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", default="/tmp/toolathlon-mail")
+    parser.add_argument("--smtp-port", type=int, default=25)
+    parser.add_argument("--submission-port", type=int, default=587)
+    parser.add_argument("--imap-port", type=int, default=143)
+    parser.add_argument("--http-port", type=int, default=80)
+    parser.add_argument("--ready-file", default="/tmp/poste-ready")
+    args = parser.parse_args()
+
+    store = MailStore(Path(args.root))
+    SMTPHandler.store = store
+    IMAPHandler.store = store
+
+    servers: list[ThreadingTCPServer] = []
+    for port, handler in (
+        (args.smtp_port, SMTPHandler),
+        (args.submission_port, SMTPHandler),
+        (args.imap_port, IMAPHandler),
+        (args.http_port, HealthHandler),
+    ):
+        server = ThreadingTCPServer(("0.0.0.0", port), handler)
+        servers.append(server)
+        _serve(server)
+
+    Path(args.ready_file).write_text("ready\n")
+    print(
+        "toolathlon fake mail ready "
+        f"(smtp={args.smtp_port}, submission={args.submission_port}, "
+        f"imap={args.imap_port}, http={args.http_port})",
+        flush=True,
+    )
+    try:
+        while True:
+            time.sleep(3600)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        for server in servers:
+            server.shutdown()
+            server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/benchflow/adapters/_toolathlon_services.py
+++ b/src/benchflow/adapters/_toolathlon_services.py
@@ -11,14 +11,13 @@ auto-routes the task to the DinD / Docker compose sandbox strategy
 (``sandbox/daytona.py`` picks ``_DaytonaDinD`` when ``docker-compose.yaml``
 exists), so no run-time flag change is needed.
 
-Implemented: **poste.io** email (24 tasks), **Canvas** (8 tasks),
-**WooCommerce** (9 tasks), and **k8s/kind** (5 tasks). The poste sidecar boots the stock
-``analogic/poste.io`` image, seeds the fixed 503-user roster upstream ships in
-``configs/users_data.json`` (vendored here as ``_toolathlon_poste_users.tsv`` so
-the feature is hermetic), and re-applies poste's plaintext-auth config on every
-boot (poste regenerates that config on start). The task's email ``*_config.json``
-files are rewritten to reach the sidecar by service name, so the ``emails`` MCP
-server, preprocess and verifier all transparently talk to it.
+Implemented: **email** (24 tasks), **Canvas** (8 tasks), **WooCommerce** (9
+tasks), and **k8s/kind** (5 tasks). The email sidecar runs a tiny
+BenchFlow-managed SMTP/IMAP service from the already-built task image; it avoids
+pulling the much larger poste.io appliance inside Daytona's 10 GB DinD sandbox.
+The task's email ``*_config.json`` files are rewritten to reach the sidecar by
+service name, so the ``emails`` MCP server, preprocess and verifier all
+transparently talk to it.
 
 Canvas and WooCommerce boot stock upstream images with task-local first-boot
 seed scripts. k8s tasks run their upstream kind scripts from the main container
@@ -40,9 +39,6 @@ WOO = "woo"
 CANVAS = "canvas"
 K8S = "k8s"
 
-# Pulled via the GCR Docker Hub mirror to dodge anonymous Docker Hub rate limits
-# inside concurrent DinD sandboxes (stock analogic/poste.io, unmodified).
-_POSTE_IMAGE = "mirror.gcr.io/analogic/poste.io:2.5.5"
 _WOO_DB_IMAGE = "mysql:8.0"
 _WOO_WP_IMAGE = "wordpress:6.8.2-php8.2-apache"
 _CANVAS_IMAGE = "lbjay/canvas-docker"
@@ -161,17 +157,12 @@ def _is_localhost_mail_config(data: dict) -> bool:
 def _write_poste_assets(task_dir: Path) -> None:
     """Write the sidecar's boot assets under ``environment/poste/``."""
     poste_dir = task_dir / "environment" / POSTE
-    _write(poste_dir / "pairs.tsv", _poste_users_tsv())
-    _write(poste_dir / "plaintext_fix.sh", _POSTE_PLAINTEXT_FIX)
-    _write(poste_dir / "entry.sh", _POSTE_ENTRY)
-
-
-def _poste_users_tsv() -> str:
-    return (
+    fake_mail = (
         resources.files("benchflow.adapters")
-        .joinpath("_toolathlon_poste_users.tsv")
+        .joinpath("_toolathlon_fake_mail.py")
         .read_text()
     )
+    _write(poste_dir / "fake_mail.py", fake_mail)
 
 
 def _compose_yaml(services: set[str]) -> str:
@@ -207,83 +198,35 @@ def _poste_compose_service(*, publish_host_ports: bool) -> str:
     )
 
 
-# poste seeds ~503 users + re-applies plaintext auth from entry.sh, then touches
-# /tmp/poste-ready; main gates on that sentinel so preprocess never races an
-# unseeded mailbox. start_period is generous — first-boot seeding takes ~1-2 min.
+# The fake mail sidecar runs from ``${MAIN_IMAGE_NAME}``, the image BenchFlow has
+# already built for the task's main container, so email tasks do not pull a
+# second large mail appliance into Daytona's 10 GB DinD VM. It keeps the service
+# name ``poste`` because generated task configs are already rewritten to that
+# hostname.
 _POSTE_COMPOSE_SERVICE_TEMPLATE = """  poste:
-    image: mirror.gcr.io/analogic/poste.io:2.5.5
-    hostname: mcp.com
-    cap_add:
-      - NET_ADMIN
-      - NET_RAW
-      - NET_BIND_SERVICE
-      - SYS_PTRACE
-    environment:
-      DISABLE_CLAMAV: "TRUE"
-      DISABLE_RSPAMD: "TRUE"
-      DISABLE_P0F: "TRUE"
-      HTTPS_FORCE: "0"
-      HTTPS: "OFF"{ports}
+    image: ${{MAIN_IMAGE_NAME}}
+    hostname: poste{ports}
     volumes:
       - ./poste:/toolathlon-poste:ro
-    entrypoint: ["/bin/bash", "/toolathlon-poste/entry.sh"]
+    command:
+      - /usr/bin/python3
+      - /toolathlon-poste/fake_mail.py
+      - --smtp-port
+      - "25"
+      - --submission-port
+      - "587"
+      - --imap-port
+      - "143"
+      - --http-port
+      - "80"
+      - --ready-file
+      - /tmp/poste-ready
     healthcheck:
       test: ["CMD-SHELL", "test -f /tmp/poste-ready"]
-      interval: 10s
-      timeout: 5s
-      retries: 90
-      start_period: 30s"""
-
-
-# Re-apply poste's plaintext-auth config (poste regenerates dovecot/haraka
-# config on each boot, so this must run every start, not be baked as files).
-# Mirrors upstream deployment/poste/scripts/setup.sh::configure_dovecot.
-_POSTE_PLAINTEXT_FIX = r"""#!/bin/bash
-set +e
-for i in $(seq 1 90); do
-  [ -f /etc/dovecot/conf.d/10-ssl.conf ] && [ -f /opt/haraka-submission/config/auth.ini ] && break
-  sleep 2
-done
-sleep 6
-sed -i 's/ssl = required/ssl = yes/' /etc/dovecot/conf.d/10-ssl.conf
-sed -i 's/auth_allow_cleartext = no/auth_allow_cleartext = yes/' /etc/dovecot/conf.d/10-auth.conf
-sed -i '/disable_plaintext_auth/d' /etc/dovecot/conf.d/10-auth.conf
-sed -i 's/tls_required = true/tls_required = false/' /opt/haraka-smtp/config/auth.ini
-sed -i 's/tls_required = true/tls_required = false/' /opt/haraka-submission/config/auth.ini
-sed -i 's#^auth/poste#\#auth/poste#' /opt/haraka-submission/config/plugins
-printf '127.0.0.1/8\n192.168.0.0/16\n172.16.0.0/12\n10.0.0.0/8\n' > /opt/haraka-submission/config/relay_acl_allow
-doveadm reload 2>/dev/null || kill -HUP "$(pgrep dovecot | head -1)" 2>/dev/null
-kill "$(pgrep -f 'haraka.*smtp')" 2>/dev/null
-kill "$(pgrep -f 'haraka.*submission')" 2>/dev/null
-"""
-
-
-# Runs as the poste entrypoint: launch poste's own /init (PID 1), then in the
-# background wait for the admin console, create the mcp.com domain, seed the
-# roster (uid 8 = mail, matching upstream's `docker exec --user=8`), apply the
-# plaintext-auth fix, and finally signal readiness.
-_POSTE_ENTRY = r"""#!/bin/bash
-run8() { setpriv --reuid=8 --regid=8 --clear-groups "$@"; }
-(
-  for i in $(seq 1 120); do
-    run8 php /opt/admin/bin/console domain:list >/dev/null 2>&1 && break
-    sleep 3
-  done
-  run8 php /opt/admin/bin/console domain:create mcp.com >/dev/null 2>&1
-  n=0
-  while IFS=$'\t' read -r email pass name; do
-    [ -z "$email" ] && continue
-    run8 php /opt/admin/bin/console email:create "$email" "$pass" "$name" >/dev/null 2>&1 &
-    n=$((n + 1))
-    [ $((n % 40)) -eq 0 ] && wait
-  done < /toolathlon-poste/pairs.tsv
-  wait
-  bash /toolathlon-poste/plaintext_fix.sh
-  touch /tmp/poste-ready
-  echo "[poste entry] seeded $n mailboxes, plaintext auth applied, ready"
-) &
-exec /init
-"""
+      interval: 5s
+      timeout: 3s
+      retries: 24
+      start_period: 5s"""
 
 
 def _write(path: Path, value: str) -> None:

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -429,11 +429,10 @@ def _write_runtime_files(
 # deadline so a slow-but-fine proxy is not killed; a genuine crash still fails fast
 # via the process-exit check below.
 #
-# Scope: this deadline covers only ``_poll_host_health``. The in-sandbox proxy
-# pollers (``_wait_for_sandbox_state`` / ``_poll_sandbox_health``) keep their own
-# ``range(120)`` loop, where each iteration is bounded by a ``sandbox.exec`` round
-# trip rather than a fixed 0.25s sleep — so they already wait far longer than 30s
-# and are deliberately not governed by this budget.
+# Scope: this deadline covers host and sandbox LiteLLM readiness. The sandbox
+# pollers also use it as their overall deadline; a single slow Daytona
+# ``sandbox.exec`` probe is treated as one failed attempt, not a fatal startup
+# failure.
 def _health_deadline_sec() -> float:
     # Parse defensively: a malformed BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC must not
     # crash ``import benchflow``. Floor at one poll cycle so a 0/negative value still
@@ -709,21 +708,27 @@ async def _wait_for_sandbox_state(
     *,
     state_path: str,
     stderr_path: str,
+    deadline_s: float = _HEALTH_DEADLINE_SEC,
 ) -> dict[str, Any]:
     last_output = ""
-    for _ in range(120):
-        result = await sandbox.exec(
-            f"cat {shlex.quote(state_path)} 2>/dev/null || true",
-            timeout_sec=5,
-        )
-        last_output = (result.stdout or "").strip()
-        if last_output:
-            try:
-                state = json.loads(last_output)
-                if int(state.get("port") or 0) > 0:
-                    return state
-            except (TypeError, ValueError, json.JSONDecodeError):
-                pass
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    while loop.time() - start < deadline_s:
+        try:
+            result = await sandbox.exec(
+                f"cat {shlex.quote(state_path)} 2>/dev/null || true",
+                timeout_sec=5,
+            )
+            last_output = (result.stdout or "").strip()
+            if last_output:
+                try:
+                    state = json.loads(last_output)
+                    if int(state.get("port") or 0) > 0:
+                        return state
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    pass
+        except Exception as exc:
+            last_output = str(exc)
         await asyncio.sleep(0.25)
     stderr = await sandbox.exec(
         f"tail -c 4000 {shlex.quote(stderr_path)} 2>/dev/null || true",
@@ -736,7 +741,12 @@ async def _wait_for_sandbox_state(
 
 
 async def _poll_sandbox_health(
-    sandbox: Any, *, python: str, port: int, stderr_path: str
+    sandbox: Any,
+    *,
+    python: str,
+    port: int,
+    stderr_path: str,
+    deadline_s: float = _HEALTH_DEADLINE_SEC,
 ) -> None:
     probe = (
         f"{shlex.quote(python)} - <<'PY'\n"
@@ -748,10 +758,15 @@ async def _poll_sandbox_health(
         "    urllib.request.urlopen(url.replace('/health/liveliness','/health'), timeout=2).read()\n"
         "PY"
     )
-    for _ in range(120):
-        result = await sandbox.exec(probe, timeout_sec=5)
-        if result.return_code == 0:
-            return
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    while loop.time() - start < deadline_s:
+        try:
+            result = await sandbox.exec(probe, timeout_sec=5)
+            if result.return_code == 0:
+                return
+        except Exception:
+            pass
         await asyncio.sleep(0.25)
     stderr = await sandbox.exec(
         f"tail -c 4000 {shlex.quote(stderr_path)} 2>/dev/null || true",

--- a/src/benchflow/sandbox/_compose_files/docker-compose-build.yaml
+++ b/src/benchflow/sandbox/_compose_files/docker-compose-build.yaml
@@ -1,5 +1,6 @@
 services:
   main:
+    image: ${MAIN_IMAGE_NAME}
     build:
       context: ${CONTEXT_DIR}
     pull_policy: build

--- a/src/benchflow/sandbox/daytona.py
+++ b/src/benchflow/sandbox/daytona.py
@@ -229,12 +229,20 @@ _DAYTONA_TRANSIENT_RETRY_CLASS_NAMES = frozenset(
         "DaytonaTimeoutError",
     }
 )
+_DAYTONA_EMPTY_EXIT_CODE_MARKERS = (
+    "failed to convert exit code to int",
+    'strconv.Atoi: parsing "": invalid syntax',
+)
 
 
 def _is_daytona_transient_retry_error(exc: BaseException) -> bool:
     if isinstance(exc, (ConnectionError, TimeoutError)):
         return True
     exc_type = type(exc)
+    if exc_type.__module__.startswith("daytona.") and all(
+        marker in str(exc) for marker in _DAYTONA_EMPTY_EXIT_CODE_MARKERS
+    ):
+        return True
     return (
         exc_type.__module__.startswith("daytona.")
         and exc_type.__name__ in _DAYTONA_TRANSIENT_RETRY_CLASS_NAMES

--- a/tests/test_daytona_poll_deadline.py
+++ b/tests/test_daytona_poll_deadline.py
@@ -28,6 +28,13 @@ from benchflow.sandbox import daytona as daytona_module
 from benchflow.sandbox.daytona import DaytonaSandbox
 
 
+class _FakeDaytonaError(Exception):
+    pass
+
+
+_FakeDaytonaError.__module__ = "daytona.common.errors"
+
+
 def _install_fake_clock(monkeypatch) -> dict[str, float]:
     """Make the poll loop time-deterministic, independent of wall clock.
 
@@ -80,6 +87,15 @@ def _make_sandbox(process: _FakeProcess) -> DaytonaSandbox:
     sandbox = DaytonaSandbox.__new__(DaytonaSandbox)
     sandbox._sandbox = SimpleNamespace(process=process)
     return sandbox
+
+
+def test_daytona_empty_exit_code_parse_error_is_retryable() -> None:
+    exc = _FakeDaytonaError(
+        "Failed to get session command: failed to convert exit code to int: "
+        'strconv.Atoi: parsing "": invalid syntax'
+    )
+
+    assert daytona_module._is_daytona_transient_retry_error(exc)
 
 
 class TestPollDeadline:

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -979,3 +980,51 @@ def test_health_deadline_env_parse_is_defensive(monkeypatch):
     assert rt._health_deadline_sec() >= 1.0
     monkeypatch.setenv("BENCHFLOW_LITELLM_HEALTH_TIMEOUT_SEC", "240")
     assert rt._health_deadline_sec() == 240.0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_sandbox_state_retries_slow_exec_probe():
+    class _Sandbox:
+        def __init__(self):
+            self.calls = 0
+
+        async def exec(self, _command, timeout_sec):
+            self.calls += 1
+            if self.calls == 1:
+                raise TimeoutError("Command timed out after 5 seconds")
+            return SimpleNamespace(return_code=0, stdout='{"port": 32123}')
+
+    sandbox = _Sandbox()
+    state = await runtime_mod._wait_for_sandbox_state(
+        sandbox,
+        state_path="/tmp/state.json",
+        stderr_path="/tmp/stderr.log",
+        deadline_s=1.0,
+    )
+
+    assert state["port"] == 32123
+    assert sandbox.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_poll_sandbox_health_retries_slow_exec_probe():
+    class _Sandbox:
+        def __init__(self):
+            self.calls = 0
+
+        async def exec(self, _command, timeout_sec):
+            self.calls += 1
+            if self.calls == 1:
+                raise TimeoutError("Command timed out after 5 seconds")
+            return SimpleNamespace(return_code=0, stdout="")
+
+    sandbox = _Sandbox()
+    await runtime_mod._poll_sandbox_health(
+        sandbox,
+        python="/venv/bin/python",
+        port=32123,
+        stderr_path="/tmp/stderr.log",
+        deadline_s=1.0,
+    )
+
+    assert sandbox.calls == 2

--- a/tests/test_source_adapters.py
+++ b/tests/test_source_adapters.py
@@ -1,8 +1,12 @@
 import csv
+import imaplib
 import json
 import os
+import smtplib
 import subprocess
 import sys
+import time
+from email.mime.text import MIMEText
 from pathlib import Path
 
 import yaml
@@ -240,22 +244,21 @@ def test_toolathlon_email_task_gets_poste_sidecar(tmp_path: Path, monkeypatch) -
         )
     )
 
-    # Email task: compose with a poste sidecar + gated main.
+    # Email task: compose with a lightweight mail sidecar + gated main.
     email = adapted.path / "apply-phd-email"
     compose = yaml.safe_load(
         (email / "environment" / "docker-compose.yaml").read_text()
     )
-    assert compose["services"]["poste"]["image"].endswith("analogic/poste.io:2.5.5")
+    assert compose["services"]["poste"]["image"] == "${MAIN_IMAGE_NAME}"
+    assert compose["services"]["poste"]["hostname"] == "poste"
     assert (
         compose["services"]["main"]["depends_on"]["poste"]["condition"]
         == "service_healthy"
     )
     assert "ports" not in compose["services"]["poste"]
     poste_dir = email / "environment" / "poste"
-    assert (poste_dir / "entry.sh").exists()
-    assert (poste_dir / "plaintext_fix.sh").exists()
-    # Vendored roster is materialized, not the (empty) upstream users_data.json.
-    assert len((poste_dir / "pairs.tsv").read_text().splitlines()) > 100
+    assert (poste_dir / "fake_mail.py").exists()
+    assert "/toolathlon-poste/fake_mail.py" in compose["services"]["poste"]["command"]
 
     task = Task(email)
     # Extra headroom for the DinD compose + sidecar image.
@@ -270,6 +273,107 @@ def test_toolathlon_email_task_gets_poste_sidecar(tmp_path: Path, monkeypatch) -
     # Non-email task: single container, no compose.
     other = adapted.path / "find-alita-paper"
     assert not (other / "environment" / "docker-compose.yaml").exists()
+
+
+def test_toolathlon_fake_mail_records_sender_sent(tmp_path: Path) -> None:
+    """The lightweight mail sidecar preserves the sender Sent-folder contract
+    Toolathlon verifiers use."""
+    root = tmp_path / "mail"
+    ready = tmp_path / "ready"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "benchflow.adapters._toolathlon_fake_mail",
+            "--root",
+            str(root),
+            "--smtp-port",
+            "11587",
+            "--submission-port",
+            "12587",
+            "--imap-port",
+            "11143",
+            "--http-port",
+            "11080",
+            "--ready-file",
+            str(ready),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        for _ in range(50):
+            if ready.exists():
+                break
+            if proc.poll() is not None:
+                stdout, stderr = proc.communicate(timeout=1)
+                raise AssertionError(f"fake mail exited: {stdout} {stderr}")
+            time.sleep(0.1)
+        assert ready.exists()
+
+        msg = MIMEText(
+            "Survey: https://docs.google.com/forms/d/abcdefghijk1234567890/edit",
+            "plain",
+        )
+        msg["From"] = "Customer Support Team"
+        msg["To"] = "tyler_perez28@mcp.com"
+        msg["Subject"] = "Survey"
+
+        smtp = smtplib.SMTP("127.0.0.1", 12587, timeout=10)
+        smtp.send_message(msg, from_addr="jason_cruz@mcp.com")
+        smtp.quit()
+
+        imap = imaplib.IMAP4("127.0.0.1", 11143, timeout=10)
+        imap.login("jason_cruz@mcp.com", "anything")
+        assert imap.select("Sent")[0] == "OK"
+        status, nums = imap.search(None, "ALL")
+        assert status == "OK"
+        assert nums and nums[0] == b"1"
+        status, data = imap.fetch(b"1", "(RFC822)")
+        assert status == "OK"
+        assert b"tyler_perez28@mcp.com" in data[0][1]
+        assert b"docs.google.com/forms" in data[0][1]
+        status, _ = imap.append(
+            "Sent",
+            None,
+            None,
+            (
+                b"From: jason_cruz@mcp.com\r\n"
+                b"To: followup@mcp.com\r\n"
+                b"Subject: Follow-up\r\n\r\n"
+                b"Thanks"
+            ),
+        )
+        assert status == "OK"
+        status, nums = imap.search(None, "ALL")
+        assert status == "OK"
+        assert nums and nums[0] == b"1 2"
+        status, data = imap.fetch(b"2", "(RFC822)")
+        assert status == "OK"
+        assert b"followup@mcp.com" in data[0][1]
+        imap.logout()
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def test_compose_build_tags_main_image_for_sidecar_reuse() -> None:
+    """Compose sidecars can reference ${MAIN_IMAGE_NAME} without registry pulls."""
+    compose_path = (
+        Path(__file__).resolve().parents[1]
+        / "src"
+        / "benchflow"
+        / "sandbox"
+        / "_compose_files"
+        / "docker-compose-build.yaml"
+    )
+    compose = yaml.safe_load(compose_path.read_text())
+    assert compose["services"]["main"]["image"] == "${MAIN_IMAGE_NAME}"
 
 
 def test_toolathlon_k8s_task_gets_host_network_runtime(
@@ -828,7 +932,7 @@ def test_toolathlon_container_launch_resolves_tokens(tmp_path: Path) -> None:
         {"TOOLATHLON_TASK_DIR": str(task_dir)},
     )
     assert result.returncode == 0, result.stderr
-    out = result.stdout.strip()
+    out = f"{result.stdout}\n{result.stderr}"
     assert "--project=global-proj" in out  # from global
     assert "--dataset=demo_ds" in out  # per-task override wins
     assert "--folder=FID-999" in out  # runtime file value
@@ -848,7 +952,7 @@ def test_toolathlon_container_launch_resolves_env(tmp_path: Path) -> None:
         },
     )
     assert result.returncode == 0, result.stderr
-    assert "GITHUB_TOKEN=gho_secret" in result.stdout
+    assert "GITHUB_TOKEN=gho_secret" in f"{result.stdout}\n{result.stderr}"
 
 
 def test_toolathlon_container_launch_prefers_generated_kubeconfig(
@@ -873,7 +977,7 @@ def test_toolathlon_container_launch_prefers_generated_kubeconfig(
         {"TOOLATHLON_TASK_DIR": str(task_dir)},
     )
     assert result.returncode == 0, result.stderr
-    assert f"KUBECONFIG={generated}" in result.stdout
+    assert f"KUBECONFIG={generated}" in f"{result.stdout}\n{result.stderr}"
 
 
 def test_toolathlon_container_launch_ensures_dirs(tmp_path: Path) -> None:
@@ -893,6 +997,33 @@ def test_toolathlon_container_launch_ensures_dirs(tmp_path: Path) -> None:
     )
     assert result.returncode == 0, result.stderr
     assert storage.is_dir()
+
+
+def test_toolathlon_container_launch_filters_non_json_stdout(
+    tmp_path: Path,
+) -> None:
+    """Noisy MCP startup logs are moved off stdout before they reach clients."""
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "token_key_session.py").write_text(
+        "all_token_key_session = {}\n"
+    )
+    result = _run_container_helper(
+        tmp_path,
+        [
+            "launch",
+            sys.executable,
+            "-c",
+            (
+                "import sys; "
+                "print('server started'); "
+                'print(\'{"jsonrpc":"2.0","id":1,"result":{}}\')'
+            ),
+        ],
+        {"TOOLATHLON_TASK_DIR": str(tmp_path)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == '{"jsonrpc":"2.0","id":1,"result":{}}'
+    assert "server started" in result.stderr
 
 
 def test_toolathlon_arxiv_server_declares_ensure_dirs(


### PR DESCRIPTION
## Summary
- replace heavy poste.io email sidecar with a lightweight BenchFlow SMTP/IMAP sidecar that runs from the already-built task image
- tag the main compose image so Toolathlon sidecars can reuse it inside Daytona without registry pulls
- filter noisy MCP server startup logs away from stdio JSON-RPC stdout
- retry transient Daytona sandbox exec/probe failures during LiteLLM and sandbox readiness polling

## Validation
- `uv run python -m pytest tests/test_source_adapters.py tests/test_daytona_poll_deadline.py tests/test_litellm_hardening.py -q`
- `uv run ruff check src/benchflow/adapters/_toolathlon_container.py src/benchflow/adapters/_toolathlon_fake_mail.py src/benchflow/adapters/_toolathlon_services.py src/benchflow/providers/litellm_runtime.py src/benchflow/sandbox/daytona.py tests/test_source_adapters.py tests/test_litellm_hardening.py tests/test_daytona_poll_deadline.py`
- `uv run ruff format --check src/benchflow/adapters/_toolathlon_container.py src/benchflow/adapters/_toolathlon_fake_mail.py src/benchflow/adapters/_toolathlon_services.py src/benchflow/providers/litellm_runtime.py src/benchflow/sandbox/daytona.py tests/test_source_adapters.py tests/test_litellm_hardening.py tests/test_daytona_poll_deadline.py`
- live Daytona proof: `woocommerce-customer-survey` scored `1/1 (100.0%), errors=0` in `.local/toolathlon-daytona-stability/proof-woocommerce-customer-survey-filtered-20260705T0935Z`

Generated by Codex on behalf of the user.