### PR TITLE
chore: start 0.6.10 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.9"
+version = "0.6.10.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.9"
+version = "0.6.10.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- bump the project version to `0.6.10.dev0` after the public 0.6.9 release
- keep the root `uv.lock` package version in sync

## Verification
- `uv lock --check`
- `uv run python -m pytest tests/test_cli_misc.py -q` (7 passed)
- runtime version assertion reports `0.6.10.dev0`

Public release: https://github.com/benchflow-ai/benchflow/releases/tag/v0.6.9
Release workflow: https://github.com/benchflow-ai/benchflow/actions/runs/31901305670