### PR TITLE
feat(environment): built-in manifest registry shipped in the wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 ## [Unreleased]
 
 ### Added
+- **Built-in environment registry.** The committed env-axis pins
+  (`env0@prod`, `env0@outage`) moved from `benchmarks/_environments/` into
+  the package (`benchflow/environment/_registry/`) and ship inside the
+  wheel, so `--environment-manifest env0@prod` resolves on a bare
+  `pip install benchflow` with no checkout and no env vars.
+  `$BENCHFLOW_ENV_REGISTRY`, when set, still wins entirely; resolution
+  stays content-addressed (sha256 logged), and unknown names now error
+  listing the available specs.
 - **Console progress heartbeat.** Single-concurrency eval runs print a
   throttled progress line (`… 6.2min, 12 tool calls (last: …)`) about every
   45 seconds while the agent works, so a long prompt is distinguishable from

--- a/benchmarks/_environments/README.md
+++ b/benchmarks/_environments/README.md
@@ -1,32 +1,36 @@
-# Committed environment registry
+# Environment registry — moved into the package
 
-A git-tracked [environment registry](../../src/benchflow/_utils/env_registry.py)
-so the env-axis pins from PR #790 resolve from the repo instead of a `/tmp` dir.
+The committed environment pins that used to live here (`env0@prod.toml`,
+`env0@outage.toml`) are now **built-in registry** entries shipped inside the
+`benchflow` wheel:
 
-Each `<name>@<version>.toml` **or** `<name>@<version>.yaml` is an Environment-plane
-manifest. YAML is canonical for new manifests (consistent with the task / run /
-job configs); TOML stays supported for back-compat. Bind one at the command line,
-decoupled from the task:
+    src/benchflow/environment/_registry/
+
+That directory is the single source of truth — this one intentionally keeps no
+copies, so the pins cannot drift. The move fixes the pip-install gap: a bare
+`pip install benchflow` used to have no checkout to point
+`$BENCHFLOW_ENV_REGISTRY` at and had to hand-download the pins; now the specs
+resolve with **no env vars and no checkout**:
 
 ```bash
-export BENCHFLOW_ENV_REGISTRY=benchmarks/_environments
 bench eval create --tasks-dir <tasks> --environment-manifest env0@prod  --sandbox daytona ...
 bench eval create --tasks-dir <tasks> --environment-manifest env0@outage --sandbox daytona ...
 ```
 
-`$BENCHFLOW_ENV_REGISTRY` can be **any** local directory of
-`name@version.toml` files — a pip install has no repo checkout, so download
-the pinned manifest instead (e.g. from
-`https://raw.githubusercontent.com/benchflow-ai/benchflow/main/benchmarks/_environments/env0@prod.toml`
-into `./env-registry/`, then `export BENCHFLOW_ENV_REGISTRY=$PWD/env-registry`).
+`$BENCHFLOW_ENV_REGISTRY` still works and, when set, wins entirely: point it at
+any local directory of `name@version.toml` (or `.yaml`) files to resolve your
+own pins instead of the built-ins. In a checkout that is simply:
 
-`resolve_environment` parses `name@version`, looks it up here, and content-
-addresses it (`sha256:…`) so every run records exactly which environment it bound.
+```bash
+export BENCHFLOW_ENV_REGISTRY=src/benchflow/environment/_registry
+```
 
-| entry | what it is |
-|-------|------------|
-| `env0@prod`   | env-0 — 8 services (mock-auth/-gmail/-gcal/-gdrive/-gdoc/-slack/-discord/-stripe), mirroring upstream `tasks/_manifests/env-0.toml` verbatim. The pinned production environment. |
-| `env0@outage` | The "Same state, tool outage" perturbation variant: `env0@prod` minus the `mock-gmail` and `mock-slack` services (6 of the 8 declared). Bind the same task to both pins to attribute the reward delta to the environment. |
+Resolution stays content-addressed (`env_hash = sha256(manifest bytes)`) so
+every run records exactly which environment it bound. See
+[`docs/environment-plane.md`](../../docs/environment-plane.md#registry-nameversion)
+for the full registry contract and
+[`src/benchflow/_utils/env_registry.py`](../../src/benchflow/_utils/env_registry.py)
+for the resolver.
 
 ## Running env0 tasks
 

--- a/docs/environment-plane.md
+++ b/docs/environment-plane.md
@@ -191,10 +191,9 @@ Environment plane).
 ## Registry (`name@version`)
 
 `--environment-manifest` (and `--state`) also accept a **registry spec**
