### PR TITLE
Complete TRL rollout artifacts and selective task snapshots

### DIFF
--- a/src/benchflow/_utils/hf_datasets.py
+++ b/src/benchflow/_utils/hf_datasets.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import shutil
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -33,6 +34,29 @@ def _copy_tree(src: Path, dst: Path, *, overwrite: bool) -> None:
     shutil.copytree(src, dst, ignore=shutil.ignore_patterns(".git"))
 
 
+def _copy_selected_tasks(
+    source_root: Path,
+    output_dir: Path,
+    task_ids: Sequence[str],
+    *,
+    overwrite: bool,
+) -> None:
+    if output_dir.exists():
+        if not overwrite:
+            raise FileExistsError(f"Output already exists: {output_dir}")
+        if output_dir.is_dir():
+            shutil.rmtree(output_dir)
+        else:
+            output_dir.unlink()
+    output_dir.mkdir(parents=True)
+    for task_id in task_ids:
+        shutil.copytree(
+            source_root / task_id,
+            output_dir / task_id,
+            ignore=shutil.ignore_patterns(".git"),
+        )
+
+
 def _read_hf_revision(repo_id: str, revision: str | None) -> str:
     try:
         from huggingface_hub import HfApi
@@ -48,7 +72,11 @@ def _read_hf_revision(repo_id: str, revision: str | None) -> str:
 
 
 def _download_snapshot(
-    repo_id: str, *, revision: str | None, cache_dir: Path | None
+    repo_id: str,
+    *,
+    revision: str | None,
+    cache_dir: Path | None,
+    allow_patterns: Sequence[str] = (),
 ) -> Path:
     try:
         from huggingface_hub import snapshot_download
@@ -65,6 +93,8 @@ def _download_snapshot(
     }
     if cache_dir is not None:
         kwargs["cache_dir"] = str(cache_dir)
+    if allow_patterns:
+        kwargs["allow_patterns"] = list(allow_patterns)
     return Path(snapshot_download(**kwargs))
 
 
@@ -75,11 +105,12 @@ def hf_dataset_provenance(
     resolved_revision: str,
     source_path: str,
     local_path: Path,
+    include_tasks: Sequence[str] = (),
 ) -> dict[str, Any]:
     """Build generic HF dataset source provenance for a local task tree."""
 
     path = source_path.strip("/")
-    return {
+    provenance: dict[str, Any] = {
         "type": "huggingface_dataset",
         "repo": repo_id,
         "repo_type": "dataset",
@@ -92,6 +123,9 @@ def hf_dataset_provenance(
         if (local_path / "task.toml").is_file() or (local_path / "task.md").is_file()
         else {},
     }
+    if include_tasks:
+        provenance["include_tasks"] = list(include_tasks)
+    return provenance
 
 
 def write_source_sidecar(root: Path, provenance: dict[str, Any]) -> Path:
@@ -135,25 +169,54 @@ def snapshot_hf_dataset(
     path: str | None = None,
     cache_dir: Path | None = None,
     overwrite: bool = False,
+    include_tasks: Sequence[str] = (),
 ) -> HfDatasetSnapshot:
     """Materialize a HF dataset snapshot and stamp local source metadata."""
 
     resolved_revision = _read_hf_revision(repo_id, revision)
-    snapshot_root = _download_snapshot(repo_id, revision=revision, cache_dir=cache_dir)
     source_path = (path or "").strip("/")
+    selected_tasks = tuple(dict.fromkeys(include_tasks))
+    allow_patterns = tuple(
+        f"{source_path}/{task_id}/**" if source_path else f"{task_id}/**"
+        for task_id in selected_tasks
+    )
+    snapshot_root = _download_snapshot(
+        repo_id,
+        revision=revision,
+        cache_dir=cache_dir,
+        allow_patterns=allow_patterns,
+    )
     source_root = snapshot_root / source_path if source_path else snapshot_root
     if not source_root.is_dir():
         raise FileNotFoundError(
             f"Path {source_path!r} not found in HF dataset {repo_id!r}"
         )
 
-    _copy_tree(source_root, output_dir, overwrite=overwrite)
+    missing_tasks = [
+        task_id for task_id in selected_tasks if not (source_root / task_id).is_dir()
+    ]
+    if missing_tasks:
+        raise FileNotFoundError(
+            f"Tasks not found under {source_path or '.'!r} in HF dataset "
+            f"{repo_id!r}: {', '.join(missing_tasks)}"
+        )
+
+    if selected_tasks:
+        _copy_selected_tasks(
+            source_root,
+            output_dir,
+            selected_tasks,
+            overwrite=overwrite,
+        )
+    else:
+        _copy_tree(source_root, output_dir, overwrite=overwrite)
     provenance = hf_dataset_provenance(
         repo_id=repo_id,
         requested_revision=revision,
         resolved_revision=resolved_revision,
         source_path=source_path,
         local_path=output_dir,
+        include_tasks=selected_tasks,
     )
     write_source_sidecar(output_dir, provenance)
     return HfDatasetSnapshot(path=output_dir, provenance=provenance)

--- a/src/benchflow/cli/tasks.py
+++ b/src/benchflow/cli/tasks.py
@@ -380,6 +380,13 @@ def register_tasks(app: typer.Typer) -> None:
             bool,
             typer.Option("--overwrite", help="Replace an existing output directory"),
         ] = False,
+        include_task: Annotated[
+            list[str] | None,
+            typer.Option(
+                "--include-task",
+                help="Download only this task directory; repeat for multiple tasks",
+            ),
+        ] = None,
     ) -> None:
         """Materialize a Hugging Face dataset task tree with provenance."""
         from benchflow._utils.hf_datasets import SOURCE_SIDECAR, snapshot_hf_dataset
