### PR TITLE
release: 0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.6.8 — 2026-08-15
+
 ### Added
 - **Public trajectory contribution.** `bench traj upload PATH` validates and
   structurally redacts trajectory JSONL, creates a content-addressed manifest,
@@ -36,6 +38,29 @@
   (`--environment-manifest`, `benchflow.environment.manifest`, the
   eval-config `environment:` docker/daytona selector) is a different
   subsystem and is unchanged.
+
+### Fixed
+- **Coherent integration coverage for code-and-fixture changes.** The
+  credential-free fixture job now tests pull-request source together with its
+  task fixtures, while the secret-bearing smoke job retains trusted fixtures;
+  the release gate requires both results. (#969)
+- **Retryable Daytona transport failures stay retryable.** Transient SDK
+  transport errors are stamped while their vendor type is still available,
+  empty exception messages retain useful type information, and permanent
+  errors remain outside the retry policy. (#970)
+- **Live token counters no longer freeze behind callback-log reads.** Larger,
+  bounded ranged reads distinguish EOF from read failure, expose lag, and keep
+  terminal phase labels from moving backwards. (#971)
+- **Fresh OpenClaw installs and GPT-5.4 calls use compatible limits.** OpenClaw
+  is pinned to a Node-compatible runtime, and raw plus ACP-alias GPT-5.4 model
+  IDs clamp output tokens to the provider's 128,000-token limit. (#977, #986)
+- **Anthropic Vertex routes include their required runtime.** The gateway now
+  installs the Google Cloud Vertex AI SDK used by LiteLLM's Anthropic Vertex
+  path. (#978)
+- **ACP subprocess diagnostics survive normal teardown.** A bounded, redacted
+  stderr tail is retained even when stdout remains open; stderr drain failures
+  cannot mask the structured transport diagnosis, and repeated process close
+  calls are idempotent. (#980)
 
 ## 0.6.7 — 2026-08-09
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/benchflow-ai/benchflow"
 url: "https://github.com/benchflow-ai/benchflow"
 license: Apache-2.0
-version: 0.6.7
-date-released: 2026-08-09
+version: 0.6.8
+date-released: 2026-08-15
 keywords:
   - benchmark
   - llm-agents

--- a/docs/integration-tests.md
+++ b/docs/integration-tests.md
@@ -350,14 +350,14 @@ The gate combines two requirements:
 uv run python tests/integration/agent_judge.py jobs/integration-eval --json
 ```
 
-The lightweight `.github/workflows/integration-eval.yml` workflow runs one
-small task through `bench eval run --agent openhands --model
-deepseek/deepseek-v4-flash --sandbox docker`, then runs the agent judge over
-the rollout and fails the job if the run is not REAL or the judge fails. It
-triggers on `workflow_dispatch` and nightly, and is capped at one task to keep
-the check cheap. It references the `DEEPSEEK_API_KEY`, `DEEPSEEK_BASE_URL`, and
-`GEMINI_API_KEY` repository secrets; the judge SDKs come from the `judge`
-extra (`uv sync --extra judge`).
+The lightweight `.github/workflows/integration-light.yml` workflow selects the
+first exposed provider that passes a live probe, runs one small task through
+`bench eval run --sandbox docker`, then judges that rollout with the same
+provider. It fails when the rollout is not REAL or the judge fails. It runs for
+internal pull requests, after a successful `test` workflow on `main`, and on
+manual dispatch. Provider credentials come from the `pypi-internal-preview`
+environment; GitHub Models is the built-in fallback. The judge SDKs come from
+the `judge` extra (`uv sync --extra judge`).
 
 ## Robust integration suite (`tests/test_integration_suite.py`)
 

--- a/docs/integration-tiers.md
+++ b/docs/integration-tiers.md
@@ -19,7 +19,7 @@ representative 3-agent SUBSET at L2 and the full DeepSeek roster (5 agents) at L
 via `expanded`, with the 2 gated native agents (`codex-acp`, `claude-agent-acp`)
 running only via affected-agent, plus the per-agent model policy and
 credential-aware emission. Vocabulary shared across the docs and the
-`benchflow-experiment-review` skill is in the [Glossary](#glossary) (§12).
+`benchflow-experiment-review` skill is in the [Glossary](#12-glossary) (§12).
 
 > **Terminology rename.** The deterministic verdict is user-facing as
 > **`mergeable`** / **`mergeable with quarantines`** / **`not mergeable`**. These

--- a/docs/release.md
+++ b/docs/release.md
@@ -104,19 +104,19 @@ Internal preview:
 
 1. Merge a PR to `main`.
 2. `.github/workflows/test.yml` runs.
-3. `.github/workflows/integration-eval.yml` runs a real rollout after the
+3. `.github/workflows/integration-light.yml` runs a real rollout after the
    tested `main` commit passes.
 4. The terminal integration gate uploads the exact tested commit and source
    run number as provenance. `.github/workflows/internal-preview-release.yml`
    downloads and validates that artifact from the successful integration run,
    verifies the commit is on `main`, then publishes it.
 
-The integration gate selects the first configured live LLM provider that can
+The integration gate selects the first exposed live LLM provider that can
 answer a small probe request, then uses that same provider for the smoke rollout
-and agent judge. Configure at least one of `DEEPSEEK_API_KEY`, `GLM_API_KEY`,
-`QWEN_API_KEY`, `LITELLM_API_KEY`/`BF_TOKEN`, `OPENAI_API_KEY`, or
-`GITHUB_MODELS_TOKEN` as GitHub Actions secrets for the job environment.
-`DAYTONA_API_KEY` is optional and enables the Daytona parity and reaper checks.
+and agent judge. The workflow maps DeepSeek and GLM credentials from the
+`pypi-internal-preview` environment and falls back to GitHub Models through the
+workflow token. Keep at least one of those routes working; the L1 job does not
+receive Daytona or reviewer credentials.
 
 The GitHub Deployments page for `pypi-internal-preview` can show integration
 gate statuses because the integration workflow uses that same GitHub environment

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -500,10 +500,9 @@ export AWS_BEARER_TOKEN_BEDROCK=...
 export AWS_REGION=us-west-2 AWS_DEFAULT_REGION=us-west-2
 export GEMINI_API_KEY=...
 
-# 4. MAX thinking for Opus-4.8 (opt-in). WITHOUT this the run uses the agent's
-#    default effort = adaptive-thinking `high`, NOT max. LiteLLM receives this
-#    env var on both Daytona and Docker.
-export BENCHFLOW_BEDROCK_THINKING_EFFORT=max
+# 4. Adaptive thinking for Opus-4.8. Current LiteLLM Bedrock support clamps
+#    requested xhigh/max to high, so request the effective value directly.
+export BENCHFLOW_BEDROCK_THINKING_EFFORT=high
 
 # 5. Strip stale external gateway vars; BenchFlow will generate its own LiteLLM config:
 unset LLM_BASE_URL LLM_API_KEY OPENAI_BASE_URL BENCHFLOW_PROVIDER_BASE_URL \
@@ -512,8 +511,8 @@ unset LLM_BASE_URL LLM_API_KEY OPENAI_BASE_URL BENCHFLOW_PROVIDER_BASE_URL \
 
 > Pick a **light** task — Daytona caps each sandbox at 10 GB (see the note above).
 > `citation-check` is a good default; heavy tasks need `--sandbox docker`. Note that
-> MAX effort makes each Opus turn much slower (deep server-side reasoning — a
-> `citation-check` cell took ~10–15 min at `max` vs ~3 min at the default effort).
+> Opus adaptive thinking can make each turn substantially slower than the
+> Gemini cells, so keep the first validation task light.
 
 ### Run the four cells
 
@@ -522,11 +521,11 @@ TASK=citation-check
 COMMON="--tasks-dir $SKILLSBENCH/tasks --include $TASK --agent openhands \
   --sandbox daytona --concurrency 1 --usage-tracking required --agent-idle-timeout none"
 
-# (1) Opus-4.8 (MAX) — with skills
+# (1) Opus-4.8 (adaptive high) — with skills
 bench eval run $COMMON --model aws-bedrock/us.anthropic.claude-opus-4-8 \
   --skill-mode with-skill --jobs-dir jobs/opus-skill
 
-# (2) Opus-4.8 (MAX) — without skills
+# (2) Opus-4.8 (adaptive high) — without skills
 bench eval run $COMMON --model aws-bedrock/us.anthropic.claude-opus-4-8 \
   --skill-mode no-skill --jobs-dir jobs/opus-noskill
 
@@ -539,9 +538,10 @@ bench eval run $COMMON --model gemini-3.5-flash --agent-env LLM_CACHING_PROMPT=f
   --skill-mode no-skill --jobs-dir jobs/gemini-noskill
 ```
 
-`BENCHFLOW_BEDROCK_THINKING_EFFORT=max` is what makes the two Opus cells actually
-run at MAX. LiteLLM writes the provider call metadata to
-`trajectory/llm_trajectory.jsonl`; confirm the adaptive thinking effort there.
+LiteLLM writes provider call metadata to `trajectory/llm_trajectory.jsonl`;
+confirm that the effective adaptive thinking effort is `high` there. Requested
+`xhigh` or `max` values are also recorded as `high` after the compatibility
+clamp.
 
 | Model (`--model`) | Skills | Cell-specific flags |
 |-------------------|--------|---------------------|
@@ -571,7 +571,7 @@ Quick smoke checks before the full audit (per jobs-dir):
 J=jobs/opus-skill
 find $J -name rewards.jsonl -exec tail -1 {} \;                                  # reward
 grep -ho '"usage_source": "[a-z_]*"' $(find $J -name result.json)                # expect provider_response
-grep -ho '"effort": "[a-z]*"' $(find $J -name llm_trajectory.jsonl) | sort -u    # Opus MAX -> "max"
+grep -ho '"effort": "[a-z]*"' $(find $J -name llm_trajectory.jsonl) | sort -u    # Opus -> "high"
 python3 .agents/skills/benchflow-experiment-review/scripts/extract_harness_skills.py \
   "$(find $J -name llm_trajectory.jsonl | head -1)" --task-skill <task-skill-name>
 ```

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -28,11 +28,12 @@ one expected blob at a time; they do not grant list, read, or delete access.
 An Event Grid-triggered validator independently checks the manifest contract,
 the 8 MiB per-record JSONL bound and structural complexity limits,
 allowlisted object names, byte sizes, SHA-256 hashes, strict JSONL syntax, and
-final artifact and manifest secret scans. Only then does it copy artifacts into the immutable
-`sources/community/<digest>/` namespace, with `manifest.json` as the commit
-marker. Failed captures are removed from the live quarantine namespace and are
-never promoted. Blob versioning and lifecycle policy bound recovery and
-retention for attempted overwrites.
+final artifact and manifest secret scans. Only then does it copy artifacts into
+the content-addressed `sources/community/<digest>/` namespace, with
+`manifest.json` as the commit marker. Failed captures are removed from the live
+quarantine namespace and are never promoted. Blob versioning and lifecycle
+policy provide recovery and bound retention for attempted overwrites; the
+deployment does not configure an immutable-storage policy.
 
 The digest excludes contributor labels, timestamps, and transport details, so
 the same redacted bytes are idempotent across machines. Repeating an ingested
@@ -55,8 +56,11 @@ bench traj upload path/to/trial --direct \
 ```
 
 Direct mode uses `DefaultAzureCredential` and create-only blob calls. The
-identity needs `Storage Blob Data Creator` on the target container. For routine
-community contributions, use the default broker mode.
+identity needs a custom role with blob create/write data actions on the target
+container. The production deployment creates this as
+`TasksMiner Blob Data Creator`; Azure's broader `Storage Blob Data Contributor`
+role also works but grants more than direct upload needs. For routine community
+contributions, use the default broker mode.
 
 Deployment configuration and verification live in
 [`infra/trajectory-upload/`](../infra/trajectory-upload/README.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.8.dev0"
+version = "0.6.8"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/benchflow/sandbox/process/_base.py
+++ b/src/benchflow/sandbox/process/_base.py
@@ -156,6 +156,26 @@ class SubprocessLiveProcess(LiveProcess):
             if len(self._stderr_tail) > _STDERR_TAIL_LIMIT:
                 del self._stderr_tail[:-_STDERR_TAIL_LIMIT]
 
+    async def _finish_stderr_drain(self, *, cancel_on_timeout: bool) -> None:
+        """Bound the stderr drain without leaking its transport failures."""
+        stderr_task = getattr(self, "_stderr_task", None)
+        if not stderr_task or stderr_task.cancelled():
+            return
+        try:
+            await asyncio.wait_for(
+                asyncio.shield(stderr_task), timeout=_STDERR_DRAIN_TIMEOUT_SEC
+            )
+        except asyncio.CancelledError:
+            if not stderr_task.cancelled():
+                raise
+        except TimeoutError:
+            if cancel_on_timeout:
+                stderr_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stderr_task
+        except Exception:
+            logger.debug("Could not finish draining subprocess stderr", exc_info=True)
+
     @property
     def stderr_tail(self) -> str:
         """Bounded stderr captured while the subprocess was alive."""
@@ -176,10 +196,7 @@ class SubprocessLiveProcess(LiveProcess):
         if not line:
             stderr_task = getattr(self, "_stderr_task", None)
             if stderr_task:
-                with contextlib.suppress(TimeoutError):
-                    await asyncio.wait_for(
-                        asyncio.shield(stderr_task), timeout=_STDERR_DRAIN_TIMEOUT_SEC
-                    )
+                await self._finish_stderr_drain(cancel_on_timeout=False)
                 stderr_text = self.stderr_tail.strip()
             else:
                 stderr_text = ""
@@ -257,16 +274,7 @@ class SubprocessLiveProcess(LiveProcess):
                 except TimeoutError:
                     self._process.kill()
                     await self._process.wait()
-            stderr_task = getattr(self, "_stderr_task", None)
-            if stderr_task:
-                try:
-                    await asyncio.wait_for(
-                        asyncio.shield(stderr_task), timeout=_STDERR_DRAIN_TIMEOUT_SEC
-                    )
-                except TimeoutError:
-                    stderr_task.cancel()
-                    with contextlib.suppress(asyncio.CancelledError):
-                        await stderr_task
+            await self._finish_stderr_drain(cancel_on_timeout=True)
             logger.info("Process terminated")
 
     @property

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -46,6 +46,40 @@ async def test_subprocess_close_cancels_stderr_drain_that_never_reaches_eof(
     )
     await process.close()
     assert process._stderr_task.cancelled()
+    await process.close()
+
+
+@pytest.mark.asyncio
+async def test_subprocess_readline_keeps_typed_error_when_stderr_drain_fails() -> None:
+    """Guards PR #980 against stderr failures masking transport diagnostics."""
+    from benchflow.diagnostics import TransportClosedError
+    from benchflow.sandbox.process import SubprocessLiveProcess
+
+    class _LiveProcess(SubprocessLiveProcess):
+        async def start(self, command, env=None, cwd=None) -> None:
+            pass
+
+    async def fail_stderr_drain() -> None:
+        raise ConnectionResetError("stderr transport reset")
+
+    stdout = MagicMock()
+    stdout.readline = AsyncMock(return_value=b"")
+    child = MagicMock(
+        stdout=stdout,
+        stderr=None,
+        returncode=1,
+        pid=12345,
+    )
+    process = _LiveProcess()
+    process._process = child
+    process._stderr_tail = bytearray(b"diagnostic before reset")
+    process._stderr_task = asyncio.create_task(fail_stderr_drain())
+
+    with pytest.raises(TransportClosedError) as exc_info:
+        await process.readline()
+
+    assert exc_info.value.diagnostic.stderr_snippet == "diagnostic before reset"
+    assert exc_info.value.diagnostic.transport_diagnosis == "process_exited"
 
 
 class _FakeStdin:

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -291,6 +291,11 @@ def test_broker_put_conflicts_are_cloud_neutral_skips(
 
 def test_help_exposes_only_the_planned_upload_command() -> None:
     """The trajectory CLI surface remains a single clean command."""
+    traj_group = next(group for group in app.registered_groups if group.name == "traj")
+    assert {
+        command.name for command in traj_group.typer_instance.registered_commands
+    } == {"upload"}
+
     result = runner.invoke(app, ["traj", "--help"])
     assert result.exit_code == 0
     assert "upload" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.8.dev0"
+version = "0.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- publish BenchFlow 0.6.8 with the public `bench traj upload PATH` command
- include the task `environment:` to `sandbox:` rename and runtime fixes merged since v0.6.7
- make ACP stderr teardown diagnostics robust and keep `close()` idempotent
- correct release, integration, Opus thinking, and Azure upload documentation
- update changelog, citation metadata, package version, and lockfile

## Release gates

- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check src services`
- `uv lock --check`
- `TAG_NAME=v0.6.8 uv run --with packaging --no-project python tools/release_version.py public-release`
- `uv run python -m pytest tests/` — 5500 passed, 65 skipped, 7 deselected
- `uv build --no-sources`
- `python -m twine check dist/*`
- isolated Python 3.12 wheel install reports `benchflow 0.6.8`; `bench traj --help` exposes only `upload`

After reviewed squash merge, the matching `v0.6.8` tag will trigger the public PyPI/GitHub release. A separate PR will then advance main to `0.6.9.dev0`.