### PR TITLE
Add optional TRL GRPO integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ train = [
     # handing JSONL rows to Prime-RL.
     "transformers==5.6.2",
 ]
+trl = [
+    "trl>=0.24.0",
+    "datasets>=2.19.0",
+]
 sandbox-daytona = [
     # >=0.183: list() returns an auto-paginating Iterator[Sandbox] (the older
     # paged list(page=, limit=) -> .items API was removed).

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -83,7 +83,14 @@ from benchflow.rewards import (
     load_rubric_json,
     load_rubric_toml,
 )
-from benchflow.rollout import Rollout, RolloutConfig
+from benchflow.rollout import (
+    BashToolResult,
+    Rollout,
+    RolloutConfig,
+    TaskRuntime,
+    TaskRuntimeConfig,
+    TaskRuntimeResult,
+)
 from benchflow.runtime import (
     Agent,
     Environment,
@@ -211,6 +218,10 @@ __all__ = [
     "list_snapshots",
     "Rollout",
     "RolloutConfig",
+    "BashToolResult",
+    "TaskRuntime",
+    "TaskRuntimeConfig",
+    "TaskRuntimeResult",
     "rollout_config_from_yaml",
     "BaseUser",
     "DocumentNudgeUser",

--- a/src/benchflow/integrations/__init__.py
+++ b/src/benchflow/integrations/__init__.py
@@ -1,0 +1,3 @@
+"""Optional third-party training and evaluation integrations."""
+
+__all__: list[str] = []

--- a/src/benchflow/integrations/trl/__init__.py
+++ b/src/benchflow/integrations/trl/__init__.py
@@ -1,0 +1,19 @@
+"""TRL integration surface for online GRPO training."""
+
+from benchflow.integrations.trl.spec import (
+    BashHarnessConfig,
+    BenchFlowOptionalDependencyError,
+    BenchFlowRuntimeEnvironment,
+    BenchFlowSpec,
+    BenchFlowSpecConfig,
+    benchflow_environment_reward,
+)
+
+__all__ = [
+    "BashHarnessConfig",
+    "BenchFlowOptionalDependencyError",
+    "BenchFlowRuntimeEnvironment",
+    "BenchFlowSpec",
+    "BenchFlowSpecConfig",
+    "benchflow_environment_reward",
+]

--- a/src/benchflow/integrations/trl/spec.py
+++ b/src/benchflow/integrations/trl/spec.py
@@ -1,0 +1,436 @@
+"""BenchFlow-owned adapter for TRL online training.
+
+The adapter maps BenchFlow-compatible task directories onto the three slots
+expected by TRL's environment-training APIs: ``train_dataset``,
+``environment_factory``, and ``reward_funcs``. BenchFlow owns task loading,
+sandbox lifecycle, verifier execution, and artifacts; TRL owns optimization.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+import threading
+from collections.abc import Callable, Coroutine, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from benchflow._utils.task_authoring import check_task, task_document_parse_error
+from benchflow.rollout import TaskRuntime, TaskRuntimeConfig
+from benchflow.task.package import TaskPackage
+
+
+class BenchFlowOptionalDependencyError(ImportError):
+    """Raised when optional TRL integration dependencies are used but missing."""
+
+
+@dataclass(frozen=True)
+class BashHarnessConfig:
+    """Runtime settings for the minimal bash tool surface exposed to TRL."""
+
+    environment: str = "docker"
+    sandbox_user: str | None = "agent"
+    jobs_dir: Path | str = "jobs/trl"
+    bash_timeout_sec: int = 30
+    max_output_chars: int = 4096
+    submit_path: str = "/workdir/answer.txt"
+    reset_message: str | None = None
+    planes: Any | None = None
+
+    def normalized(self) -> BashHarnessConfig:
+        if self.bash_timeout_sec < 1:
+            raise ValueError("bash_timeout_sec must be >= 1")
+        if self.max_output_chars < 1:
+            raise ValueError("max_output_chars must be >= 1")
+        if not self.submit_path.startswith("/"):
+            raise ValueError("submit_path must be absolute")
+        return BashHarnessConfig(
+            environment=self.environment,
+            sandbox_user=self.sandbox_user,
+            jobs_dir=Path(self.jobs_dir),
+            bash_timeout_sec=self.bash_timeout_sec,
+            max_output_chars=self.max_output_chars,
+            submit_path=self.submit_path,
+            reset_message=self.reset_message,
+            planes=self.planes,
+        )
+
+
+@dataclass(frozen=True)
+class BenchFlowSpecConfig:
+    """Configuration for building a TRL-compatible BenchFlow spec."""
+
+    tasks_dir: Path | str
+    include_tasks: Sequence[str] = ()
+    exclude_tasks: Sequence[str] = ()
+    max_tasks: int | None = None
+    bash_harness: BashHarnessConfig = field(default_factory=BashHarnessConfig)
+
+    def normalized(self) -> BenchFlowSpecConfig:
+        max_tasks = self.max_tasks
+        if max_tasks is not None and max_tasks < 1:
+            raise ValueError("max_tasks must be >= 1")
+        return BenchFlowSpecConfig(
+            tasks_dir=Path(self.tasks_dir),
+            include_tasks=tuple(dict.fromkeys(self.include_tasks)),
+            exclude_tasks=tuple(dict.fromkeys(self.exclude_tasks)),
+            max_tasks=max_tasks,
+            bash_harness=self.bash_harness.normalized(),
+        )
+
+
+@dataclass(frozen=True)
+class _TaskRow:
+    task_id: str
+    task_name: str
+    task_dir: Path
+    entrypoint: str
+    prompt_turn_index: int
+    prompt: list[dict[str, str]]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "prompt": self.prompt,
+            "benchflow_task_id": self.task_id,
+            "benchflow_task_name": self.task_name,
+            "benchflow_task_dir": str(self.task_dir),
+            "benchflow_entrypoint": self.entrypoint,
+            "benchflow_prompt_turn_index": self.prompt_turn_index,
+        }
+
+
+class BenchFlowRuntimeEnvironment:
+    """Synchronous TRL environment backed by ``TaskRuntime``.
+
+    TRL discovers public methods as tools. ``run_bash`` and ``submit`` are the
+    v1 tool surface; both execute inside the BenchFlow task sandbox.
+    """
+
+    def __init__(self, harness: BashHarnessConfig) -> None:
+        self._harness = harness.normalized()
+        self._runtime: TaskRuntime | None = None
+        self.task_id: str | None = None
+        self.reward: float = 0.0
+        self.rollout_dir: Path | None = None
+        self.last_returncode: int | None = None
+
+    def reset(self, **kwargs: Any) -> str | None:
+        """Start a fresh BenchFlow runtime for one training rollout."""
+
+        self._close()
+        task_dir_value = kwargs.get("benchflow_task_dir")
+        if not isinstance(task_dir_value, str) or not task_dir_value:
+            raise ValueError("BenchFlow TRL rows must include benchflow_task_dir")
+        task_id = kwargs.get("benchflow_task_id")
+        self.task_id = (
+            str(task_id) if task_id is not None else Path(task_dir_value).name
+        )
+        runtime_config = TaskRuntimeConfig(
+            task_path=task_dir_value,
+            environment=self._harness.environment,
+            sandbox_user=self._harness.sandbox_user,
+            jobs_dir=self._harness.jobs_dir,
+            planes=self._harness.planes,
+        )
+        self._runtime = _run_blocking(TaskRuntime.create(runtime_config))
+        self.reward = 0.0
+        self.rollout_dir = self._runtime.rollout_dir
+        return self._harness.reset_message
+
+    def run_bash(self, command: str) -> str:
+        """Run a bash command in the BenchFlow task sandbox.
+
+        Args:
+            command: Bash command to execute in the task workspace.
+
+        Returns:
+            Combined standard output and standard error, truncated if needed.
+        """
+
+        runtime = self._require_runtime()
+        result = _run_blocking(
+            runtime.bash(command, timeout_sec=self._harness.bash_timeout_sec)
+        )
+        self.last_returncode = result.return_code
+        output = result.stdout
+        if result.stderr:
+            output = f"{output}{result.stderr}"
+        return _truncate(output, self._harness.max_output_chars)
+
+    def submit(self, answer: str) -> str:
+        """Write the final answer and run the BenchFlow verifier.
+
+        Args:
+            answer: Final answer string to write to the configured submission path.
+
+        Returns:
+            Confirmation text including the verifier reward.
+        """
+
+        runtime = self._require_runtime()
+        answer_literal = shlex.quote(str(answer))
+        submit_path = shlex.quote(self._harness.submit_path)
+        _run_blocking(
+            runtime.bash(
+                f"mkdir -p $(dirname {submit_path}) && printf %s {answer_literal} > {submit_path}",
+                timeout_sec=self._harness.bash_timeout_sec,
+            )
+        )
+        result = _run_blocking(runtime.verify())
+        self.reward = (
+            float(result.reward) if isinstance(result.reward, int | float) else 0.0
+        )
+        self.rollout_dir = result.rollout_dir
+        self._runtime = None
+        _run_blocking(runtime.close())
+        return f"submission recorded; reward={self.reward:g}"
+
+    def _close(self) -> None:
+        runtime = self._runtime
+        self._runtime = None
+        if runtime is not None:
+            _run_blocking(runtime.close())
+
+    def _require_runtime(self) -> TaskRuntime:
+        if self._runtime is None:
+            raise RuntimeError("environment must be reset before tool use")
+        return self._runtime
+
+
+def benchflow_environment_reward(
+    completions: Sequence[Any],
+    *,
+    environments: Sequence[Any] | None = None,
+    **_: Any,
+) -> list[float]:
+    """TRL custom reward function reading reward from BenchFlow environments."""
+
+    if environments is None:
+        return [0.0 for _ in completions]
+
+    rewards: list[float] = []
+    for index, _completion in enumerate(completions):
+        env = environments[index] if index < len(environments) else None
+        value = getattr(env, "reward", 0.0)
+        rewards.append(
+            float(value)
+            if isinstance(value, int | float) and not isinstance(value, bool)
+            else 0.0
+        )
+    return rewards
+
+
+class BenchFlowSpec:
+    """Public TRL adapter for BenchFlow task suites."""
+
+    def __init__(
+        self,
+        config: BenchFlowSpecConfig | str | Path | None = None,
+        *,
+        tasks_dir: str | Path | None = None,
+        include_tasks: Sequence[str] = (),
+        exclude_tasks: Sequence[str] = (),
+        max_tasks: int | None = None,
+        bash_harness: BashHarnessConfig | None = None,
+    ) -> None:
+        if isinstance(config, BenchFlowSpecConfig):
+            if tasks_dir is not None:
+                raise ValueError("tasks_dir cannot be passed with BenchFlowSpecConfig")
+            normalized = config.normalized()
+        else:
+            resolved_tasks_dir = tasks_dir if config is None else config
+            if resolved_tasks_dir is None:
+                raise ValueError("BenchFlowSpec requires tasks_dir")
+            normalized = BenchFlowSpecConfig(
+                tasks_dir=resolved_tasks_dir,
+                include_tasks=include_tasks,
+                exclude_tasks=exclude_tasks,
+                max_tasks=max_tasks,
+                bash_harness=bash_harness or BashHarnessConfig(),
+            ).normalized()
+        self.config = normalized
+        self._rows = tuple(_load_task_rows(normalized))
+        if not self._rows:
+            raise ValueError(
+                f"No runnable BenchFlow tasks found under {normalized.tasks_dir}"
+            )
+
+    @classmethod
+    def from_tasks_dir(
+        cls,
+        tasks_dir: str | Path,
+        **kwargs: Any,
+    ) -> BenchFlowSpec:
+        return cls(tasks_dir, **kwargs)
+
+    @property
+    def train_dataset_rows(self) -> tuple[dict[str, Any], ...]:
+        return tuple(row.as_dict() for row in self._rows)
+
+    @property
+    def train_dataset(self) -> Any:
+        try:
+            from datasets import Dataset
+        except ImportError as exc:
+            raise BenchFlowOptionalDependencyError(
+                "benchflow.integrations.trl.BenchFlowSpec.train_dataset requires "
+                "the optional TRL integration dependencies. Install with "
+                "`pip install 'benchflow[trl]'` or `uv sync --extra trl`."
+            ) from exc
+        return Dataset.from_list(list(self.train_dataset_rows))
+
+    @property
+    def environment_factory(self) -> Callable[[], BenchFlowRuntimeEnvironment]:
+        def factory() -> BenchFlowRuntimeEnvironment:
+            return BenchFlowRuntimeEnvironment(self.config.bash_harness)
+
+        return factory
+
+    @property
+    def reward_funcs(self) -> list[Callable[..., list[float]]]:
+        return [benchflow_environment_reward]
+
+    def trainer_kwargs(self) -> dict[str, Any]:
+        return {
+            "train_dataset": self.train_dataset,
+            "environment_factory": self.environment_factory,
+            "reward_funcs": self.reward_funcs,
+        }
+
+    def create_trainer(self, *, model: Any, **kwargs: Any) -> Any:
+        try:
+            from trl import GRPOTrainer
+        except ImportError as exc:
+            raise BenchFlowOptionalDependencyError(
+                "benchflow.integrations.trl.BenchFlowSpec.create_trainer requires "
+                "TRL. Install with `pip install 'benchflow[trl]'` or "
+                "`uv sync --extra trl`."
+            ) from exc
+
+        trainer_kwargs = self.trainer_kwargs()
+        trainer_kwargs.update(kwargs)
+        return GRPOTrainer(model=model, **trainer_kwargs)
+
+
+def _load_task_rows(config: BenchFlowSpecConfig) -> list[_TaskRow]:
+    rows: list[_TaskRow] = []
+    for task_dir in _discover_task_dirs(
+        Path(config.tasks_dir),
+        include_tasks=set(config.include_tasks),
+        exclude_tasks=set(config.exclude_tasks),
+    ):
+        package = TaskPackage.from_task_dir(task_dir)
+        rows.extend(_rows_for_package(package))
+        if (
+            config.max_tasks is not None
+            and len({row.task_id for row in rows}) >= config.max_tasks
+        ):
+            break
+    return rows
+
+
+def _discover_task_dirs(
+    tasks_dir: Path,
+    *,
+    include_tasks: set[str],
+    exclude_tasks: set[str],
+) -> list[Path]:
+    if not tasks_dir.is_dir():
+        raise NotADirectoryError(f"Not a directory: {tasks_dir}")
+    if _is_runnable_task_dir(tasks_dir):
+        if tasks_dir.name in exclude_tasks:
+            return []
+        if include_tasks and tasks_dir.name not in include_tasks:
+            return []
+        return [tasks_dir]
+
+    selected: list[Path] = []
+    for child in sorted(path for path in tasks_dir.iterdir() if path.is_dir()):
+        if child.name in exclude_tasks:
+            continue
+        if include_tasks and child.name not in include_tasks:
+            continue
+        if _is_runnable_task_dir(child):
+            selected.append(child)
+            continue
+        task_md = child / "task.md"
+        parse_error = task_document_parse_error(task_md) if task_md.is_file() else None
+        if parse_error is not None:
+            raise ValueError(f"Malformed BenchFlow task {child}: {parse_error}")
+    root_task_md = tasks_dir / "task.md"
+    root_parse_error = (
+        task_document_parse_error(root_task_md) if root_task_md.is_file() else None
+    )
+    if root_parse_error is not None and not selected:
+        raise ValueError(f"Malformed BenchFlow task {tasks_dir}: {root_parse_error}")
+    return selected
+
+
+def _is_runnable_task_dir(path: Path) -> bool:
+    if (path / "task.md").is_file():
+        return check_task(path) == []
+    return (path / "task.toml").is_file() and check_task(path) == []
+
+
+def _rows_for_package(package: TaskPackage) -> list[_TaskRow]:
+    prompt_plan = package.prompt_plan
+    turns = prompt_plan.turns if prompt_plan is not None else ()
+    if not turns:
+        return []
+
+    task_config = package.view.config.task
+    task_name = task_config.name if task_config is not None else package.task_dir.name
+    return [
+        _TaskRow(
+            task_id=package.task_dir.name,
+            task_name=task_name,
+            task_dir=package.task_dir,
+            entrypoint=package.view.entrypoint,
+            prompt_turn_index=index,
+            prompt=[{"role": "user", "content": turn.prompt}],
+        )
+        for index, turn in enumerate(turns)
+    ]
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    if len(text) <= max_chars:
+        return text
+    marker = "\n[benchflow output truncated]\n"
+    keep = max(0, max_chars - len(marker))
+    return f"{text[:keep]}{marker}"
+
+
+def _run_blocking(coro: Coroutine[Any, Any, Any]) -> Any:
+    """Run an async BenchFlow primitive from TRL's sync tool surface."""
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    result: dict[str, Any] = {}
+
+    def runner() -> None:
+        try:
+            result["value"] = asyncio.run(coro)
+        except BaseException as exc:  # pragma: no cover - re-raised in caller
+            result["error"] = exc
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in result:
+        raise result["error"]
+    return result.get("value")
+
+
+__all__ = [
+    "BashHarnessConfig",
+    "BenchFlowOptionalDependencyError",
+    "BenchFlowRuntimeEnvironment",
+    "BenchFlowSpec",
+    "BenchFlowSpecConfig",
+    "benchflow_environment_reward",
+]

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -187,6 +187,10 @@ from benchflow.rollout._user_loop import (
 )
 from benchflow.rollout._user_loop import _run_steps as _run_steps_engine
 from benchflow.rollout._user_loop import _run_user_loop as _run_user_loop_engine
+from benchflow.rollout.task_runtime import BashToolResult as BashToolResult
+from benchflow.rollout.task_runtime import TaskRuntime as TaskRuntime
+from benchflow.rollout.task_runtime import TaskRuntimeConfig as TaskRuntimeConfig
+from benchflow.rollout.task_runtime import TaskRuntimeResult as TaskRuntimeResult
 from benchflow.rollout_branch import ChildRunner
 from benchflow.rollout_branch import branch as _branch_engine
 from benchflow.sandbox.metadata import persist_sandbox_info
@@ -703,6 +707,36 @@ class Rollout:
     @property
     def trajectory(self) -> list[dict]:
         return self._trajectory
+
+    def record_external_tool_call(
+        self,
+        *,
+        tool_name: str,
+        event: dict,
+    ) -> None:
+        """Record a tool call driven outside the ACP prompt loop.
+
+        Training integrations can own model generation while still preserving
+        BenchFlow's verifier and rollout artifact contract. Normal ACP rollouts
+        should continue to use ``execute``.
+        """
+
+        reserved = {"type", "tool_name"} & set(event)
+        if reserved:
+            reserved_text = ", ".join(sorted(reserved))
+            raise ValueError(
+                "record_external_tool_call event cannot contain reserved fields: "
+                f"{reserved_text}"
+            )
+
+        self._n_tool_calls += 1
+        self._trajectory.append(
+            {
+                "type": "tool_call",
+                "tool_name": tool_name,
+                **event,
+            }
+        )
 
     @property
     def tree(self) -> RolloutTree:
@@ -2443,4 +2477,8 @@ __all__ = [
     "Turn",
     "Rollout",
     "RolloutConfig",
+    "BashToolResult",
+    "TaskRuntime",
+    "TaskRuntimeConfig",
+    "TaskRuntimeResult",
 ]

--- a/src/benchflow/rollout/task_runtime.py
+++ b/src/benchflow/rollout/task_runtime.py
@@ -1,0 +1,277 @@
+"""Reusable single-task runtime primitive for training loops.
+
+This module exposes the sandbox + verifier subset of a :class:`Rollout`
+without launching an ACP agent. It is intentionally small: online training
+loops can bring their own policy/model loop, execute bash-like actions in the
+BenchFlow task sandbox, then call the normal verifier and artifact writers.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from time import monotonic
+from typing import Any
+
+from benchflow.environment.manifest import EnvironmentManifest
+from benchflow.models import RolloutResult
+from benchflow.rollout._config import RolloutConfig
+from benchflow.skill_policy import SKILL_MODE_NO_SKILL, SKILL_MODE_WITH_SKILL
+
+
+@dataclass
+class TaskRuntimeConfig:
+    """Configuration for a BenchFlow task runtime session."""
+
+    task_path: str | Path
+    environment: str = "docker"
+    sandbox_user: str | None = "agent"
+    sandbox_locked_paths: list[str] | None = None
+    sandbox_setup_timeout: int = 120
+    job_name: str | None = None
+    rollout_name: str | None = None
+    jobs_dir: str | Path = "jobs"
+    context_root: str | Path | None = None
+    base_image_override: str | None = None
+    pre_agent_hooks: list | None = None
+    environment_manifest: EnvironmentManifest | None = None
+    config_override: dict | None = None
+    skills_dir: str | Path | None = None
+    skill_mode: str = SKILL_MODE_NO_SKILL
+    runtime_label: str = "task-runtime"
+    planes: Any | None = None
+
+    def __post_init__(self) -> None:
+        self.task_path = Path(self.task_path)
+        if self.context_root is not None:
+            self.context_root = Path(self.context_root)
+        if self.skills_dir is not None:
+            self.skills_dir = Path(self.skills_dir)
+        if self.skill_mode not in {SKILL_MODE_NO_SKILL, SKILL_MODE_WITH_SKILL}:
+            raise ValueError("TaskRuntimeConfig supports no-skill and with-skill only")
+
+    def to_rollout_config(self) -> RolloutConfig:
+        """Lower to the Rollout configuration used to own lifecycle/artifacts."""
+
+        return RolloutConfig(
+            task_path=Path(self.task_path),
+            environment=self.environment,
+            sandbox_user=self.sandbox_user,
+            sandbox_locked_paths=self.sandbox_locked_paths,
+            sandbox_setup_timeout=self.sandbox_setup_timeout,
+            skip_agent_install=True,
+            job_name=self.job_name,
+            rollout_name=self.rollout_name,
+            jobs_dir=self.jobs_dir,
+            context_root=self.context_root,
+            base_image_override=self.base_image_override,
+            pre_agent_hooks=self.pre_agent_hooks,
+            environment_manifest=self.environment_manifest,
+            config_override=self.config_override,
+            agent=self.runtime_label,
+            model=None,
+            prompts=[],
+            skills_dir=self.skills_dir,
+            skill_mode=self.skill_mode,
+            allow_document_user=False,
+            planes=self.planes,
+        )
+
+
+@dataclass(frozen=True)
+class BashToolResult:
+    """Result from a runtime bash tool call."""
+
+    command: str
+    return_code: int
+    stdout: str
+    stderr: str
+    elapsed_sec: float
+
+
+@dataclass(frozen=True)
+class TaskRuntimeResult:
+    """Verifier result plus the normal BenchFlow artifact location."""
+
+    task_name: str
+    rollout_name: str
+    reward: float | None
+    rewards: dict | None
+    verifier_error: str | None
+    error: str | None
+    rollout_dir: Path
+    result: RolloutResult
+
+
+class TaskRuntime:
+    """Run one BenchFlow-compatible task as a reusable sandbox primitive.
+
+    The caller drives the policy/training loop externally through
+    :meth:`bash`. :meth:`verify` then runs the same verifier and result writers
+    as a regular rollout, preserving artifact paths under ``jobs_dir``.
+    """
+
+    def __init__(self, config: TaskRuntimeConfig) -> None:
+        self.config = config
+        self._rollout: Any | None = None
+        self._started = False
+        self._verified = False
+
+    @classmethod
+    async def create(cls, config: TaskRuntimeConfig) -> TaskRuntime:
+        """Create and start a task runtime session."""
+
+        runtime = cls(config)
+        await runtime.start()
+        return runtime
+
+    @property
+    def rollout(self) -> Any:
+        if self._rollout is None:
+            raise RuntimeError("TaskRuntime.start() must run first")
+        return self._rollout
+
+    @property
+    def env(self) -> Any:
+        return self.rollout.env
+
+    @property
+    def workspace(self) -> str:
+        rollout = self.rollout
+        return getattr(rollout, "_agent_cwd", None) or "/app"
+
+    @property
+    def rollout_dir(self) -> Path:
+        rollout_dir = getattr(self.rollout, "_rollout_dir", None)
+        if not isinstance(rollout_dir, Path):
+            raise RuntimeError("TaskRuntime.start() did not initialize artifacts")
+        return rollout_dir
+
+    async def start(self) -> None:
+        """Set up and start the sandbox without launching an ACP agent."""
+
+        if self._started:
+            return
+        from benchflow.rollout import Rollout
+
+        rollout = await Rollout.create(self.config.to_rollout_config())
+        try:
+            await rollout.setup()
+            await rollout.start()
+            await rollout.install_agent()
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await rollout.cleanup()
+            raise
+        self._rollout = rollout
+        self._started = True
+
+    async def bash(
+        self,
+        command: str,
+        *,
+        timeout_sec: int = 30,
+        user: str | None = None,
+    ) -> BashToolResult:
+        """Execute a bash-like command in the task workspace.
+
+        The command is run through ``bash -lc`` after ``cd`` into the resolved
+        task workspace. This mirrors the shell affordance most training loops
+        need while keeping provider-specific tool protocols out of BenchFlow.
+        """
+
+        if not self._started:
+            raise RuntimeError("TaskRuntime.start() must run before bash()")
+        if not hasattr(self.env, "exec"):
+            raise RuntimeError("Active sandbox does not expose exec()")
+        workspace = shlex.quote(self.workspace)
+        script = f"cd {workspace} && {command}"
+        shell_command = f"bash -lc {shlex.quote(script)}"
+        exec_user = user if user is not None else self.config.sandbox_user
+
+        t0 = monotonic()
+        result = await self.env.exec(
+            shell_command,
+            user=exec_user or "root",
+            timeout_sec=timeout_sec,
+        )
+        elapsed = monotonic() - t0
+        tool_result = BashToolResult(
+            command=command,
+            return_code=int(
+                getattr(result, "return_code", getattr(result, "exit_code", 0))
+            ),
+            stdout=str(getattr(result, "stdout", "") or ""),
+            stderr=str(getattr(result, "stderr", "") or ""),
+            elapsed_sec=round(elapsed, 3),
+        )
+        self._record_bash_event(tool_result, timeout_sec=timeout_sec, user=exec_user)
+        return tool_result
+
+    def _record_bash_event(
+        self,
+        result: BashToolResult,
+        *,
+        timeout_sec: int,
+        user: str | None,
+    ) -> None:
+        self.rollout.record_external_tool_call(
+            tool_name="bash",
+            event={
+                "command": result.command,
+                "return_code": result.return_code,
+                "status": "completed" if result.return_code == 0 else "failed",
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "timeout_sec": timeout_sec,
+                "user": user,
+                "elapsed_sec": result.elapsed_sec,
+            },
+        )
+
+    async def verify(self) -> TaskRuntimeResult:
+        """Run the task verifier, write normal rollout artifacts, and return reward."""
+
+        if self._verified:
+            raise RuntimeError("TaskRuntime.verify() can only be called once")
+        rewards = await self.rollout.verify()
+        self._verified = True
+        result = self.rollout.result
+        if result is None:
+            raise RuntimeError("Rollout did not produce a verified result")
+        reward = (rewards or {}).get("reward") if isinstance(rewards, dict) else None
+        return TaskRuntimeResult(
+            task_name=result.task_name,
+            rollout_name=result.rollout_name,
+            reward=reward,
+            rewards=rewards,
+            verifier_error=result.verifier_error,
+            error=result.error,
+            rollout_dir=self.rollout_dir,
+            result=result,
+        )
+
+    async def close(self) -> None:
+        """Clean up the sandbox lifecycle owned by this runtime."""
+
+        if self._rollout is None:
+            return
+        await self._rollout.cleanup()
+        self._started = False
+
+    async def __aenter__(self) -> TaskRuntime:
+        await self.start()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        await self.close()
+
+
+__all__ = [
+    "BashToolResult",
+    "TaskRuntime",
+    "TaskRuntimeConfig",
+    "TaskRuntimeResult",
+]

--- a/tests/test_task_runtime_primitive.py
+++ b/tests/test_task_runtime_primitive.py
@@ -1,0 +1,334 @@
+"""Tests for the reusable BenchFlow task runtime primitive."""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchflow.rollout import Rollout, TaskRuntime, TaskRuntimeConfig
+from benchflow.skill_policy import SKILL_MODE_SELF_GEN
+from benchflow.task import VerifierResult
+
+TASK_PATH = Path(__file__).parent / "examples" / "hello-world-task"
+
+
+@dataclass
+class _ExecResult:
+    return_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class _FakeSandbox:
+    def __init__(self) -> None:
+        self.started = 0
+        self.stopped = 0
+        self.exec_calls: list[dict[str, Any]] = []
+        self.uploads: list[tuple[str, str]] = []
+        self.files: dict[str, str] = {}
+        self.sandbox_id = "synthetic-sandbox"
+
+    async def start(self, *args: Any, **kwargs: Any) -> None:
+        self.started += 1
+
+    async def stop(self, *args: Any, **kwargs: Any) -> None:
+        self.stopped += 1
+
+    async def exec(self, cmd: str, **kwargs: Any) -> _ExecResult:
+        self.exec_calls.append({"cmd": cmd, **kwargs})
+        if cmd == "pwd":
+            return _ExecResult(stdout="/app\n")
+        if cmd.startswith("bash -lc "):
+            tokens = shlex.split(cmd)
+            script = tokens[2] if len(tokens) > 2 else ""
+            if "hello.txt" in script and "Hello, world!" in script:
+                self.files["/app/hello.txt"] = "Hello, world!"
+            if "exit 7" in script:
+                return _ExecResult(return_code=7, stderr="bad command\n")
+        return _ExecResult()
+
+    async def upload_file(self, src: str | Path, dst: str) -> None:
+        self.uploads.append((str(src), dst))
+        self.files[dst] = Path(src).read_text()
+
+    async def upload_dir(
+        self, src: str | Path, dst: str, service: str = "main"
+    ) -> None:
+        self.uploads.append((str(src), dst))
+
+
+class _FakeVerifier:
+    def __init__(self, sandbox: _FakeSandbox, rollout_paths: Any) -> None:
+        self.sandbox = sandbox
+        self.rollout_paths = rollout_paths
+
+    async def verify(self) -> VerifierResult:
+        reward = (
+            1.0 if self.sandbox.files.get("/app/hello.txt") == "Hello, world!" else 0.0
+        )
+        self.rollout_paths.reward_text_path.write_text(str(reward))
+        return VerifierResult(rewards={"reward": reward})
+
+
+class _FakePlanes:
+    def __init__(self) -> None:
+        self.sandbox = _FakeSandbox()
+        self.created: list[dict[str, Any]] = []
+        self.locked_paths: list[str] = []
+
+    def install_docker_compat(self) -> None:
+        return None
+
+    def extract_usage(self, runtime: Any) -> dict[str, Any]:
+        return {"usage_source": "unavailable"}
+
+    def agent_launch(self, agent: str, *, disallow_web_tools: bool) -> str:
+        return agent
+
+    def agent_config(self, agent: str) -> Any:
+        return None
+
+    def resolve_agent_env(
+        self,
+        agent: str,
+        model: str | None,
+        agent_env: dict[str, str] | None,
+    ) -> dict[str, str]:
+        return {}
+
+    def resolve_locked_paths(
+        self, sandbox_user: str | None, locked_paths: list[str] | None
+    ) -> list[str]:
+        if locked_paths is not None:
+            return locked_paths
+        if sandbox_user is None:
+            return []
+        return ["/oracle", "/solution", "/verifier", "/tests", "/testbed_verify"]
+
+    def stage_dockerfile_deps(self, task_path: Path, context_root: Path) -> None:
+        return None
+
+    def override_dockerfile_base_image(self, task_path: Path, base_image: str) -> int:
+        return 0
+
+    def inject_skills_into_dockerfile(
+        self, task_path: Path, skills_dir: Path, *, sandbox_dir: str = "/skills"
+    ) -> None:
+        return None
+
+    def create_environment(
+        self,
+        environment: str,
+        task: Any,
+        task_path: Path,
+        rollout_name: str | None,
+        rollout_paths: Any,
+        *,
+        preserve_agent_network: bool,
+        environment_manifest: Any,
+    ) -> _FakeSandbox:
+        self.created.append(
+            {
+                "environment": environment,
+                "task_path": task_path,
+                "rollout_name": rollout_name,
+                "preserve_agent_network": preserve_agent_network,
+            }
+        )
+        return self.sandbox
+
+    def manifest_environment(self, manifest: Any, *, sandbox: Any) -> Any:
+        raise AssertionError("environment manifests are not used in this test")
+
+    async def setup_sandbox_user(
+        self,
+        env: Any,
+        sandbox_user: str,
+        *,
+        workspace: str,
+        timeout_sec: int = 120,
+    ) -> str:
+        return workspace
+
+    async def snapshot_build_config(self, env: Any, *, workspace: str) -> None:
+        return None
+
+    async def seed_verifier_workspace(
+        self, env: Any, *, workspace: str, sandbox_user: str | None
+    ) -> None:
+        return None
+
+    async def deploy_skills(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def lockdown_paths(self, env: Any, locked_paths: list[str]) -> None:
+        self.locked_paths = list(locked_paths)
+
+    async def install_agent(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not install an ACP agent")
+
+    async def write_credential_files(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def upload_subscription_auth(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def apply_web_tool_policy(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def link_skill_paths(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def ensure_litellm_runtime(self, *args: Any, **kwargs: Any) -> Any:
+        return {}, None
+
+    async def stop_provider_runtime(self, runtime: Any) -> None:
+        return None
+
+    async def connect_acp(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not connect ACP")
+
+    async def execute_prompts(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not execute ACP prompts")
+
+    async def connect_session_factory(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not connect session factories")
+
+    async def execute_prompts_session_factory(self, *args: Any, **kwargs: Any) -> Any:
+        raise AssertionError("TaskRuntime must not execute session-factory prompts")
+
+    async def harden_before_verify(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def verifier(self, *args: Any, **kwargs: Any) -> _FakeVerifier:
+        return _FakeVerifier(kwargs["sandbox"], kwargs["rollout_paths"])
+
+    async def clear_verifier_output_dir(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def ensure_legacy_app_dir(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    async def cleanup_verifier_python_hooks(self, *args: Any, **kwargs: Any) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_task_runtime_bash_verify_writes_rollout_artifacts(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #902: training loops can exec, verify, and keep artifacts."""
+
+    planes = _FakePlanes()
+    config = TaskRuntimeConfig(
+        task_path=TASK_PATH,
+        environment="synthetic",
+        jobs_dir=tmp_path / "jobs",
+        rollout_name="train-loop",
+        planes=planes,
+    )
+
+    async with TaskRuntime(config) as runtime:
+        tool = await runtime.bash("printf 'Hello, world!' > hello.txt", timeout_sec=5)
+        failed_tool = await runtime.bash("printf bad >&2; exit 7", timeout_sec=5)
+        result = await runtime.verify()
+
+    assert tool.return_code == 0
+    assert failed_tool.return_code == 7
+    assert result.reward == 1.0
+    assert result.rewards == {"reward": 1.0}
+    assert planes.sandbox.started == 1
+    assert planes.sandbox.stopped == 1
+    assert planes.locked_paths == [
+        "/oracle",
+        "/solution",
+        "/verifier",
+        "/tests",
+        "/testbed_verify",
+    ]
+
+    bash_call = next(
+        call for call in planes.sandbox.exec_calls if "bash -lc" in call["cmd"]
+    )
+    assert bash_call["user"] == "agent"
+    assert "cd /app && printf" in shlex.split(bash_call["cmd"])[2]
+
+    rollout_dir = result.rollout_dir
+    assert (rollout_dir / "config.json").is_file()
+    assert (rollout_dir / "result.json").is_file()
+    assert (rollout_dir / "rewards.jsonl").is_file()
+    assert (rollout_dir / "trajectory" / "acp_trajectory.jsonl").is_file()
+    assert planes.sandbox.files["/logs/agent/acp_trajectory.jsonl"]
+    trajectory_events = [
+        json.loads(line)
+        for line in (rollout_dir / "trajectory" / "acp_trajectory.jsonl")
+        .read_text()
+        .splitlines()
+    ]
+    assert [
+        (event["type"], event["tool_name"], event["return_code"], event["status"])
+        for event in trajectory_events
+    ] == [
+        ("tool_call", "bash", 0, "completed"),
+        ("tool_call", "bash", 7, "failed"),
+    ]
+
+    result_json = json.loads((rollout_dir / "result.json").read_text())
+    assert result_json["agent"] == "task-runtime"
+    assert result_json["n_tool_calls"] == 2
+    assert result_json["rewards"] == {"reward": 1.0}
+    assert result_json["sandbox_id"] == "synthetic-sandbox"
+
+
+@pytest.mark.asyncio
+async def test_task_runtime_returns_zero_reward_from_verifier(tmp_path: Path) -> None:
+    """Guards PR #902: scalar rewards come from the verifier, not bash exit."""
+
+    planes = _FakePlanes()
+    runtime = await TaskRuntime.create(
+        TaskRuntimeConfig(
+            task_path=TASK_PATH,
+            environment="synthetic",
+            jobs_dir=tmp_path / "jobs",
+            rollout_name="unanswered",
+            planes=planes,
+        )
+    )
+    try:
+        result = await runtime.verify()
+    finally:
+        await runtime.close()
+
+    assert result.reward == 0.0
+    assert result.rewards == {"reward": 0.0}
+
+
+def test_task_runtime_rejects_self_gen_skill_mode() -> None:
+    """Guards PR #902: this primitive does not run skill-generation flows."""
+
+    with pytest.raises(ValueError, match="no-skill and with-skill"):
+        TaskRuntimeConfig(task_path=TASK_PATH, skill_mode=SKILL_MODE_SELF_GEN)
+
+
+def test_external_tool_call_rejects_reserved_event_fields(tmp_path: Path) -> None:
+    """Guards PR #902: external tool events cannot override canonical fields."""
+
+    rollout = Rollout(
+        TaskRuntimeConfig(
+            task_path=TASK_PATH,
+            environment="synthetic",
+            jobs_dir=tmp_path / "jobs",
+            planes=_FakePlanes(),
+        ).to_rollout_config()
+    )
+
+    with pytest.raises(ValueError, match="reserved fields: tool_name, type"):
+        rollout.record_external_tool_call(
+            tool_name="bash",
+            event={"type": "agent_message", "tool_name": "python"},
+        )

--- a/tests/test_trl_integration.py
+++ b/tests/test_trl_integration.py
@@ -1,0 +1,305 @@
+"""Synthetic coverage for the optional TRL GRPO integration."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+import types
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pytest
+
+from benchflow.integrations.trl import (
+    BashHarnessConfig,
+    BenchFlowOptionalDependencyError,
+    BenchFlowRuntimeEnvironment,
+    BenchFlowSpec,
+    BenchFlowSpecConfig,
+)
+
+
+def _make_task(parent: Path, name: str, instruction: str) -> Path:
+    task = parent / name
+    task.mkdir()
+    (task / "task.toml").write_text(
+        f"""
+version = "1.0"
+
+[task]
+name = "benchflow/{name}"
+description = "Synthetic TRL fixture"
+
+[verifier]
+timeout_sec = 60
+
+[agent]
+timeout_sec = 60
+
+[environment]
+""".lstrip()
+    )
+    (task / "instruction.md").write_text(instruction)
+    environment = task / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM ubuntu:24.04\n")
+    tests = task / "tests"
+    tests.mkdir()
+    test_sh = tests / "test.sh"
+    test_sh.write_text("#!/usr/bin/env bash\necho 1 >/logs/verifier/reward.txt\n")
+    test_sh.chmod(0o755)
+    return task
+
+
+@dataclass
+class _FakeBashResult:
+    return_code: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass
+class _FakeRuntimeResult:
+    reward: float
+    rollout_dir: Path
+
+
+class _FakeRuntime:
+    created_configs: ClassVar[list[Any]] = []
+
+    def __init__(self, config: Any) -> None:
+        self.config = config
+        self.rollout_dir = Path(config.jobs_dir) / "fake-rollout"
+        self.commands: list[str] = []
+        self.closed = False
+
+    @classmethod
+    async def create(cls, config: Any) -> _FakeRuntime:
+        cls.created_configs.append(config)
+        return cls(config)
+
+    async def bash(self, command: str, *, timeout_sec: int = 30) -> _FakeBashResult:
+        self.commands.append(command)
+        if command == "printf hi":
+            return _FakeBashResult(stdout="hi")
+        return _FakeBashResult()
+
+    async def verify(self) -> _FakeRuntimeResult:
+        reward = (
+            1.0 if any("/workdir/answer.txt" in cmd for cmd in self.commands) else 0.0
+        )
+        return _FakeRuntimeResult(reward=reward, rollout_dir=self.rollout_dir)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_public_import_path_does_not_require_trl(monkeypatch: pytest.MonkeyPatch):
+    """Guards PR #903: importing the public path must not import TRL."""
+
+    monkeypatch.setitem(sys.modules, "trl", None)
+
+    from benchflow.integrations.trl import BenchFlowSpec as Imported
+
+    assert Imported is BenchFlowSpec
+
+
+def test_spec_loads_task_rows_without_trl_dependency(tmp_path: Path):
+    """Guards PR #903: task dataset rows load from BenchFlow packages."""
+
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    _make_task(tasks, "beta", "Answer beta")
+
+    spec = BenchFlowSpec(tasks_dir=tasks, include_tasks=["beta"])
+
+    rows = spec.train_dataset_rows
+    assert len(rows) == 1
+    assert rows[0]["benchflow_task_id"] == "beta"
+    assert rows[0]["benchflow_task_name"] == "benchflow/beta"
+    assert rows[0]["prompt"] == [{"role": "user", "content": "Answer beta"}]
+
+
+def test_train_dataset_uses_hf_dataset_when_available(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards PR #903: train_dataset has the TRL/HF dataset shape."""
+
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+
+    fake_datasets = types.ModuleType("datasets")
+
+    class FakeDataset:
+        def __init__(self, rows):
+            self.rows = rows
+
+        @classmethod
+        def from_list(cls, rows):
+            return cls(rows)
+
+    fake_datasets.Dataset = FakeDataset
+    monkeypatch.setitem(sys.modules, "datasets", fake_datasets)
+
+    spec = BenchFlowSpec.from_tasks_dir(tasks)
+
+    dataset = spec.train_dataset
+    assert isinstance(dataset, FakeDataset)
+    assert dataset.rows == list(spec.train_dataset_rows)
+
+
+def test_train_dataset_missing_optional_dependency_is_actionable(tmp_path: Path):
+    """Guards PR #903: missing datasets/TRL deps fail only when used."""
+
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec.from_tasks_dir(tasks)
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "datasets" or name.startswith("datasets."):
+            raise ImportError("blocked datasets for test")
+        return real_import(name, *args, **kwargs)
+
+    import pytest
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(builtins, "__import__", guarded_import)
+        with pytest.raises(
+            BenchFlowOptionalDependencyError, match="benchflow\\[trl\\]"
+        ):
+            _ = spec.train_dataset
+
+
+def test_train_dataset_available_when_extra_is_installed(tmp_path: Path):
+    """Guards PR #903 with installed optional dependencies."""
+
+    try:
+        import datasets  # noqa: F401
+    except ImportError:
+        pytest.skip("datasets optional dependency is not installed")
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec.from_tasks_dir(tasks)
+
+    assert len(spec.train_dataset) == 1
+
+
+def test_environment_reset_lets_rollout_generate_unique_names(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards PR #903 against same-task GRPO artifact overwrite."""
+
+    _FakeRuntime.created_configs = []
+    monkeypatch.setattr("benchflow.integrations.trl.spec.TaskRuntime", _FakeRuntime)
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec(
+        tasks_dir=tasks,
+        bash_harness=BashHarnessConfig(jobs_dir=tmp_path / "jobs"),
+    )
+
+    env = spec.environment_factory()
+    row = spec.train_dataset_rows[0]
+    env.reset(**row)
+    first = _FakeRuntime.created_configs[-1]
+    env.reset(**row)
+    second = _FakeRuntime.created_configs[-1]
+
+    assert first.rollout_name is None
+    assert second.rollout_name is None
+
+
+def test_environment_public_tools_have_transformers_schema() -> None:
+    """Guards PR #903 so TRL sees only intended callable tools."""
+
+    from transformers.utils import get_json_schema
+
+    public_callables = [
+        name
+        for name in dir(BenchFlowRuntimeEnvironment)
+        if not name.startswith("_")
+        and name != "reset"
+        and callable(getattr(BenchFlowRuntimeEnvironment, name))
+    ]
+
+    assert public_callables == ["run_bash", "submit"]
+    for name in public_callables:
+        schema = get_json_schema(getattr(BenchFlowRuntimeEnvironment, name))
+        assert schema["function"]["name"] == name
+
+
+def test_reward_func_returns_zero_without_environment(tmp_path: Path):
+    """Guards PR #903: reward funcs are safe before environment plumbing."""
+
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec.from_tasks_dir(tasks)
+
+    assert spec.reward_funcs[0](completions=["ok"]) == [0.0]
+
+
+def test_create_trainer_missing_trl_is_actionable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards PR #903: TRL is imported lazily by create_trainer."""
+
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec.from_tasks_dir(tasks)
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == "trl" or name.startswith("trl."):
+            raise ImportError("blocked trl for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    with pytest.raises(BenchFlowOptionalDependencyError, match="create_trainer"):
+        spec.create_trainer(model="dummy-model")
+
+
+def test_environment_factory_and_reward_func_shape(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards PR #903: environment_factory and reward_funcs match GRPO shape."""
+
+    _FakeRuntime.created_configs = []
+    monkeypatch.setattr("benchflow.integrations.trl.spec.TaskRuntime", _FakeRuntime)
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    task = _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec(
+        BenchFlowSpecConfig(
+            tasks_dir=tasks,
+            bash_harness=BashHarnessConfig(jobs_dir=tmp_path / "jobs"),
+        )
+    )
+
+    env = spec.environment_factory()
+    assert isinstance(env, BenchFlowRuntimeEnvironment)
+    row = spec.train_dataset_rows[0]
+    reset_message = env.reset(**row)
+    assert reset_message is None
+    assert _FakeRuntime.created_configs[-1].task_path == task
+    assert _FakeRuntime.created_configs[-1].jobs_dir == tmp_path / "jobs"
+    assert env.run_bash("printf hi") == "hi"
+    assert env.submit("done") == "submission recorded; reward=1"
+
+    rewards = spec.reward_funcs[0](completions=["ok"], environments=[env])
+    assert rewards == [1.0]

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,30 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14'",
-    "python_full_version < '3.14'",
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "accelerate"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyyaml" },
+    { name = "safetensors" },
+    { name = "torch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/75/94cd5d389649578aca399e5aa822637eec18319a1dadc400ffe2f9a7493f/accelerate-1.14.0.tar.gz", hash = "sha256:41b9c4377a54e0b460a959b0defa1b736e4ca0a2373252d9a539964c2afe3c8d", size = 412167, upload-time = "2026-06-11T13:45:52.326Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/db/253133d7e7cb40d3af384bb2f5c0b4a2b7fdcffbc95c688cc67a20a3c103/accelerate-1.14.0-py3-none-any.whl", hash = "sha256:e94390c2863b873be18f623f9df48a0d8fe5eff13ea7f1a00092b0a7904888c6", size = 389246, upload-time = "2026-06-11T13:45:50.477Z" },
 ]
 
 [[package]]
@@ -334,6 +356,10 @@ sandbox-modal = [
 train = [
     { name = "transformers" },
 ]
+trl = [
+    { name = "datasets" },
+    { name = "trl" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -341,6 +367,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
     { name = "anyio", specifier = ">=4.0" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40" },
+    { name = "datasets", marker = "extra == 'trl'", specifier = ">=2.19.0" },
     { name = "daytona", marker = "extra == 'sandbox-daytona'", specifier = ">=0.184.0" },
     { name = "deepagents", marker = "extra == 'deepagents'", specifier = ">=0.6" },
     { name = "google-genai", marker = "extra == 'judge'", specifier = ">=1.0" },
@@ -361,10 +388,11 @@ requires-dist = [
     { name = "tenacity", marker = "extra == 'sandbox-modal'", specifier = ">=8.0" },
     { name = "tomli-w", specifier = ">=1.0" },
     { name = "transformers", marker = "extra == 'train'", specifier = "==5.6.2" },
+    { name = "trl", marker = "extra == 'trl'", specifier = ">=0.24.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.9" },
 ]
-provides-extras = ["dev", "train", "sandbox-daytona", "sandbox-modal", "bedrock", "judge", "deepagents"]
+provides-extras = ["dev", "train", "trl", "sandbox-daytona", "sandbox-modal", "bedrock", "judge", "deepagents"]
 
 [[package]]
 name = "boto3"
@@ -678,6 +706,106 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+]
+
+[[package]]
+name = "datasets"
+version = "5.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+    { name = "filelock" },
+    { name = "fsspec", extra = ["http"] },
+    { name = "httpx" },
+    { name = "huggingface-hub" },
+    { name = "multiprocess" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pyarrow" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/66/73034ad30b59f13439b75e620989dacba4c047256e358ba7c2e9ec98ea22/datasets-5.0.0-py3-none-any.whl", hash = "sha256:7dd34927a0fd7046e98aad5cb9430e699c373238a15befa7b9bf22b991a7fee6", size = 555084, upload-time = "2026-06-05T13:18:24.435Z" },
+]
+
+[[package]]
 name = "daytona"
 version = "0.184.0"
 source = { registry = "https://pypi.org/simple" }
@@ -797,6 +925,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
+name = "dill"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/e1/56027a71e31b02ddc53c7d65b01e68edf64dea2932122fe7746a516f75d5/dill-0.4.1.tar.gz", hash = "sha256:423092df4182177d4d8ba8290c8a5b640c66ab35ec7da59ccfa00f6fa3eea5fa", size = 187315, upload-time = "2026-01-19T02:36:56.85Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/77/dc8c558f7593132cf8fefec57c4f60c83b16941c574ac5f619abb3ae7933/dill-0.4.1-py3-none-any.whl", hash = "sha256:1e1ce33e978ae97fcfcff5638477032b801c46c7c65cf717f95fbc2248f79a9d", size = 120019, upload-time = "2026-01-19T02:36:55.663Z" },
 ]
 
 [[package]]
@@ -1035,6 +1172,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d5/8d/1c51c094345df128ca4a990d633fe1a0ff28726c9e6b3c41ba65087bba1d/fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4", size = 312760, upload-time = "2026-04-29T20:42:38.635Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d5/0c/043d5e551459da400957a1395e0febbf771446ff34291afcbe3d8be2a279/fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2", size = 203402, upload-time = "2026-04-29T20:42:36.842Z" },
+]
+
+[package.optional-dependencies]
+http = [
+    { name = "aiohttp" },
 ]
 
 [[package]]
@@ -1885,6 +2027,15 @@ wheels = [
 ]
 
 [[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "msal"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2010,6 +2161,32 @@ wheels = [
 ]
 
 [[package]]
+name = "multiprocess"
+version = "0.70.19"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dill" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f2/e783ac7f2aeeed14e9e12801f22529cc7e6b7ab80928d6dcce4e9f00922d/multiprocess-0.70.19.tar.gz", hash = "sha256:952021e0e6c55a4a9fe4cd787895b86e239a40e76802a789d6305398d3975897", size = 2079989, upload-time = "2026-01-19T06:47:39.744Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e3/45/8004d1e6b9185c1a444d6b55ac5682acf9d98035e54386d967366035a03a/multiprocess-0.70.19-py310-none-any.whl", hash = "sha256:97404393419dcb2a8385910864eedf47a3cadf82c66345b44f036420eb0b5d87", size = 134948, upload-time = "2026-01-19T06:47:32.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c2/dec9722dc3474c164a0b6bcd9a7ed7da542c98af8cabce05374abab35edd/multiprocess-0.70.19-py311-none-any.whl", hash = "sha256:928851ae7973aea4ce0eaf330bbdafb2e01398a91518d5c8818802845564f45c", size = 144457, upload-time = "2026-01-19T06:47:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/71/70/38998b950a97ea279e6bd657575d22d1a2047256caf707d9a10fbce4f065/multiprocess-0.70.19-py312-none-any.whl", hash = "sha256:3a56c0e85dd5025161bac5ce138dcac1e49174c7d8e74596537e729fd5c53c28", size = 150281, upload-time = "2026-01-19T06:47:35.037Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/74/d2c27e03cb84251dfe7249b8e82923643c6d48fa4883b9476b025e7dc7eb/multiprocess-0.70.19-py313-none-any.whl", hash = "sha256:8d5eb4ec5017ba2fab4e34a747c6d2c2b6fecfe9e7236e77988db91580ada952", size = 156414, upload-time = "2026-01-19T06:47:35.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/61/af9115673a5870fd885247e2f1b68c4f1197737da315b520a91c757a861a/multiprocess-0.70.19-py314-none-any.whl", hash = "sha256:e8cc7fbdff15c0613f0a1f1f8744bef961b0a164c0ca29bdff53e9d2d93c5e5f", size = 160318, upload-time = "2026-01-19T06:47:37.497Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/82/69e539c4c2027f1e1697e09aaa2449243085a0edf81ae2c6341e84d769b6/multiprocess-0.70.19-py39-none-any.whl", hash = "sha256:0d4b4397ed669d371c81dcd1ef33fd384a44d6c3de1bd0ca7ac06d837720d3c5", size = 133477, upload-time = "2026-01-19T06:47:38.619Z" },
+]
+
+[[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2077,6 +2254,158 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
     { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
     { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
+name = "nvidia-cublas"
+version = "13.1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
+]
+
+[[package]]
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -2380,6 +2709,58 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -2548,6 +2929,77 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "pyarrow"
+version = "24.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/a9/9686d9f07837f91f775e8932659192e02c74f9d8920524b480b85212cc68/pyarrow-24.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810", size = 34981559, upload-time = "2026-04-21T10:47:22.17Z" },
+    { url = "https://files.pythonhosted.org/packages/80/b6/0ddf0e9b6ead3474ab087ae598c76b031fc45532bf6a63f3a553440fb258/pyarrow-24.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a", size = 36663654, upload-time = "2026-04-21T10:47:28.315Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3b/926382efe8ce27ba729071d3566ade6dfb86bdf112f366000196b2f5780a/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66", size = 45679394, upload-time = "2026-04-21T10:47:34.821Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/7a/829f7d9dfd37c207206081d6dad474d81dde29952401f07f2ba507814818/pyarrow-24.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb", size = 48863122, upload-time = "2026-04-21T10:47:42.056Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/e8/f88ce625fe8babaae64e8db2d417c7653adb3019b08aae85c5ed787dc816/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e", size = 49376032, upload-time = "2026-04-21T10:47:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/36/7a/82c363caa145fff88fb475da50d3bf52bb024f61917be5424c3392eaf878/pyarrow-24.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6", size = 51929490, upload-time = "2026-04-21T10:47:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1c/e3e72c8014ad2743ca64a701652c733cc5cbcee15c0463a32a8c55518d9e/pyarrow-24.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826", size = 27355660, upload-time = "2026-04-21T10:48:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]
@@ -3237,6 +3689,15 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3306,6 +3767,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -3421,6 +3894,45 @@ wheels = [
 ]
 
 [[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3450,6 +3962,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a4/e9/c6c80a07690142a7d05444271f47b9f3c8aac7dea01d52e1137ee480ad78/transformers-5.6.2.tar.gz", hash = "sha256:e657134c3e5a6bc00a3c35f4e2674bb51adfcd89898495b788a18552bac2b91a", size = 8311867, upload-time = "2026-04-23T18:33:29.332Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/95/0b0218149b0d6f14df35f5b8f676fa83df4f19ed253c3cc447107ef86eca/transformers-5.6.2-py3-none-any.whl", hash = "sha256:f8d3a1bb96778fed9b8aabfd0dd6e19843e4b0f2bb6b59f32b8a92051b0f348f", size = 10364898, upload-time = "2026-04-23T18:33:26.081Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
+]
+
+[[package]]
+name = "trl"
+version = "1.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "accelerate" },
+    { name = "datasets" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "transformers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/74/34b50058ea7d8c2a1c0bec49dcb6dda4ac929589bace52522fe8d1487306/trl-1.7.1.tar.gz", hash = "sha256:36609abf76f61d305d4c8a8ad5c903b79f177b7e5c4ec1014c4ade4cb7ac4a43", size = 691318, upload-time = "2026-07-04T04:03:09.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/34/24d445a6156db4a9b976b1ab4aefc5e8ee8046da95524768fb78a0f705f0/trl-1.7.1-py3-none-any.whl", hash = "sha256:d5ef8ac38c64746eebf23005dccefc6488874643039d0b4a20f036e1124115b4", size = 842380, upload-time = "2026-07-04T04:03:08.223Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add `benchflow.integrations.trl.BenchFlowSpec` as the BenchFlow-owned adapter for TRL environment training
- expose `train_dataset`, `environment_factory`, and `reward_funcs` for GRPOTrainer wiring
- use the BenchFlow `TaskRuntime` primitive for sandboxed bash actions and verifier-backed rewards
- keep TRL/datasets optional behind the `trl` extra

## Validation
- `uv run python -m pytest tests/test_trl_integration.py tests/test_base_install_imports.py -q`
- `uv run ruff check src/benchflow/integrations tests/test_trl_integration.py`
- `uv run ruff format --check src/benchflow/integrations tests/test_trl_integration.py`
- `uv run ty check src/benchflow/integrations`
- `uv lock --check`

## Notes
- stacked on #902 / `bry/benchflow-grpo-runtime-primitive`
- live Daytona + Qwen/Qwen3-4B GRPO validation remains a follow-up integration run after review of this adapter stack.