### PR TITLE
Restore optional skill prompt nudge

### DIFF
--- a/.agents/skills/benchflow/SKILL.md
+++ b/.agents/skills/benchflow/SKILL.md
@@ -230,7 +230,8 @@ bench eval run \
   --agent claude-agent-acp \
   --sandbox daytona \
   --skills-dir skills/ \
-  --skill-mode with-skill
+  --skill-mode with-skill \
+  --agent-env BENCHFLOW_SKILL_NUDGE=name
 ```
 
 `--skill-mode with-skill` is required whenever you pass `--skills-dir` (omitting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,15 +41,6 @@
   tool-call validation, repaired results conversion, and reproducible
   compatibility controls. (#849–#865)
 
-### Removed
-- **`BENCHFLOW_SKILL_NUDGE` skill prompt nudge.** The optional prompt injection
-  that prepended mounted-skill names/descriptions/bodies to the task
-  instruction (#207) is gone. Setting the environment variable now has no
-  effect: prompt resolution never reads skill directories, and mounted skills
-  reach agents only through their native skill paths. This keeps prompts
-  identical across skill modes and closes off accidental prompt-level skill
-  leakage. (#908)
-
 ## 0.6.4 — 2026-06-27
 
 ### Added

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -126,8 +126,13 @@ provide a custom `--skills-dir` only in `with-skill` mode.
 
 Claude Code reads each skill's frontmatter name and description for native
 discovery. The full `SKILL.md` body and bundled resources are loaded by the
-agent when it invokes or reads the skill; BenchFlow never inlines mounted
-skill bodies into the task prompt.
+agent when it invokes or reads the skill; BenchFlow does not inline every
+mounted skill body into the task prompt by default.
+
+`BENCHFLOW_SKILL_NUDGE` is an optional prompt nudge layered on top of native
+discovery. Use `name` to tell the agent which skills are mounted, `description`
+to include each mounted skill's description, or `full` to include the full
+`SKILL.md` body. Omit the variable to keep BenchFlow's runtime default off.
 
 **Environment — the world (Han's S).** The stateful world the agent acts in. Owns the world's lifecycle: `provision / readiness / query / snapshot / restore / reset / teardown`. See "The Environment plane & the manifest."
 

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -20,8 +20,8 @@ Sandboxes are `docker`, `daytona`, and `modal`.
 
 ## Skills
 
-When an example or task has a skills directory, mount it with
-`--skill-mode with-skill`:
+When an example or task has a skills directory, mount it and pass the skill
+nudge. The docs use `BENCHFLOW_SKILL_NUDGE=name` as the default recommendation:
 
 ```bash
 bench eval run \
@@ -30,11 +30,12 @@ bench eval run \
   --model gemini-3.1-flash-lite-preview \
   --sandbox daytona \
   --skill-mode with-skill \
-  --skills-dir tasks/my-task/environment/skills
+  --skills-dir tasks/my-task/environment/skills \
+  --agent-env BENCHFLOW_SKILL_NUDGE=name
 ```
 
 See [Architecture: skill loading](../architecture.md#skill-loading) for the
-skill loading semantics.
+skill loading semantics and available nudge modes.
 
 ## Demos
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -149,7 +149,8 @@ GEMINI_API_KEY=... bench eval run \
   --model gemini-3.1-pro-preview \
   --sandbox daytona \
   --skill-mode with-skill \
-  --skills-dir tasks/edit-pdf/environment/skills
+  --skills-dir tasks/edit-pdf/environment/skills \
+  --agent-env BENCHFLOW_SKILL_NUDGE=name
 
 # A whole batch from YAML config
 bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
@@ -180,8 +181,10 @@ cd skillsbench && git sparse-checkout set tasks/edit-pdf
 bench eval run --tasks-dir tasks/edit-pdf --agent gemini --model gemini-3.1-pro-preview
 ```
 
