### PR TITLE
feat(traj): require contributor metadata on uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- **Trajectory uploads require contributor provenance.** The single
+  `bench traj upload` command now requires `--github-id` and `--email`; both
+  values are validated locally and server-side and stored in `manifest.json`
+  under the structured `contributor` field. Existing 0.6.8 manifests remain
+  readable by the validator during the client transition.
+
 ## 0.6.8 — 2026-08-15
 
 ### Added

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -863,13 +863,17 @@ writes a content-addressed manifest last, and treats an already-ingested digest
 as a successful no-op.
 
 ```bash
-bench traj upload path/to/trial
-bench traj upload path/to/trajectory.jsonl --source-id my-project/run-42
-bench traj upload path/to/trial --dry-run
+bench traj upload path/to/trial --github-id octocat --email octocat@example.com
+bench traj upload path/to/trajectory.jsonl --github-id octocat \
+  --email octocat@example.com --source-id my-project/run-42
+bench traj upload path/to/trial --github-id octocat \
+  --email octocat@example.com --dry-run
 ```
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--github-id` | required | Self-asserted GitHub username stored in `manifest.json` |
+| `--email` | required | Contributor email stored in `manifest.json`; not printed by the CLI |
 | `--source-id` | derived from `PATH` | Stable contributor/run label stored in the manifest |
 | `--dry-run` | `false` | Validate, redact, hash, and list staged files without network traffic |
 | `--direct` | `false` | Use local Azure credentials instead of the public broker; requires the `azure` extra |

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -4,7 +4,9 @@ Anyone with BenchFlow installed can contribute a completed trajectory with one
 command:
 
 ```bash
