### PR TITLE
Preserve healthy native ACP subscription results

### DIFF
--- a/.agents/skills/benchflow-experiment-review/SKILL.md
+++ b/.agents/skills/benchflow-experiment-review/SKILL.md
@@ -57,6 +57,16 @@ counts, or a plausible final answer is still unhealthy if either required
 trajectory file or `results.jsonl` is missing, empty, truncated, unparsable, or
 usage-only without recoverable request/response evidence.
 
+One explicit evidence-only exception exists for native ACP subscription auth,
+where provider HTTP capture is unavailable by construction. With
+`--allow-native-subscription-without-llm`, the validator may accept a missing
+LLM trajectory only when `agent_result.usage_source == "agent_native_acp"`, ACP
+events and native token usage are healthy, timing and reward are complete, and
+`results.jsonl` marks the rollout completed but not training-ready with reason
+`missing_healthy_structured_llm_trajectory`. This exception never creates
+training data, never accepts an empty/malformed present LLM trajectory, and is
+off by default.
+
 `results.jsonl` must be reviewed as a training artifact, not just a sidecar. For
 a healthy model rollout it should contain a parseable row with
 `info.training_ready == true`, non-empty `prompt`, `completion`, and

--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -15,6 +15,10 @@ BenchFlow model result:
   Prime-RL/Verifiers-shaped training-readiness row backed by the LLM trajectory.
 - token usage, timing, and tool usage metadata are present.
 
