### PR TITLE
fix(acp): restore Gemini on Daytona

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -484,8 +484,12 @@ async def connect_acp(
             if environment == "docker":
                 live_proc = DockerProcess.from_sandbox_env(env)
             elif environment == "daytona":
-                live_proc = await DaytonaPtyProcess.from_sandbox_env(env)
-                logger.info("Using PTY transport for Daytona sandbox")
+                if agent == "gemini":
+                    live_proc = await DaytonaProcess.from_sandbox_env(env)
+                    logger.info("Using SSH transport for Gemini on Daytona")
+                else:
+                    live_proc = await DaytonaPtyProcess.from_sandbox_env(env)
+                    logger.info("Using PTY transport for Daytona sandbox")
             else:
                 is_dind = hasattr(env, "_strategy") and hasattr(
                     env._strategy, "_compose_cmd"

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1252,6 +1252,44 @@ class TestConnectAcpModelSelection:
         mock_pty.assert_awaited_once_with(mock_env)
         mock_ssh.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_daytona_gemini_uses_ssh_transport(self, tmp_path):
+        """Guards the Gemini regression introduced by PR #896's PTY migration."""
+        from benchflow.acp.runtime import connect_acp
+
+        mock_acp = self._make_mocks()
+        mock_env = MagicMock()
+        mock_env.exec = AsyncMock(return_value=MagicMock(return_code=1, stdout=""))
+
+        with (
+            patch(
+                "benchflow.acp.runtime.DaytonaPtyProcess.from_sandbox_env",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_pty,
+            patch(
+                "benchflow.acp.runtime.DaytonaProcess.from_sandbox_env",
+                new_callable=AsyncMock,
+                return_value=MagicMock(),
+            ) as mock_ssh,
+            patch("benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()),
+            patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        ):
+            await connect_acp(
+                env=mock_env,
+                agent="gemini",
+                agent_launch="gemini --acp --yolo",
+                agent_env={"GEMINI_API_KEY": "test"},
+                sandbox_user=None,
+                model="gemini-3.1-flash-lite",
+                rollout_dir=tmp_path,
+                environment="daytona",
+                agent_cwd="/app",
+            )
+
+        mock_ssh.assert_awaited_once_with(mock_env)
+        mock_pty.assert_not_awaited()
+
 
 class TestSandboxStartupDiagnostics:
     """Guards ENG-147: sandbox startup failures must carry structured diagnostics."""


### PR DESCRIPTION
## Summary

- route the native Gemini ACP agent through Daytona SSH instead of PTY
- keep PTY transport unchanged for OpenHands and every other Daytona agent
- add a regression test for the transport selection

## Root cause

Gemini ACP succeeds over a normal pipe but stalls when attached to Daytona PTY: the process emits terminal-mode output and never answers ACP `initialize`. The regression dates to the all-agent PTY migration in PR #896.

## Live validation

- host ACPX/Gemini: `initialize -> session/new -> OK -> end_turn`
- Daytona PTY, Gemini CLI 0.41.2 / 0.42.0 / 0.50.0: all stalled with empty ACP trajectories
- isolated SSH transport, Daytona hello-world: reward 1.0, no errors
- isolated SSH transport, SkillsBench `jax-computing-basics`: completed 24 tool calls and verifier scoring with no infrastructure error

## Tests

- `pytest tests/test_acp.py` — 80 passed
- `ruff check` / `ruff format --check` — passed
- `ty check src/benchflow/acp/runtime.py` — passed

Native Gemini still lacks provider-level LLM telemetry and is therefore not training-ready evidence; this PR restores agent execution compatibility only.