### PR TITLE
fix(task): accept Harbor 1.3 [task] version field

### DIFF
--- a/src/benchflow/task/config.py
+++ b/src/benchflow/task/config.py
@@ -117,6 +117,16 @@ class PackageInfo(TaskConfigModel):
         ...,
         description="Package name in org/name format (e.g., 'benchflow/hello-world')",
     )
+    version: str = Field(
+        default="",
+        description=(
+            "Package version (Harbor schema 1.3 [task] field). Informational "
+            "only — recorded, never interpreted. Absent from this model it was "
+            "extra_forbidden, which made every Harbor-1.3 task authored by the "
+            "govbench/frontier-bench curation pipeline unloadable (2026-08-09: "
+            "all 6 tasks in the local corpus failed on exactly this field)."
+        ),
+    )
     description: str = Field(
         default="",
         description="Human-readable description of the task",

--- a/tests/test_task_config.py
+++ b/tests/test_task_config.py
@@ -89,6 +89,7 @@ artifacts = [{ source = "/logs/artifacts", destination = "artifacts" }]
 
 [task]
 name = "benchflow/harbor-parity"
+version = "1.0.0"
 description = "Exercises Harbor-compatible task.toml fields"
 authors = [{ name = "BenchFlow", email = "benchflow@example.com" }]
 keywords = ["parity", "task-md"]
@@ -167,6 +168,9 @@ env = { STEP = "scaffold" }
     assert cfg.schema_version == "1.3"
     assert cfg.task is not None
     assert cfg.task.name == "benchflow/harbor-parity"
+    # Harbor 1.3 [task] version — informational, recorded verbatim. Its absence
+    # made every govbench/frontier-bench curated task unloadable (2026-08-09).
+    assert cfg.task.version == "1.0.0"
     assert cfg.metadata["custom"]["kept"] is True
     assert cfg.agent.network_mode == NetworkMode.ALLOWLIST
     assert cfg.agent.allowed_hosts == ["api.example.com"]


### PR DESCRIPTION
Found running frontier-bench/govbench tasks through the adopted-benchmark e2e battery: `[task] version = "1.0.0"` — present in every task our own curation pipeline authors to Harbor schema 1.3 — hit TaskConfig's `extra_forbidden` and made the tasks unloadable entirely.

Survey before fixing: validated every task.toml in the local corpus (~/benchflow/samples-jul-30-no-skills, 38 tasks) — **all 6 failures were this single field**; no other 1.3 surface is missing. After: 38/38 load. The field is stored verbatim (informational), the Harbor-surface guard test pins it, and the 154-test task-config/roundtrip sweep is green.

E2E context: with the field stripped as a scratch workaround, the nanoparticle-macroscopicity-inference task proceeds into a real Daytona rollout (run in progress under the battery).