### PR TITLE
Start BenchFlow 0.7.1 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.0"
+version = "0.7.1.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.0"
+version = "0.7.1.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Follow-up to v0.7.0

Returns `main` to the next development line after the successful public `0.7.0` release.

- `pyproject.toml`: `0.7.0` → `0.7.1.dev0`
- root `benchflow` entry in `uv.lock`: aligned
- no implementation changes

## Verification

- public `v0.7.0` workflow succeeded
- PyPI exposes wheel + sdist for `benchflow==0.7.0`
- GitHub Release is published with both assets
- `uv lock --check`: passed
- internal-preview policy computes `0.7.1.dev1`: passed
- release/version/base-install suite: 45 passed
- `uv run bench --version`: `benchflow 0.7.1.dev0`
