### PR TITLE
feat(cli): surface fractional rewards in console summaries

### DIFF
--- a/src/benchflow/_utils/scoring.py
+++ b/src/benchflow/_utils/scoring.py
@@ -1,5 +1,6 @@
 """Pure scoring and classification helpers — no external dependencies."""
 
+import math
 from collections.abc import Iterable, Mapping
 from typing import Any, Literal
 
@@ -341,6 +342,26 @@ def count_audit_outcomes(results: Iterable[Mapping[str, Any]]) -> dict[str, int]
 def count_result_outcomes(results: Iterable[Mapping[str, Any]]) -> dict[str, int]:
     """Backward-compatible alias for audit/reporting outcome accounting."""
     return count_audit_outcomes(results)
+
+
+def mean_scored_reward(results: Iterable[Mapping[str, Any]]) -> float | None:
+    """Mean reward over scored rollouts, or None when nothing scored.
+
+    A rollout is scored when ``rewards.reward`` is a finite numeric value.
+    Bools are excluded — ``classify_result`` treats a persisted ``true`` as a
+    pass (``True == 1``), but a bool is not a reward magnitude — and so are
+    non-finite values, which the resume path can feed in unvalidated (Python's
+    ``json`` round-trips NaN). Errored rollouts (reward None) are excluded,
+    not zeroed: a mean diluted by infra errors would misread as capability.
+    """
+    scored = [
+        rw
+        for r in results
+        if isinstance(rw := extract_reward(r), (int, float))
+        and not isinstance(rw, bool)
+        and math.isfinite(rw)
+    ]
+    return sum(scored) / len(scored) if scored else None
 
 
 def pass_rate(*, passed: int, total: int) -> float:

--- a/src/benchflow/cli/_shared.py
+++ b/src/benchflow/cli/_shared.py
@@ -189,9 +189,14 @@ def _report_eval_result(result: EvaluationResult, job_dir: Path | None = None) -
         err_part = f", [red]{detail}[/red]"
     else:
         err_part = ", errors=0"
+    # Mean reward alongside the binarized counts: pass/fail thresholds at
+    # reward==1, so "0/1" alone can't distinguish 0.3 partial credit from a
+    # flat 0. getattr(): sharded aggregation and older callers don't carry it.
+    mean_reward = getattr(result, "mean_reward", None)
+    mean_part = f", mean reward {mean_reward:.2f}" if mean_reward is not None else ""
     console.print(
         f"\n[{style}]{mark} Score: {result.passed}/{result.total} "
-        f"({result.score:.1%})[/{style}]{err_part}"
+        f"({result.score:.1%})[/{style}]{mean_part}{err_part}"
     )
     # One dim reason line per FAILED task, so "0/1" doesn't force a dig into
     # summary.json to learn why. getattr(): sharded aggregation and older

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -609,6 +609,10 @@ class EvaluationResult:
     memory_score: float | None = None
     memory_scores: dict[str, float] = field(default_factory=dict)
     task_failures: list[TaskFailure] = field(default_factory=list)
+    # Mean of rewards over scored rollouts (None when nothing scored). The
+    # pass/fail counts binarize at reward==1, which erases partial credit —
+    # a 0.3 rubric score and a flat 0 both print as FAIL without this.
+    mean_reward: float | None = None
 
     @property
     def score(self) -> float:
@@ -1391,7 +1395,16 @@ class Evaluation:
         status = "PASS" if reward == 1 else ("FAIL" if reward is not None else "ERR")
         err_msg = result.error or result.verifier_error
         err = f" ({truncate_end(err_msg, 50)})" if err_msg else ""
-        logger.info(f"[{status}] {td.name} (tools={result.n_tool_calls}){err}")
+        # Show the fractional reward on scored lines: pass/fail binarizes at
+        # reward==1, so without it a 0.3 rubric score reads as a flat 0.
+        reward_part = (
+            f"reward={reward:.2f}, "
+            if isinstance(reward, (int, float)) and not isinstance(reward, bool)
+            else ""
+        )
+        logger.info(
+            f"[{status}] {td.name} ({reward_part}tools={result.n_tool_calls}){err}"
+        )
         self._fire_progress(self._on_result, td.name, result)
 
     async def _run_parallel_independent(
@@ -1812,6 +1825,15 @@ class Evaluation:
             for name, r in sorted(all_results.items())
             if classify_score_outcome(r) == "failed"
         ]
