### PR TITLE
fix(metrics): count opencode skill invocations

### DIFF
--- a/src/benchflow/trajectories/metrics.py
+++ b/src/benchflow/trajectories/metrics.py
@@ -8,6 +8,15 @@ from typing import Any
 
 _SKILL_TOOL_NAMES = frozenset({"invoke_skill", "activate_skill", "skill"})
 
+# ``skill`` is unambiguous as a tool *kind* or tool *name*, but a title is
+# display text — a file or command merely named "skill" can produce it. A title
+# therefore proves a skill invocation outright only under the explicit
+# spellings; the bare word is honored for unclassified kinds alone, behind the
+# same gate as content sniffing (see ``is_skill_invocation_event``). Deriving
+# the subset here keeps the two sets from drifting apart — the inline-literal
+# drift is how PR #597 lost the ``skill`` spelling in the first place.
+_EXPLICIT_SKILL_TOOL_NAMES = _SKILL_TOOL_NAMES - {"skill"}
+
 # OpenHands legacy ACP artifacts render an invoke-skill *result* as a text block
 # that begins with the tool header (``Tool: invoke_skill``) and carries a
 # ``[skill: <name>]`` result marker. Anchoring the header to the start of the
@@ -18,13 +27,21 @@ _SKILL_RESULT_HEADER_RE = re.compile(
 )
 _SKILL_RESULT_MARKER = "[skill:"
 
-# opencode renders a skill invocation as ``kind == "other"`` / ``title ==
-# "skill"`` and returns the skill body wrapped in a ``<skill_content>`` element
-# naming the skill. That envelope opens the tool result, so it is anchored with
-# ``\A`` for the same reason as the OpenHands header above: a tool whose output
-# merely quotes the tag mid-stream is not a skill invocation.
+# Harnesses that do not set the canonical kind open a skill *result* with a
+# recognizable envelope: the pinned opencode (1.17.x) renders a markdown
+# ``## Skill: <name>`` header, opencode 1.18.x a ``<skill_content name="...">``
+# element, and claude-agent-acp a ``Launching skill: <name>`` line. Each is
+# anchored with ``\A`` for the same reason as the OpenHands header above: a
+# tool whose output merely quotes such a marker mid-stream is not a skill
+# invocation. This content path is what keeps the counter honest when the
+# title mutates across exports — issue #998 records a trajectory export whose
+# title carries the serialized arguments (``skill {"name": ...}``), which the
+# bare-title branch cannot see.
 _SKILL_CONTENT_ENVELOPE_RE = re.compile(
-    r"\A\s*<skill_content\s+name\s*=\s*\"[^\"]+\"", re.IGNORECASE
+    r"\A\s*(?:<skill_content\s+name\s*=\s*\"[^\"]+\""
+    r"|#{1,6}\s*Skill:\s*\S"
+    r"|Launching\s+skill:\s*\S)",
+    re.IGNORECASE,
 )
 
 # Only these unclassified tool kinds are eligible for content sniffing. Any tool
@@ -90,13 +107,15 @@ def _event_tool_name(event: Mapping[str, Any]) -> str:
 def content_contains_skill_invocation_tool(content: Any) -> bool:
     """Return whether tool-call content is a skill-invocation tool result.
 
-    Two structured envelopes are recognized, both anchored to the start of a
-    tool-result text block:
+    Recognized envelopes, each anchored to the start of a tool-result text
+    block:
 
     * OpenHands legacy — a ``Tool: invoke_skill`` / ``Tool: activate_skill``
       header carrying a ``[skill: ...]`` marker.
-    * opencode — a ``<skill_content name="...">`` element wrapping the skill
-      body.
+    * opencode — the skill body behind a ``## Skill: <name>`` markdown header
+      (1.17.x, the pinned agent) or wrapped in a ``<skill_content name="...">``
+      element (1.18.x).
+    * claude-agent-acp — a ``Launching skill: <name>`` line.
 
     The anchoring is what distinguishes a genuine skill result from ordinary
     output that merely quotes such text. This is intentionally narrow; it is the
@@ -122,11 +141,12 @@ def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
     kind, tool name, or title naming ``invoke_skill`` / ``activate_skill``) are
     trusted outright. Harnesses that do not set the canonical kind are matched
     on their own structured shape -- OpenHands legacy emits ``invoke_skill`` as
-    ``kind == "other"`` with the tool result in ``content``, and opencode emits
-    ``kind == "other"`` / ``title == "skill"`` with a ``<skill_content>``
-    envelope. Both are recognized only when the tool kind is unclassified, so an
-    ordinary ``read`` / ``execute`` / ``search`` tool whose title or output
-    happens to mention a skill is never reclassified.
+    ``kind == "other"`` with the tool result in ``content``, opencode emits
+    ``kind == "other"`` / ``title == "skill"`` with a versioned result envelope,
+    and claude-agent-acp emits ``kind == "other"`` / ``title == "Skill"`` with a
+    ``Launching skill:`` line. All are recognized only when the tool kind is
+    unclassified, so an ordinary ``read`` / ``execute`` / ``search`` tool whose
+    title or output happens to mention a skill is never reclassified.
     """
     if event.get("type") != "tool_call":
         return False
