### PR TITLE
fix: validate separate verifier evidence

### DIFF
--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -814,6 +814,52 @@ def load_run_config(root: Path) -> dict[str, Any] | None:
     return None
 
 
+def separate_verifier_declared(root: Path) -> bool:
+    preflight, _ = read_json(root / "benchguard" / "preflight.json")
+    facts = (
+        preflight.get("report", {}).get("task_binding", {}).get("facts", {})
+        if isinstance(preflight, dict)
+        else {}
+    )
+    if isinstance(facts, dict) and facts.get("verifier_environment_mode") == "separate":
+        return True
+
+    waivers, _ = read_json(root / "benchguard" / "runtime_capability_waivers.json")
+    rows = waivers.get("waived", []) if isinstance(waivers, dict) else []
+    return any(
+        isinstance(row, dict) and row.get("path") == "verifier.environment_mode"
+        for row in rows
+    )
+
+
+def validate_separate_verifier_actions(
+    root: Path,
+) -> tuple[list[str], dict[str, Any]]:
+    path = root / "benchguard" / "action_records.jsonl"
+    if not path.is_file():
+        return [f"separate verifier lacks action evidence: {path}"], {}
+    rows, issues = read_jsonl(path)
+    started = any(
+        row.get("event_type") == "StartBenchGuardVerifierService"
+        and row.get("service") == "benchguard-verifier"
+        and row.get("phase") == "Verify"
+        and row.get("status") == "ok"
+        for row in rows
+    )
+    verified = any(
+        row.get("event_type") == "SandboxExec"
+        and row.get("service") == "benchguard-verifier"
+        and row.get("phase") == "Verify"
+        and row.get("status") == "ok"
+        for row in rows
+    )
+    if not started:
+        issues.append(f"{path}: no successful verifier sidecar start action")
+    if not verified:
+        issues.append(f"{path}: no successful Verify exec on benchguard-verifier")
+    return issues, {"sidecar_started": started, "verify_exec": verified}
+
+
 def validate_rollout(
     root: Path,
     *,
@@ -878,6 +924,11 @@ def validate_rollout(
     issues.extend(results_issues)
     if results_summary:
         artifact_summary["results"] = results_summary
+
+    if separate_verifier_declared(root):
+        action_issues, action_summary = validate_separate_verifier_actions(root)
+        issues.extend(action_issues)
+        artifact_summary["separate_verifier"] = action_summary
 
     tokens = numeric_token_total(result)
     if not oracle_without_llm and (not tokens or tokens <= 0):

--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -248,6 +248,40 @@ def validate_acp(rows: list[dict[str, Any]], path: Path) -> list[str]:
     return issues
 
 
+def validate_terminal_timeout(rows: list[dict[str, Any]], path: Path) -> list[str]:
+    issues: list[str] = []
+    timeout_complete = False
+    for index, row in enumerate(rows, start=1):
+        if row.get("type") == "agent_timeout":
+            timeout_complete = row.get("terminal_trajectory_complete") is True
+        if row.get("type") != "tool_call":
+            continue
+        if row.get("status") in {"pending", "in_progress"}:
+            issues.append(f"{path}:{index}: timeout trajectory has pending tool")
+        if row.get("terminal_source") == "benchflow" and (
+            row.get("status") != "cancelled" or row.get("effects") != "unknown"
+        ):
+            issues.append(f"{path}:{index}: invalid BenchFlow timeout terminalization")
+    if not timeout_complete:
+        issues.append(f"{path}: missing complete terminal timeout event")
+    return issues
+
+
+def is_normal_timeout_result(result: dict[str, Any]) -> bool:
+    info = result.get("agent_timeout_info")
+    return bool(
+        isinstance(info, dict)
+        and info.get("reason") == "wall_clock_timeout"
+        and info.get("terminal_event_recorded") is True
+        and info.get("terminal_trajectory_complete") is True
+        and result.get("error_category") == "timeout"
+        and bool(result.get("error"))
+        and result.get("partial_trajectory") is False
+        and result.get("trajectory_source") == "acp"
+        and result.get("verifier_error") is None
+    )
+
+
 def validate_llm(
     rows: list[dict[str, Any]], path: Path
 ) -> tuple[list[str], dict[str, Any]]:
@@ -606,6 +640,7 @@ def validate_results_row(
 
     if native_subscription_without_llm:
         expected_reason = "missing_healthy_structured_llm_trajectory"
+        normal_timeout = is_normal_timeout_result(result)
         if training_ready is not False:
             issues.append(
                 f"{row_path}: native subscription row must not be training-ready"
@@ -614,13 +649,22 @@ def validate_results_row(
             issues.append(
                 f"{row_path}: native subscription row has unexpected training_ready_reason"
             )
-        if row_error is not None:
-            issues.append(f"{row_path}: native subscription row carries non-null error")
-        if row.get("is_completed") is not True:
-            issues.append(f"{row_path}: native subscription row is not completed")
+        if normal_timeout:
+            if row_error is None:
+                issues.append(f"{row_path}: normal timeout row lacks error payload")
+            if row.get("is_completed") is not False:
+                issues.append(f"{row_path}: normal timeout row is completed")
+        else:
+            if row_error is not None:
+                issues.append(
+                    f"{row_path}: native subscription row carries non-null error"
+                )
+            if row.get("is_completed") is not True:
+                issues.append(f"{row_path}: native subscription row is not completed")
         if row.get("is_truncated") is not False:
             issues.append(f"{row_path}: native subscription row is truncated")
-        if row.get("stop_condition") != "agent_completed":
+        expected_stop = "agent_error" if normal_timeout else "agent_completed"
+        if row.get("stop_condition") != expected_stop:
             issues.append(
                 f"{row_path}: native subscription row has unexpected stop_condition"
             )
@@ -900,6 +944,8 @@ def validate_rollout(
         acp_rows, acp_issues = read_jsonl(acp_path)
         issues.extend(acp_issues)
         issues.extend(validate_acp(acp_rows, acp_path))
+        if is_normal_timeout_result(result):
+            issues.extend(validate_terminal_timeout(acp_rows, acp_path))
         artifact_summary["acp_events"] = len(acp_rows)
 
     if oracle_without_llm:

--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -607,7 +607,9 @@ def validate_results_row(
     if native_subscription_without_llm:
         expected_reason = "missing_healthy_structured_llm_trajectory"
         if training_ready is not False:
-            issues.append(f"{row_path}: native subscription row must not be training-ready")
+            issues.append(
+                f"{row_path}: native subscription row must not be training-ready"
+            )
         if info.get("training_ready_reason") != expected_reason:
             issues.append(
                 f"{row_path}: native subscription row has unexpected training_ready_reason"
@@ -816,11 +818,9 @@ def load_run_config(root: Path) -> dict[str, Any] | None:
 
 def separate_verifier_declared(root: Path) -> bool:
     preflight, _ = read_json(root / "benchguard" / "preflight.json")
-    facts = (
-        preflight.get("report", {}).get("task_binding", {}).get("facts", {})
-        if isinstance(preflight, dict)
-        else {}
-    )
+    report = preflight.get("report") if isinstance(preflight, dict) else None
+    task_binding = report.get("task_binding") if isinstance(report, dict) else None
+    facts = task_binding.get("facts") if isinstance(task_binding, dict) else None
     if isinstance(facts, dict) and facts.get("verifier_environment_mode") == "separate":
         return True
 

--- a/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
+++ b/.agents/skills/benchflow-experiment-review/scripts/validate_run_artifacts.py
@@ -821,8 +821,12 @@ def separate_verifier_declared(root: Path) -> bool:
     report = preflight.get("report") if isinstance(preflight, dict) else None
     task_binding = report.get("task_binding") if isinstance(report, dict) else None
     facts = task_binding.get("facts") if isinstance(task_binding, dict) else None
-    if isinstance(facts, dict) and facts.get("verifier_environment_mode") == "separate":
-        return True
+    if (
+        isinstance(task_binding, dict)
+        and isinstance(facts, dict)
+        and facts.get("verifier_environment_mode") == "separate"
+    ):
+        return facts.get("verifier_environment_mode_declared") is not False
 
     waivers, _ = read_json(root / "benchguard" / "runtime_capability_waivers.json")
     rows = waivers.get("waived", []) if isinstance(waivers, dict) else []

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -195,6 +195,35 @@ def test_validator_accepts_structural_separate_verifier_actions(tmp_path: Path) 
     }
 
 
+def test_validator_does_not_require_sidecar_for_undeclared_default(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #1050: undeclared verifier defaults continue on main in audit."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    benchguard = rollout / "benchguard"
+    benchguard.mkdir()
+    (benchguard / "preflight.json").write_text(
+        json.dumps(
+            {
+                "report": {
+                    "task_binding": {
+                        "facts": {
+                            "verifier_environment_mode": "separate",
+                            "verifier_environment_mode_declared": False,
+                        },
+                    }
+                }
+            }
+        )
+    )
+
+    report = validator.validate_rollout(rollout)
+
+    assert report["healthy"] is True
+    assert "separate_verifier" not in report["artifacts"]
+
+
 def test_validator_recognizes_legacy_separate_verifier_waiver(tmp_path: Path) -> None:
     """Guards PR #1049 follow-up for runs predating structured preflight facts."""
     validator = _load_validator()

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -478,6 +478,82 @@ def test_validator_accepts_explicit_native_subscription_mode(tmp_path: Path) -> 
     assert any("native subscription rollout" in item for item in native["warnings"])
 
 
+def _native_subscription_timeout_rollout(tmp_path: Path) -> Path:
+    rollout = _native_subscription_rollout(tmp_path)
+    result = json.loads((rollout / "result.json").read_text())
+    result.update(
+        {
+            "error": "Agent prompt exceeded wall-clock budget 45s",
+            "error_category": "timeout",
+            "partial_trajectory": False,
+            "trajectory_source": "acp",
+            "verifier_error": None,
+            "agent_timeout_info": {
+                "reason": "wall_clock_timeout",
+                "terminal_event_recorded": True,
+                "terminal_trajectory_complete": True,
+            },
+        }
+    )
+    (rollout / "result.json").write_text(json.dumps(result))
+    _write_jsonl(
+        rollout / "trajectory" / "acp_trajectory.jsonl",
+        [
+            {
+                "type": "tool_call",
+                "status": "cancelled",
+                "effects": "unknown",
+                "terminal_source": "benchflow",
+            },
+            {"type": "agent_timeout", "terminal_trajectory_complete": True},
+        ],
+    )
+    row = json.loads((rollout / "results.jsonl").read_text())
+    row.update(
+        {
+            "error": {"error": "agent_error"},
+            "is_completed": False,
+            "stop_condition": "agent_error",
+        }
+    )
+    _write_jsonl(rollout / "results.jsonl", [row])
+    return rollout
+
+
+def test_validator_accepts_complete_native_subscription_timeout(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #1050: complete native timeouts are countable, not trainable."""
+    validator = _load_validator()
+    rollout = _native_subscription_timeout_rollout(tmp_path)
+
+    report = validator.validate_rollout(
+        rollout, allow_native_subscription_without_llm=True
+    )
+
+    assert report["healthy"] is True
+
+
+def test_validator_rejects_pending_native_subscription_timeout(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #1050: timeout evidence must terminalize every tool."""
+    validator = _load_validator()
+    rollout = _native_subscription_timeout_rollout(tmp_path)
+    rows = [
+        {"type": "tool_call", "status": "in_progress"},
+        {"type": "agent_timeout", "terminal_trajectory_complete": True},
+    ]
+    _write_jsonl(rollout / "trajectory" / "acp_trajectory.jsonl", rows)
+
+    report = validator.validate_rollout(
+        rollout, allow_native_subscription_without_llm=True
+    )
+
+    assert report["healthy"] is False
+    assert any("pending tool" in issue for issue in report["issues"])
+
+
 def test_validator_native_mode_rejects_wrong_usage_source(tmp_path: Path) -> None:
     """Guards this PR against widening subscription mode to other runs."""
     validator = _load_validator()

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -4,6 +4,8 @@ import importlib.util
 import json
 from pathlib import Path
 
+import pytest
+
 SCRIPT = (
     Path(__file__).resolve().parents[1]
     / ".agents"
@@ -140,9 +142,7 @@ def _declare_separate_verifier(rollout: Path) -> None:
         json.dumps(
             {
                 "report": {
-                    "task_binding": {
-                        "facts": {"verifier_environment_mode": "separate"}
-                    }
+                    "task_binding": {"facts": {"verifier_environment_mode": "separate"}}
                 }
             }
         )
@@ -209,6 +209,32 @@ def test_validator_recognizes_legacy_separate_verifier_waiver(tmp_path: Path) ->
 
     assert report["healthy"] is False
     assert any("lacks action evidence" in issue for issue in report["issues"])
+
+
+@pytest.mark.parametrize(
+    "report",
+    [
+        None,
+        [],
+        {"task_binding": None},
+        {"task_binding": []},
+        {"task_binding": {"facts": None}},
+        {"task_binding": {"facts": []}},
+    ],
+)
+def test_validator_tolerates_malformed_optional_preflight_nesting(
+    tmp_path: Path, report: object
+) -> None:
+    """Guards PR #1050: optional malformed preflight fields cannot crash review."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    benchguard = rollout / "benchguard"
+    benchguard.mkdir()
+    (benchguard / "preflight.json").write_text(json.dumps({"report": report}))
+
+    result = validator.validate_rollout(rollout)
+
+    assert result["healthy"] is True
 
 
 def test_validator_oracle_mode_accepts_reward_only_rollout(tmp_path: Path) -> None:

--- a/tests/test_benchflow_experiment_review_validator.py
+++ b/tests/test_benchflow_experiment_review_validator.py
@@ -133,6 +133,84 @@ def test_validator_accepts_training_ready_results_jsonl(tmp_path: Path) -> None:
     }
 
 
+def _declare_separate_verifier(rollout: Path) -> None:
+    benchguard = rollout / "benchguard"
+    benchguard.mkdir()
+    (benchguard / "preflight.json").write_text(
+        json.dumps(
+            {
+                "report": {
+                    "task_binding": {
+                        "facts": {"verifier_environment_mode": "separate"}
+                    }
+                }
+            }
+        )
+    )
+
+
+def test_validator_rejects_separate_verifier_without_sidecar_actions(
+    tmp_path: Path,
+) -> None:
+    """Guards PR #1049 follow-up: masked main-container verification is unhealthy."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    _declare_separate_verifier(rollout)
+
+    report = validator.validate_rollout(rollout)
+
+    assert report["healthy"] is False
+    assert any("lacks action evidence" in issue for issue in report["issues"])
+
+
+def test_validator_accepts_structural_separate_verifier_actions(tmp_path: Path) -> None:
+    """Guards PR #1049 follow-up using action records, not verifier stdout text."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    _declare_separate_verifier(rollout)
+    _write_jsonl(
+        rollout / "benchguard" / "action_records.jsonl",
+        [
+            {
+                "event_type": "StartBenchGuardVerifierService",
+                "phase": "Verify",
+                "service": "benchguard-verifier",
+                "status": "ok",
+            },
+            {
+                "event_type": "SandboxExec",
+                "phase": "Verify",
+                "service": "benchguard-verifier",
+                "status": "ok",
+            },
+        ],
+    )
+
+    report = validator.validate_rollout(rollout)
+
+    assert report["healthy"] is True
+    assert report["artifacts"]["separate_verifier"] == {
+        "sidecar_started": True,
+        "verify_exec": True,
+    }
+
+
+def test_validator_recognizes_legacy_separate_verifier_waiver(tmp_path: Path) -> None:
+    """Guards PR #1049 follow-up for runs predating structured preflight facts."""
+    validator = _load_validator()
+    rollout = _rollout(tmp_path)
+    benchguard = rollout / "benchguard"
+    benchguard.mkdir()
+    (benchguard / "runtime_capability_waivers.json").write_text(
+        json.dumps({"waived": [{"path": "verifier.environment_mode"}]})
+    )
+
+    report = validator.validate_rollout(rollout)
+
+    assert report["healthy"] is False
+    assert any("lacks action evidence" in issue for issue in report["issues"])
+
+
 def test_validator_oracle_mode_accepts_reward_only_rollout(tmp_path: Path) -> None:
     """Guards BenchFlow PR #1049's explicit oracle artifact exception."""
     validator = _load_validator()


### PR DESCRIPTION
## Summary\n- detect declared separate-verifier rollouts from structured preflight facts or legacy capability waivers\n- require structural action evidence for sidecar start and Verify execution\n- keep validation independent of verifier stdout text\n\nFollow-up defense for #1049 and benchflow-ai/benchguard#39.\n\n## Verification\n- ...................                                                      [100%]
19 passed in 0.10s (19 passed)\n- All checks passed!\n- old WAL rollout now rejected for missing sidecar start/Verify actions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1050" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->