### PR TITLE
Refresh BenchFlow docs with a local-first quickstart

### DIFF
--- a/.agents/skills/benchflow/SKILL.md
+++ b/.agents/skills/benchflow/SKILL.md
@@ -35,7 +35,7 @@ bench eval run \
   --tasks-dir <task-path> \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
-  --sandbox daytona
+  --sandbox docker
 ```
 
 Or via Python SDK:
@@ -49,7 +49,7 @@ async def main():
     config = RolloutConfig(
         task_path=resolve_source("benchflow-ai/skillsbench", path="tasks/edit-pdf"),
         scenes=[Scene.single(agent="gemini", model="gemini-3.1-flash-lite-preview")],
-        environment="daytona",
+        environment="docker",
     )
     result = await bf.run(config)
     print(f"Reward: {result.rewards}, Tools: {result.n_tool_calls}")
@@ -70,8 +70,8 @@ bench eval run \
   --source-path tasks \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
-  --sandbox daytona \
-  --concurrency 64
+  --sandbox docker \
+  --concurrency 2
 ```
 
 Or via YAML config:
@@ -86,8 +86,8 @@ source:
   path: tasks
 agent: gemini
 model: gemini-3.1-flash-lite-preview
-environment: daytona
-concurrency: 64
+environment: docker
+concurrency: 2
 max_retries: 1
 ```
 
@@ -167,7 +167,7 @@ bench agent list
 
 Any agent can be prefixed with `acpx/` to run via ACPX (https://acpx.sh/):
 ```bash
-bench eval run --tasks-dir tasks/edit-pdf --agent acpx/gemini --model gemini-3.1-flash-lite-preview --sandbox daytona
+bench eval run --tasks-dir tasks/edit-pdf --agent acpx/gemini --model gemini-3.1-flash-lite-preview --sandbox docker
 ```
 
 ACPX is a headless ACP client with persistent sessions and crash recovery.
@@ -201,18 +201,18 @@ asyncio.run(main())
 uv tool install --python 3.12 --upgrade benchflow
 # (or from source: uv sync --extra dev --locked)
 export GEMINI_API_KEY=...     # or ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.
-export DAYTONA_API_KEY=...    # for cloud sandboxes
 ```
 
 ## Sandboxes
 
 | Sandbox | Flag | Best for |
 |---------|------|----------|
-| `docker` | `--sandbox docker` | Local dev, small runs (<=10 tasks) |
+| `docker` | `--sandbox docker` | Local development and small runs; the default |
 | `daytona` | `--sandbox daytona` | Cloud runs with concurrency (needs DAYTONA_API_KEY) |
 | `modal` | `--sandbox modal` | Serverless, high concurrency (needs Modal auth) |
 
-Use `daytona` for benchmarks. Docker is limited by network exhaustion.
+Start with Docker. Use Daytona or Modal only when the run needs remote
+isolation or more parallel machines than the local host can provide.
 
 ## Skills in tasks
 
@@ -228,7 +228,7 @@ COPY skills /root/.claude/skills
 bench eval run \
   --tasks-dir task-dir \
   --agent claude-agent-acp \
-  --sandbox daytona \
+  --sandbox docker \
   --skills-dir skills/ \
   --skill-mode with-skill
 ```

--- a/README.md
+++ b/README.md
@@ -13,26 +13,7 @@
 
 BenchFlow is a universal environment framework: it runs AI agents against task environments and scores them through one hardened contract. **A benchmark is just a frozen environment** — point BenchFlow at any of them, drive it with *any* ACP agent, and run single-agent, multi-agent, or multi-round patterns over the same Scene-based lifecycle.
 
-## Qucik start: 1. Upload a trajectory
-
-For local Claude Code or Codex jsonl formatted trajectory files that you are proud of (contain challenging tasks you dealed with via chatting to agents), you can upload that file to BenchFlow to join the competition for winning $2,000 cash reward. No BenchFlow account, credentials, or API key is required:
-
-```bash
-# Install or upgrade BenchFlow
-uv tool install --python 3.12 --upgrade benchflow
-
-# Upload one capture
-bench traj upload /absolute/path/to/trial \
-  --github-id YOUR_GITHUB_ID \
-  --email YOU@example.com
-```
-
-The path may be a trial directory, a directory of JSONL files, or one JSONL
-file. Both contributor fields are required and are stored in `manifest.json`.
-See the concise [upload skill](./.agents/skills/benchflow-traj-upload/SKILL.md)
-or the [trajectory upload guide](./docs/traj-upload.md).
-
-## Qucik start: 2. Run with a ChatGPT or Claude subscription
+## Quick start: run locally with a subscription
 
 No OpenAI or Anthropic API key is required. Start Docker, install BenchFlow,
 then run **one** of these options. BenchFlow detects the saved host login and
@@ -53,7 +34,7 @@ unset OPENAI_API_KEY CODEX_API_KEY  # ensure subscription auth is used
 
 bench eval run \
   --source-repo benchflow-ai/skillsbench \
-  --source-path tasks/citation-check \
+  --source-path tasks/3d-scan-calc \
   --agent codex \
   --model gpt-5.5 \
   --sandbox docker
@@ -69,7 +50,7 @@ unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN  # ensure subscription auth is used
 
 bench eval run \
   --source-repo benchflow-ai/skillsbench \
-  --source-path tasks/citation-check \
+  --source-path tasks/3d-scan-calc \
   --agent claude \
   --model claude-sonnet-4-6 \
   --sandbox docker
@@ -78,7 +59,9 @@ bench eval run \
 The agent may pass or fail the benchmark task; either result means the
 evaluation completed. Each run writes rewards, token usage, and the full
 trajectory under `jobs/`. See [Getting started](./docs/getting-started.md) for
-other agents, models, and sandboxes.
+the complete local path, or [Start in 5 minutes](./docs/start-in-5-minutes.md)
+for the shortest tested walkthrough. Daytona and other cloud sandboxes are
+optional.
 
 ## Install
 
@@ -99,19 +82,26 @@ Internal users wanting the newest preview from `main` install the [internal prev
 
 **Requirements & auth.** Install [uv](https://docs.astral.sh/uv/); the
 `--python 3.12` flag lets it provision a compatible interpreter for the tool
-install. Set `DAYTONA_API_KEY` for Daytona or configure Modal auth for Modal;
-export an agent API key (`GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, …) or use
-subscription auth (`claude auth login` / `codex login`). Provider-prefixed models
-may need provider-specific credentials; Azure Foundry uses `AZURE_API_KEY` +
-`AZURE_API_ENDPOINT`.
+install. Local runs need Docker plus either subscription auth
+(`claude auth login` / `codex login`) or an agent API key. Configure Daytona,
+Modal, or AgentCore only when you intentionally select that remote backend.
 
 ## Documentation
 
-Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/concepts.md) for the mental model. Prefer to have an AI coding agent run the whole quickstart for you? Paste the [agent quickstart prompt](./docs/agent-quickstart.md) into Claude Code, Codex CLI, or Gemini CLI. Then by goal:
+Read the published documentation at
+[www.benchflow.ai/docs/benchflow](https://www.benchflow.ai/docs/benchflow).
+Its BenchFlow pages are generated from the Markdown in [`docs/`](./docs/), so
+fixes stay versioned with the runtime. Start with
+[Start in 5 minutes](./docs/start-in-5-minutes.md), then
+[Concepts](./docs/concepts.md) for the mental model.
 
 | If you want to… | Read |
 |------------------|------|
+| Run a real local task immediately | [Start in 5 minutes](./docs/start-in-5-minutes.md) |
 | Run an eval on an existing task | [Getting started](./docs/getting-started.md) |
+| Choose an agent login, API key, or provider | [Authentication](./docs/authentication.md) |
+| Run a local batch or compare skill modes | [Running evaluations](./docs/running-evaluations.md) |
+| Choose between local and cloud sandboxes | [Sandboxes](./docs/sandboxes.md) |
 | Understand how BenchFlow runs *any* benchmark (the three-layer model) | [Run any benchmark](./docs/running-any-benchmark.md) |
 | Have an AI agent install + run the quickstart end to end | [Agent quickstart prompt](./docs/agent-quickstart.md) |
 | Run an agent from the public agents repo (goose, qwen-code, prime-agent, …) | [Running external agents](./docs/external-agents.md) |
@@ -121,6 +111,10 @@ Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/
 | Run a hosted PrimeIntellect / Verifiers environment | [CLI reference](./docs/reference/cli.md) |
 | Multi-agent: coder + reviewer, simulated user, BYOS, stateful envs | [Use cases](./docs/use-cases.md) |
 | Multi-round single-agent (progressive disclosure, oracle access) | [Progressive disclosure](./docs/progressive-disclosure.md) |
+| Continue a timed-out run without losing its conversation | [Continue runs](./docs/continue-runs.md) |
+| Provision stateful services independently from tasks | [Environment plane](./docs/environment-plane.md) |
+| Score subjective outputs with an LLM | [LLM-as-judge](./docs/llm-judge.md) |
+| Audit finished rollouts for reward hacking or task quality | [Rubric review](./docs/rubric-review.md) |
 | Skill evaluation (when the artifact is a skill, not a workspace) | [Skill eval](./docs/skill-eval.md) |
 | Contribute a trajectory capture | [Trajectory upload](./docs/traj-upload.md) |
 | Understand the security model | [Sandbox hardening](./docs/sandbox-hardening.md) |
@@ -129,6 +123,21 @@ Start with [Getting started](./docs/getting-started.md), then [Concepts](./docs/
 | Python API surface | [Python API reference](./docs/reference/python-api.md) |
 
 Notebooks and runnable example scripts live under [`docs/examples/`](./docs/examples/) so examples stay versioned with the docs that explain them.
+
+## Contribute an existing trajectory
+
+You can upload a local Claude Code or Codex JSONL trajectory without a
+BenchFlow account or model API key:
+
+```bash
+bench traj upload /absolute/path/to/trial \
+  --github-id YOUR_GITHUB_ID \
+  --email YOU@example.com
+```
+
+The path may be a trial directory, a directory of JSONL files, or one JSONL
+file. Both contributor fields are required and stored in `manifest.json`.
+See the [trajectory upload guide](./docs/traj-upload.md).
 
 > **`bench agent` vs `bench eval adopt`.** `bench agent list` / `bench agent show`
 > inspect **registered AI agents** (the solver programs like Claude Code or

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,102 @@
+# Authentication
+
+BenchFlow installs and runs an agent inside each sandbox. The agent therefore
+needs the same model credentials it would use when run directly. Choose one
+authentication method for the agent/model pair you plan to evaluate.
+
+## Subscription login on your machine
+
+For an interactive local run, this is usually the shortest path. Sign in once
+with the agent's host CLI:
+
+| Agent | Host login | Credential BenchFlow detects |
+|---|---|---|
+| `codex` | `codex login` | `~/.codex/auth.json` |
+| `claude` | `claude auth login` | `~/.claude/.credentials.json` |
+| `gemini` | `gemini` interactive flow | `~/.gemini/oauth_creds.json` |
+
+BenchFlow copies the relevant credential into the sandbox for that run. You do
+not need a Daytona account or a model API key to use a supported subscription
+login with the local Docker sandbox.
+
+## API keys
+
+Export the key for your provider before invoking `bench`:
+
+```bash
+export OPENAI_API_KEY='...'
+export ANTHROPIC_API_KEY='...'
+export GEMINI_API_KEY='...'
+```
+
+Other common variables include:
+
+```bash
+export CODEX_API_KEY='...'        # Codex alias for OPENAI_API_KEY
+export LLM_API_KEY='...'          # OpenHands / LiteLLM-compatible providers
+export AZURE_API_KEY='...'
+export AZURE_API_ENDPOINT='https://<resource>.openai.azure.com/'
+```
+
+Never put a key directly in a committed run config or command example. Shell
+variables must be exported to reach BenchFlow. For a local `.env` file:
+
+```bash
+set -a
+source .env
+set +a
+bench eval run ...
+```
+
+BenchFlow also reads well-known credential keys from a `.env` in the current
+directory, but exporting works regardless of where the command is run.
+
+## CI and headless machines
+
+Claude supports a long-lived OAuth token:
+
+```bash
+claude setup-token
+export CLAUDE_CODE_OAUTH_TOKEN='<paste-token>'
+```
+
+Codex can use `CODEX_ACCESS_TOKEN` when a host or orchestrator provides one.
+Gemini currently uses either the saved host login or an API key.
+
+Store CI credentials in the CI system's secret manager, not in the repository.
+
+## Provider-prefixed models
+
+Models routed through a user-supplied endpoint generally use
+`<PROVIDER>_API_KEY` plus `<PROVIDER>_BASE_URL`. For example:
+
+```bash
+export DEEPSEEK_API_KEY='...'
+export DEEPSEEK_BASE_URL='https://api.deepseek.com'
+```
+
+Providers with a fixed endpoint may need only the API key. Azure Foundry uses
+`AZURE_API_KEY` and `AZURE_API_ENDPOINT` with model names such as
+`azure-foundry-openai/gpt-5.5`.
+
+## Credential precedence
+
+Provider-specific credentials selected by the model prefix take precedence
+over the agent's native credentials. Claude's native order is: cloud provider
+credentials, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, `apiKeyHelper`,
+`CLAUDE_CODE_OAUTH_TOKEN`, then the saved host subscription login.
+
+If you intended to use a subscription but an API key is set, unset the key
+before running:
+
+```bash
+unset OPENAI_API_KEY CODEX_API_KEY
+# or
+unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
+```
+
+To see the available agent names and their native auth requirements:
+
+```bash
+bench agent list
+```

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -9,7 +9,7 @@ The mental model for benchflow. Read once, then refer back from the how-tos.
 |-----------|------------|
 | **Task** | A directory on disk: a `task.md` document (YAML frontmatter + prompt body) plus `environment/Dockerfile` for the sandbox, `verifier/` checks, and optional `oracle/` — or the legacy split layout (`task.toml` + `instruction.md` + `tests/` + `solution/`). Authored once, evaluated many times. |
 | **Agent** | A registered ACP-speaking program (Claude Code, Gemini CLI, OpenCode, etc.). Identified by name (`"gemini"`, `"opencode"`) plus an optional model ID. Use the `acpx/` prefix (e.g. `acpx/gemini`) to route through [ACPX](https://acpx.sh/), a headless ACP client with persistent sessions and crash recovery. |
-| **Environment** | The sandbox where the agent runs and the verifier checks the result. Docker locally, Daytona for cloud, Modal for serverless/GPU. Abstracted behind the `Sandbox` protocol — bring your own sandbox backend. |
+| **Environment** | The sandbox where the agent runs and the verifier checks the result. Docker is the local default; Daytona, Modal, and AgentCore are optional remote backends. See [Sandboxes](./sandboxes.md). |
 | **Verifier** | The test runner that scores the rollout. Its entry point is a `test.sh` script (native `verifier/test.sh`, legacy `tests/test.sh`) — which typically runs `pytest` against the workspace the agent left behind. For subjective tasks, use an [LLM-as-judge](./llm-judge.md) verifier scored against a rubric. Outputs `rewards: {reward: float}`. See the [verifier file map](#verifier-file-map) for which file lives where in native vs legacy packages. |
 | **Rollout** | One agent run on one task. Holds the lifecycle (setup → start → install → execute → verify → cleanup). All higher-level primitives below are built on Rollouts. |
 
@@ -50,7 +50,7 @@ from pathlib import Path
 config = RolloutConfig(
     task_path=Path("tasks/edit-pdf"),
     scenes=[Scene.single(agent="gemini", model="gemini-3.1-pro-preview")],
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)   # full lifecycle
 print(result.rewards)            # {'reward': 1.0}
@@ -196,6 +196,8 @@ Trajectories are written to `<jobs_dir>/<job_name>/<rollout_name>/trajectory/acp
 ## Where to go next
 
 - [Getting started](./getting-started.md) — install, run your first eval.
+- [Running evaluations](./running-evaluations.md) — single tasks, batches, skills, and results.
+- [Sandboxes](./sandboxes.md) — start with Docker and choose a cloud backend only when needed.
 - [Task authoring (native task.md)](./task-authoring-task-md.md) — write a task as a single `task.md` document plus `environment/` and `verifier/`.
 - [Migrating a legacy task](./task-authoring.md) — convert an existing `task.toml` + `instruction.md` split package to `task.md` (the split layout is no longer a first-class authoring path).
 - [LLM-as-judge](./llm-judge.md) — use an LLM to score subjective tasks against a rubric (see the [verifier file map](#verifier-file-map) for native vs legacy rubric paths).

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -13,10 +13,11 @@ bench eval run \
   --source-path tasks/edit-pdf \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
-  --sandbox daytona
+  --sandbox docker
 ```
 
-Sandboxes are `docker`, `daytona`, and `modal`.
+Docker is the local default. Daytona, Modal, Apple Container, and AgentCore are
+optional alternatives; see [Sandboxes](../sandboxes.md).
 
 ## Skills
 
@@ -28,7 +29,7 @@ bench eval run \
   --tasks-dir tasks/my-task \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
-  --sandbox daytona \
+  --sandbox docker \
   --skill-mode with-skill \
   --skills-dir tasks/my-task/environment/skills
 ```

--- a/docs/external-agents.md
+++ b/docs/external-agents.md
@@ -9,18 +9,14 @@ first one is all there is to know.
 ## 1. Zero-config remote autoload (the default)
 
 Using an agent name BenchFlow doesn't recognize triggers a one-shot fetch of
-the declarative manifests from `benchflow-ai/agents@main`. Nothing to install
-or configure. End to end, from an empty directory to a scored rollout
-(verified as written: skillsbench `edit-pdf`, reward 1.0, ~23 min, a few
-cents on `deepseek-v4-flash` — rates approximate):
+the declarative manifests from `benchflow-ai/agents@main`. There is no separate
+agent package to install for manifest-based agents:
 
 ```bash
-# Install. `uv tool install --python 3.12 'benchflow[sandbox-daytona]'` (the
-# README's global-CLI idiom) and a plain venv + pip both work; pick one.
-pip install 'benchflow[sandbox-daytona]'
+# Install the normal local CLI; no cloud-sandbox extra is needed.
+uv tool install --python 3.12 --upgrade benchflow
 
 export DEEPSEEK_API_KEY=sk-...          # credentials for your --model provider
-export DAYTONA_API_KEY=dtn_...          # or use --sandbox docker
 
 # Get a task (sparse checkout of one SkillsBench task — same recipe as
 # getting-started; any task.md/Harbor-format task directory works):
@@ -29,8 +25,11 @@ git clone --depth 1 --filter=blob:none --sparse \
 cd skillsbench && git sparse-checkout set tasks/edit-pdf
 
 bench eval run --tasks-dir tasks/edit-pdf --agent prime-agent \
-  --model deepseek/deepseek-v4-flash --sandbox daytona
+  --model deepseek/deepseek-v4-flash --sandbox docker
 ```
+
+Use another sandbox only if the run needs remote scale; see
+[Sandboxes](./sandboxes.md).
 
 While the agent works, a terminal (TTY) shows the live Rich dashboard —
 progress bar, pass/fail counts, and a per-task activity column that tracks

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,263 +1,156 @@
 # Getting started
-A 5-minute path from install to first eval.
 
-## Prerequisites
+Run one scored BenchFlow evaluation on your own machine. This path uses Docker
+and an existing Codex, Claude, or Gemini login; it does not require Daytona or
+another cloud sandbox account.
 
-- [`uv`](https://docs.astral.sh/uv/) for the CLI install; use the documented
-  `--python 3.12` flag so it provisions a compatible Python automatically
-- Docker for local sandboxes; Apple Container is also built in on supported
-  Apple Silicon Macs. Install the matching extra for Daytona, Modal, or
-  AgentCore cloud runs.
-- An API key or subscription/OAuth auth for at least one agent (see below)
+Want the shortest copy-paste path? [Start a real local task in five
+minutes](./start-in-5-minutes.md). This page explains each part of that run and
+the available alternatives.
 
-## Install
+## What you need
 
-Install or upgrade to the latest stable release from PyPI with `uv`:
+- [`uv`](https://docs.astral.sh/uv/) — the install command below can provision
+  the required Python 3.12 runtime for you
+- Docker Desktop or another working Docker daemon
+- One supported agent login or API key
+
+Start Docker, then confirm it is reachable:
+
+```bash
+docker info >/dev/null
+```
+
+If this command fails, start Docker before continuing. BenchFlow builds a task
+image and runs the agent inside it; the agent itself does not run directly on
+your host.
+
+## 1. Install BenchFlow
 
 ```bash
 uv tool install --python 3.12 --upgrade benchflow
+bench --version
 ```
 
-If `uv` reports `Executables already exist: bench, benchflow`, rerun with
-`uv tool install --python 3.12 --upgrade --force benchflow` to replace older non-`uv`
-entrypoints. Confirm with `bench --version`.
-See [Release channels](./release.md) for the full command matrix.
+`benchflow` and `bench` are aliases for the same CLI. If `uv` reports
+`Executables already exist: bench, benchflow`, repeat the install with
+`--force` to replace an older entrypoint.
 
-BenchFlow's CLI package requires Python 3.12 or newer. If `uv` is allowed to
-reuse Python 3.10 or 3.11, it may resolve an old `benchflow` package that does
-not provide the `bench` / `benchflow` executables and fail with
-`No executables are provided by package benchflow`. Keeping `--python 3.12` in
-the install command avoids that resolver fallback.
-
-For optional sandbox integrations, include the extra in the tool install:
-
-```bash
-uv tool install --python 3.12 --upgrade 'benchflow[sandbox-daytona]'
-uv tool install --python 3.12 --upgrade 'benchflow[sandbox-modal]'
-uv tool install --python 3.12 --upgrade 'benchflow[sandbox-agentcore]'
-```
-
-This gives you the isolated `benchflow` (alias `bench`) CLI. To import the
-Python SDK from your own program, add `benchflow` to that program's Python
-environment. To install for editable development:
+Working from a source checkout instead? Use the repository environment:
 
 ```bash
 git clone https://github.com/benchflow-ai/benchflow
 cd benchflow
 uv sync --extra dev --locked
+uv run bench --version
 ```
 
-## Auth: OAuth, long-lived token, or API key
+## 2. Sign in to one agent
 
-You don't need an API key if you're a Claude / Codex / Gemini subscriber. Three options, pick one per agent:
-
-### Option 1 — Subscription OAuth from host CLI login
-
-If you've logged into the agent's CLI on your host (`claude auth login`,
-`codex login`, or the `gemini` interactive flow), benchflow picks up the
-credential file and copies it into the sandbox. No API key billing.
-
-| Agent | How to log in on the host | What benchflow detects | Replaces env var |
-|-------|---------------------------|------------------------|------------------|
-| `claude-agent-acp` | `claude auth login` (Claude Code CLI) | `~/.claude/.credentials.json` | `ANTHROPIC_API_KEY` |
-| `codex-acp` | `codex login` (Codex CLI) | `~/.codex/auth.json` | `OPENAI_API_KEY` |
-| `gemini` | `gemini` (interactive login) | `~/.gemini/oauth_creds.json` | `GEMINI_API_KEY` |
-
-When benchflow finds the detect file, you'll see:
-
-```
-Using host subscription auth (no ANTHROPIC_API_KEY set)
-```
-
-### Option 2 — Long-lived OAuth token (CI / headless)
-
-For CI pipelines, scripts, or anywhere the host can't run an interactive browser login, generate a 1-year OAuth token with `claude setup-token` and export it:
+An existing subscription login is enough; an API key is not required for the
+Codex or Claude examples.
 
 ```bash
-claude setup-token            # walks you through browser auth, prints a token
-export CLAUDE_CODE_OAUTH_TOKEN='<paste-token>'
+# ChatGPT subscription through Codex CLI
+codex login
+
+# Or Claude subscription through Claude Code
+claude auth login
+
+# Or Gemini CLI's interactive login
+gemini
 ```
 
-benchflow auto-inherits `CLAUDE_CODE_OAUTH_TOKEN` from your shell into the sandbox; the Claude CLI inside reads it directly. Same auth precedence as plain `claude` ([Anthropic docs](https://code.claude.com/docs/en/authentication#authentication-precedence)): API keys override OAuth tokens, so unset `ANTHROPIC_API_KEY` if you want the token to win.
+BenchFlow detects the saved host credential and makes it available inside the
+sandbox. If you prefer API keys, CI tokens, or a provider-hosted model, see
+[Authentication](./authentication.md).
 
-`claude setup-token` only authenticates Claude. Codex can also use a provided subscription access token, such as `CODEX_ACCESS_TOKEN` from a host/orchestrator integration; benchflow passes it through to Codex without copying `~/.codex/auth.json`. Gemini does not have an equivalent today — use Option 1 (host login) or Option 3 (API key).
+## 3. Run one local evaluation
 
-### Option 3 — API key
-
-Set the API-key env var directly. Works with every agent:
+This example downloads one public SkillsBench task, runs Codex inside a local
+Docker sandbox, executes the task's verifier, and saves the full trajectory:
 
 ```bash
-export ANTHROPIC_API_KEY=sk-ant-...
-export OPENAI_API_KEY=sk-...
-export CODEX_API_KEY=sk-...       # Codex alias for OPENAI_API_KEY
-export GEMINI_API_KEY=...
-export LLM_API_KEY=...           # OpenHands / LiteLLM-compatible providers
-export AZURE_API_KEY=...
-export AZURE_API_ENDPOINT='https://<resource>.openai.azure.com/'
+bench eval run \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks/3d-scan-calc \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker \
+  --concurrency 1
 ```
 
-benchflow auto-inherits well-known API key env vars from your shell into the sandbox.
-Provider-prefixed models can use credentials that differ from the agent's
-native default auth. For Azure Foundry, use models such as
-`azure-foundry-openai/gpt-5.5` or
-`azure-foundry-anthropic/claude-opus-4-5`; benchflow derives the Azure resource
-from `AZURE_API_ENDPOINT` and routes the selected agent through a generated
-LiteLLM gateway config.
+Use one of these agent/model pairs if you signed in somewhere else:
 
-Several providers with user-supplied endpoints — `glm`, `kimi`, `minimax`,
-`hunyuan`, and others — follow the `<PROVIDER>_API_KEY` +
-`<PROVIDER>_BASE_URL` convention; providers with fixed or default endpoints
-(such as `deepseek`, `zai`, or `openai`) need only the API key. Override the
-DeepSeek endpoint only when necessary:
+| Host login | Replace the two flags with |
+|---|---|
+| Claude Code | `--agent claude --model claude-sonnet-4-6` |
+| Gemini CLI | `--agent gemini --model gemini-3.1-pro-preview` |
 
-```bash
-export DEEPSEEK_API_KEY=...
-export DEEPSEEK_BASE_URL=https://api.deepseek.com  # optional default override
-```
+The first run may take several minutes while Docker downloads and builds the
+task image. The benchmarked agent may pass or fail the task; either outcome is
+a valid completed evaluation.
 
-These variables must be **exported** to reach the benchflow runtime — a plain
-shell assignment or a `source .env` without `export` stays local to your shell
-and never reaches the `bench` process. The portable pattern for a `.env` file:
+## 4. Read the result
 
-```bash
-set -a; source .env; set +a
-bench eval run ...
-```
+The console ends with `[PASS]`, `[FAIL]`, or an execution error. `[FAIL]` means
+the agent completed but did not reach the verifier's pass threshold; it does
+not mean BenchFlow itself failed.
 
-(benchflow also picks up well-known credential keys from a `.env` file in the
-current directory; exporting works from any directory.)
+Results are written under `jobs/`:
 
-### Precedence
-
-If multiple credentials are set, benchflow / the agent CLI uses provider-specific
-credentials selected by the model prefix first, then the agent's native auth
-precedence. For Claude, native auth is (high to low): cloud provider creds →
-`ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY` → `apiKeyHelper` →
-`CLAUDE_CODE_OAUTH_TOKEN` → host subscription OAuth. To force a lower-priority
-option, unset the higher one in your shell before running.
-
-## Run your first eval
-
-```bash
-# Single task fetched from the public task repository
-GEMINI_API_KEY=... bench eval run \
-  --source-repo benchflow-ai/skillsbench --source-path tasks \
-  --include edit-pdf \
-  --agent gemini \
-  --model gemini-3.1-pro-preview \
-  --sandbox docker
-
-# Single task with mounted skills
-GEMINI_API_KEY=... bench eval run \
-  --source-repo benchflow-ai/skillsbench --source-path tasks \
-  --include edit-pdf \
-  --agent gemini \
-  --model gemini-3.1-pro-preview \
-  --sandbox daytona \
-  --skill-mode with-skill
-
-# Batch over the remote tasks directory with concurrency
-GEMINI_API_KEY=... bench eval run \
-    --source-repo benchflow-ai/skillsbench --source-path tasks \
-    --agent gemini --model gemini-3.1-pro-preview --sandbox daytona --concurrency 32
-
-# List the registered agents
-bench agent list
-```
-
-`bench eval run` is the primary command for running evaluations — it works for
-single tasks, batch runs, and remote repos. Use `--tasks-dir <dir>` for a local
-directory or `--config <config.yaml>` for a YAML config.
-
-You can also fetch tasks straight from a remote repo with
-`--source-repo <org/repo> --source-path <subpath>`, but note that this clones
-the full repository (`git clone --depth 1` into `.cache/datasets/<org>/<repo>/`
-under the enclosing git repo root, or the current directory when you run
-outside one) — large for big task repos. To download only the task you need,
-use a sparse checkout and point `--tasks-dir` at it:
-
-```bash
-git clone --depth 1 --filter=blob:none --sparse https://github.com/benchflow-ai/skillsbench
-cd skillsbench && git sparse-checkout set tasks/edit-pdf
-bench eval run --tasks-dir tasks/edit-pdf --agent gemini --model gemini-3.1-pro-preview
-```
-
-See [Architecture: skill loading](./architecture.md#skill-loading) for how
-mounted skills reach the agent.
-
-### Where results land
-
-Each run writes under `--jobs-dir` (default `jobs/`):
-
-```
-<jobs-dir>/
-  summary.json                      # copy of the latest job summary (overwritten by the next run)
-  <YYYY-MM-DD__HH-MM-SS>/           # job directory, named by start time
-    summary.json                    # job-level aggregate (pass counts plus mean_reward — mean over scored rollouts)
-    <task>__<hash8>/                # one rollout: task name + 8-char id
-      result.json                   # rollout summary: rewards, errors, token usage/cost
-      results.jsonl                 # Verifiers/Prime-RL shaped rollout row
-      rewards.jsonl                 # reward record for this rollout
-      timing.json                   # per-phase timing breakdown
-      prompts.json                  # prompts sent to the agent
+```text
+jobs/
+  <timestamp>/
+    summary.json
+    <task>__<hash>/
+      result.json
+      timing.json
+      prompts.json
       trajectory/
-        acp_trajectory.jsonl        # full agent trace (ACP events)
-        llm_trajectory.jsonl        # raw provider requests/responses (when the usage-tracking proxy captured exchanges)
-      trainer/
-        verifiers.jsonl             # trainer-ready scored trajectory (Verifiers/ORS record)
-        atif.json                   # ATIF trajectory record (omitted if the trajectory is empty)
-        adp.jsonl                   # ADP trajectory record
+        acp_trajectory.jsonl
+        llm_trajectory.jsonl  # optional provider-level trace
       verifier/
-        ctrf.json                   # CTRF test report (when test.sh emits one)
-        reward.txt                  # raw verifier reward (0.0-1.0)
-        test-stdout.txt             # verifier stdout
+        reward.txt
+        test-stdout.txt
 ```
 
-### Reading results
+Use the CLI to summarize them:
 
-Exit code 0 means the pipeline completed — it is not a pass/fail signal. A
-rollout whose reward is below the pass threshold still exits 0 and prints
-`[FAIL]` with `Score: 0/1`: `Score` is pass-threshold aggregation (a task
-counts as passed only at reward 1.0), while `reward` — in `result.json` and
-`verifier/reward.txt` — is the raw verifier value. Config errors (unknown
-agents, missing credentials) exit 1, and so do runs with agent or verifier
-errors. CLI usage errors (bad flags) exit 2.
-
-The Docker sandbox needs the Docker daemon running. There is no up-front
-check — if the daemon is down the run fails partway through rather than at
-startup, so start Docker before `bench eval run --sandbox docker`.
-
-## Run from Python
-
-The CLI is a thin shim over the Python API. For programmatic use:
-
-```python
-import benchflow as bf
-from benchflow import RolloutConfig, Scene
-from benchflow._utils.benchmark_repos import resolve_source
-
-config = RolloutConfig(
-    task_path=resolve_source("benchflow-ai/skillsbench", path="tasks/edit-pdf"),
-    scenes=[Scene.single(agent="gemini", model="gemini-3.1-pro-preview")],
-    environment="docker",
-)
-result = await bf.run(config)
-print(result.rewards)         # {'reward': 1.0}
-print(result.n_tool_calls)
+```bash
+bench eval list jobs/
+bench eval metrics jobs/
 ```
 
-`Rollout` is decomposable — invoke each lifecycle phase individually for custom flows. See [Concepts: rollout lifecycle](./concepts.md#rollout-lifecycle).
+`result.json` is the quickest place to check the raw reward, error status,
+tool-call count, and token usage. `trajectory/acp_trajectory.jsonl` contains
+the agent/tool interaction trace.
 
-## What to read next
+## Run your own local task
 
-| If you want to… | Read |
-|------------------|------|
-| Understand how BenchFlow runs *any* benchmark (the three-layer model) | [Run any benchmark](./running-any-benchmark.md) |
-| Understand the model — Rollout, Scene, Role, Verifier | [Concepts](./concepts.md) |
-| Author a task | [Task authoring](./task-authoring.md) |
-| Run multi-agent patterns (coder/reviewer, simulated user, BYOS) | [Use cases](./use-cases.md) |
-| Run multi-round single-agent (progressive disclosure) | [Progressive disclosure](./progressive-disclosure.md) |
-| Evaluate skills, not tasks | [Skill eval](./skill-eval.md) |
-| Understand the security model | [Sandbox hardening](./sandbox-hardening.md) |
-| CLI flags + commands | [CLI reference](./reference/cli.md) |
-| Python API surface | [Python API reference](./reference/python-api.md) |
+Point `--tasks-dir` at either one task package or a directory of task packages:
+
+```bash
+bench eval run \
+  --tasks-dir tasks/my-task \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker
+```
+
+Docker is BenchFlow's default, so `--sandbox docker` may be omitted. Keeping it
+in your first commands makes the execution location explicit.
+
+## Where to go next
+
+| Goal | Read |
+|---|---|
+| Use a different login, API key, or provider | [Authentication](./authentication.md) |
+| Run local batches, YAML configs, or skill comparisons | [Running evaluations](./running-evaluations.md) |
+| Decide between Docker, Apple Container, Daytona, Modal, and AgentCore | [Sandboxes](./sandboxes.md) |
+| Understand task, agent, rollout, and verifier terminology | [Concepts](./concepts.md) |
+| Create a task | [Task authoring](./task-authoring.md) |
+| Look up every flag | [CLI reference](./reference/cli.md) |
+
+For local development and small evaluation sets, you can stop here: no
+Daytona setup is necessary.

--- a/docs/progressive-disclosure.md
+++ b/docs/progressive-disclosure.md
@@ -32,7 +32,7 @@ config = RolloutConfig(
     scenes=[Scene.single(agent="opencode", model="anthropic/claude-sonnet-4-6")],
     user=FunctionUser(progressive),
     max_user_rounds=3,
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -158,6 +158,13 @@ runs; it also accepts a single task directory.
 # From YAML config
 bench eval run --config benchmarks/harvey-lab/harvey-lab-gemini-flash-lite.yaml
 
+# One task on the default local Docker sandbox
+bench eval run \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks/citation-check \
+  --agent codex \
+  --model gpt-5.5
+
 # From remote repo (fast Daytona batch; token usage may be unavailable)
 bench eval run \
   --source-repo benchflow-ai/skillsbench \
@@ -619,7 +626,7 @@ Evaluate a skill against its evals.json test cases.
 bench skills eval skills/my-skill/ \
   --agent gemini \
   --model gemini-3.1-flash-lite-preview \
-  --sandbox daytona
+  --sandbox docker
 ```
 
 
@@ -932,8 +939,8 @@ bench hub check --level check --tasks-per-dataset 2 --out hub.jsonl
 source:
   repo: benchflow-ai/skillsbench
   path: tasks
-environment: daytona
-concurrency: 64
+environment: docker
+concurrency: 2
 sandbox_setup_timeout: 300
 agent: gemini
 model: gemini-3.1-flash-lite-preview
@@ -950,7 +957,7 @@ directly in Python.
 
 ```yaml
 task_dir: tasks/my-task
-environment: daytona
+environment: docker
 sandbox_setup_timeout: 300
 
 scenes:

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -36,7 +36,7 @@ from benchflow import RolloutConfig, Scene, Role, Turn
 config = RolloutConfig(
     task_path=Path("tasks/my-task"),
     scenes=[Scene.single(agent="gemini", model="gemini-3.1-flash-lite-preview")],
-    environment="daytona",
+    environment="docker",
     sandbox_setup_timeout=120,
 )
 
@@ -49,7 +49,7 @@ config = RolloutConfig(
         Scene(name="solve", roles=[Role("solver", "gemini", "gemini-3.1-flash-lite-preview")],
               turns=[Turn("solver")]),
     ],
-    environment="daytona",
+    environment="docker",
     sandbox_setup_timeout=120,
 )
 ```
@@ -114,7 +114,7 @@ from benchflow.runtime import Agent, Environment, Runtime, RuntimeConfig
 
 config = RuntimeConfig(sandbox_setup_timeout=300)
 agent = Agent("gemini", model="gemini-3.1-flash-lite-preview")
-env = Environment.from_task("tasks/X", sandbox="daytona")
+env = Environment.from_task("tasks/X", sandbox="docker")
 runtime = Runtime(env, agent, config=config)
 result = await runtime.execute()
 ```
@@ -131,7 +131,7 @@ result = await bf.run(config)
 
 # 2. Agent + Environment (0.3 style)
 agent = bf.Agent("gemini", model="gemini-3.1-flash-lite-preview")
-env = bf.Environment.from_task("tasks/X", sandbox="daytona")
+env = bf.Environment.from_task("tasks/X", sandbox="docker")
 runtime_config = bf.RuntimeConfig(sandbox_setup_timeout=300)
 result = await bf.run(agent, env, runtime_config)
 
@@ -196,7 +196,7 @@ config = RolloutConfig(
             Turn("coder", "Read feedback and fix."),
         ],
     )],
-    environment="daytona",
+    environment="docker",
 )
 ```
 
@@ -213,7 +213,7 @@ config = RolloutConfig(
               roles=[Role("solver", "gemini", "flash")],
               turns=[Turn("solver")]),
     ],
-    environment="daytona",
+    environment="docker",
 )
 ```
 
@@ -244,7 +244,7 @@ config = RolloutConfig(
     scenes=[Scene.single(agent="gemini", model="gemini-3.1-flash-lite-preview")],
     user=FunctionUser(user),
     max_user_rounds=3,
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)
 ```
@@ -378,8 +378,8 @@ from benchflow import Evaluation, EvaluationConfig, EvaluationResult, RetryConfi
 # applied to every task discovered under tasks_dir.
 config = EvaluationConfig(
     model="gemini-3.1-flash-lite-preview",
-    environment="daytona",
-    concurrency=8,
+    environment="docker",
+    concurrency=2,
     retry=RetryConfig(max_retries=2),
 )
 evaluation = Evaluation(tasks_dir="tasks", jobs_dir="jobs/my-run", config=config)

--- a/docs/rubric-review.md
+++ b/docs/rubric-review.md
@@ -68,28 +68,30 @@ Rubric resolution order, per reviewed rollout:
 ## Running a review
 
 ```bash
-# review one rollout
+# review one rollout locally with a Codex subscription
 bench review jobs/<job>/<rollout> --sandbox docker \
-  --model gemini/gemini-2.5-flash --tasks-root ./tasks
+  --agent codex --model gpt-5.5 --tasks-root ./tasks
 
-# review every rollout in a job, eight at a time, on Daytona
-bench review jobs/<job> --sandbox daytona -n 8 \
-  --model gemini/gemini-2.5-flash --tasks-root ./tasks
+# review a small job locally, two rollouts at a time
+bench review jobs/<job> --sandbox docker -n 2 \
+  --agent codex --model gpt-5.5 --tasks-root ./tasks
 
 # audit the winners for grader manipulation
-bench review jobs/<job> --passing --model gemini/gemini-2.5-flash
+bench review jobs/<job> --passing \
+  --agent codex --model gpt-5.5
 
 # analyze the losers for specification gaps
 bench review jobs/<job> --failing -r spec-rubric.json \
-  --model gemini/gemini-2.5-flash
+  --agent codex --model gpt-5.5
 ```
 
 `--passing` selects rollouts with reward 1.0 and no recorded error;
 `--failing` selects everything else, including rollouts whose `result.json`
 is unreadable. The reviewer agent (`--agent`, default `opencode`) and model
-(`--model`; agents without a registry default require one — pass a gateway
-model id such as `gemini/gemini-2.5-flash`) are independent of whatever ran
-the original job.
+(`--model`; agents without a registry default require one) are independent of
+whatever ran the original job. Docker is the default and is appropriate for
+one review or a small local job; choose a remote sandbox only when you need
+more isolated parallel reviewers.
 
 ## How a review executes
 

--- a/docs/running-evaluations.md
+++ b/docs/running-evaluations.md
@@ -1,0 +1,142 @@
+# Running evaluations
+
+`bench eval run` is the main command for both one task and a batch. It accepts
+a local directory, a remote Git repository, a YAML run config, or a pinned
+dataset version. All of these use Docker by default.
+
+Start with [Getting started](./getting-started.md) if you have not completed a
+local run yet.
+
+## One task from a remote repository
+
+```bash
+bench eval run \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks/citation-check \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker
+```
+
+BenchFlow clones and caches the source under `.cache/datasets/`. Pin a branch,
+tag, or commit with `--source-ref` when reproducibility matters.
+
+## One local task
+
+```bash
+bench eval run \
+  --tasks-dir tasks/my-task \
+  --agent codex \
+  --model gpt-5.5
+```
+
+The omitted `--sandbox` defaults to `docker`. A task directory contains a
+native `task.md` plus its `environment/` and `verifier/` directories. BenchFlow
+can still read the retired split layout for compatibility.
+
+## A local batch
+
+Point `--tasks-dir` at the parent directory and choose a conservative local
+concurrency:
+
+```bash
+bench eval run \
+  --tasks-dir tasks \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker \
+  --concurrency 2
+```
+
+Use repeatable filters to select task names:
+
+```bash
+bench eval run \
+  --tasks-dir tasks \
+  --include citation-check \
+  --include weighted-gdp-calc \
+  --agent codex \
+  --model gpt-5.5
+```
+
+Local concurrency is limited by your Docker daemon, CPU, memory, and model
+rate limits. Increase it gradually. A cloud sandbox becomes useful when you
+need more isolation or more parallel machines, not because BenchFlow requires
+one; see [Sandboxes](./sandboxes.md).
+
+## YAML run configs
+
+Use a config when the same run should be repeated or reviewed:
+
+```yaml
+source:
+  repo: benchflow-ai/skillsbench
+  path: tasks
+agent: codex
+model: gpt-5.5
+environment: docker
+concurrency: 2
+include:
+  - citation-check
+```
+
+```bash
+bench eval run --config run.yaml
+```
+
+Check the [CLI reference](./reference/cli.md#bench-eval-run) for the full run
+schema and flags.
+
+## Compare a task with and without skills
+
+For a task that already contains its skill payload, run the two modes into
+separate job directories:
+
+```bash
+bench eval run \
+  --tasks-dir tasks/my-task \
+  --agent codex --model gpt-5.5 \
+  --skill-mode no-skill \
+  --jobs-dir jobs/my-task-no-skill
+
+bench eval run \
+  --tasks-dir tasks/my-task \
+  --agent codex --model gpt-5.5 \
+  --skill-mode with-skill \
+  --jobs-dir jobs/my-task-with-skill
+```
+
+Use `--skills-dir <directory>` when the skills live outside the task package.
+For a structured lift experiment backed by `evals/evals.json`, use
+`bench skills eval`; see [Skill evals](./skill-eval.md).
+
+## Results and exit status
+
+By default, artifacts land in `jobs/<timestamp>/`. Summarize them with:
+
+```bash
+bench eval list jobs/
+bench eval metrics jobs/
+```
+
+Exit code 0 means the evaluation pipeline completed. It does not mean every
+task passed. Read each rollout's reward or the printed `[PASS]` / `[FAIL]`
+status to assess model performance. Configuration, agent, or verifier errors
+produce a non-zero exit.
+
+Use a new `--jobs-dir` for an independent rerun. Reusing one intentionally
+resumes it and skips completed rollouts.
+
+## Reproducible published runs
+
+For leaderboard, paper, or release evidence, prefer a pinned registry dataset:
+
+```bash
+bench eval run \
+  --dataset skillsbench@1.1 \
+  --agent codex \
+  --model gpt-5.5
+```
+
+Dataset runs verify the pinned commit and per-task content digests. Ad-hoc
+`--tasks-dir` and floating repository runs are better suited to development.

--- a/docs/sandboxes.md
+++ b/docs/sandboxes.md
@@ -1,0 +1,92 @@
+# Sandboxes
+
+BenchFlow needs an isolated place to install an agent, expose the task
+workspace, and run the verifier. For local development, that place is Docker.
+Cloud sandboxes are optional scaling backends.
+
+## Which sandbox should I use?
+
+| Sandbox | Use it when | Setup |
+|---|---|---|
+| **Docker** | You are learning BenchFlow, developing a task, debugging a run, or running a small batch locally | Docker daemon; included in the base install |
+| **Apple Container** | You are on a supported Apple Silicon Mac and want Apple's native container runtime | Apple `container` CLI; no BenchFlow extra |
+| **Daytona** | You need many independent cloud VMs for a light, highly parallel batch | Optional extra plus `DAYTONA_API_KEY` |
+| **Modal** | You need serverless or GPU-backed remote execution | Optional extra plus Modal auth |
+| **AgentCore** | Your deployment is built around AWS Bedrock AgentCore Runtime | Optional extra plus AWS configuration |
+
+Docker is the CLI default. If your tasks and model calls fit on one machine,
+there is no reason to configure Daytona.
+
+## Local Docker
+
+```bash
+docker info >/dev/null
+
+bench eval run \
+  --tasks-dir tasks/my-task \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker
+```
+
+Start with `--concurrency 1` or `2`, then raise it while watching local CPU,
+memory, disk, Docker build pressure, and provider rate limits. Docker uses host
+disk capacity and supports multi-container task environments.
+
+## Apple Container
+
+On supported Apple Silicon Macs:
+
+```bash
+bench eval run \
+  --tasks-dir tasks/my-task \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox apple-container
+```
+
+Apple Container is a single-container backend and currently cannot enforce a
+task's `no-network` policy. Use Docker for multi-service or strict no-network
+tasks.
+
+## Daytona
+
+Install Daytona support only when you need it:
+
+```bash
+uv tool install --python 3.12 --upgrade 'benchflow[sandbox-daytona]'
+export DAYTONA_API_KEY='...'
+
+bench eval run \
+  --tasks-dir tasks \
+  --agent gemini \
+  --model gemini-3.1-pro-preview \
+  --sandbox daytona \
+  --concurrency 32
+```
+
+Daytona is useful for parallel experiments because each rollout gets a remote
+VM. It is not a prerequisite for a single evaluation. Daytona also caps each
+sandbox at 10 GB of storage, so tasks with large model snapshots, Playwright,
+LaTeX, or other heavy images may fail during bootstrap. Run those tasks with
+Docker when local host disk is available.
+
+## Modal and AgentCore
+
+```bash
+uv tool install --python 3.12 --upgrade 'benchflow[sandbox-modal]'
+uv tool install --python 3.12 --upgrade 'benchflow[sandbox-agentcore]'
+```
+
+Select them with `--sandbox modal` or `--sandbox agentcore` after configuring
+the provider's authentication. Both are deployment choices for specific
+remote workloads, not part of the local quickstart. They are single-container
+backends; AgentCore also cannot enforce `no-network` tasks.
+
+## Keep the task portable
+
+The sandbox flag selects where a task runs; it should not change what the task
+means. Develop and debug with Docker first, then run a small parity check on
+the intended cloud backend before starting a batch. If a task requires a
+backend-specific capability, document that requirement in the task rather
+than silently assuming Daytona.

--- a/docs/skill-eval.md
+++ b/docs/skill-eval.md
@@ -146,18 +146,12 @@ directly with `bench skills eval`, add a sibling `evals/evals.json` inside that
 skill directory or copy the skill into a standalone skill directory with the
 same `evals/` contract.
 
-The repo includes a real standalone example at
-[`skills/citation-management/`](../skills/citation-management/), adapted
-from the SkillsBench `citation-check` task:
-
-```bash
-bench skills eval skills/citation-management \
-  --agent gemini \
-  --model gemini-3.1-flash-lite-preview \
-  --sandbox docker \
-  --jobs-dir jobs/skill-eval-citation-management \
-  --concurrency 1
-```
+The repo includes a real task-embedded example at
+[`docs/examples/task-md/real-skillsbench/citation-check/environment/skills/citation-management/`](./examples/task-md/real-skillsbench/citation-check/environment/skills/citation-management/),
+adapted from the SkillsBench `citation-check` task. It is intentionally a task
+fixture rather than a standalone skill-eval package, so copy it to your own
+skill directory and add `evals/evals.json` before passing that directory to
+`bench skills eval`.
 
 ## Multi-agent comparison
 

--- a/docs/start-in-5-minutes.md
+++ b/docs/start-in-5-minutes.md
@@ -1,0 +1,156 @@
+# Start in 5 minutes
+
+Launch a real, scored BenchFlow evaluation on your own machine in about five
+minutes. This path uses a public SkillsBench task, your existing ChatGPT
+subscription through Codex, and local Docker. You do not need Daytona or a
+model API key.
+
+The task is `3d-scan-calc`, not a toy prompt. The agent must parse a binary STL,
+remove disconnected scan debris, recover a material ID stored in each triangle,
+look up its density, calculate the largest component's mass, and write a JSON
+report that an independent verifier checks to 0.1% accuracy.
+
+> Five minutes is a quickstart target, not a timeout or performance guarantee.
+> A first run may take longer while Docker pulls images or BenchFlow downloads
+> the task and agent. A cold local smoke test for this guide completed in 278.7
+> seconds with a 1/1 score; machine and network speeds vary.
+
+## 0:00 — Check the two prerequisites
+
+Start Docker and confirm that the daemon is reachable:
+
+```bash
+docker info >/dev/null
+```
+
+Install the [Codex CLI](https://github.com/openai/codex), sign in with your
+ChatGPT subscription, and confirm the saved login:
+
+```bash
+codex login
+codex login status
+```
+
+If you already use Codex, the login command normally opens no new setup work.
+
+## 1:00 — Install BenchFlow
+
+[`uv`](https://docs.astral.sh/uv/) can install BenchFlow and provision the
+required Python 3.12 runtime in one command:
+
+```bash
+uv tool install --python 3.12 --upgrade benchflow
+bench --version
+```
+
+If `uv` reports that the `bench` or `benchflow` executable already exists,
+repeat the install with `--force` to replace the stale entrypoint.
+
+## 2:00 — Run the real task locally
+
+Copy this command as-is:
+
+```bash
+bench eval run \
+  --source-repo benchflow-ai/skillsbench \
+  --source-path tasks/3d-scan-calc \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker \
+  --concurrency 1 \
+  --jobs-dir jobs/first-local-run
+```
+
+BenchFlow now performs the entire evaluation lifecycle:
+
+1. fetches the real task package and builds its local Docker image;
+2. makes your saved Codex login available to the agent in the sandbox;
+3. lets the agent inspect the STL and create `mass_report.json`;
+4. runs the task's verifier outside the agent's control; and
+5. saves the score, timings, token usage, and full ACP trajectory.
+
+The default skill mode is `no-skill`, so this first run measures the base agent.
+You can compare the task's bundled mesh-analysis skill later with
+`--skill-mode with-skill`.
+
+## Read the result
+
+A completed run ends with a summary like this:
+
+```text
+✓ Score: 1/1 (100.0%), mean reward 1.00, errors=0
+Artifacts: jobs/first-local-run/<timestamp>
+```
+
+The benchmarked agent is not guaranteed to pass. A 0/1 score with no execution
+error still means BenchFlow ran the agent and verifier successfully; it means
+the agent's answer did not satisfy the task.
+
+Summarize the saved run from the CLI:
+
+```bash
+bench eval list jobs/first-local-run
+bench eval metrics jobs/first-local-run
+```
+
+The important files are:
+
+```text
+jobs/first-local-run/<timestamp>/
+  summary.json
+  3d-scan-calc__<hash>/
+    result.json
+    timing.json
+    prompts.json
+    trajectory/acp_trajectory.jsonl
+    verifier/reward.txt
+    verifier/test-stdout.txt
+```
+
+- `summary.json` gives the job-level pass rate, elapsed time, token totals, and
+  telemetry coverage.
+- `result.json` is the quickest per-task record of reward, errors, tool calls,
+  and token usage.
+- `trajectory/acp_trajectory.jsonl` records the agent and tool interaction.
+- `verifier/reward.txt` and `test-stdout.txt` explain the score.
+
+Some agent/provider combinations also write
+`trajectory/llm_trajectory.jsonl`; subscription-backed ACP agents can report
+usage without producing that optional provider-level trace.
+
+Use a different `--jobs-dir` for an independent second trial. Reusing
+`jobs/first-local-run` intentionally resumes the existing run and skips work
+that is already complete.
+
+## Use Claude or Gemini instead
+
+Keep the task, Docker, and output flags unchanged, and replace the agent/model
+pair after signing in:
+
+| Login | Flags |
+|---|---|
+| Claude Code | `--agent claude --model claude-sonnet-4-6` |
+| Gemini CLI | `--agent gemini --model gemini-3.1-pro-preview` |
+
+For API keys, CI credentials, and provider-hosted models, see
+[Authentication](./authentication.md). For batches and pinned dataset runs,
+continue to [Running evaluations](./running-evaluations.md).
+
+## Reproduce the documentation smoke test from source
+
+The repository keeps a versioned copy of this real task so maintainers can test
+the guide without depending on a fresh remote clone:
+
+```bash
+uv sync --extra dev --locked
+uv run bench eval run \
+  --tasks-dir docs/examples/task-md/real-skillsbench/3d-scan-calc \
+  --agent codex \
+  --model gpt-5.5 \
+  --sandbox docker \
+  --concurrency 1 \
+  --jobs-dir jobs/docs-start-in-5-minutes
+```
+
+The documented smoke run used local Docker, made nine tool calls, received a
+1.0 verifier reward, and recorded complete timing and token metadata.

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -29,8 +29,8 @@ In BenchFlow, this is a two-role Scene where the "user" role is just another age
 source:
   repo: benchflow-ai/skillsbench
   path: tasks
-environment: daytona
-concurrency: 64
+environment: docker
+concurrency: 2
 
 scenes:
   - name: interactive-assist
@@ -87,7 +87,7 @@ config = RolloutConfig(
                   Turn("assistant", "The user provided additional guidance..."),
               ]),
     ],
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)
 ```
@@ -115,8 +115,8 @@ A coder agent solves the task, then an independent reviewer agent critiques the 
 source:
   repo: benchflow-ai/skillsbench
   path: tasks
-environment: daytona
-concurrency: 64
+environment: docker
+concurrency: 2
 
 scenes:
   - name: review-loop
@@ -160,7 +160,7 @@ config = RolloutConfig(
                   Turn("coder", "Call the review_code MCP tool to get feedback, then fix issues."),
               ]),
     ],
-    environment="daytona",
+    environment="docker",
     pre_agent_hooks=[mcp_reviewer_hook(port=8100, model="gemini-3.1-flash-lite")],
 )
 result = await bf.run(config)
@@ -199,8 +199,8 @@ An agent generates a task-specific skill before solving. This is a two-scene rol
 source:
   repo: benchflow-ai/skillsbench
   path: tasks
-environment: daytona
-concurrency: 64
+environment: docker
+concurrency: 2
 
 scenes:
   - name: skill-gen
@@ -241,7 +241,7 @@ config = RolloutConfig(
               roles=[Role("solver", "gemini", "gemini-3.1-flash-lite-preview")],
               turns=[Turn("solver")]),  # None prompt = native goal inline (legacy: instruction.md)
     ],
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)
 ```
@@ -269,8 +269,8 @@ The same agent receives multiple prompts in sequence, maintaining full conversat
 source:
   repo: benchflow-ai/skillsbench
   path: tasks
-environment: daytona
-concurrency: 64
+environment: docker
+concurrency: 2
 
 scenes:
   - name: iterative-solve
@@ -304,7 +304,7 @@ config = RolloutConfig(
                   Turn("solver", "Final check: verify every requirement is met."),
               ]),
     ],
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)
 ```
@@ -333,8 +333,8 @@ Different models fill different roles in the same scene. A cheap model codes, an
 source:
   repo: benchflow-ai/skillsbench
   path: tasks
-environment: daytona
-concurrency: 32
+environment: docker
+concurrency: 2
 
 scenes:
   - name: cross-model-review
@@ -378,7 +378,7 @@ config = RolloutConfig(
                   Turn("coder", "Address the reviewer's feedback."),
               ]),
     ],
-    environment="daytona",
+    environment="docker",
 )
 result = await bf.run(config)
 ```
