### PR TITLE
Release BenchFlow 0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 0.7.5 — 2026-08-19
+
 ### Added
 
 - **Weighted rubric-review contract (v0.2).** `bench review` now accepts the
@@ -14,6 +16,12 @@
   their `pass` / `fail` / `not_applicable` behavior unchanged. Docker runs now
   probe whether verifier-log bind mounts are genuinely visible to the container
   and fall back to explicit copy-out when path translation is unavailable.
+
+### Fixed
+
+- **Linked-worktree `.git` pointer files stay out of workspace attachments.**
+  Workspace capture now excludes `.git` files as well as directories, preventing
+  local absolute worktree metadata from entering uploaded archives. (#1032)
 
 ## 0.7.4 — 2026-08-16
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.4"
+version = "0.7.5"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- release the weighted rubric-review contract (v0.2) and Docker verifier-log recovery from #1040
- document the linked-worktree workspace-archive privacy fix from #1032
- set the public package version to `0.7.5`

## Validation

- `uv lock --check`
- `tools/release_version.py public-release --tag v0.7.5` → `version=0.7.5`
- 58 release/workflow/pinning tests passed
- `ruff check src tests tools`
- `ruff format --check src tests tools`
- `ty check`
- `uv build --no-sources`
- `twine check dist/*`

The full suite was also exercised locally. Host-specific WSL failures were limited to inherited credentials, terminal rendering, local-clone provenance, and the existing heartbeat timing flake; the authoritative clean GitHub Actions run is required before merge.

After this PR merges and the tested `main` commit is green, the exact squash-merge commit will be tagged `v0.7.5`.