### PR TITLE
Release BenchFlow 0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.7.4 — 2026-08-16
+
 ### Added
 - **Uploads are confirmed all the way into cloud storage.** After the
   progress bar finishes, `bench traj upload` now polls the contribution

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.3"
+version = "0.7.4"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.3"
+version = "0.7.4"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
Release PR following the established pattern: promotes the #1026 notes (storage-verification wait + `bench traj status`, the traj TUI with the scrolling week-of-sessions picker, and workspace zip attachments) into the changelog and bumps the version so the `v0.7.4` tag can publish.

The matching server code is already live in production (status endpoint + workspace contract, deployed and e2e-verified today); this release delivers the CLI side to contributors.