### PR TITLE
feat(cli): mid-prompt live token usage via the gateway's existing live capture

### DIFF
--- a/src/benchflow/_utils/live_activity.py
+++ b/src/benchflow/_utils/live_activity.py
@@ -18,10 +18,13 @@ from typing import Any, NamedTuple
 class SessionCounters(NamedTuple):
     """The live ACP session counters the console heartbeat logs.
 
-    ``total_tokens`` is None until the session has a usage snapshot (i.e.
-    after a completed prompt). ``distinct_tools`` counts distinct tool
-    display titles seen this session; None means unknown, which renderers
-    treat like varied (keep the ``last:`` cell).
+    ``total_tokens`` is None until a live usage signal exists: the producer
+    (``Rollout.activity_snapshot``) fills it with max(ACP prompt-completion
+    snapshot, LiteLLM gateway live-capture total), so it becomes non-None as
+    soon as the gateway has mirrored a usage-bearing record — mid-prompt —
+    even when no ACP prompt has completed yet. ``distinct_tools`` counts
+    distinct tool display titles seen this session; None means unknown, which
+    renderers treat like varied (keep the ``last:`` cell).
     """
 
     tool_calls: int

--- a/src/benchflow/cli/_live_progress.py
+++ b/src/benchflow/cli/_live_progress.py
@@ -162,9 +162,12 @@ def _activity_cell(snap: live_activity.ActivitySnapshot | None) -> str:
     which the Live display otherwise mutes. Until the agent session exists
     (and after it is closed for the verifier) the cell shows the rollout's
     lifecycle phase as a label instead, and a registry miss (None) shows the
