### PR TITLE
chore: start 0.6.8 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.7"
+version = "0.6.8.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.7"
+version = "0.6.8.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- advance project version from `0.6.7` to `0.6.8.dev0` after public `v0.6.7` release
- keep lockfile project metadata in sync

## Why

`main` remained on final version `0.6.7` after the release. Final-version commits make the internal-preview workflow skip publication, so the four post-release commits have not produced `0.6.8.devN` previews.

After merge, successful `main` test and integration workflows can publish `0.6.8.dev<run-number>` again. Tag `v0.6.7` remains unchanged.

## Validation

- `uv lock --check`
- `uv run --with packaging --no-project python tools/release_version.py internal-preview --run-number 12345` → `publish=true`, `version=0.6.8.dev12345`
- `uv run --extra dev python -m pytest tests/test_release_version.py tests/test_release_workflow_wiring.py tests/test_workflow_action_pinning.py` → 54 passed
- `git diff --check`