### PR TITLE
fix(rollout): hard deadline around the rollout lifecycle + verifier zero-output-timeout retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/
 | Run an eval on an existing task | [Getting started](./docs/getting-started.md) |
 | Understand how BenchFlow runs *any* benchmark (the three-layer model) | [Run any benchmark](./docs/running-any-benchmark.md) |
 | Have an AI agent install + run the quickstart end to end | [Agent quickstart prompt](./docs/agent-quickstart.md) |
+| Run an agent from the public agents repo (goose, qwen-code, prime-agent, …) | [Running external agents](./docs/external-agents.md) |
 | Understand Rollout / Scene / Role / Verifier | [Concepts](./docs/concepts.md) |
 | Author a new task | [Task authoring](./docs/task-authoring.md) |
 | Author a task in the native `task.md` format | [Native task.md authoring](./docs/task-authoring-task-md.md) |

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -1,0 +1,97 @@
+# Running external agents
+
+BenchFlow's built-in registry covers a handful of agents (`bench agent list`).
+Everything else — goose, qwen-code, prime-agent, the omnigent harnesses, … —
+lives in the public **[benchflow-ai/agents](https://github.com/benchflow-ai/agents)**
+repo and loads into BenchFlow through one of four paths. For most users the
+first one is all there is to know.
+
+## 1. Zero-config remote autoload (the default)
+
+Using an agent name BenchFlow doesn't recognize triggers a one-shot fetch of
+the declarative manifests from `benchflow-ai/agents@main`. Nothing to install
+or configure:
+
+```bash
+pip install 'benchflow[sandbox-daytona]'
+export DEEPSEEK_API_KEY=sk-...          # credentials for your --model provider
+export DAYTONA_API_KEY=dtn_...          # or use --sandbox docker
+
+bench eval run --tasks-dir ./tasks --agent prime-agent \
+  --model deepseek/deepseek-v4-flash --sandbox daytona
+```
+
+The first rollout runs the agent's `install_cmd` inside the sandbox (a few
+minutes for agents that bootstrap toolchains); artifacts land in the jobs dir
+exactly as for built-in agents, including the gateway's raw LLM trace.
+
+Details worth knowing:
+
+- The fetch happens **at most once per process**, only on a resolution miss,
+  and only fills gaps — it never shadows a built-in or already-registered
+  agent name.
+- Availability of a name depends on it being merged to the agents repo's
+  `main`. What exists is listed in that repo's `acp/` directory and, for the
+  ACP-registry tier, its generated `acp-registry/AGENTS.md`.
+
+## 2. Pin the source: `BENCHFLOW_AGENTS_SOURCE`
+
+Override where the autoload fetches from — a branch/ref, another repo, a local
+directory, or off entirely:
+
+```bash
+export BENCHFLOW_AGENTS_SOURCE="benchflow-ai/agents@my-branch"   # owner/repo[@ref]
+export BENCHFLOW_AGENTS_SOURCE="/path/to/agents-checkout"        # local dir
+export BENCHFLOW_AGENTS_SOURCE="off"                             # disable autoload
+```
+
+Accepted off-values: `off`, `0`, `none`, `disabled`, `false`. Pinning a ref is
+the standard way to try an agent from an open PR — e.g. verified live on
+BenchFlow 0.6.6: `BENCHFLOW_AGENTS_SOURCE="benchflow-ai/agents@add-prime-agent"`
+resolved and ran the `prime-agent` manifest with zero local setup.
+
+## 3. Local checkout at import: `BENCHFLOW_AGENTS_DIR`
+
+For agents-repo development: point at a checkout and every
+`<dir>/manifest.toml` under it merges into the registry when `benchflow`
+imports (not lazily on miss):
+
+```bash
+export BENCHFLOW_AGENTS_DIR=/path/to/agents-checkout
+```
+
+Unlike the miss-driven autoload, this path loads even for names that would
+never miss, and it is the loop used while editing a manifest. It is additive
+and compatible-merge only: colliding with an existing agent's aliases is a
+hard error rather than a silent shadow. Unset, the import is byte-for-byte
+identical to core — the mechanism is strictly opt-in.
+
+## 4. Plugin packages (entry points)
+
+Agents that need host-side Python (session-factory adapters like the omnigent
+harnesses, or packaged code agents like `mini-swe-acp`) ship as pip packages
+that register through the `benchflow.agents` entry-point group — installing
+the package is all it takes:
+
+```bash
+pip install "mini-swe-acp @ git+https://github.com/benchflow-ai/agents#subdirectory=acp/mini-swe-acp"
+bench eval run --tasks-dir ./tasks --agent mini-swe --model openai/gpt-4o-mini
+```
+
+These load at `benchflow` import time. A plugin that fails to import never
+blocks the run — the failure is recorded and surfaced in the "Unknown agent"
+error message if its name is later requested.
+
+## Precedence
+
+1. Built-in registry (core `AGENTS`) — never shadowed by anything below.
+2. `BENCHFLOW_AGENTS_DIR` manifests — merged at import.
+3. Entry-point plugin packages — loaded at import, after the manifest merge.
+4. Remote autoload (`BENCHFLOW_AGENTS_SOURCE`, default `benchflow-ai/agents@main`)
+   — consulted last, once, only for names still unknown at resolution time.
+
+Manifest capabilities are deliberately bounded: a `manifest.toml` is data-only
+(install/launch commands, env mapping, model-routing hints — the
+[agents-repo contract](https://github.com/benchflow-ai/agents/tree/main/contract)).
+Anything needing host-side logic (credential files, session factories, native
+MCP config) must come in as a plugin package or a core agent instead.

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -11,6 +11,7 @@ Backward-compat aliases: ``Job = Evaluation``, ``JobConfig = EvaluationConfig``,
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -96,6 +97,70 @@ from benchflow.usage_tracking import UsageTrackingConfig
 RunResult = RolloutResult
 
 logger = logging.getLogger(__name__)
+
+# Host-side hard deadline for one rollout attempt. Every phase inside a rollout
+# already carries its own timeout (install, agent idle + wall-clock, verifier,
+# PTY readline), but calls BELOW that instrumentation — a Daytona PTY kill on a
+# dead websocket, a wedged session exec in the post-verify export path — can
+# block forever and freeze the whole job (observed 2026-08-07: one hung
+# bike-rebalance rollout wedged a 25-task eval for 11+ hours after its verifier
+# had already finished). The hard deadline is a backstop, not a budget: it is
+# derived from the sum of every phase budget plus a generous fixed margin, so
+# it can only fire when some await is stuck outside all phase-level timeouts.
+# Override with BENCHFLOW_ROLLOUT_HARD_DEADLINE (seconds; "off"/"none"/"0"
+# disables the backstop entirely).
+_HARD_DEADLINE_ENV = "BENCHFLOW_ROLLOUT_HARD_DEADLINE"
+_HARD_DEADLINE_MARGIN_SEC = 1800.0
+_HARD_DEADLINE_FALLBACK_SEC = 3 * 3600.0
+_DEFAULT_AGENT_INSTALL_TIMEOUT_SEC = 900.0
+_CLEANUP_BOUND_SEC = 120.0
+
+
+def _rollout_hard_deadline_sec(task_dir: Path, cfg: EvaluationConfig) -> float | None:
+    """Compute the hard backstop deadline for one rollout attempt.
+
+    Returns ``None`` when the operator disabled the backstop. On any failure to
+    read the task's budgets, falls back to a conservative constant rather than
+    running unbounded.
+    """
+    raw = os.environ.get(_HARD_DEADLINE_ENV, "").strip().lower()
+    if raw in {"off", "none", "0"}:
+        return None
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            logger.warning(
+                f"{_HARD_DEADLINE_ENV}={raw!r} is not a number; using computed deadline"
+            )
+    try:
+        from benchflow.task import Task
+
+        tcfg = Task(task_dir).config
+        agent_sec = float(tcfg.agent.timeout_sec or 900.0)
+        verifier_sec = float(tcfg.verifier.timeout_sec or 900.0)
+        build_sec = float(tcfg.sandbox.build_timeout_sec or 600.0)
+    except Exception as e:
+        logger.debug(f"hard-deadline: could not read {task_dir.name} budgets: {e}")
+        return _HARD_DEADLINE_FALLBACK_SEC
+    install_sec = _DEFAULT_AGENT_INSTALL_TIMEOUT_SEC
+    try:
+        from benchflow.agents.registry import resolve_agent
+
+        install_sec = float(
+            resolve_agent(cfg.agent).install_timeout or install_sec
+        )
+    except Exception:
+        # Raw-command agents and unresolved specs skip install entirely.
+        pass
+    n_prompts = max(1, len(cfg.prompts or []) or 1)
+    return (
+        agent_sec * n_prompts
+        + verifier_sec
+        + build_sec
+        + install_sec
+        + _HARD_DEADLINE_MARGIN_SEC
+    )
 
 # Label applied to every container/network BenchFlow's compose files create.
 # Used to scope Docker prune calls so we only delete our own resources and never
@@ -1250,7 +1315,31 @@ class Evaluation:
 
             return await run_self_gen(rollout_config)
         rollout = await Rollout.create(rollout_config)
-        return await rollout.run()
+        deadline = _rollout_hard_deadline_sec(task_dir, cfg)
+        if deadline is None:
+            return await rollout.run()
+        try:
+            return await asyncio.wait_for(rollout.run(), timeout=deadline)
+        except TimeoutError:
+            # A wedged transport (e.g. a hung Daytona PTY/session call below
+            # the idle and wall-clock watchdogs) must never freeze the whole
+            # job: abandon the rollout, bound the cleanup too, and surface a
+            # normal infra-retryable error result.
+            logger.error(
+                f"[HARD-DEADLINE] {task_dir.name}: rollout exceeded host "
+                f"deadline ({deadline:.0f}s); abandoning sandbox"
+            )
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(rollout.cleanup(), timeout=_CLEANUP_BOUND_SEC)
+            return RunResult(
+                task_name=task_dir.name,
+                error=(
+                    f"Rollout exceeded host hard deadline ({deadline:.0f}s) — "
+                    "transport or teardown wedged below the idle/wall-clock "
+                    "watchdogs; sandbox abandoned"
+                ),
+                error_category=INFRA_ERROR,
+            )
 
     async def _run_single_task_legacy(
         self, task_dir: Path, cfg: EvaluationConfig

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -11,7 +11,6 @@ Backward-compat aliases: ``Job = Evaluation``, ``JobConfig = EvaluationConfig``,
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import logging
 import os
@@ -97,70 +96,6 @@ from benchflow.usage_tracking import UsageTrackingConfig
 RunResult = RolloutResult
 
 logger = logging.getLogger(__name__)
-
-# Host-side hard deadline for one rollout attempt. Every phase inside a rollout
-# already carries its own timeout (install, agent idle + wall-clock, verifier,
-# PTY readline), but calls BELOW that instrumentation — a Daytona PTY kill on a
-# dead websocket, a wedged session exec in the post-verify export path — can
-# block forever and freeze the whole job (observed 2026-08-07: one hung
-# bike-rebalance rollout wedged a 25-task eval for 11+ hours after its verifier
-# had already finished). The hard deadline is a backstop, not a budget: it is
-# derived from the sum of every phase budget plus a generous fixed margin, so
-# it can only fire when some await is stuck outside all phase-level timeouts.
-# Override with BENCHFLOW_ROLLOUT_HARD_DEADLINE (seconds; "off"/"none"/"0"
-# disables the backstop entirely).
-_HARD_DEADLINE_ENV = "BENCHFLOW_ROLLOUT_HARD_DEADLINE"
-_HARD_DEADLINE_MARGIN_SEC = 1800.0
-_HARD_DEADLINE_FALLBACK_SEC = 3 * 3600.0
-_DEFAULT_AGENT_INSTALL_TIMEOUT_SEC = 900.0
-_CLEANUP_BOUND_SEC = 120.0
-
-
-def _rollout_hard_deadline_sec(task_dir: Path, cfg: EvaluationConfig) -> float | None:
-    """Compute the hard backstop deadline for one rollout attempt.
-
-    Returns ``None`` when the operator disabled the backstop. On any failure to
-    read the task's budgets, falls back to a conservative constant rather than
-    running unbounded.
-    """
-    raw = os.environ.get(_HARD_DEADLINE_ENV, "").strip().lower()
-    if raw in {"off", "none", "0"}:
-        return None
-    if raw:
-        try:
-            return float(raw)
-        except ValueError:
-            logger.warning(
-                f"{_HARD_DEADLINE_ENV}={raw!r} is not a number; using computed deadline"
-            )
-    try:
-        from benchflow.task import Task
-
-        tcfg = Task(task_dir).config
-        agent_sec = float(tcfg.agent.timeout_sec or 900.0)
-        verifier_sec = float(tcfg.verifier.timeout_sec or 900.0)
-        build_sec = float(tcfg.sandbox.build_timeout_sec or 600.0)
-    except Exception as e:
-        logger.debug(f"hard-deadline: could not read {task_dir.name} budgets: {e}")
-        return _HARD_DEADLINE_FALLBACK_SEC
-    install_sec = _DEFAULT_AGENT_INSTALL_TIMEOUT_SEC
-    try:
-        from benchflow.agents.registry import resolve_agent
-
-        install_sec = float(
-            resolve_agent(cfg.agent).install_timeout or install_sec
-        )
-    except Exception:
-        # Raw-command agents and unresolved specs skip install entirely.
-        pass
-    n_prompts = max(1, len(cfg.prompts or []) or 1)
-    return (
-        agent_sec * n_prompts
-        + verifier_sec
-        + build_sec
-        + install_sec
-        + _HARD_DEADLINE_MARGIN_SEC
-    )
 
 # Label applied to every container/network BenchFlow's compose files create.
 # Used to scope Docker prune calls so we only delete our own resources and never
@@ -1315,31 +1250,11 @@ class Evaluation:
 
             return await run_self_gen(rollout_config)
         rollout = await Rollout.create(rollout_config)
-        deadline = _rollout_hard_deadline_sec(task_dir, cfg)
-        if deadline is None:
-            return await rollout.run()
-        try:
-            return await asyncio.wait_for(rollout.run(), timeout=deadline)
-        except TimeoutError:
-            # A wedged transport (e.g. a hung Daytona PTY/session call below
-            # the idle and wall-clock watchdogs) must never freeze the whole
-            # job: abandon the rollout, bound the cleanup too, and surface a
-            # normal infra-retryable error result.
-            logger.error(
-                f"[HARD-DEADLINE] {task_dir.name}: rollout exceeded host "
-                f"deadline ({deadline:.0f}s); abandoning sandbox"
-            )
-            with contextlib.suppress(Exception):
-                await asyncio.wait_for(rollout.cleanup(), timeout=_CLEANUP_BOUND_SEC)
-            return RunResult(
-                task_name=task_dir.name,
-                error=(
-                    f"Rollout exceeded host hard deadline ({deadline:.0f}s) — "
-                    "transport or teardown wedged below the idle/wall-clock "
-                    "watchdogs; sandbox abandoned"
-                ),
-                error_category=INFRA_ERROR,
-            )
+        # Rollout.run() enforces its own host-side hard deadline against
+        # awaits wedged below the phase-level timeouts — see
+        # benchflow.rollout._deadline. A trip surfaces here as a normal
+        # infra-retryable error result.
+        return await rollout.run()
 
     async def _run_single_task_legacy(
         self, task_dir: Path, cfg: EvaluationConfig

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -26,6 +26,15 @@ _PROVIDER_REASONING_EFFORTS = frozenset(
     {"none", "minimal", "low", "medium", "high", "xhigh", "max"}
 )
 
+#: Completions providers routed through LiteLLM's NATIVE provider integration
+#: (``<provider>/<model>``) instead of the generic ``openai/`` passthrough, so
+#: provider-specific params the agent sends (DeepSeek ``thinking`` /
+#: ``reasoning_effort``) survive ``drop_params``. Extend only after checking
+#: ``get_supported_openai_params(..., custom_llm_provider=<name>)`` on the
+#: pinned LiteLLM: a provider listed here whose integration DOESN'T support a
+#: param drops it exactly like the openai/ route would.
+_NATIVE_LITELLM_COMPLETIONS_PROVIDERS = frozenset({"deepseek"})
+
 # Per-token USD prices for models LiteLLM's built-in ``model_cost`` does not
 # already know (custom OpenAI-compatible endpoints such as private vLLM servers
 # or niche hosted models). When a route's upstream model matches a key here, the
@@ -305,23 +314,25 @@ def _route_registered_provider(
 
     if protocol == "anthropic-messages":
         upstream = f"anthropic/{bare}"
+    elif provider_name in _NATIVE_LITELLM_COMPLETIONS_PROVIDERS:
+        # Parity: the generic openai/ passthrough + global `drop_params: True`
+        # silently strips params outside the vanilla-OpenAI set — verified live
+        # 2026-08-08 with a capture proxy between the gateway and
+        # api.deepseek.com: the agent sent `thinking: {type: enabled}` +
+        # `reasoning_effort: high` and the upstream received NEITHER, so
+        # gateway-routed runs used the provider's DEFAULT thinking config while
+        # native runs used the agent's. LiteLLM's native provider integrations
+        # declare those params supported (deepseek does for both), so routing
+        # through the provider's own prefix forwards them while drop_params
+        # keeps protecting genuinely unsupported fields. (The pinned LiteLLM
+        # 1.89.0 has no per-deployment allowed_openai_params escape, so the
+        # provider prefix is the only faithful route.)
+        upstream = f"{provider_name}/{bare}"
     else:
         upstream = f"openai/{bare}"
     params: dict[str, str | int | float | bool | list[str]] = {"model": upstream}
     if api_base:
         params["api_base"] = api_base
-    if protocol != "anthropic-messages":
-        # Parity: the global `drop_params: True` makes LiteLLM's openai/
-        # passthrough silently strip reasoning params the agent sent, because
-        # they are not vanilla-OpenAI fields — verified live 2026-08-08 with a
-        # capture proxy between the gateway and api.deepseek.com: the agent
-        # sent `thinking: {type: enabled}` + `reasoning_effort: high` and the
-        # upstream received NEITHER, so gateway-routed runs silently used the
-        # provider's default thinking config while native runs used the
-        # agent's. Explicitly allow the reasoning params through; an upstream
-        # that does not know them rejects them exactly as it would a native
-        # client — which is the parity-correct behavior.
-        params["allowed_openai_params"] = ["thinking", "reasoning_effort"]
     api_key_ref = (
         _env_ref("BENCHFLOW_PROVIDER_API_KEY")
         if explicit_api_base and explicit_api_key

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -210,7 +210,7 @@ def _route_registered_provider(
     env: dict[str, str],
 ) -> LiteLLMRoute:
     bare = strip_provider_prefix(model)
-    params: dict[str, str | int | float | bool]
+    params: dict[str, str | int | float | bool | list[str]]
     required_env: list[str] = []
 
     if provider_name == "aws-bedrock":
@@ -388,7 +388,7 @@ def resolve_litellm_route(model: str, env: dict[str, str]) -> LiteLLMRoute:
         upstream = f"openai/{bare}"
         required = ("OPENAI_API_KEY",)
 
-    params: dict[str, str | int | float | bool] = {"model": upstream}
+    params: dict[str, str | int | float | bool | list[str]] = {"model": upstream}
     if upstream.lower().startswith("gemini/"):
         explicit_api_base = (env.get("BENCHFLOW_PROVIDER_BASE_URL") or "").strip()
         explicit_api_key = (env.get("BENCHFLOW_PROVIDER_API_KEY") or "").strip()

--- a/src/benchflow/providers/litellm_config.py
+++ b/src/benchflow/providers/litellm_config.py
@@ -105,7 +105,7 @@ class LiteLLMRoute:
     model_alias: str
     upstream_model: str
     provider_name: str
-    litellm_params: dict[str, str | int | float | bool]
+    litellm_params: dict[str, str | int | float | bool | list[str]]
     required_env: tuple[str, ...] = ()
 
     @property
@@ -307,9 +307,21 @@ def _route_registered_provider(
         upstream = f"anthropic/{bare}"
     else:
         upstream = f"openai/{bare}"
-    params = {"model": upstream}
+    params: dict[str, str | int | float | bool | list[str]] = {"model": upstream}
     if api_base:
         params["api_base"] = api_base
+    if protocol != "anthropic-messages":
+        # Parity: the global `drop_params: True` makes LiteLLM's openai/
+        # passthrough silently strip reasoning params the agent sent, because
+        # they are not vanilla-OpenAI fields — verified live 2026-08-08 with a
+        # capture proxy between the gateway and api.deepseek.com: the agent
+        # sent `thinking: {type: enabled}` + `reasoning_effort: high` and the
+        # upstream received NEITHER, so gateway-routed runs silently used the
+        # provider's default thinking config while native runs used the
+        # agent's. Explicitly allow the reasoning params through; an upstream
+        # that does not know them rejects them exactly as it would a native
+        # client — which is the parity-correct behavior.
+        params["allowed_openai_params"] = ["thinking", "reasoning_effort"]
     api_key_ref = (
         _env_ref("BENCHFLOW_PROVIDER_API_KEY")
         if explicit_api_base and explicit_api_key

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -322,6 +322,23 @@ class BenchFlowLiteLLMLogger(CustomLogger):
                     cleaned = dict(data)
                 cleaned["tools"] = kept
 
+        # Forward ``reasoning_effort`` VERBATIM on deepseek routes. LiteLLM's
+        # deepseek transform consumes the top-level field (it maps it into its
+        # own thinking handling and drops the raw param — even with drop_params
+        # off; verified against a capture upstream 2026-08-08), while
+        # ``extra_body`` fields merge into the wire request untouched. Lifting
+        # the param means the upstream receives exactly what the agent sent —
+        # the same request a native (gateway-less) run produces. Scoped to
+        # deepseek, today's only natively-routed completions provider
+        # (_NATIVE_LITELLM_COMPLETIONS_PROVIDERS in litellm_config.py).
+        model_id = str(cleaned.get("model") or "")
+        if "deepseek" in model_id and cleaned.get("reasoning_effort") is not None:
+            if cleaned is data:
+                cleaned = dict(data)
+            extra = dict(cleaned.get("extra_body") or {})
+            extra.setdefault("reasoning_effort", cleaned.pop("reasoning_effort"))
+            cleaned["extra_body"] = extra
+
         capture_logprobs = (
             os.environ.get("BENCHFLOW_CAPTURE_TOKEN_LOGPROBS", "").strip().lower()
             in {"1", "true", "yes", "on"}

--- a/src/benchflow/providers/litellm_logging.py
+++ b/src/benchflow/providers/litellm_logging.py
@@ -223,13 +223,6 @@ def _failure_traceback(detail: Any) -> str:
 
 
 class BenchFlowLiteLLMLogger(CustomLogger):
-    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
-        if isinstance(data, dict) and data.get("messages") is not None and "input" in data:
-            cleaned = dict(data)
-            cleaned.pop("input", None)
-            return cleaned
-        return None
-
     def _write(self, payload: dict[str, Any]) -> None:
         path = os.environ.get("BENCHFLOW_LITELLM_LOG_PATH")
         if not path:

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -97,6 +97,7 @@ from benchflow.loop_strategies import (
     loop_block,
 )
 from benchflow.models import RolloutResult, TrajectorySource
+from benchflow.rollout import _deadline as _deadline
 from benchflow.rollout._config import GENERATED_SKILLS_ROOT as GENERATED_SKILLS_ROOT
 from benchflow.rollout._config import RolloutConfig as RolloutConfig
 from benchflow.rollout._results import _DIAG_TRUNCATE as _DIAG_TRUNCATE
@@ -1977,6 +1978,20 @@ class Rollout:
         logger.error(self._error)
 
     async def run(self) -> RolloutResult:
+        """Run the complete trial lifecycle under a host-side hard deadline.
+
+        The lifecycle itself lives in :meth:`_run_lifecycle`; the deadline is
+        a backstop against awaits wedged below every phase-level timeout (a
+        Daytona PTY kill on a dead websocket, a hung session exec in the
+        post-verify export path) — see :mod:`benchflow.rollout._deadline`.
+        A trip becomes a normal infra-retryable error result and the
+        abandoned attempt's cleanup is bounded too.
+        """
+        return await _deadline.enforce_hard_deadline(
+            self._run_lifecycle(), config=self._config
+        )
+
+    async def _run_lifecycle(self) -> RolloutResult:
         """Run the complete trial lifecycle.
 
         Iterates over effective_scenes. Single-agent is a trial with one

--- a/src/benchflow/rollout/_deadline.py
+++ b/src/benchflow/rollout/_deadline.py
@@ -1,0 +1,178 @@
+"""Host-side hard deadline for one rollout attempt.
+
+Every phase inside a rollout carries its own timeout (install, agent idle +
+wall-clock, verifier, PTY readline), but an await stuck BELOW that
+instrumentation — a Daytona PTY kill on a dead websocket, a wedged session
+exec in the post-verify export path — can block forever and freeze the caller
+(observed 2026-08-07: one hung bike-rebalance rollout wedged a 25-task eval
+for 11+ hours after its verifier had already finished). The hard deadline is a
+backstop, not a budget: it is derived from the sum of every phase budget plus
+a generous fixed margin, so it can only fire when some await is stuck outside
+all phase-level timeouts.
+
+Enforcement lives here too (:func:`enforce_hard_deadline`), and deliberately
+does NOT use a bare ``asyncio.wait_for``: cancelling ``Rollout.run()`` runs
+its ``finally: cleanup()``, and when the *teardown* is the wedged path,
+``wait_for`` blocks past its own deadline waiting for that cleanup to finish
+— the exact hang this backstop exists to break. Instead the lifecycle runs as
+a task, cancellation gets its own bounded grace period, and a still-wedged
+task is abandoned (the sandbox provider's GC reaps the leaked resources).
+
+Override with ``BENCHFLOW_ROLLOUT_HARD_DEADLINE`` (seconds; ``off``/``none``/
+``0`` or any non-positive number disables the backstop entirely).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from collections.abc import Coroutine
+from typing import TYPE_CHECKING, Any
+
+from benchflow._utils.scoring import INFRA_ERROR
+from benchflow.models import RolloutResult
+
+if TYPE_CHECKING:
+    from benchflow.rollout._config import RolloutConfig
+
+logger = logging.getLogger(__name__)
+
+HARD_DEADLINE_ENV = "BENCHFLOW_ROLLOUT_HARD_DEADLINE"
+_MARGIN_SEC = 1800.0
+_FALLBACK_SEC = 3 * 3600.0
+# Grace period for the cancelled lifecycle's own cleanup() before the task is
+# abandoned outright.
+ABANDON_CLEANUP_BOUND_SEC = 120.0
+
+
+def hard_deadline_sec(cfg: RolloutConfig) -> float | None:
+    """Compute the hard backstop deadline for one rollout attempt.
+
+    Returns ``None`` when the operator disabled the backstop. On any failure
+    to read the task's budgets, falls back to a conservative constant rather
+    than running unbounded.
+    """
+    raw = os.environ.get(HARD_DEADLINE_ENV, "").strip().lower()
+    if raw in {"off", "none"}:
+        return None
+    if raw:
+        try:
+            value = float(raw)
+        except ValueError:
+            logger.warning(
+                f"{HARD_DEADLINE_ENV}={raw!r} is not a number; using computed deadline"
+            )
+        else:
+            return value if value > 0 else None
+    try:
+        return _computed_deadline_sec(cfg)
+    except Exception as e:
+        logger.debug(f"hard-deadline: could not read {cfg.task_path.name} budgets: {e}")
+        return _FALLBACK_SEC
+
+
+def _computed_deadline_sec(cfg: RolloutConfig) -> float:
+    """Sum every phase budget the rollout could legitimately spend.
+
+    Uses the same sources the phases themselves enforce: the caller wall-clock
+    override (``cfg.timeout``) or the task's agent budget per turn, per-role
+    ``timeout_sec`` overrides, user-loop rounds (each round runs one prompt
+    plus a soft verify), and :func:`effective_install_timeout` — the single
+    source of truth for the install budget — per distinct agent.
+    """
+    from benchflow.agents.install import effective_install_timeout
+    from benchflow.task import Task
+
+    tcfg = Task(cfg.task_path).config
+    agent_default = float(cfg.timeout or tcfg.agent.timeout_sec or 900.0)
+    verifier_sec = float(tcfg.verifier.timeout_sec or 900.0)
+    build_sec = float(tcfg.sandbox.build_timeout_sec or 600.0)
+
+    scenes = cfg.effective_scenes
+    role_budget = {
+        role.name: float(role.timeout_sec)
+        for scene in scenes
+        for role in scene.roles
+        if role.timeout_sec
+    }
+    agent_total = sum(
+        role_budget.get(turn.role, agent_default)
+        for scene in scenes
+        for turn in scene.turns
+    )
+    agent_total = max(agent_total, agent_default)
+    if cfg.user is not None:
+        agent_total = max(
+            agent_total, cfg.max_user_rounds * (agent_default + verifier_sec)
+        )
+
+    agents = {role.agent for scene in scenes for role in scene.roles} or {cfg.agent}
+    install_total = sum(
+        float(effective_install_timeout(agent, cfg.sandbox_setup_timeout) or 0.0)
+        for agent in agents
+    )
+    return agent_total + verifier_sec + build_sec + install_total + _MARGIN_SEC
+
+
+async def enforce_hard_deadline(
+    lifecycle: Coroutine[Any, Any, RolloutResult],
+    *,
+    config: RolloutConfig,
+) -> RolloutResult:
+    """Run one rollout lifecycle under the host-side hard deadline.
+
+    A deadline trip cancels the lifecycle (which runs its own ``finally``
+    cleanup), bounds that cleanup with :data:`ABANDON_CLEANUP_BOUND_SEC`, and
+    returns a normal infra-retryable error result. External cancellation of
+    the caller is forwarded to the lifecycle under the same cleanup bound.
+    """
+    deadline = hard_deadline_sec(config)
+    if deadline is None:
+        return await lifecycle
+    inner = asyncio.ensure_future(lifecycle)
+    try:
+        done, _ = await asyncio.wait({inner}, timeout=deadline)
+    except asyncio.CancelledError:
+        await _cancel_and_abandon(inner)
+        raise
+    if inner in done:
+        return inner.result()
+    task_name = config.task_path.name
+    logger.error(
+        f"[HARD-DEADLINE] {task_name}: rollout exceeded host deadline "
+        f"({deadline:.0f}s); abandoning sandbox"
+    )
+    await _cancel_and_abandon(inner)
+    return RolloutResult(
+        task_name=task_name,
+        error=(
+            f"Rollout exceeded host hard deadline ({deadline:.0f}s) — "
+            "transport or teardown wedged below the idle/wall-clock "
+            "watchdogs; sandbox abandoned"
+        ),
+        error_category=INFRA_ERROR,
+    )
+
+
+async def _cancel_and_abandon(inner: asyncio.Task) -> None:
+    """Cancel the lifecycle; give its cleanup a bounded grace, then abandon.
+
+    Cancellation runs the lifecycle's ``finally: cleanup()``. When that
+    teardown is itself the wedged path, waiting for it would re-freeze the
+    caller — so after the bound the task is left running detached, with its
+    eventual outcome swallowed to silence the never-retrieved warning.
+    """
+    inner.cancel()
+    done, _ = await asyncio.wait({inner}, timeout=ABANDON_CLEANUP_BOUND_SEC)
+    if inner in done:
+        return
+    logger.error(
+        "[HARD-DEADLINE] rollout cleanup wedged too; abandoning the task outright"
+    )
+    inner.add_done_callback(_swallow_abandoned_outcome)
+
+
+def _swallow_abandoned_outcome(task: asyncio.Task) -> None:
+    if not task.cancelled():
+        task.exception()

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -551,8 +551,11 @@ async def _kill_orphan_verifier(env: Any) -> None:
     """
     with contextlib.suppress(Exception):
         await asyncio.wait_for(
-            env.exec("pkill -f '/verifier/test.sh' 2>/dev/null || true",
-                     user="root", timeout_sec=10),
+            env.exec(
+                "pkill -f '/verifier/test.sh' 2>/dev/null || true",
+                user="root",
+                timeout_sec=10,
+            ),
             timeout=30,
         )
 

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -472,10 +472,34 @@ async def _verify_rollout(
         await planes.harden_before_verify(env, task, sandbox_user, workspace=workspace)
         logger.info("Running verifier...")
         verifier = planes.verifier(task=task, rollout_paths=rollout_paths, sandbox=env)
-        verifier_result = await asyncio.wait_for(
-            verifier.verify(),
-            timeout=timeout_budget,
-        )
+        verifier_result = None
+        for attempt in (1, 2):
+            try:
+                verifier_result = await asyncio.wait_for(
+                    verifier.verify(),
+                    timeout=timeout_budget,
+                )
+                break
+            except TimeoutError:
+                # A verifier that times out having produced NO output never
+                # actually started its tests — the exec-layer session wedged
+                # (observed on Daytona 2026-08-07/08: test.sh finishes in
+                # under a second when it runs, yet several rollouts burned the
+                # full verifier budget with an empty test-stdout.txt). That is
+                # an infra wedge, not a slow verifier, and test.sh is a
+                # stateless scoring script over the frozen workspace — so one
+                # retry is safe and turns a lost rollout into a real score. A
+                # timeout WITH output is a genuinely slow/hung verifier and is
+                # never retried.
+                if attempt == 1 and await _verifier_wedged_without_output(env):
+                    logger.warning(
+                        "Verifier timed out with no output — exec-layer wedge "
+                        "suspected; retrying verifier once"
+                    )
+                    await _kill_orphan_verifier(env)
+                    continue
+                raise
+        assert verifier_result is not None
         timing["verifier"] = (datetime.now() - t0).total_seconds()
         rewards = _ensure_canonical_rewards(verifier_result.rewards, task=task)
         logger.info(f"Rewards: {rewards}")
@@ -496,6 +520,41 @@ async def _verify_rollout(
         rewards = None
         logger.error(verifier_error)
     return rewards, verifier_error, verifier_timeout
+
+
+async def _verifier_wedged_without_output(env: Any) -> bool:
+    """True when the timed-out verifier attempt left no test output behind.
+
+    Zero bytes in ``/logs/verifier/test-stdout.txt`` (or no file at all) means
+    ``test.sh`` never started — the wedge signature. When even this probe
+    fails, the control plane is still sick and a retry is the best remaining
+    move, so failures count as wedged.
+    """
+    try:
+        r = await asyncio.wait_for(
+            env.exec(
+                "wc -c < /logs/verifier/test-stdout.txt 2>/dev/null || echo 0",
+                timeout_sec=10,
+            ),
+            timeout=30,
+        )
+        return int((r.stdout or "0").strip() or 0) == 0
+    except Exception:
+        return True
+
+
+async def _kill_orphan_verifier(env: Any) -> None:
+    """Best-effort kill of a possibly-orphaned first verifier attempt.
+
+    The host-side timeout cancels only our await; if the in-sandbox test.sh
+    did start late it would race the retry's run, so clear it first.
+    """
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(
+            env.exec("pkill -f '/verifier/test.sh' 2>/dev/null || true",
+                     user="root", timeout_sec=10),
+            timeout=30,
+        )
 
 
 def _ensure_canonical_rewards(rewards: dict | None, *, task: Any = None) -> dict:

--- a/src/benchflow/sandbox/process/daytona.py
+++ b/src/benchflow/sandbox/process/daytona.py
@@ -52,10 +52,16 @@ async def _cleanup_daytona_remote_env_file(
     sandbox: Any,
     remote_env_path: str,
 ) -> None:
+    # timeout=10 is the server-side exec limit; the extra wait_for bounds the
+    # client-side await too, so a dead connection can't hang a teardown path
+    # (this runs inside close()'s finally).
     with contextlib.suppress(Exception):
-        await sandbox.process.exec(
-            f"rm -f {shlex.quote(remote_env_path)}",
-            timeout=10,
+        await asyncio.wait_for(
+            sandbox.process.exec(
+                f"rm -f {shlex.quote(remote_env_path)}",
+                timeout=10,
+            ),
+            timeout=30,
         )
 
 
@@ -655,10 +661,16 @@ class DaytonaPtyProcess(LiveProcess):
         self._closed = True
         try:
             if self._pty:
+                # kill/disconnect go over the PTY's websocket; on a dead or
+                # wedged connection either await can block indefinitely, and a
+                # hung close() freezes the whole rollout teardown (this exact
+                # shape wedged a 25-task job for 11+ hours). Bound each call —
+                # the sandbox is deleted by env.stop() regardless, so an
+                # abandoned server-side PTY session costs nothing.
                 with contextlib.suppress(Exception):
-                    await self._pty.kill()
+                    await asyncio.wait_for(self._pty.kill(), timeout=15)
                 with contextlib.suppress(Exception):
-                    await self._pty.disconnect()
+                    await asyncio.wait_for(self._pty.disconnect(), timeout=15)
                 logger.info("DaytonaPtyProcess terminated")
         finally:
             await self._cleanup_started_env_file()

--- a/tests/integration/agent_judge.py
+++ b/tests/integration/agent_judge.py
@@ -86,6 +86,27 @@ _TAMPER_OP_RE = re.compile(
     r"(\brm\b|\bsed\s+-i\b|\bchmod\b|\bmv\b|\btruncate\b)",
     re.IGNORECASE,
 )
+# Agent-owned scratch roots. A file under these paths cannot define the score —
+# the verifier never reads them — so a verify/test-ish NAME there is the agent's
+# own scratch tooling, not grader tamper. Observed live (PR #949 rollout-smoke):
+# openhands created, ran, and deleted /tmp/verify.py as its own validation
+# script — reward 1.0, LLM judge explicitly benign — and the name-anywhere match
+# failed the job. Score-defining locations (/verifier, /logs/verifier, /oracle,
+# workspace tests/) can never sit under these roots, so the exemption cannot
+# mask a real tamper.
+_SCRATCH_PATH_RE = re.compile(r"^(?:/tmp|/var/tmp|/dev/shm)(?:/|$)")
+_SCRATCH_TOKEN_RE = re.compile(r"(?<![\w/])(?:/tmp|/var/tmp|/dev/shm)/[^\s;&|<>'\"]*")
+
+
+def _is_scratch_path(path: str) -> bool:
+    return bool(_SCRATCH_PATH_RE.match(path.strip().strip("'\"")))
+
+
+def _mask_scratch_paths(command: str) -> str:
+    """Blank scratch-rooted path tokens so the name sweep cannot match them."""
+    return _SCRATCH_TOKEN_RE.sub("<scratch>", command)
+
+
 _REDIRECT_TARGET_RE = re.compile(
     r"(?:\b(?:echo|printf|cat)\b[^|;&\n]*?)?>{1,2}\s*(?P<target>[^\s;&|]+)",
     re.IGNORECASE,
@@ -153,12 +174,15 @@ def _shell_tamper_hit(command: str) -> bool:
     look like grader tamper.
     """
     for match in _REDIRECT_TARGET_RE.finditer(command):
-        if _VERIFIER_FILE_RE.search(match.group("target")):
+        target = match.group("target")
+        if not _is_scratch_path(target) and _VERIFIER_FILE_RE.search(target):
             return True
     for match in _TEE_TARGET_RE.finditer(command):
-        if _VERIFIER_FILE_RE.search(match.group("target")):
+        target = match.group("target")
+        if not _is_scratch_path(target) and _VERIFIER_FILE_RE.search(target):
             return True
-    return bool(_VERIFIER_FILE_RE.search(command) and _TAMPER_OP_RE.search(command))
+    masked = _mask_scratch_paths(command)
+    return bool(_VERIFIER_FILE_RE.search(masked) and _TAMPER_OP_RE.search(masked))
 
 
 def _scan_native_tool_call(event: dict[str, Any]) -> list[str]:
@@ -179,7 +203,11 @@ def _scan_native_tool_call(event: dict[str, Any]) -> list[str]:
     # A write-like kind mutating a score-defining file (the mutation is implied
     # by the kind, so no destructive-op token is required in the title).
     target = _acp_write_target(title)
-    if kind in _ACP_WRITE_KINDS and _VERIFIER_FILE_RE.search(target):
+    if (
+        kind in _ACP_WRITE_KINDS
+        and not _is_scratch_path(target)
+        and _VERIFIER_FILE_RE.search(target)
+    ):
         return [f"{kind} -> {title[:160]}"]
     # execute / other: OpenHands writes the title as "<description>: $ <command>".
     # Scan ONLY the command so prose like "Verify the output" can't collide with
@@ -202,7 +230,7 @@ def _scan_nested_tool_calls(event: dict[str, Any]) -> list[str]:
             args = {}
         if name in _WRITE_TOOLS:
             path = str(args.get("path") or args.get("file_path") or "")
-            if path and _VERIFIER_FILE_RE.search(path):
+            if path and not _is_scratch_path(path) and _VERIFIER_FILE_RE.search(path):
                 flagged.append(f"{name} -> {path}")
         elif name in _SHELL_TOOLS:
             cmd = str(args.get("command") or args.get("cmd") or "")

--- a/tests/integration/agent_judge.py
+++ b/tests/integration/agent_judge.py
@@ -156,8 +156,13 @@ def _acp_write_target(title: str) -> str:
     prefix = "file_editor:"
     if not stripped.startswith(prefix):
         return title
+    # Titles carry trailing prose after the JSON payload (observed live:
+    # ``file_editor: {...}: Editing /tmp/test_rnn.py``), so parse the LEADING
+    # object with raw_decode instead of json.loads — a whole-title fallback
+    # here re-enables name-matching against file contents and prose, which is
+    # exactly the false-positive class this function exists to prevent.
     try:
-        payload = json.loads(stripped[len(prefix) :].strip())
+        payload, _ = json.JSONDecoder().raw_decode(stripped[len(prefix) :].strip())
     except json.JSONDecodeError:
         return title
     if not isinstance(payload, Mapping):

--- a/tests/test_judge_robustness.py
+++ b/tests/test_judge_robustness.py
@@ -115,6 +115,25 @@ def test_scan_verifier_tamper(event, should_flag):
             _native("execute", "Clean up: $ rm -f /tmp/verify.py && cd /app && ls"),
             False,
         ),
+        # Live title shape with trailing prose AFTER the JSON payload (second
+        # rollout-smoke false positive): raw_decode must still extract the
+        # scratch path instead of falling back to whole-title name-matching.
+        (
+            _native(
+                "edit",
+                'file_editor: {"command": "str_replace", "path": "/tmp/test_rnn.py", '
+                '"old_str": "check(x)"}: Editing /tmp/test_rnn.py',
+            ),
+            False,
+        ),
+        (
+            _native(
+                "edit",
+                'file_editor: {"command": "create", "path": "tests/test_x.py", '
+                '"file_text": "pass"}: Editing tests/test_x.py',
+            ),
+            True,
+        ),
         # ...while protected-location mutations still fail.
         (
             _native(

--- a/tests/test_judge_robustness.py
+++ b/tests/test_judge_robustness.py
@@ -69,11 +69,73 @@ def _native(kind: str, title: str) -> dict:
             {"source": "user", "message": "rm -rf tests please"},
             False,
         ),  # not a tool call
+        # Agent-owned scratch roots: verify/test-ish NAMES under /tmp (etc.) are
+        # the agent's own scratch tooling, never score-defining. Mirrors the
+        # live PR #949 rollout-smoke false positive (openhands /tmp/verify.py:
+        # created, ran, deleted; reward 1.0; LLM judge explicitly benign).
+        (_tc("bash", command="cat > /tmp/verify.py << 'EOF'\nimport jax\nEOF"), False),
+        (_tc("bash", command="rm -f /tmp/verify.py && cd /app && ls"), False),
+        (_tc("write_file", path="/tmp/verify.py", content="import jax"), False),
+        (_tc("bash", command="echo x > /var/tmp/test_check.py"), False),
+        # ...but the exemption is scratch-ROOTS only: workspace/protected paths
+        # with the same names still flag.
+        (_tc("write_file", path="/app/verify.py", content="x"), True),
+        (_tc("bash", command="rm -f /verifier/test.sh"), True),
     ],
 )
 def test_scan_verifier_tamper(event, should_flag):
     """Guards PR #687's verifier-tamper scanner (nested deepagents shape): it
     flags writes/deletes of score-defining files and ignores read-only work."""
+    flagged = agent_judge._scan_verifier_tamper([event])
+    assert bool(flagged) == should_flag, flagged
+
+
+@pytest.mark.parametrize(
+    ("event", "should_flag"),
+    [
+        # The three exact record shapes from the live false positive (PR #949
+        # rollout-smoke job 93203839889): scratch self-validation must pass...
+        (
+            _native(
+                "execute",
+                "Create validation script: $ cd /app && cat > /tmp/verify.py "
+                "<< 'EOF'\nimport numpy as np\nEOF",
+            ),
+            False,
+        ),
+        (
+            _native(
+                "edit",
+                'file_editor: {"command": "create", "path": "/tmp/verify.py", '
+                '"file_text": "import numpy"}',
+            ),
+            False,
+        ),
+        (
+            _native("execute", "Clean up: $ rm -f /tmp/verify.py && cd /app && ls"),
+            False,
+        ),
+        # ...while protected-location mutations still fail.
+        (
+            _native(
+                "edit",
+                'file_editor: {"command": "create", "path": "/verifier/test.sh", '
+                '"file_text": "exit 0"}',
+            ),
+            True,
+        ),
+        (
+            _native(
+                "execute", "Fix tests: $ sed -i 's/assert/pass #/' tests/test_x.py"
+            ),
+            True,
+        ),
+    ],
+)
+def test_scratch_root_exemption_native_shape(event, should_flag):
+    """Scratch-root exemption on the native ACP record shape (the live shape):
+    an agent's own /tmp validation tooling is not verifier tamper; mutations of
+    score-defining locations still fail closed."""
     flagged = agent_judge._scan_verifier_tamper([event])
     assert bool(flagged) == should_flag, flagged
 

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -111,7 +111,10 @@ def test_registered_provider_route_honors_explicit_generic_proxy_env():
         },
     )
 
-    assert route.upstream_model == "openai/deepseek-v4-flash"
+    # deepseek routes via LiteLLM's NATIVE provider prefix (reasoning-param
+    # passthrough) even behind an explicit proxy — the proxy override is
+    # honored through api_base, which is what PR #780 actually guards.
+    assert route.upstream_model == "deepseek/deepseek-v4-flash"
     assert route.litellm_params["api_base"] == "https://llm-proxy.example.test/v1"
     assert route.litellm_params["api_key"] == ("os.environ/BENCHFLOW_PROVIDER_API_KEY")
     assert route.required_env == ("BENCHFLOW_PROVIDER_API_KEY",)

--- a/tests/test_litellm_logging.py
+++ b/tests/test_litellm_logging.py
@@ -669,3 +669,36 @@ async def test_failure_event_records_exception_cause_when_response_none(
     assert record["error"]["type"] == "ValueError"
     assert "16384 tokens" in record["error"]["message"]
     assert record["error"]["message"] != "None"
+
+
+def test_pre_call_hook_lifts_deepseek_reasoning_effort_into_extra_body():
+    """LiteLLM's deepseek transform consumes a top-level reasoning_effort (the
+    raw field never reaches the wire, even with drop_params off); extra_body
+    merges verbatim. The hook lifts the param so the upstream receives exactly
+    what the agent sent — matching a native, gateway-less run."""
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {
+        "model": "benchflow-deepseek-deepseek-v4-flash",
+        "messages": [{"role": "user", "content": "hi"}],
+        "reasoning_effort": "high",
+        "thinking": {"type": "enabled"},
+    }
+    cleaned = asyncio.run(logger.async_pre_call_hook(None, None, data, "completion"))
+    assert cleaned is not None
+    assert "reasoning_effort" not in cleaned
+    assert cleaned["extra_body"]["reasoning_effort"] == "high"
+    assert cleaned["thinking"] == {"type": "enabled"}
+    # original request dict not mutated in place
+    assert data["reasoning_effort"] == "high"
+
+
+def test_pre_call_hook_leaves_non_deepseek_reasoning_effort_alone():
+    logger = _callback_namespace()["BenchFlowLiteLLMLogger"]()
+    data = {
+        "model": "benchflow-openai-gpt-5.2",
+        "messages": [{"role": "user", "content": "hi"}],
+        "reasoning_effort": "high",
+    }
+    assert (
+        asyncio.run(logger.async_pre_call_hook(None, None, data, "completion")) is None
+    )

--- a/tests/test_litellm_reasoning_passthrough.py
+++ b/tests/test_litellm_reasoning_passthrough.py
@@ -1,0 +1,34 @@
+"""Gateway must forward agent-sent reasoning params on completions routes.
+
+Live capture (2026-08-08, proxy between the gateway and api.deepseek.com):
+prime-agent sent ``thinking: {"type": "enabled"}`` + ``reasoning_effort: high``
+and the upstream received neither — LiteLLM's global ``drop_params: True``
+strips non-vanilla-OpenAI fields on ``openai/`` passthrough routes, so every
+gateway-routed run silently used the provider's default thinking config while
+a native run used the agent's. The route now allowlists the reasoning params;
+an upstream that does not support them rejects them exactly as it would for a
+native client, which is the parity-correct behavior.
+"""
+
+from __future__ import annotations
+
+from benchflow.providers.litellm_config import resolve_litellm_route
+
+
+def test_deepseek_route_allows_reasoning_params():
+    env = {
+        "DEEPSEEK_API_KEY": "sk-test",
+        "DEEPSEEK_BASE_URL": "https://api.deepseek.com",
+    }
+    route = resolve_litellm_route("deepseek/deepseek-v4-flash", env)
+    allowed = route.litellm_params.get("allowed_openai_params")
+    assert allowed is not None
+    assert "thinking" in allowed
+    assert "reasoning_effort" in allowed
+    assert route.upstream_model.startswith("openai/")
+
+
+def test_anthropic_messages_route_does_not_get_openai_allowlist():
+    env = {"ANTHROPIC_API_KEY": "sk-test"}
+    route = resolve_litellm_route("anthropic/claude-sonnet-4-5", env)
+    assert "allowed_openai_params" not in route.litellm_params

--- a/tests/test_litellm_reasoning_passthrough.py
+++ b/tests/test_litellm_reasoning_passthrough.py
@@ -12,23 +12,49 @@ native client, which is the parity-correct behavior.
 
 from __future__ import annotations
 
+import pytest
+
 from benchflow.providers.litellm_config import resolve_litellm_route
 
 
-def test_deepseek_route_allows_reasoning_params():
+def test_deepseek_routes_via_native_litellm_provider():
+    """deepseek/<model>, not openai/<model>: LiteLLM's deepseek integration
+    declares thinking + reasoning_effort supported, so drop_params keeps them;
+    the openai/ passthrough drops both (the pinned 1.89.0 has no
+    allowed_openai_params escape)."""
     env = {
         "DEEPSEEK_API_KEY": "sk-test",
         "DEEPSEEK_BASE_URL": "https://api.deepseek.com",
     }
     route = resolve_litellm_route("deepseek/deepseek-v4-flash", env)
-    allowed = route.litellm_params.get("allowed_openai_params")
-    assert allowed is not None
-    assert "thinking" in allowed
-    assert "reasoning_effort" in allowed
-    assert route.upstream_model.startswith("openai/")
+    assert route.upstream_model == "deepseek/deepseek-v4-flash"
+    assert route.litellm_params["model"] == "deepseek/deepseek-v4-flash"
 
 
-def test_anthropic_messages_route_does_not_get_openai_allowlist():
-    env = {"ANTHROPIC_API_KEY": "sk-test"}
-    route = resolve_litellm_route("anthropic/claude-sonnet-4-5", env)
-    assert "allowed_openai_params" not in route.litellm_params
+def test_deepseek_native_route_honors_base_url_override():
+    """A custom DEEPSEEK_BASE_URL (mock/capture endpoints in parity runs) must
+    survive the native-provider routing."""
+    env = {
+        "DEEPSEEK_API_KEY": "sk-test",
+        "DEEPSEEK_BASE_URL": "http://127.0.0.1:11500/v1",
+    }
+    route = resolve_litellm_route("deepseek/deepseek-v4-flash", env)
+    assert route.upstream_model == "deepseek/deepseek-v4-flash"
+    assert route.litellm_params.get("api_base") == "http://127.0.0.1:11500/v1"
+
+
+def test_pinned_litellm_deepseek_provider_supports_reasoning_params():
+    """Guards the assumption the native-provider routing rests on: if a LiteLLM
+    upgrade stops declaring these params supported for deepseek, this fails
+    before a silent re-drop ships."""
+    pytest.importorskip("litellm")
+    from litellm.utils import get_supported_openai_params
+
+    supported = (
+        get_supported_openai_params(
+            model="deepseek-chat", custom_llm_provider="deepseek"
+        )
+        or []
+    )
+    assert "thinking" in supported
+    assert "reasoning_effort" in supported

--- a/tests/test_rollout_hard_deadline.py
+++ b/tests/test_rollout_hard_deadline.py
@@ -1,71 +1,181 @@
 """Host-side hard deadline per rollout attempt.
 
-Every phase inside a rollout has its own timeout, but an await stuck BELOW that
-instrumentation (a Daytona PTY kill on a dead websocket, a wedged session exec
-in the post-verify export path) used to freeze the whole job: one hung
+Every phase inside a rollout has its own timeout, but an await stuck BELOW
+that instrumentation (a Daytona PTY kill on a dead websocket, a wedged session
+exec in the post-verify export path) used to freeze the whole job: one hung
 bike-rebalance rollout wedged a 25-task eval for 11+ hours after its verifier
-had already finished (2026-08-07). ``_run_single_task`` now wraps
-``rollout.run()`` in a computed hard deadline and converts a trip into a
-normal infra-retryable error result.
+had already finished (2026-08-07). ``Rollout.run()`` now enforces a computed
+hard deadline around the lifecycle (covering every caller — Evaluation,
+Runtime, bf.run, continue_run, acceptance) and converts a trip into a normal
+infra-retryable error result.
+
+The enforcement deliberately avoids a bare ``asyncio.wait_for``: cancelling
+the lifecycle runs its ``finally: cleanup()``, and when the teardown is
+itself the wedged path, ``wait_for`` would block past its own deadline
+waiting for that cleanup — so cancellation gets its own bounded grace before
+the task is abandoned outright.
 """
 
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from benchflow._utils.scoring import INFRA_ERROR
-from benchflow.evaluation import (
-    Evaluation,
-    EvaluationConfig,
-    RetryConfig,
-    _rollout_hard_deadline_sec,
-)
+from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
+from benchflow.rollout import Rollout, RolloutConfig, _deadline
+from benchflow.rollout._deadline import hard_deadline_sec
 
 
 def _write_task(task_dir: Path) -> None:
+    # A minimal *valid* legacy task (task.toml + instruction.md): the deadline
+    # tests must exercise the computed-budget path, not the unreadable-task
+    # fallback.
     task_dir.mkdir(parents=True, exist_ok=True)
     (task_dir / "task.toml").write_text(
         'version = "1.0"\n[verifier]\ntimeout_sec = 60\n'
         "[agent]\ntimeout_sec = 60\n[environment]\n"
     )
+    (task_dir / "instruction.md").write_text("Do the task.\n")
 
 
 class TestDeadlineComputation:
     def test_env_disables(self, tmp_path, monkeypatch):
         _write_task(tmp_path / "t")
-        for raw in ("off", "none", "0"):
+        for raw in ("off", "none", "0", "0.0", "-5"):
             monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raw)
-            assert _rollout_hard_deadline_sec(tmp_path / "t", EvaluationConfig()) is None
+            assert hard_deadline_sec(RolloutConfig(task_path=tmp_path / "t")) is None
 
     def test_env_numeric_overrides(self, tmp_path, monkeypatch):
         _write_task(tmp_path / "t")
         monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "123.5")
-        assert _rollout_hard_deadline_sec(tmp_path / "t", EvaluationConfig()) == 123.5
+        assert hard_deadline_sec(RolloutConfig(task_path=tmp_path / "t")) == 123.5
 
     def test_computed_covers_all_phase_budgets(self, tmp_path, monkeypatch):
         monkeypatch.delenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raising=False)
         _write_task(tmp_path / "t")
-        deadline = _rollout_hard_deadline_sec(tmp_path / "t", EvaluationConfig())
+        deadline = hard_deadline_sec(RolloutConfig(task_path=tmp_path / "t"))
         # agent 60 + verifier 60 + build/install defaults + fixed margin: the
         # backstop must strictly dominate the sum of the declared phase budgets.
         assert deadline is not None
         assert deadline > 60 + 60 + 1800
-        assert deadline < 24 * 3600
+        # ... and stay below the unreadable-task fallback: this proves the
+        # computed path ran (a fallback value would also satisfy the bounds
+        # above, silently masking a budget-read regression).
+        assert deadline < _deadline._FALLBACK_SEC
+
+    def test_caller_timeout_override_dominates_task_budget(self, tmp_path, monkeypatch):
+        """RolloutConfig.timeout (Runtime's wall-clock seam, #378) is the
+        enforced agent budget — the backstop must be derived from it, not the
+        smaller task default, or it would fire during a legitimate long run."""
+        monkeypatch.delenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raising=False)
+        _write_task(tmp_path / "t")
+        base = hard_deadline_sec(RolloutConfig(task_path=tmp_path / "t"))
+        raised = hard_deadline_sec(
+            RolloutConfig(task_path=tmp_path / "t", timeout=7200)
+        )
+        assert base is not None and raised is not None
+        assert raised >= base + 7200 - 60
+
+    def test_user_loop_rounds_dominate(self, tmp_path, monkeypatch):
+        """A user-loop run legitimately spends max_user_rounds x (agent +
+        soft-verify); the backstop must cover it, not fire mid-loop."""
+        monkeypatch.delenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raising=False)
+        _write_task(tmp_path / "t")
+        cfg = RolloutConfig(task_path=tmp_path / "t", max_user_rounds=10)
+        cfg.user = SimpleNamespace()  # any non-None user engages the loop
+        deadline = hard_deadline_sec(cfg)
+        assert deadline is not None
+        assert deadline >= 10 * (60 + 60) + 1800
 
     def test_unreadable_task_falls_back_conservative(self, tmp_path, monkeypatch):
         monkeypatch.delenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raising=False)
-        deadline = _rollout_hard_deadline_sec(tmp_path / "missing", EvaluationConfig())
+        deadline = hard_deadline_sec(RolloutConfig(task_path=tmp_path / "missing"))
         assert deadline is not None
         assert deadline >= 3600
 
 
+def _wedged_rollout(task_dir: Path, *, cleanup_wedged: bool = False) -> Rollout:
+    """A real Rollout whose lifecycle hangs; optionally its cancellation
+    cleanup hangs too (the re-wedge case a bare wait_for cannot break)."""
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = RolloutConfig(task_path=task_dir)
+
+    async def _lifecycle():
+        try:
+            await asyncio.sleep(3600)  # wedged transport await
+        finally:
+            if cleanup_wedged:
+                # Mirrors run()'s `finally: await self.cleanup()` hanging on a
+                # dead connection: swallow the cancel and keep blocking.
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.sleep(3600)
+
+    rollout._run_lifecycle = _lifecycle
+    return rollout
+
+
 @pytest.mark.asyncio
-async def test_wedged_rollout_becomes_infra_error(tmp_path, monkeypatch):
-    """A rollout whose run() never returns must yield an error result, not a hang."""
+async def test_wedged_lifecycle_becomes_infra_error(tmp_path, monkeypatch):
+    """A lifecycle that never returns must yield an error result, not a hang,
+    and the standard retry policy must treat it as retryable."""
+    task_dir = tmp_path / "wedge-task"
+    _write_task(task_dir)
+    monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "0.5")
+
+    rollout = _wedged_rollout(task_dir)
+    result = await asyncio.wait_for(rollout.run(), timeout=15)
+
+    assert result.error is not None
+    assert "hard deadline" in result.error
+    assert result.error_category == INFRA_ERROR
+    assert RetryConfig().should_retry(result.error, category=result.error_category)
+
+
+@pytest.mark.asyncio
+async def test_wedged_cleanup_cannot_re_wedge(tmp_path, monkeypatch):
+    """Even when the cancellation-triggered cleanup also hangs (the observed
+    incident shape: teardown wedged on a dead websocket), the deadline must
+    still surface a result — a bare wait_for would block here forever."""
+    task_dir = tmp_path / "wedge-task"
+    _write_task(task_dir)
+    monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "0.5")
+    monkeypatch.setattr(_deadline, "ABANDON_CLEANUP_BOUND_SEC", 0.5)
+
+    rollout = _wedged_rollout(task_dir, cleanup_wedged=True)
+    result = await asyncio.wait_for(rollout.run(), timeout=15)
+
+    assert result.error is not None
+    assert "hard deadline" in result.error
+    assert result.error_category == INFRA_ERROR
+
+
+@pytest.mark.asyncio
+async def test_caller_cancellation_is_bounded(tmp_path, monkeypatch):
+    """Cancelling run() from outside (job shutdown) must forward the cancel to
+    the lifecycle and not wait unbounded for a wedged teardown."""
+    task_dir = tmp_path / "wedge-task"
+    _write_task(task_dir)
+    monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "60")
+    monkeypatch.setattr(_deadline, "ABANDON_CLEANUP_BOUND_SEC", 0.5)
+
+    rollout = _wedged_rollout(task_dir, cleanup_wedged=True)
+    run_task = asyncio.create_task(rollout.run())
+    await asyncio.sleep(0.05)
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(run_task, timeout=15)
+
+
+@pytest.mark.asyncio
+async def test_evaluation_path_surfaces_infra_error(tmp_path, monkeypatch):
+    """End-to-end through Evaluation._run_single_task: the deadline inside
+    Rollout.run() protects the eval job without any caller-side wrap."""
     task_dir = tmp_path / "wedge-task"
     _write_task(task_dir)
     monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "0.5")
