### PR TITLE
chore: release v0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## [Unreleased]
 
+## 0.6.5 — 2026-07-10
+
+### Added
+- **Reproducible evaluation artifact workflows.** `bench eval run` can emit
+  task/run manifests, trajectory-health summaries, canonical one-rollout-per-task
+  selections, materialized trainer inputs, repeated model matrices, and
+  Hugging Face dataset uploads with source provenance. (#844, #907)
+- **Prime-RL supervised fine-tuning integration.** `bench train validate` and
+  `bench train run sft --backend prime-rl` add fail-closed trainer-row checks,
+  local/Hugging Face dataset staging, publishing hooks, and compatibility
+  controls for reproducing the Mobile300 PR828 training recipe. (#842–#865)
+- **Native external benchmark adapters.** BenchFlow can materialize MCP Atlas
+  and Toolathlon sources, credential-backed task packages, and the service
+  sidecars required by their hosted runtimes. (#878, #885, #889)
+- **Registry-driven agent extension.** Agent packages can autoload through
+  `benchflow.agents` entry points or declarative manifests, including namespace
+  shorthand for externally registered agents. (#873, #877)
+- **BenchFlow-native GRPO/TRL pipeline.** Adds reusable `TaskRuntime`, the
+  optional `BenchFlowSpec` TRL adapter, selective Hugging Face task snapshots,
+  paired `bench eval compare-lift` reporting, and an end-to-end GRPO runbook.
+  (#901–#907)
+
+### Changed
+- BenchFlow CLI and SDK installations now explicitly require Python 3.12 or
+  newer, with `uv tool install --python 3.12` as the recommended CLI path.
+  (#899)
+
+### Fixed
+- Hardened LiteLLM and provider routing across Responses/chat bridges, Gemini
+  custom endpoints, Claude OAuth, Harvey LAB, OpenHands Azure reasoning effort,
+  diagnostics, and parallel ACP shim startup. (#868, #871, #879–#881, #886,
+  #888, #911)
+- Stabilized Daytona execution for Toolathlon and ACP agents, including DinD
+  retries, PTY handling, orphan-free long-command heartbeats, and Gemini's SSH
+  transport fallback. (#890, #892–#896, #910, #912)
+- Tightened trajectory and Prime-SFT artifact integrity with secret redaction,
+  tool-call validation, repaired results conversion, and reproducible
+  compatibility controls. (#849–#865)
+
 ### Removed
 - **`BENCHFLOW_SKILL_NUDGE` skill prompt nudge.** The optional prompt injection
   that prepended mounted-skill names/descriptions/bodies to the task
@@ -9,7 +48,7 @@
   effect: prompt resolution never reads skill directories, and mounted skills
   reach agents only through their native skill paths. This keeps prompts
   identical across skill modes and closes off accidental prompt-level skill
-  leakage.
+  leakage. (#908)
 
 ## 0.6.4 — 2026-06-27
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/benchflow-ai/benchflow"
 url: "https://github.com/benchflow-ai/benchflow"
 license: Apache-2.0
-version: 0.6.4
-date-released: 2026-06-27
+version: 0.6.5
+date-released: 2026-07-10
 keywords:
   - benchmark
   - llm-agents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.4"
+version = "0.6.5"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.4"
+version = "0.6.5"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release v0.6.5

Release BenchFlow 0.6.5 from current main with the changelog, citation metadata, package version, and lockfile aligned.

## Validation

- [x] `ruff format --check src tests tools`
- [x] `ruff check src tests tools`
- [x] `ty check` with the exact CI dependency shape
- [x] `pytest tests/ -q` — 4837 passed, 8 skipped, 7 deselected
- [x] `uv lock --check`
- [x] dependency audit — no known vulnerabilities, one documented ignore
- [x] real Gemini + Daytona hello-world rollout — reward 1.0
- [x] `tools/release_version.py public-release` validates `v0.6.5`
- [x] wheel and sdist pass `twine check`
- [x] clean Python 3.12 wheel install reports `benchflow 0.6.5`

## Release checklist

- [x] CHANGELOG updated
- [x] `CITATION.cff` version/date updated
- [x] Version bumped in `pyproject.toml`
- [x] `uv.lock` refreshed
- [ ] Human approval
- [ ] Merge and tag `v0.6.5` after CI and rollout smoke are green