### PR TITLE
Stream LLM trajectories during active rollouts

### DIFF
--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import inspect
 import json
@@ -49,6 +50,7 @@ from benchflow.providers.litellm_logging import (
     trajectory_from_litellm_callback_log,
 )
 from benchflow.sandbox.providers import OFF_BOX_MODEL_PROVIDERS
+from benchflow.trajectories._llm_capture import LiveLLMTrajectoryWriter
 from benchflow.trajectories.types import Trajectory
 from benchflow.usage_tracking import UsageTrackingConfig, usage_unavailable
 
@@ -69,6 +71,8 @@ _PATCH_MODULE = "benchflow_litellm_bedrock_patch"
 _PROXY_DOCS_DISABLE_ENV = {"DOCS_URL": "", "NO_DOCS": "true"}
 _SKILL_CATALOG_GATE_AGENT_ENV = "BENCHFLOW_SKILL_CATALOG_GATE_AGENT"
 _REQUIRED_SKILL_NAMES_ENV = "BENCHFLOW_REQUIRED_SKILL_NAMES_JSON"
+_LIVE_CAPTURE_CHUNK_BYTES = 24 * 1024
+_LIVE_CAPTURE_INTERVAL_SEC = 1.0
 
 # Agents that speak a provider-native wire protocol the LiteLLM proxy does not
 # expose on its OpenAI/Anthropic surfaces. Routing them through the proxy would
@@ -94,6 +98,8 @@ class LiteLLMProcess:
 
     route: LiteLLMRoute
     trajectory: Trajectory | None
+    session_id: str
+    agent_name: str
 
     @property
     def base_url(self) -> str:
@@ -104,6 +110,84 @@ class LiteLLMProcess:
 
     async def is_running(self) -> bool:
         raise NotImplementedError
+
+    def start_live_capture(self, path: Path) -> None:
+        """Mirror completed callback records into a redacted local artifact."""
+        existing_path = getattr(self, "_live_trajectory_path", None)
+        task = getattr(self, "_live_capture_task", None)
+        if existing_path == Path(path) and task is not None and not task.done():
+            return
+        if task is not None and not task.done():
+            task.cancel()
+        self._live_trajectory_path = Path(path)
+        self._live_writer = LiveLLMTrajectoryWriter(Path(path))
+        self._live_trajectory = Trajectory(
+            session_id=self.session_id,
+            agent_name=self.agent_name,
+        )
+        self._live_callback_offset = 0
+        self._live_callback_remainder = b""
+        self._live_capture_task = asyncio.create_task(self._live_capture_loop())
+
+    async def _read_callback_chunk(self, offset: int, limit: int) -> bytes:
+        raise NotImplementedError
+
+    async def _capture_live_records(self) -> None:
+        trajectory = getattr(self, "_live_trajectory", None)
+        writer = getattr(self, "_live_writer", None)
+        if trajectory is None or writer is None:
+            return
+
+        changed = False
+        for _ in range(64):
+            offset = int(getattr(self, "_live_callback_offset", 0))
+            chunk = await self._read_callback_chunk(offset, _LIVE_CAPTURE_CHUNK_BYTES)
+            if not chunk:
+                break
+            self._live_callback_offset = offset + len(chunk)
+            data = getattr(self, "_live_callback_remainder", b"") + chunk
+            lines = data.split(b"\n")
+            self._live_callback_remainder = lines.pop()
+            for raw_line in lines:
+                if not raw_line.strip():
+                    continue
+                parsed = trajectory_from_litellm_callback_log(
+                    raw_line.decode("utf-8", errors="replace"),
+                    session_id=self.session_id,
+                    agent_name=self.agent_name,
+                )
+                if parsed.exchanges:
+                    trajectory.exchanges.extend(parsed.exchanges)
+                    changed = True
+            if len(chunk) < _LIVE_CAPTURE_CHUNK_BYTES:
+                break
+        if changed:
+            writer.write(trajectory)
+
+    async def _live_capture_loop(self) -> None:
+        while True:
+            try:
+                await self._capture_live_records()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.debug("Live LLM trajectory mirror failed: %s", exc)
+            await asyncio.sleep(_LIVE_CAPTURE_INTERVAL_SEC)
+
+    async def _stop_live_capture(self) -> None:
+        task = getattr(self, "_live_capture_task", None)
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            self._live_capture_task = None
+        with contextlib.suppress(Exception):
+            await self._capture_live_records()
+
+    def _reconcile_live_capture(self) -> None:
+        writer = getattr(self, "_live_writer", None)
+        if writer is not None:
+            writer.reconcile(self.trajectory)
 
 
 class HostLiteLLMProcess(LiteLLMProcess):