+The explicit ``--allow-native-subscription-without-llm`` mode accepts only a
+healthy ``agent_native_acp`` evidence row that is completed but not
+training-ready. It does not relax the default model-training artifact gate.
+
 Any violation makes that rollout unhealthy. The script exits 1 if any checked
 rollout is unhealthy.
 """
@@ -541,6 +545,7 @@ def validate_results_row(
     row_path: str,
     result: dict[str, Any],
     llm_summary: dict[str, Any] | None,
+    native_subscription_without_llm: bool = False,
 ) -> list[str]:
     issues: list[str] = []
     leaked = sorted(BANNED_TRAINING_ROW_KEYS.intersection(row))
@@ -565,7 +570,11 @@ def validate_results_row(
         issues.append(
             f"{row_path}: terminal errored/partial rollout marked training_ready=true"
         )
-    if not result_has_terminal_error(result) and training_ready is False:
+    if (
+        not result_has_terminal_error(result)
+        and training_ready is False
+        and not native_subscription_without_llm
+    ):
         issues.append(f"{row_path}: healthy rollout marked training_ready=false")
 
     row_error = row.get("error")
@@ -589,14 +598,62 @@ def validate_results_row(
             issues.append(
                 f"{row_path}: non-training-ready row lacks training_ready_reason"
             )
-        if row_error is None:
+        if row_error is None and not native_subscription_without_llm:
             issues.append(f"{row_path}: non-training-ready row lacks error payload")
 
-    messages = normalize_training_messages(row, row_path, issues)
+    if native_subscription_without_llm:
+        expected_reason = "missing_healthy_structured_llm_trajectory"
+        if training_ready is not False:
+            issues.append(f"{row_path}: native subscription row must not be training-ready")
+        if info.get("training_ready_reason") != expected_reason:
+            issues.append(
+                f"{row_path}: native subscription row has unexpected training_ready_reason"
+            )
+        if row_error is not None:
+            issues.append(f"{row_path}: native subscription row carries non-null error")
+        if row.get("is_completed") is not True:
+            issues.append(f"{row_path}: native subscription row is not completed")
+        if row.get("is_truncated") is not False:
+            issues.append(f"{row_path}: native subscription row is truncated")
+        if row.get("stop_condition") != "agent_completed":
+            issues.append(
+                f"{row_path}: native subscription row has unexpected stop_condition"
+            )
+        if row.get("completion") is not None or row.get("trajectory") != []:
+            issues.append(
+                f"{row_path}: native subscription row must not synthesize training data"
+            )
+        token_usage = row.get("token_usage")
+        if not isinstance(token_usage, dict):
+            issues.append(f"{row_path}: missing object token_usage")
+        elif not (
+            (
+                positive_number(token_usage.get("final_input_tokens"))
+                or positive_number(token_usage.get("input_tokens"))
+            )
+            and (
+                positive_number(token_usage.get("final_output_tokens"))
+                or positive_number(token_usage.get("output_tokens"))
+            )
+        ):
+            issues.append(
+                f"{row_path}: native subscription row lacks positive token components"
+            )
+        if row.get("reward") is None and row.get("score") is None:
+            issues.append(f"{row_path}: missing reward/score")
+
+    messages = (
+        []
+        if native_subscription_without_llm
+        else normalize_training_messages(row, row_path, issues)
+    )
     tools, tool_error = normalize_tool_defs(row, row_path)
     if tool_error:
         issues.append(tool_error)
-    issues.extend(validate_training_messages(messages, tools=tools, row_path=row_path))
+    if not native_subscription_without_llm:
+        issues.extend(
+            validate_training_messages(messages, tools=tools, row_path=row_path)
+        )
 
     if training_ready:
         for field in ("prompt", "completion", "trajectory"):
@@ -700,6 +757,7 @@ def validate_results_jsonl(
     *,
     result: dict[str, Any],
     llm_summary: dict[str, Any] | None,
+    native_subscription_without_llm: bool = False,
 ) -> tuple[list[str], dict[str, Any]]:
     path = root / "results.jsonl"
     if not path.is_file():
@@ -717,6 +775,7 @@ def validate_results_jsonl(
                 row_path=f"{path}:{idx}",
                 result=result,
                 llm_summary=llm_summary,
+                native_subscription_without_llm=native_subscription_without_llm,
             )
         )
     summary = {
@@ -751,7 +810,10 @@ def load_run_config(root: Path) -> dict[str, Any] | None:
 
 
 def validate_rollout(
-    root: Path, *, allow_oracle_without_llm: bool = False
+    root: Path,
+    *,
+    allow_oracle_without_llm: bool = False,
+    allow_native_subscription_without_llm: bool = False,
 ) -> dict[str, Any]:
     result_path = root / "result.json"
     result, result_error = read_json(result_path)
@@ -768,6 +830,13 @@ def validate_rollout(
     llm_path = root / "trajectory" / "llm_trajectory.jsonl"
     artifact_summary: dict[str, Any] = {}
     llm_summary: dict[str, Any] | None = None
+    agent_result = result.get("agent_result")
+    native_subscription_without_llm = bool(
+        allow_native_subscription_without_llm
+        and isinstance(agent_result, dict)
+        and agent_result.get("usage_source") == "agent_native_acp"
+        and not llm_path.is_file()
+    )
 
     if not acp_path.is_file():
         issues.append(f"missing required artifact: {acp_path}")
@@ -779,6 +848,10 @@ def validate_rollout(
 
     if oracle and allow_oracle_without_llm:
         warnings.append("oracle rollout: llm_trajectory requirement bypassed by flag")
+    elif native_subscription_without_llm:
+        warnings.append(
+            "native subscription rollout: llm_trajectory requirement bypassed by flag"
+        )
     elif not llm_path.is_file():
         issues.append(f"missing required artifact: {llm_path}")
     else:
@@ -793,6 +866,7 @@ def validate_rollout(
         root,
         result=result,
         llm_summary=llm_summary,
+        native_subscription_without_llm=native_subscription_without_llm,
     )
     issues.extend(results_issues)
     if results_summary:
@@ -862,6 +936,14 @@ def main(argv: list[str] | None = None) -> int:
         help="Treat oracle reward-only runs as out of scope for LLM trajectory capture.",
     )
     parser.add_argument(
+        "--allow-native-subscription-without-llm",
+        action="store_true",
+        help=(
+            "Accept a healthy agent_native_acp rollout without provider LLM capture "
+            "as completed but not training-ready."
+        ),
+    )
+    parser.add_argument(
         "--json",
         action="store_true",
         help="Print machine-readable JSON instead of a concise text report.",
@@ -877,6 +959,9 @@ def main(argv: list[str] | None = None) -> int:
         validate_rollout(
             rollout,
             allow_oracle_without_llm=args.allow_oracle_without_llm,
+            allow_native_subscription_without_llm=(
+                args.allow_native_subscription_without_llm
+            ),
         )
         for rollout in deduped
     ]

--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -546,6 +546,7 @@ def validate_results_row(
     result: dict[str, Any],
     llm_summary: dict[str, Any] | None,
     native_subscription_without_llm: bool = False,
+    oracle_without_llm: bool = False,
 ) -> list[str]:
     issues: list[str] = []
     leaked = sorted(BANNED_TRAINING_ROW_KEYS.intersection(row))
@@ -573,7 +574,7 @@ def validate_results_row(
     if (
         not result_has_terminal_error(result)
         and training_ready is False
-        and not native_subscription_without_llm
+        and not (native_subscription_without_llm or oracle_without_llm)
     ):
         issues.append(f"{row_path}: healthy rollout marked training_ready=false")
 
@@ -598,7 +599,9 @@ def validate_results_row(
             issues.append(
                 f"{row_path}: non-training-ready row lacks training_ready_reason"
             )
-        if row_error is None and not native_subscription_without_llm:
+        if row_error is None and not (
+            native_subscription_without_llm or oracle_without_llm
+        ):
             issues.append(f"{row_path}: non-training-ready row lacks error payload")
 
     if native_subscription_without_llm:
@@ -644,13 +647,13 @@ def validate_results_row(
 
     messages = (
         []
-        if native_subscription_without_llm
+        if native_subscription_without_llm or oracle_without_llm
         else normalize_training_messages(row, row_path, issues)
     )
     tools, tool_error = normalize_tool_defs(row, row_path)
     if tool_error:
         issues.append(tool_error)
-    if not native_subscription_without_llm:
+    if not (native_subscription_without_llm or oracle_without_llm):
         issues.extend(
             validate_training_messages(messages, tools=tools, row_path=row_path)
         )
@@ -758,6 +761,7 @@ def validate_results_jsonl(
     result: dict[str, Any],
     llm_summary: dict[str, Any] | None,
     native_subscription_without_llm: bool = False,
+    oracle_without_llm: bool = False,
 ) -> tuple[list[str], dict[str, Any]]:
     path = root / "results.jsonl"
     if not path.is_file():
@@ -776,6 +780,7 @@ def validate_results_jsonl(
                 result=result,
                 llm_summary=llm_summary,
                 native_subscription_without_llm=native_subscription_without_llm,
+                oracle_without_llm=oracle_without_llm,
             )
         )
     summary = {
@@ -825,6 +830,7 @@ def validate_rollout(
 
     run_config = load_run_config(root)
     oracle = is_oracle_result(result, run_config)
+    oracle_without_llm = bool(oracle and allow_oracle_without_llm)
 
     acp_path = root / "trajectory" / "acp_trajectory.jsonl"
     llm_path = root / "trajectory" / "llm_trajectory.jsonl"
@@ -846,7 +852,7 @@ def validate_rollout(
         issues.extend(validate_acp(acp_rows, acp_path))
         artifact_summary["acp_events"] = len(acp_rows)
 
-    if oracle and allow_oracle_without_llm:
+    if oracle_without_llm:
         warnings.append("oracle rollout: llm_trajectory requirement bypassed by flag")
     elif native_subscription_without_llm:
         warnings.append(
@@ -867,18 +873,19 @@ def validate_rollout(
         result=result,
         llm_summary=llm_summary,
         native_subscription_without_llm=native_subscription_without_llm,
+        oracle_without_llm=oracle_without_llm,
     )
     issues.extend(results_issues)
     if results_summary:
         artifact_summary["results"] = results_summary
 
     tokens = numeric_token_total(result)
-    if not tokens or tokens <= 0:
+    if not oracle_without_llm and (not tokens or tokens <= 0):
         issues.append("missing or zero token usage in result metadata")
     if not timing_present(result):
         issues.append("missing timing metadata")
     tools = tool_usage_count(result)
-    if tools is None or tools <= 0:
+    if not oracle_without_llm and (tools is None or tools <= 0):
         issues.append("missing or zero tool usage metadata")
     if not reward_present(result):
         issues.append("missing verifier reward/score")

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -671,8 +671,6 @@ def _patch_docker_dind() -> None:
     def _patched(self, include_os_env=True):  # type: ignore[override]
         env = _original(self, include_os_env=include_os_env)
         for key in (
-            "CONTEXT_DIR",
-            "BENCHGUARD_VERIFIER_CONTEXT_DIR",
             "HOST_VERIFIER_LOGS_PATH",
             "HOST_AGENT_LOGS_PATH",
             "HOST_ARTIFACTS_PATH",

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -568,6 +568,37 @@ def _inject_skills_into_dockerfile(
     )
 
 
+def _decode_mountinfo_path(value: str) -> str:
+    """Decode the octal escapes used by ``/proc/self/mountinfo``."""
+    return (
+        value.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+    )
+
+
+def _mountinfo_path_mapping(cwd: str, mountinfo: str) -> tuple[str, str] | None:
+    """Return host-source/container-destination for a containing bind mount."""
+    current = Path(cwd)
+    best: tuple[str, str] | None = None
+    for line in mountinfo.splitlines():
+        fields = line.split(" - ", 1)[0].split()
+        if len(fields) < 5:
+            continue
+        root = _decode_mountinfo_path(fields[3])
+        dest = _decode_mountinfo_path(fields[4])
+        try:
+            current.relative_to(dest)
+        except ValueError:
+            continue
+        if root == "/" or dest == "/":
+            continue
+        if best is None or len(dest) > len(best[1]):
+            best = (root, dest)
+    return best
+
+
 def _detect_dind_mount() -> tuple[str, str] | None:
     """Detect Docker-in-Docker host path translation.
 