@@ -393,6 +400,7 @@ def register_tasks(app: typer.Typer) -> None:
                 path=path,
                 cache_dir=cache_dir,
                 overwrite=overwrite,
+                include_tasks=include_task or (),
             )
         except (ImportError, OSError, ValueError) as e:
             print_error(f"{e}")

--- a/src/benchflow/integrations/trl/spec.py
+++ b/src/benchflow/integrations/trl/spec.py
@@ -177,14 +177,22 @@ class BenchFlowRuntimeEnvironment:
                 timeout_sec=self._harness.bash_timeout_sec,
             )
         )
-        result = _run_blocking(runtime.verify())
-        self.reward = (
-            float(result.reward) if isinstance(result.reward, int | float) else 0.0
-        )
-        self.rollout_dir = result.rollout_dir
-        self._runtime = None
-        _run_blocking(runtime.close())
+        self._finalize()
         return f"submission recorded; reward={self.reward:g}"
+
+    def _finalize(self) -> None:
+        runtime = self._runtime
+        if runtime is None:
+            return
+        try:
+            result = _run_blocking(runtime.verify())
+            self.reward = (
+                float(result.reward) if isinstance(result.reward, int | float) else 0.0
+            )
+            self.rollout_dir = result.rollout_dir
+        finally:
+            self._runtime = None
+            _run_blocking(runtime.close())
 
     def _close(self) -> None:
         runtime = self._runtime
