### PR TITLE
Redaction transparency: itemize masked secrets in the upload preview and viewer confirm bar

### DIFF
--- a/.agents/skills/benchflow-traj-upload/SKILL.md
+++ b/.agents/skills/benchflow-traj-upload/SKILL.md
@@ -85,11 +85,30 @@ yet — the viewer is how they decide the session is the one they meant.
 
 ## Step 4 — View
 
-Open the viewer with the in-page confirm bar and tell the user the URL:
+First stage a dry run so you can show the user what upload-time redaction
+would mask for them (nothing is uploaded):
 
 ```bash
-bench eval view /path/to/session.jsonl --confirm --port 8889
+bench traj upload /path/to/session.jsonl --dry-run
 ```
+
+Its output ends with a plain `Masked for you: ...` line (for example
+`Masked for you: 2 API keys, 1 bearer token`, or
+`Masked for you: nothing — no secrets detected`). Extract the text after
+`Masked for you: ` — call it the masking summary.
+
+Then open the viewer with the in-page confirm bar and tell the user the URL,
+passing the masking summary so it renders next to the Approve button:
+
+```bash
+bench eval view /path/to/session.jsonl --confirm --port 8889 \
+  --redaction-summary "2 API keys, 1 bearer token"
+```
+
+The viewer shows the ORIGINAL session (it does not redact); the
+`--redaction-summary` note tells the reviewer what the upload step will mask.
+If the installed CLI rejects `--redaction-summary` (older than 0.7.2), drop
+the flag and state the masking summary in chat instead.
 
 That path may also be a trial directory. If the port is taken, pick another.
 
@@ -126,8 +145,12 @@ and stores `repo/<owner>/<name>` as the source id (it prints
 confirmation — "This session will be tagged `repo/owner/name`; say the word
 if you want it omitted" — so they can opt out for private repos.
 
-Before upload, remind them not to submit secrets. The CLI masks detected
-secret values locally before anything leaves the machine, but redaction is a
+Before upload, remind them not to submit secrets, and repeat the masking
+summary from the Step 4 dry run when asking for approval — "Before upload,
+BenchFlow masks: 2 API keys, 1 bearer token; originals never leave this
+machine" — so they know exactly what redaction handles for them. The CLI
+masks detected secret values locally before anything leaves the machine (the
+server independently rescans and rejects any survivor), but redaction is a
 safety net, not a license to upload credentials.
 
 ## Step 6 — Submit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 ## [Unreleased]
 
 ### Added
+- **The upload preview itemizes what redaction masked, by kind.** The
+  redactor now categorizes every replacement by the rule that fired — API
+  keys, bearer tokens, private key blocks, passwords, URL credentials, and
+  credential-bearing field values — and the terminal trajectory report shows
+  a `Masked for you: 2 API keys, 1 bearer token — originals never leave this
+  machine` breakdown under the masked-count row, plus a reassurance that
+  redaction ran locally and the server independently rescans staged
+  artifacts (or `No secrets or personal identifiers detected — nothing
+  needed masking.` when nothing matched). `bench traj upload --dry-run`
+  prints the same breakdown as a plain `Masked for you:` line, and
+  `bench eval view --confirm` gains a display-only `--redaction-summary`
+  flag that renders it in the confirm bar next to the Approve button; the
+  `benchflow-traj-upload` skill stages a dry run first and passes the line
+  through. The total `redaction_replacements` count and the manifest
+  `trajectory_report` contract are unchanged (the server validates the
+  report with a closed schema and exact recompute equality, so per-category
+  counts stay display-only).
 - **The trajectory viewer can collect the eval-prize confirmation in the
   browser.** `bench eval view PATH --confirm` renders the normal page plus a
   sticky site-styled bottom bar ("Submit this trajectory to the BenchFlow

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -426,11 +426,20 @@ Ctrl+C stop), `3` rejected — deliberately not `1`/`2`, which stay reserved
 for errors and usage mistakes. Without `--confirm` the server has no
 `/decision` endpoint and runs until Ctrl+C, as before.
 
+`--redaction-summary "2 API keys, 1 bearer token"` adds a display-only note to
+the `--confirm` bar — "Before upload, BenchFlow masks: … Originals never leave
+this machine." — so the reviewer sees what upload-time redaction will mask
+(the viewer itself shows the original session and never redacts). The upload
+skill fills it from the `Masked for you` line printed by
+`bench traj upload PATH --dry-run`. Without `--confirm` the flag has no
+effect; without the flag the bar is unchanged.
+
 ```bash
 bench eval view jobs/run/task__abc123
 bench eval view jobs/ --port 9000
 bench eval view ~/.claude/projects/<project>/<session>.jsonl
 bench eval view ~/.claude/projects/<project>/<session>.jsonl --confirm
+bench eval view session.jsonl --confirm --redaction-summary "2 API keys, 1 bearer token"
 ```
 
 ## bench train
@@ -921,7 +930,7 @@ bench traj upload path/to/trial --dry-run
 | `--source-id` | derived from `PATH` | Stable contributor/run label stored in the manifest |
 | `--repo` / `--no-repo` | on | Tag the upload with the repository the session was about: `repo/<owner>/<name>` from the session's recorded cwd git remote becomes the source id and the CLI prints `Repo: owner/name (use --no-repo to omit)`; explicit `--source-id` wins; undetectable repos fall back silently |
 | `--preview-steps` | `5` | Number of redacted trajectory steps to preview; accepts 0–20 |
-| `--dry-run` | `false` | Validate, redact, hash, and list staged files without network traffic |
+| `--dry-run` | `false` | Validate, redact, hash, and list staged files without network traffic; ends with a plain `Masked for you: ...` line itemizing masked secrets by kind (API keys, bearer tokens, private key blocks, passwords, URL credentials, credential-bearing field values) for `bench eval view --redaction-summary` |
 | `--direct` | `false` | Use local Azure credentials instead of the public broker; requires the `azure` extra |
 | `--container-url` | — | Azure Blob container URL for `--direct`; alternatively set `BENCHFLOW_AZURE_CONTAINER_URL` |
 

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -73,7 +73,10 @@ otherwise-valid JSONL ineligible: the local staging pass replaces them with
 manifest metadata, computes a content digest, and uploads a manifest last. The
 first request can take a minute while the public broker wakes up; retries are
 safe. Use `--dry-run` to inspect the staged file list, digest, sizes, ignored
-siblings, and redaction count without making a network request.
+siblings, and redaction count without making a network request; its output ends
+with a plain `Masked for you: ...` line itemizing the masked secrets by kind,
+which the contributor skill lifts into the viewer's confirm bar via
+`bench eval view --confirm --redaction-summary`.
 
 Uploads are tagged with the repository the session was about: unless you pass
 `--source-id`, the CLI reads the session's recorded working directory,
@@ -97,7 +100,18 @@ The report is generated only from the staged, redacted copy. It shows:
   no extractable redacted text are skipped instead of producing placeholder
   steps such as `Assistant response`;
 - the number of API-key or secret-like values replaced with
-  `<XXX-benchflow-key-values-XXX>`; and
+  `<XXX-benchflow-key-values-XXX>`, followed by a `Masked for you` line that
+  itemizes what kind of secret each replacement was — API keys, bearer tokens,
+  private key blocks, passwords, URL credentials, and credential-bearing field
+  values, e.g. `2 API keys, 1 bearer token — originals never leave this
+  machine` — with a reminder that redaction ran locally and the server
+  independently rescans staged artifacts. The categories name what the
+  redaction rules actually detect (there is no PII/email detection); when
+  nothing matched, the line reads `No secrets or personal identifiers detected
+  — nothing needed masking.` The per-category counts are display-only: the
+  uploaded `trajectory_report` manifest field is validated by the server with
+  a closed schema and an exact recompute check, so it keeps only the total
+  masked-value count; and
 - the first five meaningful steps as a preview containing up to the first 100
   words of each step's redacted text.
 
@@ -141,7 +155,12 @@ contributor skill opens this before upload. Viewing a JSONL file does not
 write `trajectory.html` next to the session. With `--confirm` (0.7.2+) the
 page adds an approve/reject bar and the process prints `DECISION: approved`
 or `DECISION: rejected` and exits (0 approve / 3 reject), so the agent can
-wait on the click instead of a chat reply.
+wait on the click instead of a chat reply. The viewer shows the original
+session and never redacts; `--redaction-summary "2 API keys, 1 bearer token"`
+adds a display-only note to the confirm bar ("Before upload, BenchFlow
+masks: … Originals never leave this machine.") so the reviewer sees what the
+upload step will mask — the skill fills it from the `Masked for you` line of
+a `bench traj upload --dry-run`.
 
 ## What reaches the dataset
 

--- a/src/benchflow/cli/_traj_upload_ui.py
+++ b/src/benchflow/cli/_traj_upload_ui.py
@@ -20,9 +20,28 @@ from rich.progress import (
 from rich.table import Table
 from rich.text import Text
 
-from benchflow.publish.redact import REDACTED
+from benchflow.publish.redact import REDACTED, format_redaction_breakdown
 from benchflow.publish.traj_capture import StagedFile
 from benchflow.publish.traj_report import PREVIEW_WORD_LIMIT, TrajectoryReport
+
+# Redaction-transparency copy shown with the masked-value count. The wording is
+# deliberately honest: redaction is a local structural pass (no agents, no
+# token spend), and the server independently rescans staged artifacts.
+NO_MASKING_NEEDED_COPY = (
+    "No secrets or personal identifiers detected — nothing needed masking."
+)
+REDACTION_REASSURANCE_COPY = (
+    "Redaction ran locally before anything was staged; "
+    "the server independently rescans and rejects any survivor."
+)
+
+
+def masked_for_you_line(report: TrajectoryReport) -> str:
+    """Itemized ``Masked for you`` copy for a report with masked values."""
+    breakdown = format_redaction_breakdown(dict(report.masked_categories))
+    if not breakdown:  # category data unavailable — fall back to the total
+        breakdown = f"{report.masked_values} secret-like values"
+    return f"{breakdown} — originals never leave this machine"
 
 
 def render_trajectory_report(report: TrajectoryReport, *, console: Console) -> None:
@@ -43,8 +62,17 @@ def render_trajectory_report(report: TrajectoryReport, *, console: Console) -> N
         "API keys / secrets masked",
         Text(str(report.masked_values), style="bold green"),
     )
+    if report.masked_values:
+        facts.add_row(
+            "Masked for you",
+            Text(masked_for_you_line(report), style="green"),
+        )
+    else:
+        facts.add_row("Masked for you", Text(NO_MASKING_NEEDED_COPY, style="dim"))
     facts.add_row("Safe replacement", Text(REDACTED))
     console.print(Panel(facts, title="Trajectory report", border_style="cyan"))
+    if report.masked_values:
+        console.print(f"[dim]{REDACTION_REASSURANCE_COPY}[/dim]")
 
     if not report.preview:
         return

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1239,11 +1239,25 @@ def eval_view(
             ),
         ),
     ] = False,