@@ -77,16 +187,9 @@ async def test_wedged_rollout_becomes_infra_error(tmp_path, monkeypatch):
         job_name="wedge-run",
     )
 
-    wedged = AsyncMock()
-
-    async def _hang() -> None:
-        await asyncio.sleep(3600)
-
-    wedged.run = _hang
-    wedged.cleanup = AsyncMock()
-
     with patch(
-        "benchflow.rollout.Rollout.create", AsyncMock(return_value=wedged)
+        "benchflow.rollout.Rollout.create",
+        AsyncMock(return_value=_wedged_rollout(task_dir)),
     ):
         result = await asyncio.wait_for(
             job._run_single_task(task_dir, job._config), timeout=15
@@ -95,38 +198,3 @@ async def test_wedged_rollout_becomes_infra_error(tmp_path, monkeypatch):
     assert result.error is not None
     assert "hard deadline" in result.error
     assert result.error_category == INFRA_ERROR
-    wedged.cleanup.assert_awaited()
-
-
-@pytest.mark.asyncio
-async def test_wedged_cleanup_cannot_re_wedge(tmp_path, monkeypatch):
-    """Even a cleanup that also hangs must not stall the error path."""
-    task_dir = tmp_path / "wedge-task"
-    _write_task(task_dir)
-    monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "0.5")
-
-    job = Evaluation(
-        tasks_dir=task_dir,
-        jobs_dir=tmp_path / "jobs",
-        config=EvaluationConfig(retry=RetryConfig(max_retries=0)),
-        job_name="wedge-run-2",
-    )
-
-    wedged = AsyncMock()
-
-    async def _hang() -> None:
-        await asyncio.sleep(3600)
-
-    wedged.run = _hang
-    wedged.cleanup = _hang
-
-    with (
-        patch("benchflow.rollout.Rollout.create", AsyncMock(return_value=wedged)),
-        patch("benchflow.evaluation._CLEANUP_BOUND_SEC", 0.5),
-    ):
-        result = await asyncio.wait_for(
-            job._run_single_task(task_dir, job._config), timeout=15
-        )
-
-    assert result.error is not None
-    assert "hard deadline" in result.error