@@ -576,30 +607,33 @@ def _detect_dind_mount() -> tuple[str, str] | None:
 
     Returns (host_source, container_dest) tuple, or None if not in DinD.
     """
-    if not Path("/.dockerenv").exists():
-        return None
     import subprocess as _sp
 
     try:
-        hostname = _sp.check_output(["hostname"], text=True).strip()
-        result = _sp.run(
-            ["docker", "inspect", hostname],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return None
-        data = json.loads(result.stdout)
         cwd = str(Path.cwd())
-        best = None
-        for mount in data[0].get("Mounts", []):
-            if mount.get("Type") != "bind":
-                continue
-            dest = mount.get("Destination", "")
-            if cwd.startswith(dest) and (best is None or len(dest) > len(best[1])):
-                best = (mount["Source"], dest)
-        return best
+        if Path("/.dockerenv").exists():
+            hostname = _sp.check_output(["hostname"], text=True).strip()
+            result = _sp.run(
+                ["docker", "inspect", hostname],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0:
+                data = json.loads(result.stdout)
+                best = None
+                for mount in data[0].get("Mounts", []):
+                    if mount.get("Type") != "bind":
+                        continue
+                    dest = mount.get("Destination", "")
+                    if cwd.startswith(dest) and (
+                        best is None or len(dest) > len(best[1])
+                    ):
+                        best = (mount["Source"], dest)
+                if best is not None:
+                    return best
+        mountinfo = Path("/proc/self/mountinfo").read_text(errors="replace")
+        return _mountinfo_path_mapping(cwd, mountinfo)
     except Exception:
         logger.debug("DinD mount detection failed", exc_info=True)
         return None
@@ -637,6 +671,8 @@ def _patch_docker_dind() -> None:
     def _patched(self, include_os_env=True):  # type: ignore[override]
         env = _original(self, include_os_env=include_os_env)
         for key in (
+            "CONTEXT_DIR",
+            "BENCHGUARD_VERIFIER_CONTEXT_DIR",
             "HOST_VERIFIER_LOGS_PATH",
             "HOST_AGENT_LOGS_PATH",
             "HOST_ARTIFACTS_PATH",

--- a/src/benchflow/trajectories/results.py
+++ b/src/benchflow/trajectories/results.py
@@ -30,6 +30,7 @@ from benchflow.trajectories.export_prime_sft import (
     validate_prime_sft_row,
 )
 from benchflow.trajectories.types import redact_trajectory_obj
+from benchflow.usage_tracking import USAGE_SOURCE_AGENT_NATIVE_ACP
 
 ROLLOUT_RESULTS_FILENAME = "results.jsonl"
 JOB_RESULTS_FILENAME = "results.jsonl"
@@ -465,6 +466,12 @@ def build_rollout_results_record(
         export_error=effective_export_error,
     )
     terminal_health_error = bool(error or verifier_error or partial_trajectory)
+    native_subscription_without_llm = bool(
+        (agent_result or {}).get("usage_source") == USAGE_SOURCE_AGENT_NATIVE_ACP
+        and not (rollout_path / "trajectory" / "llm_trajectory.jsonl").exists()
+        and effective_export_error is None
+        and not terminal_health_error
+    )
     training_ready = bool(
         steps
         and completion
@@ -493,7 +500,7 @@ def build_rollout_results_record(
             training_ready_reason = "verifier_error"
         else:
             training_ready_reason = "missing_healthy_structured_llm_trajectory"
-        if error_obj is None:
+        if error_obj is None and not native_subscription_without_llm:
             error_name = (
                 training_ready_reason
                 if training_ready_reason

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -133,6 +133,71 @@ def test_validator_accepts_training_ready_results_jsonl(tmp_path: Path) -> None:
     }
 
 
+def test_validator_oracle_mode_accepts_reward_only_rollout(tmp_path: Path) -> None:
+    """Guards BenchFlow PR #1049's explicit oracle artifact exception."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    result_path = rollout / "result.json"
+    result = json.loads(result_path.read_text())
+    result.update(
+        {
+            "agent": "oracle",
+            "agent_name": "oracle",
+            "model": None,
+            "n_tool_calls": 0,
+            "agent_result": {
+                "n_tool_calls": 0,
+                "n_input_tokens": 0,
+                "n_output_tokens": 0,
+                "total_tokens": 0,
+                "usage_source": "unavailable",
+            },
+        }
+    )
+    result_path.write_text(json.dumps(result))
+    (rollout / "trajectory" / "llm_trajectory.jsonl").unlink()
+    _write_jsonl(
+        rollout / "results.jsonl",
+        [
+            {
+                "example_id": 0,
+                "prompt": [{"role": "user", "content": "solve"}],
+                "completion": None,
+                "info": {
+                    "task_id": "task-a",
+                    "training_ready": False,
+                    "training_ready_reason": (
+                        "missing_healthy_structured_llm_trajectory"
+                    ),
+                },
+                "reward": 1.0,
+                "error": {
+                    "error": "missing_llm_trajectory",
+                    "error_chain_str": "oracle has no LLM trajectory",
+                },
+                "is_completed": False,
+                "is_truncated": False,
+                "stop_condition": "agent_completed",
+                "metrics": {"n_tool_calls": 0, "reward": 1.0},
+                "tool_defs": [],
+                "token_usage": {
+                    "final_input_tokens": 0,
+                    "final_output_tokens": 0,
+                    "total_tokens": 0,
+                },
+                "trajectory": [],
+            }
+        ],
+    )
+
+    strict = validator.validate_rollout(rollout)
+    oracle = validator.validate_rollout(rollout, allow_oracle_without_llm=True)
+
+    assert strict["healthy"] is False
+    assert oracle["healthy"] is True
+    assert oracle["issues"] == []
+
+
 def test_validator_accepts_provider_total_only_token_usage(tmp_path: Path) -> None:
     """Some providers expose only total tokens; Prime-RL can still render the row."""
     validator = _load_validator()

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -240,6 +240,92 @@ def test_validator_rejects_unready_results_for_healthy_rollout(tmp_path: Path) -
     assert any("training_ready=false" in issue for issue in report["issues"])
 
 
