### PR TITLE
feat: add secure public trajectory upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Added
+- **Public trajectory contribution.** `bench traj upload PATH` validates and
+  structurally redacts trajectory JSONL, creates a content-addressed manifest,
+  and uploads through the built-in public broker. Azure Blob quarantine,
+  versioning, short-lived create/write-only user-delegation SAS grants, and an
+  event-driven fail-closed validator keep untrusted captures out of the
+  community namespace until hashes, sizes, JSONL, and secret scans pass.
+  Replaying an ingested digest is a no-op; trusted operators can opt into direct
+  Azure upload with the `azure` extra and `--direct`.
+
 ### Changed
 - **BREAKING (task.md): the `environment:` frontmatter key is renamed to
   `sandbox:`.** The native task-config surface now accepts only `sandbox:`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **Public trajectory contribution.** `bench traj upload PATH` validates and
   structurally redacts trajectory JSONL, creates a content-addressed manifest,
   and uploads through the built-in public broker. Azure Blob quarantine,
-  versioning, short-lived create/write-only user-delegation SAS grants, and an
+  versioning, short-lived create-only user-delegation SAS grants, and an
   event-driven fail-closed validator keep untrusted captures out of the
   community namespace until hashes, sizes, JSONL, and secret scans pass.
   Replaying an ingested digest is a no-op; trusted operators can opt into direct

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
   and uploads through the built-in public broker. Azure Blob quarantine,
   versioning, short-lived create-only user-delegation SAS grants, and an
   event-driven fail-closed validator keep untrusted captures out of the
-  community namespace until hashes, sizes, JSONL, and secret scans pass.
+  community namespace until hashes, sizes, strict JSONL (including duplicate-key
+  and non-finite-number rejection), and artifact/manifest secret scans pass.
   Replaying an ingested digest is a no-op; trusted operators can opt into direct
   Azure upload with the `azure` extra and `--direct`.
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/
 | Multi-agent: coder + reviewer, simulated user, BYOS, stateful envs | [Use cases](./docs/use-cases.md) |
 | Multi-round single-agent (progressive disclosure, oracle access) | [Progressive disclosure](./docs/progressive-disclosure.md) |
 | Skill evaluation (when the artifact is a skill, not a workspace) | [Skill eval](./docs/skill-eval.md) |
+| Contribute a trajectory capture | [Trajectory upload](./docs/traj-upload.md) |
 | Understand the security model | [Sandbox hardening](./docs/sandbox-hardening.md) |
 | Use public vs internal preview SDK releases | [Release channels](./docs/release.md) |
 | CLI flags + commands | [CLI reference](./docs/reference/cli.md) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -854,6 +854,29 @@ and hosted-provider browsing to [`bench hub list`](#bench-hub). The old
 `bench environment create|list|cleanup` and `show|inspect` (plus `list
 --provider`/`--hub`) still work, each printing a one-line stderr notice.
 
+## bench traj upload
+
+Validate, redact, and contribute trajectory JSONL through BenchFlow's public
+broker. `PATH` can be one JSONL file, a directory of JSONL files, or a trial
+directory containing `trajectory/`. The command stages only JSONL artifacts,
+writes a content-addressed manifest last, and treats an already-ingested digest
+as a successful no-op.
+
+```bash
+bench traj upload path/to/trial
+bench traj upload path/to/trajectory.jsonl --source-id my-project/run-42
+bench traj upload path/to/trial --dry-run
+```
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--source-id` | derived from `PATH` | Stable contributor/run label stored in the manifest |
+| `--dry-run` | `false` | Validate, redact, hash, and list staged files without network traffic |
+| `--direct` | `false` | Use local Azure credentials instead of the public broker; requires the `azure` extra |
+| `--container-url` | — | Azure Blob container URL for `--direct`; alternatively set `BENCHFLOW_AZURE_CONTAINER_URL` |
+
+See [Trajectory upload](../traj-upload.md) for privacy and operator details.
+
 ## bench hub
 
 External environment hubs: browse a hub's environments (`list`/`show`/`inspect`)

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -1,0 +1,60 @@
+# Contribute trajectory captures
+
+Anyone with BenchFlow installed can contribute a completed trajectory with one
+command:
+
+```bash
+bench traj upload path/to/trial
+```
+
+`path/to/trial` may be a trial directory containing `trajectory/`, a directory
+of JSONL files, or one JSONL file. BenchFlow validates every line as JSON,
+structurally redacts credential-bearing keys and secret-like values, computes a
+content digest, and uploads a manifest last. Use `--dry-run` to inspect the
+staged file list, digest, sizes, ignored siblings, and redaction count without
+making a network request.
+
+The public broker URL is built into the CLI. `BENCHFLOW_TRAJ_BROKER_URL` can
+override it for development or disaster recovery, and
+`BENCHFLOW_TRAJ_UPLOADED_BY` can add a non-secret contributor label. Do not put
+credentials or personal data in either label.
+
+## What reaches the dataset
+
+Public uploads first enter a private, versioned Azure Blob quarantine prefix.
+The broker issues short-lived user-delegation SAS URLs scoped to create/write
+one expected blob at a time; they do not grant list, read, or delete access.
+An Event Grid-triggered validator independently checks the manifest contract,
+allowlisted object names, byte sizes, SHA-256 hashes, JSONL syntax, and a final
+secret scan. Only then does it copy artifacts into the immutable
+`sources/community/<digest>/` namespace, with `manifest.json` as the commit
+marker. Failed captures are removed from the live quarantine namespace and are
+never promoted. Blob versioning and lifecycle policy bound recovery and
+retention for attempted overwrites.
+
+The digest excludes contributor labels, timestamps, and transport details, so
+the same redacted bytes are idempotent across machines. Repeating an ingested
+upload prints `Already uploaded` and performs no blob writes.
+
+Redaction is a safety net, not a license to upload secrets. Review sensitive
+trajectories before contributing them; once a capture is promoted, dataset
+operators may retain it for benchmark provenance.
+
+## Trusted direct upload
+
+Operators with Azure RBAC can bypass the public broker while keeping the same
+staging and manifest contract:
+
+```bash
+uv tool install 'benchflow[azure]'
+az login
+bench traj upload path/to/trial --direct \
+  --container-url https://ACCOUNT.blob.core.windows.net/bronze
+```
+
+Direct mode uses `DefaultAzureCredential` and create-only blob calls. The
+identity needs `Storage Blob Data Creator` on the target container. For routine
+community contributions, use the default broker mode.
+
+Deployment configuration and verification live in
+[`infra/trajectory-upload/`](../infra/trajectory-upload/README.md).

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -22,9 +22,10 @@ credentials or personal data in either label.
 ## What reaches the dataset
 
 Public uploads first enter a private, versioned Azure Blob quarantine prefix.
-The broker issues short-lived user-delegation SAS URLs scoped to create/write
+The broker issues short-lived user-delegation SAS URLs scoped to create
 one expected blob at a time; they do not grant list, read, or delete access.
 An Event Grid-triggered validator independently checks the manifest contract,
+the 8 MiB per-record JSONL bound and structural complexity limits,
 allowlisted object names, byte sizes, SHA-256 hashes, JSONL syntax, and a final
 secret scan. Only then does it copy artifacts into the immutable
 `sources/community/<digest>/` namespace, with `manifest.json` as the commit

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -8,9 +8,10 @@ bench traj upload path/to/trial
 ```
 
 `path/to/trial` may be a trial directory containing `trajectory/`, a directory
-of JSONL files, or one JSONL file. BenchFlow validates every line as JSON,
-structurally redacts credential-bearing keys and secret-like values, computes a
-content digest, and uploads a manifest last. Use `--dry-run` to inspect the
+of JSONL files, or one JSONL file. BenchFlow rejects duplicate object keys and
+non-finite numbers, structurally redacts credential-bearing keys and secret-like
+values in both artifacts and manifest metadata, computes a content digest, and
+uploads a manifest last. Use `--dry-run` to inspect the
 staged file list, digest, sizes, ignored siblings, and redaction count without
 making a network request.
 
@@ -26,8 +27,8 @@ The broker issues short-lived user-delegation SAS URLs scoped to create
 one expected blob at a time; they do not grant list, read, or delete access.
 An Event Grid-triggered validator independently checks the manifest contract,
 the 8 MiB per-record JSONL bound and structural complexity limits,
-allowlisted object names, byte sizes, SHA-256 hashes, JSONL syntax, and a final
-secret scan. Only then does it copy artifacts into the immutable
+allowlisted object names, byte sizes, SHA-256 hashes, strict JSONL syntax, and
+final artifact and manifest secret scans. Only then does it copy artifacts into the immutable
 `sources/community/<digest>/` namespace, with `manifest.json` as the commit
 marker. Failed captures are removed from the live quarantine namespace and are
 never promoted. Blob versioning and lifecycle policy bound recovery and

--- a/infra/trajectory-upload/README.md
+++ b/infra/trajectory-upload/README.md
@@ -6,8 +6,9 @@
   containers, Shared Key and anonymous access disabled;
 - a scale-to-zero Container App broker with a user-assigned identity limited to
   create/write blob data actions, delegation-key signing, and the upload ledger;
-- Event Grid delivery of committed inbox manifests to an Entra-authenticated
-  Storage Queue;
+- Event Grid delivery of inbox object creations to an Entra-authenticated
+  Storage Queue, so manifests commit pending captures and terminal replays are
+  cleaned;
 - an event-driven Container Apps validator Job with separate read, promotion,
   cleanup, queue, and ledger authority;
 - two-day inbox/version expiry plus storage read/write/delete diagnostics.

--- a/infra/trajectory-upload/README.md
+++ b/infra/trajectory-upload/README.md
@@ -1,0 +1,25 @@
+# Azure trajectory upload deployment
+
+`deploy-azure.sh` provisions the production upload path with Azure CLI:
+
+- one private, versioned storage account with `bronze`, `silver`, and `gold`
+  containers, Shared Key and anonymous access disabled;
+- a scale-to-zero Container App broker with a user-assigned identity limited to
+  create/write blob data actions, delegation-key signing, and the upload ledger;
+- Event Grid delivery of committed inbox manifests to an Entra-authenticated
+  Storage Queue;
+- an event-driven Container Apps validator Job with separate read, promotion,
+  cleanup, queue, and ledger authority;
+- two-day inbox/version expiry plus storage read/write/delete diagnostics.
+
+The script is idempotent for the named production resources. It requires an
+Azure subscription Owner or User Access Administrator because it creates a
+custom role and managed-identity role assignments.
+
+```bash
+./infra/trajectory-upload/deploy-azure.sh
+```
+
+Override names and region with the `BENCHFLOW_UPLOAD_*` variables declared at
+the top of the script. The final line is the public broker URL to bake into the
+CLI release after a successful end-to-end validation.

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task_rg="${BENCHFLOW_UPLOAD_RESOURCE_GROUP:-tasksminer-upload-prod}"
+task_location="${BENCHFLOW_UPLOAD_LOCATION:-westus2}"
+task_storage="${BENCHFLOW_UPLOAD_STORAGE_ACCOUNT:-tasksminerdata}"
+task_acr="${BENCHFLOW_UPLOAD_ACR:-tasksminerregistry}"
+task_environment="${BENCHFLOW_UPLOAD_ENVIRONMENT:-tasksminer-upload}"
+task_broker="${BENCHFLOW_UPLOAD_BROKER_APP:-tasksminer-traj-broker}"
+task_validator="${BENCHFLOW_UPLOAD_VALIDATOR_JOB:-tasksminer-traj-validator}"
+task_queue="trajectory-validation"
+task_table="trajectoryuploads"
+task_subscription="$(az account show --query id -o tsv)"
+task_user_id="$(az ad signed-in-user show --query id -o tsv)"
+task_repo_root="$(git rev-parse --show-toplevel)"
+task_image_tag="$(git rev-parse --short=12 HEAD)"
+task_image="${task_acr}.azurecr.io/trajectory-upload:${task_image_tag}"
+
+ensure_role_assignment() {
+    local principal_id="$1"
+    local role="$2"
+    local scope="$3"
+    local present
+    present="$(az role assignment list \
+        --assignee-object-id "$principal_id" \
+        --scope "$scope" \
+        --query "[?roleDefinitionName=='$role'] | length(@)" \
+        -o tsv)"
+    if [[ "$present" == "0" ]]; then
+        az role assignment create \
+            --assignee-object-id "$principal_id" \
+            --role "$role" \
+            --scope "$scope" \
+            --output none
+    fi
+}
+
+az group create \
+    --name "$task_rg" \
+    --location "$task_location" \
+    --tags service=trajectory-upload environment=production \
+    --output none
+
+az storage account create \
+    --name "$task_storage" \
+    --resource-group "$task_rg" \
+    --location "$task_location" \
+    --sku Standard_LRS \
+    --kind StorageV2 \
+    --https-only true \
+    --min-tls-version TLS1_2 \
+    --allow-blob-public-access false \
+    --allow-shared-key-access false \
+    --output none
+
+task_storage_id="$(az storage account show \
+    --name "$task_storage" \
+    --resource-group "$task_rg" \
+    --query id -o tsv)"
+task_blob_scope="${task_storage_id}/blobServices/default"
+task_bronze_scope="${task_blob_scope}/containers/bronze"
+task_queue_scope="${task_storage_id}/queueServices/default/queues/${task_queue}"
+task_table_scope="${task_storage_id}/tableServices/default/tables/${task_table}"
+
+# The deploying owner needs data-plane access because account keys are disabled.
+ensure_role_assignment "$task_user_id" "Storage Blob Data Contributor" "$task_storage_id"
+ensure_role_assignment "$task_user_id" "Storage Queue Data Contributor" "$task_storage_id"
+ensure_role_assignment "$task_user_id" "Storage Table Data Contributor" "$task_storage_id"
+
+az storage account blob-service-properties update \
+    --account-name "$task_storage" \
+    --resource-group "$task_rg" \
+    --enable-versioning true \
+    --output none
+
+for task_container in bronze silver gold; do
+    az storage container create \
+        --name "$task_container" \
+        --account-name "$task_storage" \
+        --auth-mode login \
+        --public-access off \
+        --output none
+done
+az storage queue create \
+    --name "$task_queue" \
+    --account-name "$task_storage" \
+    --auth-mode login \
+    --output none
+az storage table create \
+    --name "$task_table" \
+    --account-name "$task_storage" \
+    --auth-mode login \
+    --output none
+az storage account management-policy create \
+    --account-name "$task_storage" \
+    --resource-group "$task_rg" \
+    --policy "@${task_repo_root}/infra/trajectory-upload/lifecycle.json" \
+    --output none
+
+task_logs="${task_environment}-logs"
+az monitor log-analytics workspace create \
+    --resource-group "$task_rg" \
+    --workspace-name "$task_logs" \
+    --location "$task_location" \
+    --output none
+task_logs_id="$(az monitor log-analytics workspace show \
+    --resource-group "$task_rg" \
+    --workspace-name "$task_logs" \
+    --query id -o tsv)"
+az monitor diagnostic-settings create \
+    --name trajectory-upload-storage \
+    --resource "$task_blob_scope" \
+    --workspace "$task_logs_id" \
+    --logs '[{"category":"StorageRead","enabled":true},{"category":"StorageWrite","enabled":true},{"category":"StorageDelete","enabled":true}]' \
+    --output none
+
+az acr create \
+    --name "$task_acr" \
+    --resource-group "$task_rg" \
+    --location "$task_location" \
+    --sku Basic \
+    --admin-enabled false \
+    --output none
+task_acr_id="$(az acr show --name "$task_acr" --query id -o tsv)"
+
+task_broker_identity="${task_broker}-id"
+task_validator_identity="${task_validator}-id"
+az identity create \
+    --name "$task_broker_identity" \
+    --resource-group "$task_rg" \
+    --location "$task_location" \
+    --output none
+az identity create \
+    --name "$task_validator_identity" \
+    --resource-group "$task_rg" \
+    --location "$task_location" \
+    --output none
+task_broker_identity_id="$(az identity show -g "$task_rg" -n "$task_broker_identity" --query id -o tsv)"
+task_broker_principal_id="$(az identity show -g "$task_rg" -n "$task_broker_identity" --query principalId -o tsv)"
+task_validator_identity_id="$(az identity show -g "$task_rg" -n "$task_validator_identity" --query id -o tsv)"
+task_validator_principal_id="$(az identity show -g "$task_rg" -n "$task_validator_identity" --query principalId -o tsv)"
+
+task_role_name="TasksMiner Blob Data Creator"
+task_role_exists="$(az role definition list --name "$task_role_name" --query 'length(@)' -o tsv)"
+if [[ "$task_role_exists" == "0" ]]; then
+    task_role_json="$(jq -n \
+        --arg scope "/subscriptions/${task_subscription}" \
+        --arg name "$task_role_name" \
+        '{Name:$name,Description:"Create and write blobs without read, list, or delete data actions.",Actions:[],NotActions:[],DataActions:["Microsoft.Storage/storageAccounts/blobServices/containers/blobs/write","Microsoft.Storage/storageAccounts/blobServices/containers/blobs/add/action"],NotDataActions:[],AssignableScopes:[$scope]}')"
+    az role definition create --role-definition "$task_role_json" --output none
+fi
+
+ensure_role_assignment "$task_broker_principal_id" "$task_role_name" "$task_bronze_scope"
+ensure_role_assignment "$task_broker_principal_id" "Storage Blob Delegator" "$task_storage_id"
+ensure_role_assignment "$task_broker_principal_id" "Storage Table Data Contributor" "$task_table_scope"
+ensure_role_assignment "$task_broker_principal_id" "AcrPull" "$task_acr_id"
+
+ensure_role_assignment "$task_validator_principal_id" "Storage Blob Data Contributor" "$task_bronze_scope"
+ensure_role_assignment "$task_validator_principal_id" "Storage Queue Data Reader" "$task_queue_scope"
+ensure_role_assignment "$task_validator_principal_id" "Storage Queue Data Message Processor" "$task_queue_scope"
+ensure_role_assignment "$task_validator_principal_id" "Storage Table Data Contributor" "$task_table_scope"
+ensure_role_assignment "$task_validator_principal_id" "AcrPull" "$task_acr_id"
+
+az acr build \
+    --registry "$task_acr" \
+    --image "trajectory-upload:${task_image_tag}" \
+    --file services/trajectory_upload/Dockerfile \
+    "$task_repo_root" \
+    --output none
+
+az containerapp env create \
+    --name "$task_environment" \
+    --resource-group "$task_rg" \
+    --location "$task_location" \
+    --logs-workspace-id "$(az monitor log-analytics workspace show -g "$task_rg" -n "$task_logs" --query customerId -o tsv)" \
+    --logs-workspace-key "$(az monitor log-analytics workspace get-shared-keys -g "$task_rg" -n "$task_logs" --query primarySharedKey -o tsv)" \
+    --output none
+
+task_ip_hash_key="$(openssl rand -hex 32)"
+az containerapp create \
+    --name "$task_broker" \
+    --resource-group "$task_rg" \
+    --environment "$task_environment" \
+    --image "$task_image" \
+    --user-assigned "$task_broker_identity_id" \
+    --registry-server "${task_acr}.azurecr.io" \
+    --registry-identity "$task_broker_identity_id" \
+    --ingress external \
+    --target-port 8000 \
+    --transport http \
+    --allow-insecure false \
+    --min-replicas 0 \
+    --max-replicas 1 \
+    --cpu 0.5 \
+    --memory 1.0Gi \
+    --secrets "ip-hash-key=${task_ip_hash_key}" \
+    --env-vars \
+        "AZURE_CLIENT_ID=$(az identity show -g "$task_rg" -n "$task_broker_identity" --query clientId -o tsv)" \
+        "AZURE_STORAGE_ACCOUNT_NAME=${task_storage}" \
+        "AZURE_BLOB_CONTAINER=bronze" \
+        "AZURE_LEDGER_TABLE=${task_table}" \
+        "TRAJ_UPLOAD_IP_HASH_KEY=secretref:ip-hash-key" \
+        "TRAJ_UPLOAD_RATE_LIMIT=20" \
+        "TRAJ_UPLOAD_SAS_MINUTES=15" \
+    --output none
+
+az containerapp job create \
+    --name "$task_validator" \
+    --resource-group "$task_rg" \
+    --environment "$task_environment" \
+    --trigger-type Event \
+    --image "$task_image" \
+    --mi-user-assigned "$task_validator_identity_id" \
+    --registry-server "${task_acr}.azurecr.io" \
+    --registry-identity "$task_validator_identity_id" \
+    --command python \
+    --args -m services.trajectory_upload.validator \
+    --cpu 0.5 \
+    --memory 1.0Gi \
+    --replica-timeout 1800 \
+    --replica-retry-limit 3 \
+    --parallelism 1 \
+    --replica-completion-count 1 \
+    --polling-interval 30 \
+    --min-executions 0 \
+    --max-executions 5 \
+    --scale-rule-name trajectory-queue \
+    --scale-rule-type azure-queue \
+    --scale-rule-metadata \
+        "accountName=${task_storage}" \
+        "cloud=AzurePublicCloud" \
+        "queueLength=1" \
+        "queueName=${task_queue}" \
+    --scale-rule-identity "$task_validator_identity_id" \
+    --env-vars \
+        "AZURE_CLIENT_ID=$(az identity show -g "$task_rg" -n "$task_validator_identity" --query clientId -o tsv)" \
+        "AZURE_STORAGE_ACCOUNT_NAME=${task_storage}" \
+        "AZURE_BLOB_CONTAINER=bronze" \
+        "AZURE_VALIDATION_QUEUE=${task_queue}" \
+        "AZURE_LEDGER_TABLE=${task_table}" \
+    --output none
+
+task_event_name="trajectory-manifest-created"
+task_event_exists="$(az eventgrid event-subscription show \
+    --name "$task_event_name" \
+    --source-resource-id "$task_storage_id" \
+    --query name -o tsv 2>/dev/null || true)"
+if [[ -z "$task_event_exists" ]]; then
+    az eventgrid event-subscription create \
+        --name "$task_event_name" \
+        --source-resource-id "$task_storage_id" \
+        --included-event-types Microsoft.Storage.BlobCreated \
+        --subject-begins-with "/blobServices/default/containers/bronze/blobs/inbox/" \
+        --subject-ends-with "manifest.json" \
+        --delivery-identity systemassigned \
+        --delivery-identity-endpoint-type storagequeue \
+        --delivery-identity-endpoint "$task_queue_scope" \
+        --max-delivery-attempts 30 \
+        --event-ttl 1440 \
+        --output none
+fi
+task_event_principal_id="$(az eventgrid event-subscription show \
+    --name "$task_event_name" \
+    --source-resource-id "$task_storage_id" \
+    --query deliveryWithResourceIdentity.identity.principalId -o tsv)"
+ensure_role_assignment "$task_event_principal_id" "Storage Queue Data Message Sender" "$task_queue_scope"
+
+az storage account update \
+    --name "$task_storage" \
+    --resource-group "$task_rg" \
+    --allow-blob-public-access false \
+    --allow-shared-key-access false \
+    --min-tls-version TLS1_2 \
+    --https-only true \
+    --output none
+
+task_broker_fqdn="$(az containerapp show \
+    --name "$task_broker" \
+    --resource-group "$task_rg" \
+    --query properties.configuration.ingress.fqdn -o tsv)"
+echo "https://${task_broker_fqdn}"

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -295,7 +295,7 @@ az containerapp job create \
 task_event_name="trajectory-manifest-created"
 task_event_body="$(jq -n \
     --arg storage "$task_storage_id" \
-    '{properties:{deliveryWithResourceIdentity:{identity:{type:"SystemAssigned"},destination:{endpointType:"StorageQueue",properties:{resourceId:$storage,queueName:"trajectory-validation",queueMessageTimeToLiveInSeconds:604800}}},filter:{isSubjectCaseSensitive:false,subjectBeginsWith:"/blobServices/default/containers/bronze/blobs/inbox/",subjectEndsWith:"manifest.json",includedEventTypes:["Microsoft.Storage.BlobCreated"]},retryPolicy:{maxDeliveryAttempts:30,eventTimeToLiveInMinutes:1440},eventDeliverySchema:"EventGridSchema"}}')"
+    '{properties:{deliveryWithResourceIdentity:{identity:{type:"SystemAssigned"},destination:{endpointType:"StorageQueue",properties:{resourceId:$storage,queueName:"trajectory-validation",queueMessageTimeToLiveInSeconds:604800}}},filter:{isSubjectCaseSensitive:false,subjectBeginsWith:"/blobServices/default/containers/bronze/blobs/inbox/",includedEventTypes:["Microsoft.Storage.BlobCreated"]},retryPolicy:{maxDeliveryAttempts:30,eventTimeToLiveInMinutes:1440},eventDeliverySchema:"EventGridSchema"}}')"
 az rest \
     --method put \
     --url "https://management.azure.com${task_system_topic_id}/eventSubscriptions/${task_event_name}?api-version=2025-02-15" \

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -16,6 +16,23 @@ task_repo_root="$(git rev-parse --show-toplevel)"
 task_image_tag="$(git rev-parse --short=12 HEAD)"
 task_image="${task_acr}.azurecr.io/trajectory-upload:${task_image_tag}"
 
+for task_provider in \
+    Microsoft.App \
+    Microsoft.ContainerRegistry \
+    Microsoft.EventGrid \
+    Microsoft.Insights \
+    Microsoft.ManagedIdentity \
+    Microsoft.OperationalInsights \
+    Microsoft.Storage; do
+    az provider register --namespace "$task_provider" --wait --output none
+done
+az extension add \
+    --name containerapp \
+    --upgrade \
+    --allow-preview true \
+    --yes \
+    --output none
+
 ensure_role_assignment() {
     local principal_id="$1"
     local role="$2"

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -267,8 +267,8 @@ az containerapp job create \
     --registry-server "${task_acr}.azurecr.io" \
     --registry-identity "$task_validator_identity_id" \
     --command /app/services/trajectory_upload/validator-entrypoint \
-    --cpu 0.5 \
-    --memory 1.0Gi \
+    --cpu 1.0 \
+    --memory 2.0Gi \
     --replica-timeout 1800 \
     --replica-retry-limit 3 \
     --parallelism 1 \

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -213,8 +213,7 @@ az containerapp job create \
     --mi-user-assigned "$task_validator_identity_id" \
     --registry-server "${task_acr}.azurecr.io" \
     --registry-identity "$task_validator_identity_id" \
-    --command python \
-    --args -m services.trajectory_upload.validator \
+    --command /app/services/trajectory_upload/validator-entrypoint \
     --cpu 0.5 \
     --memory 1.0Gi \
     --replica-timeout 1800 \

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -161,6 +161,42 @@ ensure_role_assignment "$task_validator_principal_id" "Storage Queue Data Messag
 ensure_role_assignment "$task_validator_principal_id" "Storage Table Data Contributor" "$task_table_scope"
 ensure_role_assignment "$task_validator_principal_id" "AcrPull" "$task_acr_id"
 
+# Event Grid needs an identity on the parent system topic before an event
+# subscription can use managed-identity delivery. Creating a subscription
+# directly on the storage source produces an identity-less implicit topic.
+task_system_topic="$(az eventgrid system-topic list \
+    --resource-group "$task_rg" \
+    --query '[0].name' -o tsv)"
+if [[ -z "$task_system_topic" ]]; then
+    task_system_topic="trajectory-storage-events"
+    az eventgrid system-topic create \
+        --resource-group "$task_rg" \
+        --name "$task_system_topic" \
+        --location "$task_location" \
+        --topic-type microsoft.storage.storageaccounts \
+        --source "$task_storage_id" \
+        --identity systemassigned \
+        --output none
+else
+    az eventgrid system-topic update \
+        --resource-group "$task_rg" \
+        --name "$task_system_topic" \
+        --identity systemassigned \
+        --output none
+fi
+task_system_topic_id="$(az eventgrid system-topic show \
+    --resource-group "$task_rg" \
+    --name "$task_system_topic" \
+    --query id -o tsv)"
+task_system_topic_principal_id="$(az eventgrid system-topic show \
+    --resource-group "$task_rg" \
+    --name "$task_system_topic" \
+    --query identity.principalId -o tsv)"
+ensure_role_assignment \
+    "$task_system_topic_principal_id" \
+    "Storage Queue Data Message Sender" \
+    "$task_storage_id"
+
 az acr build \
     --registry "$task_acr" \
     --image "trajectory-upload:${task_image_tag}" \
@@ -240,29 +276,14 @@ az containerapp job create \
     --output none
 
 task_event_name="trajectory-manifest-created"
-task_event_exists="$(az eventgrid event-subscription show \
-    --name "$task_event_name" \
-    --source-resource-id "$task_storage_id" \
-    --query name -o tsv 2>/dev/null || true)"
-if [[ -z "$task_event_exists" ]]; then
-    az eventgrid event-subscription create \
-        --name "$task_event_name" \
-        --source-resource-id "$task_storage_id" \
-        --included-event-types Microsoft.Storage.BlobCreated \
-        --subject-begins-with "/blobServices/default/containers/bronze/blobs/inbox/" \
-        --subject-ends-with "manifest.json" \
-        --delivery-identity systemassigned \
-        --delivery-identity-endpoint-type storagequeue \
-        --delivery-identity-endpoint "$task_queue_scope" \
-        --max-delivery-attempts 30 \
-        --event-ttl 1440 \
-        --output none
-fi
-task_event_principal_id="$(az eventgrid event-subscription show \
-    --name "$task_event_name" \
-    --source-resource-id "$task_storage_id" \
-    --query deliveryWithResourceIdentity.identity.principalId -o tsv)"
-ensure_role_assignment "$task_event_principal_id" "Storage Queue Data Message Sender" "$task_queue_scope"
+task_event_body="$(jq -n \
+    --arg storage "$task_storage_id" \
+    '{properties:{deliveryWithResourceIdentity:{identity:{type:"SystemAssigned"},destination:{endpointType:"StorageQueue",properties:{resourceId:$storage,queueName:"trajectory-validation",queueMessageTimeToLiveInSeconds:604800}}},filter:{isSubjectCaseSensitive:false,subjectBeginsWith:"/blobServices/default/containers/bronze/blobs/inbox/",subjectEndsWith:"manifest.json",includedEventTypes:["Microsoft.Storage.BlobCreated"]},retryPolicy:{maxDeliveryAttempts:30,eventTimeToLiveInMinutes:1440},eventDeliverySchema:"EventGridSchema"}}')"
+az rest \
+    --method put \
+    --url "https://management.azure.com${task_system_topic_id}/eventSubscriptions/${task_event_name}?api-version=2025-02-15" \
+    --body "$task_event_body" \
+    --output none
 
 az storage account update \
     --name "$task_storage" \

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -185,7 +185,7 @@ task_system_topic="$(az eventgrid system-topic list \
     --resource-group "$task_rg" \
     --output json | jq -r \
         --arg source "$task_storage_id" \
-        'map(select(.source == $source))[0].name // empty')"
+        'map(select((.source | ascii_downcase) == ($source | ascii_downcase)))[0].name // empty')"
 if [[ -z "$task_system_topic" ]]; then
     task_system_topic="trajectory-storage-events"
     az eventgrid system-topic create \

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -214,7 +214,21 @@ task_system_topic_principal_id="$(az eventgrid system-topic show \
 ensure_role_assignment \
     "$task_system_topic_principal_id" \
     "Storage Queue Data Message Sender" \
-    "$task_storage_id"
+    "$task_queue_scope"
+
+# Early revisions scoped this role at the full storage account. This topic is
+# dedicated to one queue, so converge existing deployments to the narrow scope.
+task_legacy_event_sender_count="$(az role assignment list \
+    --assignee-object-id "$task_system_topic_principal_id" \
+    --scope "$task_storage_id" \
+    --query "[?roleDefinitionName=='Storage Queue Data Message Sender'] | length(@)" \
+    -o tsv)"
+if [[ "$task_legacy_event_sender_count" != "0" ]]; then
+    az role assignment delete \
+        --assignee-object-id "$task_system_topic_principal_id" \
+        --role "Storage Queue Data Message Sender" \
+        --scope "$task_storage_id"
+fi
 
 az acr build \
     --registry "$task_acr" \

--- a/infra/trajectory-upload/deploy-azure.sh
+++ b/infra/trajectory-upload/deploy-azure.sh
@@ -183,7 +183,9 @@ ensure_role_assignment "$task_validator_principal_id" "AcrPull" "$task_acr_id"
 # directly on the storage source produces an identity-less implicit topic.
 task_system_topic="$(az eventgrid system-topic list \
     --resource-group "$task_rg" \
-    --query '[0].name' -o tsv)"
+    --output json | jq -r \
+        --arg source "$task_storage_id" \
+        'map(select(.source == $source))[0].name // empty')"
 if [[ -z "$task_system_topic" ]]; then
     task_system_topic="trajectory-storage-events"
     az eventgrid system-topic create \

