### PR TITLE
fix(skill-eval): match punctuated exact answers

### DIFF
--- a/src/benchflow/templates/judge.py.tmpl
+++ b/src/benchflow/templates/judge.py.tmpl
@@ -163,11 +163,18 @@ def judge_with_llm(trajectory_text: str) -> float:
         return 0.0
 
 
+def exact_ground_truth_pattern(ground_truth: str) -> re.Pattern:
+    """Return a regex that matches a standalone exact ground-truth string."""
+    return re.compile(r"(?<!\w)" + re.escape(ground_truth) + r"(?!\w)")
+
+
 def judge_exact_match() -> float:
     """Fallback: exact string match against ground_truth."""
     ground_truth = CASE.get("ground_truth", "").strip()
     if not ground_truth:
         return 0.0
+
+    pattern = exact_ground_truth_pattern(ground_truth)
 
     # Only check agent output files, not arbitrary filesystem content
     search_paths = [AGENT_LOG_DIR, APP_DIR]
@@ -179,8 +186,9 @@ def judge_exact_match() -> float:
                 continue
             try:
                 content = f.read_text()
-                # Check for exact match on word boundaries (not substring)
-                if re.search(r'\b' + re.escape(ground_truth) + r'\b', content):
+                # Check for an exact standalone answer without requiring
+                # code-like punctuation such as ")" to form a word boundary.
+                if pattern.search(content):
                     return 1.0
             except (UnicodeDecodeError, PermissionError):
                 pass

--- a/tests/test_skill_eval_sweep.py
+++ b/tests/test_skill_eval_sweep.py
@@ -9,6 +9,9 @@ from __future__ import annotations
 
 import json
 import math
+import os
+import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -172,6 +175,62 @@ class TestJudgeResultCopy:
         assert "BENCHFLOW_REWARD_DETAILS_JSON" in test_sh
         assert "$VERIFIER_DIR/judge_result.json" in test_sh
         assert "/logs/verifier/judge_result.json" in test_sh
+
+
+# Issue #897 — exact-match judge delimiter handling
+
+
+class TestExactMatchJudgeDelimiters:
+    """Guards #897: exact-match judge handles code-like answer delimiters."""
+
+    @pytest.mark.parametrize(
+        ("content", "expected_reward"),
+        [
+            ("The method is getPageCount().\n", 1.0),
+            ("The method is getPageCount()Wrapper.\n", 0.0),
+        ],
+    )
+    def test_non_word_suffix_ground_truth_uses_word_char_delimiters(
+        self, tmp_path, content, expected_reward
+    ):
+        """Guards GitHub issue #897 against exact answers ending in non-word chars."""
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        ds = EvalDataset(
+            skill_name="method-skill",
+            skill_dir=skill_dir,
+            cases=[
+                EvalCase(
+                    id="case-001",
+                    question="Which method returns the page count?",
+                    ground_truth="getPageCount()",
+                )
+            ],
+        )
+        task = generate_tasks(ds, tmp_path / "tasks", with_skill=False)[0]
+        verifier_dir = TaskPaths(task).tests_dir
+
+        agent_log_dir = tmp_path / "logs" / "agent"
+        agent_log_dir.mkdir(parents=True)
+        (agent_log_dir / "answer.txt").write_text(content)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        subprocess.run(
+            [sys.executable, str(verifier_dir / "judge.py")],
+            check=True,
+            env={
+                **os.environ,
+                "BENCHFLOW_VERIFIER_DIR": str(verifier_dir),
+                "BENCHFLOW_AGENT_LOG_DIR": str(agent_log_dir),
+                "BENCHFLOW_WORKSPACE": str(workspace),
+            },
+            text=True,
+            capture_output=True,
+        )
+
+        reward = json.loads((verifier_dir / "reward.json").read_text())
+        assert reward == {"reward": expected_reward}
 
 
 # Issue #424 — evals.json schema validation

--- a/tests/test_skill_eval_sweep.py
+++ b/tests/test_skill_eval_sweep.py
@@ -193,7 +193,7 @@ class TestExactMatchJudgeDelimiters:
     def test_non_word_suffix_ground_truth_uses_word_char_delimiters(
         self, tmp_path, content, expected_reward
     ):
-        """Guards GitHub issue #897 against exact answers ending in non-word chars."""
+        """Guards PR #900 / issue #897 against punctuated exact answers."""
         skill_dir = tmp_path / "skill"
         skill_dir.mkdir()
         ds = EvalDataset(


### PR DESCRIPTION
## Summary

Fixes #897 by changing skill-eval's exact-match fallback from fixed `\b...\b` word-boundary matching to word-character lookaround delimiters. This keeps exact answers standalone without making code-like punctuation such as trailing `)` impossible to match.

## Context

The generated skill-eval judge template currently uses a fixed word-boundary regex around `ground_truth`. That cannot match valid ground truths ending in non-word characters, including examples like `getPageCount()` or `mcp.run(transport="streamable_http")`. A correct agent answer can therefore score `0.0` in no-rubric exact-match mode.

## Validation

- `uv run python -m pytest tests/test_skill_eval_sweep.py::TestExactMatchJudgeDelimiters`
- `uv run python -m pytest tests/test_skill_eval_sweep.py`
- `uv run ruff check src/benchflow/templates/judge.py.tmpl tests/test_skill_eval_sweep.py`

## Notes

A follow-up commit will update the regression docstring with this PR number after GitHub assigns it.