+def _native_subscription_rollout(tmp_path: Path) -> Path:
+    rollout = _rollout(tmp_path)
+    (rollout / "trajectory" / "llm_trajectory.jsonl").unlink()
+    result = json.loads((rollout / "result.json").read_text())
+    result["agent_result"]["usage_source"] = "agent_native_acp"
+    (rollout / "result.json").write_text(json.dumps(result))
+    row = json.loads((rollout / "results.jsonl").read_text())
+    row.update(
+        {
+            "completion": None,
+            "error": None,
+            "is_completed": True,
+            "trajectory": [],
+        }
+    )
+    row["info"].update(
+        {
+            "training_ready": False,
+            "training_ready_reason": "missing_healthy_structured_llm_trajectory",
+        }
+    )
+    _write_jsonl(rollout / "results.jsonl", [row])
+    return rollout
+
+
+def test_validator_accepts_explicit_native_subscription_mode(tmp_path: Path) -> None:
+    """Guards this PR's explicit native-subscription evidence mode."""
+    validator = _load_validator()
+    rollout = _native_subscription_rollout(tmp_path)
+
+    strict = validator.validate_rollout(rollout)
+    native = validator.validate_rollout(
+        rollout, allow_native_subscription_without_llm=True
+    )
+
+    assert strict["healthy"] is False
+    assert native["healthy"] is True
+    assert any("native subscription rollout" in item for item in native["warnings"])
+
+
+def test_validator_native_mode_rejects_wrong_usage_source(tmp_path: Path) -> None:
+    """Guards this PR against widening subscription mode to other runs."""
+    validator = _load_validator()
+    rollout = _native_subscription_rollout(tmp_path)
+    result = json.loads((rollout / "result.json").read_text())
+    result["agent_result"]["usage_source"] = "provider_response"
+    (rollout / "result.json").write_text(json.dumps(result))
+
+    report = validator.validate_rollout(
+        rollout, allow_native_subscription_without_llm=True
+    )
+
+    assert report["healthy"] is False
+    assert any("missing required artifact" in issue for issue in report["issues"])
+
+
+def test_validator_native_mode_requires_token_components(tmp_path: Path) -> None:
+    """Guards this PR against accepting usage-free subscription evidence."""
+    validator = _load_validator()
+    rollout = _native_subscription_rollout(tmp_path)
+    row = json.loads((rollout / "results.jsonl").read_text())
+    row["token_usage"] = {"total_tokens": 17}
+    _write_jsonl(rollout / "results.jsonl", [row])
+
+    report = validator.validate_rollout(
+        rollout, allow_native_subscription_without_llm=True
+    )
+
+    assert report["healthy"] is False
+    assert any("positive token components" in issue for issue in report["issues"])
+
+
+def test_validator_native_mode_rejects_malformed_present_llm(tmp_path: Path) -> None:
+    """Guards this PR against bypassing malformed provider evidence."""
+    validator = _load_validator()
+    rollout = _native_subscription_rollout(tmp_path)
+    (rollout / "trajectory" / "llm_trajectory.jsonl").write_text("{\n")
+
+    report = validator.validate_rollout(
+        rollout, allow_native_subscription_without_llm=True
+    )
+
+    assert report["healthy"] is False
+    assert any("JSON parse error" in issue for issue in report["issues"])
+
+
 def test_validator_rejects_results_with_dropped_successful_exchange(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_rollout_import_no_side_effects.py
+++ b/tests/test_rollout_import_no_side_effects.py
@@ -180,7 +180,7 @@ def test_dind_patch_translates_context_and_output_paths() -> None:
             env_artifacts_path="/artifacts",
         ).to_env_dict(include_os_env=False)
 
