### PR TITLE
fix(acp): modernize codex-acp dispatch — shim 1.6.0, effort via model id

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -193,7 +193,11 @@ def _codex_reasoning_effort(model_id: str) -> str:
     return model_id.rsplit("[", 1)[1][:-1]
 
 
-def _codex_session_model_id(model: str, session: object | None) -> str:
+def _codex_session_model_id(
+    model: str,
+    session: object | None,
+    reasoning_effort: str | None = None,
+) -> str:
     """Map a bare Codex model to the exact ACP modelId returned by session/new.
 
     ``@agentclientprotocol/codex-acp`` validates ``session/set_model`` against
@@ -210,6 +214,10 @@ def _codex_session_model_id(model: str, session: object | None) -> str:
     if (
         isinstance(current_model, str)
         and _codex_model_name(current_model) == requested_name
+        and (
+            not reasoning_effort
+            or _codex_reasoning_effort(current_model) == reasoning_effort
+        )
     ):
         return current_model
 
@@ -226,7 +234,13 @@ def _codex_session_model_id(model: str, session: object | None) -> str:
     if not candidates:
         return model
 
-    preferred_efforts = ("medium", "high", "low", "minimal", "none")
+    # A requested reasoning effort rides the codex model id: codex-acp
+    # declares no ACP effort config option, and its session/set_model
+    # validates ``model[effort]`` ids, so picking the matching advertised
+    # variant is the only way the run's effort actually reaches the agent.
+    preferred_efforts: tuple[str, ...] = ("medium", "high", "low", "minimal", "none")
+    if reasoning_effort:
+        preferred_efforts = (reasoning_effort, *preferred_efforts)
     for effort in preferred_efforts:
         for candidate in candidates:
             if _codex_reasoning_effort(candidate) == effort:
@@ -303,11 +317,12 @@ def _select_acp_model_id(
     model: str,
     agent: str,
     session: object | None,
+    reasoning_effort: str | None = None,
 ) -> str:
     """Return the concrete modelId to send through ACP session/set_model."""
     formatted = _format_acp_model(model, agent)
     if agent == "codex-acp":
-        return _codex_session_model_id(formatted, session)
+        return _codex_session_model_id(formatted, session, reasoning_effort)
     return formatted
 
 
@@ -400,12 +415,19 @@ def _resolve_acp_model_option_id(
     This is what lets the ``@agentclientprotocol`` family migrate from
     ``session/set_model`` to a ``"model"`` config option with no registry
     change: a member that advertises a model option is configured through it
-    automatically, while a member that does not (e.g. current ``codex-acp``,
-    which advertises only ``fast-mode``) keeps using ``session/set_model``.
+    automatically, while a member that does not keeps using
+    ``session/set_model``.
+
+    codex-acp is the documented exception: 1.6.0 advertises a "model" config
+    option whose values reject the ``model[effort]`` ids its own
+    ``session/set_model`` requires (-32602 Invalid params, verified live
+    2026-08-19), so codex stays on the set_model path.
     """
     declared = getattr(agent_cfg, "acp_model_config_id", "") or ""
     if declared:
         return declared
+    if getattr(agent_cfg, "name", "") == "codex-acp":
+        return None
     if "model" in _session_config_option_ids(session):
         return "model"
     return None
@@ -476,6 +498,7 @@ async def _configure_acp_session(
     reasoning_effort: str | None,
 ) -> None:
     agent_cfg = AGENTS.get(agent)
