### PR TITLE
Release BenchFlow 0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+## 0.7.3 — 2026-08-16
+
+### Added
+- **`bench traj upload` waits out short rate-limit responses instead of
+  failing.** When the contribution service answers 429 with a short
+  `Retry-After`, the handshake now sleeps it out with jitter and retries up
+  to three times (two-minute cap per wait), so a crowd of simultaneous
+  contributors self-heals instead of surfacing errors. Longer waits still
+  fail fast with the actionable retry-after message. (#1027)
+
+### Changed
+- **The contribution service rate-limits per contributor, not per venue.**
+  Upload budgets are token buckets keyed on contributor identity with a
+  wide per-IP abuse backstop, refill continuously, and answer 429 with
+  seconds-until-next-token instead of the remainder of the clock hour, so
+  many contributors behind one NAT no longer starve each other. Contended
+  bucket updates back off with jitter rather than shedding simultaneous
+  crowds. (#1027, #1028)
+
 ## 0.7.2 — 2026-08-16
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.2"
+version = "0.7.3"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release PR following the #1024 pattern: promotes the #1027/#1028 notes into the changelog and bumps the version so the `v0.7.3` tag can publish.

**Why now:** PyPI latest was stuck at 0.7.1 because the merged 0.7.2 release was never tagged — root cause of "0.7.2 never reached PyPI" was simply the missing `v0.7.2` tag push, no pipeline failure. I pushed the tag at the #1024 merge commit and `public-release` published **0.7.2 to PyPI** (run 31964997416, 30s, green) with the GitHub release created.

0.7.3 gets the hackathon-relevant CLI change to contributors: `bench traj upload` now waits out short 429 `Retry-After`s with jitter (≤3 retries, ≤120s each) instead of hard-failing, matching the server's new per-contributor token buckets (live in prod, verified end to end today).

**After merging:** push the tag at the merge commit and the workflow does the rest:

```bash
git fetch origin main && git tag v0.7.3 origin/main && git push origin v0.7.3
```

(I can do the tag push once this merges — say the word.)