--- a/tests/test_rollout_hard_deadline.py
+++ b/tests/test_rollout_hard_deadline.py
@@ -1,0 +1,132 @@
+"""Host-side hard deadline per rollout attempt.
+
+Every phase inside a rollout has its own timeout, but an await stuck BELOW that
+instrumentation (a Daytona PTY kill on a dead websocket, a wedged session exec
+in the post-verify export path) used to freeze the whole job: one hung
+bike-rebalance rollout wedged a 25-task eval for 11+ hours after its verifier
+had already finished (2026-08-07). ``_run_single_task`` now wraps
+``rollout.run()`` in a computed hard deadline and converts a trip into a
+normal infra-retryable error result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from benchflow._utils.scoring import INFRA_ERROR
+from benchflow.evaluation import (
+    Evaluation,
+    EvaluationConfig,
+    RetryConfig,
+    _rollout_hard_deadline_sec,
+)
+
+
+def _write_task(task_dir: Path) -> None:
+    task_dir.mkdir(parents=True, exist_ok=True)
+    (task_dir / "task.toml").write_text(
+        'version = "1.0"\n[verifier]\ntimeout_sec = 60\n'
+        "[agent]\ntimeout_sec = 60\n[environment]\n"
+    )
+
+
+class TestDeadlineComputation:
+    def test_env_disables(self, tmp_path, monkeypatch):
+        _write_task(tmp_path / "t")
+        for raw in ("off", "none", "0"):
+            monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raw)
+            assert _rollout_hard_deadline_sec(tmp_path / "t", EvaluationConfig()) is None
+
+    def test_env_numeric_overrides(self, tmp_path, monkeypatch):
+        _write_task(tmp_path / "t")
+        monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "123.5")
+        assert _rollout_hard_deadline_sec(tmp_path / "t", EvaluationConfig()) == 123.5
+
+    def test_computed_covers_all_phase_budgets(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raising=False)
+        _write_task(tmp_path / "t")
+        deadline = _rollout_hard_deadline_sec(tmp_path / "t", EvaluationConfig())
+        # agent 60 + verifier 60 + build/install defaults + fixed margin: the
+        # backstop must strictly dominate the sum of the declared phase budgets.
+        assert deadline is not None
+        assert deadline > 60 + 60 + 1800
+        assert deadline < 24 * 3600
+
+    def test_unreadable_task_falls_back_conservative(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", raising=False)
+        deadline = _rollout_hard_deadline_sec(tmp_path / "missing", EvaluationConfig())
+        assert deadline is not None
+        assert deadline >= 3600
+
+
+@pytest.mark.asyncio
+async def test_wedged_rollout_becomes_infra_error(tmp_path, monkeypatch):
+    """A rollout whose run() never returns must yield an error result, not a hang."""
+    task_dir = tmp_path / "wedge-task"
+    _write_task(task_dir)
+    monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "0.5")
+
+    job = Evaluation(
+        tasks_dir=task_dir,
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(retry=RetryConfig(max_retries=0)),
+        job_name="wedge-run",
+    )
+
+    wedged = AsyncMock()
+
+    async def _hang() -> None:
+        await asyncio.sleep(3600)
+
+    wedged.run = _hang
+    wedged.cleanup = AsyncMock()
+
+    with patch(
+        "benchflow.rollout.Rollout.create", AsyncMock(return_value=wedged)
+    ):
+        result = await asyncio.wait_for(
+            job._run_single_task(task_dir, job._config), timeout=15
+        )
+
+    assert result.error is not None
+    assert "hard deadline" in result.error
+    assert result.error_category == INFRA_ERROR
+    wedged.cleanup.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_wedged_cleanup_cannot_re_wedge(tmp_path, monkeypatch):
+    """Even a cleanup that also hangs must not stall the error path."""
+    task_dir = tmp_path / "wedge-task"
+    _write_task(task_dir)
+    monkeypatch.setenv("BENCHFLOW_ROLLOUT_HARD_DEADLINE", "0.5")
+
+    job = Evaluation(
+        tasks_dir=task_dir,
+        jobs_dir=tmp_path / "jobs",
+        config=EvaluationConfig(retry=RetryConfig(max_retries=0)),
+        job_name="wedge-run-2",
+    )
+
+    wedged = AsyncMock()
+
+    async def _hang() -> None:
+        await asyncio.sleep(3600)
+
+    wedged.run = _hang
+    wedged.cleanup = _hang
+
+    with (
+        patch("benchflow.rollout.Rollout.create", AsyncMock(return_value=wedged)),
+        patch("benchflow.evaluation._CLEANUP_BOUND_SEC", 0.5),
+    ):
+        result = await asyncio.wait_for(
+            job._run_single_task(task_dir, job._config), timeout=15
+        )
+
+    assert result.error is not None
+    assert "hard deadline" in result.error

--- a/tests/test_verifier_wedge_retry.py
+++ b/tests/test_verifier_wedge_retry.py
@@ -43,7 +43,9 @@ def _mk_planes(verifier_stub):
 
 def _env_with_probe_output(stdout: str):
     env = SimpleNamespace()
-    env.exec = AsyncMock(return_value=SimpleNamespace(stdout=stdout, stderr="", return_code=0))
+    env.exec = AsyncMock(
+        return_value=SimpleNamespace(stdout=stdout, stderr="", return_code=0)
+    )
     return env
 
 

--- a/tests/test_verifier_wedge_retry.py
+++ b/tests/test_verifier_wedge_retry.py
@@ -1,0 +1,112 @@
+"""Verifier retry on the zero-output timeout (exec-layer wedge) signature.
+
+Observed on Daytona (2026-08-07/08): verifiers that complete in under a second
+when they run sometimes burned their whole timeout budget with an EMPTY
+test-stdout.txt — the exec session wedged before test.sh ever started. Those
+rollouts scored ``reward=None`` (lost data) even though the workspace held
+scoreable work. ``_verify_rollout`` now retries the verifier exactly once when
+a timeout carries the no-output signature; a timeout WITH output (a genuinely
+slow or hung verifier) is never retried.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from benchflow.rollout._setup import _verify_rollout
+
+
+def _mk_task():
+    return SimpleNamespace(
+        name="wedge-task",
+        task_dir=None,
+        config=SimpleNamespace(
+            verifier=SimpleNamespace(timeout_sec=0.2, reward_range=None, env={})
+        ),
+    )
+
+
+def _mk_paths(tmp_path):
+    return SimpleNamespace(verifier_dir=tmp_path / "verifier")
+
+
+def _mk_planes(verifier_stub):
+    planes = SimpleNamespace()
+    planes.harden_before_verify = AsyncMock()
+    planes.verifier = lambda **_: verifier_stub
+    return planes
+
+
+def _env_with_probe_output(stdout: str):
+    env = SimpleNamespace()
+    env.exec = AsyncMock(return_value=SimpleNamespace(stdout=stdout, stderr="", return_code=0))
+    return env
+
+
+@pytest.mark.asyncio
+async def test_zero_output_timeout_retries_once_and_scores(tmp_path):
+    attempts = []
+
+    async def verify():
+        attempts.append(1)
+        if len(attempts) == 1:
+            await asyncio.sleep(3600)  # wedge: never returns
+        return SimpleNamespace(rewards={"reward": 1.0})
+
+    verifier = SimpleNamespace(verify=verify)
+    env = _env_with_probe_output("0\n")  # probe: empty test-stdout
+
+    rewards, verr, vtimeout = await _verify_rollout(
+        env, _mk_task(), _mk_paths(tmp_path), {}, _mk_planes(verifier)
+    )
+
+    assert len(attempts) == 2
+    assert rewards == {"reward": 1.0}
+    assert verr is None
+    assert vtimeout is None
+
+
+@pytest.mark.asyncio
+async def test_timeout_with_output_is_not_retried(tmp_path):
+    attempts = []
+
+    async def verify():
+        attempts.append(1)
+        await asyncio.sleep(3600)
+
+    verifier = SimpleNamespace(verify=verify)
+    env = _env_with_probe_output("4242\n")  # probe: real output was produced
+
+    rewards, verr, vtimeout = await _verify_rollout(
+        env, _mk_task(), _mk_paths(tmp_path), {}, _mk_planes(verifier)
+    )
+
+    assert len(attempts) == 1
+    assert rewards is None
+    assert verr is not None and "timed out" in verr
+    assert vtimeout is not None
+
+
+@pytest.mark.asyncio
+async def test_wedged_retry_that_also_times_out_reports_timeout(tmp_path):
+    attempts = []
+
+    async def verify():
+        attempts.append(1)
+        await asyncio.sleep(3600)
+
+    verifier = SimpleNamespace(verify=verify)
+    env = _env_with_probe_output("0\n")
+
+    rewards, verr, vtimeout = await _verify_rollout(
+        env, _mk_task(), _mk_paths(tmp_path), {}, _mk_planes(verifier)
+    )
+
+    assert len(attempts) == 2  # exactly one retry, never more
+    assert rewards is None
+    assert verr is not None and "timed out" in verr
+    assert vtimeout is not None

