### PR TITLE
bench traj: verify uploads into Azure storage + coherent professional TUI

### DIFF
--- a/.agents/skills/benchflow-traj-upload-ops/references/cli-contract.md
+++ b/.agents/skills/benchflow-traj-upload-ops/references/cli-contract.md
@@ -33,6 +33,9 @@ bench traj upload [PATH]
   [--container-url TEXT]
   [--dry-run]
   [--preview-steps INTEGER]
+  [--wait | --no-wait]
+
+bench traj status [DIGEST]
 ```
 
 | Input | Contract |
@@ -46,6 +49,8 @@ bench traj upload [PATH]
 | `--dry-run` | Validate, redact, report, and finalize a temporary manifest without confirmation or network access. |
 | `--direct` | Use trusted local Azure credentials instead of the public contribution service. |
 | `--container-url` | Azure container URL for `--direct`; invalid without `--direct`. |
+| `--wait` / `--no-wait` | Storage verification, on by default for public uploads: after the byte transfer, poll the broker's capture-status endpoint until the validator's verdict. `BENCHFLOW_TRAJ_WAIT_SECONDS` overrides the polling budget (default 240; `0` disables the wait entirely). Never applies to `--direct` or `--dry-run`. |
+| `DIGEST` (`traj status`) | `sha256:<64 hex>` or the bare 64-hex digest printed by an upload; prompted for when omitted. |
 
 Use `uv run bench` in a source checkout and `bench` for an installed release.
 
@@ -219,6 +224,34 @@ as a successful no-op.
 Never print signed PUT URLs, request headers, internal service endpoints,
 credentials, detected secrets, or contributor email.
 
+## Storage verification
+
+After a public upload, the CLI polls `GET /v1/uploads/<digest>` on the broker
+(the validation-ledger state) until one of these outcomes:
+
+- `ingested` → print `Verified in Azure storage`. The validator records
+  `ingested` only after promoting every file to `sources/community/<digest>/`,
+  so this line is proof the capture reached durable storage — a stronger claim
+  than the transfer finishing.
+- `rejected` → exit 1 with the bounded, user-fixable rejection detail. The
+  transfer succeeded but the capture is not in the dataset.
+- HTTP 404 from the endpoint → the deployed broker predates status reporting;
+  return silently with exactly the pre-verification behavior.
+- Budget exhausted (default 240 s with backoff from 2 s to 10 s) or repeated
+  transport failures → say the upload is safely queued and print the
+  `bench traj status sha256:<digest>` line to check later.
+
+A handshake 409 (already ingested) prints the verified line immediately
+without polling. `bench traj status DIGEST` runs one poll on demand and maps
+states to exit codes: `ingested`/`pending`/`validating` exit 0; `rejected`,
+an unknown digest, rate limiting, and a status-less deployment exit 1.
+
+The status endpoint reveals only the ledger state, the bounded rejection
+detail, and the public promotion prefix for a digest the caller already
+holds — never contributor identity, source ids, or quarantine internals.
+Status polls consume a separate, much higher rate-limit budget than upload
+grants (`TRAJ_STATUS_RATE_LIMIT`, default 720/hour/IP).
+
 ## Public upload protocol
 
 The public client:
@@ -288,6 +321,7 @@ Use precise claims:
 | Unit or CLI-runner tests | Local implementation behavior under mocks. |
 | `--dry-run` on a real capture | Real local parsing, masking, report, and manifest behavior; no network proof. |
 | Real public command returns success | Client and contribution-service upload path accepted the capture; promotion still needs checking. |
+| CLI prints `Verified in Azure storage` (or `traj status` reports `ingested`) against a deployed broker | The validation ledger recorded promotion for that digest; equivalent to promotion unless the ledger itself is suspect. |
 | Trusted storage shows the exact digest under `sources/community/`, with validator-recomputed schema-1.2 manifest and no quarantine residue | Production public upload worked end to end for that exact build and capture. |
 
 Record the CLI version or Git SHA, digest, command mode, result, and storage
@@ -300,8 +334,13 @@ Use the implementation, not this prose, as the final authority when reviewing a
 new code change:
 
 - `src/benchflow/cli/traj.py`: options, prompts, confirmation, dry-run, routing,
-  and result text.
+  result text, the storage-verification wait, and `bench traj status`.
 - `src/benchflow/cli/_traj_upload_ui.py`: report and byte-progress rendering.
+- `src/benchflow/cli/_traj_tui.py`: the shared `bench traj` design language —
+  banner, styled prompts, and the TTY-only session picker (presentation only;
+  every interactive affordance falls back to the plain prompt contract).
+- `services/trajectory_upload/broker_app.py` + `azure_backend.py`: the
+  `GET /v1/uploads/{digest}` capture-status endpoint over the ledger.
 - `src/benchflow/publish/traj_capture.py`: input limits, strict JSONL, staging,
   digest, contributor metadata, and manifest.
 - `src/benchflow/publish/redact.py`: local secret detection and convergence.

--- a/.agents/skills/benchflow-traj-upload-ops/references/cli-contract.md
+++ b/.agents/skills/benchflow-traj-upload-ops/references/cli-contract.md
@@ -233,7 +233,7 @@ credentials, detected secrets, or contributor email.
 After a public upload, the CLI polls `GET /v1/uploads/<digest>` on the broker
 (the validation-ledger state) until one of these outcomes:
 
-- `ingested` → print `Verified in Azure storage`. The validator records
+- `ingested` → print `Verified in cloud storage`. The validator records
   `ingested` only after promoting every file to `sources/community/<digest>/`,
   so this line is proof the capture reached durable storage — a stronger claim
   than the transfer finishing.
@@ -325,7 +325,7 @@ Use precise claims:
 | Unit or CLI-runner tests | Local implementation behavior under mocks. |
 | `--dry-run` on a real capture | Real local parsing, masking, report, and manifest behavior; no network proof. |
 | Real public command returns success | Client and contribution-service upload path accepted the capture; promotion still needs checking. |
-| CLI prints `Verified in Azure storage` (or `traj status` reports `ingested`) against a deployed broker | The validation ledger recorded promotion for that digest; equivalent to promotion unless the ledger itself is suspect. |
+| CLI prints `Verified in cloud storage` (or `traj status` reports `ingested`) against a deployed broker | The validation ledger recorded promotion for that digest; equivalent to promotion unless the ledger itself is suspect. |
 | Trusted storage shows the exact digest under `sources/community/`, with validator-recomputed schema-1.2 manifest and no quarantine residue | Production public upload worked end to end for that exact build and capture. |
 
 Record the CLI version or Git SHA, digest, command mode, result, and storage

--- a/.agents/skills/benchflow-traj-upload-ops/references/cli-contract.md
+++ b/.agents/skills/benchflow-traj-upload-ops/references/cli-contract.md
@@ -29,6 +29,8 @@ bench traj upload [PATH]
   [--email TEXT]
   [--source-id TEXT]
   [--repo | --no-repo]
+  [--workspace | --no-workspace]
+  [--workspace-dir PATH]
   [--direct]
   [--container-url TEXT]
   [--dry-run]
@@ -45,6 +47,8 @@ bench traj status [DIGEST]
 | `--email` | Bounded ASCII contributor email, stored in `manifest.json`. |
 | `--source-id` | Optional stable source identifier. If omitted, derive it from the selected file stem or directory name. Accept 1-128 letters, numbers, dots, underscores, hyphens, or single path separators; reject `.`/`..` segments and repeated separators. |
 | `--repo` / `--no-repo` | Repo tagging, on by default. When no `--source-id` is given, read the session's recorded working directory (Claude `cwd` events or the Codex `session_meta` payload), resolve its git `origin` remote (2 s timeout, silent failure), normalize https/ssh URLs to `owner/name`, and use `repo/<owner>/<name>` as the source id, printing `Repo: <owner>/<name> (from session cwd <path>; use --no-repo to omit)` (the local path is terminal output only, never uploaded). The session's own recorded cwd is the only provenance source — there is no fallback to the upload invocation directory. No recorded cwd, a missing directory, or no GitHub remote mean no tag: the upload silently keeps the derived source id, exactly like `--no-repo`. Local-path remotes never produce a tag; an explicit `--source-id` always wins. |
+| `--workspace` / `--no-workspace` | Workspace attachment, on by default. Reads the same session-recorded cwd as repo tagging; when it is an existing directory, the folder is zipped into the capture as `workspace/<name>.zip` and the CLI prints `Workspace: <path> (from session cwd; use --no-workspace to omit)` then `Workspace attached: workspace/<name>.zip (<size>, <n> files, <m> excluded)`. `.git`/VCS internals, dependency trees (`node_modules`, `.venv`, …), caches, symlinks, and secret-shaped filenames (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `.netrc`, …) are excluded; everything else is archived **as-is, without content redaction** — the CLI says so on the attach line. The workspace is skipped (with a printed reason, never an error) when the included files exceed 1 GiB before compression, exceed 50,000 files, the folder is missing or empty, or the resulting zip exceeds 1 GiB; the zip is created inside the staging temporary directory and is always deleted when staging exits. When detection fails on a real terminal, one optional `◇ Workspace folder to attach (optional, Enter to skip)` prompt accepts a folder or skips; off-TTY there is no prompt. |
+| `--workspace-dir` | Explicit workspace folder to attach instead of auto-detection; a missing folder is a hard error. Implies nothing about repo tagging. |
 | `--preview-steps` | Number of meaningful redacted steps to show; range 0-20, default 5. Zero suppresses the preview table. |
 | `--dry-run` | Validate, redact, report, and finalize a temporary manifest without confirmation or network access. |
 | `--direct` | Use trusted local Azure credentials instead of the public contribution service. |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## [Unreleased]
 
 ### Added
-- **Uploads are confirmed all the way into Azure storage.** After the
+- **Uploads are confirmed all the way into cloud storage.** After the
   progress bar finishes, `bench traj upload` now polls the contribution
   service's new `GET /v1/uploads/{digest}` capture-status endpoint (the
-  validation ledger) until the validator's verdict: `✓ Verified in Azure
+  validation ledger) until the validator's verdict: `✓ Verified in cloud
   storage` once the capture is promoted to `sources/community/<digest>/`, a
   concise exit-1 error with the fixable detail if the validator rejects it,
   and a `bench traj status sha256:<digest>` handoff line if validation is
@@ -30,6 +30,30 @@
   and rounded panels. Every interactive affordance degrades to the exact
   previous prompt-driven flow off-TTY (agents, pipes, CI, Windows), and all
   machine-read lines (`Masked for you:`, `Digest:`, `Repo:`) stay plain.
+- **Uploads can carry the session's workspace folder as a zip attachment.**
+  `bench traj upload` reads the session's recorded working directory (the
+  same Claude `cwd` / Codex `session_meta` provenance as repo tagging) and
+  archives it into the capture as `workspace/<name>.zip`, printing
+  `Workspace: <path> (from session cwd; use --no-workspace to omit)` and a
+  `Workspace attached:` line with size, file count, and exclusion count.
+  VCS internals, dependency trees, caches, symlinks, and secret-shaped
+  filenames (`.env*`, `*.pem`, `*.key`, `id_rsa*`, `.netrc`, …) never enter
+  the archive; everything else is archived as-is without content redaction,
+  and the attach line says so. Workspaces over 1 GiB (measured before
+  compression, so the zip is never created), over 50,000 files, missing, or
+  empty are skipped with a printed reason instead of failing the upload.
+  When detection fails on a real terminal, one optional prompt accepts a
+  folder or skips on Enter; `--workspace-dir` overrides detection and
+  `--no-workspace` opts out. The archive is staged in the upload's
+  temporary directory and always deleted afterwards. Server side, the
+  contribution service accepts the new `workspace/*.zip` namespace with a
+  1 GiB per-archive cap (trajectory JSONL keeps 128 MiB), allows at most
+  one archive per capture and never an archive alone, verifies the zip
+  container format instead of JSONL strictness, promotes it with an
+  `application/zip` content type, and scopes trajectory-report
+  cross-checks to trajectory artifacts so an attachment cannot fail
+  report equality.
+
 ## 0.7.3 — 2026-08-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## [Unreleased]
 
+### Added
+- **Uploads are confirmed all the way into Azure storage.** After the
+  progress bar finishes, `bench traj upload` now polls the contribution
+  service's new `GET /v1/uploads/{digest}` capture-status endpoint (the
+  validation ledger) until the validator's verdict: `✓ Verified in Azure
+  storage` once the capture is promoted to `sources/community/<digest>/`, a
+  concise exit-1 error with the fixable detail if the validator rejects it,
+  and a `bench traj status sha256:<digest>` handoff line if validation is
+  still running when the budget (default 240 s, `BENCHFLOW_TRAJ_WAIT_SECONDS`
+  override, `--no-wait` opt-out) runs out. A handshake 409 ("already
+  submitted") prints the verified line immediately, and a deployed broker
+  that predates the endpoint (404) keeps today's behavior unchanged. The new
+  `bench traj status DIGEST` command runs one check on demand. Status polls
+  consume a separate, higher rate-limit budget (`TRAJ_STATUS_RATE_LIMIT`,
+  default 720/hour/IP) and reveal only the ledger state, the bounded
+  rejection detail, and the public promotion prefix — never contributor
+  identity or quarantine internals. The broker must be redeployed
+  (`deploy-trajectory-upload` workflow or `scripts/deploy.sh`) before the
+  endpoint answers in production; the CLI degrades gracefully until then.
+- **The `bench traj` family shares one polished terminal design language.**
+  A new presentation-only kit (`cli/_traj_tui.py`) gives `traj setup`,
+  `traj upload`, and `traj status` a coherent look: a `◆ benchflow · <command>`
+  banner, styled `◇` input prompts, an arrow-key recent-session picker (↑/↓,
+  1-9 jump, esc to fall back to typing a path) on real terminals, colored
+  step kinds in the report preview matching the browser viewer's palette,
+  and rounded panels. Every interactive affordance degrades to the exact
+  previous prompt-driven flow off-TTY (agents, pipes, CI, Windows), and all
+  machine-read lines (`Masked for you:`, `Digest:`, `Repo:`) stay plain.
 ## 0.7.3 — 2026-08-16
 
 ### Added

--- a/services/trajectory_upload/README.md
+++ b/services/trajectory_upload/README.md
@@ -38,6 +38,15 @@ services/trajectory_upload/
   cleanup, queue, and ledger authority;
 - two-day inbox/version expiry plus storage read/write/delete diagnostics.
 
+The broker also serves `GET /v1/uploads/{digest}`: the public capture-status
+endpoint the CLI polls after an upload (and `bench traj status` on demand). It
+reads the validation ledger and reports `pending`, `validating`, `ingested`
+(with the `sources/community/<digest>/` promotion prefix), `rejected` (with
+the bounded rejection detail), or `unknown`; unknown digests are a 200 so
+clients can use 404 to detect a deployment that predates the endpoint. Status
+polls consume their own per-IP budget (`TRAJ_STATUS_RATE_LIMIT`, default
+720/hour) instead of upload-grant quota.
+
 `infra/main.bicep` owns the stable resource topology: private storage and data
 containers, queue/table, diagnostics, registry, identities, log workspace, and
 Container Apps environment. `scripts/deploy.sh` owns operations that require

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -21,10 +21,15 @@ from services.trajectory_upload.broker_app import (
     UploadDeclarationConflict,
 )
 from services.trajectory_upload.contract import (
+    CaptureStatusInfo,
     UploadGrant,
     UploadObject,
     UploadRequest,
 )
+
+# Ledger states a contributor may see. Anything else in the table (corruption,
+# a future migration) is reported as ``unknown`` rather than leaked verbatim.
+_PUBLIC_STATUSES = frozenset({"pending", "validating", "ingested", "rejected"})
 
 
 class AzureUploadBroker:
@@ -40,6 +45,7 @@ class AzureUploadBroker:
         ip_hash_key: bytes,
         rate_limit: int = 20,
         ip_rate_limit: int = 500,
+        status_rate_limit: int = 720,
         sas_minutes: int = 15,
     ) -> None:
         self.account_name = account_name
@@ -49,6 +55,10 @@ class AzureUploadBroker:
         self.ip_hash_key = ip_hash_key
         self.rate_limit = rate_limit
         self.ip_rate_limit = ip_rate_limit
+        # Status polls are cheap ledger reads, so their ceiling is far above
+        # the upload grant limit: one CLI wait polls a handful of times per
+        # minute for a few minutes.
+        self.status_rate_limit = status_rate_limit
         self.sas_minutes = min(max(sas_minutes, 1), 15)
         self._state_lock = threading.Lock()
         self._delegation_key: Any = None
@@ -79,6 +89,7 @@ class AzureUploadBroker:
             ip_hash_key=_required_env("TRAJ_UPLOAD_IP_HASH_KEY").encode(),
             rate_limit=int(os.environ.get("TRAJ_UPLOAD_RATE_LIMIT", "20")),
             ip_rate_limit=int(os.environ.get("TRAJ_UPLOAD_IP_RATE_LIMIT", "500")),
+            status_rate_limit=int(os.environ.get("TRAJ_STATUS_RATE_LIMIT", "720")),
             sas_minutes=int(os.environ.get("TRAJ_UPLOAD_SAS_MINUTES", "15")),
         )
 
@@ -164,6 +175,45 @@ class AzureUploadBroker:
             objects=objects,
             expires_at=expires_at,
         )
+
+    def get_capture_status(self, digest: str, *, client_ip: str) -> CaptureStatusInfo:
+        """Report the ledger state of one digest for the public status route.
+
+        The ledger row is written by the broker at handshake time and advanced
+        by the validator, and ``ingested`` is only recorded after promotion to
+        ``sources/community/<digest>/`` completes — so that status is proof the
+        capture is present in durable storage. Only the bounded, user-fixable
+        rejection detail is exposed; source ids and attempt internals are not.
+        """
+        self._consume_token("status", client_ip, self.status_rate_limit)
+        entity = self._capture_entity(digest)
+        if entity is None:
+            return CaptureStatusInfo(digest=digest, status="unknown")
+        status = entity.get("status")
+        if not isinstance(status, str) or status not in _PUBLIC_STATUSES:
+            return CaptureStatusInfo(digest=digest, status="unknown")
+        updated_at = entity.get("updated_at")
+        info = CaptureStatusInfo(
+            digest=digest,
+            status=status,
+            updated_at=updated_at if isinstance(updated_at, str) else None,
+        )
+        if status == "ingested":
+            return CaptureStatusInfo(
+                digest=info.digest,
+                status=info.status,
+                updated_at=info.updated_at,
+                prefix=f"sources/community/{digest}/",
+            )
+        if status == "rejected":
+            detail = entity.get("detail")
+            return CaptureStatusInfo(
+                digest=info.digest,
+                status=info.status,
+                updated_at=info.updated_at,
+                detail=detail[:512] if isinstance(detail, str) and detail else None,
+            )
+        return info
 
     @property
     def container_url(self) -> str:

--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -249,6 +249,11 @@ class AzureUploadBroker:
             ResourceNotFoundError,
         )
 
+        if capacity <= 0:
+            # A zero-capacity bucket is an operator kill switch: nothing ever
+            # refills, so reject without touching the table (a first-seen key
+            # would otherwise be admitted while creating its row).
+            raise RateLimited(3600)
         digest = hmac.new(self.ip_hash_key, key.encode(), hashlib.sha256).hexdigest()
         row = f"{scope}-{digest}"
         for attempt in range(10):

--- a/services/trajectory_upload/broker_app.py
+++ b/services/trajectory_upload/broker_app.py
@@ -2,17 +2,23 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from threading import Lock
 from typing import Protocol
 
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Path, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 
-from services.trajectory_upload.contract import UploadGrant, UploadRequest
+from services.trajectory_upload.contract import (
+    CaptureStatusInfo,
+    UploadGrant,
+    UploadRequest,
+)
 
 MAX_HANDSHAKE_BYTES = 1024**2
+DIGEST_PATTERN = re.compile(r"^[0-9a-f]{64}$")
 
 
 class AlreadyUploaded(Exception):
@@ -38,6 +44,10 @@ class UploadBroker(Protocol):
     def create_upload(
         self, request: UploadRequest, *, client_ip: str
     ) -> UploadGrant: ...
+
+    def get_capture_status(
+        self, digest: str, *, client_ip: str
+    ) -> CaptureStatusInfo: ...
 
 
 def create_app(
@@ -131,6 +141,36 @@ def create_app(
                 },
             )
         return JSONResponse(status_code=200, content=grant.as_dict())
+
+    @app.get("/v1/uploads/{digest}")
+    def capture_status(
+        request: Request,
+        digest: str = Path(min_length=64, max_length=64),
+    ) -> JSONResponse:
+        """Report the ledger state of one capture digest.
+
+        Contributors already hold the digest of anything they can ask about
+        (it is content-derived and printed by the CLI), and the response never
+        includes contributor identity, source ids, or storage internals beyond
+        the public promotion prefix. An unknown digest is a 200 ``unknown``
+        rather than a 404 so clients can use 404 to detect a deployment that
+        predates this endpoint.
+        """
+        if DIGEST_PATTERN.fullmatch(digest) is None:
+            return JSONResponse(
+                status_code=400,
+                content={"detail": "digest must be 64 lowercase hex characters"},
+            )
+        service = _backend(request.app)
+        try:
+            info = service.get_capture_status(digest, client_ip=_client_ip(request))
+        except RateLimited as exc:
+            return JSONResponse(
+                status_code=429,
+                headers={"Retry-After": str(exc.retry_after)},
+                content={"detail": "status rate limit exceeded"},
+            )
+        return JSONResponse(status_code=200, content=info.as_dict())
 
     return app
 

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -15,11 +15,15 @@ from benchflow.publish.traj_capture import (
 )
 from benchflow.publish.traj_capture import (
     MAX_ARTIFACTS,
+    MAX_ATTACHMENT_BYTES,
     MAX_CAPTURE_BYTES,
     MAX_EMAIL_LENGTH,
     MAX_FILE_BYTES,
     MAX_GITHUB_ID_LENGTH,
+    MAX_TOTAL_ARTIFACTS,
     MAX_UPLOADED_BY_LENGTH,
+    WORKSPACE_ARTIFACT_PREFIX,
+    max_artifact_bytes,
     validate_artifact_name,
     validate_email,
     validate_github_id,
@@ -40,7 +44,7 @@ class Artifact(BaseModel):
 
     name: str
     sha256: str
-    bytes: int = Field(ge=1, le=MAX_ARTIFACT_BYTES)
+    bytes: int = Field(ge=1, le=MAX_ATTACHMENT_BYTES)
 
     @field_validator("name")
     @classmethod
@@ -53,6 +57,13 @@ class Artifact(BaseModel):
         if not SHA256.fullmatch(value):
             raise ValueError("artifact sha256 must be 64 lowercase hex characters")
         return value
+
+    @model_validator(mode="after")
+    def validate_size_for_namespace(self) -> Self:
+        limit = max_artifact_bytes(self.name)
+        if self.bytes > limit:
+            raise ValueError(f"artifact exceeds {limit} bytes: {self.name}")
+        return self
 
 
 class ContributorInfo(BaseModel):
@@ -79,7 +90,7 @@ class CaptureDeclaration(BaseModel):
     source_id: str
     traj_digest: str
     uploaded_by: str | None = Field(default=None, max_length=MAX_UPLOADED_BY_LENGTH)
-    artifacts: list[Artifact] = Field(min_length=1, max_length=MAX_ARTIFACTS)
+    artifacts: list[Artifact] = Field(min_length=1, max_length=MAX_TOTAL_ARTIFACTS)
 
     @field_validator("source_id")
     @classmethod
@@ -99,6 +110,13 @@ class CaptureDeclaration(BaseModel):
         names = [artifact.name for artifact in self.artifacts]
         if len(names) != len(set(names)):
             raise ValueError("artifact names must be unique")
+        workspace_count = sum(
+            1 for name in names if name.startswith(WORKSPACE_ARTIFACT_PREFIX)
+        )
+        if workspace_count > 1:
+            raise ValueError("a capture may declare at most one workspace archive")
+        if workspace_count == len(names):
+            raise ValueError("a capture needs at least one trajectory artifact")
         if sum(artifact.bytes for artifact in self.artifacts) > MAX_CAPTURE_BYTES:
             raise ValueError(f"capture exceeds {MAX_CAPTURE_BYTES} bytes")
         if self.traj_digest != f"sha256:{trajectory_digest(self.artifacts)}":

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -247,14 +247,21 @@ class ContributionManifest(CaptureDeclaration):
             raise ValueError("trajectory report metadata requires schema 1.2.0")
         if self.trajectory_report is not None:
             report = self.trajectory_report
-            artifact_names = {artifact.name for artifact in self.artifacts}
+            # The report describes the trajectory JSONL alone; the optional
+            # workspace archive is an opaque attachment outside its scope.
+            trajectory_artifacts = [
+                artifact
+                for artifact in self.artifacts
+                if not artifact.name.startswith(WORKSPACE_ARTIFACT_PREFIX)
+            ]
+            artifact_names = {artifact.name for artifact in trajectory_artifacts}
             if report.primary_file not in artifact_names:
                 raise ValueError("trajectory report primary file is not an artifact")
-            if report.file_count != len(self.artifacts):
+            if report.file_count != len(trajectory_artifacts):
                 raise ValueError(
                     "trajectory report file count does not match artifacts"
                 )
-            if report.size_bytes != sum(item.bytes for item in self.artifacts):
+            if report.size_bytes != sum(item.bytes for item in trajectory_artifacts):
                 raise ValueError("trajectory report size does not match artifacts")
             if report.masked_values > self.redaction.replacements:
                 raise ValueError(

--- a/services/trajectory_upload/contract.py
+++ b/services/trajectory_upload/contract.py
@@ -246,6 +246,36 @@ class ContributionManifest(CaptureDeclaration):
 
 
 @dataclass(frozen=True)
+class CaptureStatusInfo:
+    """Public validation state of one capture digest.
+
+    ``status`` is one of ``pending``, ``validating``, ``ingested``,
+    ``rejected``, or ``unknown``. Only the bounded rejection detail and the
+    public promotion prefix ever accompany it — never contributor identity,
+    source ids, or quarantine internals.
+    """
+
+    digest: str
+    status: str
+    detail: str | None = None
+    prefix: str | None = None
+    updated_at: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "digest": f"sha256:{self.digest}",
+            "status": self.status,
+        }
+        if self.detail:
+            payload["detail"] = self.detail
+        if self.prefix:
+            payload["prefix"] = self.prefix
+        if self.updated_at:
+            payload["updated_at"] = self.updated_at
+        return payload
+
+
+@dataclass(frozen=True)
 class UploadObject:
     name: str
     put_url: str

--- a/services/trajectory_upload/validation.py
+++ b/services/trajectory_upload/validation.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from benchflow.publish.redact import redact_value
 from benchflow.publish.traj_capture import (
     MAX_JSONL_RECORD_BYTES,
+    WORKSPACE_ARTIFACT_PREFIX,
     strict_json_loads,
     validate_json_complexity,
 )
@@ -57,7 +58,12 @@ def validate_local_capture(
             raise CaptureRejected(f"size mismatch for {artifact.name}")
         if _sha256(path) != artifact.sha256:
             raise CaptureRejected(f"sha256 mismatch for {artifact.name}")
-        _validate_and_scan_jsonl(path, artifact.name)
+        if artifact.name.startswith(WORKSPACE_ARTIFACT_PREFIX):
+            # Workspace snapshots are opaque archives: integrity is the hash
+            # binding above; require only the zip container format.
+            _validate_zip_magic(path, artifact.name)
+        else:
+            _validate_and_scan_jsonl(path, artifact.name)
     _validate_trajectory_report(manifest, artifact_paths)
     return ValidatedCapture(
         manifest=manifest,
@@ -76,6 +82,8 @@ def _validate_trajectory_report(
     fallback_created_at = (
         declared.created_at if declared.created_at_source == "file timestamp" else None
     )
+    # The report describes the trajectory JSONL alone; a workspace archive is
+    # an opaque attachment and must not perturb the recompute-equality check.
     artifacts = tuple(
         _ReportArtifact(
             relname=item.name,
@@ -84,6 +92,7 @@ def _validate_trajectory_report(
             created_at=fallback_created_at,
         )
         for item in manifest.artifacts
+        if not item.name.startswith(WORKSPACE_ARTIFACT_PREFIX)
     )
     recomputed = build_trajectory_report(
         artifacts,
@@ -163,6 +172,13 @@ def _validate_and_scan_jsonl(path: Path, relname: str) -> None:
             records += 1
     if records == 0:
         raise CaptureRejected(f"{relname}: trajectory JSONL has no records")
+
+
+def _validate_zip_magic(path: Path, relname: str) -> None:
+    with path.open("rb") as stream:
+        magic = stream.read(4)
+    if magic[:2] != b"PK":
+        raise CaptureRejected(f"{relname}: workspace archive is not a zip file")
 
 
 def _reject_secrets(record: dict, relname: str, line_number: int) -> None:

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -16,9 +16,9 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
+from benchflow.publish.traj_capture import max_artifact_bytes
 from services.trajectory_upload.contract import (
     ARTIFACT_NAME,
-    MAX_ARTIFACT_BYTES,
     MAX_CAPTURE_BYTES,
     MAX_MANIFEST_BYTES,
 )
@@ -177,8 +177,8 @@ class AzureCaptureValidator:
             ).get_blob_properties()
         except ResourceNotFoundError:
             return None
-        if properties.size > MAX_ARTIFACT_BYTES:
-            return f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {relname}"
+        if properties.size > max_artifact_bytes(relname):
+            return f"artifact exceeds {max_artifact_bytes(relname)} bytes: {relname}"
 
         declared = self._declared_artifacts(digest, attempt_id)
         if declared is not None and declared.get(relname) != properties.size:
@@ -195,8 +195,11 @@ class AzureCaptureValidator:
                 )
             except ResourceNotFoundError:
                 continue
-            if size > MAX_ARTIFACT_BYTES:
-                return f"artifact exceeds {MAX_ARTIFACT_BYTES} bytes: {item_relname}"
+            if size > max_artifact_bytes(item_relname):
+                return (
+                    f"artifact exceeds {max_artifact_bytes(item_relname)} "
+                    f"bytes: {item_relname}"
+                )
             capture_bytes += size
             if capture_bytes > MAX_CAPTURE_BYTES:
                 return f"capture exceeds {MAX_CAPTURE_BYTES} bytes"
@@ -284,6 +287,11 @@ class AzureCaptureValidator:
             "benchflow_version": capture.manifest.tool.version,
         }
         for artifact in capture.manifest.artifacts:
+            content_type = (
+                "application/zip"
+                if artifact.name.endswith(".zip")
+                else "application/jsonl"
+            )
             with (
                 suppress(ResourceExistsError),
                 capture.artifact_paths[artifact.name].open("rb") as stream,
@@ -293,7 +301,7 @@ class AzureCaptureValidator:
                     data=stream,
                     overwrite=False,
                     metadata=metadata,
-                    content_settings=ContentSettings(content_type="application/jsonl"),
+                    content_settings=ContentSettings(content_type=content_type),
                 )
         with suppress(ResourceExistsError):
             self.container.upload_blob(

--- a/src/benchflow/cli/_traj_tui.py
+++ b/src/benchflow/cli/_traj_tui.py
@@ -198,10 +198,18 @@ def _select_tty(
 
 
 def _read_key(stream) -> str:
-    """Decode one keypress, folding escape sequences into named keys."""
+    """Decode one keypress, folding escape sequences into named keys.
+
+    Reads the raw descriptor, never the buffered text stream: an arrow key
+    arrives as ``ESC [ A`` in one burst, and a buffered ``read(1)`` would
+    swallow ``[ A`` into Python's buffer, making the descriptor look idle and
+    the ESC read as a bare cancel.
+    """
+    import os
     import select as selectors
 
-    char = stream.read(1)
+    descriptor = stream.fileno()
+    char = os.read(descriptor, 1).decode("utf-8", "replace")
     if char in {"\r", "\n"}:
         return "enter"
     if char == "\x03":
@@ -209,12 +217,12 @@ def _read_key(stream) -> str:
     if char != "\x1b":
         return char
     # Distinguish a bare Escape from a CSI arrow sequence.
-    if not selectors.select([stream], [], [], 0.05)[0]:
+    if not selectors.select([descriptor], [], [], 0.05)[0]:
         return "esc"
-    second = stream.read(1)
+    second = os.read(descriptor, 1).decode("utf-8", "replace")
     if second != "[":
         return "esc"
-    final = stream.read(1)
+    final = os.read(descriptor, 1).decode("utf-8", "replace")
     return {"A": "up", "B": "down"}.get(final, "esc")
 
 

--- a/src/benchflow/cli/_traj_tui.py
+++ b/src/benchflow/cli/_traj_tui.py
@@ -1,0 +1,256 @@
+"""Shared terminal design language for the ``bench traj`` command family.
+
+``bench traj setup``, ``bench traj upload``, and ``bench traj status`` render
+through this one small kit — a banner, a glyph vocabulary, styled prompts, and
+an arrow-key list picker — so the family reads as one coherent tool instead of
+three ad-hoc scripts. The look borrows from opencode's TUI: a single accent
+color, dim structural text, `◆`/`◇` step glyphs, and a `❯` selection pointer.
+
+Two hard rules keep this compatible with agents and the upload skill:
+
+1. Machine-read lines stay plain. Copy such as ``Masked for you: …``,
+   ``Digest: sha256:…``, and the ``Repo:`` line are printed by the command
+   modules with ``print`` — never boxed or wrapped here.
+2. Every interactive affordance has a dumb-terminal fallback. The picker
+   degrades to a numbered prompt whenever stdin/stdout is not a TTY (CI,
+   agents piping input, Windows without termios), preserving the exact
+   prompt-driven contract the tests pin.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import typer
+from rich.console import Console, Group
+from rich.rule import Rule
+from rich.text import Text
+
+ACCENT = "cyan"
+OK = "green"
+WARN = "yellow"
+ERR = "red"
+
+GLYPH_STEP = "◆"
+GLYPH_FIELD = "◇"
+# The heavy angle quotation is the intended selection pointer (same glyph
+# opencode and modern shell prompts use); it is not a mistyped ``>``.
+GLYPH_POINTER = "❯"  # noqa: RUF001
+GLYPH_OK = "✓"
+GLYPH_FAIL = "✗"
+
+# Preview/table styling for trajectory step kinds, matching the color language
+# of the browser viewer (PR #1020) so the terminal report and the viewer agree.
+KIND_STYLES = {
+    "Human": "bold green",
+    "Assistant": "cyan",
+    "Thinking": "magenta",
+    "Tool call": "yellow",
+}
+
+_PICKER_HELP = "↑/↓ move · enter select · 1-9 jump · esc cancel"
+
+
+def banner(console: Console, command: str, subtitle: str = "") -> None:
+    """One-line product banner: ``◆ benchflow · <command>`` plus a dim subtitle."""
+    console.print(
+        f"[bold {ACCENT}]{GLYPH_STEP} benchflow[/] [dim]·[/] [bold]{command}[/]"
+    )
+    if subtitle:
+        console.print(f"  [dim]{subtitle}[/]")
+    console.print()
+
+
+def section(console: Console, title: str) -> None:
+    """A dim rule that separates flow phases (report / upload / verify)."""
+    console.print(Rule(Text(title, style=f"bold {ACCENT}"), style="dim", align="left"))
+
+
+def field_label(label: str) -> str:
+    """Style an input prompt label; the trailing ``:`` stays typer's."""
+    return typer.style(f"{GLYPH_FIELD} ", fg="cyan") + typer.style(label, bold=True)
+
+
+def question_label(label: str) -> str:
+    """Style a yes/no confirmation label."""
+    return typer.style(f"{GLYPH_STEP} ", fg="cyan") + typer.style(label, bold=True)
+
+
+@dataclass(frozen=True)
+class SelectOption:
+    """One row of the picker: a primary label and an optional dim hint."""
+
+    label: str
+    hint: str = ""
+
+
+def interactive_terminal() -> bool:
+    """True when arrow-key interaction is possible on this terminal."""
+    try:
+        if not (sys.stdin.isatty() and sys.stdout.isatty()):
+            return False
+    except (AttributeError, ValueError):
+        return False
+    import os
+
+    if os.environ.get("TERM", "").lower() == "dumb":
+        return False
+    try:
+        import termios  # noqa: F401
+        import tty  # noqa: F401
+    except ImportError:  # Windows: fall back to the numbered prompt
+        return False
+    return True
+
+
+def select(
+    console: Console,
+    *,
+    title: str,
+    options: Sequence[SelectOption],
+    initial: int = 0,
+) -> int | None:
+    """Pick one option; returns its index, or ``None`` when cancelled.
+
+    Arrow-key navigation on a real terminal, a numbered prompt everywhere
+    else. The chosen label is echoed with a ``❯`` so the transcript records
+    the decision after the transient picker disappears.
+    """
+    if not options:
+        return None
+    initial = max(0, min(initial, len(options) - 1))
+    if interactive_terminal():
+        choice = _select_tty(console, title=title, options=options, initial=initial)
+    else:
+        choice = _select_numbered(console, title=title, options=options)
+    if choice is not None:
+        console.print(f"[{ACCENT}]{GLYPH_POINTER}[/] {_escaped(options[choice].label)}")
+    return choice
+
+
+def _escaped(value: str) -> str:
+    from rich.markup import escape
+
+    return escape(value)
+
+
+def _select_tty(
+    console: Console,
+    *,
+    title: str,
+    options: Sequence[SelectOption],
+    initial: int,
+) -> int | None:
+    import termios
+    import tty
+
+    from rich.live import Live
+
+    index = initial
+    # Hints share the row; keep every row one physical line so the Live
+    # region never jitters while navigating.
+    width = console.width or 100
+
+    def row(position: int, option: SelectOption) -> Text:
+        selected = position == index
+        pointer = f" {GLYPH_POINTER} " if selected else "   "
+        text = Text(no_wrap=True, overflow="ellipsis")
+        text.append(pointer, style=ACCENT if selected else "")
+        text.append(option.label, style=f"bold {ACCENT}" if selected else "")
+        if option.hint:
+            text.append("  " + option.hint, style="dim")
+        text.truncate(max(20, width - 2), overflow="ellipsis")
+        return text
+
+    def view() -> Group:
+        lines: list[Text | Rule] = []
+        if title:
+            lines.append(Text(f"{GLYPH_STEP} {title}", style=f"bold {ACCENT}"))
+        lines.extend(row(position, option) for position, option in enumerate(options))
+        lines.append(Text(_PICKER_HELP, style="dim"))
+        return Group(*lines)
+
+    stream = sys.stdin
+    descriptor = stream.fileno()
+    saved = termios.tcgetattr(descriptor)
+    try:
+        tty.setcbreak(descriptor)
+        with Live(view(), console=console, auto_refresh=False, transient=True) as live:
+            while True:
+                key = _read_key(stream)
+                if key in {"up", "k"}:
+                    index = (index - 1) % len(options)
+                elif key in {"down", "j"}:
+                    index = (index + 1) % len(options)
+                elif key in {"enter"}:
+                    return index
+                elif key in {"esc", "q", "interrupt"}:
+                    return None
+                elif key.isdigit() and 1 <= int(key) <= len(options):
+                    index = int(key) - 1
+                    return index
+                live.update(view(), refresh=True)
+    finally:
+        termios.tcsetattr(descriptor, termios.TCSADRAIN, saved)
+
+
+def _read_key(stream) -> str:
+    """Decode one keypress, folding escape sequences into named keys."""
+    import select as selectors
+
+    char = stream.read(1)
+    if char in {"\r", "\n"}:
+        return "enter"
+    if char == "\x03":
+        return "interrupt"
+    if char != "\x1b":
+        return char
+    # Distinguish a bare Escape from a CSI arrow sequence.
+    if not selectors.select([stream], [], [], 0.05)[0]:
+        return "esc"
+    second = stream.read(1)
+    if second != "[":
+        return "esc"
+    final = stream.read(1)
+    return {"A": "up", "B": "down"}.get(final, "esc")
+
+
+def _select_numbered(
+    console: Console,
+    *,
+    title: str,
+    options: Sequence[SelectOption],
+) -> int | None:
+    if title:
+        console.print(f"[bold {ACCENT}]{GLYPH_STEP} {title}[/]")
+    for position, option in enumerate(options, start=1):
+        console.print(f"[bold {ACCENT}]{position:>2}[/] {_escaped(option.label)}")
+        if option.hint:
+            console.print(f"   [dim]{_escaped(option.hint)}[/]")
+    while True:
+        raw = typer.prompt("Which number?", default="1").strip()
+        if raw.lower() in {"q", "quit", "esc"}:
+            return None
+        try:
+            value = int(raw)
+        except ValueError:
+            console.print(f"[{ERR}]Need a number between 1 and {len(options)}.[/]")
+            continue
+        if 1 <= value <= len(options):
+            return value - 1
+        console.print(f"[{ERR}]Need a number between 1 and {len(options)}.[/]")
+
+
+def compact_path(path: Path, *, limit: int = 64) -> str:
+    """Home-relative, tail-preserving path label for one-line picker rows."""
+    try:
+        text = "~/" + str(path.relative_to(Path.home()))
+    except ValueError:
+        text = str(path)
+    if len(text) <= limit:
+        return text
+    tail = "/".join(Path(text).parts[-2:])
+    return f"…/{tail}" if tail else text

--- a/src/benchflow/cli/_traj_tui.py
+++ b/src/benchflow/cli/_traj_tui.py
@@ -52,6 +52,18 @@ KIND_STYLES = {
 }
 
 _PICKER_HELP = "↑/↓ move · enter select · 1-9 jump · esc cancel"
+# Rows visible at once in the arrow-key picker. The cursor scrolls the list
+# through this viewport (the same feel as Claude Code's session-resume
+# picker), so a week of sessions stays browsable without flooding the screen.
+_PICKER_VIEWPORT_ROWS = 10
+
+
+def _visible_window(index: int, total: int, height: int) -> tuple[int, int]:
+    """First/last-plus-one visible option, keeping the cursor centered."""
+    if total <= height:
+        return 0, total
+    start = max(0, min(index - height // 2, total - height))
+    return start, start + height
 
 
 def banner(console: Console, command: str, subtitle: str = "") -> None:
@@ -169,8 +181,18 @@ def _select_tty(
         lines: list[Text | Rule] = []
         if title:
             lines.append(Text(f"{GLYPH_STEP} {title}", style=f"bold {ACCENT}"))
-        lines.extend(row(position, option) for position, option in enumerate(options))
-        lines.append(Text(_PICKER_HELP, style="dim"))
+        start, end = _visible_window(index, len(options), _PICKER_VIEWPORT_ROWS)
+        if start > 0:
+            lines.append(Text(f"   ↑ {start} more", style="dim"))
+        lines.extend(row(position, options[position]) for position in range(start, end))
+        if end < len(options):
+            lines.append(Text(f"   ↓ {len(options) - end} more", style="dim"))
+        lines.append(
+            Text(
+                f"{_PICKER_HELP} · {index + 1}/{len(options)}",
+                style="dim",
+            )
+        )
         return Group(*lines)
 
     stream = sys.stdin

--- a/src/benchflow/cli/_traj_upload_ui.py
+++ b/src/benchflow/cli/_traj_upload_ui.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 
+from rich import box
 from rich.console import Console
 from rich.panel import Panel
 from rich.progress import (
@@ -20,6 +21,7 @@ from rich.progress import (
 from rich.table import Table
 from rich.text import Text
 
+from benchflow.cli._traj_tui import KIND_STYLES
 from benchflow.publish.redact import REDACTED, format_redaction_breakdown
 from benchflow.publish.traj_capture import StagedFile
 from benchflow.publish.traj_report import PREVIEW_WORD_LIMIT, TrajectoryReport
@@ -52,15 +54,15 @@ def render_trajectory_report(report: TrajectoryReport, *, console: Console) -> N
     facts.add_row("Primary trajectory", Text(report.primary_file))
     facts.add_row("Format", report.format.value)
     facts.add_row("Created", _format_created_at(report))
-    facts.add_row("JSONL files", str(report.file_count))
+    facts.add_row("JSONL files", f"{report.file_count:,}")
     facts.add_row("Trajectory size", format_bytes(report.size_bytes))
-    facts.add_row("Total steps", str(report.total_steps))
-    facts.add_row("Thinking steps", str(report.thinking_steps))
-    facts.add_row("Tool-call steps", str(report.tool_call_steps))
-    facts.add_row("Human steps", str(report.human_steps))
+    facts.add_row("Total steps", f"{report.total_steps:,}")
+    facts.add_row("Thinking steps", _kind_count(report.thinking_steps, "Thinking"))
+    facts.add_row("Tool-call steps", _kind_count(report.tool_call_steps, "Tool call"))
+    facts.add_row("Human steps", _kind_count(report.human_steps, "Human"))
     facts.add_row(
         "API keys / secrets masked",
-        Text(str(report.masked_values), style="bold green"),
+        Text(f"{report.masked_values:,}", style="bold green"),
     )
     if report.masked_values:
         facts.add_row(
@@ -70,7 +72,15 @@ def render_trajectory_report(report: TrajectoryReport, *, console: Console) -> N
     else:
         facts.add_row("Masked for you", Text(NO_MASKING_NEEDED_COPY, style="dim"))
     facts.add_row("Safe replacement", Text(REDACTED))
-    console.print(Panel(facts, title="Trajectory report", border_style="cyan"))
+    console.print(
+        Panel(
+            facts,
+            title="[bold]Trajectory report[/]",
+            border_style="cyan",
+            box=box.ROUNDED,
+            padding=(0, 1),
+        )
+    )
     if report.masked_values:
         console.print(f"[dim]{REDACTION_REASSURANCE_COPY}[/dim]")
 
@@ -81,20 +91,32 @@ def render_trajectory_report(report: TrajectoryReport, *, console: Console) -> N
             f"First {len(report.preview)} trajectory steps "
             f"(up to {PREVIEW_WORD_LIMIT} words each)"
         ),
+        title_style="bold",
         show_lines=True,
         header_style="bold cyan",
+        box=box.ROUNDED,
+        border_style="dim",
     )
     preview.add_column("#", justify="right", style="dim", no_wrap=True)
     preview.add_column("Kind", no_wrap=True)
     preview.add_column("Preview", overflow="fold")
     for step in report.preview:
-        preview.add_row(str(step.number), step.kind, Text(step.summary))
+        preview.add_row(
+            str(step.number),
+            Text(step.kind, style=KIND_STYLES.get(step.kind, "")),
+            Text(step.summary),
+        )
     console.print(preview)
     if len(report.preview) < report.total_steps:
         console.print(
             f"[dim]Showing {len(report.preview)} of {report.total_steps} steps. "
             "Use --preview-steps to change the preview.[/dim]"
         )
+
+
+def _kind_count(count: int, kind: str) -> Text:
+    """A step count tinted with its preview-kind color when nonzero."""
+    return Text(f"{count:,}", style=KIND_STYLES.get(kind, "") if count else "dim")
 
 
 @dataclass(frozen=True)

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -810,7 +810,7 @@ def _confirm_storage(
 
 def _print_verified() -> None:
     console.print(
-        f"[bold green]{tui.GLYPH_OK} Verified in Azure storage[/] "
+        f"[bold green]{tui.GLYPH_OK} Verified in cloud storage[/] "
         "[dim]— the validator accepted and promoted this capture.[/]"
     )
 

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -28,6 +28,7 @@ from benchflow.cli._traj_upload_ui import (
 from benchflow.publish.redact import format_redaction_breakdown
 from benchflow.publish.traj_capture import (
     StagedCapture,
+    attach_workspace_archive,
     default_source_id,
     finalize_trajectory_capture,
     stage_trajectory_artifacts,
@@ -173,6 +174,8 @@ class _UploadOptions:
     dry_run: bool
     preview_steps: int
     wait: bool = True
+    workspace: bool = True
+    workspace_dir: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -281,6 +284,22 @@ def register_traj(app: typer.Typer) -> None:
                 "(owner/name from its git remote) as the source id",
             ),
         ] = True,
+        workspace: Annotated[
+            bool,
+            typer.Option(
+                "--workspace/--no-workspace",
+                help="Attach the session's workspace folder as a zip "
+                "(auto-detected from the session's recorded cwd; skipped "
+                "over 1 GiB)",
+            ),
+        ] = True,
+        workspace_dir: Annotated[
+            Path | None,
+            typer.Option(
+                "--workspace-dir",
+                help="Workspace folder to attach instead of auto-detection",
+            ),
+        ] = None,
         direct: Annotated[
             bool,
             typer.Option("--direct", help="Upload with local Azure credentials"),
@@ -321,6 +340,8 @@ def register_traj(app: typer.Typer) -> None:
                     email=email,
                     source_id=source_id,
                     repo=repo,
+                    workspace=workspace,
+                    workspace_dir=workspace_dir,
                     direct=direct,
                     container_url=container_url,
                     dry_run=dry_run,
@@ -375,6 +396,8 @@ def _run_upload(options: _UploadOptions) -> None:
             f"Repo: {detected.slug} "
             f"(from session cwd {detected.session_cwd}; use --no-repo to omit)"
         )
+    workspace_dir, workspace_prompted = _resolve_workspace_dir(options, path)
+    prompted = prompted or workspace_prompted
     destination = _resolve_destination(options)
 
     with (
@@ -391,6 +414,22 @@ def _run_upload(options: _UploadOptions) -> None:
         )
         status.stop()
         render_trajectory_report(report, console=console)
+
+        if workspace_dir is not None:
+            with console.status("[bold cyan]Archiving workspace folder…"):
+                attach = attach_workspace_archive(artifacts, workspace_dir)
+            artifacts = attach.artifacts
+            if attach.attached is not None:
+                # Plain print: one physical line per machine-readable fact.
+                print(
+                    f"Workspace attached: {attach.attached.relname} "
+                    f"({format_bytes(attach.attached.size_bytes)}, "
+                    f"{attach.file_count} files, {attach.excluded_count} "
+                    "excluded) — archived as-is; VCS internals and "
+                    "secret-like filenames stay local"
+                )
+            else:
+                print(f"Workspace skipped: {attach.skipped_reason}")
 
         github_id, email, identity_prompted = _resolve_contributor(
             options.github_id, options.email
@@ -527,6 +566,45 @@ def _detect_repo_slug(path: Path) -> _DetectedRepo | None:
     if slug:
         return _DetectedRepo(slug=slug, session_cwd=session_cwd)
     return None
+
+
+def _resolve_workspace_dir(
+    options: _UploadOptions, session_path: Path
+) -> tuple[Path | None, bool]:
+    """Pick the workspace folder to attach, mirroring identity resolution.
+
+    Auto-detection reads only the session's recorded cwd (Claude ``cwd``
+    events, Codex ``session_meta``) — the same provenance rule as repo
+    tagging. When detection fails on a real terminal, one optional prompt
+    lets the contributor point at a folder; Enter skips. Returns the folder
+    (or ``None``) and whether a human was prompted.
+    """
+    if not options.workspace:
+        return None, False
+    if options.workspace_dir is not None:
+        explicit = options.workspace_dir.expanduser()
+        if not explicit.is_dir():
+            raise ValueError(f"workspace folder not found: {explicit}")
+        print(f"Workspace: {explicit} (from --workspace-dir)")
+        return explicit, False
+    recorded = _session_cwd(session_path)
+    if recorded is not None and recorded.is_dir():
+        print(f"Workspace: {recorded} (from session cwd; use --no-workspace to omit)")
+        return recorded, False
+    if not sys.stdin.isatty():
+        return None, False
+    while True:
+        raw = typer.prompt(
+            tui.field_label("Workspace folder to attach (optional, Enter to skip)"),
+            default="",
+            show_default=False,
+        ).strip()
+        if not raw:
+            return None, True
+        candidate = Path(raw.strip("'\"")).expanduser()
+        if candidate.is_dir():
+            return candidate, True
+        print_error(f"not a folder: {candidate}")
 
 
 def _session_cwd(path: Path) -> Path | None:

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -824,10 +824,11 @@ def _run_status(digest_argument: str | None) -> None:
     raw = digest_argument or typer.prompt(tui.field_label("Digest (sha256:…)"))
     traj_digest = _normalize_digest(raw)
     broker_url = _resolve_broker_url()
+    # Plain print, and before the fetch: the digest stays selectable and
+    # visible even when the check errors (stderr interleaves with stdout).
+    print(f"Digest: sha256:{traj_digest}")
     with console.status(f"[bold {tui.ACCENT}]Checking capture status…[/]"):
         snapshot = fetch_capture_status(broker_url=broker_url, traj_digest=traj_digest)
-    # Plain print keeps the digest selectable for retries and reports.
-    print(f"Digest: sha256:{traj_digest}")
     if snapshot.status == "ingested":
         _print_verified()
         return

--- a/src/benchflow/cli/traj.py
+++ b/src/benchflow/cli/traj.py
@@ -1,4 +1,4 @@
-"""``bench traj upload`` / ``bench traj setup`` — contribute trajectory captures."""
+"""``bench traj upload`` / ``setup`` / ``status`` — contribute trajectory captures."""
 
 from __future__ import annotations
 
@@ -7,6 +7,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -16,6 +17,7 @@ import click
 import typer
 from rich.markup import escape
 
+import benchflow.cli._traj_tui as tui
 from benchflow.cli._shared import console, print_error
 from benchflow.cli._traj_upload_ui import (
     UploadProgressHooks,
@@ -136,6 +138,29 @@ def _maybe_print_update_hint() -> None:
     print(f"A newer BenchFlow ({latest}) is available — run: {UPGRADE_COMMAND}")
 
 
+# Post-upload storage verification: how long the CLI polls the broker for the
+# validator's verdict before handing off to ``bench traj status``. The env
+# variable overrides the budget; ``0`` disables waiting entirely (the test
+# suite sets it for hermeticity).
+DEFAULT_WAIT_SECONDS = 240.0
+_WAIT_INITIAL_DELAY = 2.0
+_WAIT_MAX_DELAY = 10.0
+_WAIT_BACKOFF = 1.5
+_WAIT_TRANSIENT_LIMIT = 3
+
+_WAIT_STATE_COPY = {
+    "pending": "queued for validation",
+    "validating": "validator is checking this capture",
+    "unknown": "waiting for the ledger entry",
+    "throttled": "status endpoint is busy — backing off",
+}
+
+# Module-level indirections so the wait-loop tests control time without
+# patching the global ``time`` module.
+_sleep = time.sleep
+_monotonic = time.monotonic
+
+
 @dataclass(frozen=True)
 class _UploadOptions:
     path: Path | None
@@ -147,6 +172,7 @@ class _UploadOptions:
     container_url: str | None
     dry_run: bool
     preview_steps: int
+    wait: bool = True
 
 
 @dataclass(frozen=True)
@@ -194,14 +220,22 @@ def register_traj(app: typer.Typer) -> None:
         if list_sessions:
             _print_session_hits()
             return
+        tui.banner(
+            console,
+            "traj setup",
+            "Install the submit skill and hand your coding agent the prompt",
+        )
         interactive = sys.stdin.isatty() and not yes
         if interactive:
             if typer.confirm(
-                "Install the trajectory skill into this project?", default=True
+                tui.question_label("Install the trajectory skill into this project?"),
+                default=True,
             ):
                 _install_project_skill(Path.cwd())
             if shutil.which("npx") and typer.confirm(
-                "Also install for Claude / Codex / Cursor on this machine?",
+                tui.question_label(
+                    "Also install for Claude / Codex / Cursor on this machine?"
+                ),
                 default=False,
             ):
                 _run_npx_skill_install()
@@ -209,7 +243,8 @@ def register_traj(app: typer.Typer) -> None:
             _install_project_skill(Path.cwd())
         _print_contributor_prompt()
         if interactive and typer.confirm(
-            "List recent sessions and open the viewer now?", default=False
+            tui.question_label("List recent sessions and open the viewer now?"),
+            default=False,
         ):
             _interactive_view()
 
@@ -267,6 +302,14 @@ def register_traj(app: typer.Typer) -> None:
                 help="Number of redacted trajectory steps to preview",
             ),
         ] = DEFAULT_PREVIEW_STEPS,
+        wait: Annotated[
+            bool,
+            typer.Option(
+                "--wait/--no-wait",
+                help="After uploading, wait until the capture is verified "
+                "in storage (BENCHFLOW_TRAJ_WAIT_SECONDS overrides the budget)",
+            ),
+        ] = True,
     ) -> None:
         """Inspect, redact, confirm, and upload trajectory JSONL."""
         _maybe_print_update_hint()
@@ -282,14 +325,37 @@ def register_traj(app: typer.Typer) -> None:
                     container_url=container_url,
                     dry_run=dry_run,
                     preview_steps=preview_steps,
+                    wait=wait,
                 )
             )
         except ValueError as exc:
             print_error(str(exc))
             raise typer.Exit(1) from None
 
+    @traj_app.command("status")
+    def status(
+        digest: Annotated[
+            str | None,
+            typer.Argument(
+                help="Capture digest printed by bench traj upload (sha256:…)"
+            ),
+        ] = None,
+    ) -> None:
+        """Check whether an uploaded trajectory is verified in storage."""
+        _maybe_print_update_hint()
+        try:
+            _run_status(digest)
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+
 
 def _run_upload(options: _UploadOptions) -> None:
+    tui.banner(
+        console,
+        "traj upload",
+        "Inspect, redact, confirm — nothing leaves this machine unreviewed",
+    )
     prompted = options.path is None
     path = options.path or _prompt_for_path()
     detected: _DetectedRepo | None = None
@@ -345,7 +411,7 @@ def _run_upload(options: _UploadOptions) -> None:
         # non-interactive so agents driving the CLI never hang on a TTY
         # prompt — their confirmation happens in chat, before this command.
         if prompted and not typer.confirm(
-            "Upload this trajectory?",
+            tui.question_label("Upload this trajectory?"),
             default=False,
         ):
             console.print("[yellow]Upload cancelled.[/yellow]")
@@ -357,6 +423,13 @@ def _run_upload(options: _UploadOptions) -> None:
         with upload_progress(staged.files, console=console) as hooks:
             result = _publish(staged, destination=destination, hooks=hooks)
         _print_upload_result(staged, result, direct=destination.direct)
+        if not destination.direct:
+            _confirm_storage(
+                result,
+                broker_url=destination.url,
+                traj_digest=staged.traj_digest,
+                wait=options.wait,
+            )
 
 
 def _resolve_contributor(
@@ -537,8 +610,17 @@ def _command_stdout(*args: str) -> str | None:
 
 
 def _prompt_for_path() -> Path:
+    # On a real terminal, offer the recent-session picker first; typing a
+    # path stays one keystroke away and is the only path everywhere else
+    # (agents, pipes, CI), preserving the prompt-driven contract.
+    if tui.interactive_terminal():
+        selected = _pick_recent_session()
+        if selected is not None:
+            return selected
     while True:
-        raw = typer.prompt("Trajectory JSONL file or trial directory").strip()
+        raw = typer.prompt(
+            tui.field_label("Trajectory JSONL file or trial directory")
+        ).strip()
         # Shells wrap dragged-in paths in quotes; accept them as typed.
         if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in {"'", '"'}:
             raw = raw[1:-1]
@@ -548,10 +630,40 @@ def _prompt_for_path() -> Path:
         print_error(f"path not found: {path}")
 
 
+def _pick_recent_session() -> Path | None:
+    """Arrow-key picker over recent sessions; ``None`` falls back to typing."""
+    from benchflow.trajectories.sessions import list_recent_sessions
+
+    try:
+        hits = list_recent_sessions()
+    except OSError:
+        return None
+    if not hits:
+        return None
+    options = [
+        *_session_options(hits),
+        tui.SelectOption(label="Enter a path manually…"),
+    ]
+    choice = tui.select(console, title="Pick a session to upload", options=options)
+    if choice is None or choice >= len(hits):
+        return None
+    return hits[choice].path
+
+
+def _session_options(hits) -> list[tui.SelectOption]:
+    return [
+        tui.SelectOption(
+            label=f"{hit.when}  {hit.source:<6} {tui.compact_path(hit.path)}",
+            hint=hit.snippet or "(no prompt yet)",
+        )
+        for hit in hits
+    ]
+
+
 def _prompt_valid(label: str, validate: Callable[[str], str]) -> str:
     while True:
         try:
-            return validate(typer.prompt(label))
+            return validate(typer.prompt(tui.field_label(label)))
         except ValueError as exc:
             print_error(str(exc))
 
@@ -568,6 +680,10 @@ def _resolve_destination(options: _UploadOptions) -> _UploadDestination:
         return _UploadDestination(url=destination, direct=True)
     if options.container_url:
         raise ValueError("--container-url is only valid with --direct")
+    return _UploadDestination(url=_resolve_broker_url(), direct=False)
+
+
+def _resolve_broker_url() -> str:
     destination = os.environ.get("BENCHFLOW_TRAJ_BROKER_URL") or DEFAULT_TRAJ_BROKER_URL
     if not destination:
         raise ValueError(
@@ -575,7 +691,187 @@ def _resolve_destination(options: _UploadOptions) -> _UploadDestination:
             "or use --direct with --container-url/BENCHFLOW_AZURE_CONTAINER_URL "
             "if you have Azure credentials"
         )
-    return _UploadDestination(url=destination, direct=False)
+    return destination
+
+
+def _wait_budget_seconds() -> float:
+    raw = os.environ.get("BENCHFLOW_TRAJ_WAIT_SECONDS", "").strip()
+    if not raw:
+        return DEFAULT_WAIT_SECONDS
+    try:
+        return max(float(raw), 0.0)
+    except ValueError:
+        return DEFAULT_WAIT_SECONDS
+
+
+def _confirm_storage(
+    result: _PublishResult,
+    *,
+    broker_url: str,
+    traj_digest: str,
+    wait: bool,
+) -> None:
+    """Confirm the capture reached durable storage, or say how to check later.
+
+    The broker's status endpoint reads the validation ledger; ``ingested`` is
+    recorded only after the validator promotes every file to
+    ``sources/community/<digest>/`` in the Azure container, so a verified
+    result here is proof the files are in final storage — not just accepted
+    into quarantine.
+    """
+    if getattr(result, "already_ingested", False):
+        _print_verified()
+        return
+    if not wait:
+        return
+    budget = _wait_budget_seconds()
+    if budget <= 0:
+        return
+    _wait_for_validation(broker_url=broker_url, traj_digest=traj_digest, budget=budget)
+
+
+def _print_verified() -> None:
+    console.print(
+        f"[bold green]{tui.GLYPH_OK} Verified in Azure storage[/] "
+        "[dim]— the validator accepted and promoted this capture.[/]"
+    )
+
+
+def _print_status_hint(traj_digest: str) -> None:
+    # Plain print keeps the command selectable in agents and terminals.
+    print(f"  bench traj status sha256:{traj_digest}")
+
+
+def _wait_for_validation(*, broker_url: str, traj_digest: str, budget: float) -> None:
+    """Poll the broker until the validator's verdict, a timeout, or a 404.
+
+    Success and every soft outcome return normally; only a validator
+    rejection raises ``ValueError`` so the command exits 1 — the capture is
+    not in the dataset and the detail says what to fix.
+    """
+    from benchflow.publish.broker import fetch_capture_status
+
+    started = _monotonic()
+    delay = _WAIT_INITIAL_DELAY
+    transient_failures = 0
+    state_copy = _WAIT_STATE_COPY["pending"]
+    with console.status(
+        f"[bold {tui.ACCENT}]Verifying in storage[/] [dim]— {state_copy}[/]"
+    ) as live_status:
+        while True:
+            elapsed = _monotonic() - started
+            remaining = budget - elapsed
+            if remaining <= 0:
+                live_status.stop()
+                console.print(
+                    f"[yellow]Still validating after {int(elapsed)}s.[/] "
+                    "Your upload is safely queued; check on it any time:"
+                )
+                _print_status_hint(traj_digest)
+                return
+            try:
+                snapshot = fetch_capture_status(
+                    broker_url=broker_url, traj_digest=traj_digest
+                )
+                transient_failures = 0
+            except ValueError:
+                transient_failures += 1
+                if transient_failures >= _WAIT_TRANSIENT_LIMIT:
+                    live_status.stop()
+                    console.print(
+                        "[yellow]Couldn't confirm the storage status "
+                        "(network hiccup).[/] The upload itself succeeded; "
+                        "check on it any time:"
+                    )
+                    _print_status_hint(traj_digest)
+                    return
+                snapshot = None
+            if snapshot is not None:
+                if snapshot.status == "ingested":
+                    live_status.stop()
+                    _print_verified()
+                    return
+                if snapshot.status == "rejected":
+                    live_status.stop()
+                    detail = snapshot.detail or "the validator declined this capture"
+                    raise ValueError(
+                        f"the validator rejected this capture: {detail}. "
+                        "Fix the input and run the upload again."
+                    )
+                if snapshot.status == "unsupported":
+                    # Deployed broker predates the status endpoint: keep the
+                    # pre-verification behavior without any noise.
+                    return
+                if snapshot.status == "throttled" and snapshot.retry_after:
+                    delay = max(delay, min(snapshot.retry_after, remaining))
+                state_copy = _WAIT_STATE_COPY.get(snapshot.status, state_copy)
+                live_status.update(
+                    f"[bold {tui.ACCENT}]Verifying in storage[/] "
+                    f"[dim]— {state_copy} ({int(elapsed)}s)[/]"
+                )
+            _sleep(min(delay, max(remaining, 0.1)))
+            delay = min(delay * _WAIT_BACKOFF, _WAIT_MAX_DELAY)
+
+
+def _run_status(digest_argument: str | None) -> None:
+    from benchflow.publish.broker import fetch_capture_status
+
+    tui.banner(
+        console,
+        "traj status",
+        "Ask the contribution service about an uploaded capture",
+    )
+    raw = digest_argument or typer.prompt(tui.field_label("Digest (sha256:…)"))
+    traj_digest = _normalize_digest(raw)
+    broker_url = _resolve_broker_url()
+    with console.status(f"[bold {tui.ACCENT}]Checking capture status…[/]"):
+        snapshot = fetch_capture_status(broker_url=broker_url, traj_digest=traj_digest)
+    # Plain print keeps the digest selectable for retries and reports.
+    print(f"Digest: sha256:{traj_digest}")
+    if snapshot.status == "ingested":
+        _print_verified()
+        return
+    if snapshot.status == "pending":
+        console.print(
+            f"[{tui.ACCENT}]● Queued[/] — uploaded and waiting for the validator. "
+            "Check again in a minute."
+        )
+        return
+    if snapshot.status == "validating":
+        console.print(
+            f"[{tui.ACCENT}]● Validating[/] — the validator is checking this "
+            "capture right now. Check again shortly."
+        )
+        return
+    if snapshot.status == "rejected":
+        detail = snapshot.detail or "the validator declined this capture"
+        raise ValueError(f"the validator rejected this capture: {detail}")
+    if snapshot.status == "throttled":
+        suffix = (
+            f"; retry after {int(snapshot.retry_after)}s"
+            if snapshot.retry_after
+            else ""
+        )
+        raise ValueError(f"status checks are rate limited right now{suffix}")
+    if snapshot.status == "unsupported":
+        raise ValueError(
+            "the deployed contribution service does not report capture status "
+            "yet; uploads still work, and this command will once the latest "
+            "service is deployed"
+        )
+    raise ValueError(
+        "the service has no record of this digest. Check the digest, or run "
+        "bench traj upload first."
+    )
+
+
+def _normalize_digest(value: str) -> str:
+    body = value.strip().strip("'\"").removeprefix("sha256:")
+    if len(body) == 64 and all(char in "0123456789abcdef" for char in body):
+        return body
+    raise ValueError(
+        "digest must be sha256:<64 hex characters>, as printed by bench traj upload"
+    )
 
 
 def _publish(
@@ -720,11 +1016,15 @@ def _print_session_hits() -> None:
         return
     for index, hit in enumerate(hits, start=1):
         snippet = hit.snippet or "(no prompt yet)"
-        # Plain print + path on its own line: Rich wrapping used to split
-        # long session paths mid-token and make them unselectable.
-        print(f"{index}. [{hit.source}] {hit.when}")
+        # Styled facts first, then the path via plain print on its own line:
+        # Rich wrapping used to split long session paths mid-token and make
+        # them unselectable.
+        console.print(
+            f"[bold {tui.ACCENT}]{index:>2}[/] [magenta]{hit.source:<6}[/] "
+            f"[dim]{hit.when}[/]"
+        )
         print(f"   {hit.path}")
-        print(f"   {snippet}")
+        console.print(f"   [dim]└ {escape(snippet)}[/]")
 
 
 def _interactive_view() -> None:
@@ -735,14 +1035,10 @@ def _interactive_view() -> None:
     if not hits:
         console.print("No recent sessions found.")
         return
-    _print_session_hits()
-    choice = typer.prompt("Which number?", default="1")
-    try:
-        index = int(choice)
-    except ValueError:
-        print_error("Need a session number.")
-        raise typer.Exit(1) from None
-    if index < 1 or index > len(hits):
-        print_error("That number is not in the list.")
-        raise typer.Exit(1)
-    serve(str(hits[index - 1].path))
+    choice = tui.select(
+        console, title="Recent sessions", options=_session_options(hits)
+    )
+    if choice is None:
+        console.print("[yellow]Cancelled.[/]")
+        return
+    serve(str(hits[choice].path))

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -20,6 +20,9 @@ from benchflow.publish.traj_capture import StagedCapture, StagedFile
 # the first SAS grant. Retries are safe; keep this under two minutes.
 HANDSHAKE_TIMEOUT_SEC = 90.0
 PUT_TIMEOUT_SEC = 300.0
+# Workspace archives can approach 1 GiB; give every PUT at least the base
+# budget plus a floor of ~1 MiB/s of transfer time so slow uplinks finish.
+PUT_TIMEOUT_BYTES_PER_SEC = 1024**2
 # The broker's token buckets answer 429 with an honest, usually-short
 # Retry-After. Waiting it out inline turns a crowd burst into a smooth queue;
 # anything longer than this cap is surfaced to the contributor instead.
@@ -152,7 +155,8 @@ def upload_capture_via_broker(
                         upload["put_url"],
                         headers=upload["headers"],
                         content=content,
-                        timeout=PUT_TIMEOUT_SEC,
+                        timeout=PUT_TIMEOUT_SEC
+                        + staged_file.size_bytes / PUT_TIMEOUT_BYTES_PER_SEC,
                     )
                 if _is_create_only_conflict(put_response):
                     skipped.append(object_name)

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -26,6 +26,11 @@ PUT_TIMEOUT_SEC = 300.0
 HANDSHAKE_RETRY_LIMIT = 3
 HANDSHAKE_RETRY_MAX_WAIT_SEC = 120.0
 
+# Capture states the broker's status endpoint may report. ``unsupported`` is
+# client-synthesized for deployments that predate the endpoint (HTTP 404), and
+# ``throttled`` for a rate-limited poll; neither ever comes from the ledger.
+CAPTURE_STATES = frozenset({"pending", "validating", "ingested", "rejected", "unknown"})
+
 
 @dataclass(frozen=True)
 class BrokerPublishResult:
@@ -33,10 +38,73 @@ class BrokerPublishResult:
     prefix: str
     uploaded: tuple[str, ...]
     skipped: tuple[str, ...]
+    # True only for a handshake 409: the ledger already recorded this digest as
+    # ingested, so the capture is verified in storage without polling.
+    already_ingested: bool = False
 
     @property
     def url(self) -> str:
         return f"{self.base_url.rstrip('/')}/{self.prefix.lstrip('/')}"
+
+
+@dataclass(frozen=True)
+class CaptureStatus:
+    """One poll of the broker's capture-status endpoint."""
+
+    status: str
+    detail: str | None = None
+    retry_after: float | None = None
+
+    @property
+    def terminal(self) -> bool:
+        return self.status in {"ingested", "rejected"}
+
+
+def fetch_capture_status(
+    *,
+    broker_url: str,
+    traj_digest: str,
+    http_client: httpx.Client | None = None,
+) -> CaptureStatus:
+    """Read the validation state of one uploaded capture from the broker.
+
+    Returns a :class:`CaptureStatus` for every well-formed outcome, including
+    ``unsupported`` when the deployed broker predates the endpoint (404) and
+    ``throttled`` on HTTP 429, so a polling loop can decide without exception
+    plumbing. Raises :class:`ValueError` only for transport failures or a
+    malformed response, which callers should treat as transient.
+    """
+    digest = traj_digest.removeprefix("sha256:")
+    endpoint = f"{broker_url.rstrip('/')}/v1/uploads/{digest}"
+    manager = nullcontext(http_client) if http_client is not None else httpx.Client()
+    try:
+        with _quiet_httpx_request_logging(), manager as client:
+            response = client.get(endpoint, timeout=HANDSHAKE_TIMEOUT_SEC)
+    except httpx.HTTPError as exc:
+        raise ValueError(f"capture status request failed: {exc}") from exc
+    if response.status_code == 404:
+        return CaptureStatus(status="unsupported")
+    if response.status_code == 429:
+        retry_after = response.headers.get("Retry-After")
+        try:
+            seconds = float(retry_after) if retry_after else None
+        except ValueError:
+            seconds = None
+        return CaptureStatus(status="throttled", retry_after=seconds)
+    if response.status_code >= 400:
+        detail = response.text.strip().replace("\n", " ")[:300]
+        raise ValueError(
+            f"capture status request failed with HTTP {response.status_code}: {detail}"
+        )
+    payload = _response_object(response)
+    status = payload.get("status")
+    if not isinstance(status, str) or status not in CAPTURE_STATES:
+        raise ValueError("trajectory broker returned an unknown capture status")
+    detail = payload.get("detail")
+    return CaptureStatus(
+        status=status,
+        detail=detail if isinstance(detail, str) and detail else None,
+    )
 
 
 def upload_capture_via_broker(
@@ -188,6 +256,7 @@ def _already_uploaded_result(
         prefix=prefix,
         uploaded=(),
         skipped=tuple(prefix + item.relname for item in staged.files),
+        already_ingested=True,
     )
 
 

--- a/src/benchflow/publish/traj_capture.py
+++ b/src/benchflow/publish/traj_capture.py
@@ -24,7 +24,14 @@ from benchflow.publish.redact import (
 
 MAX_FILE_BYTES = 128 * 1024**2
 MAX_ARTIFACTS = 8
-MAX_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
+MAX_JSONL_CAPTURE_BYTES = 2 * MAX_FILE_BYTES
+# One optional workspace snapshot may ride along with the JSONL trajectory.
+# Zips above this cap are skipped locally (never created) so contributors'
+# disks and uplinks are not burdened by runaway workspaces.
+MAX_ATTACHMENT_BYTES = 1024**3
+MAX_ATTACHMENT_FILES = 50_000
+MAX_TOTAL_ARTIFACTS = MAX_ARTIFACTS + 1
+MAX_CAPTURE_BYTES = MAX_JSONL_CAPTURE_BYTES + MAX_ATTACHMENT_BYTES
 MAX_MANIFEST_BYTES = 1024**2
 MAX_RUN_METADATA_BYTES = 1024**2
 MAX_UPLOADED_BY_LENGTH = 256
@@ -34,7 +41,45 @@ MAX_JSONL_RECORD_BYTES = 8 * 1024**2
 MAX_JSON_NESTING = 100
 MAX_JSON_NODES = 100_000
 SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]{0,127}$")
-ARTIFACT_NAME_PATTERN = re.compile(r"^trajectory/[A-Za-z0-9._-]{1,128}\.jsonl$")
+ARTIFACT_NAME_PATTERN = re.compile(
+    r"^(?:trajectory/[A-Za-z0-9._-]{1,128}\.jsonl"
+    r"|workspace/[A-Za-z0-9._-]{1,128}\.zip)$"
+)
+TRAJECTORY_ARTIFACT_PREFIX = "trajectory/"
+WORKSPACE_ARTIFACT_PREFIX = "workspace/"
+# Directories that never belong in a workspace snapshot: VCS internals,
+# dependency trees, and caches. ``.git`` also keeps credential-bearing
+# remotes and hooks out of the archive.
+WORKSPACE_EXCLUDED_DIRS = frozenset(
+    {
+        ".git",
+        ".hg",
+        ".svn",
+        "node_modules",
+        ".venv",
+        "venv",
+        ".tox",
+        ".uv-cache",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".cache",
+        ".DS_Store",
+    }
+)
+# Filename shapes that overwhelmingly carry credentials. Workspace archives
+# are uploaded as-is (no content redaction), so obvious secret carriers stay
+# on the contributor's machine.
+WORKSPACE_EXCLUDED_FILES = (
+    re.compile(r"^\.env(\..+)?$", re.IGNORECASE),
+    re.compile(r".*\.(pem|key|p12|pfx|keystore)$", re.IGNORECASE),
+    re.compile(r"^id_(rsa|dsa|ecdsa|ed25519)(\..+)?$", re.IGNORECASE),
+    re.compile(r"^\.netrc$", re.IGNORECASE),
+    re.compile(r"^\.npmrc$", re.IGNORECASE),
+    re.compile(r"^(credentials|secrets?)(\..+)?$", re.IGNORECASE),
+    re.compile(r"^\.DS_Store$", re.IGNORECASE),
+)
 GITHUB_ID_PATTERN = re.compile(
     rf"^[A-Za-z0-9](?:[A-Za-z0-9-]{{0,{MAX_GITHUB_ID_LENGTH - 2}}}[A-Za-z0-9])?$"
 )
@@ -173,13 +218,22 @@ def validate_email(email: str) -> str:
 
 
 def validate_artifact_name(name: str) -> str:
-    """Require the canonical public trajectory object namespace."""
+    """Require the canonical public capture object namespaces."""
     if not ARTIFACT_NAME_PATTERN.fullmatch(name):
-        raise ValueError("artifact name is outside trajectory/*.jsonl")
+        raise ValueError(
+            "artifact name is outside trajectory/*.jsonl and workspace/*.zip"
+        )
     _, replacements = redact_value(name)
     if replacements:
         raise ValueError("artifact filename resembles a secret")
     return name
+
+
+def max_artifact_bytes(name: str) -> int:
+    """Per-artifact byte ceiling for an artifact's namespace."""
+    if name.startswith(WORKSPACE_ARTIFACT_PREFIX):
+        return MAX_ATTACHMENT_BYTES
+    return MAX_FILE_BYTES
 
 
 @contextmanager
@@ -198,9 +252,9 @@ def stage_trajectory_artifacts(
             f"{len(resolved.files)} files"
         )
     capture_bytes = sum(source.stat().st_size for source in resolved.files)
-    if capture_bytes > MAX_CAPTURE_BYTES:
+    if capture_bytes > MAX_JSONL_CAPTURE_BYTES:
         raise ValueError(
-            f"trajectory capture exceeds {MAX_CAPTURE_BYTES} bytes: "
+            f"trajectory capture exceeds {MAX_JSONL_CAPTURE_BYTES} bytes: "
             f"{capture_bytes} bytes"
         )
     for source in resolved.files:
@@ -239,10 +293,10 @@ def stage_trajectory_artifacts(
                     f"{payload.relname} ({payload.size_bytes} bytes)"
                 )
         staged_capture_bytes = sum(payload.size_bytes for payload in payloads)
-        if staged_capture_bytes > MAX_CAPTURE_BYTES:
+        if staged_capture_bytes > MAX_JSONL_CAPTURE_BYTES:
             raise ValueError(
-                f"staged trajectory capture exceeds {MAX_CAPTURE_BYTES} bytes: "
-                f"{staged_capture_bytes} bytes"
+                f"staged trajectory capture exceeds {MAX_JSONL_CAPTURE_BYTES} "
+                f"bytes: {staged_capture_bytes} bytes"
             )
         traj_digest = _trajectory_digest(payloads)
         yield StagedTrajectoryArtifacts(
@@ -256,6 +310,136 @@ def stage_trajectory_artifacts(
             _redact=redact,
             redaction_categories=redaction_breakdown(replacement_categories),
         )
+
+
+@dataclass(frozen=True)
+class WorkspaceAttachResult:
+    """Outcome of trying to attach a workspace snapshot to staged artifacts."""
+
+    artifacts: StagedTrajectoryArtifacts
+    attached: StagedFile | None
+    file_count: int
+    excluded_count: int
+    skipped_reason: str | None
+
+
+def _workspace_archive_name(folder: Path) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", folder.name).strip("-._")
+    return f"workspace/{sanitized[:120] or 'workspace'}.zip"
+
+
+def _workspace_file_excluded(name: str) -> bool:
+    return any(pattern.fullmatch(name) for pattern in WORKSPACE_EXCLUDED_FILES)
+
+
+def _collect_workspace_files(
+    folder: Path, *, max_bytes: int
+) -> tuple[list[Path], int, int] | str:
+    """Walk the workspace, honoring exclusions; return a reason string to skip.
+
+    Aborts the walk as soon as the included size passes ``max_bytes`` so a
+    runaway workspace never costs a full scan, let alone a zip.
+    """
+    import os
+
+    included: list[Path] = []
+    total_bytes = 0
+    excluded = 0
+    for root, dirnames, filenames in os.walk(folder, followlinks=False):
+        kept_dirs = []
+        for dirname in dirnames:
+            if dirname in WORKSPACE_EXCLUDED_DIRS or (Path(root, dirname).is_symlink()):
+                excluded += 1
+            else:
+                kept_dirs.append(dirname)
+        dirnames[:] = kept_dirs
+        for filename in filenames:
+            candidate = Path(root, filename)
+            if candidate.is_symlink() or _workspace_file_excluded(filename):
+                excluded += 1
+                continue
+            try:
+                size = candidate.stat().st_size
+            except OSError:
+                excluded += 1
+                continue
+            total_bytes += size
+            if total_bytes > max_bytes:
+                return f"workspace folder exceeds {max_bytes} bytes before compression"
+            included.append(candidate)
+            if len(included) > MAX_ATTACHMENT_FILES:
+                return f"workspace folder exceeds {MAX_ATTACHMENT_FILES} files"
+    if not included:
+        return "workspace folder has no files to archive"
+    return included, total_bytes, excluded
+
+
+def attach_workspace_archive(
+    artifacts: StagedTrajectoryArtifacts,
+    folder: Path,
+    *,
+    max_bytes: int | None = None,
+) -> WorkspaceAttachResult:
+    """Zip a workspace folder into the staging area as ``workspace/*.zip``.
+
+    The archive is written inside the staging temporary directory, so it is
+    always deleted when staging exits — success, cancel, or crash alike.
+    Contents are archived as-is (no redaction); callers exclude VCS internals,
+    dependency trees, and secret-shaped filenames via the module exclusion
+    lists and must surface that trade-off to the contributor.
+    """
+    import dataclasses
+    import zipfile
+
+    if max_bytes is None:
+        max_bytes = MAX_ATTACHMENT_BYTES
+
+    def skipped(reason: str) -> WorkspaceAttachResult:
+        return WorkspaceAttachResult(
+            artifacts=artifacts,
+            attached=None,
+            file_count=0,
+            excluded_count=0,
+            skipped_reason=reason,
+        )
+
+    resolved = folder.expanduser()
+    if resolved.is_symlink() or not resolved.is_dir():
+        return skipped(f"workspace folder not found: {resolved}")
+    resolved = resolved.resolve()
+    collected = _collect_workspace_files(resolved, max_bytes=max_bytes)
+    if isinstance(collected, str):
+        return skipped(collected)
+    included, _total_bytes, excluded = collected
+
+    relname = validate_artifact_name(_workspace_archive_name(resolved))
+    target = artifacts._staging_dir / relname
+    target.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with zipfile.ZipFile(target, "w", zipfile.ZIP_DEFLATED) as archive:
+            for source in sorted(included):
+                archive.write(source, arcname=str(source.relative_to(resolved)))
+    except (OSError, ValueError) as exc:
+        target.unlink(missing_ok=True)
+        return skipped(f"could not archive workspace folder: {exc}")
+    if target.stat().st_size > max_bytes:
+        target.unlink(missing_ok=True)
+        return skipped(f"workspace archive exceeds {max_bytes} bytes")
+
+    attached = _staged_file(target, relname, "application/zip")
+    payloads = sorted((*artifacts.files, attached), key=lambda item: item.relname)
+    updated = dataclasses.replace(
+        artifacts,
+        files=tuple(payloads),
+        traj_digest=_trajectory_digest(payloads),
+    )
+    return WorkspaceAttachResult(
+        artifacts=updated,
+        attached=attached,
+        file_count=len(included),
+        excluded_count=excluded,
+        skipped_reason=None,
+    )
 
 
 def finalize_trajectory_capture(

--- a/src/benchflow/trajectories/sessions.py
+++ b/src/benchflow/trajectories/sessions.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
 _CLAUDE_SKIP_PARTS = frozenset({"subagents", "workflows"})
+# "Recent" for the submit flow means this week's work, across every source.
+RECENT_WINDOW_DAYS = 7.0
+MAX_RECENT_SESSIONS = 50
 
 
 @dataclass(frozen=True)
@@ -28,7 +32,11 @@ def encode_claude_project_dir(absolute_path: str) -> str:
 
 
 def list_recent_sessions(
-    *, cwd: Path | None = None, home: Path | None = None, limit: int = 8
+    *,
+    cwd: Path | None = None,
+    home: Path | None = None,
+    limit: int = MAX_RECENT_SESSIONS,
+    window_days: float | None = RECENT_WINDOW_DAYS,
 ) -> list[SessionHit]:
     cwd = (cwd or Path.cwd()).resolve()
     home = home or Path.home()
@@ -41,6 +49,13 @@ def list_recent_sessions(
         *_trial_candidates(cwd),
     ]
     candidates.sort(key=lambda item: item[2], reverse=True)
+    if window_days is not None:
+        cutoff = time.time() - window_days * 86400
+        windowed = [item for item in candidates if item[2] >= cutoff]
+        # An idle machine still deserves a picker: fall back to the newest
+        # sessions overall rather than presenting nothing.
+        if windowed:
+            candidates = windowed
     return [
         SessionHit(
             path=display_path,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,16 @@ def skip_update_check(monkeypatch) -> None:
     monkeypatch.setenv("BENCHFLOW_SKIP_UPDATE_CHECK", "1")
 
 
+@pytest.fixture(autouse=True)
+def skip_traj_wait(monkeypatch) -> None:
+    """Keep the post-upload storage-verification poll out of unit tests.
+
+    Tests that exercise the wait loop set their own budget and monkeypatch
+    the status fetch instead of touching the network.
+    """
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "0")
+
+
 @pytest.fixture
 def hello_world_task_dir() -> Path:
     path = REF_TASKS / "hello-world"

--- a/tests/test_publish_azure_blob.py
+++ b/tests/test_publish_azure_blob.py
@@ -180,7 +180,7 @@ def test_staging_enforces_shared_capture_count_and_size_limits(
         stage_trajectory_capture(trial, source_id="demo").__enter__()
 
     monkeypatch.setattr(capture_module, "MAX_ARTIFACTS", 8)
-    monkeypatch.setattr(capture_module, "MAX_CAPTURE_BYTES", 1)
+    monkeypatch.setattr(capture_module, "MAX_JSONL_CAPTURE_BYTES", 1)
     with pytest.raises(ValueError, match="capture exceeds 1 bytes"):
         stage_trajectory_capture(trial, source_id="demo").__enter__()
 
@@ -211,7 +211,7 @@ def test_staging_rechecks_capture_limit_after_redaction(
         (source_dir / name).write_text('{"password":"x"}\n', encoding="utf-8")
     source_bytes = sum(path.stat().st_size for path in source_dir.iterdir())
     monkeypatch.setattr(capture_module, "MAX_FILE_BYTES", 1024)
-    monkeypatch.setattr(capture_module, "MAX_CAPTURE_BYTES", source_bytes)
+    monkeypatch.setattr(capture_module, "MAX_JSONL_CAPTURE_BYTES", source_bytes)
 
     with pytest.raises(ValueError, match="staged trajectory capture exceeds"):
         stage_trajectory_capture(source_dir, source_id="demo").__enter__()

--- a/tests/test_traj_tui.py
+++ b/tests/test_traj_tui.py
@@ -39,6 +39,52 @@ def test_banner_names_the_command() -> None:
     assert "subtitle copy" in output
 
 
+def test_tty_picker_arrow_burst_navigates_instead_of_cancelling(
+    monkeypatch,
+) -> None:
+    """Guards the PR #1026 picker against buffered-stdin arrow decoding: an
+    arrow key arrives as ``ESC [ B`` in one burst, and reading the buffered
+    text stream swallowed ``[ B`` after the ESC, so every arrow press
+    cancelled the picker and dumped the user at the manual path prompt."""
+    import os
+    import pty
+    import termios
+    import threading
+
+    master, slave = pty.openpty()
+    try:
+        # Nothing reads the master side in this test, so slave echo would make
+        # setcbreak's TCSADRAIN wait forever on undrained output.
+        attributes = termios.tcgetattr(slave)
+        attributes[3] &= ~termios.ECHO
+        termios.tcsetattr(slave, termios.TCSANOW, attributes)
+        # setcbreak flushes queued input (TCSAFLUSH), so the burst must land
+        # after the picker is reading, exactly like a real keypress.
+        writer = threading.Timer(
+            0.3, os.write, (master, b"\x1b[B\x1b[B\r")
+        )  # down, down, enter — one burst
+        writer.start()
+        with open(slave, closefd=False) as stream:
+            monkeypatch.setattr(tui.sys, "stdin", stream)
+            console, _buffer = _console()
+            choice = tui._select_tty(
+                console,
+                title="Pick a session to upload",
+                options=[
+                    tui.SelectOption(label="first"),
+                    tui.SelectOption(label="second"),
+                    tui.SelectOption(label="third"),
+                ],
+                initial=0,
+            )
+        writer.join()
+    finally:
+        os.close(master)
+        os.close(slave)
+
+    assert choice == 2
+
+
 def test_select_uses_numbered_fallback_without_tty(monkeypatch) -> None:
     """Off-TTY, the picker is a plain numbered prompt that retries bad input."""
     monkeypatch.setattr(tui, "interactive_terminal", lambda: False)

--- a/tests/test_traj_tui.py
+++ b/tests/test_traj_tui.py
@@ -1,0 +1,98 @@
+"""Unit tests for the shared ``bench traj`` terminal design language.
+
+The kit is presentation-only: these tests pin the compatibility contract —
+styled labels unstyle back to their plain copy, and every interactive
+affordance degrades to the plain numbered/prompt flow off-TTY — not pixels.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import click
+import typer
+from rich.console import Console
+
+import benchflow.cli._traj_tui as tui
+
+
+def _console() -> tuple[Console, io.StringIO]:
+    buffer = io.StringIO()
+    return Console(file=buffer, width=100, force_terminal=False), buffer
+
+
+def test_styled_labels_unstyle_to_plain_copy() -> None:
+    """Prompts keep their greppable copy under click.unstyle (agent contract)."""
+    assert click.unstyle(tui.field_label("Email")) == "◇ Email"
+    assert click.unstyle(tui.question_label("Upload this trajectory?")) == (
+        "◆ Upload this trajectory?"
+    )
+
+
+def test_banner_names_the_command() -> None:
+    console, buffer = _console()
+    tui.banner(console, "traj upload", "subtitle copy")
+    output = buffer.getvalue()
+    assert "benchflow" in output
+    assert "traj upload" in output
+    assert "subtitle copy" in output
+
+
+def test_select_uses_numbered_fallback_without_tty(monkeypatch) -> None:
+    """Off-TTY, the picker is a plain numbered prompt that retries bad input."""
+    monkeypatch.setattr(tui, "interactive_terminal", lambda: False)
+    answers = iter(["oops", "9", "2"])
+    monkeypatch.setattr(typer, "prompt", lambda *args, **kwargs: next(answers))
+    console, buffer = _console()
+
+    choice = tui.select(
+        console,
+        title="Recent sessions",
+        options=[
+            tui.SelectOption(label="one"),
+            tui.SelectOption(label="two", hint="a hint"),
+        ],
+    )
+
+    assert choice == 1
+    output = buffer.getvalue()
+    assert "Recent sessions" in output
+    assert "one" in output and "two" in output and "a hint" in output
+    assert "Need a number between 1 and 2" in output
+    # The selection is echoed so the transcript records the decision.
+    assert f"{tui.GLYPH_POINTER} two" in output
+
+
+def test_select_fallback_quits_cleanly(monkeypatch) -> None:
+    monkeypatch.setattr(tui, "interactive_terminal", lambda: False)
+    monkeypatch.setattr(typer, "prompt", lambda *args, **kwargs: "q")
+    console, buffer = _console()
+
+    choice = tui.select(console, title="", options=[tui.SelectOption(label="only")])
+
+    assert choice is None
+    assert tui.GLYPH_POINTER not in buffer.getvalue()
+
+
+def test_select_with_no_options_is_none() -> None:
+    console, _buffer = _console()
+    assert tui.select(console, title="x", options=[]) is None
+
+
+def test_compact_path_prefers_home_relative_and_preserves_tail() -> None:
+    home = Path.home()
+    inside = home / ".claude" / "projects" / "demo" / "session.jsonl"
+    assert tui.compact_path(inside) == "~/.claude/projects/demo/session.jsonl"
+
+    deep = Path("/very/long/path") / ("x" * 80) / "project" / "session.jsonl"
+    label = tui.compact_path(deep)
+    assert label.startswith("…/")
+    assert label.endswith("project/session.jsonl")
+
+
+def test_escaped_neutralizes_rich_markup() -> None:
+    """User-controlled labels (paths, snippets) cannot inject Rich markup."""
+    console, buffer = _console()
+    console.print(tui._escaped("[red]not markup[/red]"))
+    assert "[red]not markup[/red]" in buffer.getvalue()

--- a/tests/test_traj_tui.py
+++ b/tests/test_traj_tui.py
@@ -85,6 +85,47 @@ def test_tty_picker_arrow_burst_navigates_instead_of_cancelling(
     assert choice == 2
 
 
+def test_visible_window_scrolls_around_the_cursor() -> None:
+    """Short lists show whole; long lists keep the cursor centered, clamped."""
+    assert tui._visible_window(0, 5, 10) == (0, 5)
+    assert tui._visible_window(0, 30, 10) == (0, 10)
+    assert tui._visible_window(15, 30, 10) == (10, 20)
+    assert tui._visible_window(29, 30, 10) == (20, 30)
+
+
+def test_tty_picker_scrolls_through_a_week_of_sessions(monkeypatch) -> None:
+    """Arrow keys browse past the viewport (Claude-resume-style scrolling)."""
+    import os
+    import pty
+    import termios
+    import threading
+
+    master, slave = pty.openpty()
+    try:
+        attributes = termios.tcgetattr(slave)
+        attributes[3] &= ~termios.ECHO
+        termios.tcsetattr(slave, termios.TCSANOW, attributes)
+        writer = threading.Timer(
+            0.3, os.write, (master, b"\x1b[B" * 15 + b"\r")
+        )  # down x15, enter — well past the 10-row viewport
+        writer.start()
+        with open(slave, closefd=False) as stream:
+            monkeypatch.setattr(tui.sys, "stdin", stream)
+            console, _buffer = _console()
+            choice = tui._select_tty(
+                console,
+                title="Pick a session to upload",
+                options=[tui.SelectOption(label=f"session-{n}") for n in range(30)],
+                initial=0,
+            )
+        writer.join()
+    finally:
+        os.close(master)
+        os.close(slave)
+
+    assert choice == 15
+
+
 def test_select_uses_numbered_fallback_without_tty(monkeypatch) -> None:
     """Off-TTY, the picker is a plain numbered prompt that retries bad input."""
     monkeypatch.setattr(tui, "interactive_terminal", lambda: False)

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -1177,7 +1177,7 @@ def test_upload_waits_until_verified_in_storage(
     assert result.exit_code == 0, result.output
     output = click.unstyle(result.output)
     assert "Submitted" in output
-    assert "Verified in Azure storage" in output
+    assert "Verified in cloud storage" in output
     assert len(calls) == 3
 
 
@@ -1222,7 +1222,7 @@ def test_upload_wait_timeout_hands_off_to_traj_status(
     output = click.unstyle(result.output)
     assert "Still validating" in output
     assert "bench traj status sha256:" in output
-    assert "Verified in Azure storage" not in output
+    assert "Verified in cloud storage" not in output
 
 
 def test_upload_wait_missing_endpoint_keeps_legacy_behavior(
@@ -1242,7 +1242,7 @@ def test_upload_wait_missing_endpoint_keeps_legacy_behavior(
     assert result.exit_code == 0, result.output
     output = click.unstyle(result.output)
     assert "Submitted" in output
-    assert "Verified in Azure storage" not in output
+    assert "Verified in cloud storage" not in output
     assert "bench traj status" not in output
     assert len(calls) == 1
 
@@ -1316,13 +1316,13 @@ def test_already_ingested_conflict_prints_verified_without_polling(
     assert result.exit_code == 0, result.output
     output = click.unstyle(result.output)
     assert "Already submitted" in output
-    assert "Verified in Azure storage" in output
+    assert "Verified in cloud storage" in output
 
 
 @pytest.mark.parametrize(
     ("status", "exit_code", "copy"),
     [
-        ("ingested", 0, "Verified in Azure storage"),
+        ("ingested", 0, "Verified in cloud storage"),
         ("pending", 0, "Queued"),
         ("validating", 0, "Validating"),
         ("rejected", 1, "validator rejected"),

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -392,17 +392,18 @@ def test_broker_put_conflicts_are_cloud_neutral_skips(
     assert completed == [item.relname for item in staged.files]
 
 
-def test_help_exposes_setup_and_upload() -> None:
+def test_help_exposes_setup_upload_and_status() -> None:
     """Guards PR #992 while ignoring Rich's environment-specific ANSI styling."""
     traj_group = next(group for group in app.registered_groups if group.name == "traj")
     assert {
         command.name for command in traj_group.typer_instance.registered_commands
-    } == {"setup", "upload"}
+    } == {"setup", "upload", "status"}
 
     result = runner.invoke(app, ["traj", "--help"])
     assert result.exit_code == 0
     assert "upload" in result.output
     assert "setup" in result.output
+    assert "status" in result.output
 
     upload_help = runner.invoke(app, ["traj", "upload", "--help"])
     assert upload_help.exit_code == 0
@@ -410,6 +411,7 @@ def test_help_exposes_setup_and_upload() -> None:
     assert "--github-id" in upload_help_output
     assert "--email" in upload_help_output
     assert "--preview-steps" in upload_help_output
+    assert "--wait" in upload_help_output
 
 
 def test_upload_prompts_for_path_github_id_and_email_in_order(
@@ -1094,3 +1096,274 @@ def test_session_without_usable_cwd_never_tags_from_invocation_directory(
     assert result.exit_code == 0, result.output
     assert captured["source_id"] == "session"
     assert "Repo:" not in click.unstyle(result.output)
+
+
+# --- storage verification wait + bench traj status (this PR) -----------------
+
+VALID_DIGEST = "a1" * 32
+
+
+def _fake_broker_upload(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_upload(staged, *, broker_url, on_file_complete, on_bytes):
+        for staged_file in staged.files:
+            on_file_complete(staged_file)
+        return SimpleNamespace(
+            url=broker_url, uploaded=("payload", "manifest"), skipped=()
+        )
+
+    monkeypatch.setattr(
+        "benchflow.publish.broker.upload_capture_via_broker", fake_upload
+    )
+
+
+class _FakeClock:
+    """Deterministic monotonic clock: sleeping advances time instantly."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += max(seconds, 0.01)
+
+
+def _patch_wait_clock(monkeypatch: pytest.MonkeyPatch) -> _FakeClock:
+    clock = _FakeClock()
+    monkeypatch.setattr("benchflow.cli.traj._monotonic", clock.monotonic)
+    monkeypatch.setattr("benchflow.cli.traj._sleep", clock.sleep)
+    return clock
+
+
+def _patch_status_fetch(monkeypatch: pytest.MonkeyPatch, *outcomes):
+    """Feed scripted CaptureStatus results (or exceptions); repeat the last."""
+    from benchflow.publish.broker import CaptureStatus
+
+    calls: list[str] = []
+    sequence = list(outcomes)
+
+    def fake_fetch(*, broker_url, traj_digest, http_client=None) -> CaptureStatus:
+        calls.append(traj_digest)
+        outcome = sequence.pop(0) if len(sequence) > 1 else sequence[0]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr("benchflow.publish.broker.fetch_capture_status", fake_fetch)
+    return calls
+
+
+def test_upload_waits_until_verified_in_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """After the transfer, the CLI polls the ledger until the validator's
+    promotion is confirmed, then reports the capture verified in storage."""
+    from benchflow.publish.broker import CaptureStatus
+
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "60")
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    _fake_broker_upload(monkeypatch)
+    _patch_wait_clock(monkeypatch)
+    calls = _patch_status_fetch(
+        monkeypatch,
+        CaptureStatus(status="pending"),
+        CaptureStatus(status="validating"),
+        CaptureStatus(status="ingested"),
+    )
+
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "Submitted" in output
+    assert "Verified in Azure storage" in output
+    assert len(calls) == 3
+
+
+def test_upload_wait_rejection_is_a_cli_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A validator rejection after the transfer exits 1 with the fixable detail."""
+    from benchflow.publish.broker import CaptureStatus
+
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "60")
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    _fake_broker_upload(monkeypatch)
+    _patch_wait_clock(monkeypatch)
+    _patch_status_fetch(
+        monkeypatch,
+        CaptureStatus(status="rejected", detail="size mismatch for trajectory/a.jsonl"),
+    )
+
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 1
+    output = click.unstyle(result.output)
+    assert "validator rejected" in output
+    assert "size mismatch for trajectory/a.jsonl" in output
+
+
+def test_upload_wait_timeout_hands_off_to_traj_status(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exhausted budget stays a success and prints the status command."""
+    from benchflow.publish.broker import CaptureStatus
+
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "20")
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    _fake_broker_upload(monkeypatch)
+    _patch_wait_clock(monkeypatch)
+    _patch_status_fetch(monkeypatch, CaptureStatus(status="pending"))
+
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "Still validating" in output
+    assert "bench traj status sha256:" in output
+    assert "Verified in Azure storage" not in output
+
+
+def test_upload_wait_missing_endpoint_keeps_legacy_behavior(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deployed broker without the endpoint (404) changes nothing visible."""
+    from benchflow.publish.broker import CaptureStatus
+
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "60")
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    _fake_broker_upload(monkeypatch)
+    _patch_wait_clock(monkeypatch)
+    calls = _patch_status_fetch(monkeypatch, CaptureStatus(status="unsupported"))
+
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "Submitted" in output
+    assert "Verified in Azure storage" not in output
+    assert "bench traj status" not in output
+    assert len(calls) == 1
+
+
+def test_upload_wait_transient_failures_give_up_gracefully(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repeated transport failures never fail an already-successful upload."""
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "60")
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    _fake_broker_upload(monkeypatch)
+    _patch_wait_clock(monkeypatch)
+    _patch_status_fetch(monkeypatch, ValueError("connection reset"))
+
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "Couldn't confirm" in output
+    assert "bench traj status sha256:" in output
+
+
+def test_upload_no_wait_and_suite_default_never_poll(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """--no-wait and BENCHFLOW_TRAJ_WAIT_SECONDS=0 both skip polling entirely."""
+
+    def fail_fetch(**_kwargs):
+        raise AssertionError("status endpoint polled despite disabled wait")
+
+    monkeypatch.setattr("benchflow.publish.broker.fetch_capture_status", fail_fetch)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    _fake_broker_upload(monkeypatch)
+    trial = _trial(tmp_path)
+
+    # Suite default: the conftest fixture sets the budget to 0.
+    result = runner.invoke(app, _upload_command(trial))
+    assert result.exit_code == 0, result.output
+
+    # Explicit opt-out beats a generous budget.
+    monkeypatch.setenv("BENCHFLOW_TRAJ_WAIT_SECONDS", "60")
+    result = runner.invoke(app, _upload_command(trial, "--no-wait"))
+    assert result.exit_code == 0, result.output
+
+
+def test_already_ingested_conflict_prints_verified_without_polling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A handshake 409 is proof of promotion: verified line, zero polls."""
+
+    def fail_fetch(**_kwargs):
+        raise AssertionError("an already-ingested digest must not be polled")
+
+    monkeypatch.setattr("benchflow.publish.broker.fetch_capture_status", fail_fetch)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    conflict = httpx.Client(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(
+                409,
+                json={
+                    "base_url": "https://tasksminerdata.blob.core.windows.net/bronze",
+                    "prefix": "sources/community/demo/",
+                },
+            )
+        )
+    )
+    monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: conflict)
+
+    result = runner.invoke(app, _upload_command(_trial(tmp_path)))
+
+    assert result.exit_code == 0, result.output
+    output = click.unstyle(result.output)
+    assert "Already submitted" in output
+    assert "Verified in Azure storage" in output
+
+
+@pytest.mark.parametrize(
+    ("status", "exit_code", "copy"),
+    [
+        ("ingested", 0, "Verified in Azure storage"),
+        ("pending", 0, "Queued"),
+        ("validating", 0, "Validating"),
+        ("rejected", 1, "validator rejected"),
+        ("unknown", 1, "no record"),
+        ("unsupported", 1, "does not report"),
+    ],
+)
+def test_traj_status_maps_states_to_exit_codes(
+    monkeypatch: pytest.MonkeyPatch, status: str, exit_code: int, copy: str
+) -> None:
+    from benchflow.publish.broker import CaptureStatus
+
+    detail = "size mismatch" if status == "rejected" else None
+    _patch_status_fetch(monkeypatch, CaptureStatus(status=status, detail=detail))
+
+    result = runner.invoke(app, ["traj", "status", f"sha256:{VALID_DIGEST}"])
+
+    assert result.exit_code == exit_code, result.output
+    output = click.unstyle(result.output)
+    assert copy in output
+    assert f"Digest: sha256:{VALID_DIGEST}" in output
+
+
+def test_traj_status_accepts_bare_hex_and_prompts_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from benchflow.publish.broker import CaptureStatus
+
+    calls = _patch_status_fetch(monkeypatch, CaptureStatus(status="ingested"))
+
+    bare = runner.invoke(app, ["traj", "status", VALID_DIGEST])
+    assert bare.exit_code == 0, bare.output
+
+    prompted = runner.invoke(app, ["traj", "status"], input=f"sha256:{VALID_DIGEST}\n")
+    assert prompted.exit_code == 0, prompted.output
+    assert "Digest" in click.unstyle(prompted.output)
+    assert calls == [VALID_DIGEST, VALID_DIGEST]
+
+
+def test_traj_status_rejects_malformed_digest() -> None:
+    result = runner.invoke(app, ["traj", "status", "not-a-digest"])
+
+    assert result.exit_code == 1
+    assert "sha256:<64 hex characters>" in click.unstyle(result.output)

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -856,6 +856,44 @@ def test_list_recent_sessions_scans_all_projects_most_recent_first(
     assert "prize session please" in hits[1].snippet
 
 
+def test_list_recent_sessions_windows_seven_days_across_sources(
+    tmp_path: Path,
+) -> None:
+    """The picker browses the past week of Claude AND Codex sessions in one
+    time-ordered list; older sessions drop out when recent ones exist."""
+    import os
+    import time
+
+    from benchflow.trajectories.sessions import list_recent_sessions
+
+    now = time.time()
+    home = tmp_path / "home"
+    claude_dir = home / ".claude" / "projects" / "-work"
+    claude_dir.mkdir(parents=True)
+    claude_recent = claude_dir / "recent.jsonl"
+    claude_recent.write_text(
+        '{"type":"user","message":{"content":"claude work"}}\n', encoding="utf-8"
+    )
+    os.utime(claude_recent, (now - 3600, now - 3600))
+    claude_stale = claude_dir / "stale.jsonl"
+    claude_stale.write_text(
+        '{"type":"user","message":{"content":"last month"}}\n', encoding="utf-8"
+    )
+    os.utime(claude_stale, (now - 30 * 86400, now - 30 * 86400))
+    codex_dir = home / ".codex" / "sessions" / "2026" / "08" / "16"
+    codex_dir.mkdir(parents=True)
+    codex_recent = codex_dir / "rollout.jsonl"
+    codex_recent.write_text(
+        '{"type":"session_meta","payload":{"cwd":"/tmp"}}\n', encoding="utf-8"
+    )
+    os.utime(codex_recent, (now - 60, now - 60))
+
+    hits = list_recent_sessions(cwd=tmp_path, home=home)
+
+    assert [hit.path for hit in hits] == [codex_recent, claude_recent]
+    assert [hit.source for hit in hits] == ["codex", "claude"]
+
+
 def test_setup_list_prints_path_on_its_own_line(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_traj_workspace.py
+++ b/tests/test_traj_workspace.py
@@ -207,6 +207,46 @@ def test_validator_accepts_zip_artifact_and_rejects_fake_zip(tmp_path: Path) -> 
             validate_local_capture(manifest_bytes, paths)
 
 
+def test_schema_12_manifest_with_workspace_validates_end_to_end(
+    tmp_path: Path,
+) -> None:
+    """Guards the live rejection from the first workspace deploy: the manifest
+    model cross-checked the trajectory report's file count and size against
+    ALL artifacts, so any capture carrying a workspace zip failed with
+    'trajectory report file count does not match artifacts'. The report
+    describes the JSONL alone on both sides."""
+    from benchflow.publish.traj_capture import finalize_trajectory_capture
+    from benchflow.publish.traj_report import build_trajectory_report
+
+    session = _session(tmp_path)
+    folder = tmp_path / "ws"
+    folder.mkdir()
+    (folder / "file.txt").write_text("content\n")
+    with stage_trajectory_artifacts(session, source_id="demo") as artifacts:
+        report = build_trajectory_report(
+            artifacts.files,
+            masked_values=artifacts.redaction_replacements,
+            preview_steps=0,
+        )
+        result = attach_workspace_archive(artifacts, folder)
+        assert result.attached is not None
+        staged = finalize_trajectory_capture(
+            result.artifacts,
+            github_id=GITHUB_ID,
+            email=EMAIL,
+            trajectory_report=report.as_manifest_metadata(),
+        )
+        assert staged.manifest["schema_version"] == "1.2.0"
+        manifest_bytes = staged.files[-1].local_path.read_bytes()
+        paths = {
+            item.relname: item.local_path
+            for item in staged.files
+            if item.relname != "manifest.json"
+        }
+        validated = validate_local_capture(manifest_bytes, paths)
+        assert "workspace/ws.zip" in validated.artifact_paths
+
+
 def test_validator_zip_magic_rejects_non_zip_bytes(tmp_path: Path) -> None:
     from services.trajectory_upload.validation import _validate_zip_magic
 

--- a/tests/test_traj_workspace.py
+++ b/tests/test_traj_workspace.py
@@ -1,0 +1,355 @@
+"""Workspace-attachment behavior for ``bench traj upload``.
+
+The feature zips the session's workspace folder into the capture as
+``workspace/<name>.zip``: auto-detected from the session's recorded cwd,
+optional and skippable, capped at 1 GiB before compression, archived without
+content redaction but with VCS/dependency/secret-shaped names excluded, and
+always cleaned up with the staging directory.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+import benchflow.publish.traj_capture as capture_module
+from benchflow.cli.main import app
+from benchflow.publish.traj_capture import (
+    attach_workspace_archive,
+    stage_trajectory_artifacts,
+)
+from services.trajectory_upload.contract import UploadRequest
+from services.trajectory_upload.validation import (
+    CaptureRejected,
+    validate_local_capture,
+)
+
+runner = CliRunner()
+GITHUB_ID = "benchflow-user"
+EMAIL = "user@example.com"
+
+
+def _session(tmp_path: Path, *, cwd: Path | None = None, codex: bool = False) -> Path:
+    """A minimal real-shaped session JSONL, optionally recording a cwd."""
+    lines = []
+    if cwd is not None and codex:
+        lines.append(json.dumps({"type": "session_meta", "payload": {"cwd": str(cwd)}}))
+    elif cwd is not None:
+        lines.append(json.dumps({"type": "user", "cwd": str(cwd)}))
+    lines.append(json.dumps({"type": "message", "text": "demo step"}))
+    session = tmp_path / "session.jsonl"
+    session.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return session
+
+
+def _workspace(tmp_path: Path) -> Path:
+    folder = tmp_path / "demo-workspace"
+    (folder / "src").mkdir(parents=True)
+    (folder / "src" / "main.py").write_text("print('hi')\n")
+    (folder / "README.md").write_text("# demo\n")
+    (folder / ".git").mkdir()
+    (folder / ".git" / "config").write_text("[remote]\n")
+    (folder / "node_modules").mkdir()
+    (folder / "node_modules" / "big.js").write_text("x" * 100)
+    (folder / ".env").write_text("SECRET=1\n")
+    (folder / "server.key").write_text("private\n")
+    return folder
+
+
+def _upload_command(path: Path, *args: str) -> list[str]:
+    return [
+        "traj",
+        "upload",
+        str(path),
+        "--github-id",
+        GITHUB_ID,
+        "--email",
+        EMAIL,
+        *args,
+    ]
+
+
+def test_attach_archives_workspace_and_excludes_vcs_and_secrets(
+    tmp_path: Path,
+) -> None:
+    session = _session(tmp_path)
+    folder = _workspace(tmp_path)
+    with stage_trajectory_artifacts(session, source_id="demo") as artifacts:
+        before_digest = artifacts.traj_digest
+        result = attach_workspace_archive(artifacts, folder)
+
+        assert result.skipped_reason is None
+        assert result.attached is not None
+        assert result.attached.relname == "workspace/demo-workspace.zip"
+        assert result.attached.content_type == "application/zip"
+        assert result.file_count == 2
+        assert result.excluded_count >= 4  # .git, node_modules, .env, server.key
+        assert result.artifacts.traj_digest != before_digest
+        assert [item.relname for item in result.artifacts.files] == [
+            "trajectory/session.jsonl",
+            "workspace/demo-workspace.zip",
+        ]
+        with zipfile.ZipFile(result.attached.local_path) as archive:
+            assert sorted(archive.namelist()) == ["README.md", "src/main.py"]
+        zip_path = result.attached.local_path
+        assert zip_path.exists()
+    assert not zip_path.exists()  # staging exit always removes the archive
+
+
+def test_attach_skips_oversized_workspace_without_zipping(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+    folder = _workspace(tmp_path)
+    with stage_trajectory_artifacts(session, source_id="demo") as artifacts:
+        result = attach_workspace_archive(artifacts, folder, max_bytes=4)
+
+        assert result.attached is None
+        assert result.skipped_reason is not None
+        assert "before" in result.skipped_reason
+        assert result.artifacts is artifacts  # untouched
+        staged_root = artifacts._staging_dir
+        assert not list(staged_root.glob("workspace/*"))  # nothing was created
+
+
+def test_attach_skips_missing_and_empty_folders(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    with stage_trajectory_artifacts(session, source_id="demo") as artifacts:
+        missing = attach_workspace_archive(artifacts, tmp_path / "nope")
+        assert missing.attached is None
+        assert "not found" in (missing.skipped_reason or "")
+        hollow = attach_workspace_archive(artifacts, empty)
+        assert hollow.attached is None
+        assert "no files" in (hollow.skipped_reason or "")
+
+
+def test_attach_skips_symlinked_files(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+    folder = tmp_path / "ws"
+    folder.mkdir()
+    (folder / "real.txt").write_text("data\n")
+    (folder / "link.txt").symlink_to(folder / "real.txt")
+    with stage_trajectory_artifacts(session, source_id="demo") as artifacts:
+        result = attach_workspace_archive(artifacts, folder)
+        assert result.attached is not None
+        with zipfile.ZipFile(result.attached.local_path) as archive:
+            assert archive.namelist() == ["real.txt"]
+
+
+def test_contract_accepts_one_workspace_archive_and_rejects_extras() -> None:
+    def request_body(artifacts: list[dict]) -> dict:
+        from services.trajectory_upload.contract import trajectory_digest
+
+        parsed = [
+            SimpleNamespace(name=a["name"], sha256=a["sha256"]) for a in artifacts
+        ]
+        return {
+            "schema_version": "1.1.0",
+            "kind": "bronze.trajectory",
+            "source_id": "demo",
+            "traj_digest": f"sha256:{trajectory_digest(parsed)}",
+            "uploaded_by": None,
+            "artifacts": artifacts,
+            "contributor": {"github_id": GITHUB_ID, "email": EMAIL},
+        }
+
+    jsonl = {"name": "trajectory/a.jsonl", "sha256": "a" * 64, "bytes": 10}
+    archive = {"name": "workspace/ws.zip", "sha256": "b" * 64, "bytes": 900 * 1024**2}
+    UploadRequest.model_validate(request_body([jsonl, archive]))
+
+    second = {"name": "workspace/other.zip", "sha256": "c" * 64, "bytes": 5}
+    with pytest.raises(ValueError, match="at most one workspace archive"):
+        UploadRequest.model_validate(request_body([jsonl, archive, second]))
+    with pytest.raises(ValueError, match="at least one trajectory artifact"):
+        UploadRequest.model_validate(request_body([archive]))
+    oversized_zip = dict(archive, bytes=1024**3 + 1)
+    with pytest.raises(ValueError):
+        UploadRequest.model_validate(request_body([jsonl, oversized_zip]))
+    oversized_jsonl = dict(jsonl, bytes=129 * 1024**2)
+    with pytest.raises(ValueError, match="exceeds"):
+        UploadRequest.model_validate(request_body([jsonl, oversized_jsonl]))
+
+
+def test_validator_accepts_zip_artifact_and_rejects_fake_zip(tmp_path: Path) -> None:
+    session = _session(tmp_path)
+    folder = tmp_path / "ws"
+    folder.mkdir()
+    (folder / "file.txt").write_text("content\n")
+    with stage_trajectory_artifacts(session, source_id="demo") as artifacts:
+        result = attach_workspace_archive(artifacts, folder)
+        assert result.attached is not None
+        from benchflow.publish.traj_capture import finalize_trajectory_capture
+
+        staged = finalize_trajectory_capture(
+            result.artifacts,
+            github_id=GITHUB_ID,
+            email=EMAIL,
+        )
+        manifest_bytes = staged.files[-1].local_path.read_bytes()
+        paths = {
+            item.relname: item.local_path
+            for item in staged.files
+            if item.relname != "manifest.json"
+        }
+        validated = validate_local_capture(manifest_bytes, paths)
+        assert "workspace/ws.zip" in validated.artifact_paths
+
+        # Corrupt the archive: hash mismatch must reject before zip checks.
+        result.attached.local_path.write_bytes(b"not a zip")
+        with pytest.raises(CaptureRejected, match=r"size mismatch|sha256 mismatch"):
+            validate_local_capture(manifest_bytes, paths)
+
+
+def test_validator_zip_magic_rejects_non_zip_bytes(tmp_path: Path) -> None:
+    from services.trajectory_upload.validation import _validate_zip_magic
+
+    fake = tmp_path / "fake.zip"
+    fake.write_bytes(b"ZZZZ not a zip")
+    with pytest.raises(CaptureRejected, match="not a zip"):
+        _validate_zip_magic(fake, "workspace/fake.zip")
+    real = tmp_path / "real.zip"
+    with zipfile.ZipFile(real, "w") as archive:
+        archive.writestr("a.txt", "x")
+    _validate_zip_magic(real, "workspace/real.zip")
+
+
+def test_cli_attaches_detected_workspace_end_to_end(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Claude-style cwd detection feeds the zip through the whole client flow."""
+    folder = _workspace(tmp_path)
+    session = _session(tmp_path, cwd=folder)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    declared: list[str] = []
+    put_names: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            body = json.loads(request.content)
+            declared.extend(a["name"] for a in body["artifacts"])
+            from tests.test_traj_upload_cli import _broker_payload
+
+            return httpx.Response(200, json=_broker_payload(request))
+        put_names.append(request.url.path.rsplit("/", 2)[-2:][0])
+        return httpx.Response(201)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: client)
+    result = runner.invoke(app, _upload_command(session, "--no-repo", "--no-wait"))
+
+    assert result.exit_code == 0, result.output
+    assert "Workspace attached: workspace/demo-workspace.zip" in result.output.replace(
+        "\n", ""
+    )
+    assert "trajectory/session.jsonl" in declared
+    assert "workspace/demo-workspace.zip" in declared
+
+
+def test_cli_codex_session_meta_detection(tmp_path: Path) -> None:
+    folder = _workspace(tmp_path)
+    session = _session(tmp_path, cwd=folder, codex=True)
+    from benchflow.cli.traj import _session_cwd
+
+    assert _session_cwd(session) == folder
+
+
+def test_cli_no_workspace_flag_skips_attachment(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    folder = _workspace(tmp_path)
+    session = _session(tmp_path, cwd=folder)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    result = runner.invoke(
+        app, _upload_command(session, "--no-repo", "--no-workspace", "--dry-run")
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "workspace/" not in result.output
+    assert "Workspace" not in result.output
+
+
+def test_cli_dry_run_lists_workspace_archive(tmp_path: Path) -> None:
+    folder = _workspace(tmp_path)
+    session = _session(tmp_path, cwd=folder)
+    result = runner.invoke(app, _upload_command(session, "--no-repo", "--dry-run"))
+
+    assert result.exit_code == 0, result.output
+    flattened = result.output.replace("\n", "")
+    assert "Workspace attached: workspace/demo-workspace.zip" in flattened
+    assert "workspace/demo-workspace.zip" in flattened
+
+
+def test_cli_oversized_workspace_prints_skip_and_uploads_trajectory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    folder = _workspace(tmp_path)
+    session = _session(tmp_path, cwd=folder)
+    monkeypatch.setattr(capture_module, "MAX_ATTACHMENT_BYTES", 4)
+    result = runner.invoke(app, _upload_command(session, "--no-repo", "--dry-run"))
+
+    assert result.exit_code == 0, result.output
+    flattened = result.output.replace("\n", "")
+    assert "Workspace skipped:" in flattened
+    assert "workspace/demo-workspace.zip" not in flattened
+    assert "trajectory/session.jsonl" in flattened
+
+
+def test_workspace_prompt_is_optional_and_validating(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Detection failure on a TTY asks once; Enter skips, bad paths re-ask."""
+    from benchflow.cli.traj import _resolve_workspace_dir, _UploadOptions
+
+    session = _session(tmp_path)  # records no cwd
+    options = _UploadOptions(
+        path=session,
+        github_id=GITHUB_ID,
+        email=EMAIL,
+        source_id=None,
+        repo=False,
+        direct=False,
+        container_url=None,
+        dry_run=True,
+        preview_steps=0,
+    )
+    monkeypatch.setattr(
+        "benchflow.cli.traj.sys.stdin", SimpleNamespace(isatty=lambda: True)
+    )
+    answers = iter(["", str(tmp_path / "missing"), str(tmp_path)])
+    monkeypatch.setattr(
+        "benchflow.cli.traj.typer.prompt", lambda *a, **k: next(answers)
+    )
+
+    chosen, prompted = _resolve_workspace_dir(options, session)
+    assert chosen is None and prompted  # Enter skipped
+
+    chosen, prompted = _resolve_workspace_dir(options, session)
+    assert chosen == tmp_path and prompted  # re-asked after the bad path
+
+
+def test_workspace_prompt_skipped_off_tty(tmp_path: Path) -> None:
+    from benchflow.cli.traj import _resolve_workspace_dir, _UploadOptions
+
+    session = _session(tmp_path)
+    options = _UploadOptions(
+        path=session,
+        github_id=GITHUB_ID,
+        email=EMAIL,
+        source_id=None,
+        repo=False,
+        direct=False,
+        container_url=None,
+        dry_run=True,
+        preview_steps=0,
+    )
+    with io.StringIO() as fake_stdin:
+        assert not fake_stdin.isatty()
+    chosen, prompted = _resolve_workspace_dir(options, session)
+    assert chosen is None and not prompted

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -1358,7 +1358,9 @@ def test_pending_oversized_artifact_event_is_rejected_and_cleaned(
     queue = FakeQueue(event)
     table = _pending_table(digest)
     container = FakeContainer(blobs)
-    monkeypatch.setattr("services.trajectory_upload.validator.MAX_ARTIFACT_BYTES", 1)
+    monkeypatch.setattr(
+        "services.trajectory_upload.validator.max_artifact_bytes", lambda _name: 1
+    )
 
     assert AzureCaptureValidator(
         container=container, queue=queue, table=table
@@ -1419,7 +1421,8 @@ def test_pending_artifact_event_enforces_legacy_aggregate_limit(
     container = FakeContainer(blobs)
     queue = FakeQueue(event)
     monkeypatch.setattr(
-        "services.trajectory_upload.validator.MAX_ARTIFACT_BYTES", len(content) + 1
+        "services.trajectory_upload.validator.max_artifact_bytes",
+        lambda _name: len(content) + 1,
     )
     monkeypatch.setattr(
         "services.trajectory_upload.validator.MAX_CAPTURE_BYTES", capture_limit

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -1887,12 +1887,13 @@ def test_azure_backend_status_reads_ledger_without_upload_quota() -> None:
     with pytest.raises(RateLimited):
         backend.get_capture_status(digest, client_ip="127.0.0.1")
 
-    partitions = {entity["PartitionKey"] for entity in table.entities}
-    assert any(partition.startswith("rate-status-") for partition in partitions)
-    assert not any(
-        partition.startswith("rate-") and not partition.startswith("rate-status-")
-        for partition in partitions
-    )
+    status_rows = {
+        entity["RowKey"]
+        for entity in table.entities
+        if entity["PartitionKey"] == "ratebucket"
+    }
+    assert any(row.startswith("status-") for row in status_rows)
+    assert not any(row.startswith(("contributor-", "ip-")) for row in status_rows)
 
 
 def test_azure_backend_status_bounds_detail_and_hides_corrupt_states() -> None:

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -31,6 +31,7 @@ from services.trajectory_upload.broker_app import (
     create_app,
 )
 from services.trajectory_upload.contract import (
+    CaptureStatusInfo,
     UploadGrant,
     UploadObject,
     UploadRequest,
@@ -86,6 +87,9 @@ class FakeBroker:
         if isinstance(self.result, Exception):
             raise self.result
         return self.result
+
+    def get_capture_status(self, digest: str, *, client_ip: str) -> CaptureStatusInfo:
+        raise AssertionError("handshake tests must not reach the status route")
 
 
 def test_broker_cold_start_constructs_one_shared_backend() -> None:
@@ -1761,3 +1765,166 @@ def test_expired_validation_lease_is_reclaimed(tmp_path: Path) -> None:
     assert table.entities[-1]["status"] == "ingested"
     assert container.uploaded[-1] == f"sources/community/{digest}/manifest.json"
     assert queue.deleted == [("m1", "p1")]
+
+
+class FakeStatusBroker:
+    """Status-route double; the handshake route is never exercised here."""
+
+    def __init__(self, result: CaptureStatusInfo | Exception) -> None:
+        self.result = result
+        self.client_ip: str | None = None
+        self.digest: str | None = None
+
+    def create_upload(self, request: UploadRequest, *, client_ip: str) -> UploadGrant:
+        raise AssertionError("status tests must not reach the handshake route")
+
+    def get_capture_status(self, digest: str, *, client_ip: str) -> CaptureStatusInfo:
+        self.digest = digest
+        self.client_ip = client_ip
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+def test_capture_status_route_reports_states_and_rate_limit() -> None:
+    """GET /v1/uploads/{digest} maps ledger states, 429s, and forwarded IPs."""
+    digest = "ab" * 32
+    backend = FakeStatusBroker(
+        CaptureStatusInfo(
+            digest=digest,
+            status="ingested",
+            prefix=f"sources/community/{digest}/",
+            updated_at="2026-08-16T00:00:00+00:00",
+        )
+    )
+    response = TestClient(create_app(backend)).get(
+        f"/v1/uploads/{digest}",
+        headers={"x-forwarded-for": "spoofed, 203.0.113.9"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["digest"] == f"sha256:{digest}"
+    assert payload["status"] == "ingested"
+    assert payload["prefix"] == f"sources/community/{digest}/"
+    assert backend.digest == digest
+    assert backend.client_ip == "203.0.113.9"
+
+    rejected = TestClient(
+        create_app(
+            FakeStatusBroker(
+                CaptureStatusInfo(
+                    digest=digest, status="rejected", detail="size mismatch"
+                )
+            )
+        )
+    ).get(f"/v1/uploads/{digest}")
+    assert rejected.status_code == 200
+    assert rejected.json()["status"] == "rejected"
+    assert rejected.json()["detail"] == "size mismatch"
+    assert "prefix" not in rejected.json()
+
+    unknown = TestClient(
+        create_app(FakeStatusBroker(CaptureStatusInfo(digest=digest, status="unknown")))
+    ).get(f"/v1/uploads/{digest}")
+    assert unknown.status_code == 200
+    assert unknown.json() == {"digest": f"sha256:{digest}", "status": "unknown"}
+
+    limited = TestClient(create_app(FakeStatusBroker(RateLimited(42)))).get(
+        f"/v1/uploads/{digest}"
+    )
+    assert limited.status_code == 429
+    assert limited.headers["Retry-After"] == "42"
+
+
+def test_capture_status_route_rejects_malformed_digests() -> None:
+    """Only a 64-lowercase-hex digest reaches the backend; 404 stays reserved
+    for deployments that predate the endpoint."""
+    backend = FakeStatusBroker(AssertionError("malformed digest reached the backend"))
+    client = TestClient(create_app(backend))
+
+    non_hex = client.get(f"/v1/uploads/{'zz' * 32}")
+    assert non_hex.status_code == 400
+
+    uppercase = client.get(f"/v1/uploads/{'AB' * 32}")
+    assert uppercase.status_code == 400
+
+    too_short = client.get(f"/v1/uploads/{'ab' * 31}")
+    assert too_short.status_code == 400
+
+
+def test_azure_backend_status_reads_ledger_without_upload_quota() -> None:
+    """Status polls consume a separate, larger budget than upload grants."""
+    digest = "ab" * 32
+    table = FakeTable(
+        [
+            {
+                "PartitionKey": "capture",
+                "RowKey": digest,
+                "status": "ingested",
+                "updated_at": "2026-08-16T00:00:00+00:00",
+            }
+        ]
+    )
+    backend = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=table,
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+        rate_limit=0,  # any upload-quota consumption would 429 immediately
+        status_rate_limit=3,
+    )
+
+    info = backend.get_capture_status(digest, client_ip="127.0.0.1")
+    assert info.status == "ingested"
+    assert info.prefix == f"sources/community/{digest}/"
+    assert info.updated_at == "2026-08-16T00:00:00+00:00"
+
+    assert backend.get_capture_status("cd" * 32, client_ip="127.0.0.1").status == (
+        "unknown"
+    )
+    backend.get_capture_status(digest, client_ip="127.0.0.1")
+    with pytest.raises(RateLimited):
+        backend.get_capture_status(digest, client_ip="127.0.0.1")
+
+    partitions = {entity["PartitionKey"] for entity in table.entities}
+    assert any(partition.startswith("rate-status-") for partition in partitions)
+    assert not any(
+        partition.startswith("rate-") and not partition.startswith("rate-status-")
+        for partition in partitions
+    )
+
+
+def test_azure_backend_status_bounds_detail_and_hides_corrupt_states() -> None:
+    """Rejection detail is truncated and non-public ledger states stay opaque."""
+    digest = "ab" * 32
+    rejected = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=FakeTable(
+            [
+                {
+                    "PartitionKey": "capture",
+                    "RowKey": digest,
+                    "status": "rejected",
+                    "detail": "x" * 600,
+                }
+            ]
+        ),
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+    )
+    info = rejected.get_capture_status(digest, client_ip="127.0.0.1")
+    assert info.status == "rejected"
+    assert info.detail == "x" * 512
+
+    corrupt = AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=FakeTable(
+            [{"PartitionKey": "capture", "RowKey": digest, "status": "exploded"}]
+        ),
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+    )
+    assert corrupt.get_capture_status(digest, client_ip="127.0.0.1").status == "unknown"


### PR DESCRIPTION
## What

Two upgrades to the trajectory contribution flow:

### 1. Uploads are now confirmed all the way into Azure blob storage

The transfer finishing was never the end of the story — the validator still had to promote the capture from quarantine to `sources/community/<digest>/`. The CLI now closes that loop:

- **Broker** gains `GET /v1/uploads/{digest}`: reads the validation ledger and reports `pending` / `validating` / `ingested` (with the public promotion prefix) / `rejected` (with the bounded, user-fixable detail) / `unknown`. Unknown digests are a `200 unknown` so a `404` uniquely identifies a deployment that predates the endpoint. Status polls consume a separate, much higher per-IP budget (`TRAJ_STATUS_RATE_LIMIT`, default 720/h) instead of upload-grant quota — the endpoint never mints SAS and exposes no contributor identity, source ids, or quarantine internals.
- **`bench traj upload`** polls after the progress bar (default budget 240 s, backoff 2→10 s; `BENCHFLOW_TRAJ_WAIT_SECONDS` override, `--no-wait` opt-out): `✓ Verified in Azure storage` on promotion; exit 1 with the rejection detail if the validator declines; a `bench traj status sha256:<digest>` handoff on timeout or repeated transport failures. A handshake 409 prints the verified line instantly (the conflict is itself proof of ingestion). A 404 keeps today's behavior byte-identical.
- **`bench traj status DIGEST`** (new) runs one check on demand; `ingested`/`pending`/`validating` exit 0, everything else exits 1.

### 2. One professional TUI across the `bench traj` family (presentation-only)

New `cli/_traj_tui.py` kit shared by `setup` / `upload` / `status`: a `◆ benchflow · <command>` banner, styled `◇` prompts, an arrow-key recent-session picker (↑/↓, `1-9` jump, `esc` falls back to typing a path) on real terminals, viewer-matched kind colors in the report preview (#1020's palette), and rounded panels. **No logic changes**: every affordance degrades to the exact previous prompt-driven flow off-TTY (agents, pipes, CI, Windows), and all machine-read lines (`Masked for you:`, `Digest:`, `Repo:`) stay plain prints.

## Production verification (real Azure, this branch)

- Pre-existing capture `sha256:dbb61ef6…` (the 12.2 MB FrontierPhysics session): listed 2 blobs under `sources/community/<digest>/`, manifest present, zero quarantine residue — confirms the semantics the status endpoint reports.
- Canary `sha256:1ee53eef…` (`--source-id canary/traj-verify-pr`, safe synthetic content; operators may prune it): uploaded through the **deployed production broker** with this branch's CLI → wait phase hit the old broker's 404 and fell back silently → validator promoted it in ~160 s → blob listing confirmed promotion + clean quarantine.
- Re-upload of the canary against production: handshake 409 → `Already submitted.` + `✓ Verified in Azure storage` with zero polling.
- `bench traj status` against the production broker: clean "does not report capture status yet" (exit 1) until the service is redeployed.
- Local broker (`uvicorn … broker_app:app` with real storage-account env): `/healthz` ok, malformed digests 400 over real HTTP. Ledger reads were `AuthorizationPermissionMismatch` with the local service principal (blob-only RBAC) — the deployed broker's managed identity already holds the ledger role, so production serves the endpoint after redeploy.

`137` trajectory-suite tests pass (`test_traj_upload_cli`, `test_trajectory_upload_service`, `test_traj_tui`, `test_traj_upload_skill`, `test_trajectory_upload_layout`); ruff + ruff-format clean; the suite stays hermetic via a conftest `BENCHFLOW_TRAJ_WAIT_SECONDS=0` fixture mirroring the update-check guard.

## Deploy

The broker must be redeployed for the status endpoint to answer in production (`deploy-trajectory-upload` workflow, or `./services/trajectory_upload/scripts/deploy.sh`), then `scripts/smoke-test.sh`. The CLI is safe to release first — it degrades gracefully until then. No validator or infra (Bicep) changes.