### PR TITLE
fix(acp): request summarized thinking from Claude

### DIFF
--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -293,7 +293,10 @@ class ACPClient:
         return self._initialize_result
 
     async def session_new(
-        self, cwd: str = "/app", mcp_servers: list[McpServerSpec] | None = None
+        self,
+        cwd: str = "/app",
+        mcp_servers: list[McpServerSpec] | None = None,
+        session_meta: dict[str, Any] | None = None,
     ) -> ACPSession:
         """Create a new agent session.
 
@@ -302,13 +305,23 @@ class ACPClient:
         is projected to its per-transport wire shape by
         :meth:`McpServerSpec.to_new_session_param`. ``None`` attaches no
         servers — the historical benchmark default.
+
+        ``session_meta`` rides along as ACP's ``_meta`` extension field. It
+        carries agent-specific session options the protocol does not model —
+        for Claude Code, the thinking-display setting that decides whether
+        ``agent_thought_chunk`` arrives with text. Comes from the registry
+        (``AgentConfig.acp_session_meta``), never from the call site.
         """
         server_params = [spec.to_new_session_param() for spec in mcp_servers or []]
         # Validate through model_validate (not the constructor) so the SDK's
         # discriminated mcp_servers union coerces each per-transport dict and
         # catches invalid task-authored MCP wire shapes before the agent sees them.
         params = NewSessionParams.model_validate(
-            {"cwd": cwd, "mcpServers": server_params}
+            {
+                "cwd": cwd,
+                "mcpServers": server_params,
+                **({"_meta": session_meta} if session_meta else {}),
+            }
         )
         result = await self._send_request(
             "session/new", params.model_dump(by_alias=True, exclude_none=True)

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -616,8 +616,15 @@ async def connect_acp(
             )
             logger.info(f"ACP agent: {agent_name}")
 
+            registered = AGENTS.get(agent)
             session = await _wait_for_acp_handshake(
-                acp_client.session_new(cwd=agent_cwd, mcp_servers=mcp_servers),
+                acp_client.session_new(
+                    cwd=agent_cwd,
+                    mcp_servers=mcp_servers,
+                    session_meta=(registered.acp_session_meta or None)
+                    if registered
+                    else None,
+                ),
                 phase="session_new",
             )
             logger.info(f"Session: {session.session_id}")

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -440,9 +440,15 @@ class ACPSession:
         elif update_type == "agent_message_chunk":
             content = update.get("content", {})
             if content.get("type") == "text":
+                # A content block opens with an empty chunk before its deltas
+                # arrive; recording it would put a contentless event in the
+                # trajectory and inflate the step counts in
+                # trajectory_summary. The text_update/agent_thought branches
+                # below have always guarded this way.
                 text = content.get("text", "")
-                self.message_chunks.append(text)
-                self._pending_text.append({"type": "agent_message", "text": text})
+                if text:
+                    self.message_chunks.append(text)
+                    self._pending_text.append({"type": "agent_message", "text": text})
 
         elif update_type == "text_update":
             # Used by openclaw shim — full text (not chunked)
@@ -462,8 +468,9 @@ class ACPSession:
             content = update.get("content", {})
             if content.get("type") == "text":
                 text = content.get("text", "")
-                self.thought_chunks.append(text)
-                self._pending_text.append({"type": "agent_thought", "text": text})
+                if text:
+                    self.thought_chunks.append(text)
+                    self._pending_text.append({"type": "agent_thought", "text": text})
 
         self._notify_change()
 

--- a/src/benchflow/agents/manifest.py
+++ b/src/benchflow/agents/manifest.py
@@ -86,6 +86,7 @@ _SHIM_ONLY = frozenset(
         "subscription_auth",
         "acp_model_config_id",
         "acp_effort_config_id",
+        "acp_session_meta",
         "disallow_web_tools_setup_cmd",
         "disallow_web_tools_owned_paths",
         "disallow_web_tools_launch_suffix",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -52,6 +52,7 @@ import base64
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from benchflow._utils.text import describe_exception
 
@@ -491,6 +492,11 @@ class AgentConfig:
     acp_model_config_id: str = ""
     # ACP session config option id used for reasoning/thinking effort.
     acp_effort_config_id: str = ""
+    # Extension metadata sent as ``_meta`` on ``session/new``. ACP reserves
+    # ``_meta`` for agent-specific options that the protocol itself does not
+    # model, so this keeps per-agent knobs in the registry instead of an
+    # ``if agent == ...`` in the runtime.
+    acp_session_meta: dict[str, Any] = field(default_factory=dict)
     # Shell snippet run after credentials/subscription auth are written when
     # BenchFlow's no-web policy is active. Uses BENCHFLOW_AGENT_HOME for the
     # target home so settings land in the same home the agent will run from.
@@ -553,6 +559,18 @@ AGENTS: dict[str, AgentConfig] = {
         supports_acp_set_model=False,
         acp_model_config_id="model",
         acp_effort_config_id="effort",
+        # Ask for thinking summaries. The Claude Agent SDK defaults adaptive
+        # thinking to `display: "omitted"` on models that support it, so the
+        # agent still reasons but the bridge relays `agent_thought_chunk` with
+        # an empty text — reasoning happens and the trajectory cannot show it.
+        # `effort` controls thinking *depth*, and MAX_THINKING_TOKENS its
+        # *budget*; neither turns the text back on. Verified against
+        # @anthropic-ai/claude-agent-sdk 0.3.160's ThinkingAdaptive type.
+        acp_session_meta={
+            "claudeCode": {
+                "options": {"thinking": {"type": "adaptive", "display": "summarized"}}
+            }
+        },
     ),
     "pi-acp": AgentConfig(
         name="pi-acp",

--- a/tests/test_acp_session_meta.py
+++ b/tests/test_acp_session_meta.py
@@ -1,0 +1,116 @@
+"""ACP ``session/new`` extension metadata (``_meta``).
+
+Guards the fix for empty Claude thoughts: the Claude Agent SDK defaults
+adaptive thinking to ``display: "omitted"``, so ``agent_thought_chunk``
+arrives with empty text and a trajectory records that reasoning happened
+without being able to show any of it. BenchFlow opts into summaries through
+``session/new``'s ``_meta``, which is registry data rather than a runtime
+special case.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from benchflow.acp.client import ACPClient
+from benchflow.agents.registry import AGENTS
+
+
+class _RecordingTransport:
+    """Captures the ``session/new`` payload instead of speaking to an agent."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def start(self) -> None:  # pragma: no cover - not exercised
+        return None
+
+    async def send(self, message: dict[str, Any]) -> None:
+        self.sent.append(message)
+
+    async def close(self) -> None:  # pragma: no cover - not exercised
+        return None
+
+
+async def _session_new_payload(**kwargs: Any) -> dict[str, Any]:
+    transport = _RecordingTransport()
+    client = ACPClient(transport)  # type: ignore[arg-type]
+
+    async def _fake_send_request(method: str, params: dict[str, Any]) -> dict[str, Any]:
+        transport.sent.append({"method": method, "params": params})
+        return {"sessionId": "s-1"}
+
+    client._send_request = _fake_send_request  # type: ignore[assignment]
+    await client.session_new(**kwargs)
+    return transport.sent[0]["params"]
+
+
+async def test_session_new_omits_meta_when_the_agent_declares_none() -> None:
+    params = await _session_new_payload(cwd="/app")
+
+    assert params["cwd"] == "/app"
+    # An absent _meta must stay absent — an empty dict is a different wire
+    # message and some agents validate it.
+    assert "_meta" not in params
+
+
+async def test_session_new_forwards_session_meta_verbatim() -> None:
+    meta = {"claudeCode": {"options": {"thinking": {"type": "adaptive"}}}}
+
+    params = await _session_new_payload(cwd="/app", session_meta=meta)
+
+    assert params["_meta"] == meta
+
+
+@pytest.mark.parametrize("agent", ["claude-agent-acp"])
+def test_claude_asks_for_summarized_thinking(agent: str) -> None:
+    """Without this the trajectory's agent_thought events carry empty text.
+
+    `effort` controls thinking depth and MAX_THINKING_TOKENS its budget;
+    neither restores the text, so the display setting is the one that matters.
+    """
+    thinking = AGENTS[agent].acp_session_meta["claudeCode"]["options"]["thinking"]
+
+    assert thinking["display"] == "summarized"
+    # Valid ThinkingConfig variants in @anthropic-ai/claude-agent-sdk 0.3.160.
+    assert thinking["type"] in {"adaptive", "enabled"}
+
+
+def test_agents_without_session_meta_send_nothing() -> None:
+    # The field is opt-in per agent; a blanket default would put Claude-shaped
+    # options on every harness's session/new.
+    assert AGENTS["codex-acp"].acp_session_meta == {}
+
+
+def _chunk(kind: str, text: str) -> dict[str, Any]:
+    return {"sessionUpdate": kind, "content": {"type": "text", "text": text}}
+
+
+@pytest.mark.parametrize(
+    ("kind", "event_type"),
+    [
+        ("agent_thought_chunk", "agent_thought"),
+        ("agent_message_chunk", "agent_message"),
+    ],
+)
+def test_empty_content_chunks_do_not_become_events(kind: str, event_type: str) -> None:
+    """A content block opens with an empty chunk before its deltas arrive.
+
+    Recording it produced contentless agent_thought/agent_message events that
+    inflated `steps` and `agent_thought_steps` in the run's
+    trajectory_summary — a run could report 2 thinking steps with 0 characters
+    of thinking.
+    """
+    from benchflow.acp.session import ACPSession
+
+    session = ACPSession("s-1")
+    session.handle_update(_chunk(kind, ""))
+    session.handle_update(_chunk(kind, "real "))
+    session.handle_update(_chunk(kind, "content"))
+    session._flush_agent_text()
+
+    events = [e for e in session.events if e.get("type") == event_type]
+    assert len(events) == 1
+    assert events[0]["text"] == "real content"


### PR DESCRIPTION
## Summary

Fixes #982.

Claude models that default `thinking.display` to `"omitted"` produce no usable thinking text in BenchFlow ACP trajectories.

This PR:

- passes agent-specific `_meta` through `ACPClient.session_new()`
- configures `claude-agent-acp` to request `thinking.display="summarized"`
- keeps the configuration registry-driven instead of adding a Claude-specific runtime branch
- ignores empty `agent_thought_chunk` and `agent_message_chunk` events so trajectory step counts only reflect actual content

## Validation

Using the same task (lake-warming-attribution) before and after enabling summarized thinking:

| Model | Configuration | Non-empty thought events | Thinking chars |
|---|---|---:|---:|
| `claude-sonnet-5` | default | 0 | 0 |
| `claude-sonnet-5` | `summarized` | 2 | 2126 (partial; stopped after confirming the result) |
| Haiku 4.5 | default | 9 | 3532 |
| Haiku 4.5 | `summarized` | 9 | 3559 |

Added tests for:

- forwarding `_meta` through `session/new`
- omitting `_meta` when no session metadata is configured
- Claude's summarized-thinking registry configuration
- filtering empty thought/message chunks
