### PR TITLE
ci(integration-light): grade code+fixture changes on a coherent tree

### DIFF
--- a/.github/workflows/integration-light.yml
+++ b/.github/workflows/integration-light.yml
@@ -12,6 +12,22 @@
 #   * detect-scope holds NO secrets (contents: read only) and runs in seconds so
 #     this whole workflow can be UNCONDITIONALLY REQUIRED in branch protection:
 #     when the diff needs no rollout it reports a green no-op (should_run=false).
+#   * TASK FIXTURES are DATA UNDER TEST, not verdict logic — but they are not
+#     inert: docs/examples/task-md/**/task.md carries sandbox.setup_commands and
+#     sandbox.docker_image, and each task ships solve.sh + verifier/test.sh. So
+#     PR-head fixtures run ONLY in fixture-scenarios, which holds NO secrets and
+#     keeps the assertions (tests/) trusted-main. The secret-bearing job never
+#     executes a PR's fixtures.
+#
+# WHY fixture-scenarios EXISTS (the src-only-overlay blind spot):
+#   rollout-smoke overlays ONLY src/benchflow onto the trusted base tree, so a PR
+#   that must change src AND the in-repo task fixtures together is graded against
+#   an INCOHERENT tree: new code + base fixtures. PR #966 (the task-config
+#   'environment' -> 'sandbox' rename) hit exactly this — the overlaid new parser
+#   correctly rejected base's un-migrated task.md, so a red check reported a
+#   version skew the PR itself had already fixed, and main went green the moment
+#   both halves landed together. fixture-scenarios grades the coherent PR-head
+#   pair; rollout-smoke keeps the trusted-fixture, secret-bearing coverage.
 #
 # This workflow REPLACES the role of the old integration-eval.yml (L1).
 name: integration-light
@@ -273,12 +289,30 @@ jobs:
             --json
 
       - name: Run the live oracle/parity scenarios
-        # Oracle determinism + docker<->daytona parity + reaper safety. The
-        # agent-rollout scenario is skipped here because the step above already
-        # ran a real agent + judge.
+        # Docker<->daytona parity + reaper safety. Two exclusions:
+        #   * agent_rollout — the step above already ran a real agent + judge.
+        #   * oracle_determinism — fixture-scenarios grades it against the
+        #     coherent PR-head pair (code + fixtures); running it here, where
+        #     fixtures are base and code is PR-head, is the incoherent-tree
+        #     false-red this split exists to remove.
+        # The remaining fixture-dependent leg (sandbox_parity) needs
+        # DAYTONA_API_KEY, so it cannot move to the secretless job. When the PR
+        # changes the fixtures it would hit the same skew, so it is skipped with
+        # a LOUD notice rather than failing on a version mismatch the PR already
+        # resolved. Coverage is never silently dropped: fixture-scenarios still
+        # graded the coherent pair, and main re-runs this leg after merge.
+        env:
+          FIXTURES_PATH: docs/examples/task-md
         run: |
+          set -euo pipefail
+          DESELECT="not agent_rollout and not oracle_determinism"
+          if [ "${{ github.event_name }}" = "pull_request" ] && \
+             ! git diff --quiet "origin/$BASE_REF...$HEAD_SHA" -- "$FIXTURES_PATH"; then
+            echo "::notice title=sandbox_parity skipped::This PR changes $FIXTURES_PATH, so this trusted-fixture job would grade PR code against base fixtures (an incoherent tree). The coherent pair was graded by the fixture-scenarios job; this leg re-runs on main after merge."
+            DESELECT="$DESELECT and not sandbox_parity"
+          fi
           uv run pytest tests/test_integration_suite.py \
-            -m integration -k "not agent_rollout" \
+            -m integration -k "$DESELECT" \
             -p no:cacheprovider -v
 
       - name: Upload smoke rollout artifacts
