### PR TITLE
release: 0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.6.9 — 2026-08-15
+
 ### Changed
 - **Trajectory uploads require contributor provenance.** The single
   `bench traj upload` command now requires `--github-id` and `--email`; both

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
 repository-code: "https://github.com/benchflow-ai/benchflow"
 url: "https://github.com/benchflow-ai/benchflow"
 license: Apache-2.0
-version: 0.6.8
+version: 0.6.9
 date-released: 2026-08-15
 keywords:
   - benchmark

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.9.dev0"
+version = "0.6.9"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.9.dev0"
+version = "0.6.9"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release 0.6.9

Publishes required trajectory contributor provenance after the compatible Azure broker/validator deployment.

## Metadata-only changes
- `pyproject.toml`: `0.6.9.dev0` → `0.6.9`
- `uv.lock`: root package version only
- `CHANGELOG.md`: 0.6.9 release heading
- `CITATION.cff`: 0.6.9

## Pre-release evidence
- exact main `c52d0505` unit, audit, parity, rollout-smoke, fixture, and release-gate workflows: green
- Azure broker and validator: image `trajectory-upload:c52d0505b893` (`sha256:e08ff294…`)
- candidate wheel uploaded through the built-in public endpoint and was ingested
- promoted schema 1.1 manifest contains exact GitHub ID and email; quarantine is empty
- anonymous read/list/create/delete probes denied
- release checks: 109 passed
- wheel and sdist: `twine check` passed