### PR TITLE
Start BenchFlow 0.7.2 development

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.1"
+version = "0.7.2.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.1"
+version = "0.7.2.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- Bump `main` from the just-published `0.7.1` back to the next development line `0.7.2.dev0` (pyproject.toml + uv.lock), per `docs/release.md`.

Follows the v0.7.1 public release (PR #1016, tag `v0.7.1`); mirrors #1012.