### PR TITLE
fix(agents): pin compatible OpenClaw runtime

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -126,9 +126,7 @@ _JS_AGENT_PATH = (
     f"{_BENCHFLOW_BIN_PREFIX}:{_BENCHFLOW_JS_AGENT_PREFIX}/bin:"
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
 )
-# Node >=22.19 is required by current openclaw (the JS agents install
-# @latest); keep this pin at or above that floor or the openclaw ACP
-# bootstrap aborts at its runtime version check (BF-10).
+# Node 22.20.0 supports OpenClaw 2026.6.9. Keep their pin pair in sync.
 _NODE_INSTALL = (
     "export DEBIAN_FRONTEND=noninteractive; "
     f"BF_NODE_DIR={_BENCHFLOW_NODE_PREFIX}; "
@@ -585,7 +583,7 @@ AGENTS: dict[str, AgentConfig] = {
         description="OpenClaw agent via ACP shim — model set at runtime via --model",
         skill_paths=["$HOME/.claude/skills", "$WORKSPACE/skills"],
         install_cmd=(
-            f"{_js_agent_install('openclaw', 'openclaw')} && "
+            f"{_js_agent_install('openclaw', 'openclaw@2026.6.9')} && "
             # Configure: auto-approve tools (no model — set at runtime via ACP set_model)
             "mkdir -p ~/.openclaw && "
             'echo \'{"version":1,"defaults":{"allow_all":true}}\''

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -186,6 +186,11 @@ def test_js_acp_agents_use_isolated_node_runtime(name):
         )
 
 
+def test_openclaw_is_pinned_to_node_22_20_compatibility():
+    """Guards PR #704's Node 22.20.0 pin against floating OpenClaw releases."""
+    assert "openclaw@2026.6.9" in AGENTS["openclaw"].install_cmd
+
+
 # Bash-isms not supported by dash (Ubuntu/Debian's /bin/sh). The sandbox
 # Docker/Daytona exec paths invoke ``sh -c install_cmd``; if /bin/sh is dash
 # (ubuntu:24.04 base), any of these aborts the install on line 1. See #341.


### PR DESCRIPTION
## Summary

Pins the OpenClaw package used by the ACP agent to `2026.6.9`.

## Root cause

BenchFlow kept Node at `22.20.0` while resolving `openclaw@latest`; a newer OpenClaw release raised its Node floor, so installation succeeded with an engine warning but the agent could not start.

## Impact

Fresh OpenClaw rollouts use a deterministic Node/OpenClaw-compatible pair.

## Validation

- `uv run python -m pytest tests/test_registry_invariants.py`
- `uv run ruff check src/benchflow/agents/registry.py tests/test_registry_invariants.py`
- `git diff --check`

Fixes #972.