@@ -139,16 +159,17 @@ def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
         return True
 
     title = _normalized_tool_name(event.get("title"))
-    if title in {"invoke_skill", "activate_skill"}:
+    if title in _EXPLICIT_SKILL_TOOL_NAMES:
         return True
 
     if kind not in _CONTENT_SNIFFABLE_KINDS:
         return False
 
-    # opencode labels the call simply ``skill``. That bare word is too generic
-    # to trust on a tool that already declares a real ACP kind, so unlike the
-    # explicit ``invoke_skill`` spellings above it is only honored for the
-    # unclassified kinds -- the same gate the content sniffing sits behind.
+    # opencode and claude-agent-acp label the call simply ``skill``. That bare
+    # word is too generic to trust on a tool that already declares a real ACP
+    # kind, so unlike the explicit ``invoke_skill`` spellings above it is only
+    # honored for the unclassified kinds -- the same gate the content sniffing
+    # sits behind.
     if title in _SKILL_TOOL_NAMES:
         return True
 

--- a/src/benchflow/trajectories/metrics.py
+++ b/src/benchflow/trajectories/metrics.py
@@ -18,6 +18,15 @@ _SKILL_RESULT_HEADER_RE = re.compile(
 )
 _SKILL_RESULT_MARKER = "[skill:"
 
+# opencode renders a skill invocation as ``kind == "other"`` / ``title ==
+# "skill"`` and returns the skill body wrapped in a ``<skill_content>`` element
+# naming the skill. That envelope opens the tool result, so it is anchored with
+# ``\A`` for the same reason as the OpenHands header above: a tool whose output
+# merely quotes the tag mid-stream is not a skill invocation.
+_SKILL_CONTENT_ENVELOPE_RE = re.compile(
+    r"\A\s*<skill_content\s+name\s*=\s*\"[^\"]+\"", re.IGNORECASE
+)
+
 # Only these unclassified tool kinds are eligible for content sniffing. Any tool
 # carrying a real ACP kind (read, edit, execute, search, fetch, ...) is trusted
 # as-is and never reinterpreted from its output text.
@@ -79,18 +88,25 @@ def _event_tool_name(event: Mapping[str, Any]) -> str:
 
 
 def content_contains_skill_invocation_tool(content: Any) -> bool:
-    """Return whether tool-call content is an OpenHands invoke-skill result.
+    """Return whether tool-call content is a skill-invocation tool result.
 