@@ -290,12 +324,90 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  # ----------------------------------------------------------------------------
+  # fixture-scenarios — the COHERENT-TREE half of the live gate. NO SECRETS, so
+  # a PR's own task fixtures (setup_commands, solve.sh, verifier/test.sh) can be
+  # executed here without anything to exfiltrate: this job holds no provider
+  # environment and only contents: read. Verdict integrity is preserved the same
+  # way rollout-smoke preserves it — the assertions (tests/) come from trusted
+  # base; only src/benchflow AND the task fixtures come from the PR head, and
+  # they must agree with each other.
+  #
+  # Scope is deliberately the Docker+oracle scenario: it needs no provider key
+  # and no Daytona token, which is exactly what lets it run secretless. The
+  # Daytona parity leg cannot move here (it needs DAYTONA_API_KEY) and stays in
+  # rollout-smoke, guarded there by the fixture-drift skip.
+  # ----------------------------------------------------------------------------
+  fixture-scenarios:
+    name: fixture-scenarios
+    needs: detect-scope
+    if: >-
+      ${{
+        needs.detect-scope.outputs.should_run == 'true' &&
+        github.repository == 'benchflow-ai/benchflow' &&
+        !contains(github.event.pull_request.labels.*.name, 'integration:deep') &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          (
+            github.event_name == 'workflow_run' &&
+            github.event.workflow_run.conclusion == 'success' &&
+            github.event.workflow_run.event == 'push' &&
+            github.event.workflow_run.head_branch == 'main'
+          ) ||
+          github.event_name == 'pull_request'
+        )
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # No `environment:` — this job must never hold provider credentials.
+    permissions:
+      contents: read
+    env:
+      BASE_REF: ${{ needs.detect-scope.outputs.base_ref }}
+      HEAD_SHA: ${{ needs.detect-scope.outputs.head_sha }}
+    steps:
+      # Trusted-base checkout: the scenarios and their assertions stay base code
+      # so a PR cannot rewrite the test that grades it.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          ref: ${{ needs.detect-scope.outputs.base_ref }}
+          fetch-depth: 0
+
+      - name: Overlay PR-head code AND task fixtures (the coherent pair)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "$HEAD_SHA"
+          # Both halves from the same commit — that coherence IS the point of
+          # this job. Safe only because this job holds no secrets; do NOT copy
+          # this overlay into a job that has an `environment:`.
+          git checkout "$HEAD_SHA" -- src/benchflow
+          git checkout "$HEAD_SHA" -- docs/examples/task-md
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3.2.4
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --extra dev --locked
+
+      - name: Run the coherent-tree oracle scenario on Docker
+        run: |
+          uv run pytest tests/test_integration_suite.py \
+            -m integration -k "oracle_determinism" \
+            -p no:cacheprovider -v
+
   # The preview publisher consumes this workflow's overall conclusion.  A
   # condition regression must never turn a skipped live job into a green
   # release gate, so successful-main workflow_run events end here and require
   # both the unit source and the live rollout job to have succeeded.
   release-gate:
-    needs: [detect-scope, rollout-smoke]
+    needs: [detect-scope, rollout-smoke, fixture-scenarios]
     if: >-
       ${{
         always() &&
@@ -312,6 +424,7 @@ jobs:
           SOURCE_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           DETECT_SCOPE_RESULT: ${{ needs.detect-scope.result }}
           ROLLOUT_SMOKE_RESULT: ${{ needs.rollout-smoke.result }}
+          FIXTURE_SCENARIOS_RESULT: ${{ needs.fixture-scenarios.result }}
           TESTED_SHA: ${{ github.event.workflow_run.head_sha }}
           SOURCE_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
         run: |
@@ -326,6 +439,12 @@ jobs:
           fi
           if [ "$ROLLOUT_SMOKE_RESULT" != "success" ]; then
             echo "::error::live integration concluded $ROLLOUT_SMOKE_RESULT"
+            exit 1
+          fi
+          # The coherent-tree half is a gate too: without this check, adding it
+          # to `needs` would only make the gate WAIT for it, not require it.
+          if [ "$FIXTURE_SCENARIOS_RESULT" != "success" ]; then
+            echo "::error::fixture scenarios concluded $FIXTURE_SCENARIOS_RESULT"
             exit 1
           fi
           echo "Unit and live integration gates both succeeded."

--- a/tests/test_release_workflow_wiring.py
+++ b/tests/test_release_workflow_wiring.py
@@ -77,6 +77,7 @@ def _run_terminal_gate(
     source: str = "success",
     detect: str = "success",
     rollout: str = "success",
+    fixtures: str = "success",
 ) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["bash", "-c", _release_gate_script(integration)],
@@ -86,6 +87,7 @@ def _run_terminal_gate(
             "SOURCE_CONCLUSION": source,
             "DETECT_SCOPE_RESULT": detect,
             "ROLLOUT_SMOKE_RESULT": rollout,
+            "FIXTURE_SCENARIOS_RESULT": fixtures,
             "TESTED_SHA": "b" * 40,
             "SOURCE_RUN_NUMBER": "456",
         },
@@ -146,7 +148,14 @@ def test_preview_publish_is_downstream_of_tested_main_live_gate() -> None:
         assert fail_closed_condition in integration_gate
 
     terminal_gate = integration["jobs"]["release-gate"]
-    assert terminal_gate["needs"] == ["detect-scope", "rollout-smoke"]
+    # fixture-scenarios grades the coherent PR-head code+fixture pair that
+    # rollout-smoke's src-only overlay structurally cannot; it is a gate, not
+    # advisory, so the preview chain must depend on it too.
+    assert terminal_gate["needs"] == [
+        "detect-scope",
+        "rollout-smoke",
+        "fixture-scenarios",
+    ]
     for terminal_condition in (
         "always()",
         "github.event_name == 'workflow_run'",
@@ -279,6 +288,20 @@ def test_terminal_gate_rejects_skipped_live_integration(tmp_path: Path) -> None:
 
     assert result.returncode != 0
     assert "live integration concluded skipped" in result.stdout
+
+
+def test_terminal_gate_rejects_failed_fixture_scenarios(tmp_path: Path) -> None:
+    """The coherent-tree job must gate the preview, not merely be waited on.
+
+    Listing a job in ``needs`` only makes the gate WAIT for it; without an
+    explicit conclusion check a red fixture-scenarios would still publish.
+    """
+    integration = _workflow("integration-light.yml")
+
+    result = _run_terminal_gate(tmp_path, integration, fixtures="failure")
+
+    assert result.returncode != 0
+    assert "fixture scenarios concluded failure" in result.stdout
 
 
 def test_terminal_gate_accepts_only_fully_green_chain(tmp_path: Path) -> None:


### PR DESCRIPTION
`rollout-smoke` checks out the PR's **base** and overlays only `src/benchflow` from the head. That's a deliberate boundary — but it means any PR that must change `src/` **and** the in-repo task fixtures together is graded against an incoherent tree: PR code + base fixtures.

#966 (the `environment:` → `sandbox:` rename) hit it exactly: the overlaid new parser correctly rejected base's un-migrated `task.md`, discovery found 0 tasks, and the lane went red for a version skew the PR itself had already fixed — main went green the moment both halves landed together. Reproduced locally on the real trees: coherent pair → 4 tasks discovered; incoherent pair → 0.

## Fix — option (c), split by secret need
**New `fixture-scenarios` job (no secrets).** No `environment:`, `contents: read` only. It overlays `src/benchflow` **and** `docs/examples/task-md` from the PR head — the coherence *is* the point — and runs the Docker+oracle scenario, which needs no provider key and no Daytona token. That is precisely what lets it be secretless.

**Why not (a) "overlay only declarative task.md":** task.md is not inert. `sandbox.setup_commands` is shell and `sandbox.docker_image` is arbitrary, and each task ships `solve.sh` + `verifier/test.sh` — so PR fixtures can both weaken a gate and reach whatever the job holds. They execute only where there is nothing to steal.

**Verdict integrity is unchanged.** The assertions (`tests/`, `agent_judge.py`) still come from trusted base in both jobs, so a PR still cannot rewrite the test that grades it. Only the *data under test* moves.

**`rollout-smoke`** keeps the secret-bearing, trusted-fixture coverage and hands `oracle_determinism` to the new job. Its one remaining fixture-dependent leg, `sandbox_parity`, needs `DAYTONA_API_KEY` and cannot move; when the PR changes fixtures it's skipped with a loud `::notice` — a narrow (b) applied only where (c) is impossible. Coverage is never silently dropped: the coherent pair was graded by `fixture-scenarios`, and main re-runs the leg after merge.

**`release-gate`** now checks the new job's conclusion explicitly — adding it to `needs` alone would make the gate *wait* for it without *requiring* it.

## Verification
- YAML parses; job wiring asserted (`fixture-scenarios` has no `environment`, `permissions: {contents: read}`).
- `-k` selections partition cleanly: new job = 1 test (`oracle_determinism`); rollout-smoke = 3 normally, 2 when drifted.
- Drift guard exercised on real ranges: fixture-changing (`v0.6.7...4d23063e`) → skips parity; code-only (#967) → runs it.
- Dependency scope checked: the test module and its helpers import only stdlib + benchflow core, and the Docker sandbox shells out to the CLI, so `--extra dev` is sufficient.