### PR TITLE
Trajectory viewer: in-browser Approve/Reject confirmation (--confirm)

### DIFF
--- a/.agents/skills/benchflow-traj-upload/SKILL.md
+++ b/.agents/skills/benchflow-traj-upload/SKILL.md
@@ -31,8 +31,8 @@ manifests, promotion checks), use `benchflow-traj-upload-ops` instead.
 1. setup     → ensure the latest benchflow is installed
 2. discover  → list recent local Claude / Codex / trial sessions
 3. pick      → user chooses one (or confirms your recommendation)
-4. view      → open the trajectory viewer and give them the localhost URL
-5. confirm   → wait until they say it looks good
+4. view      → open the viewer with --confirm and give them the localhost URL
+5. confirm   → wait for the Approve button (or their chat reply)
 6. submit    → you upload; report Submitted / Already submitted + digest
 7. persist   → if this repo has no local copy of this skill, write one
 ```
@@ -85,19 +85,38 @@ yet — the viewer is how they decide the session is the one they meant.
 
 ## Step 4 — View
 
-Open the viewer in the background and tell the user the URL:
+Open the viewer with the in-page confirm bar and tell the user the URL:
 
 ```bash
-bench eval view /path/to/session.jsonl
+bench eval view /path/to/session.jsonl --confirm --port 8889
 ```
 
-That path may also be a trial directory. Leave the server running until they
-finish reviewing. If the port is taken, try `--port 8889`.
+That path may also be a trial directory. If the port is taken, pick another.
+
+With `--confirm` the page shows an **Approve & submit** / **Not this one**
+bar. When the user clicks, the server prints one line to stdout —
+`DECISION: approved` or `DECISION: rejected` — and exits (exit code 0 on
+approve, 3 on reject). Run the command so you can wait on that output:
+either start it in the background and poll its output for the `DECISION:`
+line, or run it blocking with a generous timeout.
+
+If the installed CLI predates `--confirm` (`bench --version` below 0.7.2),
+run the plain `bench eval view /path/to/session.jsonl` in the background
+instead and rely on the chat confirmation in Step 5.
 
 ## Step 5 — Confirm
 
-Ask them to look at the viewer. Do not upload until they say it looks good.
-If they want a different session, go back to pick.
+Ask them to review the page and click a button in the viewer:
+
+- `DECISION: approved` (exit 0) → they approved; proceed to Step 6.
+- `DECISION: rejected` (exit 3) → they want a different session; go back to
+  pick.
+- If they answer in chat before clicking anything, kill the viewer process
+  and honor the chat answer.
+- Without `--confirm` (older CLI), wait until they say in chat that it looks
+  good.
+
+Do not upload until one of those signals says the session is right.
 
 The upload is tagged with the repository the session was about: the CLI reads
 the session's recorded working directory, resolves its git `origin` remote,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 ## [Unreleased]
 
 ### Added
+- **The trajectory viewer can collect the eval-prize confirmation in the
+  browser.** `bench eval view PATH --confirm` renders the normal page plus a
+  sticky site-styled bottom bar ("Submit this trajectory to the BenchFlow
+  eval prize?") with **Approve & submit** / **Not this one** buttons. A click
+  POSTs to `/decision`; the server prints a machine-readable
+  `DECISION: approved` or `DECISION: rejected` line to stdout, shuts down,
+  and the CLI exits `0` on approve and `3` on reject (non-1/2 so rejection
+  never collides with error or usage exits). Without the flag, behavior is
+  unchanged (no bar, no endpoint, Ctrl+C to stop). The
+  `benchflow-traj-upload` skill now prefers the button flow and falls back
+  to chat confirmation on CLIs older than 0.7.2.
 - **Trajectory uploads are tagged with the session's repository by
   default.** Unless `--source-id` is given, `bench traj upload` reads the
   session's recorded working directory (Claude `cwd` events, Codex

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -418,10 +418,19 @@ directory, or a Claude Code / Codex / ACP session JSONL file. Contributors
 reach this through the [trajectory upload skill](../../.agents/skills/benchflow-traj-upload/SKILL.md),
 not by running the command themselves.
 
+`--confirm` adds a sticky approve/reject bar to the page. When the reviewer
+clicks **Approve & submit** or **Not this one**, the server prints one
+machine-readable line to stdout — `DECISION: approved` or
+`DECISION: rejected` — and exits. Exit codes: `0` approved (also the normal
+Ctrl+C stop), `3` rejected — deliberately not `1`/`2`, which stay reserved
+for errors and usage mistakes. Without `--confirm` the server has no
+`/decision` endpoint and runs until Ctrl+C, as before.
+
 ```bash
 bench eval view jobs/run/task__abc123
 bench eval view jobs/ --port 9000
 bench eval view ~/.claude/projects/<project>/<session>.jsonl