-See [Architecture: skill loading](./architecture.md#skill-loading) for how
-mounted skills reach the agent.
+When you mount skills, use `BENCHFLOW_SKILL_NUDGE=name` as the default docs
+option. See [Architecture: skill loading](./architecture.md#skill-loading) for
+how mounted skills reach the agent and how `name`, `description`, and `full`
+differ.
 
 ### Where results land
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -203,13 +203,14 @@ bench eval run \
   --agent gemini \
   --model google/gemini-2.5-flash-lite
 
-# Single task with mounted skills
+# Single task with mounted skills and the recommended skill nudge
 bench eval run \
   --tasks-dir tasks/pdf-fix \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
   --sandbox daytona \
-  --skill-mode with-skill
+  --skill-mode with-skill \
+  --agent-env BENCHFLOW_SKILL_NUDGE=name
 
 # Pinned registry dataset: resolves skillsbench@1.1, verifies task digests,
 # and stamps dataset identity into every result.json/config.json
@@ -282,8 +283,10 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 | `--matrix` | — | YAML model matrix for repeated evals; currently requires `--tasks-dir` |
 | `--trials` | `1` | Number of trials for `--matrix` |
 
-See [Architecture: skill loading](../architecture.md#skill-loading) for how
-`with-skill` mode is registered with each agent.
+When mounting skills, the recommended docs default is
+`--agent-env BENCHFLOW_SKILL_NUDGE=name`. See
+[Architecture: skill loading](../architecture.md#skill-loading) for how
+`with-skill` mode is registered with each agent and how the nudge modes differ.
 
 Daytona batch runs collect provider token/cost telemetry by default with a
 sandbox-local LiteLLM gateway. Use `--usage-tracking required` when missing telemetry
@@ -749,7 +752,7 @@ bench hub check --level check --tasks-per-dataset 2 --out hub.jsonl
 
 ## YAML Config Format
 
-### Batch config with skills
+### Batch config with skills and skill nudge
 
 ```yaml
 source:
@@ -762,6 +765,8 @@ agent: gemini
 model: gemini-3.1-flash-lite-preview
 skill_mode: with-skill
 skills_dir: shared-skills/
+agent_env:
+  BENCHFLOW_SKILL_NUDGE: name
 max_retries: 2
 ```
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -141,6 +141,7 @@ from benchflow.rollout._setup import (
 from benchflow.rollout._setup import _resolve_agent_cwd as _resolve_agent_cwd
 from benchflow.rollout._setup import _resolve_prompts as _resolve_prompts
 from benchflow.rollout._setup import _run_oracle as _run_oracle
+from benchflow.rollout._setup import _skill_nudge as _skill_nudge
 from benchflow.rollout._setup import _start_env_and_upload as _start_env_and_upload
 from benchflow.rollout._setup import (
     _task_disallows_internet as _task_disallows_internet,
@@ -869,7 +870,14 @@ class Rollout:
             declared_sandbox_skills_dir=getattr(env_config, "skills_dir", None),
         )
         self._task_skill_policy = task_skill_policy
-        self._resolved_prompts = _resolve_prompts(cfg.task_path, cfg.prompts)
+        self._resolved_prompts = _resolve_prompts(
+            cfg.task_path,
+            cfg.prompts,
+            skills_dir=task_skill_policy.prompt_dir,
+            skill_nudge=_skill_nudge(cfg.agent_env),
+            agent=cfg.primary_agent,
+            planes=self._planes,
+        )
         self._agent_launch = self._planes.agent_launch(
             cfg.primary_agent,
             disallow_web_tools=self._disallow_web_tools,

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -236,6 +236,13 @@ async def _resolve_agent_cwd(env: Any, task: Any) -> str:
     return (getattr(result, "stdout", "") or "").strip() or configured
 
 
+def _skill_nudge(agent_env: dict[str, str] | None) -> str:
+    """Read skill nudge from explicit agent env or the host environment."""
+    return (agent_env or {}).get("BENCHFLOW_SKILL_NUDGE") or os.environ.get(
+        "BENCHFLOW_SKILL_NUDGE", ""
+    )
+
+
 async def _ensure_sandbox_dir(
     env: Any, path: str | Path, sandbox_user: str | None = None
 ) -> None:
@@ -279,9 +286,63 @@ def _init_rollout(
 def _resolve_prompts(
     task_path: Path,
     prompts: list[str | None] | None,
+    skills_dir: str | Path | None = None,
+    task_skills_dir: str | Path | None = None,
+    skill_nudge: str = "",
+    agent: str | None = None,
+    planes: RolloutPlanes | None = None,
 ) -> list[str]:
     """Read the task instruction and resolve prompt list."""
     instruction = _read_task_instruction(task_path)
+
+    if skill_nudge:
+        skill_display_path = "~/.claude/skills"
+        if agent:
+            agent_cfg = (planes or default_rollout_planes()).agent_config(agent)
+            if agent_cfg and agent_cfg.skill_paths:
+                skill_display_path = agent_cfg.skill_paths[0].replace("$HOME", "~")
+
+        skills = []
+        for src in [skills_dir, task_skills_dir]:
+            if src and Path(src).is_dir():
+                for d in sorted(Path(src).iterdir()):
+                    if d.is_dir() and (d / "SKILL.md").exists():
+                        content = d.joinpath("SKILL.md").read_text()
+                        name = d.name
+                        desc = ""
+                        if content.startswith("---"):
+                            parts = content.split("---", 2)
+                            if len(parts) >= 3:
+                                import yaml
+
+                                try:
+                                    fm = yaml.safe_load(parts[1])
+                                    desc = fm.get("description", "") if fm else ""
+                                except Exception:
+                                    pass
+                        skills.append({"name": name, "desc": desc, "content": content})
+                if skills:
+                    break
+
+        if skills:
+            if skill_nudge == "name":
+                names = ", ".join(s["name"] for s in skills)
+                nudge = f"Skills available at {skill_display_path}: {names}. Read them before starting."
+                instruction = nudge + "\n\n" + instruction
+            elif skill_nudge == "description":
+                lines = [f"Skills available at {skill_display_path}:\n"]
+                for s in skills:
+                    lines.append(f"- **{s['name']}**: {s['desc']}")
+                lines.append("\nRead the relevant skills before starting.")
+                instruction = "\n".join(lines) + "\n\n" + instruction
+            elif skill_nudge == "full":
+                blocks = []
+                for s in skills:
+                    blocks.append(
+                        f'<skill name="{s["name"]}">\n{s["content"]}\n</skill>'
+                    )
+                instruction = "\n\n".join(blocks) + "\n\n" + instruction
+
     if prompts is None:
         return [instruction]
     return [p if p is not None else instruction for p in prompts]

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -67,8 +67,19 @@ class SDK:
     def _resolve_prompts(
         task_path: Path,
         prompts: list[str | None] | None,
+        skills_dir: str | Path | None = None,
+        task_skills_dir: str | Path | None = None,
+        skill_nudge: str = "",
+        agent: str | None = None,
     ) -> list[str]:
-        return _resolve_prompts(task_path, prompts)
+        return _resolve_prompts(
+            task_path,
+            prompts,
+            skills_dir=skills_dir,
+            task_skills_dir=task_skills_dir,
+            skill_nudge=skill_nudge,
+            agent=agent,
+        )
 
     @staticmethod
     def _build_result(

--- a/src/benchflow/skill_policy.py
+++ b/src/benchflow/skill_policy.py
@@ -46,6 +46,10 @@ class TaskSkillPolicy:
     strip_bundled_dir_from_copy: bool
 
     @property
+    def prompt_dir(self) -> Path | None:
+        return self.host_dir
+
+    @property
     def needs_task_copy(self) -> bool:
         return self.has_bundled_dir or self.host_dir is not None
 

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -12,6 +12,7 @@ from benchflow.rollout import (
     Scene,
     _agent_launch_with_web_policy,
     _apply_web_policy,
+    _skill_nudge,
     _task_disallows_internet,
 )
 
@@ -58,8 +59,20 @@ def test_apply_web_policy_sets_marker_without_mutating_input():
     assert "BENCHFLOW_DISALLOW_WEB_TOOLS" not in env
 
 
-def test_resolve_prompts_ignores_task_skills(monkeypatch, tmp_path):
-    """Prompt resolution never inlines skills — mounted skills reach agents natively."""
+def test_skill_nudge_prefers_explicit_agent_env(monkeypatch):
+    monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
+
+    assert _skill_nudge({"BENCHFLOW_SKILL_NUDGE": "description"}) == "description"
+
+
+def test_skill_nudge_falls_back_to_host_env(monkeypatch):
+    monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
+
+    assert _skill_nudge({}) == "name"
+
+
+def test_host_skill_nudge_does_not_read_task_skills_by_default(monkeypatch, tmp_path):
+    """Guards PR #586 against prompt-level no-skills leaks."""
     from benchflow.sdk import SDK
 
     monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
@@ -70,12 +83,44 @@ def test_resolve_prompts_ignores_task_skills(monkeypatch, tmp_path):
         "---\nname: alpha\ndescription: Alpha skill.\n---\n# Alpha\n"
     )
 
-    prompts = SDK._resolve_prompts(tmp_path, prompts=None)
+    prompts = SDK._resolve_prompts(
+        tmp_path,
+        prompts=None,
+        skill_nudge=_skill_nudge({}),
+        agent="claude-agent-acp",
+    )
 
     assert prompts == ["Do the thing."]
     assert "alpha" not in prompts[0]
     assert "Internet access is disabled" not in prompts[0]
     assert "Do not browse" not in prompts[0]
+
+
+def test_host_skill_nudge_reads_task_skills_when_explicitly_enabled(
+    monkeypatch, tmp_path
+):
+    """Guards PR #586 so with-task-skills mode still gets skill nudges."""
+    from benchflow.sdk import SDK
+
+    monkeypatch.setenv("BENCHFLOW_SKILL_NUDGE", "name")
+    (tmp_path / "instruction.md").write_text("Do the thing.")
+    task_skills = tmp_path / "environment" / "skills"
+    skill_dir = task_skills / "alpha"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: alpha\ndescription: Alpha skill.\n---\n# Alpha\n"
+    )
+
+    prompts = SDK._resolve_prompts(
+        tmp_path,
+        prompts=None,
+        task_skills_dir=task_skills,
+        skill_nudge=_skill_nudge({}),
+        agent="claude-agent-acp",
+    )
+
+    assert prompts[0].startswith("Skills available at ~/.claude/skills: alpha.")
+    assert prompts[0].endswith("Do the thing.")
 
 
 def test_create_environment_preserves_agent_network_for_llm_runs(tmp_path):

--- a/tests/test_skill_policy.py
+++ b/tests/test_skill_policy.py
@@ -41,6 +41,7 @@ def test_task_skills_are_stripped_from_no_skills_task_copy(tmp_path: Path) -> No
     assert policy.include_task_skills is False
     assert policy.host_dir is None
     assert policy.sandbox_dir is None
+    assert policy.prompt_dir is None
     assert policy.needs_task_copy is True
     assert policy.strip_bundled_dir_from_copy is True
 
@@ -94,6 +95,7 @@ def test_with_skill_mode_keeps_task_bundle(tmp_path: Path) -> None:
     assert policy.include_task_skills is True
     assert policy.host_dir == skills_root
     assert policy.sandbox_dir == "/skills"
+    assert policy.prompt_dir == skills_root
     assert policy.strip_bundled_dir_from_copy is False
 
 
@@ -115,12 +117,13 @@ def test_declared_task_skills_only_apply_when_included(tmp_path: Path) -> None:
         declared_sandbox_skills_dir="/skills",
     )
 
-    assert disabled.host_dir is None
+    assert disabled.prompt_dir is None
     assert disabled.sandbox_dir is None
     assert disabled.strip_bundled_dir_from_copy is True
     assert enabled.enabled is True
     assert enabled.host_dir == skills_root
     assert enabled.sandbox_dir == "/skills"
+    assert enabled.prompt_dir == skills_root
     assert enabled.strip_bundled_dir_from_copy is False
 
 


### PR DESCRIPTION
## Summary

- Reverts #908 to restore the optional `BENCHFLOW_SKILL_NUDGE=name|description|full` prompt injection.
- Keeps native `with-skill` mounting unchanged.
- Restores the original focused regression tests and documentation.

## Why

OpenCode receives the native skill catalog but did not activate the relevant task skill in matched SkillsBench canaries. This restores the explicit opt-in nudge as a separate harness configuration; runs without the environment variable remain unchanged.

## Validation

- `uv run python -m pytest tests/test_internet_policy.py tests/test_skill_policy.py` (50 passed)
- `uv run ruff check` on restored source/tests
- `uv run ruff format --check` on restored source/tests