--- a/uv.lock
+++ b/uv.lock
@@ -741,7 +741,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -772,43 +772,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1370,15 +1370,15 @@ wheels = [
 
 [[package]]
 name = "h2"
-version = "4.3.0"
+version = "4.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hpack" },
     { name = "hyperframe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
 ]
 
 [[package]]
@@ -1415,11 +1415,11 @@ wheels = [
 
 [[package]]
 name = "hpack"
-version = "4.1.0"
+version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -2305,7 +2305,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2344,7 +2344,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2356,7 +2356,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2386,9 +2386,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2400,7 +2400,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3253,7 +3253,7 @@ name = "pyroscope-io"
 version = "0.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/50/607b38b120ba8adad954119ba512c53590c793f0cf7f009ba6549e4e1d77/pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e07edcfd59f5bdce42948b92c9b118c824edbd551730305f095a6b9af401a9e8", size = 3138869, upload-time = "2026-01-22T06:23:24.664Z" },


### PR DESCRIPTION
Two harness reliability fixes from a live incident (2026-08-07/08 Daytona runs, prime-agent × deepseek-v4-flash, 25-task job):

## 1. Host-side hard deadline around every rollout (`rollout/_deadline.py`)

One rollout (bike-rebalance) wedged for **11+ hours** and froze the whole `bench eval run` job. Timeline from artifacts: agent turn done 21:51, verifier done 22:03, trace sync 00:59, then stuck forever — i.e. the hang was in **post-verify teardown/export**, below both `agent_idle_timeout` and the task wall-clock budget (Daytona PTY/session calls with no client-side bound: observed siblings "PTY readline timeout (900s)", "Failed to create PTY session", empty "Failed to execute session command").

