### PR TITLE
Fix Qwen3.5 TRL SFT tokenization

### DIFF
--- a/src/benchflow/trajectories/trl_sft_tokenization.py
+++ b/src/benchflow/trajectories/trl_sft_tokenization.py
@@ -81,13 +81,27 @@ def validate_tokenized_row(
     prompt_ids = _input_ids(prompt_output)
     full_ids = _input_ids(full_output)
     assistant_masks = _assistant_masks(full_output)
-    if full_ids[: len(prompt_ids)] != prompt_ids:
-        raise ValueError(
-            f"row {row_num}: tokenized prompt is not a prefix of prompt+completion"
-        )
     if len(assistant_masks) != len(full_ids):
         raise ValueError(
             f"row {row_num}: assistant mask length does not match input_ids"
+        )
+    prefix_length = 0
+    for prompt_id, full_id in zip(prompt_ids, full_ids, strict=False):
+        if prompt_id != full_id:
+            break
+        prefix_length += 1
+    first_assistant = next(
+        (index for index, value in enumerate(assistant_masks) if value),
+        None,
+    )
+    if full_ids[: len(prompt_ids)] != prompt_ids and (
+        len(prompt_ids) > len(full_ids)
+        or first_assistant is None
+        or prefix_length < first_assistant
+    ):
+        raise ValueError(
+            f"row {row_num}: tokenized prompt differs before the assistant "
+            "generation boundary"
         )
     trainable = sum(assistant_masks[len(prompt_ids) :])
     if trainable < 1:

--- a/tests/test_train_trl_cli.py
+++ b/tests/test_train_trl_cli.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
@@ -47,6 +48,38 @@ class _FakeTrlTokenizer:
                 result["assistant_masks"] = assistant_masks
             return result
         return input_ids
+
+
+class _GenerationPrefixDriftTokenizer:
+    chat_template = "fake"
+
+    def __init__(self, *, early_drift: bool = False) -> None:
+        self.early_drift = early_drift
+
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        add_generation_prompt: bool = False,
+        return_dict: bool = False,
+        return_assistant_tokens_mask: bool = False,
+        **kwargs: Any,
+    ):
+        del messages, kwargs
+        if add_generation_prompt:
+            input_ids = [1, 9 if self.early_drift else 2, 3]
+            return {"input_ids": input_ids} if return_dict else input_ids
+        result = {
+            "input_ids": [1, 2, 4, 5],
+            "assistant_masks": [0, 0, 1, 1],
+        }
+        if return_dict:
+            return (
+                result
+                if return_assistant_tokens_mask
+                else {"input_ids": result["input_ids"]}
+            )
+        return result["input_ids"]
 
 
 def _tool(name: str = "finish") -> dict[str, Any]:
@@ -149,6 +182,43 @@ def _patch_tokenizer(monkeypatch) -> None:
         "training_chat_template",
         lambda tokenizer: None,
     )
+
+
+def test_tokenized_row_allows_generation_prefix_drift_after_assistant_boundary() -> (
+    None
+):
+    token_length, trainable = trl_sft_tokenization.validate_tokenized_row(
+        {
+            "prompt": [{"role": "user", "content": "do it"}],
+            "completion": [{"role": "assistant", "content": "done"}],
+            "tools": [],
+        },
+        row_num=1,
+        tokenizer=_GenerationPrefixDriftTokenizer(),
+        chat_template=None,
+        max_length=8,
+    )
+
+    assert token_length == 4
+    assert trainable == 1
+
+
+def test_tokenized_row_rejects_drift_before_assistant_boundary() -> None:
+    with pytest.raises(
+        ValueError,
+        match="differs before the assistant generation boundary",
+    ):
+        trl_sft_tokenization.validate_tokenized_row(
+            {
+                "prompt": [{"role": "user", "content": "do it"}],
+                "completion": [{"role": "assistant", "content": "done"}],
+                "tools": [],
+            },
+            row_num=1,
+            tokenizer=_GenerationPrefixDriftTokenizer(early_drift=True),
+            chat_template=None,
+            max_length=8,
+        )
 
 
 def test_trl_sft_cli_excludes_opencode_helpers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- tolerate chat-template drift that begins inside the assistant generation boundary
- keep fail-closed validation for any drift in the system/user prompt
- add focused regression coverage for both accepted and rejected cases

## Why
Qwen3.5 training templates render the generation prompt with a partial think prefix, then rewrite that suffix when the assistant completion is present. The previous strict prefix check rejected otherwise valid TRL prompt/completion rows.

## Verification
- `8 passed` in `tests/test_train_trl_cli.py`
- `ruff check` and `ruff format --check`
- real `Qwen/Qwen3.5-9B@c202236...` conversion: 3 rows converted and validated, max 7,465 tokens, minimum 26 trainable assistant tokens