-    fallback label, so the row is never blank. Tokens appear only once the
-    session has a usage snapshot (i.e. after a completed prompt); once they
-    do, a single-tool agent's cell is ``38 calls · 412.0k tok`` (no ``last:``).
+    fallback label, so the row is never blank. Tokens appear as soon as
+    either live signal exists — the gateway's live callback capture (per
+    completed LLM request, i.e. mid-prompt) or the ACP usage snapshot (per
+    completed prompt); ``Rollout.activity_snapshot`` reconciles the two as
+    max(). Once tokens are present, a single-tool agent's cell is
+    ``38 calls · 412.0k tok`` (no ``last:``).
     """
     if snap is None:
         return _PHASE_FALLBACK
@@ -379,12 +382,19 @@ class LiveEvalProgress:
             parts.append(tbl)
 
         # Footer: pass-rate (excl errors) + token/cost economics. Tokens sum
-        # the completed tasks' trusted telemetry PLUS the running sessions'
-        # live ACP usage (stepping forward as each prompt completes), so a
-        # 51-minute agent phase shows its spend while it runs, not only at
-        # scoring. The total is NOT monotonic across a task's completion
-        # boundary: scoring swaps the ACP self-report for the gateway
-        # measurement (which can be lower), and a task completing with
+        # the completed tasks' trusted telemetry PLUS the running rollouts'
+        # live usage — per running task, max(ACP prompt-completion snapshot,
+        # gateway live-capture total): the gateway side steps forward per
+        # completed LLM *request*, so a single-prompt agent phase shows its
+        # spend while the prompt runs, not only at scoring (the ACP side
+        # alone stays empty until the prompt completes). Reconciliation
+        # (documented at Rollout.activity_snapshot): max() keeps the running
+        # figure monotonic whichever signal leads, and degrades to the
+        # ACP-only value when the gateway capture is unavailable. The total
+        # is still NOT monotonic across a task's completion boundary: scoring
+        # swaps the live figure for the trusted gateway import (which can be
+        # lower than either live signal — untracked discards, cache
+        # accounting, ACP over-report), and a task completing with
         # untrusted/absent telemetry drops its live contribution entirely —
         # a sole-task footer can collapse back to "— tokens". Clamping would
         # falsify the trusted sum, so the dip is intended. Show "—" (not 0 /

--- a/src/benchflow/contracts/planes.py
+++ b/src/benchflow/contracts/planes.py
@@ -13,6 +13,22 @@ from typing import Any, Protocol, runtime_checkable
 from benchflow.environment.manifest import EnvironmentManifest
 
 
+class LiveUsageGateway(Protocol):
+    """A provider gateway process that reports live cumulative token usage.
+
+    The eval dashboard's mid-prompt token signal reads this accessor through
+    the rollout kernel (``Rollout.activity_snapshot`` →
+    ``_gateway_live_tokens``), which cannot import the concrete provider
+    plane — so the NAME is agreed here, at the contract boundary.
+    ``LiteLLMProcess`` asserts static conformance in
+    ``benchflow.providers.litellm_runtime``; renaming the accessor on either
+    side fails the type checker there instead of silently blanking the
+    dashboard signal.
+    """
+
+    def live_usage_tokens(self) -> int | None: ...
+
+
 @runtime_checkable
 class RolloutPlanes(Protocol):
     """Concrete-plane operations the rollout kernel needs."""

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -126,7 +126,27 @@ class LiteLLMProcess:
         )
         self._live_callback_offset = 0
         self._live_callback_remainder = b""
+        self._live_usage_total_tokens = 0
+        self._live_usage_seen = False
         self._live_capture_task = asyncio.create_task(self._live_capture_loop())
+
+    def live_usage_tokens(self) -> int | None:
+        """Cumulative provider tokens the live callback capture has mirrored.
+
+        Read-only, O(1) — safe to call from the dashboard's render thread while
+        the capture loop appends on the event loop (two monotonic attribute
+        reads; a torn read is at worst one record stale). None until a
+        usage-bearing gateway record has been parsed, so callers can tell "no
+        signal yet" from a genuine zero. The value updates per completed LLM
+        *request* — mid-prompt — which is exactly the granularity the ACP
+        per-completed-prompt snapshots lack (a single-prompt rollout otherwise
+        shows no tokens until scoring). It may lag the gateway log by the
+        capture cadence/backlog and is display-only: trusted usage still comes
+        from the full log import at ``stop()``.
+        """
+        if not getattr(self, "_live_usage_seen", False):
+            return None
+        return int(getattr(self, "_live_usage_total_tokens", 0))
 
     async def _read_callback_chunk(self, offset: int, limit: int) -> bytes:
         raise NotImplementedError
@@ -157,6 +177,17 @@ class LiteLLMProcess:
                 )
                 if parsed.exchanges:
                     trajectory.exchanges.extend(parsed.exchanges)
+                    # Live token counter for the eval dashboard: accumulate the
+                    # same canonical per-exchange accounting scoring sums at
+                    # stop() (Trajectory.total_provider_tokens over the same
+                    # parser's output), so the live figure converges to the
+                    # trusted total as the capture catches up. Failure records
+                    # carry no usage and leave the counter untouched.
+                    if parsed.has_provider_usage:
+                        self._live_usage_total_tokens = int(
+                            getattr(self, "_live_usage_total_tokens", 0)
+                        ) + int(parsed.total_provider_tokens)
+                        self._live_usage_seen = True
                     changed = True
             if len(chunk) < _LIVE_CAPTURE_CHUNK_BYTES:
                 break

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -19,7 +19,7 @@ import tempfile
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, NoReturn, cast
+from typing import TYPE_CHECKING, Any, NoReturn, cast
 from uuid import uuid4
 
 import httpx
@@ -53,6 +53,9 @@ from benchflow.sandbox.providers import SANDBOX_MODEL_PROXY_PROVIDERS
 from benchflow.trajectories._llm_capture import LiveLLMTrajectoryWriter
 from benchflow.trajectories.types import Trajectory
 from benchflow.usage_tracking import UsageTrackingConfig, usage_unavailable
+
+if TYPE_CHECKING:
+    from benchflow.contracts.planes import LiveUsageGateway
 
 logger = logging.getLogger(__name__)
 
@@ -99,6 +102,10 @@ class LiteLLMProcess:
     trajectory: Trajectory | None
     session_id: str
     agent_name: str
+    # Live-capture token counter (class-level defaults so reads are plain
+    # attribute access even before start_live_capture ever runs).
+    _live_usage_total_tokens: int = 0
+    _live_usage_seen: bool = False
 
     @property
     def base_url(self) -> str:
@@ -126,8 +133,10 @@ class LiteLLMProcess:
         )
         self._live_callback_offset = 0
         self._live_callback_remainder = b""
-        self._live_usage_total_tokens = 0
+        # Clear ``seen`` BEFORE the total so a racing render-thread read can
+        # only observe None (fresh capture) — never a transient "0 tokens".
         self._live_usage_seen = False
+        self._live_usage_total_tokens = 0
         self._live_capture_task = asyncio.create_task(self._live_capture_loop())
 
     def live_usage_tokens(self) -> int | None:
@@ -144,9 +153,9 @@ class LiteLLMProcess:
         capture cadence/backlog and is display-only: trusted usage still comes
         from the full log import at ``stop()``.
         """
-        if not getattr(self, "_live_usage_seen", False):
+        if not self._live_usage_seen:
             return None
-        return int(getattr(self, "_live_usage_total_tokens", 0))
+        return self._live_usage_total_tokens
 
     async def _read_callback_chunk(self, offset: int, limit: int) -> bytes:
         raise NotImplementedError
