### PR TITLE
Pin OpenCode harness to 1.17.20

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -700,7 +700,7 @@ AGENTS: dict[str, AgentConfig] = {
         skill_paths=["$HOME/.opencode/skills"],
         home_dirs=[".opencode"],
         install_cmd=(
-            _js_agent_install("opencode", "opencode-ai")
+            _js_agent_install("opencode", "opencode-ai@1.17.20")
             + " && "
             + _opencode_family_proxy_wrapper_install(
                 "opencode", ".config/opencode/opencode.json"

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -259,6 +259,14 @@ def test_js_agent_install_respects_explicit_npm_package_specs():
     assert "some-agent@latest" in default_cmd
 
 
+def test_opencode_install_is_pinned_for_reproducible_harness_runs():
+    """Guards PR #931 against silently changing OpenCode between eval stages."""
+    install_cmd = AGENTS["opencode"].install_cmd
+
+    assert "opencode-ai@1.17.20" in install_cmd
+    assert "opencode-ai@latest" not in install_cmd
+
+
 def test_gemini_cli_install_is_pinned():
     """Guards v0.5-integration@27752fa against Daytona installing moving latest."""
     install_cmd = AGENTS["gemini"].install_cmd


### PR DESCRIPTION
## What changed

- Pins the built-in OpenCode ACP harness installer to `opencode-ai@1.17.20`.
- Adds a registry invariant that rejects a return to the moving `@latest` tag.
- Companion manifest parity change: benchflow-ai/agents#56.

## Why

BenchFlow currently installs `opencode-ai@latest` inside every sandbox. During the PostTrain Arena baseline/SFT/GRPO/final evaluation pipeline, that allows different stages or even different tasks to run different OpenCode binaries if npm publishes between installs. A fixed model seed cannot make pass-rate comparisons reproducible when the agent harness itself floats.

`1.17.20` is the exact native OpenCode binary validated in the live Qwen3.5-9B + Docker + model-bridge canaries.

## Validation

- `4,856` tests passed, `16` skipped, `7` deselected.
- `184` registry invariant tests passed.
- `uv run ty check src/` passed.
- `uv run ruff check .` passed.
- Local cross-repo manifest parity passed: `12 passed`.
- The full test environment used `uv sync --extra dev --extra sandbox-daytona --locked`.
