### PR TITLE
docs: fix post-merge drift from #949–#954; restore env0@outage perturbation

### DIFF
--- a/.agents/skills/docs-review/SKILL.md
+++ b/.agents/skills/docs-review/SKILL.md
@@ -23,23 +23,27 @@ The user may say `/docs-review` with an optional argument:
 ### Full review (all seven checks)
 
 - `docs/architecture.md`
-- `docs/cli-reference.md`
-- `docs/task-authoring.md`
+- `docs/reference/cli.md`
+- `docs/reference/python-api.md`
 - `docs/getting-started.md`
-- `docs/labs.md`
+- `docs/task-authoring-task-md.md`
+- `docs/task-authoring.md`
 - `README.md`
 - `AGENTS.md`
 
 ### Light-touch (checks 1, 2, 6 only — drift, stale refs, link integrity)
 
-- `.claude/dev-docs/harden-sandbox.md` — sandbox hardening notes; verify
-  referenced files / knobs / env vars still exist.
-- `.claude/dev-docs/tested-agents.md` — matrix of agent × model × provider;
-  verify names still appear in `agents/registry.py` and `agents/providers.py`.
+Every other top-level `docs/*.md` — e.g. `docs/concepts.md`,
+`docs/environment-plane.md`, `docs/external-agents.md`,
+`docs/running-any-benchmark.md`, `docs/running-benchmarks.md`,
+`docs/sandbox-hardening.md`, `docs/skill-eval.md`, `docs/task-standard.md`,
+`docs/use-cases.md`, … (enumerate with `ls docs/*.md` at review time).
 
 ### Skipped entirely
 
 - Anything matching `*-notes.md`, `*-archive.md`.
+- `docs/examples/` (task fixtures) and `docs/reports/` (dated reports —
+  they reflect state at the time they were written).
 - `.smoke-jobs/`, `trajectories/`, `examples/`, `fixtures/` — generated or
   sample output, not documentation.
 
@@ -54,14 +58,13 @@ entries. Cross-check:
   `ls src/benchflow/cli/` against trees in `architecture.md` and `Key
   modules` blocks in README/AGENTS.
 - Module descriptions — does `sdk.py` still own what the doc claims?
-  Does `job.py` still drive the run loop? Spot-check first ~40 lines of
-  each named module.
+  Does `evaluation.py` still drive the batch run loop? Spot-check first
+  ~40 lines of each named module.
 - **Registry drift** (high-churn surface). For each agent/provider name
   mentioned in docs, grep `src/benchflow/agents/registry.py` and
   `src/benchflow/agents/providers.py`. A name in docs but not in the
   registry dict → stale; a name in the registry but not documented where
