### PR TITLE
docs: add trajectory upload skill and quickstart

### DIFF
--- a/.agents/skills/benchflow-traj-upload/SKILL.md
+++ b/.agents/skills/benchflow-traj-upload/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: benchflow-traj-upload
+description: Upload completed BenchFlow trajectory captures with required contributor metadata. Use whenever a user asks to upload, submit, share, or contribute one or more BenchFlow trajectories.
+user-invocable: true
+allowed-tools:
+  - Bash
+---
+
+# Upload BenchFlow trajectories
+
+Require a local capture path, GitHub ID, and email; ask only for missing values.
+If needed, install the latest stable CLI:
+
+```bash
+uv tool install --python 3.12 --upgrade benchflow
+```
+
+Run once per capture:
+
+```bash
+bench traj upload <PATH> --github-id <GITHUB_ID> --email <EMAIL>
+```
+
+Use the public default: do not add broker URLs, Azure credentials, or extra
+flags. The CLI stores the GitHub ID and email under `contributor` in
+`manifest.json`. Report whether each capture was uploaded or already present.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ subscription auth (`claude auth login` / `codex login`). Provider-prefixed model
 may need provider-specific credentials; Azure Foundry uses `AZURE_API_KEY` +
 `AZURE_API_ENDPOINT`.
 
+## Upload trajectories
+
+Anyone can contribute completed trajectories through the public service; no
+Azure account or API key is required. Run one command per capture:
+
+```bash
+# Install or upgrade the latest stable CLI
+uv tool install --python 3.12 --upgrade benchflow
+
+# Upload each capture
+bench traj upload /path/to/traj-1 --github-id YOUR_GITHUB_ID --email YOU@example.com
+bench traj upload /path/to/traj-2 --github-id YOUR_GITHUB_ID --email YOU@example.com
+bench traj upload /path/to/traj-3 --github-id YOUR_GITHUB_ID --email YOU@example.com
+```
+
+Both contributor fields are required and are stored under `contributor` in the
+uploaded `manifest.json`. A path may be a trial directory, a directory of JSONL
+files, or one JSONL file. See the concise
+[upload skill](./.agents/skills/benchflow-traj-upload/SKILL.md) for agent use and
+[trajectory upload guide](./docs/traj-upload.md) for privacy and security details.
+
 ## Documentation
 
 Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/concepts.md) for the mental model. Prefer to have an AI coding agent run the whole quickstart for you? Paste the [agent quickstart prompt](./docs/agent-quickstart.md) into Claude Code, Codex CLI, or Gemini CLI. Then by goal:


### PR DESCRIPTION
## Summary
- add a concise `benchflow-traj-upload` agent skill
- add a self-contained README quick path for installing BenchFlow and uploading three captures
- document that GitHub ID and email are required and stored in `manifest.json`

## Verification
- `uv run bench skills list --dir .agents/skills`
- `uv run python -m pytest tests/test_skills.py tests/test_skill_eval_integration.py -q` (29 passed)
- public PyPI 0.6.9 CLI dry-run against a real trajectory fixture