### PR TITLE
Add HF task snapshot provenance support

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -569,6 +569,27 @@ Arguments: `TASK_DIR` (task directory to export) and optional `OUTPUT_DIR`
 | `--overwrite` | `false` | Replace an existing export directory |
 | `--report-only` | `false` | Print the compatibility loss report without writing files |
 
+### bench tasks snapshot-hf
+
+Materialize a Hugging Face dataset repo or subpath as a local BenchFlow task
+tree and write `.benchflow-source.json` provenance beside it. The resulting
+directory can be passed to `bench eval run --tasks-dir`; split-layout task
+snapshots under `tasks/<task_id>/` are discovered directly.
+
+```bash
+bench tasks snapshot-hf benchflow/my-tasks .cache/hf-tasks/my-tasks
+bench tasks snapshot-hf benchflow/my-tasks .cache/hf-tasks/my-tasks --revision abc123 --path tasks --overwrite
+```
+
+Arguments: `REPO_ID` (Hugging Face dataset repo ID) and `OUTPUT_DIR`.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--revision`, `--ref` | — | Dataset revision, branch, tag, or commit |
+| `--path` | — | Optional subpath inside the dataset repo, e.g. `tasks` |
+| `--cache-dir` | HF default | Optional Hugging Face cache directory |
+| `--overwrite` | `false` | Replace an existing output directory |
+
 ### bench tasks digest
 
 Compute the content digest that pins a task's files, independent of git — the

--- a/src/benchflow/_utils/benchmark_repos.py
+++ b/src/benchflow/_utils/benchmark_repos.py
@@ -276,6 +276,8 @@ def task_file_hashes(task_path: Path) -> dict[str, str]:
         if not path.is_file():
             continue
         rel_parts = path.relative_to(task_path).parts
+        if rel_parts == (".benchflow-source.json",):
+            continue
         if ".git" in rel_parts or "__pycache__" in rel_parts:
             continue
         rel = Path(*rel_parts).as_posix()
@@ -405,6 +407,15 @@ def infer_task_source_provenance(task_path: Path) -> dict[str, Any] | None:
         task_resolved = task_path.resolve(strict=True)
     except OSError:
         return None
+
+    try:
+        from benchflow._utils.hf_datasets import load_source_sidecar
+
+        sidecar_source = load_source_sidecar(task_resolved)
+    except ImportError:
+        sidecar_source = None
+    if sidecar_source is not None:
+        return task_source_provenance(sidecar_source, task_resolved)
 
     cache_root = _cache_dir()
     try:

--- a/src/benchflow/_utils/hf_datasets.py
+++ b/src/benchflow/_utils/hf_datasets.py
@@ -1,0 +1,181 @@
+"""Hugging Face dataset snapshot helpers for task-tree sources."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from benchflow._utils.benchmark_repos import ResolvedSource, task_file_hashes
+
+SOURCE_SIDECAR = ".benchflow-source.json"
+
+
+@dataclass(frozen=True, slots=True)
+class HfDatasetSnapshot:
+    """A local Hugging Face dataset snapshot plus source provenance."""
+
+    path: Path
+    provenance: dict[str, Any]
+
+
+def _copy_tree(src: Path, dst: Path, *, overwrite: bool) -> None:
+    if dst.exists():
+        if not overwrite:
+            raise FileExistsError(f"Output already exists: {dst}")
+        if dst.is_dir():
+            shutil.rmtree(dst)
+        else:
+            dst.unlink()
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(src, dst, ignore=shutil.ignore_patterns(".git"))
+
+
+def _read_hf_revision(repo_id: str, revision: str | None) -> str:
+    try:
+        from huggingface_hub import HfApi
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required for HF dataset snapshots. "
+            "Install it with `pip install huggingface_hub`."
+        ) from exc
+
+    info = HfApi().repo_info(repo_id, repo_type="dataset", revision=revision)
+    sha = getattr(info, "sha", None)
+    return str(sha or revision or "main")
+
+
+def _download_snapshot(
+    repo_id: str, *, revision: str | None, cache_dir: Path | None
+) -> Path:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise ImportError(
+            "huggingface_hub is required for HF dataset snapshots. "
+            "Install it with `pip install huggingface_hub`."
+        ) from exc
+
+    kwargs: dict[str, Any] = {
+        "repo_id": repo_id,
+        "repo_type": "dataset",
+        "revision": revision,
+    }
+    if cache_dir is not None:
+        kwargs["cache_dir"] = str(cache_dir)
+    return Path(snapshot_download(**kwargs))
+
+
+def hf_dataset_provenance(
+    *,
+    repo_id: str,
+    requested_revision: str | None,
+    resolved_revision: str,
+    source_path: str,
+    local_path: Path,
+) -> dict[str, Any]:
+    """Build generic HF dataset source provenance for a local task tree."""
+
+    path = source_path.strip("/")
+    return {
+        "type": "huggingface_dataset",
+        "repo": repo_id,
+        "repo_type": "dataset",
+        "requested_revision": requested_revision,
+        "resolved_revision": resolved_revision,
+        "path": path,
+        "local_path": str(local_path),
+        "dirty": False,
+        "file_hashes": task_file_hashes(local_path)
+        if (local_path / "task.toml").is_file() or (local_path / "task.md").is_file()
+        else {},
+    }
+
+
+def write_source_sidecar(root: Path, provenance: dict[str, Any]) -> Path:
+    """Persist source provenance beside a materialized task snapshot."""
+
+    sidecar = root / SOURCE_SIDECAR
+    sidecar.write_text(json.dumps(provenance, indent=2, sort_keys=True) + "\n")
+    return sidecar
+
+
+def load_source_sidecar(path: Path) -> dict[str, Any] | None:
+    """Load a source sidecar from *path* or one of its parents."""
+
+    try:
+        resolved = path.resolve(strict=True)
+    except OSError:
+        return None
+    candidates = [resolved] if resolved.is_dir() else [resolved.parent]
+    candidates.extend(resolved.parents)
+    for candidate in candidates:
+        sidecar = candidate / SOURCE_SIDECAR
+        if not sidecar.is_file():
+            continue
+        try:
+            data = json.loads(sidecar.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        data = dict(data)
+        data["local_path"] = str(candidate)
+        return data
+    return None
+
+
+def snapshot_hf_dataset(
+    repo_id: str,
+    *,
+    output_dir: Path,
+    revision: str | None = None,
+    path: str | None = None,
+    cache_dir: Path | None = None,
+    overwrite: bool = False,
+) -> HfDatasetSnapshot:
+    """Materialize a HF dataset snapshot and stamp local source metadata."""
+
+    resolved_revision = _read_hf_revision(repo_id, revision)
+    snapshot_root = _download_snapshot(repo_id, revision=revision, cache_dir=cache_dir)
+    source_path = (path or "").strip("/")
+    source_root = snapshot_root / source_path if source_path else snapshot_root
+    if not source_root.is_dir():
+        raise FileNotFoundError(
+            f"Path {source_path!r} not found in HF dataset {repo_id!r}"
+        )
+
+    _copy_tree(source_root, output_dir, overwrite=overwrite)
+    provenance = hf_dataset_provenance(
+        repo_id=repo_id,
+        requested_revision=revision,
+        resolved_revision=resolved_revision,
+        source_path=source_path,
+        local_path=output_dir,
+    )
+    write_source_sidecar(output_dir, provenance)
+    return HfDatasetSnapshot(path=output_dir, provenance=provenance)
+
+
+def resolved_source_from_hf_snapshot(
+    repo_id: str,
+    *,
+    output_dir: Path,
+    revision: str | None = None,
+    path: str | None = None,
+    cache_dir: Path | None = None,
+    overwrite: bool = False,
+) -> ResolvedSource:
+    """Return a ``ResolvedSource`` for a materialized HF task snapshot."""
+
+    snapshot = snapshot_hf_dataset(
+        repo_id,
+        output_dir=output_dir,
+        revision=revision,
+        path=path,
+        cache_dir=cache_dir,
+        overwrite=overwrite,
+    )
+    return ResolvedSource(path=snapshot.path, provenance=snapshot.provenance)

--- a/src/benchflow/_utils/source_provenance.py
+++ b/src/benchflow/_utils/source_provenance.py
@@ -5,11 +5,21 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, cast
 
-SOURCE_REQUIRED = {
+GITHUB_SOURCE_REQUIRED = {
     "type",
     "repo",
     "requested_ref",
     "resolved_sha",
+    "path",
+    "dirty",
+    "file_hashes",
+}
+HF_DATASET_SOURCE_REQUIRED = {
+    "type",
+    "repo",
+    "repo_type",
+    "requested_revision",
+    "resolved_revision",
     "path",
     "dirty",
     "file_hashes",
@@ -46,17 +56,29 @@ def source_issues(
 
     source_dict = cast(dict[str, Any], source)
     issues: list[str] = []
-    missing = SOURCE_REQUIRED - set(source_dict.keys())
+    source_type = source_dict.get("type")
+    required = (
+        HF_DATASET_SOURCE_REQUIRED
+        if source_type == "huggingface_dataset"
+        else GITHUB_SOURCE_REQUIRED
+    )
+    missing = required - set(source_dict.keys())
     if missing:
         issues.append(f"{label}: source missing {missing}")
         return issues
-    if source_dict.get("type") != "github":
-        issues.append(f"{label}: source.type must be 'github'")
+    if source_type not in {"github", "huggingface_dataset"}:
+        issues.append(f"{label}: source.type must be 'github' or 'huggingface_dataset'")
     repo = source_dict.get("repo")
     if not isinstance(repo, str) or "/" not in repo:
         issues.append(f"{label}: source.repo must be org/repo")
-    if not is_git_hash(source_dict.get("resolved_sha")):
+    if source_type == "github" and not is_git_hash(source_dict.get("resolved_sha")):
         issues.append(f"{label}: source.resolved_sha must be a git hash")
+    if source_type == "huggingface_dataset":
+        if source_dict.get("repo_type") != "dataset":
+            issues.append(f"{label}: source.repo_type must be 'dataset'")
+        resolved_revision = source_dict.get("resolved_revision")
+        if not isinstance(resolved_revision, str) or not resolved_revision:
+            issues.append(f"{label}: source.resolved_revision must be a string")
     dirty = source_dict.get("dirty")
     if not isinstance(dirty, bool):
         issues.append(f"{label}: source.dirty must be a boolean")
@@ -93,7 +115,13 @@ def source_matches_parent(
     """Return True when a task source is covered by a parent source."""
     if not isinstance(result_source, dict):
         return False
-    for key in ("type", "repo", "requested_ref", "resolved_sha", "dirty"):
+    source_type = parent_source.get("type")
+    keys = (
+        ("type", "repo", "requested_revision", "resolved_revision", "dirty")
+        if source_type == "huggingface_dataset"
+        else ("type", "repo", "requested_ref", "resolved_sha", "dirty")
+    )
+    for key in keys:
         if result_source.get(key) != parent_source.get(key):
             return False
     parent_path = str(parent_source.get("path") or "").strip("/")

--- a/src/benchflow/_utils/task_authoring/__init__.py
+++ b/src/benchflow/_utils/task_authoring/__init__.py
@@ -129,6 +129,8 @@ def task_digest(task_dir: Path) -> str:
     # Path.rglob), keeping "symlinks are excluded" true for whole subtrees.
     for dirpath, _dirnames, filenames in os.walk(task_dir):
         for filename in filenames:
+            if filename == ".benchflow-source.json":
+                continue
             path = Path(dirpath) / filename
             if path.is_symlink() or not path.is_file():
                 continue

--- a/src/benchflow/adapters/source.py
+++ b/src/benchflow/adapters/source.py
@@ -24,6 +24,11 @@ import tomli_w
 
 from benchflow._utils.benchmark_repos import ResolvedSource
 from benchflow.adapters._toolathlon import materialize_toolathlon, toolathlon_tasks_root
+from benchflow.task.discovery import (
+    contains_immediate_task,
+    is_task_dir,
+    resolve_task_collection_root,
+)
 
 _ADAPTER_VERSION = "2026-07-05.5"
 _NOOP_EXCLUDE_TAG = "__benchflow_exclude_no_tools__"
@@ -90,15 +95,8 @@ def adapt_resolved_source_if_needed(resolved: ResolvedSource) -> ResolvedSource:
 
 
 def _contains_native_task(path: Path) -> bool:
-    if (path / "task.toml").is_file() or (path / "task.md").is_file():
-        return True
-    if not path.is_dir():
-        return False
-    return any(
-        child.is_dir()
-        and ((child / "task.toml").is_file() or (child / "task.md").is_file())
-        for child in path.iterdir()
-    )
+    root = resolve_task_collection_root(path)
+    return is_task_dir(root) or contains_immediate_task(root)
 
 
 def _infer_repo_root(resolved: ResolvedSource) -> Path:

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -43,6 +43,17 @@ def _redacted_eval_config(eval_config: EvaluationConfig) -> dict:
     }
 
 
+def _apply_source_sidecar(
+    eval_config: EvaluationConfig, resolved_tasks_dir: Path
+) -> EvaluationConfig:
+    if eval_config.source_provenance is not None:
+        return eval_config
+    from benchflow._utils.hf_datasets import load_source_sidecar
+
+    eval_config.source_provenance = load_source_sidecar(resolved_tasks_dir)
+    return eval_config
+
+
 def postprocess_eval_artifacts(
     plan: EvalPlan,
     resolved_tasks_dir: Path,
@@ -52,6 +63,7 @@ def postprocess_eval_artifacts(
     req = plan.request
     if job_dir is None:
         return
+    eval_config = _apply_source_sidecar(eval_config, resolved_tasks_dir)
     from benchflow.eval_artifacts import (
         TaskManifestOptions,
         materialize_canonical_job,
@@ -189,6 +201,7 @@ def _write_matrix_task_manifest(
     req = plan.request
     if req.task_manifest_out is None:
         return
+    eval_config = _apply_source_sidecar(eval_config, resolved_tasks_dir)
     from benchflow.eval_artifacts import TaskManifestOptions, write_task_manifest
 
     manifest = write_task_manifest(
@@ -216,6 +229,8 @@ def run_matrix_eval(
     resolved_tasks_dir: Path,
     run_batch_eval: Callable[[EvalPlan, Path, EvaluationConfig], EvaluationResult],
 ) -> None:
+    from benchflow.task.discovery import resolve_task_collection_root
+
     req = plan.request
     assert req.matrix is not None
     try:
@@ -224,7 +239,8 @@ def run_matrix_eval(
         print_error(str(exc))
         raise typer.Exit(1) from None
     root = Path(plan.output_jobs_dir)
-    _write_matrix_task_manifest(plan, resolved_tasks_dir, plan.make_eval_config())
+    task_collection_dir = resolve_task_collection_root(resolved_tasks_dir)
+    _write_matrix_task_manifest(plan, task_collection_dir, plan.make_eval_config())
     matrix_runs = []
     for alias, raw in models.items():
         for trial in range(1, req.trials + 1):
@@ -263,7 +279,7 @@ def run_matrix_eval(
             eval_config.model = str(raw["model"])
             if raw.get("agent"):
                 eval_config.agent = str(raw["agent"])
-            result = run_batch_eval(trial_plan, resolved_tasks_dir, eval_config)
+            result = run_batch_eval(trial_plan, task_collection_dir, eval_config)
             matrix_runs.append(
                 {
                     "alias": alias,

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -787,6 +787,13 @@ def run_batch_eval(
     """
     from benchflow.eval_sharding import ShardWorkerError
     from benchflow.evaluation import EmptyTaskSelectionError, Evaluation
+    from benchflow.task.discovery import resolve_task_collection_root
+
+    task_collection_dir = resolve_task_collection_root(resolved_tasks_dir)
+    if eval_config.source_provenance is None:
+        from benchflow._utils.hf_datasets import load_source_sidecar
+
+        eval_config.source_provenance = load_source_sidecar(task_collection_dir)
 
     try:
         if plan.request.retry_attempts is not None:
@@ -800,7 +807,7 @@ def run_batch_eval(
             if progress_enabled(console):
                 live = LiveEvalProgress(
                     console,
-                    label=_eval_label(plan, resolved_tasks_dir),
+                    label=_eval_label(plan, task_collection_dir),
                     agent=eval_config.agent,
                     model=eval_config.model,
                     sandbox=eval_config.environment,
@@ -814,7 +821,7 @@ def run_batch_eval(
             with run_ctx:
                 result = asyncio.run(
                     Evaluation(
-                        tasks_dir=str(resolved_tasks_dir),
+                        tasks_dir=str(task_collection_dir),
                         jobs_dir=plan.output_jobs_dir,
                         config=eval_config,
                         **hooks,
@@ -825,7 +832,7 @@ def run_batch_eval(
 
             result = asyncio.run(
                 run_sharded_evaluation(
-                    tasks_dir=resolved_tasks_dir,
+                    tasks_dir=task_collection_dir,
                     jobs_dir=Path(plan.output_jobs_dir),
                     config=eval_config,
                     worker_concurrency=plan.request.worker_concurrency,
@@ -842,7 +849,7 @@ def run_batch_eval(
 
     job_name = getattr(result, "job_name", None)
     job_dir = Path(plan.output_jobs_dir) / job_name if job_name else None
-    postprocess_eval_artifacts(plan, resolved_tasks_dir, eval_config, job_dir)
+    postprocess_eval_artifacts(plan, task_collection_dir, eval_config, job_dir)
     _report_eval_result(result, job_dir)
     _exit_if_evaluation_had_errors(result)
     return result

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -347,6 +347,73 @@ def register_tasks(app: typer.Typer) -> None:
         console.print(f"  losses: {len(report.losses)}")
         console.print("  report: compatibility/export-report.json")
 
+    @tasks_app.command("snapshot-hf")
+    def tasks_snapshot_hf(
+        repo_id: Annotated[
+            str,
+            typer.Argument(help="Hugging Face dataset repo ID, e.g. org/name"),
+        ],
+        output_dir: Annotated[
+            Path,
+            typer.Argument(help="Local output directory for the materialized snapshot"),
+        ],
+        revision: Annotated[
+            str | None,
+            typer.Option(
+                "--revision",
+                "--ref",
+                help="Dataset revision, branch, tag, or commit",
+            ),
+        ] = None,
+        path: Annotated[
+            str | None,
+            typer.Option(
+                "--path",
+                help="Optional subpath inside the dataset repo, e.g. tasks",
+            ),
+        ] = None,
+        cache_dir: Annotated[
+            Path | None,
+            typer.Option("--cache-dir", help="Optional Hugging Face cache directory"),
+        ] = None,
+        overwrite: Annotated[
+            bool,
+            typer.Option("--overwrite", help="Replace an existing output directory"),
+        ] = False,
+    ) -> None:
+        """Materialize a Hugging Face dataset task tree with provenance."""
+        from benchflow._utils.hf_datasets import SOURCE_SIDECAR, snapshot_hf_dataset
+        from benchflow.task.discovery import is_task_dir, resolve_task_collection_root
+
+        try:
+            snapshot = snapshot_hf_dataset(
+                repo_id,
+                output_dir=output_dir,
+                revision=revision,
+                path=path,
+                cache_dir=cache_dir,
+                overwrite=overwrite,
+            )
+        except (ImportError, OSError, ValueError) as e:
+            print_error(f"{e}")
+            raise typer.Exit(1) from None
+
+        task_root = resolve_task_collection_root(snapshot.path)
+        if is_task_dir(task_root):
+            task_count = 1
+        else:
+            task_count = sum(
+                1
+                for child in task_root.iterdir()
+                if child.is_dir() and is_task_dir(child)
+            )
+        console.print(f"[green]Snapshot:[/green] {escape(str(snapshot.path))}")
+        console.print(f"  tasks: {task_count} under {escape(str(task_root))}")
+        console.print(
+            f"  source: {escape(repo_id)}@{escape(str(snapshot.provenance['resolved_revision']))}"
+        )
+        console.print(f"  provenance: {SOURCE_SIDECAR}")
+
     @tasks_app.command("digest")
     def tasks_digest(
         path: Annotated[

--- a/src/benchflow/eval_artifacts.py
+++ b/src/benchflow/eval_artifacts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from benchflow._utils.task_authoring import task_digest
+from benchflow.task.discovery import is_task_dir, resolve_task_collection_root
 from benchflow.trajectories.export_prime_sft import (
     PrimeSftTrajectoryJsonlError,
     load_llm_trajectory_jsonl,
@@ -42,18 +43,15 @@ def _read_json(path: Path) -> dict[str, Any] | None:
     return data if isinstance(data, dict) else None
 
 
-def _is_task_dir(path: Path) -> bool:
-    return (path / "task.md").is_file() or (path / "task.toml").is_file()
-
-
 def _selected_task_dirs(
     tasks_dir: Path, include_tasks: set[str], exclude_tasks: set[str]
 ) -> list[Path]:
-    if _is_task_dir(tasks_dir):
-        candidates = [tasks_dir]
+    root = resolve_task_collection_root(tasks_dir)
+    if is_task_dir(root):
+        candidates = [root]
     else:
-        candidates = sorted(path for path in tasks_dir.iterdir() if path.is_dir())
-        candidates = [path for path in candidates if _is_task_dir(path)]
+        candidates = sorted(path for path in root.iterdir() if path.is_dir())
+        candidates = [path for path in candidates if is_task_dir(path)]
     selected = []
     for task_dir in candidates:
         name = task_dir.name
@@ -66,10 +64,11 @@ def _selected_task_dirs(
 
 
 def build_task_manifest(options: TaskManifestOptions) -> dict[str, Any]:
+    resolved_tasks_dir = resolve_task_collection_root(options.tasks_dir)
     tasks = []
     dataset_digests = options.dataset_task_digests or {}
     for task_dir in _selected_task_dirs(
-        options.tasks_dir, options.include_tasks, options.exclude_tasks
+        resolved_tasks_dir, options.include_tasks, options.exclude_tasks
     ):
         digest = task_digest(task_dir)
         entry: dict[str, Any] = {
@@ -84,7 +83,7 @@ def build_task_manifest(options: TaskManifestOptions) -> dict[str, Any]:
         tasks.append(entry)
     return {
         "schema_version": 1,
-        "tasks_dir": str(options.tasks_dir),
+        "tasks_dir": str(resolved_tasks_dir),
         "source": options.source_provenance,
         "dataset_name": options.dataset_name,
         "dataset_version": options.dataset_version,

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -83,6 +83,12 @@ from benchflow.skill_policy import (
     SKILL_MODE_WITH_SKILL,
     normalize_skill_mode,
 )
+from benchflow.task.discovery import (
+    is_task_dir as _is_structural_task_dir,
+)
+from benchflow.task.discovery import (
+    resolve_task_collection_root,
+)
 from benchflow.trajectories.tree import RolloutNode
 from benchflow.usage_tracking import UsageTrackingConfig
 
@@ -137,7 +143,7 @@ _SENTINEL: Any = object()  # default value for _sdk; tests replace with AsyncMoc
 
 def _is_task_dir(path: Path) -> bool:
     if not (path / "task.md").exists():
-        return (path / "task.toml").exists()
+        return _is_structural_task_dir(path)
     from benchflow._utils.task_authoring import check_task
 
     return check_task(path) == []
@@ -655,9 +661,13 @@ class Evaluation:
         on_task_start: Callable[[str], None] | None = None,
         on_plan: Callable[[int, int, int, tuple[int, int, int]], None] | None = None,
     ):
-        self._tasks_dir = Path(tasks_dir)
+        self._tasks_dir = resolve_task_collection_root(tasks_dir)
         self._jobs_dir = Path(jobs_dir)
         self._config = config or EvaluationConfig()
+        if self._config.source_provenance is None:
+            from benchflow._utils.hf_datasets import load_source_sidecar
+
+            self._config.source_provenance = load_source_sidecar(self._tasks_dir)
         self._job_name = job_name or self._resolve_job_name(self._jobs_dir)
         self._on_result = on_result
         # UI-progress hooks (the CLI live dashboard; None everywhere else). Fired

--- a/src/benchflow/task/discovery.py
+++ b/src/benchflow/task/discovery.py
@@ -1,0 +1,37 @@
+"""Task-directory discovery helpers shared by eval and artifact writers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def is_task_dir(path: Path) -> bool:
+    """Return whether *path* is a BenchFlow task package directory."""
+
+    return (path / "task.md").is_file() or (path / "task.toml").is_file()
+
+
+def contains_immediate_task(path: Path) -> bool:
+    """Return whether *path* directly contains one or more task directories."""
+
+    if not path.is_dir():
+        return False
+    return any(child.is_dir() and is_task_dir(child) for child in path.iterdir())
+
+
+def resolve_task_collection_root(path: str | Path) -> Path:
+    """Return the directory whose immediate children are task dirs.
+
+    Besides the historical inputs (a single task dir or a parent containing task
+    dirs), this accepts dataset snapshots that wrap tasks under ``tasks/``:
+
+    ``snapshot_root/tasks/<task_id>/{instruction.md, task.toml, ...}``
+    """
+
+    root = Path(path)
+    if is_task_dir(root) or contains_immediate_task(root):
+        return root
+    nested_tasks = root / "tasks"
+    if contains_immediate_task(nested_tasks):
+        return nested_tasks
+    return root

--- a/tests/test_cli_docs_drift.py
+++ b/tests/test_cli_docs_drift.py
@@ -191,6 +191,7 @@ def test_documented_subcommands_exist() -> None:
         ["tasks", "check"],
         ["tasks", "generate"],
         ["tasks", "overlap"],
+        ["tasks", "snapshot-hf"],
         ["tasks", "list-sources"],
         ["skills", "list"],
         ["skills", "eval"],

--- a/tests/test_eval_source_provenance.py
+++ b/tests/test_eval_source_provenance.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 import pytest
 from typer.testing import CliRunner
 
+from benchflow._utils.hf_datasets import SOURCE_SIDECAR
 from benchflow.cli.main import app
 from benchflow.evaluation import Evaluation, EvaluationConfig
 from benchflow.models import RolloutResult
@@ -222,6 +223,71 @@ def test_evaluation_discovers_single_task_directory(tmp_path):
     evaluation = Evaluation(tasks_dir=task_dir, jobs_dir=tmp_path / "jobs")
 
     assert evaluation._get_task_dirs() == [task_dir]
+
+
+@pytest.mark.asyncio
+async def test_evaluation_uses_hf_snapshot_tasks_subdir_and_sidecar_provenance(
+    monkeypatch, tmp_path
+):
+    """Guards PR slice 1 so HF split-layout snapshots run from their root."""
+    snapshot_root = tmp_path / "hf-snapshot"
+    tasks_root = snapshot_root / "tasks"
+    task_dir = tasks_root / "task-a"
+    (task_dir / "tests").mkdir(parents=True)
+    _write_minimal_task_toml(task_dir)
+    (task_dir / "instruction.md").write_text("Solve it.\n")
+    (task_dir / "tests" / "test.sh").write_text("exit 0\n")
+    (snapshot_root / SOURCE_SIDECAR).write_text(
+        json.dumps(
+            {
+                "type": "huggingface_dataset",
+                "repo": "benchflow/sample-tasks",
+                "repo_type": "dataset",
+                "requested_revision": "main",
+                "resolved_revision": "a" * 40,
+                "path": "",
+                "local_path": str(snapshot_root),
+                "dirty": False,
+                "file_hashes": {},
+            }
+        )
+    )
+    captured = {}
+
+    async def fake_create(config):
+        captured["source_provenance"] = config.source_provenance
+
+        class FakeRollout:
+            async def run(self):
+                return RolloutResult(task_name="task-a", rewards={"reward": 1.0})
+
+        return FakeRollout()
+
+    monkeypatch.setattr("benchflow.rollout.Rollout.create", fake_create)
+
+    evaluation = Evaluation(
+        tasks_dir=snapshot_root,
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(
+            agent="gemini",
+            model="gemini-3.1-flash-lite-preview",
+        ),
+    )
+
+    assert evaluation._tasks_dir == tasks_root
+    assert evaluation._get_task_dirs() == [task_dir]
+    await evaluation._run_single_task(task_dir, evaluation._config)
+
+    source = captured["source_provenance"]
+    assert source["type"] == "huggingface_dataset"
+    assert source["repo"] == "benchflow/sample-tasks"
+    assert source["resolved_revision"] == "a" * 40
+    assert source["path"] == "tasks/task-a"
+    assert set(source["file_hashes"]) == {
+        "instruction.md",
+        "task.toml",
+        "tests/test.sh",
+    }
 
 
 def test_eval_create_config_applies_concurrency_override(monkeypatch, tmp_path):

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -1,6 +1,9 @@
 """Tests for benchmark task repository materialization."""
 
+import json
 import shutil
+import sys
+import types
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -13,6 +16,7 @@ from benchflow._utils.benchmark_repos import (
     resolve_source_with_metadata,
     task_source_provenance,
 )
+from benchflow._utils.hf_datasets import SOURCE_SIDECAR, snapshot_hf_dataset
 
 
 def _fake_worktree(cmd):
@@ -341,6 +345,60 @@ def test_task_source_provenance_derives_batch_task_path_and_hashes(tmp_path):
         "tests/test.sh",
     }
     assert "sample-task/task.toml" not in task_provenance["file_hashes"]
+
+
+def test_snapshot_hf_dataset_writes_generic_source_sidecar(tmp_path, monkeypatch):
+    """Guards PR slice 1 HF task snapshots without Harbor-specific imports."""
+    remote = tmp_path / "remote"
+    task = remote / "tasks" / "sample-task"
+    (task / "tests").mkdir(parents=True)
+    (task / "task.toml").write_text("[task]\n")
+    (task / "instruction.md").write_text("Solve it.\n")
+    (task / "tests" / "test.sh").write_text("exit 0\n")
+
+    class FakeHfApi:
+        def repo_info(self, repo_id, repo_type=None, revision=None):
+            assert repo_id == "benchflow/sample-tasks"
+            assert repo_type == "dataset"
+            assert revision == "abc123"
+            return SimpleNamespace(sha="d" * 40)
+
+    def fake_snapshot_download(**kwargs):
+        assert kwargs["repo_id"] == "benchflow/sample-tasks"
+        assert kwargs["repo_type"] == "dataset"
+        assert kwargs["revision"] == "abc123"
+        return str(remote)
+
+    fake_hub = types.ModuleType("huggingface_hub")
+    fake_hub.HfApi = lambda: FakeHfApi()
+    fake_hub.snapshot_download = fake_snapshot_download
+    monkeypatch.setitem(sys.modules, "huggingface_hub", fake_hub)
+
+    output = tmp_path / "snapshot"
+    snapshot = snapshot_hf_dataset(
+        "benchflow/sample-tasks",
+        output_dir=output,
+        revision="abc123",
+    )
+
+    assert snapshot.path == output
+    assert (output / "tasks" / "sample-task" / "task.toml").is_file()
+    sidecar = json.loads((output / SOURCE_SIDECAR).read_text())
+    assert sidecar["type"] == "huggingface_dataset"
+    assert sidecar["repo"] == "benchflow/sample-tasks"
+    assert sidecar["repo_type"] == "dataset"
+    assert sidecar["requested_revision"] == "abc123"
+    assert sidecar["resolved_revision"] == "d" * 40
+
+    task_provenance = task_source_provenance(None, output / "tasks" / "sample-task")
+    assert task_provenance is not None
+    assert task_provenance["type"] == "huggingface_dataset"
+    assert task_provenance["path"] == "tasks/sample-task"
+    assert set(task_provenance["file_hashes"]) == {
+        "instruction.md",
+        "task.toml",
+        "tests/test.sh",
+    }
 
 
 def test_task_source_provenance_rejects_task_outside_source_root(tmp_path):


### PR DESCRIPTION
## Summary
- add generic Hugging Face dataset snapshot materialization with `.benchflow-source.json` provenance
- harden task discovery so dataset roots with `tasks/<task_id>/...` run directly through `bench eval run --tasks-dir`
- stamp HF dataset source metadata through eval artifacts and task manifests without adding Harbor runtime dependencies

## Validation
- `uv run python -m pytest tests/test_task_download.py tests/test_eval_source_provenance.py tests/test_cli_docs_drift.py -q`
- `uv run ruff check src/benchflow/_utils/hf_datasets.py src/benchflow/task/discovery.py src/benchflow/_utils/source_provenance.py src/benchflow/adapters/source.py src/benchflow/cli/eval_artifacts.py src/benchflow/cli/main.py src/benchflow/cli/tasks.py src/benchflow/eval_artifacts.py src/benchflow/evaluation.py tests/test_task_download.py tests/test_eval_source_provenance.py tests/test_cli_docs_drift.py`
- `uv run ruff format --check src/benchflow/_utils/hf_datasets.py src/benchflow/task/discovery.py src/benchflow/_utils/source_provenance.py src/benchflow/adapters/source.py src/benchflow/cli/eval_artifacts.py src/benchflow/cli/main.py src/benchflow/cli/tasks.py src/benchflow/eval_artifacts.py src/benchflow/evaluation.py tests/test_task_download.py tests/test_eval_source_provenance.py tests/test_cli_docs_drift.py`
- `git diff --check`
- authenticated smoke: `bench tasks snapshot-hf AdithyaSK/data_agent_rl_environment_eval .local/hf-snapshot-smoke/eval-tasks --path tasks --overwrite`, then `bench tasks check .local/hf-snapshot-smoke/eval-tasks/0000_369_369503_qa_1`

## Notes
- no Harbor import/runtime dependency is added; this is generic HF dataset task-tree support
- an unauthenticated smoke initially hit HF 429s; rerun with `HF_TOKEN` from the local env succeeded.