-bench traj upload path/to/trial
+bench traj upload path/to/trial \
+  --github-id YOUR_GITHUB_ID \
+  --email YOU@example.com
 ```
 
 `path/to/trial` may be a trial directory containing `trajectory/`, a directory
@@ -14,6 +16,13 @@ values in both artifacts and manifest metadata, computes a content digest, and
 uploads a manifest last. Use `--dry-run` to inspect the
 staged file list, digest, sizes, ignored siblings, and redaction count without
 making a network request.
+
+`--github-id` and `--email` are required for both public and direct uploads.
+They are self-asserted contributor provenance, not proof of account ownership,
+and are stored in `manifest.json` as
+`{"contributor":{"github_id":"...","email":"..."}}`. The email is not
+printed by the CLI, but dataset operators may retain or publish the manifest;
+use an address you are comfortable associating with the contribution.
 
 The public broker URL is built into the CLI. `BENCHFLOW_TRAJ_BROKER_URL` can
 override it for development or disaster recovery, and
@@ -52,6 +61,8 @@ staging and manifest contract:
 uv tool install 'benchflow[azure]'
 az login
 bench traj upload path/to/trial --direct \
+  --github-id YOUR_GITHUB_ID \
+  --email YOU@example.com \
   --container-url https://ACCOUNT.blob.core.windows.net/bronze
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.8"
+version = "0.6.9.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -75,12 +75,12 @@ class ContributorInfo(BaseModel):
 class UploadRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["1.0.0", "1.1.0"]
+    schema_version: Literal["1.1.0"]
     kind: Literal["bronze.trajectory"]
     source_id: str
     traj_digest: str
     uploaded_by: str | None = Field(default=None, max_length=MAX_UPLOADED_BY_LENGTH)
-    contributor: ContributorInfo | None = None
+    contributor: ContributorInfo
     artifacts: list[Artifact] = Field(min_length=1, max_length=MAX_ARTIFACTS)
 
     @field_validator("source_id")
@@ -98,8 +98,6 @@ class UploadRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_capture(self) -> Self:
-        if self.schema_version == "1.1.0" and self.contributor is None:
-            raise ValueError("schema 1.1.0 requires contributor metadata")
         names = [artifact.name for artifact in self.artifacts]
         if len(names) != len(set(names)):
             raise ValueError("artifact names must be unique")
@@ -145,10 +143,18 @@ class RedactionInfo(BaseModel):
 class ContributionManifest(UploadRequest):
     model_config = ConfigDict(extra="forbid")
 
+    schema_version: Literal["1.0.0", "1.1.0"]
+    contributor: ContributorInfo | None = None
     created_at: datetime
     tool: ToolInfo
     run: RunInfo
     redaction: RedactionInfo
+
+    @model_validator(mode="after")
+    def validate_manifest_version(self) -> Self:
+        if self.schema_version == "1.1.0" and self.contributor is None:
+            raise ValueError("schema 1.1.0 requires contributor metadata")
+        return self
 
 
 @dataclass(frozen=True)

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -16,9 +16,13 @@ from benchflow.publish.traj_capture import (
 from benchflow.publish.traj_capture import (
     MAX_ARTIFACTS,
     MAX_CAPTURE_BYTES,
+    MAX_EMAIL_LENGTH,
     MAX_FILE_BYTES,
+    MAX_GITHUB_ID_LENGTH,
     MAX_UPLOADED_BY_LENGTH,
     validate_artifact_name,
+    validate_email,
+    validate_github_id,
     validate_source_id,
 )
 from benchflow.publish.traj_capture import (
@@ -51,14 +55,32 @@ class Artifact(BaseModel):
         return value
 
 
+class ContributorInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    github_id: str = Field(min_length=1, max_length=MAX_GITHUB_ID_LENGTH)
+    email: str = Field(min_length=3, max_length=MAX_EMAIL_LENGTH)
+
+    @field_validator("github_id")
+    @classmethod
+    def validate_github(cls, value: str) -> str:
+        return validate_github_id(value)
+
+    @field_validator("email")
+    @classmethod
+    def validate_contributor_email(cls, value: str) -> str:
+        return validate_email(value)
+
+
 class UploadRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: Literal["1.0.0"]
+    schema_version: Literal["1.0.0", "1.1.0"]
     kind: Literal["bronze.trajectory"]
     source_id: str
     traj_digest: str
     uploaded_by: str | None = Field(default=None, max_length=MAX_UPLOADED_BY_LENGTH)
+    contributor: ContributorInfo | None = None
     artifacts: list[Artifact] = Field(min_length=1, max_length=MAX_ARTIFACTS)
 
     @field_validator("source_id")
@@ -76,6 +98,8 @@ class UploadRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_capture(self) -> Self:
+        if self.schema_version == "1.1.0" and self.contributor is None:
+            raise ValueError("schema 1.1.0 requires contributor metadata")
         names = [artifact.name for artifact in self.artifacts]
         if len(names) != len(set(names)):
             raise ValueError("artifact names must be unique")

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -29,6 +29,14 @@ def register_traj(app: typer.Typer) -> None:
             Path,
             typer.Argument(help="Trajectory JSONL file, directory, or trial directory"),
         ],
+        github_id: Annotated[
+            str,
+            typer.Option("--github-id", help="Contributor GitHub username"),
+        ],
+        email: Annotated[
+            str,
+            typer.Option("--email", help="Contributor email stored in the manifest"),
+        ],
         source_id: Annotated[
             str | None,
             typer.Option("--source-id", help="Stable contributor source identifier"),
@@ -84,6 +92,8 @@ def register_traj(app: typer.Typer) -> None:
                 path,
                 source_id=selected_source_id,
                 uploaded_by=os.environ.get("BENCHFLOW_TRAJ_UPLOADED_BY"),
+                github_id=github_id,
+                email=email,
             ) as staged:
                 if dry_run:
                     _print_dry_run(staged, destination=destination, direct=direct)

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -42,6 +42,8 @@ def upload_capture_via_broker(
         "uploaded_by": staged.manifest["uploaded_by"],
         "artifacts": artifacts,
     }
+    if contributor := staged.manifest.get("contributor"):
+        request_body["contributor"] = contributor
     manager = nullcontext(http_client) if http_client is not None else httpx.Client()
     try:
         with _quiet_httpx_request_logging(), manager as client:

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -23,11 +23,18 @@ MAX_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
 MAX_MANIFEST_BYTES = 1024**2
 MAX_RUN_METADATA_BYTES = 1024**2
 MAX_UPLOADED_BY_LENGTH = 256
+MAX_GITHUB_ID_LENGTH = 39
+MAX_EMAIL_LENGTH = 254
 MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
 SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
 ARTIFACT_NAME_PATTERN = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
+GITHUB_ID_PATTERN = re.compile(
+    rf"^[A-Za-z0-9](?:[A-Za-z0-9-]{{0,{MAX_GITHUB_ID_LENGTH - 2}}}[A-Za-z0-9])?$"
+)
+EMAIL_LOCAL_PATTERN = re.compile(r"^[A-Za-z0-9.!#$%&'*+/=?^_`{|}~-]+$")
+EMAIL_DOMAIN_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$")
 
 
 def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
