### PR TITLE
Fix OpenCode proxy in non-Python sandboxes

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -343,30 +343,34 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
     # ``credential_files`` write to — so all writers target one config file even
     # when the sandbox home differs from ``$HOME``. Falls back to ``~``.
     config_relpath = config_path.lstrip("/")
-    register_py = "\n".join(
+    register_js = "\n".join(
         [
-            "import json, os, pathlib",
-            'alias = os.environ.get("BENCHFLOW_LITELLM_MODEL_ALIAS", "").strip()',
-            "if alias:",
-            '    home = os.environ.get("BENCHFLOW_AGENT_HOME", "").strip() or os.path.expanduser("~")',
-            f"    p = pathlib.Path(home) / {config_relpath!r}",
-            "    p.parent.mkdir(parents=True, exist_ok=True)",
-            "    d = json.loads(p.read_text()) if p.exists() and p.read_text().strip() else {}",
+            'const fs = require("fs");',
+            'const os = require("os");',
+            'const path = require("path");',
+            'const alias = (process.env.BENCHFLOW_LITELLM_MODEL_ALIAS || "").trim();',
+            "if (alias) {",
+            '  const home = (process.env.BENCHFLOW_AGENT_HOME || "").trim() || os.homedir();',
+            f"  const p = path.join(home, {config_relpath!r});",
+            "  fs.mkdirSync(path.dirname(p), { recursive: true });",
+            '  const text = fs.existsSync(p) ? fs.readFileSync(p, "utf8").trim() : "";',
+            "  const d = text ? JSON.parse(text) : {};",
             # Dedicated provider id (see docstring) → chat completions, not the
             # Responses API the built-in ``openai`` id is hard-coded to.
-            f'    prov = d.setdefault("provider", {{}}).setdefault({provider_id!r}, {{}})',
-            '    prov["npm"] = "@ai-sdk/openai-compatible"',
-            '    prov.setdefault("name", "BenchFlow Gateway")',
-            '    opts = prov.setdefault("options", {})',
-            '    base = os.environ.get("OPENAI_BASE_URL", "").strip()',
-            "    if base:",
-            '        opts["baseURL"] = base',
-            '    key = os.environ.get("OPENAI_API_KEY", "").strip()',
-            "    if key:",
-            '        opts["apiKey"] = key',
-            '    prov.setdefault("models", {}).setdefault(alias, {"name": alias})',
-            f'    d["small_model"] = "{provider_id}/" + alias',
-            '    p.write_text(json.dumps(d, indent=2) + "\\n")',
+            "  const providers = d.provider ||= {};",
+            f"  const prov = providers[{provider_id!r}] ||= {{}};",
+            '  prov.npm = "@ai-sdk/openai-compatible";',
+            '  prov.name ||= "BenchFlow Gateway";',
+            "  const opts = prov.options ||= {};",
+            '  const base = (process.env.OPENAI_BASE_URL || "").trim();',
+            "  if (base) opts.baseURL = base;",
+            '  const key = (process.env.OPENAI_API_KEY || "").trim();',
+            "  if (key) opts.apiKey = key;",
+            "  const models = prov.models ||= {};",
+            "  models[alias] ||= { name: alias };",
+            f'  d.small_model = "{provider_id}/" + alias;',
+            '  fs.writeFileSync(p, JSON.stringify(d, null, 2) + "\\n");',
+            "}",
         ]
     )
     wrapper = (
@@ -377,9 +381,9 @@ def _opencode_family_proxy_wrapper_install(binary: str, config_path: str) -> str
         # and hit ProviderModelNotFoundError with nothing explaining why. A hard
         # exit surfaces the cause instead of a silent broken proxy path.
         'if [ -n "$BENCHFLOW_LITELLM_MODEL_ALIAS" ]; then\n'
-        "  if ! python3 - <<'PYEOF'\n"
-        f"{register_py}\n"
-        "PYEOF\n"
+        f"  if ! {_BENCHFLOW_NODE_PREFIX}/bin/node - <<'JSEOF'\n"
+        f"{register_js}\n"
+        "JSEOF\n"
         "  then\n"
         f'    echo "benchflow {binary}-proxy: gateway alias registration failed; '
         'refusing to launch in proxy mode" >&2\n'

--- a/tests/test_opencode_family_proxy_tracking.py
+++ b/tests/test_opencode_family_proxy_tracking.py
@@ -66,7 +66,7 @@ def test_proxy_wrapper_forces_chat_completions_sdk(agent, wrapper_bin, cfg):
     ``apiKey``."""
     w = _wrapper_script(agent, wrapper_bin)
     assert "@ai-sdk/openai-compatible" in w  # chat completions, not Responses API
-    assert '"npm"' in w
+    assert "prov.npm" in w
     assert "OPENAI_API_KEY" in w and "apiKey" in w
 
 
@@ -100,7 +100,17 @@ def test_proxy_wrapper_fails_loud_on_registration_error(agent, wrapper_bin, cfg)
     w = _wrapper_script(agent, wrapper_bin)
     assert "|| true" not in w
     assert "exit 1" in w
-    assert "if ! python3" in w
+    assert "if ! /opt/benchflow/node/bin/node" in w
+
+
+@pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)
+def test_proxy_wrapper_does_not_require_task_image_python(agent, wrapper_bin, cfg):
+    """OpenCode's proxy must work in non-Python task images (for example the
+    Spring Boot SkillsBench environment). Use BenchFlow's isolated Node runtime
+    instead of assuming a task image provides an executable ``python3``."""
+    w = _wrapper_script(agent, wrapper_bin)
+    assert "python3" not in w
+    assert "/opt/benchflow/node/bin/node" in w
 
 
 @pytest.mark.parametrize("agent,wrapper_bin,cfg", CASES)


### PR DESCRIPTION
## Summary
- generate the OpenCode gateway registration helper as JavaScript
- execute it with BenchFlow's isolated Node runtime instead of assuming task images provide `python3`
- preserve the existing fail-closed registration behavior and config shape

## Failure reproduced
SkillsBench `spring-boot-jakarta-migration` uses an Ubuntu/Java image without an executable `python3`. The current wrapper exits before OpenCode starts with `python3: Permission denied`, producing zero model tokens and a transport/timeout-shaped infrastructure failure.

## Validation
- `uv run --with pytest pytest -q tests/test_opencode_family_proxy_tracking.py` (11 passed)
- live Daytona smoke on the unmodified Spring Boot task: OpenCode launched, emitted 50 parsed tool calls, completed verification, and produced a healthy scored model failure (not an infrastructure error)

No SkillsBench task changes are required.