### PR TITLE
fix(acp): preserve streamed usage on timeout

### DIFF
--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -233,11 +233,21 @@ class ACPSession:
 
     def record_prompt_usage(self, usage: object | None) -> None:
         """Record cumulative ACP token usage returned by session/prompt."""
+        if self._record_usage_snapshot(usage):
+            self._notify_change()
+
+    def _record_usage_snapshot(self, usage: object | None) -> bool:
         snapshot = normalize_acp_usage(usage)
         if snapshot is None:
-            return
+            return False
         self.usage_snapshots.append(snapshot)
-        self._notify_change()
+        return True
+
+    def _record_update_usage(self, update: dict) -> bool:
+        snapshot_source = update.get("usage")
+        if snapshot_source is not None and self._record_usage_snapshot(snapshot_source):
+            return True
+        return self._record_usage_snapshot(update)
 
     def latest_usage_totals(self) -> ACPUsageSnapshot | None:
         """Return the latest cumulative ACP usage snapshot, if any."""
@@ -274,12 +284,15 @@ class ACPSession:
         """Process a session/update notification."""
         self._events_active = True
         update_type = update.get("sessionUpdate")
+        usage_recorded = self._record_update_usage(update)
         # Unknown update types (future ACP versions, agent-specific
         # extensions) mutate no state and must not trigger a no-op
         # snapshot. Mark events_active so the snapshot path stays on
-        # the modern branch, but skip _notify_change for unrecognized
-        # types.
+        # the modern branch, but only notify for unrecognized types when they
+        # carried usage telemetry.
         if update_type not in self._RECOGNIZED_UPDATE_TYPES:
+            if usage_recorded:
+                self._notify_change()
             return
 
         if update_type == "tool_call":

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1886,6 +1886,7 @@ class Rollout:
             finally:
                 self._usage_runtime = None
 
+        self._collect_native_acp_usage()
         self._finalize_usage_metrics()
         self._enforce_required_usage_tracking()
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1828,6 +1828,7 @@ class Rollout:
     async def cleanup(self) -> None:
         """Close ACP client and stop the environment."""
         self._capture_partial_acp_trajectory()
+        self._collect_native_acp_usage()
         await self.disconnect()
 
         if self._env and self._config.export_generated_skills_to:
@@ -1886,7 +1887,6 @@ class Rollout:
             finally:
                 self._usage_runtime = None
 
-        self._collect_native_acp_usage()
         self._finalize_usage_metrics()
         self._enforce_required_usage_tracking()
 

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -93,6 +93,97 @@ def test_rollout_native_acp_usage_uses_cumulative_deltas():
     }
 
 
