### PR TITLE
chore: start 0.6.7 development

### DIFF
--- a/.github/workflows/integration-light.yml
+++ b/.github/workflows/integration-light.yml
@@ -36,7 +36,7 @@ on:
 # Cancel superseded L1 runs on the same PR branch — this is the fast-feedback
 # lane, so a newer push supersedes the older run.
 concurrency:
-  group: integration-light-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.ref }}
+  group: integration-light-${{ github.event_name }}-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.ref }}
   cancel-in-progress: true
 
 # Workflow-level least privilege; jobs elevate only what they need.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- Isolated pull-request and post-test integration concurrency groups so a
+  credential-free workflow completion cannot cancel an active PR rollout.
+
 ## 0.6.6 — 2026-08-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.6"
+version = "0.6.7.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_release_workflow_wiring.py
+++ b/tests/test_release_workflow_wiring.py
@@ -215,6 +215,17 @@ def test_preview_publish_is_downstream_of_tested_main_live_gate() -> None:
     assert "${{ steps.provenance.outputs.source_run_number }}" in version_step["run"]
 
 
+def test_pr_integration_is_not_cancelled_by_test_workflow_completion() -> None:
+    """Guards PR #944 against cross-event integration concurrency cancellation."""
+    integration = _workflow("integration-light.yml")
+
+    assert integration["concurrency"]["group"] == (
+        "integration-light-${{ github.event_name }}-"
+        "${{ github.event.pull_request.head.sha || "
+        "github.event.workflow_run.head_sha || github.ref }}"
+    )
+
+
 def test_failed_main_unit_run_makes_integration_gate_red(tmp_path: Path) -> None:
     """Guards the 0.6.6 fix against publishing after a failed main unit run."""
     integration = _workflow("integration-light.yml")

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.6"
+version = "0.6.7.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- advance the project version from 0.6.6 to 0.6.7.dev0 after the public 0.6.6 release
- keep the lockfile project metadata in sync

## Verification

- uv lock --check
- 30 focused release and workflow tests pass
- internal preview policy computes 0.6.7.dev123 for source test run 123

After this PR merges, the main unit and live integration chain should publish the corresponding 0.6.7.devN internal preview.