### PR TITLE
Release BenchFlow 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.6.10.dev0"
+version = "0.7.0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.6.10.dev0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Release

Stages the public BenchFlow `0.7.0` release after the production-proven trajectory-upload work in #1008.

- changes `[project].version` from `0.6.10.dev0` to `0.7.0`
- keeps the root package entry in `uv.lock` aligned
- contains no implementation changes

## Verification

- `TAG_NAME=v0.7.0 uv run --with packaging --no-project python tools/release_version.py public-release`: passed
- `uv lock --check`: passed
- release/version/base-install suite: 45 passed
- `uv build --no-sources`: wheel and sdist built
- `twine check`: both distributions passed
- `uv run bench --version`: `benchflow 0.7.0`

After merge, the exact merge commit will be tagged `v0.7.0`; the tag workflow must publish PyPI and the GitHub Release before main is advanced to `0.7.1.dev0` in a follow-up PR.