+def test_acp_session_records_usage_from_session_update():
+    """Guards #933: ACP timeout accounting can use pre-cancel update usage."""
+    from benchflow.acp.session import ACPSession
+
+    session = ACPSession("session-1")
+
+    session.handle_update(
+        {
+            "sessionUpdate": "agent_message_chunk",
+            "content": {"type": "text", "text": "working"},
+            "usage": {
+                "inputTokens": 10,
+                "outputTokens": 4,
+                "totalTokens": 16,
+                "cachedReadTokens": 2,
+                "cachedWriteTokens": 1,
+                "thoughtTokens": 1,
+            },
+        }
+    )
+
+    assert session.latest_usage_totals() == {
+        "input_tokens": 10,
+        "output_tokens": 4,
+        "total_tokens": 16,
+        "cached_read_tokens": 2,
+        "cached_write_tokens": 1,
+        "thought_tokens": 1,
+    }
+
+
+@pytest.mark.asyncio
+async def test_cleanup_collects_update_usage_after_timed_out_prompt(tmp_path):
+    """Guards #933: timed-out ACP prompts do not lose streamed token usage."""
+    from benchflow.acp.session import ACPSession
+    from benchflow.rollout import Rollout, RolloutConfig
+    from benchflow.rollout._usage import _zero_native_acp_usage_metrics
+
+    session = ACPSession("session-1")
+    session.handle_update(
+        {
+            "sessionUpdate": "usage",
+            "usage": {
+                "inputTokens": 20,
+                "outputTokens": 7,
+                "totalTokens": 30,
+                "cachedReadTokens": 1,
+                "cachedWriteTokens": 2,
+                "thoughtTokens": 3,
+            },
+        }
+    )
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._session = session
+    rollout._acp_client = SimpleNamespace(session=session)
+    rollout._trajectory = []
+    rollout._session_traj_count = 0
+    rollout._session_tool_count = 0
+    rollout._terminal_timeout = True
+    rollout._partial_trajectory = False
+    rollout._trajectory_source = "none"
+    rollout._n_tool_calls = 0
+    rollout._usage_runtime = None
+    rollout._usage_metrics = {"usage_source": "unavailable"}
+    rollout._native_usage_checkpoint = None
+    rollout._native_usage_metrics = _zero_native_acp_usage_metrics()
+    rollout._env = None
+    rollout._environment = None
+    rollout._config = RolloutConfig(task_path=tmp_path)
+
+    async def fake_disconnect():
+        return None
+
+    rollout.disconnect = fake_disconnect
+
+    await rollout.cleanup()
+
+    assert rollout._usage_metrics == {
+        "n_input_tokens": 20,
+        "n_output_tokens": 7,
+        "n_cache_read_tokens": 1,
+        "n_cache_creation_tokens": 2,
+        "total_tokens": 30,
+        "cost_usd": None,
+        "usage_source": "agent_native_acp",
+        "price_source": None,
+        "usage_details": {"thought_tokens": 3},
+    }
+
+
 def test_rollout_provider_usage_wins_over_native_acp_usage():
     """Guards PR #613 follow-up: LiteLLM provider telemetry remains authoritative."""
     from benchflow.rollout import Rollout

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -94,7 +94,7 @@ def test_rollout_native_acp_usage_uses_cumulative_deltas():
 
 
 def test_acp_session_records_usage_from_session_update():
-    """Guards #933: ACP timeout accounting can use pre-cancel update usage."""
+    """Guards PR #934 / issue #933: timeout accounting uses update usage."""
     from benchflow.acp.session import ACPSession
 
     session = ACPSession("session-1")
@@ -126,7 +126,7 @@ def test_acp_session_records_usage_from_session_update():
 
 @pytest.mark.asyncio
 async def test_cleanup_collects_update_usage_after_timed_out_prompt(tmp_path):
-    """Guards #933: timed-out ACP prompts do not lose streamed token usage."""
+    """Guards PR #934 / issue #933: cleanup preserves streamed usage."""
     from benchflow.acp.session import ACPSession
     from benchflow.rollout import Rollout, RolloutConfig
     from benchflow.rollout._usage import _zero_native_acp_usage_metrics
@@ -160,17 +160,15 @@ async def test_cleanup_collects_update_usage_after_timed_out_prompt(tmp_path):
     rollout._usage_metrics = {"usage_source": "unavailable"}
     rollout._native_usage_checkpoint = None
     rollout._native_usage_metrics = _zero_native_acp_usage_metrics()
+    rollout._agent_launch = ""
     rollout._env = None
     rollout._environment = None
+    rollout._error = None
     rollout._config = RolloutConfig(task_path=tmp_path)
-
-    async def fake_disconnect():
-        return None
-
-    rollout.disconnect = fake_disconnect
 
     await rollout.cleanup()
 