@@ -139,6 +223,7 @@ class HostLiteLLMProcess(LiteLLMProcess):
         return self.process.poll() is None
 
     async def stop(self) -> None:
+        await self._stop_live_capture()
         await _await_log_stable(self._log_size)
         if self.process.poll() is None:
             self.process.terminate()
@@ -148,6 +233,7 @@ class HostLiteLLMProcess(LiteLLMProcess):
                 self.process.kill()
                 await asyncio.to_thread(self.process.wait, 10)
         self._load_callback_log()
+        self._reconcile_live_capture()
         with contextlib.suppress(Exception):
             shutil.rmtree(self.runtime_dir, ignore_errors=True)
 
@@ -156,6 +242,17 @@ class HostLiteLLMProcess(LiteLLMProcess):
             return self.log_path.stat().st_size
         except OSError:
             return -1
+
+    async def _read_callback_chunk(self, offset: int, limit: int) -> bytes:
+        def _read() -> bytes:
+            try:
+                with self.log_path.open("rb") as handle:
+                    handle.seek(offset)
+                    return handle.read(limit)
+            except OSError:
+                return b""
+
+        return await asyncio.to_thread(_read)
 
     def _load_callback_log(self) -> None:
         if not self.log_path.exists():
@@ -223,6 +320,7 @@ class SandboxLiteLLMProcess(LiteLLMProcess):
         return result.return_code == 0 and (result.stdout or "").strip() == "yes"
 
     async def stop(self) -> None:
+        await self._stop_live_capture()
         await _await_log_stable(self._remote_log_size)
         with contextlib.suppress(Exception):
             await self.sandbox.exec(
@@ -234,6 +332,7 @@ class SandboxLiteLLMProcess(LiteLLMProcess):
                 timeout_sec=10,
             )
         await self._load_callback_log()
+        self._reconcile_live_capture()
         with contextlib.suppress(Exception):
             await self.sandbox.exec(
                 f"rm -rf {shlex.quote(self.runtime_dir)}", timeout_sec=10
@@ -247,6 +346,17 @@ class SandboxLiteLLMProcess(LiteLLMProcess):
             )
             return int((result.stdout or "-1").strip() or -1)
         return -1
+
+    async def _read_callback_chunk(self, offset: int, limit: int) -> bytes:
+        command = (
+            f"dd if={shlex.quote(self.log_path)} bs=1 skip={offset} count={limit} "
+            "2>/dev/null | base64 -w 0"
+        )
+        result = await self.sandbox.exec(command, timeout_sec=10)
+        encoded = (result.stdout or "").strip()
+        if result.return_code != 0 or not encoded:
+            return b""
+        return base64.b64decode(encoded, validate=True)
 
     async def _load_callback_log(self) -> None:
         text = ""
