### PR TITLE
Add reusable task runtime primitive

### DIFF
--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -83,7 +83,14 @@ from benchflow.rewards import (
     load_rubric_json,
     load_rubric_toml,
 )
-from benchflow.rollout import Rollout, RolloutConfig
+from benchflow.rollout import (
+    BashToolResult,
+    Rollout,
+    RolloutConfig,
+    TaskRuntime,
+    TaskRuntimeConfig,
+    TaskRuntimeResult,
+)
 from benchflow.runtime import (
     Agent,
     Environment,
@@ -211,6 +218,10 @@ __all__ = [
     "list_snapshots",
     "Rollout",
     "RolloutConfig",
+    "BashToolResult",
+    "TaskRuntime",
+    "TaskRuntimeConfig",
+    "TaskRuntimeResult",
     "rollout_config_from_yaml",
     "BaseUser",
     "DocumentNudgeUser",

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -187,6 +187,10 @@ from benchflow.rollout._user_loop import (
 )
 from benchflow.rollout._user_loop import _run_steps as _run_steps_engine
 from benchflow.rollout._user_loop import _run_user_loop as _run_user_loop_engine
+from benchflow.rollout.task_runtime import BashToolResult as BashToolResult
+from benchflow.rollout.task_runtime import TaskRuntime as TaskRuntime
+from benchflow.rollout.task_runtime import TaskRuntimeConfig as TaskRuntimeConfig
+from benchflow.rollout.task_runtime import TaskRuntimeResult as TaskRuntimeResult
 from benchflow.rollout_branch import ChildRunner
 from benchflow.rollout_branch import branch as _branch_engine
 from benchflow.sandbox.metadata import persist_sandbox_info
@@ -703,6 +707,36 @@ class Rollout:
     @property
     def trajectory(self) -> list[dict]:
         return self._trajectory
+
+    def record_external_tool_call(
+        self,
+        *,
+        tool_name: str,
+        event: dict,
+    ) -> None:
+        """Record a tool call driven outside the ACP prompt loop.
+
+        Training integrations can own model generation while still preserving
+        BenchFlow's verifier and rollout artifact contract. Normal ACP rollouts
+        should continue to use ``execute``.
+        """
+
+        reserved = {"type", "tool_name"} & set(event)
+        if reserved:
+            reserved_text = ", ".join(sorted(reserved))
+            raise ValueError(
+                "record_external_tool_call event cannot contain reserved fields: "
+                f"{reserved_text}"
+            )
+
+        self._n_tool_calls += 1
+        self._trajectory.append(
+            {
+                "type": "tool_call",
+                "tool_name": tool_name,
+                **event,
+            }
+        )
 
     @property
     def tree(self) -> RolloutTree:
@@ -2443,4 +2477,8 @@ __all__ = [
     "Turn",
     "Rollout",
     "RolloutConfig",
+    "BashToolResult",
+    "TaskRuntime",
+    "TaskRuntimeConfig",
+    "TaskRuntimeResult",
 ]

--- a/src/benchflow/rollout/task_runtime.py
+++ b/src/benchflow/rollout/task_runtime.py
@@ -1,0 +1,277 @@
+"""Reusable single-task runtime primitive for training loops.
+
+This module exposes the sandbox + verifier subset of a :class:`Rollout`
+without launching an ACP agent. It is intentionally small: online training
+loops can bring their own policy/model loop, execute bash-like actions in the
+BenchFlow task sandbox, then call the normal verifier and artifact writers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from time import monotonic
+from typing import Any
+
+from benchflow.environment.manifest import EnvironmentManifest
+from benchflow.models import RolloutResult
+from benchflow.rollout._config import RolloutConfig
+from benchflow.skill_policy import SKILL_MODE_NO_SKILL, SKILL_MODE_WITH_SKILL
+
+
+@dataclass
+class TaskRuntimeConfig:
+    """Configuration for a BenchFlow task runtime session."""
+
+    task_path: str | Path
+    environment: str = "docker"
+    sandbox_user: str | None = "agent"
+    sandbox_locked_paths: list[str] | None = None
+    sandbox_setup_timeout: int = 120
+    job_name: str | None = None
+    rollout_name: str | None = None
+    jobs_dir: str | Path = "jobs"
+    context_root: str | Path | None = None
+    base_image_override: str | None = None
+    pre_agent_hooks: list | None = None
+    environment_manifest: EnvironmentManifest | None = None
+    config_override: dict | None = None
+    skills_dir: str | Path | None = None
+    skill_mode: str = SKILL_MODE_NO_SKILL
+    runtime_label: str = "task-runtime"
+    planes: Any | None = None
+
+    def __post_init__(self) -> None:
+        self.task_path = Path(self.task_path)
+        if self.context_root is not None:
+            self.context_root = Path(self.context_root)
+        if self.skills_dir is not None:
+            self.skills_dir = Path(self.skills_dir)
+        if self.skill_mode not in {SKILL_MODE_NO_SKILL, SKILL_MODE_WITH_SKILL}:
+            raise ValueError("TaskRuntimeConfig supports no-skill and with-skill only")
+
+    def to_rollout_config(self) -> RolloutConfig:
+        """Lower to the Rollout configuration used to own lifecycle/artifacts."""
+
+        return RolloutConfig(
+            task_path=Path(self.task_path),
+            environment=self.environment,
+            sandbox_user=self.sandbox_user,
+            sandbox_locked_paths=self.sandbox_locked_paths,
+            sandbox_setup_timeout=self.sandbox_setup_timeout,
+            skip_agent_install=True,
+            job_name=self.job_name,
+            rollout_name=self.rollout_name,
+            jobs_dir=self.jobs_dir,
+            context_root=self.context_root,
+            base_image_override=self.base_image_override,
+            pre_agent_hooks=self.pre_agent_hooks,
+            environment_manifest=self.environment_manifest,
+            config_override=self.config_override,
+            agent=self.runtime_label,
+            model=None,
+            prompts=[],
+            skills_dir=self.skills_dir,
+            skill_mode=self.skill_mode,
+            allow_document_user=False,
+            planes=self.planes,
+        )
+
+
+@dataclass(frozen=True)
+class BashToolResult:
+    """Result from a runtime bash tool call."""
+
+    command: str
+    return_code: int
+    stdout: str
+    stderr: str
+    elapsed_sec: float
+
+
+@dataclass(frozen=True)
+class TaskRuntimeResult:
+    """Verifier result plus the normal BenchFlow artifact location."""
+
+    task_name: str
+    rollout_name: str
+    reward: float | None
+    rewards: dict | None
+    verifier_error: str | None
+    error: str | None
+    rollout_dir: Path
+    result: RolloutResult
+
+
+class TaskRuntime:
+    """Run one BenchFlow-compatible task as a reusable sandbox primitive.
+
+    The caller drives the policy/training loop externally through
+    :meth:`bash`. :meth:`verify` then runs the same verifier and result writers
+    as a regular rollout, preserving artifact paths under ``jobs_dir``.
+    """
+
+    def __init__(self, config: TaskRuntimeConfig) -> None:
+        self.config = config
+        self._rollout: Any | None = None
+        self._started = False
+        self._verified = False
+
+    @classmethod
+    async def create(cls, config: TaskRuntimeConfig) -> TaskRuntime:
+        """Create and start a task runtime session."""
+
+        runtime = cls(config)
+        await runtime.start()
+        return runtime
+
+    @property
+    def rollout(self) -> Any:
+        if self._rollout is None:
+            raise RuntimeError("TaskRuntime.start() must run first")
+        return self._rollout
+
+    @property
+    def env(self) -> Any:
+        return self.rollout.env
+
+    @property
+    def workspace(self) -> str:
+        rollout = self.rollout
+        return getattr(rollout, "_agent_cwd", None) or "/app"
+
+    @property
+    def rollout_dir(self) -> Path:
+        rollout_dir = getattr(self.rollout, "_rollout_dir", None)
+        if not isinstance(rollout_dir, Path):
+            raise RuntimeError("TaskRuntime.start() did not initialize artifacts")
+        return rollout_dir
+
+    async def start(self) -> None:
+        """Set up and start the sandbox without launching an ACP agent."""
+
+        if self._started:
+            return
+        from benchflow.rollout import Rollout
+
+        rollout = await Rollout.create(self.config.to_rollout_config())
+        try:
+            await rollout.setup()
+            await rollout.start()
+            await rollout.install_agent()
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await rollout.cleanup()
+            raise
+        self._rollout = rollout
+        self._started = True
+
+    async def bash(
+        self,
+        command: str,
+        *,
+        timeout_sec: int = 30,
+        user: str | None = None,
+    ) -> BashToolResult:
+        """Execute a bash-like command in the task workspace.
+
+        The command is run through ``bash -lc`` after ``cd`` into the resolved
+        task workspace. This mirrors the shell affordance most training loops
+        need while keeping provider-specific tool protocols out of BenchFlow.
+        """
+
+        if not self._started:
+            raise RuntimeError("TaskRuntime.start() must run before bash()")
+        if not hasattr(self.env, "exec"):
+            raise RuntimeError("Active sandbox does not expose exec()")
+        workspace = shlex.quote(self.workspace)
+        script = f"cd {workspace} && {command}"
+        shell_command = f"bash -lc {shlex.quote(script)}"
+        exec_user = user if user is not None else self.config.sandbox_user
+
+        t0 = monotonic()
+        result = await self.env.exec(
+            shell_command,
+            user=exec_user or "root",
+            timeout_sec=timeout_sec,
+        )
+        elapsed = monotonic() - t0
+        tool_result = BashToolResult(
+            command=command,
+            return_code=int(
+                getattr(result, "return_code", getattr(result, "exit_code", 0))
+            ),
+            stdout=str(getattr(result, "stdout", "") or ""),
+            stderr=str(getattr(result, "stderr", "") or ""),
+            elapsed_sec=round(elapsed, 3),
+        )
+        self._record_bash_event(tool_result, timeout_sec=timeout_sec, user=exec_user)
+        return tool_result
+
+    def _record_bash_event(
+        self,
+        result: BashToolResult,
+        *,
+        timeout_sec: int,
+        user: str | None,
+    ) -> None:
+        self.rollout.record_external_tool_call(
+            tool_name="bash",
+            event={
+                "command": result.command,
+                "return_code": result.return_code,
+                "status": "completed" if result.return_code == 0 else "failed",
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "timeout_sec": timeout_sec,
+                "user": user,
+                "elapsed_sec": result.elapsed_sec,
+            },
+        )
+
+    async def verify(self) -> TaskRuntimeResult:
+        """Run the task verifier, write normal rollout artifacts, and return reward."""
+
+        if self._verified:
+            raise RuntimeError("TaskRuntime.verify() can only be called once")
+        rewards = await self.rollout.verify()
+        self._verified = True
+        result = self.rollout.result
+        if result is None:
+            raise RuntimeError("Rollout did not produce a verified result")
+        reward = (rewards or {}).get("reward") if isinstance(rewards, dict) else None
+        return TaskRuntimeResult(
+            task_name=result.task_name,
+            rollout_name=result.rollout_name,
+            reward=reward,
+            rewards=rewards,
+            verifier_error=result.verifier_error,
+            error=result.error,
+            rollout_dir=self.rollout_dir,
+            result=result,
+        )
+
+    async def close(self) -> None:
+        """Clean up the sandbox lifecycle owned by this runtime."""
+
+        if self._rollout is None:
+            return
+        await self._rollout.cleanup()
+        self._started = False
+
+    async def __aenter__(self) -> TaskRuntime:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+
+__all__ = [
+    "BashToolResult",
+    "TaskRuntime",
+    "TaskRuntimeConfig",
+    "TaskRuntimeResult",
+]

--- a/tests/test_task_runtime_primitive.py
+++ b/tests/test_task_runtime_primitive.py
@@ -1,0 +1,334 @@
+"""Tests for the reusable BenchFlow task runtime primitive."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.rollout import Rollout, TaskRuntime, TaskRuntimeConfig
+from benchflow.skill_policy import SKILL_MODE_SELF_GEN
+from benchflow.task import VerifierResult
+
+TASK_PATH = Path(__file__).parent / "examples" / "hello-world-task"
+
+
+@dataclass
+class _ExecResult:
+    return_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.started = 0
+        self.stopped = 0
+        self.exec_calls: list[dict[str, Any]] = []
+        self.uploads: list[tuple[str, str]] = []
+        self.files: dict[str, str] = {}
+        self.sandbox_id = "synthetic-sandbox"
+
+    async def start(self, *args: Any, **kwargs: Any) -> None:
+        self.started += 1
+
+    async def stop(self, *args: Any, **kwargs: Any) -> None:
+        self.stopped += 1
+
+    async def exec(self, cmd: str, **kwargs: Any) -> _ExecResult:
+        self.exec_calls.append({"cmd": cmd, **kwargs})
+        if cmd == "pwd":
+            return _ExecResult(stdout="/app\n")
+        if cmd.startswith("bash -lc "):
+            tokens = shlex.split(cmd)
+            script = tokens[2] if len(tokens) > 2 else ""
+            if "hello.txt" in script and "Hello, world!" in script:
+                self.files["/app/hello.txt"] = "Hello, world!"
+            if "exit 7" in script:
+                return _ExecResult(return_code=7, stderr="bad command\n")
+        return _ExecResult()
+
+    async def upload_file(self, src: str | Path, dst: str) -> None:
+        self.uploads.append((str(src), dst))
+        self.files[dst] = Path(src).read_text()
+
+    async def upload_dir(
+        self, src: str | Path, dst: str, service: str = "main"
+    ) -> None:
+        self.uploads.append((str(src), dst))
+
+
+class _FakeVerifier:
+    def __init__(self, sandbox: _FakeSandbox, rollout_paths: Any) -> None:
+        self.sandbox = sandbox
+        self.rollout_paths = rollout_paths
+
+    async def verify(self) -> VerifierResult:
+        reward = (
+            1.0 if self.sandbox.files.get("/app/hello.txt") == "Hello, world!" else 0.0
+        )
+        self.rollout_paths.reward_text_path.write_text(str(reward))
+        return VerifierResult(rewards={"reward": reward})
+
+
+class _FakePlanes:
+    def __init__(self) -> None:
+        self.sandbox = _FakeSandbox()
+        self.created: list[dict[str, Any]] = []
+        self.locked_paths: list[str] = []
+
+    def install_docker_compat(self) -> None:
+        return None
+
+    def extract_usage(self, runtime: Any) -> dict[str, Any]:
+        return {"usage_source": "unavailable"}
+
+    def agent_launch(self, agent: str, *, disallow_web_tools: bool) -> str:
+        return agent
+
+    def agent_config(self, agent: str) -> Any:
+        return None
+
+    def resolve_agent_env(
+        self,
+        agent: str,
+        model: str | None,
+        agent_env: dict[str, str] | None,
+    ) -> dict[str, str]:
+        return {}
+
+    def resolve_locked_paths(
+        self, sandbox_user: str | None, locked_paths: list[str] | None
+    ) -> list[str]:
+        if locked_paths is not None:
+            return locked_paths
+        if sandbox_user is None:
+            return []
+        return ["/oracle", "/solution", "/verifier", "/tests", "/testbed_verify"]
+
+    def stage_dockerfile_deps(self, task_path: Path, context_root: Path) -> None:
+        return None
+
+    def override_dockerfile_base_image(self, task_path: Path, base_image: str) -> int:
+        return 0
+
+    def inject_skills_into_dockerfile(
+        self, task_path: Path, skills_dir: Path, *, sandbox_dir: str = "/skills"
+    ) -> None:
+        return None
+
+    def create_environment(
+        self,
+        environment: str,
+        task: Any,
+        task_path: Path,
+        rollout_name: str | None,
+        rollout_paths: Any,
+        *,
+        preserve_agent_network: bool,
+        environment_manifest: Any,
+    ) -> _FakeSandbox:
+        self.created.append(
+            {
+                "environment": environment,
+                "task_path": task_path,
+                "rollout_name": rollout_name,
+                "preserve_agent_network": preserve_agent_network,
+            }
+        )
+        return self.sandbox
+
+    def manifest_environment(self, manifest: Any, *, sandbox: Any) -> Any:
+        raise AssertionError("environment manifests are not used in this test")
+
+    async def setup_sandbox_user(
+        self,
+        env: Any,
+        sandbox_user: str,
+        *,
+        workspace: str,
+        timeout_sec: int = 120,
+    ) -> str:
+        return workspace
+
+    async def snapshot_build_config(self, env: Any, *, workspace: str) -> None:
+        return None
+
+    async def seed_verifier_workspace(
+        self, env: Any, *, workspace: str, sandbox_user: str | None
+    ) -> None:
+        return None
+
+    async def deploy_skills(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def lockdown_paths(self, env: Any, locked_paths: list[str]) -> None:
+        self.locked_paths = list(locked_paths)
+
+    async def install_agent(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not install an ACP agent")
+
+    async def write_credential_files(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def upload_subscription_auth(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def apply_web_tool_policy(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def link_skill_paths(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def ensure_litellm_runtime(self, *args: Any, **kwargs: Any) -> Any:
+        return {}, None
+
+    async def stop_provider_runtime(self, runtime: Any) -> None:
+        return None
+
+    async def connect_acp(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not connect ACP")
+
+    async def execute_prompts(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not execute ACP prompts")
+
+    async def connect_session_factory(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not connect session factories")
+
+    async def execute_prompts_session_factory(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not execute session-factory prompts")
+
+    async def harden_before_verify(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def verifier(self, *args: Any, **kwargs: Any) -> _FakeVerifier:
+        return _FakeVerifier(kwargs["sandbox"], kwargs["rollout_paths"])
+
+    async def clear_verifier_output_dir(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def ensure_legacy_app_dir(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def cleanup_verifier_python_hooks(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_task_runtime_bash_verify_writes_rollout_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #902: training loops can exec, verify, and keep artifacts."""
+
+    planes = _FakePlanes()
+    config = TaskRuntimeConfig(
+        task_path=TASK_PATH,
+        environment="synthetic",
+        jobs_dir=tmp_path / "jobs",
+        rollout_name="train-loop",
+        planes=planes,
+    )
+
+    async with TaskRuntime(config) as runtime:
+        tool = await runtime.bash("printf 'Hello, world!' > hello.txt", timeout_sec=5)
+        failed_tool = await runtime.bash("printf bad >&2; exit 7", timeout_sec=5)
+        result = await runtime.verify()
+
+    assert tool.return_code == 0
+    assert failed_tool.return_code == 7
+    assert result.reward == 1.0
+    assert result.rewards == {"reward": 1.0}
+    assert planes.sandbox.started == 1
+    assert planes.sandbox.stopped == 1
+    assert planes.locked_paths == [
+        "/oracle",
+        "/solution",
+        "/verifier",
+        "/tests",
+        "/testbed_verify",
+    ]
+
+    bash_call = next(
+        call for call in planes.sandbox.exec_calls if "bash -lc" in call["cmd"]
+    )
+    assert bash_call["user"] == "agent"
+    assert "cd /app && printf" in shlex.split(bash_call["cmd"])[2]
+
+    rollout_dir = result.rollout_dir
+    assert (rollout_dir / "config.json").is_file()
+    assert (rollout_dir / "result.json").is_file()
+    assert (rollout_dir / "rewards.jsonl").is_file()
+    assert (rollout_dir / "trajectory" / "acp_trajectory.jsonl").is_file()
+    assert planes.sandbox.files["/logs/agent/acp_trajectory.jsonl"]
+    trajectory_events = [
+        json.loads(line)
+        for line in (rollout_dir / "trajectory" / "acp_trajectory.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    assert [
+        (event["type"], event["tool_name"], event["return_code"], event["status"])
+        for event in trajectory_events
+    ] == [
+        ("tool_call", "bash", 0, "completed"),
+        ("tool_call", "bash", 7, "failed"),
+    ]
+
+    result_json = json.loads((rollout_dir / "result.json").read_text())
+    assert result_json["agent"] == "task-runtime"
+    assert result_json["n_tool_calls"] == 2
+    assert result_json["rewards"] == {"reward": 1.0}
+    assert result_json["sandbox_id"] == "synthetic-sandbox"
+
+
+@pytest.mark.asyncio
+async def test_task_runtime_returns_zero_reward_from_verifier(tmp_path: Path) -> None:
+    """Guards PR #902: scalar rewards come from the verifier, not bash exit."""
+
+    planes = _FakePlanes()
+    runtime = await TaskRuntime.create(
+        TaskRuntimeConfig(
+            task_path=TASK_PATH,
+            environment="synthetic",
+            jobs_dir=tmp_path / "jobs",
+            rollout_name="unanswered",
+            planes=planes,
+        )
+    )
+    try:
+        result = await runtime.verify()
+    finally:
+        await runtime.close()
+
+    assert result.reward == 0.0
+    assert result.rewards == {"reward": 0.0}
+
+
+def test_task_runtime_rejects_self_gen_skill_mode() -> None:
+    """Guards PR #902: this primitive does not run skill-generation flows."""
+
+    with pytest.raises(ValueError, match="no-skill and with-skill"):
+        TaskRuntimeConfig(task_path=TASK_PATH, skill_mode=SKILL_MODE_SELF_GEN)
+
+
+def test_external_tool_call_rejects_reserved_event_fields(tmp_path: Path) -> None:
+    """Guards PR #902: external tool events cannot override canonical fields."""
+
+    rollout = Rollout(
+        TaskRuntimeConfig(
+            task_path=TASK_PATH,
+            environment="synthetic",
+            jobs_dir=tmp_path / "jobs",
+            planes=_FakePlanes(),
+        ).to_rollout_config()
+    )
+
+    with pytest.raises(ValueError, match="reserved fields: tool_name, type"):
+        rollout.record_external_tool_call(
+            tool_name="bash",
+            event={"type": "agent_message", "tool_name": "python"},
+        )


### PR DESCRIPTION
## Summary
- add a BenchFlow-native `TaskRuntime` primitive for external training loops
- expose a small public Rollout hook for externally-driven tool calls
- preserve normal rollout verifier/artifact output without adding TRL or Harbor dependencies

## Validation
- `uv run python -m pytest tests/test_task_runtime_primitive.py tests/test_runtime_live_sandbox.py tests/test_rollout_architecture.py -q`
- `uv run ruff check src/benchflow/rollout/task_runtime.py tests/test_task_runtime_primitive.py`
- `uv run ruff format --check src/benchflow/rollout/task_runtime.py tests/test_task_runtime_primitive.py`
- `uv run ty check src/benchflow/rollout/task_runtime.py`

## Notes
- live Daytona validation is intentionally deferred to the pipeline integration PR; this PR reuses the existing RolloutPlanes environment path and tests with synthetic planes.