### PR TITLE
fix(agents): run the no-web JSON policy on the provisioned Node runtime

### DIFF
--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -294,16 +294,39 @@ _DEEPAGENTS_SHIM = (Path(__file__).parent / "deepagents_acp_shim.py").read_text(
 
 
 def _json_settings_merge(path: str, mutator: str) -> str:
-    """Idempotent JSON-settings merge as a one-line bash snippet."""
-    py = (
-        "import json,os,pathlib;"
-        f"p=pathlib.Path(os.path.expandvars(os.path.expanduser({path!r})));"
-        "p.parent.mkdir(parents=True, exist_ok=True);"
-        "d=json.loads(p.read_text()) if p.exists() and p.read_text().strip() else {};"
+    """Idempotent JSON-settings merge as a one-line bash snippet.
+
+    Runs on the Node runtime ``_NODE_INSTALL`` provisions, not on ``python3``:
+    policy setup executes inside the *task* image, which owes BenchFlow no
+    interpreter, so a Python-free image used to abort a rollout with exit 127
+    before ACP launch (#1047). Callers must therefore be agents whose install
+    guarantees ``_BENCHFLOW_NODE_PREFIX`` — every JS agent does, via
+    ``_js_agent_install`` or the mimo manifest.
+
+    ``mutator`` is a JavaScript statement operating on ``d``. The escape pass
+    reproduces ``json.dumps``' ``ensure_ascii`` so upgrading BenchFlow leaves
+    an existing settings file byte-identical: agent homes can arrive
+    pre-populated from the host (gemini copies ``~/.gemini/settings.json`` in
+    via ``subscription_auth``), and rewriting a user's non-ASCII values on
+    first run would break the idempotence this merge promises. It starts at
+    U+007F because ``JSON.stringify`` has already escaped in-string control
+    characters, while the newlines and indent it emits must stay literal.
+    """
+    js = (
+        "const fs=require('fs'),pa=require('path');"
+        "const p=process.argv[1];"
+        "fs.mkdirSync(pa.dirname(p),{recursive:true});"
+        "let d={};"
+        "try{const t=fs.readFileSync(p,'utf8');if(t.trim())d=JSON.parse(t);}"
+        "catch(e){if(e.code!=='ENOENT')throw e;}"
         f"{mutator};"
-        "p.write_text(json.dumps(d, indent=2) + '\\n')"
+        "fs.writeFileSync(p,JSON.stringify(d,null,2)"
+        ".replace(/[\\u007f-\\uffff]/g,"
+        "c=>'\\\\u'+c.charCodeAt(0).toString(16).padStart(4,'0'))+'\\n');"
     )
-    return f"python3 -c {shlex.quote(py)}"
+    # The path stays a shell word so the surrounding bash expands
+    # $BENCHFLOW_AGENT_HOME, matching what os.path.expandvars did before.
+    return f'{_BENCHFLOW_NODE_PREFIX}/bin/node -e {shlex.quote(js)} "{path}"'
 
 
 # OpenCode-family proxy fix: OpenCode and its MiMo fork validate provider/model
@@ -545,9 +568,10 @@ AGENTS: dict[str, AgentConfig] = {
         ),
         disallow_web_tools_setup_cmd=_json_settings_merge(
             "$BENCHFLOW_AGENT_HOME/.claude/settings.json",
-            'd.setdefault("permissions",{}).setdefault("deny",[]);'
-            '[d["permissions"]["deny"].append(t) for t in ["WebSearch","WebFetch"] '
-            'if t not in d["permissions"]["deny"]]',
+            "if(!('permissions' in d))d.permissions={};"
+            "if(!('deny' in d.permissions))d.permissions.deny=[];"
+            'for(const t of ["WebSearch","WebFetch"])'
+            "if(!d.permissions.deny.includes(t))d.permissions.deny.push(t)",
         ),
         disallow_web_tools_owned_paths=["$HOME/.claude"],
         supports_acp_set_model=False,
@@ -690,10 +714,10 @@ AGENTS: dict[str, AgentConfig] = {
         ),
         disallow_web_tools_setup_cmd=_json_settings_merge(
             "$BENCHFLOW_AGENT_HOME/.gemini/settings.json",
-            'd.setdefault("tools",{}).setdefault("exclude",[]);'
-            '[d["tools"]["exclude"].append(t) for t in '
-            '["google_web_search","web_fetch"] '
-            'if t not in d["tools"]["exclude"]]',
+            "if(!('tools' in d))d.tools={};"
+            "if(!('exclude' in d.tools))d.tools.exclude=[];"
+            'for(const t of ["google_web_search","web_fetch"])'
+            "if(!d.tools.exclude.includes(t))d.tools.exclude.push(t)",
         ),
         disallow_web_tools_owned_paths=["$HOME/.gemini"],
     ),
@@ -721,7 +745,7 @@ AGENTS: dict[str, AgentConfig] = {
         },
         disallow_web_tools_setup_cmd=_json_settings_merge(
             "$BENCHFLOW_AGENT_HOME/.config/opencode/opencode.json",
-            'd.setdefault("tools",{})["webfetch"]=False',
+            "if(!('tools' in d))d.tools={};d.tools.webfetch=false",
         ),
         disallow_web_tools_owned_paths=["$HOME/.config/opencode"],
     ),
