### PR TITLE
Version-check hint and latest-version precondition for trajectory contribution

### DIFF
--- a/.agents/skills/benchflow-traj-upload/SKILL.md
+++ b/.agents/skills/benchflow-traj-upload/SKILL.md
@@ -28,7 +28,7 @@ manifests, promotion checks), use `benchflow-traj-upload-ops` instead.
 ## Workflow
 
 ```
-1. setup     → install benchflow if `bench` is missing
+1. setup     → ensure the latest benchflow is installed
 2. discover  → list recent local Claude / Codex / trial sessions
 3. pick      → user chooses one (or confirms your recommendation)
 4. view      → open the trajectory viewer and give them the localhost URL
@@ -39,14 +39,17 @@ manifests, promotion checks), use `benchflow-traj-upload-ops` instead.
 
 ## Step 1 — Setup
 
-If `bench` is not on PATH:
+Always make sure the latest BenchFlow is installed before anything else —
+`bench traj setup` and the session-JSONL viewer only exist in 0.7.1+:
 
 ```bash
 uv tool install --python 3.12 --upgrade benchflow
 ```
 
-If uv reports `Executables already exist`, rerun with `--force`. Confirm with
-`bench --version`.
+If uv reports `Executables already exist`, rerun with `--force`. Verify that
+`bench --version` reports at least 0.7.1. If the installed CLI lacks
+`bench traj setup` or cannot open a session JSONL in the viewer, upgrade
+first rather than working around it.
 
 ## Step 2 — Discover
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+- **`bench traj setup` / `bench traj upload` print an upgrade hint when
+  outdated.** Both commands start with a lightweight PyPI latest-version
+  check (2 s timeout, completely silent on any network or parse failure) and
+  print a one-line `uv tool install --python 3.12 --upgrade --force
+  benchflow` hint when the installed version is older than the latest
+  release; dev/prereleases of a newer-or-equal base are not outdated.
+  `BENCHFLOW_SKIP_UPDATE_CHECK=1` disables the check. The
+  `benchflow-traj-upload` skill and docs now tell contributors to upgrade to
+  the latest BenchFlow (0.7.1+) before using the trajectory-upload flow.
+
 ### Changed
 - **Trajectory contribution is a copy-paste line, plus optional setup.**
   Contributors paste one line into their agent; the agent reads

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Submit my best local Claude Code or Codex session to the BenchFlow eval prize. R
 The agent finds sessions on this machine, opens the viewer, and uploads after
 you like what you see.
 
+Be on the latest BenchFlow first — `uv tool install --python 3.12 --upgrade
+--force benchflow`. The `bench traj` commands print a one-line upgrade hint
+when a newer release is available.
+
 Prefer the terminal instead? The guided upload inspects before anything leaves
 your machine — it renders a redacted trajectory report (step counts, masked
 secrets, preview) and asks for confirmation:

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -863,7 +863,10 @@ and hosted-provider browsing to [`bench hub list`](#bench-hub). The old
 Install the trajectory skill into the current project, or print the line
 contributors paste into an agent. Interactive by default. `--yes` copies the
 skill without prompts. `--prompt` prints only the copy-paste line. `--list`
-prints recent Claude Code / Codex / trial sessions.
+prints recent Claude Code / Codex / trial sessions. On start, the command
+checks PyPI for a newer release (2 s timeout, silent on any failure) and
+prints a one-line upgrade hint when the installed version is outdated; set
+`BENCHFLOW_SKIP_UPDATE_CHECK=1` to disable the check.
 
 ```bash
 bench traj setup
@@ -889,7 +892,10 @@ format-aware trajectory report. GitHub username and email are inferred from
 `gh` / `git` when omitted; run the bare command to be prompted for the path
 and for identity that inference cannot find. Sessions that prompted require
 confirmation and then show byte progress; invocations that resolved without
