### PR TITLE
docs: clarify upload and subscription quickstarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,72 @@ BenchFlow is a universal environment framework: it runs AI agents against task e
 - **Hardened verifier** — defaults block BenchJack/Meerkat-style reward-hacking; tasks opt out per-feature
 - **Training-ready output** — scored rollouts emit a Verifiers/ORS reward record and best-effort ATIF (`trainer/atif.json`) / ADP (`trainer/adp.jsonl`) conversions; ATIF is omitted when the trajectory is empty, and conversion errors are reported in the rollout result
 
-## Quickstart
+## 1. Upload a trajectory
+
+No BenchFlow account, Azure credentials, or API key is required:
 
 ```bash
-# Install or upgrade to the latest stable BenchFlow CLI
+# Install or upgrade BenchFlow
 uv tool install --python 3.12 --upgrade benchflow
 
-# Run a benchmark: any task source, any ACP agent, any sandbox
-export GEMINI_API_KEY=...            # or claude auth login / codex login for subscription auth
-bench eval run \
-    --source-repo benchflow-ai/skillsbench --source-path tasks \
-    --agent gemini --model gemini-3.1-flash-lite-preview \
-    --sandbox docker
+# Upload one capture
+bench traj upload /absolute/path/to/trial \
+  --github-id YOUR_GITHUB_ID \
+  --email YOU@example.com
 ```
 
-Each run writes a per-task `result.json` (rewards, trajectory summary, and token usage), full events under `trajectory/`, and a job `summary.json` (pass-rate, cost, and — for looped runs — a pass@iteration convergence curve). New here? Start with [Getting started](./docs/getting-started.md), or paste the [agent quickstart prompt](./docs/agent-quickstart.md) into Claude Code / Codex / Gemini CLI and let it drive the whole thing.
+The path may be a trial directory, a directory of JSONL files, or one JSONL
+file. Both contributor fields are required and are stored in `manifest.json`.
+See the concise [upload skill](./.agents/skills/benchflow-traj-upload/SKILL.md)
+or the [trajectory upload guide](./docs/traj-upload.md).
+
+## 2. Run with a ChatGPT or Claude subscription
+
+No OpenAI or Anthropic API key is required. Start Docker, install BenchFlow,
+then run **one** of these options. BenchFlow detects the saved host login and
+makes it available to the agent inside the sandbox.
+
+```bash
+uv tool install --python 3.12 --upgrade benchflow
+docker info >/dev/null  # Docker must be running
+```
+
+### ChatGPT subscription via Codex
+
+Install the [Codex CLI](https://github.com/openai/codex), then:
+
+```bash
+codex login
+unset OPENAI_API_KEY CODEX_API_KEY  # ensure subscription auth is used
+
+bench eval run \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks/citation-check \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker
+```
+
+### Claude subscription via Claude Code
+
+Install [Claude Code](https://code.claude.com/docs/en/quickstart), then:
+
+```bash
+claude auth login
+unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN  # ensure subscription auth is used
+
+bench eval run \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks/citation-check \
+  --agent claude \
+  --model claude-sonnet-4-6 \
+  --sandbox docker
+```
+
+The agent may pass or fail the benchmark task; either result means the
+evaluation completed. Each run writes rewards, token usage, and the full
+trajectory under `jobs/`. See [Getting started](./docs/getting-started.md) for
+other agents, models, and sandboxes.
 
 ## Install
 
@@ -63,27 +114,6 @@ export an agent API key (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, …) or use
 subscription auth (`claude auth login` / `codex login`). Provider-prefixed models
 may need provider-specific credentials; Azure Foundry uses `AZURE_API_KEY` +
 `AZURE_API_ENDPOINT`.
-
-## Upload trajectories
-
-Anyone can contribute completed trajectories through the public service; no
-Azure account or API key is required. Run one command per capture:
-
-```bash
-# Install or upgrade the latest stable CLI
-uv tool install --python 3.12 --upgrade benchflow
-
-# Upload each capture
-bench traj upload /path/to/traj-1 --github-id YOUR_GITHUB_ID --email YOU@example.com
-bench traj upload /path/to/traj-2 --github-id YOUR_GITHUB_ID --email YOU@example.com
-bench traj upload /path/to/traj-3 --github-id YOUR_GITHUB_ID --email YOU@example.com
-```
-
-Both contributor fields are required and are stored under `contributor` in the
-uploaded `manifest.json`. A path may be a trial directory, a directory of JSONL
-files, or one JSONL file. See the concise
-[upload skill](./.agents/skills/benchflow-traj-upload/SKILL.md) for agent use and
-[trajectory upload guide](./docs/traj-upload.md) for privacy and security details.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- put trajectory upload immediately after the README What section with one copy-pasteable public command
- add separate ChatGPT/Codex and Claude Code subscription quickstarts with explicit host login and Docker eval commands
- remove the later duplicate upload section so new users have one authoritative path

## Verification

- `uv run pytest tests/test_cli_docs_drift.py tests/test_subscription_auth.py tests/test_traj_upload_cli.py -q` (56 passed)
- verified `tasks/citation-check` exists in `benchflow-ai/skillsbench`
- verified the current CLI exposes every documented option
- verified `codex login` and `claude auth login` against the installed native CLIs and official authentication docs
- `git diff --check`
