### PR TITLE
fix(rollout): keep completed rollouts when publish-path execs time out

### DIFF
--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -437,7 +437,14 @@ async def _publish_trajectory_for_verifier(
     payload = redact_acp_trajectory_jsonl(trajectory) + "\n"
     agent_dir.mkdir(parents=True, exist_ok=True)
     (agent_dir / "acp_trajectory.jsonl").write_text(payload)
-    await env.exec("mkdir -p /logs/agent", user="root", timeout_sec=10)
+    # Only defensive: mounted backends already have /logs/agent from the bind
+    # mount, and remote ones fail loudly on the upload below if it is missing.
+    # Publishing runs after the agent finished, so a slow or failing exec here
+    # must not discard an otherwise complete rollout.
+    try:
+        await env.exec("mkdir -p /logs/agent", user="root", timeout_sec=10)
+    except Exception as exc:
+        logger.warning(f"Could not pre-create /logs/agent, publishing anyway: {exc}")
     with tempfile.NamedTemporaryFile(mode="w", suffix=".jsonl", delete=False) as f:
         f.write(payload)
         tmp_path = f.name

--- a/src/benchflow/trajectories/_capture.py
+++ b/src/benchflow/trajectories/_capture.py
@@ -230,10 +230,17 @@ async def _scrape_agent_trajectory(
 
     # Gemini CLI: writes ~/.gemini/sessions/*/gemini-cli.trajectory.json
     if "gemini" in agent:
-        result = await env.exec(
-            f"cat $(find {home}/.gemini -name 'gemini-cli.trajectory.json' 2>/dev/null | head -1) 2>/dev/null",
-            timeout_sec=10,
-        )
+        # A non-zero return code and unparseable JSON both degrade to "no
+        # scraped trajectory" below, so a slow container must not be the one
+        # case that propagates and aborts verification instead (#948).
+        try:
+            result = await env.exec(
+                f"cat $(find {home}/.gemini -name 'gemini-cli.trajectory.json' 2>/dev/null | head -1) 2>/dev/null",
+                timeout_sec=10,
+            )
+        except Exception as e:
+            logger.warning(f"Could not scrape gemini trajectory: {e}")
+            return []
         if result.return_code == 0 and result.stdout and result.stdout.strip():
             try:
                 return _parse_gemini_trajectory(json.loads(result.stdout))

--- a/tests/test_capture_trajectory.py
+++ b/tests/test_capture_trajectory.py
@@ -6,12 +6,15 @@ Writer / streaming / multi-scene / partial-capture-fix tests live in
 
 import json
 
+import pytest
+
 from benchflow.acp.session import ACPSession
 from benchflow.acp.types import ToolCallStatus
 from benchflow.trajectories._capture import (
     _capture_session_trajectory,
     _parse_provider_tool_evidence,
     _reconcile_tool_evidence,
+    _scrape_agent_trajectory,
 )
 from benchflow.trajectories.types import LLMExchange, LLMRequest, LLMResponse
 
@@ -897,3 +900,20 @@ class TestFlushArrivalOrder:
         ]
         assert result[1]["text"] == "before tool"
         assert result[3]["text"] == "after tool"
+
+
+@pytest.mark.asyncio
+async def test_scrape_agent_trajectory_survives_exec_timeout():
+    """Guards issue #948 at the sibling call site that runs first.
+
+    ``verify()`` awaits the scrape before publishing, so a container too slow
+    for the 10 second budget aborted the rollout here before the publish-side
+    guard could apply. Every other failure in this fallback already degrades to
+    "no scraped trajectory"; a timeout must do the same.
+    """
+
+    class TimingOutEnv:
+        async def exec(self, command, user=None, timeout_sec=None):
+            raise RuntimeError(f"Command timed out after {timeout_sec} seconds")
+
+    assert await _scrape_agent_trajectory(TimingOutEnv(), "gemini", None) == []

--- a/tests/test_rollout_upload.py
+++ b/tests/test_rollout_upload.py
@@ -381,6 +381,63 @@ async def test_publish_trajectory_for_verifier_uploads_acp_jsonl(
     ]
 
 
+class FakeTimingOutMkdirEnv(FakeUploadEnv):
+    """Loaded backend whose bookkeeping ``exec`` blows its client-side timeout."""
+
+    async def exec(
+        self, command: str, user: str | None = None, timeout_sec: int | None = None
+    ) -> None:
+        await super().exec(command, user, timeout_sec)
+        raise RuntimeError(f"Command timed out after {timeout_sec} seconds")
+
+
+@pytest.mark.asyncio
+async def test_publish_trajectory_survives_mkdir_timeout(tmp_path: Path) -> None:
+    """Guards issue #948: a timed-out ``mkdir -p /logs/agent`` discarded rollouts.
+
+    Publishing runs after the agent already finished, so a client-side timeout
+    on that bookkeeping exec used to throw away a completed rollout — a ~40
+    minute run lost to a 10 second budget on a step that does no work on
+    mounted backends. Both trajectory copies must still be published.
+    """
+    env = FakeTimingOutMkdirEnv()
+    agent_dir = tmp_path / "agent"
+
+    await _publish_trajectory_for_verifier(
+        env, [{"type": "agent_message", "text": "ok"}], agent_dir
+    )
+
+    expected = '{"type": "agent_message", "text": "ok"}\n'
+    assert ("mkdir -p /logs/agent", "root", 10) in env.exec_calls
+    assert env.uploaded_file_contents == [
+        (expected, "/logs/agent/acp_trajectory.jsonl")
+    ]
+    assert (agent_dir / "acp_trajectory.jsonl").read_text() == expected
+
+
+@pytest.mark.asyncio
+async def test_publish_trajectory_still_raises_on_upload_failure(
+    tmp_path: Path,
+) -> None:
+    """Guards issue #948 against over-suppression: only the mkdir is defensive.
+
+    A genuinely missing ``/logs/agent`` surfaces through the upload, which must
+    stay fatal — otherwise the rollout would claim a trajectory the verifier
+    never received.
+    """
+
+    class FailingUploadEnv(FakeTimingOutMkdirEnv):
+        async def upload_file(self, source: Path | str, target: str) -> None:
+            raise RuntimeError("upload boom")
+
+    with pytest.raises(RuntimeError, match="upload boom"):
+        await _publish_trajectory_for_verifier(
+            FailingUploadEnv(),
+            [{"type": "agent_message", "text": "ok"}],
+            tmp_path / "agent",
+        )
+
+
 class FakeMountedUploadEnv(FakeUploadEnv):
     """Docker-like backend: ``/logs/agent`` is bind-mounted to the host agent dir."""
 


### PR DESCRIPTION
Fixes #948.

## Summary

Makes both publish-path `exec` calls non-fatal, so a container too slow for their
hardcoded 10s budget no longer discards a rollout whose work already succeeded.

## Root cause

`_publish_trajectory_for_verifier` runs `mkdir -p /logs/agent` at `timeout_sec=10`.
Publishing happens *after* the agent has run to completion, so on a loaded host —
where Docker exec setup alone can exceed 10s — the `RuntimeError` propagates and
throws away a ~40 minute rollout over a bookkeeping step.

On mounted backends that exec cannot help: `agent_dir.mkdir()` two lines above
already created the directory Docker bind-mounts to `/logs/agent`. On backends
that don't mirror, a genuinely missing directory still surfaces through the
`upload_file` immediately after.

`_scrape_agent_trajectory` carries the same 10s exec and is awaited unguarded by
`verify()` *before* the publish call, so it hits the failure first. Every other
failure in that fallback already degrades to "no scraped trajectory" (non-zero
return code, unparseable JSON); the timeout was the one case that propagated
instead.

## Safety

- `upload_file` stays fatal — suppressing it too would let a rollout claim a
  trajectory the verifier never received.
- Both guards log a warning rather than using `contextlib.suppress(Exception)` as
  the issue suggests. The exec failing is a real signal about host health, and the
  visible `RuntimeError` is what made the reported incident diagnosable; silencing
  it removes the only trace. Happy to switch to `suppress` for a smaller diff.

## End-to-end Validation

Docker sandbox, oracle agent, single task, injecting a slow exec at the `mkdir`
call site:

| Injection | Branch | Outcome |
| --- | --- | --- |
| none (control) | this branch | reward 1.00 |
| `sleep 30 && mkdir -p /logs/agent` | `main` | rollout lost — `RuntimeError: Command timed out after 10 seconds` |
| `sleep 30 && mkdir -p /logs/agent` | this branch | warning logged, reward 1.00, both trajectory copies written |
| `sleep 600 && mkdir -p /logs/agent` | this branch | identical to the 30s row — the client-side budget aborts at 10s either way |

Regression tests (the first and third fail with their fix reverted; the second
guards against over-suppression and passes either way):

| Test | Guards |
| --- | --- |
| `test_publish_trajectory_survives_mkdir_timeout` | publish completes and writes both trajectory copies when the `mkdir` exec times out |
| `test_publish_trajectory_still_raises_on_upload_failure` | a failing `upload_file` stays fatal |
| `test_scrape_agent_trajectory_survives_exec_timeout` | scrape degrades to `[]` instead of aborting `verify()` |

- `uv run python -m pytest tests/test_rollout_upload.py tests/test_capture_trajectory.py`
- `uv run python -m pytest` — 5667 passed; the only failures are the 11 in
  `tests/test_cli_live_progress.py`, which reproduce unchanged on a clean checkout
  (terminal-width-dependent assertions)
- `uv run ruff check .`
- `uv run ruff format --check .`
- `git diff --check`

Fixes #948.
