### PR TITLE
Contributor paste line tells the agent to upgrade BenchFlow first

### DIFF
--- a/.agents/skills/benchflow-traj-upload/SKILL.md
+++ b/.agents/skills/benchflow-traj-upload/SKILL.md
@@ -64,7 +64,15 @@ If that command is missing, search these locations and skip nested
 
 - Claude Code: `~/.claude/projects/**/*.jsonl`
 - Codex: `~/.codex/sessions/**/*.jsonl` and `~/.codex/archived_sessions/*.jsonl`
+- Cursor: agent transcripts at `~/.cursor/projects/*/agent-transcripts/**/*.jsonl`
+- OpenCode: newer versions keep sessions in a SQLite database at
+  `~/.local/share/opencode/opencode.db` (run `opencode db path` to confirm);
+  older versions used JSON files under `~/.local/share/opencode/storage/session/`
 - BenchFlow trials: `jobs/**/trajectory/` or a directory with `turn*.txt`
+
+If the user described a time window or topic (for example, sessions from the
+last 72 hours on a specific project), prefer sessions matching that
+description.
 
 Show the 8 most recent with mtime, path, and the first user-prompt snippet.
 Skip sessions that clearly contain private or proprietary work unless the

--- a/.agents/skills/benchflow-traj-upload/evals/evals.json
+++ b/.agents/skills/benchflow-traj-upload/evals/evals.json
@@ -3,7 +3,7 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 hours on laptop to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I (the human) review it.",
+      "prompt": "Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session from the re:Agent e2e agentic science / ai4bio hackathon (last 72 hours, on this laptop) to the BenchFlow eval prize.\n\n1. First make sure the latest benchflow CLI is installed: uv tool install --python 3.12 --upgrade --force benchflow\n\n2. Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, and upload only after I (the human) review it.",
       "expected_output": "Agent discovers local sessions, opens the viewer, waits for review, then uploads. Human is not told to run a CLI command.",
       "files": []
     },

--- a/.agents/skills/benchflow-traj-upload/evals/evals.json
+++ b/.agents/skills/benchflow-traj-upload/evals/evals.json
@@ -3,7 +3,7 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Submit my best local Claude Code or Codex session to the BenchFlow eval prize. Read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.",
+      "prompt": "Submit my best local Claude Code or Codex session to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.",
       "expected_output": "Agent discovers local sessions, opens the viewer, waits for review, then uploads. Human is not told to run a CLI command.",
       "files": []
     },

--- a/.agents/skills/benchflow-traj-upload/evals/evals.json
+++ b/.agents/skills/benchflow-traj-upload/evals/evals.json
@@ -3,7 +3,7 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "Submit my best local Claude Code or Codex session to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.",
+      "prompt": "Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 hours on laptop to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I (the human) review it.",
       "expected_output": "Agent discovers local sessions, opens the viewer, waits for review, then uploads. Human is not told to run a CLI command.",
       "files": []
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@
   `docs/traj-upload.md`, and the `benchflow-traj-upload` skill evals) says to
   run `uv tool install --python 3.12 --upgrade --force benchflow` before
   reading the skill, so agents that skim the skill or hit a stale copy still
-  install the latest CLI. Follow-up to the version precondition from
-  #1013/#1014.
+  install the latest CLI. The line also names OpenCode and Cursor sessions
+  and the re:Agent hackathon 72-hour window, and the skill's Discover step
+  gains best-effort Cursor (`~/.cursor/projects/*/agent-transcripts/`) and
+  OpenCode (`~/.local/share/opencode/opencode.db`, `opencode db path`)
+  locations plus a prefer-recent-matching-sessions note. Follow-up to the
+  version precondition from #1013/#1014.
 - **Trajectory contribution is a copy-paste line, plus optional setup.**
   Contributors paste one line into their agent; the agent reads
   `benchflow-traj-upload`, opens the viewer, then uploads. Optional setup is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,20 @@
 ## [Unreleased]
 
 ### Changed