@@ -770,7 +794,7 @@ AGENTS: dict[str, AgentConfig] = {
         },
         disallow_web_tools_setup_cmd=_json_settings_merge(
             "$BENCHFLOW_AGENT_HOME/.config/mimocode/mimocode.json",
-            'd.setdefault("tools",{})["webfetch"]=False',
+            "if(!('tools' in d))d.tools={};d.tools.webfetch=false",
         ),
         disallow_web_tools_owned_paths=["$HOME/.config/mimocode"],
     ),

--- a/tests/test_internet_policy.py
+++ b/tests/test_internet_policy.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -266,13 +267,25 @@ def test_apply_web_policy_noop_when_not_disallowed():
 
 def _run_setup_cmd(agent_name: str, tmp_path) -> dict:
     """Execute an agent's disallow_web_tools_setup_cmd and return the JSON it wrote."""
-    from benchflow.agents.registry import AGENTS
+    from benchflow.agents.registry import _BENCHFLOW_NODE_PREFIX, AGENTS
 
     cfg = AGENTS[agent_name]
     assert cfg.disallow_web_tools_setup_cmd, f"{agent_name} has no setup_cmd"
 
+    # JSON-merge policies target the Node runtime BenchFlow provisions inside the
+    # sandbox (#1047); a dev host has no such prefix, so retarget the local one.
+    # This is what kept the old python3 dependency invisible to these tests, so
+    # coverage on a real task image lives in the container test below.
+    cmd = cfg.disallow_web_tools_setup_cmd
+    sandbox_node = f"{_BENCHFLOW_NODE_PREFIX}/bin/node"
+    if sandbox_node in cmd:
+        host_node = shutil.which("node")
+        if host_node is None:
+            pytest.skip("no node runtime on PATH to exercise the JSON-merge policy")
+        cmd = cmd.replace(sandbox_node, host_node)
+
     result = subprocess.run(
-        ["bash", "-c", cfg.disallow_web_tools_setup_cmd],
+        ["bash", "-c", cmd],
         env={"BENCHFLOW_AGENT_HOME": str(tmp_path), "PATH": "/usr/bin:/bin"},
         capture_output=True,
         text=True,
@@ -424,3 +437,103 @@ def test_task_toml_missing_allow_internet_defaults_to_allowed(tmp_path):
 
     task = Task(task_dir)
     assert _task_disallows_internet(task) is False
+
+
+def test_json_merge_policies_do_not_borrow_task_image_interpreters():
+    """Policy setup runs in the task image, which owes BenchFlow no runtime.
+
+    The JSON merge used to shell out to ``python3``; a Python-free task image
+    with ``allow_internet = false`` then aborted at exit 127 before ACP launch
+    (#1047).
+    """
+    from benchflow.agents.registry import _BENCHFLOW_NODE_PREFIX, AGENTS
+
+    for agent in ("claude-agent-acp", "gemini", "opencode", "mimo"):
+        cmd = AGENTS[agent].disallow_web_tools_setup_cmd
+        assert "python3" not in cmd, agent
+        assert cmd.startswith(f"{_BENCHFLOW_NODE_PREFIX}/bin/node "), agent
+
+
+def test_node_backed_policies_are_guaranteed_by_their_own_install():
+    """Whoever depends on the Node runtime must also be the one installing it.
+
+    Pins the ownership boundary #1047 is about, rather than today's four
+    agents: a policy may only reach for the Node prefix if that agent's own
+    install_cmd provisions it.
+    """
+    from benchflow.agents.registry import _BENCHFLOW_NODE_PREFIX, AGENTS
+
+    for name, cfg in AGENTS.items():
+        cmd = cfg.disallow_web_tools_setup_cmd or ""
+        if f"{_BENCHFLOW_NODE_PREFIX}/bin/node" not in cmd:
+            continue
+        assert _BENCHFLOW_NODE_PREFIX in (cfg.install_cmd or ""), (
+            f"{name} runs its no-web policy on the BenchFlow Node runtime but "
+            "its install does not provision one"
+        )
+
+
+@pytest.mark.skipif(
+    not shutil.which("docker"), reason="needs a Docker daemon to build the task image"
+)
+async def test_no_web_policies_apply_in_a_python_free_task_image():
+    """End-to-end guard for #1047 on an image that ships no Python at all.
+
+    Provisions the agent runtime first — exactly what the JS installers do
+    before policy application — then applies each policy twice, so the run
+    covers the merge content and the idempotence it promises.
+    """
+    from benchflow.agents.install import apply_web_tool_policy
+    from benchflow.agents.registry import _NODE_INSTALL, AGENTS
+
+    expected = {
+        "claude-agent-acp": (
+            "/root/.claude/settings.json",
+            {"permissions": {"deny": ["WebSearch", "WebFetch"]}},
+        ),
+        "gemini": (
+            "/root/.gemini/settings.json",
+            {"tools": {"exclude": ["google_web_search", "web_fetch"]}},
+        ),
+        "opencode": (
+            "/root/.config/opencode/opencode.json",
+            {"tools": {"webfetch": False}},
+        ),
+        "mimo": (
+            "/root/.config/mimocode/mimocode.json",
+            {"tools": {"webfetch": False}},
+        ),
+    }
+
+    def sh(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(args, capture_output=True, text=True, timeout=900)
+
+    container = subprocess.check_output(
+        ["docker", "run", "--detach", "--rm", "ubuntu:24.04", "sleep", "infinity"],
+        text=True,
+    ).strip()
+
+    class ContainerEnv:
+        async def exec(self, command: str, *, timeout_sec=None, **_kwargs):
+            done = sh("docker", "exec", container, "bash", "-lc", command)
+            return SimpleNamespace(
+                return_code=done.returncode, stdout=done.stdout, stderr=done.stderr
+            )
+
+    try:
+        probe = sh("docker", "exec", container, "bash", "-lc", "command -v python3")
+        assert probe.returncode != 0, "base image unexpectedly ships python3"
+
+        provision = sh("docker", "exec", container, "bash", "-lc", _NODE_INSTALL)
+        assert provision.returncode == 0, provision.stderr[-400:]
+
+        for agent, (path, want) in expected.items():
+            for _ in range(2):
+                await apply_web_tool_policy(
+                    ContainerEnv(), agent, AGENTS[agent], "/root", disallow=True
+                )
+            written = sh("docker", "exec", container, "cat", path)
+            assert written.returncode == 0, f"{agent}: {path} not written"
+            assert json.loads(written.stdout) == want, agent
+    finally:
+        sh("docker", "rm", "--force", container)


### PR DESCRIPTION
### Summary

Agent-owned pre-launch setup runs inside the **task** image, but the no-web JSON settings merge shelled out to `python3` — something no task image is required to ship. On a Python-free task with `allow_internet = false`, all four JS agents (`claude-agent-acp`, `gemini`, `opencode`, `mimo`) died at exit 127 before ACP ever started. I moved the merge onto the Node runtime BenchFlow provisions itself and kept the output byte-identical, verified across 40 base-vs-head combinations and end-to-end on both `docker` and `daytona` with a real Gemini key.

Fixes #1047

### Reproduction

I reproduced it with a real `bench eval run`. `tests/examples/hello-world-task` already ships a Python-free image (`ubuntu:24.04` + `curl`), so all I had to change was `network_mode = "no-network"`:

```
RuntimeError: Failed to apply no-web policy for gemini: exit code 127;
command: export BENCHFLOW_AGENT_HOME=/home/agent; python3 -c '...'
error_category: other
```

I got a byte-identical failure on `--sandbox docker` and `--sandbox daytona`, which matches the report: an infrastructure fault surfacing as a rollout error rather than a model failure.

### The fix

I moved the merge onto `/opt/benchflow/node/bin/node` — the absolute path `_js_agent_install` already provisions — and translated the four mutators to JavaScript. The ordering holds by construction: `install_agent()` is `rollout/__init__.py:1195`, `apply_web_tool_policy` is `:1228`, so the runtime is always in place before the policy needs it. I left the path as an unquoted shell word so the surrounding bash expands `$BENCHFLOW_AGENT_HOME`, which is what `os.path.expandvars` did before.

**Output stays byte-identical, including non-ASCII.** This is the one place I could have made the change silently lossy. `json.dumps` defaults to `ensure_ascii=True`; `JSON.stringify` emits raw UTF-8. Semantically equivalent, but not the same bytes — and an agent home can arrive pre-populated from the host, since gemini copies `~/.gemini/settings.json` in via `subscription_auth`. A user with non-ASCII values would have had that file rewritten on their first upgraded run, breaking exactly the idempotence this merge promises. So I re-escape from U+007F up, matching `json.dumps` byte for byte. I start at U+007F rather than U+0080 because `JSON.stringify` has already escaped in-string control characters, while the newlines and indent it emits must stay literal.

I also kept the semantics strict rather than quietly "improving" them: `if(!('k' in d))` reproduces `setdefault` instead of `d.k ||= {}`, so a config with `"tools": null` still fails loudly rather than being silently repaired. Same fail-closed behaviour, same error surface.

**The ownership boundary is now asserted, not implied.** The reason a `python3` dependency could sit in a JS agent's policy unnoticed is that nothing tied the two together. I added `test_node_backed_policies_are_guaranteed_by_their_own_install`, which walks the whole registry and requires that any policy reaching for the Node prefix belongs to an agent whose own `install_cmd` provisions it — so the next agent that grows a JSON policy either brings its runtime or fails in CI.

### End-to-end verification

Both canaries are live runs, not stubs: I used a **real Gemini API key** on `gemini-3.5-flash-lite` and a **real Daytona cloud sandbox**. Same task and flags throughout — `tests/examples/hello-world-task` with `network_mode = "no-network"`, `--agent gemini`, `--trials 1`.

| Sandbox | Version | Result |
| --- | --- | --- |
| `docker` | `62cc7e41` (previous version) | Dies at `apply_web_tool_policy` — `exit code 127`, `python3: command not found`. Never reaches ACP |
| `docker` | this PR | Clears the policy; ACP connection initialised and `_configure_acp_session` completed. Stops further downstream at `enforce_agent_egress_firewall` (`acp/runtime.py:692`) — `iptables: Permission denied`, the container lacked `NET_ADMIN`. Unrelated to this change and strictly after the step it fixes |
| `daytona` | `62cc7e41` (previous version) | Same exit 127 at the same step — the failure is backend-independent |
| `daytona` | this PR | **Full graded rollout: `1/1 passed, mean reward 1.00, errors=0, 56.6k tokens, telemetry 100%`** — the agent actually solved the task, with model traffic flowing through the in-sandbox LiteLLM proxy |

Beyond the canaries I A/B'd the merge itself directly: 4 agents × 10 scenarios, previous version vs this PR, **byte-for-byte identical in all 40** — absent file, empty file, unrelated keys, partly-applied config, already-applied (idempotence), Chinese text, emoji (surrogate pair), mixed non-ASCII with quotes and backslashes, `null` where an object is expected (both fail), malformed JSON (both fail). I ran the previous version in `python:3.12-slim` and this PR in `node:22-slim`, with no Python present at all.

### Acceptance criteria

| Criterion | Evidence |
| --- | --- |
| Setup depends only on runtimes BenchFlow provisions | Generated commands for all four agents contain no `python3` and start with the provisioned Node prefix; a registry-wide invariant test ties the dependency to the installer |
| Preserve JSON merge, idempotence, ownership repair, fail-closed | Merge, idempotence and fail-closed: the 40 byte-identical combinations above. Ownership repair covers a different code path — the `chown` that `apply_web_tool_policy` appends with `&&` — so I exercised it separately: with `BENCHFLOW_AGENT_HOME=/home/agent` and a root-owned pre-existing config, the policy leaves both the directory and the file `agent:agent` and writable by the sandbox user |
| Regression in a Python-free image after runtime provisioning | `test_no_web_policies_apply_in_a_python_free_task_image`: asserts `ubuntu:24.04` ships no `python3`, runs `_NODE_INSTALL`, applies each policy **twice**, checks the resulting config content. Fails on the previous version with `exit 127 python3: command not found`, passes on this PR |
| Docker no-network canary reaches ACP start | The `docker` / this PR row above |
| Daytona equivalent reaches ACP start, confirming backend parity | The `daytona` / this PR row above. Parity holds in both directions: the previous version fails identically on both backends, this PR clears the policy on both |

### Regression coverage

I added three tests to `tests/test_internet_policy.py`: the two invariants above plus the containerised regression (`skipif` no Docker, in line with how the repo guards `container`/`docker` tests).

I also had to fix six existing tests, which is the report's own point — `_run_setup_cmd` executes policy commands on the developer host, where Python is always present, so it could never have caught this. It now retargets the sandbox Node prefix at the host's `node` and skips when there is none; real task-image coverage lives in the new container test rather than in a host shell.

Full suite: 5742 passed, zero regressions against `62cc7e41` — I checked that the failure set is identical with the change stashed. `ruff check` and `ruff format --check` clean.