-        assert env["CONTEXT_DIR"] == "/host/work/repo/environment"
+        assert env["CONTEXT_DIR"] == "/workspace/repo/environment"
         assert env["HOST_VERIFIER_LOGS_PATH"] == "/host/work/jobs/verifier"
         assert env["HOST_AGENT_LOGS_PATH"] == "/host/work/jobs/agent"
         assert env["HOST_ARTIFACTS_PATH"] == "/host/work/jobs/artifacts"

--- a/tests/test_rollout_import_no_side_effects.py
+++ b/tests/test_rollout_import_no_side_effects.py
@@ -135,3 +135,60 @@ def test_without_dind_environment_patch_does_not_apply() -> None:
         f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
     )
     assert "OK" in result.stdout
+
+
+def test_mountinfo_fallback_maps_workspace_subtree() -> None:
+    """Guards the fix from PR #1049 for host-Docker bind-mounted shells."""
+    from benchflow.sandbox.setup import _mountinfo_path_mapping
+
+    mountinfo = (
+        "1001 991 259:5 /workspace/docker /workspace rw,noatime "
+        "- ext4 /dev/nvme1n1p3 rw\n"
+    )
+
+    assert _mountinfo_path_mapping("/workspace/repo", mountinfo) == (
+        "/workspace/docker",
+        "/workspace",
+    )
+
+
+def test_dind_patch_translates_context_and_output_paths() -> None:
+    """Guards the fix from PR #1049 for every host-side Compose path."""
+    result = _run_python(
+        """
+        from unittest.mock import patch
+
+        from benchflow.sandbox.docker import DockerSandboxEnvVars
+        from benchflow.sandbox import setup as sandbox_setup
+        from benchflow.rollout import _install_docker_compat
+
+        with patch.object(
+            sandbox_setup,
+            "_detect_dind_mount",
+            return_value=("/host/work", "/workspace"),
+        ):
+            _install_docker_compat()
+
+        env = DockerSandboxEnvVars(
+            main_image_name="main",
+            context_dir="/workspace/repo/environment",
+            host_verifier_logs_path="/workspace/jobs/verifier",
+            host_agent_logs_path="/workspace/jobs/agent",
+            host_artifacts_path="/workspace/jobs/artifacts",
+            env_verifier_logs_path="/logs/verifier",
+            env_agent_logs_path="/logs/agent",
+            env_artifacts_path="/artifacts",
+        ).to_env_dict(include_os_env=False)
+
+        assert env["CONTEXT_DIR"] == "/host/work/repo/environment"
+        assert env["HOST_VERIFIER_LOGS_PATH"] == "/host/work/jobs/verifier"
+        assert env["HOST_AGENT_LOGS_PATH"] == "/host/work/jobs/agent"
+        assert env["HOST_ARTIFACTS_PATH"] == "/host/work/jobs/artifacts"
+        assert env["ENV_VERIFIER_LOGS_PATH"] == "/logs/verifier"
+        print("OK")
+        """
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed: stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+    assert "OK" in result.stdout

--- a/tests/test_train_mode_artifact_emission.py
+++ b/tests/test_train_mode_artifact_emission.py
@@ -1101,6 +1101,83 @@ def test_build_rollout_result_results_jsonl_is_unhealthy_without_llm(tmp_path):
     assert row["stop_condition"] == "partial_trajectory"
 
 
+def test_native_subscription_without_llm_is_completed_but_not_training_ready(
+    tmp_path,
+):
+    """Guards this PR's native-subscription result semantics."""
+    rollout_dir = tmp_path / "native-subscription"
+    rollout_dir.mkdir()
+
+    _build_rollout_result(
+        rollout_dir,
+        task_name="subscription-task",
+        rollout_name="r1",
+        agent="claude-agent-acp",
+        agent_name="Claude Agent",
+        model="claude-opus-5",
+        n_tool_calls=1,
+        prompts=["Solve this."],
+        error=None,
+        verifier_error=None,
+        trajectory=_acp_trajectory(),
+        partial_trajectory=False,
+        trajectory_source="acp",
+        rewards={"reward": 1.0},
+        started_at=datetime.now(),
+        timing={"agent_execution": 1.0, "verifier": 1.0},
+        n_input_tokens=11,
+        n_output_tokens=6,
+        total_tokens=17,
+        usage_source="agent_native_acp",
+    )
+
+    row = json.loads((rollout_dir / "results.jsonl").read_text())
+    assert row["completion"] is None
+    assert row["trajectory"] == []
+    assert row["info"]["training_ready"] is False
+    assert (
+        row["info"]["training_ready_reason"]
+        == "missing_healthy_structured_llm_trajectory"
+    )
+    assert row["error"] is None
+    assert row["is_completed"] is True
+    assert row["is_truncated"] is False
+    assert row["stop_condition"] == "agent_completed"
+
+
+def test_native_subscription_without_llm_preserves_terminal_errors(tmp_path):
+    """Guards this PR against hiding native-subscription verifier failures."""
+    rollout_dir = tmp_path / "native-subscription-error"
+    rollout_dir.mkdir()
+
+    _build_rollout_result(
+        rollout_dir,
+        task_name="subscription-task",
+        rollout_name="r1",
+        agent="claude-agent-acp",
+        agent_name="Claude Agent",
+        model="claude-opus-5",
+        n_tool_calls=1,
+        prompts=["Solve this."],
+        error=None,
+        verifier_error="verifier crashed",
+        trajectory=_acp_trajectory(),
+        partial_trajectory=False,
+        trajectory_source="acp",
+        rewards=None,
+        started_at=datetime.now(),
+        timing={"agent_execution": 1.0},
+        n_input_tokens=11,
+        n_output_tokens=6,
+        total_tokens=17,
+        usage_source="agent_native_acp",
+    )
+
+    row = json.loads((rollout_dir / "results.jsonl").read_text())
+    assert row["error"]["error"] == "verifier_error"
+    assert row["is_completed"] is False
+
+
 def test_results_jsonl_token_usage_falls_back_to_provider_total(tmp_path):
     """Guards PR #828: total-only telemetry still feeds Prime-RL token batches."""
     rollout_dir = tmp_path / "rollout-total-only"


### PR DESCRIPTION
## Summary
- keep healthy native ACP subscription runs completed when provider LLM capture is absent by construction
- keep them explicitly non-training-ready; never synthesize training messages
- add opt-in artifact-validator mode with exact usage, timing, reward, ACP, and result-shape checks

## Verification
- 49 focused tests passed
- ruff passed
- ty passed
- full suite: 5765 passed, 57 skipped, 7 deselected; 2 host-dependent smoke failures because ~/.claude/.credentials.json exists

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1049" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->