### PR TITLE
feat(review): support weighted blocker rubrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@
   `0` / `1` / `2` scores with raw and gated quality plus publication bands in
   the report. Blocker weights are excluded from quality, and the wrapper reward
   remains a structural-validity signal. Existing three-field v0.1 rubrics keep
-  their `pass` / `fail` / `not_applicable` behavior unchanged.
+  their `pass` / `fail` / `not_applicable` behavior unchanged. Docker runs now
+  probe whether verifier-log bind mounts are genuinely visible to the container
+  and fall back to explicit copy-out when path translation is unavailable.
 
 ## 0.7.4 — 2026-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Weighted rubric-review contract (v0.2).** `bench review` now accepts the
+  versionless `rubric.json` shape introduced by FrontierPhysics PR #109, where
+  every criterion adds strict `blocker` (`0` or `1`) and `weight` (`1` through
+  `10`) fields. Binary blockers gate publication; non-blockers receive weighted
+  `0` / `1` / `2` scores with raw and gated quality plus publication bands in
+  the report. Blocker weights are excluded from quality, and the wrapper reward
+  remains a structural-validity signal. Existing three-field v0.1 rubrics keep
+  their `pass` / `fail` / `not_applicable` behavior unchanged.
+
 ## 0.7.4 — 2026-08-16
 
 ### Added

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -386,12 +386,24 @@ required with it (a run without one exits with an actionable error).
 | `--allow-open-network` | `false` | Run reviewers without the no-internet declaration (required on backends that cannot enforce isolation, e.g. agentcore; recorded in the report) |
 | `--out-dir`, `-o` | `jobs/review-<ts>` | Review output directory |
 
-A rubric is a JSON object with one `criteria` list; each criterion is three
-strings —
-`name` (identifier; becomes a structured-output field), `description`
-(author-facing documentation, never shown to the reviewer), and `guidance`
-(the grading contract the reviewer follows). The reviewer answers each
-criterion with `pass` / `fail` / `not_applicable` plus an explanation.
+A rubric is a versionless JSON object with one `criteria` list. BenchFlow
+supports two backward-compatible shapes:
+
+- Legacy v0.1 criteria contain exactly `name`, `description`, and `guidance`;
+  the reviewer returns `pass`, `fail`, or `not_applicable` plus an explanation.
+- Weighted v0.2 criteria all add strict integer `blocker` (`0` or `1`) and
+  `weight` (`1` through `10`) fields. Blockers return `pass` or `fail`; scored
+  criteria return `0`, `1`, or `2`. Blocker weights do not enter the quality
+  calculation.
+
+For v0.2, `raw_quality` is the weighted scored points divided by twice the
+sum of non-blocker weights. The deterministic reward and all blocker verdicts
+gate that quality: if either gate fails, `gated_quality` is zero and the result
+is `not_publishable`. Otherwise, quality `>= 0.80` is `publishable`, quality
+`>= 0.65` is `presentable_with_revisions`, and lower quality is
+`not_publishable`. The wrapper reward still means only that the review is
+structurally valid; it is not a quality or publication score. See
+[Rubric review](../rubric-review.md) for the full contract and report shape.
 
 ### bench eval list
 

--- a/docs/rubric-review.md
+++ b/docs/rubric-review.md
@@ -3,8 +3,9 @@
 Rubric review is a detached, agentic quality review of finished rollouts. A
 reviewer agent reads a rollout's records — trajectory, result, verifier
 output, and the task definition — inside its own sandbox and grades the run
-against a rubric, one `pass` / `fail` / `not_applicable` verdict plus an
-explanation per criterion.
+against a rubric. Legacy rubrics produce one `pass` / `fail` /
+`not_applicable` verdict per criterion; weighted rubrics combine binary
+blocker verdicts with 0–2 scores.
 
 Review is **report-only**. It runs after a job is over, from the host-side
 rollout directories, and writes `review_report.json`. It never modifies a
@@ -17,9 +18,14 @@ an llm-judge is part of a task's verifier and *produces* the reward, while
 rubric review is downstream quality assurance *about* finished runs — is the
 task well specified, did the agent game the grader, was the method sound.
 
-## The rubric (contract v0.1)
+## The rubric (versionless contracts v0.1 and v0.2)
 
-A rubric is a JSON file with one list:
+A rubric is a JSON file with one `criteria` list and no in-file version key.
+BenchFlow identifies its contract from the fields present on every criterion.
+
+### Legacy v0.1 rubric
+
+The original shape remains fully supported:
 
 ```json
 {
@@ -33,7 +39,7 @@ A rubric is a JSON file with one list:
 }
 ```
 
-Each criterion is exactly three strings:
+Each v0.1 criterion is exactly three strings:
 
 | Field | Purpose |
 |---|---|
@@ -41,16 +47,74 @@ Each criterion is exactly three strings:
 | `description` | Documentation for humans reading the rubric. **Never included in the reviewer prompt** — grading must not depend on it. |
 | `guidance` | The grading contract the reviewer follows. Put the full pass/fail/not-applicable conditions here. |
 
-There are no weights, gates, thresholds, or aggregate scores. Consumers read
-per-criterion outcomes from the report and apply their own policy.
+The reviewer answers each criterion with `pass`, `fail`, or `not_applicable`
+plus a non-empty explanation. There are no weights, gates, thresholds, or
+aggregate scores. Consumers read per-criterion outcomes from the report and
+apply their own policy.
 
-The contract is named **v0.1**; the document itself carries no version key
-— a rubric is exactly its `criteria` list.
+### Weighted v0.2 rubric
+
+The weighted contract used by
+[FrontierPhysics PR #109](https://github.com/benchflow-ai/FrontierPhysics/pull/109)
+adds `blocker` and `weight` to **every** criterion:
+
+```json
+{
+  "criteria": [
+    {
+      "name": "required_artifact",
+      "blocker": 1,
+      "weight": 10,
+      "description": "The required artifact must be present and usable.",
+      "guidance": "PASS only when the evidence contains the complete artifact. Otherwise FAIL."
+    },
+    {
+      "name": "technical_quality",
+      "blocker": 0,
+      "weight": 8,
+      "description": "Quality of the technical result.",
+      "guidance": "Score 0 for incorrect, 1 for partially correct, or 2 for complete and correct."
+    }
+  ]
+}
+```
+
+`blocker` is a strict integer `0` or `1`; `weight` is a strict integer from
+`1` through `10`. Booleans, numeric strings, floats, omitted fields, and mixed
+v0.1/v0.2 criteria are rejected. A v0.2 rubric must contain at least one
+non-blocker criterion so its quality denominator is nonzero.
+
+- A criterion with `blocker: 1` receives `pass` or `fail`. Any failure closes
+  the blocker gate. Its `weight` is validated for a uniform authoring format
+  but is excluded from weighted quality.
+- A criterion with `blocker: 0` receives an integer score of `0`, `1`, or `2`.
+  Its contribution is `score * weight` out of `2 * weight`.
+
+BenchFlow aggregates a structurally valid v0.2 review on the host:
+
+```text
+raw_quality = sum(score * weight) / (2 * sum(non-blocker weights))
+gates_pass = deterministic reward is 1.0 with no recorded error
+             AND every blocker passes
+gated_quality = raw_quality if gates_pass, otherwise 0
+```
+
+The raw quality remains visible when a gate fails, making the rubric judgment
+auditable without mistaking it for a publishable result. A failed gate always
+produces `not_publishable`. With both gates open, the publication bands are:
+
+| Gated quality | Decision |
+|---|---|
+| `>= 0.80` | `publishable` |
+| `>= 0.65` and `< 0.80` | `presentable_with_revisions` |
+| `< 0.65` | `not_publishable` |
+
+### Validation and discovery
 
 A rubric must contain at least one criterion, names must be unique, and
 unknown fields are rejected. (Validation is stricter than the shape alone
 requires: rubrics that would produce vacuous or ambiguous reviews are
-refused. Every rubric that passes is exactly the v0.1 shape.) `rubric.json` is an overloaded filename —
+refused.) `rubric.json` is an overloaded filename —
 llm-judge verifier rubrics use `{id, match_criteria}` entries. Discovery is
 fail-closed: a `rubric.json` is treated as a review rubric — and validated
 loudly — **unless** every entry carries the full judge shape (both `id`
@@ -148,23 +212,28 @@ the host, which is why every sandbox backend (`docker`, `daytona`,
   evidence** and says so in `notes`; an old or unverifiable rollout is never
   reviewed against current task content.
 - **The rubric never enters the sandbox.** It is decomposed host-side:
-  `guidance` lines render into the instruction, criterion names become the
-  output schema and `tests/criteria.json`. `description` goes nowhere.
+  `guidance` lines render into the instruction; names and the minimum contract
+  metadata needed for structural validation become the output schema and
+  `tests/criteria.json`. `description` goes nowhere.
 - **Validity-only reward.** The wrapper's verifier is a stdlib-only
   structural check of the reviewer's `review-result.json` (every criterion
-  answered, outcomes in vocabulary, non-empty explanations). Reward 1.0
-  means "a well-formed review exists" — never "the reviewed run was good".
+  answered, outcomes or scores in the contract's vocabulary, non-empty
+  explanations). Its reward remains structural for both rubric contracts:
+  reward 1.0 means "a well-formed review exists" — never "the reviewed run
+  was good." Weighted quality and publication decisions are separate,
+  deterministic host-side report fields.
 - **Failure isolation.** A review that crashes or produces malformed output
   becomes an error entry for that rollout; the rest of the job continues.
 
 ## Output
 
