### PR TITLE
fix(env0): sync drifted service pins + fail loud on zero startable services

### DIFF
--- a/benchmarks/_environments/env0@outage.toml
+++ b/benchmarks/_environments/env0@outage.toml
@@ -19,27 +19,50 @@ mechanism = "image"
 [environment.readiness]
 timeout_sec = 60
 
+# Services below are copied VERBATIM from the upstream env-0.toml pin
+# (2026-08-09 sync). The previous pin had drifted: bare CLI names
+# (auth/gmail/...) that do not exist in ghcr.io/benchflow-ai/env0:0.2.0
+# images (which ship mock-auth/mock-gmail/... console scripts), plus a
+# phantom slack service and shifted ports — so ManifestEnvironment
+# probed, found ZERO startable services, and readiness passed vacuously
+# while every rollout died at the verifier with connection-refused.
+
 [[environment.services]]
-name    = "auth"
-command = "auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
+name    = "mock-auth"
+command = "mock-auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
 port    = 9000
 
 [[environment.services]]
-name    = "gcal"
-command = "gcal --db /data/gcal.db serve --host 0.0.0.0 --port 9003 --no-mcp"
+name    = "mock-gmail"
+command = "mock-gmail --db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
+port    = 9001
+
+[[environment.services]]
+name    = "mock-gcal"
+command = "mock-gcal --db /data/gcal.db serve --host 0.0.0.0 --port 9002 --no-mcp"
+port    = 9002
+
+[[environment.services]]
+name    = "mock-gdrive"
+command = "mock-gdrive --db /data/gdrive.db serve --host 0.0.0.0 --port 9003 --no-mcp"
 port    = 9003
 
 [[environment.services]]
-name    = "gdoc"
-command = "gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
+name    = "mock-gdoc"
+command = "mock-gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
 port    = 9004
 
 [[environment.services]]
-name    = "gdrive"
-command = "gdrive --db /data/gdrive.db serve --host 0.0.0.0 --port 9005 --no-mcp"
+name    = "mock-slack"
+command = "mock-slack --db /data/slack.db serve --host 0.0.0.0 --port 9005 --no-mcp"
 port    = 9005
 
 [[environment.services]]
-name    = "stripe"
-command = "stripe --db /data/stripe.db serve --host 0.0.0.0 --port 9007 --no-mcp"
+name    = "mock-discord"
+command = "mock-discord --db /data/discord.db serve --host 0.0.0.0 --port 9006 --no-mcp"
+port    = 9006
+
+[[environment.services]]
+name    = "mock-stripe"
+command = "mock-stripe --db /data/stripe.db serve --host 0.0.0.0 --port 9007 --no-mcp"
 port    = 9007

--- a/benchmarks/_environments/env0@prod.toml
+++ b/benchmarks/_environments/env0@prod.toml
@@ -6,7 +6,7 @@
 #   export BENCHFLOW_ENV_REGISTRY=benchmarks/_environments
 #   bench eval create --tasks-dir <env0 tasks> --environment-manifest env0@prod ...
 #
-# Mirrors smolclaws tasks/_manifests/env0.toml. env-0's per-task images build
+# Mirrors benchflow-ai/env0 tasks/_manifests/env-0.toml (the source of truth). env-0's per-task images build
 # FROM the shared base and bake seed data; benchflow's ManifestEnvironment
 # probes each service's CLI and starts only the ones installed in the per-task
 # image, gating the agent on each service's /health.
@@ -25,37 +25,50 @@ mechanism = "image"
 [environment.readiness]
 timeout_sec = 60
 
+# Services below are copied VERBATIM from the upstream env-0.toml pin
+# (2026-08-09 sync). The previous pin had drifted: bare CLI names
+# (auth/gmail/...) that do not exist in ghcr.io/benchflow-ai/env0:0.2.0
+# images (which ship mock-auth/mock-gmail/... console scripts), plus a
+# phantom slack service and shifted ports — so ManifestEnvironment
+# probed, found ZERO startable services, and readiness passed vacuously
+# while every rollout died at the verifier with connection-refused.
+
 [[environment.services]]
-name    = "auth"
-command = "auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
+name    = "mock-auth"
+command = "mock-auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
 port    = 9000
 
 [[environment.services]]
-name    = "gmail"
-command = "gmail --db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
+name    = "mock-gmail"
+command = "mock-gmail --db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
 port    = 9001
 
 [[environment.services]]
-name    = "slack"
-command = "slack --db /data/slack.db serve --host 0.0.0.0 --port 9002 --no-mcp"
+name    = "mock-gcal"
+command = "mock-gcal --db /data/gcal.db serve --host 0.0.0.0 --port 9002 --no-mcp"
 port    = 9002
 
 [[environment.services]]
-name    = "gcal"
-command = "gcal --db /data/gcal.db serve --host 0.0.0.0 --port 9003 --no-mcp"
+name    = "mock-gdrive"
+command = "mock-gdrive --db /data/gdrive.db serve --host 0.0.0.0 --port 9003 --no-mcp"
 port    = 9003
 
 [[environment.services]]