@@ -184,9 +193,11 @@ class LiteLLMProcess:
                     # trusted total as the capture catches up. Failure records
                     # carry no usage and leave the counter untouched.
                     if parsed.has_provider_usage:
-                        self._live_usage_total_tokens = int(
-                            getattr(self, "_live_usage_total_tokens", 0)
-                        ) + int(parsed.total_provider_tokens)
+                        # Total before ``seen``: a racing reader can never
+                        # observe seen=True with a not-yet-updated total.
+                        self._live_usage_total_tokens += int(
+                            parsed.total_provider_tokens
+                        )
                         self._live_usage_seen = True
                     changed = True
             if len(chunk) < _LIVE_CAPTURE_CHUNK_BYTES:
@@ -218,6 +229,19 @@ class LiteLLMProcess:
         writer = getattr(self, "_live_writer", None)
         if writer is not None:
             writer.reconcile(self.trajectory)
+
+
+def _live_usage_gateway_conformance(process: LiteLLMProcess) -> LiveUsageGateway:
+    """Static assertion: LiteLLMProcess satisfies the contract the rollout
+    kernel's dashboard read binds to (``contracts.planes.LiveUsageGateway``).
+
+    The kernel cannot import this module (#515 architecture invariant), so
+    its ``server.live_usage_tokens()`` call is dynamically typed there; this
+    return-type check is what makes a rename of the accessor — on either the
+    protocol or the process side — fail ``ty`` instead of silently blanking
+    the live token signal. Never called at runtime.
+    """
+    return process
 
 
 class HostLiteLLMProcess(LiteLLMProcess):

--- a/src/benchflow/providers/runtime.py
+++ b/src/benchflow/providers/runtime.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from benchflow.usage_tracking import UsageTrackingConfig
+
+if TYPE_CHECKING:
+    from benchflow.providers.litellm_runtime import LiteLLMProcess
 
 
 @dataclass
@@ -21,7 +24,11 @@ class ProviderRuntime:
     kind: str
     agent_base_url: str
     backend_model: str | None = None
-    server: Any | None = None
+    # Typed (not Any) so cross-module reads of the server's accessors —
+    # e.g. the dashboard's live_usage_tokens dig in rollout — are bound by
+    # the type checker: a rename on LiteLLMProcess breaks ty, not silently
+    # blanks a signal behind a getattr default.
+    server: LiteLLMProcess | None = None
     config_key: str | None = None
     master_key: str | None = None
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -581,23 +581,38 @@ async def _run_environment_healthcheck(env: Any, task: Any) -> None:
             await asyncio.sleep(delay)
 
 
-def _gateway_live_tokens(usage_runtime: Any) -> int | None:
+def _gateway_live_tokens(runtime: Any) -> int | None:
     """Cumulative provider tokens from the LiteLLM gateway's live capture.
 
     Piggybacks on the llm_trajectory.jsonl mirror the proxy runtime already
     runs for every rollout (``LiteLLMProcess.start_live_capture``, wired in
     ``connect()`` and cancelled by the proxy's ``stop()`` in cleanup) — this
     read generates no additional sandbox exec traffic, at any concurrency.
-    Best-effort by the dashboard contract: any absence (no runtime, a server
-    without the accessor, the reader raising, a non-int value) degrades to
-    None — #963's ACP-only behavior — never to a render error.
+
+    ``runtime`` stays ``Any`` because the rollout kernel must not import the
+    concrete provider plane (``benchflow.providers.runtime``; the #515
+    architecture test forbids even a TYPE_CHECKING import, and the planes
+    contract is deliberately Any-typed). Rename-safety for the
+    ``server.live_usage_tokens`` accessor lives where typing IS allowed: the
+    name is agreed in ``contracts.planes.LiveUsageGateway``, LiteLLMProcess
+    statically asserts conformance in the providers plane
+    (``_live_usage_gateway_conformance`` — a rename on either side fails
+    ty), and ``test_gateway_live_tokens_reach_rollout_activity_snapshot``
+    pins THIS call site to the real classes end-to-end (a drift here fails
+    pytest). The attribute access is direct (no getattr default) so the
+    failure mode under a fake without the accessor is the caught exception
+    below, not a permanent silent None.
+    Best-effort by the dashboard contract: any absence (no runtime, no
+    server, the accessor raising, a non-int value) degrades to None —
+    #963's ACP-only behavior — never to a render error.
     """
-    server = getattr(usage_runtime, "server", None)
-    read = getattr(server, "live_usage_tokens", None)
-    if read is None:
+    if runtime is None:
         return None
     try:
