### PR TITLE
Bump BenchFlow to 0.7.6.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "benchflow"
-version = "0.7.5"
+version = "0.7.6.dev0"
 description = "Multi-turn agent benchmarking with ACP — run any agent, any model, any provider."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ wheels = [
 
 [[package]]
 name = "benchflow"
-version = "0.7.5"
+version = "0.7.6.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "agent-client-protocol" },


### PR DESCRIPTION
## Summary

- restore `main` to the next development line after the public [v0.7.5 release](https://github.com/benchflow-ai/benchflow/releases/tag/v0.7.5)
- update both project and lockfile metadata to `0.7.6.dev0`
- re-enable automatic internal preview publication from tested `main` commits

## Validation

- `uv lock --check`
- `tools/release_version.py internal-preview --run-number 1` → `publish=true`, `version=0.7.6.dev1`
- 33 release-version and release-workflow tests passed

No release tag is created for this development bump.