-  expected (`docs/architecture.md` matrix, `.claude/dev-docs/tested-agents.md`)
-  → gap.
+  expected (e.g. `docs/architecture.md`) → gap.
 - Env vars mentioned in docs (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`,
   `GROQ_API_KEY`, `BENCHFLOW_*`, etc.) — still referenced in
   `src/benchflow/`?
@@ -90,11 +93,10 @@ Grep for implementation-tracking words:
 
 For each hit, ask: is this describing the *design* (stays true) or
 *in-flight work* (rots)? In-flight language belongs in commit messages,
-PR descriptions, or `.claude/dev-docs/*-notes.md`, not user-facing reference
-docs.
+PR descriptions, or dated notes/reports, not user-facing reference docs.
 
-**Suppress for `.claude/dev-docs/*-notes.md`** — dated refactor notes
-legitimately carry status language.
+**Suppress for `*-notes.md` and `docs/reports/`** — dated refactor notes
+and reports legitimately carry status language.
 
 ### 4. Duplication
 
@@ -107,28 +109,26 @@ for benchflow:
 - **Registry examples** — one copy in `architecture.md` + one in
   `task-authoring.md` is OK if they illustrate distinct use cases; two
   near-identical `register_agent(...)` blocks is not.
-- **Agent × Model × Provider matrix** — live in
-  `.claude/dev-docs/tested-agents.md`; `architecture.md` should link, not
-  duplicate.
 - **Env var reference** — should live in `docs/getting-started.md` or
-  `docs/cli-reference.md`; not re-listed in README.
+  `docs/reference/cli.md`; not re-listed in README.
 
 Target state: `architecture.md` is the sole deep reference for internals,
-`cli-reference.md` for commands, `task-authoring.md` for task YAML /
-verifier shape. README and AGENTS.md link to them instead of duplicating.
+`reference/cli.md` for commands, `task-authoring-task-md.md` for task
+frontmatter / verifier shape. README and AGENTS.md link to them instead of
+duplicating.
 
 ### 5. Cross-doc alignment
 
-- `docs/cli-reference.md` flag list ↔ actual Typer definitions in
+- `docs/reference/cli.md` flag list ↔ actual Typer definitions in
   `src/benchflow/cli/`. Every documented flag resolves; every command in
-  the CLI has a documented entry (or an intentional hide).
-- `docs/task-authoring.md` YAML schema ↔ `TaskConfig` / loader in
-  `src/benchflow/tasks.py`. Every field has a loader path.
-- `docs/architecture.md` "Error Taxonomy" / "Trajectory event format"
-  sections ↔ the actual dataclass fields in `src/benchflow/models.py`
-  and emit sites in `job.py` / `_trajectory.py`.
-- `docs/architecture.md` ACP Protocol section ↔ `src/benchflow/acp/` and
-  `_acp_run.py`.
+  the CLI has a documented entry (or an intentional hide). CI already pins
+  part of this via `tests/test_cli_docs_drift.py`.
+- `docs/task-authoring-task-md.md` frontmatter schema ↔ `TaskConfig` in
+  `src/benchflow/task/config.py`. Every field has a loader path.
+- `docs/architecture.md` "Error Taxonomy" / trajectory sections ↔ the
+  actual dataclass fields in `src/benchflow/models.py` and the emit sites
+  in `src/benchflow/rollout/` and `src/benchflow/trajectories/`.
+- `docs/architecture.md` ACP Protocol section ↔ `src/benchflow/acp/`.
 - Cross-references between docs — does each `[text](other-doc.md)` link
   still point at a section that exists?
 
@@ -154,13 +154,14 @@ All markdown links resolve:
 - **docs/architecture.md**: sole deep reference for internals. All module
   descriptions, full project tree, SDK phases, registry pattern, error
   taxonomy live here.
-- **docs/cli-reference.md**: flag-level reference. Not narrative.
-- **docs/task-authoring.md**: task YAML + verifier contract. Not a
-  "how benchflow works" overview — link to architecture for that.
-- **docs/getting-started.md / docs/labs.md**: tutorial tone; design
-  rationale belongs elsewhere.
-- **.claude/dev-docs/**: internal — can carry status language, refactor
-  histories, signature tables.
+- **docs/reference/cli.md**: flag-level reference. Not narrative.
+- **docs/task-authoring-task-md.md / docs/task-authoring.md**: task
+  frontmatter + verifier contract. Not a "how benchflow works" overview —
+  link to architecture for that.
+- **docs/getting-started.md**: tutorial tone; design rationale belongs
+  elsewhere.
+- **docs/reports/**: dated, internal-leaning — can carry status language
+  and refactor histories.
 
 ## Execution
 
@@ -202,9 +203,9 @@ For a full review:
   prose quality or tone.
 - **Don't grow scope.** If a check isn't in the seven above, don't add it
   mid-review. File a suggestion in the punch list instead.
-- **Don't touch archives or refactor notes.** `.claude/dev-docs/*-notes.md`
-  legitimately carry status language and reflect state at the time they
-  were written; don't normalize them.
+- **Don't touch archives or refactor notes.** `*-notes.md` files and
+  `docs/reports/` legitimately carry status language and reflect state at
+  the time they were written; don't normalize them.
 - **Don't flag registry drift without reading the registry dict.**
   `registry.py` and `providers.py` are the source of truth — a name
   missing from docs is a doc bug; a name missing from the registry is a
@@ -217,14 +218,14 @@ Docs review punch list (3 blocker, 4 stale, 2 polish)
 
 Blockers:
 - docs/architecture.md:114 — references AgentConfig at src/benchflow/agents/registry.py, but file defines AgentSpec (renamed)
-- docs/cli-reference.md:142 — documents `benchflow verify --strict` flag; flag doesn't exist in cli/verify.py
+- docs/reference/cli.md:142 — documents `benchflow verify --strict` flag; flag doesn't exist in cli/verify.py
 - README.md:62 — example uses register_agent(..., model=...) kwarg; signature takes models=[...] (list)
 
 Stale:
 - docs/architecture.md:39 — "Phase 1: SETUP (host)" numbering implies sequential work-in-progress; phases are always-on
 - docs/task-authoring.md:88 — "TODO: document verifier timeout knob"
 - docs/getting-started.md:121 — example task ID "demo-fizzbuzz" renamed to "examples-fizzbuzz"
-- .claude/dev-docs/tested-agents.md:14 — lists claude-code-acp; registry only has claude-agent-acp
+- docs/external-agents.md:14 — lists claude-code-acp; registry only has claude-agent-acp
 
 Polish:
 - README.md:98-134 — full src/ tree duplicates docs/architecture.md:12-38

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,47 @@
 
 ## [Unreleased]
 
+### Added
+- **Console progress heartbeat.** Single-concurrency eval runs print a
+  throttled progress line (`… 6.2min, 12 tool calls (last: …)`) about every
+  45 seconds while the agent works, so a long prompt is distinguishable from
+  a hang. The heartbeat is auto-gated off for multi-concurrency jobs;
+  `bench eval run --quiet` suppresses it, and `BENCHFLOW_PROGRESS=on`/`off`
+  overrides the auto-gate. (#951)
+
+### Changed
+- Migrated the clawsbench `archive-amazon-shipping` task to the native
+  `task.md` package layout (`bench tasks migrate --remove-legacy`), and a
+  clawsbench run launched without `--environment-manifest` now fails with an
+  actionable verifier message naming the exact flag to pass instead of an
+  opaque connection error. (#952)
+
 ### Fixed
 - Isolated pull-request and post-test integration concurrency groups so a
   credential-free workflow completion cannot cancel an active PR rollout.
+- **Host-side hard rollout deadline.** An await wedged below the phase-level
+  watchdogs (e.g. a Daytona PTY teardown on a dead websocket) could freeze an
+  entire eval job. Every rollout attempt now runs under a host-side hard
+  deadline derived from the task's own phase budgets plus a fixed margin; a
+  trip returns a retryable infra-error result and abandons the sandbox after
+  a bounded cleanup grace. Override with `BENCHFLOW_ROLLOUT_HARD_DEADLINE`
+  (seconds; `off`/`none`/`0` disables). Verifier timeouts that produced zero
+  output are retried once — that signature is an exec-layer wedge, not a slow
+  verifier. Agent-sent reasoning parameters are also forwarded through the
+  LLM gateway, and DeepSeek routes natively with `reasoning_effort` passed
+  verbatim. (#949)
+- Quieter Daytona teardown: successful runs end at the score line — the
+  atexit client cleanup no longer prints a cancelled-reader traceback after
+  `✓ Score`, and benign engineio PTY-disconnect errors are silenced. (#951)
+- Accept the Harbor 1.3 `[task] version` field in task configs. It is
+  informational and stored verbatim; the strict schema previously rejected
+  it, which made every Harbor-1.3 curated task unloadable. (#953)
+- Synced the committed `env0@prod` / `env0@outage` environment pins with the
+  upstream `benchflow-ai/env0` manifest (the pins had drifted to stale
+  service CLI names, a phantom service, and shifted ports), and a manifest
+  environment now fails loud when it declares services but none are startable
+  in the image, instead of passing a vacuous readiness gate and dying at the
+  verifier. (#954)
 
 ## 0.6.6 — 2026-08-04
 

--- a/benchmarks/_environments/README.md
+++ b/benchmarks/_environments/README.md
@@ -14,24 +14,42 @@ bench eval create --tasks-dir <tasks> --environment-manifest env0@prod  --sandbo
 bench eval create --tasks-dir <tasks> --environment-manifest env0@outage --sandbox daytona ...
 ```
 
+`$BENCHFLOW_ENV_REGISTRY` can be **any** local directory of
+`name@version.toml` files — a pip install has no repo checkout, so download
+the pinned manifest instead (e.g. from
+`https://raw.githubusercontent.com/benchflow-ai/benchflow/main/benchmarks/_environments/env0@prod.toml`
+into `./env-registry/`, then `export BENCHFLOW_ENV_REGISTRY=$PWD/env-registry`).
+
 `resolve_environment` parses `name@version`, looks it up here, and content-
 addresses it (`sha256:…`) so every run records exactly which environment it bound.
 
 | entry | what it is |
 |-------|------------|
-| `env0@prod`   | env-0 — 7 services (auth/gmail/slack/gcal/gdoc/gdrive/stripe). The pinned production environment. |
-| `env0@outage` | env-0 with gmail + slack removed — the "Same state, tool outage" perturbation variant. |
+| `env0@prod`   | env-0 — 8 services (mock-auth/-gmail/-gcal/-gdrive/-gdoc/-slack/-discord/-stripe), mirroring upstream `tasks/_manifests/env-0.toml` verbatim. The pinned production environment. |
+| `env0@outage` | Intended as the "Same state, tool outage" perturbation variant (gmail + slack removed). Since the 2026-08-09 upstream sync it declares the same 8 services as `env0@prod`; the outage perturbation needs re-applying before it differs. |
 
 ## Running env0 tasks
 
-env0 per-task images build `FROM xdotli/env0-base:latest`, which is **amd64-only**
-— run env0 on **Daytona** (x86_64), not local Docker on Apple Silicon.
+The env0 tasks are public in
+[`benchflow-ai/env0`](https://github.com/benchflow-ai/env0) under `tasks/` —
+the 60-task Standard60 snapshot (exact list in its
+`tasks/STANDARD60_MANIFEST.txt`).
 
-env0 tasks (in `benchflow-ai/smolclaws`) author their Dockerfiles with a
-repo-root build context (`COPY tasks/<name>/data …`). benchflow builds from each
-task's `environment/` directory, so stage them first with the bundled adapter:
+env0 per-task images build `FROM ghcr.io/benchflow-ai/env0:0.2.0`, which is
+**amd64-only** — run env0 on **Daytona** (x86_64), not local Docker on Apple
+Silicon.
+
+env0 tasks author their Dockerfiles with a repo-root build context
+(`COPY tasks/<name>/data …`). benchflow builds from each task's
+`environment/` directory, so stage them first with the bundled adapter:
 
 ```bash
-python -m benchflow._utils.build_context_stage <smolclaws>/tasks /tmp/env0-staged
+git clone https://github.com/benchflow-ai/env0
+python -m benchflow._utils.build_context_stage env0/tasks /tmp/env0-staged
 bench eval create --tasks-dir /tmp/env0-staged --environment-manifest env0@prod --sandbox daytona ...
 ```
+
+env0's `task.md` frontmatter also pins a manifest
+(`benchflow.environment.manifest: ../_manifests/env-0.toml`); an explicit
+`--environment-manifest` (or `--state`) always overrides that pin — the
+frontmatter applies only when neither flag is given.

--- a/benchmarks/_environments/README.md
+++ b/benchmarks/_environments/README.md
@@ -26,7 +26,7 @@ addresses it (`sha256:…`) so every run records exactly which environment it bo
 | entry | what it is |
 |-------|------------|
 | `env0@prod`   | env-0 — 8 services (mock-auth/-gmail/-gcal/-gdrive/-gdoc/-slack/-discord/-stripe), mirroring upstream `tasks/_manifests/env-0.toml` verbatim. The pinned production environment. |
-| `env0@outage` | Intended as the "Same state, tool outage" perturbation variant (gmail + slack removed). Since the 2026-08-09 upstream sync it declares the same 8 services as `env0@prod`; the outage perturbation needs re-applying before it differs. |
+| `env0@outage` | The "Same state, tool outage" perturbation variant: `env0@prod` minus the `mock-gmail` and `mock-slack` services (6 of the 8 declared). Bind the same task to both pins to attribute the reward delta to the environment. |
 
 ## Running env0 tasks
 

--- a/benchmarks/_environments/env0@outage.toml
+++ b/benchmarks/_environments/env0@outage.toml
@@ -2,7 +2,7 @@
 #
 # A perturbation variant for the "Same state, tool outage" experiment: bind the
 # SAME task to env0@prod vs env0@outage and attribute the reward delta to the
-# environment alone (the S axis). A task that needs slack (port 9002) scores 1.0
+# environment alone (the S axis). A task that needs slack (port 9005) scores 1.0
 # under env0@prod and fails under env0@outage because the service is absent.
 #
 #   bench eval create --tasks-dir <task> --environment-manifest env0@outage ...
@@ -32,10 +32,6 @@ name    = "mock-auth"
 command = "mock-auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
 port    = 9000
 
-[[environment.services]]
-name    = "mock-gmail"
-command = "mock-gmail --db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
-port    = 9001
 
 [[environment.services]]
 name    = "mock-gcal"
@@ -52,10 +48,6 @@ name    = "mock-gdoc"
 command = "mock-gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
 port    = 9004
 
-[[environment.services]]
-name    = "mock-slack"
-command = "mock-slack --db /data/slack.db serve --host 0.0.0.0 --port 9005 --no-mcp"
-port    = 9005
 
 [[environment.services]]
 name    = "mock-discord"

--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -178,9 +178,53 @@ bench eval run --tasks-dir benchmarks/clawsbench/tasks \
 YAML configs may declare the same seam with ``environment_manifest:
 <path>`` at the top level so the batch run is reproducible from disk.
 
+A task can also pin its own manifest in `task.md` frontmatter
+(`benchflow.environment.manifest: <path>`, resolved relative to the task
+directory). An explicit per-run binding always wins: `--state` beats
+`--environment-manifest`, and either flag beats the frontmatter pin, which
+applies only when no flag is given.
+
 `--environment-manifest` is distinct from `--sandbox`: the sandbox is *where*
 it runs (the Sandbox plane); the environment manifest is *the world* (the
 Environment plane).
+
+## Registry (`name@version`)
+
+`--environment-manifest` (and `--state`) also accept a **registry spec**
+instead of a file path: `name@version`, or a bare `name`, resolved against
+the directory named by `$BENCHFLOW_ENV_REGISTRY`
+([`_utils/env_registry.py`](../src/benchflow/_utils/env_registry.py)). The
+registry is just a local directory of manifest files:
+
+```
+<registry>/<name>@<version>.toml   # a pinned environment version
+<registry>/<name>.toml             # optional default for a bare <name>
+```
+
+`.yaml` / `.yml` work too. A bare `name` resolves to `<name>.toml` when
+present, else the highest-sorting pinned version. Every resolution is
+content-addressed (`env_hash = sha256(manifest bytes)`) so a run records
+exactly which environment it bound.
+
+```bash
+export BENCHFLOW_ENV_REGISTRY=benchmarks/_environments
+bench eval run --tasks-dir <tasks> --environment-manifest env0@prod ...
+```
+
+Any local directory works — a pip install has no repo checkout, so download
+the pinned manifest you need into one:
+
+```bash
+mkdir -p env-registry
+curl -fsSLo 'env-registry/env0@prod.toml' \
+  'https://raw.githubusercontent.com/benchflow-ai/benchflow/main/benchmarks/_environments/env0@prod.toml'
+export BENCHFLOW_ENV_REGISTRY=$PWD/env-registry
+```
+
+The repo commits two pins,
+[`benchmarks/_environments/env0@prod.toml`](../benchmarks/_environments/env0@prod.toml)
+and [`env0@outage.toml`](../benchmarks/_environments/env0@outage.toml) — see
+[`benchmarks/_environments/README.md`](../benchmarks/_environments/README.md).
 
 ## Exporting for training
 

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -32,9 +32,12 @@ bench eval run --tasks-dir tasks/edit-pdf --agent prime-agent \
   --model deepseek/deepseek-v4-flash --sandbox daytona
 ```
 
-Expect a quiet stretch while the agent works (its events stream to
-`trajectory/acp_trajectory.jsonl` in the rollout dir, not the console) — the
-console picks back up at the verifier and the `✓ Score` line.
+While the agent works, single-concurrency runs print a throttled progress
+heartbeat about every 45 seconds (`… 6.2min, 12 tool calls (last: …)`);
+`--quiet` suppresses it, and multi-concurrency jobs gate it off by default.
+The full event stream lands in `trajectory/acp_trajectory.jsonl` in the
+rollout dir; the console picks back up at the verifier and the `✓ Score`
+line.
 
 The first rollout runs the agent's `install_cmd` inside the sandbox (a few
 minutes for agents that bootstrap toolchains); artifacts land in the jobs dir
@@ -99,11 +102,18 @@ error message if its name is later requested.
 
 ## Precedence
 
-1. Built-in registry (core `AGENTS`) — never shadowed by anything below.
-2. `BENCHFLOW_AGENTS_DIR` manifests — merged at import.
+1. Built-in registry (core `AGENTS`).
+2. `BENCHFLOW_AGENTS_DIR` manifests — merged at import; a collision with an
+   existing agent name or alias is a hard error, so manifests never shadow
+   built-ins.
 3. Entry-point plugin packages — loaded at import, after the manifest merge.
+   These register through plain `register_agent`, which overwrites by name:
+   a plugin **can** replace a built-in (or manifest-registered) agent that
+   shares its name. Well-behaved plugins skip names the registry already owns
+   (as the acp-registry package does).
 4. Remote autoload (`BENCHFLOW_AGENTS_SOURCE`, default `benchflow-ai/agents@main`)
-   — consulted last, once, only for names still unknown at resolution time.
+   — consulted last, once, only for names still unknown at resolution time;
+   it fills gaps and never overwrites.
 
 Manifest capabilities are deliberately bounded: a `manifest.toml` is data-only
 (install/launch commands, env mapping, model-routing hints — the

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -242,7 +242,7 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 | `--reasoning-effort` | — | Agent reasoning/thinking effort when the agent exposes one (e.g. `max`) |
 | `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |
 | `--usage-tracking` | `auto` | Token usage telemetry policy: `auto`, `required`, or `off` |
-| `--environment-manifest` | — | Path to an Environment-plane manifest (`environment.toml`); applied to every rollout in the batch |
+| `--environment-manifest` | — | Environment-plane manifest applied to every rollout in the batch: a path to an `environment.toml`, or a `name@version` registry spec resolved via `$BENCHFLOW_ENV_REGISTRY` (see [Environment plane: Registry](../environment-plane.md#registry-nameversion)). Overrides a task.md `benchflow.environment.manifest` pin |
 | `--state` | — | S-axis environment binding; inline JSON, registry `name@version`, or manifest path. Takes precedence over `--environment-manifest` |
 | `--prompt` | task prompt | Prompt to send to the agent; repeatable for multi-prompt runs |
 | `--config-override` | — | C-axis task config overlay; inline JSON/YAML/TOML or `@file`, deep-merged into each task's resolved config |
@@ -285,6 +285,13 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 
 See [Architecture: skill loading](../architecture.md#skill-loading) for how
 `with-skill` mode is registered with each agent.
+
+Single-concurrency runs print a console progress heartbeat about every 45
+seconds while the agent works (`… 6.2min, 12 tool calls (last: …)`); the
+heartbeat is auto-gated off for multi-concurrency jobs. Setting
+`BENCHFLOW_PROGRESS=on`/`off` overrides the auto-gate; `--quiet` is
+shorthand for setting `BENCHFLOW_PROGRESS=off` for the run (so it also wins
+over an exported `on`).
 
 Daytona batch runs collect provider token/cost telemetry by default with a
 sandbox-local LiteLLM gateway. Use `--usage-tracking required` when missing telemetry
@@ -794,6 +801,13 @@ Daytona-backed evals also reap orphaned sandboxes automatically at run start
 an idle-activity guard means concurrent live runs are never reaped). Set
 `BENCHFLOW_DAYTONA_AUTO_REAP` to any of `0`/`false`/`no`/`off` (case-insensitive)
 to disable that automatic pass and rely on the manual command above.
+
+Every rollout attempt also runs under a host-side hard deadline computed from
+the task's own phase budgets — a backstop for awaits wedged below the
+phase-level timeouts (a tripped deadline abandons the sandbox to the
+provider's reaper). Set `BENCHFLOW_ROLLOUT_HARD_DEADLINE` to a number of
+seconds to override the computed value, or to `off`/`none`/`0` to disable the
+backstop.
 
 ## bench environment (deprecated)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -240,7 +240,7 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 | `--agent` | `claude-agent-acp` | Agent name |
 | `--model` | Agent default | Model ID |
 | `--reasoning-effort` | — | Agent reasoning/thinking effort when the agent exposes one (e.g. `max`) |
-| `--sandbox` | `docker` | Sandbox: docker, daytona, or modal |
+| `--sandbox` | `docker` | Sandbox: docker, daytona, modal, apple-container, or agentcore |
 | `--usage-tracking` | `auto` | Token usage telemetry policy: `auto`, `required`, or `off` |
 | `--environment-manifest` | — | Environment-plane manifest applied to every rollout in the batch: a path to an `environment.toml`, or a `name@version` registry spec resolved via `$BENCHFLOW_ENV_REGISTRY` (see [Environment plane: Registry](../environment-plane.md#registry-nameversion)). Overrides a task.md `benchflow.environment.manifest` pin |
 | `--state` | — | S-axis environment binding; inline JSON, registry `name@version`, or manifest path. Takes precedence over `--environment-manifest` |

--- a/docs/running-any-benchmark.md
+++ b/docs/running-any-benchmark.md
@@ -101,7 +101,7 @@ bench tasks check <dir>
 ```
 
 That is the structural gate (`check_task` in
-[`_utils/task_authoring.py`](../src/benchflow/_utils/task_authoring.py)): it
+[`_utils/task_authoring/`](../src/benchflow/_utils/task_authoring/__init__.py)): it
 rejects unreplaced `[REPLACE: …]` placeholders, missing required files, and a
 verifier package with no runnable entrypoint. This flow records no
 `parity_experiment.json` and runs no parity gate — it is a faithful in-place

--- a/docs/task-authoring-task-md.md
+++ b/docs/task-authoring-task-md.md
@@ -72,7 +72,7 @@ so typos fail at parse time instead of becoming silently-ignored config:
 | Key | Meaning |
 |---|---|
 | `schema_version` (alias `version`) | Config schema version, currently `"1.3"` |
-| `task` | Package identity: `name` (`org/name` format), `description`, `authors`, `keywords` |
+| `task` | Package identity: `name` (`org/name` format), `description`, `authors`, `keywords`, `version` (informational Harbor 1.3 field, stored verbatim) |
 | `metadata` | Freeform mapping — difficulty, category, tags, anything descriptive |
 | `agent` | Agent run policy: `timeout_sec`, `user`, `network_mode`, `allowed_hosts` |
 | `verifier` | Verifier run policy: `timeout_sec` (default 600), `env`, `user`, `service`, … |


### PR DESCRIPTION
Follow-up sweep after the #949–#954 merge round: a read-only docs-drift review plus three fresh-user dogfood runs surfaced 15 verified issues. Every claim below was re-verified against source before editing.

## Docs fixes
- **external-agents.md**: corrected the false "built-ins never shadowed" precedence claim (entry-point plugins CAN overwrite by name — `register_agent` has no collision guard); replaced the stale "quiet stretch" note with the #951 heartbeat behavior; documents `DEEPSEEK_BASE_URL` handling was left to the in-flight dashboard branch.
- **reference/cli.md**: `--environment-manifest` also accepts a `name@version` registry spec via `$BENCHFLOW_ENV_REGISTRY`; documented `BENCHFLOW_PROGRESS` (env var overrides the multi-concurrency auto-gate; `--quiet` is shorthand for `=off`) and `BENCHFLOW_ROLLOUT_HARD_DEADLINE`; `--sandbox` row updated to the real provider set (apple-container, agentcore).
- **environment-plane.md**: new "Registry (`name@version`)" section — layout, newest-version resolution, content addressing, the committed env0 pins, pip-user recipe, and flag-vs-frontmatter precedence (`--state` > `--environment-manifest` > task.md pin, per `evaluation.py`).
- **running-any-benchmark.md**: fixed dead link to the old `task_authoring.py` module (now a package).
- **task-authoring-task-md.md**: `task` key row now lists the Harbor 1.3 `version` field (#953).
- **CHANGELOG**: per-PR `[Unreleased]` entries for #949/#951/#952/#953/#954 in the established 0.6.6 style.
- **benchmarks/_environments/README.md**: env0 tasks pointer fixed — `benchflow-ai/smolclaws` is private/404s; the tasks are public at `benchflow-ai/env0` (60 tasks); added a registry recipe that works without a repo checkout.
- **docs-review skill**: refreshed its stale in-scope inventory (named several files that no longer exist).

## Functional fix
- **`env0@outage.toml` had lost its perturbation**: the #954 verbatim upstream sync mirrored all 8 services into both pins, so outage no longer differed from prod. Re-applied the documented perturbation (minus `mock-gmail`/`mock-slack`) on top of the synced set and corrected the header's stale slack port (9005). Parse-verified: 6 services remain.

Gates: `tests/test_cli_docs_drift.py` 8/8, `ruff format --check` clean.