### PR TITLE
chore(release): start 0.6.6 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.5"
+version = "0.6.6.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -310,7 +310,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.5"
+version = "0.6.6.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- move `main` from the published `0.6.5` final version to `0.6.6.dev0`
- refresh `uv.lock`
- restore the internal-preview version line after the public release

## Validation

- `tools/release_version.py internal-preview --run-number 123` -> `0.6.6.dev123`
- `pytest tests/test_release_version.py` -> 22 passed