@@ -416,7 +416,7 @@ services = [SERVICES["gmail"], SERVICES["gcal"], SERVICES["slack"]]
 config = RolloutConfig(
     task_path=Path("tasks/schedule-meeting-from-email"),
     scenes=[Scene.single(agent="gemini", model="gemini-3.1-flash-lite-preview")],
-    environment="daytona",
+    environment="docker",
     pre_agent_hooks=build_service_hooks(services),
 )
 result = await bf.run(config)
@@ -457,4 +457,3 @@ tasks/schedule-meeting-from-email/
 └── verifier/
     └── test.sh             # Verify: check gcal.db has the new event
 ```
-


### PR DESCRIPTION
## Summary

- replace the cloud-first onboarding path with a local Docker + subscription-auth flow
- add a tested **Start in 5 minutes** guide using the real SkillsBench `3d-scan-calc` task
- add focused authentication, evaluation-running, and sandbox-selection guides
- refresh the README, concepts, examples, agent, CLI, and Python API documentation
- document local rubric review and fix the removed standalone skill-eval example

## Why

The existing docs assumed too much prior BenchFlow knowledge and made Daytona look necessary for ordinary local use. The public onboarding path should start with one understandable local evaluation, explain what pass/fail means, and defer cloud sandboxes until remote scale or isolation is actually needed.

## Validation

- `UV_CACHE_DIR=/private/tmp/benchflow-uv-cache uv run python -m pytest tests/test_cli_docs_drift.py` — 8 passed
- real local Docker run of `3d-scan-calc` with Codex/`gpt-5.5` — 1/1, reward 1.0, 9 tool calls, complete timing/token metadata
- relative-link audit across all 22 public BenchFlow docs — passed
- `git diff --check` — passed

Companion website PR: [benchflow-ai/www.benchflow.ai#55](https://github.com/benchflow-ai/www.benchflow.ai/pull/55).