+bench eval view ~/.claude/projects/<project>/<session>.jsonl --confirm
 ```
 
 ## bench train

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -138,7 +138,10 @@ credentials or personal data in either label.
 `bench eval view PATH` serves a localhost page for a trial directory, a job
 directory, or a raw Claude Code / Codex / ACP session JSONL file. The
 contributor skill opens this before upload. Viewing a JSONL file does not
-write `trajectory.html` next to the session.
+write `trajectory.html` next to the session. With `--confirm` (0.7.2+) the
+page adds an approve/reject bar and the process prints `DECISION: approved`
+or `DECISION: rejected` and exits (0 approve / 3 reject), so the agent can
+wait on the click instead of a chat reply.
 
 ## What reaches the dataset
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1228,11 +1228,27 @@ def eval_view(
         ),
     ],
     port: Annotated[int, typer.Option(help="Server port")] = 8888,
+    confirm: Annotated[
+        bool,
+        typer.Option(
+            "--confirm",
+            help=(
+                "Show an Approve & submit / Not this one bar on the page; "
+                "print DECISION: approved|rejected and exit 0 on approve, "
+                "3 on reject."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """View a trial or session trajectory in the browser."""
-    from benchflow.trajectories.viewer import serve
+    from benchflow.trajectories import viewer
 
-    serve(str(rollout_dir), port)
+    decision = viewer.serve(str(rollout_dir), port, confirm=confirm)
+    # Exit-code contract for --confirm: 0 approved, 3 rejected. 3 is chosen
+    # so a rejection never collides with the CLI's existing error exits
+    # (1 = errors, 2 = Typer usage errors).
+    if decision == "rejected":
+        raise typer.Exit(3)
 
 
 # ── Command-group wiring ──────────────────────────────────────────────

--- a/src/benchflow/trajectories/viewer.py
+++ b/src/benchflow/trajectories/viewer.py
@@ -80,6 +80,57 @@ body { font-family: var(--font-sans); background: var(--background); color: var(
 .turn-divider { border-top: 1px solid var(--border); margin: 24px 0; }
 """
 
+# Sticky bottom confirmation bar injected only in --confirm mode. Styling
+# reuses the page's CSS variables (white surface, top border, ink text, pill
+# buttons) so it reads as part of the same www.benchflow.ai design language.
+# The <style> block rides along with the snippet so plain (non-confirm) pages
+# carry zero confirm markup or CSS.
+_CONFIRM_BAR_HTML = """\
+<style>
+body { padding-bottom: 104px; }
+.confirm-bar { position: fixed; bottom: 0; left: 0; right: 0; background: var(--card); border-top: 1px solid var(--border); box-shadow: 0 -1px 3px rgba(10, 10, 10, 0.05); z-index: 10; }
+.confirm-inner { max-width: 960px; margin: 0 auto; padding: 14px 20px; display: flex; align-items: center; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+.confirm-question { font-size: 14px; font-weight: 500; color: var(--ink); }
+.confirm-actions { display: flex; gap: 8px; flex: none; }
+.confirm-btn { font-family: var(--font-sans); font-size: 13px; font-weight: 600; letter-spacing: -0.01em; padding: 8px 18px; border-radius: 9999px; cursor: pointer; transition: background 0.15s ease; }
+.confirm-btn.approve { background: var(--ink); color: var(--background); border: 1px solid var(--ink); }
+.confirm-btn.approve:hover { background: #262626; }
+.confirm-btn.reject { background: var(--card); color: var(--ink); border: 1px solid var(--rule-strong); }
+.confirm-btn.reject:hover { background: var(--secondary); }
+</style>
+<div class="confirm-bar">
+<div class="confirm-inner" id="confirm-inner">
+<span class="confirm-question">Submit this trajectory to the BenchFlow eval prize?</span>
+<div class="confirm-actions">
+<button class="confirm-btn approve" onclick="__benchDecide('approve')">Approve &amp; submit</button>
+<button class="confirm-btn reject" onclick="__benchDecide('reject')">Not this one</button>
+</div>
+</div>
+</div>
+<script>
+async function __benchDecide(choice) {
+  try {
+    await fetch("/decision", { method: "POST", body: choice });
+  } catch (err) {
+    // The server exits right after answering; a dropped socket is still a
+    // delivered decision, so fall through to the confirmation note.
+  }
+  document.getElementById("confirm-inner").innerHTML =
+    choice === "approve"
+      ? '<span class="confirm-question">Approved — go back to your agent.</span>'
+      : '<span class="confirm-question">Rejected — tell your agent which session instead.</span>';
+}
+</script>
+"""
+
+
+def _inject_confirm_bar(page: str) -> str:
+    """Append the confirm bar just before </body> (or at the end as fallback)."""
+    if "</body>" in page:
+        return page.replace("</body>", f"{_CONFIRM_BAR_HTML}</body>", 1)
+    return page + _CONFIRM_BAR_HTML
+
+
 # Small BenchFlow wordmark header (inline SVG logo from the site's icon set —
 # no external requests) shown above the page title on every viewer page.
 _WORDMARK_HTML = (
@@ -634,9 +685,21 @@ def _stream_json_page(title: str, events: list[dict], turn_blocks: list[str]) ->
 
 
 def serve(
-    rollout_path: str, port: int = 8888, prompts: list[str] | None = None
-) -> None:
-    """Serve a trial directory or a session JSONL file as a web page."""
+    rollout_path: str,
+    port: int = 8888,
+    prompts: list[str] | None = None,
+    confirm: bool = False,
+) -> str | None:
+    """Serve a trial directory or a session JSONL file as a web page.
+
+    With ``confirm=True`` the page carries an Approve/Reject bar posting to
+    ``/decision``; the first valid decision shuts the server down and is
+    returned as ``"approved"`` or ``"rejected"`` after printing a
+    machine-readable ``DECISION: <value>`` line to stdout. Without it the
+    server runs until Ctrl+C and the return value is ``None`` — exactly the
+    pre-confirm behavior (no bar, no POST endpoint).
+    """
+    import threading
     from http.server import HTTPServer, SimpleHTTPRequestHandler
 
     path = Path(rollout_path)
@@ -656,11 +719,20 @@ def serve(
         print(f"No trajectories found in {path}")
         sys.exit(1)
     if write_sidecar:
+        # The sidecar stays the plain page: the confirm bar is a one-shot
+        # interaction against this live server, not part of the artifact.
         (path / "trajectory.html").write_text(html_content)
+    if confirm:
+        html_content = _inject_confirm_bar(html_content)
 
     print(f"Trajectory viewer: http://localhost:{port}")
     print(f"Trial: {path}")
-    print("Press Ctrl+C to stop\n")
+    if confirm:
+        print("Waiting for Approve / Not this one in the browser (Ctrl+C to stop)\n")
+    else:
+        print("Press Ctrl+C to stop\n")
+
+    decision: str | None = None
 
     class Handler(SimpleHTTPRequestHandler):
         def do_GET(self):
@@ -672,11 +744,44 @@ def serve(
         def log_message(self, format, *args):
             pass
 
-    server = HTTPServer(("localhost", port), Handler)
+    handler_cls: type[SimpleHTTPRequestHandler] = Handler
+
+    if confirm:
+
+        class ConfirmHandler(Handler):
+            def do_POST(self):
+                nonlocal decision
+                if self.path != "/decision":
+                    self.send_error(404)
+                    return
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length).decode("utf-8", "replace").strip()
+                if body not in ("approve", "reject"):
+                    self.send_error(400, "Body must be 'approve' or 'reject'")
+                    return
+                decision = "approved" if body == "approve" else "rejected"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(decision.encode())
+                # shutdown() blocks until serve_forever returns, and this
+                # handler runs inside that loop — stop from a helper thread.
+                threading.Thread(target=server.shutdown, daemon=True).start()
+
+        handler_cls = ConfirmHandler
+
+    server = HTTPServer(("localhost", port), handler_cls)
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         print("\nStopped.")
+        return None
+    finally:
+        server.server_close()
+
+    if decision is not None:
+        print(f"DECISION: {decision}", flush=True)
+    return decision
 
 
 if __name__ == "__main__":

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -747,7 +747,8 @@ def test_setup_prompt_prints_the_copy_paste_line() -> None:
     assert len(prompt_lines) == 3
     for line in prompt_lines:
         assert line in readme_text
-    assert "send them to your coding agent" in readme_text
+    # Wording updated on main in 8cae2a42 ("Send these to your coding agent.").
+    assert "Send these to your coding agent" in readme_text
 
     assert UPGRADE_COMMAND in CONTRIBUTOR_PROMPT
     assert CONTRIBUTOR_PROMPT.index(UPGRADE_COMMAND) < CONTRIBUTOR_PROMPT.index(

--- a/tests/test_viewer_confirm.py
+++ b/tests/test_viewer_confirm.py
@@ -1,0 +1,201 @@
+"""Tests for the trajectory viewer's --confirm flow (in-browser approve/reject).
+
+The eval-prize contributor loop is agent-driven: the agent serves the viewer,
+the human clicks **Approve & submit** or **Not this one**, and the process
+reports the decision via a machine-readable ``DECISION:`` stdout line plus the
+exit code (0 approve, 3 reject) so the agent can wait on it instead of a chat
+reply.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from benchflow.cli.main import app
+from benchflow.trajectories import viewer
+from benchflow.trajectories.viewer import render_jsonl_file, serve
+
+runner = CliRunner()
+
+_BAR_NEEDLES = (
+    "Submit this trajectory to the BenchFlow eval prize?",
+    "Approve &amp; submit",
+    "Not this one",
+    "/decision",
+)
+
+
+def _write_session(tmp_path: Path) -> Path:
+    session = tmp_path / "session.jsonl"
+    session.write_text(
+        json.dumps({"type": "user", "message": {"content": "review me"}}) + "\n"
+    )
+    return session
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+def _serve_in_thread(
+    path: Path, *, confirm: bool
+) -> tuple[int, threading.Thread, dict]:
+    """Run serve() in a daemon thread; poll GET / until it answers."""
+    port = _free_port()
+    result: dict = {}
+
+    def run() -> None:
+        result["decision"] = serve(str(path), port, confirm=confirm)
+
+    thread = threading.Thread(target=run, daemon=True)
+    thread.start()
+    deadline = time.monotonic() + 10
+    while True:
+        try:
+            with urllib.request.urlopen(f"http://localhost:{port}/", timeout=1) as r:
+                result["page"] = r.read().decode()
+                break
+        except OSError:
+            if time.monotonic() > deadline:
+                raise
+            time.sleep(0.05)
+    return port, thread, result
+
+
+def _post_decision(port: int, body: str) -> str:
+    req = urllib.request.Request(
+        f"http://localhost:{port}/decision", data=body.encode(), method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=5) as r:
+        return r.read().decode()
+
+
+def test_confirm_page_has_bar_and_plain_page_does_not(tmp_path):
+    """--confirm injects the sticky decision bar; plain rendering carries none of it."""
+    session = _write_session(tmp_path)
+
+    plain_html = render_jsonl_file(session)
+    for needle in _BAR_NEEDLES:
+        assert needle not in plain_html
+
+    port, thread, result = _serve_in_thread(session, confirm=True)
+    for needle in _BAR_NEEDLES:
+        assert needle in result["page"]
+
+    # Shut the server down so the thread exits.
+    _post_decision(port, "reject")
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+
+
+@pytest.mark.parametrize(
+    "body, expected", [("approve", "approved"), ("reject", "rejected")]
+)
+def test_post_decision_returns_decision_and_prints_line(
+    tmp_path, capsys, body, expected
+):
+    """POST /decision shuts the server down; serve() returns the decision and
+    prints exactly one machine-readable DECISION line to stdout."""
+    session = _write_session(tmp_path)
+    port, thread, result = _serve_in_thread(session, confirm=True)
+
+    response = _post_decision(port, body)
+    thread.join(timeout=10)
+    assert not thread.is_alive()
+
+    assert response == expected
+    assert result["decision"] == expected
+    out = capsys.readouterr().out
+    assert out.count(f"DECISION: {expected}") == 1
+
+
+def test_post_decision_rejects_garbage_body(tmp_path):
+    """A body other than approve/reject is a 400 and keeps the server alive."""
+    session = _write_session(tmp_path)
+    port, thread, result = _serve_in_thread(session, confirm=True)
+
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post_decision(port, "maybe")
+    assert exc.value.code == 400
+    assert thread.is_alive()  # still waiting for a real decision
+
+    _post_decision(port, "reject")
+    thread.join(timeout=10)
+    assert result["decision"] == "rejected"
+
+
+def test_plain_mode_has_no_decision_endpoint(tmp_path):
+    """Without --confirm, POST /decision does not exist (501 from the stdlib
+    handler) and GET / serves the page exactly as before."""
+    session = _write_session(tmp_path)
+    port, _thread, result = _serve_in_thread(session, confirm=False)
+
+    assert "review me" in result["page"]
+    with pytest.raises(urllib.error.HTTPError) as exc:
+        _post_decision(port, "approve")
+    assert exc.value.code == 501
+    # The plain server only stops on Ctrl+C; the daemon thread is reaped at
+    # process exit, matching the documented always-on behavior.
+
+
+def test_confirm_sidecar_stays_plain(tmp_path):
+    """The trajectory.html sidecar written for directories must not embed the
+    one-shot confirm bar."""
+    rollout = tmp_path / "rollout"
+    rollout.mkdir()
+    (rollout / "turn1.txt").write_text(
+        '{"type":"system","session_id":"s","model":"m"}\n'
+    )
+    port, thread, _result = _serve_in_thread(rollout, confirm=True)
+    sidecar = (rollout / "trajectory.html").read_text()
+    for needle in _BAR_NEEDLES:
+        assert needle not in sidecar
+
+    _post_decision(port, "reject")
+    thread.join(timeout=10)
+
+
+@pytest.mark.parametrize(
+    "decision, expected_exit", [("approved", 0), ("rejected", 3), (None, 0)]
+)
+def test_eval_view_maps_decision_to_exit_code(
+    tmp_path, monkeypatch, decision, expected_exit
+):
+    """The Typer command owns the exit-code mapping: approve → 0, reject → 3
+    (non-1/2 so it cannot collide with error or usage exits), Ctrl+C → 0."""
+    calls: dict = {}
+
+    def fake_serve(path, port=8888, prompts=None, confirm=False):
+        calls["confirm"] = confirm
+        return decision
+
+    monkeypatch.setattr(viewer, "serve", fake_serve)
+    res = runner.invoke(app, ["eval", "view", str(tmp_path), "--confirm"])
+    assert res.exit_code == expected_exit
+    assert calls["confirm"] is True
+
+
+def test_eval_view_defaults_to_no_confirm(tmp_path, monkeypatch):
+    """Without the flag, serve() must be called with confirm=False so today's
+    behavior (no bar, no endpoint) is preserved."""
+    calls: dict = {}
+
+    def fake_serve(path, port=8888, prompts=None, confirm=False):
+        calls["confirm"] = confirm
+        return None
+
+    monkeypatch.setattr(viewer, "serve", fake_serve)
+    res = runner.invoke(app, ["eval", "view", str(tmp_path)])
+    assert res.exit_code == 0
+    assert calls["confirm"] is False

--- a/tests/test_viewer_confirm.py
+++ b/tests/test_viewer_confirm.py
@@ -1,5 +1,9 @@
 """Tests for the trajectory viewer's --confirm flow (in-browser approve/reject).
 
+Guards the feature shipped in PR #1021: --confirm must add the decision bar +
+/decision endpoint and the DECISION stdout/exit-code contract, while plain
+mode stays byte-for-byte the pre-#1021 viewer.
+
 The eval-prize contributor loop is agent-driven: the agent serves the viewer,
 the human clicks **Approve & submit** or **Not this one**, and the process
 reports the decision via a machine-readable ``DECISION:`` stdout line plus the


### PR DESCRIPTION
## Summary
- `bench eval view PATH --confirm` renders the normal trajectory page plus a sticky bottom bar (white surface, top border, ink text — matching the #1019/#1020 site styling): "Submit this trajectory to the BenchFlow eval prize?" with **Approve & submit** (ink pill) and **Not this one** (outlined pill). Clicking POSTs `approve`/`reject` to `/decision` via vanilla-JS fetch, then swaps the bar for a confirmation note.
- On a decision the server prints one machine-readable line — `DECISION: approved` or `DECISION: rejected` — flushes, shuts down cleanly, and the CLI exits **0 on approve, 3 on reject** (non-1/2 so rejection never collides with error/usage exits). `serve()` now returns `"approved" | "rejected" | None` and the Typer command owns the exit-code mapping.
- Without `--confirm`, behavior is byte-for-byte today's: no bar, no `/decision` endpoint (stdlib 501), Ctrl+C to stop; the directory sidecar `trajectory.html` stays the plain page even in confirm mode.
- `benchflow-traj-upload` skill: the View step now prefers `--confirm --port 8889` and waits on the `DECISION:` line; rejected → back to pick; a chat reply first → kill the viewer and honor it; CLI < 0.7.2 → fall back to chat-confirm.
- Docs (`docs/reference/cli.md`, `docs/traj-upload.md`) + CHANGELOG Unreleased entry.

## Test plan
- [x] `tests/test_viewer_confirm.py`: confirm page has bar/buttons, plain page doesn't; POST approve/reject → return value + single `DECISION:` stdout line; garbage body → 400, server stays up; plain mode `/decision` → 501; sidecar stays plain; CLI exit-code mapping (0/3/0) and default `confirm=False`.
- [x] `tests/test_cli_edge_case_hardening.py` stays green (69 passed total).
- [x] ruff check/format, `ty check` on viewer + CLI.
- [x] Visual: served the bio session with `--confirm`, headless-Chrome screenshot verified against the site style; `curl -X POST -d approve /decision` → `DECISION: approved`, exit 0.