-        tokens = read()
+        server = runtime.server
+        if server is None:
+            return None
+        tokens = server.live_usage_tokens()
     except Exception:
         return None
     return tokens if isinstance(tokens, int) else None
@@ -814,7 +829,7 @@ class Rollout:
         calls, last_title = session.progress_snapshot()
         usage = session.latest_usage_totals()
         acp_tokens = usage.get("total_tokens") if usage else None
-        gateway_tokens = _gateway_live_tokens(getattr(self, "_usage_runtime", None))
+        gateway_tokens = _gateway_live_tokens(self._usage_runtime)
         if acp_tokens is None and gateway_tokens is None:
             tokens = None
         else:

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -581,6 +581,28 @@ async def _run_environment_healthcheck(env: Any, task: Any) -> None:
             await asyncio.sleep(delay)
 
 
+def _gateway_live_tokens(usage_runtime: Any) -> int | None:
+    """Cumulative provider tokens from the LiteLLM gateway's live capture.
+
+    Piggybacks on the llm_trajectory.jsonl mirror the proxy runtime already
+    runs for every rollout (``LiteLLMProcess.start_live_capture``, wired in
+    ``connect()`` and cancelled by the proxy's ``stop()`` in cleanup) — this
+    read generates no additional sandbox exec traffic, at any concurrency.
+    Best-effort by the dashboard contract: any absence (no runtime, a server
+    without the accessor, the reader raising, a non-int value) degrades to
+    None — #963's ACP-only behavior — never to a render error.
+    """
+    server = getattr(usage_runtime, "server", None)
+    read = getattr(server, "live_usage_tokens", None)
+    if read is None:
+        return None
+    try:
+        tokens = read()
+    except Exception:
+        return None
+    return tokens if isinstance(tokens, int) else None
+
+
 class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
 
@@ -765,17 +787,38 @@ class Rollout:
         ("creating sandbox…", "verifying…"), so a 90s sandbox create is not
         indistinguishable from a hang.
 
+        ``total_tokens`` reconciles two cumulative live signals as
+        ``max(acp_snapshot, gateway_live)``: the ACP session's self-reported
+        usage (updates only when a *prompt* completes — a single-prompt
+        rollout stays None for the whole agent phase) and the LiteLLM
+        gateway's live callback capture (updates per completed LLM *request*,
+        mid-prompt). max() because both inputs are non-decreasing counters, so
+        the cell/footer never step down mid-run whichever signal leads —
+        gateway-live can exceed the ACP self-report (requests the agent
+        discarded, cache accounting) and vice versa (capture lag behind large
+        log records) — and a dead gateway signal (None) degrades to exactly
+        the ACP-only behavior. The winner is display-only: at completion the
+        trusted scoring total replaces it (see the footer contract in
+        cli/_live_progress.py for the sanctioned non-monotonic boundary).
+
         Rollout owns the client/session dig so a rename breaks here — in
         typed, tested code — instead of silently blanking the dashboard cell
         (see benchflow._utils.live_activity). Session-factory agents have no
