### PR TITLE
chore: start 0.6.9 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.8"
+version = "0.6.9.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.8"
+version = "0.6.9.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- advance the package version from the public 0.6.8 release to `0.6.9.dev0`
- keep `uv.lock` aligned

This restores the development-version invariant after tag `v0.6.8`. The required GitHub ID and email upload work will follow on top of this development baseline.