+        scored_rewards = [
+            rw
+            for r in all_results.values()
+            if isinstance(rw := (r.get("rewards") or {}).get("reward"), (int, float))
+            and not isinstance(rw, bool)
+        ]
+        mean_reward = (
+            sum(scored_rewards) / len(scored_rewards) if scored_rewards else None
+        )
         job_result = EvaluationResult(
             job_name=self._job_name,
             config=cfg,
@@ -1828,6 +1850,7 @@ class Evaluation:
             memory_score=memory["avg_score"],
             memory_scores=memory_scores,
             task_failures=task_failures,
+            mean_reward=mean_reward,
         )
 
         assert (
@@ -1885,6 +1908,7 @@ class Evaluation:
             "score_excl_errors_ratio": pass_rate_excl_errors(
                 passed=audit_counts["passed"], failed=audit_counts["failed"]
             ),
+            "mean_reward": job_result.mean_reward,
             "elapsed_sec": elapsed,
             "memory_score": job_result.memory_score,
             "memory_score_coverage": (
@@ -1984,9 +2008,14 @@ class Evaluation:
                     "This likely indicates a systemic verifier bug, not agent failure."
                 )
 
+        mean_part = (
+            f"mean_reward={job_result.mean_reward:.2f}, "
+            if job_result.mean_reward is not None
+            else ""
+        )
         logger.info(
             f"Job complete: {job_result.passed}/{job_result.total} "
-            f"({job_result.score:.1%}), errors={job_result.errored}, "
+            f"({job_result.score:.1%}), {mean_part}errors={job_result.errored}, "
             f"idle_timeouts={error_category_counts.get(IDLE_TIMEOUT, 0)}, "
             f"time={elapsed / 60:.1f}min"
         )

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -64,6 +64,7 @@ from benchflow._utils.scoring import (
     classify_verifier_error,
     count_audit_outcomes,
     count_score_outcomes,
+    mean_scored_reward,
     pass_rate,
     pass_rate_excl_errors,
 )
@@ -1825,15 +1826,6 @@ class Evaluation:
             for name, r in sorted(all_results.items())
             if classify_score_outcome(r) == "failed"
         ]
-        scored_rewards = [
-            rw
-            for r in all_results.values()
-            if isinstance(rw := (r.get("rewards") or {}).get("reward"), (int, float))
-            and not isinstance(rw, bool)
-        ]
-        mean_reward = (
-            sum(scored_rewards) / len(scored_rewards) if scored_rewards else None
-        )
         job_result = EvaluationResult(
             job_name=self._job_name,
             config=cfg,
@@ -1850,7 +1842,7 @@ class Evaluation:
             memory_score=memory["avg_score"],
             memory_scores=memory_scores,
             task_failures=task_failures,
-            mean_reward=mean_reward,
+            mean_reward=mean_scored_reward(all_results.values()),
         )
 
         assert (

--- a/tests/test_cli_live_progress.py
+++ b/tests/test_cli_live_progress.py
@@ -354,6 +354,42 @@ def _failed_result(task_failures):
     )
 
 