+    assert rollout._session is None
     assert rollout._usage_metrics == {
         "n_input_tokens": 20,
         "n_output_tokens": 7,

--- a/uv.lock
+++ b/uv.lock
@@ -1982,7 +1982,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.2"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2000,9 +2000,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

Fixes #933.

ACP native usage was only recorded after `session/prompt` returned a final `PromptResult`. When a prompt hit BenchFlow's wall-clock or idle timeout, the prompt task was cancelled before that return path, so the session could have no usage snapshots and cleanup finalized the rollout as `usage_source=unavailable` with `total_tokens=0`.

That is wrong for agents that already stream cumulative usage through `session/update`: timed-out runs can have real token usage available before cancellation, and BenchFlow should preserve that best-effort lower bound instead of dropping it.

## Fix

- Teach `ACPSession.handle_update()` to normalize and record usage telemetry carried by `session/update` notifications.
- Support both nested `usage` payloads and top-level ACP usage fields, so agents/protocol extensions can send either shape.
- Preserve the existing unknown-update behavior: unknown updates still do not produce trajectory snapshots unless they actually carried usage telemetry.
- Collect native ACP usage during `Rollout.cleanup()` before `disconnect()` clears the live session, so timeout/error paths that skipped the normal execution commit still promote the latest session snapshot.
- Tighten the timeout-cleanup regression test so it uses the real `Rollout.disconnect()` ordering and verifies `_session` is cleared after usage is preserved.
- Refresh `mcp` in `uv.lock` from `1.27.2` to `1.28.1` after CI `pip-audit` flagged `CVE-2026-59950`; this is a lock-only security update required for the same PR checks to pass.

## Regression coverage

- `test_acp_session_records_usage_from_session_update` covers update-time usage capture.
- `test_cleanup_collects_update_usage_after_timed_out_prompt` covers the production cleanup path so streamed usage is collected before disconnect clears the session.
- Existing cumulative-delta/native-provider precedence tests continue to pass.
- MCP session wiring tests pass after the `mcp` lock refresh.

## Validation

Local validation on current head `3bacd9e42cb92de585ffaa35ffa6c9db281a4e7e`:

- `uv sync --extra dev --extra sandbox-daytona --locked`
- `uv run python -m pytest tests/test_native_acp_usage.py tests/test_acp.py::TestIdleTimeoutDiagnostics::test_wall_clock_timeout_records_terminal_diagnostic tests/test_acp.py::TestIdleTimeoutDiagnostics::test_wall_clock_timeout_with_pending_tool_stays_partial -q` -> 10 passed
- `uv run python -m pytest tests/test_native_acp_usage.py tests/test_acp.py -q` -> 91 passed
- `uv run python -m pytest tests/test_acp_mcp_servers.py tests/test_task_config.py::test_task_config_accepts_mcp_tool_filter_surface` -> 16 passed on earlier same-PR head after the `mcp` lock refresh
- `uv run ruff check .`
- `uv run ruff check src/benchflow/rollout/__init__.py tests/test_native_acp_usage.py`
- `uv run ruff format --check src/benchflow/rollout/__init__.py tests/test_native_acp_usage.py`
- `uv run ty check src/`
- `git diff --check`
- `uv export --locked --extra dev --extra sandbox-daytona --extra sandbox-modal --format requirements-txt --no-hashes --output-file /tmp/req-audit-pr934-exact && uv run --with pip-audit pip-audit -r /tmp/req-audit-pr934-exact --no-deps --disable-pip --ignore-vuln GHSA-537c-gmf6-5ccf` -> no known vulnerabilities found on earlier same-PR head after the lock refresh

Current-head GitHub validation:

- `test` passed
- `pip-audit` passed
- `manifest-parity / parity` passed
- `integration-light / detect-scope` passed
- `integration-scope / detect-scope` passed
- `integration-light / rollout-smoke` passed
- `integration-scope` matrix/final-review jobs skipped by scope

Artifact validation from run `29922386377`:

- Downloaded `integration-light-jobs` and validated with `.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py /tmp/pr934-artifacts.6gAhD8/integration-light-jobs --json`.
- Result: healthy 1/1 rollout, ACP + LLM trajectories present, rollout-level `results.jsonl` training-ready, reward present, 323,363 tokens, 17 tool calls, 27 ACP events, and 18/18 LLM responses with usage.

## Notes

This is intentionally narrow. It does not invent a new partial-usage source type or claim exact provider-cost accounting for every cancellation path. It preserves trusted native ACP usage when an ACP agent has already provided it before timeout, and leaves provider-response telemetry authoritative when available.