@@ -1209,6 +1319,7 @@ async def ensure_litellm_runtime(
     sandbox: Any | None = None,
     sandbox_setup_timeout: int = 120,
     required_skill_names: tuple[str, ...] = (),
+    live_trajectory_path: Path | None = None,
 ) -> tuple[dict[str, str], Any | None]:
     """Start/reuse LiteLLM and rewrite the agent env to talk to it.
 
@@ -1281,6 +1392,8 @@ async def ensure_litellm_runtime(
         if getattr(runtime, "config_key", None) == config_key and server is not None:
             is_running = await server.is_running()
             if is_running:
+                if live_trajectory_path is not None:
+                    server.start_live_capture(live_trajectory_path)
                 return (
                     _apply_litellm_agent_env(
                         agent=agent,
@@ -1339,6 +1452,8 @@ async def ensure_litellm_runtime(
         config_key=config_key,
         master_key=master_key,
     )
+    if live_trajectory_path is not None:
+        server.start_live_capture(live_trajectory_path)
     return (
         _apply_litellm_agent_env(
             agent=agent,

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -8,6 +8,7 @@ from the concrete host/sandbox process launcher.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from benchflow.usage_tracking import UsageTrackingConfig
@@ -41,6 +42,7 @@ async def ensure_litellm_runtime(
     sandbox: Any | None = None,
     sandbox_setup_timeout: int = 120,
     required_skill_names: tuple[str, ...] = (),
+    live_trajectory_path: Path | None = None,
 ) -> tuple[dict[str, str], ProviderRuntime | None]:
     from benchflow.providers.litellm_runtime import (
         ensure_litellm_runtime as _ensure_litellm_runtime,
@@ -57,6 +59,7 @@ async def ensure_litellm_runtime(
         sandbox=sandbox,
         sandbox_setup_timeout=sandbox_setup_timeout,
         required_skill_names=required_skill_names,
+        live_trajectory_path=live_trajectory_path,
     )
 
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -212,6 +212,7 @@ from benchflow.trajectories._capture import (
     _scrape_agent_trajectory,
     make_trajectory_sink,
 )
+from benchflow.trajectories._llm_capture import LiveLLMTrajectoryWriter
 from benchflow.trajectories.tree import RolloutNode, RolloutTree, Step
 from benchflow.usage_tracking import (
     USAGE_SOURCE_AGENT_NATIVE_ACP,
@@ -1186,6 +1187,7 @@ class Rollout:
             sandbox=self._env,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
             required_skill_names=getattr(self, "_required_skill_names", ()),
+            live_trajectory_path=rollout_dir / "trajectory" / "llm_trajectory.jsonl",
         )
         sf_entrypoint = self._session_factory_entrypoint(cfg.primary_agent)
         self._is_session_factory = sf_entrypoint is not None
@@ -2144,6 +2146,7 @@ class Rollout:
             sandbox=self._env,
             sandbox_setup_timeout=cfg.sandbox_setup_timeout,
             required_skill_names=getattr(self, "_required_skill_names", ()),
+            live_trajectory_path=rollout_dir / "trajectory" / "llm_trajectory.jsonl",
         )
 
         role_agent_differs = role.agent != cfg.primary_agent
@@ -2340,11 +2343,9 @@ class Rollout:
         trajectory = getattr(getattr(usage_runtime, "server", None), "trajectory", None)
         if trajectory is None or not trajectory.exchanges:
             return
-        traj_dir = self._rollout_dir / "trajectory"
-        traj_dir.mkdir(parents=True, exist_ok=True)
-        (traj_dir / "llm_trajectory.jsonl").write_text(
-            trajectory.to_jsonl(redact_keys=True)
-        )
+        LiveLLMTrajectoryWriter(
+            self._rollout_dir / "trajectory" / "llm_trajectory.jsonl"
+        ).reconcile(trajectory)
 
     def _usage_tracking_metadata(self) -> dict[str, Any]:
         usage_cfg = self._config.usage_tracking.with_env_defaults()

--- a/src/benchflow/trajectories/_llm_capture.py
+++ b/src/benchflow/trajectories/_llm_capture.py
@@ -1,0 +1,46 @@
+"""Crash-safe live persistence for provider LLM trajectories."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from benchflow.trajectories.types import Trajectory
+
+
+class LiveLLMTrajectoryWriter:
+    """Atomically publish redacted snapshots of completed LLM exchanges.
+
+    LiteLLM's callback log is append-only, but the public BenchFlow artifact is
+    rewritten from a parsed snapshot. This keeps concurrent readers from ever
+    observing a partial JSON line and lets end-of-run reconciliation repair a
+    missed live poll without changing the trajectory schema.
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        self._tmp.unlink(missing_ok=True)
+        self._last_payload: str | None = None
+
+    def write(self, trajectory: Trajectory | None) -> bool:
+        """Publish *trajectory* when it is non-empty and changed."""
+        if trajectory is None or not trajectory.exchanges:
+            return False
+        payload = trajectory.to_jsonl(redact_keys=True)
+        if payload == self._last_payload:
+            return False
+        self._tmp.write_text(payload)
+        os.replace(self._tmp, self.path)
+        self._last_payload = payload
+        return True
+
+    def reconcile(self, trajectory: Trajectory | None) -> bool:
+        """Publish the authoritative final snapshot.
+
+        This deliberately shares the same serialization and atomic replacement
+        path as live writes; callers may invoke it even if the last poll already
+        captured the final exchange.
+        """
+        return self.write(trajectory)

--- a/tests/test_live_llm_trajectory.py
+++ b/tests/test_live_llm_trajectory.py
@@ -68,6 +68,7 @@ def _callback_line(*, content: str = "ok") -> str:
 
 
 def test_writer_redacts_and_atomically_replaces_snapshot(tmp_path):
+    """Guards live redaction and atomic replacement from commit c86adfb."""
     path = tmp_path / "trajectory" / "llm_trajectory.jsonl"
     writer = LiveLLMTrajectoryWriter(path)
 
@@ -81,6 +82,7 @@ def test_writer_redacts_and_atomically_replaces_snapshot(tmp_path):
 
 
 def test_writer_deduplicates_unchanged_snapshot_and_reconciles(tmp_path):
+    """Guards snapshot deduplication and reconciliation from commit c86adfb."""
     path = tmp_path / "llm_trajectory.jsonl"
     writer = LiveLLMTrajectoryWriter(path)
     trajectory = _trajectory()
@@ -94,6 +96,7 @@ def test_writer_deduplicates_unchanged_snapshot_and_reconciles(tmp_path):
 
 
 def test_writer_does_not_create_empty_live_artifact(tmp_path):
+    """Guards empty-artifact suppression from commit c86adfb."""
     path = tmp_path / "llm_trajectory.jsonl"
     writer = LiveLLMTrajectoryWriter(path)
 
@@ -103,6 +106,7 @@ def test_writer_does_not_create_empty_live_artifact(tmp_path):
 
 @pytest.mark.asyncio
 async def test_host_proxy_mirrors_callback_before_stop(tmp_path, monkeypatch):
+    """Guards host-side live callback mirroring from commit c86adfb."""
     monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
     log_path = tmp_path / "callback.jsonl"
     output_path = tmp_path / "rollout" / "trajectory" / "llm_trajectory.jsonl"
@@ -147,6 +151,7 @@ class _SandboxWithCallbackLog:
 
 @pytest.mark.asyncio
 async def test_daytona_proxy_incrementally_mirrors_callback(tmp_path, monkeypatch):
+    """Guards incremental Daytona callback mirroring from commit c86adfb."""
     monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
     sandbox = _SandboxWithCallbackLog(_callback_line(content="first").encode())
     output_path = tmp_path / "trajectory" / "llm_trajectory.jsonl"

--- a/tests/test_live_llm_trajectory.py
+++ b/tests/test_live_llm_trajectory.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from types import SimpleNamespace
+
+import pytest
+
+from benchflow.providers import litellm_runtime as runtime_mod
+from benchflow.providers.litellm_runtime import (
+    HostLiteLLMProcess,
+    LiteLLMEndpoint,
+    SandboxLiteLLMProcess,
+)
+from benchflow.trajectories._llm_capture import LiveLLMTrajectoryWriter
+from benchflow.trajectories.types import (
+    LLMExchange,
+    LLMRequest,
+    LLMResponse,
+    Trajectory,
+)
+
+
+def _trajectory(*, content: str = "ok") -> Trajectory:
+    trajectory = Trajectory(session_id="run", agent_name="opencode")
+    trajectory.exchanges.append(
+        LLMExchange(
+            request=LLMRequest(
+                timestamp=datetime(2026, 7, 11),
+                body={
+                    "messages": [{"role": "user", "content": "hello"}],
+                    "api_key": "sk-secret",
+                },
+            ),
+            response=LLMResponse(
+                timestamp=datetime(2026, 7, 11),
+                body={"choices": [{"message": {"content": content}}]},
+            ),
+            duration_ms=12,
+        )
+    )
+    return trajectory
+
+
+def _callback_line(*, content: str = "ok") -> str:
+    return (
+        json.dumps(
+            {
+                "event": "success",
+                "request": {
+                    "method": "POST",
+                    "path": "/v1/chat/completions",
+                    "body": {
+                        "messages": [{"role": "user", "content": "hello"}],
+                        "api_key": "sk-secret",
+                    },
+                },
+                "response": {"choices": [{"message": {"content": content}}]},
+                "start_time": "2026-07-11T00:00:00Z",
+                "end_time": "2026-07-11T00:00:01Z",
+                "duration_ms": 1000,
+            },
+            separators=(",", ":"),
+        )
+        + "\n"
+    )
+
+
+def test_writer_redacts_and_atomically_replaces_snapshot(tmp_path):
+    path = tmp_path / "trajectory" / "llm_trajectory.jsonl"
+    writer = LiveLLMTrajectoryWriter(path)
+
+    assert writer.write(_trajectory()) is True
+
+    rows = [json.loads(line) for line in path.read_text().splitlines()]
+    assert len(rows) == 1
+    assert "sk-secret" not in path.read_text()
+    assert rows[0]["request"]["body"]["api_key"] == "***REDACTED***"
+    assert not path.with_suffix(".jsonl.tmp").exists()
+
+
+def test_writer_deduplicates_unchanged_snapshot_and_reconciles(tmp_path):
+    path = tmp_path / "llm_trajectory.jsonl"
+    writer = LiveLLMTrajectoryWriter(path)
+    trajectory = _trajectory()
+
+    assert writer.write(trajectory) is True
+    assert writer.write(trajectory) is False
+
+    trajectory.exchanges.extend(_trajectory(content="second").exchanges)
+    assert writer.reconcile(trajectory) is True
+    assert len(path.read_text().splitlines()) == 2
+
+
+def test_writer_does_not_create_empty_live_artifact(tmp_path):
+    path = tmp_path / "llm_trajectory.jsonl"
+    writer = LiveLLMTrajectoryWriter(path)
+
+    assert writer.write(Trajectory(session_id="run")) is False
+    assert not path.exists()
+
+
+@pytest.mark.asyncio
+async def test_host_proxy_mirrors_callback_before_stop(tmp_path, monkeypatch):
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+    log_path = tmp_path / "callback.jsonl"
+    output_path = tmp_path / "rollout" / "trajectory" / "llm_trajectory.jsonl"
+    process = HostLiteLLMProcess(
+        route=SimpleNamespace(),
+        process=SimpleNamespace(poll=lambda: None),
+        runtime_dir=tmp_path,
+        endpoint=LiteLLMEndpoint("http://agent", "http://local"),
+        log_path=log_path,
+        stdout_path=tmp_path / "stdout.log",
+        stderr_path=tmp_path / "stderr.log",
+        session_id="run",
+        agent_name="opencode",
+    )
+
+    process.start_live_capture(output_path)
+    log_path.write_text(_callback_line())
+    for _ in range(50):
+        if output_path.exists():
+            break
+        await runtime_mod.asyncio.sleep(0.01)
+    await process._stop_live_capture()
+
+    assert output_path.exists()
+    assert len(output_path.read_text().splitlines()) == 1
+    assert "sk-secret" not in output_path.read_text()
+
+
+class _SandboxWithCallbackLog:
+    def __init__(self, data: bytes) -> None:
+        self.data = data
+
+    async def exec(self, command: str, timeout_sec: int):
+        del timeout_sec
+        skip = int(re.search(r"skip=(\d+)", command).group(1))
+        count = int(re.search(r"count=(\d+)", command).group(1))
+        import base64
+
+        encoded = base64.b64encode(self.data[skip : skip + count]).decode()
+        return SimpleNamespace(return_code=0, stdout=encoded)
+
+
+@pytest.mark.asyncio
+async def test_daytona_proxy_incrementally_mirrors_callback(tmp_path, monkeypatch):
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+    sandbox = _SandboxWithCallbackLog(_callback_line(content="first").encode())
+    output_path = tmp_path / "trajectory" / "llm_trajectory.jsonl"
+    process = SandboxLiteLLMProcess(
+        sandbox=sandbox,
+        route=SimpleNamespace(),
+        runtime_dir="/tmp/runtime",
+        endpoint=LiteLLMEndpoint("http://agent", "http://local"),
+        log_path="/tmp/runtime/callback.jsonl",
+        pid_path="/tmp/runtime/pid",
+        stdout_path="/tmp/runtime/stdout",
+        stderr_path="/tmp/runtime/stderr",
+        session_id="run",
+        agent_name="opencode",
+    )
+
+    process.start_live_capture(output_path)
+    for _ in range(50):
+        if output_path.exists():
+            break
+        await runtime_mod.asyncio.sleep(0.01)
+    sandbox.data += _callback_line(content="second").encode()
+    for _ in range(50):
+        if output_path.exists() and len(output_path.read_text().splitlines()) == 2:
+            break
+        await runtime_mod.asyncio.sleep(0.01)
+    await process._stop_live_capture()
+
+    assert len(output_path.read_text().splitlines()) == 2


### PR DESCRIPTION
## Summary
- publish redacted `trajectory/llm_trajectory.jsonl` snapshots while LiteLLM-backed rollouts are still running
- mirror host callback logs locally and Daytona callback logs incrementally in bounded chunks
- retain the existing end-of-run import as the authoritative atomic reconciliation path
- leave agent routing, requests, scoring, and the final trajectory schema unchanged

## Safety
- redaction runs before every public artifact write
- atomic temp-file replacement prevents readers from seeing partial JSONL
- live-mirror failures are non-fatal and final cleanup repairs missed polls
- Daytona transfers only newly appended callback bytes, not the full growing log

## Validation
- `uv run ty check src/benchflow/trajectories/_llm_capture.py src/benchflow/providers/runtime.py src/benchflow/providers/litellm_runtime.py src/benchflow/rollout/__init__.py`
- `uv run ruff check ...`
- `uv run pytest -q` — 4839 passed, 16 skipped, 7 deselected

No external provider spend was used; Daytona behavior is covered with a simulated incremental sandbox callback log.