+def test_report_eval_result_shows_mean_reward():
+    # Partial credit must be visible next to the binarized counts: pass/fail
+    # thresholds at reward==1, so "0/1 (0.0%)" alone can't distinguish a 0.3
+    # rubric score from a flat 0.
+    out = _reported(
+        SimpleNamespace(
+            passed=0,
+            total=1,
+            errored=0,
+            verifier_errored=0,
+            score=0.0,
+            job_name="j",
+            mean_reward=0.3,
+        )
+    )
+    assert "Score: 0/1" in out
+    assert "mean reward 0.30" in out
+
+
+def test_report_eval_result_omits_mean_reward_when_unavailable():
+    # Sharded aggregation and older callers don't carry mean_reward — the line
+    # must render without it rather than showing a misleading 0.00.
+    out = _reported(
+        SimpleNamespace(
+            passed=0,
+            total=1,
+            errored=1,
+            verifier_errored=0,
+            score=0.0,
+            job_name="j",
+        )
+    )
+    assert "Score: 0/1" in out
+    assert "mean reward" not in out
+
+
 def test_report_eval_result_prints_failure_reason_lines():
     # Dogfood follow-up: "✗ Score: 0/1" alone forces a dig into summary.json.
     # Each FAILED task gets one dim reason line — verifier_error first, else a

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -686,6 +686,9 @@ class TestJobRunOrchestration:
         assert "[FAIL] task-1 (reward=0.30, tools=0)" in caplog.text
         assert "[ERR] task-2 (tools=0)" in caplog.text
         assert "mean_reward=0.65" in caplog.text
+        # The machine-readable surface must agree with the console.
+        summary = json.loads((job._jobs_dir / "summary.json").read_text())
+        assert summary["mean_reward"] == pytest.approx(0.65)
 
     @pytest.mark.asyncio
     async def test_run_mean_reward_none_when_nothing_scored(self, tmp_path, caplog):

--- a/tests/test_job.py
+++ b/tests/test_job.py
@@ -657,6 +657,54 @@ class TestJobRunOrchestration:
         ]
 
     @pytest.mark.asyncio
