### PR TITLE
Fail closed on incomplete agent skill paths

### DIFF
--- a/src/benchflow/agents/install.py
+++ b/src/benchflow/agents/install.py
@@ -18,6 +18,7 @@ Does not own:
 
 import logging
 import shlex
+from collections.abc import Sequence
 from pathlib import Path
 
 from benchflow.agents.registry import AGENT_INSTALLERS, AGENTS, AgentConfig
@@ -126,6 +127,7 @@ async def _link_skill_paths(
     home: str,
     cwd: str,
     sandbox_user: str | None,
+    expected_skill_names: Sequence[str] = (),
 ) -> int:
     """Link one shared skills tree into each configured discovery path."""
     _VALID_PREFIXES = ("$HOME/", "$WORKSPACE/")
@@ -134,12 +136,23 @@ async def _link_skill_paths(
             raise ValueError(f"skill_path {sp!r} must start with $HOME/ or $WORKSPACE/")
 
     parts = []
+    expected = tuple(sorted(set(expected_skill_names)))
+    expected_text = "\n".join(expected)
     for sp in skill_paths:
         prefix = home if sp.startswith("$HOME/") else cwd
         expanded = sp.replace("$HOME", home).replace("$WORKSPACE", cwd)
         leaf = expanded if source == expanded else str(Path(expanded).parent)
         chain = _intermediate_dirs(prefix, leaf) if sandbox_user else []
         parts.append(_skill_link_cmd(source, expanded, sandbox_user, chain))
+        if expected:
+            q_expected = shlex.quote(expected_text)
+            q_expanded = shlex.quote(expanded)
+            parts.append(
+                'actual="$(find -L '
+                f"{q_expanded} -mindepth 2 -maxdepth 2 -type f -name SKILL.md "
+                "-printf '%h\\n' | sed 's#.*/##' | LC_ALL=C sort -u)" + '"'
+                f' && test "$actual" = {q_expected}'
+            )
     if parts:
         cmd = " && ".join(parts)
         result = await env.exec(cmd, timeout_sec=15)
@@ -154,6 +167,11 @@ async def _link_skill_paths(
                 details.append(f"stdout: {stdout}")
             if stderr:
                 details.append(f"stderr: {stderr}")
+            if expected:
+                raise RuntimeError(
+                    "experiment_fidelity/skill_deployment_missing: "
+                    f"expected={','.join(expected)}; {'; '.join(details)}"
+                )
             raise RuntimeError(
                 f"Failed to link skills from {source}: {'; '.join(details)}"
             )
@@ -286,6 +304,11 @@ async def deploy_skills(
     skills_sandbox_dir: str | None = None,
 ) -> None:
     """Deploy and distribute skills into sandbox."""
+    expected_skill_names = (
+        tuple(sorted(path.parent.name for path in Path(skills_dir).glob("*/SKILL.md")))
+        if skills_dir
+        else ()
+    )
     target_skills_dir = (
         validate_container_mount_path(skills_sandbox_dir or "/skills")
         if skills_dir or skills_sandbox_dir
@@ -331,6 +354,7 @@ async def deploy_skills(
             home,
             agent_cwd,
             sandbox_user,
+            expected_skill_names,
         )
         label = agent_cfg.name if agent_cfg else "oracle"
         if count:

--- a/src/benchflow/agents/install.py
+++ b/src/benchflow/agents/install.py
@@ -144,15 +144,21 @@ async def _link_skill_paths(
         leaf = expanded if source == expanded else str(Path(expanded).parent)
         chain = _intermediate_dirs(prefix, leaf) if sandbox_user else []
         parts.append(_skill_link_cmd(source, expanded, sandbox_user, chain))
+        q_source = shlex.quote(source)
+        q_expanded = shlex.quote(expanded)
+        parts.append(
+            f"test -d {q_source} && test -d {q_expanded}"
+            ' && source_catalog="$(find -L '
+            f"{q_source} -mindepth 2 -maxdepth 2 -type f -name SKILL.md "
+            "-printf '%h\\n' | sed 's#.*/##' | LC_ALL=C sort -u)" + '"'
+            ' && actual="$(find -L '
+            f"{q_expanded} -mindepth 2 -maxdepth 2 -type f -name SKILL.md "
+            "-printf '%h\\n' | sed 's#.*/##' | LC_ALL=C sort -u)" + '"'
+            ' && test "$actual" = "$source_catalog"'
+        )
         if expected:
             q_expected = shlex.quote(expected_text)
-            q_expanded = shlex.quote(expanded)
-            parts.append(
-                'actual="$(find -L '
-                f"{q_expanded} -mindepth 2 -maxdepth 2 -type f -name SKILL.md "
-                "-printf '%h\\n' | sed 's#.*/##' | LC_ALL=C sort -u)" + '"'
-                f' && test "$actual" = {q_expected}'
-            )
+            parts.append(f'test "$source_catalog" = {q_expected}')
     if parts:
         cmd = " && ".join(parts)
         result = await env.exec(cmd, timeout_sec=15)
@@ -175,7 +181,7 @@ async def _link_skill_paths(
             raise RuntimeError(
                 f"Failed to link skills from {source}: {'; '.join(details)}"
             )
-    return len(parts)
+    return len(skill_paths) if parts else 0
 
 
 def effective_install_timeout(

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -85,6 +85,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import time
 import traceback
 from datetime import datetime, timezone
@@ -92,6 +93,70 @@ from typing import Any
 
 import litellm
 from litellm.integrations.custom_logger import CustomLogger
+
+
+_skill_catalog_gate_passed = False
+
+
+def _required_skill_names() -> tuple[str, ...]:
+    raw = os.environ.get("BENCHFLOW_REQUIRED_SKILL_NAMES_JSON", "")
+    if not raw:
+        return ()
+    try:
+        values = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            "experiment_fidelity/skill_catalog_gate_config_invalid"
+        ) from exc
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        raise RuntimeError("experiment_fidelity/skill_catalog_gate_config_invalid")
+    return tuple(sorted(set(values)))
+
+
+def _message_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            str(item.get("text", ""))
+            for item in content
+            if isinstance(item, dict)
+        )
+    return ""
+
+
+def _opencode_catalog_names(data: dict[str, Any]) -> set[str]:
+    system = "\n".join(
+        _message_text(message.get("content"))
+        for message in data.get("messages") or []
+        if isinstance(message, dict) and message.get("role") == "system"
+    )
+    match = re.search(
+        r"<available_skills>(.*?)</available_skills>", system, flags=re.DOTALL
+    )
+    if not match:
+        return set()
+    return set(re.findall(r"<name>\s*([^<]+?)\s*</name>", match.group(1)))
+
+
+def _gate_opencode_skill_catalog(data: dict[str, Any]) -> None:
+    global _skill_catalog_gate_passed
+    if _skill_catalog_gate_passed:
+        return
+    if os.environ.get("BENCHFLOW_SKILL_CATALOG_GATE_AGENT") != "opencode":
+        return
+    expected = _required_skill_names()
+    if not expected:
+        return
+    visible = _opencode_catalog_names(data)
+    missing = sorted(set(expected) - visible)
+    if missing:
+        raise RuntimeError(
+            "experiment_fidelity/skill_catalog_missing: "
+            f"missing={','.join(missing)} expected={','.join(expected)} "
+            f"visible={','.join(sorted(visible))}"
+        )
+    _skill_catalog_gate_passed = True
 
 
 def _jsonable(value: Any) -> Any:
@@ -218,6 +283,8 @@ class BenchFlowLiteLLMLogger(CustomLogger):
     ):
         if not isinstance(data, dict):
             return None
+
+        _gate_opencode_skill_catalog(data)
 
         cleaned = data
 

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -67,6 +67,8 @@ _PATCH_MODULE = "benchflow_litellm_bedrock_patch"
 # it's ignored) and `NO_DOCS=true` so the docs route is skipped regardless of the
 # inherited environment.
 _PROXY_DOCS_DISABLE_ENV = {"DOCS_URL": "", "NO_DOCS": "true"}
+_SKILL_CATALOG_GATE_AGENT_ENV = "BENCHFLOW_SKILL_CATALOG_GATE_AGENT"
+_REQUIRED_SKILL_NAMES_ENV = "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON"
 
 # Agents that speak a provider-native wire protocol the LiteLLM proxy does not
 # expose on its OpenAI/Anthropic surfaces. Routing them through the proxy would
@@ -1044,6 +1046,19 @@ def _apply_litellm_agent_env(
     return updated
 
 
+def _litellm_proxy_env(
+    *, agent: str, agent_env: dict[str, str], required_skill_names: tuple[str, ...]
+) -> dict[str, str]:
+    updated = dict(agent_env)
+    updated.pop(_SKILL_CATALOG_GATE_AGENT_ENV, None)
+    updated.pop(_REQUIRED_SKILL_NAMES_ENV, None)
+    expected = sorted(set(required_skill_names))
+    if agent == "opencode" and expected:
+        updated[_SKILL_CATALOG_GATE_AGENT_ENV] = agent
+        updated[_REQUIRED_SKILL_NAMES_ENV] = json.dumps(expected)
+    return updated
+
+
 def _wire_litellm_agent_env(
     *,
     agent: str,
@@ -1053,6 +1068,8 @@ def _wire_litellm_agent_env(
     master_key: str,
 ) -> dict[str, str]:
     updated = dict(agent_env)
+    updated.pop(_SKILL_CATALOG_GATE_AGENT_ENV, None)
+    updated.pop(_REQUIRED_SKILL_NAMES_ENV, None)
     # Isolation: the agent must reach providers only through the proxy. Drop raw
     # upstream provider secrets AND endpoints so a compromised or curious agent
     # cannot bypass the gateway (and its usage metering) or read live keys. The
@@ -1191,6 +1208,7 @@ async def ensure_litellm_runtime(
     usage_tracking: UsageTrackingConfig | dict[str, Any] | str | None = None,
     sandbox: Any | None = None,
     sandbox_setup_timeout: int = 120,
+    required_skill_names: tuple[str, ...] = (),
 ) -> tuple[dict[str, str], Any | None]:
     """Start/reuse LiteLLM and rewrite the agent env to talk to it.
 
@@ -1252,7 +1270,12 @@ async def ensure_litellm_runtime(
         agent_env.get(LITELLM_MASTER_KEY_ENV)
         or f"sk-benchflow-{secrets.token_urlsafe(24)}"
     )
-    config_key = f"{environment}:{route.config_key}:{agent}:{session_id}"
+    skill_gate_key = json.dumps(
+        sorted(set(required_skill_names)), separators=(",", ":")
+    )
+    config_key = (
+        f"{environment}:{route.config_key}:{agent}:{session_id}:{skill_gate_key}"
+    )
     if runtime is not None and getattr(runtime, "kind", None) == "litellm":
         server = getattr(runtime, "server", None)
         if getattr(runtime, "config_key", None) == config_key and server is not None:
@@ -1271,12 +1294,17 @@ async def ensure_litellm_runtime(
         await stop_litellm_runtime(runtime)
 
     try:
+        proxy_env = _litellm_proxy_env(
+            agent=agent,
+            agent_env=agent_env,
+            required_skill_names=required_skill_names,
+        )
         if environment in _SANDBOX_LOCAL_ENVIRONMENTS:
             server = await _start_sandbox_litellm(
                 sandbox=sandbox,
                 route=route,
                 master_key=master_key,
-                agent_env=agent_env,
+                agent_env=proxy_env,
                 session_id=session_id,
                 agent_name=agent,
                 install_timeout_sec=max(600, int(sandbox_setup_timeout)),
@@ -1285,7 +1313,7 @@ async def ensure_litellm_runtime(
             server = await _start_host_litellm(
                 route=route,
                 master_key=master_key,
-                agent_env=agent_env,
+                agent_env=proxy_env,
                 environment=environment,
                 session_id=session_id,
                 agent_name=agent,

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -40,6 +40,7 @@ async def ensure_litellm_runtime(
     usage_tracking: UsageTrackingConfig | dict[str, Any] | str | None = None,
     sandbox: Any | None = None,
     sandbox_setup_timeout: int = 120,
+    required_skill_names: tuple[str, ...] = (),
 ) -> tuple[dict[str, str], ProviderRuntime | None]:
     from benchflow.providers.litellm_runtime import (
         ensure_litellm_runtime as _ensure_litellm_runtime,
@@ -55,6 +56,7 @@ async def ensure_litellm_runtime(
         usage_tracking=usage_tracking,
         sandbox=sandbox,
         sandbox_setup_timeout=sandbox_setup_timeout,
+        required_skill_names=required_skill_names,
     )
 
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -920,6 +920,15 @@ class Rollout:
         self._effective_task_path = effective_task_path
         self._effective_skills_dir = effective_skills_dir
         self._effective_skills_sandbox_dir = task_skill_policy.sandbox_dir
+        self._required_skill_names = (
+            tuple(
+                sorted(
+                    path.parent.name for path in effective_skills_dir.glob("*/SKILL.md")
+                )
+            )
+            if effective_skills_dir is not None
+            else ()
+        )
 
         # Honour an externally-supplied sandbox (use_prebuilt_env, set by
         # Runtime.execute() when the caller passes a live Environment).
@@ -1176,6 +1185,7 @@ class Rollout:
             usage_tracking=cfg.usage_tracking,
             sandbox=self._env,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+            required_skill_names=getattr(self, "_required_skill_names", ()),
         )
         sf_entrypoint = self._session_factory_entrypoint(cfg.primary_agent)
         self._is_session_factory = sf_entrypoint is not None
@@ -2133,6 +2143,7 @@ class Rollout:
             usage_tracking=cfg.usage_tracking,
             sandbox=self._env,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
+            required_skill_names=getattr(self, "_required_skill_names", ()),
         )
 
         role_agent_differs = role.agent != cfg.primary_agent

--- a/src/benchflow/rollout/_user_loop.py
+++ b/src/benchflow/rollout/_user_loop.py
@@ -131,6 +131,7 @@ async def _activate_step_skills(rollout: Rollout, step: Step) -> None:
     role = scene_step_role(step)
     source = str(skills_dir)
     local_source = Path(source).expanduser()
+    expected_skill_names: tuple[str, ...] = ()
     # Upload whenever skills_dir resolves to a real directory on the
     # orchestrator host, regardless of whether it arrived as a str or a
     # PathLike. The SkillsBench entrypoint passes an absolute *str* host
@@ -142,6 +143,9 @@ async def _activate_step_skills(rollout: Rollout, step: Step) -> None:
     # host is a sandbox path produced by an earlier scene and is linked
     # as-is.
     if local_source.is_dir():
+        expected_skill_names = tuple(
+            sorted(path.parent.name for path in local_source.glob("*/SKILL.md"))
+        )
         remote_source = f"/skills/{_safe_skill_name(scene_name)}"
         await _ensure_sandbox_dir(rollout._env, Path(remote_source).parent)
         await rollout._env.upload_dir(local_source, remote_source)
@@ -165,6 +169,7 @@ async def _activate_step_skills(rollout: Rollout, step: Step) -> None:
         home,
         rollout._agent_cwd,
         rollout._config.sandbox_user,
+        expected_skill_names=expected_skill_names,
     )
 
 

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -110,7 +110,7 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
 
 @pytest.mark.asyncio
 async def test_deploy_skills_fails_closed_when_expected_catalog_is_unreadable(tmp_path):
-    """Guards the OpenCode task-skill fidelity gate from this PR."""
+    """Guards the OpenCode task-skill fidelity gate from PR #919."""
     env = MagicMock()
     env.exec = AsyncMock(
         return_value=MagicMock(return_code=1, stdout="", stderr="missing SKILL.md")

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -14,6 +14,22 @@ from benchflow.models import AgentInstallError
 from benchflow.rollout._setup import _agent_process_kill_pattern
 
 
+class LocalShellEnv:
+    async def exec(self, command: str, timeout_sec: int):
+        completed = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout_sec,
+        )
+        return SimpleNamespace(
+            return_code=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
 @pytest.mark.asyncio
 async def test_deploy_skills_symlinks_agent_skill_paths_instead_of_copying(tmp_path):
     env = MagicMock()
@@ -82,10 +98,18 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
         name="test-agent",
         install_cmd="true",
         launch_cmd="true",
-        skill_paths=["$HOME/.agents/skills", "$WORKSPACE/skills"],
+        skill_paths=[
+            "$HOME/.agents/skills",
+            "$HOME/.claude/skills",
+            "$HOME/.codex/skills",
+            "$HOME/.opencode/skills",
+            "$WORKSPACE/skills",
+        ],
     )
     skills_dir = tmp_path / "skills"
-    skills_dir.mkdir()
+    skill = skills_dir / "mesh-analysis" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Mesh analysis\n")
 
     await deploy_skills(
         env=env,
@@ -103,21 +127,33 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
     assert " && " in distributed_link_cmd
     assert ";" not in distributed_link_cmd
     assert "ln -sfn /skills /home/agent/.agents/skills" in distributed_link_cmd
+    assert "ln -sfn /skills /home/agent/.claude/skills" in distributed_link_cmd
+    assert "ln -sfn /skills /home/agent/.codex/skills" in distributed_link_cmd
+    assert "ln -sfn /skills /home/agent/.opencode/skills" in distributed_link_cmd
     assert "ln -sfn /skills /workspace/skills" in distributed_link_cmd
+    for discovery_path in (
+        "/home/agent/.agents/skills",
+        "/home/agent/.claude/skills",
+        "/home/agent/.codex/skills",
+        "/home/agent/.opencode/skills",
+        "/workspace/skills",
+    ):
+        assert f"find -L {discovery_path}" in distributed_link_cmd
+    assert distributed_link_cmd.count("mesh-analysis") == 5
     assert "/root/.agents/skills" not in distributed_link_cmd
     assert "/app/skills" not in distributed_link_cmd
 
 
 @pytest.mark.asyncio
 async def test_deploy_skills_fails_closed_when_expected_catalog_is_unreadable(tmp_path):
-    """Guards the OpenCode task-skill fidelity gate from PR #919."""
+    """Guards the agent-neutral task-skill fidelity gate from PR #919."""
     env = MagicMock()
     env.exec = AsyncMock(
         return_value=MagicMock(return_code=1, stdout="", stderr="missing SKILL.md")
     )
     env.upload_dir = AsyncMock()
     agent_cfg = AgentConfig(
-        name="opencode",
+        name="test-agent",
         install_cmd="true",
         launch_cmd="true",
         skill_paths=["$HOME/.opencode/skills"],
@@ -138,6 +174,30 @@ async def test_deploy_skills_fails_closed_when_expected_catalog_is_unreadable(tm
             agent_cfg=agent_cfg,
             sandbox_user="agent",
             agent_cwd="/workspace",
+        )
+
+
+@pytest.mark.asyncio
+async def test_deploy_skills_rejects_dangling_remote_skill_root(tmp_path):
+    """Guards every agent discovery path against a dangling source in PR #919."""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    agent_cfg = AgentConfig(
+        name="test-agent",
+        install_cmd="true",
+        launch_cmd="true",
+        skill_paths=["$WORKSPACE/.agents/skills"],
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to link skills"):
+        await deploy_skills(
+            env=LocalShellEnv(),
+            task_path=tmp_path,
+            skills_dir=None,
+            agent_cfg=agent_cfg,
+            sandbox_user=None,
+            agent_cwd=str(workspace),
+            skills_sandbox_dir=str(tmp_path / "missing-skills"),
         )
 
 

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -109,6 +109,39 @@ async def test_deploy_skills_uploads_runtime_skills_and_links_shared_tree(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_deploy_skills_fails_closed_when_expected_catalog_is_unreadable(tmp_path):
+    """Guards the OpenCode task-skill fidelity gate from this PR."""
+    env = MagicMock()
+    env.exec = AsyncMock(
+        return_value=MagicMock(return_code=1, stdout="", stderr="missing SKILL.md")
+    )
+    env.upload_dir = AsyncMock()
+    agent_cfg = AgentConfig(
+        name="opencode",
+        install_cmd="true",
+        launch_cmd="true",
+        skill_paths=["$HOME/.opencode/skills"],
+    )
+    skills_dir = tmp_path / "skills"
+    skill = skills_dir / "mesh-analysis" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text("# Mesh analysis\n")
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"experiment_fidelity/skill_deployment_missing.*mesh-analysis",
+    ):
+        await deploy_skills(
+            env=env,
+            task_path=tmp_path,
+            skills_dir=skills_dir,
+            agent_cfg=agent_cfg,
+            sandbox_user="agent",
+            agent_cwd="/workspace",
+        )
+
+
+@pytest.mark.asyncio
 async def test_deploy_skills_uses_policy_sandbox_dir(tmp_path):
     """Guards PR #586 so task skills can mount outside the default /skills."""
     env = MagicMock()

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -95,6 +95,77 @@ async def test_callback_pre_call_hook_preserves_input_only_requests():
     assert await logger.async_pre_call_hook(None, None, data, "responses") is None
 
 
+@pytest.mark.asyncio
+async def test_callback_rejects_missing_required_opencode_skill_before_provider(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards the OpenCode first-request catalog gate from this PR."""
+    monkeypatch.setenv("BENCHFLOW_SKILL_CATALOG_GATE_AGENT", "opencode")
+    monkeypatch.setenv(
+        "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON", json.dumps(["mesh-analysis"])
+    )
+    namespace: dict[str, object] = {}
+    exec(callback_module_source(), namespace)
+    logger = namespace["proxy_handler_instance"]
+    data = {
+        "model": "qwen35-9b-base",
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "<available_skills><skill><name>customize-opencode</name>"
+                    "</skill></available_skills>"
+                ),
+            },
+            {"role": "user", "content": "calculate mass"},
+        ],
+    }
+
+    with pytest.raises(
+        RuntimeError,
+        match=r"experiment_fidelity/skill_catalog_missing.*mesh-analysis",
+    ):
+        await logger.async_pre_call_hook(None, None, data, "completion")
+
+
+@pytest.mark.asyncio
+async def test_callback_accepts_matching_opencode_catalog_once(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Guards the OpenCode first-request catalog gate from this PR."""
+    monkeypatch.setenv("BENCHFLOW_SKILL_CATALOG_GATE_AGENT", "opencode")
+    monkeypatch.setenv(
+        "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON", json.dumps(["mesh-analysis"])
+    )
+    namespace: dict[str, object] = {}
+    exec(callback_module_source(), namespace)
+    logger = namespace["proxy_handler_instance"]
+    first = {
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "<available_skills>"
+                    "<skill><name>customize-opencode</name></skill>"
+                    "<skill><name>mesh-analysis</name></skill>"
+                    "</available_skills>"
+                ),
+            }
+        ]
+    }
+
+    assert await logger.async_pre_call_hook(None, None, first, "completion") is None
+    assert (
+        await logger.async_pre_call_hook(
+            None,
+            None,
+            {"messages": [{"role": "user", "content": "continue"}]},
+            "completion",
+        )
+        is None
+    )
+
+
 def test_litellm_callback_jsonl_imports_usage_and_cost():
     record = {
         "event": "success",

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -99,7 +99,7 @@ async def test_callback_pre_call_hook_preserves_input_only_requests():
 async def test_callback_rejects_missing_required_opencode_skill_before_provider(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Guards the OpenCode first-request catalog gate from this PR."""
+    """Guards the OpenCode first-request catalog gate from PR #919."""
     monkeypatch.setenv("BENCHFLOW_SKILL_CATALOG_GATE_AGENT", "opencode")
     monkeypatch.setenv(
         "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON", json.dumps(["mesh-analysis"])
@@ -132,7 +132,7 @@ async def test_callback_rejects_missing_required_opencode_skill_before_provider(
 async def test_callback_accepts_matching_opencode_catalog_once(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Guards the OpenCode first-request catalog gate from this PR."""
+    """Guards the OpenCode first-request catalog gate from PR #919."""
     monkeypatch.setenv("BENCHFLOW_SKILL_CATALOG_GATE_AGENT", "opencode")
     monkeypatch.setenv(
         "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON", json.dumps(["mesh-analysis"])

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -84,7 +84,7 @@ async def test_host_litellm_rewrites_codex_env(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_opencode_required_skills_reach_proxy_not_agent(monkeypatch):
-    """Guards the OpenCode first-request catalog gate from this PR."""
+    """Guards the OpenCode first-request catalog gate from PR #919."""
     starts = []
 
     async def fake_start(**kwargs):

--- a/tests/test_litellm_runtime.py
+++ b/tests/test_litellm_runtime.py
@@ -83,6 +83,35 @@ async def test_host_litellm_rewrites_codex_env(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_opencode_required_skills_reach_proxy_not_agent(monkeypatch):
+    """Guards the OpenCode first-request catalog gate from this PR."""
+    starts = []
+
+    async def fake_start(**kwargs):
+        starts.append(kwargs)
+        return FakeLiteLLMServer("http://127.0.0.1:32123", kwargs["route"])
+
+    monkeypatch.setattr(runtime_mod, "_start_host_litellm", fake_start)
+    updated, _runtime = await ensure_litellm_runtime(
+        agent="opencode",
+        agent_env={"OPENAI_API_KEY": "sk-test"},
+        model="openai/gpt-4.1-mini",
+        runtime=None,
+        environment="docker",
+        session_id="run-skill-gate",
+        required_skill_names=("mesh-analysis",),
+    )
+
+    proxy_env = starts[0]["agent_env"]
+    assert proxy_env["BENCHFLOW_SKILL_CATALOG_GATE_AGENT"] == "opencode"
+    assert json.loads(proxy_env["BENCHFLOW_REQUIRED_SKILL_NAMES_JSON"]) == [
+        "mesh-analysis"
+    ]
+    assert "BENCHFLOW_SKILL_CATALOG_GATE_AGENT" not in updated
+    assert "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON" not in updated
+
+
+@pytest.mark.asyncio
 async def test_claude_agent_uses_anthropic_compatible_litellm_endpoint(monkeypatch):
     async def fake_start(**kwargs):
         return FakeLiteLLMServer("http://127.0.0.1:4000", kwargs["route"])

--- a/tests/test_scene_outbox_trial.py
+++ b/tests/test_scene_outbox_trial.py
@@ -363,6 +363,11 @@ async def test_scene_skills_link_remote_generated_root() -> None:
         "ln -sfn /app/generated-skills /home/agent/.claude/skills" in cmd
         for cmd in trial._env._exec_log
     )
+    assert any(
+        "find -L /app/generated-skills" in cmd
+        and "find -L /home/agent/.claude/skills" in cmd
+        for cmd in trial._env._exec_log
+    )
 
 
 async def test_scene_skills_prefers_remote_string_path_over_matching_host_path(
@@ -419,5 +424,9 @@ async def test_scene_skills_upload_absolute_str_host_dir(tmp_path: Path) -> None
     assert trial._env._uploads == [(skills_root, "/skills/solve")]
     assert any(
         "ln -sfn /skills/solve /home/agent/.claude/skills" in cmd
+        for cmd in trial._env._exec_log
+    )
+    assert any(
+        "find -L /home/agent/.claude/skills" in cmd and "mesh-analysis" in cmd
         for cmd in trial._env._exec_log
     )

--- a/tests/test_trial_litellm_runtime.py
+++ b/tests/test_trial_litellm_runtime.py
@@ -28,6 +28,7 @@ async def test_trial_connect_starts_litellm_before_connect_acp(tmp_path: Path):
     rollout._agent_cwd = "/workspace"
     rollout._env = SimpleNamespace()
     rollout._usage_runtime = None
+    rollout._required_skill_names = ("mesh-analysis",)
     rollout._timing = {}
     rollout._reapply_ask_user_handler = lambda: None
     rollout._attach_trajectory_writer = lambda _rollout_dir: None
@@ -36,6 +37,7 @@ async def test_trial_connect_starts_litellm_before_connect_acp(tmp_path: Path):
     async def fake_litellm(**kwargs):
         calls.append("litellm")
         assert kwargs["environment"] == "docker"
+        assert kwargs["required_skill_names"] == ("mesh-analysis",)
         env = dict(kwargs["agent_env"])
         env["OPENAI_BASE_URL"] = "http://host.docker.internal:4000/v1"
         return env, SimpleNamespace(kind="litellm")


### PR DESCRIPTION
## Summary

- validate every configured agent discovery path against its sandbox source, including `.agents/skills`, `.claude/skills`, `.codex/skills`, `.opencode/skills`, and workspace paths
- require both source and destination directories to exist, so dangling links cannot pass as two empty catalogs
- apply the same check to uploaded task skills, skipped-install agents, and dynamically generated scene-local skill roots
- retain an OpenCode-specific first-request gate that requires every task skill in `<available_skills>` before provider forwarding
- keep expected task-skill metadata inside the LiteLLM proxy instead of exposing it to the agent

## Scope and root cause

BenchFlow #908 fixed the underlying absolute-string host-path upload bug. The remaining problem was silent success: an agent could start after receiving an incomplete or dangling skill path, and OpenCode could produce a healthy-looking rollout containing only generic skills.

The deployment fix is agent-neutral: every discovery path configured by `AgentConfig.skill_paths` must resolve to the same task `SKILL.md` catalog before the agent connects, including when binary installation is skipped. OpenCode additionally verifies that its first wire-level prompt contains the complete required task catalog before any inference request is forwarded. OpenCode-owned built-in skills are allowed in addition to the task catalog.

## Validation

- full suite: 4,834 passed, 16 skipped, 7 deselected
- focused skill/scene/LiteLLM suite: 94 passed
- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run ty check src/` — passed