### PR TITLE
Skip TRL schema test without transformers

### DIFF
--- a/tests/test_trl_integration.py
+++ b/tests/test_trl_integration.py
@@ -222,7 +222,7 @@ def test_environment_reset_lets_rollout_generate_unique_names(
 def test_environment_public_tools_have_transformers_schema() -> None:
     """Guards PR #903 so TRL sees only intended callable tools."""
 
-    from transformers.utils import get_json_schema
+    transformers_utils = pytest.importorskip("transformers.utils")
 
     public_callables = [
         name
@@ -234,7 +234,9 @@ def test_environment_public_tools_have_transformers_schema() -> None:
 
     assert public_callables == ["run_bash", "submit"]
     for name in public_callables:
-        schema = get_json_schema(getattr(BenchFlowRuntimeEnvironment, name))
+        schema = transformers_utils.get_json_schema(
+            getattr(BenchFlowRuntimeEnvironment, name)
+        )
         assert schema["function"]["name"] == name
 
 


### PR DESCRIPTION
## Summary

- make the TRL schema regression test skip when the optional `transformers` dependency is not installed
- keep the real schema assertion active when `benchflow[trl]` / `transformers` is installed

## Why

The post-merge `main` test workflow for #905 failed because the standard CI install uses `dev + sandbox-*`, not the optional `trl` extra, so `transformers` is absent:

`tests/test_trl_integration.py::test_environment_public_tools_have_transformers_schema - ModuleNotFoundError: No module named 'transformers'`

## Validation

- `uv run --extra dev --extra sandbox-daytona --extra sandbox-modal --locked python -m pytest tests/test_trl_integration.py -q`
- `uv run --extra dev --extra trl --locked python -m pytest tests/test_trl_integration.py -q`
- `uv run --extra dev --locked ruff check tests/test_trl_integration.py`
- `uv run --extra dev --locked ruff format --check tests/test_trl_integration.py`
