### PR TITLE
Add --publish-bucket and --eval-results-* flags to bench eval run

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -287,6 +287,11 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 | `--matrix` | — | YAML model matrix for repeated evals; currently requires `--tasks-dir` |
 | `--trials` | `1` | Number of trials for `--matrix` |
 
+`--publish-hf`/`--publish-bucket` also write a `README.md` run summary
+(agent, model, per-task reward and any error/verifier issue, deduplicated
+across retries) into the job dir before upload — buckets render it on the
+directory page automatically.
+
 See [Architecture: skill loading](../architecture.md#skill-loading) for how
 `with-skill` mode is registered with each agent.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -278,8 +278,12 @@ bench eval run --tasks-dir ./tasks --matrix matrix.yaml --trials 3
 | `--retry-attempts` | — | Override retry attempts for the eval run |
 | `--retry-concurrency` | — | Reserved retry concurrency setting recorded in run config |
 | `--publish-hf` | — | Upload final eval artifacts to this Hugging Face dataset repo |
-| `--hf-prefix` | — | Path prefix inside the Hugging Face repo; requires `--publish-hf` |
+| `--hf-prefix` | — | Path prefix inside the Hugging Face repo or bucket; requires `--publish-hf` or `--publish-bucket` |
 | `--hf-public-read-check` | `false` | Verify public Hugging Face reads after upload |
+| `--publish-bucket` | — | Upload final eval artifacts to this Hugging Face storage bucket |
+| `--eval-results-model` | — | Hugging Face model repo to open a community eval-results PR on |
+| `--eval-results-dataset` | — | Hugging Face benchmark dataset id for the eval-results entry, e.g. `org/benchmark` |
+| `--eval-results-task` | — | Benchmark `task_id`, as defined in the dataset's `eval.yaml` |
 | `--matrix` | — | YAML model matrix for repeated evals; currently requires `--tasks-dir` |
 | `--trials` | `1` | Number of trials for `--matrix` |
 

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -66,6 +66,7 @@ def postprocess_eval_artifacts(
     eval_config = _apply_source_sidecar(eval_config, resolved_tasks_dir)
     from benchflow.eval_artifacts import (
         TaskManifestOptions,
+        build_health_summary,
         materialize_canonical_job,
         write_canonical_selection,
         write_health_summary,
@@ -154,6 +155,39 @@ def postprocess_eval_artifacts(
             print_error(str(exc))
             raise typer.Exit(1) from None
         console.print(f"[green]Published HF artifacts:[/green] {escape(published.url)}")
+    if req.publish_bucket is not None:
+        from benchflow.publish.huggingface import publish_folder_to_bucket
+
+        prefix = req.hf_prefix or job_dir.name
+        try:
+            published = publish_folder_to_bucket(
+                job_dir, bucket_id=req.publish_bucket, path_in_repo=prefix
+            )
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from None
+        console.print(f"[green]Published HF bucket:[/green] {escape(published.url)}")
+    if req.eval_results_model is not None:
+        from benchflow.publish.huggingface import open_eval_results_pr
+
+        rewards = [
+            row["reward"]
+            for row in build_health_summary(job_dir)["rows"]
+            if row["scored"]
+        ]
+        if rewards:
+            value = round(100.0 * sum(rewards) / len(rewards), 2)
+            try:
+                pr_url = open_eval_results_pr(
+                    model_repo=req.eval_results_model,
+                    dataset_id=cast(str, req.eval_results_dataset),
+                    task_id=cast(str, req.eval_results_task),
+                    value=value,
+                )
+            except ValueError as exc:
+                print_error(str(exc))
+                raise typer.Exit(1) from None
+            console.print(f"[green]Eval-results PR:[/green] {escape(pr_url or '')}")
 
 
 def _load_eval_matrix(path: Path) -> dict[str, dict]:

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -68,6 +68,7 @@ def postprocess_eval_artifacts(
         TaskManifestOptions,
         build_health_summary,
         materialize_canonical_job,
+        render_run_summary_markdown,
         write_canonical_selection,
         write_health_summary,
         write_task_manifest,
@@ -139,6 +140,12 @@ def postprocess_eval_artifacts(
             console.print(
                 f"[green]Canonical jobs:[/green] {escape(str(req.canonical_jobs_dir))}"
             )
+    if req.publish_hf is not None or req.publish_bucket is not None:
+        (job_dir / "README.md").write_text(
+            render_run_summary_markdown(
+                job_dir, agent=eval_config.agent, model=eval_config.model
+            )
+        )
     if req.publish_hf is not None:
         from benchflow.publish.huggingface import publish_folder_to_hf
 

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -188,6 +188,11 @@ def postprocess_eval_artifacts(
                 print_error(str(exc))
                 raise typer.Exit(1) from None
             console.print(f"[green]Eval-results PR:[/green] {escape(pr_url or '')}")
+        else:
+            console.print(
+                "[yellow]--eval-results-model set but no scored rollouts were "
+                "found; skipping eval-results PR[/yellow]"
+            )
 
 
 def _load_eval_matrix(path: Path) -> dict[str, dict]:

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -66,7 +66,7 @@ def postprocess_eval_artifacts(
     eval_config = _apply_source_sidecar(eval_config, resolved_tasks_dir)
     from benchflow.eval_artifacts import (
         TaskManifestOptions,
-        build_health_summary,
+        canonical_task_rows,
         materialize_canonical_job,
         render_run_summary_markdown,
         write_canonical_selection,
@@ -178,9 +178,7 @@ def postprocess_eval_artifacts(
         from benchflow.publish.huggingface import open_eval_results_pr
 
         rewards = [
-            row["reward"]
-            for row in build_health_summary(job_dir)["rows"]
-            if row["scored"]
+            row["reward"] for row in canonical_task_rows(job_dir) if row["scored"]
         ]
         if rewards:
             value = round(100.0 * sum(rewards) / len(rewards), 2)

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -581,6 +581,31 @@ def eval_run(
             "--hf-public-read-check", help="Verify public HF reads after upload"
         ),
     ] = False,
+    publish_bucket: Annotated[
+        str | None,
+        typer.Option(
+            "--publish-bucket", help="Upload final eval artifacts to a HF bucket"
+        ),
+    ] = None,
+    eval_results_model: Annotated[
+        str | None,
+        typer.Option(
+            "--eval-results-model",
+            help="HF model repo to open a community eval-results PR on",
+        ),
+    ] = None,
+    eval_results_dataset: Annotated[
+        str | None,
+        typer.Option(
+            "--eval-results-dataset", help="HF benchmark dataset id, e.g. org/benchmark"
+        ),
+    ] = None,
+    eval_results_task: Annotated[
+        str | None,
+        typer.Option(
+            "--eval-results-task", help="Benchmark task_id from the dataset's eval.yaml"
+        ),
+    ] = None,
     matrix: Annotated[
         Path | None,
         typer.Option("--matrix", help="YAML model matrix for repeated evals"),
@@ -653,6 +678,10 @@ def eval_run(
         publish_hf=publish_hf,
         hf_prefix=hf_prefix,
         hf_public_read_check=hf_public_read_check,
+        publish_bucket=publish_bucket,
+        eval_results_model=eval_results_model,
+        eval_results_dataset=eval_results_dataset,
+        eval_results_task=eval_results_task,
         matrix=matrix,
         trials=trials,
     )

--- a/src/benchflow/eval_artifacts.py
+++ b/src/benchflow/eval_artifacts.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from benchflow._utils.task_authoring import task_digest
+from benchflow._utils.text import truncate_end
 from benchflow.task.discovery import is_task_dir, resolve_task_collection_root
 from benchflow.trajectories.export_prime_sft import (
     PrimeSftTrajectoryJsonlError,
@@ -272,14 +273,28 @@ def _escape_md_cell(text: str) -> str:
     return text.replace("|", "\\|").replace("\n", " ").strip()
 
 
+_ISSUE_CELL_LIMIT = 120
+
+
+def canonical_task_rows(job_dir: Path) -> list[dict[str, Any]]:
+    """One row per task_id — the best-scored/highest-reward rollout.
+
+    Reused by the README summary and ``--eval-results-model`` so retry
+    attempts (multiple rollout dirs for the same task) are never counted
+    or averaged as if they were distinct tasks.
+    """
+    return build_canonical_selection(job_dir, policy="one-healthy-per-task")["selected"]
+
+
 def render_run_summary_markdown(
     job_dir: Path, *, agent: str | None = None, model: str | None = None
 ) -> str:
     """Render a Markdown run summary (results + issues) for publish folders."""
-    summary = build_health_summary(job_dir)
-    rows = summary["rows"]
+    rows = canonical_task_rows(job_dir)
     rewards = [row["reward"] for row in rows if row["scored"]]
     mean_reward = sum(rewards) / len(rewards) if rewards else None
+    scored_count = sum(1 for row in rows if row["scored"])
+    tool_call_count = sum(1 for row in rows if row["tool_calls"] > 0)
 
     lines = ["# BenchFlow run summary", ""]
     if agent:
@@ -287,12 +302,12 @@ def render_run_summary_markdown(
     if model:
         lines.append(f"- Model: `{model}`")
     lines += [
-        f"- Tasks: {summary['total_rows']}",
-        f"- Scored: {summary['scored_rows']} / Unscored: {summary['unscored_rows']}",
+        f"- Tasks: {len(rows)}",
+        f"- Scored: {scored_count} / Unscored: {len(rows) - scored_count}",
         f"- Mean reward: {mean_reward:.3f}"
         if mean_reward is not None
         else "- Mean reward: n/a",
-        f"- Rows with tool calls: {summary['rows_with_tool_calls']}",
+        f"- Tasks with tool calls: {tool_call_count}",
         "",
         "## Tasks",
         "",
@@ -302,9 +317,10 @@ def render_run_summary_markdown(
     for row in rows:
         reward = f"{row['reward']:.3f}" if isinstance(row["reward"], float) else "—"
         issue = row.get("error") or row.get("verifier_error") or ""
+        issue = truncate_end(_escape_md_cell(str(issue)), _ISSUE_CELL_LIMIT)
         lines.append(
             f"| {_escape_md_cell(str(row['task_id']))} | {reward} | "
-            f"{row['tool_calls']} | {_escape_md_cell(str(issue))} |"
+            f"{row['tool_calls']} | {issue} |"
         )
     return "\n".join(lines) + "\n"
 

--- a/src/benchflow/eval_artifacts.py
+++ b/src/benchflow/eval_artifacts.py
@@ -268,6 +268,47 @@ def write_health_summary(path: Path, job_dir: Path) -> dict[str, Any]:
     return summary
 
 
+def _escape_md_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def render_run_summary_markdown(
+    job_dir: Path, *, agent: str | None = None, model: str | None = None
+) -> str:
+    """Render a Markdown run summary (results + issues) for publish folders."""
+    summary = build_health_summary(job_dir)
+    rows = summary["rows"]
+    rewards = [row["reward"] for row in rows if row["scored"]]
+    mean_reward = sum(rewards) / len(rewards) if rewards else None
+
+    lines = ["# BenchFlow run summary", ""]
+    if agent:
+        lines.append(f"- Agent: `{agent}`")
+    if model:
+        lines.append(f"- Model: `{model}`")
+    lines += [
+        f"- Tasks: {summary['total_rows']}",
+        f"- Scored: {summary['scored_rows']} / Unscored: {summary['unscored_rows']}",
+        f"- Mean reward: {mean_reward:.3f}"
+        if mean_reward is not None
+        else "- Mean reward: n/a",
+        f"- Rows with tool calls: {summary['rows_with_tool_calls']}",
+        "",
+        "## Tasks",
+        "",
+        "| Task | Reward | Tool calls | Issue |",
+        "| --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        reward = f"{row['reward']:.3f}" if isinstance(row["reward"], float) else "—"
+        issue = row.get("error") or row.get("verifier_error") or ""
+        lines.append(
+            f"| {_escape_md_cell(str(row['task_id']))} | {reward} | "
+            f"{row['tool_calls']} | {_escape_md_cell(str(issue))} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
 def _canonical_score(row: dict[str, Any]) -> tuple[int, float, int]:
     scored = 1 if row["scored"] else 0
     reward = row["reward"] if isinstance(row["reward"], float) else float("-inf")

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -126,6 +126,10 @@ class EvalCreateRequest:
     publish_hf: str | None = None
     hf_prefix: str | None = None
     hf_public_read_check: bool = False
+    publish_bucket: str | None = None
+    eval_results_model: str | None = None
+    eval_results_dataset: str | None = None
+    eval_results_task: str | None = None
     matrix: Path | None = None
     trials: int = 1
 
@@ -276,6 +280,12 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--retry-concurrency must be >= 1")
     if request.hf_prefix and not request.publish_hf:
         raise EvalPlanError("--hf-prefix requires --publish-hf")
+    if request.eval_results_model and not (
+        request.eval_results_dataset and request.eval_results_task
+    ):
+        raise EvalPlanError(
+            "--eval-results-model requires --eval-results-dataset and --eval-results-task"
+        )
     if request.tasks_dir and not Path(request.tasks_dir).exists():
         raise EvalPlanError(f"--tasks-dir not found: {request.tasks_dir}")
     if request.matrix is not None and not Path(request.matrix).is_file():

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -278,8 +278,8 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--retry-attempts must be >= 0")
     if request.retry_concurrency is not None and request.retry_concurrency < 1:
         raise EvalPlanError("--retry-concurrency must be >= 1")
-    if request.hf_prefix and not request.publish_hf:
-        raise EvalPlanError("--hf-prefix requires --publish-hf")
+    if request.hf_prefix and not (request.publish_hf or request.publish_bucket):
+        raise EvalPlanError("--hf-prefix requires --publish-hf or --publish-bucket")
     if request.eval_results_model and not (
         request.eval_results_dataset and request.eval_results_task
     ):

--- a/src/benchflow/publish/huggingface.py
+++ b/src/benchflow/publish/huggingface.py
@@ -91,8 +91,11 @@ def publish_folder_to_bucket(
     try:
         from huggingface_hub import create_bucket, sync_bucket
         from huggingface_hub.errors import HfHubHTTPError
-    except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
-        raise ValueError("huggingface_hub is required for --publish-bucket") from exc
+    except ImportError as exc:  # pragma: no cover - depends on env
+        raise ValueError(
+            "huggingface_hub with bucket support (create_bucket/sync_bucket) is "
+            "required for --publish-bucket; upgrade huggingface_hub"
+        ) from exc
     try:
         create_bucket(bucket_id, private=private)
     except HfHubHTTPError as exc:
@@ -123,7 +126,7 @@ def open_eval_results_pr(
     try:
         import yaml
         from huggingface_hub import CommitOperationAdd, HfApi
-    except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
+    except ImportError as exc:  # pragma: no cover - depends on env
         raise ValueError(
             "huggingface_hub is required for --eval-results-model"
         ) from exc

--- a/src/benchflow/publish/huggingface.py
+++ b/src/benchflow/publish/huggingface.py
@@ -79,6 +79,74 @@ def publish_folder_to_hf(
     )
 
 
+def publish_folder_to_bucket(
+    folder: Path,
+    *,
+    bucket_id: str,
+    path_in_repo: str = "",
+    private: bool = False,
+) -> HfPublishResult:
+    if not folder.is_dir():
+        raise ValueError(f"publish source folder not found: {folder}")
+    try:
+        from huggingface_hub import create_bucket, sync_bucket
+        from huggingface_hub.errors import HfHubHTTPError
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
+        raise ValueError("huggingface_hub is required for --publish-bucket") from exc
+    try:
+        create_bucket(bucket_id, private=private)
+    except HfHubHTTPError as exc:
+        if exc.response is None or exc.response.status_code != 409:
+            raise
+    prefix = path_in_repo.strip("/")
+    remote = (
+        f"hf://buckets/{bucket_id}/{prefix}" if prefix else f"hf://buckets/{bucket_id}"
+    )
+    sync_bucket(str(folder), remote)
+    return HfPublishResult(
+        repo_id=bucket_id,
+        repo_type="bucket",
+        path_in_repo=prefix,
+        url=f"https://huggingface.co/buckets/{bucket_id}/resolve/{prefix}",
+    )
+
+
+def open_eval_results_pr(
+    *,
+    model_repo: str,
+    dataset_id: str,
+    task_id: str,
+    value: float,
+    source_url: str | None = None,
+    notes: str | None = None,
+) -> str | None:
+    try:
+        import yaml
+        from huggingface_hub import CommitOperationAdd, HfApi
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
+        raise ValueError(
+            "huggingface_hub is required for --eval-results-model"
+        ) from exc
+    entry: dict = {"dataset": {"id": dataset_id, "task_id": task_id}, "value": value}
+    if source_url:
+        entry["source"] = {"url": source_url}
+    if notes:
+        entry["notes"] = notes
+    content = yaml.safe_dump([entry], sort_keys=False).encode("utf-8")
+    commit = HfApi().create_commit(
+        repo_id=model_repo,
+        repo_type="model",
+        operations=[
+            CommitOperationAdd(
+                path_in_repo=".eval_results/benchflow.yaml", path_or_fileobj=content
+            )
+        ],
+        commit_message=f"Add {dataset_id} eval results",
+        create_pr=True,
+    )
+    return commit.pr_url
+
+
 def publish_file_to_hf(
     file_path: Path,
     *,

--- a/src/benchflow/publish/huggingface.py
+++ b/src/benchflow/publish/huggingface.py
@@ -38,6 +38,14 @@ def _resolve_url(repo_id: str, repo_type: str, path_in_repo: str) -> str:
     return f"https://huggingface.co/{kind}{repo_id}/resolve/main/{path_in_repo}"
 
 
+def _bucket_tree_url(bucket_id: str, path_in_repo: str) -> str:
+    # Buckets are non-versioned (no "main" branch), so the browsable listing
+    # is /tree/<path> directly, not /resolve/<path> (which 404s) or
+    # /tree/main/<path> (the git-repo convention _tree_url uses).
+    suffix = f"/tree/{path_in_repo.strip('/')}" if path_in_repo else ""
+    return f"https://huggingface.co/buckets/{bucket_id}{suffix}"
+
+
 def _check_public_files(repo_id: str, repo_type: str, path_in_repo: str) -> None:
     index_url = _tree_url(repo_id, repo_type, path_in_repo)
     response = httpx.get(index_url, follow_redirects=True, timeout=20)
@@ -110,8 +118,38 @@ def publish_folder_to_bucket(
         repo_id=bucket_id,
         repo_type="bucket",
         path_in_repo=prefix,
-        url=f"https://huggingface.co/buckets/{bucket_id}/resolve/{prefix}",
+        url=_bucket_tree_url(bucket_id, prefix),
     )
+
+
+_EVAL_RESULTS_PATH = ".eval_results/benchflow.yaml"
+
+
+def _existing_eval_results(model_repo: str) -> list[dict]:
+    from huggingface_hub import hf_hub_download
+    from huggingface_hub.errors import EntryNotFoundError, RepositoryNotFoundError
+
+    try:
+        downloaded = hf_hub_download(
+            repo_id=model_repo, filename=_EVAL_RESULTS_PATH, repo_type="model"
+        )
+    except (EntryNotFoundError, RepositoryNotFoundError):
+        return []
+    import yaml
+
+    data = yaml.safe_load(Path(downloaded).read_text())
+    return data if isinstance(data, list) else []
+
+
+def _upsert_eval_result(existing: list[dict], entry: dict) -> list[dict]:
+    key = (entry["dataset"]["id"], entry["dataset"]["task_id"])
+    kept = [
+        row
+        for row in existing
+        if (row.get("dataset", {}).get("id"), row.get("dataset", {}).get("task_id"))
+        != key
+    ]
+    return [*kept, entry]
 
 
 def open_eval_results_pr(
@@ -135,14 +173,13 @@ def open_eval_results_pr(
         entry["source"] = {"url": source_url}
     if notes:
         entry["notes"] = notes
-    content = yaml.safe_dump([entry], sort_keys=False).encode("utf-8")
+    merged = _upsert_eval_result(_existing_eval_results(model_repo), entry)
+    content = yaml.safe_dump(merged, sort_keys=False).encode("utf-8")
     commit = HfApi().create_commit(
         repo_id=model_repo,
         repo_type="model",
         operations=[
-            CommitOperationAdd(
-                path_in_repo=".eval_results/benchflow.yaml", path_or_fileobj=content
-            )
+            CommitOperationAdd(path_in_repo=_EVAL_RESULTS_PATH, path_or_fileobj=content)
         ],
         commit_message=f"Add {dataset_id} eval results",
         create_pr=True,

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -393,6 +393,29 @@ def test_agent_timeout_sec_accepts_positive_or_none(ok):
 # --- v0.6 CLI-dogfood guards: clean fail-fast instead of raw tracebacks -------
 
 
+def test_hf_prefix_accepted_with_publish_bucket(tmp_path: Path):
+    # Guards against --hf-prefix rejecting --publish-bucket: the bucket
+    # postprocess path reads req.hf_prefix, so it must be a valid pairing.
+    plan = build_eval_plan(
+        EvalCreateRequest(
+            tasks_dir=_task_dir(tmp_path),
+            agent="oracle",
+            publish_bucket="org/bucket",
+            hf_prefix="runs/x",
+        )
+    )
+    assert plan.request.hf_prefix == "runs/x"
+
+
+def test_hf_prefix_without_publish_hf_or_bucket_rejected(tmp_path: Path):
+    with pytest.raises(EvalPlanError, match="--publish-hf or --publish-bucket"):
+        build_eval_plan(
+            EvalCreateRequest(
+                tasks_dir=_task_dir(tmp_path), agent="oracle", hf_prefix="runs/x"
+            )
+        )
+
+
 def test_config_missing_path_rejected_cleanly(tmp_path: Path):
     # Was: a raw FileNotFoundError traceback from Evaluation.from_yaml's open().
     with pytest.raises(EvalPlanError, match="--config not found"):

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -205,6 +205,191 @@ def test_eval_run_publish_bucket_writes_readme_summary(
     assert "`oracle`" in text
 
 
+def test_eval_run_publish_bucket_readme_dedupes_retry_attempts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Retry rollout dirs for the same task must count as one task, best-scored.
+
+    Guards against README.md (and the --eval-results-model reward mean)
+    treating each retry attempt as a distinct task.
+    """
+    tasks = tmp_path / "tasks"
+    _write_task(tasks / "task-a")
+
+    async def fake_run(self):
+        job_dir = self._jobs_dir / self._job_name
+        _write_rollout(job_dir / "task-a__attempt1", "task-a")
+        (job_dir / "task-a__attempt1" / "result.json").write_text(
+            json.dumps({"task_name": "task-a", "rewards": {"reward": 0.0}}),
+            encoding="utf-8",
+        )
+        _write_rollout(job_dir / "task-a__attempt2", "task-a")
+        return SimpleNamespace(
+            job_name=self._job_name,
+            passed=1,
+            failed=0,
+            errored=0,
+            verifier_errored=0,
+            total=1,
+            score=1.0,
+            score_excl_errors=1.0,
+        )
+
+    monkeypatch.setattr(Evaluation, "run", fake_run)
+
+    captured: dict[str, Path] = {}
+
+    def fake_publish_folder_to_bucket(
+        folder, *, bucket_id, path_in_repo="", private=False
+    ):
+        captured["folder"] = folder
+        return SimpleNamespace(url=f"https://huggingface.co/buckets/{bucket_id}")
+
+    import benchflow.publish.huggingface as hf_publish
+
+    monkeypatch.setattr(
+        hf_publish, "publish_folder_to_bucket", fake_publish_folder_to_bucket
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "--tasks-dir",
+            str(tasks),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--publish-bucket",
+            "org/some-bucket",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    text = (captured["folder"] / "README.md").read_text()
+    assert "- Tasks: 1" in text
+    assert "- Mean reward: 1.000" in text
+    assert text.count("| task-a |") == 1
+
+
+def test_eval_run_eval_results_dedupes_retry_attempts(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The --eval-results-model reward mean must not double-count retries."""
+    tasks = tmp_path / "tasks"
+    _write_task(tasks / "task-a")
+
+    async def fake_run(self):
+        job_dir = self._jobs_dir / self._job_name
+        _write_rollout(job_dir / "task-a__attempt1", "task-a")
+        (job_dir / "task-a__attempt1" / "result.json").write_text(
+            json.dumps({"task_name": "task-a", "rewards": {"reward": 0.0}}),
+            encoding="utf-8",
+        )
+        _write_rollout(job_dir / "task-a__attempt2", "task-a")
+        return SimpleNamespace(
+            job_name=self._job_name,
+            passed=1,
+            failed=0,
+            errored=0,
+            verifier_errored=0,
+            total=1,
+            score=1.0,
+            score_excl_errors=1.0,
+        )
+
+    monkeypatch.setattr(Evaluation, "run", fake_run)
+
+    captured: dict[str, float] = {}
+
+    def fake_open_eval_results_pr(
+        *, model_repo, dataset_id, task_id, value, source_url=None, notes=None
+    ):
+        captured["value"] = value
+        return "https://huggingface.co/org/model/discussions/1"
+
+    import benchflow.publish.huggingface as hf_publish
+
+    monkeypatch.setattr(hf_publish, "open_eval_results_pr", fake_open_eval_results_pr)
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "--tasks-dir",
+            str(tasks),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--eval-results-model",
+            "org/model",
+            "--eval-results-dataset",
+            "org/bench",
+            "--eval-results-task",
+            "t1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    # Best-of-retries reward is 1.0 -> 100.0, not the naive two-attempt mean (50.0).
+    assert captured["value"] == 100.0
+
+
+def test_eval_run_eval_results_warns_when_nothing_scored(
+    tmp_path: Path, monkeypatch
+) -> None:
+    tasks = tmp_path / "tasks"
+    _write_task(tasks / "task-a")
+
+    async def fake_run(self):
+        job_dir = self._jobs_dir / self._job_name
+        rollout = job_dir / "task-a__abc"
+        rollout.mkdir(parents=True)
+        (rollout / "result.json").write_text(
+            json.dumps({"task_name": "task-a", "rewards": None}),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(
+            job_name=self._job_name,
+            passed=0,
+            failed=1,
+            errored=0,
+            verifier_errored=0,
+            total=1,
+            score=0.0,
+            score_excl_errors=0.0,
+        )
+
+    monkeypatch.setattr(Evaluation, "run", fake_run)
+
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "--tasks-dir",
+            str(tasks),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(tmp_path / "jobs"),
+            "--eval-results-model",
+            "org/model",
+            "--eval-results-dataset",
+            "org/bench",
+            "--eval-results-task",
+            "t1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "no scored rollouts" in result.output
+
+
 def test_sharded_health_and_selection_discover_worker_shards(tmp_path: Path) -> None:
     jobs_dir = tmp_path / "jobs"
     advertised_job_dir = jobs_dir / "worker-sharded"

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -142,6 +142,69 @@ def test_eval_run_writes_manifest_health_and_canonical_artifacts(
     assert (canonical_jobs / "task-a__abc" / "result.json").is_file()
 
 
+def test_eval_run_publish_bucket_writes_readme_summary(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """--publish-bucket writes a README.md run summary into job_dir before upload."""
+    tasks = tmp_path / "tasks"
+    _write_task(tasks / "task-a")
+
+    async def fake_run(self):
+        job_dir = self._jobs_dir / self._job_name
+        _write_rollout(job_dir / "task-a__abc", "task-a")
+        return SimpleNamespace(
+            job_name=self._job_name,
+            passed=1,
+            failed=0,
+            errored=0,
+            verifier_errored=0,
+            total=1,
+            score=1.0,
+            score_excl_errors=1.0,
+        )
+
+    monkeypatch.setattr(Evaluation, "run", fake_run)
+
+    captured: dict[str, Path] = {}
+
+    def fake_publish_folder_to_bucket(
+        folder, *, bucket_id, path_in_repo="", private=False
+    ):
+        captured["folder"] = folder
+        return SimpleNamespace(url=f"https://huggingface.co/buckets/{bucket_id}")
+
+    import benchflow.publish.huggingface as hf_publish
+
+    monkeypatch.setattr(
+        hf_publish, "publish_folder_to_bucket", fake_publish_folder_to_bucket
+    )
+
+    jobs_dir = tmp_path / "jobs"
+    result = runner.invoke(
+        app,
+        [
+            "eval",
+            "run",
+            "--tasks-dir",
+            str(tasks),
+            "--agent",
+            "oracle",
+            "--jobs-dir",
+            str(jobs_dir),
+            "--publish-bucket",
+            "org/some-bucket",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    readme = captured["folder"] / "README.md"
+    assert readme.is_file()
+    text = readme.read_text()
+    assert "task-a" in text
+    assert "Mean reward: 1.000" in text
+    assert "`oracle`" in text
+
+
 def test_sharded_health_and_selection_discover_worker_shards(tmp_path: Path) -> None:
     jobs_dir = tmp_path / "jobs"
     advertised_job_dir = jobs_dir / "worker-sharded"

--- a/tests/test_publish_huggingface.py
+++ b/tests/test_publish_huggingface.py
@@ -1,0 +1,147 @@
+"""Unit tests for the HF bucket publish and eval-results PR helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from benchflow.publish.huggingface import open_eval_results_pr, publish_folder_to_bucket
+
+
+def _folder(tmp_path: Path) -> Path:
+    folder = tmp_path / "run"
+    folder.mkdir()
+    (folder / "result.json").write_text("{}")
+    return folder
+
+
+def test_publish_folder_to_bucket_missing_bucket_api_raises_clear_error(
+    tmp_path, monkeypatch
+):
+    """Guards against an installed huggingface_hub too old for bucket support.
+
+    huggingface_hub lazily resolves top-level attributes (no create_bucket/
+    sync_bucket in __dict__ until accessed), so delattr can't simulate a
+    missing name — swap in a plain stub module instead.
+    """
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub", types.ModuleType("huggingface_hub")
+    )
+    with pytest.raises(ValueError, match="bucket support"):
+        publish_folder_to_bucket(_folder(tmp_path), bucket_id="org/bucket")
+
+
+def test_publish_folder_to_bucket_url_uses_tree_not_resolve(tmp_path, monkeypatch):
+    """Buckets are non-versioned; /resolve/<path> 404s, /tree/<path> is correct."""
+    calls: dict = {}
+    monkeypatch.setattr(
+        "huggingface_hub.create_bucket",
+        lambda bucket_id, private=False: calls.setdefault(
+            "create", (bucket_id, private)
+        ),
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.sync_bucket",
+        lambda local, remote: calls.setdefault("sync", (local, remote)),
+    )
+
+    result = publish_folder_to_bucket(
+        _folder(tmp_path), bucket_id="org/bucket", path_in_repo="runs/x"
+    )
+
+    assert result.url == "https://huggingface.co/buckets/org/bucket/tree/runs/x"
+    assert calls["sync"][1] == "hf://buckets/org/bucket/runs/x"
+
+
+def test_publish_folder_to_bucket_ignores_existing_bucket_conflict(
+    tmp_path, monkeypatch
+):
+    from huggingface_hub.errors import HfHubHTTPError
+
+    response = httpx.Response(409, request=httpx.Request("POST", "https://example.com"))
+
+    def fake_create_bucket(bucket_id, private=False):
+        raise HfHubHTTPError("exists", response=response)
+
+    monkeypatch.setattr("huggingface_hub.create_bucket", fake_create_bucket)
+    monkeypatch.setattr("huggingface_hub.sync_bucket", lambda local, remote: None)
+
+    result = publish_folder_to_bucket(_folder(tmp_path), bucket_id="org/bucket")
+    assert result.repo_id == "org/bucket"
+
+
+def test_open_eval_results_pr_missing_api_raises_clear_error(monkeypatch):
+    monkeypatch.setitem(
+        sys.modules, "huggingface_hub", types.ModuleType("huggingface_hub")
+    )
+    with pytest.raises(ValueError, match="huggingface_hub is required"):
+        open_eval_results_pr(
+            model_repo="org/model", dataset_id="org/bench", task_id="t1", value=1.0
+        )
+
+
+class _FakeCommitInfo:
+    pr_url = "https://huggingface.co/org/model/discussions/1"
+
+
+def _fake_hf_api(monkeypatch, captured: dict):
+    class FakeHfApi:
+        def create_commit(
+            self, *, repo_id, repo_type, operations, commit_message, create_pr
+        ):
+            captured["content"] = operations[0].path_or_fileobj
+            return _FakeCommitInfo()
+
+    monkeypatch.setattr("huggingface_hub.HfApi", FakeHfApi)
+
+
+def test_open_eval_results_pr_upserts_without_clobbering_other_entries(
+    tmp_path, monkeypatch
+):
+    """Guards against overwriting unrelated (dataset, task_id) entries."""
+    existing_path = tmp_path / "existing.yaml"
+    existing_path.write_text(
+        "- dataset:\n    id: org/bench\n    task_id: other-task\n  value: 42.0\n"
+        "- dataset:\n    id: org/bench\n    task_id: t1\n  value: 1.0\n"
+    )
+    monkeypatch.setattr(
+        "huggingface_hub.hf_hub_download",
+        lambda repo_id, filename, repo_type=None: str(existing_path),
+    )
+    captured: dict = {}
+    _fake_hf_api(monkeypatch, captured)
+
+    pr_url = open_eval_results_pr(
+        model_repo="org/model", dataset_id="org/bench", task_id="t1", value=88.0
+    )
+
+    assert pr_url == _FakeCommitInfo.pr_url
+    entries = yaml.safe_load(captured["content"])
+    by_key = {
+        (e["dataset"]["id"], e["dataset"]["task_id"]): e["value"] for e in entries
+    }
+    assert by_key == {("org/bench", "other-task"): 42.0, ("org/bench", "t1"): 88.0}
+
+
+def test_open_eval_results_pr_no_existing_file_writes_single_entry(monkeypatch):
+    from huggingface_hub.errors import EntryNotFoundError
+
+    def fake_hf_hub_download(repo_id, filename, repo_type=None):
+        raise EntryNotFoundError("nope")
+
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", fake_hf_hub_download)
+    captured: dict = {}
+    _fake_hf_api(monkeypatch, captured)
+
+    open_eval_results_pr(
+        model_repo="org/model", dataset_id="org/bench", task_id="t1", value=1.0
+    )
+
+    entries = yaml.safe_load(captured["content"])
+    assert len(entries) == 1
+    assert entries[0]["dataset"] == {"id": "org/bench", "task_id": "t1"}


### PR DESCRIPTION
Extends the existing \`--publish-hf\` mechanism with two more HF options on \`bench eval run\`:

- \`--publish-bucket <bucket_id>\` — syncs job artifacts to a HF Storage Bucket (\`publish_folder_to_bucket\`, alongside the existing \`publish_folder_to_hf\` dataset-repo path).
- \`--eval-results-model/-dataset/-task\` — opens a community eval-results PR (\`.eval_results/*.yaml\`) on a model's own HF repo, scored from the run's mean reward (reuses \`build_health_summary\`).

Both are lazy-imported (\`huggingface_hub\`), same pattern as \`publish/huggingface.py\`'s existing functions — no new dependency.

Test plan:
- \`ruff check\`/\`format\`, \`ty check\` pass on touched files
- \`pytest tests/test_eval_artifact_cli.py tests/test_cli_arg_validation.py\` pass
- smoke-tested reward aggregation + new CLI flags against a synthetic job dir

🤖 Generated with [Claude Code](https://claude.com/claude-code)