@@ -102,6 +109,42 @@ def validate_source_id(source_id: str) -> str:
     return normalized
 
 
+def validate_github_id(github_id: str) -> str:
+    """Validate a self-asserted GitHub username stored as contributor provenance."""
+    normalized = github_id.strip()
+    if not GITHUB_ID_PATTERN.fullmatch(normalized) or "--" in normalized:
+        raise ValueError(
+            "invalid GitHub ID; use the 1-39 character username without '@'"
+        )
+    return normalized
+
+
+def validate_email(email: str) -> str:
+    """Validate a bounded ASCII contributor email address."""
+    normalized = email.strip()
+    if len(normalized) > MAX_EMAIL_LENGTH or normalized.count("@") != 1:
+        raise ValueError("invalid contributor email address")
+    local, domain = normalized.rsplit("@", 1)
+    labels = domain.split(".")
+    if (
+        not local
+        or len(local) > 64
+        or local.startswith(".")
+        or local.endswith(".")
+        or ".." in local
+        or not EMAIL_LOCAL_PATTERN.fullmatch(local)
+        or len(labels) < 2
+        or any(
+            not label
+            or len(label) > 63
+            or not EMAIL_DOMAIN_LABEL_PATTERN.fullmatch(label)
+            for label in labels
+        )
+    ):
+        raise ValueError("invalid contributor email address")
+    return normalized
+
+
 def validate_artifact_name(name: str) -> str:
     """Require the canonical public trajectory object namespace."""
     if not ARTIFACT_NAME_PATTERN.fullmatch(name):
@@ -119,6 +162,8 @@ def stage_trajectory_capture(
     source_id: str,
     redact: bool = True,
     uploaded_by: str | None = None,
+    github_id: str | None = None,
+    email: str | None = None,
 ) -> Iterator[StagedCapture]:
     """Validate and stage a trajectory capture without mutating its source."""
     source_id = validate_source_id(source_id)