-    Requires the structured legacy envelope: a tool-result text block that
-    *begins* with the ``Tool: invoke_skill`` / ``Tool: activate_skill`` header
-    and carries a ``[skill: ...]`` marker. The anchored header is what
-    distinguishes a genuine invoke-skill tool result from ordinary output that
-    merely quotes such text. This is intentionally narrow; it is the only
-    text-derived path and is paired with the no-skill experiment-health
+    Two structured envelopes are recognized, both anchored to the start of a
+    tool-result text block:
+
+    * OpenHands legacy — a ``Tool: invoke_skill`` / ``Tool: activate_skill``
+      header carrying a ``[skill: ...]`` marker.
+    * opencode — a ``<skill_content name="...">`` element wrapping the skill
+      body.
+
+    The anchoring is what distinguishes a genuine skill result from ordinary
+    output that merely quotes such text. This is intentionally narrow; it is the
+    only text-derived path and is paired with the no-skill experiment-health
     invariant in the result checker as a backstop.
     """
     for text in _tool_result_texts(content):
         if _SKILL_RESULT_HEADER_RE.match(text) and _SKILL_RESULT_MARKER in text.lower():
+            return True
+        if _SKILL_CONTENT_ENVELOPE_RE.match(text):
             return True
     return False
 
@@ -104,11 +120,13 @@ def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
 
     ``kind == "skill"`` is the canonical representation. Identity signals (tool
     kind, tool name, or title naming ``invoke_skill`` / ``activate_skill``) are
-    trusted outright. Older OpenHands ACP artifacts emitted ``invoke_skill``
-    calls as ``kind == "other"`` with the structured tool result in ``content``;
-    that shape is recognized only when the tool kind is unclassified, so an
-    ordinary ``read`` / ``execute`` / ``search`` tool whose output happens to
-    quote the marker is never reclassified.
+    trusted outright. Harnesses that do not set the canonical kind are matched
+    on their own structured shape -- OpenHands legacy emits ``invoke_skill`` as
+    ``kind == "other"`` with the tool result in ``content``, and opencode emits
+    ``kind == "other"`` / ``title == "skill"`` with a ``<skill_content>``
+    envelope. Both are recognized only when the tool kind is unclassified, so an
+    ordinary ``read`` / ``execute`` / ``search`` tool whose title or output
+    happens to mention a skill is never reclassified.
     """
     if event.get("type") != "tool_call":
         return False
@@ -126,6 +144,13 @@ def is_skill_invocation_event(event: Mapping[str, Any]) -> bool:
 
     if kind not in _CONTENT_SNIFFABLE_KINDS:
         return False
+
+    # opencode labels the call simply ``skill``. That bare word is too generic
+    # to trust on a tool that already declares a real ACP kind, so unlike the
+    # explicit ``invoke_skill`` spellings above it is only honored for the
+    # unclassified kinds -- the same gate the content sniffing sits behind.
+    if title in _SKILL_TOOL_NAMES:
+        return True
 
     return content_contains_skill_invocation_tool(event.get("content"))
 

--- a/tests/test_skill_invocation_artifacts.py
+++ b/tests/test_skill_invocation_artifacts.py
@@ -131,10 +131,11 @@ def test_skill_invocation_count_ignores_marker_in_nested_metadata() -> None:
 
 
 def test_skill_invocation_count_accepts_opencode_skill_content_envelope() -> None:
-    """opencode reports a skill call as kind="other" / title="skill" with the
-    skill body in a <skill_content> envelope. Neither the canonical kind nor the
-    OpenHands header is present, so before this shape was recognized every
-    opencode with-skill rollout reported n_skill_invocations=0."""
+    """Guards the fix from PR #939 (issue #998): opencode reports a skill call
+    as kind="other" / title="skill" with the skill body in a <skill_content>
+    envelope. Neither the canonical kind nor the OpenHands header is present,
+    so before PR #939 every opencode with-skill rollout reported
+    n_skill_invocations=0."""
     trajectory = [
         {
             "type": "tool_call",
@@ -161,8 +162,9 @@ def test_skill_invocation_count_accepts_opencode_skill_content_envelope() -> Non
 
 
 def test_skill_invocation_count_ignores_quoted_skill_content_envelope() -> None:
-    """The <skill_content> envelope counts only when it opens the tool result.
-    A tool that greps for the tag is not a skill invocation."""
+    """Guards the fix from PR #939: the <skill_content> envelope counts only
+    when it opens the tool result. A tool that greps for the tag is not a
+    skill invocation."""
     trajectory = [
         {
             "type": "tool_call",
@@ -184,12 +186,154 @@ def test_skill_invocation_count_ignores_quoted_skill_content_envelope() -> None:
 
 
 def test_skill_titled_tool_with_real_kind_is_not_a_skill_invocation() -> None:
-    """title="skill" is honored only for unclassified kinds. A read/execute tool
-    that happens to be titled "skill" keeps its declared identity, so no-skill
-    rollouts cannot be contaminated by a filename."""
+    """Guards the fix from PR #939: title="skill" is honored only for
+    unclassified kinds. A read/execute tool that happens to be titled "skill"
+    keeps its declared identity, so no-skill rollouts cannot be contaminated
+    by a filename."""
     trajectory = [
         {"type": "tool_call", "kind": "read", "title": "skill"},
         {"type": "tool_call", "kind": "execute", "title": "Skill"},
+    ]
+
+    assert count_skill_invocations(trajectory) == 0
+
+
+def test_skill_invocation_count_accepts_opencode_export_appended_title() -> None:
+    """Guards the fix from PR #939 (issue #998): a trajectory export can append
+    the serialized arguments to the title (``skill {"name": ...}``), so the
+    bare-title branch cannot see it and the <skill_content> envelope alone
+    must carry the count."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": 'skill {"name": "transmon-calibration-chain"}',
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": (
+                            '<skill_content name="transmon-calibration-chain">\n'
+                            "# Skill: transmon-calibration-chain\n"
+                        ),
+                    },
+                }
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 1
+
+
+def test_skill_invocation_count_accepts_pinned_opencode_markdown_header() -> None:
+    """Guards the fix from PR #939: the pinned agent (opencode-ai@1.17.20)
+    opens a skill result with a markdown ``## Skill: <name>`` header rather
+    than 1.18's <skill_content> element. Combined with an args-appended title
+    (issue #998) no title branch applies, so the header alone must carry the
+    count."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": 'skill {"name": "polar-electrostatics-mentor"}',
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": (
+                            "## Skill: polar-electrostatics-mentor\n\n"
+                            "**Base directory**: /skills/polar-electrostatics-mentor\n"
+                        ),
+                    },
+                }
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 1
+
+
+def test_skill_invocation_count_accepts_claude_agent_acp_launch_shape() -> None:
+    """Guards the fix from PR #939: claude-agent-acp emits a skill launch as
+    kind="other" / title="Skill" with a ``Launching skill: <name>`` content
+    line. Both the title and the anchored launch line are recognized, so the
+    count survives either signal mutating in an export."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": "Skill",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": "Launching skill: document-extraction",
+                    },
+                }
+            ],
+        },
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": 'Skill {"name": "document-extraction"}',
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": "Launching skill: document-extraction",
+                    },
+                }
+            ],
+        },
+    ]
+
+    assert count_skill_invocations(trajectory) == 2
+
+
+def test_skill_invocation_count_ignores_unanchored_or_real_kind_headers() -> None:
+    """Guards the fix from PR #939: the ``## Skill:`` / ``Launching skill:``
+    openings count only for unclassified kinds and only when they open the
+    tool result. A read tool returning a skill document, or a tool whose
+    output quotes a launch line mid-stream, is not a skill invocation."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "read",
+            "title": "read polar-mentor.md",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": "## Skill: polar-electrostatics-mentor\n",
+                    },
+                }
+            ],
+        },
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": "tail session.log",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": "12:01 agent: Launching skill: pdf\n",
+                    },
+                }
+            ],
+        },
     ]
 
     assert count_skill_invocations(trajectory) == 0

--- a/tests/test_skill_invocation_artifacts.py
+++ b/tests/test_skill_invocation_artifacts.py
@@ -130,6 +130,71 @@ def test_skill_invocation_count_ignores_marker_in_nested_metadata() -> None:
     assert count_skill_invocations(trajectory) == 0
 
 