--- a/infra/trajectory-upload/lifecycle.json
+++ b/infra/trajectory-upload/lifecycle.json
@@ -1,0 +1,31 @@
+{
+  "rules": [
+    {
+      "enabled": true,
+      "name": "expire-trajectory-inbox",
+      "type": "Lifecycle",
+      "definition": {
+        "actions": {
+          "baseBlob": {
+            "delete": {
+              "daysAfterModificationGreaterThan": 2
+            }
+          },
+          "version": {
+            "delete": {
+              "daysAfterCreationGreaterThan": 2
+            }
+          }
+        },
+        "filters": {
+          "blobTypes": [
+            "blockBlob"
+          ],
+          "prefixMatch": [
+            "bronze/inbox/"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,20 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
+azure = [
+    # Direct Azure Blob trajectory uploads (bench traj upload --direct).
+    # Broker-mode uploads need neither package.
+    "azure-storage-blob>=12.19",
+    "azure-identity>=1.16",
+]
+azure-service = [
+    # Dependencies baked into the public trajectory broker/validator image.
+    "azure-storage-blob>=12.19",
+    "azure-identity>=1.16",
+    "azure-data-tables>=12.5",
+    "azure-storage-queue>=12.9",
+    "uvicorn>=0.30",
+]
 dev = [
     "pre-commit>=3.7",
     # AgentCore's CodeBuild path must reproduce Docker's ignore rules in tests

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Deployment-only services maintained with BenchFlow."""

--- a/services/trajectory_upload/Dockerfile
+++ b/services/trajectory_upload/Dockerfile
@@ -1,0 +1,16 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock README.md LICENSE ./
+COPY src ./src
+COPY services ./services
+
+RUN uv sync --frozen --no-dev --extra azure-service
+
+ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONUNBUFFERED=1
+
+EXPOSE 8000
+
+CMD ["uvicorn", "services.trajectory_upload.broker_app:app", "--host", "0.0.0.0", "--port", "8000", "--proxy-headers", "--forwarded-allow-ips", "*"]

--- a/services/trajectory_upload/Dockerfile
+++ b/services/trajectory_upload/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim@sha256:e5b65587bce7de595f299855d7385fe7fca39b8a74baa261ba1b7147afa78e58
 
 WORKDIR /app
 
@@ -6,10 +6,15 @@ COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY src ./src
 COPY services ./services
 
-RUN uv sync --frozen --no-dev --extra azure-service
+RUN uv sync --frozen --no-dev --extra azure-service \
+    && groupadd --system benchflow \
+    && useradd --system --gid benchflow --no-create-home benchflow
 
 ENV PATH="/app/.venv/bin:${PATH}" \
+    PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
+
+USER benchflow
 
 EXPOSE 8000
 

--- a/services/trajectory_upload/__init__.py
+++ b/services/trajectory_upload/__init__.py
@@ -1,0 +1,1 @@
+"""Public trajectory-upload broker and quarantine validator."""

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -11,7 +11,11 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import quote
 
-from services.trajectory_upload.broker_app import AlreadyUploaded, RateLimited
+from services.trajectory_upload.broker_app import (
+    AlreadyUploaded,
+    RateLimited,
+    RejectedUpload,
+)
 from services.trajectory_upload.contract import (
     UploadGrant,
     UploadObject,
@@ -80,16 +84,19 @@ class AzureUploadBroker:
                     base_url=self.container_url,
                     prefix=f"sources/community/{digest}/",
                 )
+            if status == "rejected":
+                raise RejectedUpload
             self._consume_rate_limit(client_ip)
-            self.table.upsert_entity(
-                {
-                    "PartitionKey": "capture",
-                    "RowKey": digest,
-                    "status": "pending",
-                    "source_id": request.source_id,
-                    "updated_at": datetime.now(UTC).isoformat(),
-                }
-            )
+            if status is None:
+                self.table.upsert_entity(
+                    {
+                        "PartitionKey": "capture",
+                        "RowKey": digest,
+                        "status": "pending",
+                        "source_id": request.source_id,
+                        "updated_at": datetime.now(UTC).isoformat(),
+                    }
+                )
 
         now = datetime.now(UTC)
         expires_at = now + timedelta(minutes=self.sas_minutes)

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -79,6 +79,7 @@ class AzureUploadBroker:
     def create_upload(self, request: UploadRequest, *, client_ip: str) -> UploadGrant:
         digest = request.traj_digest.removeprefix("sha256:")
         with self._state_lock:
+            self._consume_rate_limit(client_ip)
             status = self._capture_status(digest)
             if status == "ingested":
                 raise AlreadyUploaded(
@@ -87,7 +88,6 @@ class AzureUploadBroker:
                 )
             if status == "rejected":
                 raise RejectedUpload
-            self._consume_rate_limit(client_ip)
             if status is None:
                 self.table.upsert_entity(
                     {

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -15,7 +15,6 @@ from urllib.parse import quote
 from services.trajectory_upload.broker_app import (
     AlreadyUploaded,
     RateLimited,
-    RejectedUpload,
 )
 from services.trajectory_upload.contract import (
     UploadGrant,
@@ -78,22 +77,38 @@ class AzureUploadBroker:
 
     def create_upload(self, request: UploadRequest, *, client_ip: str) -> UploadGrant:
         digest = request.traj_digest.removeprefix("sha256:")
+        upload_id = f"u_{uuid.uuid4().hex}"
         with self._state_lock:
             self._consume_rate_limit(client_ip)
-            status = self._capture_status(digest)
+            entity = self._capture_entity(digest)
+            status = entity.get("status") if entity is not None else None
             if status == "ingested":
                 raise AlreadyUploaded(
                     base_url=self.container_url,
                     prefix=f"sources/community/{digest}/",
                 )
-            if status == "rejected":
-                raise RejectedUpload
-            if status is None:
+            if status in {"pending", "validating"}:
+                if entity is None:  # pragma: no cover - implied by status above
+                    raise RuntimeError("active capture ledger entry is missing")
+                persisted_attempt = entity.get("attempt_id")
+                if persisted_attempt and not _valid_upload_id(persisted_attempt):
+                    raise RuntimeError(
+                        "active capture ledger has an invalid attempt id"
+                    )
+                if isinstance(persisted_attempt, str) and persisted_attempt:
+                    upload_id = persisted_attempt
+                    prefix = f"inbox/{digest}/{upload_id}/"
+                else:
+                    # Preserve the pre-attempt namespace for captures that were
+                    # already in flight when this version was deployed.
+                    prefix = f"inbox/{digest}/"
+            else:
                 self.table.upsert_entity(
                     {
                         "PartitionKey": "capture",
                         "RowKey": digest,
                         "status": "pending",
+                        "attempt_id": upload_id,
                         "source_id": request.source_id,
                         "declared_artifacts": json.dumps(
                             {
@@ -104,13 +119,15 @@ class AzureUploadBroker:
                             sort_keys=True,
                         ),
                         "updated_at": datetime.now(UTC).isoformat(),
+                        "validation_lease_until": "",
+                        "detail": "",
                     }
                 )
+                prefix = f"inbox/{digest}/{upload_id}/"
 
         now = datetime.now(UTC)
         expires_at = now + timedelta(minutes=self.sas_minutes)
         delegation_key = self._user_delegation_key(now)
-        prefix = f"inbox/{digest}/"
         objects = tuple(
             self._upload_object(
                 prefix=prefix,
@@ -126,7 +143,7 @@ class AzureUploadBroker:
             ]
         )
         return UploadGrant(
-            upload_id=f"u_{uuid.uuid4().hex}",
+            upload_id=upload_id,
             bucket=self.container,
             base_url=self.container_url,
             prefix=prefix,
@@ -138,15 +155,13 @@ class AzureUploadBroker:
     def container_url(self) -> str:
         return f"https://{self.account_name}.blob.core.windows.net/{self.container}"
 
-    def _capture_status(self, digest: str) -> str | None:
+    def _capture_entity(self, digest: str) -> Any | None:
         from azure.core.exceptions import ResourceNotFoundError
 
         try:
-            entity = self.table.get_entity(partition_key="capture", row_key=digest)
+            return self.table.get_entity(partition_key="capture", row_key=digest)
         except ResourceNotFoundError:
             return None
-        status = entity.get("status")
-        return status if isinstance(status, str) else None
 
     def _consume_rate_limit(self, client_ip: str) -> None:
         from azure.core.exceptions import ResourceNotFoundError
@@ -228,3 +243,12 @@ def _required_env(name: str) -> str:
     if not value:
         raise RuntimeError(f"required environment variable is not set: {name}")
     return value
+
+
+def _valid_upload_id(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 34
+        and value.startswith("u_")
+        and all(char in "0123456789abcdef" for char in value[2:])
+    )

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -1,0 +1,211 @@
+"""Managed-identity Azure backend for broker SAS grants and durable rate limits."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import threading
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import quote
+
+from services.trajectory_upload.broker_app import AlreadyUploaded, RateLimited
+from services.trajectory_upload.contract import (
+    UploadGrant,
+    UploadObject,
+    UploadRequest,
+)
+
+
+class AzureUploadBroker:
+    """Mint blob-scoped user-delegation SAS URLs without blob read authority."""
+
+    def __init__(
+        self,
+        *,
+        account_name: str,
+        container: str,
+        table: Any,
+        blob_service: Any,
+        ip_hash_key: bytes,
+        rate_limit: int = 20,
+        sas_minutes: int = 15,
+    ) -> None:
+        self.account_name = account_name
+        self.container = container
+        self.table = table
+        self.blob_service = blob_service
+        self.ip_hash_key = ip_hash_key
+        self.rate_limit = rate_limit
+        self.sas_minutes = min(max(sas_minutes, 1), 15)
+        self._state_lock = threading.Lock()
+        self._delegation_key: Any = None
+        self._delegation_key_expires = datetime.min.replace(tzinfo=UTC)
+
+    @classmethod
+    def from_env(cls) -> AzureUploadBroker:
+        from azure.data.tables import TableClient
+        from azure.identity import DefaultAzureCredential
+        from azure.storage.blob import BlobServiceClient
+
+        account_name = _required_env("AZURE_STORAGE_ACCOUNT_NAME")
+        container = os.environ.get("AZURE_BLOB_CONTAINER", "bronze")
+        table_name = os.environ.get("AZURE_LEDGER_TABLE", "trajectoryuploads")
+        credential = DefaultAzureCredential()
+        return cls(
+            account_name=account_name,
+            container=container,
+            table=TableClient(
+                endpoint=f"https://{account_name}.table.core.windows.net",
+                table_name=table_name,
+                credential=credential,
+            ),
+            blob_service=BlobServiceClient(
+                account_url=f"https://{account_name}.blob.core.windows.net",
+                credential=credential,
+            ),
+            ip_hash_key=_required_env("TRAJ_UPLOAD_IP_HASH_KEY").encode(),
+            rate_limit=int(os.environ.get("TRAJ_UPLOAD_RATE_LIMIT", "20")),
+            sas_minutes=int(os.environ.get("TRAJ_UPLOAD_SAS_MINUTES", "15")),
+        )
+
+    def create_upload(self, request: UploadRequest, *, client_ip: str) -> UploadGrant:
+        digest = request.traj_digest.removeprefix("sha256:")
+        with self._state_lock:
+            status = self._capture_status(digest)
+            if status == "ingested":
+                raise AlreadyUploaded(
+                    base_url=self.container_url,
+                    prefix=f"sources/community/{digest}/",
+                )
+            self._consume_rate_limit(client_ip)
+            self.table.upsert_entity(
+                {
+                    "PartitionKey": "capture",
+                    "RowKey": digest,
+                    "status": "pending",
+                    "source_id": request.source_id,
+                    "updated_at": datetime.now(UTC).isoformat(),
+                }
+            )
+
+        now = datetime.now(UTC)
+        expires_at = now + timedelta(minutes=self.sas_minutes)
+        delegation_key = self._user_delegation_key(now)
+        prefix = f"inbox/{digest}/"
+        objects = tuple(
+            self._upload_object(
+                prefix=prefix,
+                relname=name,
+                content_type=content_type,
+                delegation_key=delegation_key,
+                starts_at=now - timedelta(minutes=5),
+                expires_at=expires_at,
+            )
+            for name, content_type in [
+                *((item.name, "application/jsonl") for item in request.artifacts),
+                ("manifest.json", "application/json"),
+            ]
+        )
+        return UploadGrant(
+            upload_id=f"u_{uuid.uuid4().hex}",
+            bucket=self.container,
+            base_url=self.container_url,
+            prefix=prefix,
+            objects=objects,
+            expires_at=expires_at,
+        )
+
+    @property
+    def container_url(self) -> str:
+        return f"https://{self.account_name}.blob.core.windows.net/{self.container}"
+
+    def _capture_status(self, digest: str) -> str | None:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        try:
+            entity = self.table.get_entity(partition_key="capture", row_key=digest)
+        except ResourceNotFoundError:
+            return None
+        status = entity.get("status")
+        return status if isinstance(status, str) else None
+
+    def _consume_rate_limit(self, client_ip: str) -> None:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        now = datetime.now(UTC)
+        partition = f"rate-{now:%Y%m%d%H}"
+        row = hmac.new(
+            self.ip_hash_key,
+            client_ip.encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        try:
+            entity = self.table.get_entity(partition_key=partition, row_key=row)
+        except ResourceNotFoundError:
+            count = 0
+        else:
+            count = int(entity.get("count", 0))
+        if count >= self.rate_limit:
+            retry_after = 3600 - now.minute * 60 - now.second
+            raise RateLimited(max(retry_after, 1))
+        self.table.upsert_entity(
+            {
+                "PartitionKey": partition,
+                "RowKey": row,
+                "count": count + 1,
+                "updated_at": now.isoformat(),
+            }
+        )
+
+    def _user_delegation_key(self, now: datetime):
+        if now < self._delegation_key_expires - timedelta(minutes=10):
+            return self._delegation_key
+        self._delegation_key_expires = now + timedelta(hours=1)
+        self._delegation_key = self.blob_service.get_user_delegation_key(
+            key_start_time=now - timedelta(minutes=5),
+            key_expiry_time=self._delegation_key_expires,
+        )
+        return self._delegation_key
+
+    def _upload_object(
+        self,
+        *,
+        prefix: str,
+        relname: str,
+        content_type: str,
+        delegation_key: Any,
+        starts_at: datetime,
+        expires_at: datetime,
+    ) -> UploadObject:
+        from azure.storage.blob import BlobSasPermissions, generate_blob_sas
+
+        blob_name = prefix + relname
+        sas = generate_blob_sas(
+            account_name=self.account_name,
+            container_name=self.container,
+            blob_name=blob_name,
+            user_delegation_key=delegation_key,
+            permission=BlobSasPermissions(create=True, write=True),
+            start=starts_at,
+            expiry=expires_at,
+            protocol="https",
+        )
+        return UploadObject(
+            name=relname,
+            put_url=f"{self.container_url}/{quote(blob_name, safe='/')}?{sas}",
+            headers={
+                "x-ms-blob-type": "BlockBlob",
+                "Content-Type": content_type,
+                "If-None-Match": "*",
+            },
+        )
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"required environment variable is not set: {name}")
+    return value

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
 import os
 import threading
 import uuid
@@ -94,6 +95,14 @@ class AzureUploadBroker:
                         "RowKey": digest,
                         "status": "pending",
                         "source_id": request.source_id,
+                        "declared_artifacts": json.dumps(
+                            {
+                                artifact.name: artifact.bytes
+                                for artifact in request.artifacts
+                            },
+                            separators=(",", ":"),
+                            sort_keys=True,
+                        ),
                         "updated_at": datetime.now(UTC).isoformat(),
                     }
                 )

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -191,7 +191,7 @@ class AzureUploadBroker:
             container_name=self.container,
             blob_name=blob_name,
             user_delegation_key=delegation_key,
-            permission=BlobSasPermissions(create=True, write=True),
+            permission=BlobSasPermissions(create=True),
             start=starts_at,
             expiry=expires_at,
             protocol="https",

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -161,7 +161,10 @@ class AzureUploadBroker:
         )
 
     def _user_delegation_key(self, now: datetime):
-        if now < self._delegation_key_expires - timedelta(minutes=10):
+        if (
+            self._delegation_key is not None
+            and now < self._delegation_key_expires - timedelta(minutes=10)
+        ):
             return self._delegation_key
         self._delegation_key_expires = now + timedelta(hours=1)
         self._delegation_key = self.blob_service.get_user_delegation_key(

--- a/services/trajectory_upload/broker_app.py
+++ b/services/trajectory_upload/broker_app.py
@@ -11,6 +11,8 @@ from fastapi.responses import JSONResponse
 
 from services.trajectory_upload.contract import UploadGrant, UploadRequest
 
+MAX_HANDSHAKE_BYTES = 1024**2
+
 
 class AlreadyUploaded(Exception):
     def __init__(self, *, base_url: str, prefix: str) -> None:
@@ -42,16 +44,48 @@ def create_app(
         app.state.backend = backend
     app.state.backend_factory = backend_factory or _azure_backend
 
+    @app.middleware("http")
+    async def limit_handshake_body(request: Request, call_next):
+        if request.method == "POST" and request.url.path == "/v1/uploads":
+            content_length = request.headers.get("content-length")
+            if content_length is None:
+                return JSONResponse(
+                    status_code=411,
+                    content={"detail": "Content-Length is required"},
+                )
+            try:
+                body_size = int(content_length)
+            except ValueError:
+                return JSONResponse(
+                    status_code=400,
+                    content={"detail": "invalid Content-Length"},
+                )
+            if body_size < 0 or body_size > MAX_HANDSHAKE_BYTES:
+                return JSONResponse(
+                    status_code=413,
+                    content={"detail": "upload handshake exceeds 1 MiB"},
+                )
+        return await call_next(request)
+
     @app.exception_handler(RequestValidationError)
     async def validation_error(
         _request: Request, exc: RequestValidationError
     ) -> JSONResponse:
+        errors = exc.errors()
         oversized = any(
-            error["type"] in {"less_than_equal", "too_long"} for error in exc.errors()
+            error["type"] in {"less_than_equal", "too_long"} for error in errors
         )
+        details = [
+            {
+                "type": str(error["type"]),
+                "loc": [str(part) for part in error["loc"]],
+                "msg": str(error["msg"]),
+            }
+            for error in errors
+        ]
         return JSONResponse(
             status_code=413 if oversized else 400,
-            content={"detail": exc.errors(include_url=False)},
+            content={"detail": details},
         )
 
     @app.get("/healthz")

--- a/services/trajectory_upload/broker_app.py
+++ b/services/trajectory_upload/broker_app.py
@@ -1,0 +1,101 @@
+"""FastAPI surface for public, anonymous trajectory-upload handshakes."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from services.trajectory_upload.contract import UploadGrant, UploadRequest
+
+
+class AlreadyUploaded(Exception):
+    def __init__(self, *, base_url: str, prefix: str) -> None:
+        self.base_url = base_url
+        self.prefix = prefix
+
+
+class RateLimited(Exception):
+    def __init__(self, retry_after: int) -> None:
+        self.retry_after = retry_after
+
+
+class UploadBroker(Protocol):
+    def create_upload(
+        self, request: UploadRequest, *, client_ip: str
+    ) -> UploadGrant: ...
+
+
+def create_app(
+    backend: UploadBroker | None = None,
+    *,
+    backend_factory: Callable[[], UploadBroker] | None = None,
+) -> FastAPI:
+    """Create the broker app, with an injectable backend for offline tests."""
+    app = FastAPI(
+        title="BenchFlow trajectory upload broker", docs_url=None, redoc_url=None
+    )
+    if backend is not None:
+        app.state.backend = backend
+    app.state.backend_factory = backend_factory or _azure_backend
+
+    @app.exception_handler(RequestValidationError)
+    async def validation_error(
+        _request: Request, exc: RequestValidationError
+    ) -> JSONResponse:
+        oversized = any(
+            error["type"] in {"less_than_equal", "too_long"} for error in exc.errors()
+        )
+        return JSONResponse(
+            status_code=413 if oversized else 400,
+            content={"detail": exc.errors(include_url=False)},
+        )
+
+    @app.get("/healthz")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/v1/uploads")
+    def create_upload(request: Request, body: UploadRequest) -> JSONResponse:
+        service = _backend(request.app)
+        try:
+            grant = service.create_upload(body, client_ip=_client_ip(request))
+        except AlreadyUploaded as exc:
+            return JSONResponse(
+                status_code=409,
+                content={"base_url": exc.base_url, "prefix": exc.prefix},
+            )
+        except RateLimited as exc:
+            return JSONResponse(
+                status_code=429,
+                headers={"Retry-After": str(exc.retry_after)},
+                content={"detail": "upload rate limit exceeded"},
+            )
+        return JSONResponse(status_code=200, content=grant.as_dict())
+
+    return app
+
+
+def _backend(app: FastAPI) -> UploadBroker:
+    if not hasattr(app.state, "backend"):
+        app.state.backend = app.state.backend_factory()
+    return app.state.backend
+
+
+def _azure_backend() -> UploadBroker:
+    from services.trajectory_upload.azure_backend import AzureUploadBroker
+
+    return AzureUploadBroker.from_env()
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for", "")
+    if forwarded:
+        return forwarded.rsplit(",", maxsplit=1)[-1].strip()
+    return request.client.host if request.client is not None else "unknown"
+
+
+app = create_app()

--- a/services/trajectory_upload/broker_app.py
+++ b/services/trajectory_upload/broker_app.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from threading import Lock
 from typing import Protocol
 
 from fastapi import FastAPI, Request
@@ -47,6 +48,7 @@ def create_app(
     if backend is not None:
         app.state.backend = backend
     app.state.backend_factory = backend_factory or _azure_backend
+    app.state.backend_lock = Lock()
 
     @app.middleware("http")
     async def limit_handshake_body(request: Request, call_next):
@@ -124,7 +126,9 @@ def create_app(
 
 def _backend(app: FastAPI) -> UploadBroker:
     if not hasattr(app.state, "backend"):
-        app.state.backend = app.state.backend_factory()
+        with app.state.backend_lock:
+            if not hasattr(app.state, "backend"):
+                app.state.backend = app.state.backend_factory()
     return app.state.backend
 
 

--- a/services/trajectory_upload/broker_app.py
+++ b/services/trajectory_upload/broker_app.py
@@ -25,6 +25,10 @@ class RateLimited(Exception):
         self.retry_after = retry_after
 
 
+class RejectedUpload(Exception):
+    """The same immutable capture digest already failed validation."""
+
+
 class UploadBroker(Protocol):
     def create_upload(
         self, request: UploadRequest, *, client_ip: str
@@ -107,6 +111,11 @@ def create_app(
                 status_code=429,
                 headers={"Retry-After": str(exc.retry_after)},
                 content={"detail": "upload rate limit exceeded"},
+            )
+        except RejectedUpload:
+            return JSONResponse(
+                status_code=422,
+                content={"detail": "trajectory capture was previously rejected"},
             )
         return JSONResponse(status_code=200, content=grant.as_dict())
 

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -81,7 +81,11 @@ class ToolInfo(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: Literal["benchflow"]
-    version: str = Field(min_length=1, max_length=64)
+    version: str = Field(
+        min_length=1,
+        max_length=64,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._+-]*$",
+    )
 
 
 Scalar = str | int | float | bool | None

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -11,18 +11,23 @@ from typing import Any, Literal, Self
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from benchflow.publish.traj_capture import (
+    ARTIFACT_NAME_PATTERN as _ARTIFACT_NAME_PATTERN,
+)
+from benchflow.publish.traj_capture import (
     MAX_ARTIFACTS,
     MAX_CAPTURE_BYTES,
     MAX_FILE_BYTES,
+    MAX_UPLOADED_BY_LENGTH,
+    validate_artifact_name,
     validate_source_id,
 )
 from benchflow.publish.traj_capture import (
     MAX_MANIFEST_BYTES as _MAX_MANIFEST_BYTES,
 )
 
+ARTIFACT_NAME = _ARTIFACT_NAME_PATTERN
 MAX_ARTIFACT_BYTES = MAX_FILE_BYTES
 MAX_MANIFEST_BYTES = _MAX_MANIFEST_BYTES
-ARTIFACT_NAME = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
 SHA256 = re.compile(r"^[0-9a-f]{64}$")
 
 
@@ -36,9 +41,7 @@ class Artifact(BaseModel):
     @field_validator("name")
     @classmethod
     def validate_name(cls, value: str) -> str:
-        if not ARTIFACT_NAME.fullmatch(value):
-            raise ValueError("artifact name is outside trajectory/*.jsonl")
-        return value
+        return validate_artifact_name(value)
 
     @field_validator("sha256")
     @classmethod
@@ -55,7 +58,7 @@ class UploadRequest(BaseModel):
     kind: Literal["bronze.trajectory"]
     source_id: str
     traj_digest: str
-    uploaded_by: str | None = Field(default=None, max_length=256)
+    uploaded_by: str | None = Field(default=None, max_length=MAX_UPLOADED_BY_LENGTH)
     artifacts: list[Artifact] = Field(min_length=1, max_length=MAX_ARTIFACTS)
 
     @field_validator("source_id")

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -10,11 +10,14 @@ from typing import Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from benchflow.publish.traj_capture import MAX_FILE_BYTES, validate_source_id
+from benchflow.publish.traj_capture import (
+    MAX_ARTIFACTS,
+    MAX_CAPTURE_BYTES,
+    MAX_FILE_BYTES,
+    validate_source_id,
+)
 
-MAX_ARTIFACTS = 8
 MAX_ARTIFACT_BYTES = MAX_FILE_BYTES
-MAX_CAPTURE_BYTES = 2 * MAX_ARTIFACT_BYTES
 MAX_MANIFEST_BYTES = 1024**2
 ARTIFACT_NAME = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
 SHA256 = re.compile(r"^[0-9a-f]{64}$")

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -10,11 +10,11 @@ from typing import Any, Literal, Self
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from benchflow.publish.traj_capture import validate_source_id
+from benchflow.publish.traj_capture import MAX_FILE_BYTES, validate_source_id
 
 MAX_ARTIFACTS = 8
-MAX_ARTIFACT_BYTES = 1024**3
-MAX_CAPTURE_BYTES = 2 * 1024**3
+MAX_ARTIFACT_BYTES = MAX_FILE_BYTES
+MAX_CAPTURE_BYTES = 2 * MAX_ARTIFACT_BYTES
 MAX_MANIFEST_BYTES = 1024**2
 ARTIFACT_NAME = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
 SHA256 = re.compile(r"^[0-9a-f]{64}$")

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -16,9 +16,12 @@ from benchflow.publish.traj_capture import (
     MAX_FILE_BYTES,
     validate_source_id,
 )
+from benchflow.publish.traj_capture import (
+    MAX_MANIFEST_BYTES as _MAX_MANIFEST_BYTES,
+)
 
 MAX_ARTIFACT_BYTES = MAX_FILE_BYTES
-MAX_MANIFEST_BYTES = 1024**2
+MAX_MANIFEST_BYTES = _MAX_MANIFEST_BYTES
 ARTIFACT_NAME = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
 SHA256 = re.compile(r"^[0-9a-f]{64}$")
 

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -1,0 +1,156 @@
+"""Typed public and storage contracts for trajectory contributions."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from benchflow.publish.traj_capture import validate_source_id
+
+MAX_ARTIFACTS = 8
+MAX_ARTIFACT_BYTES = 1024**3
+MAX_CAPTURE_BYTES = 2 * 1024**3
+MAX_MANIFEST_BYTES = 1024**2
+ARTIFACT_NAME = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class Artifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    sha256: str
+    bytes: int = Field(ge=1, le=MAX_ARTIFACT_BYTES)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        if not ARTIFACT_NAME.fullmatch(value):
+            raise ValueError("artifact name is outside trajectory/*.jsonl")
+        return value
+
+    @field_validator("sha256")
+    @classmethod
+    def validate_sha256(cls, value: str) -> str:
+        if not SHA256.fullmatch(value):
+            raise ValueError("artifact sha256 must be 64 lowercase hex characters")
+        return value
+
+
+class UploadRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1.0.0"]
+    kind: Literal["bronze.trajectory"]
+    source_id: str
+    traj_digest: str
+    uploaded_by: str | None = Field(default=None, max_length=256)
+    artifacts: list[Artifact] = Field(min_length=1, max_length=MAX_ARTIFACTS)
+
+    @field_validator("source_id")
+    @classmethod
+    def validate_source(cls, value: str) -> str:
+        return validate_source_id(value)
+
+    @field_validator("traj_digest")
+    @classmethod
+    def validate_traj_digest(cls, value: str) -> str:
+        prefix, separator, digest = value.partition(":")
+        if prefix != "sha256" or separator != ":" or not SHA256.fullmatch(digest):
+            raise ValueError("traj_digest must be sha256:<64 lowercase hex characters>")
+        return value
+
+    @model_validator(mode="after")
+    def validate_capture(self) -> Self:
+        names = [artifact.name for artifact in self.artifacts]
+        if len(names) != len(set(names)):
+            raise ValueError("artifact names must be unique")
+        if sum(artifact.bytes for artifact in self.artifacts) > MAX_CAPTURE_BYTES:
+            raise ValueError(f"capture exceeds {MAX_CAPTURE_BYTES} bytes")
+        if self.traj_digest != f"sha256:{trajectory_digest(self.artifacts)}":
+            raise ValueError("traj_digest does not match the artifact hashes")
+        return self
+
+
+class ToolInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: Literal["benchflow"]
+    version: str = Field(min_length=1, max_length=64)
+
+
+Scalar = str | int | float | bool | None
+
+
+class RunInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    agent: Scalar = None
+    model: Scalar = None
+    harness: Scalar = None
+    skill_mode: Scalar = None
+    task_id: Scalar = None
+    reward: Scalar = None
+
+
+class RedactionInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: Literal[True]
+    replacements: int = Field(ge=0)
+
+
+class ContributionManifest(UploadRequest):
+    model_config = ConfigDict(extra="forbid")
+
+    created_at: datetime
+    tool: ToolInfo
+    run: RunInfo
+    redaction: RedactionInfo
+
+
+@dataclass(frozen=True)
+class UploadObject:
+    name: str
+    put_url: str
+    headers: dict[str, str]
+
+
+@dataclass(frozen=True)
+class UploadGrant:
+    upload_id: str
+    bucket: str
+    base_url: str
+    prefix: str
+    objects: tuple[UploadObject, ...]
+    expires_at: datetime
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "upload_id": self.upload_id,
+            "bucket": self.bucket,
+            "base_url": self.base_url,
+            "prefix": self.prefix,
+            "objects": [
+                {
+                    "name": item.name,
+                    "put_url": item.put_url,
+                    "headers": item.headers,
+                }
+                for item in self.objects
+            ],
+            "expires_at": self.expires_at.isoformat().replace("+00:00", "Z"),
+        }
+
+
+def trajectory_digest(artifacts: list[Artifact]) -> str:
+    digest_input = "\n".join(
+        f"{artifact.name}\t{artifact.sha256}"
+        for artifact in sorted(artifacts, key=lambda item: item.name)
+    )
+    return hashlib.sha256(digest_input.encode()).hexdigest()

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -1,0 +1,114 @@
+"""Fail-closed validation of quarantined trajectory contributions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from pydantic import ValidationError
+
+from benchflow.publish.redact import redact_value
+from benchflow.trajectories.export_prime_sft import (
+    PrimeSftTrajectoryJsonlError,
+    load_llm_trajectory_jsonl,
+)
+from services.trajectory_upload.contract import (
+    MAX_MANIFEST_BYTES,
+    ContributionManifest,
+)
+
+
+class CaptureRejected(ValueError):
+    """A quarantined capture failed an integrity or format gate."""
+
+
+@dataclass(frozen=True)
+class ValidatedCapture:
+    manifest: ContributionManifest
+    artifact_paths: dict[str, Path]
+    manifest_bytes: bytes
+
+
+def validate_local_capture(
+    manifest_bytes: bytes,
+    artifact_paths: dict[str, Path],
+) -> ValidatedCapture:
+    """Validate manifest, digests, strict JSONL shape, and secret redaction."""
+    if len(manifest_bytes) > MAX_MANIFEST_BYTES:
+        raise CaptureRejected("manifest exceeds the 1 MiB limit")
+    try:
+        raw_manifest = json.loads(manifest_bytes)
+        manifest = ContributionManifest.model_validate(raw_manifest)
+    except (json.JSONDecodeError, ValidationError) as exc:
+        raise CaptureRejected(f"invalid manifest: {exc}") from exc
+
+    expected_names = {artifact.name for artifact in manifest.artifacts}
+    if set(artifact_paths) != expected_names:
+        raise CaptureRejected("downloaded artifacts do not match the manifest")
+
+    for artifact in manifest.artifacts:
+        path = artifact_paths[artifact.name]
+        if path.stat().st_size != artifact.bytes:
+            raise CaptureRejected(f"size mismatch for {artifact.name}")
+        if _sha256(path) != artifact.sha256:
+            raise CaptureRejected(f"sha256 mismatch for {artifact.name}")
+        _validate_and_scan_jsonl(path, artifact.name)
+    return ValidatedCapture(
+        manifest=manifest,
+        artifact_paths=artifact_paths,
+        manifest_bytes=manifest_bytes,
+    )
+
+
+def _validate_and_scan_jsonl(path: Path, relname: str) -> None:
+    if path.name == "llm_trajectory.jsonl":
+        try:
+            records = load_llm_trajectory_jsonl(path, strict=True)
+        except PrimeSftTrajectoryJsonlError as exc:
+            raise CaptureRejected(str(exc)) from exc
+        if not records:
+            raise CaptureRejected(f"{relname}: trajectory JSONL has no records")
+        for line_number, record in enumerate(records, start=1):
+            _reject_secrets(record, relname, line_number)
+        return
+
+    records = 0
+    try:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise CaptureRejected(
+                        f"{relname}: line {line_number}: invalid JSON: {exc}"
+                    ) from exc
+                if not isinstance(record, dict):
+                    raise CaptureRejected(
+                        f"{relname}: line {line_number}: top-level record must be an object"
+                    )
+                _reject_secrets(record, relname, line_number)
+                records += 1
+    except UnicodeDecodeError as exc:
+        raise CaptureRejected(f"{relname}: trajectory JSONL must be UTF-8") from exc
+    if records == 0:
+        raise CaptureRejected(f"{relname}: trajectory JSONL has no records")
+
+
+def _reject_secrets(record: dict, relname: str, line_number: int) -> None:
+    _, replacements = redact_value(record)
+    if replacements:
+        raise CaptureRejected(
+            f"{relname}: line {line_number}: secret-like value survived client redaction"
+        )
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -10,10 +10,6 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from benchflow.publish.redact import redact_value
-from benchflow.trajectories.export_prime_sft import (
-    PrimeSftTrajectoryJsonlError,
-    load_llm_trajectory_jsonl,
-)
 from services.trajectory_upload.contract import (
     MAX_MANIFEST_BYTES,
     ContributionManifest,
@@ -63,17 +59,6 @@ def validate_local_capture(
 
 
 def _validate_and_scan_jsonl(path: Path, relname: str) -> None:
-    if path.name == "llm_trajectory.jsonl":
-        try:
-            records = load_llm_trajectory_jsonl(path, strict=True)
-        except PrimeSftTrajectoryJsonlError as exc:
-            raise CaptureRejected(str(exc)) from exc
-        if not records:
-            raise CaptureRejected(f"{relname}: trajectory JSONL has no records")
-        for line_number, record in enumerate(records, start=1):
-            _reject_secrets(record, relname, line_number)
-        return
-
     records = 0
     try:
         with path.open(encoding="utf-8") as stream:

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -32,13 +32,7 @@ def validate_local_capture(
     artifact_paths: dict[str, Path],
 ) -> ValidatedCapture:
     """Validate manifest, digests, strict JSONL shape, and secret redaction."""
-    if len(manifest_bytes) > MAX_MANIFEST_BYTES:
-        raise CaptureRejected("manifest exceeds the 1 MiB limit")
-    try:
-        raw_manifest = json.loads(manifest_bytes)
-        manifest = ContributionManifest.model_validate(raw_manifest)
-    except (json.JSONDecodeError, ValidationError) as exc:
-        raise CaptureRejected(f"invalid manifest: {exc}") from exc
+    manifest = validate_manifest_bytes(manifest_bytes)
 
     expected_names = {artifact.name for artifact in manifest.artifacts}
     if set(artifact_paths) != expected_names:
@@ -56,6 +50,18 @@ def validate_local_capture(
         artifact_paths=artifact_paths,
         manifest_bytes=manifest_bytes,
     )
+
+
+def validate_manifest_bytes(manifest_bytes: bytes) -> ContributionManifest:
+    """Parse the complete manifest contract before touching declared artifacts."""
+    if len(manifest_bytes) > MAX_MANIFEST_BYTES:
+        raise CaptureRejected("manifest exceeds the 1 MiB limit")
+    try:
+        raw_manifest = json.loads(manifest_bytes)
+        manifest = ContributionManifest.model_validate(raw_manifest)
+    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+        raise CaptureRejected(f"invalid manifest: {exc}") from exc
+    return manifest
 
 
 def _validate_and_scan_jsonl(path: Path, relname: str) -> None:

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from dataclasses import dataclass
 from pathlib import Path
-
-from pydantic import ValidationError
 
 from benchflow.publish.redact import redact_value
 from benchflow.publish.traj_capture import (
     MAX_JSONL_RECORD_BYTES,
+    strict_json_loads,
     validate_json_complexity,
 )
 from services.trajectory_upload.contract import (
@@ -61,15 +59,18 @@ def validate_manifest_bytes(manifest_bytes: bytes) -> ContributionManifest:
     if len(manifest_bytes) > MAX_MANIFEST_BYTES:
         raise CaptureRejected("manifest exceeds the 1 MiB limit")
     try:
-        raw_manifest = json.loads(manifest_bytes)
+        raw_manifest = strict_json_loads(manifest_bytes)
         manifest = ContributionManifest.model_validate(raw_manifest)
-    except (
-        UnicodeDecodeError,
-        json.JSONDecodeError,
-        RecursionError,
-        ValidationError,
-    ) as exc:
+    except (UnicodeDecodeError, RecursionError, ValueError) as exc:
         raise CaptureRejected(f"invalid manifest: {exc}") from exc
+    try:
+        _, replacements = redact_value(raw_manifest)
+    except RecursionError as exc:
+        raise CaptureRejected(
+            "invalid manifest: JSON nesting exceeds the limit"
+        ) from exc
+    if replacements:
+        raise CaptureRejected("manifest contains a secret-like value")
     return manifest
 
 
@@ -93,8 +94,8 @@ def _validate_and_scan_jsonl(path: Path, relname: str) -> None:
             if not line.strip():
                 continue
             try:
-                record = json.loads(line)
-            except (json.JSONDecodeError, RecursionError) as exc:
+                record = strict_json_loads(line)
+            except (RecursionError, ValueError) as exc:
                 raise CaptureRejected(
                     f"{relname}: line {line_number}: invalid JSON: {exc}"
                 ) from exc

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -59,7 +59,12 @@ def validate_manifest_bytes(manifest_bytes: bytes) -> ContributionManifest:
     try:
         raw_manifest = json.loads(manifest_bytes)
         manifest = ContributionManifest.model_validate(raw_manifest)
-    except (UnicodeDecodeError, json.JSONDecodeError, ValidationError) as exc:
+    except (
+        UnicodeDecodeError,
+        json.JSONDecodeError,
+        RecursionError,
+        ValidationError,
+    ) as exc:
         raise CaptureRejected(f"invalid manifest: {exc}") from exc
     return manifest
 

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -10,6 +10,10 @@ from pathlib import Path
 from pydantic import ValidationError
 
 from benchflow.publish.redact import redact_value
+from benchflow.publish.traj_capture import (
+    MAX_JSONL_RECORD_BYTES,
+    validate_json_complexity,
+)
 from services.trajectory_upload.contract import (
     MAX_MANIFEST_BYTES,
     ContributionManifest,
@@ -71,25 +75,44 @@ def validate_manifest_bytes(manifest_bytes: bytes) -> ContributionManifest:
 
 def _validate_and_scan_jsonl(path: Path, relname: str) -> None:
     records = 0
-    try:
-        with path.open(encoding="utf-8") as stream:
-            for line_number, line in enumerate(stream, start=1):
-                if not line.strip():
-                    continue
-                try:
-                    record = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise CaptureRejected(
-                        f"{relname}: line {line_number}: invalid JSON: {exc}"
-                    ) from exc
-                if not isinstance(record, dict):
-                    raise CaptureRejected(
-                        f"{relname}: line {line_number}: top-level record must be an object"
-                    )
+    with path.open("rb") as stream:
+        line_number = 0
+        while line_bytes := stream.readline(MAX_JSONL_RECORD_BYTES + 1):
+            line_number += 1
+            if len(line_bytes) > MAX_JSONL_RECORD_BYTES:
+                raise CaptureRejected(
+                    f"{relname}: line {line_number}: JSONL record exceeds "
+                    f"{MAX_JSONL_RECORD_BYTES} bytes"
+                )
+            try:
+                line = line_bytes.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise CaptureRejected(
+                    f"{relname}: trajectory JSONL must be UTF-8"
+                ) from exc
+            if not line.strip():
+                continue
+            try:
+                record = json.loads(line)
+            except (json.JSONDecodeError, RecursionError) as exc:
+                raise CaptureRejected(
+                    f"{relname}: line {line_number}: invalid JSON: {exc}"
+                ) from exc
+            if not isinstance(record, dict):
+                raise CaptureRejected(
+                    f"{relname}: line {line_number}: top-level record must be an object"
+                )
+            try:
+                validate_json_complexity(record)
+            except ValueError as exc:
+                raise CaptureRejected(f"{relname}: line {line_number}: {exc}") from exc
+            try:
                 _reject_secrets(record, relname, line_number)
-                records += 1
-    except UnicodeDecodeError as exc:
-        raise CaptureRejected(f"{relname}: trajectory JSONL must be UTF-8") from exc
+            except RecursionError as exc:  # defense in depth after complexity gate
+                raise CaptureRejected(
+                    f"{relname}: line {line_number}: JSON nesting exceeds the limit"
+                ) from exc
+            records += 1
     if records == 0:
         raise CaptureRejected(f"{relname}: trajectory JSONL has no records")
 

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -59,9 +59,13 @@ def validate_manifest_bytes(manifest_bytes: bytes) -> ContributionManifest:
     if len(manifest_bytes) > MAX_MANIFEST_BYTES:
         raise CaptureRejected("manifest exceeds the 1 MiB limit")
     try:
-        raw_manifest = strict_json_loads(manifest_bytes)
+        manifest_text = manifest_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise CaptureRejected("invalid manifest: content must be UTF-8") from exc
+    try:
+        raw_manifest = strict_json_loads(manifest_text)
         manifest = ContributionManifest.model_validate(raw_manifest)
-    except (UnicodeDecodeError, RecursionError, ValueError) as exc:
+    except (RecursionError, ValueError) as exc:
         raise CaptureRejected(f"invalid manifest: {exc}") from exc
     try:
         _, replacements = redact_value(raw_manifest)

--- a/services/trajectory_upload/validator-entrypoint
+++ b/services/trajectory_upload/validator-entrypoint
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+exec python -m services.trajectory_upload.validator

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -202,7 +202,6 @@ class AzureCaptureValidator:
     def _claim_capture(self, digest: str) -> bool:
         from azure.core import MatchConditions
         from azure.core.exceptions import ResourceModifiedError, ResourceNotFoundError
-        from azure.data.tables import UpdateMode
 
         now = datetime.now(UTC)
         try:
@@ -229,7 +228,7 @@ class AzureCaptureValidator:
         try:
             self.table.update_entity(
                 entity=claimed,
-                mode=UpdateMode.MERGE,
+                mode="merge",
                 etag=entity.metadata["etag"],
                 match_condition=MatchConditions.IfNotModified,
             )

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -82,9 +82,14 @@ class AzureCaptureValidator:
             self._delete_message(message)
             return True
 
+        from azure.core.exceptions import ResourceNotFoundError
+
         try:
             with tempfile.TemporaryDirectory(prefix="benchflow-validator-") as name:
-                validated = self._download_and_validate(prefix, Path(name))
+                try:
+                    validated = self._download_and_validate(prefix, Path(name))
+                except ResourceNotFoundError as exc:
+                    raise CaptureRejected("a declared capture blob is missing") from exc
                 if validated.manifest.traj_digest != f"sha256:{digest}":
                     raise CaptureRejected(
                         "manifest digest does not match its quarantine prefix"

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -16,6 +16,7 @@ from urllib.parse import unquote, urlparse
 from services.trajectory_upload.contract import (
     ARTIFACT_NAME,
     MAX_ARTIFACT_BYTES,
+    MAX_CAPTURE_BYTES,
     MAX_MANIFEST_BYTES,
 )
 from services.trajectory_upload.validation import (
@@ -96,11 +97,15 @@ class AzureCaptureValidator:
         # to clean terminal-state replays without treating an in-flight capture
         # as a prematurely committed upload.
         if relname != "manifest.json":
-            if status == "pending" and self._artifact_exceeds_limit(prefix + relname):
+            violation = (
+                self._artifact_violation(digest, prefix, relname)
+                if status == "pending"
+                else None
+            )
+            if violation is not None:
                 if self._claim_capture(digest):
-                    detail = f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {relname}"
-                    logger.warning("capture %s rejected: %s", digest, detail)
-                    self._record_status(digest, "rejected", detail=detail)
+                    logger.warning("capture %s rejected: %s", digest, violation)
+                    self._record_status(digest, "rejected", detail=violation)
                     self._cleanup_prefix(prefix)
                     self._delete_message(message)
                 else:
@@ -146,14 +151,58 @@ class AzureCaptureValidator:
         self._delete_message(message)
         return True
 
-    def _artifact_exceeds_limit(self, blob_name: str) -> bool:
+    def _artifact_violation(self, digest: str, prefix: str, relname: str) -> str | None:
         from azure.core.exceptions import ResourceNotFoundError
 
         try:
-            properties = self.container.get_blob_client(blob_name).get_blob_properties()
+            properties = self.container.get_blob_client(
+                prefix + relname
+            ).get_blob_properties()
         except ResourceNotFoundError:
-            return False
-        return properties.size > MAX_ARTIFACT_BYTES
+            return None
+        if properties.size > MAX_ARTIFACT_BYTES:
+            return f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {relname}"
+
+        declared = self._declared_artifacts(digest)
+        if declared is not None and declared.get(relname) != properties.size:
+            return f"artifact size does not match declaration: {relname}"
+
+        capture_bytes = 0
+        for item in self.container.list_blobs(name_starts_with=prefix):
+            item_relname = item.name.removeprefix(prefix)
+            if ARTIFACT_NAME.fullmatch(item_relname) is None:
+                continue
+            try:
+                size = (
+                    self.container.get_blob_client(item.name).get_blob_properties().size
+                )
+            except ResourceNotFoundError:
+                continue
+            if size > MAX_ARTIFACT_BYTES:
+                return f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {item_relname}"
+            capture_bytes += size
+            if capture_bytes > MAX_CAPTURE_BYTES:
+                return f"capture exceeds {MAX_CAPTURE_BYTES} bytes"
+        return None
+
+    def _declared_artifacts(self, digest: str) -> dict[str, int] | None:
+        entity = self._capture_entity(digest)
+        raw = entity.get("declared_artifacts") if entity is not None else None
+        if not isinstance(raw, str):
+            return None
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+        if not isinstance(parsed, dict) or not all(
+            isinstance(name, str)
+            and isinstance(size, int)
+            and not isinstance(size, bool)
+            and size > 0
+            for name, size in parsed.items()
+        ):
+            return None
+        return parsed
 
     def _download_and_validate(
         self, prefix: str, staging_dir: Path
@@ -264,14 +313,19 @@ class AzureCaptureValidator:
         return True
 
     def _capture_status(self, digest: str) -> str | None:
-        from azure.core.exceptions import ResourceNotFoundError
-
-        try:
-            entity = self.table.get_entity(partition_key="capture", row_key=digest)
-        except ResourceNotFoundError:
+        entity = self._capture_entity(digest)
+        if entity is None:
             return None
         status = entity.get("status")
         return status if isinstance(status, str) else None
+
+    def _capture_entity(self, digest: str) -> Any | None:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        try:
+            return self.table.get_entity(partition_key="capture", row_key=digest)
+        except ResourceNotFoundError:
+            return None
 
     def _delete_message(self, message: Any) -> None:
         self.queue.delete_message(message.id, message.pop_receipt)

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -1,0 +1,215 @@
+"""Azure Queue-driven quarantine validator and manifest-last promoter."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from contextlib import suppress
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote, urlparse
+
+from services.trajectory_upload.contract import MAX_MANIFEST_BYTES
+from services.trajectory_upload.validation import (
+    CaptureRejected,
+    ValidatedCapture,
+    validate_local_capture,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AzureCaptureValidator:
+    """Consume one Event Grid message and promote a valid capture atomically."""
+
+    def __init__(self, *, container: Any, queue: Any, table: Any) -> None:
+        self.container = container
+        self.queue = queue
+        self.table = table
+
+    @classmethod
+    def from_env(cls) -> AzureCaptureValidator:
+        from azure.data.tables import TableClient
+        from azure.identity import DefaultAzureCredential
+        from azure.storage.blob import ContainerClient
+        from azure.storage.queue import QueueClient
+
+        account_name = _required_env("AZURE_STORAGE_ACCOUNT_NAME")
+        container_name = os.environ.get("AZURE_BLOB_CONTAINER", "bronze")
+        queue_name = os.environ.get("AZURE_VALIDATION_QUEUE", "trajectory-validation")
+        table_name = os.environ.get("AZURE_LEDGER_TABLE", "trajectoryuploads")
+        credential = DefaultAzureCredential()
+        return cls(
+            container=ContainerClient(
+                account_url=f"https://{account_name}.blob.core.windows.net",
+                container_name=container_name,
+                credential=credential,
+            ),
+            queue=QueueClient(
+                account_url=f"https://{account_name}.queue.core.windows.net",
+                queue_name=queue_name,
+                credential=credential,
+            ),
+            table=TableClient(
+                endpoint=f"https://{account_name}.table.core.windows.net",
+                table_name=table_name,
+                credential=credential,
+            ),
+        )
+
+    def run_once(self) -> bool:
+        """Process at most one queue message; return whether one was received."""
+        messages = self.queue.receive_messages(
+            messages_per_page=1,
+            visibility_timeout=900,
+        )
+        message = next(iter(messages), None)
+        if message is None:
+            return False
+        try:
+            prefix, digest = _capture_from_event(message.content)
+        except CaptureRejected as exc:
+            logger.warning("discarding invalid validation event: %s", exc)
+            self._delete_message(message)
+            return True
+
+        try:
+            with tempfile.TemporaryDirectory(prefix="benchflow-validator-") as name:
+                validated = self._download_and_validate(prefix, Path(name))
+                if validated.manifest.traj_digest != f"sha256:{digest}":
+                    raise CaptureRejected(
+                        "manifest digest does not match its quarantine prefix"
+                    )
+                self._promote(validated, digest)
+        except CaptureRejected as exc:
+            logger.warning("capture %s rejected: %s", digest, exc)
+            self._cleanup_prefix(prefix)
+            self._record_status(digest, "rejected", detail=str(exc)[:512])
+        else:
+            self._cleanup_prefix(prefix)
+            self._record_status(digest, "ingested")
+            logger.info("capture %s promoted", digest)
+        self._delete_message(message)
+        return True
+
+    def _download_and_validate(
+        self, prefix: str, staging_dir: Path
+    ) -> ValidatedCapture:
+        manifest_blob = self.container.get_blob_client(prefix + "manifest.json")
+        properties = manifest_blob.get_blob_properties()
+        if properties.size > MAX_MANIFEST_BYTES:
+            raise CaptureRejected("manifest exceeds the 1 MiB limit")
+        manifest_bytes = manifest_blob.download_blob().readall()
+        try:
+            manifest_data = json.loads(manifest_bytes)
+            artifacts = manifest_data["artifacts"]
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            raise CaptureRejected(f"invalid manifest: {exc}") from exc
+        if not isinstance(artifacts, list):
+            raise CaptureRejected("manifest artifacts must be a list")
+
+        artifact_paths: dict[str, Path] = {}
+        for item in artifacts:
+            if not isinstance(item, dict) or not isinstance(item.get("name"), str):
+                raise CaptureRejected("manifest contains an invalid artifact entry")
+            relname = item["name"]
+            blob = self.container.get_blob_client(prefix + relname)
+            expected_size = item.get("bytes")
+            if blob.get_blob_properties().size != expected_size:
+                raise CaptureRejected(f"size mismatch for {relname}")
+            local_path = staging_dir / Path(relname).name
+            with local_path.open("wb") as output:
+                blob.download_blob(max_concurrency=1).readinto(output)
+            artifact_paths[relname] = local_path
+        return validate_local_capture(manifest_bytes, artifact_paths)
+
+    def _promote(self, capture: ValidatedCapture, digest: str) -> None:
+        from azure.core.exceptions import ResourceExistsError
+        from azure.storage.blob import ContentSettings
+
+        prefix = f"sources/community/{digest}/"
+        metadata = {
+            "source_id": capture.manifest.source_id,
+            "traj_digest": capture.manifest.traj_digest,
+            "schema_version": capture.manifest.schema_version,
+            "manifest": "manifest.json",
+            "benchflow_version": capture.manifest.tool.version,
+        }
+        for artifact in capture.manifest.artifacts:
+            with (
+                suppress(ResourceExistsError),
+                capture.artifact_paths[artifact.name].open("rb") as stream,
+            ):
+                self.container.upload_blob(
+                    name=prefix + artifact.name,
+                    data=stream,
+                    overwrite=False,
+                    metadata=metadata,
+                    content_settings=ContentSettings(content_type="application/jsonl"),
+                )
+        with suppress(ResourceExistsError):
+            self.container.upload_blob(
+                name=prefix + "manifest.json",
+                data=capture.manifest_bytes,
+                overwrite=False,
+                metadata=metadata,
+                content_settings=ContentSettings(content_type="application/json"),
+            )
+
+    def _cleanup_prefix(self, prefix: str) -> None:
+        for blob in self.container.list_blobs(name_starts_with=prefix):
+            self.container.delete_blob(blob.name)
+
+    def _record_status(self, digest: str, status: str, **extra: str) -> None:
+        self.table.upsert_entity(
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": status,
+                "updated_at": datetime.now(UTC).isoformat(),
+                **extra,
+            }
+        )
+
+    def _delete_message(self, message: Any) -> None:
+        self.queue.delete_message(message.id, message.pop_receipt)
+
+
+def _capture_from_event(content: str) -> tuple[str, str]:
+    try:
+        event = json.loads(content)
+        if isinstance(event, list):
+            if len(event) != 1:
+                raise CaptureRejected("event batch must contain exactly one event")
+            event = event[0]
+        blob_url = event["data"]["url"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise CaptureRejected(f"invalid Event Grid message: {exc}") from exc
+    if not isinstance(blob_url, str):
+        raise CaptureRejected("Event Grid blob URL must be a string")
+    parts = unquote(urlparse(blob_url).path).strip("/").split("/")
+    if len(parts) != 4 or parts[1] != "inbox" or parts[3] != "manifest.json":
+        raise CaptureRejected("event is not for inbox/<digest>/manifest.json")
+    digest = parts[2]
+    if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
+        raise CaptureRejected("event contains an invalid trajectory digest")
+    return f"inbox/{digest}/", digest
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"required environment variable is not set: {name}")
+    return value
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    AzureCaptureValidator.from_env().run_once()
+
+
+if __name__ == "__main__":
+    main()

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -6,6 +6,7 @@ import base64
 import json
 import logging
 import os
+import re
 import tempfile
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
@@ -31,6 +32,7 @@ logger = logging.getLogger(__name__)
 # prevents a replacement worker from overlapping a replica that Azure has not
 # terminated yet; an abandoned queue message can reclaim the digest afterward.
 VALIDATION_LEASE = timedelta(minutes=35)
+ATTEMPT_ID = re.compile(r"^u_[0-9a-f]{32}$")
 
 
 class AzureCaptureValidator:
@@ -81,13 +83,13 @@ class AzureCaptureValidator:
         if message is None:
             return False
         try:
-            prefix, digest, relname = _capture_from_event(message.content)
+            prefix, digest, attempt_id, relname = _capture_from_event(message.content)
         except CaptureRejected as exc:
             logger.warning("discarding invalid validation event: %s", exc)
             self._delete_message(message)
             return True
 
-        status = self._capture_status(digest)
+        status = self._capture_status(digest, attempt_id)
         if status in {"ingested", "rejected"} or status is None:
             self._cleanup_prefix(prefix)
             self._delete_message(message)
@@ -98,18 +100,20 @@ class AzureCaptureValidator:
         # as a prematurely committed upload.
         if relname != "manifest.json":
             violation = (
-                self._artifact_violation(digest, prefix, relname)
+                self._artifact_violation(digest, attempt_id, prefix, relname)
                 if status == "pending"
                 else None
             )
             if violation is not None:
-                if self._claim_capture(digest):
+                if self._claim_capture(digest, attempt_id):
                     logger.warning("capture %s rejected: %s", digest, violation)
-                    self._record_status(digest, "rejected", detail=violation)
+                    self._record_status(
+                        digest, attempt_id, "rejected", detail=violation
+                    )
                     self._cleanup_prefix(prefix)
                     self._delete_message(message)
                 else:
-                    status = self._capture_status(digest)
+                    status = self._capture_status(digest, attempt_id)
                     if status in {"ingested", "rejected"} or status is None:
                         self._cleanup_prefix(prefix)
                         self._delete_message(message)
@@ -117,11 +121,11 @@ class AzureCaptureValidator:
             self._delete_message(message)
             return True
 
-        if not self._claim_capture(digest):
+        if not self._claim_capture(digest, attempt_id):
             # A concurrent worker owns an unexpired validation lease. Leave the
             # queue message for a later retry so a crashed owner cannot strand
             # the capture permanently.
-            status = self._capture_status(digest)
+            status = self._capture_status(digest, attempt_id)
             if status in {"ingested", "rejected"} or status is None:
                 self._cleanup_prefix(prefix)
                 self._delete_message(message)
@@ -142,16 +146,22 @@ class AzureCaptureValidator:
                 self._promote(validated, digest)
         except CaptureRejected as exc:
             logger.warning("capture %s rejected: %s", digest, exc)
-            self._record_status(digest, "rejected", detail=str(exc)[:512])
+            self._record_status(digest, attempt_id, "rejected", detail=str(exc)[:512])
             self._cleanup_prefix(prefix)
         else:
-            self._record_status(digest, "ingested")
+            self._record_status(digest, attempt_id, "ingested")
             self._cleanup_prefix(prefix)
             logger.info("capture %s promoted", digest)
         self._delete_message(message)
         return True
 
-    def _artifact_violation(self, digest: str, prefix: str, relname: str) -> str | None:
+    def _artifact_violation(
+        self,
+        digest: str,
+        attempt_id: str | None,
+        prefix: str,
+        relname: str,
+    ) -> str | None:
         from azure.core.exceptions import ResourceNotFoundError
 
         try:
@@ -163,7 +173,7 @@ class AzureCaptureValidator:
         if properties.size > MAX_ARTIFACT_BYTES:
             return f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {relname}"
 
-        declared = self._declared_artifacts(digest)
+        declared = self._declared_artifacts(digest, attempt_id)
         if declared is not None and declared.get(relname) != properties.size:
             return f"artifact size does not match declaration: {relname}"
 
@@ -185,9 +195,13 @@ class AzureCaptureValidator:
                 return f"capture exceeds {MAX_CAPTURE_BYTES} bytes"
         return None
 
-    def _declared_artifacts(self, digest: str) -> dict[str, int] | None:
+    def _declared_artifacts(
+        self, digest: str, attempt_id: str | None
+    ) -> dict[str, int] | None:
         entity = self._capture_entity(digest)
-        raw = entity.get("declared_artifacts") if entity is not None else None
+        if entity is None or entity.get("attempt_id") != attempt_id:
+            return None
+        raw = entity.get("declared_artifacts")
         if not isinstance(raw, str):
             return None
         try:
@@ -263,19 +277,26 @@ class AzureCaptureValidator:
         for blob in self.container.list_blobs(name_starts_with=prefix):
             self.container.delete_blob(blob.name)
 
-    def _record_status(self, digest: str, status: str, **extra: str) -> None:
-        self.table.upsert_entity(
-            {
-                "PartitionKey": "capture",
-                "RowKey": digest,
-                "status": status,
-                "updated_at": datetime.now(UTC).isoformat(),
-                "validation_lease_until": "",
-                **extra,
-            }
-        )
+    def _record_status(
+        self,
+        digest: str,
+        attempt_id: str | None,
+        status: str,
+        **extra: str,
+    ) -> None:
+        entity = {
+            "PartitionKey": "capture",
+            "RowKey": digest,
+            "status": status,
+            "updated_at": datetime.now(UTC).isoformat(),
+            "validation_lease_until": "",
+            **extra,
+        }
+        if attempt_id is not None:
+            entity["attempt_id"] = attempt_id
+        self.table.upsert_entity(entity)
 
-    def _claim_capture(self, digest: str) -> bool:
+    def _claim_capture(self, digest: str, attempt_id: str | None) -> bool:
         from azure.core import MatchConditions
         from azure.core.exceptions import ResourceModifiedError, ResourceNotFoundError
 
@@ -283,6 +304,8 @@ class AzureCaptureValidator:
         try:
             entity = self.table.get_entity(partition_key="capture", row_key=digest)
         except ResourceNotFoundError:
+            return False
+        if entity.get("attempt_id") != attempt_id:
             return False
         status = entity.get("status")
         lease_until = _parse_datetime(entity.get("validation_lease_until"))
@@ -312,9 +335,9 @@ class AzureCaptureValidator:
             return False
         return True
 
-    def _capture_status(self, digest: str) -> str | None:
+    def _capture_status(self, digest: str, attempt_id: str | None) -> str | None:
         entity = self._capture_entity(digest)
-        if entity is None:
+        if entity is None or entity.get("attempt_id") != attempt_id:
             return None
         status = entity.get("status")
         return status if isinstance(status, str) else None
@@ -331,7 +354,7 @@ class AzureCaptureValidator:
         self.queue.delete_message(message.id, message.pop_receipt)
 
 
-def _capture_from_event(content: str) -> tuple[str, str, str]:
+def _capture_from_event(content: str) -> tuple[str, str, str | None, str]:
     # Event Grid's Storage Queue destination base64-encodes its JSON envelope;
     # accepting plain JSON as well keeps the parser usable with test and replay
     # tools that already decode queue messages.
@@ -357,10 +380,12 @@ def _capture_from_event(content: str) -> tuple[str, str, str]:
     digest = parts[2]
     if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
         raise CaptureRejected("event contains an invalid trajectory digest")
-    relname = "/".join(parts[3:])
+    attempt_id = parts[3] if ATTEMPT_ID.fullmatch(parts[3]) else None
+    relname = "/".join(parts[4:] if attempt_id is not None else parts[3:])
     if relname != "manifest.json" and ARTIFACT_NAME.fullmatch(relname) is None:
         raise CaptureRejected("event is not for a declared capture object")
-    return f"inbox/{digest}/", digest, relname
+    prefix = f"inbox/{digest}/{attempt_id}/" if attempt_id else f"inbox/{digest}/"
+    return prefix, digest, attempt_id, relname
 
 
 def _required_env(name: str) -> str:

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -13,7 +13,11 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from services.trajectory_upload.contract import ARTIFACT_NAME, MAX_MANIFEST_BYTES
+from services.trajectory_upload.contract import (
+    ARTIFACT_NAME,
+    MAX_ARTIFACT_BYTES,
+    MAX_MANIFEST_BYTES,
+)
 from services.trajectory_upload.validation import (
     CaptureRejected,
     ValidatedCapture,
@@ -76,13 +80,14 @@ class AzureCaptureValidator:
         if message is None:
             return False
         try:
-            prefix, digest, is_manifest = _capture_from_event(message.content)
+            prefix, digest, relname = _capture_from_event(message.content)
         except CaptureRejected as exc:
             logger.warning("discarding invalid validation event: %s", exc)
             self._delete_message(message)
             return True
 
-        if self._capture_status(digest) in {"ingested", "rejected"}:
+        status = self._capture_status(digest)
+        if status in {"ingested", "rejected"} or status is None:
             self._cleanup_prefix(prefix)
             self._delete_message(message)
             return True
@@ -90,7 +95,20 @@ class AzureCaptureValidator:
         # Artifacts arrive before the manifest. Their events keep the Job able
         # to clean terminal-state replays without treating an in-flight capture
         # as a prematurely committed upload.
-        if not is_manifest:
+        if relname != "manifest.json":
+            if status == "pending" and self._artifact_exceeds_limit(prefix + relname):
+                if self._claim_capture(digest):
+                    detail = f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {relname}"
+                    logger.warning("capture %s rejected: %s", digest, detail)
+                    self._record_status(digest, "rejected", detail=detail)
+                    self._cleanup_prefix(prefix)
+                    self._delete_message(message)
+                else:
+                    status = self._capture_status(digest)
+                    if status in {"ingested", "rejected"} or status is None:
+                        self._cleanup_prefix(prefix)
+                        self._delete_message(message)
+                return True
             self._delete_message(message)
             return True
 
@@ -127,6 +145,15 @@ class AzureCaptureValidator:
             logger.info("capture %s promoted", digest)
         self._delete_message(message)
         return True
+
+    def _artifact_exceeds_limit(self, blob_name: str) -> bool:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        try:
+            properties = self.container.get_blob_client(blob_name).get_blob_properties()
+        except ResourceNotFoundError:
+            return False
+        return properties.size > MAX_ARTIFACT_BYTES
 
     def _download_and_validate(
         self, prefix: str, staging_dir: Path
@@ -250,7 +277,7 @@ class AzureCaptureValidator:
         self.queue.delete_message(message.id, message.pop_receipt)
 
 
-def _capture_from_event(content: str) -> tuple[str, str, bool]:
+def _capture_from_event(content: str) -> tuple[str, str, str]:
     # Event Grid's Storage Queue destination base64-encodes its JSON envelope;
     # accepting plain JSON as well keeps the parser usable with test and replay
     # tools that already decode queue messages.
@@ -277,10 +304,9 @@ def _capture_from_event(content: str) -> tuple[str, str, bool]:
     if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
         raise CaptureRejected("event contains an invalid trajectory digest")
     relname = "/".join(parts[3:])
-    is_manifest = relname == "manifest.json"
-    if not is_manifest and ARTIFACT_NAME.fullmatch(relname) is None:
+    if relname != "manifest.json" and ARTIFACT_NAME.fullmatch(relname) is None:
         raise CaptureRejected("event is not for a declared capture object")
-    return f"inbox/{digest}/", digest, is_manifest
+    return f"inbox/{digest}/", digest, relname
 
 
 def _required_env(name: str) -> str:

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from services.trajectory_upload.contract import MAX_MANIFEST_BYTES
+from services.trajectory_upload.contract import ARTIFACT_NAME, MAX_MANIFEST_BYTES
 from services.trajectory_upload.validation import (
     CaptureRejected,
     ValidatedCapture,
@@ -71,7 +71,7 @@ class AzureCaptureValidator:
         if message is None:
             return False
         try:
-            prefix, digest = _capture_from_event(message.content)
+            prefix, digest, is_manifest = _capture_from_event(message.content)
         except CaptureRejected as exc:
             logger.warning("discarding invalid validation event: %s", exc)
             self._delete_message(message)
@@ -79,6 +79,13 @@ class AzureCaptureValidator:
 
         if self._capture_status(digest) in {"ingested", "rejected"}:
             self._cleanup_prefix(prefix)
+            self._delete_message(message)
+            return True
+
+        # Artifacts arrive before the manifest. Their events keep the Job able
+        # to clean terminal-state replays without treating an in-flight capture
+        # as a prematurely committed upload.
+        if not is_manifest:
             self._delete_message(message)
             return True
 
@@ -199,7 +206,7 @@ class AzureCaptureValidator:
         self.queue.delete_message(message.id, message.pop_receipt)
 
 
-def _capture_from_event(content: str) -> tuple[str, str]:
+def _capture_from_event(content: str) -> tuple[str, str, bool]:
     # Event Grid's Storage Queue destination base64-encodes its JSON envelope;
     # accepting plain JSON as well keeps the parser usable with test and replay
     # tools that already decode queue messages.
@@ -220,12 +227,16 @@ def _capture_from_event(content: str) -> tuple[str, str]:
     if not isinstance(blob_url, str):
         raise CaptureRejected("Event Grid blob URL must be a string")
     parts = unquote(urlparse(blob_url).path).strip("/").split("/")
-    if len(parts) != 4 or parts[1] != "inbox" or parts[3] != "manifest.json":
-        raise CaptureRejected("event is not for inbox/<digest>/manifest.json")
+    if len(parts) < 4 or parts[1] != "inbox":
+        raise CaptureRejected("event is not for an inbox capture object")
     digest = parts[2]
     if len(digest) != 64 or any(char not in "0123456789abcdef" for char in digest):
         raise CaptureRejected("event contains an invalid trajectory digest")
-    return f"inbox/{digest}/", digest
+    relname = "/".join(parts[3:])
+    is_manifest = relname == "manifest.json"
+    if not is_manifest and ARTIFACT_NAME.fullmatch(relname) is None:
+        raise CaptureRejected("event is not for a declared capture object")
+    return f"inbox/{digest}/", digest, is_manifest
 
 
 def _required_env(name: str) -> str:

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tempfile
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
@@ -18,9 +18,14 @@ from services.trajectory_upload.validation import (
     CaptureRejected,
     ValidatedCapture,
     validate_local_capture,
+    validate_manifest_bytes,
 )
 
 logger = logging.getLogger(__name__)
+# The Container Apps Job times out after 30 minutes. A slightly longer lease
+# prevents a replacement worker from overlapping a replica that Azure has not
+# terminated yet; an abandoned queue message can reclaim the digest afterward.
+VALIDATION_LEASE = timedelta(minutes=35)
 
 
 class AzureCaptureValidator:
@@ -89,6 +94,16 @@ class AzureCaptureValidator:
             self._delete_message(message)
             return True
 
+        if not self._claim_capture(digest):
+            # A concurrent worker owns an unexpired validation lease. Leave the
+            # queue message for a later retry so a crashed owner cannot strand
+            # the capture permanently.
+            status = self._capture_status(digest)
+            if status in {"ingested", "rejected"} or status is None:
+                self._cleanup_prefix(prefix)
+                self._delete_message(message)
+            return True
+
         from azure.core.exceptions import ResourceNotFoundError
 
         try:
@@ -104,11 +119,11 @@ class AzureCaptureValidator:
                 self._promote(validated, digest)
         except CaptureRejected as exc:
             logger.warning("capture %s rejected: %s", digest, exc)
-            self._cleanup_prefix(prefix)
             self._record_status(digest, "rejected", detail=str(exc)[:512])
-        else:
             self._cleanup_prefix(prefix)
+        else:
             self._record_status(digest, "ingested")
+            self._cleanup_prefix(prefix)
             logger.info("capture %s promoted", digest)
         self._delete_message(message)
         return True
@@ -121,22 +136,13 @@ class AzureCaptureValidator:
         if properties.size > MAX_MANIFEST_BYTES:
             raise CaptureRejected("manifest exceeds the 1 MiB limit")
         manifest_bytes = manifest_blob.download_blob().readall()
-        try:
-            manifest_data = json.loads(manifest_bytes)
-            artifacts = manifest_data["artifacts"]
-        except (json.JSONDecodeError, KeyError, TypeError) as exc:
-            raise CaptureRejected(f"invalid manifest: {exc}") from exc
-        if not isinstance(artifacts, list):
-            raise CaptureRejected("manifest artifacts must be a list")
+        manifest = validate_manifest_bytes(manifest_bytes)
 
         artifact_paths: dict[str, Path] = {}
-        for item in artifacts:
-            if not isinstance(item, dict) or not isinstance(item.get("name"), str):
-                raise CaptureRejected("manifest contains an invalid artifact entry")
-            relname = item["name"]
+        for artifact in manifest.artifacts:
+            relname = artifact.name
             blob = self.container.get_blob_client(prefix + relname)
-            expected_size = item.get("bytes")
-            if blob.get_blob_properties().size != expected_size:
+            if blob.get_blob_properties().size != artifact.bytes:
                 raise CaptureRejected(f"size mismatch for {relname}")
             local_path = staging_dir / Path(relname).name
             with local_path.open("wb") as output:
@@ -188,9 +194,48 @@ class AzureCaptureValidator:
                 "RowKey": digest,
                 "status": status,
                 "updated_at": datetime.now(UTC).isoformat(),
+                "validation_lease_until": "",
                 **extra,
             }
         )
+
+    def _claim_capture(self, digest: str) -> bool:
+        from azure.core import MatchConditions
+        from azure.core.exceptions import ResourceModifiedError, ResourceNotFoundError
+        from azure.data.tables import UpdateMode
+
+        now = datetime.now(UTC)
+        try:
+            entity = self.table.get_entity(partition_key="capture", row_key=digest)
+        except ResourceNotFoundError:
+            return False
+        status = entity.get("status")
+        lease_until = _parse_datetime(entity.get("validation_lease_until"))
+        if status in {"ingested", "rejected"}:
+            return False
+        if status == "validating" and lease_until is not None and lease_until > now:
+            return False
+        if status not in {"pending", "validating"}:
+            return False
+
+        claimed = dict(entity)
+        claimed.update(
+            {
+                "status": "validating",
+                "updated_at": now.isoformat(),
+                "validation_lease_until": (now + VALIDATION_LEASE).isoformat(),
+            }
+        )
+        try:
+            self.table.update_entity(
+                entity=claimed,
+                mode=UpdateMode.MERGE,
+                etag=entity.metadata["etag"],
+                match_condition=MatchConditions.IfNotModified,
+            )
+        except ResourceModifiedError:
+            return False
+        return True
 
     def _capture_status(self, digest: str) -> str | None:
         from azure.core.exceptions import ResourceNotFoundError
@@ -244,6 +289,16 @@ def _required_env(name: str) -> str:
     if not value:
         raise RuntimeError(f"required environment variable is not set: {name}")
     return value
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
 def main() -> None:

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -78,6 +78,7 @@ class AzureCaptureValidator:
             return True
 
         if self._capture_status(digest) in {"ingested", "rejected"}:
+            self._cleanup_prefix(prefix)
             self._delete_message(message)
             return True
 

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import os
@@ -179,6 +180,14 @@ class AzureCaptureValidator:
 
 
 def _capture_from_event(content: str) -> tuple[str, str]:
+    # Event Grid's Storage Queue destination base64-encodes its JSON envelope;
+    # accepting plain JSON as well keeps the parser usable with test and replay
+    # tools that already decode queue messages.
+    if not content.lstrip().startswith(("{", "[")):
+        try:
+            content = base64.b64decode(content, validate=True).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise CaptureRejected("invalid base64 Event Grid message") from exc
     try:
         event = json.loads(content)
         if isinstance(event, list):

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -77,6 +77,10 @@ class AzureCaptureValidator:
             self._delete_message(message)
             return True
 
+        if self._capture_status(digest) in {"ingested", "rejected"}:
+            self._delete_message(message)
+            return True
+
         try:
             with tempfile.TemporaryDirectory(prefix="benchflow-validator-") as name:
                 validated = self._download_and_validate(prefix, Path(name))
@@ -174,6 +178,16 @@ class AzureCaptureValidator:
                 **extra,
             }
         )
+
+    def _capture_status(self, digest: str) -> str | None:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        try:
+            entity = self.table.get_entity(partition_key="capture", row_key=digest)
+        except ResourceNotFoundError:
+            return None
+        status = entity.get("status")
+        return status if isinstance(status, str) else None
 
     def _delete_message(self, message: Any) -> None:
         self.queue.delete_message(message.id, message.pop_receipt)

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -57,6 +57,7 @@ from benchflow.cli.sandbox import register_sandbox
 from benchflow.cli.skills import register_skills
 from benchflow.cli.tasks import register_tasks
 from benchflow.cli.train import register_train
+from benchflow.cli.traj import register_traj
 from benchflow.eval_plan import EvalCreateRequest, EvalPlanError, build_eval_plan
 from benchflow.evaluation import DEFAULT_AGENT, effective_model
 from benchflow.sandbox.providers import providers_phrase
@@ -1242,6 +1243,7 @@ register_continue(eval_app, alias_app=app)
 register_skills(app)
 register_review(app)
 register_tasks(app)
+register_traj(app)
 register_train(app)
 register_hub(app)
 register_agent(app)

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -1,0 +1,136 @@
+"""``bench traj upload`` — contribute validated trajectory captures."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from rich.markup import escape
+
+from benchflow.cli._shared import console, print_error
+
+# Set to the production Container App endpoint after deployment. The environment
+# variable remains an override for development and disaster recovery.
+DEFAULT_TRAJ_BROKER_URL: str | None = None
+
+
+def register_traj(app: typer.Typer) -> None:
+    """Attach the trajectory contribution group to the top-level app."""
+    traj_app = typer.Typer(help="Trajectory commands.")
+    app.add_typer(traj_app, name="traj", rich_help_panel="Core")
+
+    @traj_app.command("upload")
+    def upload(
+        path: Annotated[
+            Path,
+            typer.Argument(help="Trajectory JSONL file, directory, or trial directory"),
+        ],
+        source_id: Annotated[
+            str | None,
+            typer.Option("--source-id", help="Stable contributor source identifier"),
+        ] = None,
+        direct: Annotated[
+            bool,
+            typer.Option("--direct", help="Upload with local Azure credentials"),
+        ] = False,
+        container_url: Annotated[
+            str | None,
+            typer.Option("--container-url", help="Azure container URL for --direct"),
+        ] = None,
+        dry_run: Annotated[
+            bool,
+            typer.Option("--dry-run", help="Validate and stage without uploading"),
+        ] = False,
+    ) -> None:
+        """Validate, redact, and upload trajectory JSONL."""
+        from benchflow.publish.azure_blob import upload_capture_direct
+        from benchflow.publish.broker import upload_capture_via_broker
+        from benchflow.publish.traj_capture import (
+            default_source_id,
+            stage_trajectory_capture,
+        )
+
+        try:
+            selected_source_id = source_id or default_source_id(path)
+            if direct:
+                destination = container_url or os.environ.get(
+                    "BENCHFLOW_AZURE_CONTAINER_URL"
+                )
+                if not destination:
+                    raise ValueError(
+                        "--direct requires --container-url or "
+                        "BENCHFLOW_AZURE_CONTAINER_URL"
+                    )
+            else:
+                if container_url:
+                    raise ValueError("--container-url is only valid with --direct")
+                destination = (
+                    os.environ.get("BENCHFLOW_TRAJ_BROKER_URL")
+                    or DEFAULT_TRAJ_BROKER_URL
+                )
+                if not destination:
+                    raise ValueError(
+                        "no trajectory broker is configured; set "
+                        "BENCHFLOW_TRAJ_BROKER_URL, or use --direct with "
+                        "--container-url/BENCHFLOW_AZURE_CONTAINER_URL if you have "
+                        "Azure credentials"
+                    )
+
+            with stage_trajectory_capture(
+                path,
+                source_id=selected_source_id,
+                uploaded_by=os.environ.get("BENCHFLOW_TRAJ_UPLOADED_BY"),
+            ) as staged:
+                if dry_run:
+                    _print_dry_run(staged, destination=destination, direct=direct)
+                    return
+                if direct:
+                    result = upload_capture_direct(
+                        staged,
+                        container_url=destination,
+                    )
+                else:
+                    result = upload_capture_via_broker(
+                        staged,
+                        broker_url=destination,
+                    )
+                size = sum(item.size_bytes for item in staged.files)
+                if result.uploaded:
+                    console.print(
+                        "[green]Uploaded trajectory:[/green] "
+                        f"{escape(result.url)} "
+                        f"({len(result.uploaded)} uploaded, {len(result.skipped)} skipped, "
+                        f"{_format_bytes(size)}, "
+                        f"{staged.redaction_replacements} redactions)"
+                    )
+                else:
+                    console.print(
+                        f"[green]Already uploaded:[/green] {escape(result.url)} (no-op)"
+                    )
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+
+
+def _print_dry_run(staged, *, destination: str, direct: bool) -> None:
+    mode = "Azure container" if direct else "broker"
+    console.print(f"[bold]Dry run[/bold] — {mode}: {escape(destination)}")
+    console.print(f"Digest: sha256:{staged.traj_digest}")
+    for staged_file in staged.files:
+        console.print(
+            f"  {escape(staged_file.relname)} ({_format_bytes(staged_file.size_bytes)})"
+        )
+    if staged.ignored:
+        console.print(f"Ignored: {escape(', '.join(staged.ignored))}")
+    console.print(f"Redactions: {staged.redaction_replacements}")
+
+
+def _format_bytes(size: int) -> str:
+    value = float(size)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024 or unit == "GB":
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    raise AssertionError("unreachable")

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -11,9 +11,11 @@ from rich.markup import escape
 
 from benchflow.cli._shared import console, print_error
 
-# Set to the production Container App endpoint after deployment. The environment
-# variable remains an override for development and disaster recovery.
-DEFAULT_TRAJ_BROKER_URL: str | None = None
+# The environment variable remains an override for development and disaster
+# recovery.
+DEFAULT_TRAJ_BROKER_URL: str | None = (
+    "https://tasksminer-traj-broker.nicewave-c3abaecf.westus2.azurecontainerapps.io"
+)
 
 
 def register_traj(app: typer.Typer) -> None:

--- a/src/benchflow/publish/azure_blob.py
+++ b/src/benchflow/publish/azure_blob.py
@@ -1,0 +1,127 @@
+"""Direct Azure Blob publishing for staged trajectory captures."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from benchflow import __version__
+from benchflow.publish.traj_capture import StagedCapture
+
+
+@dataclass(frozen=True)
+class BlobPublishResult:
+    account: str
+    container: str
+    prefix: str
+    uploaded: tuple[str, ...]
+    skipped: tuple[str, ...]
+
+    @property
+    def url(self) -> str:
+        return (
+            f"https://{self.account}.blob.core.windows.net/"
+            f"{self.container}/{self.prefix}"
+        )
+
+
+def upload_capture_direct(
+    staged: StagedCapture,
+    *,
+    container_url: str,
+    credential: Any = None,
+) -> BlobPublishResult:
+    """Create staged files in an Azure container without overwriting blobs."""
+    try:
+        from azure.core.exceptions import (
+            ClientAuthenticationError,
+            HttpResponseError,
+            ResourceExistsError,
+            ResourceNotFoundError,
+        )
+        from azure.identity import DefaultAzureCredential
+        from azure.storage.blob import ContainerClient, ContentSettings
+    except ModuleNotFoundError as exc:  # pragma: no cover - environment dependent
+        raise ValueError(
+            "azure-storage-blob and azure-identity are required for --direct; "
+            "install with: pip install 'benchflow[azure]'"
+        ) from exc
+
+    account, container = _parse_container_url(container_url)
+    auth = credential if credential is not None else DefaultAzureCredential()
+    client = ContainerClient.from_container_url(container_url, credential=auth)
+    prefix = f"sources/{staged.source_id}/{staged.traj_digest}/"
+    metadata = {
+        "source_id": staged.source_id,
+        "traj_digest": f"sha256:{staged.traj_digest}",
+        "schema_version": str(staged.manifest["schema_version"]),
+        "manifest": "manifest.json",
+        "benchflow_version": __version__,
+    }
+    uploaded: list[str] = []
+    skipped: list[str] = []
+    for staged_file in staged.files:
+        blob_name = prefix + staged_file.relname
+        try:
+            with staged_file.local_path.open("rb") as stream:
+                client.upload_blob(
+                    name=blob_name,
+                    data=stream,
+                    overwrite=False,
+                    content_settings=ContentSettings(
+                        content_type=staged_file.content_type
+                    ),
+                    metadata=metadata,
+                )
+        except ResourceExistsError:
+            skipped.append(blob_name)
+        except ResourceNotFoundError as exc:
+            raise ValueError(
+                f"Azure container not found: {container_url}; create the storage "
+                "account and private container before using --direct"
+            ) from exc
+        except ClientAuthenticationError as exc:
+            raise ValueError(
+                "Azure authentication failed; run 'az login' (or configure managed "
+                "identity) and grant the Blob Data Creator role"
+            ) from exc
+        except HttpResponseError as exc:
+            if getattr(exc, "status_code", None) == 403:
+                raise ValueError(
+                    "Azure upload was forbidden; run 'az login' (or configure "
+                    "managed identity) and grant the Blob Data Creator role"
+                ) from exc
+            raise ValueError(
+                f"Azure Blob upload failed for {blob_name}: {exc}"
+            ) from exc
+        else:
+            uploaded.append(blob_name)
+    return BlobPublishResult(
+        account=account,
+        container=container,
+        prefix=prefix,
+        uploaded=tuple(uploaded),
+        skipped=tuple(skipped),
+    )
+
+
+def _parse_container_url(container_url: str) -> tuple[str, str]:
+    parsed = urlparse(container_url.rstrip("/"))
+    host_suffix = ".blob.core.windows.net"
+    container = parsed.path.strip("/")
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or not parsed.hostname.endswith(host_suffix)
+        or not container
+        or "/" in container
+    ):
+        raise ValueError(
+            "--container-url must look like "
+            "https://<account>.blob.core.windows.net/<container>"
+        )
+    account = parsed.hostname[: -len(host_suffix)]
+    if not account:
+        raise ValueError("--container-url is missing the storage account name")
+    return account, container

--- a/src/benchflow/publish/azure_blob.py
+++ b/src/benchflow/publish/azure_blob.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
@@ -48,55 +50,56 @@ def upload_capture_direct(
             "install with: pip install 'benchflow[azure]'"
         ) from exc
 
-    account, container = _parse_container_url(container_url)
-    auth = credential if credential is not None else DefaultAzureCredential()
-    client = ContainerClient.from_container_url(container_url, credential=auth)
-    prefix = f"sources/{staged.source_id}/{staged.traj_digest}/"
-    metadata = {
-        "source_id": staged.source_id,
-        "traj_digest": f"sha256:{staged.traj_digest}",
-        "schema_version": str(staged.manifest["schema_version"]),
-        "manifest": "manifest.json",
-        "benchflow_version": __version__,
-    }
-    uploaded: list[str] = []
-    skipped: list[str] = []
-    for staged_file in staged.files:
-        blob_name = prefix + staged_file.relname
-        try:
-            with staged_file.local_path.open("rb") as stream:
-                client.upload_blob(
-                    name=blob_name,
-                    data=stream,
-                    overwrite=False,
-                    content_settings=ContentSettings(
-                        content_type=staged_file.content_type
-                    ),
-                    metadata=metadata,
-                )
-        except ResourceExistsError:
-            skipped.append(blob_name)
-        except ResourceNotFoundError as exc:
-            raise ValueError(
-                f"Azure container not found: {container_url}; create the storage "
-                "account and private container before using --direct"
-            ) from exc
-        except ClientAuthenticationError as exc:
-            raise ValueError(
-                "Azure authentication failed; run 'az login' (or configure managed "
-                "identity) and grant the Blob Data Creator role"
-            ) from exc
-        except HttpResponseError as exc:
-            if getattr(exc, "status_code", None) == 403:
+    with _quiet_azure_request_logging():
+        account, container = _parse_container_url(container_url)
+        auth = credential if credential is not None else DefaultAzureCredential()
+        client = ContainerClient.from_container_url(container_url, credential=auth)
+        prefix = f"sources/{staged.source_id}/{staged.traj_digest}/"
+        metadata = {
+            "source_id": staged.source_id,
+            "traj_digest": f"sha256:{staged.traj_digest}",
+            "schema_version": str(staged.manifest["schema_version"]),
+            "manifest": "manifest.json",
+            "benchflow_version": __version__,
+        }
+        uploaded: list[str] = []
+        skipped: list[str] = []
+        for staged_file in staged.files:
+            blob_name = prefix + staged_file.relname
+            try:
+                with staged_file.local_path.open("rb") as stream:
+                    client.upload_blob(
+                        name=blob_name,
+                        data=stream,
+                        overwrite=False,
+                        content_settings=ContentSettings(
+                            content_type=staged_file.content_type
+                        ),
+                        metadata=metadata,
+                    )
+            except ResourceExistsError:
+                skipped.append(blob_name)
+            except ResourceNotFoundError as exc:
                 raise ValueError(
-                    "Azure upload was forbidden; run 'az login' (or configure "
-                    "managed identity) and grant the Blob Data Creator role"
+                    f"Azure container not found: {container_url}; create the storage "
+                    "account and private container before using --direct"
                 ) from exc
-            raise ValueError(
-                f"Azure Blob upload failed for {blob_name}: {exc}"
-            ) from exc
-        else:
-            uploaded.append(blob_name)
+            except ClientAuthenticationError as exc:
+                raise ValueError(
+                    "Azure authentication failed; run 'az login' (or configure managed "
+                    "identity) and grant the Blob Data Creator role"
+                ) from exc
+            except HttpResponseError as exc:
+                if getattr(exc, "status_code", None) == 403:
+                    raise ValueError(
+                        "Azure upload was forbidden; run 'az login' (or configure "
+                        "managed identity) and grant the Blob Data Creator role"
+                    ) from exc
+                raise ValueError(
+                    f"Azure Blob upload failed for {blob_name}: {exc}"
+                ) from exc
+            else:
+                uploaded.append(blob_name)
     return BlobPublishResult(
         account=account,
         container=container,
@@ -104,6 +107,18 @@ def upload_capture_direct(
         uploaded=tuple(uploaded),
         skipped=tuple(skipped),
     )
+
+
+@contextmanager
+def _quiet_azure_request_logging():
+    """Keep Azure SDK request diagnostics out of the one-line CLI result."""
+    azure_logger = logging.getLogger("azure")
+    previous_level = azure_logger.level
+    azure_logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        azure_logger.setLevel(previous_level)
 
 
 def _parse_container_url(container_url: str) -> tuple[str, str]:

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -1,0 +1,167 @@
+"""Cloud-neutral client for the public trajectory upload broker."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from benchflow.publish.traj_capture import StagedCapture
+
+
+@dataclass(frozen=True)
+class BrokerPublishResult:
+    base_url: str
+    prefix: str
+    uploaded: tuple[str, ...]
+    skipped: tuple[str, ...]
+
+    @property
+    def url(self) -> str:
+        return f"{self.base_url.rstrip('/')}/{self.prefix.lstrip('/')}"
+
+
+def upload_capture_via_broker(
+    staged: StagedCapture,
+    *,
+    broker_url: str,
+    http_client: httpx.Client | None = None,
+) -> BrokerPublishResult:
+    """Request scoped upload URLs and PUT every staged file in server order."""
+    endpoint = f"{broker_url.rstrip('/')}/v1/uploads"
+    artifacts = staged.manifest["artifacts"]
+    request_body = {
+        "schema_version": staged.manifest["schema_version"],
+        "kind": staged.manifest["kind"],
+        "source_id": staged.manifest["source_id"],
+        "traj_digest": staged.manifest["traj_digest"],
+        "uploaded_by": staged.manifest["uploaded_by"],
+        "artifacts": artifacts,
+    }
+    manager = nullcontext(http_client) if http_client is not None else httpx.Client()
+    try:
+        with manager as client:
+            response = client.post(endpoint, json=request_body, timeout=30)
+            if response.status_code == 409:
+                return _already_uploaded_result(response, staged, broker_url)
+            _raise_for_broker_response(response, operation="upload handshake")
+            payload = _response_object(response)
+            objects = _validated_objects(payload, staged)
+            base_url, prefix = _destination(payload)
+
+            uploaded: list[str] = []
+            skipped: list[str] = []
+            for staged_file, upload in zip(staged.files, objects, strict=True):
+                object_name = prefix + staged_file.relname
+                with staged_file.local_path.open("rb") as stream:
+                    put_response = client.put(
+                        upload["put_url"],
+                        headers=upload["headers"],
+                        content=stream,
+                        timeout=300,
+                    )
+                if put_response.status_code in {409, 412}:
+                    skipped.append(object_name)
+                    continue
+                _raise_for_broker_response(
+                    put_response,
+                    operation=f"upload of {staged_file.relname}",
+                )
+                uploaded.append(object_name)
+    except httpx.HTTPError as exc:
+        raise ValueError(f"trajectory broker request failed: {exc}") from exc
+
+    return BrokerPublishResult(
+        base_url=base_url,
+        prefix=prefix,
+        uploaded=tuple(uploaded),
+        skipped=tuple(skipped),
+    )
+
+
+def _already_uploaded_result(
+    response: httpx.Response,
+    staged: StagedCapture,
+    broker_url: str,
+) -> BrokerPublishResult:
+    try:
+        payload = _response_object(response)
+        base_url, prefix = _destination(payload)
+    except ValueError:
+        base_url = broker_url.rstrip("/")
+        prefix = f"sources/community/{staged.traj_digest}/"
+    return BrokerPublishResult(
+        base_url=base_url,
+        prefix=prefix,
+        uploaded=(),
+        skipped=tuple(prefix + item.relname for item in staged.files),
+    )
+
+
+def _response_object(response: httpx.Response) -> dict[str, Any]:
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise ValueError("trajectory broker returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("trajectory broker returned a non-object response")
+    return payload
+
+
+def _validated_objects(
+    payload: dict[str, Any], staged: StagedCapture
+) -> list[dict[str, Any]]:
+    objects = payload.get("objects")
+    if not isinstance(objects, list) or not all(
+        isinstance(item, dict) for item in objects
+    ):
+        raise ValueError("trajectory broker protocol violation: objects must be a list")
+    expected_names = [item.relname for item in staged.files]
+    names = [item.get("name") for item in objects]
+    if names != expected_names:
+        raise ValueError(
+            "trajectory broker protocol violation: response objects must match "
+            "the staged files in canonical manifest-last order"
+        )
+    for item in objects:
+        if not isinstance(item.get("put_url"), str):
+            raise ValueError("trajectory broker protocol violation: missing put_url")
+        headers = item.get("headers")
+        if not isinstance(headers, dict) or not all(
+            isinstance(key, str) and isinstance(value, str)
+            for key, value in headers.items()
+        ):
+            raise ValueError(
+                "trajectory broker protocol violation: headers must map strings to strings"
+            )
+    return objects
+
+
+def _destination(payload: dict[str, Any]) -> tuple[str, str]:
+    prefix = payload.get("prefix")
+    if not isinstance(prefix, str) or not prefix:
+        raise ValueError("trajectory broker protocol violation: missing prefix")
+    base_url = payload.get("base_url")
+    if isinstance(base_url, str) and base_url.startswith("https://"):
+        return base_url, prefix
+    bucket = payload.get("bucket")
+    if isinstance(bucket, str) and bucket:
+        return f"gs://{bucket}", prefix
+    raise ValueError("trajectory broker protocol violation: missing destination")
+
+
+def _raise_for_broker_response(response: httpx.Response, *, operation: str) -> None:
+    if response.status_code < 400:
+        return
+    detail = response.text.strip().replace("\n", " ")[:300]
+    if response.status_code == 413:
+        raise ValueError(f"trajectory broker rejected an oversized capture: {detail}")
+    if response.status_code == 429:
+        retry_after = response.headers.get("Retry-After")
+        suffix = f"; retry after {retry_after}" if retry_after else ""
+        raise ValueError(f"trajectory broker rate limit exceeded{suffix}: {detail}")
+    raise ValueError(
+        f"trajectory broker {operation} failed with HTTP {response.status_code}: {detail}"
+    )

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from contextlib import nullcontext
+import logging
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import Any
 
@@ -42,7 +43,7 @@ def upload_capture_via_broker(
     }
     manager = nullcontext(http_client) if http_client is not None else httpx.Client()
     try:
-        with manager as client:
+        with _quiet_httpx_request_logging(), manager as client:
             response = client.post(endpoint, json=request_body, timeout=30)
             if response.status_code == 409:
                 return _already_uploaded_result(response, staged, broker_url)
@@ -79,6 +80,18 @@ def upload_capture_via_broker(
         uploaded=tuple(uploaded),
         skipped=tuple(skipped),
     )
+
+
+@contextmanager
+def _quiet_httpx_request_logging():
+    """Keep short-lived signed upload URLs out of the global INFO stream."""
+    httpx_logger = logging.getLogger("httpx")
+    previous_level = httpx_logger.level
+    httpx_logger.setLevel(logging.WARNING)
+    try:
+        yield
+    finally:
+        httpx_logger.setLevel(previous_level)
 
 
 def _already_uploaded_result(

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -6,6 +6,7 @@ import logging
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -139,8 +140,20 @@ def _validated_objects(
             "the staged files in canonical manifest-last order"
         )
     for item in objects:
-        if not isinstance(item.get("put_url"), str):
+        put_url = item.get("put_url")
+        if not isinstance(put_url, str):
             raise ValueError("trajectory broker protocol violation: missing put_url")
+        parsed_url = urlparse(put_url)
+        if (
+            parsed_url.scheme != "https"
+            or not parsed_url.hostname
+            or parsed_url.username is not None
+            or parsed_url.password is not None
+        ):
+            raise ValueError(
+                "trajectory broker protocol violation: put_url must be an "
+                "authenticated HTTPS URL"
+            )
         headers = item.get("headers")
         if not isinstance(headers, dict) or not all(
             isinstance(key, str) and isinstance(value, str)

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -41,7 +41,7 @@ VALUE_PATTERNS = (
     RedactionPattern(re.compile(r"sk-[A-Za-z0-9_-]{16,}"), REDACTED),
     RedactionPattern(re.compile(r"AIza[0-9A-Za-z_-]{35}"), REDACTED),
     RedactionPattern(re.compile(r"AQ\.[0-9A-Za-z_-]{20,}"), REDACTED),
-    RedactionPattern(re.compile(r"AKIA[0-9A-Z]{16}"), REDACTED),
+    RedactionPattern(re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Z])"), REDACTED),
     RedactionPattern(re.compile(r"ghp_[A-Za-z0-9]{36,}"), REDACTED),
     RedactionPattern(re.compile(r"github_pat_[A-Za-z0-9_]{22,}"), REDACTED),
     RedactionPattern(re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), REDACTED),

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -87,6 +87,17 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
         replacements = 0
         original_keys = set(value)
         secret_key_index = 0
+        carrier_field = next(
+            (
+                item
+                for key, item in value.items()
+                if isinstance(key, str)
+                and _normalize_key(key) in {"key", "name"}
+                and isinstance(item, str)
+                and _is_sensitive_key(item)
+            ),
+            None,
+        )
         for key, item in value.items():
             clean_key = key
             if isinstance(key, str):
@@ -100,7 +111,14 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
                     replacements += key_replacements
             clean, count = redact_value(
                 item,
-                field_name=key if isinstance(key, str) else None,
+                field_name=(
+                    carrier_field
+                    if isinstance(key, str)
+                    and _normalize_key(key) in {"value", "values"}
+                    else key
+                    if isinstance(key, str)
+                    else None
+                ),
             )
             redacted[clean_key] = clean
             replacements += count
@@ -177,11 +195,15 @@ def _redact_argv(
 
 
 def _is_sensitive_key(field_name: str) -> bool:
-    normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", field_name)
-    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
-    normalized = re.sub(r"[^a-z0-9]+", "_", normalized.casefold()).strip("_")
+    normalized = _normalize_key(field_name)
     return (
         normalized in DENYLISTED_KEYS
         or normalized.endswith(SEPARATED_SENSITIVE_KEY_SUFFIXES)
         or normalized.replace("_", "").endswith(COMPACT_SENSITIVE_KEY_SUFFIXES)
     )
+
+
+def _normalize_key(field_name: str) -> str:
+    normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", field_name)
+    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
+    return re.sub(r"[^a-z0-9]+", "_", normalized.casefold()).strip("_")

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -25,12 +25,38 @@ DENYLISTED_KEYS = frozenset(
         "aws_bearer_token_bedrock",
         "aws_secret_access_key",
         "access_token",
+        "access_key",
+        "account_key",
+        "credential",
         "refresh_token",
         "client_secret",
+        "encryption_key",
         "password",
+        "passwd",
         "secret",
+        "secret_key",
         "token",
     }
+)
+SENSITIVE_KEY_SUFFIXES = (
+    "api_key",
+    "token",
+    "secret",
+    "password",
+    "passwd",
+    "access_key",
+    "secret_key",
+    "account_key",
+    "private_key",
+    "encryption_key",
+    "credential",
+    "credentials",
+)
+SEPARATED_SENSITIVE_KEY_SUFFIXES = tuple(
+    f"_{suffix}" for suffix in SENSITIVE_KEY_SUFFIXES
+)
+COMPACT_SENSITIVE_KEY_SUFFIXES = tuple(
+    suffix.replace("_", "") for suffix in SENSITIVE_KEY_SUFFIXES
 )
 
 
@@ -106,19 +132,8 @@ def _is_sensitive_key(field_name: str) -> bool:
     normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", field_name)
     normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
     normalized = re.sub(r"[^a-z0-9]+", "_", normalized.casefold()).strip("_")
-    return normalized in DENYLISTED_KEYS or normalized.endswith(
-        (
-            "_api_key",
-            "_token",
-            "_secret",
-            "_password",
-            "_passwd",
-            "_access_key",
-            "_secret_key",
-            "_account_key",
-            "_private_key",
-            "_encryption_key",
-            "_credential",
-            "_credentials",
-        )
+    return (
+        normalized in DENYLISTED_KEYS
+        or normalized.endswith(SEPARATED_SENSITIVE_KEY_SUFFIXES)
+        or normalized.replace("_", "").endswith(COMPACT_SENSITIVE_KEY_SUFFIXES)
     )

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -13,16 +13,15 @@ REDACTED = "[REDACTED]"
 DENYLISTED_KEYS = frozenset(
     {
         "authorization",
-        "proxy-authorization",
-        "x-api-key",
-        "api-key",
+        "proxy_authorization",
+        "x_api_key",
         "api_key",
         "apikey",
         "cookie",
         "credentials",
         "private_key",
-        "set-cookie",
-        "x-goog-api-key",
+        "set_cookie",
+        "x_goog_api_key",
         "aws_bearer_token_bedrock",
         "aws_secret_access_key",
         "access_token",
@@ -30,6 +29,7 @@ DENYLISTED_KEYS = frozenset(
         "client_secret",
         "password",
         "secret",
+        "token",
     }
 )
 
@@ -103,7 +103,22 @@ def _redact_text(value: str) -> tuple[str, int]:
 
 
 def _is_sensitive_key(field_name: str) -> bool:
-    normalized = field_name.casefold()
+    normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", field_name)
+    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
+    normalized = normalized.casefold().replace("-", "_")
     return normalized in DENYLISTED_KEYS or normalized.endswith(
-        ("_api_key", "-api-key", "_secret", "-secret", "_password", "-password")
+        (
+            "_api_key",
+            "_token",
+            "_secret",
+            "_password",
+            "_passwd",
+            "_access_key",
+            "_secret_key",
+            "_account_key",
+            "_private_key",
+            "_encryption_key",
+            "_credential",
+            "_credentials",
+        )
     )

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -105,7 +105,7 @@ def _redact_text(value: str) -> tuple[str, int]:
 def _is_sensitive_key(field_name: str) -> bool:
     normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", field_name)
     normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
-    normalized = normalized.casefold().replace("-", "_")
+    normalized = re.sub(r"[^a-z0-9]+", "_", normalized.casefold()).strip("_")
     return normalized in DENYLISTED_KEYS or normalized.endswith(
         (
             "_api_key",

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -16,7 +16,12 @@ DENYLISTED_KEYS = frozenset(
         "api-key",
         "api_key",
         "apikey",
+        "cookie",
+        "credentials",
+        "private_key",
+        "set-cookie",
         "x-goog-api-key",
+        "aws_bearer_token_bedrock",
         "aws_secret_access_key",
         "access_token",
         "refresh_token",
@@ -72,7 +77,7 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
 
     if not isinstance(value, str):
         return value, 0
-    if field_name is not None and field_name.casefold() in DENYLISTED_KEYS:
+    if field_name is not None and _is_sensitive_key(field_name):
         return (REDACTED, 1) if value != REDACTED else (value, 0)
 
     redacted_text = value
@@ -81,3 +86,10 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
         redacted_text, count = pattern.subn(replacement, redacted_text)
         replacements += count
     return redacted_text, replacements
+
+
+def _is_sensitive_key(field_name: str) -> bool:
+    normalized = field_name.casefold()
+    return normalized in DENYLISTED_KEYS or normalized.endswith(
+        ("_api_key", "-api-key", "_secret", "-secret", "_password", "-password")
+    )

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -54,6 +54,9 @@ VALUE_PATTERNS = (
 
 def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int]:
     """Return a structurally redacted JSON value and replacement count."""
+    if field_name is not None and _is_sensitive_key(field_name):
+        return (value, 0) if value == REDACTED else (REDACTED, 1)
+
     if isinstance(value, Mapping):
         redacted: dict[Any, Any] = {}
         replacements = 0
@@ -77,8 +80,6 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
 
     if not isinstance(value, str):
         return value, 0
-    if field_name is not None and _is_sensitive_key(field_name):
-        return (REDACTED, 1) if value != REDACTED else (value, 0)
 
     redacted_text = value
     replacements = 0

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -1,0 +1,83 @@
+"""Structural secret redaction for trajectory contributions."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any, NamedTuple
+
+REDACTED = "[REDACTED]"
+
+DENYLISTED_KEYS = frozenset(
+    {
+        "authorization",
+        "proxy-authorization",
+        "x-api-key",
+        "api-key",
+        "api_key",
+        "apikey",
+        "x-goog-api-key",
+        "aws_secret_access_key",
+        "access_token",
+        "refresh_token",
+        "client_secret",
+        "password",
+        "secret",
+    }
+)
+
+
+class RedactionPattern(NamedTuple):
+    pattern: re.Pattern[str]
+    replacement: str
+
+
+VALUE_PATTERNS = (
+    RedactionPattern(re.compile(r"sk-[A-Za-z0-9_-]{16,}"), REDACTED),
+    RedactionPattern(re.compile(r"AIza[0-9A-Za-z_-]{35}"), REDACTED),
+    RedactionPattern(re.compile(r"AQ\.[0-9A-Za-z_-]{20,}"), REDACTED),
+    RedactionPattern(re.compile(r"AKIA[0-9A-Z]{16}"), REDACTED),
+    RedactionPattern(re.compile(r"ghp_[A-Za-z0-9]{36,}"), REDACTED),
+    RedactionPattern(re.compile(r"github_pat_[A-Za-z0-9_]{22,}"), REDACTED),
+    RedactionPattern(re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), REDACTED),
+    RedactionPattern(
+        re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]{16,}", re.IGNORECASE),
+        f"Bearer {REDACTED}",
+    ),
+)
+
+
+def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int]:
+    """Return a structurally redacted JSON value and replacement count."""
+    if isinstance(value, Mapping):
+        redacted: dict[Any, Any] = {}
+        replacements = 0
+        for key, item in value.items():
+            clean, count = redact_value(
+                item,
+                field_name=key if isinstance(key, str) else None,
+            )
+            redacted[key] = clean
+            replacements += count
+        return redacted, replacements
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        redacted_items = []
+        replacements = 0
+        for item in value:
+            clean, count = redact_value(item)
+            redacted_items.append(clean)
+            replacements += count
+        return redacted_items, replacements
+
+    if not isinstance(value, str):
+        return value, 0
+    if field_name is not None and field_name.casefold() in DENYLISTED_KEYS:
+        return (REDACTED, 1) if value != REDACTED else (value, 0)
+
+    redacted_text = value
+    replacements = 0
+    for pattern, replacement in VALUE_PATTERNS:
+        redacted_text, count = pattern.subn(replacement, redacted_text)
+        replacements += count
+    return redacted_text, replacements

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple
 
@@ -106,13 +107,7 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
         return redacted, replacements
 
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        redacted_items = []
-        replacements = 0
-        for item in value:
-            clean, count = redact_value(item)
-            redacted_items.append(clean)
-            replacements += count
-        return redacted_items, replacements
+        return _redact_argv(value, redact_other_values=True)
 
     if not isinstance(value, str):
         return value, 0
@@ -125,7 +120,60 @@ def _redact_text(value: str) -> tuple[str, int]:
     for pattern, replacement in VALUE_PATTERNS:
         redacted_text, count = pattern.subn(replacement, redacted_text)
         replacements += count
+    cli_redacted, cli_replacements = _redact_cli_text(redacted_text)
+    redacted_text = cli_redacted
+    replacements += cli_replacements
     return redacted_text, replacements
+
+
+def _redact_cli_text(value: str) -> tuple[str, int]:
+    if "--" not in value:
+        return value, 0
+    try:
+        argv = shlex.split(value)
+    except ValueError:
+        return value, 0
+    redacted, replacements = _redact_argv(argv, redact_other_values=False)
+    return (shlex.join(redacted), replacements) if replacements else (value, 0)
+
+
+def _redact_argv(
+    values: Sequence[Any], *, redact_other_values: bool
+) -> tuple[list[Any], int]:
+    redacted: list[Any] = []
+    replacements = 0
+    redact_next = False
+    for item in values:
+        if redact_next:
+            if item == REDACTED or item == "***REDACTED***":
+                redacted.append(item)
+            else:
+                redacted.append(REDACTED)
+                replacements += 1
+            redact_next = False
+            continue
+
+        if isinstance(item, str) and item.startswith("-"):
+            option, separator, option_value = item.partition("=")
+            if _is_sensitive_key(option):
+                if separator and option_value:
+                    if option_value in {REDACTED, "***REDACTED***"}:
+                        redacted.append(item)
+                    else:
+                        redacted.append(f"{option}={REDACTED}")
+                        replacements += 1
+                else:
+                    redacted.append(item)
+                    redact_next = not separator
+                continue
+
+        if redact_other_values:
+            clean, count = redact_value(item)
+            redacted.append(clean)
+            replacements += count
+        else:
+            redacted.append(item)
+    return redacted, replacements
 
 
 def _is_sensitive_key(field_name: str) -> bool:

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -6,6 +6,8 @@ import re
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple
 
+from benchflow.trajectories.types import redact_trajectory_text_with_count
+
 REDACTED = "[REDACTED]"
 
 DENYLISTED_KEYS = frozenset(
@@ -38,16 +40,12 @@ class RedactionPattern(NamedTuple):
 
 
 VALUE_PATTERNS = (
-    RedactionPattern(re.compile(r"sk-[A-Za-z0-9_-]{16,}"), REDACTED),
-    RedactionPattern(re.compile(r"AIza[0-9A-Za-z_-]{35}"), REDACTED),
-    RedactionPattern(re.compile(r"AQ\.[0-9A-Za-z_-]{20,}"), REDACTED),
-    RedactionPattern(re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{16}(?![0-9A-Z])"), REDACTED),
-    RedactionPattern(re.compile(r"ghp_[A-Za-z0-9]{36,}"), REDACTED),
-    RedactionPattern(re.compile(r"github_pat_[A-Za-z0-9_]{22,}"), REDACTED),
-    RedactionPattern(re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), REDACTED),
+    # Google AI Studio's newer token format is not covered by the canonical
+    # trajectory redactor yet.
+    RedactionPattern(re.compile(r"AQ\.[0-9A-Za-z_-]{20,}"), "***REDACTED***"),
     RedactionPattern(
         re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]{16,}", re.IGNORECASE),
-        f"Bearer {REDACTED}",
+        "Bearer ***REDACTED***",
     ),
 )
 
@@ -81,8 +79,7 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
     if not isinstance(value, str):
         return value, 0
 
-    redacted_text = value
-    replacements = 0
+    redacted_text, replacements = redact_trajectory_text_with_count(value)
     for pattern, replacement in VALUE_PATTERNS:
         redacted_text, count = pattern.subn(replacement, redacted_text)
         replacements += count

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -58,12 +58,24 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
     if isinstance(value, Mapping):
         redacted: dict[Any, Any] = {}
         replacements = 0
+        original_keys = set(value)
+        secret_key_index = 0
         for key, item in value.items():
+            clean_key = key
+            if isinstance(key, str):
+                _, key_replacements = _redact_text(key)
+                if key_replacements:
+                    secret_key_index += 1
+                    clean_key = f"***REDACTED_KEY_{secret_key_index}***"
+                    while clean_key in original_keys or clean_key in redacted:
+                        secret_key_index += 1
+                        clean_key = f"***REDACTED_KEY_{secret_key_index}***"
+                    replacements += key_replacements
             clean, count = redact_value(
                 item,
                 field_name=key if isinstance(key, str) else None,
             )
-            redacted[key] = clean
+            redacted[clean_key] = clean
             replacements += count
         return redacted, replacements
 
@@ -79,6 +91,10 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
     if not isinstance(value, str):
         return value, 0
 
+    return _redact_text(value)
+
+
+def _redact_text(value: str) -> tuple[str, int]:
     redacted_text, replacements = redact_trajectory_text_with_count(value)
     for pattern, replacement in VALUE_PATTERNS:
         redacted_text, count = pattern.subn(replacement, redacted_text)

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Never
 
 from benchflow import __version__
 from benchflow.publish.redact import redact_value
@@ -22,6 +22,28 @@ MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
 SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    parsed: dict[str, Any] = {}
+    for key, item in pairs:
+        if key in parsed:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        parsed[key] = item
+    return parsed
+
+
+def _reject_non_finite_json(constant: str) -> Never:
+    raise ValueError(f"non-finite JSON number: {constant}")
+
+
+def strict_json_loads(value: str | bytes) -> Any:
+    """Parse standards-compliant JSON while rejecting ambiguous object keys."""
+    return json.loads(
+        value,
+        object_pairs_hook=_reject_duplicate_json_keys,
+        parse_constant=_reject_non_finite_json,
+    )
 
 
 @dataclass(frozen=True)
@@ -114,9 +136,16 @@ def stage_trajectory_capture(
             redact=redact,
             replacement_count=replacement_count,
         )
+        if redact:
+            redacted_manifest, manifest_replacements = redact_value(manifest)
+            if redacted_manifest["source_id"] != manifest["source_id"]:
+                raise ValueError("source id contains a secret-like value")
+            replacement_count += manifest_replacements
+            redacted_manifest["redaction"]["replacements"] = replacement_count
+            manifest = redacted_manifest
         manifest_path = staging_dir / "manifest.json"
         manifest_path.write_text(
-            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
             encoding="utf-8",
         )
         manifest_file = _staged_file(
@@ -188,8 +217,8 @@ def _validate_jsonl(path: Path) -> None:
             if not line.strip():
                 continue
             try:
-                value = json.loads(line)
-            except (json.JSONDecodeError, RecursionError) as exc:
+                value = strict_json_loads(line)
+            except (RecursionError, ValueError) as exc:
                 raise ValueError(
                     f"{path}: line {line_number}: invalid JSON: {exc}"
                 ) from exc
@@ -217,7 +246,7 @@ def _redact_jsonl(source: Path, target: Path) -> int:
             if not body.strip():
                 output_stream.write(line)
                 continue
-            value = json.loads(body)
+            value = strict_json_loads(body)
             try:
                 redacted, count = redact_value(value)
             except RecursionError as exc:  # defense in depth after complexity gate
@@ -338,8 +367,8 @@ def _load_run_metadata(metadata_dir: Path | None) -> dict[str, Any]:
 
 def _read_object(path: Path) -> dict[str, Any]:
     try:
-        value = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        value = strict_json_loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
         return {}
     return value if isinstance(value, dict) else {}
 

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -18,6 +18,8 @@ from benchflow import __version__
 from benchflow.publish.redact import redact_value
 
 MAX_FILE_BYTES = 128 * 1024**2
+MAX_ARTIFACTS = 8
+MAX_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
 MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
@@ -107,6 +109,17 @@ def stage_trajectory_capture(
     """Validate and stage a trajectory capture without mutating its source."""
     source_id = validate_source_id(source_id)
     resolved = _resolve_input(path)
+    if len(resolved.files) > MAX_ARTIFACTS:
+        raise ValueError(
+            f"trajectory capture exceeds {MAX_ARTIFACTS} artifact files: "
+            f"{len(resolved.files)} files"
+        )
+    capture_bytes = sum(source.stat().st_size for source in resolved.files)
+    if capture_bytes > MAX_CAPTURE_BYTES:
+        raise ValueError(
+            f"trajectory capture exceeds {MAX_CAPTURE_BYTES} bytes: "
+            f"{capture_bytes} bytes"
+        )
     for source in resolved.files:
         _validate_jsonl(source)
 
@@ -164,7 +177,10 @@ def stage_trajectory_capture(
 
 
 def _resolve_input(path: Path) -> _ResolvedInput:
-    resolved = path.expanduser().resolve()
+    expanded = path.expanduser()
+    if expanded.is_symlink():
+        raise ValueError(f"trajectory path must not be a symlink: {expanded}")
+    resolved = expanded.resolve()
     if resolved.is_file():
         if resolved.suffix.casefold() != ".jsonl":
             raise ValueError(f"trajectory file must end in .jsonl: {resolved}")
@@ -172,13 +188,23 @@ def _resolve_input(path: Path) -> _ResolvedInput:
     if not resolved.is_dir():
         raise ValueError(f"trajectory path not found: {resolved}")
 
-    trial_dir = resolved if (resolved / "trajectory").is_dir() else None
-    payload_dir = resolved / "trajectory" if trial_dir is not None else resolved
+    trajectory_dir = resolved / "trajectory"
+    if trajectory_dir.is_symlink():
+        raise ValueError(
+            f"trajectory directory must not be a symlink: {trajectory_dir}"
+        )
+    trial_dir = resolved if trajectory_dir.is_dir() else None
+    payload_dir = trajectory_dir if trial_dir is not None else resolved
     entries = sorted(payload_dir.iterdir(), key=lambda item: item.name)
+    for item in entries:
+        if item.is_symlink() and item.suffix.casefold() == ".jsonl":
+            raise ValueError(f"trajectory file must not be a symlink: {item}")
     files = tuple(
         item
         for item in entries
-        if item.is_file() and item.suffix.casefold() == ".jsonl"
+        if not item.is_symlink()
+        and item.is_file()
+        and item.suffix.casefold() == ".jsonl"
     )
     ignored = tuple(
         item.name

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -106,6 +106,9 @@ def validate_artifact_name(name: str) -> str:
     """Require the canonical public trajectory object namespace."""
     if not ARTIFACT_NAME_PATTERN.fullmatch(name):
         raise ValueError("artifact name is outside trajectory/*.jsonl")
+    _, replacements = redact_value(name)
+    if replacements:
+        raise ValueError("artifact filename resembles a secret")
     return name
 
 

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -22,10 +22,12 @@ MAX_ARTIFACTS = 8
 MAX_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
 MAX_MANIFEST_BYTES = 1024**2
 MAX_RUN_METADATA_BYTES = 1024**2
+MAX_UPLOADED_BY_LENGTH = 256
 MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
 SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
+ARTIFACT_NAME_PATTERN = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
 
 
 def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -100,6 +102,13 @@ def validate_source_id(source_id: str) -> str:
     return normalized
 
 
+def validate_artifact_name(name: str) -> str:
+    """Require the canonical public trajectory object namespace."""
+    if not ARTIFACT_NAME_PATTERN.fullmatch(name):
+        raise ValueError("artifact name is outside trajectory/*.jsonl")
+    return name
+
+
 @contextmanager
 def stage_trajectory_capture(
     path: Path,
@@ -110,6 +119,10 @@ def stage_trajectory_capture(
 ) -> Iterator[StagedCapture]:
     """Validate and stage a trajectory capture without mutating its source."""
     source_id = validate_source_id(source_id)
+    if uploaded_by is not None and len(uploaded_by) > MAX_UPLOADED_BY_LENGTH:
+        raise ValueError(
+            f"trajectory contributor label exceeds {MAX_UPLOADED_BY_LENGTH} characters"
+        )
     resolved = _resolve_input(path)
     if len(resolved.files) > MAX_ARTIFACTS:
         raise ValueError(
@@ -130,7 +143,7 @@ def stage_trajectory_capture(
         payloads: list[StagedFile] = []
         replacement_count = 0
         for source in resolved.files:
-            relname = f"trajectory/{source.name}"
+            relname = validate_artifact_name(f"trajectory/{source.name}")
             target = staging_dir / relname
             target.parent.mkdir(parents=True, exist_ok=True)
             if redact:
@@ -420,7 +433,7 @@ def _read_object(path: Path) -> dict[str, Any]:
         if len(payload) > MAX_RUN_METADATA_BYTES:
             return {}
         value = strict_json_loads(payload)
-    except (OSError, UnicodeDecodeError, ValueError):
+    except (OSError, RecursionError, UnicodeDecodeError, ValueError):
         return {}
     return value if isinstance(value, dict) else {}
 

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -392,6 +392,8 @@ def _load_run_metadata(metadata_dir: Path | None) -> dict[str, Any]:
 
 
 def _read_object(path: Path) -> dict[str, Any]:
+    if path.is_symlink():
+        return {}
     try:
         value = strict_json_loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, ValueError):

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -1,0 +1,324 @@
+"""Pure-local staging for trajectory contributions."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import shutil
+import tempfile
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from benchflow import __version__
+from benchflow.publish.redact import redact_value
+from benchflow.trajectories.export_prime_sft import (
+    PrimeSftTrajectoryJsonlError,
+    load_llm_trajectory_jsonl,
+)
+
+MAX_FILE_BYTES = 1024**3
+SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
+
+
+@dataclass(frozen=True)
+class StagedFile:
+    relname: str
+    local_path: Path
+    sha256: str
+    size_bytes: int
+    content_type: str
+
+
+@dataclass(frozen=True)
+class StagedCapture:
+    source_id: str
+    traj_digest: str
+    files: tuple[StagedFile, ...]
+    manifest: dict[str, Any]
+    ignored: tuple[str, ...]
+    redaction_replacements: int
+
+
+@dataclass(frozen=True)
+class _ResolvedInput:
+    files: tuple[Path, ...]
+    metadata_dir: Path | None
+    ignored: tuple[str, ...]
+
+
+def default_source_id(path: Path) -> str:
+    """Derive a safe source id from a trajectory path."""
+    resolved = path.expanduser().resolve()
+    raw = resolved.stem if resolved.is_file() else resolved.name
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", raw).strip("-._")
+    return validate_source_id(sanitized or "trajectory")
+
+
+def validate_source_id(source_id: str) -> str:
+    """Validate and normalize a source id used in object names."""
+    normalized = source_id.strip().strip("/")
+    if not SOURCE_ID_PATTERN.fullmatch(normalized) or "//" in normalized:
+        raise ValueError(
+            "invalid source id; use --source-id with 1-128 letters, numbers, "
+            "dots, underscores, hyphens, or single path separators"
+        )
+    return normalized
+
+
+@contextmanager
+def stage_trajectory_capture(
+    path: Path,
+    *,
+    source_id: str,
+    redact: bool = True,
+    uploaded_by: str | None = None,
+) -> Iterator[StagedCapture]:
+    """Validate and stage a trajectory capture without mutating its source."""
+    source_id = validate_source_id(source_id)
+    resolved = _resolve_input(path)
+    for source in resolved.files:
+        _validate_jsonl(source)
+
+    with tempfile.TemporaryDirectory(prefix="benchflow-traj-") as temp_name:
+        staging_dir = Path(temp_name)
+        payloads: list[StagedFile] = []
+        replacement_count = 0
+        for source in resolved.files:
+            relname = f"trajectory/{source.name}"
+            target = staging_dir / relname
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if redact:
+                replacements = _redact_jsonl(source, target)
+                replacement_count += replacements
+            else:
+                shutil.copyfile(source, target)
+            payloads.append(_staged_file(target, relname, "application/jsonl"))
+
+        payloads.sort(key=lambda item: item.relname)
+        traj_digest = _trajectory_digest(payloads)
+        manifest = _build_manifest(
+            source_id=source_id,
+            traj_digest=traj_digest,
+            payloads=payloads,
+            metadata_dir=resolved.metadata_dir,
+            uploaded_by=uploaded_by,
+            redact=redact,
+            replacement_count=replacement_count,
+        )
+        manifest_path = staging_dir / "manifest.json"
+        manifest_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        manifest_file = _staged_file(
+            manifest_path,
+            "manifest.json",
+            "application/json",
+        )
+        yield StagedCapture(
+            source_id=source_id,
+            traj_digest=traj_digest,
+            files=(*payloads, manifest_file),
+            manifest=manifest,
+            ignored=resolved.ignored,
+            redaction_replacements=replacement_count,
+        )
+
+
+def _resolve_input(path: Path) -> _ResolvedInput:
+    resolved = path.expanduser().resolve()
+    if resolved.is_file():
+        if resolved.suffix.casefold() != ".jsonl":
+            raise ValueError(f"trajectory file must end in .jsonl: {resolved}")
+        return _ResolvedInput((resolved,), resolved.parent, ())
+    if not resolved.is_dir():
+        raise ValueError(f"trajectory path not found: {resolved}")
+
+    trial_dir = resolved if (resolved / "trajectory").is_dir() else None
+    payload_dir = resolved / "trajectory" if trial_dir is not None else resolved
+    entries = sorted(payload_dir.iterdir(), key=lambda item: item.name)
+    files = tuple(
+        item
+        for item in entries
+        if item.is_file() and item.suffix.casefold() == ".jsonl"
+    )
+    ignored = tuple(
+        item.name
+        for item in entries
+        if item.is_file() and item.suffix.casefold() != ".jsonl"
+    )
+    if not files:
+        raise ValueError(f"no .jsonl trajectory files found in {payload_dir}")
+    return _ResolvedInput(files, trial_dir or resolved, ignored)
+
+
+def _validate_jsonl(path: Path) -> None:
+    size = path.stat().st_size
+    if size > MAX_FILE_BYTES:
+        raise ValueError(
+            f"trajectory file exceeds {MAX_FILE_BYTES} bytes: {path} ({size} bytes)"
+        )
+    if size == 0:
+        raise ValueError(f"trajectory JSONL is empty: {path}")
+    if path.name == "llm_trajectory.jsonl":
+        try:
+            records = load_llm_trajectory_jsonl(path, strict=True)
+        except PrimeSftTrajectoryJsonlError as exc:
+            raise ValueError(str(exc)) from exc
+        if not records:
+            raise ValueError(f"trajectory JSONL has no records: {path}")
+        return
+
+    records = 0
+    try:
+        with path.open(encoding="utf-8") as stream:
+            for line_number, line in enumerate(stream, start=1):
+                if not line.strip():
+                    continue
+                try:
+                    value = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    raise ValueError(
+                        f"{path}: line {line_number}: invalid JSON: {exc}"
+                    ) from exc
+                if not isinstance(value, dict):
+                    raise ValueError(
+                        f"{path}: line {line_number}: top-level record must be an object"
+                    )
+                records += 1
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"{path}: trajectory JSONL must be UTF-8: {exc}") from exc
+    if records == 0:
+        raise ValueError(f"trajectory JSONL has no records: {path}")
+
+
+def _redact_jsonl(source: Path, target: Path) -> int:
+    replacements = 0
+    with (
+        source.open(encoding="utf-8", newline="") as input_stream,
+        target.open("w", encoding="utf-8", newline="") as output_stream,
+    ):
+        for line in input_stream:
+            body, newline = _split_newline(line)
+            if not body.strip():
+                output_stream.write(line)
+                continue
+            value = json.loads(body)
+            redacted, count = redact_value(value)
+            if count:
+                output_stream.write(
+                    json.dumps(redacted, separators=(",", ":"), ensure_ascii=False)
+                    + newline
+                )
+            else:
+                output_stream.write(line)
+            replacements += count
+    return replacements
+
+
+def _split_newline(line: str) -> tuple[str, str]:
+    if line.endswith("\r\n"):
+        return line[:-2], "\r\n"
+    if line.endswith("\n") or line.endswith("\r"):
+        return line[:-1], line[-1]
+    return line, ""
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _staged_file(path: Path, relname: str, content_type: str) -> StagedFile:
+    return StagedFile(
+        relname=relname,
+        local_path=path,
+        sha256=_sha256(path),
+        size_bytes=path.stat().st_size,
+        content_type=content_type,
+    )
+
+
+def _trajectory_digest(payloads: list[StagedFile]) -> str:
+    digest_input = "\n".join(
+        f"{item.relname}\t{item.sha256}"
+        for item in sorted(payloads, key=lambda f: f.relname)
+    )
+    return hashlib.sha256(digest_input.encode()).hexdigest()
+
+
+def _build_manifest(
+    *,
+    source_id: str,
+    traj_digest: str,
+    payloads: list[StagedFile],
+    metadata_dir: Path | None,
+    uploaded_by: str | None,
+    redact: bool,
+    replacement_count: int,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "1.0.0",
+        "kind": "bronze.trajectory",
+        "created_at": datetime.now(UTC)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        "source_id": source_id,
+        "traj_digest": f"sha256:{traj_digest}",
+        "uploaded_by": uploaded_by,
+        "tool": {"name": "benchflow", "version": __version__},
+        "run": _load_run_metadata(metadata_dir),
+        "artifacts": [
+            {"name": item.relname, "sha256": item.sha256, "bytes": item.size_bytes}
+            for item in payloads
+        ],
+        "redaction": {"applied": redact, "replacements": replacement_count},
+    }
+
+
+def _load_run_metadata(metadata_dir: Path | None) -> dict[str, Any]:
+    result = _read_object(metadata_dir / "result.json") if metadata_dir else {}
+    config = _read_object(metadata_dir / "config.json") if metadata_dir else {}
+    raw_rewards = result.get("rewards")
+    rewards: Mapping[str, Any] = (
+        raw_rewards if isinstance(raw_rewards, Mapping) else {}
+    )
+    return {
+        "agent": _first_scalar(result.get("agent"), config.get("agent")),
+        "model": _first_scalar(result.get("model"), config.get("model")),
+        "harness": _first_scalar(result.get("harness"), config.get("harness")),
+        "skill_mode": _first_scalar(result.get("skill_mode"), config.get("skill_mode")),
+        "task_id": _first_scalar(
+            result.get("task_id"),
+            result.get("task"),
+            config.get("task_id"),
+            config.get("task"),
+        ),
+        "reward": _first_scalar(result.get("reward"), rewards.get("reward")),
+    }
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def _first_scalar(*values: Any) -> str | int | float | bool | None:
+    for value in values:
+        if value is None or isinstance(value, (dict, list)):
+            continue
+        if isinstance(value, (str, int, float, bool)):
+            return value
+    return None

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -62,7 +62,14 @@ def default_source_id(path: Path) -> str:
 def validate_source_id(source_id: str) -> str:
     """Validate and normalize a source id used in object names."""
     normalized = source_id.strip().strip("/")
-    if not SOURCE_ID_PATTERN.fullmatch(normalized) or "//" in normalized:
+    invalid_segment = any(
+        segment in {".", ".."} for segment in normalized.split("/")
+    )
+    if (
+        not SOURCE_ID_PATTERN.fullmatch(normalized)
+        or "//" in normalized
+        or invalid_segment
+    ):
         raise ValueError(
             "invalid source id; use --source-id with 1-128 letters, numbers, "
             "dots, underscores, hyphens, or single path separators"

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -62,9 +62,7 @@ def default_source_id(path: Path) -> str:
 def validate_source_id(source_id: str) -> str:
     """Validate and normalize a source id used in object names."""
     normalized = source_id.strip().strip("/")
-    invalid_segment = any(
-        segment in {".", ".."} for segment in normalized.split("/")
-    )
+    invalid_segment = any(segment in {".", ".."} for segment in normalized.split("/"))
     if (
         not SOURCE_ID_PATTERN.fullmatch(normalized)
         or "//" in normalized
@@ -296,9 +294,7 @@ def _load_run_metadata(metadata_dir: Path | None) -> dict[str, Any]:
     result = _read_object(metadata_dir / "result.json") if metadata_dir else {}
     config = _read_object(metadata_dir / "config.json") if metadata_dir else {}
     raw_rewards = result.get("rewards")
-    rewards: Mapping[str, Any] = (
-        raw_rewards if isinstance(raw_rewards, Mapping) else {}
-    )
+    rewards: Mapping[str, Any] = raw_rewards if isinstance(raw_rewards, Mapping) else {}
     return {
         "agent": _first_scalar(result.get("agent"), config.get("agent")),
         "model": _first_scalar(result.get("model"), config.get("model")),

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -16,12 +16,8 @@ from typing import Any
 
 from benchflow import __version__
 from benchflow.publish.redact import redact_value
-from benchflow.trajectories.export_prime_sft import (
-    PrimeSftTrajectoryJsonlError,
-    load_llm_trajectory_jsonl,
-)
 
-MAX_FILE_BYTES = 1024**3
+MAX_FILE_BYTES = 128 * 1024**2
 SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 
 
@@ -170,15 +166,6 @@ def _validate_jsonl(path: Path) -> None:
         )
     if size == 0:
         raise ValueError(f"trajectory JSONL is empty: {path}")
-    if path.name == "llm_trajectory.jsonl":
-        try:
-            records = load_llm_trajectory_jsonl(path, strict=True)
-        except PrimeSftTrajectoryJsonlError as exc:
-            raise ValueError(str(exc)) from exc
-        if not records:
-            raise ValueError(f"trajectory JSONL has no records: {path}")
-        return
-
     records = 0
     try:
         with path.open(encoding="utf-8") as stream:

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -21,6 +21,7 @@ MAX_FILE_BYTES = 128 * 1024**2
 MAX_ARTIFACTS = 8
 MAX_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
 MAX_MANIFEST_BYTES = 1024**2
+MAX_RUN_METADATA_BYTES = 1024**2
 MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
@@ -414,7 +415,11 @@ def _read_object(path: Path) -> dict[str, Any]:
     if path.is_symlink():
         return {}
     try:
-        value = strict_json_loads(path.read_text(encoding="utf-8"))
+        with path.open("rb") as stream:
+            payload = stream.read(MAX_RUN_METADATA_BYTES + 1)
+        if len(payload) > MAX_RUN_METADATA_BYTES:
+            return {}
+        value = strict_json_loads(payload)
     except (OSError, UnicodeDecodeError, ValueError):
         return {}
     return value if isinstance(value, dict) else {}

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -20,6 +20,7 @@ from benchflow.publish.redact import redact_value
 MAX_FILE_BYTES = 128 * 1024**2
 MAX_ARTIFACTS = 8
 MAX_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
+MAX_MANIFEST_BYTES = 1024**2
 MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
@@ -139,6 +140,18 @@ def stage_trajectory_capture(
             payloads.append(_staged_file(target, relname, "application/jsonl"))
 
         payloads.sort(key=lambda item: item.relname)
+        for payload in payloads:
+            if payload.size_bytes > MAX_FILE_BYTES:
+                raise ValueError(
+                    f"staged trajectory file exceeds {MAX_FILE_BYTES} bytes: "
+                    f"{payload.relname} ({payload.size_bytes} bytes)"
+                )
+        staged_capture_bytes = sum(payload.size_bytes for payload in payloads)
+        if staged_capture_bytes > MAX_CAPTURE_BYTES:
+            raise ValueError(
+                f"staged trajectory capture exceeds {MAX_CAPTURE_BYTES} bytes: "
+                f"{staged_capture_bytes} bytes"
+            )
         traj_digest = _trajectory_digest(payloads)
         manifest = _build_manifest(
             source_id=source_id,
@@ -161,6 +174,12 @@ def stage_trajectory_capture(
             json.dumps(manifest, indent=2, sort_keys=True, allow_nan=False) + "\n",
             encoding="utf-8",
         )
+        manifest_size = manifest_path.stat().st_size
+        if manifest_size > MAX_MANIFEST_BYTES:
+            raise ValueError(
+                f"trajectory manifest exceeds {MAX_MANIFEST_BYTES} bytes: "
+                f"{manifest_size} bytes"
+            )
         manifest_file = _staged_file(
             manifest_path,
             "manifest.json",

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -18,6 +18,9 @@ from benchflow import __version__
 from benchflow.publish.redact import redact_value
 
 MAX_FILE_BYTES = 128 * 1024**2
+MAX_JSONL_RECORD_BYTES = 8 * 1024**2
+MAX_JSON_NESTING = 100
+MAX_JSON_NODES = 100_000
 SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 
 
@@ -167,24 +170,38 @@ def _validate_jsonl(path: Path) -> None:
     if size == 0:
         raise ValueError(f"trajectory JSONL is empty: {path}")
     records = 0
-    try:
-        with path.open(encoding="utf-8") as stream:
-            for line_number, line in enumerate(stream, start=1):
-                if not line.strip():
-                    continue
-                try:
-                    value = json.loads(line)
-                except json.JSONDecodeError as exc:
-                    raise ValueError(
-                        f"{path}: line {line_number}: invalid JSON: {exc}"
-                    ) from exc
-                if not isinstance(value, dict):
-                    raise ValueError(
-                        f"{path}: line {line_number}: top-level record must be an object"
-                    )
-                records += 1
-    except UnicodeDecodeError as exc:
-        raise ValueError(f"{path}: trajectory JSONL must be UTF-8: {exc}") from exc
+    with path.open("rb") as stream:
+        line_number = 0
+        while line_bytes := stream.readline(MAX_JSONL_RECORD_BYTES + 1):
+            line_number += 1
+            if len(line_bytes) > MAX_JSONL_RECORD_BYTES:
+                raise ValueError(
+                    f"{path}: line {line_number}: JSONL record exceeds "
+                    f"{MAX_JSONL_RECORD_BYTES} bytes"
+                )
+            try:
+                line = line_bytes.decode("utf-8")
+            except UnicodeDecodeError as exc:
+                raise ValueError(
+                    f"{path}: trajectory JSONL must be UTF-8: {exc}"
+                ) from exc
+            if not line.strip():
+                continue
+            try:
+                value = json.loads(line)
+            except (json.JSONDecodeError, RecursionError) as exc:
+                raise ValueError(
+                    f"{path}: line {line_number}: invalid JSON: {exc}"
+                ) from exc
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"{path}: line {line_number}: top-level record must be an object"
+                )
+            try:
+                validate_json_complexity(value)
+            except ValueError as exc:
+                raise ValueError(f"{path}: line {line_number}: {exc}") from exc
+            records += 1
     if records == 0:
         raise ValueError(f"trajectory JSONL has no records: {path}")
 
@@ -201,7 +218,10 @@ def _redact_jsonl(source: Path, target: Path) -> int:
                 output_stream.write(line)
                 continue
             value = json.loads(body)
-            redacted, count = redact_value(value)
+            try:
+                redacted, count = redact_value(value)
+            except RecursionError as exc:  # defense in depth after complexity gate
+                raise ValueError("trajectory JSONL nesting exceeds the limit") from exc
             if count:
                 output_stream.write(
                     json.dumps(redacted, separators=(",", ":"), ensure_ascii=False)
@@ -219,6 +239,25 @@ def _split_newline(line: str) -> tuple[str, str]:
     if line.endswith("\n") or line.endswith("\r"):
         return line[:-1], line[-1]
     return line, ""
+
+
+def validate_json_complexity(value: Any) -> None:
+    """Bound container depth and nodes before recursive redaction."""
+    nodes = 0
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > MAX_JSON_NODES:
+            raise ValueError(f"JSON record exceeds {MAX_JSON_NODES} values")
+        if isinstance(item, Mapping):
+            if depth >= MAX_JSON_NESTING:
+                raise ValueError(f"JSON nesting exceeds {MAX_JSON_NESTING} levels")
+            stack.extend((child, depth + 1) for child in item.values())
+        elif isinstance(item, list):
+            if depth >= MAX_JSON_NESTING:
+                raise ValueError(f"JSON nesting exceeds {MAX_JSON_NESTING} levels")
+            stack.extend((child, depth + 1) for child in item)
 
 
 def _sha256(path: Path) -> str:

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -419,9 +419,16 @@ def redact_trajectory_text(text: str) -> str:
     forms; this includes generic ``*TOKEN*``/``*SECRET*`` carriers so a
     ``GITHUB_TOKEN=...`` env dump is scrubbed even without a known prefix.
     """
+    return redact_trajectory_text_with_count(text)[0]
+
+
+def redact_trajectory_text_with_count(text: str) -> tuple[str, int]:
+    """Apply the canonical patterns and report how many matches were replaced."""
+    replacements = 0
     for pattern, replacement in _REDACTION_PATTERNS:
-        text = pattern.sub(replacement, text)
-    return text
+        text, count = pattern.subn(replacement, text)
+        replacements += count
+    return text, replacements
 
 
 def redact_trajectory_obj(obj: Any) -> Any:

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -243,6 +244,32 @@ def test_direct_upload_preserves_canonical_order_and_metadata(
     assert all("-" not in key for key in client.calls[0]["metadata"])
     assert client.calls[0]["content_settings"].content_type == "application/jsonl"
     assert result.url.startswith("https://tasksminerdata.blob.core.windows.net/bronze/")
+
+
+def test_direct_upload_suppresses_azure_sdk_info_logs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Azure request diagnostics do not clutter or disclose the direct CLI path."""
+
+    class LoggingClient(FakeContainerClient):
+        def upload_blob(self, **kwargs) -> None:
+            logging.getLogger("azure.core.pipeline").info(
+                "signed request %s", kwargs["name"]
+            )
+            super().upload_blob(**kwargs)
+
+    client = LoggingClient()
+    _install_fake_azure(monkeypatch, client)
+    caplog.set_level(logging.INFO)
+    trial = _trial(tmp_path)
+
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        upload_capture_direct(
+            staged,
+            container_url="https://tasksminerdata.blob.core.windows.net/bronze",
+        )
+
+    assert "signed request" not in caplog.text
 
 
 def test_direct_upload_skips_existing_blobs_and_continues_manifest(

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -254,6 +254,28 @@ def test_contribution_redactor_preserves_kebab_case_sk_identifiers() -> None:
     assert redact_value(value) == (value, 0)
 
 
+def test_contribution_redactor_replaces_credential_mapping_keys_without_collision() -> (
+    None
+):
+    """Guards PR #989 against tokens used as JSON object keys."""
+    first = "dtn_1234567890abcdefghijklmnop"
+    second = "hf_1234567890abcdefghijklmnop"
+    value = {
+        first: "first",
+        "***REDACTED_KEY_1***": "reserved",
+        second: "second",
+    }
+
+    redacted, replacements = redact_value(value)
+
+    assert first not in redacted
+    assert second not in redacted
+    assert redacted["***REDACTED_KEY_1***"] == "reserved"
+    assert redacted["***REDACTED_KEY_2***"] == "first"
+    assert redacted["***REDACTED_KEY_3***"] == "second"
+    assert replacements == 2
+
+
 def test_manifest_free_text_is_redacted_and_counted(tmp_path: Path) -> None:
     """Guards PR #989 against leaking contributor and run metadata."""
     token = "dtn_1234567890abcdefghijklmnop"

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -144,6 +144,11 @@ def test_invalid_empty_and_oversize_inputs_fail_cleanly(
     with pytest.raises(ValueError, match="empty"):
         stage_trajectory_capture(empty, source_id="demo").__enter__()
 
+    invalid_utf8 = tmp_path / "llm_trajectory.jsonl"
+    invalid_utf8.write_bytes(b"\xff\n")
+    with pytest.raises(ValueError, match="must be UTF-8"):
+        stage_trajectory_capture(invalid_utf8, source_id="demo").__enter__()
+
     import benchflow.publish.traj_capture as capture_module
 
     monkeypatch.setattr(capture_module, "MAX_FILE_BYTES", 1)
@@ -166,6 +171,9 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
                     {
                         "nested": {"api_key": "prefixless"},
                         "OPENAI_API_KEY": "another-prefixless-value",
+                        "credentials": {"token": "opaque-object-secret"},
+                        "secret": ["opaque-list-secret"],
+                        "password": 123456,
                         "text": f"token={secret}",
                     }
                 )
@@ -178,10 +186,13 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
         payload = staged.files[0].local_path.read_text(encoding="utf-8")
         assert payload.startswith(untouched)
         assert secret not in payload
+        assert "opaque-object-secret" not in payload
+        assert "opaque-list-secret" not in payload
+        assert "123456" not in payload
         assert '"api_key":"[REDACTED]"' in payload
         assert "another-prefixless-value" not in payload
-        assert staged.redaction_replacements == 3
-        assert staged.manifest["redaction"] == {"applied": True, "replacements": 3}
+        assert staged.redaction_replacements == 6
+        assert staged.manifest["redaction"] == {"applied": True, "replacements": 6}
 
     with stage_trajectory_capture(trial, source_id="demo", redact=False) as staged:
         assert secret in staged.files[0].local_path.read_text(encoding="utf-8")

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -151,6 +151,21 @@ def test_invalid_empty_and_oversize_inputs_fail_cleanly(
 
     import benchflow.publish.traj_capture as capture_module
 
+    bounded = tmp_path / "bounded.jsonl"
+    bounded.write_text(json.dumps({"text": "x" * 64}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(capture_module, "MAX_JSONL_RECORD_BYTES", 32)
+    with pytest.raises(ValueError, match="JSONL record exceeds"):
+        stage_trajectory_capture(bounded, source_id="demo").__enter__()
+
+    nested: object = "leaf"
+    for _ in range(101):
+        nested = {"child": nested}
+    deeply_nested = tmp_path / "deeply-nested.jsonl"
+    deeply_nested.write_text(json.dumps(nested) + "\n", encoding="utf-8")
+    monkeypatch.setattr(capture_module, "MAX_JSONL_RECORD_BYTES", 8 * 1024**2)
+    with pytest.raises(ValueError, match="JSON nesting exceeds"):
+        stage_trajectory_capture(deeply_nested, source_id="demo").__enter__()
+
     monkeypatch.setattr(capture_module, "MAX_FILE_BYTES", 1)
     with pytest.raises(ValueError, match="exceeds"):
         stage_trajectory_capture(malformed, source_id="demo").__enter__()
@@ -174,6 +189,7 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
                         "credentials": {"token": "opaque-object-secret"},
                         "secret": ["opaque-list-secret"],
                         "password": 123456,
+                        "aws_session_key": "ASIAQWERTYUIOPASDFGH",
                         "text": f"token={secret}",
                     }
                 )
@@ -189,10 +205,11 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
         assert "opaque-object-secret" not in payload
         assert "opaque-list-secret" not in payload
         assert "123456" not in payload
+        assert "ASIAQWERTYUIOPASDFGH" not in payload
         assert '"api_key":"[REDACTED]"' in payload
         assert "another-prefixless-value" not in payload
-        assert staged.redaction_replacements == 6
-        assert staged.manifest["redaction"] == {"applied": True, "replacements": 6}
+        assert staged.redaction_replacements == 7
+        assert staged.manifest["redaction"] == {"applied": True, "replacements": 7}
 
     with stage_trajectory_capture(trial, source_id="demo", redact=False) as staged:
         assert secret in staged.files[0].local_path.read_text(encoding="utf-8")

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -11,6 +11,7 @@ from types import ModuleType
 import pytest
 
 from benchflow.publish.azure_blob import upload_capture_direct
+from benchflow.publish.redact import redact_value
 from benchflow.publish.traj_capture import stage_trajectory_capture
 
 
@@ -139,6 +140,16 @@ def test_invalid_empty_and_oversize_inputs_fail_cleanly(
     with pytest.raises(ValueError, match=r"bad\.jsonl: line 1"):
         stage_trajectory_capture(malformed, source_id="demo").__enter__()
 
+    duplicate = tmp_path / "duplicate.jsonl"
+    duplicate.write_text('{"password":"live","password":"[REDACTED]"}\n')
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        stage_trajectory_capture(duplicate, source_id="demo").__enter__()
+
+    non_finite = tmp_path / "non-finite.jsonl"
+    non_finite.write_text('{"reward":NaN}\n')
+    with pytest.raises(ValueError, match="non-finite JSON number"):
+        stage_trajectory_capture(non_finite, source_id="demo").__enter__()
+
     empty = tmp_path / "empty.jsonl"
     empty.write_text("", encoding="utf-8")
     with pytest.raises(ValueError, match="empty"):
@@ -214,6 +225,54 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
     with stage_trajectory_capture(trial, source_id="demo", redact=False) as staged:
         assert secret in staged.files[0].local_path.read_text(encoding="utf-8")
         assert staged.manifest["redaction"] == {"applied": False, "replacements": 0}
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "dtn_1234567890abcdefghijklmnop",
+        "gsk_1234567890abcdefghijklmnop",
+        "xai-1234567890abcdefghijklmnop",
+        "r8_1234567890abcdefghijklmnop",
+        "hf_1234567890abcdefghijklmnop",
+        "fw_1234567890abcdefghijklmnop",
+        "eyJabcdefghij.abcdef.abcdefghijklmnopqrst",
+    ],
+)
+def test_contribution_redactor_covers_canonical_credential_families(token: str) -> None:
+    """Guards PR #989 by sharing BenchFlow's established credential families."""
+    redacted, replacements = redact_value({"output": token})
+
+    assert token not in redacted["output"]
+    assert replacements == 1
+
+
+def test_contribution_redactor_preserves_kebab_case_sk_identifiers() -> None:
+    """Guards PR #989 against corrupting ordinary sk-prefixed task identifiers."""
+    value = {"output": "task-sk-us-east-1-refactor-auth"}
+
+    assert redact_value(value) == (value, 0)
+
+
+def test_manifest_free_text_is_redacted_and_counted(tmp_path: Path) -> None:
+    """Guards PR #989 against leaking contributor and run metadata."""
+    token = "dtn_1234567890abcdefghijklmnop"
+    trial = _trial(tmp_path)
+    (trial / "result.json").write_text(
+        json.dumps({"model": token}),
+        encoding="utf-8",
+    )
+
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        uploaded_by=token,
+    ) as staged:
+        assert staged.manifest["uploaded_by"] == "***REDACTED***"
+        assert staged.manifest["run"]["model"] == "***REDACTED***"
+        assert staged.manifest["redaction"]["replacements"] == 2
+        assert staged.redaction_replacements == 2
+        assert token not in staged.files[-1].local_path.read_text(encoding="utf-8")
 
 
 @pytest.mark.parametrize("source_id", ["../private", "team/../private", "team/./run"])

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -229,6 +229,28 @@ def test_staging_rejects_generated_manifest_over_shared_limit(
         stage_trajectory_capture(trial, source_id="demo").__enter__()
 
 
+def test_staging_bounds_optional_run_metadata_before_reading(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against oversized agent-produced metadata exhausting memory."""
+    import benchflow.publish.traj_capture as capture_module
+
+    trial = _trial(tmp_path)
+    metadata = trial / "result.json"
+    metadata.write_text(json.dumps({"agent": "must-not-be-read"}), encoding="utf-8")
+    monkeypatch.setattr(capture_module, "MAX_RUN_METADATA_BYTES", 8)
+    original_read_text = Path.read_text
+
+    def guarded_read_text(path: Path, *args, **kwargs):
+        if path == metadata:
+            raise AssertionError("oversized metadata was read")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", guarded_read_text)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        assert staged.manifest["run"]["agent"] is None
+
+
 def test_invalid_empty_and_oversize_inputs_fail_cleanly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -354,6 +376,9 @@ def test_contribution_redactor_covers_canonical_credential_families(token: str) 
         "token",
         "accessToken",
         "clientSecret",
+        "api key",
+        "access.token",
+        "client secret",
         "refreshToken",
         "bearerToken",
         "serviceCredentials",

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -251,6 +251,40 @@ def test_staging_bounds_optional_run_metadata_before_reading(
         assert staged.manifest["run"]["agent"] is None
 
 
+def test_staging_ignores_recursive_optional_run_metadata(tmp_path: Path) -> None:
+    """Guards PR #989 against malformed optional metadata leaking RecursionError."""
+    trial = _trial(tmp_path)
+    nested = '{"child":' * 1_200 + '"leaf"' + "}" * 1_200
+    (trial / "result.json").write_text(nested, encoding="utf-8")
+
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        assert staged.manifest["run"]["agent"] is None
+
+
+def test_staging_enforces_contributor_label_bound(tmp_path: Path) -> None:
+    """Guards PR #989 against producing a broker-invalid contributor label."""
+    trial = _trial(tmp_path)
+
+    with pytest.raises(ValueError, match="contributor label exceeds 256"):
+        stage_trajectory_capture(
+            trial, source_id="demo", uploaded_by="x" * 257
+        ).__enter__()
+
+
+@pytest.mark.parametrize(
+    "filename", ["capture with space.jsonl", "capture.JSONL", "x" * 129 + ".jsonl"]
+)
+def test_staging_rejects_noncanonical_artifact_names(
+    tmp_path: Path, filename: str
+) -> None:
+    """Guards PR #989 against direct uploads bypassing artifact-name validation."""
+    source = tmp_path / filename
+    source.write_text('{"type":"message"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"outside trajectory/\*\.jsonl"):
+        stage_trajectory_capture(source, source_id="demo").__enter__()
+
+
 def test_invalid_empty_and_oversize_inputs_fail_cleanly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -374,6 +408,9 @@ def test_contribution_redactor_covers_canonical_credential_families(token: str) 
     "field_name",
     [
         "token",
+        "passwd",
+        "clientsecret",
+        "accesskey",
         "accessToken",
         "clientSecret",
         "api key",

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -450,11 +450,33 @@ def test_contribution_redactor_covers_sensitive_command_arguments(command) -> No
     assert replacements == 1
 
 
+@pytest.mark.parametrize("label", ["name", "key", "Name", "Key"])
+def test_contribution_redactor_propagates_structured_secret_carriers(
+    label: str,
+) -> None:
+    """Guards PR #989 against prefixless secrets in name/value carriers."""
+    value = {"headers": [{label: "Authorization", "Value": "opaque-value"}]}
+
+    redacted, replacements = redact_value(value)
+
+    assert redacted["headers"][0]["Value"] == "[REDACTED]"
+    assert replacements == 1
+
+
 def test_contribution_redactor_preserves_kebab_case_sk_identifiers() -> None:
     """Guards PR #989 against corrupting ordinary sk-prefixed task identifiers."""
     value = {"output": "task-sk-us-east-1-refactor-auth"}
 
     assert redact_value(value) == (value, 0)
+
+
+def test_staging_rejects_credential_like_artifact_filename(tmp_path: Path) -> None:
+    """Guards PR #989 against manifest-only filename redaction."""
+    trajectory = tmp_path / "sk-abcdefghijklmnop.jsonl"
+    trajectory.write_text('{"type":"message","text":"safe"}\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="artifact filename resembles a secret"):
+        stage_trajectory_capture(trajectory, source_id="demo").__enter__()
 
 
 def test_contribution_redactor_replaces_credential_mapping_keys_without_collision() -> (

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -155,6 +155,14 @@ def test_staging_rejects_symlinked_trajectory_inputs(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="directory must not be a symlink"):
         stage_trajectory_capture(trial, source_id="demo").__enter__()
 
+    metadata_trial = _trial(tmp_path)
+    external_metadata = tmp_path / "external-result.json"
+    external_metadata.write_text('{"agent":"outside-secret"}', encoding="utf-8")
+    (metadata_trial / "result.json").symlink_to(external_metadata)
+    with stage_trajectory_capture(metadata_trial, source_id="demo") as staged:
+        assert staged.manifest["run"]["agent"] is None
+        assert "outside-secret" not in json.dumps(staged.manifest)
+
 
 def test_staging_enforces_shared_capture_count_and_size_limits(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -1,0 +1,313 @@
+"""Offline tests for trajectory staging, redaction, and Azure direct upload."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from benchflow.publish.azure_blob import upload_capture_direct
+from benchflow.publish.traj_capture import stage_trajectory_capture
+
+
+class ResourceExistsError(Exception):
+    pass
+
+
+class ResourceNotFoundError(Exception):
+    pass
+
+
+class ClientAuthenticationError(Exception):
+    pass
+
+
+class HttpResponseError(Exception):
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class FakeContainerClient:
+    def __init__(self, failures: dict[str, Exception] | None = None) -> None:
+        self.failures = failures or {}
+        self.calls: list[dict] = []
+
+    def upload_blob(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+        failure = self.failures.get(kwargs["name"])
+        if failure is not None:
+            raise failure
+
+
+def _trial(tmp_path: Path, files: dict[str, str] | None = None) -> Path:
+    trial = tmp_path / "trial-01"
+    trajectory = trial / "trajectory"
+    trajectory.mkdir(parents=True)
+    for name, content in (
+        files
+        or {
+            "llm_trajectory.jsonl": '{"request":{"model":"demo"}}\n',
+            "acp_trajectory.jsonl": '{"type":"message","text":"hello"}\n',
+        }
+    ).items():
+        (trajectory / name).write_text(content, encoding="utf-8")
+    return trial
+
+
+def _install_fake_azure(
+    monkeypatch: pytest.MonkeyPatch, client: FakeContainerClient
+) -> None:
+    azure = ModuleType("azure")
+    core = ModuleType("azure.core")
+    exceptions = ModuleType("azure.core.exceptions")
+    identity = ModuleType("azure.identity")
+    storage = ModuleType("azure.storage")
+    blob = ModuleType("azure.storage.blob")
+
+    class ContainerClient:
+        @staticmethod
+        def from_container_url(container_url: str, credential=None):
+            client.container_url = container_url
+            client.credential = credential
+            return client
+
+    class ContentSettings:
+        def __init__(self, *, content_type: str) -> None:
+            self.content_type = content_type
+
+    exceptions.ResourceExistsError = ResourceExistsError
+    exceptions.ResourceNotFoundError = ResourceNotFoundError
+    exceptions.ClientAuthenticationError = ClientAuthenticationError
+    exceptions.HttpResponseError = HttpResponseError
+    identity.DefaultAzureCredential = lambda: "default-credential"
+    blob.ContainerClient = ContainerClient
+    blob.ContentSettings = ContentSettings
+    for name, module in {
+        "azure": azure,
+        "azure.core": core,
+        "azure.core.exceptions": exceptions,
+        "azure.identity": identity,
+        "azure.storage": storage,
+        "azure.storage.blob": blob,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def test_trial_resolution_uses_only_jsonl_and_reports_ignored(tmp_path: Path) -> None:
+    """A trial stages non-recursive trajectory JSONL and reports ignored siblings."""
+    trial = _trial(tmp_path)
+    (trial / "trajectory" / "notes.txt").write_text("ignored", encoding="utf-8")
+    (trial / "result.json").write_text('{"agent":"demo"}', encoding="utf-8")
+
+    with stage_trajectory_capture(trial, source_id="source/demo") as staged:
+        assert [item.relname for item in staged.files] == [
+            "trajectory/acp_trajectory.jsonl",
+            "trajectory/llm_trajectory.jsonl",
+            "manifest.json",
+        ]
+        assert staged.ignored == ("notes.txt",)
+        assert staged.manifest["run"]["agent"] == "demo"
+
+
+@pytest.mark.parametrize("kind", ["file", "directory"])
+def test_file_and_bare_directory_normalize_under_trajectory(
+    tmp_path: Path, kind: str
+) -> None:
+    """Single-file and bare-directory inputs use the same object namespace."""
+    source = tmp_path / "capture.jsonl"
+    source.write_text('{"type":"demo"}\n', encoding="utf-8")
+    path = source if kind == "file" else tmp_path
+
+    with stage_trajectory_capture(path, source_id="demo") as staged:
+        assert staged.files[0].relname == "trajectory/capture.jsonl"
+
+
+def test_invalid_empty_and_oversize_inputs_fail_cleanly(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Staging rejects missing, malformed, empty, and over-limit trajectories."""
+    with pytest.raises(ValueError, match=r"no \.jsonl"):
+        stage_trajectory_capture(tmp_path, source_id="demo").__enter__()
+
+    malformed = tmp_path / "bad.jsonl"
+    malformed.write_text("{bad\n", encoding="utf-8")
+    with pytest.raises(ValueError, match=r"bad\.jsonl: line 1"):
+        stage_trajectory_capture(malformed, source_id="demo").__enter__()
+
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    with pytest.raises(ValueError, match="empty"):
+        stage_trajectory_capture(empty, source_id="demo").__enter__()
+
+    import benchflow.publish.traj_capture as capture_module
+
+    monkeypatch.setattr(capture_module, "MAX_FILE_BYTES", 1)
+    with pytest.raises(ValueError, match="exceeds"):
+        stage_trajectory_capture(malformed, source_id="demo").__enter__()
+
+
+def test_redaction_is_structural_counted_and_preserves_untouched_lines(
+    tmp_path: Path,
+) -> None:
+    """Nested keys and token values redact while untouched lines remain byte-identical."""
+    untouched = '{"type": "message", "text": "safe"}\n'
+    secret = "sk-1234567890abcdefghijklmnop"
+    trial = _trial(
+        tmp_path,
+        {
+            "acp_trajectory.jsonl": (
+                untouched
+                + json.dumps(
+                    {
+                        "nested": {"api_key": "prefixless"},
+                        "text": f"token={secret}",
+                    }
+                )
+                + "\n"
+            )
+        },
+    )
+
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        payload = staged.files[0].local_path.read_text(encoding="utf-8")
+        assert payload.startswith(untouched)
+        assert secret not in payload
+        assert '"api_key":"[REDACTED]"' in payload
+        assert staged.redaction_replacements == 2
+        assert staged.manifest["redaction"] == {"applied": True, "replacements": 2}
+
+    with stage_trajectory_capture(trial, source_id="demo", redact=False) as staged:
+        assert secret in staged.files[0].local_path.read_text(encoding="utf-8")
+        assert staged.manifest["redaction"] == {"applied": False, "replacements": 0}
+
+
+def test_digest_manifest_and_metadata_are_transport_independent(tmp_path: Path) -> None:
+    """Digest order, manifest schema, metadata, and manifest-last order are stable."""
+    trial = _trial(tmp_path)
+    (trial / "result.json").write_text(
+        json.dumps({"agent": "codex", "model": "gpt-demo", "rewards": {"reward": 1.0}}),
+        encoding="utf-8",
+    )
+    (trial / "config.json").write_text(
+        json.dumps({"skill_mode": "with-skill", "task_id": "demo-task"}),
+        encoding="utf-8",
+    )
+
+    with stage_trajectory_capture(trial, source_id="demo") as first:
+        first_digest = first.traj_digest
+        manifest = first.manifest
+        assert first.files[-1].relname == "manifest.json"
+        assert manifest["schema_version"] == "1.0.0"
+        assert manifest["kind"] == "bronze.trajectory"
+        assert "mode" not in manifest["tool"]
+        assert manifest["run"] == {
+            "agent": "codex",
+            "model": "gpt-demo",
+            "harness": None,
+            "skill_mode": "with-skill",
+            "task_id": "demo-task",
+            "reward": 1.0,
+        }
+
+    with stage_trajectory_capture(trial, source_id="demo") as second:
+        assert second.traj_digest == first_digest
+
+    path = trial / "trajectory" / "acp_trajectory.jsonl"
+    path.write_text('{"type":"changed"}\n', encoding="utf-8")
+    with stage_trajectory_capture(trial, source_id="demo") as changed:
+        assert changed.traj_digest != first_digest
+
+
+def test_direct_upload_preserves_canonical_order_and_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Azure direct upload is a create-only loop over staged files verbatim."""
+    client = FakeContainerClient()
+    _install_fake_azure(monkeypatch, client)
+    trial = _trial(tmp_path)
+
+    with stage_trajectory_capture(trial, source_id="demo/source") as staged:
+        result = upload_capture_direct(
+            staged,
+            container_url="https://tasksminerdata.blob.core.windows.net/bronze",
+        )
+        expected = [f"{result.prefix}{item.relname}" for item in staged.files]
+
+    assert [call["name"] for call in client.calls] == expected
+    assert client.calls[-1]["name"].endswith("manifest.json")
+    assert all(call["overwrite"] is False for call in client.calls)
+    assert all("-" not in key for key in client.calls[0]["metadata"])
+    assert client.calls[0]["content_settings"].content_type == "application/jsonl"
+    assert result.url.startswith("https://tasksminerdata.blob.core.windows.net/bronze/")
+
+
+def test_direct_upload_skips_existing_blobs_and_continues_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Existing Azure blobs are resumable no-ops, including the commit marker."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        prefix = f"sources/demo/{staged.traj_digest}/"
+        failures = {
+            prefix + staged.files[0].relname: ResourceExistsError(),
+            prefix + "manifest.json": ResourceExistsError(),
+        }
+        client = FakeContainerClient(failures)
+        _install_fake_azure(monkeypatch, client)
+        result = upload_capture_direct(
+            staged,
+            container_url="https://tasksminerdata.blob.core.windows.net/bronze",
+        )
+
+    assert len(result.skipped) == 2
+    assert result.skipped[-1].endswith("manifest.json")
+    assert len(client.calls) == len(staged.files)
+
+
+@pytest.mark.parametrize(
+    ("failure", "message"),
+    [
+        (ResourceNotFoundError(), "container not found"),
+        (ClientAuthenticationError(), "az login"),
+        (HttpResponseError("forbidden", 403), "Blob Data Creator"),
+    ],
+)
+def test_direct_upload_surfaces_azure_prerequisites(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure: Exception,
+    message: str,
+) -> None:
+    """Azure SDK failures become actionable CLI-safe errors."""
+    trial = _trial(tmp_path, {"acp_trajectory.jsonl": '{"type":"demo"}\n'})
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        name = f"sources/demo/{staged.traj_digest}/{staged.files[0].relname}"
+        _install_fake_azure(monkeypatch, FakeContainerClient({name: failure}))
+        with pytest.raises(ValueError, match=message):
+            upload_capture_direct(
+                staged,
+                container_url="https://tasksminerdata.blob.core.windows.net/bronze",
+            )
+
+
+def test_direct_upload_explains_missing_optional_sdk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stock broker-only install gets precise optional-extra guidance."""
+    for name in tuple(sys.modules):
+        if name == "azure" or name.startswith("azure."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+    monkeypatch.setitem(sys.modules, "azure", None)
+    trial = _trial(tmp_path, {"acp_trajectory.jsonl": '{"type":"demo"}\n'})
+    with (
+        stage_trajectory_capture(trial, source_id="demo") as staged,
+        pytest.raises(ValueError, match=r"pip install 'benchflow\[azure\]'"),
+    ):
+        upload_capture_direct(
+            staged,
+            container_url="https://tasksminerdata.blob.core.windows.net/bronze",
+        )

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -128,6 +128,51 @@ def test_file_and_bare_directory_normalize_under_trajectory(
         assert staged.files[0].relname == "trajectory/capture.jsonl"
 
 
+def test_staging_rejects_symlinked_trajectory_inputs(tmp_path: Path) -> None:
+    """Guards PR #989 against reading trajectory data outside the selected tree."""
+    external = tmp_path / "external.jsonl"
+    external.write_text('{"type":"outside"}\n', encoding="utf-8")
+
+    file_link = tmp_path / "capture.jsonl"
+    file_link.symlink_to(external)
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        stage_trajectory_capture(file_link, source_id="demo").__enter__()
+
+    bare = tmp_path / "bare"
+    bare.mkdir()
+    (bare / "capture.jsonl").symlink_to(external)
+    with pytest.raises(ValueError, match="must not be a symlink"):
+        stage_trajectory_capture(bare, source_id="demo").__enter__()
+
+    trial = tmp_path / "trial-symlink"
+    trial.mkdir()
+    external_dir = tmp_path / "external-trajectory"
+    external_dir.mkdir()
+    (external_dir / "capture.jsonl").write_text(
+        '{"type":"outside"}\n', encoding="utf-8"
+    )
+    (trial / "trajectory").symlink_to(external_dir, target_is_directory=True)
+    with pytest.raises(ValueError, match="directory must not be a symlink"):
+        stage_trajectory_capture(trial, source_id="demo").__enter__()
+
+
+def test_staging_enforces_shared_capture_count_and_size_limits(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against direct uploads bypassing contribution limits."""
+    import benchflow.publish.traj_capture as capture_module
+
+    trial = _trial(tmp_path)
+    monkeypatch.setattr(capture_module, "MAX_ARTIFACTS", 1)
+    with pytest.raises(ValueError, match="exceeds 1 artifact files"):
+        stage_trajectory_capture(trial, source_id="demo").__enter__()
+
+    monkeypatch.setattr(capture_module, "MAX_ARTIFACTS", 8)
+    monkeypatch.setattr(capture_module, "MAX_CAPTURE_BYTES", 1)
+    with pytest.raises(ValueError, match="capture exceeds 1 bytes"):
+        stage_trajectory_capture(trial, source_id="demo").__enter__()
+
+
 def test_invalid_empty_and_oversize_inputs_fail_cleanly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -433,6 +433,23 @@ def test_contribution_redactor_covers_token_and_camel_case_fields(
     assert replacements == 1
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        ["tool", "--api-key", "opaque-prefixless-value"],
+        ["tool", "--client-secret", "opaque-prefixless-value"],
+        ["tool", "--access_token=opaque-prefixless-value"],
+        "tool --api-key opaque-prefixless-value",
+    ],
+)
+def test_contribution_redactor_covers_sensitive_command_arguments(command) -> None:
+    """Guards PR #989 against prefixless credentials following CLI flags."""
+    redacted, replacements = redact_value({"command": command})
+
+    assert "opaque-prefixless-value" not in json.dumps(redacted)
+    assert replacements == 1
+
+
 def test_contribution_redactor_preserves_kebab_case_sk_identifiers() -> None:
     """Guards PR #989 against corrupting ordinary sk-prefixed task identifiers."""
     value = {"output": "task-sk-us-east-1-refactor-auth"}

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -181,6 +181,54 @@ def test_staging_enforces_shared_capture_count_and_size_limits(
         stage_trajectory_capture(trial, source_id="demo").__enter__()
 
 
+def test_staging_rechecks_file_limit_after_redaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against redaction expanding an artifact past its limit."""
+    import benchflow.publish.traj_capture as capture_module
+
+    source = tmp_path / "capture.jsonl"
+    source.write_text('{"password":"x"}\n', encoding="utf-8")
+    monkeypatch.setattr(capture_module, "MAX_FILE_BYTES", source.stat().st_size)
+
+    with pytest.raises(ValueError, match="staged trajectory file exceeds"):
+        stage_trajectory_capture(source, source_id="demo").__enter__()
+
+
+def test_staging_rechecks_capture_limit_after_redaction(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against redaction expanding the aggregate capture size."""
+    import benchflow.publish.traj_capture as capture_module
+
+    source_dir = tmp_path / "capture"
+    source_dir.mkdir()
+    for name in ("first.jsonl", "second.jsonl"):
+        (source_dir / name).write_text('{"password":"x"}\n', encoding="utf-8")
+    source_bytes = sum(path.stat().st_size for path in source_dir.iterdir())
+    monkeypatch.setattr(capture_module, "MAX_FILE_BYTES", 1024)
+    monkeypatch.setattr(capture_module, "MAX_CAPTURE_BYTES", source_bytes)
+
+    with pytest.raises(ValueError, match="staged trajectory capture exceeds"):
+        stage_trajectory_capture(source_dir, source_id="demo").__enter__()
+
+
+def test_staging_rejects_generated_manifest_over_shared_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against uploading a manifest the validator must reject."""
+    import benchflow.publish.traj_capture as capture_module
+
+    trial = _trial(tmp_path)
+    (trial / "result.json").write_text(
+        json.dumps({"model": "x" * 2_000}), encoding="utf-8"
+    )
+    monkeypatch.setattr(capture_module, "MAX_MANIFEST_BYTES", 1024)
+
+    with pytest.raises(ValueError, match="trajectory manifest exceeds 1024 bytes"):
+        stage_trajectory_capture(trial, source_id="demo").__enter__()
+
+
 def test_invalid_empty_and_oversize_inputs_fail_cleanly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -297,6 +345,29 @@ def test_contribution_redactor_covers_canonical_credential_families(token: str) 
     redacted, replacements = redact_value({"output": token})
 
     assert token not in redacted["output"]
+    assert replacements == 1
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    [
+        "token",
+        "accessToken",
+        "clientSecret",
+        "refreshToken",
+        "bearerToken",
+        "serviceCredentials",
+        "set-cookie",
+        "x-goog-api-key",
+    ],
+)
+def test_contribution_redactor_covers_token_and_camel_case_fields(
+    field_name: str,
+) -> None:
+    """Guards PR #989 against prefixless credentials in common JSON fields."""
+    redacted, replacements = redact_value({field_name: "opaque-prefixless-value"})
+
+    assert redacted[field_name] == "[REDACTED]"
     assert replacements == 1
 
 

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -165,6 +165,7 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
                 + json.dumps(
                     {
                         "nested": {"api_key": "prefixless"},
+                        "OPENAI_API_KEY": "another-prefixless-value",
                         "text": f"token={secret}",
                     }
                 )
@@ -178,12 +179,23 @@ def test_redaction_is_structural_counted_and_preserves_untouched_lines(
         assert payload.startswith(untouched)
         assert secret not in payload
         assert '"api_key":"[REDACTED]"' in payload
-        assert staged.redaction_replacements == 2
-        assert staged.manifest["redaction"] == {"applied": True, "replacements": 2}
+        assert "another-prefixless-value" not in payload
+        assert staged.redaction_replacements == 3
+        assert staged.manifest["redaction"] == {"applied": True, "replacements": 3}
 
     with stage_trajectory_capture(trial, source_id="demo", redact=False) as staged:
         assert secret in staged.files[0].local_path.read_text(encoding="utf-8")
         assert staged.manifest["redaction"] == {"applied": False, "replacements": 0}
+
+
+@pytest.mark.parametrize("source_id", ["../private", "team/../private", "team/./run"])
+def test_source_id_rejects_relative_path_segments(
+    tmp_path: Path, source_id: str
+) -> None:
+    """Direct upload labels cannot introduce relative-looking blob segments."""
+    trial = _trial(tmp_path)
+    with pytest.raises(ValueError, match="invalid source id"):
+        stage_trajectory_capture(trial, source_id=source_id).__enter__()
 
 
 def test_digest_manifest_and_metadata_are_transport_independent(tmp_path: Path) -> None:

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -135,6 +136,31 @@ def test_broker_mode_uses_exact_manifest_and_server_order(
     assert result.exit_code == 0, result.output
     assert [request.method for request in requests] == ["POST", "PUT", "PUT"]
     assert requests[-1].url.path.endswith("manifest.json")
+
+
+def test_broker_never_logs_signed_upload_urls(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Signed SAS query parameters never enter BenchFlow's global INFO log."""
+    trial = _trial(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            payload = _broker_payload(request)
+            for item in payload["objects"]:
+                item["put_url"] += "?sig=must-not-be-logged"
+            return httpx.Response(200, json=payload)
+        return httpx.Response(201)
+
+    caplog.set_level(logging.INFO)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        upload_capture_via_broker(
+            staged,
+            broker_url="https://broker.test",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+
+    assert "must-not-be-logged" not in caplog.text
 
 
 def test_broker_conflict_is_success_and_rate_limit_is_actionable(

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -238,7 +238,7 @@ def test_validation_failure_names_the_bad_file(
     assert "line 1" in result.output
 
 
-@pytest.mark.parametrize("shape", ["unknown", "missing"])
+@pytest.mark.parametrize("shape", ["unknown", "missing", "insecure_url"])
 def test_broker_mapping_violation_sends_zero_puts(tmp_path: Path, shape: str) -> None:
     """A non-bijective broker response fails before any trajectory bytes leave."""
     trial = _trial(tmp_path)
@@ -249,8 +249,10 @@ def test_broker_mapping_violation_sends_zero_puts(tmp_path: Path, shape: str) ->
         payload = _broker_payload(request)
         if shape == "unknown":
             payload["objects"][0]["name"] = "trajectory/unknown.jsonl"
-        else:
+        elif shape == "missing":
             payload["objects"].pop()
+        else:
+            payload["objects"][0]["put_url"] = "http://upload.test/capture"
         return httpx.Response(200, json=payload)
 
     with (

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -28,6 +28,15 @@ def _trial(tmp_path: Path) -> Path:
     return trial
 
 
+def test_stock_cli_has_the_verified_public_broker() -> None:
+    """A wheel install can contribute without private endpoint configuration."""
+    from benchflow.cli.traj import DEFAULT_TRAJ_BROKER_URL
+
+    assert DEFAULT_TRAJ_BROKER_URL == (
+        "https://tasksminer-traj-broker.nicewave-c3abaecf.westus2.azurecontainerapps.io"
+    )
+
+
 def _broker_payload(
     request: httpx.Request, *, objects: list[dict] | None = None
 ) -> dict:

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -1,0 +1,259 @@
+"""CLI and broker-protocol tests for ``bench traj upload``."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+from benchflow.publish.broker import upload_capture_via_broker
+from benchflow.publish.traj_capture import stage_trajectory_capture
+
+runner = CliRunner()
+
+
+def _trial(tmp_path: Path) -> Path:
+    trial = tmp_path / "trial-demo"
+    trajectory = trial / "trajectory"
+    trajectory.mkdir(parents=True)
+    (trajectory / "acp_trajectory.jsonl").write_text(
+        '{"type":"message","text":"demo"}\n', encoding="utf-8"
+    )
+    return trial
+
+
+def _broker_payload(
+    request: httpx.Request, *, objects: list[dict] | None = None
+) -> dict:
+    body = json.loads(request.content)
+    digest = body["traj_digest"].removeprefix("sha256:")
+    expected = [artifact["name"] for artifact in body["artifacts"]] + ["manifest.json"]
+    return {
+        "upload_id": "u_demo",
+        "bucket": "bronze",
+        "base_url": "https://tasksminerdata.blob.core.windows.net/bronze",
+        "prefix": f"inbox/{digest}/",
+        "objects": objects
+        or [
+            {
+                "name": name,
+                "put_url": f"https://upload.test/{name}",
+                "headers": {"x-ms-blob-type": "BlockBlob", "If-None-Match": "*"},
+            }
+            for name in expected
+        ],
+        "expires_at": "2026-08-15T12:00:00Z",
+    }
+
+
+def test_dry_run_stages_without_constructing_a_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Dry-run lists canonical files and never constructs a network client."""
+    trial = _trial(tmp_path)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+
+    def fail_client(*args, **kwargs):
+        raise AssertionError("network client constructed during --dry-run")
+
+    monkeypatch.setattr(httpx, "Client", fail_client)
+    result = runner.invoke(app, ["traj", "upload", str(trial), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    assert "sha256:" in result.output
+    assert "trajectory/acp_trajectory.jsonl" in result.output
+    assert "manifest.json" in result.output
+
+
+def test_direct_mode_reports_azure_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI delegates direct mode and renders the returned Azure URL."""
+    trial = _trial(tmp_path)
+
+    def fake_upload(staged, *, container_url):
+        return SimpleNamespace(
+            url=f"{container_url}/sources/demo/{staged.traj_digest}/",
+            uploaded=("payload", "manifest"),
+            skipped=(),
+        )
+
+    monkeypatch.setattr(
+        "benchflow.publish.azure_blob.upload_capture_direct", fake_upload
+    )
+    result = runner.invoke(
+        app,
+        [
+            "traj",
+            "upload",
+            str(trial),
+            "--direct",
+            "--container-url",
+            "https://tasksminerdata.blob.core.windows.net/bronze",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Uploaded trajectory" in result.output
+    assert "tasksminerdata.blob.core.windows.net/bronze" in result.output
+
+
+def test_broker_mode_uses_exact_manifest_and_server_order(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Broker mode sends the manifest handshake and returned PUT headers verbatim."""
+    trial = _trial(tmp_path)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        if request.method == "POST":
+            body = json.loads(request.content)
+            assert set(body) == {
+                "schema_version",
+                "kind",
+                "source_id",
+                "traj_digest",
+                "uploaded_by",
+                "artifacts",
+            }
+            return httpx.Response(200, json=_broker_payload(request))
+        assert request.headers["x-ms-blob-type"] == "BlockBlob"
+        assert request.headers["if-none-match"] == "*"
+        return httpx.Response(201)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: client)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    result = runner.invoke(app, ["traj", "upload", str(trial)])
+
+    assert result.exit_code == 0, result.output
+    assert [request.method for request in requests] == ["POST", "PUT", "PUT"]
+    assert requests[-1].url.path.endswith("manifest.json")
+
+
+def test_broker_conflict_is_success_and_rate_limit_is_actionable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An ingested digest no-ops while rate limits preserve Retry-After."""
+    trial = _trial(tmp_path)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+
+    conflict = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                409,
+                json={
+                    "base_url": "https://tasksminerdata.blob.core.windows.net/bronze",
+                    "prefix": "sources/community/demo/",
+                },
+            )
+        )
+    )
+    limited = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                429, text="slow down", headers={"Retry-After": "60"}
+            )
+        )
+    )
+    monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: conflict)
+    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    assert result.exit_code == 0, result.output
+    assert "Already uploaded" in result.output
+
+    monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: limited)
+    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    assert result.exit_code == 1
+    assert "retry after 60" in result.output
+
+
+def test_missing_broker_names_both_available_modes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A development build without a default endpoint explains both modes."""
+    trial = _trial(tmp_path)
+    monkeypatch.delenv("BENCHFLOW_TRAJ_BROKER_URL", raising=False)
+    monkeypatch.setattr("benchflow.cli.traj.DEFAULT_TRAJ_BROKER_URL", None)
+    result = runner.invoke(app, ["traj", "upload", str(trial)])
+
+    assert result.exit_code == 1
+    assert "BENCHFLOW_TRAJ_BROKER_URL" in result.output
+    assert "--direct" in result.output
+    assert "BENCHFLOW_AZURE_CONTAINER_URL" in result.output
+
+
+def test_validation_failure_names_the_bad_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Malformed contributor JSONL exits cleanly and identifies its source."""
+    trial = _trial(tmp_path)
+    path = trial / "trajectory" / "acp_trajectory.jsonl"
+    path.write_text("{bad\n", encoding="utf-8")
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    result = runner.invoke(app, ["traj", "upload", str(trial)])
+
+    assert result.exit_code == 1
+    assert "acp_trajectory.jsonl" in result.output.replace("\n", "")
+    assert "line 1" in result.output
+
+
+@pytest.mark.parametrize("shape", ["unknown", "missing"])
+def test_broker_mapping_violation_sends_zero_puts(tmp_path: Path, shape: str) -> None:
+    """A non-bijective broker response fails before any trajectory bytes leave."""
+    trial = _trial(tmp_path)
+    methods: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        methods.append(request.method)
+        payload = _broker_payload(request)
+        if shape == "unknown":
+            payload["objects"][0]["name"] = "trajectory/unknown.jsonl"
+        else:
+            payload["objects"].pop()
+        return httpx.Response(200, json=payload)
+
+    with (
+        stage_trajectory_capture(trial, source_id="demo") as staged,
+        pytest.raises(ValueError, match="protocol violation"),
+    ):
+        upload_capture_via_broker(
+            staged,
+            broker_url="https://broker.test",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+    assert methods == ["POST"]
+
+
+@pytest.mark.parametrize("status", [409, 412])
+def test_broker_put_conflicts_are_cloud_neutral_skips(
+    tmp_path: Path, status: int
+) -> None:
+    """Azure 409 and GCS 412 both mean an idempotent create-only skip."""
+    trial = _trial(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(200, json=_broker_payload(request))
+        return httpx.Response(status)
+
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        result = upload_capture_via_broker(
+            staged,
+            broker_url="https://broker.test",
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+    assert not result.uploaded
+    assert len(result.skipped) == len(staged.files)
+
+
+def test_help_exposes_only_the_planned_upload_command() -> None:
+    """The trajectory CLI surface remains a single clean command."""
+    result = runner.invoke(app, ["traj", "--help"])
+    assert result.exit_code == 0
+    assert "upload" in result.output

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -393,7 +393,61 @@ def test_event_grid_queue_base64_envelope_is_decoded(tmp_path: Path) -> None:
     )
     encoded = base64.b64encode(event.encode()).decode()
 
-    assert _capture_from_event(encoded) == (f"inbox/{digest}/", digest)
+    assert _capture_from_event(encoded) == (f"inbox/{digest}/", digest, True)
+
+
+def test_pending_artifact_event_waits_for_manifest_commit(tmp_path: Path) -> None:
+    """Guards PR #989 against treating artifact creation as a partial upload."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    event = json.dumps(
+        {"data": {"url": ("https://account.blob.core.windows.net/bronze/" + artifact)}}
+    )
+    queue = FakeQueue(event)
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "pending",
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+    assert container.blobs == blobs
+    assert container.uploaded == []
+    assert table.entities[-1]["status"] == "pending"
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_terminal_artifact_replay_is_cleaned(tmp_path: Path) -> None:
+    """Guards PR #989 against replaying a grant after terminal cleanup."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    event = json.dumps(
+        {"data": {"url": ("https://account.blob.core.windows.net/bronze/" + artifact)}}
+    )
+    queue = FakeQueue(event)
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "ingested",
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+    assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
+    assert queue.deleted == [("m1", "p1")]
 
 
 @pytest.mark.parametrize("terminal_status", ["ingested", "rejected"])

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -86,6 +86,40 @@ def test_first_delegation_key_request_does_not_underflow() -> None:
     )
 
     assert backend._user_delegation_key(datetime.now(UTC)) == "delegation-key"
+
+
+def test_broker_sas_permission_is_service_enforced_create_only(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller cannot omit If-None-Match to turn a grant into an overwrite."""
+    captured: dict = {}
+
+    def fake_generate_blob_sas(**kwargs) -> str:
+        captured.update(kwargs)
+        return "sp=c&sig=test"
+
+    monkeypatch.setattr("azure.storage.blob.generate_blob_sas", fake_generate_blob_sas)
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=SimpleNamespace(),
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+    )
+    now = datetime.now(UTC)
+
+    grant = backend._upload_object(
+        prefix="inbox/" + "a" * 64 + "/",
+        relname="trajectory/capture.jsonl",
+        content_type="application/jsonl",
+        delegation_key="delegation-key",
+        starts_at=now,
+        expires_at=now + timedelta(minutes=5),
+    )
+
+    assert captured["permission"].create is True
+    assert captured["permission"].write is False
+    assert grant.headers["If-None-Match"] == "*"
 
 
 def test_upload_contract_recomputes_digest_and_rejects_object_injection(
@@ -243,6 +277,10 @@ class FakeBlobClient:
         self.name = name
 
     def get_blob_properties(self):
+        if self.name not in self.container.blobs:
+            from azure.core.exceptions import ResourceNotFoundError
+
+            raise ResourceNotFoundError("missing test blob")
         content = self.container.blobs[self.name]
         return SimpleNamespace(size=len(content))
 
@@ -417,4 +455,33 @@ def test_queue_validator_rejects_corruption_without_promotion(tmp_path: Path) ->
 
     assert not any(name.startswith("sources/community/") for name in container.blobs)
     assert table.entities[-1]["status"] == "rejected"
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_queue_validator_rejects_missing_declared_artifact(tmp_path: Path) -> None:
+    """An incomplete anonymous commit is terminal and cannot retry for seven days."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    blobs.pop(artifact)
+    container = FakeContainer(blobs)
+    queue = FakeQueue(
+        json.dumps(
+            {
+                "data": {
+                    "url": (
+                        "https://account.blob.core.windows.net/bronze/"
+                        f"inbox/{digest}/manifest.json"
+                    )
+                }
+            }
+        )
+    )
+    table = FakeTable()
+
+    AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
+
+    assert not any(name.startswith("sources/community/") for name in container.blobs)
+    assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
+    assert table.entities[-1]["status"] == "rejected"
+    assert "missing" in table.entities[-1]["detail"]
     assert queue.deleted == [("m1", "p1")]

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -291,10 +291,7 @@ class FakeTable:
         from azure.core.exceptions import ResourceNotFoundError
 
         for entity in reversed(self.entities):
-            if (
-                entity["PartitionKey"] == partition_key
-                and entity["RowKey"] == row_key
-            ):
+            if entity["PartitionKey"] == partition_key and entity["RowKey"] == row_key:
                 return entity
         raise ResourceNotFoundError("not found")
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -266,6 +266,36 @@ def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> Non
     with pytest.raises(CaptureRejected, match="must be UTF-8"):
         _validate_and_scan_jsonl(invalid_utf8, "trajectory/llm_trajectory.jsonl")
 
+    aws_session_key = tmp_path / "aws-session.jsonl"
+    aws_session_key.write_text(
+        json.dumps({"output": "ASIAQWERTYUIOPASDFGH"}) + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(CaptureRejected, match="secret-like"):
+        _validate_and_scan_jsonl(aws_session_key, "trajectory/aws-session.jsonl")
+
+
+def test_validator_bounds_record_bytes_and_complexity(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against JSONL record memory and recursion bombs."""
+    import services.trajectory_upload.validation as validation_module
+
+    oversized = tmp_path / "oversized.jsonl"
+    oversized.write_text(json.dumps({"text": "x" * 64}) + "\n", encoding="utf-8")
+    monkeypatch.setattr(validation_module, "MAX_JSONL_RECORD_BYTES", 32)
+    with pytest.raises(CaptureRejected, match="JSONL record exceeds"):
+        _validate_and_scan_jsonl(oversized, "trajectory/oversized.jsonl")
+
+    nested: object = "leaf"
+    for _ in range(101):
+        nested = {"child": nested}
+    recursive = tmp_path / "recursive.jsonl"
+    recursive.write_text(json.dumps(nested) + "\n", encoding="utf-8")
+    monkeypatch.setattr(validation_module, "MAX_JSONL_RECORD_BYTES", 8 * 1024**2)
+    with pytest.raises(CaptureRejected, match="JSON nesting exceeds"):
+        _validate_and_scan_jsonl(recursive, "trajectory/recursive.jsonl")
+
 
 class FakeDownloader:
     def __init__(self, content: bytes) -> None:
@@ -731,6 +761,37 @@ def test_manifest_contract_is_validated_before_artifact_downloads(
 
     assert container.requested == [manifest_name]
     assert table.entities[-1]["status"] == "rejected"
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_manifest_rejects_unsafe_metadata_version_before_promotion(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #989 against injecting invalid Azure metadata headers."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    manifest_name = f"inbox/{digest}/manifest.json"
+    manifest = json.loads(blobs[manifest_name])
+    manifest["tool"]["version"] = "bad\nvalue"
+    blobs[manifest_name] = json.dumps(manifest).encode()
+    container = FakeContainer(blobs)
+    queue = FakeQueue(
+        json.dumps(
+            {
+                "data": {
+                    "url": (
+                        "https://account.blob.core.windows.net/bronze/" + manifest_name
+                    )
+                }
+            }
+        )
+    )
+    table = _pending_table(digest)
+
+    AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
+
+    assert container.requested == [manifest_name]
+    assert table.entities[-1]["status"] == "rejected"
+    assert container.uploaded == []
     assert queue.deleted == [("m1", "p1")]
 
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -308,6 +308,18 @@ def test_validator_scans_manifest_strings_before_artifacts(tmp_path: Path) -> No
             validate_local_capture(manifest_bytes, paths)
 
 
+def test_validator_rejects_credential_shaped_mapping_keys(tmp_path: Path) -> None:
+    """Guards PR #989 against tokens used as JSON object keys."""
+    artifact = tmp_path / "credential-key.jsonl"
+    artifact.write_text(
+        '{"dtn_1234567890abcdefghijklmnop":"result"}\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CaptureRejected, match="secret-like"):
+        _validate_and_scan_jsonl(artifact, "trajectory/credential-key.jsonl")
+
+
 def test_validator_bounds_record_bytes_and_complexity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -320,7 +320,10 @@ def test_validator_rejects_credential_shaped_mapping_keys(tmp_path: Path) -> Non
         _validate_and_scan_jsonl(artifact, "trajectory/credential-key.jsonl")
 
 
-@pytest.mark.parametrize("field_name", ["token", "accessToken", "clientSecret"])
+@pytest.mark.parametrize(
+    "field_name",
+    ["token", "accessToken", "clientSecret", "api key", "access.token"],
+)
 def test_validator_rejects_prefixless_credentials_in_common_fields(
     tmp_path: Path, field_name: str
 ) -> None:
@@ -555,6 +558,34 @@ def test_broker_does_not_reopen_rejected_digest(tmp_path: Path) -> None:
     )
 
     with pytest.raises(RejectedUpload):
+        backend.create_upload(request, client_ip="127.0.0.1")
+
+
+@pytest.mark.parametrize(
+    ("status", "terminal_exception"),
+    [("ingested", AlreadyUploaded), ("rejected", RejectedUpload)],
+)
+def test_terminal_digest_handshakes_consume_rate_limit(
+    tmp_path: Path, status: str, terminal_exception: type[Exception]
+) -> None:
+    """Guards PR #989 against terminal ledger lookups bypassing broker quotas."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
+        digest = staged.traj_digest
+    table = FakeTable([{"PartitionKey": "capture", "RowKey": digest, "status": status}])
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=table,
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+        rate_limit=1,
+    )
+
+    with pytest.raises(terminal_exception):
+        backend.create_upload(request, client_ip="127.0.0.1")
+    with pytest.raises(RateLimited):
         backend.create_upload(request, client_ip="127.0.0.1")
 
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -1,0 +1,300 @@
+"""Offline contract and promotion tests for the Azure upload services."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from benchflow.publish.traj_capture import stage_trajectory_capture
+from services.trajectory_upload.broker_app import (
+    AlreadyUploaded,
+    RateLimited,
+    create_app,
+)
+from services.trajectory_upload.contract import (
+    UploadGrant,
+    UploadObject,
+    UploadRequest,
+)
+from services.trajectory_upload.validation import (
+    CaptureRejected,
+    validate_local_capture,
+)
+from services.trajectory_upload.validator import AzureCaptureValidator
+
+
+def _trial(tmp_path: Path, text: str = "safe") -> Path:
+    trial = tmp_path / "trial"
+    trajectory = trial / "trajectory"
+    trajectory.mkdir(parents=True)
+    (trajectory / "acp_trajectory.jsonl").write_text(
+        json.dumps({"type": "message", "text": text}) + "\n",
+        encoding="utf-8",
+    )
+    return trial
+
+
+def _request_from_manifest(manifest: dict) -> dict:
+    return {
+        key: manifest[key]
+        for key in (
+            "schema_version",
+            "kind",
+            "source_id",
+            "traj_digest",
+            "uploaded_by",
+            "artifacts",
+        )
+    }
+
+
+class FakeBroker:
+    def __init__(self, result: UploadGrant | Exception) -> None:
+        self.result = result
+        self.client_ip: str | None = None
+
+    def create_upload(self, request: UploadRequest, *, client_ip: str) -> UploadGrant:
+        self.client_ip = client_ip
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def test_upload_contract_recomputes_digest_and_rejects_object_injection(
+    tmp_path: Path,
+) -> None:
+    """The broker accepts only content-addressed trajectory JSONL object names."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        body = _request_from_manifest(staged.manifest)
+        request = UploadRequest.model_validate(body)
+        assert request.traj_digest == staged.manifest["traj_digest"]
+
+        body["artifacts"][0]["name"] = "../sources/private.jsonl"
+        with pytest.raises(ValidationError, match="outside trajectory"):
+            UploadRequest.model_validate(body)
+
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        body = _request_from_manifest(staged.manifest)
+        body["traj_digest"] = "sha256:" + "0" * 64
+        with pytest.raises(ValidationError, match="does not match"):
+            UploadRequest.model_validate(body)
+
+
+def test_broker_http_surface_returns_scoped_grants_and_protocol_statuses(
+    tmp_path: Path,
+) -> None:
+    """The public endpoint emits v1 grants, conflict, and Retry-After responses."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        body = _request_from_manifest(staged.manifest)
+        grant = UploadGrant(
+            upload_id="u_demo",
+            bucket="bronze",
+            base_url="https://account.blob.core.windows.net/bronze",
+            prefix=f"inbox/{staged.traj_digest}/",
+            objects=tuple(
+                UploadObject(
+                    name=item.relname,
+                    put_url=f"https://upload.test/{item.relname}?sig=test",
+                    headers={"If-None-Match": "*"},
+                )
+                for item in staged.files
+            ),
+            expires_at=datetime.fromisoformat(
+                staged.manifest["created_at"].replace("Z", "+00:00")
+            ),
+        )
+
+    backend = FakeBroker(grant)
+    response = TestClient(create_app(backend)).post(
+        "/v1/uploads",
+        json=body,
+        headers={"x-forwarded-for": "spoofed, 203.0.113.9"},
+    )
+    assert response.status_code == 200
+    assert response.json()["objects"][-1]["name"] == "manifest.json"
+    assert backend.client_ip == "203.0.113.9"
+
+    conflict = TestClient(
+        create_app(
+            FakeBroker(
+                AlreadyUploaded(
+                    base_url="https://account.blob.core.windows.net/bronze",
+                    prefix="sources/community/demo/",
+                )
+            )
+        )
+    ).post("/v1/uploads", json=body)
+    assert conflict.status_code == 409
+    assert conflict.json()["prefix"].startswith("sources/community/")
+
+    limited = TestClient(create_app(FakeBroker(RateLimited(42)))).post(
+        "/v1/uploads", json=body
+    )
+    assert limited.status_code == 429
+    assert limited.headers["Retry-After"] == "42"
+
+
+def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> None:
+    """Promotion validation rejects digest corruption, malformed JSONL, and secrets."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        manifest_bytes = staged.files[-1].local_path.read_bytes()
+        paths = {item.relname: item.local_path for item in staged.files[:-1]}
+        validated = validate_local_capture(manifest_bytes, paths)
+        assert validated.manifest.source_id == "demo"
+
+        staged.files[0].local_path.write_text('{"type":"changed"}\n', encoding="utf-8")
+        with pytest.raises(CaptureRejected, match=r"size mismatch|sha256 mismatch"):
+            validate_local_capture(manifest_bytes, paths)
+
+    secret_trial = _trial(tmp_path / "secret", "sk-1234567890abcdefghijklmnop")
+    with stage_trajectory_capture(
+        secret_trial, source_id="demo", redact=False
+    ) as staged:
+        manifest = dict(staged.manifest)
+        manifest["redaction"] = {"applied": True, "replacements": 0}
+        manifest_bytes = json.dumps(manifest).encode()
+        paths = {item.relname: item.local_path for item in staged.files[:-1]}
+        with pytest.raises(CaptureRejected, match="secret-like"):
+            validate_local_capture(manifest_bytes, paths)
+
+
+class FakeDownloader:
+    def __init__(self, content: bytes) -> None:
+        self.content = content
+
+    def readall(self) -> bytes:
+        return self.content
+
+    def readinto(self, stream) -> int:
+        return stream.write(self.content)
+
+
+class FakeBlobClient:
+    def __init__(self, container: FakeContainer, name: str) -> None:
+        self.container = container
+        self.name = name
+
+    def get_blob_properties(self):
+        content = self.container.blobs[self.name]
+        return SimpleNamespace(size=len(content))
+
+    def download_blob(self, **_kwargs) -> FakeDownloader:
+        return FakeDownloader(self.container.blobs[self.name])
+
+
+class FakeContainer:
+    def __init__(self, blobs: dict[str, bytes]) -> None:
+        self.blobs = dict(blobs)
+        self.uploaded: list[str] = []
+
+    def get_blob_client(self, name: str) -> FakeBlobClient:
+        return FakeBlobClient(self, name)
+
+    def upload_blob(self, *, name: str, data, **_kwargs) -> None:
+        content = data if isinstance(data, bytes) else data.read()
+        self.blobs[name] = content
+        self.uploaded.append(name)
+
+    def list_blobs(self, *, name_starts_with: str):
+        return [
+            SimpleNamespace(name=name)
+            for name in tuple(self.blobs)
+            if name.startswith(name_starts_with)
+        ]
+
+    def delete_blob(self, name: str) -> None:
+        self.blobs.pop(name, None)
+
+
+class FakeQueue:
+    def __init__(self, content: str) -> None:
+        self.message = SimpleNamespace(id="m1", pop_receipt="p1", content=content)
+        self.deleted: list[tuple[str, str]] = []
+
+    def receive_messages(self, **_kwargs):
+        return [self.message]
+
+    def delete_message(self, message_id: str, pop_receipt: str) -> None:
+        self.deleted.append((message_id, pop_receipt))
+
+
+class FakeTable:
+    def __init__(self) -> None:
+        self.entities: list[dict] = []
+
+    def upsert_entity(self, entity: dict) -> None:
+        self.entities.append(entity)
+
+
+def _quarantine_capture(tmp_path: Path) -> tuple[str, dict[str, bytes]]:
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        digest = staged.traj_digest
+        prefix = f"inbox/{digest}/"
+        blobs = {
+            prefix + item.relname: item.local_path.read_bytes() for item in staged.files
+        }
+    return digest, blobs
+
+
+def test_queue_validator_promotes_manifest_last_and_cleans_quarantine(
+    tmp_path: Path,
+) -> None:
+    """A valid Event Grid capture reaches community sources with manifest last."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    container = FakeContainer(blobs)
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"inbox/{digest}/manifest.json"
+                )
+            }
+        }
+    )
+    queue = FakeQueue(event)
+    table = FakeTable()
+    validator = AzureCaptureValidator(container=container, queue=queue, table=table)
+
+    assert validator.run_once() is True
+    assert container.uploaded[-1] == f"sources/community/{digest}/manifest.json"
+    assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
+    assert table.entities[-1]["status"] == "ingested"
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_queue_validator_rejects_corruption_without_promotion(tmp_path: Path) -> None:
+    """Corrupt quarantine bytes are deleted and never enter the trusted namespace."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    blobs[artifact] = b'{"type":"corrupted"}\n'
+    container = FakeContainer(blobs)
+    queue = FakeQueue(
+        json.dumps(
+            {
+                "data": {
+                    "url": (
+                        "https://account.blob.core.windows.net/bronze/"
+                        f"inbox/{digest}/manifest.json"
+                    )
+                }
+            }
+        )
+    )
+    table = FakeTable()
+
+    AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
+
+    assert not any(name.startswith("sources/community/") for name in container.blobs)
+    assert table.entities[-1]["status"] == "rejected"
+    assert queue.deleted == [("m1", "p1")]

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -568,7 +568,11 @@ def test_event_grid_queue_base64_envelope_is_decoded(tmp_path: Path) -> None:
     )
     encoded = base64.b64encode(event.encode()).decode()
 
-    assert _capture_from_event(encoded) == (f"inbox/{digest}/", digest, True)
+    assert _capture_from_event(encoded) == (
+        f"inbox/{digest}/",
+        digest,
+        "manifest.json",
+    )
 
 
 def test_pending_artifact_event_waits_for_manifest_commit(tmp_path: Path) -> None:
@@ -596,6 +600,30 @@ def test_pending_artifact_event_waits_for_manifest_commit(tmp_path: Path) -> Non
     assert container.blobs == blobs
     assert container.uploaded == []
     assert table.entities[-1]["status"] == "pending"
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_pending_oversized_artifact_event_is_rejected_and_cleaned(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against retaining artifact-only storage amplification."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    event = json.dumps(
+        {"data": {"url": ("https://account.blob.core.windows.net/bronze/" + artifact)}}
+    )
+    queue = FakeQueue(event)
+    table = _pending_table(digest)
+    container = FakeContainer(blobs)
+    monkeypatch.setattr("services.trajectory_upload.validator.MAX_ARTIFACT_BYTES", 1)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+
+    assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
+    assert table.entities[-1]["status"] == "rejected"
+    assert "artifact exceeds 1 bytes" in table.entities[-1]["detail"]
     assert queue.deleted == [("m1", "p1")]
 
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -17,6 +17,7 @@ from services.trajectory_upload.azure_backend import AzureUploadBroker
 from services.trajectory_upload.broker_app import (
     AlreadyUploaded,
     RateLimited,
+    RejectedUpload,
     create_app,
 )
 from services.trajectory_upload.contract import (
@@ -197,6 +198,12 @@ def test_broker_http_surface_returns_scoped_grants_and_protocol_statuses(
     assert limited.status_code == 429
     assert limited.headers["Retry-After"] == "42"
 
+    rejected = TestClient(create_app(FakeBroker(RejectedUpload()))).post(
+        "/v1/uploads", json=body
+    )
+    assert rejected.status_code == 422
+    assert "previously rejected" in rejected.json()["detail"]
+
 
 def test_broker_validation_errors_are_fail_closed_and_json_safe(
     tmp_path: Path,
@@ -292,8 +299,10 @@ class FakeContainer:
     def __init__(self, blobs: dict[str, bytes]) -> None:
         self.blobs = dict(blobs)
         self.uploaded: list[str] = []
+        self.requested: list[str] = []
 
     def get_blob_client(self, name: str) -> FakeBlobClient:
+        self.requested.append(name)
         return FakeBlobClient(self, name)
 
     def upload_blob(self, *, name: str, data, **_kwargs) -> None:
@@ -324,20 +333,111 @@ class FakeQueue:
         self.deleted.append((message_id, pop_receipt))
 
 
+class FakeEntity(dict):
+    def __init__(self, entity: dict, etag: str) -> None:
+        super().__init__(entity)
+        self.metadata = {"etag": etag}
+
+
 class FakeTable:
     def __init__(self, entities: list[dict] | None = None) -> None:
         self.entities = entities or []
+        self.version = len(self.entities)
 
     def upsert_entity(self, entity: dict) -> None:
         self.entities.append(entity)
+        self.version += 1
+
+    def update_entity(self, *, entity: dict, etag: str, **_kwargs) -> None:
+        assert etag == str(self.version)
+        self.entities.append(entity)
+        self.version += 1
 
     def get_entity(self, *, partition_key: str, row_key: str) -> dict:
         from azure.core.exceptions import ResourceNotFoundError
 
         for entity in reversed(self.entities):
             if entity["PartitionKey"] == partition_key and entity["RowKey"] == row_key:
-                return entity
+                return FakeEntity(entity, str(self.version))
         raise ResourceNotFoundError("not found")
+
+
+def _pending_table(digest: str) -> FakeTable:
+    return FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "pending",
+            }
+        ]
+    )
+
+
+@pytest.mark.parametrize("status", ["pending", "validating"])
+def test_broker_regrant_does_not_downgrade_ledger_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, status: str
+) -> None:
+    """Guards PR #989 against a retry clearing an active validation lease."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
+        digest = staged.traj_digest
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": status,
+                "validation_lease_until": "future" if status == "validating" else "",
+            }
+        ]
+    )
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=table,
+        blob_service=SimpleNamespace(
+            get_user_delegation_key=lambda **_kwargs: "delegation-key"
+        ),
+        ip_hash_key=b"test",
+    )
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(
+        "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
+    )
+
+    grant = backend.create_upload(request, client_ip="127.0.0.1")
+
+    assert grant.prefix == f"inbox/{digest}/"
+    assert table.entities[-1]["status"] == status
+    assert len(table.entities) == 1
+
+
+def test_broker_does_not_reopen_rejected_digest(tmp_path: Path) -> None:
+    """Guards PR #989 against downgrading a terminal rejected capture."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
+        digest = staged.traj_digest
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=FakeTable(
+            [
+                {
+                    "PartitionKey": "capture",
+                    "RowKey": digest,
+                    "status": "rejected",
+                }
+            ]
+        ),
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+    )
+
+    with pytest.raises(RejectedUpload):
+        backend.create_upload(request, client_ip="127.0.0.1")
 
 
 def _quarantine_capture(tmp_path: Path) -> tuple[str, dict[str, bytes]]:
@@ -368,7 +468,7 @@ def test_queue_validator_promotes_manifest_last_and_cleans_quarantine(
         }
     )
     queue = FakeQueue(event)
-    table = FakeTable()
+    table = _pending_table(digest)
     validator = AzureCaptureValidator(container=container, queue=queue, table=table)
 
     assert validator.run_once() is True
@@ -503,7 +603,7 @@ def test_queue_validator_rejects_corruption_without_promotion(tmp_path: Path) ->
             }
         )
     )
-    table = FakeTable()
+    table = _pending_table(digest)
 
     AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
 
@@ -530,7 +630,7 @@ def test_queue_validator_rejects_missing_declared_artifact(tmp_path: Path) -> No
             }
         )
     )
-    table = FakeTable()
+    table = _pending_table(digest)
 
     AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
 
@@ -538,4 +638,134 @@ def test_queue_validator_rejects_missing_declared_artifact(tmp_path: Path) -> No
     assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
     assert table.entities[-1]["status"] == "rejected"
     assert "missing" in table.entities[-1]["detail"]
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_queue_validator_rejects_invalid_utf8_manifest(tmp_path: Path) -> None:
+    """Guards PR #989 against retrying an undecodable anonymous manifest."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    manifest_name = f"inbox/{digest}/manifest.json"
+    blobs[manifest_name] = b"\xff"
+    container = FakeContainer(blobs)
+    queue = FakeQueue(
+        json.dumps(
+            {
+                "data": {
+                    "url": (
+                        "https://account.blob.core.windows.net/bronze/" + manifest_name
+                    )
+                }
+            }
+        )
+    )
+    table = _pending_table(digest)
+
+    AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
+
+    assert table.entities[-1]["status"] == "rejected"
+    assert "invalid manifest" in table.entities[-1]["detail"]
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_manifest_contract_is_validated_before_artifact_downloads(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #989 against manifest-driven download amplification."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    manifest_name = f"inbox/{digest}/manifest.json"
+    manifest = json.loads(blobs[manifest_name])
+    manifest["artifacts"] = manifest["artifacts"] * 9
+    blobs[manifest_name] = json.dumps(manifest).encode()
+    container = FakeContainer(blobs)
+    queue = FakeQueue(
+        json.dumps(
+            {
+                "data": {
+                    "url": (
+                        "https://account.blob.core.windows.net/bronze/" + manifest_name
+                    )
+                }
+            }
+        )
+    )
+    table = _pending_table(digest)
+
+    AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
+
+    assert container.requested == [manifest_name]
+    assert table.entities[-1]["status"] == "rejected"
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_concurrent_manifest_event_waits_for_validation_lease(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #989 against duplicate workers downgrading an ingested capture."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"inbox/{digest}/manifest.json"
+                )
+            }
+        }
+    )
+    queue = FakeQueue(event)
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "validating",
+                "validation_lease_until": (
+                    datetime.now(UTC) + timedelta(minutes=10)
+                ).isoformat(),
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+    assert container.blobs == blobs
+    assert container.uploaded == []
+    assert queue.deleted == []
+
+
+def test_expired_validation_lease_is_reclaimed(tmp_path: Path) -> None:
+    """Guards PR #989 against stranding a capture after a validator crash."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"inbox/{digest}/manifest.json"
+                )
+            }
+        }
+    )
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "validating",
+                "validation_lease_until": (
+                    datetime.now(UTC) - timedelta(minutes=1)
+                ).isoformat(),
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+    queue = FakeQueue(event)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+    assert table.entities[-1]["status"] == "ingested"
+    assert container.uploaded[-1] == f"sources/community/{digest}/manifest.json"
     assert queue.deleted == [("m1", "p1")]

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import base64
 import json
+import time
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from threading import Barrier
 from types import SimpleNamespace
 
 import pytest
@@ -18,6 +21,7 @@ from services.trajectory_upload.broker_app import (
     AlreadyUploaded,
     RateLimited,
     RejectedUpload,
+    _backend,
     create_app,
 )
 from services.trajectory_upload.contract import (
@@ -29,6 +33,7 @@ from services.trajectory_upload.validation import (
     CaptureRejected,
     _validate_and_scan_jsonl,
     validate_local_capture,
+    validate_manifest_bytes,
 )
 from services.trajectory_upload.validator import (
     AzureCaptureValidator,
@@ -71,6 +76,31 @@ class FakeBroker:
         if isinstance(self.result, Exception):
             raise self.result
         return self.result
+
+
+def test_broker_cold_start_constructs_one_shared_backend() -> None:
+    """Guards PR #989 against cold-start requests splitting quota locks."""
+    service = FakeBroker(AssertionError())
+    calls = 0
+
+    def factory() -> FakeBroker:
+        nonlocal calls
+        calls += 1
+        time.sleep(0.02)
+        return service
+
+    app = create_app(backend_factory=factory)
+    barrier = Barrier(8)
+
+    def load_backend() -> object:
+        barrier.wait()
+        return _backend(app)
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        backends = list(executor.map(lambda _item: load_backend(), range(8)))
+
+    assert calls == 1
+    assert all(backend is service for backend in backends)
 
 
 def test_first_delegation_key_request_does_not_underflow() -> None:
@@ -275,6 +305,19 @@ def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> Non
         _validate_and_scan_jsonl(aws_session_key, "trajectory/aws-session.jsonl")
 
 
+@pytest.mark.parametrize("encoding", ["utf-16", "utf-32"])
+def test_validator_rejects_non_utf8_manifest_bytes(
+    tmp_path: Path, encoding: str
+) -> None:
+    """Guards PR #989 against JSON byte-parser encoding auto-detection."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        encoded = json.dumps(staged.manifest).encode(encoding)
+
+    with pytest.raises(CaptureRejected, match="must be UTF-8"):
+        validate_manifest_bytes(encoded)
+
+
 @pytest.mark.parametrize(
     "record, message",
     [
@@ -336,6 +379,19 @@ def test_validator_rejects_prefixless_credentials_in_common_fields(
 
     with pytest.raises(CaptureRejected, match="secret-like"):
         _validate_and_scan_jsonl(artifact, "trajectory/credential-field.jsonl")
+
+
+def test_validator_rejects_prefixless_secret_in_argv_sequence(tmp_path: Path) -> None:
+    """Guards PR #989 against raw credentials following sensitive CLI flags."""
+    artifact = tmp_path / "command.jsonl"
+    artifact.write_text(
+        json.dumps({"command": ["tool", "--api-key", "opaque-prefixless-value"]})
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CaptureRejected, match="secret-like"):
+        _validate_and_scan_jsonl(artifact, "trajectory/command.jsonl")
 
 
 def test_validator_bounds_record_bytes_and_complexity(

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -734,6 +734,23 @@ def test_deploy_selects_event_topic_by_storage_source() -> None:
     assert "--query '[0].name'" not in script
 
 
+def test_deploy_scopes_event_delivery_identity_to_validation_queue() -> None:
+    """Guards PR #989 against granting Event Grid account-wide queue access."""
+    script = Path("infra/trajectory-upload/deploy-azure.sh").read_text()
+
+    assert (
+        '"$task_system_topic_principal_id" \\\n'
+        '    "Storage Queue Data Message Sender" \\\n'
+        '    "$task_queue_scope"'
+    ) in script
+    assert (
+        "az role assignment delete \\\n"
+        '        --assignee-object-id "$task_system_topic_principal_id" \\\n'
+        '        --role "Storage Queue Data Message Sender" \\\n'
+        '        --scope "$task_storage_id"'
+    ) in script
+
+
 def test_manifest_contract_is_validated_before_artifact_downloads(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -251,6 +251,14 @@ def test_broker_validation_errors_are_fail_closed_and_json_safe(
     assert injection_response.status_code == 400
     assert injection_response.json()["detail"][0]["type"] == "value_error"
 
+    secret_named = json.loads(json.dumps(body))
+    secret_named["artifacts"][0]["name"] = "trajectory/sk-abcdefghijklmnop.jsonl"
+    secret_name_response = TestClient(create_app(FakeBroker(AssertionError()))).post(
+        "/v1/uploads", json=secret_named
+    )
+    assert secret_name_response.status_code == 400
+    assert secret_name_response.json()["detail"][0]["type"] == "value_error"
+
     oversized = json.loads(json.dumps(body))
     oversized["artifacts"][0]["bytes"] = 1024**3 + 1
     oversized_response = TestClient(create_app(FakeBroker(AssertionError()))).post(
@@ -303,6 +311,19 @@ def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> Non
     )
     with pytest.raises(CaptureRejected, match="secret-like"):
         _validate_and_scan_jsonl(aws_session_key, "trajectory/aws-session.jsonl")
+
+    structured_header = tmp_path / "structured-header.jsonl"
+    structured_header.write_text(
+        json.dumps(
+            {"headers": [{"name": "Authorization", "value": "opaque-prefixless-value"}]}
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(CaptureRejected, match="secret-like"):
+        _validate_and_scan_jsonl(
+            structured_header, "trajectory/structured-header.jsonl"
+        )
 
 
 @pytest.mark.parametrize("encoding", ["utf-16", "utf-32"])
@@ -586,50 +607,65 @@ def test_broker_persists_declared_artifact_sizes(
         "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
     )
 
-    backend.create_upload(request, client_ip="127.0.0.1")
+    grant = backend.create_upload(request, client_ip="127.0.0.1")
 
     assert json.loads(table.entities[-1]["declared_artifacts"]) == expected
+    assert table.entities[-1]["attempt_id"] == grant.upload_id
+    assert grant.prefix.endswith(f"/{grant.upload_id}/")
 
 
-def test_broker_does_not_reopen_rejected_digest(tmp_path: Path) -> None:
-    """Guards PR #989 against downgrading a terminal rejected capture."""
+def test_broker_reopens_rejected_digest_in_isolated_attempt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against a rejected attempt poisoning a valid digest."""
     trial = _trial(tmp_path)
     with stage_trajectory_capture(trial, source_id="demo") as staged:
         request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
         digest = staged.traj_digest
+    old_attempt = "u_" + "0" * 32
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "rejected",
+                "attempt_id": old_attempt,
+            }
+        ]
+    )
     backend = AzureUploadBroker(
         account_name="account",
         container="bronze",
-        table=FakeTable(
-            [
-                {
-                    "PartitionKey": "capture",
-                    "RowKey": digest,
-                    "status": "rejected",
-                }
-            ]
+        table=table,
+        blob_service=SimpleNamespace(
+            get_user_delegation_key=lambda **_kwargs: "delegation-key"
         ),
-        blob_service=SimpleNamespace(),
         ip_hash_key=b"test",
     )
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(
+        "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
+    )
 
-    with pytest.raises(RejectedUpload):
-        backend.create_upload(request, client_ip="127.0.0.1")
+    grant = backend.create_upload(request, client_ip="127.0.0.1")
+
+    assert grant.upload_id != old_attempt
+    assert grant.prefix == f"inbox/{digest}/{grant.upload_id}/"
+    assert table.entities[-1]["status"] == "pending"
+    assert table.entities[-1]["attempt_id"] == grant.upload_id
 
 
-@pytest.mark.parametrize(
-    ("status", "terminal_exception"),
-    [("ingested", AlreadyUploaded), ("rejected", RejectedUpload)],
-)
 def test_terminal_digest_handshakes_consume_rate_limit(
-    tmp_path: Path, status: str, terminal_exception: type[Exception]
+    tmp_path: Path,
 ) -> None:
     """Guards PR #989 against terminal ledger lookups bypassing broker quotas."""
     trial = _trial(tmp_path)
     with stage_trajectory_capture(trial, source_id="demo") as staged:
         request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
         digest = staged.traj_digest
-    table = FakeTable([{"PartitionKey": "capture", "RowKey": digest, "status": status}])
+    table = FakeTable(
+        [{"PartitionKey": "capture", "RowKey": digest, "status": "ingested"}]
+    )
     backend = AzureUploadBroker(
         account_name="account",
         container="bronze",
@@ -639,7 +675,7 @@ def test_terminal_digest_handshakes_consume_rate_limit(
         rate_limit=1,
     )
 
-    with pytest.raises(terminal_exception):
+    with pytest.raises(AlreadyUploaded):
         backend.create_upload(request, client_ip="127.0.0.1")
     with pytest.raises(RateLimited):
         backend.create_upload(request, client_ip="127.0.0.1")
@@ -701,8 +737,122 @@ def test_event_grid_queue_base64_envelope_is_decoded(tmp_path: Path) -> None:
     assert _capture_from_event(encoded) == (
         f"inbox/{digest}/",
         digest,
+        None,
         "manifest.json",
     )
+
+
+def test_attempt_scoped_event_path_is_parsed(tmp_path: Path) -> None:
+    """Guards PR #989 attempt isolation in Event Grid validation."""
+    digest, _ = _quarantine_capture(tmp_path)
+    attempt_id = "u_" + "a" * 32
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"inbox/{digest}/{attempt_id}/manifest.json"
+                )
+            }
+        }
+    )
+
+    assert _capture_from_event(event) == (
+        f"inbox/{digest}/{attempt_id}/",
+        digest,
+        attempt_id,
+        "manifest.json",
+    )
+
+
+def test_stale_attempt_event_cleans_only_its_prefix(tmp_path: Path) -> None:
+    """Guards PR #989 against an old SAS attempt changing the active ledger."""
+    digest, legacy_blobs = _quarantine_capture(tmp_path)
+    old_attempt = "u_" + "0" * 32
+    current_attempt = "u_" + "1" * 32
+    old_prefix = f"inbox/{digest}/{old_attempt}/"
+    current_prefix = f"inbox/{digest}/{current_attempt}/"
+    blobs = {
+        name.replace(f"inbox/{digest}/", old_prefix): value
+        for name, value in legacy_blobs.items()
+    }
+    blobs[current_prefix + "trajectory/current.jsonl"] = b'{"safe":true}\n'
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"{old_prefix}manifest.json"
+                )
+            }
+        }
+    )
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "pending",
+                "attempt_id": current_attempt,
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+    queue = FakeQueue(event)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+
+    assert not any(name.startswith(old_prefix) for name in container.blobs)
+    assert current_prefix + "trajectory/current.jsonl" in container.blobs
+    assert table.entities[-1]["status"] == "pending"
+    assert table.entities[-1]["attempt_id"] == current_attempt
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_queue_validator_promotes_attempt_scoped_capture(tmp_path: Path) -> None:
+    """Guards PR #989 end-to-end validation of an isolated upload attempt."""
+    digest, legacy_blobs = _quarantine_capture(tmp_path)
+    attempt_id = "u_" + "a" * 32
+    legacy_prefix = f"inbox/{digest}/"
+    prefix = f"{legacy_prefix}{attempt_id}/"
+    blobs = {
+        name.replace(legacy_prefix, prefix): value
+        for name, value in legacy_blobs.items()
+    }
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"{prefix}manifest.json"
+                )
+            }
+        }
+    )
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "pending",
+                "attempt_id": attempt_id,
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+    queue = FakeQueue(event)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+
+    assert container.uploaded[-1] == f"sources/community/{digest}/manifest.json"
+    assert not any(name.startswith(prefix) for name in container.blobs)
+    assert table.entities[-1]["status"] == "ingested"
+    assert table.entities[-1]["attempt_id"] == attempt_id
+    assert queue.deleted == [("m1", "p1")]
 
 
 def test_pending_artifact_event_waits_for_manifest_commit(tmp_path: Path) -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -320,6 +320,21 @@ def test_validator_rejects_credential_shaped_mapping_keys(tmp_path: Path) -> Non
         _validate_and_scan_jsonl(artifact, "trajectory/credential-key.jsonl")
 
 
+@pytest.mark.parametrize("field_name", ["token", "accessToken", "clientSecret"])
+def test_validator_rejects_prefixless_credentials_in_common_fields(
+    tmp_path: Path, field_name: str
+) -> None:
+    """Guards PR #989 against promoting raw token and camelCase fields."""
+    artifact = tmp_path / "credential-field.jsonl"
+    artifact.write_text(
+        json.dumps({field_name: "opaque-prefixless-value"}) + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(CaptureRejected, match="secret-like"):
+        _validate_and_scan_jsonl(artifact, "trajectory/credential-field.jsonl")
+
+
 def test_validator_bounds_record_bytes_and_complexity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -489,6 +504,34 @@ def test_broker_regrant_does_not_downgrade_ledger_state(
     assert len(table.entities) == 1
 
 
+def test_broker_persists_declared_artifact_sizes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against artifact-only uploads exceeding their declaration."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
+        expected = {item.name: item.bytes for item in request.artifacts}
+    table = FakeTable()
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=table,
+        blob_service=SimpleNamespace(
+            get_user_delegation_key=lambda **_kwargs: "delegation-key"
+        ),
+        ip_hash_key=b"test",
+    )
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(
+        "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
+    )
+
+    backend.create_upload(request, client_ip="127.0.0.1")
+
+    assert json.loads(table.entities[-1]["declared_artifacts"]) == expected
+
+
 def test_broker_does_not_reopen_rejected_digest(tmp_path: Path) -> None:
     """Guards PR #989 against downgrading a terminal rejected capture."""
     trial = _trial(tmp_path)
@@ -624,6 +667,71 @@ def test_pending_oversized_artifact_event_is_rejected_and_cleaned(
     assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
     assert table.entities[-1]["status"] == "rejected"
     assert "artifact exceeds 1 bytes" in table.entities[-1]["detail"]
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_pending_artifact_event_enforces_declared_size(tmp_path: Path) -> None:
+    """Guards PR #989 against uploads larger than broker-declared artifact bytes."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    prefix = f"inbox/{digest}/"
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    relname = artifact.removeprefix(prefix)
+    event = json.dumps(
+        {"data": {"url": ("https://account.blob.core.windows.net/bronze/" + artifact)}}
+    )
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "pending",
+                "declared_artifacts": json.dumps({relname: 1}),
+            }
+        ]
+    )
+    container = FakeContainer(blobs)
+    queue = FakeQueue(event)
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+
+    assert not any(name.startswith(prefix) for name in container.blobs)
+    assert table.entities[-1]["status"] == "rejected"
+    assert "does not match declaration" in table.entities[-1]["detail"]
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_pending_artifact_event_enforces_legacy_aggregate_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards PR #989 against aggregate amplification without ledger metadata."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    prefix = f"inbox/{digest}/"
+    artifact = next(name for name in blobs if name.endswith(".jsonl"))
+    content = blobs[artifact]
+    blobs[prefix + "trajectory/second.jsonl"] = content
+    capture_limit = len(content) * 2 - 1
+    event = json.dumps(
+        {"data": {"url": ("https://account.blob.core.windows.net/bronze/" + artifact)}}
+    )
+    table = _pending_table(digest)
+    container = FakeContainer(blobs)
+    queue = FakeQueue(event)
+    monkeypatch.setattr(
+        "services.trajectory_upload.validator.MAX_ARTIFACT_BYTES", len(content) + 1
+    )
+    monkeypatch.setattr(
+        "services.trajectory_upload.validator.MAX_CAPTURE_BYTES", capture_limit
+    )
+
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+
+    assert not any(name.startswith(prefix) for name in container.blobs)
+    assert table.entities[-1]["status"] == "rejected"
+    assert f"capture exceeds {capture_limit} bytes" in table.entities[-1]["detail"]
     assert queue.deleted == [("m1", "p1")]
 
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -667,6 +667,40 @@ def test_queue_validator_rejects_invalid_utf8_manifest(tmp_path: Path) -> None:
     assert queue.deleted == [("m1", "p1")]
 
 
+def test_queue_validator_rejects_excessively_nested_manifest(tmp_path: Path) -> None:
+    """Guards PR #989 against retrying JSON parser recursion failures."""
+    digest, blobs = _quarantine_capture(tmp_path)
+    manifest_name = f"inbox/{digest}/manifest.json"
+    blobs[manifest_name] = b"[" * 2_000 + b"]" * 2_000
+    container = FakeContainer(blobs)
+    queue = FakeQueue(
+        json.dumps(
+            {
+                "data": {
+                    "url": (
+                        "https://account.blob.core.windows.net/bronze/" + manifest_name
+                    )
+                }
+            }
+        )
+    )
+    table = _pending_table(digest)
+
+    AzureCaptureValidator(container=container, queue=queue, table=table).run_once()
+
+    assert table.entities[-1]["status"] == "rejected"
+    assert "invalid manifest" in table.entities[-1]["detail"]
+    assert queue.deleted == [("m1", "p1")]
+
+
+def test_deploy_selects_event_topic_by_storage_source() -> None:
+    """Guards PR #989 against attaching events to an unrelated system topic."""
+    script = Path("infra/trajectory-upload/deploy-azure.sh").read_text()
+
+    assert "map(select(.source == $source))[0].name // empty" in script
+    assert "--query '[0].name'" not in script
+
+
 def test_manifest_contract_is_validated_before_artifact_downloads(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 from datetime import UTC, datetime
 from pathlib import Path
@@ -27,7 +28,10 @@ from services.trajectory_upload.validation import (
     CaptureRejected,
     validate_local_capture,
 )
-from services.trajectory_upload.validator import AzureCaptureValidator
+from services.trajectory_upload.validator import (
+    AzureCaptureValidator,
+    _capture_from_event,
+)
 
 
 def _trial(tmp_path: Path, text: str = "safe") -> Path:
@@ -288,6 +292,24 @@ def test_queue_validator_promotes_manifest_last_and_cleans_quarantine(
     assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
     assert table.entities[-1]["status"] == "ingested"
     assert queue.deleted == [("m1", "p1")]
+
+
+def test_event_grid_queue_base64_envelope_is_decoded(tmp_path: Path) -> None:
+    """Guards the live Azure queue fix after commit 0717c061 discarded events."""
+    digest, _ = _quarantine_capture(tmp_path)
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"inbox/{digest}/manifest.json"
+                )
+            }
+        }
+    )
+    encoded = base64.b64encode(event.encode()).decode()
+
+    assert _capture_from_event(encoded) == (f"inbox/{digest}/", digest)
 
 
 def test_queue_validator_rejects_corruption_without_promotion(tmp_path: Path) -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -697,7 +697,10 @@ def test_deploy_selects_event_topic_by_storage_source() -> None:
     """Guards PR #989 against attaching events to an unrelated system topic."""
     script = Path("infra/trajectory-upload/deploy-azure.sh").read_text()
 
-    assert "map(select(.source == $source))[0].name // empty" in script
+    assert (
+        "map(select((.source | ascii_downcase) == ($source | ascii_downcase)))"
+        in script
+    )
     assert "--query '[0].name'" not in script
 
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -322,7 +322,7 @@ def test_validator_rejects_credential_shaped_mapping_keys(tmp_path: Path) -> Non
 
 @pytest.mark.parametrize(
     "field_name",
-    ["token", "accessToken", "clientSecret", "api key", "access.token"],
+    ["token", "passwd", "accessToken", "clientSecret", "api key", "access.token"],
 )
 def test_validator_rejects_prefixless_credentials_in_common_fields(
     tmp_path: Path, field_name: str

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -26,6 +26,7 @@ from services.trajectory_upload.contract import (
 )
 from services.trajectory_upload.validation import (
     CaptureRejected,
+    _validate_and_scan_jsonl,
     validate_local_capture,
 )
 from services.trajectory_upload.validator import (
@@ -219,6 +220,11 @@ def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> Non
         with pytest.raises(CaptureRejected, match="secret-like"):
             validate_local_capture(manifest_bytes, paths)
 
+    invalid_utf8 = tmp_path / "llm_trajectory.jsonl"
+    invalid_utf8.write_bytes(b"\xff\n")
+    with pytest.raises(CaptureRejected, match="must be UTF-8"):
+        _validate_and_scan_jsonl(invalid_utf8, "trajectory/llm_trajectory.jsonl")
+
 
 class FakeDownloader:
     def __init__(self, content: bytes) -> None:
@@ -357,7 +363,7 @@ def test_duplicate_terminal_event_is_an_idempotent_no_op(
     tmp_path: Path, terminal_status: str
 ) -> None:
     """At-least-once Event Grid delivery cannot reopen a terminal capture."""
-    digest, _ = _quarantine_capture(tmp_path)
+    digest, blobs = _quarantine_capture(tmp_path)
     event = json.dumps(
         {
             "data": {
@@ -379,12 +385,11 @@ def test_duplicate_terminal_event_is_an_idempotent_no_op(
         ]
     )
 
-    assert (
-        AzureCaptureValidator(
-            container=FakeContainer({}), queue=queue, table=table
-        ).run_once()
-        is True
-    )
+    container = FakeContainer(blobs)
+    assert AzureCaptureValidator(
+        container=container, queue=queue, table=table
+    ).run_once()
+    assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
     assert queue.deleted == [("m1", "p1")]
 
 

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -163,6 +163,38 @@ def test_broker_http_surface_returns_scoped_grants_and_protocol_statuses(
     assert limited.headers["Retry-After"] == "42"
 
 
+def test_broker_validation_errors_are_fail_closed_and_json_safe(
+    tmp_path: Path,
+) -> None:
+    """Guards the live Azure fix after malformed handshakes returned HTTP 500."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        body = _request_from_manifest(staged.manifest)
+
+    injected = json.loads(json.dumps(body))
+    injected["artifacts"][0]["name"] = "../private.jsonl"
+    injection_response = TestClient(create_app(FakeBroker(AssertionError()))).post(
+        "/v1/uploads", json=injected
+    )
+    assert injection_response.status_code == 400
+    assert injection_response.json()["detail"][0]["type"] == "value_error"
+
+    oversized = json.loads(json.dumps(body))
+    oversized["artifacts"][0]["bytes"] = 1024**3 + 1
+    oversized_response = TestClient(create_app(FakeBroker(AssertionError()))).post(
+        "/v1/uploads", json=oversized
+    )
+    assert oversized_response.status_code == 413
+    assert oversized_response.json()["detail"][0]["type"] == "less_than_equal"
+
+    body_limit_response = TestClient(create_app(FakeBroker(AssertionError()))).post(
+        "/v1/uploads",
+        content=b"{}",
+        headers={"Content-Length": str(1024**2 + 1)},
+    )
+    assert body_limit_response.status_code == 413
+
+
 def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> None:
     """Promotion validation rejects digest corruption, malformed JSONL, and secrets."""
     trial = _trial(tmp_path)
@@ -249,11 +281,22 @@ class FakeQueue:
 
 
 class FakeTable:
-    def __init__(self) -> None:
-        self.entities: list[dict] = []
+    def __init__(self, entities: list[dict] | None = None) -> None:
+        self.entities = entities or []
 
     def upsert_entity(self, entity: dict) -> None:
         self.entities.append(entity)
+
+    def get_entity(self, *, partition_key: str, row_key: str) -> dict:
+        from azure.core.exceptions import ResourceNotFoundError
+
+        for entity in reversed(self.entities):
+            if (
+                entity["PartitionKey"] == partition_key
+                and entity["RowKey"] == row_key
+            ):
+                return entity
+        raise ResourceNotFoundError("not found")
 
 
 def _quarantine_capture(tmp_path: Path) -> tuple[str, dict[str, bytes]]:
@@ -310,6 +353,42 @@ def test_event_grid_queue_base64_envelope_is_decoded(tmp_path: Path) -> None:
     encoded = base64.b64encode(event.encode()).decode()
 
     assert _capture_from_event(encoded) == (f"inbox/{digest}/", digest)
+
+
+@pytest.mark.parametrize("terminal_status", ["ingested", "rejected"])
+def test_duplicate_terminal_event_is_an_idempotent_no_op(
+    tmp_path: Path, terminal_status: str
+) -> None:
+    """At-least-once Event Grid delivery cannot reopen a terminal capture."""
+    digest, _ = _quarantine_capture(tmp_path)
+    event = json.dumps(
+        {
+            "data": {
+                "url": (
+                    "https://account.blob.core.windows.net/bronze/"
+                    f"inbox/{digest}/manifest.json"
+                )
+            }
+        }
+    )
+    queue = FakeQueue(event)
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": terminal_status,
+            }
+        ]
+    )
+
+    assert (
+        AzureCaptureValidator(
+            container=FakeContainer({}), queue=queue, table=table
+        ).run_once()
+        is True
+    )
+    assert queue.deleted == [("m1", "p1")]
 
 
 def test_queue_validator_rejects_corruption_without_promotion(tmp_path: Path) -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -12,6 +12,7 @@ from fastapi.testclient import TestClient
 from pydantic import ValidationError
 
 from benchflow.publish.traj_capture import stage_trajectory_capture
+from services.trajectory_upload.azure_backend import AzureUploadBroker
 from services.trajectory_upload.broker_app import (
     AlreadyUploaded,
     RateLimited,
@@ -64,6 +65,22 @@ class FakeBroker:
         if isinstance(self.result, Exception):
             raise self.result
         return self.result
+
+
+def test_first_delegation_key_request_does_not_underflow() -> None:
+    """Guards the live Azure fix against the underflow in commit 158ef108."""
+    blob_service = SimpleNamespace(
+        get_user_delegation_key=lambda **_kwargs: "delegation-key"
+    )
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=SimpleNamespace(),
+        blob_service=blob_service,
+        ip_hash_key=b"test",
+    )
+
+    assert backend._user_delegation_key(datetime.now(UTC)) == "delegation-key"
 
 
 def test_upload_contract_recomputes_digest_and_rejects_object_injection(

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -275,6 +275,39 @@ def test_validator_recomputes_bytes_jsonl_and_secret_scan(tmp_path: Path) -> Non
         _validate_and_scan_jsonl(aws_session_key, "trajectory/aws-session.jsonl")
 
 
+@pytest.mark.parametrize(
+    "record, message",
+    [
+        ('{"password":"live","password":"[REDACTED]"}\n', "duplicate JSON"),
+        ('{"reward":NaN}\n', "non-finite JSON"),
+        ('{"reward":Infinity}\n', "non-finite JSON"),
+        ('{"reward":-Infinity}\n', "non-finite JSON"),
+    ],
+)
+def test_validator_rejects_ambiguous_or_nonstandard_json(
+    tmp_path: Path, record: str, message: str
+) -> None:
+    """Guards PR #989 against duplicate keys and non-finite JSON numbers."""
+    artifact = tmp_path / "strict.jsonl"
+    artifact.write_text(record, encoding="utf-8")
+
+    with pytest.raises(CaptureRejected, match=message):
+        _validate_and_scan_jsonl(artifact, "trajectory/strict.jsonl")
+
+
+def test_validator_scans_manifest_strings_before_artifacts(tmp_path: Path) -> None:
+    """Guards PR #989 against secrets in contributor and run metadata."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(trial, source_id="demo") as staged:
+        manifest = dict(staged.manifest)
+        manifest["uploaded_by"] = "dtn_1234567890abcdefghijklmnop"
+        manifest_bytes = json.dumps(manifest).encode()
+        paths = {item.relname: item.local_path for item in staged.files[:-1]}
+
+        with pytest.raises(CaptureRejected, match="manifest contains a secret-like"):
+            validate_local_capture(manifest_bytes, paths)
+
+
 def test_validator_bounds_record_bytes_and_complexity(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -272,6 +272,21 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-data-tables"
+version = "12.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/b8/e76cfa7f5f847722664c6f8108c391deadcb9d9aad579650c128affd4669/azure_data_tables-12.7.0.tar.gz", hash = "sha256:b14fc94a3223a2835ff5688e17d8e107b27c7cd7c4114138f2ac81373723705d", size = 258650, upload-time = "2025-05-06T17:51:06.323Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/3e/2b8da274b49402659cd732def2ae217f2e86312278feb56b55ccbffbbc26/azure_data_tables-12.7.0-py3-none-any.whl", hash = "sha256:24ed9b5690aa46c213182e32bb1b39a68dd9f526d84f447c287e3a401b437c10", size = 133178, upload-time = "2025-05-06T17:51:07.65Z" },
+]
+
+[[package]]
 name = "azure-identity"
 version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
@@ -300,6 +315,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/59/25/fdcf1e381922dbab8ba23d6fd78d397fe6cbac6b480310218834b7bc91fe/azure_storage_blob-12.29.0.tar.gz", hash = "sha256:2824ddd7ebc9056034ebc76b17971a38e9aa5835abb0d565b9700493f2a6c657", size = 611359, upload-time = "2026-05-15T03:34:59.865Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/2c/6ddee6a3e42d0236ba9259e4df7fa97fdc415ff0802b736c634baaf4b285/azure_storage_blob-12.29.0-py3-none-any.whl", hash = "sha256:ccf8a1bcd5e49df83ab85aab793b579e5ba2eeea2ad8900b2f62ca3a37dc391f", size = 434823, upload-time = "2026-05-15T03:35:01.837Z" },
+]
+
+[[package]]
+name = "azure-storage-queue"
+version = "12.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/84/7d/babb616eb1ed1ac5f13cbb336875fd91c9c6f8b1702bf2ff860b222cb833/azure_storage_queue-12.17.0.tar.gz", hash = "sha256:6eb108a88554be371feb2eba9715fa0e3f7baca7b3f00c19ec417fc7ce5b3834", size = 203777, upload-time = "2026-06-08T18:03:16.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/e3/6aee19df63974d87e55dc0ddf5bb18eb1022cd290b125a46792594a00673/azure_storage_queue-12.17.0-py3-none-any.whl", hash = "sha256:aaef08ee2613f84a3a85e60a059d29567361e5a2af455298bb0e529f0b47d5a1", size = 189526, upload-time = "2026-06-08T18:03:19.139Z" },
 ]
 
 [[package]]
@@ -349,6 +379,17 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
+]
+azure-service = [
+    { name = "azure-data-tables" },
+    { name = "azure-identity" },
+    { name = "azure-storage-blob" },
+    { name = "azure-storage-queue" },
+    { name = "uvicorn" },
+]
 bedrock = [
     { name = "boto3" },
 ]
@@ -396,6 +437,12 @@ requires-dist = [
     { name = "agent-client-protocol", specifier = ">=0.10" },
     { name = "anthropic", marker = "extra == 'judge'", specifier = ">=0.40" },
     { name = "anyio", specifier = ">=4.0" },
+    { name = "azure-data-tables", marker = "extra == 'azure-service'", specifier = ">=12.5" },
+    { name = "azure-identity", marker = "extra == 'azure'", specifier = ">=1.16" },
+    { name = "azure-identity", marker = "extra == 'azure-service'", specifier = ">=1.16" },
+    { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19" },
+    { name = "azure-storage-blob", marker = "extra == 'azure-service'", specifier = ">=12.19" },
+    { name = "azure-storage-queue", marker = "extra == 'azure-service'", specifier = ">=12.9" },
     { name = "bedrock-agentcore", marker = "extra == 'sandbox-agentcore'", specifier = ">=1.18" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.40" },
     { name = "boto3", marker = "extra == 'sandbox-agentcore'", specifier = ">=1.43.31" },
@@ -427,8 +474,9 @@ requires-dist = [
     { name = "trl", marker = "extra == 'trl'", specifier = ">=1.8.0,<2" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.1a1" },
     { name = "typer", specifier = ">=0.9" },
+    { name = "uvicorn", marker = "extra == 'azure-service'", specifier = ">=0.30" },
 ]
-provides-extras = ["dev", "train", "trl", "sandbox-daytona", "sandbox-modal", "sandbox-agentcore", "bedrock", "judge", "deepagents"]
+provides-extras = ["azure", "azure-service", "dev", "train", "trl", "sandbox-daytona", "sandbox-modal", "sandbox-agentcore", "bedrock", "judge", "deepagents"]
 
 [[package]]
 name = "boto3"
@@ -746,7 +794,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -777,43 +825,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -2533,7 +2581,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2572,7 +2620,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2584,7 +2632,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2614,9 +2662,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2628,7 +2676,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3506,7 +3554,7 @@ name = "pyroscope-io"
 version = "0.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "sys_platform != 'win32'" },
+    { name = "cffi" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/50/607b38b120ba8adad954119ba512c53590c793f0cf7f009ba6549e4e1d77/pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e07edcfd59f5bdce42948b92c9b118c824edbd551730305f095a6b9af401a9e8", size = 3138869, upload-time = "2026-01-22T06:23:24.664Z" },

--- a/uv.lock
+++ b/uv.lock
@@ -794,7 +794,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -825,43 +825,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -2581,7 +2581,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2620,7 +2620,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2632,7 +2632,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2662,9 +2662,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2676,7 +2676,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3554,7 +3554,7 @@ name = "pyroscope-io"
 version = "0.8.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/50/607b38b120ba8adad954119ba512c53590c793f0cf7f009ba6549e4e1d77/pyroscope_io-0.8.16-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:e07edcfd59f5bdce42948b92c9b118c824edbd551730305f095a6b9af401a9e8", size = 3138869, upload-time = "2026-01-22T06:23:24.664Z" },


### PR DESCRIPTION
## Summary

- adds the single public CLI surface: bench traj upload PATH
- validates JSONL, structurally redacts secrets, and creates a transport-neutral content-addressed manifest
- supports the built-in public broker and an optional trusted Azure direct mode
- deploys an Azure Container Apps broker plus Event Grid, Storage Queue, quarantine validator job, private versioned Blob Storage, durable ledger/rate limit, least-privilege managed identities, lifecycle policy, and diagnostics
- documents contributor privacy, idempotency, direct mode, and production deployment

## Production evidence

- broker: https://tasksminer-traj-broker.nicewave-c3abaecf.westus2.azurecontainerapps.io
- deployed image: tasksminerregistry.azurecr.io/trajectory-upload:8b4d21f3f56d
- deployment script completed successfully against both a fresh setup and the existing resource group
- public demo digest 2d0263bd134435704109df1e8e405fe75104d45a9c1fb2dd19cc067102e18c19 was promoted to sources/community after the validator job succeeded; quarantine was empty afterward
- replay of the same digest returned Already uploaded and performed no writes
- trusted direct-mode demo uploaded payload plus manifest and replayed as a no-op

## Security probes

- object-name injection: HTTP 400 before SAS issuance
- declared oversize and actual request-body oversize: HTTP 413 before SAS issuance
- SAS replay as GET: HTTP 403
- SAS replay as DELETE: HTTP 403
- tampered expiry: HTTP 403
- intentional quarantine overwrite retained two Azure versions; the validator rejected the hash/size mismatch and did not promote it
- signed SAS URLs and Azure SDK INFO request logs are suppressed from CLI output

## Verification

- uv run ruff check .
- uv run ty check src/
- uv run pytest tests/
- 5413 passed, 65 skipped, 7 deselected
- focused trajectory upload suite: 40 passed
- live health, Event Grid identity route, validator execution, promoted objects, ledger status, empty quarantine, direct upload, and replay all checked with az CLI

## Review focus

Please verify the one-command CLI boundary, manifest/redaction contract, broker SAS permissions, validator fail-closed promotion, duplicate-event behavior, and Azure IAM scopes. The branch has also passed the requested thermo-nuclear structural review; unrelated uv.lock resolver churn was removed.