-prompting stay non-interactive.
+prompting stay non-interactive. Like `bench traj setup`, the command starts
+with a silent-on-failure PyPI check and prints a one-line upgrade hint when a
+newer BenchFlow release is available (`BENCHFLOW_SKIP_UPDATE_CHECK=1`
+disables it).
 
 ```bash
 bench traj upload

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -9,6 +9,11 @@ Submit my best local Claude Code or Codex session to the BenchFlow eval prize. R
 The agent reads the skill, finds a local session, opens the viewer, and
 uploads after you say it looks good.
 
+Be on the latest BenchFlow first — `uv tool install --python 3.12 --upgrade
+--force benchflow` — because `bench traj setup` and the session-JSONL viewer
+require 0.7.1+. When a newer release is available on PyPI, `bench traj setup`
+and `bench traj upload` print a one-line upgrade hint.
+
 ## Optional: set the skill up once
 
 If you want later chats to know the workflow without pasting the long line:

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -59,6 +59,67 @@ CONTRIBUTOR_PROMPT = (
     "and follow it: find a session, open the viewer, upload only after I review it."
 )
 
+UPGRADE_COMMAND = "uv tool install --python 3.12 --upgrade --force benchflow"
+
+
+def _fetch_latest_version() -> str | None:
+    """Return the latest release on PyPI, or ``None`` when unavailable.
+
+    Module-level so tests monkeypatch it and never touch the network.
+    """
+    import logging
+
+    import httpx
+
+    # The CLI configures INFO logging; keep httpx's "HTTP Request" line for
+    # this background check out of the user's terminal.
+    logger = logging.getLogger("httpx")
+    previous_level = logger.level
+    logger.setLevel(logging.WARNING)
+    try:
+        response = httpx.get("https://pypi.org/pypi/benchflow/json", timeout=2.0)
+        response.raise_for_status()
+        version = response.json()["info"]["version"]
+    finally:
+        logger.setLevel(previous_level)
+    return version if isinstance(version, str) else None
+
+
+def _installed_version() -> str | None:
+    import importlib.metadata
+
+    try:
+        return importlib.metadata.version("benchflow")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _maybe_print_update_hint() -> None:
+    """Print a one-line upgrade hint when a newer release exists on PyPI.
+
+    Best-effort only: any network, parse, or metadata failure is silent and
+    never blocks the command. ``BENCHFLOW_SKIP_UPDATE_CHECK`` disables the
+    check entirely (the test suite sets it for hermeticity).
+    """
+    if os.environ.get("BENCHFLOW_SKIP_UPDATE_CHECK"):
+        return
+    try:
+        installed = _installed_version()
+        latest = _fetch_latest_version()
+        if installed is None or latest is None:
+            return
+        from packaging.version import Version
+
+        # Compare release tuples so a dev/prerelease of a newer (or equal)
+        # base — e.g. 0.7.1.dev0 against PyPI 0.7.0 — never counts as
+        # outdated.
+        if Version(installed).release >= Version(latest).release:
+            return
+    except Exception:
+        return
+    # Plain print keeps the hint one physical line (no Rich wrapping).
+    print(f"A newer BenchFlow ({latest}) is available — run: {UPGRADE_COMMAND}")
+
 
 @dataclass(frozen=True)
 class _UploadOptions:
@@ -110,6 +171,7 @@ def register_traj(app: typer.Typer) -> None:
         ] = False,
     ) -> None:
         """Install the submit skill, or print the line to paste into an agent."""
+        _maybe_print_update_hint()
         if prompt_only:
             _print_contributor_prompt()
             return
@@ -184,6 +246,7 @@ def register_traj(app: typer.Typer) -> None:
         ] = DEFAULT_PREVIEW_STEPS,
     ) -> None:
         """Inspect, redact, confirm, and upload trajectory JSONL."""
+        _maybe_print_update_hint()
         try:
             _run_upload(
                 _UploadOptions(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,16 @@ def isolate_local_dotenv(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(tmp_path / ".env"))
 
 
+@pytest.fixture(autouse=True)
+def skip_update_check(monkeypatch) -> None:
+    """Keep the `bench traj` PyPI latest-version check out of unit tests.
+
+    Tests that exercise the hint delete this variable and monkeypatch the
+    fetch instead of touching the network.
+    """
+    monkeypatch.setenv("BENCHFLOW_SKIP_UPDATE_CHECK", "1")
+
+
 @pytest.fixture
 def hello_world_task_dir() -> Path:
     path = REF_TASKS / "hello-world"

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -634,6 +634,86 @@ def test_handshake_timeout_tells_people_to_retry(tmp_path: Path) -> None:
         )
 
 
+def _enable_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo the suite-wide BENCHFLOW_SKIP_UPDATE_CHECK conftest fixture."""
+    monkeypatch.delenv("BENCHFLOW_SKIP_UPDATE_CHECK", raising=False)
+
+
+def test_outdated_install_prints_the_upgrade_hint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards this PR (the version-check follow-up to PR #1013): an install
+    older than the PyPI latest gets one hint line on setup and upload."""
+    _enable_update_check(monkeypatch)
+    monkeypatch.setattr("benchflow.cli.traj._installed_version", lambda: "0.7.0")
+    monkeypatch.setattr("benchflow.cli.traj._fetch_latest_version", lambda: "0.7.2")
+
+    hint = (
+        "A newer BenchFlow (0.7.2) is available — run: "
+        "uv tool install --python 3.12 --upgrade --force benchflow"
+    )
+    setup_result = runner.invoke(app, ["traj", "setup", "--prompt"])
+    assert setup_result.exit_code == 0, setup_result.output
+    assert hint in click.unstyle(setup_result.output)
+
+    upload_result = runner.invoke(app, _upload_command(_trial(tmp_path), "--dry-run"))
+    assert upload_result.exit_code == 0, upload_result.output
+    assert hint in click.unstyle(upload_result.output)
+
+
+def test_update_check_network_failure_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards this PR (the version-check follow-up to PR #1013): a PyPI
+    failure prints nothing and leaves the exit code untouched."""
+    from benchflow.cli.traj import CONTRIBUTOR_PROMPT
+
+    _enable_update_check(monkeypatch)
+
+    def fail_fetch() -> str | None:
+        raise httpx.ConnectError("no network")
+
+    monkeypatch.setattr("benchflow.cli.traj._fetch_latest_version", fail_fetch)
+    result = runner.invoke(app, ["traj", "setup", "--prompt"])
+
+    assert result.exit_code == 0, result.output
+    assert "newer BenchFlow" not in result.output
+    assert CONTRIBUTOR_PROMPT in click.unstyle(result.output)
+
+
+@pytest.mark.parametrize(
+    "installed", ["0.7.2", "0.8.0", "0.7.2.dev0", "0.7.3.dev1", "0.7.2rc1"]
+)
+def test_current_or_newer_dev_install_prints_no_hint(
+    installed: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards this PR (the version-check follow-up to PR #1013): up-to-date
+    installs and dev/prereleases of a newer-or-equal base are not outdated."""
+    _enable_update_check(monkeypatch)
+    monkeypatch.setattr("benchflow.cli.traj._installed_version", lambda: installed)
+    monkeypatch.setattr("benchflow.cli.traj._fetch_latest_version", lambda: "0.7.2")
+    result = runner.invoke(app, ["traj", "setup", "--prompt"])
+
+    assert result.exit_code == 0, result.output
+    assert "newer BenchFlow" not in result.output
+
+
+def test_skip_update_check_env_var_never_fetches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards this PR (the version-check follow-up to PR #1013): the conftest
+    hermeticity guard BENCHFLOW_SKIP_UPDATE_CHECK short-circuits the fetch."""
+
+    def fail_fetch() -> str | None:
+        raise AssertionError("update check fetched despite skip env var")
+
+    monkeypatch.setattr("benchflow.cli.traj._fetch_latest_version", fail_fetch)
+    result = runner.invoke(app, ["traj", "setup", "--prompt"])
+
+    assert result.exit_code == 0, result.output
+    assert "newer BenchFlow" not in result.output
+
+
 def test_setup_prompt_prints_the_copy_paste_line() -> None:
     """The human path is one line to paste into an agent."""
     from benchflow.cli.traj import CONTRIBUTOR_PROMPT, SKILL_RAW_URL

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -642,7 +642,7 @@ def _enable_update_check(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_outdated_install_prints_the_upgrade_hint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Guards this PR (the version-check follow-up to PR #1013): an install
+    """Guards PR #1014 (the version-check follow-up to PR #1013): an install
     older than the PyPI latest gets one hint line on setup and upload."""
     _enable_update_check(monkeypatch)
     monkeypatch.setattr("benchflow.cli.traj._installed_version", lambda: "0.7.0")
@@ -664,7 +664,7 @@ def test_outdated_install_prints_the_upgrade_hint(
 def test_update_check_network_failure_is_silent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Guards this PR (the version-check follow-up to PR #1013): a PyPI
+    """Guards PR #1014 (the version-check follow-up to PR #1013): a PyPI
     failure prints nothing and leaves the exit code untouched."""
     from benchflow.cli.traj import CONTRIBUTOR_PROMPT
 
@@ -687,7 +687,7 @@ def test_update_check_network_failure_is_silent(
 def test_current_or_newer_dev_install_prints_no_hint(
     installed: str, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Guards this PR (the version-check follow-up to PR #1013): up-to-date
+    """Guards PR #1014 (the version-check follow-up to PR #1013): up-to-date
     installs and dev/prereleases of a newer-or-equal base are not outdated."""
     _enable_update_check(monkeypatch)
     monkeypatch.setattr("benchflow.cli.traj._installed_version", lambda: installed)
@@ -701,7 +701,7 @@ def test_current_or_newer_dev_install_prints_no_hint(
 def test_skip_update_check_env_var_never_fetches(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Guards this PR (the version-check follow-up to PR #1013): the conftest
+    """Guards PR #1014 (the version-check follow-up to PR #1013): the conftest
     hermeticity guard BENCHFLOW_SKIP_UPDATE_CHECK short-circuits the fetch."""
 
     def fail_fetch() -> str | None:


### PR DESCRIPTION
## Summary

Follow-up to #1013. The paste-line trajectory flow depends on `bench traj setup` and session-JSONL viewer support that only exist in 0.7.1+, so anyone on released 0.7.0 or older hits missing commands.

- `bench traj setup` and `bench traj upload` now start with a lightweight PyPI latest-version check (httpx GET, 2 s timeout) and print a one-line hint when the installed version is older than the latest release: `A newer BenchFlow (X.Y.Z) is available — run: uv tool install --python 3.12 --upgrade --force benchflow`. Any network/parse failure is completely silent and never blocks the command; dev/prereleases of a newer-or-equal base are not outdated; `BENCHFLOW_SKIP_UPDATE_CHECK=1` disables the check (the test suite sets it via a conftest fixture for hermeticity).
- The `benchflow-traj-upload` skill's Step 1 now always upgrades to the latest BenchFlow first and verifies `bench --version` is at least 0.7.1, rather than working around a stale CLI.
- README, docs/traj-upload.md, and docs/reference/cli.md mention the upgrade precondition and the hint behavior.

## Test plan

- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] `uv run ty check src/benchflow/cli/traj.py` (test-file diagnostics are pre-existing on main)
- [x] `uv run python -m pytest tests/test_traj_upload_cli.py tests/test_traj_upload_skill.py tests/test_cli_edge_case_hardening.py -q` — 100 passed, including new tests: outdated version prints the hint (setup + upload), network failure is silent with exit code unaffected, up-to-date / newer-dev versions print nothing, skip env var never fetches
- [x] Real smoke: `uv run bench traj setup --prompt` prints the paste line with no hint noise (0.7.1.dev0 vs PyPI 0.7.0 is correctly not outdated)