+def test_skill_invocation_count_accepts_opencode_skill_content_envelope() -> None:
+    """opencode reports a skill call as kind="other" / title="skill" with the
+    skill body in a <skill_content> envelope. Neither the canonical kind nor the
+    OpenHands header is present, so before this shape was recognized every
+    opencode with-skill rollout reported n_skill_invocations=0."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "tool_call_id": "call_D3Vsvu3AN2TVSjfUuJpeDJdF",
+            "kind": "other",
+            "title": "skill",
+            "status": "completed",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": (
+                            '<skill_content name="polar-electrostatics-mentor">\n'
+                            "# Skill: polar-electrostatics-mentor\n"
+                        ),
+                    },
+                }
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 1
+
+
+def test_skill_invocation_count_ignores_quoted_skill_content_envelope() -> None:
+    """The <skill_content> envelope counts only when it opens the tool result.
+    A tool that greps for the tag is not a skill invocation."""
+    trajectory = [
+        {
+            "type": "tool_call",
+            "kind": "other",
+            "title": "grep skill_content trajectory.jsonl",
+            "content": [
+                {
+                    "type": "content",
+                    "content": {
+                        "type": "text",
+                        "text": 'trajectory.jsonl:8:<skill_content name="pdf">',
+                    },
+                }
+            ],
+        }
+    ]
+
+    assert count_skill_invocations(trajectory) == 0
+
+
+def test_skill_titled_tool_with_real_kind_is_not_a_skill_invocation() -> None:
+    """title="skill" is honored only for unclassified kinds. A read/execute tool
+    that happens to be titled "skill" keeps its declared identity, so no-skill
+    rollouts cannot be contaminated by a filename."""
+    trajectory = [
+        {"type": "tool_call", "kind": "read", "title": "skill"},
+        {"type": "tool_call", "kind": "execute", "title": "Skill"},
+    ]
+
+    assert count_skill_invocations(trajectory) == 0
+
+
 def test_build_rollout_result_writes_skill_invocation_metric(tmp_path) -> None:
     """Guards issue #507: result.json exposes structured skill invocation counts."""
     trajectory = [


### PR DESCRIPTION
## Problem

`n_skill_invocations` is **0 for every opencode rollout**, including ones that
demonstrably loaded a skill. opencode's ACP skill call looks like this:

```json
{"type": "tool_call", "kind": "other", "title": "skill", "status": "completed",
 "content": [{"type": "content", "content": {"type": "text",
   "text": "<skill_content name=\"polar-electrostatics-mentor\">\n# Skill: ..."}}]}
```

`is_skill_invocation_event` misses it four ways over:

1. `kind` is `"other"`, not the canonical `"skill"`.
2. The event carries no `tool_name` / `name` / `function` key, so
   `_event_tool_name` returns `""`.
3. The title check used an inline literal `{"invoke_skill", "activate_skill"}`
   which dropped the `"skill"` spelling that `_SKILL_TOOL_NAMES` — used by the
   `kind` check three lines above — already contains.
4. Content sniffing only recognized the OpenHands `Tool: invoke_skill` header.

This matters more than a cosmetic counter: `n_skill_invocations` is the field
that answers *"did the agent actually use the skill?"*, and it is the control
variable for every with-skill vs no-skill comparison. Reading a hard `0` for an
entire harness makes those comparisons unfalsifiable — you cannot tell a skill
that didn't help from a skill that was never loaded.

## Fix

Recognize both opencode signals, preserving the module's existing rule that a
tool declaring a real ACP kind is never reclassified from its title or output:

- `<skill_content name="...">` counts only when it **opens** a structured
  tool-result text block (anchored `\A`, exactly as the OpenHands header is), so
  a `grep` whose output quotes the tag is not counted.
- Bare `title == "skill"` is honored **only for unclassified kinds**
  (`""`/`other`/`tool`) — the same gate content sniffing sits behind. The
  explicit `invoke_skill` / `activate_skill` spellings stay trusted outright, so
  existing behavior is unchanged. A `read` or `execute` tool titled `skill`
  (a filename, say) is still not a skill invocation.

## Verification

Replayed against **206 recorded opencode trajectories** from a 29-task,
6-arm evaluation:

| | before | after |
|---|---|---|
| counter agrees with an independent `<skill_content name=...>` scan | 0 / 206 | **206 / 206** |
| with-skill rollouts reporting a nonzero count | 0 | **56** |
| no-skill rollouts falsely counted | 0 | **0** |

The no-skill invariant that backstops the text-derived path still holds.

New tests cover the opencode envelope, a quoted-tag negative, and a
real-kind tool titled `skill`. `tests/test_skill_invocation_artifacts.py`
passes 10/10 (7 pre-existing unchanged); 697 tests pass across the
skill/metrics/trajectory suites. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