-instead of a file path: `name@version`, or a bare `name`, resolved against
-the directory named by `$BENCHFLOW_ENV_REGISTRY`
-([`_utils/env_registry.py`](../src/benchflow/_utils/env_registry.py)). The
-registry is just a local directory of manifest files:
+instead of a file path: `name@version`, or a bare `name`, resolved by
+[`_utils/env_registry.py`](../src/benchflow/_utils/env_registry.py). The
+registry is just a directory of manifest files:
 
 ```
 <registry>/<name>@<version>.toml   # a pinned environment version
@@ -206,25 +205,28 @@ present, else the highest-sorting pinned version. Every resolution is
 content-addressed (`env_hash = sha256(manifest bytes)`) so a run records
 exactly which environment it bound.
 
+Which directory is the registry:
+
+1. **`$BENCHFLOW_ENV_REGISTRY`**, when set — any local directory of
+   `name@version.toml` files. It wins entirely: names it does not contain do
+   not fall back to the built-in registry.
+2. **The built-in registry** otherwise — the pinned manifests shipped inside
+   the `benchflow` wheel
+   ([`src/benchflow/environment/_registry/`](../src/benchflow/environment/_registry)):
+   [`env0@prod.toml`](../src/benchflow/environment/_registry/env0@prod.toml)
+   and
+   [`env0@outage.toml`](../src/benchflow/environment/_registry/env0@outage.toml).
+   A bare `pip install benchflow` resolves these with no checkout and no env
+   vars.
+
 ```bash
-export BENCHFLOW_ENV_REGISTRY=benchmarks/_environments
+# works on a bare pip install — no $BENCHFLOW_ENV_REGISTRY needed
 bench eval run --tasks-dir <tasks> --environment-manifest env0@prod ...
-```
 
-Any local directory works — a pip install has no repo checkout, so download
-the pinned manifest you need into one:
-
-```bash
-mkdir -p env-registry
-curl -fsSLo 'env-registry/env0@prod.toml' \
-  'https://raw.githubusercontent.com/benchflow-ai/benchflow/main/benchmarks/_environments/env0@prod.toml'
+# override with your own registry directory
 export BENCHFLOW_ENV_REGISTRY=$PWD/env-registry