-        ACP client and always report counter-less snapshots.
+        ACP client and always report counter-less snapshots (their
+        gateway-live tokens are not surfaced — the counters seam is the only
+        token carrier).
         """
         session = self._acp_client.session if self._acp_client else None
         if session is None:
             return ActivitySnapshot(self._phase, None)
         calls, last_title = session.progress_snapshot()
         usage = session.latest_usage_totals()
-        tokens = usage.get("total_tokens") if usage else None
+        acp_tokens = usage.get("total_tokens") if usage else None
+        gateway_tokens = _gateway_live_tokens(getattr(self, "_usage_runtime", None))
+        if acp_tokens is None and gateway_tokens is None:
+            tokens = None
+        else:
+            tokens = max(acp_tokens or 0, gateway_tokens or 0)
         return ActivitySnapshot(
             self._phase,
             SessionCounters(calls, last_title, tokens, session.distinct_tool_titles),

--- a/tests/test_cli_live_progress.py
+++ b/tests/test_cli_live_progress.py
@@ -277,6 +277,101 @@ def test_rollout_activity_snapshot_reads_acp_session():
     ) == ActivitySnapshot("setup", None)
 
 
+class _NoUsageSession(_FakeSession):
+    """An ACP session mid-first-prompt: counters exist, usage doesn't yet."""
+
+    def latest_usage_totals(self):
+        return None
+
+
+def _gateway_server(tokens):
+    if isinstance(tokens, Exception):
+
+        def _boom():
+            raise tokens
+
+        return SimpleNamespace(live_usage_tokens=_boom)
+    return SimpleNamespace(live_usage_tokens=lambda: tokens)
+
+
+def _rollout_ns(session, gateway):
+    return SimpleNamespace(
+        _acp_client=SimpleNamespace(session=session),
+        _phase="connected",
+        _usage_runtime=SimpleNamespace(server=_gateway_server(gateway)),
+    )
+
+
+@pytest.mark.parametrize(
+    ("session", "gateway", "expected_tokens"),
+    [
+        # The round-7 failure case: a single-prompt rollout has NO ACP usage
+        # snapshot until the prompt completes — the gateway live capture is
+        # the only mid-run signal and must carry the counters.
+        (_NoUsageSession(), 412_000, 412_000),
+        # Both signals: max() — whichever cumulative counter leads wins, so
+        # the footer never steps down mid-run (documented at
+        # Rollout.activity_snapshot).
+        (_FakeSession(), 900, 1500),
+        (_FakeSession(), 2_000, 2_000),
+        # Gateway signal dead (no usage-bearing record yet / reader raising /
+        # garbage): degrade to exactly #963's ACP-only behavior.
+        (_FakeSession(), None, 1500),
+        (_FakeSession(), RuntimeError("teardown race"), 1500),
+        (_FakeSession(), "not-an-int", 1500),
+        (_NoUsageSession(), None, None),
+        (_NoUsageSession(), RuntimeError("teardown race"), None),
+    ],
+)
+def test_rollout_activity_snapshot_reconciles_acp_and_gateway_usage(
+    session, gateway, expected_tokens
+):
+    from benchflow.rollout import Rollout
+
+    snap = Rollout.activity_snapshot(_rollout_ns(session, gateway))
+    assert snap.counters is not None
+    assert snap.counters.total_tokens == expected_tokens
+
+
+def test_rollout_activity_snapshot_without_usage_runtime_matches_963():
+    # A rollout whose proxy never started (oracle, native-subscription auth)
+    # has no _usage_runtime server — the ACP-only path must be untouched.
+    from benchflow.rollout import Rollout
+
+    ns = SimpleNamespace(
+        _acp_client=SimpleNamespace(session=_NoUsageSession()),
+        _phase="connected",
+        _usage_runtime=None,
+    )
+    snap = Rollout.activity_snapshot(ns)
+    assert snap.counters is not None
+    assert snap.counters.total_tokens is None
+
+
+def test_footer_and_cell_render_gateway_live_tokens_mid_prompt():
+    # End-to-end through __rich__ with the REAL Rollout.activity_snapshot dig:
+    # a single-prompt run mid-prompt (no ACP usage) whose gateway capture has
+    # tokens must light BOTH the footer sum and the activity cell — the
+    # e2e acceptance criterion, unit-shaped.
+    from benchflow.rollout import Rollout
+
+    session = _NoUsageSession()
+    session.distinct_tool_titles = 1  # single-tool agent (prime-agent shape)
+    ns = _rollout_ns(session, 412_000)
+    rollout = SimpleNamespace(activity_snapshot=lambda: Rollout.activity_snapshot(ns))
+    live_activity.register("dialogue-parser", rollout)
+    try:
+        d = _dash()
+        d.on_plan(total=1, done=0, remaining=1)
+        d.on_task_start("dialogue-parser")
+        text = _rendered(d)
+    finally:
+        live_activity.unregister("dialogue-parser")
+    assert "412.0k tokens" in text  # footer live sum
+    assert "38 calls · 412.0k tok" in text  # constant-tool activity cell
+    assert "— tokens" not in text
+
+
 def test_dashboard_renders_activity_for_registered_running_task():
     # End-to-end through __rich__: a registered running task's activity must
     # appear in the rendered panel — reverting the table wiring fails this.

