### PR TITLE
fix(acp): align reasoning effort capabilities

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -436,9 +436,7 @@ def _resolve_acp_effort_option_id(
     return declared or None
 
 
-def _normalize_acp_effort_value(
-    reasoning_effort: str, config_id: str
-) -> str:
+def _normalize_acp_effort_value(reasoning_effort: str, config_id: str) -> str:
     """Translate BenchFlow's neutral ``none`` value to Pi ACP's ``off``."""
     if config_id == "thought_level" and reasoning_effort == "none":
         return "off"
@@ -556,9 +554,7 @@ async def _configure_acp_session(
             await _set_acp_model(acp_client, agent=agent, model_id=acp_model_id)
             # Legacy Codex ACP represents reasoning effort as part of the
             # selected model ID, e.g. ``gpt-5.5[high]``.
-            effort_encoded_in_model_id = bool(
-                reasoning_effort and agent == "codex-acp"
-            )
+            effort_encoded_in_model_id = bool(reasoning_effort and agent == "codex-acp")
         else:
             logger.info(
                 f"Skipping ACP model configuration for {agent} — launch/env config owns model selection"

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -176,7 +176,11 @@ def _codex_reasoning_effort(model_id: str) -> str:
     return model_id.rsplit("[", 1)[1][:-1]
 
 
-def _codex_session_model_id(model: str, session: object | None) -> str:
+def _codex_session_model_id(
+    model: str,
+    session: object | None,
+    reasoning_effort: str | None = None,
+) -> str:
     """Map a bare Codex model to the exact ACP modelId returned by session/new.
 
     ``@agentclientprotocol/codex-acp`` validates ``session/set_model`` against
@@ -193,6 +197,10 @@ def _codex_session_model_id(model: str, session: object | None) -> str:
     if (
         isinstance(current_model, str)
         and _codex_model_name(current_model) == requested_name
+        and (
+            not reasoning_effort
+            or _codex_reasoning_effort(current_model) == reasoning_effort
+        )
     ):
         return current_model
 
@@ -208,6 +216,11 @@ def _codex_session_model_id(model: str, session: object | None) -> str:
     ]
     if not candidates:
         return model
+
+    if reasoning_effort:
+        for candidate in candidates:
+            if _codex_reasoning_effort(candidate) == reasoning_effort:
+                return candidate
 
     preferred_efforts = ("medium", "high", "low", "minimal", "none")
     for effort in preferred_efforts:
@@ -286,11 +299,12 @@ def _select_acp_model_id(
     model: str,
     agent: str,
     session: object | None,
+    reasoning_effort: str | None = None,
 ) -> str:
     """Return the concrete modelId to send through ACP session/set_model."""
     formatted = _format_acp_model(model, agent)
     if agent == "codex-acp":
-        return _codex_session_model_id(formatted, session)
+        return _codex_session_model_id(formatted, session, reasoning_effort)
     return formatted
 
 
@@ -394,6 +408,43 @@ def _resolve_acp_model_option_id(
     return None
 
 
+_ACP_EFFORT_CONFIG_OPTION_IDS = (
+    "reasoning_effort",
+    "effort",
+    "thought_level",
+)
+
+
+def _resolve_acp_effort_option_id(
+    agent_cfg: object | None, session: object | None
+) -> str | None:
+    """Return the effort config option declared by the connected ACP agent.
+
+    Prefer the live ``session/new`` capability over a registry hint so an agent
+    package upgrade cannot silently retain a stale option name. The ordered
+    fallback covers the common ACP spellings used by Codex, Claude, and Pi.
+    """
+    option_ids = _session_config_option_ids(session)
+    declared = getattr(agent_cfg, "acp_effort_config_id", "") or ""
+    if option_ids:
+        if declared in option_ids:
+            return declared
+        for option_id in _ACP_EFFORT_CONFIG_OPTION_IDS:
+            if option_id in option_ids:
+                return option_id
+        return None
+    return declared or None
+
+
+def _normalize_acp_effort_value(
+    reasoning_effort: str, config_id: str
+) -> str:
+    """Translate BenchFlow's neutral ``none`` value to Pi ACP's ``off``."""
+    if config_id == "thought_level" and reasoning_effort == "none":
+        return "off"
+    return reasoning_effort
+
+
 async def _set_acp_model(
     acp_client: ACPClient,
     *,
@@ -459,6 +510,7 @@ async def _configure_acp_session(
     reasoning_effort: str | None,
 ) -> None:
     agent_cfg = AGENTS.get(agent)
+    effort_encoded_in_model_id = False
 
     if model and _model_selection_owned_by_env(agent, model, agent_env):
         logger.info(
@@ -466,7 +518,6 @@ async def _configure_acp_session(
         )
     elif model:
         acp_model_input = _resolve_acp_model_input(agent, model, agent_env)
-        acp_model_id = _select_acp_model_id(acp_model_input, agent, session)
         model_option_id = _resolve_acp_model_option_id(agent_cfg, session)
         if model_option_id:
             # Capability-first: the agent advertises a model config option (or
@@ -478,13 +529,36 @@ async def _configure_acp_session(
                 session,
                 agent=agent,
                 config_id=model_option_id,
-                value=acp_model_id,
+                # Config options use the public, effort-free model name. The
+                # legacy Codex ``session/set_model`` API instead expects an
+                # advertised ``model[effort]`` identifier.
+                value=_format_acp_model(acp_model_input, agent),
                 label="model",
             )
         elif not agent_cfg or agent_cfg.supports_acp_set_model:
             # No model config option advertised/declared — use the legacy
             # session/set_model path. Fails closed if the agent rejects it.
+            acp_model_id = _select_acp_model_id(
+                acp_model_input,
+                agent,
+                session,
+                reasoning_effort,
+            )
+            if (
+                reasoning_effort
+                and agent == "codex-acp"
+                and _codex_reasoning_effort(acp_model_id) != reasoning_effort
+            ):
+                raise RuntimeError(
+                    f"ACP agent {agent!r} does not advertise reasoning effort "
+                    f"{reasoning_effort!r} for model {acp_model_input!r}"
+                )
             await _set_acp_model(acp_client, agent=agent, model_id=acp_model_id)
+            # Legacy Codex ACP represents reasoning effort as part of the
+            # selected model ID, e.g. ``gpt-5.5[high]``.
+            effort_encoded_in_model_id = bool(
+                reasoning_effort and agent == "codex-acp"
+            )
         else:
             logger.info(
                 f"Skipping ACP model configuration for {agent} — launch/env config owns model selection"
@@ -492,17 +566,29 @@ async def _configure_acp_session(
 
     if not reasoning_effort:
         return
-    if not agent_cfg or not agent_cfg.acp_effort_config_id:
+    effort_env = getattr(agent_cfg, "reasoning_effort_env", "") or ""
+    if effort_env and agent_env.get(effort_env):
+        logger.info(
+            "Reasoning effort for %s is configured at launch through %s",
+            agent,
+            effort_env,
+        )
+        return
+    if effort_encoded_in_model_id:
+        return
+    effort_option_id = _resolve_acp_effort_option_id(agent_cfg, session)
+    if not effort_option_id:
         raise RuntimeError(
             f"reasoning_effort={reasoning_effort!r} was requested for agent "
-            f"{agent!r}, but that agent does not declare an ACP effort config option"
+            f"{agent!r}, but the connected ACP session does not expose an effort "
+            "config option"
         )
     await _set_acp_config_option(
         acp_client,
         session,
         agent=agent,
-        config_id=agent_cfg.acp_effort_config_id,
-        value=reasoning_effort,
+        config_id=effort_option_id,
+        value=_normalize_acp_effort_value(reasoning_effort, effort_option_id),
         label="reasoning effort",
     )
 

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -831,3 +831,21 @@ def resolve_agent_env(
     # Disable telemetry/non-essential traffic in container
     agent_env.setdefault("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
     return agent_env
+
+
+def apply_reasoning_effort_env(
+    agent: str, agent_env: dict[str, str], reasoning_effort: str | None
+) -> dict[str, str]:
+    """Apply a requested effort to agents configured at process launch.
+
+    ACP config options are set after ``session/new``.  Launch-configured
+    agents need the same value in their environment before their process is
+    started, so their registry entry declares the exact native variable.
+    """
+    if not reasoning_effort:
+        return agent_env
+    config = AGENTS.get(agent)
+    env_key = getattr(config, "reasoning_effort_env", "") if config else ""
+    if env_key:
+        agent_env[env_key] = reasoning_effort
+    return agent_env

--- a/src/benchflow/agents/harvey_lab_acp_shim.py
+++ b/src/benchflow/agents/harvey_lab_acp_shim.py
@@ -716,6 +716,9 @@ def main():
                     output_dir=output_dir,
                     workspace_dir=workspace_dir,
                     session_id=session_id,
+                    reasoning_effort=(
+                        os.environ.get("BENCHFLOW_REASONING_EFFORT") or None
+                    ),
                 )
                 _emit_text(
                     session_id,

--- a/src/benchflow/agents/manifest.py
+++ b/src/benchflow/agents/manifest.py
@@ -86,6 +86,7 @@ _SHIM_ONLY = frozenset(
         "subscription_auth",
         "acp_model_config_id",
         "acp_effort_config_id",
+        "reasoning_effort_env",
         "disallow_web_tools_setup_cmd",
         "disallow_web_tools_owned_paths",
         "disallow_web_tools_launch_suffix",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -124,13 +124,12 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_BIN_PREFIX}:{_BENCHFLOW_JS_AGENT_PREFIX}/bin:"
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
-# Node >=22.19 is required by current openclaw (the JS agents install
-# @latest); keep this pin at or above that floor or the openclaw ACP
-# bootstrap aborts at its runtime version check (BF-10).
+# OpenClaw 2026.7.1-2 requires Node >=22.22.3. Keep the isolated runtime at
+# or above that floor so the ACP bootstrap does not abort its version check.
 _NODE_INSTALL = (
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
-    "BF_NODE_VERSION=22.20.0; "
+    "BF_NODE_VERSION=22.22.3; "
     'if [ ! -x "$BF_NODE_DIR/bin/node" ]; then '
     "  if ! command -v curl >/dev/null 2>&1 || "
     "     ! command -v tar >/dev/null 2>&1 || "
@@ -209,7 +208,7 @@ _MIMO_MANIFEST_INSTALL_CMD = (
     + 'printf \'%s\' \'{"name":"bf-mimo-acp","private":true,"type":"module"}\' '
     + "> /opt/benchflow/js-agents/mimo-acp/package.json && "
     + "cd /opt/benchflow/js-agents/mimo-acp && "
-    + "/opt/benchflow/node/bin/npm install @mimo-ai/cli@0.1.4 "
+    + "/opt/benchflow/node/bin/npm install @mimo-ai/cli@0.1.9 "
     + "--no-audit --no-fund >/dev/null 2>&1 && "
     + "chmod -R a+rX /opt/benchflow && "
     + "[ -f /opt/benchflow/js-agents/mimo-acp/node_modules/@mimo-ai/cli/bin/mimo ]"
@@ -491,6 +490,11 @@ class AgentConfig:
     acp_model_config_id: str = ""
     # ACP session config option id used for reasoning/thinking effort.
     acp_effort_config_id: str = ""
+    # Agent-native environment variable that receives the requested reasoning
+    # effort before the ACP process starts. Used by launch-configured agents
+    # such as OpenHands; unlike ``acp_effort_config_id`` this is not an ACP
+    # session capability.
+    reasoning_effort_env: str = ""
     # Shell snippet run after credentials/subscription auth are written when
     # BenchFlow's no-web policy is active. Uses BENCHFLOW_AGENT_HOME for the
     # target home so settings land in the same home the agent will run from.
@@ -517,13 +521,13 @@ AGENTS: dict[str, AgentConfig] = {
         description="Claude Code via ACP (Anthropic's Agent Client Protocol)",
         skill_paths=["$HOME/.claude/skills"],
         home_dirs=[".claude"],
-        # Pinned to 0.40.0: the config-option wiring below (set_config_option +
+        # Pinned to 0.64.2: the config-option wiring below (set_config_option +
         # the "model"/"effort" ids) targets this version's ACP protocol (sdk
         # 0.24, which dropped session/set_model). The option ids are coupled to
         # this pin — re-verify them when bumping. runtime.py uses
         # capability-first dispatch for the rest of the family.
         install_cmd=_js_agent_install(
-            "claude-agent-acp", "@agentclientprotocol/claude-agent-acp@0.40.0"
+            "claude-agent-acp", "@agentclientprotocol/claude-agent-acp@0.64.2"
         ),
         launch_cmd=_js_agent_launch("claude-agent-acp"),
         protocol="acp",
@@ -559,8 +563,8 @@ AGENTS: dict[str, AgentConfig] = {
         description="Pi agent via ACP",
         skill_paths=["$HOME/.pi/agent/skills", "$HOME/.agents/skills"],
         install_cmd=(
-            f"{_js_agent_install('pi', '@mariozechner/pi-coding-agent')} && "
-            f"{_js_agent_install('pi-acp', 'pi-acp')} && "
+            f"{_js_agent_install('pi', '@mariozechner/pi-coding-agent@0.73.1')} && "
+            f"{_js_agent_install('pi-acp', 'pi-acp@0.0.33')} && "
             # Deploy launch wrapper (bridges BENCHFLOW_PROVIDER_* → Pi config)
             + _install_python_script(
                 f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher", _PI_LAUNCHER
@@ -569,6 +573,7 @@ AGENTS: dict[str, AgentConfig] = {
         launch_cmd=f"{_BENCHFLOW_BIN_PREFIX}/pi-acp-launcher",
         protocol="acp",
         acp_model_format="registered-provider/model",
+        acp_effort_config_id="thought_level",
         requires_env=[],  # inferred from --model at runtime
         # Pi is multi-protocol: speaks Anthropic natively and OpenAI via
         # models.json.  Empty lets the provider determine the protocol so
@@ -583,7 +588,7 @@ AGENTS: dict[str, AgentConfig] = {
         description="OpenClaw agent via ACP shim — model set at runtime via --model",
         skill_paths=["$HOME/.claude/skills", "$WORKSPACE/skills"],
         install_cmd=(
-            f"{_js_agent_install('openclaw', 'openclaw')} && "
+            f"{_js_agent_install('openclaw', 'openclaw@2026.7.1-2')} && "
             # Configure: auto-approve tools (no model — set at runtime via ACP set_model)
             "mkdir -p ~/.openclaw && "
             'echo \'{"version":1,"defaults":{"allow_all":true}}\''
@@ -602,16 +607,10 @@ AGENTS: dict[str, AgentConfig] = {
         name="codex-acp",
         description="OpenAI Codex agent via ACP",
         skill_paths=["$HOME/.agents/skills"],
-        # Pinned for reproducibility: an unpinned @agentclientprotocol install
-        # floats to latest and can silently break agent activation when the ACP
-        # protocol changes (claude-agent-acp above hit exactly this — sdk 0.24
-        # dropped session/set_model). 0.0.45 ships sdk 0.22.x, which still
-        # implements session/set_model. If a future bump advertises a model
-        # config option instead, runtime.py's capability-first dispatch routes
-        # the model through that option — but re-verify model selection when
-        # bumping this pin.
+        # Pinned for reproducibility. This version exposes separate ``model``
+        # and ``reasoning_effort`` session config options.
         install_cmd=_js_agent_install(
-            "codex-acp", "@agentclientprotocol/codex-acp@0.0.45"
+            "codex-acp", "@agentclientprotocol/codex-acp@1.1.9"
         ),
         # Self-write ~/.codex/auth.json from OPENAI_API_KEY in the launcher itself,
         # ONLY when the key is set (so subscription/host-auth mode is untouched),
@@ -644,15 +643,18 @@ AGENTS: dict[str, AgentConfig] = {
                 HostAuthFile("~/.codex/auth.json", "{home}/.codex/auth.json"),
             ],
         ),
+        acp_effort_config_id="reasoning_effort",
         disallow_web_tools_launch_suffix=" -c tools.web_search=false",
     ),
     "gemini": AgentConfig(
         name="gemini",
         description="Google Gemini CLI via ACP",
         skill_paths=["$HOME/.gemini/skills"],
-        install_cmd=_js_agent_install("gemini", "@google/gemini-cli@0.42.0"),
+        install_cmd=_js_agent_install("gemini", "@google/gemini-cli@0.53.1"),
         launch_cmd=_js_agent_launch("gemini", "--acp --yolo"),
         protocol="acp",
+        # Gemini CLI ACP currently exposes model selection but no generic
+        # reasoning/thinking-effort session option.
         # The Gemini CLI reads GEMINI_API_KEY natively. GOOGLE_API_KEY is
         # accepted as an alias: auto_inherit_env mirrors it both ways so users
         # can set either one. Advertise GEMINI_API_KEY here so `agent show`
@@ -700,7 +702,7 @@ AGENTS: dict[str, AgentConfig] = {
         skill_paths=["$HOME/.opencode/skills"],
         home_dirs=[".opencode"],
         install_cmd=(
-            _js_agent_install("opencode", "opencode-ai@1.18.11")
+            _js_agent_install("opencode", "opencode-ai@1.18.13")
             + " && "
             + _opencode_family_proxy_wrapper_install(
                 "opencode", ".config/opencode/opencode.json"
@@ -799,6 +801,7 @@ AGENTS: dict[str, AgentConfig] = {
         ),
         launch_cmd=f"HARVEY_LABS_ROOT=/opt/harvey-labs /opt/benchflow/harvey-lab-venv/bin/python {_BENCHFLOW_BIN_PREFIX}/harvey-lab-acp-shim",
         protocol="acp",
+        reasoning_effort_env="BENCHFLOW_REASONING_EFFORT",
         requires_env=[],  # inferred from model at runtime (ANTHROPIC_API_KEY, etc.)
         # Harvey LAB's Anthropic/Gemini adapters read ANTHROPIC_API_KEY /
         # GOOGLE_API_KEY directly (auto_inherit_env propagates a host key). But
@@ -967,6 +970,7 @@ AGENTS: dict[str, AgentConfig] = {
             "openhands acp --always-approve --override-with-envs"
         ),
         protocol="acp",
+        reasoning_effort_env="LLM_REASONING_EFFORT",
         requires_env=["LLM_API_KEY"],
         api_protocol="",
         env_mapping={
@@ -1171,6 +1175,7 @@ def _acpx_wrap(config: AgentConfig) -> AgentConfig:
         supports_acp_set_model=config.supports_acp_set_model,
         acp_model_config_id=config.acp_model_config_id,
         acp_effort_config_id=config.acp_effort_config_id,
+        reasoning_effort_env=config.reasoning_effort_env,
         disallow_web_tools_setup_cmd=config.disallow_web_tools_setup_cmd,
         disallow_web_tools_owned_paths=config.disallow_web_tools_owned_paths,
         disallow_web_tools_launch_suffix=config.disallow_web_tools_launch_suffix,
@@ -1365,6 +1370,7 @@ def register_agent(
     supports_acp_set_model: bool = True,
     acp_model_config_id: str = "",
     acp_effort_config_id: str = "",
+    reasoning_effort_env: str = "",
     disallow_web_tools_setup_cmd: str = "",
     disallow_web_tools_owned_paths: list[str] | None = None,
     disallow_web_tools_launch_suffix: str = "",
@@ -1404,6 +1410,7 @@ def register_agent(
         supports_acp_set_model=supports_acp_set_model,
         acp_model_config_id=acp_model_config_id,
         acp_effort_config_id=acp_effort_config_id,
+        reasoning_effort_env=reasoning_effort_env,
         disallow_web_tools_setup_cmd=disallow_web_tools_setup_cmd,
         disallow_web_tools_owned_paths=disallow_web_tools_owned_paths or [],
         disallow_web_tools_launch_suffix=disallow_web_tools_launch_suffix,

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -75,6 +75,7 @@ from benchflow._types import Role, Scene, Turn
 from benchflow._utils.scoring import classify_error as classify_error
 from benchflow.acp.types import McpServerSpec
 from benchflow.agents.credentials import upload_credential
+from benchflow.agents.env import apply_reasoning_effort_env
 from benchflow.agents.registry import AGENTS
 from benchflow.contracts import (
     AgentProtocolError,
@@ -865,6 +866,9 @@ class Rollout:
                 cfg.primary_agent, cfg.primary_model, cfg.agent_env
             ),
             disallow=self._disallow_web_tools,
+        )
+        apply_reasoning_effort_env(
+            cfg.primary_agent, self._agent_env, cfg.primary_reasoning_effort
         )
         env_config = getattr(getattr(self._task, "config", None), "environment", None)
         task_skill_policy = resolve_task_skill_policy(
@@ -2155,6 +2159,7 @@ class Rollout:
             ),
             disallow=disallow_web_tools,
         )
+        apply_reasoning_effort_env(role.agent, agent_env, role.reasoning_effort)
         agent_env, self._usage_runtime = await self._planes.ensure_litellm_runtime(
             agent=role.agent,
             agent_env=agent_env,

--- a/tests/test_acp_model_config_dispatch.py
+++ b/tests/test_acp_model_config_dispatch.py
@@ -132,9 +132,7 @@ async def test_codex_model_option_does_not_receive_legacy_effort_suffix(tmp_path
         config_options=[{"id": "model"}],
         model_state={"currentModelId": "gpt-5.6-sol[medium]"},
     )
-    await _connect(
-        mock_acp, agent="codex-acp", model="gpt-5.6-sol", tmp_path=tmp_path
-    )
+    await _connect(mock_acp, agent="codex-acp", model="gpt-5.6-sol", tmp_path=tmp_path)
 
     mock_acp.set_config_option.assert_awaited_once_with("model", "gpt-5.6-sol")
     mock_acp.set_model.assert_not_awaited()
@@ -143,9 +141,7 @@ async def test_codex_model_option_does_not_receive_legacy_effort_suffix(tmp_path
 @pytest.mark.asyncio
 async def test_codex_current_acp_uses_dedicated_effort_option(tmp_path):
     """Guards ACP capability mapping against dropping Codex's requested effort."""
-    mock_acp = _make_mocks(
-        config_options=[{"id": "model"}, {"id": "reasoning_effort"}]
-    )
+    mock_acp = _make_mocks(config_options=[{"id": "model"}, {"id": "reasoning_effort"}])
     await _connect(
         mock_acp,
         agent="codex-acp",
@@ -215,9 +211,7 @@ async def test_codex_legacy_acp_rejects_unadvertised_effort(tmp_path):
 @pytest.mark.asyncio
 async def test_pi_acp_uses_thought_level_and_maps_none_to_off(tmp_path):
     """Guards Pi ACP's distinct effort option and its ``off`` spelling."""
-    mock_acp = _make_mocks(
-        config_options=[{"id": "model"}, {"id": "thought_level"}]
-    )
+    mock_acp = _make_mocks(config_options=[{"id": "model"}, {"id": "thought_level"}])
     await _connect(
         mock_acp,
         agent="pi-acp",

--- a/tests/test_acp_model_config_dispatch.py
+++ b/tests/test_acp_model_config_dispatch.py
@@ -11,7 +11,7 @@ cases live in ``tests/test_acp_setup_failure_propagation.py``.
 """
 
 import contextlib
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -125,6 +125,134 @@ async def test_codex_with_model_option_uses_config_option(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_codex_model_option_does_not_receive_legacy_effort_suffix(tmp_path):
+    """Guards ACP capability mapping against sending ``model[effort]`` to a
+    current Codex ACP ``model`` config option."""
+    mock_acp = _make_mocks(
+        config_options=[{"id": "model"}],
+        model_state={"currentModelId": "gpt-5.6-sol[medium]"},
+    )
+    await _connect(
+        mock_acp, agent="codex-acp", model="gpt-5.6-sol", tmp_path=tmp_path
+    )
+
+    mock_acp.set_config_option.assert_awaited_once_with("model", "gpt-5.6-sol")
+    mock_acp.set_model.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_codex_current_acp_uses_dedicated_effort_option(tmp_path):
+    """Guards ACP capability mapping against dropping Codex's requested effort."""
+    mock_acp = _make_mocks(
+        config_options=[{"id": "model"}, {"id": "reasoning_effort"}]
+    )
+    await _connect(
+        mock_acp,
+        agent="codex-acp",
+        model="gpt-5.6-sol",
+        tmp_path=tmp_path,
+        reasoning_effort="high",
+    )
+
+    mock_acp.set_config_option.assert_has_awaits(
+        [
+            call("model", "gpt-5.6-sol"),
+            call("reasoning_effort", "high"),
+        ]
+    )
+    mock_acp.set_model.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_codex_legacy_acp_encodes_effort_in_model_id(tmp_path):
+    """Guards ACP capability mapping for legacy Codex ``model[effort]`` IDs."""
+    mock_acp = _make_mocks(
+        config_options=[{"id": "fast-mode"}],
+        model_state={
+            "availableModels": [
+                {"modelId": "gpt-5.5[medium]"},
+                {"modelId": "gpt-5.5[high]"},
+            ],
+            "currentModelId": "gpt-5.5[medium]",
+        },
+    )
+    await _connect(
+        mock_acp,
+        agent="codex-acp",
+        model="gpt-5.5",
+        tmp_path=tmp_path,
+        reasoning_effort="high",
+    )
+
+    mock_acp.set_model.assert_awaited_once_with("gpt-5.5[high]")
+    mock_acp.set_config_option.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_codex_legacy_acp_rejects_unadvertised_effort(tmp_path):
+    """Guards the ACP capability mapping fix against silently using a default."""
+    mock_acp = _make_mocks(
+        config_options=[{"id": "fast-mode"}],
+        model_state={
+            "availableModels": [{"modelId": "gpt-5.5[medium]"}],
+            "currentModelId": "gpt-5.5[medium]",
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="does not advertise reasoning effort"):
+        await _connect(
+            mock_acp,
+            agent="codex-acp",
+            model="gpt-5.5",
+            tmp_path=tmp_path,
+            reasoning_effort="high",
+        )
+
+    mock_acp.set_model.assert_not_awaited()
+    mock_acp.set_config_option.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pi_acp_uses_thought_level_and_maps_none_to_off(tmp_path):
+    """Guards Pi ACP's distinct effort option and its ``off`` spelling."""
+    mock_acp = _make_mocks(
+        config_options=[{"id": "model"}, {"id": "thought_level"}]
+    )
+    await _connect(
+        mock_acp,
+        agent="pi-acp",
+        model="openai/gpt-5.6-sol",
+        tmp_path=tmp_path,
+        reasoning_effort="none",
+    )
+
+    mock_acp.set_config_option.assert_has_awaits(
+        [
+            call("model", "openai/gpt-5.6-sol"),
+            call("thought_level", "off"),
+        ]
+    )
+    mock_acp.set_model.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_openhands_effort_is_owned_by_its_launch_environment(tmp_path):
+    """OpenHands consumes the effort before ACP starts, not via session config."""
+    mock_acp = _make_mocks()
+    await _connect(
+        mock_acp,
+        agent="openhands",
+        model="gpt-5.6-sol",
+        tmp_path=tmp_path,
+        agent_env={"LLM_REASONING_EFFORT": "high"},
+        reasoning_effort="high",
+    )
+
+    mock_acp.set_model.assert_not_awaited()
+    mock_acp.set_config_option.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_unregistered_agent_with_model_option_uses_config_option(tmp_path):
     """An agent not in the registry that advertises a 'model' option is still
     handled via the config option — discovery is from the session, not the
@@ -153,11 +281,10 @@ async def test_registry_hint_overrides_when_session_advertises_nothing(tmp_path)
 
 
 @pytest.mark.asyncio
-async def test_effort_without_effort_config_id_fails_closed(tmp_path):
-    """reasoning_effort requested for an agent that declares no effort config
-    option must fail closed rather than silently drop the effort."""
+async def test_effort_without_advertised_option_fails_closed(tmp_path):
+    """An ACP agent without an effort option must fail rather than drop it."""
     mock_acp = _make_mocks(config_options=[])
-    with pytest.raises(RuntimeError, match="does not declare an ACP effort"):
+    with pytest.raises(RuntimeError, match="does not expose an effort"):
         await _connect(
             mock_acp,
             agent="test-agent",

--- a/tests/test_agent_env_resolution.py
+++ b/tests/test_agent_env_resolution.py
@@ -14,7 +14,21 @@ from pathlib import Path
 
 import pytest
 
-from benchflow.agents.env import auto_inherit_env, resolve_agent_env
+from benchflow.agents.env import (
+    apply_reasoning_effort_env,
+    auto_inherit_env,
+    resolve_agent_env,
+)
+
+
+def test_apply_reasoning_effort_env_uses_only_declared_agent_native_variable():
+    openhands_env: dict[str, str] = {}
+    apply_reasoning_effort_env("openhands", openhands_env, "high")
+    assert openhands_env == {"LLM_REASONING_EFFORT": "high"}
+
+    gemini_env: dict[str, str] = {}
+    apply_reasoning_effort_env("gemini", gemini_env, "high")
+    assert gemini_env == {}
 
 
 def _patch_no_subscription(monkeypatch, tmp_path):

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -33,13 +33,21 @@ class TestEnvMappingField:
         assert cfg.supports_acp_set_model is False
         assert cfg.acp_model_config_id == "model"
         assert cfg.acp_effort_config_id == "effort"
-        assert "@agentclientprotocol/claude-agent-acp@0.40.0" in cfg.install_cmd
+        assert "@agentclientprotocol/claude-agent-acp@0.64.2" in cfg.install_cmd
 
     def test_pi_acp_no_static_mapping(self):
         """pi-acp is multi-protocol — launch wrapper handles env translation."""
         cfg = AGENTS["pi-acp"]
         assert cfg.env_mapping == {}
         assert cfg.acp_model_format == "registered-provider/model"
+        assert cfg.acp_effort_config_id == "thought_level"
+        assert "@mariozechner/pi-coding-agent@0.73.1" in cfg.install_cmd
+        assert "pi-acp@0.0.33" in cfg.install_cmd
+
+    def test_openclaw_uses_a_compatible_pinned_node_runtime(self):
+        cfg = AGENTS["openclaw"]
+        assert "openclaw@2026.7.1-2" in cfg.install_cmd
+        assert "BF_NODE_VERSION=22.22.3" in cfg.install_cmd
 
     def test_codex_acp_has_mapping(self):
         cfg = AGENTS["codex-acp"]
@@ -49,10 +57,10 @@ class TestEnvMappingField:
         assert "openai_base_url=$OPENAI_BASE_URL" in cfg.launch_cmd
 
     def test_codex_acp_install_is_version_pinned(self):
-        """Same @agentclientprotocol family as claude — pin so a floating latest
-        can't silently break activation when upstream drops session/set_model."""
+        """Guards the ACP capability mapping fix against reverting Codex ACP."""
         cfg = AGENTS["codex-acp"]
-        assert "@agentclientprotocol/codex-acp@0.0.45" in cfg.install_cmd
+        assert "@agentclientprotocol/codex-acp@1.1.9" in cfg.install_cmd
+        assert cfg.acp_effort_config_id == "reasoning_effort"
 
     def test_gemini_has_mapping(self):
         cfg = AGENTS["gemini"]
@@ -63,6 +71,8 @@ class TestEnvMappingField:
         # bidirectional mirror in auto_inherit_env handles GOOGLE_API_KEY
         # callers transparently.
         assert cfg.env_mapping["BENCHFLOW_PROVIDER_API_KEY"] == "GEMINI_API_KEY"
+        assert "@google/gemini-cli@0.53.1" in cfg.install_cmd
+        assert cfg.acp_effort_config_id == ""
 
     def test_openhands_has_mapping(self):
         cfg = AGENTS["openhands"]
@@ -214,6 +224,7 @@ class TestOpenHandsConfig:
         assert ',"reasoning_effort":"%s",' in cfg.launch_cmd
         assert '"litellm_extra_body":{"reasoning_effort":"%s"}' in cfg.launch_cmd
         assert '"$LLM_REASONING_EFFORT" "$LLM_REASONING_EFFORT"' in cfg.launch_cmd
+        assert cfg.reasoning_effort_env == "LLM_REASONING_EFFORT"
 
     def test_openhands_launch_cmd_keeps_minimal_out_of_typed_effort(self, tmp_path):
         """Guards PR #921: OpenHands' typed effort enum rejects minimal."""

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -262,19 +262,19 @@ def test_js_agent_install_respects_explicit_npm_package_specs():
 def test_opencode_install_is_pinned_for_reproducible_harness_runs():
     """Guards PR #931 against silently changing OpenCode between eval stages.
 
-    The pinned version moves deliberately (PR #942 bumped it to 1.18.11 when
+    The pinned version moves deliberately (PR #942 bumped it to 1.18.13 when
     opencode became the default rubric reviewer); pinning itself must stay.
     """
     install_cmd = AGENTS["opencode"].install_cmd
 
-    assert "opencode-ai@1.18.11" in install_cmd
+    assert "opencode-ai@1.18.13" in install_cmd
     assert "opencode-ai@latest" not in install_cmd
 
 
 def test_gemini_cli_install_is_pinned():
     """Guards v0.5-integration@27752fa against Daytona installing moving latest."""
     install_cmd = AGENTS["gemini"].install_cmd
-    assert "@google/gemini-cli@0.42.0" in install_cmd
+    assert "@google/gemini-cli@0.53.1" in install_cmd
     assert "@google/gemini-cli@latest" not in install_cmd
     assert "[ -x /opt/benchflow/js-agents/bin/gemini ] ||" not in install_cmd
 


### PR DESCRIPTION
Fixes #945

## Summary

- Upgrade Codex ACP, Claude ACP, Gemini CLI, Pi ACP, OpenClaw, OpenCode, and MiMo CLI pins.
- Dispatch reasoning effort through live ACP capabilities: `reasoning_effort` (Codex), `effort` (Claude), and `thought_level` (Pi).
- Configure launch-time effort for OpenHands and Harvey LAB; leave agents without a confirmed effort interface fail-closed.

## Root cause

BenchFlow’s prior Codex ACP pin and runtime assumed the legacy `model[effort]` protocol. Current Codex ACP exposes independent `model` and `reasoning_effort` options, so effort could not be correctly configured. The same review found launch-configured agents whose declared effort setting was not injected before process startup.

## Companion manifest PR

- benchflow-ai/agents#60 synchronizes the manifest-owned runtime version pins required by the manifest-parity gate.
- The parity check will become green after that PR is merged into `benchflow-ai/agents@main` and this PR’s workflow is rerun.

## Validation

- Original regression suite: `302 passed, 2 skipped`.
- Focused ACP, registry, environment, and live manifest parity suite: `70 passed`.
- Agents contract suite: `21 passed`.
- `ruff check src tests tools`.
- `ruff format --check src tests tools`.
- `ty check src`.