@@ -126,6 +171,14 @@ def stage_trajectory_capture(
         raise ValueError(
             f"trajectory contributor label exceeds {MAX_UPLOADED_BY_LENGTH} characters"
         )
+    contributor: dict[str, str] | None = None
+    if github_id is not None or email is not None:
+        if github_id is None or email is None:
+            raise ValueError("GitHub ID and email must be provided together")
+        contributor = {
+            "github_id": validate_github_id(github_id),
+            "email": validate_email(email),
+        }
     resolved = _resolve_input(path)
     if len(resolved.files) > MAX_ARTIFACTS:
         raise ValueError(
@@ -176,6 +229,7 @@ def stage_trajectory_capture(
             payloads=payloads,
             metadata_dir=resolved.metadata_dir,
             uploaded_by=uploaded_by,
+            contributor=contributor,
             redact=redact,
             replacement_count=replacement_count,
         )
@@ -183,6 +237,8 @@ def stage_trajectory_capture(
             redacted_manifest, manifest_replacements = redact_value(manifest)
             if redacted_manifest["source_id"] != manifest["source_id"]:
                 raise ValueError("source id contains a secret-like value")
+            if redacted_manifest.get("contributor") != manifest.get("contributor"):
+                raise ValueError("contributor metadata resembles a secret-like value")
             replacement_count += manifest_replacements
             redacted_manifest["redaction"]["replacements"] = replacement_count
             manifest = redacted_manifest
@@ -384,11 +440,12 @@ def _build_manifest(
     payloads: list[StagedFile],
     metadata_dir: Path | None,
     uploaded_by: str | None,
+    contributor: dict[str, str] | None,
     redact: bool,
     replacement_count: int,
 ) -> dict[str, Any]:
-    return {
-        "schema_version": "1.0.0",
+    manifest = {
+        "schema_version": "1.1.0" if contributor is not None else "1.0.0",
         "kind": "bronze.trajectory",
         "created_at": datetime.now(UTC)
         .replace(microsecond=0)
@@ -405,6 +462,9 @@ def _build_manifest(
         ],
         "redaction": {"applied": redact, "replacements": replacement_count},
     }
+    if contributor is not None:
+        manifest["contributor"] = contributor
+    return manifest
 
 
 def _load_run_metadata(metadata_dir: Path | None) -> dict[str, Any]:

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -271,6 +271,53 @@ def test_staging_enforces_contributor_label_bound(tmp_path: Path) -> None:
         ).__enter__()
 
 
+def test_manifest_contains_validated_contributor_provenance(tmp_path: Path) -> None:
+    """CLI contributor parameters survive in the manifest uploaded last."""
+    trial = _trial(tmp_path)
+    contributor = {
+        "github_id": "benchflow-ai",
+        "email": "contributor+demo@benchflow.ai",
+    }
+
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id=contributor["github_id"],
+        email=contributor["email"],
+    ) as staged:
+        assert staged.manifest["schema_version"] == "1.1.0"
+        assert staged.manifest["contributor"] == contributor
+        persisted = json.loads(staged.files[-1].local_path.read_text(encoding="utf-8"))
+        assert persisted["contributor"] == contributor
+
+
+@pytest.mark.parametrize(
+    ("github_id", "email", "message"),
+    [
+        ("@benchflow-ai", "user@benchflow.ai", "GitHub ID"),
+        ("benchflow--ai", "user@benchflow.ai", "GitHub ID"),
+        ("benchflow-ai", "not-an-email", "email"),
+        ("benchflow-ai", "user@localhost", "email"),
+        (None, "user@benchflow.ai", "provided together"),
+        ("benchflow-ai", None, "provided together"),
+    ],
+)
+def test_staging_rejects_invalid_or_partial_contributor_provenance(
+    tmp_path: Path,
+    github_id: str | None,
+    email: str | None,
+    message: str,
+) -> None:
+    """Malformed contributor metadata never reaches a transport."""
+    with pytest.raises(ValueError, match=message):
+        stage_trajectory_capture(
+            _trial(tmp_path),
+            source_id="demo",
+            github_id=github_id,
+            email=email,
+        ).__enter__()
+
+
 @pytest.mark.parametrize(
     "filename", ["capture with space.jsonl", "capture.JSONL", "x" * 129 + ".jsonl"]
 )

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -16,6 +16,8 @@ from benchflow.publish.broker import upload_capture_via_broker
 from benchflow.publish.traj_capture import stage_trajectory_capture
 
 runner = CliRunner()
+GITHUB_ID = "benchflow-user"
+EMAIL = "user@example.com"
 
 
 def _trial(tmp_path: Path) -> Path:
@@ -26,6 +28,19 @@ def _trial(tmp_path: Path) -> Path:
         '{"type":"message","text":"demo"}\n', encoding="utf-8"
     )
     return trial
+
+
+def _upload_command(path: Path, *args: str) -> list[str]:
+    return [
+        "traj",
+        "upload",
+        str(path),
+        "--github-id",
+        GITHUB_ID,
+        "--email",
+        EMAIL,
+        *args,
+    ]
 
 
 def test_stock_cli_has_the_verified_public_broker() -> None:
@@ -72,12 +87,13 @@ def test_dry_run_stages_without_constructing_a_transport(
         raise AssertionError("network client constructed during --dry-run")
 
     monkeypatch.setattr(httpx, "Client", fail_client)
-    result = runner.invoke(app, ["traj", "upload", str(trial), "--dry-run"])
+    result = runner.invoke(app, _upload_command(trial, "--dry-run"))
 
     assert result.exit_code == 0, result.output
     assert "sha256:" in result.output
     assert "trajectory/acp_trajectory.jsonl" in result.output
     assert "manifest.json" in result.output
+    assert EMAIL not in result.output
 
 
 def test_direct_mode_reports_azure_destination(
@@ -87,6 +103,10 @@ def test_direct_mode_reports_azure_destination(
     trial = _trial(tmp_path)
 
     def fake_upload(staged, *, container_url):
+        assert staged.manifest["contributor"] == {
+            "github_id": GITHUB_ID,
+            "email": EMAIL,
+        }
         return SimpleNamespace(
             url=f"{container_url}/sources/demo/{staged.traj_digest}/",
             uploaded=("payload", "manifest"),
@@ -98,14 +118,12 @@ def test_direct_mode_reports_azure_destination(
     )
     result = runner.invoke(
         app,
-        [
-            "traj",
-            "upload",
-            str(trial),
+        _upload_command(
+            trial,
             "--direct",
             "--container-url",
             "https://tasksminerdata.blob.core.windows.net/bronze",
-        ],
+        ),
     )
 
     assert result.exit_code == 0, result.output
@@ -130,9 +148,20 @@ def test_broker_mode_uses_exact_manifest_and_server_order(
                 "source_id",
                 "traj_digest",
                 "uploaded_by",
+                "contributor",
                 "artifacts",
             }
+            assert body["contributor"] == {
+                "github_id": GITHUB_ID,
+                "email": EMAIL,
+            }
+            assert body["schema_version"] == "1.1.0"
             return httpx.Response(200, json=_broker_payload(request))
+        if request.url.path.endswith("manifest.json"):
+            assert json.loads(request.content)["contributor"] == {
+                "github_id": GITHUB_ID,
+                "email": EMAIL,
+            }
         assert request.headers["x-ms-blob-type"] == "BlockBlob"
         assert request.headers["if-none-match"] == "*"
         return httpx.Response(201)
@@ -140,7 +169,7 @@ def test_broker_mode_uses_exact_manifest_and_server_order(
     client = httpx.Client(transport=httpx.MockTransport(handler))
     monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: client)
     monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
-    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    result = runner.invoke(app, _upload_command(trial))
 
     assert result.exit_code == 0, result.output
     assert [request.method for request in requests] == ["POST", "PUT", "PUT"]
@@ -198,12 +227,12 @@ def test_broker_conflict_is_success_and_rate_limit_is_actionable(
         )
     )
     monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: conflict)
-    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    result = runner.invoke(app, _upload_command(trial))
     assert result.exit_code == 0, result.output
     assert "Already uploaded" in result.output
 
     monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: limited)
-    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    result = runner.invoke(app, _upload_command(trial))
     assert result.exit_code == 1
     assert "retry after 60" in result.output
 
@@ -215,7 +244,7 @@ def test_missing_broker_names_both_available_modes(
     trial = _trial(tmp_path)
     monkeypatch.delenv("BENCHFLOW_TRAJ_BROKER_URL", raising=False)
     monkeypatch.setattr("benchflow.cli.traj.DEFAULT_TRAJ_BROKER_URL", None)
-    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    result = runner.invoke(app, _upload_command(trial))
 
     assert result.exit_code == 1
     assert "BENCHFLOW_TRAJ_BROKER_URL" in result.output
@@ -231,7 +260,7 @@ def test_validation_failure_names_the_bad_file(
     path = trial / "trajectory" / "acp_trajectory.jsonl"
     path.write_text("{bad\n", encoding="utf-8")
     monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
-    result = runner.invoke(app, ["traj", "upload", str(trial)])
+    result = runner.invoke(app, _upload_command(trial))
 
     assert result.exit_code == 1
     assert "acp_trajectory.jsonl" in result.output.replace("\n", "")
@@ -299,3 +328,44 @@ def test_help_exposes_only_the_planned_upload_command() -> None:
     result = runner.invoke(app, ["traj", "--help"])
     assert result.exit_code == 0
     assert "upload" in result.output
+
+    upload_help = runner.invoke(app, ["traj", "upload", "--help"])
+    assert upload_help.exit_code == 0
+    assert "--github-id" in upload_help.output
+    assert "--email" in upload_help.output
+
+
+def test_upload_requires_github_id_and_email_parameters(tmp_path: Path) -> None:
+    """Every CLI upload names its contributor in the generated manifest."""
+    trial = _trial(tmp_path)
+    result = runner.invoke(app, ["traj", "upload", str(trial)])
+
+    assert result.exit_code == 2
+    assert "--github-id" in result.output
+
+    result = runner.invoke(
+        app,
+        ["traj", "upload", str(trial), "--github-id", GITHUB_ID],
+    )
+    assert result.exit_code == 2
+    assert "--email" in result.output
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (("--github-id", "@not-a-github-id", "--email", EMAIL), "GitHub ID"),
+        (("--github-id", GITHUB_ID, "--email", "not-an-email"), "email"),
+    ],
+)
+def test_upload_validates_contributor_parameters_locally(
+    tmp_path: Path, args: tuple[str, ...], message: str
+) -> None:
+    """Malformed contributor provenance fails before the upload handshake."""
+    result = runner.invoke(
+        app,
+        ["traj", "upload", str(_trial(tmp_path)), *args, "--dry-run"],
+    )
+
+    assert result.exit_code == 1
+    assert message in result.output

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -161,7 +161,12 @@ def test_upload_contract_recomputes_digest_and_rejects_object_injection(
 ) -> None:
     """The broker accepts only content-addressed trajectory JSONL object names."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         body = _request_from_manifest(staged.manifest)
         request = UploadRequest.model_validate(body)
         assert request.traj_digest == staged.manifest["traj_digest"]
@@ -170,7 +175,12 @@ def test_upload_contract_recomputes_digest_and_rejects_object_injection(
         with pytest.raises(ValidationError, match="outside trajectory"):
             UploadRequest.model_validate(body)
 
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         body = _request_from_manifest(staged.manifest)
         body["traj_digest"] = "sha256:" + "0" * 64
         with pytest.raises(ValidationError, match="does not match"):
@@ -207,8 +217,35 @@ def test_contributor_contract_is_validated_at_broker_and_manifest_boundaries(
 
     missing = _request_from_manifest(staged.manifest)
     missing.pop("contributor")
-    with pytest.raises(ValidationError, match="requires contributor"):
+    with pytest.raises(ValidationError, match="Field required"):
         UploadRequest.model_validate(missing)
+
+    legacy_request = dict(missing)
+    legacy_request["schema_version"] = "1.0.0"
+    with pytest.raises(ValidationError, match="literal_error"):
+        UploadRequest.model_validate(legacy_request)
+
+    with stage_trajectory_capture(trial, source_id="legacy") as legacy:
+        legacy_manifest = validate_manifest_bytes(
+            legacy.files[-1].local_path.read_bytes()
+        )
+    assert legacy_manifest.schema_version == "1.0.0"
+    assert legacy_manifest.contributor is None
+
+
+def test_broker_rejects_new_legacy_uploads_without_contributor(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #992 against granting contributor-free schema 1.0 uploads."""
+    with stage_trajectory_capture(_trial(tmp_path), source_id="legacy") as staged:
+        body = _request_from_manifest(staged.manifest)
+
+    response = TestClient(create_app(FakeBroker(AssertionError()))).post(
+        "/v1/uploads", json=body
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"][0]["type"] == "literal_error"
 
 
 def test_broker_http_surface_returns_scoped_grants_and_protocol_statuses(
@@ -216,7 +253,12 @@ def test_broker_http_surface_returns_scoped_grants_and_protocol_statuses(
 ) -> None:
     """The public endpoint emits v1 grants, conflict, and Retry-After responses."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         body = _request_from_manifest(staged.manifest)
         grant = UploadGrant(
             upload_id="u_demo",
@@ -277,7 +319,12 @@ def test_broker_validation_errors_are_fail_closed_and_json_safe(
 ) -> None:
     """Guards the live Azure fix after malformed handshakes returned HTTP 500."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         body = _request_from_manifest(staged.manifest)
 
     injected = json.loads(json.dumps(body))
@@ -587,7 +634,12 @@ def test_broker_regrant_does_not_downgrade_ledger_state(
 ) -> None:
     """Guards PR #989 against a retry clearing an active validation lease."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
         digest = staged.traj_digest
     table = FakeTable(
@@ -626,7 +678,12 @@ def test_broker_persists_declared_artifact_sizes(
 ) -> None:
     """Guards PR #989 against artifact-only uploads exceeding their declaration."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
         expected = {item.name: item.bytes for item in request.artifacts}
     table = FakeTable()
@@ -656,7 +713,12 @@ def test_broker_reopens_rejected_digest_in_isolated_attempt(
 ) -> None:
     """Guards PR #989 against a rejected attempt poisoning a valid digest."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
         digest = staged.traj_digest
     old_attempt = "u_" + "0" * 32
@@ -697,7 +759,12 @@ def test_terminal_digest_handshakes_consume_rate_limit(
 ) -> None:
     """Guards PR #989 against terminal ledger lookups bypassing broker quotas."""
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
         digest = staged.traj_digest
     table = FakeTable(

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -53,7 +53,7 @@ def _trial(tmp_path: Path, text: str = "safe") -> Path:
 
 
 def _request_from_manifest(manifest: dict) -> dict:
-    return {
+    request = {
         key: manifest[key]
         for key in (
             "schema_version",
@@ -64,6 +64,9 @@ def _request_from_manifest(manifest: dict) -> dict:
             "artifacts",
         )
     }
+    if "contributor" in manifest:
+        request["contributor"] = manifest["contributor"]
+    return request
 
 
 class FakeBroker:
@@ -172,6 +175,40 @@ def test_upload_contract_recomputes_digest_and_rejects_object_injection(
         body["traj_digest"] = "sha256:" + "0" * 64
         with pytest.raises(ValidationError, match="does not match"):
             UploadRequest.model_validate(body)
+
+
+def test_contributor_contract_is_validated_at_broker_and_manifest_boundaries(
+    tmp_path: Path,
+) -> None:
+    """Self-asserted GitHub and email provenance remains typed server-side."""
+    trial = _trial(tmp_path)
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
+        request = UploadRequest.model_validate(_request_from_manifest(staged.manifest))
+        manifest = validate_manifest_bytes(staged.files[-1].local_path.read_bytes())
+
+    assert request.contributor is not None
+    assert request.schema_version == "1.1.0"
+    assert request.contributor.github_id == "benchflow-ai"
+    assert request.contributor.email == "contributor@benchflow.ai"
+    assert manifest.contributor == request.contributor
+
+    invalid = _request_from_manifest(staged.manifest)
+    invalid["contributor"] = {
+        "github_id": "@invalid",
+        "email": "not-an-email",
+    }
+    with pytest.raises(ValidationError):
+        UploadRequest.model_validate(invalid)
+
+    missing = _request_from_manifest(staged.manifest)
+    missing.pop("contributor")
+    with pytest.raises(ValidationError, match="requires contributor"):
+        UploadRequest.model_validate(missing)
 
 
 def test_broker_http_surface_returns_scoped_grants_and_protocol_statuses(
@@ -683,7 +720,12 @@ def test_terminal_digest_handshakes_consume_rate_limit(
 
 def _quarantine_capture(tmp_path: Path) -> tuple[str, dict[str, bytes]]:
     trial = _trial(tmp_path)
-    with stage_trajectory_capture(trial, source_id="demo") as staged:
+    with stage_trajectory_capture(
+        trial,
+        source_id="demo",
+        github_id="benchflow-ai",
+        email="contributor@benchflow.ai",
+    ) as staged:
         digest = staged.traj_digest
         prefix = f"inbox/{digest}/"
         blobs = {
@@ -714,6 +756,13 @@ def test_queue_validator_promotes_manifest_last_and_cleans_quarantine(
 
     assert validator.run_once() is True
     assert container.uploaded[-1] == f"sources/community/{digest}/manifest.json"
+    promoted_manifest = json.loads(
+        container.blobs[f"sources/community/{digest}/manifest.json"]
+    )
+    assert promoted_manifest["contributor"] == {
+        "github_id": "benchflow-ai",
+        "email": "contributor@benchflow.ai",
+    }
     assert not any(name.startswith(f"inbox/{digest}/") for name in container.blobs)
     assert table.entities[-1]["status"] == "ingested"
     assert queue.deleted == [("m1", "p1")]

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.8"
+version = "0.6.9.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- require `--github-id` and `--email` on the single `bench traj upload` command
- validate both fields locally and server-side and preserve them in `manifest.json` under `contributor`
- roll the manifest contract to 1.1 while retaining validation support for existing 1.0 uploads

## Validation
- `uv run ruff format --check .`
- `uv run ruff check .`
- `uv run ty check src services`
- `uv lock --check`
- `uv run python -m pytest tests/` (5511 passed, 65 skipped, 7 deselected)

## Rollout
The Azure broker and validator must be deployed from the merged main commit before publishing the CLI release. A clean public-install upload will then verify the exact contributor fields in the promoted manifest.