+    async def test_run_computes_mean_reward_and_logs_fractional_rewards(
+        self, tmp_path, caplog
+    ):
+        """Partial credit must survive the binarized pass/fail view: run()
+        computes mean_reward over scored rollouts (errors excluded, not
+        zeroed), the per-task lines carry reward=, error lines don't, and the
+        job-complete line carries mean_reward=.
+        """
+        job = self._make_job(tmp_path, n_tasks=3, concurrency=1)
+        outcomes = {
+            "task-0": RunResult(task_name="task-0", rewards={"reward": 1.0}),
+            "task-1": RunResult(task_name="task-1", rewards={"reward": 0.3}),
+            "task-2": RunResult(task_name="task-2", error="agent crashed"),
+        }
+
+        async def fake_run(*, task_path, **kwargs):
+            return outcomes[task_path.name]
+
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(side_effect=fake_run)
+
+        with caplog.at_level(logging.INFO, logger="benchflow.evaluation"):
+            result = await job.run()
+
+        assert result.mean_reward == pytest.approx(0.65)
+        assert "[PASS] task-0 (reward=1.00, tools=0)" in caplog.text
+        assert "[FAIL] task-1 (reward=0.30, tools=0)" in caplog.text
+        assert "[ERR] task-2 (tools=0)" in caplog.text
+        assert "mean_reward=0.65" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_run_mean_reward_none_when_nothing_scored(self, tmp_path, caplog):
+        """An all-error job has no scored rollouts: mean_reward must be None
+        and the job-complete line must omit the field (a fabricated 0.00 would
+        read as a real capability result)."""
+        job = self._make_job(tmp_path, n_tasks=1, concurrency=1)
+        job._sdk = AsyncMock()
+        job._sdk.run = AsyncMock(
+            return_value=RunResult(task_name="task-0", error="agent crashed")
+        )
+
+        with caplog.at_level(logging.INFO, logger="benchflow.evaluation"):
+            result = await job.run()
+
+        assert result.mean_reward is None
+        assert "mean_reward=" not in caplog.text
+
+    @pytest.mark.asyncio
     async def test_error_and_verifier_error_does_not_crash_invariant(self, tmp_path):
         """A result with BOTH error and verifier_error (rewards=None) must not
         be double-counted — otherwise the passed+failed+errored+verifier_errored

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -7,6 +7,7 @@ from benchflow._utils.scoring import (
     classify_result_outcome,
     count_result_outcomes,
     extract_reward,
+    mean_scored_reward,
     pass_rate,
     pass_rate_excl_errors,
 )
@@ -280,3 +281,37 @@ class TestPassRateExclErrors:
     )
     def test_pass_rate_excl_errors(self, passed, failed, expected):
         assert pass_rate_excl_errors(passed=passed, failed=failed) == expected
+
+
+class TestMeanScoredReward:
+    """mean_scored_reward(results) -> float | None"""
+
+    def test_mean_over_scored_only(self):
+        results = [
+            {"rewards": {"reward": 1.0}},
+            {"rewards": {"reward": 0.3}},
+            {"error": "agent crashed"},
+        ]
+        assert mean_scored_reward(results) == pytest.approx(0.65)
+
+    def test_none_when_nothing_scored(self):
+        assert mean_scored_reward([{"error": "boom"}, {"rewards": None}]) is None
+        assert mean_scored_reward([]) is None
+
+    def test_bool_rewards_excluded(self):
+        # classify_result treats a persisted `true` as a pass (True == 1), but
+        # a bool is not a reward magnitude — it must not enter the mean.
+        results = [{"rewards": {"reward": True}}, {"rewards": {"reward": 0.5}}]
+        assert mean_scored_reward(results) == pytest.approx(0.5)
+
+    def test_non_finite_rewards_excluded(self):
+        # Python's json round-trips NaN; unvalidated resume data must not
+        # poison the mean.
+        results = [{"rewards": {"reward": float("nan")}}, {"rewards": {"reward": 1.0}}]
+        assert mean_scored_reward(results) == pytest.approx(1.0)
+
+    def test_malformed_rewards_shape_tolerated(self):
+        # The resume path feeds raw json.loads payloads with no shape
+        # validation — a non-dict rewards must not crash the aggregation.
+        results = [{"rewards": ["not", "a", "dict"]}, {"rewards": {"reward": 0.4}}]
+        assert mean_scored_reward(results) == pytest.approx(0.4)


### PR DESCRIPTION
The console binarizes rewards (pass = reward==1), so a task scoring 0.3 partial credit printed identically to a flat 0 — observed on a real env0 run: `[FAIL] gdoc-extract-content (tools=47)`, `Job complete: 0/1 (0.0%)`, `✗ Score: 0/1 (0.0%)` for a rollout whose verifier returned 0.3 with rich metrics. Rubric-style verifiers make 0<r<1 the common case; the fractional signal was console-invisible.

## What changed
Binarized counts stay (thresholding is intentional); the fractional view renders alongside:
- Per-task lines carry the scored reward — `[FAIL] gdoc-extract-content (reward=0.30, tools=47)`; error lines (reward None) unchanged.
- `EvaluationResult.mean_reward`: mean over scored rollouts via a new canonical `mean_scored_reward()` in `_utils/scoring.py` (built on `extract_reward`; excludes bools — `classify_result` treats a persisted `true` as a pass but a bool is not a magnitude — and non-finite values, since the resume path feeds unvalidated `json.loads` payloads). **None when nothing scored — errors are excluded, not zeroed**, so an all-error run shows no fabricated 0.00.
- Job-complete log line: `Job complete: 0/1 (0.0%), mean_reward=0.30, errors=0, …` (key=value, matching its neighbors).
- CLI Score line: `✗ Score: 0/1 (0.0%), mean reward 0.30, errors=0` (prose, matching the failure-reason lines below it). getattr-guarded: sharded aggregation omits the segment.
- `summary.json` gains the same `mean_reward` field (additive), pinned end-to-end by test.

## Review
Structural review before opening (REQUEST-CHANGES → fixed): the initial construction-site extraction was a fourth ad-hoc read of `rewards.reward` one import away from the canonical helper — and the only read in the aggregation flow that could crash on a malformed resumed payload, plus a NaN hole. The shipped version extracts `mean_scored_reward()` beside `pass_rate`/`count_score_outcomes` with unit tests for the bool/NaN/malformed-shape edges. Known follow-ups deliberately not in scope: sharded workers don't report per-shard means (aggregate `mean_reward` stays None — needs worker payload + weighted merge), and `bench eval metrics`' post-hoc summary doesn't yet carry the field.

Gates: ruff format/check, ty; test_scoring + test_job + test_cli_live_progress 135 passed; `-k "cli"` 366 passed; oracle-chokepoint/loop-strategies substring assertions verified unaffected (110 passed).