--- a/tests/test_cli_live_progress.py
+++ b/tests/test_cli_live_progress.py
@@ -265,7 +265,9 @@ def test_rollout_activity_snapshot_reads_acp_session():
     from benchflow.rollout import Rollout
 
     connected = SimpleNamespace(
-        _acp_client=SimpleNamespace(session=_FakeSession()), _phase="connected"
+        _acp_client=SimpleNamespace(session=_FakeSession()),
+        _phase="connected",
+        _usage_runtime=None,
     )
     assert Rollout.activity_snapshot(connected) == ActivitySnapshot(
         "connected", SessionCounters(38, "file_editor", 1500, 4)

--- a/tests/test_live_llm_trajectory.py
+++ b/tests/test_live_llm_trajectory.py
@@ -43,28 +43,29 @@ def _trajectory(*, content: str = "ok") -> Trajectory:
     return trajectory
 
 
-def _callback_line(*, content: str = "ok") -> str:
-    return (
-        json.dumps(
-            {
-                "event": "success",
-                "request": {
-                    "method": "POST",
-                    "path": "/v1/chat/completions",
-                    "body": {
-                        "messages": [{"role": "user", "content": "hello"}],
-                        "api_key": "sk-secret",
-                    },
-                },
-                "response": {"choices": [{"message": {"content": content}}]},
-                "start_time": "2026-07-11T00:00:00Z",
-                "end_time": "2026-07-11T00:00:01Z",
-                "duration_ms": 1000,
+def _callback_line(*, content: str = "ok", usage: dict | None = None) -> str:
+    # Mirrors BenchFlowLiteLLMLogger.async_log_success_event's record shape:
+    # ``usage`` rides both top-level and (when present) inside the response
+    # body, exactly as the sandbox callback.jsonl contains it.
+    record = {
+        "event": "success",
+        "request": {
+            "method": "POST",
+            "path": "/v1/chat/completions",
+            "body": {
+                "messages": [{"role": "user", "content": "hello"}],
+                "api_key": "sk-secret",
             },
-            separators=(",", ":"),
-        )
-        + "\n"
-    )
+        },
+        "response": {"choices": [{"message": {"content": content}}]},
+        "start_time": "2026-07-11T00:00:00Z",
+        "end_time": "2026-07-11T00:00:01Z",
+        "duration_ms": 1000,
+    }
+    if usage is not None:
+        record["usage"] = usage
+        record["response"]["usage"] = usage
+    return json.dumps(record, separators=(",", ":")) + "\n"
 
 
 def test_writer_redacts_and_atomically_replaces_snapshot(tmp_path):
@@ -213,6 +214,143 @@ async def test_daytona_proxy_incrementally_mirrors_callback(tmp_path, monkeypatc
     await process._stop_live_capture()
 
     assert len(output_path.read_text().splitlines()) == 2
+
+
+def _sandbox_process(sandbox, tmp_path=None) -> SandboxLiteLLMProcess:
+    del tmp_path
+    return SandboxLiteLLMProcess(
+        sandbox=sandbox,
+        route=SimpleNamespace(),
+        runtime_dir="/tmp/runtime",
+        endpoint=LiteLLMEndpoint("http://agent", "http://local"),
+        log_path="/tmp/runtime/callback.jsonl",
+        pid_path="/tmp/runtime/pid",
+        stdout_path="/tmp/runtime/stdout",
+        stderr_path="/tmp/runtime/stderr",
+        session_id="run",
+        agent_name="prime-agent",
+    )
+
+
+async def _wait_for(predicate, *, ticks: int = 100) -> bool:
+    for _ in range(ticks):
+        if predicate():
+            return True
+        await runtime_mod.asyncio.sleep(0.01)
+    return predicate()
+
+
+@pytest.mark.asyncio
+async def test_live_capture_accumulates_usage_tokens_mid_run(tmp_path, monkeypatch):
+    """Guards the mid-prompt live-token counter for the eval dashboard.
+
+    A single-prompt rollout has no ACP usage snapshot until the prompt
+    completes, so the dashboard's only mid-run token signal is the gateway's
+    live callback capture: ``live_usage_tokens()`` must be None before any
+    usage-bearing record, then advance per mirrored LLM request using the
+    same canonical parser/accounting scoring uses, and freeze (no leaked
+    poller) after ``_stop_live_capture``.
+    """
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+    sandbox = _SandboxWithCallbackLog(
+        _callback_line(
+            usage={"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120}
+        ).encode()
+    )
+    process = _sandbox_process(sandbox)
+    assert process.live_usage_tokens() is None  # before capture starts
+
+    process.start_live_capture(tmp_path / "trajectory" / "llm_trajectory.jsonl")
+    assert await _wait_for(lambda: process.live_usage_tokens() == 120)
+
+    sandbox.data += _callback_line(
+        content="second",
+        usage={"prompt_tokens": 60, "completion_tokens": 20, "total_tokens": 80},
+    ).encode()
+    assert await _wait_for(lambda: process.live_usage_tokens() == 200)
+
+    await process._stop_live_capture()
+    sandbox.data += _callback_line(
+        content="late", usage={"prompt_tokens": 1, "completion_tokens": 1}
+    ).encode()
+    await runtime_mod.asyncio.sleep(0.05)
+    assert process.live_usage_tokens() == 200  # cancelled: no further advance
+
+
+@pytest.mark.asyncio
+async def test_live_usage_stays_none_without_usage_records(tmp_path, monkeypatch):
+    """Usage-less successes, garbage lines, and failure records: the counter
+    must stay None (the dashboard's "no signal yet"), never a fake zero, while
+    the exchange mirror itself keeps working."""
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+    failure = (
+        json.dumps(
+            {
+                "event": "failure",
+                "request": {"method": "POST", "path": "/v1/chat/completions"},
+                "error": {"type": "Timeout", "message": "boom"},
+                "start_time": "2026-07-11T00:00:00Z",
+                "end_time": "2026-07-11T00:00:01Z",
+            }
+        )
+        + "\n"
+    )
+    sandbox = _SandboxWithCallbackLog(
+        _callback_line().encode() + b"not json at all\n" + failure.encode()
+    )
+    process = _sandbox_process(sandbox)
+    output_path = tmp_path / "trajectory" / "llm_trajectory.jsonl"
+
+    process.start_live_capture(output_path)
+    assert await _wait_for(output_path.exists)
+    await process._stop_live_capture()
+
+    assert process.live_usage_tokens() is None
+
+
+@pytest.mark.asyncio
+async def test_live_usage_survives_exec_failure_silently(monkeypatch, tmp_path):
+    """A raising exec channel (sandbox teardown race, transient Daytona error)
+    must degrade to "no signal" — never propagate into the capture loop's
+    caller or the dashboard read."""
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+
+    class _BrokenSandbox:
+        async def exec(self, command: str, timeout_sec: int):
+            raise RuntimeError("exec channel down")
+
+    process = _sandbox_process(_BrokenSandbox())
+    process.start_live_capture(tmp_path / "llm_trajectory.jsonl")
+    await runtime_mod.asyncio.sleep(0.05)
+    await process._stop_live_capture()  # must not raise
+
+    assert process.live_usage_tokens() is None
+
+
+@pytest.mark.asyncio
+async def test_live_usage_resets_when_capture_restarts_on_new_path(
+    tmp_path, monkeypatch
+):
+    """A fresh capture target (new rollout attempt) must not inherit the
+    previous attempt's token total."""
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+    sandbox = _SandboxWithCallbackLog(
+        _callback_line(
+            usage={"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}
+        ).encode()
+    )
+    process = _sandbox_process(sandbox)
+    process.start_live_capture(tmp_path / "a" / "llm_trajectory.jsonl")
+    assert await _wait_for(lambda: process.live_usage_tokens() == 10)
+    await process._stop_live_capture()
+
+    process.start_live_capture(tmp_path / "b" / "llm_trajectory.jsonl")
+    try:
+        # The counter restarts from the log's beginning (offset reset), so it
+        # re-converges to the log's true total rather than double-counting.
+        assert await _wait_for(lambda: process.live_usage_tokens() == 10)
+    finally:
+        await process._stop_live_capture()
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_llm_trajectory.py
+++ b/tests/test_live_llm_trajectory.py
@@ -216,8 +216,7 @@ async def test_daytona_proxy_incrementally_mirrors_callback(tmp_path, monkeypatc
     assert len(output_path.read_text().splitlines()) == 2
 
 
-def _sandbox_process(sandbox, tmp_path=None) -> SandboxLiteLLMProcess:
-    del tmp_path
+def _sandbox_process(sandbox) -> SandboxLiteLLMProcess:
     return SandboxLiteLLMProcess(
         sandbox=sandbox,
         route=SimpleNamespace(),
@@ -344,13 +343,75 @@ async def test_live_usage_resets_when_capture_restarts_on_new_path(
     assert await _wait_for(lambda: process.live_usage_tokens() == 10)
     await process._stop_live_capture()
 
+    # Grow the log so attempt b's true total (25) differs from attempt a's
+    # stale value (10) — without this, a missing reset would still converge
+    # to the expected number and the test could not see it.
+    sandbox.data += _callback_line(
+        content="second",
+        usage={"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    ).encode()
     process.start_live_capture(tmp_path / "b" / "llm_trajectory.jsonl")
+    # The reset's synchronous observable: BEFORE the new capture task has run,
+    # the stale total from attempt a must already read as "no signal" — not 10.
+    assert process.live_usage_tokens() is None
     try:
         # The counter restarts from the log's beginning (offset reset), so it
-        # re-converges to the log's true total rather than double-counting.
-        assert await _wait_for(lambda: process.live_usage_tokens() == 10)
+        # re-converges to the log's true total (10 + 15), not 10 + 25.
+        assert await _wait_for(lambda: process.live_usage_tokens() == 25)
     finally:
         await process._stop_live_capture()
+
+
+@pytest.mark.asyncio
+async def test_gateway_live_tokens_reach_rollout_activity_snapshot(
+    tmp_path, monkeypatch
+):
+    """Cross-boundary seam guard: a REAL SandboxLiteLLMProcess fed a canned
+    callback log, wrapped in a REAL ProviderRuntime, must surface its live
+    total through Rollout.activity_snapshot — pinning the
+    ``server.live_usage_tokens`` accessor name across the provider/rollout
+    boundary, where the unit tests on either side use fakes (a rename on
+    either side fails HERE, not silently in production)."""
+    from benchflow.providers.runtime import ProviderRuntime
+    from benchflow.rollout import Rollout
+
+    monkeypatch.setattr(runtime_mod, "_LIVE_CAPTURE_INTERVAL_SEC", 0.01)
+    sandbox = _SandboxWithCallbackLog(
+        _callback_line(
+            usage={"prompt_tokens": 100, "completion_tokens": 20, "total_tokens": 120}
+        ).encode()
+    )
+    process = _sandbox_process(sandbox)
+    process.start_live_capture(tmp_path / "trajectory" / "llm_trajectory.jsonl")
+    try:
+        assert await _wait_for(lambda: process.live_usage_tokens() == 120)
+
+        class _MidPromptSession:
+            # A single-prompt ACP session mid-prompt: tool calls exist, the
+            # ACP usage snapshot does not (it lands only at prompt end).
+            distinct_tool_titles = 1
+
+            def progress_snapshot(self):
+                return 3, "IPython cell"
+
+            def latest_usage_totals(self):
+                return None
+
+        rollout = SimpleNamespace(
+            _acp_client=SimpleNamespace(session=_MidPromptSession()),
+            _phase="connected",
+            _usage_runtime=ProviderRuntime(
+                kind="litellm",
+                agent_base_url="http://127.0.0.1:4000",
+                server=process,
+            ),
+        )
+        snap = Rollout.activity_snapshot(rollout)
+    finally:
+        await process._stop_live_capture()
+
+    assert snap.counters is not None
+    assert snap.counters.total_tokens == 120
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Round-7 dogfood confirmed #963's disclosed limitation is the common case: single-task evals are single-prompt, so the footer read `— tokens · $—` for an entire 16-minute, 2.07M-token run.

## What changed — zero new polling
The sandbox LiteLLM gateway's live capture already tails `callback.jsonl` every second (transient exec, #921 semantics) to mirror `llm_trajectory.jsonl`. This PR accumulates each parsed record's `total_provider_tokens` — the exact accounting scoring sums at stop() (verified arithmetically identical: per-line summation partitions the full-log summation) — and exposes it as an O(1) `live_usage_tokens()`. `Rollout.activity_snapshot()` reconciles `max(acp_prompt_snapshot, gateway_live)`: both inputs are non-decreasing counters so the rendered value never steps down mid-run; a dead gateway degrades to exactly #963 behavior. No render-logic changes; the footer and the constant-tool activity cell light up through the existing plumbing.

**Option (a) — polling gateway spend endpoints — was rejected on evidence**: the pinned litellm 1.89.0 proxy runs DB-less (no /spend), and the Daytona gateway binds loopback inside the sandbox — dead twice over.

## E2E acceptance (Daytona, dialogue-parser, prime-agent — the round-7 failure case)
Footer during a single prompt that never completed until 3:54: `— → 4.9k tokens → 21.3k tokens`, activity cell `7 calls · 4.9k tok`; #963 alone shows `—` for this entire run. Disclosed conservatism: the live figure lags the log under very large request bodies (21.3k live vs 297.7k final trusted — the capture's chunk budget); the recorded follow-up is a byte-ranged read + larger budget.

## Review
Structural review (APPROVE-WITH-MINORS, conditions met): the reviewer mutation-tested the branch — accumulation, reconciliation, and freeze-after-stop each genuinely pinned; two MAJORs fixed: (1) the gateway seam was rename-unsafe (stringly getattr) — fixed with a `LiveUsageGateway` Protocol at the contracts boundary + static conformance assertion (the literal TYPE_CHECKING import fix is architecturally forbidden by the kernel/planes test) + a real-classes integration test; mutation matrix: renames in all three directions now fail ty or pytest; (2) the restart-reset test passed vacuously under the exact double-count bug it guarded — fixed with a synchronous `is None` assertion + divergent log totals. Minors: reset-order race, class-level counter defaults, fixture cleanups. Recorded follow-ups: capture-lag ceiling, `ActivitySnapshot`-level live tokens (verify-phase dark window + session-factory gap).

Includes a clean merge of #964. Gates: ruff/ty; telemetry+architecture 77 passed; `-k "cli"` 398 passed.