### PR TITLE
Release BenchFlow 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.7.2 — 2026-08-16
+
 ### Added
 - **The upload preview itemizes what redaction masked, by kind.** The
   redactor now categorizes every replacement by the rule that fired — API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,14 @@
   `version` / `sessionId`, the filename stem as a session fallback) and
   hides any badge whose value is unknown — including the cost badge when no
   event carries cost data. Presentation only.
+- **Upload progress no longer claims the broker is waking up.** A warm
+  retry printed `Uploading… the first request can take a minute while the
+  service wakes up` even when the service was already up. The line is now
+  `Uploading… this can take up to a minute; retries are safe.`
+- **`bench traj setup --list` no longer wraps session paths mid-token.**
+  Each hit prints index/source/time, then the path on its own line, then
+  the snippet, via plain `print` so Rich does not split a long JSONL path
+  and break copy-paste.
 
 ### Changed
 - **Trajectory viewer tool calls are color-coded and backgrounds are light.**

--- a/docs/traj-upload.md
+++ b/docs/traj-upload.md
@@ -71,10 +71,10 @@ non-finite numbers, but detected secret-like values do not make
 otherwise-valid JSONL ineligible: the local staging pass replaces them with
 `<XXX-benchflow-key-values-XXX>`. It applies the same structural redaction to
 manifest metadata, computes a content digest, and uploads a manifest last. The
-first request can take a minute while the public broker wakes up; retries are
-safe. Use `--dry-run` to inspect the staged file list, digest, sizes, ignored
-siblings, and redaction count without making a network request; its output ends
-with a plain `Masked for you: ...` line itemizing the masked secrets by kind,
+first request can take up to a minute; retries are safe. Use `--dry-run` to
+inspect the staged file list, digest, sizes, ignored siblings, and redaction
+count without making a network request; its output ends with a plain
+`Masked for you: ...` line itemizing the masked secrets by kind,
 which the contributor skill lifts into the viewer's confirm bar via
 `bench eval view --confirm --redaction-summary`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.2.dev0"
+version = "0.7.2"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -351,10 +351,9 @@ def _run_upload(options: _UploadOptions) -> None:
             console.print("[yellow]Upload cancelled.[/yellow]")
             return
         if not destination.direct:
-            console.print(
-                "Uploading… the first request can take a minute "
-                "while the service wakes up."
-            )
+            # Honest on both cold and warm runs: the broker may already be
+            # up. Don't claim it's waking when a retry is just transferring.
+            console.print("Uploading… this can take up to a minute; retries are safe.")
         with upload_progress(staged.files, console=console) as hooks:
             result = _publish(staged, destination=destination, hooks=hooks)
         _print_upload_result(staged, result, direct=destination.direct)
@@ -717,11 +716,15 @@ def _print_session_hits() -> None:
 
     hits = list_recent_sessions()
     if not hits:
-        console.print("No recent Claude Code, Codex, or trial sessions found.")
+        print("No recent Claude Code, Codex, or trial sessions found.")
         return
     for index, hit in enumerate(hits, start=1):
         snippet = hit.snippet or "(no prompt yet)"
