### PR TITLE
Release BenchFlow 0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.7.1 — 2026-08-16
+
 ### Added
 - **`bench traj setup` / `bench traj upload` print an upgrade hint when
   outdated.** Both commands start with a lightweight PyPI latest-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.1.dev0"
+version = "0.7.1"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.1.dev0"
+version = "0.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` / `uv.lock` from `0.7.1.dev0` to the final public version `0.7.1`, following `docs/release.md`.
- Promote the CHANGELOG `[Unreleased]` section to `## 0.7.1 — 2026-08-16` (PR #1013 paste-line trajectory contribution flow, PR #1014 PyPI version-check hint), leaving Unreleased empty.

## Release plan
Per `docs/release.md`: squash-merge this PR, tag the merge commit `v0.7.1` to trigger `public-release.yml` (PyPI publish + GitHub Release), then bump `main` back to `0.7.2.dev0`.

Goal: PyPI installs match the paste-line trajectory-contribution docs used by the hackathon.