-- **The contributor paste line now tells the agent to upgrade BenchFlow
-  first.** `CONTRIBUTOR_PROMPT` (and its verbatim copies in `README.md`,
-  `docs/traj-upload.md`, and the `benchflow-traj-upload` skill evals) says to
-  run `uv tool install --python 3.12 --upgrade --force benchflow` before
-  reading the skill, so agents that skim the skill or hit a stale copy still
-  install the latest CLI. The line also names OpenCode and Cursor sessions
-  and the re:Agent hackathon 72-hour window, and the skill's Discover step
-  gains best-effort Cursor (`~/.cursor/projects/*/agent-transcripts/`) and
-  OpenCode (`~/.local/share/opencode/opencode.db`, `opencode db path`)
-  locations plus a prefer-recent-matching-sessions note. Follow-up to the
-  version precondition from #1013/#1014.
+- **The contributor prompt now tells the agent to upgrade BenchFlow first.**
+  `CONTRIBUTOR_PROMPT` (kept in sync in `README.md`, `docs/traj-upload.md`,
+  and the `benchflow-traj-upload` skill evals) is a three-line block that
+  says to run `uv tool install --python 3.12 --upgrade --force benchflow`
+  before reading the skill, so agents that skim the skill or hit a stale copy
+  still install the latest CLI. The prompt also names OpenCode and Cursor
+  sessions and the re:Agent hackathon 72-hour window; README/docs render it
+  as a blockquote (soft-wraps on GitHub) behind an explicit "send this to
+  your coding agent" framing, and `bench traj setup` prints the same framing.
+  The skill's Discover step gains best-effort Cursor
+  (`~/.cursor/projects/*/agent-transcripts/`) and OpenCode
+  (`~/.local/share/opencode/opencode.db`, `opencode db path`) locations plus
+  a prefer-recent-matching-sessions note. Follow-up to the version
+  precondition from #1013/#1014.
 
 ## 0.7.1 — 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+- **The contributor paste line now tells the agent to upgrade BenchFlow
+  first.** `CONTRIBUTOR_PROMPT` (and its verbatim copies in `README.md`,
+  `docs/traj-upload.md`, and the `benchflow-traj-upload` skill evals) says to
+  run `uv tool install --python 3.12 --upgrade --force benchflow` before
+  reading the skill, so agents that skim the skill or hit a stale copy still
+  install the latest CLI. The line also names OpenCode and Cursor sessions
+  and the re:Agent hackathon 72-hour window, and the skill's Discover step
+  gains best-effort Cursor (`~/.cursor/projects/*/agent-transcripts/`) and
+  OpenCode (`~/.local/share/opencode/opencode.db`, `opencode db path`)
+  locations plus a prefer-recent-matching-sessions note. Follow-up to the
+  version precondition from #1013/#1014.
+
 ## 0.7.1 — 2026-08-16
 
 ### Added
@@ -16,17 +29,6 @@
   the latest BenchFlow (0.7.1+) before using the trajectory-upload flow.
 
 ### Changed
-- **The contributor paste line now tells the agent to upgrade BenchFlow
-  first.** `CONTRIBUTOR_PROMPT` (and its verbatim copies in `README.md`,
-  `docs/traj-upload.md`, and the `benchflow-traj-upload` skill evals) says to
-  run `uv tool install --python 3.12 --upgrade --force benchflow` before
-  reading the skill, so agents that skim the skill or hit a stale copy still
-  install the latest CLI. The line also names OpenCode and Cursor sessions
-  and the re:Agent hackathon 72-hour window, and the skill's Discover step
-  gains best-effort Cursor (`~/.cursor/projects/*/agent-transcripts/`) and
-  OpenCode (`~/.local/share/opencode/opencode.db`, `opencode db path`)
-  locations plus a prefer-recent-matching-sessions note. Follow-up to the
-  version precondition from #1013/#1014.
 - **Trajectory contribution is a copy-paste line, plus optional setup.**
   Contributors paste one line into their agent; the agent reads
   `benchflow-traj-upload`, opens the viewer, then uploads. Optional setup is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@
   the latest BenchFlow (0.7.1+) before using the trajectory-upload flow.
 
 ### Changed