@@ -212,6 +220,8 @@ def benchflow_environment_reward(
     rewards: list[float] = []
     for index, _completion in enumerate(completions):
         env = environments[index] if index < len(environments) else None
+        if isinstance(env, BenchFlowRuntimeEnvironment):
+            env._finalize()
         value = getattr(env, "reward", 0.0)
         rewards.append(
             float(value)

--- a/src/benchflow/integrations/trl/spec.py
+++ b/src/benchflow/integrations/trl/spec.py
@@ -21,6 +21,42 @@ from benchflow.rollout import TaskRuntime, TaskRuntimeConfig
 from benchflow.task.package import TaskPackage
 
 
+class _AsyncRunner:
+    """Own one event loop for the lifetime of the synchronous TRL adapter."""
+
+    def __init__(self) -> None:
+        self._ready = threading.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+        self._ready.wait()
+
+    def _run(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        self._ready.set()
+        loop.run_forever()
+
+    def run(self, coro: Coroutine[Any, Any, Any]) -> Any:
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError("BenchFlow TRL async runner failed to start")
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
+
+
+_ASYNC_RUNNER: _AsyncRunner | None = None
+_ASYNC_RUNNER_LOCK = threading.Lock()
+
+
+def _async_runner() -> _AsyncRunner:
+    global _ASYNC_RUNNER
+    with _ASYNC_RUNNER_LOCK:
+        if _ASYNC_RUNNER is None:
+            _ASYNC_RUNNER = _AsyncRunner()
+        return _ASYNC_RUNNER
+
+
 class BenchFlowOptionalDependencyError(ImportError):
     """Raised when optional TRL integration dependencies are used but missing."""
 
@@ -415,25 +451,7 @@ def _truncate(text: str, max_chars: int) -> str:
 def _run_blocking(coro: Coroutine[Any, Any, Any]) -> Any:
     """Run an async BenchFlow primitive from TRL's sync tool surface."""
 
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(coro)
-
-    result: dict[str, Any] = {}
-
-    def runner() -> None:
-        try:
-            result["value"] = asyncio.run(coro)
-        except BaseException as exc:  # pragma: no cover - re-raised in caller
-            result["error"] = exc
-
-    thread = threading.Thread(target=runner, daemon=True)
-    thread.start()
-    thread.join()
-    if "error" in result:
-        raise result["error"]
-    return result.get("value")
+    return _async_runner().run(coro)
 
 
 __all__ = [

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -530,6 +530,51 @@ async def _run_environment_setup_commands(env: Any, task: Any) -> None:
             )
 
 
+async def _run_environment_healthcheck(env: Any, task: Any) -> None:
+    """Gate rollout startup on the task-authored environment healthcheck."""
+
+    env_config = getattr(getattr(task, "config", None), "environment", None)
+    healthcheck = getattr(env_config, "healthcheck", None)
+    if healthcheck is None:
+        return
+
+    loop = asyncio.get_running_loop()
+    start_deadline = loop.time() + healthcheck.start_period_sec
+    if healthcheck.start_period_sec > 0 and healthcheck.start_interval_sec > 0:
+        await asyncio.sleep(
+            min(healthcheck.start_interval_sec, healthcheck.start_period_sec)
+        )
+
+    failures = 0
+    while True:
+        result = await env.exec(
+            healthcheck.command,
+            user="root",
+            timeout_sec=max(1, math.ceil(healthcheck.timeout_sec)),
+        )
+        if getattr(result, "return_code", 0) == 0:
+            return
+
+        now = loop.time()
+        if now >= start_deadline:
+            failures += 1
+            if failures >= healthcheck.retries:
+                stdout = (getattr(result, "stdout", "") or "").strip()
+                stderr = (getattr(result, "stderr", "") or "").strip()
+                detail = "\n".join(part for part in (stdout, stderr) if part)
+                if len(detail) > 4000:
+                    detail = detail[:4000] + "\n... truncated ..."
+                raise RuntimeError(
+                    "environment healthcheck failed after "
+                    f"{healthcheck.retries} attempt(s): {detail}"
+                )
+            delay = healthcheck.interval_sec
+        else:
+            delay = min(healthcheck.start_interval_sec, start_deadline - now)
+        if delay > 0:
+            await asyncio.sleep(delay)
+
+
 class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
 
@@ -960,6 +1005,8 @@ class Rollout:
 
         for hook in self._config.pre_agent_hooks or []:
             await hook(self._env)
+
+        await _run_environment_healthcheck(self._env, self._task)
 
         # Environment plane: provision the manifest-declared stateful
         # environment and gate on its readiness before the agent runs.

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -45,6 +45,7 @@ import hashlib
 import io
 import json
 import logging
+import math
 import os
 import re
 import shlex

--- a/src/benchflow/task/runtime_capabilities.py
+++ b/src/benchflow/task/runtime_capabilities.py
@@ -221,13 +221,6 @@ def _append_config_issues(
             reason="GPU scheduling is parsed but not capability-gated",
             sandbox=sandbox,
         )
-    if env.healthcheck is not None:
-        _issue(
-            unsupported,
-            path="environment.healthcheck",
-            reason="environment healthchecks are parsed but not runtime-gated",
-            sandbox=sandbox,
-        )
     _append_workdir_issue(
         unsupported,
         workdir=env.workdir,

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -20,6 +20,7 @@ from benchflow.rollout import (
     _build_rollout_result,
     _publish_trajectory_for_verifier,
     _resolve_agent_cwd,
+    _run_environment_healthcheck,
     _run_environment_setup_commands,
     _start_env_and_upload,
 )
@@ -59,6 +60,75 @@ class FakeSetupCommandEnv:
     async def exec(self, command: str, **kwargs):
         self.exec_calls.append({"command": command, **kwargs})
         return SimpleNamespace(return_code=self.return_code, stdout="out", stderr="err")
+
+
+@pytest.mark.asyncio
+async def test_environment_healthcheck_retries_until_ready(monkeypatch) -> None:
+    """Guards environment healthcheck execution added with PR #907."""
+
+    env = FakeSetupCommandEnv()
+    env.return_codes = iter([1, 0])
+
+    async def exec_healthcheck(command: str, **kwargs):
+        env.exec_calls.append({"command": command, **kwargs})
+        return SimpleNamespace(
+            return_code=next(env.return_codes), stdout="warming", stderr=""
+        )
+
+    env.exec = exec_healthcheck
+    task = SimpleNamespace(
+        config=SimpleNamespace(
+            environment=SimpleNamespace(
+                healthcheck=SimpleNamespace(
+                    command="python /opt/pull_bucket.py",
+                    interval_sec=0,
+                    timeout_sec=30.2,
+                    start_period_sec=0,
+                    start_interval_sec=0,
+                    retries=3,
+                )
+            )
+        )
+    )
+
+    await _run_environment_healthcheck(env, task)
+
+    assert env.exec_calls == [
+        {
+            "command": "python /opt/pull_bucket.py",
+            "user": "root",
+            "timeout_sec": 31,
+        },
+        {
+            "command": "python /opt/pull_bucket.py",
+            "user": "root",
+            "timeout_sec": 31,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_environment_healthcheck_fails_closed() -> None:
+    """Guards environment healthcheck execution added with PR #907."""
+
+    env = FakeSetupCommandEnv(return_code=1)
+    task = SimpleNamespace(
+        config=SimpleNamespace(
+            environment=SimpleNamespace(
+                healthcheck=SimpleNamespace(
+                    command="false",
+                    interval_sec=0,
+                    timeout_sec=1,
+                    start_period_sec=0,
+                    start_interval_sec=0,
+                    retries=2,
+                )
+            )
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="after 2 attempt"):
+        await _run_environment_healthcheck(env, task)
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_download.py
+++ b/tests/test_task_download.py
@@ -347,6 +347,74 @@ def test_task_source_provenance_derives_batch_task_path_and_hashes(tmp_path):
     assert "sample-task/task.toml" not in task_provenance["file_hashes"]
 
 
+def test_snapshot_hf_dataset_filters_selected_tasks(tmp_path, monkeypatch):
+    """Guards the selective snapshot support added with PR #907."""
+
+    source = tmp_path / "source"
+    selected = source / "tasks" / "beta"
+    (selected / "tests").mkdir(parents=True)
+    (selected / "task.toml").write_text("[task]\n")
+    (selected / "instruction.md").write_text("Solve beta.\n")
+    (selected / "tests" / "test.sh").write_text("exit 0\n")
+    unselected = source / "tasks" / "alpha"
+    unselected.mkdir()
+    (unselected / "task.toml").write_text("[task]\n")
+    captured = {}
+
+    def fake_download(repo_id, *, revision, cache_dir, allow_patterns=()):
+        captured["allow_patterns"] = allow_patterns
+        return source
+
+    monkeypatch.setattr(
+        "benchflow._utils.hf_datasets._read_hf_revision",
+        lambda *args, **kwargs: "resolved-sha",
+    )
+    monkeypatch.setattr(
+        "benchflow._utils.hf_datasets._download_snapshot", fake_download
+    )
+    output = tmp_path / "output"
+
+    snapshot_hf_dataset(
+        "org/tasks",
+        output_dir=output,
+        revision="main",
+        path="tasks",
+        include_tasks=["beta"],
+    )
+
+    assert captured["allow_patterns"] == ("tasks/beta/**",)
+    assert sorted(path.name for path in output.iterdir()) == [
+        SOURCE_SIDECAR,
+        "beta",
+    ]
+    assert not (output / "alpha").exists()
+    sidecar = json.loads((output / SOURCE_SIDECAR).read_text())
+    assert sidecar["include_tasks"] == ["beta"]
+
+
+def test_snapshot_hf_dataset_rejects_missing_selected_task(tmp_path, monkeypatch):
+    """Guards the selective snapshot support added with PR #907."""
+
+    source = tmp_path / "source"
+    (source / "tasks").mkdir(parents=True)
+    monkeypatch.setattr(
+        "benchflow._utils.hf_datasets._read_hf_revision",
+        lambda *args, **kwargs: "resolved-sha",
+    )
+    monkeypatch.setattr(
+        "benchflow._utils.hf_datasets._download_snapshot",
+        lambda *args, **kwargs: source,
+    )
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        snapshot_hf_dataset(
+            "org/tasks",
+            output_dir=tmp_path / "output",
+            path="tasks",
+            include_tasks=["missing"],
+        )
+
+
 def test_snapshot_hf_dataset_writes_generic_source_sidecar(tmp_path, monkeypatch):
     """Guards PR slice 1 HF task snapshots without Harbor-specific imports."""
     remote = tmp_path / "remote"

--- a/tests/test_trl_integration.py
+++ b/tests/test_trl_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 import sys
 import types
@@ -300,6 +301,21 @@ def test_reward_func_does_not_reverify_submitted_rollout(
     assert spec.reward_funcs[0](completions=["submitted"], environments=[env]) == [1.0]
     assert runtime is not None
     assert runtime.verify_count == 1
+
+
+def test_async_bridge_reuses_one_event_loop() -> None:
+    """Guards the Daytona event-loop lifetime fix added with PR #907."""
+
+    from benchflow.integrations.trl.spec import _run_blocking
+
+    async def current_loop():
+        return asyncio.get_running_loop()
+
+    first = _run_blocking(current_loop())
+    second = _run_blocking(current_loop())
+
+    assert first is second
+    assert first.is_running()
 
 
 def test_create_trainer_missing_trl_is_actionable(

--- a/tests/test_trl_integration.py
+++ b/tests/test_trl_integration.py
@@ -73,6 +73,7 @@ class _FakeRuntime:
         self.rollout_dir = Path(config.jobs_dir) / "fake-rollout"
         self.commands: list[str] = []
         self.closed = False
+        self.verify_count = 0
 
     @classmethod
     async def create(cls, config: Any) -> _FakeRuntime:
@@ -86,6 +87,7 @@ class _FakeRuntime:
         return _FakeBashResult()
 
     async def verify(self) -> _FakeRuntimeResult:
+        self.verify_count += 1
         reward = (
             1.0 if any("/workdir/answer.txt" in cmd for cmd in self.commands) else 0.0
         )
@@ -249,6 +251,55 @@ def test_reward_func_returns_zero_without_environment(tmp_path: Path):
     spec = BenchFlowSpec.from_tasks_dir(tasks)
 
     assert spec.reward_funcs[0](completions=["ok"]) == [0.0]
+
+
+def test_reward_func_finalizes_rollout_without_submit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards the TRL artifact finalization fix after PR #903."""
+
+    monkeypatch.setattr("benchflow.integrations.trl.spec.TaskRuntime", _FakeRuntime)
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec(
+        tasks_dir=tasks,
+        bash_harness=BashHarnessConfig(jobs_dir=tmp_path / "jobs"),
+    )
+    env = spec.environment_factory()
+    env.reset(**spec.train_dataset_rows[0])
+    runtime = env._runtime
+
+    assert spec.reward_funcs[0](completions=["no submit"], environments=[env]) == [0.0]
+    assert runtime is not None
+    assert runtime.verify_count == 1
+    assert runtime.closed is True
+    assert env.rollout_dir == runtime.rollout_dir
+
+
+def test_reward_func_does_not_reverify_submitted_rollout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards the TRL artifact finalization fix after PR #903."""
+
+    monkeypatch.setattr("benchflow.integrations.trl.spec.TaskRuntime", _FakeRuntime)
+    tasks = tmp_path / "tasks"
+    tasks.mkdir()
+    _make_task(tasks, "alpha", "Answer alpha")
+    spec = BenchFlowSpec(
+        tasks_dir=tasks,
+        bash_harness=BashHarnessConfig(jobs_dir=tmp_path / "jobs"),
+    )
+    env = spec.environment_factory()
+    env.reset(**spec.train_dataset_rows[0])
+    runtime = env._runtime
+    env.submit("done")
+
+    assert spec.reward_funcs[0](completions=["submitted"], environments=[env]) == [1.0]
+    assert runtime is not None
+    assert runtime.verify_count == 1
 
 
 def test_create_trainer_missing_trl_is_actionable(


### PR DESCRIPTION
## Summary
- finalize still-open BenchFlow TRL environments before extracting rewards
- preserve verifier `result.json` artifacts for policies that never call `submit`
- keep submitted rollouts idempotent and avoid double verification
- add repeatable `bench tasks snapshot-hf --include-task` filters
- copy only selected task directories even when the shared HF cache contains other files
- record selected task IDs in `.benchflow-source.json` and fail on missing IDs

## Why
TRL can end a tool-calling rollout without invoking `submit` when the model emits a final response or exhausts the tool-iteration limit. The adapter returned reward `0`, but only closed the sandbox, so no verifier artifact was written. This silently removed failures from paired eval denominators.

The GRPO pipeline also starts from explicit train/eval task lists. Downloading the complete multi-thousand-task HF tree for 15 training tasks made each smoke unnecessarily slow. Generic selective snapshots keep the format support dataset-agnostic while preserving pinned provenance.

## Validation
- `uv run ruff check src/benchflow/_utils/hf_datasets.py src/benchflow/cli/tasks.py src/benchflow/integrations/trl/spec.py tests/test_task_download.py tests/test_trl_integration.py`
- `uv run ty check src`
- `uv run python -m pytest tests/test_task_download.py tests/test_trl_integration.py tests/test_eval_lift.py tests/test_task_runtime_primitive.py -q` (`46 passed, 2 skipped`)
- real selective snapshot of two tasks from `AdithyaSK/data_agent_rl_environment_eval@9240cc381cbadeef82923b64131e174be126c92b` produced exactly two task directories and both passed `bench tasks check`
