### PR TITLE
Per-contributor token-bucket rate limiting for trajectory uploads

### DIFF
--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import math
 import os
 import threading
 import uuid
@@ -36,6 +37,7 @@ class AzureUploadBroker:
         blob_service: Any,
         ip_hash_key: bytes,
         rate_limit: int = 20,
+        ip_rate_limit: int = 500,
         sas_minutes: int = 15,
     ) -> None:
         self.account_name = account_name
@@ -44,6 +46,7 @@ class AzureUploadBroker:
         self.blob_service = blob_service
         self.ip_hash_key = ip_hash_key
         self.rate_limit = rate_limit
+        self.ip_rate_limit = ip_rate_limit
         self.sas_minutes = min(max(sas_minutes, 1), 15)
         self._state_lock = threading.Lock()
         self._delegation_key: Any = None
@@ -73,68 +76,66 @@ class AzureUploadBroker:
             ),
             ip_hash_key=_required_env("TRAJ_UPLOAD_IP_HASH_KEY").encode(),
             rate_limit=int(os.environ.get("TRAJ_UPLOAD_RATE_LIMIT", "20")),
+            ip_rate_limit=int(os.environ.get("TRAJ_UPLOAD_IP_RATE_LIMIT", "500")),
             sas_minutes=int(os.environ.get("TRAJ_UPLOAD_SAS_MINUTES", "15")),
         )
 
     def create_upload(self, request: UploadRequest, *, client_ip: str) -> UploadGrant:
         digest = request.traj_digest.removeprefix("sha256:")
         upload_id = f"u_{uuid.uuid4().hex}"