+- **The contributor paste line now tells the agent to upgrade BenchFlow
+  first.** `CONTRIBUTOR_PROMPT` (and its verbatim copies in `README.md`,
+  `docs/traj-upload.md`, and the `benchflow-traj-upload` skill evals) says to
+  run `uv tool install --python 3.12 --upgrade --force benchflow` before
+  reading the skill, so agents that skim the skill or hit a stale copy still
+  install the latest CLI. Follow-up to the version precondition from
+  #1013/#1014.
 - **Trajectory contribution is a copy-paste line, plus optional setup.**
   Contributors paste one line into their agent; the agent reads
   `benchflow-traj-upload`, opens the viewer, then uploads. Optional setup is

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Codex, Cursor, or any coding agent. That is the $2,000 eval prize path. No
 BenchFlow account, API key, or Azure login.
 
 ```
-Submit my best local Claude Code or Codex session to the BenchFlow eval prize. Read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.
+Submit my best local Claude Code or Codex session to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.
 ```
 
 The agent finds sessions on this machine, opens the viewer, and uploads after
 you like what you see.
 
-Be on the latest BenchFlow first — `uv tool install --python 3.12 --upgrade
---force benchflow`. The `bench traj` commands print a one-line upgrade hint
-when a newer release is available.
+The paste line has the agent install the latest BenchFlow first (`uv tool
+install --python 3.12 --upgrade --force benchflow`). The `bench traj` commands
+also print a one-line upgrade hint when a newer release is available.
 
 Prefer the terminal instead? The guided upload inspects before anything leaves
 your machine — it renders a redacted trajectory report (step counts, masked

--- a/README.md
+++ b/README.md
@@ -15,18 +15,21 @@ BenchFlow is a universal environment framework: it runs AI agents against task e
 
 ## Quick start: 1. Submit a trajectory
 
-Proud of a Claude Code or Codex session? Copy this line into Claude Code,
-Codex, Cursor, or any coding agent. That is the $2,000 eval prize path. No
-BenchFlow account, API key, or Azure login.
+**Don't follow these steps yourself — send them to your coding agent.** Copy
+the block below and paste it as a message to Claude Code, Codex, OpenCode, or
+Cursor. That is the $2,000 eval prize path. No BenchFlow account, API key, or
+Azure login.
 
-```
-Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 hours on laptop to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I (the human) review it.
-```
+> Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session from the re:Agent e2e agentic science / ai4bio hackathon (last 72 hours, on this laptop) to the BenchFlow eval prize.
+>
+> 1. First make sure the latest benchflow CLI is installed: uv tool install --python 3.12 --upgrade --force benchflow
+>
+> 2. Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, and upload only after I (the human) review it.
 
 The agent finds sessions on this machine, opens the viewer, and uploads after
 you like what you see.
 
-The paste line has the agent install the latest BenchFlow first (`uv tool
+The prompt has the agent install the latest BenchFlow first (`uv tool
 install --python 3.12 --upgrade --force benchflow`). The `bench traj` commands
 also print a one-line upgrade hint when a newer release is available.
 
@@ -54,7 +57,7 @@ bench traj setup
 ```
 
 `npx skills add` asks which agents to install for. `bench traj setup` copies
-the skill into this project and prints the same paste line. See the
+the skill into this project and prints the same agent prompt. See the
 [upload skill](./.agents/skills/benchflow-traj-upload/SKILL.md).
 
 ## Quick start: 2. Run with a ChatGPT or Claude subscription

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Codex, Cursor, or any coding agent. That is the $2,000 eval prize path. No
 BenchFlow account, API key, or Azure login.
 
 ```
-Submit my best local Claude Code or Codex session to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.
+Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 hours on laptop to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I (the human) review it.
 ```
 
 The agent finds sessions on this machine, opens the viewer, and uploads after

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -3,16 +3,17 @@
 Copy this line into your coding agent. You do not run a BenchFlow command.
 
 ```
-Submit my best local Claude Code or Codex session to the BenchFlow eval prize. Read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.
+Submit my best local Claude Code or Codex session to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.
 ```
 
 The agent reads the skill, finds a local session, opens the viewer, and
 uploads after you say it looks good.
 
-Be on the latest BenchFlow first — `uv tool install --python 3.12 --upgrade
---force benchflow` — because `bench traj setup` and the session-JSONL viewer
-require 0.7.1+. When a newer release is available on PyPI, `bench traj setup`
-and `bench traj upload` print a one-line upgrade hint.
+The paste line has the agent install the latest BenchFlow first (`uv tool
+install --python 3.12 --upgrade --force benchflow`) because `bench traj setup`
+and the session-JSONL viewer require 0.7.1+. When a newer release is available
+on PyPI, `bench traj setup` and `bench traj upload` print a one-line upgrade
+hint.
 
 ## Optional: set the skill up once
 

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -1,15 +1,19 @@
 # Contribute trajectory captures
 
-Copy this line into your coding agent. You do not run a BenchFlow command.
+**Don't follow these steps yourself — send them to your coding agent.** Copy
+the block below and paste it as a message to Claude Code, Codex, OpenCode, or
+Cursor. You do not run a BenchFlow command.
 
-```
-Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 hours on laptop to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I (the human) review it.
-```
+> Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session from the re:Agent e2e agentic science / ai4bio hackathon (last 72 hours, on this laptop) to the BenchFlow eval prize.
+>
+> 1. First make sure the latest benchflow CLI is installed: uv tool install --python 3.12 --upgrade --force benchflow
+>
+> 2. Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, and upload only after I (the human) review it.
 
 The agent reads the skill, finds a local session, opens the viewer, and
 uploads after you say it looks good.
 
-The paste line has the agent install the latest BenchFlow first (`uv tool
+The prompt has the agent install the latest BenchFlow first (`uv tool
 install --python 3.12 --upgrade --force benchflow`) because `bench traj setup`
 and the session-JSONL viewer require 0.7.1+. When a newer release is available
 on PyPI, `bench traj setup` and `bench traj upload` print a one-line upgrade
@@ -17,7 +21,7 @@ hint.
 
 ## Optional: set the skill up once
 
-If you want later chats to know the workflow without pasting the long line:
+If you want later chats to know the workflow without pasting the long prompt:
 
 ```bash
 npx skills add benchflow-ai/benchflow --skill benchflow-traj-upload
@@ -32,11 +36,11 @@ bench traj setup
 `npx skills add` is interactive: it asks which agents to install for
 (Claude Code, Codex, Cursor, and other [Agent Skills](https://agentskills.io)
 hosts). `bench traj setup` copies the skill into
-`.agents/skills/benchflow-traj-upload/`, prints the same paste line, and can
+`.agents/skills/benchflow-traj-upload/`, prints the same agent prompt, and can
 list sessions or open the viewer. After setup, a short ask is enough:
 **submit my relevant session to the eval prize**.
 
-`bench traj setup --prompt` prints only the copy-paste line.
+`bench traj setup --prompt` prints only the copy-paste agent prompt.
 `bench traj setup --list` lists recent local sessions.
 
 ## Optional: interactive upload without an agent

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -3,7 +3,7 @@
 Copy this line into your coding agent. You do not run a BenchFlow command.
 
 ```
-Submit my best local Claude Code or Codex session to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I review it.
+Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 hours on laptop to the BenchFlow eval prize. First make sure the latest benchflow CLI is installed (uv tool install --python 3.12 --upgrade --force benchflow). Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, upload only after I (the human) review it.
 ```
 
 The agent reads the skill, finds a local session, opens the viewer, and
@@ -34,7 +34,7 @@ bench traj setup
 hosts). `bench traj setup` copies the skill into
 `.agents/skills/benchflow-traj-upload/`, prints the same paste line, and can
 list sessions or open the viewer. After setup, a short ask is enough:
-**submit my best session to the eval prize**.
+**submit my relevant session to the eval prize**.
 
 `bench traj setup --prompt` prints only the copy-paste line.
 `bench traj setup --list` lists recent local sessions.

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -54,15 +54,23 @@ SKILL_RAW_URL = (
 
 UPGRADE_COMMAND = "uv tool install --python 3.12 --upgrade --force benchflow"
 
+# Three unwrapped lines separated by blank lines: each logical unit is one
+# full physical line (no hard wraps mid-sentence), so the URL and the upgrade
+# command stay selectable in agents and terminals.
 CONTRIBUTOR_PROMPT = (
     "Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session "
-    "on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 "
-    "hours on laptop to the BenchFlow eval prize. First make sure the latest "
-    "benchflow CLI is installed "
-    f"({UPGRADE_COMMAND}). Then read "
-    f"{SKILL_RAW_URL} "
-    "and follow it: find a session, open the viewer, upload only after I "
-    "(the human) review it."
+    "from the re:Agent e2e agentic science / ai4bio hackathon (last 72 hours, "
+    "on this laptop) to the BenchFlow eval prize."
+    "\n\n"
+    f"1. First make sure the latest benchflow CLI is installed: {UPGRADE_COMMAND}"
+    "\n\n"
+    f"2. Then read {SKILL_RAW_URL} "
+    "and follow it: find a session, open the viewer, and upload only after "
+    "I (the human) review it."
+)
+
+CONTRIBUTOR_PROMPT_FRAMING = (
+    "Send this to your coding agent (it's a prompt for the agent, not steps for you):"
 )
 
 
@@ -167,14 +175,14 @@ def register_traj(app: typer.Typer) -> None:
         ] = False,
         prompt_only: Annotated[
             bool,
-            typer.Option("--prompt", help="Print the copy-paste agent line and exit"),
+            typer.Option("--prompt", help="Print the copy-paste agent prompt and exit"),
         ] = False,
         list_sessions: Annotated[
             bool,
             typer.Option("--list", help="List recent local sessions and exit"),
         ] = False,
     ) -> None:
-        """Install the submit skill, or print the line to paste into an agent."""
+        """Install the submit skill, or print the prompt to send to an agent."""
         _maybe_print_update_hint()
         if prompt_only:
             _print_contributor_prompt()
@@ -195,7 +203,6 @@ def register_traj(app: typer.Typer) -> None:
                 _run_npx_skill_install()
         else:
             _install_project_skill(Path.cwd())
-        console.print("Paste this to your agent:")
         _print_contributor_prompt()
         if interactive and typer.confirm(
             "List recent sessions and open the viewer now?", default=False
@@ -521,7 +528,9 @@ def _print_dry_run(staged: StagedCapture) -> None:
 
 
 def _print_contributor_prompt() -> None:
-    # One physical line so people can copy it. Rich wrapping would break that.
+    # Plain print: Rich wrapping would break the unbroken URL line and make
+    # the block awkward to copy.
+    print(CONTRIBUTOR_PROMPT_FRAMING)
     print(CONTRIBUTOR_PROMPT)
 
 
@@ -567,7 +576,7 @@ def _run_npx_skill_install() -> None:
         check=False,
     )
     if completed.returncode != 0:
-        print_error("npx skills add failed; the copy-paste line below still works.")
+        print_error("npx skills add failed; the copy-paste prompt below still works.")
 
 
 def _print_session_hits() -> None:

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -55,11 +55,14 @@ SKILL_RAW_URL = (
 UPGRADE_COMMAND = "uv tool install --python 3.12 --upgrade --force benchflow"
 
 CONTRIBUTOR_PROMPT = (
-    "Submit my best local Claude Code or Codex session to the BenchFlow eval "
-    "prize. First make sure the latest benchflow CLI is installed "
+    "Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session "
+    "on the re:Agent e2e agentic science / ai4bio hackathon in the last 72 "
+    "hours on laptop to the BenchFlow eval prize. First make sure the latest "
+    "benchflow CLI is installed "
     f"({UPGRADE_COMMAND}). Then read "
     f"{SKILL_RAW_URL} "
-    "and follow it: find a session, open the viewer, upload only after I review it."
+    "and follow it: find a session, open the viewer, upload only after I "
+    "(the human) review it."
 )
 
 

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -52,14 +52,15 @@ SKILL_RAW_URL = (
     "/.agents/skills/benchflow-traj-upload/SKILL.md"
 )
 
+UPGRADE_COMMAND = "uv tool install --python 3.12 --upgrade --force benchflow"
+
 CONTRIBUTOR_PROMPT = (
     "Submit my best local Claude Code or Codex session to the BenchFlow eval "
-    "prize. Read "
+    "prize. First make sure the latest benchflow CLI is installed "
+    f"({UPGRADE_COMMAND}). Then read "
     f"{SKILL_RAW_URL} "
     "and follow it: find a session, open the viewer, upload only after I review it."
 )
-
-UPGRADE_COMMAND = "uv tool install --python 3.12 --upgrade --force benchflow"
 
 
 def _fetch_latest_version() -> str | None:

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -715,27 +715,45 @@ def test_skip_update_check_env_var_never_fetches(
 
 
 def test_setup_prompt_prints_the_copy_paste_line() -> None:
-    """The human path is one line to paste into an agent.
+    """The human path is one prompt block to send to an agent.
 
-    Also guards the version step added in PR #1017 (follow-up to PRs #1013
-    and #1014): the paste line itself tells the agent to upgrade BenchFlow,
-    with the upgrade command appearing before the skill URL.
+    Guards the version step and hand-off framing added in PR #1017
+    (follow-up to PRs #1013 and #1014): the prompt tells the agent to
+    upgrade BenchFlow before reading the skill, the upgrade command appears
+    before the skill URL, and the URL sits on one unbroken physical line.
+    README.md renders the prompt as a blockquote (a fenced code block would
+    not soft-wrap on GitHub), so each unwrapped prompt line is asserted to be
+    present in the README instead of the whole string verbatim.
     """
-    from benchflow.cli.traj import CONTRIBUTOR_PROMPT, SKILL_RAW_URL, UPGRADE_COMMAND
+    from benchflow.cli.traj import (
+        CONTRIBUTOR_PROMPT,
+        CONTRIBUTOR_PROMPT_FRAMING,
+        SKILL_RAW_URL,
+        UPGRADE_COMMAND,
+    )
 
     result = runner.invoke(app, ["traj", "setup", "--prompt"])
     readme = Path(__file__).resolve().parents[1] / "README.md"
+    readme_text = readme.read_text(encoding="utf-8")
 
     assert result.exit_code == 0, result.output
-    assert CONTRIBUTOR_PROMPT in click.unstyle(result.output)
+    output = click.unstyle(result.output)
+    assert CONTRIBUTOR_PROMPT_FRAMING in output
+    assert CONTRIBUTOR_PROMPT in output
     assert SKILL_RAW_URL in result.output
     assert "bench traj upload" not in result.output
-    assert CONTRIBUTOR_PROMPT in readme.read_text(encoding="utf-8")
+
+    prompt_lines = [line for line in CONTRIBUTOR_PROMPT.splitlines() if line]
+    assert len(prompt_lines) == 3
+    for line in prompt_lines:
+        assert line in readme_text
+    assert "send them to your coding agent" in readme_text
+
     assert UPGRADE_COMMAND in CONTRIBUTOR_PROMPT
     assert CONTRIBUTOR_PROMPT.index(UPGRADE_COMMAND) < CONTRIBUTOR_PROMPT.index(
         SKILL_RAW_URL
     )
-    assert "\n" not in CONTRIBUTOR_PROMPT
+    assert any(SKILL_RAW_URL in line for line in prompt_lines)
 
 
 def test_setup_yes_installs_the_skill(
@@ -750,7 +768,9 @@ def test_setup_yes_installs_the_skill(
     assert skill.is_file()
     text = skill.read_text(encoding="utf-8")
     assert "open the viewer" in text
-    assert "Paste this to your agent" in click.unstyle(result.output)
+    # PR #1017 reframed the hand-off copy: the block is a prompt for the
+    # agent, not steps for the human.
+    assert "Send this to your coding agent" in click.unstyle(result.output)
 
 
 def test_list_recent_sessions_scans_all_projects_most_recent_first(

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -717,9 +717,9 @@ def test_skip_update_check_env_var_never_fetches(
 def test_setup_prompt_prints_the_copy_paste_line() -> None:
     """The human path is one line to paste into an agent.
 
-    Also guards the version step added in this PR (follow-up to PRs #1013 and
-    #1014): the paste line itself tells the agent to upgrade BenchFlow, with
-    the upgrade command appearing before the skill URL.
+    Also guards the version step added in PR #1017 (follow-up to PRs #1013
+    and #1014): the paste line itself tells the agent to upgrade BenchFlow,
+    with the upgrade command appearing before the skill URL.
     """
     from benchflow.cli.traj import CONTRIBUTOR_PROMPT, SKILL_RAW_URL, UPGRADE_COMMAND
 

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -715,8 +715,13 @@ def test_skip_update_check_env_var_never_fetches(
 
 
 def test_setup_prompt_prints_the_copy_paste_line() -> None:
-    """The human path is one line to paste into an agent."""
-    from benchflow.cli.traj import CONTRIBUTOR_PROMPT, SKILL_RAW_URL
+    """The human path is one line to paste into an agent.
+
+    Also guards the version step added in this PR (follow-up to PRs #1013 and
+    #1014): the paste line itself tells the agent to upgrade BenchFlow, with
+    the upgrade command appearing before the skill URL.
+    """
+    from benchflow.cli.traj import CONTRIBUTOR_PROMPT, SKILL_RAW_URL, UPGRADE_COMMAND
 
     result = runner.invoke(app, ["traj", "setup", "--prompt"])
     readme = Path(__file__).resolve().parents[1] / "README.md"
@@ -726,6 +731,11 @@ def test_setup_prompt_prints_the_copy_paste_line() -> None:
     assert SKILL_RAW_URL in result.output
     assert "bench traj upload" not in result.output
     assert CONTRIBUTOR_PROMPT in readme.read_text(encoding="utf-8")
+    assert UPGRADE_COMMAND in CONTRIBUTOR_PROMPT
+    assert CONTRIBUTOR_PROMPT.index(UPGRADE_COMMAND) < CONTRIBUTOR_PROMPT.index(
+        SKILL_RAW_URL
+    )
+    assert "\n" not in CONTRIBUTOR_PROMPT
 
 
 def test_setup_yes_installs_the_skill(


### PR DESCRIPTION
## Summary

Follow-up to #1013 (paste-line contributor experience) and #1014 (version-check hint + skill precondition). Those put the version precondition in the SKILL and a CLI hint, but an agent that skims the skill or reads a stale cached copy could still run an old CLI. This PR bakes the upgrade into the contributor prompt itself and reframes it as an explicit agent hand-off.

- `CONTRIBUTOR_PROMPT` in `src/benchflow/cli/traj.py` is now a three-line block (each logical unit one unwrapped physical line, blank lines between; URL and upgrade command stay selectable), built from the existing `UPGRADE_COMMAND` / `SKILL_RAW_URL` constants:

  > Submit my relevant local Claude Code, Codex, OpenCode, or Cursor session from the re:Agent e2e agentic science / ai4bio hackathon (last 72 hours, on this laptop) to the BenchFlow eval prize.
  >
  > 1. First make sure the latest benchflow CLI is installed: uv tool install --python 3.12 --upgrade --force benchflow
  >
  > 2. Then read https://raw.githubusercontent.com/benchflow-ai/benchflow/main/.agents/skills/benchflow-traj-upload/SKILL.md and follow it: find a session, open the viewer, and upload only after I (the human) review it.

- **Agent hand-off framing everywhere the block appears.** README and `docs/traj-upload.md` lead with "**Don't follow these steps yourself — send them to your coding agent.**" and render the prompt as a blockquote (a fenced code block would not soft-wrap on GitHub). `bench traj setup` / `--prompt` print `Send this to your coding agent (it's a prompt for the agent, not steps for you):` before the block (plain print, no Rich wrapping), replacing the old "Paste this to your agent:" copy.
- Synced copies: `README.md`, `docs/traj-upload.md`, and `.agents/skills/benchflow-traj-upload/evals/evals.json` eval #1 prompt (`.claude/skills` is a symlink, so covered).
- Skill Step 2 (Discover) adds best-effort locations for the newly named agents: Cursor agent transcripts (`~/.cursor/projects/*/agent-transcripts/**/*.jsonl`) and OpenCode (`~/.local/share/opencode/opencode.db` via `opencode db path`; older versions `~/.local/share/opencode/storage/session/`), plus a note to prefer sessions matching the described time window/topic. `src/benchflow/trajectories/sessions.py` deliberately untouched — skill-level guidance only.
- `test_setup_prompt_prints_the_copy_paste_line` asserts the CLI prints framing + block verbatim, the upgrade command appears before the skill URL, the URL sits on one unbroken line, and each of the three unwrapped lines is present in the README (the blockquote `> ` prefixes make a whole-string verbatim match impossible; noted in the docstring).
- CHANGELOG Unreleased entry (re-seated after the 0.7.1 release train from #1016/#1018 moved the section; merged origin/main twice, resolving one CHANGELOG conflict with #1019).

## Test plan

- [x] `uv run ruff check .` + `ruff format --check` on touched files
- [x] `uv run ty check src/`
- [x] `uv run python -m pytest tests/test_traj_upload_cli.py tests/test_traj_upload_skill.py -q` — 41 passed
- [x] `uv run bench traj setup --prompt` prints the framing line + the three-line block verbatim