-The review job directory contains `review_report.json`:
+The review job directory contains `review_report.json`. This v0.1 example has
+no aggregate score:
 
 ```json
 {
   "path": "…/jobs/2026-08-03__12-00-00",
-  "rubric": {"path": "…", "criteria": ["…"]},
+  "rubric": {"path": "…", "criteria": ["…"], "contracts": ["v0.1"]},
   "reviewer": {"agent": "opencode", "model": "gemini/gemini-2.5-flash", "environment": "docker", "network": "no-internet"},
   "job_summary": "Deterministic aggregation over VALID reviews only.",
   "trials": [
@@ -180,7 +249,13 @@ The review job directory contains `review_report.json`:
       "error": null,
       "reviewer_rollout": "…/runtime/hello-world-task__829cddb8/<run-id>/…",
       "rubric_path": "…/verifier/rubric.json",
+      "rubric_contract": "v0.1",
       "criteria": ["reward_hacking", "task_specification"],
+      "criterion_metadata": [
+        {"name": "reward_hacking", "blocker": null, "weight": null},
+        {"name": "task_specification", "blocker": null, "weight": null}
+      ],
+      "scoring": null,
       "notes": ["task evidence skipped: no --tasks-root was given"]
     }
   ]
@@ -196,13 +271,36 @@ otherwise it is `null` rather than an ambiguous parent directory. Reusing
 aggregation, not a model call — a host-side LLM call would bypass the
 sandbox backend, egress policy, and telemetry.
 
+For v0.2, blocker checks carry `outcome`, scored checks carry `score`, and the
+trial also records its rubric contract, criterion metadata, and deterministic
+aggregation. The scoring object has this shape:
+
+```json
+{
+  "deterministic_pass": true,
+  "all_blockers_pass": true,
+  "failed_blockers": [],
+  "weighted_points": 24,
+  "max_weighted_points": 30,
+  "raw_quality": 0.8,
+  "gated_quality": 0.8,
+  "decision": "publishable"
+}
+```
+
+Aggregation is emitted only for a structurally valid v0.2 review. The report
+keeps each trial's resolved contract and criterion metadata authoritative,
+because one job may review tasks with different task-local rubrics.
+
 ## Writing good criteria
 
-- Put the entire decision rule in `guidance`, including when to answer
-  `not_applicable` (for example: infrastructure failure before the agent
-  ever attempted the task).
+- Put the entire decision rule in `guidance`. For v0.1, include when to answer
+  `not_applicable` (for example: infrastructure failure before the agent ever
+  attempted the task). V0.2 has no `not_applicable`: define exact `pass` /
+  `fail` conditions for blockers and exact `0` / `1` / `2` anchors for scored
+  criteria.
 - One judgment per criterion. A criterion that bundles several claims makes
-  `fail` ambiguous.
+  a blocker verdict or numeric score ambiguous.
 - The reviewer reads evidence produced by the solver. Guidance should direct
   it to concrete records (`trial/result.json`, `trial/trajectory/`,
   `trial/verifier/`) rather than to intent.

--- a/src/benchflow/__init__.py
+++ b/src/benchflow/__init__.py
@@ -61,9 +61,12 @@ from benchflow.monitor import (
     MonitorResult,
 )
 from benchflow.review import (
+    PublicationDecision,
     ReviewReport,
     ReviewRubricError,
+    ReviewScoring,
     run_reviews,
+    score_weighted_review,
 )
 from benchflow.review import Rubric as ReviewRubric
 from benchflow.review import RubricCriterion as ReviewRubricCriterion
@@ -169,11 +172,14 @@ __all__ = [
     "load_rubric_json",
     "load_rubric_toml",
     "ReviewReport",
+    "PublicationDecision",
     "ReviewRubric",
     "ReviewRubricCriterion",
     "ReviewRubricError",
+    "ReviewScoring",
     "load_review_rubric",
     "run_reviews",
+    "score_weighted_review",
     "Sandbox",
     "SandboxExecResult",
     "SandboxImage",

--- a/src/benchflow/_utils/task_authoring/__init__.py
+++ b/src/benchflow/_utils/task_authoring/__init__.py
@@ -146,10 +146,10 @@ def task_digest(task_dir: Path) -> str:
 def _check_review_rubric(verifier_dir: Path, *, verifier_label: str) -> list[str]:
     """Validate a review ``rubric.json`` when the task ships one.
 
-    Review rubrics are ``{"criteria": [{name, description, guidance}]}``
-    JSON documents. A ``rubric.json`` that is not shaped like that (for
-    example an llm-judge rubric owned by the verifier-strategy machinery)
-    is not checked here.
+    Review rubrics use either the legacy ``{name, description, guidance}``
+    criterion shape or the weighted shape that adds ``blocker`` and
+    ``weight``. A ``rubric.json`` in the full llm-judge dialect is owned by
+    the verifier-strategy machinery and is not checked here.
     """
     from benchflow.review.config import (
         ReviewRubricError,

--- a/src/benchflow/cli/review.py
+++ b/src/benchflow/cli/review.py
@@ -25,43 +25,88 @@ _REVIEW_OUTCOME_STYLES = {
     "not_applicable": "grey50",
 }
 
+_REVIEW_SCORE_STYLES = {
+    0: "red",
+    1: "yellow",
+    2: "green",
+}
+
 
 def _render_trial_review(trial) -> None:
     table = Table(title=f"Review: {escape(str(trial.trial_name))}", show_lines=True)
     table.add_column("Criterion")
-    table.add_column("Outcome")
+    table.add_column("Result")
     table.add_column("Explanation")
     for name, check in (trial.checks or {}).items():
-        outcome = str(check.get("outcome", ""))
+        if "score" in check:
+            raw_score = check.get("score")
+            result = str(raw_score)
+            style = (
+                _REVIEW_SCORE_STYLES.get(raw_score, "white")
+                if type(raw_score) is int
+                else "white"
+            )
+        else:
+            result = str(check.get("outcome", ""))
+            style = _REVIEW_OUTCOME_STYLES.get(result, "white")
         table.add_row(
             escape(str(name).replace("_", " ").title()),
-            escape(outcome),
+            escape(result),
             escape(str(check.get("explanation", ""))),
-            style=_REVIEW_OUTCOME_STYLES.get(outcome, "white"),
+            style=style,
         )
     if trial.summary:
         console.print(f"\n[bold]Summary:[/bold] {escape(str(trial.summary))}\n")
+    scoring = getattr(trial, "scoring", None)
+    if scoring is not None:
+        console.print(
+            "[bold]Weighted quality:[/bold] "
+            f"{scoring.raw_quality:.3f} raw / {scoring.gated_quality:.3f} gated "
+            f"— {escape(scoring.decision.value)}\n"
+        )
     console.print(table)
 
 
 def _render_review_overview(trials) -> None:
     table = Table(title="Rubric Reviews", show_lines=True)
-    for column in ("Run", "Pass", "Fail", "N/A", "Valid"):
+    for column in ("Run", "Pass", "Fail", "N/A", "Quality", "Decision", "Valid"):
         table.add_column(column)
     for trial in trials:
         if trial.error and not trial.checks:
             table.add_row(
-                escape(str(trial.trial_name)), "-", "-", "-", "no", style="red"
+                escape(str(trial.trial_name)),
+                "-",
+                "-",
+                "-",
+                "-",
+                "-",
+                "no",
+                style="red",
             )
             continue
         counts = trial.outcome_counts()
+        scoring = getattr(trial, "scoring", None)
+        quality = f"{scoring.raw_quality:.3f}" if scoring is not None else "-"
+        decision = scoring.decision.value if scoring is not None else "-"
+        if (
+            not trial.review_valid
+            or counts["fail"]
+            or (scoring is not None and decision == "not_publishable")
+        ):
+            style = "red"
+        elif scoring is not None and decision == "presentable_with_revisions":
+            style = "yellow"
+        else:
+            style = "white"
         table.add_row(
             escape(str(trial.trial_name)),
             str(counts["pass"]),
             str(counts["fail"]),
             str(counts["not_applicable"]),
+            quality,
+            escape(decision),
             "yes" if trial.review_valid else "no",
-            style="red" if counts["fail"] or not trial.review_valid else "white",
+            style=style,
         )
     console.print(table)
     for trial in trials:

--- a/src/benchflow/review/__init__.py
+++ b/src/benchflow/review/__init__.py
@@ -1,10 +1,10 @@
 """Rubric review — detached agentic grading of finished rollouts.
 
-A rubric (contract **v0.1**) is a JSON object containing a ``criteria`` list;
-each criterion has ``name``, ``description``, and ``guidance``. A reviewer
-agent reads a finished rollout's records inside its own sandbox and answers
-each criterion with ``pass`` / ``fail`` / ``not_applicable`` plus an
-explanation.
+A rubric is a JSON object containing a ``criteria`` list. Legacy v0.1
+criteria have ``name``, ``description``, and ``guidance`` and receive
+pass/fail/not-applicable judgments. Weighted v0.2 criteria additionally have
+strict ``blocker`` and ``weight`` integers: blockers receive pass/fail gates,
+while non-blockers receive 0/1/2 scores that Benchflow aggregates host-side.
 
 Reviews run *after* rollouts, from their host-side directories, as ordinary
 rollouts of throwaway wrapper tasks (:mod:`benchflow.review.wrapper`), so
@@ -23,14 +23,19 @@ Public surface:
 
 from benchflow.review.config import (
     DEFAULT_RUBRIC_PATH,
+    LEGACY_REVIEW_RUBRIC_CONTRACT,
     REVIEW_RESULT_FILENAME,
     REVIEW_RUBRIC_CONTRACT,
     REVIEW_RUBRIC_FILENAME,
+    WEIGHTED_REVIEW_RUBRIC_CONTRACT,
+    BlockerCriterionCheck,
+    BlockerOutcomeValue,
     CriterionCheck,
     ReviewOutcomeValue,
     ReviewRubricError,
     Rubric,
     RubricCriterion,
+    ScoredCriterionCheck,
     build_criteria_guidance,
     build_review_response_model,
     find_task_rubric,
@@ -44,21 +49,37 @@ from benchflow.review.runner import (
     discover_rollouts,
     run_reviews,
 )
+from benchflow.review.scoring import (
+    PUBLISHABLE_QUALITY,
+    REVISIONS_QUALITY,
+    PublicationDecision,
+    ReviewScoring,
+    score_weighted_review,
+)
 from benchflow.review.wrapper import assemble_review_task
 
 __all__ = [
     "DEFAULT_RUBRIC_PATH",
+    "LEGACY_REVIEW_RUBRIC_CONTRACT",
+    "PUBLISHABLE_QUALITY",
     "REVIEW_RUBRIC_CONTRACT",
     "REVIEW_REPORT_FILENAME",
     "REVIEW_RESULT_FILENAME",
     "REVIEW_RUBRIC_FILENAME",
+    "REVISIONS_QUALITY",
+    "WEIGHTED_REVIEW_RUBRIC_CONTRACT",
+    "BlockerCriterionCheck",
+    "BlockerOutcomeValue",
     "CriterionCheck",
+    "PublicationDecision",
     "ReviewOutcomeValue",
     "ReviewReport",
     "ReviewRubricError",
     "ReviewRunError",
+    "ReviewScoring",
     "Rubric",
     "RubricCriterion",
+    "ScoredCriterionCheck",
     "TrialReview",
     "assemble_review_task",
     "build_criteria_guidance",
@@ -67,4 +88,5 @@ __all__ = [
     "find_task_rubric",
     "load_rubric",
     "run_reviews",
+    "score_weighted_review",
 ]

--- a/src/benchflow/review/config.py
+++ b/src/benchflow/review/config.py
@@ -1,39 +1,28 @@
-"""Rubric schema and loading for post-run rubric review (contract v0.1).
+"""Rubric schemas and loading for detached post-run review.
 
-A review rubric is a small JSON document listing the criteria a reviewer
-agent grades a finished rollout against:
-
-.. code-block:: json
+The current weighted contract (v0.2) extends each criterion with two strict
+integer fields::
 
     {
       "criteria": [
         {
-          "name": "reward_hacking",
+          "name": "method_soundness",
+          "blocker": 0,
+          "weight": 5,
           "description": "Author-facing note; never shown to the reviewer.",
-          "guidance": "What to inspect and when to answer pass/fail/..."
+          "guidance": "Score 2 when ...; 1 when ...; 0 when ..."
         }
       ]
     }
 
-Each criterion carries exactly three strings:
+``blocker: 1`` criteria receive a binary pass/fail judgment. ``blocker: 0``
+criteria receive an integer score from 0 to 2 and contribute to a weighted
+research-quality score. ``weight`` is an integer from 1 to 10.
 
-- ``name`` — stable identifier for the criterion.  It becomes a field in the
-  reviewer's structured-output schema, so it must be a valid Python
-  identifier.
-- ``description`` — documentation for humans reading the rubric.  It is never
-  included in the reviewer prompt; grading behavior must not depend on it.
-- ``guidance`` — the grading contract shown to the reviewer.  Put the full
-  pass/fail conditions here.
-
-The reviewer answers every criterion with an ``outcome`` of ``pass``,
-``fail``, or ``not_applicable`` plus a free-text ``explanation``.  There is
-no scoring layer on top: no weights, no thresholds, no aggregation into a
-single number.  Consumers read per-criterion outcomes from the review
-report.
-
-The document deliberately carries no in-file version key: a rubric is
-exactly its ``criteria`` list, and "v0.1" names the contract in docs and
-release notes rather than in the payload.
+Versionless v0.1 rubrics remain supported for compatibility. They omit both
+``blocker`` and ``weight`` and retain pass/fail/not-applicable judgments. A
+single rubric may not mix contracts, and a criterion may not provide only one
+of the v0.2 fields; both cases fail closed instead of guessing intent.
 """
 
 from __future__ import annotations
@@ -42,22 +31,41 @@ import json
 import keyword
 from enum import StrEnum
 from pathlib import Path
-from typing import Any
+from typing import Annotated, Any, Self
 
 from pydantic import (
+    AfterValidator,
     BaseModel,
     ConfigDict,
     Field,
     ValidationError,
     create_model,
     field_validator,
+    model_validator,
 )
 
-REVIEW_RUBRIC_CONTRACT = "v0.1"
+LEGACY_REVIEW_RUBRIC_CONTRACT = "v0.1"
+WEIGHTED_REVIEW_RUBRIC_CONTRACT = "v0.2"
+# Backward-compatible public alias. New code that needs to distinguish
+# contracts should use the explicit LEGACY_* and WEIGHTED_* constants.
+REVIEW_RUBRIC_CONTRACT = LEGACY_REVIEW_RUBRIC_CONTRACT
 REVIEW_RUBRIC_FILENAME = "rubric.json"
 REVIEW_RESULT_FILENAME = "review-result.json"
 
 DEFAULT_RUBRIC_PATH = Path(__file__).parent / "default-rubric.json"
+
+
+def _non_blank(value: str) -> str:
+    if not value.strip():
+        raise ValueError("must contain non-whitespace text")
+    return value
+
+
+NonBlankText = Annotated[
+    str,
+    Field(min_length=1),
+    AfterValidator(_non_blank),
+]
 
 
 class ReviewRubricError(ValueError):
@@ -72,6 +80,8 @@ class RubricCriterion(BaseModel):
     name: str
     description: str
     guidance: str
+    blocker: int | None = Field(default=None, strict=True, ge=0, le=1)
+    weight: int | None = Field(default=None, strict=True, ge=1, le=10)
 
     @field_validator("name")
     @classmethod
@@ -80,7 +90,7 @@ class RubricCriterion(BaseModel):
         # schema library reserves either crashes model construction
         # (``model_config``), trips protected-namespace rules
         # (``model_dump``), or is silently dropped from the generated schema
-        # (private/dunder names) — yielding an impossible reviewer/verifier
+        # (private/dunder names) -- yielding an impossible reviewer/verifier
         # contract instead of a loud failure.
         if not value.isidentifier() or keyword.iskeyword(value):
             raise ValueError(
@@ -100,9 +110,42 @@ class RubricCriterion(BaseModel):
         if hasattr(BaseModel, value):
             raise ValueError(
                 f"criterion name {value!r} collides with reserved schema "
-                "attribute {value!r}; choose another name"
+                f"attribute {value!r}; choose another name"
             )
         return value
+
+    @model_validator(mode="after")
+    def _scoring_fields_are_paired(self) -> Self:
+        blocker_supplied = "blocker" in self.model_fields_set
+        weight_supplied = "weight" in self.model_fields_set
+        if blocker_supplied != weight_supplied:
+            raise ValueError(
+                "criterion must provide both blocker and weight for the v0.2 "
+                "contract, or omit both for legacy v0.1"
+            )
+        if blocker_supplied and (self.blocker is None or self.weight is None):
+            raise ValueError(
+                "blocker and weight must be strict integers for the v0.2 "
+                "contract; null is not allowed"
+            )
+        return self
+
+    @property
+    def is_legacy(self) -> bool:
+        return self.blocker is None
+
+    @property
+    def is_blocker(self) -> bool:
+        return self.blocker == 1
+
+    def metadata(self) -> dict[str, str | int | None]:
+        """Return the non-prompt criterion contract recorded in artifacts."""
+
+        return {
+            "name": self.name,
+            "blocker": self.blocker,
+            "weight": self.weight,
+        }
 
 
 class Rubric(BaseModel):
@@ -114,7 +157,9 @@ class Rubric(BaseModel):
 
     @field_validator("criteria")
     @classmethod
-    def _names_are_unique(cls, value: list[RubricCriterion]) -> list[RubricCriterion]:
+    def _criteria_are_coherent(
+        cls, value: list[RubricCriterion]
+    ) -> list[RubricCriterion]:
         seen: set[str] = set()
         duplicates: set[str] = set()
         for criterion in value:
@@ -127,11 +172,44 @@ class Rubric(BaseModel):
                 "(duplicate names would silently collapse into one "
                 "structured-output field)"
             )
+        contracts = {criterion.is_legacy for criterion in value}
+        if len(contracts) != 1:
+            raise ValueError(
+                "all criteria must use one rubric contract; legacy v0.1 and "
+                "weighted v0.2 criteria cannot be mixed"
+            )
+        if not value[0].is_legacy and not any(
+            not criterion.is_blocker for criterion in value
+        ):
+            raise ValueError(
+                "weighted v0.2 rubrics require at least one scored "
+                "(blocker: 0) criterion"
+            )
         return value
+
+    @property
+    def contract(self) -> str:
+        return (
+            LEGACY_REVIEW_RUBRIC_CONTRACT
+            if self.criteria[0].is_legacy
+            else WEIGHTED_REVIEW_RUBRIC_CONTRACT
+        )
+
+    @property
+    def is_weighted(self) -> bool:
+        return self.contract == WEIGHTED_REVIEW_RUBRIC_CONTRACT
+
+    def metadata(self) -> dict[str, Any]:
+        """Return the rubric contract carried into wrapper/report artifacts."""
+
+        return {
+            "contract": self.contract,
+            "criteria": [criterion.metadata() for criterion in self.criteria],
+        }
 
 
 class ReviewOutcomeValue(StrEnum):
-    """Closed outcome vocabulary for one criterion."""
+    """Closed outcome vocabulary for one legacy v0.1 criterion."""
 
     PASS = "pass"
     FAIL = "fail"
@@ -139,17 +217,42 @@ class ReviewOutcomeValue(StrEnum):
 
 
 class CriterionCheck(BaseModel):
-    """The reviewer's answer for one criterion."""
+    """The reviewer's answer for one legacy v0.1 criterion."""
 
-    explanation: str
+    explanation: NonBlankText
     outcome: ReviewOutcomeValue
+
+
+class BlockerOutcomeValue(StrEnum):
+    """Closed outcome vocabulary for a v0.2 blocker."""
+
+    PASS = "pass"
+    FAIL = "fail"
+
+
+class BlockerCriterionCheck(BaseModel):
+    """The reviewer's binary answer for a v0.2 blocker."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    explanation: NonBlankText
+    outcome: BlockerOutcomeValue
+
+
+class ScoredCriterionCheck(BaseModel):
+    """The reviewer's 0-2 answer for a weighted v0.2 criterion."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    explanation: NonBlankText
+    score: int = Field(strict=True, ge=0, le=2)
 
 
 def load_rubric(path: Path | None = None) -> Rubric:
     """Load a rubric from a JSON file, or the built-in default rubric.
 
-    Only JSON is accepted; the on-disk shape is
-    ``{"criteria": [{"name", "description", "guidance"}, ...]}``.
+    Only JSON is accepted. Every criterion must consistently use either the
+    legacy v0.1 three-field shape or the weighted v0.2 five-field shape.
     """
 
     rubric_path = path if path is not None else DEFAULT_RUBRIC_PATH
@@ -172,19 +275,15 @@ def load_rubric(path: Path | None = None) -> Rubric:
 
 
 def is_review_rubric_file(path: Path) -> bool:
-    """Whether ``path`` claims this contract's dialect.
+    """Whether ``path`` claims either detached-review rubric contract.
 
     ``rubric.json`` is an overloaded filename: llm-judge verifier rubrics
-    use entries carrying the full ``{id, match_criteria}`` shape. Only that dialect is
-    disclaimed; **everything else in this slot is claimed** and then
-    validated loudly by :func:`load_rubric` — including empty ``criteria``
-    and rubrics with misspelled or missing review keys — so no malformed
-    review rubric can silently fall back to the built-in default.
+    use entries carrying the full ``{id, match_criteria}`` shape. Only that
+    dialect is disclaimed; everything else in this slot is claimed and then
+    validated loudly by :func:`load_rubric`, so malformed review rubrics can
+    never silently fall back to the built-in default.
     """
 
-    # Fail closed: unreadable files, invalid JSON, non-dict documents, and
-    # missing/non-list ``criteria`` are all CLAIMED so load_rubric reports
-    # them loudly — never silently replaced by the default rubric.
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -195,26 +294,14 @@ def is_review_rubric_file(path: Path) -> bool:
     if not isinstance(criteria, list):
         return True
 
-    # Fail closed: everything in this filename slot is claimed as a review
-    # rubric — and validated loudly by load_rubric — UNLESS it is
-    # affirmatively the llm-judge dialect (id/match_criteria entries). A
-    # rubric with every review key misspelled is therefore claimed and
-    # rejected instead of silently replaced by the default rubric.
     def is_judge_entry(entry: object) -> bool:
-        # FULL judge shape required: an entry carrying only one of the two
-        # keys is ambiguous and is claimed for loud validation instead.
         return isinstance(entry, dict) and {"id", "match_criteria"} <= set(entry)
 
     return not (criteria and all(is_judge_entry(entry) for entry in criteria))
 
 
 def find_task_rubric(task_path: Path) -> Path | None:
-    """Return the review rubric a task ships, if any.
-
-    Looks for ``rubric.json`` next to the task's test files (``verifier/`` or
-    ``tests/``). Only files affirmatively matching the full judge dialect are
-    left alone; every other shape is claimed and validated loudly.
-    """
+    """Return the detached-review rubric a task ships, if any."""
 
     for tests_dir_name in ("verifier", "tests"):
         candidate = task_path / tests_dir_name / REVIEW_RUBRIC_FILENAME
@@ -226,25 +313,47 @@ def find_task_rubric(task_path: Path) -> Path | None:
 def build_criteria_guidance(rubric: Rubric) -> str:
     """Render the criterion guidance lines included in the reviewer prompt."""
 
+    if not rubric.is_weighted:
+        return "\n".join(
+            f"- {criterion.name}: {criterion.guidance}" for criterion in rubric.criteria
+        )
+
     return "\n".join(
-        f"- {criterion.name}: {criterion.guidance}" for criterion in rubric.criteria
+        (
+            f"- {criterion.name} [BLOCKER; answer pass or fail; weight "
+            f"{criterion.weight} does not enter weighted quality]: "
+            f"{criterion.guidance}"
+            if criterion.is_blocker
+            else f"- {criterion.name} [SCORED; weight {criterion.weight}; "
+            f"answer 0, 1, or 2]: {criterion.guidance}"
+        )
+        for criterion in rubric.criteria
     )
 
 
 def build_review_response_model(rubric: Rubric) -> type[BaseModel]:
-    """Build the structured-output model for a rollout review.
+    """Build the structured-output model for one rollout review."""
 
-    The reviewer must return ``{trial_name, summary, checks}`` where
-    ``checks`` has one :class:`CriterionCheck` field per rubric criterion.
-    """
-
-    checks_fields: dict[str, Any] = {
-        criterion.name: (CriterionCheck, ...) for criterion in rubric.criteria
-    }
-    checks_model = create_model("ReviewChecks", **checks_fields)
+    checks_fields: dict[str, Any] = {}
+    for criterion in rubric.criteria:
+        check_model: type[BaseModel]
+        if criterion.is_legacy:
+            check_model = CriterionCheck
+        elif criterion.is_blocker:
+            check_model = BlockerCriterionCheck
+        else:
+            check_model = ScoredCriterionCheck
+        checks_fields[criterion.name] = (check_model, ...)
+    extra_policy = "forbid" if rubric.is_weighted else "ignore"
+    checks_model = create_model(
+        "ReviewChecks",
+        __config__=ConfigDict(extra="forbid"),
+        **checks_fields,
+    )
     return create_model(
         "ReviewResponse",
+        __config__=ConfigDict(extra=extra_policy),
         trial_name=(str, ...),
-        summary=(str, ...),
+        summary=(NonBlankText, ...),
         checks=(checks_model, ...),
     )

--- a/src/benchflow/review/prompts.py
+++ b/src/benchflow/review/prompts.py
@@ -62,7 +62,21 @@ OUTPUT_TEMPLATE = """When you are done, write your answer as JSON to {result_pat
 
 {output_schema}
 
-"trial_name" must be exactly {trial_name_json}. Every criterion listed in the schema must appear in "checks" with an "outcome" of "pass", "fail", or "not_applicable" and a non-empty "explanation". Write the file and nothing else; do not print the JSON instead of writing it."""
+"trial_name" must be exactly {trial_name_json}. {judgment_contract} Write the file and nothing else; do not print the JSON instead of writing it."""
+
+LEGACY_JUDGMENT_CONTRACT = (
+    'Every criterion listed in the schema must appear in "checks" with an '
+    '"outcome" of "pass", "fail", or "not_applicable" and a non-empty '
+    '"explanation".'
+)
+
+WEIGHTED_JUDGMENT_CONTRACT = (
+    'Every criterion listed in the schema must appear in "checks" with a '
+    'non-empty "explanation". BLOCKER criteria require an "outcome" of '
+    '"pass" or "fail". SCORED criteria require an integer "score" of 0, 1, '
+    "or 2. Do not calculate an aggregate score; Benchflow derives it "
+    "deterministically from the individual judgments and rubric weights."
+)
 
 
 def render_task_section(task_path: str | None) -> str:
@@ -97,6 +111,11 @@ def render_review_instruction(
             "result_path": result_path,
             "trial_name_json": json.dumps(trial_name),
             "output_schema": json.dumps(output_schema or {}, indent=2),
+            "judgment_contract": (
+                WEIGHTED_JUDGMENT_CONTRACT
+                if rubric.is_weighted
+                else LEGACY_JUDGMENT_CONTRACT
+            ),
         }
     )
     return f"{body.rstrip()}\n\n{output.strip()}\n"

--- a/src/benchflow/review/runner.py
+++ b/src/benchflow/review/runner.py
@@ -26,13 +26,17 @@ from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+from pydantic import ValidationError
+
 from benchflow.review.config import (
     REVIEW_RESULT_FILENAME,
     ReviewRubricError,
     Rubric,
+    build_review_response_model,
     find_task_rubric,
     load_rubric,
 )
+from benchflow.review.scoring import ReviewScoring, score_weighted_review
 from benchflow.review.wrapper import (
     REVIEWER_AGENT_TIMEOUT_SEC,
     REVIEWER_IMAGE,
@@ -67,12 +71,15 @@ class TrialReview:
     rubric_path: str | None = None
     criteria: list[str] = field(default_factory=list)
     notes: list[str] = field(default_factory=list)
+    rubric_contract: str | None = None
+    criterion_metadata: list[dict[str, str | int | None]] = field(default_factory=list)
+    scoring: ReviewScoring | None = None
 
     def outcome_counts(self) -> dict[str, int]:
         counts: dict[str, int] = {key: 0 for key in _OUTCOME_KEYS}
         for check in (self.checks or {}).values():
             outcome = check.get("outcome")
-            if outcome in counts:
+            if isinstance(outcome, str) and outcome in counts:
                 counts[outcome] += 1
         return counts
 
@@ -94,7 +101,17 @@ class ReviewReport:
     def to_dict(self) -> dict[str, Any]:
         return {
             "path": self.path,
-            "rubric": {"path": self.rubric_path, "criteria": self.criteria},
+            "rubric": {
+                "path": self.rubric_path,
+                "criteria": self.criteria,
+                "contracts": list(
+                    dict.fromkeys(
+                        trial.rubric_contract
+                        for trial in self.trials
+                        if trial.rubric_contract is not None
+                    )
+                ),
+            },
             "reviewer": {
                 "agent": self.agent,
                 "model": self.model,
@@ -112,7 +129,10 @@ class ReviewReport:
                     "error": trial.error,
                     "reviewer_rollout": trial.reviewer_rollout,
                     "rubric_path": trial.rubric_path,
+                    "rubric_contract": trial.rubric_contract,
                     "criteria": trial.criteria,
+                    "criterion_metadata": trial.criterion_metadata,
+                    "scoring": trial.scoring.to_dict() if trial.scoring else None,
                     "notes": trial.notes,
                 }
                 for trial in self.trials
@@ -294,12 +314,13 @@ def _coerce_summary(value: Any) -> str | None:
 
 
 def _coerce_checks(value: Any) -> dict[str, dict[str, Any]] | None:
-    """Normalize reviewer checks so hostile shapes cannot crash consumers.
+    """Normalize invalid reviewer checks for diagnostic display only.
 
     Even invalid reviews are retained for diagnostics, so a criterion whose
     value is a list (or anything else non-dict) must not raise later in
-    outcome counting or table rendering; it is preserved as an explanation
-    string with no outcome.
+    table rendering. Weighted reviews cross the typed boundary in
+    :func:`_validate_review_payload` and never use this lossy representation
+    for scoring; legacy reviews retain their wrapper-authoritative behavior.
     """
 
     if not isinstance(value, dict):
@@ -307,13 +328,35 @@ def _coerce_checks(value: Any) -> dict[str, dict[str, Any]] | None:
     normalized: dict[str, dict[str, Any]] = {}
     for name, check in value.items():
         if isinstance(check, dict):
-            normalized[str(name)] = {
-                "outcome": check.get("outcome"),
-                "explanation": _coerce_summary(check.get("explanation")),
+            normalized_check: dict[str, Any] = {
+                "explanation": _coerce_summary(check.get("explanation"))
             }
+            if "outcome" in check:
+                normalized_check["outcome"] = check.get("outcome")
+            if "score" in check:
+                normalized_check["score"] = check.get("score")
+            normalized[str(name)] = normalized_check
         else:
-            normalized[str(name)] = {"outcome": None, "explanation": str(check)}
+            normalized[str(name)] = {"explanation": str(check)}
     return normalized
+
+
+def _validate_review_payload(
+    rubric: Rubric,
+    review: dict[str, Any],
+    *,
+    expected_trial_name: str,
+) -> tuple[str, dict[str, dict[str, Any]]]:
+    """Validate and canonicalize one artifact before it can be scored."""
+
+    response = build_review_response_model(rubric).model_validate(review)
+    payload = response.model_dump(mode="json")
+    actual_trial_name = payload["trial_name"]
+    if actual_trial_name != expected_trial_name:
+        raise ValueError(
+            f"trial_name must be {expected_trial_name!r}, got {actual_trial_name!r}"
+        )
+    return payload["summary"], payload["checks"]
 
 
 def _reviewer_rollout_leaf(runtime_dir: Path) -> Path | None:
@@ -408,7 +451,9 @@ async def _review_one(
         trial.error = str(exc)
         return trial
     trial.rubric_path = str(resolved_rubric)
+    trial.rubric_contract = rubric.contract
     trial.criteria = [criterion.name for criterion in rubric.criteria]
+    trial.criterion_metadata = [criterion.metadata() for criterion in rubric.criteria]
 
     wrapper_dir = workdir / f"review-{rollout_dir.name}"
     # Unique per invocation: reusing --out-dir must never let this run see a
@@ -460,6 +505,31 @@ async def _review_one(
         trial.checks = _coerce_checks(review.get("checks"))
         if not trial.review_valid:
             trial.error = "reviewer output failed structural validation"
+        elif rubric.is_weighted:
+            try:
+                trial.summary, trial.checks = _validate_review_payload(
+                    rubric,
+                    review,
+                    expected_trial_name=rollout_dir.name,
+                )
+            except (ValidationError, ValueError) as exc:
+                trial.review_valid = False
+                trial.error = (
+                    f"reviewer output failed host-side structural validation: {exc}"
+                )
+        if trial.review_valid and rubric.is_weighted and trial.checks is not None:
+            try:
+                trial.scoring = score_weighted_review(
+                    rubric,
+                    trial.checks,
+                    deterministic_pass=_is_passing(rollout_dir),
+                )
+            except ValueError as exc:
+                # Defense in depth for an internal aggregation invariant.
+                trial.review_valid = False
+                trial.error = (
+                    f"reviewer output failed host-side structural validation: {exc}"
+                )
         logger.info(
             "Reviewed %s with rubric %s (valid=%s)",
             rollout_dir.name,
@@ -508,22 +578,43 @@ def _summarize_job(trials: list[TrialReview]) -> str | None:
     for trial in reviewed:
         for name, check in (trial.checks or {}).items():
             outcome = check.get("outcome")
-            if outcome in total:
+            if isinstance(outcome, str) and outcome in total:
                 total[outcome] += 1
                 bucket = per_criterion.setdefault(
                     name, {key: 0 for key in _OUTCOME_KEYS}
                 )
                 bucket[outcome] += 1
-    lines = [
-        f"{len(reviewed)} of {len(trials)} runs reviewed (valid reviews only): "
-        f"{total['pass']} pass, {total['fail']} fail, "
-        f"{total['not_applicable']} not applicable across all criteria."
-    ]
+    weighted = [trial.scoring for trial in reviewed if trial.scoring is not None]
+    if weighted:
+        lines = [
+            f"{len(reviewed)} of {len(trials)} runs reviewed (valid reviews only).",
+            "Binary judgments (legacy criteria and weighted blockers only): "
+            f"{total['pass']} pass, {total['fail']} fail, "
+            f"{total['not_applicable']} not applicable.",
+        ]
+    else:
+        lines = [
+            f"{len(reviewed)} of {len(trials)} runs reviewed (valid reviews only): "
+            f"{total['pass']} pass, {total['fail']} fail, "
+            f"{total['not_applicable']} not applicable across all criteria."
+        ]
     for name in sorted(per_criterion):
         bucket = per_criterion[name]
         lines.append(
             f"{name}: {bucket['pass']} pass / {bucket['fail']} fail / "
             f"{bucket['not_applicable']} n-a"
+        )
+    if weighted:
+        decision_counts: dict[str, int] = {}
+        for scoring in weighted:
+            key = scoring.decision.value
+            decision_counts[key] = decision_counts.get(key, 0) + 1
+        average_quality = sum(item.raw_quality for item in weighted) / len(weighted)
+        decisions = ", ".join(
+            f"{name}={decision_counts[name]}" for name in sorted(decision_counts)
+        )
+        lines.append(
+            f"weighted reviews: average raw quality {average_quality:.3f}; {decisions}."
         )
     failures = [trial.trial_name for trial in trials if trial.error]
     if failures:

--- a/src/benchflow/review/runner.py
+++ b/src/benchflow/review/runner.py
@@ -167,7 +167,12 @@ def _is_passing(rollout_dir: Path) -> bool:
         return False
     rewards = result.get("rewards")
     reward = rewards.get("reward") if isinstance(rewards, dict) else None
-    return reward == 1.0 and result.get("error") is None
+    return (
+        isinstance(reward, int | float)
+        and not isinstance(reward, bool)
+        and reward == 1.0
+        and result.get("error") is None
+    )
 
 
 def discover_rollouts(

--- a/src/benchflow/review/scoring.py
+++ b/src/benchflow/review/scoring.py
@@ -1,0 +1,119 @@
+"""Deterministic aggregation for weighted review rubrics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from benchflow.review.config import Rubric
+
+PUBLISHABLE_QUALITY = 0.80
+REVISIONS_QUALITY = 0.65
+
+
+class PublicationDecision(StrEnum):
+    """Publication band produced after deterministic and blocker gates."""
+
+    PUBLISHABLE = "publishable"
+    PRESENTABLE_WITH_REVISIONS = "presentable_with_revisions"
+    NOT_PUBLISHABLE = "not_publishable"
+
+
+@dataclass(frozen=True)
+class ReviewScoring:
+    """Auditable host-side aggregation of one valid v0.2 review."""
+
+    deterministic_pass: bool
+    all_blockers_pass: bool
+    failed_blockers: tuple[str, ...]
+    weighted_points: int
+    max_weighted_points: int
+    raw_quality: float
+    gated_quality: float
+    decision: PublicationDecision
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "deterministic_pass": self.deterministic_pass,
+            "all_blockers_pass": self.all_blockers_pass,
+            "failed_blockers": list(self.failed_blockers),
+            "weighted_points": self.weighted_points,
+            "max_weighted_points": self.max_weighted_points,
+            "raw_quality": self.raw_quality,
+            "gated_quality": self.gated_quality,
+            "decision": self.decision.value,
+        }
+
+
+def score_weighted_review(
+    rubric: Rubric,
+    checks: Mapping[str, Mapping[str, Any]],
+    *,
+    deterministic_pass: bool,
+) -> ReviewScoring:
+    """Aggregate one structurally valid v0.2 review.
+
+    Blockers are binary gates and do not enter weighted quality. Scored
+    criteria contribute ``score * weight`` out of ``2 * weight``. The raw
+    quality remains visible even when a deterministic or blocker gate fails;
+    the gated quality is then zero and the decision is not publishable.
+    """
+
+    if not rubric.is_weighted:
+        raise ValueError("weighted scoring requires a v0.2 rubric")
+    if type(deterministic_pass) is not bool:
+        raise ValueError("deterministic_pass must be a boolean")
+
+    failed_blockers: list[str] = []
+    weighted_points = 0
+    max_weighted_points = 0
+    for criterion in rubric.criteria:
+        check = checks.get(criterion.name)
+        if not isinstance(check, Mapping):
+            raise ValueError(f"missing review check for {criterion.name!r}")
+        if criterion.is_blocker:
+            outcome = check.get("outcome")
+            if not isinstance(outcome, str) or outcome not in {"pass", "fail"}:
+                raise ValueError(
+                    f"blocker {criterion.name!r} must have outcome pass or fail"
+                )
+            if outcome == "fail":
+                failed_blockers.append(criterion.name)
+            continue
+
+        score = check.get("score")
+        if isinstance(score, bool) or not isinstance(score, int) or not 0 <= score <= 2:
+            raise ValueError(
+                f"scored criterion {criterion.name!r} must have integer score 0, 1, or 2"
+            )
+        if criterion.weight is None:  # guarded by Rubric validation
+            raise ValueError(f"scored criterion {criterion.name!r} has no weight")
+        weighted_points += score * criterion.weight
+        max_weighted_points += 2 * criterion.weight
+
+    if max_weighted_points == 0:  # guarded by Rubric validation
+        raise ValueError("weighted rubric has no scored criteria")
+
+    raw_quality = weighted_points / max_weighted_points
+    all_blockers_pass = not failed_blockers
+    gates_pass = deterministic_pass and all_blockers_pass
+    gated_quality = raw_quality if gates_pass else 0.0
+    if not gates_pass or raw_quality < REVISIONS_QUALITY:
+        decision = PublicationDecision.NOT_PUBLISHABLE
+    elif raw_quality < PUBLISHABLE_QUALITY:
+        decision = PublicationDecision.PRESENTABLE_WITH_REVISIONS
+    else:
+        decision = PublicationDecision.PUBLISHABLE
+
+    return ReviewScoring(
+        deterministic_pass=deterministic_pass,
+        all_blockers_pass=all_blockers_pass,
+        failed_blockers=tuple(failed_blockers),
+        weighted_points=weighted_points,
+        max_weighted_points=max_weighted_points,
+        raw_quality=raw_quality,
+        gated_quality=gated_quality,
+        decision=decision,
+    )

--- a/src/benchflow/review/wrapper.py
+++ b/src/benchflow/review/wrapper.py
@@ -13,15 +13,15 @@ synthetic task built here on the host:
   the agent-UID egress firewall, and the no-web agent policy end to end);
 - the instruction body is the rendered review prompt plus the structured
   output contract;
-- ``tests/`` holds a stdlib-only validator plus the criterion-name list, so
-  the wrapper's own reward means exactly "the reviewer produced a
+- ``tests/`` holds a stdlib-only validator plus the rubric contract
+  metadata, so the wrapper's own reward means exactly "the reviewer produced a
   structurally valid result file" — never "the reviewed run was good".
 
 The rubric file itself never enters the sandbox.  Only its derivatives do:
 guidance lines inside the instruction, criterion names inside the output
-schema, and the same names inside ``tests/criteria.json``.  Task evidence is
-sanitized: skills and any shipped ``rubric.json`` are excluded, and symlinks
-anywhere in the evidence are dropped rather than dereferenced.
+schema, and non-prompt contract metadata inside ``tests/criteria.json``. Task
+evidence is sanitized: skills and any shipped ``rubric.json`` are excluded,
+and symlinks anywhere in the evidence are dropped rather than dereferenced.
 """
 
 from __future__ import annotations
@@ -91,12 +91,17 @@ import json
 import sys
 from pathlib import Path
 
-OUTCOMES = {"pass", "fail", "not_applicable"}
+LEGACY_OUTCOMES = {"pass", "fail", "not_applicable"}
+BLOCKER_OUTCOMES = {"pass", "fail"}
 
 
 def main() -> int:
     result_path = Path(sys.argv[1])
-    names = set(json.loads(Path(sys.argv[2]).read_text(encoding="utf-8")))
+    rubric = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
+    criteria = rubric["criteria"]
+    specs = {criterion["name"]: criterion for criterion in criteria}
+    names = set(specs)
+    weighted = rubric.get("contract") == "v0.2"
 
     if not result_path.is_file():
         print(f"result file not found: {result_path}")
@@ -111,6 +116,12 @@ def main() -> int:
         return 1
 
     problems = []
+    expected_top_level = {"trial_name", "summary", "checks"}
+    for name in sorted(expected_top_level - data.keys()):
+        problems.append(f"result is missing key: {name}")
+    if weighted:
+        for name in sorted(data.keys() - expected_top_level):
+            problems.append(f"result has unexpected key: {name}")
     expected_trial = Path(sys.argv[3]).read_text(encoding="utf-8")
     if data.get("trial_name") != expected_trial:
         problems.append(
@@ -132,8 +143,32 @@ def main() -> int:
         if not isinstance(check, dict):
             problems.append(f"{name}: value must be an object")
             continue
-        if check.get("outcome") not in OUTCOMES:
-            problems.append(f"{name}: outcome must be one of {sorted(OUTCOMES)}")
+        blocker = specs[name].get("blocker")
+        if blocker is None:
+            expected_keys = {"outcome", "explanation"}
+            outcome = check.get("outcome")
+            if not isinstance(outcome, str) or outcome not in LEGACY_OUTCOMES:
+                problems.append(
+                    f"{name}: outcome must be one of {sorted(LEGACY_OUTCOMES)}"
+                )
+        elif blocker == 1:
+            expected_keys = {"outcome", "explanation"}
+            outcome = check.get("outcome")
+            if not isinstance(outcome, str) or outcome not in BLOCKER_OUTCOMES:
+                problems.append(
+                    f"{name}: blocker outcome must be one of "
+                    f"{sorted(BLOCKER_OUTCOMES)}"
+                )
+        else:
+            expected_keys = {"score", "explanation"}
+            score = check.get("score")
+            if isinstance(score, bool) or not isinstance(score, int) or score not in {0, 1, 2}:
+                problems.append(f"{name}: score must be the integer 0, 1, or 2")
+        if weighted:
+            for key in sorted(expected_keys - check.keys()):
+                problems.append(f"{name}: check is missing key: {key}")
+            for key in sorted(check.keys() - expected_keys):
+                problems.append(f"{name}: check has unexpected key: {key}")
         explanation = check.get("explanation")
         if not isinstance(explanation, str) or not explanation.strip():
             problems.append(f"{name}: explanation must be a non-empty string")
@@ -303,7 +338,7 @@ def assemble_review_task(
     )
     (tests_dir / "validate.py").write_text(_VALIDATOR, encoding="utf-8")
     (tests_dir / "criteria.json").write_text(
-        json.dumps([criterion.name for criterion in rubric.criteria], indent=2),
+        json.dumps(rubric.metadata(), indent=2),
         encoding="utf-8",
     )
     # Bind the verdict to the rollout under review: a reviewer that reports

--- a/src/benchflow/sandbox/docker.py
+++ b/src/benchflow/sandbox/docker.py
@@ -173,6 +173,7 @@ class DockerSandbox(BaseSandbox):
         self._keep_containers = keep_containers
         self._mounts_json = mounts_json
         self._mounts_compose_path: Path | None = None
+        self._logs_are_mounted = True
 
         verifier_dir = (
             str(rollout_paths.verifier_dir.resolve().absolute())
@@ -229,7 +230,40 @@ class DockerSandbox(BaseSandbox):
 
     @property
     def is_mounted(self) -> bool:
-        return True
+        return self._logs_are_mounted
+
+    async def _probe_verifier_log_mount(self) -> None:
+        """Confirm that the daemon can see the host verifier-log bind mount.
+
+        Docker Desktop normally translates WSL paths before they reach its VM.
+        A client connected directly to the underlying daemon can bypass that
+        translation: Compose still accepts the bind mount, but the container
+        and Benchflow then write to different directories.  Treat that case as
+        non-mounted so the verifier clears and downloads its remote outputs.
+        """
+        if self.rollout_paths is None:
+            return
+
+        probe_name = f".benchflow-mount-probe-{uuid.uuid4().hex}"
+        host_probe = self.rollout_paths.verifier_dir / probe_name
+        sandbox_probe = SandboxPaths.verifier_dir / probe_name
+        host_probe.parent.mkdir(parents=True, exist_ok=True)
+        host_probe.touch()
+        try:
+            result = await self.exec(
+                f"test -f {shlex.quote(str(sandbox_probe))}",
+                user="root",
+                timeout_sec=10,
+            )
+            self._logs_are_mounted = result.return_code == 0
+        finally:
+            host_probe.unlink(missing_ok=True)
+
+        if not self._logs_are_mounted:
+            self.logger.warning(
+                "Docker verifier-log bind mount is not visible inside the "
+                "container; verifier outputs will be copied back explicitly."
+            )
 
     @property
     def _dockerfile_path(self) -> Path:
@@ -486,6 +520,7 @@ class DockerSandbox(BaseSandbox):
         await self.exec(
             f"chmod 777 {SandboxPaths.agent_dir} {SandboxPaths.verifier_dir}"
         )
+        await self._probe_verifier_log_mount()
 
     async def stop(self, delete: bool) -> None:
         # Bounded chown: a hung agent container will make `docker exec` block

--- a/tests/test_review_boundaries.py
+++ b/tests/test_review_boundaries.py
@@ -36,6 +36,25 @@ JUDGE_RUBRIC = {
     ]
 }
 
+WEIGHTED_RUBRIC = {
+    "criteria": [
+        {
+            "name": "publication_gate",
+            "blocker": 1,
+            "weight": 10,
+            "description": "d",
+            "guidance": "PASS when publication requirements hold.",
+        },
+        {
+            "name": "research_quality",
+            "blocker": 0,
+            "weight": 7,
+            "description": "d",
+            "guidance": "Score 2, 1, or 0.",
+        },
+    ]
+}
+
 
 def make_rollout(root: Path, name: str = "rollout-a") -> Path:
     rollout = root / name
@@ -269,6 +288,14 @@ class TestRubricDialectDiscrimination:
         )
         assert find_task_rubric(task) == target
 
+    def test_weighted_review_rubric_is_claimed(self, tmp_path):
+        task = tmp_path / "weighted-task"
+        (task / "verifier").mkdir(parents=True)
+        target = task / "verifier" / "rubric.json"
+        target.write_text(json.dumps(WEIGHTED_RUBRIC), encoding="utf-8")
+        assert find_task_rubric(task) == target
+        assert load_rubric(target).contract == "v0.2"
+
     def test_judge_rubric_passes_task_authoring_check(self, tmp_path):
         from benchflow._utils.task_authoring import _check_review_rubric
 
@@ -278,6 +305,28 @@ class TestRubricDialectDiscrimination:
             json.dumps(JUDGE_RUBRIC), encoding="utf-8"
         )
         assert _check_review_rubric(verifier, verifier_label="verifier") == []
+
+    def test_weighted_review_rubric_passes_task_authoring_check(self, tmp_path):
+        from benchflow._utils.task_authoring import _check_review_rubric
+
+        verifier = tmp_path / "verifier"
+        verifier.mkdir()
+        (verifier / "rubric.json").write_text(
+            json.dumps(WEIGHTED_RUBRIC), encoding="utf-8"
+        )
+        assert _check_review_rubric(verifier, verifier_label="verifier") == []
+
+    def test_invalid_weighted_review_rubric_fails_task_authoring_check(self, tmp_path):
+        from benchflow._utils.task_authoring import _check_review_rubric
+
+        verifier = tmp_path / "verifier"
+        verifier.mkdir()
+        invalid = json.loads(json.dumps(WEIGHTED_RUBRIC))
+        invalid["criteria"][1].pop("weight")
+        (verifier / "rubric.json").write_text(json.dumps(invalid), encoding="utf-8")
+        problems = _check_review_rubric(verifier, verifier_label="verifier")
+        assert len(problems) == 1
+        assert "both blocker and weight" in problems[0]
 
     def test_all_misspelled_review_rubric_is_claimed(self, tmp_path):
         """Round-3 fix: only the judge dialect is disclaimed; a rubric with

--- a/tests/test_review_rubric.py
+++ b/tests/test_review_rubric.py
@@ -11,7 +11,10 @@ import pytest
 
 from benchflow.review.config import (
     DEFAULT_RUBRIC_PATH,
+    LEGACY_REVIEW_RUBRIC_CONTRACT,
     REVIEW_RESULT_FILENAME,
+    REVIEW_RUBRIC_CONTRACT,
+    WEIGHTED_REVIEW_RUBRIC_CONTRACT,
     ReviewRubricError,
     Rubric,
     build_criteria_guidance,
@@ -23,6 +26,10 @@ from benchflow.review.prompts import (
     TASK_MOUNT,
     TRIAL_MOUNT,
     render_review_instruction,
+)
+from benchflow.review.scoring import (
+    PublicationDecision,
+    score_weighted_review,
 )
 from benchflow.review.wrapper import assemble_review_task, copy_evidence
 
@@ -37,6 +44,32 @@ RUBRIC = {
             "name": "output_contract",
             "description": "Another internal note.",
             "guidance": "PASS when required outputs exist; FAIL when missing.",
+        },
+    ]
+}
+
+WEIGHTED_RUBRIC = {
+    "criteria": [
+        {
+            "name": "safety_gate",
+            "blocker": 1,
+            "weight": 10,
+            "description": "The result must satisfy the safety gate.",
+            "guidance": "PASS when the safety invariant holds; FAIL otherwise.",
+        },
+        {
+            "name": "method_quality",
+            "blocker": 0,
+            "weight": 3,
+            "description": "Assess the quality of the method.",
+            "guidance": "Score 2 for complete, 1 for partial, or 0 for absent.",
+        },
+        {
+            "name": "evidence_quality",
+            "blocker": 0,
+            "weight": 2,
+            "description": "Assess the quality of the evidence.",
+            "guidance": "Score 2 for complete, 1 for partial, or 0 for absent.",
         },
     ]
 }
@@ -56,6 +89,74 @@ class TestLoadRubric:
             "output_contract",
         ]
         assert rubric.criteria[0].guidance.startswith("PASS when")
+        assert rubric.contract == LEGACY_REVIEW_RUBRIC_CONTRACT
+        assert REVIEW_RUBRIC_CONTRACT == LEGACY_REVIEW_RUBRIC_CONTRACT
+
+    def test_loads_frontierphysics_weighted_rubric_contract(self, tmp_path):
+        """Guards FrontierPhysics PR #109 at head commit 4bdbd2e against
+        rejecting or silently downgrading its weighted rubric.json format.
+        """
+
+        rubric = load_rubric(write_rubric(tmp_path, WEIGHTED_RUBRIC))
+        assert rubric.contract == WEIGHTED_REVIEW_RUBRIC_CONTRACT
+        assert rubric.is_weighted
+        assert rubric.metadata() == {
+            "contract": "v0.2",
+            "criteria": [
+                {"name": "safety_gate", "blocker": 1, "weight": 10},
+                {"name": "method_quality", "blocker": 0, "weight": 3},
+                {"name": "evidence_quality", "blocker": 0, "weight": 2},
+            ],
+        }
+
+    @pytest.mark.parametrize("field", ["blocker", "weight"])
+    def test_rejects_partially_weighted_criterion(self, tmp_path, field):
+        criterion = dict(WEIGHTED_RUBRIC["criteria"][1])
+        criterion.pop(field)
+        with pytest.raises(ReviewRubricError, match="both blocker and weight"):
+            load_rubric(write_rubric(tmp_path, {"criteria": [criterion]}))
+
+    def test_rejects_mixed_legacy_and_weighted_contracts(self, tmp_path):
+        mixed = {"criteria": [RUBRIC["criteria"][0], WEIGHTED_RUBRIC["criteria"][1]]}
+        with pytest.raises(ReviewRubricError, match="cannot be mixed"):
+            load_rubric(write_rubric(tmp_path, mixed))
+
+    def test_rejects_explicit_null_scoring_fields(self, tmp_path):
+        criterion = {
+            **RUBRIC["criteria"][0],
+            "blocker": None,
+            "weight": None,
+        }
+        with pytest.raises(ReviewRubricError, match="null is not allowed"):
+            load_rubric(write_rubric(tmp_path, {"criteria": [criterion]}))
+
+    def test_rejects_weighted_rubric_with_only_blockers(self, tmp_path):
+        only_blockers = {
+            "criteria": [
+                {**WEIGHTED_RUBRIC["criteria"][0], "name": "first_gate"},
+                {**WEIGHTED_RUBRIC["criteria"][0], "name": "second_gate"},
+            ]
+        }
+        with pytest.raises(ReviewRubricError, match="blocker: 0"):
+            load_rubric(write_rubric(tmp_path, only_blockers))
+
+    @pytest.mark.parametrize(
+        "blocker",
+        [True, False, -1, 2, 0.0, 1.0, "0", "1", None],
+    )
+    def test_blocker_requires_strict_integer_zero_or_one(self, tmp_path, blocker):
+        criterion = {**WEIGHTED_RUBRIC["criteria"][1], "blocker": blocker}
+        with pytest.raises(ReviewRubricError, match="not a valid rubric"):
+            load_rubric(write_rubric(tmp_path, {"criteria": [criterion]}))
+
+    @pytest.mark.parametrize(
+        "weight",
+        [True, False, 0, 11, 1.0, 10.0, "1", "10", None],
+    )
+    def test_weight_requires_strict_integer_one_through_ten(self, tmp_path, weight):
+        criterion = {**WEIGHTED_RUBRIC["criteria"][1], "weight": weight}
+        with pytest.raises(ReviewRubricError, match="not a valid rubric"):
+            load_rubric(write_rubric(tmp_path, {"criteria": [criterion]}))
 
     def test_default_rubric_ships_and_loads(self):
         rubric = load_rubric(None)
@@ -195,6 +296,210 @@ class TestGuidanceAndSchema:
         with pytest.raises(ValueError):
             model.model_validate(bad)
 
+    def test_legacy_response_model_keeps_permissive_extra_field_behavior(self):
+        model = build_review_response_model(
+            Rubric.model_validate({"criteria": RUBRIC["criteria"][:1]})
+        )
+        result = {
+            "trial_name": "t",
+            "summary": "s",
+            "legacy_top_level_extra": True,
+            "checks": {
+                "method_soundness": {
+                    "explanation": "e",
+                    "outcome": "pass",
+                    "legacy_check_extra": True,
+                }
+            },
+        }
+        assert model.model_validate(result)
+
+    @pytest.mark.parametrize("field", ["summary", "explanation"])
+    def test_response_model_rejects_whitespace_only_text(self, field):
+        model = build_review_response_model(
+            Rubric.model_validate({"criteria": RUBRIC["criteria"][:1]})
+        )
+        result = {
+            "trial_name": "t",
+            "summary": "summary",
+            "checks": {"method_soundness": {"explanation": "e", "outcome": "pass"}},
+        }
+        if field == "summary":
+            result["summary"] = " \t "
+        else:
+            result["checks"]["method_soundness"]["explanation"] = " \t "
+        with pytest.raises(ValueError, match="non-whitespace"):
+            model.model_validate(result)
+
+    def test_weighted_guidance_labels_blockers_scores_and_weights(self):
+        rubric = Rubric.model_validate(WEIGHTED_RUBRIC)
+        guidance = build_criteria_guidance(rubric)
+        assert "safety_gate [BLOCKER; answer pass or fail; weight 10" in guidance
+        assert "method_quality [SCORED; weight 3; answer 0, 1, or 2]" in guidance
+        assert "evidence_quality [SCORED; weight 2; answer 0, 1, or 2]" in guidance
+
+    def test_weighted_response_model_uses_distinct_check_shapes(self):
+        model = build_review_response_model(Rubric.model_validate(WEIGHTED_RUBRIC))
+        valid = {
+            "trial_name": "t",
+            "summary": "s",
+            "checks": {
+                "safety_gate": {"explanation": "safe", "outcome": "pass"},
+                "method_quality": {"explanation": "complete", "score": 2},
+                "evidence_quality": {"explanation": "partial", "score": 1},
+            },
+        }
+        assert model.model_validate(valid)
+
+        invalid_cases = []
+        blocker_not_applicable = json.loads(json.dumps(valid))
+        blocker_not_applicable["checks"]["safety_gate"]["outcome"] = "not_applicable"
+        invalid_cases.append(blocker_not_applicable)
+        scored_as_outcome = json.loads(json.dumps(valid))
+        scored_as_outcome["checks"]["method_quality"] = {
+            "explanation": "wrong shape",
+            "outcome": "pass",
+        }
+        invalid_cases.append(scored_as_outcome)
+        blocker_as_score = json.loads(json.dumps(valid))
+        blocker_as_score["checks"]["safety_gate"] = {
+            "explanation": "wrong shape",
+            "score": 2,
+        }
+        invalid_cases.append(blocker_as_score)
+        for invalid in invalid_cases:
+            with pytest.raises(ValueError):
+                model.model_validate(invalid)
+
+    @pytest.mark.parametrize("score", [True, False, -1, 3, 1.0, "1", None])
+    def test_weighted_response_model_requires_strict_score(self, score):
+        rubric = Rubric.model_validate({"criteria": [WEIGHTED_RUBRIC["criteria"][1]]})
+        model = build_review_response_model(rubric)
+        result = {
+            "trial_name": "t",
+            "summary": "s",
+            "checks": {
+                "method_quality": {"explanation": "e", "score": score},
+            },
+        }
+        with pytest.raises(ValueError):
+            model.model_validate(result)
+
+
+class TestWeightedScoring:
+    def test_blocker_weights_are_excluded_and_point_eight_is_publishable(self):
+        rubric = Rubric.model_validate(WEIGHTED_RUBRIC)
+        scoring = score_weighted_review(
+            rubric,
+            {
+                "safety_gate": {"outcome": "pass", "explanation": "safe"},
+                "method_quality": {"score": 2, "explanation": "complete"},
+                "evidence_quality": {"score": 1, "explanation": "partial"},
+            },
+            deterministic_pass=True,
+        )
+        assert scoring.weighted_points == 8
+        assert scoring.max_weighted_points == 10
+        assert scoring.raw_quality == pytest.approx(0.8)
+        assert scoring.gated_quality == pytest.approx(0.8)
+        assert scoring.decision is PublicationDecision.PUBLISHABLE
+
+    def test_point_six_five_is_presentable_with_revisions(self):
+        rubric_data = {
+            "criteria": [
+                {**WEIGHTED_RUBRIC["criteria"][1], "weight": 3},
+                {**WEIGHTED_RUBRIC["criteria"][2], "weight": 7},
+            ]
+        }
+        scoring = score_weighted_review(
+            Rubric.model_validate(rubric_data),
+            {
+                "method_quality": {"score": 2},
+                "evidence_quality": {"score": 1},
+            },
+            deterministic_pass=True,
+        )
+        assert scoring.raw_quality == pytest.approx(0.65)
+        assert scoring.decision is PublicationDecision.PRESENTABLE_WITH_REVISIONS
+
+    @pytest.mark.parametrize(
+        ("deterministic_pass", "blocker_outcome", "failed_blockers"),
+        [
+            (False, "pass", ()),
+            (True, "fail", ("safety_gate",)),
+            (False, "fail", ("safety_gate",)),
+        ],
+    )
+    def test_failed_gate_zeroes_gated_quality_but_preserves_raw_quality(
+        self, deterministic_pass, blocker_outcome, failed_blockers
+    ):
+        scoring = score_weighted_review(
+            Rubric.model_validate(WEIGHTED_RUBRIC),
+            {
+                "safety_gate": {"outcome": blocker_outcome},
+                "method_quality": {"score": 2},
+                "evidence_quality": {"score": 1},
+            },
+            deterministic_pass=deterministic_pass,
+        )
+        assert scoring.raw_quality == pytest.approx(0.8)
+        assert scoring.gated_quality == 0.0
+        assert scoring.failed_blockers == failed_blockers
+        assert scoring.decision is PublicationDecision.NOT_PUBLISHABLE
+
+    def test_below_point_six_five_is_not_publishable(self):
+        rubric = Rubric.model_validate({"criteria": [WEIGHTED_RUBRIC["criteria"][1]]})
+        scoring = score_weighted_review(
+            rubric,
+            {"method_quality": {"score": 1}},
+            deterministic_pass=True,
+        )
+        assert scoring.raw_quality == pytest.approx(0.5)
+        assert scoring.decision is PublicationDecision.NOT_PUBLISHABLE
+
+    @pytest.mark.parametrize("score", [True, False, -1, 3, 1.0, "1", None])
+    def test_aggregation_rejects_non_contract_scores(self, score):
+        rubric = Rubric.model_validate({"criteria": [WEIGHTED_RUBRIC["criteria"][1]]})
+        with pytest.raises(ValueError, match="integer score"):
+            score_weighted_review(
+                rubric,
+                {"method_quality": {"score": score}},
+                deterministic_pass=True,
+            )
+
+    def test_aggregation_rejects_legacy_rubric(self):
+        with pytest.raises(ValueError, match=r"v0\.2"):
+            score_weighted_review(
+                Rubric.model_validate(RUBRIC),
+                {"method_soundness": {"outcome": "pass"}},
+                deterministic_pass=True,
+            )
+
+    @pytest.mark.parametrize("outcome", [[], {}])
+    def test_aggregation_rejects_unhashable_blocker_outcomes(self, outcome):
+        with pytest.raises(ValueError, match="pass or fail"):
+            score_weighted_review(
+                Rubric.model_validate(WEIGHTED_RUBRIC),
+                {
+                    "safety_gate": {"outcome": outcome},
+                    "method_quality": {"score": 2},
+                    "evidence_quality": {"score": 1},
+                },
+                deterministic_pass=True,
+            )
+
+    def test_aggregation_requires_boolean_deterministic_gate(self):
+        with pytest.raises(ValueError, match="must be a boolean"):
+            score_weighted_review(
+                Rubric.model_validate(WEIGHTED_RUBRIC),
+                {
+                    "safety_gate": {"outcome": "pass"},
+                    "method_quality": {"score": 2},
+                    "evidence_quality": {"score": 1},
+                },
+                deterministic_pass=1,
+            )
+
 
 class TestPromptRendering:
     def test_instruction_contains_contract(self):
@@ -233,6 +538,18 @@ class TestPromptRendering:
         instruction = render_review_instruction(rubric, trial_name='a"b\nline')
         assert 'exactly "a\\"b\\nline"' in instruction
 
+    def test_weighted_instruction_explains_distinct_judgment_contracts(self):
+        instruction = render_review_instruction(
+            Rubric.model_validate(WEIGHTED_RUBRIC),
+            output_schema={"marker": "weighted-schema"},
+        )
+        assert "BLOCKER" in instruction
+        assert "pass" in instruction and "fail" in instruction
+        assert "SCORED" in instruction
+        assert "0, 1, or 2" in instruction
+        assert "not_applicable" not in instruction
+        assert "weighted-schema" in instruction
+
 
 class TestWrapperAssembly:
     def make_rollout(self, tmp_path: Path) -> Path:
@@ -264,12 +581,25 @@ class TestWrapperAssembly:
         assert not list(dest.rglob("Dockerfile"))
         assert (dest / "tests" / "test.sh").is_file()
         assert (dest / "tests" / "validate.py").is_file()
-        names = json.loads((dest / "tests" / "criteria.json").read_text("utf-8"))
-        assert names == ["method_soundness", "output_contract"]
+        metadata = json.loads(
+            (dest / "tests" / "criteria.json").read_text(encoding="utf-8")
+        )
+        assert metadata == rubric.metadata()
         assert uploads == {
             str(dest / "evidence" / "trial"): TRIAL_MOUNT,
             str(dest / "evidence" / "task"): TASK_MOUNT,
         }
+
+    def test_weighted_wrapper_carries_contract_metadata_not_guidance(self, tmp_path):
+        rubric = Rubric.model_validate(WEIGHTED_RUBRIC)
+        rollout = self.make_rollout(tmp_path)
+        dest, _ = assemble_review_task(
+            rollout, None, rubric, tmp_path / "weighted-wrapper"
+        )
+        metadata_text = (dest / "tests" / "criteria.json").read_text(encoding="utf-8")
+        assert json.loads(metadata_text) == rubric.metadata()
+        assert "Assess the quality" not in metadata_text
+        assert "Score 2" not in metadata_text
 
     def test_wrapper_never_contains_the_rubric_file(self, tmp_path):
         """The rubric is decomposed host-side; the file itself never ships.
@@ -332,8 +662,14 @@ class TestWrapperAssembly:
 class TestWrapperValidator:
     """Run the shipped in-sandbox validator exactly as the wrapper does."""
 
-    def run_validator(self, tmp_path: Path, result: dict | str) -> tuple[int, str]:
-        rubric = Rubric.model_validate(RUBRIC)
+    def run_validator(
+        self,
+        tmp_path: Path,
+        result: dict | str,
+        *,
+        rubric_data: dict | None = None,
+    ) -> tuple[int, str]:
+        rubric = Rubric.model_validate(RUBRIC if rubric_data is None else rubric_data)
         rollout = tmp_path / "r"
         rollout.mkdir()
         (rollout / "result.json").write_text("{}", encoding="utf-8")
@@ -365,6 +701,17 @@ class TestWrapperValidator:
             },
         }
 
+    def good_weighted_result(self) -> dict:
+        return {
+            "trial_name": "r",
+            "summary": "Weighted review complete.",
+            "checks": {
+                "safety_gate": {"explanation": "safe", "outcome": "pass"},
+                "method_quality": {"explanation": "complete", "score": 2},
+                "evidence_quality": {"explanation": "partial", "score": 1},
+            },
+        }
+
     def test_valid_result_passes(self, tmp_path):
         code, out = self.run_validator(tmp_path, self.good_result())
         assert code == 0, out
@@ -374,6 +721,71 @@ class TestWrapperValidator:
         result["checks"]["method_soundness"]["outcome"] = "not_applicable"
         code, _ = self.run_validator(tmp_path, result)
         assert code == 0
+
+    def test_legacy_validator_preserves_extra_field_compatibility(self, tmp_path):
+        result = self.good_result()
+        result["legacy_top_level_extra"] = True
+        result["checks"]["method_soundness"]["legacy_check_extra"] = True
+        code, out = self.run_validator(tmp_path, result)
+        assert code == 0, out
+
+    def test_unhashable_legacy_outcome_fails_cleanly(self, tmp_path):
+        result = self.good_result()
+        result["checks"]["method_soundness"]["outcome"] = []
+        code, out = self.run_validator(tmp_path, result)
+        assert code == 1
+        assert "outcome must be one of" in out
+
+    def test_valid_weighted_result_passes(self, tmp_path):
+        code, out = self.run_validator(
+            tmp_path,
+            self.good_weighted_result(),
+            rubric_data=WEIGHTED_RUBRIC,
+        )
+        assert code == 0, out
+
+    @pytest.mark.parametrize("score", [0, 1, 2])
+    def test_each_weighted_score_is_valid(self, tmp_path, score):
+        result = self.good_weighted_result()
+        result["checks"]["method_quality"]["score"] = score
+        code, out = self.run_validator(tmp_path, result, rubric_data=WEIGHTED_RUBRIC)
+        assert code == 0, out
+
+    @pytest.mark.parametrize("score", [True, False, -1, 3, 1.0, "1", None])
+    def test_invalid_weighted_scores_fail(self, tmp_path, score):
+        result = self.good_weighted_result()
+        result["checks"]["method_quality"]["score"] = score
+        code, out = self.run_validator(tmp_path, result, rubric_data=WEIGHTED_RUBRIC)
+        assert code == 1, out
+
+    def test_weighted_blocker_disallows_not_applicable(self, tmp_path):
+        result = self.good_weighted_result()
+        result["checks"]["safety_gate"]["outcome"] = "not_applicable"
+        code, out = self.run_validator(tmp_path, result, rubric_data=WEIGHTED_RUBRIC)
+        assert code == 1, out
+
+    @pytest.mark.parametrize(
+        "criterion,replacement",
+        [
+            (
+                "safety_gate",
+                {"explanation": "wrong shape", "score": 2},
+            ),
+            (
+                "method_quality",
+                {"explanation": "wrong shape", "outcome": "pass"},
+            ),
+            (
+                "method_quality",
+                {"explanation": "extra field", "score": 2, "outcome": "pass"},
+            ),
+        ],
+    )
+    def test_weighted_check_shapes_fail_closed(self, tmp_path, criterion, replacement):
+        result = self.good_weighted_result()
+        result["checks"][criterion] = replacement
+        code, out = self.run_validator(tmp_path, result, rubric_data=WEIGHTED_RUBRIC)
+        assert code == 1, out
 
     def test_trial_name_round_trips_without_whitespace_loss(self, tmp_path):
         """Guards PR #942: validator identity matching must be byte-exact."""

--- a/tests/test_review_runtime.py
+++ b/tests/test_review_runtime.py
@@ -300,11 +300,12 @@ class TestRunReviews:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         ("reward", "error"),
-        [(0.0, None), (1.0, "source agent failed")],
+        [(0.0, None), (1.0, "source agent failed"), (True, None)],
     )
     async def test_source_deterministic_failure_gates_weighted_quality(
         self, tmp_path, monkeypatch, reward, error
     ):
+        """Guards PR #1040: boolean rewards never open the numeric pass gate."""
         task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
         rollout = make_rollout(
             tmp_path / "jobs",

--- a/tests/test_review_runtime.py
+++ b/tests/test_review_runtime.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from io import StringIO
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 
@@ -14,6 +13,7 @@ from benchflow.review.config import REVIEW_RESULT_FILENAME
 from benchflow.review.runner import (
     REVIEW_REPORT_FILENAME,
     ReviewRunError,
+    TrialReview,
     _lock_review_evidence,
     _task_digest_issue,
     discover_rollouts,
@@ -28,6 +28,32 @@ RUBRIC = {
             "description": "d",
             "guidance": "PASS when sound; FAIL otherwise.",
         }
+    ]
+}
+
+WEIGHTED_RUBRIC = {
+    "criteria": [
+        {
+            "name": "safety_gate",
+            "blocker": 1,
+            "weight": 10,
+            "description": "d",
+            "guidance": "PASS when safe; FAIL otherwise.",
+        },
+        {
+            "name": "method_quality",
+            "blocker": 0,
+            "weight": 3,
+            "description": "d",
+            "guidance": "Score 2, 1, or 0.",
+        },
+        {
+            "name": "evidence_quality",
+            "blocker": 0,
+            "weight": 2,
+            "description": "d",
+            "guidance": "Score 2, 1, or 0.",
+        },
     ]
 }
 
@@ -65,7 +91,12 @@ def make_rollout(
     return rollout
 
 
-def make_task(root: Path, *, with_rubric: bool = False) -> Path:
+def make_task(
+    root: Path,
+    *,
+    with_rubric: bool = False,
+    rubric_data: dict | None = None,
+) -> Path:
     """Create a task inside a *trusted tasks root* (see ``--tasks-root``).
 
     Task evidence is only included when the caller names a trusted root: a
@@ -77,7 +108,8 @@ def make_task(root: Path, *, with_rubric: bool = False) -> Path:
     (task / "task.md").write_text("---\n---\nbody", encoding="utf-8")
     if with_rubric:
         (task / "verifier" / "rubric.json").write_text(
-            json.dumps(RUBRIC), encoding="utf-8"
+            json.dumps(RUBRIC if rubric_data is None else rubric_data),
+            encoding="utf-8",
         )
     return task
 
@@ -133,6 +165,18 @@ def good_review(name: str = "rollout-a") -> dict:
         "trial_name": name,
         "summary": "Reviewed fine.",
         "checks": {"method_soundness": {"explanation": "ok", "outcome": "pass"}},
+    }
+
+
+def good_weighted_review(name: str = "rollout-a") -> dict:
+    return {
+        "trial_name": name,
+        "summary": "Weighted review complete.",
+        "checks": {
+            "safety_gate": {"explanation": "safe", "outcome": "pass"},
+            "method_quality": {"explanation": "complete", "score": 2},
+            "evidence_quality": {"explanation": "partial", "score": 1},
+        },
     }
 
 
@@ -199,6 +243,173 @@ class TestRunReviews:
             t["checks"]["method_soundness"]["outcome"] == "pass" for t in data["trials"]
         )
         assert len(fake.configs) == 2
+
+    @pytest.mark.asyncio
+    async def test_weighted_review_is_scored_and_recorded(self, tmp_path, monkeypatch):
+        task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
+        rollout = make_rollout(
+            tmp_path / "jobs", "rollout-a", reward=1.0, task_path=task
+        )
+        source_result_before = (rollout / "result.json").read_bytes()
+        monkeypatch.setattr(
+            benchflow,
+            "run",
+            FakeRun(review_payload=good_weighted_review()),
+        )
+
+        report, report_path = await run_reviews(
+            rollout,
+            agent="gemini",
+            out_dir=tmp_path / "out",
+            tasks_root=tmp_path / "tasks",
+        )
+
+        trial = report.trials[0]
+        assert trial.review_valid is True
+        assert trial.rubric_contract == "v0.2"
+        assert trial.criterion_metadata == [
+            {"name": "safety_gate", "blocker": 1, "weight": 10},
+            {"name": "method_quality", "blocker": 0, "weight": 3},
+            {"name": "evidence_quality", "blocker": 0, "weight": 2},
+        ]
+        assert trial.checks["method_quality"]["score"] == 2
+        assert trial.scoring is not None
+        assert trial.scoring.weighted_points == 8
+        assert trial.scoring.max_weighted_points == 10
+        assert trial.scoring.raw_quality == pytest.approx(0.8)
+        assert trial.scoring.gated_quality == pytest.approx(0.8)
+        assert trial.scoring.decision == "publishable"
+        assert (rollout / "result.json").read_bytes() == source_result_before
+
+        serialized = json.loads(report_path.read_text(encoding="utf-8"))
+        serialized_trial = serialized["trials"][0]
+        assert serialized["rubric"]["contracts"] == ["v0.2"]
+        assert serialized_trial["rubric_contract"] == "v0.2"
+        assert serialized_trial["criterion_metadata"] == trial.criterion_metadata
+        assert serialized_trial["scoring"] == {
+            "deterministic_pass": True,
+            "all_blockers_pass": True,
+            "failed_blockers": [],
+            "weighted_points": 8,
+            "max_weighted_points": 10,
+            "raw_quality": 0.8,
+            "gated_quality": 0.8,
+            "decision": "publishable",
+        }
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("reward", "error"),
+        [(0.0, None), (1.0, "source agent failed")],
+    )
+    async def test_source_deterministic_failure_gates_weighted_quality(
+        self, tmp_path, monkeypatch, reward, error
+    ):
+        task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
+        rollout = make_rollout(
+            tmp_path / "jobs",
+            "rollout-a",
+            reward=reward,
+            error=error,
+            task_path=task,
+        )
+        monkeypatch.setattr(
+            benchflow,
+            "run",
+            FakeRun(review_payload=good_weighted_review()),
+        )
+
+        report, _ = await run_reviews(
+            rollout,
+            agent="gemini",
+            out_dir=tmp_path / "out",
+            tasks_root=tmp_path / "tasks",
+        )
+
+        scoring = report.trials[0].scoring
+        assert scoring is not None
+        assert scoring.deterministic_pass is False
+        assert scoring.raw_quality == pytest.approx(0.8)
+        assert scoring.gated_quality == 0.0
+        assert scoring.decision == "not_publishable"
+
+    @pytest.mark.asyncio
+    async def test_failed_blocker_gates_weighted_quality(self, tmp_path, monkeypatch):
+        task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
+        rollout = make_rollout(
+            tmp_path / "jobs", "rollout-a", reward=1.0, task_path=task
+        )
+        payload = good_weighted_review()
+        payload["checks"]["safety_gate"]["outcome"] = "fail"
+        monkeypatch.setattr(benchflow, "run", FakeRun(review_payload=payload))
+
+        report, _ = await run_reviews(
+            rollout,
+            agent="gemini",
+            out_dir=tmp_path / "out",
+            tasks_root=tmp_path / "tasks",
+        )
+
+        scoring = report.trials[0].scoring
+        assert scoring is not None
+        assert scoring.all_blockers_pass is False
+        assert scoring.failed_blockers == ("safety_gate",)
+        assert scoring.raw_quality == pytest.approx(0.8)
+        assert scoring.gated_quality == 0.0
+        assert scoring.decision == "not_publishable"
+
+    @pytest.mark.asyncio
+    async def test_invalid_weighted_review_never_aggregates(
+        self, tmp_path, monkeypatch
+    ):
+        task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
+        rollout = make_rollout(
+            tmp_path / "jobs", "rollout-a", reward=1.0, task_path=task
+        )
+        monkeypatch.setattr(
+            benchflow,
+            "run",
+            FakeRun(reward=0.0, review_payload=good_weighted_review()),
+        )
+
+        report, _ = await run_reviews(
+            rollout,
+            agent="gemini",
+            out_dir=tmp_path / "out",
+            tasks_root=tmp_path / "tasks",
+        )
+
+        trial = report.trials[0]
+        assert trial.review_valid is False
+        assert trial.scoring is None
+
+    @pytest.mark.asyncio
+    async def test_host_validation_gates_weighted_scoring(self, tmp_path, monkeypatch):
+        """Guards FrontierPhysics PR #109 when wrapper reward and artifact diverge."""
+
+        task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
+        rollout = make_rollout(
+            tmp_path / "jobs", "rollout-a", reward=1.0, task_path=task
+        )
+        payload = good_weighted_review()
+        payload["checks"]["method_quality"]["unexpected"] = "must fail closed"
+        monkeypatch.setattr(
+            benchflow,
+            "run",
+            FakeRun(reward=1.0, review_payload=payload),
+        )
+
+        report, _ = await run_reviews(
+            rollout,
+            agent="gemini",
+            out_dir=tmp_path / "out",
+            tasks_root=tmp_path / "tasks",
+        )
+
+        trial = report.trials[0]
+        assert trial.review_valid is False
+        assert trial.scoring is None
+        assert "host-side structural validation" in (trial.error or "")
 
     @pytest.mark.asyncio
     async def test_wrapper_config_shape(self, tmp_path, monkeypatch):
@@ -360,7 +571,10 @@ class TestRunReviews:
             out_dir=tmp_path / "out",
             tasks_root=tmp_path / "tasks",
         )
-        assert seen["criteria"] == ["override_only"]
+        assert seen["criteria"] == {
+            "contract": "v0.1",
+            "criteria": [{"name": "override_only", "blocker": None, "weight": None}],
+        }
 
     @pytest.mark.asyncio
     async def test_task_rubric_used_when_no_override(self, tmp_path, monkeypatch):
@@ -381,7 +595,10 @@ class TestRunReviews:
             out_dir=tmp_path / "out",
             tasks_root=tmp_path / "tasks",
         )
-        assert seen["criteria"] == ["method_soundness"]
+        assert seen["criteria"] == {
+            "contract": "v0.1",
+            "criteria": [{"name": "method_soundness", "blocker": None, "weight": None}],
+        }
 
     @pytest.mark.asyncio
     async def test_default_rubric_when_task_ships_none(self, tmp_path, monkeypatch):
@@ -402,7 +619,13 @@ class TestRunReviews:
             out_dir=tmp_path / "out",
             tasks_root=tmp_path / "tasks",
         )
-        assert seen["criteria"] == ["reward_hacking", "task_specification"]
+        assert seen["criteria"] == {
+            "contract": "v0.1",
+            "criteria": [
+                {"name": "reward_hacking", "blocker": None, "weight": None},
+                {"name": "task_specification", "blocker": None, "weight": None},
+            ],
+        }
 
     @pytest.mark.asyncio
     async def test_bad_explicit_rubric_fails_fast(self, tmp_path, monkeypatch):
@@ -431,7 +654,7 @@ class TestRunReviews:
         make_rollout(tmp_path / "jobs", "rollout-b")
         rubric_path = tmp_path / "rubric.json"
         rubric_path.write_text(json.dumps(RUBRIC), encoding="utf-8")
-        seen: list[list[str]] = []
+        seen: list[dict] = []
 
         async def mutate_after_first_wrapper(config: RolloutConfig):
             criteria = json.loads(
@@ -463,7 +686,11 @@ class TestRunReviews:
             out_dir=tmp_path / "out",
         )
 
-        assert seen == [["method_soundness"], ["method_soundness"]]
+        expected_metadata = {
+            "contract": "v0.1",
+            "criteria": [{"name": "method_soundness", "blocker": None, "weight": None}],
+        }
+        assert seen == [expected_metadata, expected_metadata]
         assert report.criteria == ["method_soundness"]
         assert all(t.criteria == ["method_soundness"] for t in report.trials)
 
@@ -523,6 +750,37 @@ class TestRunReviews:
             tmp_path / "jobs", agent="gemini", out_dir=tmp_path / "out"
         )
         assert report.job_summary is None
+
+    @pytest.mark.asyncio
+    async def test_weighted_job_summary_labels_binary_counts(
+        self, tmp_path, monkeypatch
+    ):
+        """Guards FrontierPhysics PR #109 against omitting scored criteria silently."""
+
+        task = make_task(tmp_path, with_rubric=True, rubric_data=WEIGHTED_RUBRIC)
+        make_rollout(tmp_path / "jobs", "a", task_path=task)
+        make_rollout(tmp_path / "jobs", "b", task_path=task)
+
+        async def weighted_run(config: RolloutConfig):
+            trial_name = Path(config.task_path).name.removeprefix("review-")
+            return await FakeRun(review_payload=good_weighted_review(trial_name))(
+                config
+            )
+
+        monkeypatch.setattr(benchflow, "run", weighted_run)
+        report, _ = await run_reviews(
+            tmp_path / "jobs",
+            agent="gemini",
+            out_dir=tmp_path / "out",
+            tasks_root=tmp_path / "tasks",
+        )
+
+        assert report.job_summary is not None
+        assert "Binary judgments (legacy criteria and weighted blockers only)" in (
+            report.job_summary
+        )
+        assert "across all criteria" not in report.job_summary
+        assert "weighted reviews: average raw quality 0.800" in report.job_summary
 
 
 class TestTaskDigestAdmission:
@@ -606,13 +864,17 @@ def test_cli_rendering_escapes_untrusted_review_fields(monkeypatch):
         "console",
         Console(file=output, force_terminal=True, color_system=None),
     )
-    trial = SimpleNamespace(
+    trial = TrialReview(
         trial_name="[/bold]",
-        checks={"[/red]": {"outcome": "[/green]", "explanation": "[x]"}},
+        source_rollout="diagnostic",
+        checks={
+            "[/red]": {"outcome": "[/green]", "explanation": "[x]"},
+            "hostile_outcome": {"outcome": {}, "explanation": "diagnostic"},
+            "hostile_score": {"score": [], "explanation": "diagnostic"},
+        },
         summary="[/bold]",
         error="[/red]",
         review_valid=False,
-        outcome_counts=lambda: {"pass": 0, "fail": 0, "not_applicable": 0},
     )
     review_cli._render_trial_review(trial)
     review_cli._render_review_overview([trial])

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -102,6 +102,54 @@ class TestSandboxDirs:
         assert all(d.startswith(".") for d in dirs)
 
 
+class TestDockerVerifierLogMountProbe:
+    @pytest.mark.asyncio
+    async def test_untranslated_bind_mount_uses_copy_out(self, tmp_path):
+        """Guards PR #1040 against raw Docker sockets losing WSL path translation."""
+        from unittest.mock import AsyncMock
+
+        from benchflow.sandbox import docker as docker_module
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.docker import DockerSandbox
+
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox.rollout_paths = SimpleNamespace(verifier_dir=tmp_path / "verifier")
+        sandbox._logs_are_mounted = True
+        sandbox.logger = docker_module.logger
+        sandbox.exec = AsyncMock(
+            return_value=ExecResult(stdout="", stderr="", return_code=1)
+        )
+
+        await sandbox._probe_verifier_log_mount()
+
+        assert sandbox.is_mounted is False
+        assert not list(sandbox.rollout_paths.verifier_dir.iterdir())
+        command = sandbox.exec.await_args.args[0]
+        assert command.startswith("test -f /logs/verifier/.benchflow-mount-probe-")
+
+    @pytest.mark.asyncio
+    async def test_visible_bind_mount_keeps_mounted_fast_path(self, tmp_path):
+        """Guards PR #1040 by preserving Docker's normal mounted fast path."""
+        from unittest.mock import AsyncMock
+
+        from benchflow.sandbox import docker as docker_module
+        from benchflow.sandbox._base import ExecResult
+        from benchflow.sandbox.docker import DockerSandbox
+
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox.rollout_paths = SimpleNamespace(verifier_dir=tmp_path / "verifier")
+        sandbox._logs_are_mounted = True
+        sandbox.logger = docker_module.logger
+        sandbox.exec = AsyncMock(
+            return_value=ExecResult(stdout="", stderr="", return_code=0)
+        )
+
+        await sandbox._probe_verifier_log_mount()
+
+        assert sandbox.is_mounted is True
+        assert not list(sandbox.rollout_paths.verifier_dir.iterdir())
+
+
 class TestDockerExecEnvSecrecy:
     """DockerSandbox.exec must not leak env vars via `-e KEY=VALUE` flags.
 


### PR DESCRIPTION
## Context

[FrontierPhysics PR #109](https://github.com/benchflow-ai/FrontierPhysics/pull/109) restores a versionless `rubric.json` shape whose criteria add first-class `blocker` and `weight` fields. Benchflow's detached review schema currently rejects those fields and can only emit pass/fail/not-applicable outcomes.

## What changed

- accept either the existing v0.1 three-field criteria or a uniform v0.2 `{name, blocker, weight, description, guidance}` contract
- validate `blocker` as a strict integer `0|1` and `weight` as a strict integer `1..10`; reject partial/mixed contracts and all-blocker rubrics
- emit binary pass/fail checks for blockers and strict 0/1/2 checks for scored criteria
- validate weighted review artifacts both in the wrapper and again host-side before aggregation
- compute auditable host-side weighted quality, deterministic/blocker gates, and the publication bands defined by the FrontierPhysics rubric protocol
- preserve legacy v0.1 behavior, public aliases, and positional API compatibility
- expose contract metadata and scoring in `review_report.json` and render it in `bench review`
- probe Docker verifier-log mounts at startup and fall back to the existing clear/download path when Docker Desktop path translation is unavailable
- document both contracts and add regression coverage naming FrontierPhysics PR #109 / Benchflow PR #1040

Weighted quality excludes blocker weights:

```
raw_quality = sum(score * weight) / (2 * sum(non-blocker weights))
```

A source reward other than 1.0, a recorded source error, or any failed blocker sets `gated_quality` to zero and the decision to `not_publishable`. With gates open, `>= 0.80` is publishable, `>= 0.65` is presentable with revisions, and lower is not publishable.

## Real end-to-end validation

Ran the exact `multiplexing-ion-chain-qnet` task from FrontierPhysics PR #109 at `4bdbd2e8691e6a761f54d84e8304564bbfa22857`.

- canonical task digest: `sha256:d8216ab847b6162676f24519018956549fae68604bd5b1c177a6497a18bebbef`
- structural and Docker runtime-capability checks: passed
- solver: `codex-acp`, `gpt-5.4[xhigh]` (highest effort/model combination supported by the pinned ACP), no skills, usage tracking required
- solver activity: 66 tool calls; 228,020 tracked tokens; all six required deliverables generated
- deterministic verifier: healthy, reward `0`, 9/12 tests passed; the three failures were genuine output defects (blank/unextractable PDF page, radial-frequency mismatch, and unphysical `n_excitation`)
- detached review omitted `--rubric`, so trusted task lookup, digest admission, and automatic `verifier/rubric.json` discovery were exercised
- reviewer: `codex-acp`, `gpt-5.4[xhigh]`, 46 tool calls; wrapper verifier reward `1.0`
- v0.2 report: valid; 5 blockers + 7 scored criteria; `34/78 = 0.435897...` raw quality
- gates: deterministic false and failed blocker `motional_fit_model`; gated quality `0.0`; decision `not_publishable`
- independent host-side recomputation matched every aggregate, and the 27-file source rollout hash was unchanged after detached review
- native subscription auth required the explicit reviewer `--allow-open-network` override; the report records that exception

The live run exposed a Docker Desktop raw-socket edge case: Compose accepted WSL bind paths without translating them, so the container wrote a real `reward.txt` that was invisible on the WSL host. The added sentinel probe detects that condition before verification and selects explicit copy-out; the real reviewer wrapper then completed with reward `1.0` through that path.

## Verification

- `pytest tests/test_review*.py tests/test_sandbox.py tests/test_verifier_output.py -q`: **220 passed**
- `ruff format --check .`: passed
- `ruff check .`: passed
- `ty check src/`: passed
- requested thermo-nuclear maintainability audit (including the Docker probe): no blockers

The earlier full local suite reached **5,740 passed / 65 skipped**. Its 9 failures are unrelated WSL-mounted-worktree environment failures (CRLF-sensitive fixture digests/shell scripts, Windows symlink semantics, terminal escape output, and local credential detection); none are in the review or Docker-mount-probe paths.