-name    = "gdoc"
-command = "gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
+name    = "mock-gdoc"
+command = "mock-gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
 port    = 9004
 
 [[environment.services]]
-name    = "gdrive"
-command = "gdrive --db /data/gdrive.db serve --host 0.0.0.0 --port 9005 --no-mcp"
+name    = "mock-slack"
+command = "mock-slack --db /data/slack.db serve --host 0.0.0.0 --port 9005 --no-mcp"
 port    = 9005
 
 [[environment.services]]
-name    = "stripe"
-command = "stripe --db /data/stripe.db serve --host 0.0.0.0 --port 9007 --no-mcp"
+name    = "mock-discord"
+command = "mock-discord --db /data/discord.db serve --host 0.0.0.0 --port 9006 --no-mcp"
+port    = 9006
+
+[[environment.services]]
+name    = "mock-stripe"
+command = "mock-stripe --db /data/stripe.db serve --host 0.0.0.0 --port 9007 --no-mcp"
 port    = 9007

--- a/src/benchflow/environment/manifest_env.py
+++ b/src/benchflow/environment/manifest_env.py
@@ -138,6 +138,23 @@ class ManifestEnvironment:
                     continue  # binary missing or its package absent — skip
                 await self._start_service(svc)
                 self._started.append(svc)
+            if m.services and not self._started:
+                # Per-task images legitimately carry a SUBSET of the declared
+                # services — but ZERO startable services means the manifest and
+                # the image disagree entirely (stale CLI names, wrong image),
+                # and with no explicit readiness URLs the readiness gate then
+                # passes vacuously. That exact shape shipped a drifted
+                # env0@prod pin whose every rollout burned its budget and died
+                # at the verifier with connection-refused (2026-08-09). Fail
+                # here, loudly, instead.
+                declared = ", ".join(s.command.split()[0] for s in m.services)
+                raise RuntimeError(
+                    f"Environment manifest '{m.name}' declares "
+                    f"{len(m.services)} service(s) but NONE are startable in "
+                    f"this image (probed: {declared}). The manifest's service "
+                    "commands likely no longer match the image — verify the "
+                    "binary names against the image or update the manifest."
+                )
         endpoints = {p: f"http://localhost:{p}" for p in m.all_ports}
         self._handle = EnvHandle(name=m.name, endpoints=endpoints)
         # Capture a baseline of the declared state so ``reset`` can return the

--- a/tests/environment/test_manifest_env.py
+++ b/tests/environment/test_manifest_env.py
@@ -137,6 +137,20 @@ async def test_provision_skips_absent_service_binary():
     assert "claw-gmail" in starts[0]
 
 
+async def test_provision_fails_loud_when_no_declared_service_is_startable():
+    """A manifest/image mismatch must error, not pass vacuously.
+
+    Per-task images legitimately carry a subset of declared services, but ZERO
+    startable services means the manifest's commands no longer match the image
+    (the drifted env0@prod pin, 2026-08-09: every CLI name stale, readiness
+    passed vacuously, every rollout died at the verifier connection-refused).
+    """
+    sandbox = FakeSandbox(absent_binaries={"claw-gmail", "claw-gcal"})
+    env = ManifestEnvironment(CLAWS, sandbox=sandbox)
+    with pytest.raises(RuntimeError, match="NONE are startable"):
+        await env.provision(ctx=None)
+
+
 async def test_provision_detects_services_by_running_the_entry_point():
     """Detection probes `<binary> --help`, never bare `command -v`.
 


### PR DESCRIPTION
Live-sandbox diagnosis of the env0 e2e failure (verifier connection-refused on every rollout, even with the documented invocation):

**Root cause** — the pinned `env0@prod`/`env0@outage` manifests drifted from upstream `benchflow-ai/env0 tasks/_manifests/env-0.toml` in three ways: stale CLI names (`auth`/`gmail`/… vs the `mock-auth`/`mock-gmail`/… console scripts the images actually ship — confirmed by probing a live sandbox: all five declared binaries MISSING, `pip list` showing `mock-auth`/`mock-gmail`), a phantom `slack` service, and shifted ports. `ManifestEnvironment` found zero startable services, started nothing, and the URL-less readiness gate passed **vacuously**.

**Fixes**:
1. Both pins re-synced verbatim from upstream, with provenance note.
2. `ManifestEnvironment.provision` now raises when a manifest declares services but **none** are startable — a per-task subset is by-design, an empty intersection is always manifest/image drift. This closes the failure-hiding path (same class the parity-mock setup-command wedge and the clawsbench no-manifest case exposed: silent env problems surfacing as obscure verifier failures). Regression test added; 91 env tests green.

**Verified live on Daytona**: oracle **1.0** (1.5 min) and prime-agent **1.0** (3.9 min — suspicious session revoked, zero over-revocation, incident summary drafted, safety gate passed) on `env-0/auth-emergency-revocation`.

Gotchas documented along the way: env0 Dockerfiles need `--context-root <env0 repo root>` (repo-root-relative COPY).