### PR TITLE
Capture token logprobs for training rollouts

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -290,6 +290,13 @@ sandbox-local LiteLLM gateway. Use `--usage-tracking required` when missing tele
 should fail the rollout, or `--usage-tracking off` for recovery runs that should
 leave provider traffic untouched.
 
+For online-training rollouts against a chat-completions endpoint that supports
+sampled-token log probabilities, pass
+`--agent-env BENCHFLOW_CAPTURE_TOKEN_LOGPROBS=1`. The LiteLLM gateway adds
+`logprobs=true` to each chat request and preserves the provider's token
+logprobs in `trajectory/llm_trajectory.jsonl`. This is opt-in because providers
+that do not implement chat-completion logprobs may reject the request.
+
 `--source-env` is for external hosted environment hubs. The first supported
 runner is PrimeIntellect / Verifiers: BenchFlow preserves the hosted identity
 (`env_uid`, `hub_url`), installs the versioned package into an isolated local

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -257,6 +257,12 @@ class BenchFlowLiteLLMLogger(CustomLogger):
                 value = litellm_params.get(key)
             if value is not None:
                 request_body[key] = value
+        for key in ("logprobs", "top_logprobs"):
+            value = optional_params.get(key)
+            if value is None:
+                value = kwargs.get(key)
+            if value is not None:
+                request_body[key] = value
         request_body = {k: v for k, v in request_body.items() if v is not None}
         return {
             "request_model": kwargs.get("model"),
@@ -314,6 +320,19 @@ class BenchFlowLiteLLMLogger(CustomLogger):
                 if cleaned is data:
                     cleaned = dict(data)
                 cleaned["tools"] = kept
+
+        capture_logprobs = (
+            os.environ.get("BENCHFLOW_CAPTURE_TOKEN_LOGPROBS", "").strip().lower()
+            in {"1", "true", "yes", "on"}
+        )
+        if (
+            capture_logprobs
+            and call_type in {"completion", "acompletion"}
+            and cleaned.get("messages") is not None
+        ):
+            if cleaned is data:
+                cleaned = dict(data)
+            cleaned["logprobs"] = True
         if cleaned is data:
             return None
         return cleaned

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from datetime import datetime
 
 import pytest
 
@@ -54,6 +55,55 @@ def test_pre_call_hook_is_noop_for_pure_function_tools():
     assert (
         asyncio.run(logger.async_pre_call_hook(None, None, data, "completion")) is None
     )
+
+
+def test_pre_call_hook_opt_in_requests_token_logprobs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {
+        "messages": [{"role": "user", "content": "hi"}],
+        "tools": [{"type": "function", "function": {"name": "shell"}}],
+        "logprobs": False,
+    }
+    monkeypatch.setenv("BENCHFLOW_CAPTURE_TOKEN_LOGPROBS", "1")
+
+    cleaned = asyncio.run(logger.async_pre_call_hook(None, None, data, "completion"))
+
+    assert cleaned is not data
+    assert cleaned["logprobs"] is True
+    assert data["logprobs"] is False
+
+
+def test_pre_call_hook_does_not_add_chat_logprobs_to_responses_requests(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {"messages": [{"role": "user", "content": "hi"}]}
+    monkeypatch.setenv("BENCHFLOW_CAPTURE_TOKEN_LOGPROBS", "1")
+
+    cleaned = asyncio.run(logger.async_pre_call_hook(None, None, data, "responses"))
+
+    assert cleaned is None
+    assert "logprobs" not in data
+
+
+def test_callback_record_preserves_logprob_request_fields():
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    now = datetime.now()
+
+    record = logger._base_record(
+        {
+            "model": "openai/qwen",
+            "messages": [{"role": "user", "content": "hi"}],
+            "optional_params": {"logprobs": True, "top_logprobs": 1},
+        },
+        now,
+        now,
+    )
+
+    assert record["request"]["body"]["logprobs"] is True
+    assert record["request"]["body"]["top_logprobs"] == 1
 
 
 def test_callback_module_source_exposes_proxy_handler_instance():
@@ -247,6 +297,54 @@ def test_callback_log_preserves_bedrock_reasoning_effort_in_request_body():
     )
 
     assert trajectory.exchanges[0].request.body["reasoning_effort"] == "max"
+
+
+def test_callback_log_preserves_sampled_token_logprobs():
+    record = {
+        "event": "success",
+        "request_model": "benchflow-qwen",
+        "request": {
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "body": {
+                "model": "benchflow-qwen",
+                "messages": [{"role": "user", "content": "hi"}],
+                "logprobs": True,
+            },
+        },
+        "response": {
+            "model": "openai/qwen",
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "hello"},
+                    "logprobs": {
+                        "content": [
+                            {
+                                "token": "hello",
+                                "logprob": -0.25,
+                                "bytes": [104, 101, 108, 108, 111],
+                            }
+                        ]
+                    },
+                }
+            ],
+            "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+        },
+        "start_time": "2026-07-12T10:00:00",
+        "end_time": "2026-07-12T10:00:01",
+    }
+
+    trajectory = trajectory_from_litellm_callback_log(
+        json.dumps(record),
+        session_id="session",
+        agent_name="opencode",
+    )
+
+    exchange = trajectory.exchanges[0]
+    assert exchange.request.body["logprobs"] is True
+    token = exchange.response.body["choices"][0]["logprobs"]["content"][0]
+    assert token["token"] == "hello"
+    assert token["logprob"] == -0.25
 
 
 def test_litellm_failure_records_become_error_exchanges():

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -60,6 +60,8 @@ def test_pre_call_hook_is_noop_for_pure_function_tools():
 def test_pre_call_hook_opt_in_requests_token_logprobs(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Guards PR #926: training rollouts must request sampled token logprobs."""
+
     logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
     data = {
         "messages": [{"role": "user", "content": "hi"}],
@@ -78,6 +80,8 @@ def test_pre_call_hook_opt_in_requests_token_logprobs(
 def test_pre_call_hook_does_not_add_chat_logprobs_to_responses_requests(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    """Guards PR #926: chat logprob capture must not alter Responses calls."""
+
     logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
     data = {"messages": [{"role": "user", "content": "hi"}]}
     monkeypatch.setenv("BENCHFLOW_CAPTURE_TOKEN_LOGPROBS", "1")
@@ -89,6 +93,8 @@ def test_pre_call_hook_does_not_add_chat_logprobs_to_responses_requests(
 
 
 def test_callback_record_preserves_logprob_request_fields():
+    """Guards PR #926: trajectory requests retain logprob capture settings."""
+
     logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
     now = datetime.now()
 
@@ -300,6 +306,8 @@ def test_callback_log_preserves_bedrock_reasoning_effort_in_request_body():
 
 
 def test_callback_log_preserves_sampled_token_logprobs():
+    """Guards PR #926: provider token logprobs survive trajectory import."""
+
     record = {
         "event": "success",
         "request_model": "benchflow-qwen",


### PR DESCRIPTION
## What changed

- add opt-in `BENCHFLOW_CAPTURE_TOKEN_LOGPROBS=1` handling in the sandbox/host LiteLLM callback
- force `logprobs=true` only for chat-completion calls, leaving Responses requests unchanged
- preserve `logprobs` and `top_logprobs` request fields plus provider sampled-token logprobs in `llm_trajectory.jsonl`
- document the `--agent-env` contract for online training rollouts

## Why

TRL 1.8 custom `rollout_func` requires token IDs and per-token logprobs. OpenCode rollouts already pass through BenchFlow’s LiteLLM gateway, but ordinary Chat Completions requests do not ask providers for token logprobs. This opt-in gives training callers exact sampled-token logprobs without changing normal evaluation traffic.

## Validation

- full suite: `4851 passed, 8 skipped, 7 deselected`
- focused LiteLLM tests: `119 passed`
- `uv run ruff check .`
- `uv run ty check src/`

## Compatibility

The flag is opt-in and limited to chat-completion calls because providers without logprob support may reject it. Responses API traffic is unchanged.