### PR TITLE
fix(openclaw): clamp GPT-5.4 output tokens

### DIFF
--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -47,15 +47,17 @@ _PARAM_MAP = {
     "BENCHFLOW_MODEL_TOP_P": "agents.defaults.params.topP",
     "BENCHFLOW_MODEL_MAX_TOKENS": "agents.defaults.params.maxTokens",
 }
-_MODEL_MAX_TOKENS = {
-    # OpenClaw derives an invalid ~172k default for GPT-5.4; ACP may send either ID.
-    "gpt-5.4": 128000,
-    "benchflow-openai-gpt-5.4": 128000,
-}
 
 
 def _default_max_tokens(model: str) -> int | None:
-    return _MODEL_MAX_TOKENS.get(model.removeprefix("openai/"))
+    # OpenClaw derives an invalid ~172k default for GPT-5.4; ACP sends a
+    # BenchFlow-generated LiteLLM alias in normal runs.
+    model = model.removeprefix("openai/")
+    if model == "gpt-5.4" or (
+        model.startswith("benchflow-") and model.endswith("-gpt-5.4")
+    ):
+        return 128000
+    return None
 
 
 # ── ACP stdio I/O ─────────────────────────────────────────────────────────────

--- a/src/benchflow/agents/openclaw_acp_shim.py
+++ b/src/benchflow/agents/openclaw_acp_shim.py
@@ -47,6 +47,15 @@ _PARAM_MAP = {
     "BENCHFLOW_MODEL_TOP_P": "agents.defaults.params.topP",
     "BENCHFLOW_MODEL_MAX_TOKENS": "agents.defaults.params.maxTokens",
 }
+_MODEL_MAX_TOKENS = {
+    # OpenClaw derives an invalid ~172k default for GPT-5.4; ACP may send either ID.
+    "gpt-5.4": 128000,
+    "benchflow-openai-gpt-5.4": 128000,
+}
+
+
+def _default_max_tokens(model: str) -> int | None:
+    return _MODEL_MAX_TOKENS.get(model.removeprefix("openai/"))
 
 
 # ── ACP stdio I/O ─────────────────────────────────────────────────────────────
@@ -671,6 +680,7 @@ def main():
 
         elif method == "session/set_model":
             model = params.get("modelId", "")
+            requested_model = model
             # A provider-resolution / config-write failure here must NOT crash the
             # shim: an unhandled exception exits rc=1, which benchflow sees as the
             # ACP transport dying mid-set_model ("Process closed stdout (rc=1)") —
@@ -726,6 +736,25 @@ def main():
                             check=True,
                             timeout=10,
                         )
+                max_tokens = _default_max_tokens(requested_model)
+                configured_max_tokens = os.environ.get("BENCHFLOW_MODEL_MAX_TOKENS")
+                if max_tokens is not None and (
+                    not configured_max_tokens
+                    or not configured_max_tokens.isdigit()
+                    or int(configured_max_tokens) > max_tokens
+                ):
+                    subprocess.run(
+                        [
+                            _OPENCLAW_BIN,
+                            "config",
+                            "set",
+                            _PARAM_MAP["BENCHFLOW_MODEL_MAX_TOKENS"],
+                            str(max_tokens),
+                        ],
+                        capture_output=True,
+                        check=True,
+                        timeout=10,
+                    )
             except Exception as exc:
                 diag = (
                     f"[openclaw-acp-shim] set_model setup failed, continuing: {exc!r}"

--- a/tests/test_bare_model_provider.py
+++ b/tests/test_bare_model_provider.py
@@ -25,6 +25,7 @@ These tests pin the registry-driven bare-model routing:
 import pytest
 
 from benchflow.agents.openclaw_acp_shim import (
+    _default_max_tokens,
     _infer_provider_prefix,
     _resolve_bare_model_prefix,
     _setup_bare_custom_provider,
@@ -33,6 +34,12 @@ from benchflow.agents.providers import (
     find_provider,
     find_provider_for_bare_model,
 )
+from benchflow.providers.litellm_config import safe_model_alias
+
+
+@pytest.mark.parametrize("model", ["gpt-5.4", "openai/gpt-5.4"])
+def test_gpt54_proxy_alias_has_supported_token_cap(model):
+    assert _default_max_tokens(safe_model_alias(model)) == 128000
 
 
 class TestFindProviderForBareModel:


### PR DESCRIPTION
## Summary

Clamp OpenClaw GPT-5.4 output tokens to the provider limit.

## Root cause

OpenClaw sent max_tokens=171802 while GPT-5.4 accepts at most 128000. The ACP path uses internal alias benchflow-openai-gpt-5.4, so raw gpt-5.4 matching alone misses live requests.

## Changes

- Cap raw and ACP-alias GPT-5.4 IDs at 128000.
- Replace missing, malformed, or oversized configured values.
- Preserve explicit numeric values at or below the limit.

## Scope

OpenClaw + GPT-5.4 only. No global model cap, routing change, or OpenClaw runtime-pin change. #977 is adjacent only.

## Validation

- 47 focused tests passed.
- git diff --check passed.