+    effort_in_model_id = False
 
     if model and _model_selection_owned_by_env(agent, model, agent_env):
         logger.info(
@@ -483,7 +506,14 @@ async def _configure_acp_session(
         )
     elif model:
         acp_model_input = _resolve_acp_model_input(agent, model, agent_env)
-        acp_model_id = _select_acp_model_id(acp_model_input, agent, session)
+        acp_model_id = _select_acp_model_id(
+            acp_model_input, agent, session, reasoning_effort
+        )
+        effort_in_model_id = bool(
+            reasoning_effort
+            and agent == "codex-acp"
+            and _codex_reasoning_effort(acp_model_id) == reasoning_effort
+        )
         model_option_id = _resolve_acp_model_option_id(agent_cfg, session)
         if model_option_id:
             # Capability-first: the agent advertises a model config option (or
@@ -508,6 +538,14 @@ async def _configure_acp_session(
             )
 
     if not reasoning_effort:
+        return
+    if effort_in_model_id:
+        # The effort already rides the selected ``model[effort]`` id (codex),
+        # so there is nothing further to configure.
+        logger.info(
+            f"Reasoning effort {reasoning_effort!r} applied via the model id "
+            f"for {agent}"
+        )
         return
     if not agent_cfg or not agent_cfg.acp_effort_config_id:
         raise RuntimeError(

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -605,13 +605,16 @@ AGENTS: dict[str, AgentConfig] = {
         # Pinned for reproducibility: an unpinned @agentclientprotocol install
         # floats to latest and can silently break agent activation when the ACP
         # protocol changes (claude-agent-acp above hit exactly this — sdk 0.24
-        # dropped session/set_model). 0.0.45 ships sdk 0.22.x, which still
-        # implements session/set_model. If a future bump advertises a model
-        # config option instead, runtime.py's capability-first dispatch routes
-        # the model through that option — but re-verify model selection when
-        # bumping this pin.
+        # dropped session/set_model). 1.6.0 still implements session/set_model,
+        # but validates its modelId argument as ``model[effort]`` (0.0.45
+        # accepted bare names); _codex_session_model_id maps bare ids onto the
+        # session's advertised ``model[effort]`` variants, so model selection
+        # keeps working across the bump. 1.6.0 also advertises a "model"
+        # config option, but that option rejects ``model[effort]`` ids
+        # (-32602), so runtime.py keeps codex on session/set_model — verified
+        # live 2026-08-19 against gpt-5.6-sol via an Azure provider.
         install_cmd=_js_agent_install(
-            "codex-acp", "@agentclientprotocol/codex-acp@0.0.45"
+            "codex-acp", "@agentclientprotocol/codex-acp@1.6.0"
         ),
         # Self-write ~/.codex/auth.json from OPENAI_API_KEY in the launcher itself,
         # ONLY when the key is set (so subscription/host-auth mode is untouched),

--- a/tests/test_acp_model_config_dispatch.py
+++ b/tests/test_acp_model_config_dispatch.py
@@ -71,8 +71,8 @@ async def _connect(
 
 @pytest.mark.asyncio
 async def test_codex_with_only_fastmode_option_uses_set_model(tmp_path):
-    """codex-acp@0.0.45 advertises only 'fast-mode' (no 'model'), so dispatch
-    must use session/set_model — capability-first must NOT regress it."""
+    """A codex-acp advertising only 'fast-mode' (no 'model') dispatches via
+    session/set_model — capability-first must NOT regress it."""
     mock_acp = _make_mocks(config_options=[{"id": "fast-mode"}])
     await _connect(mock_acp, agent="codex-acp", model="gpt-5.5", tmp_path=tmp_path)
 
@@ -114,14 +114,43 @@ async def test_codex_litellm_alias_uses_bare_model_for_set_model(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_codex_with_model_option_uses_config_option(tmp_path):
-    """When a future codex-acp advertises a 'model' config option (as Claude
-    already does), capability-first routes through it — no registry change."""
+async def test_codex_with_model_option_still_uses_set_model(tmp_path):
+    """codex-acp@1.6.0 advertises a 'model' config option whose values reject
+    the ``model[effort]`` ids its own session/set_model requires (-32602
+    Invalid params, verified live 2026-08-19), so codex is the documented
+    exception to capability-first and stays on session/set_model."""
     mock_acp = _make_mocks(config_options=[{"id": "model"}])
     await _connect(mock_acp, agent="codex-acp", model="gpt-5.5", tmp_path=tmp_path)
 
-    mock_acp.set_config_option.assert_awaited_once_with("model", "gpt-5.5")
-    mock_acp.set_model.assert_not_awaited()
+    mock_acp.set_model.assert_awaited_once_with("gpt-5.5")
+    mock_acp.set_config_option.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_codex_reasoning_effort_rides_the_model_id(tmp_path):
+    """codex-acp declares no ACP effort config option; a requested effort must
+    select the matching advertised ``model[effort]`` variant instead of
+    failing closed, and the effort step must treat it as satisfied."""
+    mock_acp = _make_mocks(
+        config_options=[{"id": "fast-mode"}],
+        model_state={
+            "availableModels": [
+                {"modelId": "gpt-5.5[medium]"},
+                {"modelId": "gpt-5.5[xhigh]"},
+            ],
+            "currentModelId": "gpt-5.4-mini[medium]",
+        },
+    )
+    await _connect(
+        mock_acp,
+        agent="codex-acp",
+        model="gpt-5.5",
+        tmp_path=tmp_path,
+        reasoning_effort="xhigh",
+    )
+
+    mock_acp.set_model.assert_awaited_once_with("gpt-5.5[xhigh]")
+    mock_acp.set_config_option.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -52,7 +52,7 @@ class TestEnvMappingField:
         """Same @agentclientprotocol family as claude — pin so a floating latest
         can't silently break activation when upstream drops session/set_model."""
         cfg = AGENTS["codex-acp"]
-        assert "@agentclientprotocol/codex-acp@0.0.45" in cfg.install_cmd
+        assert "@agentclientprotocol/codex-acp@1.6.0" in cfg.install_cmd
 
     def test_gemini_has_mapping(self):
         cfg = AGENTS["gemini"]


### PR DESCRIPTION
Driving `codex-acp` with current models fails three ways on the `0.0.45` pin — all hit live while benchmarking benchflow-ai/FrontierPhysics#109 with `gpt-5.6-sol` on an Azure provider (2026-08-19), and all reproduced/fixed there with exactly these patches (6 agent rollouts + 6 detached rubric reviews ran on them):

1. **Shim pin**: `codex-acp@0.0.45` rejects modern model ids outright (`-32603`). `1.6.0` validates `session/set_model` against `model[effort]` ids — which `_codex_session_model_id` already maps bare names onto — so the bump slots into the existing selection logic. Registry comment updated with the new rationale.
2. **Capability-first exception**: `1.6.0` advertises a `"model"` config option whose values reject the `model[effort]` ids its own `set_model` requires (`-32602 Invalid params`, verified live). Capability-first dispatch therefore bricks model selection for codex; it becomes the documented exception in `_resolve_acp_model_option_id` and stays on `session/set_model`.
3. **Effort has one working channel — the model id**: `--reasoning-effort` fails closed for codex ("does not declare an ACP effort config option") even though the effort can only ride the `model[effort]` id. A requested effort now steers `_codex_session_model_id` to the matching advertised variant (including past the `currentModelId` shortcut), and the effort step treats an effort embedded in the selected id as satisfied instead of raising.

**Tests**: `test_codex_with_model_option_uses_config_option` becomes `test_codex_with_model_option_still_uses_set_model` (asserting the exception, with the `-32602` evidence in the docstring); new `test_codex_reasoning_effort_rides_the_model_id`; the registry pin assertion follows the bump. `tests/test_acp_model_config_dispatch.py + test_agent_registry.py + test_acp.py`: **135 passed**; `ruff check` and `ruff format --check` clean on the touched files.

Context: these were the local patches required to run the FrontierPhysics#109 benchmark and rubric reviews (documented in that PR's run notes); this upstreams them so a stock install can drive codex end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1044" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->