### PR TITLE
Fix Toolathlon Daytona direct runtime

### DIFF
--- a/.github/workflows/integration-light.yml
+++ b/.github/workflows/integration-light.yml
@@ -172,6 +172,9 @@ jobs:
       # Low-value provider candidates only. The selector probes these in order.
       DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
       DEEPSEEK_BASE_URL: ${{ secrets.DEEPSEEK_BASE_URL }}
+      GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+      GLM_BASE_URL: ${{ secrets.GLM_BASE_URL }}
+      GLM_MODEL: ${{ secrets.GLM_MODEL }}
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
       GITHUB_MODELS_TOKEN: ${{ secrets.GITHUB_MODELS_TOKEN || github.token }}
       # The L1 smoke task. workflow_dispatch can override it.

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -483,6 +483,9 @@ async def connect_acp(
         try:
             if environment == "docker":
                 live_proc = DockerProcess.from_sandbox_env(env)
+            elif environment == "daytona":
+                live_proc = await DaytonaPtyProcess.from_sandbox_env(env)
+                logger.info("Using PTY transport for Daytona sandbox")
             else:
                 is_dind = hasattr(env, "_strategy") and hasattr(
                     env._strategy, "_compose_cmd"

--- a/src/benchflow/adapters/_toolathlon.py
+++ b/src/benchflow/adapters/_toolathlon.py
@@ -691,6 +691,8 @@ def _toolathlon_setup_command(*, task_name: str, variant: str) -> str:
             f"runpy.run_module({preprocess_module!r}, run_name='__main__')",
             "PY",
             "fi",
+            f"{python_cmd} {shlex.quote(_TOOLATHLON_CONTAINER_MODULE_PATH)} "
+            'write-task-tokens "$TASK_DIR"',
             'for private in "$TASK_DIR/groundtruth_workspace" "$TASK_DIR/evaluation"; do',
             '  if [ -e "$private" ]; then',
             '    chown -R root:root "$private"',

--- a/src/benchflow/adapters/_toolathlon_container.py
+++ b/src/benchflow/adapters/_toolathlon_container.py
@@ -21,6 +21,13 @@ invokes it in two roles:
     groundtruth-derived allowlists, per-student Canvas tokens, …), so it is
     where they must be resolved — the host adapter cannot know them.
 
+``write-task-tokens <task-dir>``
+    Snapshot the task-local token file after preprocess but before BenchFlow
+    locks private groundtruth paths. Some upstream task token files compute MCP
+    allowlists by reading groundtruth files; sandboxed agents must not retain
+    direct read access to those files, so ``launch`` consumes this scalar-only
+    snapshot when present.
+
 Kept dependency-free (plain ``python3``, with an ``addict`` shim) so it needs
 neither the upstream venv nor a ``uv`` round-trip on every MCP spawn.
 """
@@ -37,6 +44,56 @@ import types
 from pathlib import Path
 
 _PLACEHOLDER = re.compile(r"\$\{([^}]+)\}")
+_GOOGLE_CLOUD_MCP_NAMES = {"google-cloud-mcp"}
+_GOOGLE_CLOUD_MCP_PATTERN_WRAPPER = r'''#!/usr/bin/env python3
+"""BenchFlow Toolathlon wrapper for google-cloud-mcp wildcard allowlists."""
+
+from __future__ import annotations
+
+import fnmatch
+import sys
+
+
+class _PatternSet(set):
+    def __contains__(self, item: object) -> bool:
+        if super().__contains__(item):
+            return True
+        item_text = str(item)
+        for pattern in self:
+            pattern_text = str(pattern)
+            if any(ch in pattern_text for ch in "*?[]") and fnmatch.fnmatchcase(
+                item_text,
+                pattern_text,
+            ):
+                return True
+        return False
+
+
+def main() -> int | None:
+    import src.server as server
+
+    original_setup_server = server.setup_server
+
+    def setup_server(*args, **kwargs):
+        result = original_setup_server(*args, **kwargs)
+        for attr in (
+            "ALLOWED_BUCKETS",
+            "ALLOWED_DATASETS",
+            "ALLOWED_LOG_BUCKETS",
+            "ALLOWED_INSTANCES",
+        ):
+            value = getattr(server, attr, set())
+            if not isinstance(value, _PatternSet):
+                setattr(server, attr, _PatternSet(value))
+        return result
+
+    server.setup_server = setup_server
+    return server.main()
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+'''
 
 
 def _workspace() -> Path:
@@ -93,7 +150,11 @@ def _template_vars(task_dir: Path) -> dict[str, str]:
         "task_dir": str(workspace / "tasks" / "finalpool"),
     }
     tokens = _load_all_token_key_session(workspace / "configs" / "token_key_session.py")
-    tokens.update(_load_all_token_key_session(task_dir / "token_key_session.py"))
+    task_snapshot = workspace / ".toolathlon" / "task_token_key_session.py"
+    if task_snapshot.is_file():
+        tokens.update(_load_all_token_key_session(task_snapshot))
+    else:
+        tokens.update(_load_all_token_key_session(task_dir / "token_key_session.py"))
     k8s_configs = task_dir / "k8s_configs"
     if k8s_configs.is_dir():
         kubeconfigs = sorted(k8s_configs.glob("*-config.yaml"))
@@ -150,6 +211,43 @@ def _run_stdio_server(argv: list[str], env: dict[str, str]) -> int:
         return 130
 
 
+def _google_cloud_mcp_index(argv: list[str]) -> int | None:
+    for index, arg in enumerate(argv):
+        if Path(arg).name in _GOOGLE_CLOUD_MCP_NAMES:
+            return index
+    return None
+
+
+def _write_google_cloud_mcp_pattern_wrapper() -> Path:
+    runtime_dir = Path(
+        os.environ.get(
+            "TOOLATHLON_RUNTIME_DIR",
+            "/tmp/benchflow_toolathlon",
+        )
+    )
+    target = runtime_dir / "google_cloud_mcp_pattern_wrapper.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    if not target.is_file() or target.read_text() != _GOOGLE_CLOUD_MCP_PATTERN_WRAPPER:
+        target.write_text(_GOOGLE_CLOUD_MCP_PATTERN_WRAPPER)
+        target.chmod(0o644)
+    return target
+
+
+def _wrap_google_cloud_mcp(argv: list[str]) -> list[str]:
+    index = _google_cloud_mcp_index(argv)
+    if index is None:
+        return argv
+    wrapper = _write_google_cloud_mcp_pattern_wrapper()
+    # Upstream launches this as ``uvx google-cloud-mcp ...``. Keep uvx in
+    # charge of package resolution, but run a small Python wrapper from the same
+    # ephemeral environment so Toolathlon wildcard allowlists such as
+    # ``promo-assets-for-b*`` are honored by google-cloud-mcp's exact-match
+    # access checks.
+    if index == 1 and Path(argv[0]).name == "uvx":
+        return [argv[0], "--from", argv[1], "python", str(wrapper), *argv[2:]]
+    return argv
+
+
 def _launch(argv: list[str]) -> int:
     if not argv:
         sys.stderr.write("toolathlon launch: no command given\n")
@@ -173,6 +271,7 @@ def _launch(argv: list[str]) -> int:
         resolved_env["PATH"] = (
             "/usr/local/bin:/usr/bin:/bin:/usr/local/sbin:/usr/sbin:/sbin"
         )
+    resolved_argv = _wrap_google_cloud_mcp(resolved_argv)
     return _run_stdio_server(resolved_argv, resolved_env)
 
 
@@ -273,6 +372,29 @@ def _write_config() -> int:
     return 0
 
 
+def _write_task_tokens(task_dir: Path) -> int:
+    tokens = _load_all_token_key_session(task_dir / "token_key_session.py")
+    scalar_tokens = {
+        key: value
+        for key, value in tokens.items()
+        if isinstance(value, (str, int, float, bool))
+    }
+    target = _workspace() / ".toolathlon" / "task_token_key_session.py"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Generated by BenchFlow Toolathlon adapter.",
+        "# Scalar task-local token snapshot for sandboxed MCP launchers.",
+        "all_token_key_session = {",
+    ]
+    lines += [
+        f"    {key!r}: {value!r}," for key, value in sorted(scalar_tokens.items())
+    ]
+    lines.append("}")
+    target.write_text("\n".join(lines) + "\n")
+    target.chmod(0o644)
+    return 0
+
+
 def main(argv: list[str]) -> int:
     if not argv:
         sys.stderr.write("toolathlon_container: expected 'write-config' or 'launch'\n")
@@ -280,6 +402,11 @@ def main(argv: list[str]) -> int:
     mode, rest = argv[0], argv[1:]
     if mode == "write-config":
         return _write_config()
+    if mode == "write-task-tokens":
+        if len(rest) != 1:
+            sys.stderr.write("toolathlon_container: write-task-tokens needs TASK_DIR\n")
+            return 2
+        return _write_task_tokens(Path(rest[0]))
     if mode == "launch":
         return _launch(rest)
     sys.stderr.write(f"toolathlon_container: unknown mode {mode!r}\n")

--- a/src/benchflow/sandbox/process.py
+++ b/src/benchflow/sandbox/process.py
@@ -630,8 +630,9 @@ class DaytonaPtyProcess(LiveProcess):
     """Live stdin/stdout via Daytona PTY WebSocket API.
 
     Uses the Daytona SDK's PTY session (WebSocket) instead of SSH, which
-    maintains long-lived interactive pipes through DinD compose layers.
-    Falls back to this for DinD sandboxes where SSH pipes break.
+    maintains long-lived interactive pipes through Daytona sandboxes.
+    Compose sandboxes enter the ``main`` service through ``docker compose exec``;
+    direct sandboxes run the agent command directly in the PTY shell.
     """
 
     _process = None  # Not used — override readline/writeline/close
@@ -652,11 +653,18 @@ class DaytonaPtyProcess(LiveProcess):
         sandbox = env._sandbox
         if not sandbox:
             raise RuntimeError("Daytona sandbox not started")
-        strategy = env._strategy
-        compose_env = " ".join(
-            f"{k}={shlex.quote(v)}" for k, v in strategy._compose_env_vars().items()
-        )
-        compose_cmd_base = strategy._compose_cmd([])
+        strategy = getattr(env, "_strategy", None)
+        compose_env = ""
+        compose_cmd_base = ""
+        if (
+            strategy is not None
+            and hasattr(strategy, "_compose_env_vars")
+            and hasattr(strategy, "_compose_cmd")
+        ):
+            compose_env = " ".join(
+                f"{k}={shlex.quote(v)}" for k, v in strategy._compose_env_vars().items()
+            )
+            compose_cmd_base = strategy._compose_cmd([])
         return cls(
             sandbox=sandbox,
             compose_cmd_prefix=compose_env,
@@ -720,14 +728,6 @@ class DaytonaPtyProcess(LiveProcess):
             await self._pty.wait_for_connection()
             logger.info(f"DaytonaPtyProcess: PTY connected (session={session_id})")
 
-            compose_parts = (
-                shlex.split(self._compose_cmd_base)
-                if self._compose_cmd_base
-                else ["docker", "compose"]
-            )
-            exec_parts = [*compose_parts, "exec", "-i", "-T"]
-            if cwd:
-                exec_parts.extend(["-w", cwd])
             if env:
                 remote_env_path = f"/tmp/benchflow_env_{uuid.uuid4().hex[:16]}.env"
                 self._remote_env_path = remote_env_path
@@ -735,18 +735,35 @@ class DaytonaPtyProcess(LiveProcess):
                     remote_env_path=remote_env_path,
                     env=env,
                 )
-                for key in env:
-                    exec_parts.extend(["--env", key])
-            exec_parts.extend(["main", "bash", "-lc", command])
-            exec_cmd = shlex.join(exec_parts)
-            if remote_env_path:
-                remote_env_path_q = shlex.quote(remote_env_path)
-                setup_exec_cmd = (
-                    f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
-                    f"exec {exec_cmd}"
-                )
+
+            if self._compose_cmd_base:
+                compose_parts = shlex.split(self._compose_cmd_base)
+                exec_parts = [*compose_parts, "exec", "-i", "-T"]
+                if cwd:
+                    exec_parts.extend(["-w", cwd])
+                if env:
+                    for key in env:
+                        exec_parts.extend(["--env", key])
+                exec_parts.extend(["main", "bash", "-lc", command])
+                exec_cmd = shlex.join(exec_parts)
+                if remote_env_path:
+                    remote_env_path_q = shlex.quote(remote_env_path)
+                    setup_exec_cmd = (
+                        f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
+                        f"exec {exec_cmd}"
+                    )
+                else:
+                    setup_exec_cmd = f"exec {exec_cmd}"
             else:
-                setup_exec_cmd = f"exec {exec_cmd}"
+                direct_parts: list[str] = []
+                if cwd:
+                    direct_parts.append(f"cd {shlex.quote(cwd)}")
+                if remote_env_path:
+                    remote_env_path_q = shlex.quote(remote_env_path)
+                    direct_parts.append(f". {remote_env_path_q}")
+                    direct_parts.append(f"rm -f {remote_env_path_q}")
+                direct_parts.append(f"exec bash -lc {shlex.quote(command)}")
+                setup_exec_cmd = " && ".join(direct_parts)
 
             # Use a marker + stty to cleanly hand over the PTY to the agent.
             # 1. Disable echo so typed commands don't appear in output

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1214,6 +1214,44 @@ class TestConnectAcpModelSelection:
         mock_pty.assert_awaited_once_with(mock_env)
         mock_ssh.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_daytona_direct_uses_pty_transport(self, tmp_path):
+        """Direct Daytona tasks also use PTY transport, not SSH pipes."""
+        from benchflow.acp.runtime import connect_acp
+
+        mock_acp = self._make_mocks()
+        mock_env = MagicMock()
+        mock_env.exec = AsyncMock(return_value=MagicMock(return_code=1, stdout=""))
+
+        with (
+            patch(
+                "benchflow.acp.runtime.DaytonaPtyProcess.from_sandbox_env",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_pty,
+            patch(
+                "benchflow.acp.runtime.DaytonaProcess.from_sandbox_env",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_ssh,
+            patch("benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="test-agent",
+                agent_launch="test-agent",
+                agent_env={},
+                sandbox_user=None,
+                model=None,
+                rollout_dir=tmp_path,
+                environment="daytona",
+                agent_cwd="/app",
+            )
+
+        mock_pty.assert_awaited_once_with(mock_env)
+        mock_ssh.assert_not_awaited()
+
 
 class TestSandboxStartupDiagnostics:
     """Guards ENG-147: sandbox startup failures must carry structured diagnostics."""

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -660,6 +660,39 @@ class TestDaytonaPtyProcessSecretTransport:
         assert secret not in cleanup_call.args[0]
 
     @pytest.mark.asyncio
+    async def test_direct_daytona_pty_runs_without_compose_and_hides_env(self):
+        """Direct Daytona tasks use PTY transport without docker compose."""
+        sandbox, ptys = _make_daytona_pty_sandbox()
+        proc = DaytonaPtyProcess(
+            sandbox=sandbox,
+            compose_cmd_prefix="",
+            compose_cmd_base="",
+        )
+        secret = "bf_direct_pty_provider_key_should_not_be_in_input"
+
+        await proc.start(
+            command="openhands acp --always-approve",
+            env={"OPENAI_API_KEY": secret},
+            cwd="/workspace/agent_workspace",
+        )
+
+        assert ptys
+        assert len(ptys[0].inputs) == 2
+        sent_payload = "\n".join(ptys[0].inputs)
+        assert "docker compose" not in sent_payload
+        assert "cd /workspace/agent_workspace" in sent_payload
+        assert ". /tmp/benchflow_env_" in sent_payload
+        assert "rm -f /tmp/benchflow_env_" in sent_payload
+        assert "exec bash -lc 'openhands acp --always-approve'" in sent_payload
+        assert "--env OPENAI_API_KEY" not in sent_payload
+        assert secret not in sent_payload
+        bootstrap_call = sandbox.process.exec.await_args_list[0]
+        assert bootstrap_call.kwargs["env"] == {"OPENAI_API_KEY": secret}
+        assert secret not in bootstrap_call.args[0]
+
+        await proc.close()
+
+    @pytest.mark.asyncio
     async def test_bootstrapped_env_file_is_removed_when_pty_handoff_fails(self):
         """Guards remote env cleanup when Daytona PTY start fails after bootstrap."""
         sandbox, ptys = _make_daytona_pty_sandbox(

--- a/tests/test_source_adapters.py
+++ b/tests/test_source_adapters.py
@@ -197,6 +197,10 @@ params:
     assert "ModuleNotFoundError|ImportError|PermissionError" in test_sh
     assert "Traceback (most recent call last):" not in test_sh
     assert "/usr/local/bin/uv run python" in test_sh
+    assert "toolathlon_container.py write-task-tokens" in setup_command
+    assert setup_command.index("write-task-tokens") < setup_command.index(
+        'chmod -R go-rwx "$private"'
+    )
 
 
 def _write_toolathlon_repo_skeleton(repo: Path) -> Path:
@@ -936,6 +940,86 @@ def test_toolathlon_container_launch_resolves_tokens(tmp_path: Path) -> None:
     assert "--project=global-proj" in out  # from global
     assert "--dataset=demo_ds" in out  # per-task override wins
     assert "--folder=FID-999" in out  # runtime file value
+
+
+def test_toolathlon_container_launch_uses_task_token_snapshot(tmp_path: Path) -> None:
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "token_key_session.py").write_text(
+        "all_token_key_session = {'gcp_project_id': 'global-proj'}\n"
+    )
+    task_dir = tmp_path / "tasks" / "finalpool" / "ab-testing"
+    groundtruth = task_dir / "groundtruth_workspace"
+    groundtruth.mkdir(parents=True)
+    (groundtruth / "log_bucket_name.txt").write_text("abtesting_logging_123")
+    (task_dir / "token_key_session.py").write_text(
+        "import os\n"
+        "from addict import Dict\n"
+        "_here = os.path.dirname(__file__)\n"
+        "with open(os.path.join(_here, 'groundtruth_workspace', "
+        "'log_bucket_name.txt')) as f:\n"
+        "    _bucket = f.read().strip()\n"
+        "all_token_key_session = Dict("
+        "google_cloud_allowed_log_buckets=_bucket)\n"
+    )
+
+    result = _run_container_helper(
+        tmp_path,
+        ["write-task-tokens", str(task_dir)],
+    )
+    assert result.returncode == 0, result.stderr
+    (groundtruth / "log_bucket_name.txt").unlink()
+
+    result = _run_container_helper(
+        tmp_path,
+        [
+            "launch",
+            "/bin/echo",
+            "--bucket=${token.google_cloud_allowed_log_buckets}",
+        ],
+        {"TOOLATHLON_TASK_DIR": str(task_dir)},
+    )
+    assert result.returncode == 0, result.stderr
+    assert "--bucket=abtesting_logging_123" in f"{result.stdout}\n{result.stderr}"
+
+
+def test_toolathlon_container_launch_wraps_google_cloud_mcp(tmp_path: Path) -> None:
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "token_key_session.py").write_text(
+        "all_token_key_session = {}\n"
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_uvx = fake_bin / "uvx"
+    fake_uvx.write_text("#!/bin/sh\nprintf '%s\\n' \"$@\"\n")
+    fake_uvx.chmod(0o755)
+    runtime_dir = tmp_path / "runtime"
+
+    result = _run_container_helper(
+        tmp_path,
+        [
+            "launch",
+            str(fake_uvx),
+            "google-cloud-mcp",
+            "--project-id",
+            "toolathlon-bench",
+            "--allowed-buckets",
+            "promo-assets-for-b*",
+        ],
+        {
+            "TOOLATHLON_TASK_DIR": str(tmp_path),
+            "TOOLATHLON_RUNTIME_DIR": str(runtime_dir),
+        },
+    )
+    assert result.returncode == 0, result.stderr
+    out = f"{result.stdout}\n{result.stderr}"
+    assert "--from" in out
+    assert "google-cloud-mcp" in out
+    assert "python" in out
+    assert "google_cloud_mcp_pattern_wrapper.py" in out
+    assert "--allowed-buckets" in out
+    assert "promo-assets-for-b*" in out
+    wrapper = runtime_dir / "google_cloud_mcp_pattern_wrapper.py"
+    assert "_PatternSet" in wrapper.read_text()
 
 
 def test_toolathlon_container_launch_resolves_env(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- route all Daytona ACP sessions through PTY transport, including direct non-compose sandboxes
- snapshot task-local Toolathlon tokens before private groundtruth/evaluation paths are locked
- wrap google-cloud-mcp launches so Toolathlon wildcard allowlists like `promo-assets-for-b*` work with the MCP server exact-match checks

## Validation
- `uv run python -m pytest tests/test_source_adapters.py -q`
- `uv run python -m pytest tests/test_process.py::TestDaytonaPtyProcessSecretTransport -q`
- `uv run python -m pytest tests/test_acp.py -k 'daytona_dind_uses_pty_transport or daytona_direct_uses_pty_transport' -q`\n- `uv run ruff check src/benchflow/acp/runtime.py src/benchflow/sandbox/process.py src/benchflow/adapters/_toolathlon.py src/benchflow/adapters/_toolathlon_container.py tests/test_process.py tests/test_acp.py tests/test_source_adapters.py`\n- `uv run ruff format --check src/benchflow/acp/runtime.py src/benchflow/sandbox/process.py src/benchflow/adapters/_toolathlon.py src/benchflow/adapters/_toolathlon_container.py tests/test_process.py tests/test_acp.py tests/test_source_adapters.py`\n- `git diff --check`\n- Live Daytona Toolathlon proof: `ab-testing`, run `.local/toolathlon-daytona-stability/proof-ab-testing-google-prefix-tmpwrap-20260705T0925Z`, score `1/1 (100.0%)`, errors `0`, reward `1.0`\n