+bench eval run --tasks-dir <tasks> --environment-manifest myenv@v1 ...
 ```
-
-The repo commits two pins,
-[`benchmarks/_environments/env0@prod.toml`](../benchmarks/_environments/env0@prod.toml)
-and [`env0@outage.toml`](../benchmarks/_environments/env0@outage.toml) — see
-[`benchmarks/_environments/README.md`](../benchmarks/_environments/README.md).
 
 ## Exporting for training
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -242,7 +242,7 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 | `--reasoning-effort` | — | Agent reasoning/thinking effort when the agent exposes one (e.g. `max`) |
 | `--sandbox` | `docker` | Sandbox: docker, daytona, modal, apple-container, or agentcore |
 | `--usage-tracking` | `auto` | Token usage telemetry policy: `auto`, `required`, or `off` |
-| `--environment-manifest` | — | Environment-plane manifest applied to every rollout in the batch: a path to an `environment.toml`, or a `name@version` registry spec resolved via `$BENCHFLOW_ENV_REGISTRY` (see [Environment plane: Registry](../environment-plane.md#registry-nameversion)). Overrides a task.md `benchflow.environment.manifest` pin |
+| `--environment-manifest` | — | Environment-plane manifest applied to every rollout in the batch: a path to an `environment.toml`, or a `name@version` registry spec resolved via `$BENCHFLOW_ENV_REGISTRY` when set, else the built-in registry shipped with benchflow (`env0@prod`, `env0@outage`; see [Environment plane: Registry](../environment-plane.md#registry-nameversion)). Overrides a task.md `benchflow.environment.manifest` pin |
 | `--state` | — | S-axis environment binding; inline JSON, registry `name@version`, or manifest path. Takes precedence over `--environment-manifest` |
 | `--prompt` | task prompt | Prompt to send to the agent; repeatable for multi-prompt runs |
 | `--config-override` | — | C-axis task config overlay; inline JSON/YAML/TOML or `@file`, deep-merged into each task's resolved config |

--- a/src/benchflow/_utils/env_registry.py
+++ b/src/benchflow/_utils/env_registry.py
@@ -17,7 +17,8 @@ Which directory is the registry:
 
 1. an explicit ``registry=`` argument (tests, embedders);
 2. else ``$BENCHFLOW_ENV_REGISTRY`` — when set it wins entirely (no fallback
-   into the built-in registry for names it does not contain);
+   into the built-in registry for names it does not contain); an empty value
+   counts as unset;
 3. else the **built-in registry** shipped inside the ``benchflow`` wheel
    (``benchflow/environment/_registry/``), so a bare ``pip install benchflow``
    resolves the committed pins (``env0@prod``, ``env0@outage``) with no
@@ -35,12 +36,9 @@ reproducibility contract from "Decouple the task from the harness."
 
 from __future__ import annotations
 
-import functools
-import importlib.resources
 import json
 import os
 import re
-import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -93,37 +91,27 @@ def looks_like_env_spec(value: str) -> bool:
     return bool(_SPEC_RE.match(value))
 
 
-@functools.cache
 def _builtin_registry_dir() -> Path | None:
     """Directory of the pinned manifests shipped inside the ``benchflow`` wheel.
 
     ``benchflow/environment/_registry/`` is package data, so a bare
-    ``pip install benchflow`` carries the committed pins. Looked up through
-    :mod:`importlib.resources` so zipped installs work too: when the package is
-    not a plain directory on disk the manifests are materialized once per
-    process into a temp dir (resolution needs real files for globbing and
-    content-addressed reads). Returns ``None`` when the packaged registry is
-    missing (a stripped or partial install).
+    ``pip install benchflow`` carries the committed pins. Path(__file__)-relative
+    like every other package-data lookup in the repo (compose files, default
+    rubric, demo task) — zip imports are unsupported package-wide. Returns
+    ``None`` when the packaged registry is missing (a stripped install).
     """
-    try:
-        root = importlib.resources.files("benchflow.environment") / "_registry"
-    except ModuleNotFoundError:  # pragma: no cover — broken install
-        return None
-    if not root.is_dir():
-        return None
-    direct = Path(str(root))
-    if direct.is_dir():  # normal install: resources are real files on disk
-        return direct
-    extracted = Path(tempfile.mkdtemp(prefix="benchflow-env-registry-"))
-    for entry in root.iterdir():
-        if entry.is_file():
-            (extracted / entry.name).write_bytes(entry.read_bytes())
-    return extracted
+    directory = Path(__file__).resolve().parents[1] / "environment" / "_registry"
+    return directory if directory.is_dir() else None
 
 
 def _registry_dir(registry: str | os.PathLike[str] | None) -> Path:
-    raw = registry if registry is not None else os.environ.get(ENV_REGISTRY_VAR)
-    if not raw:
+    if registry is not None:
+        raw: str | os.PathLike[str] | None = registry
+        source = "the registry= argument"
+    else:
+        raw = os.environ.get(ENV_REGISTRY_VAR)
+        source = f"${ENV_REGISTRY_VAR}"
+    if not raw:  # unset or empty — empty counts as unset
         builtin = _builtin_registry_dir()
         if builtin is not None:
             return builtin
@@ -136,7 +124,7 @@ def _registry_dir(registry: str | os.PathLike[str] | None) -> Path:
     directory = Path(raw).expanduser()
     if not directory.is_dir():
         raise EnvironmentRegistryError(
-            f"environment registry {directory} is not a directory"
+            f"environment registry {directory} (from {source}) is not a directory"
         )
     return directory
 

--- a/src/benchflow/_utils/env_registry.py
+++ b/src/benchflow/_utils/env_registry.py
@@ -8,10 +8,20 @@ Lee's ``S`` axis in ``I_eval = {T, A, M, S, C, R, τ}`` — from the task, so it
 swappable per run exactly like ``--agent`` / ``--model`` / ``--sandbox`` already
 are, instead of being pinned by a relative path baked into the task file.
 
-Registry layout (filesystem; ``$BENCHFLOW_ENV_REGISTRY``)::
+Registry layout (a directory of manifest files)::
 
     <registry>/<name>@<version>.toml   # a pinned environment version
     <registry>/<name>.toml             # optional default ("latest")
+
+Which directory is the registry:
+
+1. an explicit ``registry=`` argument (tests, embedders);
+2. else ``$BENCHFLOW_ENV_REGISTRY`` — when set it wins entirely (no fallback
+   into the built-in registry for names it does not contain);
+3. else the **built-in registry** shipped inside the ``benchflow`` wheel
+   (``benchflow/environment/_registry/``), so a bare ``pip install benchflow``
+   resolves the committed pins (``env0@prod``, ``env0@outage``) with no
+   checkout and no env vars.
 
 Resolution::
 
@@ -25,9 +35,12 @@ reproducibility contract from "Decouple the task from the harness."
 
 from __future__ import annotations
 
+import functools
+import importlib.resources
 import json
 import os
 import re
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -80,12 +93,45 @@ def looks_like_env_spec(value: str) -> bool:
     return bool(_SPEC_RE.match(value))
 
 
+@functools.cache
+def _builtin_registry_dir() -> Path | None:
+    """Directory of the pinned manifests shipped inside the ``benchflow`` wheel.
+
+    ``benchflow/environment/_registry/`` is package data, so a bare
+    ``pip install benchflow`` carries the committed pins. Looked up through
+    :mod:`importlib.resources` so zipped installs work too: when the package is
+    not a plain directory on disk the manifests are materialized once per
+    process into a temp dir (resolution needs real files for globbing and
+    content-addressed reads). Returns ``None`` when the packaged registry is
+    missing (a stripped or partial install).
+    """
+    try:
+        root = importlib.resources.files("benchflow.environment") / "_registry"
+    except ModuleNotFoundError:  # pragma: no cover — broken install
+        return None
+    if not root.is_dir():
+        return None
+    direct = Path(str(root))
+    if direct.is_dir():  # normal install: resources are real files on disk
+        return direct
+    extracted = Path(tempfile.mkdtemp(prefix="benchflow-env-registry-"))
+    for entry in root.iterdir():
+        if entry.is_file():
+            (extracted / entry.name).write_bytes(entry.read_bytes())
+    return extracted
+
+
 def _registry_dir(registry: str | os.PathLike[str] | None) -> Path:
     raw = registry if registry is not None else os.environ.get(ENV_REGISTRY_VAR)
     if not raw:
+        builtin = _builtin_registry_dir()
+        if builtin is not None:
+            return builtin
         raise EnvironmentRegistryError(
-            f"no environment registry configured; set ${ENV_REGISTRY_VAR} or pass "
-            "--environment-manifest a manifest file path instead of a name@version spec"
+            "no environment registry available: the built-in registry shipped "
+            f"with benchflow is missing and ${ENV_REGISTRY_VAR} is unset; set "
+            f"${ENV_REGISTRY_VAR} or pass --environment-manifest a manifest "
+            "file path instead of a name@version spec"
         )
     directory = Path(raw).expanduser()
     if not directory.is_dir():
@@ -93,6 +139,11 @@ def _registry_dir(registry: str | os.PathLike[str] | None) -> Path:
             f"environment registry {directory} is not a directory"
         )
     return directory
+
+
+def _available_specs(directory: Path) -> list[str]:
+    """Sorted stems (``name`` / ``name@version``) present in the registry."""
+    return sorted({p.stem for ext in _MANIFEST_EXTS for p in directory.glob(f"*{ext}")})
 
 
 def _find_manifest(directory: Path, stem: str) -> Path | None:
@@ -124,9 +175,11 @@ def resolve_environment(
     if version is not None:
         path = _find_manifest(directory, f"{name}@{version}")
         if path is None:
+            available = ", ".join(_available_specs(directory)) or "none"
             raise EnvironmentRegistryError(
                 f"environment {spec!r} not found in {directory} "
-                f"(looked for {name}@{version}{{.toml,.yaml,.yml}})"
+                f"(looked for {name}@{version}{{.toml,.yaml,.yml}}; "
+                f"available: {available})"
             )
     else:
         path = _find_manifest(directory, name)
@@ -137,8 +190,10 @@ def resolve_environment(
                 p for ext in _MANIFEST_EXTS for p in directory.glob(f"{name}@*{ext}")
             )
             if not candidates:
+                available = ", ".join(_available_specs(directory)) or "none"
                 raise EnvironmentRegistryError(
-                    f"no versions of environment {name!r} found in {directory}"
+                    f"no versions of environment {name!r} found in {directory} "
+                    f"(available: {available})"
                 )
             path = candidates[-1]
             version = path.stem.split("@", 1)[1]

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -297,10 +297,11 @@ def eval_run(
             "--environment-manifest",
             help=(
                 "Environment-plane manifest applied to every rollout: a path to "
-                "an environment.toml, OR a 'name@version' registry spec resolved "
-                "via $BENCHFLOW_ENV_REGISTRY (the S axis). The manifest-declared "
-                "stateful environment is provisioned, gated on readiness, and "
-                "torn down."
+                "an environment.toml, OR a 'name@version' registry spec (the S "
+                "axis) resolved via $BENCHFLOW_ENV_REGISTRY when set, else the "
+                "built-in registry shipped with benchflow (env0@prod, "
+                "env0@outage). The manifest-declared stateful environment is "
+                "provisioned, gated on readiness, and torn down."
             ),
         ),
     ] = None,

--- a/src/benchflow/environment/_registry/env0@outage.toml
+++ b/src/benchflow/environment/_registry/env0@outage.toml
@@ -1,17 +1,14 @@
-# env0@prod — pinned, content-addressed Environment-plane manifest for env-0.
+# env0@outage — env-0 with the gmail + slack services removed.
 #
-# This is a committed registry entry so PR #790's env-axis pin is reproducible
-# from the repo (not a /tmp dir). Resolve it with:
+# A perturbation variant for the "Same state, tool outage" experiment: bind the
+# SAME task to env0@prod vs env0@outage and attribute the reward delta to the
+# environment alone (the S axis). A task that needs slack (port 9005) scores 1.0
+# under env0@prod and fails under env0@outage because the service is absent.
 #
-#   export BENCHFLOW_ENV_REGISTRY=benchmarks/_environments
-#   bench eval create --tasks-dir <env0 tasks> --environment-manifest env0@prod ...
+# Shipped inside the benchflow wheel (benchflow/environment/_registry/), so it
+# resolves on a bare pip install with no $BENCHFLOW_ENV_REGISTRY set:
 #
-# Mirrors benchflow-ai/env0 tasks/_manifests/env-0.toml (the source of truth). env-0's per-task images build
-# FROM the shared base and bake seed data; benchflow's ManifestEnvironment
-# probes each service's CLI and starts only the ones installed in the per-task
-# image, gating the agent on each service's /health.
-#
-# NOTE: xdotli/env0-base:latest is amd64-only — run env0 on Daytona (x86_64).
+#   bench eval create --tasks-dir <task> --environment-manifest env0@outage ...
 
 [environment]
 name           = "env-0"
@@ -38,10 +35,6 @@ name    = "mock-auth"
 command = "mock-auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
 port    = 9000
 
-[[environment.services]]
-name    = "mock-gmail"
-command = "mock-gmail --db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
-port    = 9001
 
 [[environment.services]]
 name    = "mock-gcal"
@@ -58,10 +51,6 @@ name    = "mock-gdoc"
 command = "mock-gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
 port    = 9004
 
-[[environment.services]]
-name    = "mock-slack"
-command = "mock-slack --db /data/slack.db serve --host 0.0.0.0 --port 9005 --no-mcp"
-port    = 9005
 
 [[environment.services]]
 name    = "mock-discord"

--- a/src/benchflow/environment/_registry/env0@prod.toml
+++ b/src/benchflow/environment/_registry/env0@prod.toml
@@ -1,11 +1,20 @@
-# env0@outage — env-0 with the gmail + slack services removed.
+# env0@prod — pinned, content-addressed Environment-plane manifest for env-0.
 #
-# A perturbation variant for the "Same state, tool outage" experiment: bind the
-# SAME task to env0@prod vs env0@outage and attribute the reward delta to the
-# environment alone (the S axis). A task that needs slack (port 9005) scores 1.0
-# under env0@prod and fails under env0@outage because the service is absent.
+# This is a built-in registry entry, shipped inside the benchflow wheel
+# (benchflow/environment/_registry/) so PR #790's env-axis pin resolves on a
+# bare pip install — no checkout, no env vars:
 #
-#   bench eval create --tasks-dir <task> --environment-manifest env0@outage ...
+#   bench eval create --tasks-dir <env0 tasks> --environment-manifest env0@prod ...
+#
+# Set $BENCHFLOW_ENV_REGISTRY to a local directory of name@version.toml files
+# to override the built-in registry entirely.
+#
+# Mirrors benchflow-ai/env0 tasks/_manifests/env-0.toml (the source of truth). env-0's per-task images build
+# FROM the shared base and bake seed data; benchflow's ManifestEnvironment
+# probes each service's CLI and starts only the ones installed in the per-task
+# image, gating the agent on each service's /health.
+#
+# NOTE: xdotli/env0-base:latest is amd64-only — run env0 on Daytona (x86_64).
 
 [environment]
 name           = "env-0"
@@ -32,6 +41,10 @@ name    = "mock-auth"
 command = "mock-auth --db /data/auth.db serve --host 0.0.0.0 --port 9000 --no-mcp"
 port    = 9000
 
+[[environment.services]]
+name    = "mock-gmail"
+command = "mock-gmail --db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
+port    = 9001
 
 [[environment.services]]
 name    = "mock-gcal"
@@ -48,6 +61,10 @@ name    = "mock-gdoc"
 command = "mock-gdoc --db /data/gdoc.db serve --host 0.0.0.0 --port 9004 --no-mcp"
 port    = 9004
 
+[[environment.services]]
+name    = "mock-slack"
+command = "mock-slack --db /data/slack.db serve --host 0.0.0.0 --port 9005 --no-mcp"
+port    = 9005
 
 [[environment.services]]
 name    = "mock-discord"

--- a/src/benchflow/environment/manifest.py
+++ b/src/benchflow/environment/manifest.py
@@ -205,7 +205,9 @@ def load_manifest(path: str | Path) -> EnvironmentManifest:
     """Load and validate an environment manifest.
 
     ``path`` is either a TOML file path (the historical behavior) or a registry
-    spec ``name@version`` resolved via ``$BENCHFLOW_ENV_REGISTRY``. The spec form
+    spec ``name@version`` resolved via ``$BENCHFLOW_ENV_REGISTRY`` when set,
+    else the built-in registry shipped inside the wheel
+    (``benchflow/environment/_registry/``). The spec form
     lets a run bind its environment (the ``S`` axis) by name at the command line —
     decoupled from the task and swappable per run, like ``--agent`` / ``--model``
     / ``--sandbox``. Resolution is content-addressed so the bound world is

--- a/tests/test_env_registry.py
+++ b/tests/test_env_registry.py
@@ -80,10 +80,87 @@ def test_resolve_invalid_spec_errors(tmp_path):
         resolve_environment("bad/spec@x", registry=tmp_path)
 
 
-def test_resolve_no_registry_configured_errors(tmp_path, monkeypatch):
+def test_resolve_no_registry_available_errors(tmp_path, monkeypatch):
+    """Env var unset AND built-in registry missing → actionable error."""
+    import benchflow._utils.env_registry as env_registry
+
     monkeypatch.delenv("BENCHFLOW_ENV_REGISTRY", raising=False)
+    monkeypatch.setattr(env_registry, "_builtin_registry_dir", lambda: None)
     with pytest.raises(EnvironmentRegistryError, match="no environment registry"):
         resolve_environment("env0")
+
+
+# ---- built-in registry (shipped inside the wheel) ---------------------------
+
+
+def test_builtin_registry_resolves_env0_prod_when_env_unset(monkeypatch):
+    """The acceptance contract: a bare pip install resolves ``env0@prod`` with
+    no ``$BENCHFLOW_ENV_REGISTRY`` set — the pins ship inside the package."""
+    monkeypatch.delenv("BENCHFLOW_ENV_REGISTRY", raising=False)
+    r = resolve_environment("env0@prod")
+    assert (r.name, r.version) == ("env0", "prod")
+    assert r.manifest_path.name == "env0@prod.toml"
+    assert r.env_hash.startswith("sha256:")
+
+
+def test_builtin_registry_resolves_env0_outage_when_env_unset(monkeypatch):
+    monkeypatch.delenv("BENCHFLOW_ENV_REGISTRY", raising=False)
+    r = resolve_environment("env0@outage")
+    assert (r.name, r.version) == ("env0", "outage")
+
+
+def test_builtin_registry_manifests_are_importlib_resources(monkeypatch):
+    """The pins are package data: importlib.resources must find them (that is
+    what makes them ship in the wheel) and they must parse as manifests."""
+    import importlib.resources
+
+    root = importlib.resources.files("benchflow.environment") / "_registry"
+    names = {entry.name for entry in root.iterdir()}
+    assert {"env0@prod.toml", "env0@outage.toml"} <= names
+
+    monkeypatch.delenv("BENCHFLOW_ENV_REGISTRY", raising=False)
+    m = load_manifest("env0@prod")
+    assert {s.name for s in m.services} >= {"mock-gmail", "mock-slack"}
+    outage = load_manifest("env0@outage")
+    assert "mock-gmail" not in {s.name for s in outage.services}
+
+
+def test_env_var_registry_wins_over_builtin(tmp_path, monkeypatch):
+    """When set, ``$BENCHFLOW_ENV_REGISTRY`` is the registry — the same spec
+    resolves from it, not from the built-in pins."""
+    _write_env(tmp_path, "env0@prod", base_image="img:override")
+    monkeypatch.setenv("BENCHFLOW_ENV_REGISTRY", str(tmp_path))
+    r = resolve_environment("env0@prod")
+    assert r.manifest_path.parent == tmp_path
+    assert load_manifest("env0@prod").base_image == "img:override"
+
+
+def test_env_var_registry_wins_entirely_no_builtin_fallback(tmp_path, monkeypatch):
+    """A name the env-var registry lacks does NOT fall back to the built-in."""
+    monkeypatch.setenv("BENCHFLOW_ENV_REGISTRY", str(tmp_path))  # empty dir
+    with pytest.raises(
+        EnvironmentRegistryError, match=r"not found in .*(available: none)"
+    ):
+        resolve_environment("env0@prod")
+
+
+def test_builtin_unknown_name_error_lists_available(monkeypatch):
+    monkeypatch.delenv("BENCHFLOW_ENV_REGISTRY", raising=False)
+    with pytest.raises(
+        EnvironmentRegistryError, match=r"available:.*env0@outage.*env0@prod"
+    ):
+        resolve_environment("nope")
+
+
+def test_builtin_resolution_logs_sha256(monkeypatch, caplog):
+    """Content-addressed provenance is preserved: resolving a built-in pin
+    logs the manifest's sha256 exactly like a ``$BENCHFLOW_ENV_REGISTRY`` one."""
+    import logging
+
+    monkeypatch.delenv("BENCHFLOW_ENV_REGISTRY", raising=False)
+    with caplog.at_level(logging.INFO, logger="benchflow.environment.manifest"):
+        load_manifest("env0@prod")
+    assert any("sha256:" in rec.getMessage() for rec in caplog.records)
 
 
 # ---- load_manifest dispatch (spec vs file) --------------------------------

--- a/tests/test_env_registry.py
+++ b/tests/test_env_registry.py
@@ -139,9 +139,47 @@ def test_env_var_registry_wins_entirely_no_builtin_fallback(tmp_path, monkeypatc
     """A name the env-var registry lacks does NOT fall back to the built-in."""
     monkeypatch.setenv("BENCHFLOW_ENV_REGISTRY", str(tmp_path))  # empty dir
     with pytest.raises(
-        EnvironmentRegistryError, match=r"not found in .*(available: none)"
+        EnvironmentRegistryError, match=r"not found in .*available: none"
     ):
         resolve_environment("env0@prod")
+
+
+def test_explicit_registry_argument_beats_set_env_var(tmp_path, monkeypatch):
+    """Resolution order: an explicit ``registry=`` beats a SET env var."""
+    env_dir = tmp_path / "from-env"
+    arg_dir = tmp_path / "from-arg"
+    env_dir.mkdir()
+    arg_dir.mkdir()
+    _write_env(env_dir, "env0@v1", base_image="img:env")
+    _write_env(arg_dir, "env0@v1", base_image="img:arg")
+    monkeypatch.setenv("BENCHFLOW_ENV_REGISTRY", str(env_dir))
+    r = resolve_environment("env0@v1", registry=arg_dir)
+    assert r.manifest_path.parent == arg_dir
+
+
+def test_empty_env_var_counts_as_unset(monkeypatch):
+    """``BENCHFLOW_ENV_REGISTRY=""`` resolves the built-in registry, exactly
+    like an unset var (empty counts as unset, pinned by the docstring)."""
+    monkeypatch.setenv("BENCHFLOW_ENV_REGISTRY", "")
+    r = resolve_environment("env0@prod")
+    assert (r.name, r.version) == ("env0", "prod")
+
+
+def test_env_var_not_a_directory_error_names_the_env_var(tmp_path, monkeypatch):
+    monkeypatch.setenv("BENCHFLOW_ENV_REGISTRY", str(tmp_path / "nope"))
+    with pytest.raises(
+        EnvironmentRegistryError,
+        match=r"from \$BENCHFLOW_ENV_REGISTRY.*is not a directory",
+    ):
+        resolve_environment("env0@prod")
+
+
+def test_registry_argument_not_a_directory_error_names_the_argument(tmp_path):
+    with pytest.raises(
+        EnvironmentRegistryError,
+        match=r"from the registry= argument.*is not a directory",
+    ):
+        resolve_environment("env0@prod", registry=tmp_path / "nope")
 
 
 def test_builtin_unknown_name_error_lists_available(monkeypatch):


### PR DESCRIPTION
A pip-installed user could not use `--environment-manifest name@version` at all: `BENCHFLOW_ENV_REGISTRY` had to point at a local directory of manifest files, and the documented recipe assumed a repo checkout. A fresh-user dogfood had to hand-download `env0@prod.toml` from raw.githubusercontent.com and reconstruct the layout by guesswork.

## What changed
- **The pinned manifests ship inside the wheel.** Canonical home moves `benchmarks/_environments/*.toml` → `src/benchflow/environment/_registry/` (git mv, byte-faithful apart from header wording; `benchmarks/_environments/` keeps a pointer README — one source of truth, no divergent copies). Verified through the actual artifacts: sdist and sdist-built wheel both carry the TOMLs.
- **Resolution order**: explicit `registry=` argument → `$BENCHFLOW_ENV_REGISTRY` (wins entirely when set — no silent fallback; a missing/non-directory path errors loudly and the message names its source, env var vs argument; empty value counts as unset, documented and tested) → built-in registry. sha256 content-addressed resolution logging unchanged.
- **Acceptance, actually run**: fresh venv + pip install of the built wheel, from outside the repo, zero env vars — `env0@prod` resolves from site-packages (8 services, sha256 logged), `env0@outage` (6 services, perturbation intact), unknown names error listing available specs.
- Docs: environment-plane.md registry section (resolution order + bare-pip example), cli.md row, pointer README, CHANGELOG.

## Review
Structural review before opening (REQUEST-CHANGES → fixed): the initial zipped-install temp-dir materialization branch was deleted on four grounds — unreachable (the repo's universal package-data idiom is `Path(__file__)`-relative, so zip imports are already unsupported package-wide), untested, leaky/racy lifecycle, and a hand-rolled `importlib.resources.as_file`. The shipped lookup is three lines matching repo precedent; packaging is still pinned by an importlib.resources test. Remaining review minors (error provenance, empty-means-unset, argument-beats-env-var ordering) all landed with tests.

Note for external consumers: the pins' sha256 content addresses changed with the header edits (no in-repo hash records them; disclosed here for anyone comparing `env_hash` across versions).

Gates: ruff format/check, ty; registry/environment/docs-drift 104 passed; manifest/registry sweep 483 passed.