### PR TITLE
fix(sandbox): resolve the no-web loopback endpoint per adapter

### DIFF
--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -28,6 +28,27 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Every variable through which an agent can be handed a model endpoint. Kept in
+# sync with providers.litellm_runtime._PROVIDER_ENDPOINT_ENV_NAMES (which that
+# module strips before re-pointing the agent at the gateway) by
+# test_no_web_endpoint_names_cover_provider_endpoint_names -- importing it here
+# would close a cycle, since litellm_runtime imports benchflow.sandbox.
+AGENT_LLM_ENDPOINT_ENV_NAMES = frozenset(
+    {
+        "LLM_BASE_URL",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_BASE",
+        "AZURE_API_ENDPOINT",
+        "AZURE_API_BASE",
+        "AZURE_OPENAI_ENDPOINT",
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_BEDROCK_BASE_URL",
+        "GEMINI_BASE_URL",
+        "GOOGLE_GEMINI_BASE_URL",
+        "BENCHFLOW_PROVIDER_BASE_URL",
+    }
+)
+
 
 # Path lockdown defaults and validation
 
@@ -143,6 +164,37 @@ def build_priv_drop_cmd(agent_launch: str, sandbox_user: str) -> str:
     )
 
 
+def _is_loopback_http_url(value: str) -> bool:
+    parsed = urlsplit(value)
+    return (
+        parsed.scheme == "http"
+        and parsed.hostname in {"127.0.0.1", "localhost"}
+        and parsed.port is not None
+    )
+
+
+def classify_agent_llm_endpoints(
+    agent_env: dict[str, str],
+) -> tuple[list[str], list[str]]:
+    """Split the agent's LLM endpoint variables into (present, non-loopback).
+
+    Every adapter injects the gateway under its own name, so there is no single
+    variable to inspect: openhands uses ``LLM_BASE_URL``, opencode and codex-acp
+    use ``OPENAI_BASE_URL``, claude-agent-acp uses ``ANTHROPIC_BASE_URL``, and
+    ``BENCHFLOW_PROVIDER_BASE_URL`` is set for every routed agent.
+    """
+    present: list[str] = []
+    offending: list[str] = []
+    for name in AGENT_LLM_ENDPOINT_ENV_NAMES:
+        value = agent_env.get(name)
+        if not value:
+            continue
+        present.append(name)
+        if not _is_loopback_http_url(value):
+            offending.append(name)
+    return present, offending
+
+
 async def enforce_agent_egress_firewall(
     env: Any,
     sandbox_user: str | None,
@@ -152,15 +204,24 @@ async def enforce_agent_egress_firewall(
     if not sandbox_user or agent_env.get("BENCHFLOW_DISALLOW_WEB_TOOLS") != "1":
         return
 
-    base_url = agent_env.get("LLM_BASE_URL", "")
-    parsed = urlsplit(base_url)
-    if (
-        parsed.scheme != "http"
-        or parsed.hostname not in {"127.0.0.1", "localhost"}
-        or parsed.port is None
-    ):
+    # The firewall below rejects every non-loopback destination for the sandbox
+    # user, so the agent's model route has to already be loopback or the agent
+    # loses its LLM the moment the rule lands. Checking one hardcoded variable
+    # made that precondition unsatisfiable for every adapter that does not
+    # happen to spell it LLM_BASE_URL -- opencode, codex-acp, claude-agent-acp
+    # and pi-acp could never run a no-network task at all. Validate whichever
+    # endpoints are actually set, and require at least one.
+    present, offending = classify_agent_llm_endpoints(agent_env)
+    if not present:
         raise RuntimeError(
-            "No-web agent requires an HTTP loopback LLM_BASE_URL with a port"
+            "No-web agent requires an HTTP loopback LLM endpoint with a port, "
+            "but none of "
+            f"{', '.join(sorted(AGENT_LLM_ENDPOINT_ENV_NAMES))} is set"
+        )
+    if offending:
+        raise RuntimeError(
+            "No-web agent requires an HTTP loopback LLM endpoint with a port; "
+            f"not loopback: {', '.join(sorted(offending))}"
         )
 
     result = await env.exec(

--- a/tests/test_sdk_lockdown.py
+++ b/tests/test_sdk_lockdown.py
@@ -459,7 +459,7 @@ class TestAgentEgressFirewall:
         env = MagicMock()
         env.exec = AsyncMock()
 
-        with pytest.raises(RuntimeError, match="loopback LLM_BASE_URL"):
+        with pytest.raises(RuntimeError, match="not loopback: LLM_BASE_URL"):
             await enforce_agent_egress_firewall(
                 env,
                 "agent",
@@ -470,3 +470,80 @@ class TestAgentEgressFirewall:
             )
 
         env.exec.assert_not_awaited()
+
+    @pytest.mark.parametrize(
+        ("agent", "endpoint_var"),
+        [
+            ("opencode", "OPENAI_BASE_URL"),
+            ("codex-acp", "OPENAI_BASE_URL"),
+            ("claude-agent-acp", "ANTHROPIC_BASE_URL"),
+            ("pi-acp", "BENCHFLOW_PROVIDER_BASE_URL"),
+        ],
+    )
+    async def test_policy_accepts_each_adapters_own_endpoint_var(
+        self, agent, endpoint_var
+    ):
+        """Only openhands spells the gateway LLM_BASE_URL. Requiring that one
+        name made no-network tasks impossible for every other adapter: the
+        firewall raised before the agent was ever prompted."""
+        from benchflow.sandbox.lockdown import enforce_agent_egress_firewall
+
+        env = MagicMock()
+        env.exec = AsyncMock(return_value=MagicMock(return_code=0))
+
+        await enforce_agent_egress_firewall(
+            env,
+            "agent",
+            {
+                "BENCHFLOW_DISALLOW_WEB_TOOLS": "1",
+                endpoint_var: "http://127.0.0.1:1234/v1",
+            },
+        )
+
+        env.exec.assert_awaited_once()
+
+    async def test_policy_rejects_any_non_loopback_endpoint(self):
+        """A loopback route on one variable does not excuse a routable one on
+        another -- the sandbox user is about to lose egress to it either way."""
+        from benchflow.sandbox.lockdown import enforce_agent_egress_firewall
+
+        env = MagicMock()
+        env.exec = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="not loopback: ANTHROPIC_BASE_URL"):
+            await enforce_agent_egress_firewall(
+                env,
+                "agent",
+                {
+                    "BENCHFLOW_DISALLOW_WEB_TOOLS": "1",
+                    "OPENAI_BASE_URL": "http://127.0.0.1:1234/v1",
+                    "ANTHROPIC_BASE_URL": "https://api.anthropic.com",
+                },
+            )
+
+        env.exec.assert_not_awaited()
+
+    async def test_policy_rejects_when_no_endpoint_is_set(self):
+        from benchflow.sandbox.lockdown import enforce_agent_egress_firewall
+
+        env = MagicMock()
+        env.exec = AsyncMock()
+
+        with pytest.raises(RuntimeError, match="none of"):
+            await enforce_agent_egress_firewall(
+                env,
+                "agent",
+                {"BENCHFLOW_DISALLOW_WEB_TOOLS": "1"},
+            )
+
+        env.exec.assert_not_awaited()
+
+    def test_no_web_endpoint_names_cover_provider_endpoint_names(self):
+        """lockdown cannot import litellm_runtime (that module imports
+        benchflow.sandbox), so the endpoint name list is duplicated. Adding a
+        provider endpoint variable there without adding it here would silently
+        exempt it from the loopback precondition -- fail loudly instead."""
+        from benchflow.providers.litellm_runtime import _PROVIDER_ENDPOINT_ENV_NAMES
+        from benchflow.sandbox.lockdown import AGENT_LLM_ENDPOINT_ENV_NAMES
+
+        assert _PROVIDER_ENDPOINT_ENV_NAMES <= AGENT_LLM_ENDPOINT_ENV_NAMES


### PR DESCRIPTION
## Problem

Any task with `sandbox.network_mode: no-network` fails before the agent is
prompted on **four of the five ACP adapters**:

```
RuntimeError: No-web agent requires an HTTP loopback LLM_BASE_URL with a port
```

`enforce_agent_egress_firewall` reads the gateway URL from `LLM_BASE_URL`, but
`_agent_env_for_route` only sets that name for **openhands**:

| adapter | endpoint variable it is given | passes the check today |
|---|---|---|
| openhands | `LLM_BASE_URL` | ✅ |
| opencode | `OPENAI_BASE_URL` | ❌ |
| codex-acp | `OPENAI_BASE_URL` | ❌ |
| claude-agent-acp | `ANTHROPIC_BASE_URL` | ❌ |
| pi-acp | `BENCHFLOW_PROVIDER_BASE_URL` | ❌ |

The check is a precondition on a firewall that rejects all non-loopback egress
for the sandbox user — reasonable in intent, but it hardcoded one adapter's
spelling, so for the rest it can never be satisfied. The only workaround is
`--sandbox-user null`, which runs the agent as root and skips the uid-based
egress firewall this check exists to guard. So the practical effect is that
no-network tasks either don't run or run *without* the isolation they asked for.

Found while running a 29-task evaluation on opencode: 9 no-network tasks × 6
arms could not start.

## Fix

Validate whichever endpoint variables are actually present, rather than one
hardcoded name.

`_agent_env_for_route` strips every provider endpoint variable
(`_PROVIDER_ENDPOINT_ENV_NAMES`) and re-points the agent at the loopback
gateway, so anything still set at firewall time must already be loopback.
Requiring **every** present endpoint to be loopback — not just one — is
strictly stronger than the previous single-variable check: a loopback route on
`OPENAI_BASE_URL` no longer excuses a routable `ANTHROPIC_BASE_URL`, which the
sandbox user is about to lose egress to regardless. An empty set still raises.

`lockdown` cannot import `litellm_runtime` (that module imports
`benchflow.sandbox`), so the name list is duplicated and pinned by
`test_no_web_endpoint_names_cover_provider_endpoint_names`. Adding a provider
endpoint variable there without adding it here now fails a test instead of
silently exempting it — the same class of bug this PR fixes.

## Tests

- Each adapter's own endpoint variable is accepted (parametrized over
  opencode / codex-acp / claude-agent-acp / pi-acp).
- A non-loopback endpoint alongside a loopback one is rejected, naming the
  offender.
- No endpoint set at all is rejected.
- The drift guard above.

`tests/test_sdk_lockdown.py` 57/57; 332 passed across the lockdown/ACP suites.
`ruff check` and `ruff format --check` clean.

The one pre-existing test that asserted the old message text
(`match="loopback LLM_BASE_URL"`) is updated to the new wording; its behavior
assertion is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
