### PR TITLE
Jittered backoff for contended rate-limit bucket updates

### DIFF
--- a/services/trajectory_upload/azure_backend.py
+++ b/services/trajectory_upload/azure_backend.py
@@ -7,7 +7,9 @@ import hmac
 import json
 import math
 import os
+import random
 import threading
+import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -199,7 +201,12 @@ class AzureUploadBroker:
 
         digest = hmac.new(self.ip_hash_key, key.encode(), hashlib.sha256).hexdigest()
         row = f"{scope}-{digest}"
-        for _attempt in range(5):
+        for attempt in range(10):
+            if attempt:
+                # A whole venue shares one IP bucket row, so a synchronized
+                # burst loses ETag races in lockstep. Jitter de-synchronizes
+                # the optimistic retries instead of failing crowds closed.
+                time.sleep(random.uniform(0.005, 0.05) * attempt)
             now = datetime.now(UTC)
             try:
                 entity = self.table.get_entity(partition_key="ratebucket", row_key=row)

--- a/tests/test_trajectory_upload_service.py
+++ b/tests/test_trajectory_upload_service.py
@@ -967,6 +967,38 @@ def test_contributor_budget_refills_continuously() -> None:
     backend._consume_rate_limit("198.51.100.9", "octocat")
 
 
+def test_token_bucket_survives_contended_conditional_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Guards PR #1027's burst fix: ETag races must not fail a crowd closed."""
+
+    class ContendedTable(FakeTable):
+        def __init__(self) -> None:
+            super().__init__()
+            self.conflicts = 0
+
+        def update_entity(self, *, entity: dict, etag: str, **kwargs) -> None:
+            from azure.core.exceptions import ResourceModifiedError
+
+            if self.conflicts:
+                self.conflicts -= 1
+                raise ResourceModifiedError("etag changed")
+            super().update_entity(entity=entity, etag=etag, **kwargs)
+
+    table = ContendedTable()
+    backend = _rate_backend(table, rate_limit=20, ip_rate_limit=500)
+    waits: list[float] = []
+    monkeypatch.setattr(
+        "services.trajectory_upload.azure_backend.time",
+        SimpleNamespace(sleep=waits.append),
+    )
+    backend._consume_rate_limit("203.0.113.9", "contended")
+
+    table.conflicts = 8
+    backend._consume_rate_limit("203.0.113.9", "contended")
+    assert waits  # the survivor backed off between optimistic retries
+
+
 def test_ip_backstop_caps_identity_rotation() -> None:
     """One host rotating github ids is still bounded by the per-IP bucket."""
     backend = _rate_backend(FakeTable(), rate_limit=20, ip_rate_limit=3)


### PR DESCRIPTION
Follow-up to #1027, found during live burst verification on prod.

**Finding:** firing 25 simultaneous handshakes with distinct contributor ids from one IP returned 21×200 + 4×429. All concurrent requests race ETag-conditional updates on the same per-IP bucket row; five back-to-back optimistic retries can all lose in a synchronized burst, and the limiter fails closed (429, Retry-After: 1). The CLI's new auto-retry masks this from contributors, but a 300-person synchronized spike shouldn't shed load it has budget for.

**Fix:** up to ten optimistic attempts with growing jittered backoff (5–50 ms × attempt) so a simultaneous crowd de-synchronizes and drains through the conditional update. Still fails closed after the budget.

**Verification (prod, image `a68a6cdc5d96`, 2026-08-16 ~18:20 UTC):**
- 25 fully simultaneous handshakes, 25 distinct contributor ids, one source IP → **25×200** (was 21×200 + 4×429 before this fix).
- Per-contributor limit still enforced: 21 handshakes from one id → 20×200 then 429 with honest `Retry-After: 176`.
- Real end-to-end check on the #1027 deploy: a real 274 KB Claude Code session uploaded via the public `uv run bench traj upload` path, promoted by the validator to `sources/community/438e4f75…/` in ~20–30 s with quarantine cleaned and the schema-1.2 manifest bound (contributor `bingran-you`, source `verify/pr-1027-rate-limit`).

**Regression test:** 8 consecutive simulated ETag conflicts must still admit the request (109 tests pass).

Note: prod already runs this image ahead of merge (same emergency-ops window as #1027).