-        console.print(f"{index}. [{hit.source}] {hit.when}  {hit.path}\n   {snippet}")
+        # Plain print + path on its own line: Rich wrapping used to split
+        # long session paths mid-token and make them unselectable.
+        print(f"{index}. [{hit.source}] {hit.when}")
+        print(f"   {hit.path}")
+        print(f"   {snippet}")
 
 
 def _interactive_view() -> None:

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -816,10 +816,10 @@ def test_list_recent_sessions_scans_all_projects_most_recent_first(
 def test_setup_list_prints_path_on_its_own_line(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Guards the collector-audit friction fix: ``bench traj setup --list``
-    used Rich wrapping on ``index. [source] when  /very/long/path``, which
-    split session paths mid-token and made them unselectable. The path must
-    sit on its own physical line after the index/source/time line."""
+    """Guards the collector-audit friction fix from PR #1024: ``bench traj
+    setup --list`` used Rich wrapping on ``index. [source] when  /very/long/path``,
+    which split session paths mid-token and made them unselectable. The path
+    must sit on its own physical line after the index/source/time line."""
     from benchflow.trajectories.sessions import SessionHit
 
     long_path = Path(
@@ -851,9 +851,10 @@ def test_setup_list_prints_path_on_its_own_line(
 def test_broker_upload_does_not_claim_the_service_is_waking(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Guards the collector-audit friction fix: a warm rerun still printed
-    ``while the service wakes up``, which is stale once the broker is up.
-    The progress line must stay honest on both cold and warm runs."""
+    """Guards the collector-audit friction fix from PR #1024: a warm rerun
+    still printed ``while the service wakes up``, which is stale once the
+    broker is up. The progress line must stay honest on both cold and warm
+    runs."""
     captured: dict[str, str] = {}
     _capture_broker_source_id(monkeypatch, captured)
     monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -813,6 +813,58 @@ def test_list_recent_sessions_scans_all_projects_most_recent_first(
     assert "prize session please" in hits[1].snippet
 
 
+def test_setup_list_prints_path_on_its_own_line(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards the collector-audit friction fix: ``bench traj setup --list``
+    used Rich wrapping on ``index. [source] when  /very/long/path``, which
+    split session paths mid-token and made them unselectable. The path must
+    sit on its own physical line after the index/source/time line."""
+    from benchflow.trajectories.sessions import SessionHit
+
+    long_path = Path(
+        "/Users/someone/.claude/projects/"
+        "-Users-someone-very-long-project-name-that-used-to-wrap/"
+        "01234567-89ab-cdef-0123-456789abcdef.jsonl"
+    )
+    monkeypatch.setattr(
+        "benchflow.trajectories.sessions.list_recent_sessions",
+        lambda: [
+            SessionHit(
+                path=long_path,
+                source="claude",
+                mtime=1_700_000_000,
+                snippet="fit a Michaelis-Menten curve",
+            )
+        ],
+    )
+    result = runner.invoke(app, ["traj", "setup", "--list"])
+
+    assert result.exit_code == 0, result.output
+    lines = [line.rstrip() for line in click.unstyle(result.output).splitlines()]
+    assert f"   {long_path}" in lines
+    path_line = next(line for line in lines if str(long_path) in line)
+    assert path_line.strip() == str(long_path)
+    assert "fit a Michaelis-Menten curve" in result.output
+
+
+def test_broker_upload_does_not_claim_the_service_is_waking(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guards the collector-audit friction fix: a warm rerun still printed
+    ``while the service wakes up``, which is stale once the broker is up.
+    The progress line must stay honest on both cold and warm runs."""
+    captured: dict[str, str] = {}
+    _capture_broker_source_id(monkeypatch, captured)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "wakes up" not in output
+    assert "Uploading… this can take up to a minute; retries are safe." in output
+
+
 def _repo_line(session_cwd: Path) -> str:
     return (
         f"Repo: benchflow-ai/benchflow (from session cwd {session_cwd}; "

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.2.dev0"
+version = "0.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary
- Cut the public `0.7.2` version (`0.7.2.dev0` → `0.7.2`) and promote CHANGELOG `[Unreleased]` to `## 0.7.2 — 2026-08-16`, following `docs/release.md`.
- This is the public cut of the contributor traj-upload train already on `main` since 0.7.1: viewer restyle + tool-call colors, in-browser Approve/Reject, redaction breakdown, session-cwd-only repo tags, and hiding unknown viewer-header badges.
- Also lands two leftover collector-audit friction items so they ship in this cut: upload copy no longer claims the broker is waking on warm reruns, and `bench traj setup --list` prints each session path on its own unwrapped line.

## Release plan
Per `docs/release.md` (no rebase, no force-push):

1. Merge this PR to `main` (human review — do not squash if you want the two commits kept; either merge commit is fine).
2. Tag the merge commit `v0.7.2` to trigger `public-release.yml` (PyPI publish + GitHub Release).
3. Open a follow-up bump-back PR: `0.7.2` → `0.7.3.dev0`.

I am stopping at this ready-to-review PR. Merge, tag, and PyPI watch need a human.

## Test plan
- [x] `uv run python -m pytest tests/test_traj_upload_cli.py` (46 passed)
- [x] `uv run ruff check .`
- [x] `uv run ty check src/`
- [ ] CI green on this PR
- [ ] After merge: tag `v0.7.2` on the merge commit and watch `public-release.yml`
- [ ] After publish: bump `main` to `0.7.3.dev0`