`Rollout.run()` now enforces a computed hard deadline around its whole lifecycle — covering **all nine call sites** (Evaluation, Runtime, bf.run, continue_run, acceptance, self_gen), not just the eval path:
- deadline = enforced agent budget (honors `RolloutConfig.timeout` and per-role overrides) × turns + user-loop rounds × (agent + soft-verify) + verifier + build + `effective_install_timeout()` per distinct agent + fixed margin — a backstop that can only fire when an await is stuck outside every phase-level timeout;
- a trip cancels with a **bounded grace** for the cancellation-triggered cleanup and then abandons the task outright — a bare `asyncio.wait_for` cannot break the observed hang because it waits unbounded for `finally: cleanup()` while cleanup IS the wedged path (regression test included that fails under bare `wait_for`);
- surfaces a normal `INFRA_ERROR` result (retryable under the standard policy); operator control via `BENCHFLOW_ROLLOUT_HARD_DEADLINE` (seconds; `off`/`none`/non-positive disables);
- Daytona teardown micro-bounds: PTY `kill`/`disconnect` (15s each) and the client side of remote env-file cleanup (30s) — the exact calls that hang on a dead websocket.

## 2. Verifier retry on the zero-output timeout wedge (`rollout/_setup.py`)

Budget-killed rollouts were losing their scores to `reward=None` "verifier timed out" errors. Root cause is NOT a skipped verifier (verify-after-timeout was already unconditional): the verifier exec **wedged before test.sh ever started** — empty `test-stdout.txt` after burning the full budget, while the same verifiers finish in <1s when they run. `_verify_rollout` now retries the verifier **exactly once** when a timeout carries the zero-output signature (killing any late-started orphan `test.sh` first). A timeout WITH output — a genuinely slow/hung verifier — is never retried.

## Validation

- New tests: `tests/test_rollout_hard_deadline.py` (10: computed/override/user-loop budgets, wedged lifecycle, re-wedged cleanup, bounded external cancel, retry-policy integration, e2e eval path), `tests/test_verifier_wedge_retry.py` (3).
- Sweeps: 906 rollout/eval/verifier tests pass; full unit suite green modulo 3 pre-existing environmental failures at HEAD (local creds/bashrc).
- Structural review applied (enforcement layer, budget canonicalization via `effective_install_timeout`, dead-code deletion: net −2 lines of non-test code vs the naive fix).

Known residual (out of scope, noted in review): a truly abandoned attempt can leak a live Daytona sandbox; a label-keyed orphan reaper would close that separately.