-        with self._state_lock:
-            self._consume_rate_limit(client_ip)
-            entity = self._capture_entity(digest)
-            status = entity.get("status") if entity is not None else None
-            if status == "ingested":
-                raise AlreadyUploaded(
-                    base_url=self.container_url,
-                    prefix=f"sources/community/{digest}/",
-                )
-            declaration_conflict = (
-                status in {"pending", "validating"}
-                and request.manifest_sha256 is not None
-                and entity is not None
-                and entity.get("declared_manifest_sha256") != request.manifest_sha256
+        self._consume_rate_limit(client_ip, request.contributor.github_id)
+        entity = self._capture_entity(digest)
+        status = entity.get("status") if entity is not None else None
+        if status == "ingested":
+            raise AlreadyUploaded(
+                base_url=self.container_url,
+                prefix=f"sources/community/{digest}/",
             )
-            if status == "validating" and declaration_conflict:
-                raise UploadDeclarationConflict
-            if status in {"pending", "validating"} and not declaration_conflict:
-                if entity is None:  # pragma: no cover - implied by status above
-                    raise RuntimeError("active capture ledger entry is missing")
-                persisted_attempt = entity.get("attempt_id")
-                if persisted_attempt and not _valid_upload_id(persisted_attempt):
-                    raise RuntimeError(
-                        "active capture ledger has an invalid attempt id"
-                    )
-                if isinstance(persisted_attempt, str) and persisted_attempt:
-                    upload_id = persisted_attempt
-                    prefix = f"inbox/{digest}/{upload_id}/"
-                else:
-                    # Preserve the pre-attempt namespace for captures that were
-                    # already in flight when this version was deployed.
-                    prefix = f"inbox/{digest}/"
-            else:
-                self.table.upsert_entity(
-                    {
-                        "PartitionKey": "capture",
-                        "RowKey": digest,
-                        "status": "pending",
-                        "attempt_id": upload_id,
-                        "source_id": request.source_id,
-                        "schema_version": request.schema_version,
-                        "declared_manifest_sha256": request.manifest_sha256 or "",
-                        "declared_artifacts": json.dumps(
-                            {
-                                artifact.name: artifact.bytes
-                                for artifact in request.artifacts
-                            },
-                            separators=(",", ":"),
-                            sort_keys=True,
-                        ),
-                        "updated_at": datetime.now(UTC).isoformat(),
-                        "validation_lease_until": "",
-                        "detail": "",
-                    }
-                )
+        declaration_conflict = (
+            status in {"pending", "validating"}
+            and request.manifest_sha256 is not None
+            and entity is not None
+            and entity.get("declared_manifest_sha256") != request.manifest_sha256
+        )
+        if status == "validating" and declaration_conflict:
+            raise UploadDeclarationConflict
+        if status in {"pending", "validating"} and not declaration_conflict:
+            if entity is None:  # pragma: no cover - implied by status above
+                raise RuntimeError("active capture ledger entry is missing")
+            persisted_attempt = entity.get("attempt_id")
+            if persisted_attempt and not _valid_upload_id(persisted_attempt):
+                raise RuntimeError("active capture ledger has an invalid attempt id")
+            if isinstance(persisted_attempt, str) and persisted_attempt:
+                upload_id = persisted_attempt
                 prefix = f"inbox/{digest}/{upload_id}/"
+            else:
+                # Preserve the pre-attempt namespace for captures that were
+                # already in flight when this version was deployed.
+                prefix = f"inbox/{digest}/"
+        else:
+            self.table.upsert_entity(
+                {
+                    "PartitionKey": "capture",
+                    "RowKey": digest,
+                    "status": "pending",
+                    "attempt_id": upload_id,
+                    "source_id": request.source_id,
+                    "schema_version": request.schema_version,
+                    "declared_manifest_sha256": request.manifest_sha256 or "",
+                    "declared_artifacts": json.dumps(
+                        {
+                            artifact.name: artifact.bytes
+                            for artifact in request.artifacts
+                        },
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "validation_lease_until": "",
+                    "detail": "",
+                }
+            )
+            prefix = f"inbox/{digest}/{upload_id}/"
 
         now = datetime.now(UTC)
         expires_at = now + timedelta(minutes=self.sas_minutes)
@@ -174,46 +175,85 @@ class AzureUploadBroker:
         except ResourceNotFoundError:
             return None
 
-    def _consume_rate_limit(self, client_ip: str) -> None:
-        from azure.core.exceptions import ResourceNotFoundError
+    def _consume_rate_limit(self, client_ip: str, github_id: str) -> None:
+        # Fairness first: every contributor gets an independent budget, so a
+        # venue NAT full of people cannot starve each other. The per-IP bucket
+        # is a wider abuse backstop against one host rotating identities.
+        contributor_key = f"{client_ip}\n{github_id.strip().lower()}"
+        self._consume_token("contributor", contributor_key, self.rate_limit)
+        self._consume_token("ip", client_ip, self.ip_rate_limit)
 
-        now = datetime.now(UTC)
-        partition = f"rate-{now:%Y%m%d%H}"
-        row = hmac.new(
-            self.ip_hash_key,
-            client_ip.encode(),
-            hashlib.sha256,
-        ).hexdigest()
-        try:
-            entity = self.table.get_entity(partition_key=partition, row_key=row)
-        except ResourceNotFoundError:
-            count = 0
-        else:
-            count = int(entity.get("count", 0))
-        if count >= self.rate_limit:
-            retry_after = 3600 - now.minute * 60 - now.second
-            raise RateLimited(max(retry_after, 1))
-        self.table.upsert_entity(
-            {
-                "PartitionKey": partition,
-                "RowKey": row,
-                "count": count + 1,
-                "updated_at": now.isoformat(),
-            }
+    def _consume_token(self, scope: str, key: str, capacity: int) -> None:
+        """Take one token from an hourly-refilling bucket, atomically.
+
+        The bucket admits a burst of ``capacity`` and refills continuously at
+        ``capacity`` per hour, so Retry-After is seconds until the next token
+        rather than the remainder of a clock hour.
+        """
+        from azure.core import MatchConditions
+        from azure.core.exceptions import (
+            ResourceExistsError,
+            ResourceModifiedError,
+            ResourceNotFoundError,
         )
+
+        digest = hmac.new(self.ip_hash_key, key.encode(), hashlib.sha256).hexdigest()
+        row = f"{scope}-{digest}"
+        for _attempt in range(5):
+            now = datetime.now(UTC)
+            try:
+                entity = self.table.get_entity(partition_key="ratebucket", row_key=row)
+            except ResourceNotFoundError:
+                try:
+                    self.table.create_entity(
+                        {
+                            "PartitionKey": "ratebucket",
+                            "RowKey": row,
+                            "tokens": float(capacity - 1),
+                            "updated_at": now.isoformat(),
+                        }
+                    )
+                except ResourceExistsError:
+                    continue
+                return
+            tokens = entity.get("tokens")
+            if isinstance(tokens, bool) or not isinstance(tokens, (int, float)):
+                tokens = 0.0
+            refilled_at = _parse_datetime(entity.get("updated_at")) or now
+            elapsed = max((now - refilled_at).total_seconds(), 0.0)
+            tokens = min(float(capacity), float(tokens) + elapsed * capacity / 3600.0)
+            if tokens < 1.0:
+                retry_after = math.ceil((1.0 - tokens) * 3600.0 / capacity)
+                raise RateLimited(max(retry_after, 1))
+            updated = dict(entity)
+            updated.update({"tokens": tokens - 1.0, "updated_at": now.isoformat()})
+            try:
+                self.table.update_entity(
+                    entity=updated,
+                    mode="replace",
+                    etag=entity.metadata["etag"],
+                    match_condition=MatchConditions.IfNotModified,
+                )
+            except ResourceModifiedError:
+                continue
+            return
+        # Contention exhausted the optimistic retries; ask for a short retry
+        # instead of silently admitting the request past the limiter.
+        raise RateLimited(1)
 
     def _user_delegation_key(self, now: datetime):
-        if (
-            self._delegation_key is not None
-            and now < self._delegation_key_expires - timedelta(minutes=10)
-        ):
+        with self._state_lock:
+            if (
+                self._delegation_key is not None
+                and now < self._delegation_key_expires - timedelta(minutes=10)
+            ):
+                return self._delegation_key
+            self._delegation_key_expires = now + timedelta(hours=1)
+            self._delegation_key = self.blob_service.get_user_delegation_key(
+                key_start_time=now - timedelta(minutes=5),
+                key_expiry_time=self._delegation_key_expires,
+            )
             return self._delegation_key
-        self._delegation_key_expires = now + timedelta(hours=1)
-        self._delegation_key = self.blob_service.get_user_delegation_key(
-            key_start_time=now - timedelta(minutes=5),
-            key_expiry_time=self._delegation_key_expires,
-        )
-        return self._delegation_key
 
     def _upload_object(
         self,
@@ -254,6 +294,16 @@ def _required_env(name: str) -> str:
     if not value:
         raise RuntimeError(f"required environment variable is not set: {name}")
     return value
+
+
+def _parse_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
 def _valid_upload_id(value: Any) -> bool:

--- a/services/trajectory_upload/scripts/deploy.sh
+++ b/services/trajectory_upload/scripts/deploy.sh
@@ -196,8 +196,8 @@ az containerapp create \
     --target-port 8000 \
     --transport http \
     --allow-insecure false \
-    --min-replicas 0 \
-    --max-replicas 1 \
+    --min-replicas 1 \
+    --max-replicas 2 \
     --cpu 0.5 \
     --memory 1.0Gi \
     --secrets "ip-hash-key=${task_ip_hash_key}" \
@@ -208,6 +208,7 @@ az containerapp create \
         "AZURE_LEDGER_TABLE=${task_table}" \
         "TRAJ_UPLOAD_IP_HASH_KEY=secretref:ip-hash-key" \
         "TRAJ_UPLOAD_RATE_LIMIT=20" \
+        "TRAJ_UPLOAD_IP_RATE_LIMIT=2000" \
         "TRAJ_UPLOAD_SAS_MINUTES=15" \
     --output none
 
@@ -227,9 +228,9 @@ az containerapp job create \
     --replica-retry-limit 3 \
     --parallelism 1 \
     --replica-completion-count 1 \
-    --polling-interval 30 \
+    --polling-interval 15 \
     --min-executions 0 \
-    --max-executions 5 \
+    --max-executions 10 \
     --scale-rule-name trajectory-queue \
     --scale-rule-type azure-queue \
     --scale-rule-metadata \

--- a/services/trajectory_upload/validator.py
+++ b/services/trajectory_upload/validator.py
@@ -9,6 +9,7 @@ import logging
 import os
 import re
 import tempfile
+import time
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -435,9 +436,26 @@ def _parse_datetime(value: Any) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
 
 
+def drain(validator: Any, *, budget_seconds: float) -> int:
+    """Process queue messages until the queue is empty or the budget expires.
+
+    One Job execution used to handle a single message, which capped promotion
+    throughput at the container start rate. Draining keeps the replica busy
+    for as long as its budget allows; the budget must stay below the Job's
+    replica timeout so Azure never kills a replica mid-validation.
+    """
+    deadline = time.monotonic() + budget_seconds
+    processed = 0
+    while time.monotonic() < deadline and validator.run_once():
+        processed += 1
+    return processed
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    AzureCaptureValidator.from_env().run_once()
+    budget = float(os.environ.get("AZURE_VALIDATOR_DRAIN_SECONDS", "1500"))
+    processed = drain(AzureCaptureValidator.from_env(), budget_seconds=budget)
+    logger.info("validator drained %d queue messages", processed)
 
 
 if __name__ == "__main__":

--- a/src/benchflow/publish/broker.py
+++ b/src/benchflow/publish/broker.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import random
+import time
 from collections.abc import Callable
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
@@ -18,6 +20,11 @@ from benchflow.publish.traj_capture import StagedCapture, StagedFile
 # the first SAS grant. Retries are safe; keep this under two minutes.
 HANDSHAKE_TIMEOUT_SEC = 90.0
 PUT_TIMEOUT_SEC = 300.0
+# The broker's token buckets answer 429 with an honest, usually-short
+# Retry-After. Waiting it out inline turns a crowd burst into a smooth queue;
+# anything longer than this cap is surfaced to the contributor instead.
+HANDSHAKE_RETRY_LIMIT = 3
+HANDSHAKE_RETRY_MAX_WAIT_SEC = 120.0
 
 
 @dataclass(frozen=True)
@@ -57,9 +64,7 @@ def upload_capture_via_broker(
     manager = nullcontext(http_client) if http_client is not None else httpx.Client()
     try:
         with _quiet_httpx_request_logging(), manager as client:
-            response = client.post(
-                endpoint, json=request_body, timeout=HANDSHAKE_TIMEOUT_SEC
-            )
+            response = _post_handshake(client, endpoint, request_body)
             if response.status_code == 409:
                 return _already_uploaded_result(response, staged, broker_url)
             _raise_for_broker_response(response, operation="upload handshake")
@@ -105,6 +110,35 @@ def upload_capture_via_broker(
         uploaded=tuple(uploaded),
         skipped=tuple(skipped),
     )
+
+
+def _post_handshake(
+    client: httpx.Client, endpoint: str, request_body: dict[str, Any]
+) -> httpx.Response:
+    """POST the handshake, waiting out short broker 429s instead of failing."""
+    response = client.post(endpoint, json=request_body, timeout=HANDSHAKE_TIMEOUT_SEC)
+    for _retry in range(HANDSHAKE_RETRY_LIMIT):
+        if response.status_code != 429:
+            return response
+        retry_after = _retry_after_seconds(response)
+        if retry_after is None or retry_after > HANDSHAKE_RETRY_MAX_WAIT_SEC:
+            return response
+        time.sleep(retry_after + random.uniform(0.0, 1.0))
+        response = client.post(
+            endpoint, json=request_body, timeout=HANDSHAKE_TIMEOUT_SEC
+        )
+    return response
+
+
+def _retry_after_seconds(response: httpx.Response) -> float | None:
+    value = response.headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        seconds = float(value.strip())
+    except ValueError:
+        return None
+    return seconds if seconds >= 0 else None
 
 
 def _is_create_only_conflict(response: httpx.Response) -> bool:

--- a/tests/test_traj_upload_cli.py
+++ b/tests/test_traj_upload_cli.py
@@ -248,12 +248,18 @@ def test_broker_conflict_is_success_and_rate_limit_is_actionable(
             )
         )
     )
-    limited = httpx.Client(
-        transport=httpx.MockTransport(
-            lambda request: httpx.Response(
-                429, text="slow down", headers={"Retry-After": "60"}
-            )
-        )
+    throttles = 0
+
+    def throttle(_request: httpx.Request) -> httpx.Response:
+        nonlocal throttles
+        throttles += 1
+        return httpx.Response(429, text="slow down", headers={"Retry-After": "60"})
+
+    limited = httpx.Client(transport=httpx.MockTransport(throttle))
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "benchflow.publish.broker.time",
+        SimpleNamespace(sleep=sleeps.append),
     )
     monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: conflict)
     result = runner.invoke(app, _upload_command(trial))
@@ -265,6 +271,41 @@ def test_broker_conflict_is_success_and_rate_limit_is_actionable(
     result = runner.invoke(app, _upload_command(trial))
     assert result.exit_code == 1
     assert "retry after 60" in result.output
+    assert throttles == 4  # the handshake waited out three short 429s first
+    assert all(60 <= wait <= 61 for wait in sleeps)
+
+
+def test_broker_handshake_recovers_from_transient_429(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crowd-burst 429 with a short Retry-After self-heals without failing."""
+    trial = _trial(tmp_path)
+    monkeypatch.setenv("BENCHFLOW_TRAJ_BROKER_URL", "https://broker.test")
+    posts = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posts
+        if request.method == "POST":
+            posts += 1
+            if posts <= 2:
+                return httpx.Response(
+                    429, text="slow down", headers={"Retry-After": "1"}
+                )
+            return httpx.Response(200, json=_broker_payload(request))
+        return httpx.Response(201)
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    sleeps: list[float] = []
+    monkeypatch.setattr(
+        "benchflow.publish.broker.time",
+        SimpleNamespace(sleep=sleeps.append),
+    )
+    monkeypatch.setattr("benchflow.publish.broker.httpx.Client", lambda: client)
+    result = runner.invoke(app, _upload_command(trial))
+
+    assert result.exit_code == 0, result.output
+    assert posts == 3
+    assert len(sleeps) == 2
 
 
 def test_missing_broker_names_both_available_modes(

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -44,6 +44,7 @@ from services.trajectory_upload.validation import (
 from services.trajectory_upload.validator import (
     AzureCaptureValidator,
     _capture_from_event,
+    drain,
 )
 
 
@@ -636,6 +637,18 @@ class FakeTable:
         self.entities.append(entity)
         self.version += 1
 
+    def create_entity(self, entity: dict) -> None:
+        from azure.core.exceptions import ResourceExistsError
+
+        for existing in self.entities:
+            if (
+                existing["PartitionKey"] == entity["PartitionKey"]
+                and existing["RowKey"] == entity["RowKey"]
+            ):
+                raise ResourceExistsError("entity already exists")
+        self.entities.append(entity)
+        self.version += 1
+
     def update_entity(self, *, entity: dict, etag: str, **_kwargs) -> None:
         assert etag == str(self.version)
         self.entities.append(entity)
@@ -695,7 +708,7 @@ def test_broker_regrant_does_not_downgrade_ledger_state(
         ),
         ip_hash_key=b"test",
     )
-    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda *_args: None)
     monkeypatch.setattr(
         "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
     )
@@ -730,7 +743,7 @@ def test_broker_persists_declared_artifact_sizes(
         ),
         ip_hash_key=b"test",
     )
-    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda *_args: None)
     monkeypatch.setattr(
         "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
     )
@@ -776,7 +789,7 @@ def test_broker_rejects_manifest_change_during_validation(
         blob_service=SimpleNamespace(),
         ip_hash_key=b"test",
     )
-    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda *_args: None)
 
     with pytest.raises(UploadDeclarationConflict):
         backend.create_upload(request, client_ip="127.0.0.1")
@@ -820,7 +833,7 @@ def test_broker_supersedes_conflicting_incomplete_attempt(
         ),
         ip_hash_key=b"test",
     )
-    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda *_args: None)
     monkeypatch.setattr(
         "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
     )
@@ -865,7 +878,7 @@ def test_broker_reopens_rejected_digest_in_isolated_attempt(
         ),
         ip_hash_key=b"test",
     )
-    monkeypatch.setattr(backend, "_consume_rate_limit", lambda _client_ip: None)
+    monkeypatch.setattr(backend, "_consume_rate_limit", lambda *_args: None)
     monkeypatch.setattr(
         "azure.storage.blob.generate_blob_sas", lambda **_kwargs: "sp=c&sig=test"
     )
@@ -907,6 +920,82 @@ def test_terminal_digest_handshakes_consume_rate_limit(
         backend.create_upload(request, client_ip="127.0.0.1")
     with pytest.raises(RateLimited):
         backend.create_upload(request, client_ip="127.0.0.1")
+
+
+def _rate_backend(
+    table: FakeTable, *, rate_limit: int = 20, ip_rate_limit: int = 500
+) -> AzureUploadBroker:
+    return AzureUploadBroker(
+        account_name="account",
+        container="bronze",
+        table=table,
+        blob_service=SimpleNamespace(),
+        ip_hash_key=b"test",
+        rate_limit=rate_limit,
+        ip_rate_limit=ip_rate_limit,
+    )
+
+
+def test_shared_nat_contributors_have_independent_budgets() -> None:
+    """A venue NAT full of contributors must not share one hourly budget."""
+    backend = _rate_backend(FakeTable(), rate_limit=1, ip_rate_limit=400)
+    for index in range(300):
+        backend._consume_rate_limit("203.0.113.7", f"contributor-{index}")
+
+    with pytest.raises(RateLimited):
+        backend._consume_rate_limit("203.0.113.7", "contributor-0")
+
+
+def test_contributor_budget_refills_continuously() -> None:
+    """Retry-After reflects the next token, not the top of the clock hour."""
+    table = FakeTable()
+    backend = _rate_backend(table, rate_limit=2)
+    backend._consume_rate_limit("198.51.100.9", "octocat")
+    backend._consume_rate_limit("198.51.100.9", "octocat")
+
+    with pytest.raises(RateLimited) as excinfo:
+        backend._consume_rate_limit("198.51.100.9", "octocat")
+    assert 1 <= excinfo.value.retry_after <= 1800
+
+    bucket = next(
+        entity
+        for entity in reversed(table.entities)
+        if entity["PartitionKey"] == "ratebucket"
+        and entity["RowKey"].startswith("contributor-")
+    )
+    bucket["updated_at"] = (datetime.now(UTC) - timedelta(minutes=31)).isoformat()
+    backend._consume_rate_limit("198.51.100.9", "octocat")
+
+
+def test_ip_backstop_caps_identity_rotation() -> None:
+    """One host rotating github ids is still bounded by the per-IP bucket."""
+    backend = _rate_backend(FakeTable(), rate_limit=20, ip_rate_limit=3)
+    for index in range(3):
+        backend._consume_rate_limit("192.0.2.4", f"rotating-{index}")
+
+    with pytest.raises(RateLimited):
+        backend._consume_rate_limit("192.0.2.4", "rotating-3")
+
+    backend._consume_rate_limit("192.0.2.5", "rotating-3")
+
+
+def test_validator_drain_stops_on_empty_queue_and_budget() -> None:
+    class CountingValidator:
+        def __init__(self, available: int) -> None:
+            self.available = available
+            self.calls = 0
+
+        def run_once(self) -> bool:
+            self.calls += 1
+            return self.calls <= self.available
+
+    counting = CountingValidator(available=3)
+    assert drain(counting, budget_seconds=30.0) == 3
+    assert counting.calls == 4
+
+    exhausted = CountingValidator(available=10)
+    assert drain(exhausted, budget_seconds=0.0) == 0
+    assert exhausted.calls == 0
 
 
 def _quarantine_capture(tmp_path: Path) -> tuple[str, dict[str, bytes]]:


### PR DESCRIPTION
## Problem

The upload broker throttles on client IP alone: a fixed window of 20 handshakes per clock hour per IP. A room of contributors behind one NAT (today: the hackathon) shares a single budget — upload 21 gets HTTP 429 with `Retry-After` up to 3600s, and `bench traj upload` hard-fails on it. Ledger evidence from today 17:00–18:00 UTC: three IP counters pegged at exactly 20 while contributors reported missing submissions.

## Fix

- **Per-contributor fairness**: the primary budget is a token bucket keyed on `(IP, github_id)` (`TRAJ_UPLOAD_RATE_LIMIT`, default 20/h). 300 people behind one venue IP each get their own bucket.
- **Abuse backstop**: a second bucket per IP (`TRAJ_UPLOAD_IP_RATE_LIMIT`, default 500/h; deploy.sh pins 2000 for the event) bounds one host rotating identities. Terminal-digest handshakes still consume quota (preserves the PR #989 guard).
- **Honest Retry-After**: buckets refill continuously, so 429 now says "wait N seconds until the next token" instead of "wait for the top of the hour". No more room-wide lockout-and-stampede cycle.
- **Multi-replica correctness**: bucket updates are ETag-conditional (retry on conflict, fail closed as a 1-second 429). The old read-modify-write lost counts across replicas.
- **Throughput**: the broker no longer serializes entire handshakes behind one in-process lock (only the delegation-key cache is guarded), and deploy.sh keeps it warm at min 1 / max 2 replicas. The validator Job now drains the queue for up to `AZURE_VALIDATOR_DRAIN_SECONDS` (default 1500s) per execution instead of one message per container start, and deploy.sh widens it to `--max-executions 10 --polling-interval 15`.
- **Client**: `bench traj upload` waits out short 429s (≤3 retries, ≤120s each, jittered) before surfacing the error.

## Ops notes

- Already applied to prod as an emergency measure ahead of this PR: `TRAJ_UPLOAD_RATE_LIMIT=2000` + `--min-replicas 1` on `tasksminer-traj-broker`. Deploying this PR resets the contributor limit to 20 and moves the wide allowance to `TRAJ_UPLOAD_IP_RATE_LIMIT=2000`; tighten after the event.
- Old `rate-YYYYMMDDHH` ledger rows are obsolete and inert; new buckets live under the `ratebucket` partition.

## Testing

- `uv run python -m pytest tests/test_trajectory_upload_service.py tests/test_traj_upload_cli.py` — 108 passed, including new coverage: shared-NAT independence, continuous refill + honest Retry-After, IP backstop on identity rotation, validator drain budget, CLI 429 recovery and bounded retries.
- Live verification on prod after deploy (real trajectory upload + >20-handshake burst) — results in the PR thread.