### PR TITLE
Use native data-agent datasets in GRPO runbook

### DIFF
--- a/docs/examples/benchflow-grpo-pipeline.md
+++ b/docs/examples/benchflow-grpo-pipeline.md
@@ -6,8 +6,16 @@ measuring held-out lift with BenchFlow eval artifacts.
 
 The example uses the public data-agent task suites:
 
-- training: `AdithyaSK/data_agent_rl_environment_train`
-- held-out eval: `AdithyaSK/data_agent_rl_environment_eval`
+- training: `benchflow/data_agent_rl_environment_train`
+  at `34ff63c91731df6b3670bfcd7e3d44e6790ddc48` (`2,238` tasks)
+- held-out eval: `benchflow/data_agent_rl_environment_eval`
+  at `0ea976c79e3248c85737c4f7363484e4d47ce287` (`366` tasks)
+
+Both repositories contain BenchFlow-native `task.md` packages with
+`environment/` and `verifier/` directories. They contain no legacy
+`task.toml`, `instruction.md`, or `tests/` paths. For difficulty analysis, use
+the published `manifest.parquet`; the source task-level difficulty metadata is
+not a reliable distribution field.
 
 BenchFlow owns task loading, Daytona/Docker sandbox lifecycle, verifier
 execution, artifacts, and lift reporting. TRL owns optimization.
@@ -37,17 +45,17 @@ can retain dataset provenance.
 
 ```bash
 bench tasks snapshot-hf \
-  AdithyaSK/data_agent_rl_environment_train \
+  benchflow/data_agent_rl_environment_train \
   .local/data-agent-train \
   --path tasks \
-  --revision <train-dataset-sha> \
+  --revision 34ff63c91731df6b3670bfcd7e3d44e6790ddc48 \
   --overwrite
 
 bench tasks snapshot-hf \
-  AdithyaSK/data_agent_rl_environment_eval \
+  benchflow/data_agent_rl_environment_eval \
   .local/data-agent-eval \
   --path tasks \
-  --revision <eval-dataset-sha> \
+  --revision 0ea976c79e3248c85737c4f7363484e4d47ce287 \
   --overwrite
 ```
 


### PR DESCRIPTION
## Summary

- replace the legacy source-layout dataset IDs in the canonical GRPO example with the BenchFlow-owned native `task.md` datasets
- pin exact train/eval revisions and record the 2,238/366 task counts
- document the zero-legacy-path contract and `manifest.parquet` difficulty caveat

## Validation

- direct Hub audit: 2,238 train and 366 eval `task.md` files
- every task has `environment/Dockerfile` and `verifier/test.sh`
- zero `task.toml`, `instruction.md`, or `tests/` paths
- BenchFlow TRL adapter test: `1 passed`
- `git diff --check`