+    redaction_summary: Annotated[
+        str | None,
+        typer.Option(
+            "--redaction-summary",
+            help=(
+                "Masked-secret breakdown shown in the --confirm bar, e.g. "
+                "'2 API keys, 1 bearer token' (lift it from "
+                "`bench traj upload PATH --dry-run`). Display-only; no effect "
+                "without --confirm."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """View a trial or session trajectory in the browser."""
     from benchflow.trajectories import viewer
 
-    decision = viewer.serve(str(rollout_dir), port, confirm=confirm)
+    decision = viewer.serve(
+        str(rollout_dir), port, confirm=confirm, redaction_summary=redaction_summary
+    )
     # Exit-code contract for --confirm: 0 approved, 3 rejected. 3 is chosen
     # so a rejection never collides with the CLI's existing error exits
     # (1 = errors, 2 = Typer usage errors).

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -23,6 +23,7 @@ from benchflow.cli._traj_upload_ui import (
     render_trajectory_report,
     upload_progress,
 )
+from benchflow.publish.redact import format_redaction_breakdown
 from benchflow.publish.traj_capture import (
     StagedCapture,
     default_source_id,
@@ -314,6 +315,7 @@ def _run_upload(options: _UploadOptions) -> None:
             artifacts.files,
             masked_values=artifacts.redaction_replacements,
             preview_steps=options.preview_steps,
+            masked_categories=artifacts.redaction_categories,
         )
         status.stop()
         render_trajectory_report(report, console=console)
@@ -633,6 +635,13 @@ def _print_dry_run(staged: StagedCapture) -> None:
     if staged.ignored:
         console.print(f"Ignored: {escape(', '.join(staged.ignored))}")
     console.print(f"Redactions: {staged.redaction_replacements}")
+    # One plain, greppable line so the upload skill can lift the breakdown into
+    # the viewer's confirm bar (bench eval view --redaction-summary "...").
+    breakdown = format_redaction_breakdown(dict(staged.artifact_redaction_categories))
+    if breakdown:
+        print(f"Masked for you: {breakdown}")
+    else:
+        print("Masked for you: nothing — no secrets detected")
 
 
 def _print_contributor_prompt() -> None:

--- a/src/benchflow/publish/redact.py
+++ b/src/benchflow/publish/redact.py
@@ -4,10 +4,19 @@ from __future__ import annotations
 
 import re
 import shlex
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from typing import Any, NamedTuple
 
-from benchflow.trajectories.types import redact_trajectory_text_with_count
+from benchflow.trajectories.types import (
+    REDACTION_CATEGORY_API_KEY,
+    REDACTION_CATEGORY_BEARER_TOKEN,
+    REDACTION_CATEGORY_CREDENTIAL_FIELD,
+    REDACTION_CATEGORY_PASSWORD,
+    REDACTION_CATEGORY_PRIVATE_KEY,
+    REDACTION_CATEGORY_URL_CREDENTIAL,
+    redact_trajectory_text_with_categories,
+)
 
 REDACTED = "<XXX-benchflow-key-values-XXX>"
 _CANONICAL_REDACTED = "***REDACTED***"
@@ -67,23 +76,81 @@ COMPACT_SENSITIVE_KEY_SUFFIXES = tuple(
 class RedactionPattern(NamedTuple):
     pattern: re.Pattern[str]
     replacement: str
+    category: str
 
 
 VALUE_PATTERNS = (
     # Google AI Studio's newer token format is not covered by the canonical
     # trajectory redactor yet.
-    RedactionPattern(re.compile(r"AQ\.[0-9A-Za-z_-]{20,}"), REDACTED),
+    RedactionPattern(
+        re.compile(r"AQ\.[0-9A-Za-z_-]{20,}"), REDACTED, REDACTION_CATEGORY_API_KEY
+    ),
     RedactionPattern(
         re.compile(r"Bearer\s+[A-Za-z0-9._~+/=-]{16,}", re.IGNORECASE),
         f"Bearer {REDACTED}",
+        REDACTION_CATEGORY_BEARER_TOKEN,
     ),
 )
 
+# Display order and pluralized labels for the per-category breakdown shown to
+# contributors ("Masked for you: 2 API keys, 1 bearer token"). Keys are the
+# canonical category names from ``benchflow.trajectories.types``; the taxonomy
+# names what the redaction rules actually detect — nothing more.
+REDACTION_CATEGORY_LABELS: tuple[tuple[str, str], ...] = (
+    (REDACTION_CATEGORY_API_KEY, "API keys"),
+    (REDACTION_CATEGORY_BEARER_TOKEN, "bearer tokens"),
+    (REDACTION_CATEGORY_PRIVATE_KEY, "private key blocks"),
+    (REDACTION_CATEGORY_PASSWORD, "passwords"),
+    (REDACTION_CATEGORY_URL_CREDENTIAL, "URL credentials"),
+    (REDACTION_CATEGORY_CREDENTIAL_FIELD, "credential-bearing field values"),
+)
 
-def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int]:
-    """Return a structurally redacted JSON value and replacement count."""
+
+def redaction_breakdown(counts: Mapping[str, int]) -> tuple[tuple[str, int], ...]:
+    """Return non-zero category counts in canonical display order."""
+    ordered = [
+        (category, counts[category])
+        for category, _ in REDACTION_CATEGORY_LABELS
+        if counts.get(category)
+    ]
+    # Unknown categories cannot arise from this module's own accumulation, but
+    # persisted/forwarded counts must never be dropped silently.
+    ordered.extend(
+        (category, count)
+        for category, count in counts.items()
+        if count and category not in dict(REDACTION_CATEGORY_LABELS)
+    )
+    return tuple(ordered)
+
+
+def format_redaction_breakdown(counts: Mapping[str, int]) -> str:
+    """Render category counts as prose, e.g. ``2 API keys, 1 bearer token``."""
+    plurals = dict(REDACTION_CATEGORY_LABELS)
+    parts = []
+    for category, count in redaction_breakdown(counts):
+        label = category if count == 1 else plurals.get(category, f"{category}s")
+        parts.append(f"{count} {label}")
+    return ", ".join(parts)
+
+
+def redact_value(
+    value: Any,
+    *,
+    field_name: str | None = None,
+    categories: Counter[str] | None = None,
+) -> tuple[Any, int]:
+    """Return a structurally redacted JSON value and replacement count.
+
+    When *categories* is given, every replacement also increments the matching
+    per-category counter (see ``REDACTION_CATEGORY_LABELS``); the counter's
+    total always equals the returned replacement count.
+    """
     if field_name is not None and _is_sensitive_key(field_name):
-        return (value, 0) if _is_redacted_value(value) else (REDACTED, 1)
+        if _is_redacted_value(value):
+            return value, 0
+        if categories is not None:
+            categories[_field_category(field_name)] += 1
+        return REDACTED, 1
 
     if isinstance(value, Mapping):
         redacted: dict[Any, Any] = {}
@@ -104,7 +171,7 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
         for key, item in value.items():
             clean_key = key
             if isinstance(key, str):
-                _, key_replacements = _redact_text(key)
+                _, key_replacements = _redact_text(key, categories=categories)
                 if key_replacements:
                     secret_key_index += 1
                     clean_key = f"***REDACTED_KEY_{secret_key_index}***"
@@ -122,73 +189,102 @@ def redact_value(value: Any, *, field_name: str | None = None) -> tuple[Any, int
                     if isinstance(key, str)
                     else None
                 ),
+                categories=categories,
             )
             redacted[clean_key] = clean
             replacements += count
         return redacted, replacements
 
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return _redact_argv(value, redact_other_values=True)
+        return _redact_argv(value, redact_other_values=True, categories=categories)
 
     if not isinstance(value, str):
         return value, 0
 
-    return _redact_text(value)
+    return _redact_text(value, categories=categories)
 
 
-def redact_value_to_stability(value: Any) -> tuple[Any, int]:
+def redact_value_to_stability(
+    value: Any, *, categories: Counter[str] | None = None
+) -> tuple[Any, int]:
     """Redact until another server-side pass would make no replacements."""
     redacted = value
     replacements = 0
     for _ in range(_MAX_REDACTION_PASSES):
-        redacted, count = redact_value(redacted)
+        redacted, count = redact_value(redacted, categories=categories)
         replacements += count
         if count == 0:
             return redacted, replacements
     raise ValueError("trajectory secret redaction did not converge")
 
 
-def _redact_text(value: str) -> tuple[str, int]:
+def _redact_text(
+    value: str, *, categories: Counter[str] | None = None
+) -> tuple[str, int]:
     # The canonical carrier patterns intentionally ignore their asterisk marker.
     # Protect our public-upload marker with that value during the scan so a second
     # client/server pass is idempotent even inside text such as ``API_KEY=...``.
     protected = value.replace(REDACTED, _CANONICAL_REDACTED)
-    redacted_text, replacements = redact_trajectory_text_with_count(protected)
+    redacted_text, text_categories = redact_trajectory_text_with_categories(protected)
+    replacements = sum(text_categories.values())
+    if categories is not None:
+        categories.update(text_categories)
     redacted_text = redacted_text.replace(_CANONICAL_REDACTED, REDACTED)
-    for pattern, replacement in VALUE_PATTERNS:
+    for pattern, replacement, category in VALUE_PATTERNS:
         redacted_text, count = pattern.subn(replacement, redacted_text)
         replacements += count
-    cli_redacted, cli_replacements = _redact_cli_text(redacted_text)
+        if count and categories is not None:
+            categories[category] += count
+    cli_redacted, cli_replacements = _redact_cli_text(
+        redacted_text, categories=categories
+    )
     redacted_text = cli_redacted
     replacements += cli_replacements
     return redacted_text, replacements
 
 
-def _redact_cli_text(value: str) -> tuple[str, int]:
+def _redact_cli_text(
+    value: str, *, categories: Counter[str] | None = None
+) -> tuple[str, int]:
     if "--" not in value:
         return value, 0
     try:
         argv = shlex.split(value)
     except ValueError:
         return value, 0
-    redacted, replacements = _redact_argv(argv, redact_other_values=False)
-    return (shlex.join(redacted), replacements) if replacements else (value, 0)
+    # Count categories only for the accepted result: a zero-replacement parse
+    # returns the original text, so nothing may be attributed for it.
+    argv_categories: Counter[str] | None = None if categories is None else Counter()
+    redacted, replacements = _redact_argv(
+        argv, redact_other_values=False, categories=argv_categories
+    )
+    if not replacements:
+        return value, 0
+    if categories is not None and argv_categories is not None:
+        categories.update(argv_categories)
+    return shlex.join(redacted), replacements
 
 
 def _redact_argv(
-    values: Sequence[Any], *, redact_other_values: bool
+    values: Sequence[Any],
+    *,
+    redact_other_values: bool,
+    categories: Counter[str] | None = None,
 ) -> tuple[list[Any], int]:
     redacted: list[Any] = []
     replacements = 0
-    redact_next = False
+    sensitive_option: str | None = None
     for item in values:
-        if redact_next:
+        if sensitive_option is not None:
+            option = sensitive_option
+            sensitive_option = None
             if _is_redacted_value(item):
                 redacted.append(item)
             else:
                 redacted.append(REDACTED)
                 replacements += 1
-            redact_next = False
+                if categories is not None:
+                    categories[_field_category(option)] += 1
             continue
 
         if isinstance(item, str) and item.startswith("-"):
@@ -200,13 +296,16 @@ def _redact_argv(
                     else:
                         redacted.append(f"{option}={REDACTED}")
                         replacements += 1
+                        if categories is not None:
+                            categories[_field_category(option)] += 1
                 else:
                     redacted.append(item)
-                    redact_next = not separator
+                    if not separator:
+                        sensitive_option = option
                 continue
 
         if redact_other_values:
-            clean, count = redact_value(item)
+            clean, count = redact_value(item, categories=categories)
             redacted.append(clean)
             replacements += count
         else:
@@ -218,6 +317,22 @@ def _is_redacted_value(value: Any) -> bool:
     return isinstance(value, str) and (
         value == REDACTED or value in _LEGACY_REDACTED_VALUES
     )
+
+
+def _field_category(field_name: str) -> str:
+    """Categorize a masked value by the credential-bearing name that matched.
+
+    Structural redaction fires on the field/option NAME, so the name is the
+    only honest signal for what kind of secret the value was.
+    """
+    compact = _normalize_key(field_name).replace("_", "")
+    if compact.endswith(("password", "passwd")):
+        return REDACTION_CATEGORY_PASSWORD
+    if compact.endswith("apikey"):
+        return REDACTION_CATEGORY_API_KEY
+    if compact.endswith("authorization") or "bearertoken" in compact:
+        return REDACTION_CATEGORY_BEARER_TOKEN
+    return REDACTION_CATEGORY_CREDENTIAL_FIELD
 
 
 def _is_sensitive_key(field_name: str) -> bool:

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -7,6 +7,7 @@ import json
 import re
 import shutil
 import tempfile
+from collections import Counter
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -15,7 +16,11 @@ from pathlib import Path
 from typing import Any, Never
 
 from benchflow import __version__
-from benchflow.publish.redact import redact_value, redact_value_to_stability
+from benchflow.publish.redact import (
+    redact_value,
+    redact_value_to_stability,
+    redaction_breakdown,
+)
 
 MAX_FILE_BYTES = 128 * 1024**2
 MAX_ARTIFACTS = 8
@@ -81,6 +86,10 @@ class StagedTrajectoryArtifacts:
     _metadata_dir: Path | None
     _staging_dir: Path
     _redact: bool
+    # Per-category artifact replacement counts in display order (display-only:
+    # the manifest/server contract stays untouched). Sums to
+    # ``redaction_replacements``.
+    redaction_categories: tuple[tuple[str, int], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -92,6 +101,8 @@ class StagedCapture:
     ignored: tuple[str, ...]
     artifact_redaction_replacements: int
     redaction_replacements: int
+    # Display-only per-category counts for the artifact replacements.
+    artifact_redaction_categories: tuple[tuple[str, int], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -199,12 +210,15 @@ def stage_trajectory_artifacts(
         staging_dir = Path(temp_name)
         payloads: list[StagedFile] = []
         replacement_count = 0
+        replacement_categories: Counter[str] = Counter()
         for source in resolved.files:
             relname = validate_artifact_name(f"trajectory/{source.name}")
             target = staging_dir / relname
             target.parent.mkdir(parents=True, exist_ok=True)
             if redact:
-                replacements = _redact_jsonl(source, target)
+                replacements = _redact_jsonl(
+                    source, target, categories=replacement_categories
+                )
                 replacement_count += replacements
             else:
                 shutil.copyfile(source, target)
@@ -240,6 +254,7 @@ def stage_trajectory_artifacts(
             _metadata_dir=resolved.metadata_dir,
             _staging_dir=staging_dir,
             _redact=redact,
+            redaction_categories=redaction_breakdown(replacement_categories),
         )
 
 
@@ -305,6 +320,7 @@ def finalize_trajectory_capture(
         ignored=artifacts.ignored,
         artifact_redaction_replacements=artifacts.redaction_replacements,
         redaction_replacements=replacement_count,
+        artifact_redaction_categories=artifacts.redaction_categories,
     )
 
 
@@ -430,7 +446,9 @@ def _validate_jsonl(path: Path) -> None:
         raise ValueError(f"trajectory JSONL has no records: {path}")
 
 
-def _redact_jsonl(source: Path, target: Path) -> int:
+def _redact_jsonl(
+    source: Path, target: Path, *, categories: Counter[str] | None = None
+) -> int:
     replacements = 0
     with (
         source.open(encoding="utf-8", newline="") as input_stream,
@@ -443,7 +461,9 @@ def _redact_jsonl(source: Path, target: Path) -> int:
                 continue
             value = strict_json_loads(body)
             try:
-                redacted, count = redact_value_to_stability(value)
+                redacted, count = redact_value_to_stability(
+                    value, categories=categories
+                )
             except RecursionError as exc:  # defense in depth after complexity gate
                 raise ValueError(
                     f"{source}: line {line_number}: trajectory JSONL nesting "

--- a/src/benchflow/publish/traj_report.py
+++ b/src/benchflow/publish/traj_report.py
@@ -54,9 +54,20 @@ class TrajectoryReport:
     created_at_source: str
     masked_values: int
     preview: tuple[TrajectoryPreviewStep, ...]
+    # Per-category masked-value counts, display order, summing to
+    # ``masked_values``. Display-only: the manifest ``trajectory_report``
+    # contract (``TrajectoryReportInfo``, ``extra="forbid"``, exact
+    # recompute-equality on the server) must not gain fields, so
+    # ``as_manifest_metadata`` deliberately excludes this.
+    masked_categories: tuple[tuple[str, int], ...] = ()
 
     def as_manifest_metadata(self) -> dict[str, Any]:
-        """Serialize every displayed report field for the upload manifest."""
+        """Serialize every displayed report field for the upload manifest.
+
+        ``masked_categories`` is intentionally absent: the server validates
+        ``trajectory_report`` with ``extra="forbid"`` and an exact equality
+        check against its own recomputation, so new fields would be rejected.
+        """
         return {
             "primary_file": self.primary_file,
             "format": self.format.value,
@@ -133,6 +144,7 @@ def build_trajectory_report(
     *,
     masked_values: int,
     preview_steps: int = DEFAULT_PREVIEW_STEPS,
+    masked_categories: tuple[tuple[str, int], ...] = (),
 ) -> TrajectoryReport:
     """Summarize one canonical trajectory view from staged, redacted artifacts."""
     if not artifacts:
@@ -183,6 +195,7 @@ def build_trajectory_report(
         created_at_source=created_at_source,
         masked_values=masked_values,
         preview=tuple(analysis.preview),
+        masked_categories=masked_categories,
     )
 
 

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -179,6 +179,18 @@ def _exchange_token_usage(exchange: "LLMExchange") -> TokenUsage:
     )
 
 
+# Human-facing redaction categories. Every canonical pattern below is tagged
+# with the kind of secret its rule actually detects, so the upload preview can
+# tell contributors WHAT was masked ("2 API keys, 1 bearer token") instead of
+# only how many values. The taxonomy names the real rules — there is no
+# PII/email detection, so no such category exists.
+REDACTION_CATEGORY_API_KEY = "API key"
+REDACTION_CATEGORY_BEARER_TOKEN = "bearer token"
+REDACTION_CATEGORY_PRIVATE_KEY = "private key block"
+REDACTION_CATEGORY_PASSWORD = "password"
+REDACTION_CATEGORY_URL_CREDENTIAL = "URL credential"
+REDACTION_CATEGORY_CREDENTIAL_FIELD = "credential-bearing field value"
+
 # Quote atom for the header/key-value carriers below: a run of 0-8 optional
 # backslashes followed by an optional quote. This makes every carrier fire on raw
 # text (``"k": "v"``), Python dict-repr (``'k': 'v'``), AND json.dumps-escaped
@@ -202,7 +214,7 @@ _SECVAL = r"[^\"'\s,}\\*&]+"
 # ``{0,64}`` makes each match attempt O(1) → overall O(n) (#830 ReDoS fix).
 _NAME = r"[A-Za-z0-9_]{0,64}"
 
-_REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+_REDACTION_PATTERNS: list[tuple[re.Pattern[str], str, str]] = [
     # PEM private-key blocks (GCP/Vertex service-account JSON, RSA keys). Redact
     # the whole armored block incl. the base64 body; the carriers below stop at
     # the first space and would leave the key material. Lazy + length-capped body
@@ -214,17 +226,23 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             r"-----END [A-Z0-9 ]{0,40}PRIVATE KEY-----"
         ),
         "***REDACTED***",
+        REDACTION_CATEGORY_PRIVATE_KEY,
     ),
     # --- Token families: redacted WHOLE (prefix included) so the v0.5 leak audit
     # greps (``AIzaSy``/``dtn_``…) see no live-key shape (#537/#585). ---
     # Anthropic: sk-ant-api03-...
-    (re.compile(r"sk-ant-[a-zA-Z0-9_-]{12,}"), "***REDACTED***"),
+    (
+        re.compile(r"sk-ant-[a-zA-Z0-9_-]{12,}"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
     # BenchFlow proxy master key (sk-benchflow-<token_urlsafe(24)>), OpenAI service
     # account (sk-svcacct-), OpenRouter (sk-or-v1-): rare labels that won't appear
     # in a normal kebab slug, so the hyphen-permitting entropy class is safe here.
     (
         re.compile(r"sk-(?:benchflow|svcacct|or-v1)-[A-Za-z0-9_-]{12,}"),
         "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
     ),
     # OpenAI org-scoped sk-proj-/sk-admin-: `proj`/`admin` ARE common identifier
     # words, so a bare hyphen class would redact kebab slugs like
@@ -236,33 +254,58 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             r"sk-(?:proj|admin)-(?=[A-Za-z0-9_-]{0,200}[A-Z])[A-Za-z0-9_-]{12,}"
         ),
         "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
     ),
     # OpenAI / generic sk- (alphanumeric only — widening to include `-` would
     # match common slugs like `task-sk-us-east-1-...`)
-    (re.compile(r"sk-[a-zA-Z0-9]{12,}"), "***REDACTED***"),
+    (re.compile(r"sk-[a-zA-Z0-9]{12,}"), "***REDACTED***", REDACTION_CATEGORY_API_KEY),
     # Google AI / Gemini: AIzaSy... (≥20 char suffix avoids matching `AIzaSy`
     # alone). Prefix is redacted too so the audit grep for `AIzaSy` is clean.
-    (re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"), "***REDACTED***"),
+    (
+        re.compile(r"AIzaSy[A-Za-z0-9_-]{20,}"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
     # AWS access keys: AKIA/ASIA + exactly 16 chars; length anchor avoids
     # matching English words like "ASIAPACIFIC".
-    (re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])"), "***REDACTED***"),
+    (
+        re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}(?![A-Z0-9])"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
     # Daytona SDK tokens: dtn_... — ≥16 char suffix avoids short ids (`dtn_v2`).
-    (re.compile(r"dtn_[A-Za-z0-9_]{16,}"), "***REDACTED***"),
+    (
+        re.compile(r"dtn_[A-Za-z0-9_]{16,}"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
     # GitHub tokens: PATs / OAuth / app / refresh (ghp_/gho_/ghu_/ghs_/ghr_) and
     # fine-grained PATs (github_pat_...). ≥20 char suffix avoids short slugs.
-    (re.compile(r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}"), "***REDACTED***"),
-    (re.compile(r"github_pat_[A-Za-z0-9_]{20,}"), "***REDACTED***"),
+    (
+        re.compile(r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
+    (
+        re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
     # Slack tokens: bot/user/app/refresh/legacy (xoxb-/xoxp-/xoxa-/xoxr-/xoxs-).
-    (re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"), "***REDACTED***"),
+    (
+        re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),
+        "***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
+    ),
     # Other provider key families with distinctive prefixes — caught here for the
     # bare-token-in-prose form that no NAME=value carrier sees (a provider
     # exception that echoes the key). Groq gsk_, xAI xai-, Replicate r8_,
     # HuggingFace hf_, Fireworks fw_. ≥20-char anchors avoid short ids (#830).
-    (re.compile(r"gsk_[A-Za-z0-9]{20,}"), "***REDACTED***"),
-    (re.compile(r"xai-[A-Za-z0-9]{20,}"), "***REDACTED***"),
-    (re.compile(r"r8_[A-Za-z0-9]{20,}"), "***REDACTED***"),
-    (re.compile(r"hf_[A-Za-z0-9]{20,}"), "***REDACTED***"),
-    (re.compile(r"fw_[A-Za-z0-9]{20,}"), "***REDACTED***"),
+    (re.compile(r"gsk_[A-Za-z0-9]{20,}"), "***REDACTED***", REDACTION_CATEGORY_API_KEY),
+    (re.compile(r"xai-[A-Za-z0-9]{20,}"), "***REDACTED***", REDACTION_CATEGORY_API_KEY),
+    (re.compile(r"r8_[A-Za-z0-9]{20,}"), "***REDACTED***", REDACTION_CATEGORY_API_KEY),
+    (re.compile(r"hf_[A-Za-z0-9]{20,}"), "***REDACTED***", REDACTION_CATEGORY_API_KEY),
+    (re.compile(r"fw_[A-Za-z0-9]{20,}"), "***REDACTED***", REDACTION_CATEGORY_API_KEY),
     # JSON Web Tokens (session/bearer creds): three base64url segments split by
     # dots. The ``eyJ`` prefix is base64url of ``{"`` — a JWT header. The 3rd
     # (signature) segment requires ≥20 chars (real HS256/RS256 sigs are 43+) so
@@ -275,6 +318,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             r"eyJ[A-Za-z0-9_-]{10,512}\.[A-Za-z0-9_-]{6,512}\.[A-Za-z0-9_-]{20,512}"
         ),
         "***REDACTED***",
+        REDACTION_CATEGORY_BEARER_TOKEN,
     ),
     # --- URL credentials ---
     # Credentials in a URL's userinfo (scheme://user:pass@host) for KNOWN
@@ -293,6 +337,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             r"[^\s/?#:@]{0,256}:[^\s/?#]{0,256}@"
         ),
         r"\1***REDACTED***@",
+        REDACTION_CATEGORY_URL_CREDENTIAL,
     ),
     # Secrets carried as URL query params. Curated EXACT param names (anchored to
     # `?`/`&` with `=` right after the name) so non-secret params (`?page=`,
@@ -317,6 +362,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_URL_CREDENTIAL,
     ),
     # Azure SAS `?sig=<token>` — bare `sig` is excluded from the curated list above
     # (a `?sig=v2` scheme-version flag is a common non-secret), so gate on a
@@ -326,6 +372,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (
         re.compile(r"([?&]sig=)[^&\s\"'*]{16,}", re.IGNORECASE),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_URL_CREDENTIAL,
     ),
     # --- Header / key-value secret carriers ---
     # Match `name: value` / `name=value` in raw, JSON, Python dict-repr
@@ -340,6 +387,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
     ),
     # Underscore form `api_key`. No leading boundary: namespaced env dumps like
     # `GEMINI_API_KEY=secret` / JSON keys such as `"openai_api_key"` must redact
@@ -349,6 +397,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             rf"({_ESCQ}api_key{_ESCQ}\s*[:=]\s*{_ESCQ}){_SECVAL}", re.IGNORECASE
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_API_KEY,
     ),
     # `master_key`/`master-key` and `private_key`/`private-key` carriers — the
     # BenchFlow proxy master key and GCP/Vertex service-account private-key field
@@ -359,6 +408,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_CREDENTIAL_FIELD,
     ),
     # Bearer-token env vars whose NAME has BEARER_TOKEN in the MIDDLE, e.g.
     # `AWS_BEARER_TOKEN_BEDROCK=` — the secret-suffix rule below anchors its marker
@@ -371,6 +421,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_BEARER_TOKEN,
     ),
     # Generic secret-NAME-suffix carriers: names ending in TOKEN/SECRET/PASSWORD or
     # a specific *secret* key suffix (ACCESS_KEY/SECRET_KEY/ACCOUNT_KEY/…). The KEY
@@ -388,6 +439,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_CREDENTIAL_FIELD,
     ),
     # authorization header WITH a scheme (Bearer/Token/Basic/…): keep scheme.
     (
@@ -397,6 +449,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_BEARER_TOKEN,
     ),
     # authorization header with a bare value (no recognized scheme). The negative
     # lookahead skips scheme-prefixed values already handled above, so
@@ -409,6 +462,7 @@ _REDACTION_PATTERNS: list[tuple[re.Pattern[str], str]] = [
             re.IGNORECASE,
         ),
         r"\1***REDACTED***",
+        REDACTION_CATEGORY_BEARER_TOKEN,
     ),
 ]
 
@@ -428,11 +482,25 @@ def redact_trajectory_text(text: str) -> str:
 
 def redact_trajectory_text_with_count(text: str) -> tuple[str, int]:
     """Apply the canonical patterns and report how many matches were replaced."""
-    replacements = 0
-    for pattern, replacement in _REDACTION_PATTERNS:
+    text, categories = redact_trajectory_text_with_categories(text)
+    return text, sum(categories.values())
+
+
+def redact_trajectory_text_with_categories(text: str) -> tuple[str, dict[str, int]]:
+    """Apply the canonical patterns and report replacements per category.
+
+    Categories name the kind of secret each rule actually detects (API key,
+    bearer token, private key block, URL credential, credential-bearing field
+    value) so upload previews can itemize what was masked without inventing
+    detection that does not exist. The total replacement count is the sum of
+    the returned values.
+    """
+    categories: dict[str, int] = {}
+    for pattern, replacement, category in _REDACTION_PATTERNS:
         text, count = pattern.subn(replacement, text)
-        replacements += count
-    return text, replacements
+        if count:
+            categories[category] = categories.get(category, 0) + count
+    return text, categories
 
 
 def redact_trajectory_obj(obj: Any) -> Any:

--- a/src/benchflow/trajectories/viewer.py
+++ b/src/benchflow/trajectories/viewer.py
@@ -97,9 +97,11 @@ body { padding-bottom: 104px; }
 .confirm-btn.approve:hover { background: #262626; }
 .confirm-btn.reject { background: var(--card); color: var(--ink); border: 1px solid var(--rule-strong); }
 .confirm-btn.reject:hover { background: var(--secondary); }
+.confirm-note { flex-basis: 100%; font-size: 12.5px; color: var(--muted); }
 </style>
 <div class="confirm-bar">
 <div class="confirm-inner" id="confirm-inner">
+<!--BENCHFLOW-REDACTION-NOTE-->
 <span class="confirm-question">Submit this trajectory to the BenchFlow eval prize?</span>
 <div class="confirm-actions">
 <button class="confirm-btn approve" onclick="__benchDecide('approve')">Approve &amp; submit</button>
@@ -124,11 +126,33 @@ async function __benchDecide(choice) {
 """
 
 
-def _inject_confirm_bar(page: str) -> str:
+_REDACTION_NOTE_MARKER = "<!--BENCHFLOW-REDACTION-NOTE-->"
+
+
+def _confirm_bar_html(redaction_summary: str | None) -> str:
+    """Confirm-bar snippet, optionally carrying the redaction-summary note.
+
+    The note is presentation-only text the caller composed (the upload skill
+    lifts it from ``bench traj upload --dry-run``); the viewer itself never
+    redacts, so without a summary the bar is byte-identical to the plain
+    ``--confirm`` bar.
+    """
+    note = ""
+    if redaction_summary:
+        note = (
+            '<div class="confirm-note">Before upload, BenchFlow masks: '
+            f"{html.escape(redaction_summary)}. "
+            "Originals never leave this machine.</div>"
+        )
+    return _CONFIRM_BAR_HTML.replace(_REDACTION_NOTE_MARKER, note, 1)
+
+
+def _inject_confirm_bar(page: str, redaction_summary: str | None = None) -> str:
     """Append the confirm bar just before </body> (or at the end as fallback)."""
+    bar = _confirm_bar_html(redaction_summary)
     if "</body>" in page:
-        return page.replace("</body>", f"{_CONFIRM_BAR_HTML}</body>", 1)
-    return page + _CONFIRM_BAR_HTML
+        return page.replace("</body>", f"{bar}</body>", 1)
+    return page + bar
 
 
 # Small BenchFlow wordmark header (inline SVG logo from the site's icon set —
@@ -689,6 +713,7 @@ def serve(
     port: int = 8888,
     prompts: list[str] | None = None,
     confirm: bool = False,
+    redaction_summary: str | None = None,
 ) -> str | None:
     """Serve a trial directory or a session JSONL file as a web page.
 
@@ -698,6 +723,11 @@ def serve(
     machine-readable ``DECISION: <value>`` line to stdout. Without it the
     server runs until Ctrl+C and the return value is ``None`` — exactly the
     pre-confirm behavior (no bar, no POST endpoint).
+
+    ``redaction_summary`` is an optional caller-composed line (e.g. ``"2 API
+    keys, 1 bearer token"``) rendered inside the confirm bar so the reviewer
+    sees what upload-time redaction would mask. Presentation-only; it has no
+    effect without ``confirm=True``.
     """
     import threading
     from http.server import HTTPServer, SimpleHTTPRequestHandler
@@ -723,7 +753,7 @@ def serve(
         # interaction against this live server, not part of the artifact.
         (path / "trajectory.html").write_text(html_content)
     if confirm:
-        html_content = _inject_confirm_bar(html_content)
+        html_content = _inject_confirm_bar(html_content, redaction_summary)
 
     print(f"Trajectory viewer: http://localhost:{port}")
     print(f"Trial: {path}")

--- a/tests/test_traj_report.py
+++ b/tests/test_traj_report.py
@@ -446,7 +446,7 @@ def test_report_rejects_preview_limits_outside_the_public_cli_contract(
 def test_report_carries_masked_categories_but_keeps_them_out_of_the_manifest(
     tmp_path: Path,
 ) -> None:
-    """Redaction transparency: staged categories flow into the report for the
+    """Guards the redaction-transparency feature from PR #1022: staged categories flow into the report for the
     terminal breakdown, but ``as_manifest_metadata`` must stay unchanged — the
     server validates ``trajectory_report`` with ``extra="forbid"`` and an exact
     recompute-equality check, so a new manifest field would be rejected."""
@@ -492,7 +492,7 @@ def _render_report(report: TrajectoryReport) -> str:
 
 
 def test_rendered_report_itemizes_masked_categories(tmp_path: Path) -> None:
-    """Redaction transparency: with masked values the terminal report shows the
+    """Guards the redaction-transparency feature from PR #1022: with masked values the terminal report shows the
     itemized ``Masked for you`` breakdown plus the local-redaction reassurance."""
     artifact = _artifact(tmp_path / "generic.jsonl", [{"type": "message", "text": "x"}])
     report = build_trajectory_report(
@@ -513,7 +513,7 @@ def test_rendered_report_itemizes_masked_categories(tmp_path: Path) -> None:
 
 
 def test_rendered_report_zero_masking_copy(tmp_path: Path) -> None:
-    """Redaction transparency: with nothing masked the report says so explicitly
+    """Guards the redaction-transparency feature from PR #1022: with nothing masked the report says so explicitly
     instead of showing an empty breakdown."""
     artifact = _artifact(tmp_path / "generic.jsonl", [{"type": "message", "text": "x"}])
     report = build_trajectory_report((artifact,), masked_values=0)

--- a/tests/test_traj_report.py
+++ b/tests/test_traj_report.py
@@ -441,3 +441,86 @@ def test_report_rejects_preview_limits_outside_the_public_cli_contract(
 
     with pytest.raises(ValueError, match="0-20"):
         build_trajectory_report((artifact,), masked_values=0, preview_steps=21)
+
+
+def test_report_carries_masked_categories_but_keeps_them_out_of_the_manifest(
+    tmp_path: Path,
+) -> None:
+    """Redaction transparency: staged categories flow into the report for the
+    terminal breakdown, but ``as_manifest_metadata`` must stay unchanged — the
+    server validates ``trajectory_report`` with ``extra="forbid"`` and an exact
+    recompute-equality check, so a new manifest field would be rejected."""
+    trajectory = tmp_path / "trajectory"
+    trajectory.mkdir()
+    (trajectory / "acp_trajectory.jsonl").write_text(
+        "".join(
+            json.dumps(record) + "\n"
+            for record in (
+                {
+                    "type": "user_message",
+                    "text": "here is sk-abc1234567defghijklmnop987654",
+                },
+                {"type": "agent_message", "text": "Done"},
+            )
+        )
+    )
+
+    with stage_trajectory_artifacts(trajectory, source_id="categories") as staged:
+        assert staged.redaction_categories == (("API key", 1),)
+        report = build_trajectory_report(
+            staged.files,
+            masked_values=staged.redaction_replacements,
+            masked_categories=staged.redaction_categories,
+        )
+
+    assert report.masked_values == 1
+    assert report.masked_categories == (("API key", 1),)
+    assert sum(count for _, count in report.masked_categories) == report.masked_values
+    assert "masked_categories" not in report.as_manifest_metadata()
+
+
+def _render_report(report: TrajectoryReport) -> str:
+    from rich.console import Console
+
+    from benchflow.cli._traj_upload_ui import render_trajectory_report
+
+    console = Console(record=True, width=120)
+    render_trajectory_report(report, console=console)
+    # Panels wrap long values and pad lines with box-drawing characters;
+    # normalize so copy assertions are wrap-insensitive.
+    return " ".join(console.export_text().replace("│", " ").split())
+
+
+def test_rendered_report_itemizes_masked_categories(tmp_path: Path) -> None:
+    """Redaction transparency: with masked values the terminal report shows the
+    itemized ``Masked for you`` breakdown plus the local-redaction reassurance."""
+    artifact = _artifact(tmp_path / "generic.jsonl", [{"type": "message", "text": "x"}])
+    report = build_trajectory_report(
+        (artifact,),
+        masked_values=3,
+        masked_categories=(("API key", 2), ("bearer token", 1)),
+    )
+
+    rendered = _render_report(report)
+    assert "Masked for you" in rendered
+    assert "2 API keys, 1 bearer token" in rendered
+    assert "originals never leave this machine" in rendered
+    assert (
+        "Redaction ran locally before anything was staged; the server "
+        "independently rescans and rejects any survivor." in rendered
+    )
+    assert "No secrets or personal identifiers detected" not in rendered
+
+
+def test_rendered_report_zero_masking_copy(tmp_path: Path) -> None:
+    """Redaction transparency: with nothing masked the report says so explicitly
+    instead of showing an empty breakdown."""
+    artifact = _artifact(tmp_path / "generic.jsonl", [{"type": "message", "text": "x"}])
+    report = build_trajectory_report((artifact,), masked_values=0)
+
+    rendered = _render_report(report)
+    assert (
+        "No secrets or personal identifiers detected — nothing needed masking."
+        in rendered
+    )
+    assert "Redaction ran locally" not in rendered

--- a/tests/test_viewer_confirm.py
+++ b/tests/test_viewer_confirm.py
@@ -53,14 +53,16 @@ def _free_port() -> int:
 
 
 def _serve_in_thread(
-    path: Path, *, confirm: bool
+    path: Path, *, confirm: bool, redaction_summary: str | None = None
 ) -> tuple[int, threading.Thread, dict]:
     """Run serve() in a daemon thread; poll GET / until it answers."""
     port = _free_port()
     result: dict = {}
 
     def run() -> None:
-        result["decision"] = serve(str(path), port, confirm=confirm)
+        result["decision"] = serve(
+            str(path), port, confirm=confirm, redaction_summary=redaction_summary
+        )
 
     thread = threading.Thread(target=run, daemon=True)
     thread.start()
@@ -180,7 +182,9 @@ def test_eval_view_maps_decision_to_exit_code(
     (non-1/2 so it cannot collide with error or usage exits), Ctrl+C → 0."""
     calls: dict = {}
 
-    def fake_serve(path, port=8888, prompts=None, confirm=False):
+    def fake_serve(
+        path, port=8888, prompts=None, confirm=False, redaction_summary=None
+    ):
         calls["confirm"] = confirm
         return decision
 
@@ -195,7 +199,9 @@ def test_eval_view_defaults_to_no_confirm(tmp_path, monkeypatch):
     behavior (no bar, no endpoint) is preserved."""
     calls: dict = {}
 
-    def fake_serve(path, port=8888, prompts=None, confirm=False):
+    def fake_serve(
+        path, port=8888, prompts=None, confirm=False, redaction_summary=None
+    ):
         calls["confirm"] = confirm
         return None
 
@@ -203,3 +209,71 @@ def test_eval_view_defaults_to_no_confirm(tmp_path, monkeypatch):
     res = runner.invoke(app, ["eval", "view", str(tmp_path)])
     assert res.exit_code == 0
     assert calls["confirm"] is False
+
+
+def test_confirm_bar_shows_redaction_summary_when_given(tmp_path):
+    """Redaction transparency: --redaction-summary renders the masked-secret
+    breakdown in the confirm bar (HTML-escaped), above the buttons."""
+    session = _write_session(tmp_path)
+    port, thread, result = _serve_in_thread(
+        session,
+        confirm=True,
+        redaction_summary="2 API keys, 1 bearer token <&>",
+    )
+
+    page = result["page"]
+    assert "Before upload, BenchFlow masks: 2 API keys, 1 bearer token" in page
+    assert "Originals never leave this machine." in page
+    assert "&lt;&amp;&gt;" in page  # summary is escaped, never raw HTML
+    assert "<&>" not in page
+    # The note precedes the question/buttons inside the bar markup.
+    assert page.index('<div class="confirm-note">') < page.index(
+        '<span class="confirm-question">'
+    )
+
+    _post_decision(port, "reject")
+    thread.join(timeout=10)
+
+
+def test_confirm_bar_without_redaction_summary_is_unchanged(tmp_path):
+    """Redaction transparency: the flag is optional — without it the confirm bar
+    carries no note markup, and plain (non-confirm) pages never carry any."""
+    session = _write_session(tmp_path)
+
+    plain_html = render_jsonl_file(session)
+    assert "confirm-note" not in plain_html
+    assert "Before upload, BenchFlow masks" not in plain_html
+
+    port, thread, result = _serve_in_thread(session, confirm=True)
+    assert "Before upload, BenchFlow masks" not in result["page"]
+    assert '<div class="confirm-note">' not in result["page"]
+
+    _post_decision(port, "reject")
+    thread.join(timeout=10)
+
+
+def test_eval_view_passes_redaction_summary_through(tmp_path, monkeypatch):
+    """Redaction transparency: the Typer command forwards --redaction-summary to
+    serve() untouched."""
+    calls: dict = {}
+
+    def fake_serve(
+        path, port=8888, prompts=None, confirm=False, redaction_summary=None
+    ):
+        calls["summary"] = redaction_summary
+        return None
+
+    monkeypatch.setattr(viewer, "serve", fake_serve)
+    res = runner.invoke(
+        app,
+        [
+            "eval",
+            "view",
+            str(tmp_path),
+            "--confirm",
+            "--redaction-summary",
+            "2 API keys, 1 bearer token",
+        ],
+    )
+    assert res.exit_code == 0
+    assert calls["summary"] == "2 API keys, 1 bearer token"

--- a/tests/test_viewer_confirm.py
+++ b/tests/test_viewer_confirm.py
@@ -212,7 +212,7 @@ def test_eval_view_defaults_to_no_confirm(tmp_path, monkeypatch):
 
 
 def test_confirm_bar_shows_redaction_summary_when_given(tmp_path):
-    """Redaction transparency: --redaction-summary renders the masked-secret
+    """Guards the redaction-transparency feature from PR #1022: --redaction-summary renders the masked-secret
     breakdown in the confirm bar (HTML-escaped), above the buttons."""
     session = _write_session(tmp_path)
     port, thread, result = _serve_in_thread(
@@ -236,7 +236,7 @@ def test_confirm_bar_shows_redaction_summary_when_given(tmp_path):
 
 
 def test_confirm_bar_without_redaction_summary_is_unchanged(tmp_path):
-    """Redaction transparency: the flag is optional — without it the confirm bar
+    """Guards the redaction-transparency feature from PR #1022: the flag is optional — without it the confirm bar
     carries no note markup, and plain (non-confirm) pages never carry any."""
     session = _write_session(tmp_path)
 
@@ -253,7 +253,7 @@ def test_confirm_bar_without_redaction_summary_is_unchanged(tmp_path):
 
 
 def test_eval_view_passes_redaction_summary_through(tmp_path, monkeypatch):
-    """Redaction transparency: the Typer command forwards --redaction-summary to
+    """Guards the redaction-transparency feature from PR #1022: the Typer command forwards --redaction-summary to
     serve() untouched."""
     calls: dict = {}
 

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -977,3 +977,145 @@ def test_redact_trajectory_obj_preserves_key_context_for_structured_secret():
     out = redact_trajectory_obj({"x-api-key": _PREFIXLESS_SECRET, "note": "plain text"})
     assert out["x-api-key"] == "***REDACTED***"
     assert out["note"] == "plain text"
+
+
+# Redaction transparency: the upload preview itemizes WHAT was masked
+# ("2 API keys, 1 bearer token"), so every rule reports a category and the
+# per-category counts must sum to the backward-compatible total.
+
+_FAKE_PEM = (
+    "-----BEGIN PRIVATE KEY-----\nMIIEvNOTAREALKEYxyz\n-----END PRIVATE KEY-----"
+)
+
+
+@pytest.mark.parametrize(
+    "text,expected_category",
+    [
+        pytest.param(
+            "sk-abc1234567defghijklmnop987654", "API key", id="token-family-api-key"
+        ),
+        pytest.param(
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.abcdefghijklmnopqrstuv",
+            "bearer token",
+            id="jwt-bearer",
+        ),
+        pytest.param(_FAKE_PEM, "private key block", id="pem-private-key"),
+        pytest.param(
+            "postgres://user:hunter2@db.example.com/app",
+            "URL credential",
+            id="url-userinfo",
+        ),
+        pytest.param(
+            "GITHUB_TOKEN=prefixlessSecretValue1234567890",
+            "credential-bearing field value",
+            id="generic-name-carrier",
+        ),
+    ],
+)
+def test_canonical_text_redaction_reports_a_category(text, expected_category):
+    """Redaction transparency: each canonical rule tags its replacements with the
+    kind of secret it actually detects."""
+    from benchflow.trajectories.types import redact_trajectory_text_with_categories
+
+    redacted, categories = redact_trajectory_text_with_categories(text)
+    assert categories == {expected_category: 1}
+    assert redacted != text
+
+
+def test_text_categories_sum_to_the_backward_compatible_count():
+    """Redaction transparency: the categorized scan and the count scan agree, so
+    ``redaction_replacements`` stays backward-compatible."""
+    from benchflow.trajectories.types import (
+        redact_trajectory_text_with_categories,
+        redact_trajectory_text_with_count,
+    )
+
+    text = (
+        "sk-abc1234567defghijklmnop987654 and "
+        "GITHUB_TOKEN=prefixlessSecretValue1234567890 and "
+        "https://user:hunter2@host/"
+    )
+    counted_text, count = redact_trajectory_text_with_count(text)
+    categorized_text, categories = redact_trajectory_text_with_categories(text)
+    assert counted_text == categorized_text
+    assert count == sum(categories.values()) == 3
+    assert categories == {
+        "API key": 1,
+        "credential-bearing field value": 1,
+        "URL credential": 1,
+    }
+
+
+def test_publish_redaction_accumulates_structural_field_categories():
+    """Redaction transparency: structural (field-name keyed) masking categorizes
+    by the credential-bearing name that fired, and the counter total equals the
+    returned replacement count."""
+    from collections import Counter
+
+    from benchflow.publish.redact import REDACTED, redact_value
+
+    categories: Counter[str] = Counter()
+    value = {
+        "password": "hunter2",
+        "api_key": "prefixlessSecretValue1234567890",
+        "client_secret": "prefixlessSecretValue0987654321",
+        "note": "no secret here",
+    }
+    redacted, count = redact_value(value, categories=categories)
+    assert redacted["password"] == REDACTED
+    assert redacted["api_key"] == REDACTED
+    assert redacted["client_secret"] == REDACTED
+    assert redacted["note"] == "no secret here"
+    assert count == 3
+    assert categories == Counter(
+        {
+            "password": 1,
+            "API key": 1,
+            "credential-bearing field value": 1,
+        }
+    )
+
+
+def test_publish_redaction_categorizes_cli_password_options():
+    """Redaction transparency: CLI-argument masking attributes the replacement to
+    the sensitive option name (``--password`` → password)."""
+    from collections import Counter
+
+    from benchflow.publish.redact import redact_value
+
+    categories: Counter[str] = Counter()
+    _, count = redact_value(["mysql", "--password", "hunter2"], categories=categories)
+    assert count == 1
+    assert categories == Counter({"password": 1})
+
+
+def test_stability_redaction_counter_matches_total():
+    """Redaction transparency: the multi-pass stability loop reports the same
+    total through the category counter as through its return value."""
+    from collections import Counter
+
+    from benchflow.publish.redact import redact_value_to_stability
+
+    categories: Counter[str] = Counter()
+    value = {
+        "text": "Bearer prefixlessSecretValue1234567890",
+        "password": "hunter2",
+    }
+    _, count = redact_value_to_stability(value, categories=categories)
+    assert count == sum(categories.values()) >= 2
+    assert categories["bearer token"] >= 1
+    assert categories["password"] == 1
+
+
+def test_format_redaction_breakdown_orders_and_pluralizes():
+    """Redaction transparency: breakdown prose is display-ordered and pluralized
+    (``2 API keys, 1 bearer token``)."""
+    from benchflow.publish.redact import (
+        format_redaction_breakdown,
+        redaction_breakdown,
+    )
+
+    counts = {"bearer token": 1, "API key": 2, "password": 0}
+    assert redaction_breakdown(counts) == (("API key", 2), ("bearer token", 1))
+    assert format_redaction_breakdown(counts) == "2 API keys, 1 bearer token"
+    assert format_redaction_breakdown({}) == ""

--- a/tests/trajectories/test_redaction.py
+++ b/tests/trajectories/test_redaction.py
@@ -1013,7 +1013,7 @@ _FAKE_PEM = (
     ],
 )
 def test_canonical_text_redaction_reports_a_category(text, expected_category):
-    """Redaction transparency: each canonical rule tags its replacements with the
+    """Guards the redaction-transparency feature from PR #1022: each canonical rule tags its replacements with the
     kind of secret it actually detects."""
     from benchflow.trajectories.types import redact_trajectory_text_with_categories
 
@@ -1023,7 +1023,7 @@ def test_canonical_text_redaction_reports_a_category(text, expected_category):
 
 
 def test_text_categories_sum_to_the_backward_compatible_count():
-    """Redaction transparency: the categorized scan and the count scan agree, so
+    """Guards the redaction-transparency feature from PR #1022: the categorized scan and the count scan agree, so
     ``redaction_replacements`` stays backward-compatible."""
     from benchflow.trajectories.types import (
         redact_trajectory_text_with_categories,
@@ -1047,7 +1047,7 @@ def test_text_categories_sum_to_the_backward_compatible_count():
 
 
 def test_publish_redaction_accumulates_structural_field_categories():
-    """Redaction transparency: structural (field-name keyed) masking categorizes
+    """Guards the redaction-transparency feature from PR #1022: structural (field-name keyed) masking categorizes
     by the credential-bearing name that fired, and the counter total equals the
     returned replacement count."""
     from collections import Counter
@@ -1077,7 +1077,7 @@ def test_publish_redaction_accumulates_structural_field_categories():
 
 
 def test_publish_redaction_categorizes_cli_password_options():
-    """Redaction transparency: CLI-argument masking attributes the replacement to
+    """Guards the redaction-transparency feature from PR #1022: CLI-argument masking attributes the replacement to
     the sensitive option name (``--password`` → password)."""
     from collections import Counter
 
@@ -1090,7 +1090,7 @@ def test_publish_redaction_categorizes_cli_password_options():
 
 
 def test_stability_redaction_counter_matches_total():
-    """Redaction transparency: the multi-pass stability loop reports the same
+    """Guards the redaction-transparency feature from PR #1022: the multi-pass stability loop reports the same
     total through the category counter as through its return value."""
     from collections import Counter
 
@@ -1108,7 +1108,7 @@ def test_stability_redaction_counter_matches_total():
 
 
 def test_format_redaction_breakdown_orders_and_pluralizes():
-    """Redaction transparency: breakdown prose is display-ordered and pluralized
+    """Guards the redaction-transparency feature from PR #1022: breakdown prose is display-ordered and pluralized
     (``2 API keys, 1 bearer token``)."""
     from benchflow.publish.redact import (
         format_redaction_breakdown,


### PR DESCRIPTION
## Summary

Contributors staging a trajectory today see only a bare count ("API keys / secrets masked: N"), which doesn't tell them what was masked or why they can feel safe submitting. This PR makes the redaction pass transparent, without changing what gets redacted or what reaches the server:

- **Per-category counts in the redactor.** Every canonical pattern in `trajectories/types.py` and every structural rule in `publish/redact.py` now tags its replacements with the kind of secret the rule actually detects: **API key** (provider token families sk-*/AIzaSy/AQ./AKIA/dtn_/gh*/xox*/gsk_/xai-/r8_/hf_/fw_ + api-key name carriers), **bearer token** (Bearer-scheme values, authorization headers, `*BEARER_TOKEN*` env carriers, JWTs), **private key block** (PEM armored blocks), **password** (password/passwd-named fields and CLI options), **URL credential** (userinfo + secret query params + SAS sig), **credential-bearing field value** (generic `*TOKEN*`/`*SECRET*`/`*_KEY` name carriers and denylisted field names). The taxonomy names existing rules only — there is no PII/email detection, so no such category is claimed. `redaction_replacements` totals stay byte-for-byte backward-compatible (category counters are an optional accumulator).
- **Terminal report breakdown.** Under the masked-count row: `Masked for you: 2 API keys, 1 bearer token — originals never leave this machine`, plus `Redaction ran locally before anything was staged; the server independently rescans and rejects any survivor.` Zero case: `No secrets or personal identifiers detected — nothing needed masking.` `--dry-run` additionally prints a plain greppable `Masked for you: ...` line.
- **Viewer confirm bar.** `bench eval view PATH --confirm --redaction-summary "2 API keys, 1 bearer token"` renders "Before upload, BenchFlow masks: … Originals never leave this machine." above the Approve/Reject buttons. Presentation-only and optional — no flag, byte-identical bar. The `benchflow-traj-upload` skill now stages a dry run first and lifts the line into the flag.
- **Manifest unchanged (deliberately).** `TrajectoryReportInfo` is `extra="forbid"` and the server does an exact recompute-equality check on `trajectory_report`, so per-category counts stay display-only; `as_manifest_metadata()` is untouched and documents why.

The owner's original phrasing suggested reporting "how many agents spend how many tokens on redacting" — redaction is a local structural pass, not agent work, so this ships the honest version of that intent: what kinds of secrets were masked, and that it all happened locally.

## Test plan

- [x] `tests/trajectories/test_redaction.py` — per-category text + structural + CLI-argv counting, category/total agreement, breakdown ordering/pluralization
- [x] `tests/test_traj_report.py` — categories flow into the report, stay out of `as_manifest_metadata()`, rendered breakdown + zero-case copy
- [x] `tests/test_viewer_confirm.py` — confirm bar with/without `--redaction-summary` (escaping, placement, plain page untouched), CLI passthrough
- [x] `tests/test_traj_upload_cli.py`, `tests/test_trajectory_upload_service.py`, `tests/test_traj_staging_phases.py` — green
- [x] Full suite: only the 14 pre-existing environment failures (`test_cli_live_progress`, `test_daytona_dind_compose_up`, `test_smoke_wiring`) also fail on unmodified origin/main
- [x] `ruff check` / `ruff format --check` / `ty check src/` clean
- [x] Visual: headless-Chrome screenshot of `--confirm --redaction-summary` bar; fixture dry run shows `Masked for you: 2 API keys, 1 bearer token`