### PR TITLE
Preserve native ACP artifacts at prompt timeout

### DIFF
--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -1,5 +1,6 @@
 """ACP client — benchflow acts as the client, agents are ACP servers."""
 
+import asyncio
 import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -413,6 +414,46 @@ class ACPClient:
             await self._send_notification(
                 "session/cancel", {"sessionId": self._session.session_id}
             )
+
+    async def drain_tool_call_updates(
+        self, tool_call_ids: set[str], timeout: float
+    ) -> bool:
+        """Process genuine ACP updates until selected tool calls are terminal.
+
+        This is used only after ``session/prompt`` has returned, so no other
+        coroutine owns the transport reader. It deliberately does not invent
+        terminal updates when an agent stops without sending them.
+        """
+        if not self._session:
+            return not tool_call_ids
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while tool_call_ids.intersection(self._session.pending_tool_call_ids()):
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+
+            async def _receive_and_dispatch() -> None:
+                msg = await self._transport.receive()
+                if "method" in msg and "id" not in msg:
+                    await self._handle_notification(msg)
+                elif "method" in msg and "id" in msg:
+                    await self._handle_agent_request(msg)
+                else:
+                    logger.debug("ACPClient ignoring message while draining: %s", msg)
+
+            try:
+                await asyncio.wait_for(_receive_and_dispatch(), timeout=remaining)
+            except TimeoutError:
+                return False
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.warning("ACP update drain failed: %s", e)
+                return False
+
+        return True
 
     @property
     def session(self) -> ACPSession | None:

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -725,7 +725,7 @@ async def execute_prompts(
                 prompt_result = await _prompt_with_wall_clock_budget(
                     acp_client, session, prompt, timeout
                 )
-            except AgentPromptTimeoutError as e:
+            except (AgentPromptTimeoutError, IdleTimeoutError) as e:
                 e.executed_prompts = prompts[: i + 1]
                 raise
         else:
@@ -733,7 +733,7 @@ async def execute_prompts(
                 prompt_result = await _prompt_with_idle_watchdog(
                     acp_client, session, prompt, timeout, idle_timeout
                 )
-            except AgentPromptTimeoutError as e:
+            except (AgentPromptTimeoutError, IdleTimeoutError) as e:
                 e.executed_prompts = prompts[: i + 1]
                 raise
         session.mark_prompt_end()
@@ -777,16 +777,18 @@ async def _request_cancel_and_drain_prompt_task(
     """Ask the ACP agent to stop, then hard-cancel if it does not respond."""
     if prompt_task.done():
         return True
+    deadline = asyncio.get_running_loop().time() + _PROMPT_CANCEL_GRACE_TIMEOUT_SEC
     try:
-        await acp_client.cancel()
+        await asyncio.wait_for(
+            acp_client.cancel(), timeout=_PROMPT_CANCEL_GRACE_TIMEOUT_SEC
+        )
     except Exception:
         logger.warning(
             "ACP session/cancel failed; hard-cancelling prompt", exc_info=True
         )
     else:
-        done, _pending = await asyncio.wait(
-            {prompt_task}, timeout=_PROMPT_CANCEL_GRACE_TIMEOUT_SEC
-        )
+        remaining = max(0.0, deadline - asyncio.get_running_loop().time())
+        done, _pending = await asyncio.wait({prompt_task}, timeout=remaining)
         if done:
             with contextlib.suppress(BaseException):
                 prompt_task.result()
@@ -818,6 +820,28 @@ def _agent_prompt_timeout_error(session, timeout: int) -> AgentPromptTimeoutErro
         f"Agent prompt exceeded wall-clock budget {timeout}s",
         trajectory=_capture_session_trajectory(session),
         diagnostic=diagnostic,
+    )
+
+
+def _idle_timeout_error(session, diagnostic: IdleTimeoutDiagnostic) -> IdleTimeoutError:
+    session.mark_prompt_end()
+    pending_tool_call_ids = session.pending_tool_call_ids()
+    terminal_complete = not pending_tool_call_ids
+    session.record_agent_timeout(
+        reason="idle_timeout",
+        timeout_sec=float(diagnostic.idle_timeout_sec),
+        pending_tool_call_ids=pending_tool_call_ids,
+        terminal_trajectory_complete=terminal_complete,
+    )
+    return IdleTimeoutError(
+        f"Agent idle for {diagnostic.idle_timeout_sec}s with no new tool call, "
+        f"message, or thought "
+        f"(last activity {diagnostic.idle_duration_sec}s ago, "
+        f"{len(session.tool_calls)} tool calls so far)",
+        diagnostic,
+        trajectory=_capture_session_trajectory(session),
+        n_tool_calls=len(session.tool_calls),
+        terminal_trajectory_complete=terminal_complete,
     )
 
 
@@ -919,13 +943,7 @@ async def _prompt_with_idle_watchdog(
                 )
                 await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
                 cleanup_attempted = True
-                raise IdleTimeoutError(
-                    f"Agent idle for {idle_timeout}s with no new tool call, "
-                    f"message, or thought "
-                    f"(last activity {int(now - last_progress)}s ago, "
-                    f"{len(session.tool_calls)} tool calls so far)",
-                    diag,
-                )
+                raise _idle_timeout_error(session, diag)
             if now > deadline:
                 await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
                 cleanup_attempted = True

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -21,6 +21,8 @@ Does not own:
 import asyncio
 import contextlib
 import logging
+import os
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -66,11 +68,63 @@ logger = logging.getLogger(__name__)
 
 _ACP_CONNECT_MAX_RETRIES = 3
 _ACP_CONNECT_BASE_DELAY = 2.0
-_PROMPT_CANCEL_GRACE_TIMEOUT_SEC = 5.0
+_PROMPT_GRACEFUL_CANCEL_TIMEOUT_SEC = 5.0
 _PROMPT_CANCEL_DRAIN_TIMEOUT_SEC = 0.25
 _ACP_HANDSHAKE_TIMEOUT_ENV = "BENCHFLOW_ACP_HANDSHAKE_TIMEOUT"
 _ACP_HANDSHAKE_TIMEOUT_DEFAULT_SEC = 60.0
 _OPENHANDS_DISABLE_SUBAGENTS_ENV = "BENCHFLOW_OPENHANDS_DISABLE_SUBAGENTS"
+_ACP_CANCEL_GRACE_TIMEOUT_DEFAULT_SEC = 60.0
+_ACP_CANCEL_GRACE_TIMEOUT_MIN_SEC = 1.0
+_ACP_CANCEL_GRACE_TIMEOUT_MAX_SEC = 300.0
+
+
+@dataclass(frozen=True)
+class _PromptCancelDrainResult:
+    requested_grace_sec: float
+    elapsed_grace_sec: float
+    prompt_completed: bool
+    tools_completed: bool
+
+
+def _log_cancel_drain(result: _PromptCancelDrainResult) -> _PromptCancelDrainResult:
+    logger.info(
+        "ACP cancellation drain: requested=%.2fs elapsed=%.2fs "
+        "prompt_completed=%s tools_completed=%s",
+        result.requested_grace_sec,
+        result.elapsed_grace_sec,
+        result.prompt_completed,
+        result.tools_completed,
+    )
+    return result
+
+
+def _prompt_response_completed(prompt_task: asyncio.Task) -> bool:
+    if not prompt_task.done() or prompt_task.cancelled():
+        return False
+    try:
+        prompt_task.result()
+    except BaseException:
+        return False
+    return True
+
+
+def _acp_cancel_grace_timeout_sec() -> float:
+    raw = os.environ.get("BENCHFLOW_ACP_CANCEL_GRACE_TIMEOUT")
+    if raw is None:
+        return _ACP_CANCEL_GRACE_TIMEOUT_DEFAULT_SEC
+    try:
+        timeout = float(raw)
+    except ValueError as e:
+        raise ValueError(
+            "BENCHFLOW_ACP_CANCEL_GRACE_TIMEOUT must be a number from 1 to 300"
+        ) from e
+    if not (
+        _ACP_CANCEL_GRACE_TIMEOUT_MIN_SEC
+        <= timeout
+        <= _ACP_CANCEL_GRACE_TIMEOUT_MAX_SEC
+    ):
+        raise ValueError("BENCHFLOW_ACP_CANCEL_GRACE_TIMEOUT must be from 1 to 300")
+    return timeout
 
 
 def _acp_handshake_timeout_sec() -> float:
@@ -771,43 +825,91 @@ async def _cancel_and_drain_prompt_task(prompt_task: asyncio.Task) -> bool:
     return False
 
 
-async def _request_cancel_and_drain_prompt_task(
-    acp_client: ACPClient, prompt_task: asyncio.Task
-) -> bool:
-    """Ask the ACP agent to stop, then hard-cancel if it does not respond."""
-    if prompt_task.done():
-        return True
-    deadline = asyncio.get_running_loop().time() + _PROMPT_CANCEL_GRACE_TIMEOUT_SEC
+async def _gracefully_cancel_prompt_task(
+    acp_client: ACPClient, session, prompt_task: asyncio.Task
+) -> _PromptCancelDrainResult:
+    """Ask ACP to cancel, then preserve only genuine terminal updates."""
+    grace = _acp_cancel_grace_timeout_sec()
+    loop = asyncio.get_running_loop()
+    pending_at_cancel = set(session.pending_tool_call_ids())
+    if prompt_task.done() and not pending_at_cancel:
+        return _log_cancel_drain(
+            _PromptCancelDrainResult(
+                grace, 0.0, _prompt_response_completed(prompt_task), True
+            )
+        )
+
+    cancel = getattr(acp_client, "cancel", None)
+    if not callable(cancel):
+        await _cancel_and_drain_prompt_task(prompt_task)
+        return _log_cancel_drain(
+            _PromptCancelDrainResult(
+                grace,
+                0.0,
+                False,
+                not pending_at_cancel.intersection(session.pending_tool_call_ids()),
+            )
+        )
     try:
-        await asyncio.wait_for(
-            acp_client.cancel(), timeout=_PROMPT_CANCEL_GRACE_TIMEOUT_SEC
+        await asyncio.wait_for(cancel(), timeout=_PROMPT_GRACEFUL_CANCEL_TIMEOUT_SEC)
+    except Exception as e:
+        logger.warning("ACP session cancellation failed: %s", e)
+        await _cancel_and_drain_prompt_task(prompt_task)
+        return _log_cancel_drain(
+            _PromptCancelDrainResult(
+                grace,
+                0.0,
+                False,
+                not pending_at_cancel.intersection(session.pending_tool_call_ids()),
+            )
         )
-    except Exception:
-        logger.warning(
-            "ACP session/cancel failed; hard-cancelling prompt", exc_info=True
+
+    drain_started = loop.time()
+    deadline = drain_started + grace
+    if not prompt_task.done():
+        remaining = max(0.0, deadline - loop.time())
+        await asyncio.wait({prompt_task}, timeout=remaining)
+
+    prompt_completed = _prompt_response_completed(prompt_task)
+
+    tools_completed = not pending_at_cancel.intersection(
+        session.pending_tool_call_ids()
+    )
+    drain = getattr(acp_client, "drain_tool_call_updates", None)
+    if prompt_completed and not tools_completed and callable(drain):
+        remaining = max(0.0, deadline - loop.time())
+        if remaining:
+            tools_completed = await drain(pending_at_cancel, remaining)
+
+    elapsed = loop.time() - drain_started
+    if not (prompt_completed and tools_completed):
+        await _cancel_and_drain_prompt_task(prompt_task)
+    return _log_cancel_drain(
+        _PromptCancelDrainResult(
+            requested_grace_sec=grace,
+            elapsed_grace_sec=elapsed,
+            prompt_completed=prompt_completed,
+            tools_completed=tools_completed,
         )
-    else:
-        remaining = max(0.0, deadline - asyncio.get_running_loop().time())
-        done, _pending = await asyncio.wait({prompt_task}, timeout=remaining)
-        if done:
-            with contextlib.suppress(BaseException):
-                prompt_task.result()
-            return True
-        logger.warning(
-            "ACP prompt did not finish within %.2fs after session/cancel",
-            _PROMPT_CANCEL_GRACE_TIMEOUT_SEC,
-        )
-    return await _cancel_and_drain_prompt_task(prompt_task)
+    )
 
 
-def _agent_prompt_timeout_error(session, timeout: int) -> AgentPromptTimeoutError:
+def _agent_prompt_timeout_error(
+    session, timeout: int, drain: _PromptCancelDrainResult
+) -> AgentPromptTimeoutError:
     session.mark_prompt_end()
     pending_tool_call_ids = session.pending_tool_call_ids()
-    terminal_complete = not pending_tool_call_ids
+    terminal_complete = (
+        drain.prompt_completed and drain.tools_completed and not pending_tool_call_ids
+    )
     session.record_agent_timeout(
         timeout_sec=float(timeout),
         pending_tool_call_ids=pending_tool_call_ids,
         terminal_trajectory_complete=terminal_complete,
+        cancel_grace_requested_sec=drain.requested_grace_sec,
+        cancel_grace_elapsed_sec=drain.elapsed_grace_sec,
+        cancel_prompt_completed=drain.prompt_completed,
+        cancel_tools_completed=drain.tools_completed,
     )
     diagnostic = AgentPromptTimeoutDiagnostic(
         timeout_sec=float(timeout),
@@ -815,6 +917,10 @@ def _agent_prompt_timeout_error(session, timeout: int) -> AgentPromptTimeoutErro
         pending_tool_call_ids=pending_tool_call_ids,
         terminal_event_recorded=True,
         terminal_trajectory_complete=terminal_complete,
+        cancel_grace_requested_sec=drain.requested_grace_sec,
+        cancel_grace_elapsed_sec=drain.elapsed_grace_sec,
+        cancel_prompt_completed=drain.prompt_completed,
+        cancel_tools_completed=drain.tools_completed,
     )
     return AgentPromptTimeoutError(
         f"Agent prompt exceeded wall-clock budget {timeout}s",
@@ -823,15 +929,25 @@ def _agent_prompt_timeout_error(session, timeout: int) -> AgentPromptTimeoutErro
     )
 
 
-def _idle_timeout_error(session, diagnostic: IdleTimeoutDiagnostic) -> IdleTimeoutError:
+def _idle_timeout_error(
+    session,
+    diagnostic: IdleTimeoutDiagnostic,
+    drain: _PromptCancelDrainResult,
+) -> IdleTimeoutError:
     session.mark_prompt_end()
     pending_tool_call_ids = session.pending_tool_call_ids()
-    terminal_complete = not pending_tool_call_ids
+    terminal_complete = (
+        drain.prompt_completed and drain.tools_completed and not pending_tool_call_ids
+    )
     session.record_agent_timeout(
         reason="idle_timeout",
         timeout_sec=float(diagnostic.idle_timeout_sec),
         pending_tool_call_ids=pending_tool_call_ids,
         terminal_trajectory_complete=terminal_complete,
+        cancel_grace_requested_sec=drain.requested_grace_sec,
+        cancel_grace_elapsed_sec=drain.elapsed_grace_sec,
+        cancel_prompt_completed=drain.prompt_completed,
+        cancel_tools_completed=drain.tools_completed,
     )
     return IdleTimeoutError(
         f"Agent idle for {diagnostic.idle_timeout_sec}s with no new tool call, "
@@ -858,9 +974,9 @@ async def _prompt_with_wall_clock_budget(
         done, _pending = await asyncio.wait({prompt_task}, timeout=timeout)
         if done:
             return prompt_task.result()
-        await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+        drain = await _gracefully_cancel_prompt_task(acp_client, session, prompt_task)
         cleanup_attempted = True
-        raise _agent_prompt_timeout_error(session, timeout)
+        raise _agent_prompt_timeout_error(session, timeout, drain)
     finally:
         if not prompt_task.done() and not cleanup_attempted:
             await _cancel_and_drain_prompt_task(prompt_task)
@@ -934,8 +1050,9 @@ async def _prompt_with_idle_watchdog(
             if now - last_progress >= idle_timeout:
                 idle_duration_sec = int(now - last_progress)
                 wall_clock_elapsed_sec = int(now - (deadline - timeout))
-                last_activity_at_iso = last_activity_at.isoformat()
-                await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+                drain = await _gracefully_cancel_prompt_task(
+                    acp_client, session, prompt_task
+                )
                 cleanup_attempted = True
                 diag = IdleTimeoutDiagnostic(
                     idle_timeout_sec=idle_timeout,
@@ -944,13 +1061,19 @@ async def _prompt_with_idle_watchdog(
                     n_tool_calls=len(session.tool_calls),
                     n_message_chunks=len(session.message_chunks),
                     n_thought_chunks=len(session.thought_chunks),
-                    last_activity_at=last_activity_at_iso,
+                    last_activity_at=last_activity_at.isoformat(),
+                    cancel_grace_requested_sec=drain.requested_grace_sec,
+                    cancel_grace_elapsed_sec=drain.elapsed_grace_sec,
+                    cancel_prompt_completed=drain.prompt_completed,
+                    cancel_tools_completed=drain.tools_completed,
                 )
-                raise _idle_timeout_error(session, diag)
+                raise _idle_timeout_error(session, diag, drain)
             if now > deadline:
-                await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+                drain = await _gracefully_cancel_prompt_task(
+                    acp_client, session, prompt_task
+                )
                 cleanup_attempted = True
-                raise _agent_prompt_timeout_error(session, timeout)
+                raise _agent_prompt_timeout_error(session, timeout, drain)
 
         return prompt_task.result()
     finally:

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -66,6 +66,7 @@ logger = logging.getLogger(__name__)
 
 _ACP_CONNECT_MAX_RETRIES = 3
 _ACP_CONNECT_BASE_DELAY = 2.0
+_PROMPT_CANCEL_GRACE_TIMEOUT_SEC = 5.0
 _PROMPT_CANCEL_DRAIN_TIMEOUT_SEC = 0.25
 _ACP_HANDSHAKE_TIMEOUT_ENV = "BENCHFLOW_ACP_HANDSHAKE_TIMEOUT"
 _ACP_HANDSHAKE_TIMEOUT_DEFAULT_SEC = 60.0
@@ -770,6 +771,33 @@ async def _cancel_and_drain_prompt_task(prompt_task: asyncio.Task) -> bool:
     return False
 
 
+async def _request_cancel_and_drain_prompt_task(
+    acp_client: ACPClient, prompt_task: asyncio.Task
+) -> bool:
+    """Ask the ACP agent to stop, then hard-cancel if it does not respond."""
+    if prompt_task.done():
+        return True
+    try:
+        await acp_client.cancel()
+    except Exception:
+        logger.warning(
+            "ACP session/cancel failed; hard-cancelling prompt", exc_info=True
+        )
+    else:
+        done, _pending = await asyncio.wait(
+            {prompt_task}, timeout=_PROMPT_CANCEL_GRACE_TIMEOUT_SEC
+        )
+        if done:
+            with contextlib.suppress(BaseException):
+                prompt_task.result()
+            return True
+        logger.warning(
+            "ACP prompt did not finish within %.2fs after session/cancel",
+            _PROMPT_CANCEL_GRACE_TIMEOUT_SEC,
+        )
+    return await _cancel_and_drain_prompt_task(prompt_task)
+
+
 def _agent_prompt_timeout_error(session, timeout: int) -> AgentPromptTimeoutError:
     session.mark_prompt_end()
     pending_tool_call_ids = session.pending_tool_call_ids()
@@ -801,15 +829,16 @@ async def _prompt_with_wall_clock_budget(
 ):
     """Run a prompt until either it finishes or BenchFlow's budget expires."""
     prompt_task = asyncio.create_task(acp_client.prompt(prompt))
+    cleanup_attempted = False
     try:
         done, _pending = await asyncio.wait({prompt_task}, timeout=timeout)
         if done:
             return prompt_task.result()
-        if await _cancel_and_drain_prompt_task(prompt_task):
-            raise _agent_prompt_timeout_error(session, timeout)
-        raise TimeoutError(f"Agent prompt exceeded wall-clock budget {timeout}s")
+        await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+        cleanup_attempted = True
+        raise _agent_prompt_timeout_error(session, timeout)
     finally:
-        if not prompt_task.done():
+        if not prompt_task.done() and not cleanup_attempted:
             await _cancel_and_drain_prompt_task(prompt_task)
 
 
@@ -838,6 +867,7 @@ async def _prompt_with_idle_watchdog(
         )
 
     prompt_task = asyncio.create_task(acp_client.prompt(prompt))
+    cleanup_attempted = False
     last_progress = asyncio.get_event_loop().time()
     last_activity_at = datetime.now(UTC)
     last_count = _activity_count()
@@ -887,6 +917,8 @@ async def _prompt_with_idle_watchdog(
                     n_thought_chunks=len(session.thought_chunks),
                     last_activity_at=last_activity_at.isoformat(),
                 )
+                await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+                cleanup_attempted = True
                 raise IdleTimeoutError(
                     f"Agent idle for {idle_timeout}s with no new tool call, "
                     f"message, or thought "
@@ -895,11 +927,9 @@ async def _prompt_with_idle_watchdog(
                     diag,
                 )
             if now > deadline:
-                if await _cancel_and_drain_prompt_task(prompt_task):
-                    raise _agent_prompt_timeout_error(session, timeout)
-                raise TimeoutError(
-                    f"Agent prompt exceeded wall-clock budget {timeout}s"
-                )
+                await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+                cleanup_attempted = True
+                raise _agent_prompt_timeout_error(session, timeout)
 
         return prompt_task.result()
     finally:
@@ -907,5 +937,5 @@ async def _prompt_with_idle_watchdog(
         # external-cancellation path (CancelledError from sleep). Bound the
         # drain so a non-cooperative Daytona/ACP read cannot hide the watchdog
         # timeout forever; cleanup will tear down the live process.
-        if not prompt_task.done():
+        if not prompt_task.done() and not cleanup_attempted:
             await _cancel_and_drain_prompt_task(prompt_task)

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -932,17 +932,20 @@ async def _prompt_with_idle_watchdog(
                 last_progress = now
                 last_activity_at = datetime.now(UTC)
             if now - last_progress >= idle_timeout:
+                idle_duration_sec = int(now - last_progress)
+                wall_clock_elapsed_sec = int(now - (deadline - timeout))
+                last_activity_at_iso = last_activity_at.isoformat()
+                await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
+                cleanup_attempted = True
                 diag = IdleTimeoutDiagnostic(
                     idle_timeout_sec=idle_timeout,
-                    idle_duration_sec=int(now - last_progress),
-                    wall_clock_elapsed_sec=int(now - (deadline - timeout)),
+                    idle_duration_sec=idle_duration_sec,
+                    wall_clock_elapsed_sec=wall_clock_elapsed_sec,
                     n_tool_calls=len(session.tool_calls),
                     n_message_chunks=len(session.message_chunks),
                     n_thought_chunks=len(session.thought_chunks),
-                    last_activity_at=last_activity_at.isoformat(),
+                    last_activity_at=last_activity_at_iso,
                 )
-                await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)
-                cleanup_attempted = True
                 raise _idle_timeout_error(session, diag)
             if now > deadline:
                 await _request_cancel_and_drain_prompt_task(acp_client, prompt_task)

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -304,6 +304,7 @@ class ACPSession:
     def record_agent_timeout(
         self,
         *,
+        reason: str = "wall_clock_timeout",
         timeout_sec: float,
         pending_tool_call_ids: list[str],
         terminal_trajectory_complete: bool,
@@ -314,7 +315,7 @@ class ACPSession:
         self.events.append(
             {
                 "type": "agent_timeout",
-                "reason": "wall_clock_timeout",
+                "reason": reason,
                 "timeout_sec": timeout_sec,
                 "pending_tool_call_ids": list(pending_tool_call_ids),
                 "terminal_trajectory_complete": terminal_trajectory_complete,

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -162,6 +162,8 @@ class ToolCallRecord:
         self.kind = kind
         self.status = ToolCallStatus.PENDING
         self.content: list[dict] = []
+        self.effects: str | None = None
+        self.terminal_source: str | None = None
         self.started_at = datetime.now()
         self.finished_at: datetime | None = None
 
@@ -334,6 +336,27 @@ class ACPSession:
         )
         self.events.append(event)
         self._notify_change()
+
+    def terminalize_pending_tools_after_process_death(self) -> list[str]:
+        """Close pending tools after BenchFlow proves agent processes are dead.
+
+        Guards PR #1051: this is framework-owned cancellation, not an
+        adapter-reported outcome, and command effects remain unknown.
+        """
+        terminalized = self.pending_tool_call_ids()
+        if not terminalized:
+            return []
+        for tool_call_id in terminalized:
+            record = self._tool_call_map[tool_call_id]
+            record.effects = "unknown"
+            record.terminal_source = "benchflow"
+            record.update_status(ToolCallStatus.CANCELLED)
+        for event in reversed(self.events):
+            if event.get("type") == "agent_timeout":
+                event["terminal_trajectory_complete"] = True
+                break
+        self._notify_change()
+        return terminalized
 
     def record_prompt_usage(self, usage: object | None) -> None:
         """Record cumulative ACP token usage returned by session/prompt."""

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -308,19 +308,31 @@ class ACPSession:
         timeout_sec: float,
         pending_tool_call_ids: list[str],
         terminal_trajectory_complete: bool,
+        cancel_grace_requested_sec: float | None = None,
+        cancel_grace_elapsed_sec: float | None = None,
+        cancel_prompt_completed: bool | None = None,
+        cancel_tools_completed: bool | None = None,
     ) -> None:
         """Append BenchFlow's terminal timeout marker to the ACP event stream."""
         self._events_active = True
         self._flush_agent_text()
-        self.events.append(
-            {
-                "type": "agent_timeout",
-                "reason": reason,
-                "timeout_sec": timeout_sec,
-                "pending_tool_call_ids": list(pending_tool_call_ids),
-                "terminal_trajectory_complete": terminal_trajectory_complete,
-            }
+        event: dict[str, object] = {
+            "type": "agent_timeout",
+            "reason": reason,
+            "timeout_sec": timeout_sec,
+            "pending_tool_call_ids": list(pending_tool_call_ids),
+            "terminal_trajectory_complete": terminal_trajectory_complete,
+        }
+        cancellation = {
+            "cancel_grace_requested_sec": cancel_grace_requested_sec,
+            "cancel_grace_elapsed_sec": cancel_grace_elapsed_sec,
+            "cancel_prompt_completed": cancel_prompt_completed,
+            "cancel_tools_completed": cancel_tools_completed,
+        }
+        event.update(
+            {key: value for key, value in cancellation.items() if value is not None}
         )
+        self.events.append(event)
         self._notify_change()
 
     def record_prompt_usage(self, usage: object | None) -> None:

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -131,6 +131,10 @@ class IdleTimeoutDiagnostic(Diagnostic):
     n_message_chunks: int = 0
     n_thought_chunks: int = 0
     last_activity_at: str = ""
+    cancel_grace_requested_sec: float | None = None
+    cancel_grace_elapsed_sec: float | None = None
+    cancel_prompt_completed: bool | None = None
+    cancel_tools_completed: bool | None = None
 
     field: ClassVar[str] = "idle_timeout_info"
     category: ClassVar[str | None] = "idle_timeout"
@@ -155,6 +159,10 @@ class AgentPromptTimeoutDiagnostic(Diagnostic):
     pending_tool_call_ids: list[str] = field(default_factory=list)
     terminal_event_recorded: bool = False
     terminal_trajectory_complete: bool = False
+    cancel_grace_requested_sec: float | None = None
+    cancel_grace_elapsed_sec: float | None = None
+    cancel_prompt_completed: bool | None = None
+    cancel_tools_completed: bool | None = None
 
     field: ClassVar[str] = "agent_timeout_info"
     category: ClassVar[str | None] = "timeout"

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -46,10 +46,9 @@ class AgentPromptTimeoutError(TimeoutError):
     """BenchFlow-owned prompt wall-clock timeout with captured ACP state.
 
     This is distinct from provider/client ``TimeoutError`` exceptions. It is
-    raised only when BenchFlow's prompt budget expires and the ACP prompt task
-    can be cancelled/drained cleanly enough to snapshot the session. The
-    attached diagnostic says whether that snapshot is a complete terminal
-    timeout trajectory or still has pending tool calls and must remain partial.
+    raised only when BenchFlow's prompt budget expires. The attached diagnostic
+    says whether the cancellation produced a complete terminal trajectory or
+    left pending tool calls and must remain partial.
     """
 
     def __init__(
@@ -357,14 +356,26 @@ DIAGNOSTIC_BY_FIELD: dict[str, type[Diagnostic]] = {
 class IdleTimeoutError(TimeoutError):
     """Raised by the idle watchdog when the agent stops producing activity.
 
-    Carries an :class:`IdleTimeoutDiagnostic` instance via ``.diagnostic`` —
-    serialize via ``exc.diagnostic.to_dict()`` to recover the result.json
-    payload (issue #503).
+    Carries an :class:`IdleTimeoutDiagnostic` plus the cancellation-time ACP
+    snapshot used to preserve terminal updates and native usage (PR #1051).
     """
 
-    def __init__(self, message: str, diagnostic: IdleTimeoutDiagnostic) -> None:
+    def __init__(
+        self,
+        message: str,
+        diagnostic: IdleTimeoutDiagnostic,
+        *,
+        trajectory: list[dict] | None = None,
+        n_tool_calls: int = 0,
+        terminal_trajectory_complete: bool = False,
+        executed_prompts: list[str] | None = None,
+    ) -> None:
         super().__init__(message)
         self.diagnostic: IdleTimeoutDiagnostic = diagnostic
+        self.trajectory = trajectory or []
+        self.n_tool_calls = n_tool_calls
+        self.terminal_trajectory_complete = terminal_trajectory_complete
+        self.executed_prompts = executed_prompts or []
 
 
 class TransportClosedError(ConnectionError):

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1512,22 +1512,31 @@ class Rollout:
             logger.warning(f"Partial trajectory capture failed: {e}")
             return
         delta = captured[getattr(self, "_session_traj_count", 0) :]
-        if not delta:
-            return
-        self._trajectory.extend(delta)
-        self._session_traj_count = len(captured)
-        if getattr(self, "_terminal_timeout", False):
-            # Clean wall-clock terminal timeout (#640): the captured tail is the
-            # complete trajectory, so leave _partial_trajectory False.
-            self._trajectory_source = "acp"
-        else:
-            self._partial_trajectory = True
-            self._trajectory_source = "partial_acp"
-        prior_session_tools = getattr(self, "_session_tool_count", 0)
-        new_tools = len(session.tool_calls) - prior_session_tools
-        if new_tools > 0:
-            self._n_tool_calls += new_tools
-        self._session_tool_count = len(session.tool_calls)
+        if delta:
+            self._trajectory.extend(delta)
+            self._session_traj_count = len(captured)
+            if getattr(self, "_terminal_timeout", False):
+                # Clean wall-clock terminal timeout (#640): the captured tail is the
+                # complete trajectory, so leave _partial_trajectory False.
+                self._trajectory_source = "acp"
+            else:
+                self._partial_trajectory = True
+                self._trajectory_source = "partial_acp"
+            prior_session_tools = getattr(self, "_session_tool_count", 0)
+            new_tools = len(session.tool_calls) - prior_session_tools
+            if new_tools > 0:
+                self._n_tool_calls += new_tools
+            self._session_tool_count = len(session.tool_calls)
+
+        diagnostics = getattr(self, "_diagnostics", None)
+        timeout_diagnostic = (
+            diagnostics.get("agent_timeout_info") if diagnostics is not None else None
+        )
+        if timeout_diagnostic is not None and session.pending_tool_call_ids():
+            self._timeout_terminalization_session = session
+            self._timeout_session_trajectory_start = len(self._trajectory) - len(
+                captured
+            )
 
     def _capture_partial_session_factory_trajectory(self) -> None:
         """Session-factory analogue of :meth:`_capture_partial_acp_trajectory`.
@@ -1840,9 +1849,9 @@ class Rollout:
                 )
 
         timeout_diagnostic = self._diagnostics.get("agent_timeout_info")
-        session = (
-            getattr(self._acp_client, "session", None) if self._acp_client else None
-        )
+        session = getattr(self, "_timeout_terminalization_session", None)
+        if session is None and self._acp_client:
+            session = getattr(self._acp_client, "session", None)
         pending_timeout = bool(
             session is not None
             and timeout_diagnostic is not None
@@ -1859,13 +1868,18 @@ class Rollout:
                     assert isinstance(timeout_diagnostic, AgentPromptTimeoutDiagnostic)
                     timeout_diagnostic.terminal_trajectory_complete = True
                     captured = _capture_session_trajectory(session)
-                    session_start = len(self._trajectory) - self._session_traj_count
+                    session_start = getattr(
+                        self,
+                        "_timeout_session_trajectory_start",
+                        len(self._trajectory) - self._session_traj_count,
+                    )
                     if session_start < 0:
                         raise RuntimeError(
                             "ACP trajectory cursor exceeds committed trajectory"
                         )
                     self._trajectory[session_start:] = captured
                     self._session_traj_count = len(captured)
+                    self._timeout_terminalization_session = None
             await _publish_trajectory_for_verifier(
                 self._env, self._trajectory, self._rollout_paths.agent_dir
             )

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -89,6 +89,7 @@ from benchflow.contracts import (
 from benchflow.contracts import RoundResult as RoundResult
 from benchflow.diagnostics import (
     AgentPromptTimeoutError,
+    IdleTimeoutError,
     ProviderApiErrorDiagnostic,
     RolloutDiagnostics,
     SuspectedApiErrorDiagnostic,
@@ -1615,7 +1616,7 @@ class Rollout:
                     timeout,
                     idle_timeout=idle_timeout,
                 )
-        except AgentPromptTimeoutError as e:
+        except (AgentPromptTimeoutError, IdleTimeoutError) as e:
             self._diagnostics.set(e.diagnostic)
             self._commit_acp_execution(
                 trajectory=e.trajectory,
@@ -2069,17 +2070,15 @@ class Rollout:
         for 600s with no new tool call ...") when it raised one, falling
         back to the generic wall-clock message only when there's no detail.
 
-        A BenchFlow-owned wall-clock prompt timeout (``AgentPromptTimeoutError``)
-        that fired with no pending tool calls is a *clean terminal* timeout:
-        the trajectory is complete, not a rerunnable partial. Record that so
-        the partial-capture path leaves ``_partial_trajectory`` False (#640).
+        A BenchFlow-owned prompt timeout that ended with no pending tool calls
+        is a *clean terminal* timeout: the trajectory is complete, not a
+        rerunnable partial. Record that so partial capture leaves
+        ``_partial_trajectory`` False (#640, #1051).
         """
         detail = str(e).strip()
         self._error = detail or f"Agent timed out after {self._timeout}s"
         self._diagnostics.capture_idle(e)
-        if isinstance(e, AgentPromptTimeoutError) and getattr(
-            e, "terminal_trajectory_complete", False
-        ):
+        if getattr(e, "terminal_trajectory_complete", False):
             self._terminal_timeout = True
         logger.error(self._error)
 

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -88,6 +88,7 @@ from benchflow.contracts import (
 )
 from benchflow.contracts import RoundResult as RoundResult
 from benchflow.diagnostics import (
+    AgentPromptTimeoutDiagnostic,
     AgentPromptTimeoutError,
     IdleTimeoutError,
     ProviderApiErrorDiagnostic,
@@ -1838,9 +1839,41 @@ class Rollout:
                     f"Using scraped trajectory ({len(scraped)} events) — UNTRUSTED"
                 )
 
-        await _publish_trajectory_for_verifier(
-            self._env, self._trajectory, self._rollout_paths.agent_dir
+        timeout_diagnostic = self._diagnostics.get("agent_timeout_info")
+        session = (
+            getattr(self._acp_client, "session", None) if self._acp_client else None
         )
+        pending_timeout = bool(
+            session is not None
+            and timeout_diagnostic is not None
+            and session.pending_tool_call_ids()
+        )
+
+        async def _publish_quiesced_timeout_trajectory() -> None:
+            if session is not None:
+                terminalized = session.terminalize_pending_tools_after_process_death()
+                if terminalized:
+                    self._terminal_timeout = True
+                    self._partial_trajectory = False
+                    self._trajectory_source = "acp"
+                    assert isinstance(timeout_diagnostic, AgentPromptTimeoutDiagnostic)
+                    timeout_diagnostic.terminal_trajectory_complete = True
+                    captured = _capture_session_trajectory(session)
+                    session_start = len(self._trajectory) - self._session_traj_count
+                    if session_start < 0:
+                        raise RuntimeError(
+                            "ACP trajectory cursor exceeds committed trajectory"
+                        )
+                    self._trajectory[session_start:] = captured
+                    self._session_traj_count = len(captured)
+            await _publish_trajectory_for_verifier(
+                self._env, self._trajectory, self._rollout_paths.agent_dir
+            )
+
+        if not pending_timeout:
+            await _publish_trajectory_for_verifier(
+                self._env, self._trajectory, self._rollout_paths.agent_dir
+            )
 
         (
             self._rewards,
@@ -1854,6 +1887,9 @@ class Rollout:
             self._planes,
             sandbox_user=cfg.sandbox_user,
             workspace=self._agent_cwd,
+            after_agent_quiesced=(
+                _publish_quiesced_timeout_trajectory if pending_timeout else None
+            ),
         )
         if verifier_timeout_diag is not None:
             self._diagnostics.set(verifier_timeout_diag)

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -28,7 +28,7 @@ import os
 import re
 import shlex
 import tempfile
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -456,6 +456,7 @@ async def _verify_rollout(
     planes: RolloutPlanes,
     sandbox_user: str | None = None,
     workspace: str | None = None,
+    after_agent_quiesced: Callable[[], Awaitable[None]] | None = None,
 ) -> tuple[dict | None, str | None, VerifierTimeoutDiagnostic | None]:
     """Run verifier with pre-verification hardening.
 
@@ -469,7 +470,32 @@ async def _verify_rollout(
     verifier_timeout: VerifierTimeoutDiagnostic | None = None
     timeout_budget = task.config.verifier.timeout_sec
     try:
-        await planes.harden_before_verify(env, task, sandbox_user, workspace=workspace)
+        if after_agent_quiesced is not None and not sandbox_user:
+            raise RuntimeError(
+                "Cannot publish terminal timeout evidence without a sandbox user "
+                "for process-death proof"
+            )
+        callback_ran = False
+
+        async def _after_agent_quiesced() -> None:
+            nonlocal callback_ran
+            if callback_ran:
+                return
+            callback_ran = True
+            if after_agent_quiesced is not None:
+                await after_agent_quiesced()
+
+        await planes.harden_before_verify(
+            env,
+            task,
+            sandbox_user,
+            workspace=workspace,
+            after_agent_quiesced=_after_agent_quiesced,
+        )
+        if after_agent_quiesced is not None and not callback_ran:
+            raise RuntimeError(
+                "Verifier hardening did not prove agent process-tree death"
+            )
         logger.info("Running verifier...")
         verifier = planes.verifier(task=task, rollout_paths=rollout_paths, sandbox=env)
         verifier_result = None

--- a/src/benchflow/sandbox/lockdown.py
+++ b/src/benchflow/sandbox/lockdown.py
@@ -1048,16 +1048,23 @@ def _purge_pycache_cmd(workspace: str) -> str:
 
 
 async def _kill_sandbox_user_procs(env, sandbox_user: str) -> None:
-    """Kill sandbox-user processes so none write during verifier teardown."""
+    """Kill sandbox-user processes and prove none remain."""
+    user = shlex.quote(sandbox_user)
     await env.exec(
-        f"pkill -u {sandbox_user} 2>/dev/null; "
-        f"sleep 1; pkill -9 -u {sandbox_user} 2>/dev/null || true",
+        f"pkill -u {user} 2>/dev/null; sleep 1; pkill -9 -u {user} 2>/dev/null || true",
+        user="root",
         timeout_sec=10,
     )
     # Second pass: catch any processes that slipped through (e.g. cron/at jobs).
     await env.exec(
-        f"! pgrep -u {sandbox_user} > /dev/null 2>&1 || "
-        f"(sleep 1 && pkill -9 -u {sandbox_user}; sleep 1)",
+        f"! pgrep -u {user} > /dev/null 2>&1 || "
+        f"(sleep 1 && pkill -9 -u {user}; sleep 1)",
+        user="root",
+    )
+    await _checked_exec(
+        env,
+        f"! pgrep -u {user} > /dev/null 2>&1",
+        "Verifier hardening failed: sandbox-user processes remain after kill",
         user="root",
     )
 
@@ -1175,6 +1182,7 @@ async def harden_before_verify(
     # contract, e.g. task config [verifier] restore_workspace = true after an
     # oracle/diff audit proves the answer is not stored in the workspace.
     restore_workspace: bool = False,
+    after_agent_quiesced=None,
 ) -> None:
     """Neutralize agent tampering before running the verifier.
 
@@ -1199,6 +1207,8 @@ async def harden_before_verify(
     # 1. Kill sandbox-user processes (prevent concurrent writes during teardown).
     if sandbox_user:
         await _kill_sandbox_user_procs(env, sandbox_user)
+        if after_agent_quiesced is not None:
+            await after_agent_quiesced()
     # 2. Wipe /logs/verifier/ contents while preserving remote bind mounts, then
     #    prepare the legacy /app rootdir fallback.
     await _checked_exec(

--- a/src/benchflow/trajectories/_capture.py
+++ b/src/benchflow/trajectories/_capture.py
@@ -83,17 +83,21 @@ def _events_to_trajectory(events: list[dict]) -> list[dict]:
         elif event["type"] in ("user_message", "agent_message", "agent_thought"):
             out.append({"type": event["type"], "text": event["text"]})
         elif event["type"] == "agent_timeout":
-            out.append(
-                {
-                    "type": "agent_timeout",
-                    "reason": event["reason"],
-                    "timeout_sec": event["timeout_sec"],
-                    "pending_tool_call_ids": event["pending_tool_call_ids"],
-                    "terminal_trajectory_complete": event[
-                        "terminal_trajectory_complete"
-                    ],
-                }
+            row = {
+                "type": "agent_timeout",
+                "reason": event["reason"],
+                "timeout_sec": event["timeout_sec"],
+                "pending_tool_call_ids": event["pending_tool_call_ids"],
+                "terminal_trajectory_complete": event["terminal_trajectory_complete"],
+            }
+            cancellation_keys = (
+                "cancel_grace_requested_sec",
+                "cancel_grace_elapsed_sec",
+                "cancel_prompt_completed",
+                "cancel_tools_completed",
             )
+            row.update({key: event[key] for key in cancellation_keys if key in event})
+            out.append(row)
     return out
 
 

--- a/src/benchflow/trajectories/_capture.py
+++ b/src/benchflow/trajectories/_capture.py
@@ -70,16 +70,19 @@ def _events_to_trajectory(events: list[dict]) -> list[dict]:
     for event in events:
         if event["type"] == "tool_call":
             tc = event["record"]
-            out.append(
-                {
-                    "type": "tool_call",
-                    "tool_call_id": tc.tool_call_id,
-                    "kind": tc.kind,
-                    "title": tc.title,
-                    "status": tc.status.value,
-                    "content": tc.content,
-                }
-            )
+            row = {
+                "type": "tool_call",
+                "tool_call_id": tc.tool_call_id,
+                "kind": tc.kind,
+                "title": tc.title,
+                "status": tc.status.value,
+                "content": tc.content,
+            }
+            if tc.effects is not None:
+                row["effects"] = tc.effects
+            if tc.terminal_source is not None:
+                row["terminal_source"] = tc.terminal_source
+            out.append(row)
         elif event["type"] in ("user_message", "agent_message", "agent_thought"):
             out.append({"type": event["type"], "text": event["text"]})
         elif event["type"] == "agent_timeout":

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -829,6 +829,63 @@ class TestACPInterleaving:
         finally:
             await client.close()
 
+    @pytest.mark.asyncio
+    async def test_drain_processes_delayed_genuine_tool_terminal(self) -> None:
+        """Guards PR #1051: post-response drain consumes real ACP terminal update."""
+
+        class DelayedTerminalTransport:
+            async def receive(self) -> dict:
+                await asyncio.sleep(0)
+                return {
+                    "jsonrpc": "2.0",
+                    "method": "session/update",
+                    "params": {
+                        "update": {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "tc_delayed",
+                            "status": "cancelled",
+                        }
+                    },
+                }
+
+        session = ACPSession("genuine-drain")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_delayed",
+                "title": "long command",
+                "kind": "bash",
+            }
+        )
+        client = ACPClient(DelayedTerminalTransport())  # type: ignore[arg-type]
+        client._session = session
+
+        assert await client.drain_tool_call_updates({"tc_delayed"}, 0.1) is True
+        assert session.tool_calls[0].status == ToolCallStatus.CANCELLED
+
+    @pytest.mark.asyncio
+    async def test_drain_fails_closed_on_transport_error(self) -> None:
+        """Guards PR #1051: broken post-response transport remains partial."""
+
+        class BrokenTransport:
+            async def receive(self) -> dict:
+                raise RuntimeError("transport closed")
+
+        session = ACPSession("broken-drain")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_pending",
+                "title": "long command",
+                "kind": "bash",
+            }
+        )
+        client = ACPClient(BrokenTransport())  # type: ignore[arg-type]
+        client._session = session
+
+        assert await client.drain_tool_call_updates({"tc_pending"}, 0.1) is False
+        assert session.pending_tool_call_ids() == ["tc_pending"]
+
 
 class TestACPIdleWatchdog:
     @pytest.mark.asyncio
@@ -839,7 +896,7 @@ class TestACPIdleWatchdog:
         from benchflow.acp import runtime
         from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
 
-        monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.1)
+        monkeypatch.setattr(runtime, "_acp_cancel_grace_timeout_sec", lambda: 0.1)
         session = ACPSession("graceful-idle-session")
 
         class GracefulClient:
@@ -881,6 +938,10 @@ class TestACPIdleWatchdog:
             "timeout_sec": 1.0,
             "pending_tool_call_ids": [],
             "terminal_trajectory_complete": True,
+            "cancel_grace_requested_sec": 0.1,
+            "cancel_grace_elapsed_sec": pytest.approx(0.0, abs=0.1),
+            "cancel_prompt_completed": True,
+            "cancel_tools_completed": True,
         }
         assert session.latest_usage_totals() == {
             "input_tokens": 11,
@@ -914,7 +975,7 @@ class TestACPIdleWatchdog:
         from benchflow.acp import runtime
         from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
 
-        monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.05)
+        monkeypatch.setattr(runtime, "_acp_cancel_grace_timeout_sec", lambda: 0.05)
 
         # release is never set while the watchdog runs, so the prompt task stays
         # wedged in its cancellation handler — exactly the stuck-drain scenario.
@@ -1103,7 +1164,7 @@ class TestIdleTimeoutDiagnostics:
 
     @pytest.mark.asyncio
     async def test_wall_clock_timeout_records_terminal_diagnostic(self) -> None:
-        """Wall-clock timeouts record runner-owned terminal timeout evidence."""
+        """Guards PR #1051: hard-cancel fallback records partial timeout evidence."""
         from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts
         from benchflow.diagnostics import AgentPromptTimeoutDiagnostic
 
@@ -1125,13 +1186,15 @@ class TestIdleTimeoutDiagnostics:
         assert isinstance(exc_info.value.diagnostic, AgentPromptTimeoutDiagnostic)
         assert exc_info.value.diagnostic.timeout_sec == 2
         assert exc_info.value.diagnostic.pending_tool_call_ids == []
-        assert exc_info.value.terminal_trajectory_complete is True
+        assert exc_info.value.diagnostic.cancel_prompt_completed is False
+        assert exc_info.value.diagnostic.cancel_tools_completed is True
+        assert exc_info.value.terminal_trajectory_complete is False
         assert exc_info.value.n_tool_calls == 1
         assert [event["type"] for event in exc_info.value.trajectory] == [
             "user_message",
             "agent_timeout",
         ]
-        assert exc_info.value.trajectory[-1]["terminal_trajectory_complete"] is True
+        assert exc_info.value.trajectory[-1]["terminal_trajectory_complete"] is False
 
     @pytest.mark.asyncio
     async def test_wall_clock_timeout_with_pending_tool_stays_partial(self) -> None:
@@ -1180,7 +1243,7 @@ class TestIdleTimeoutDiagnostics:
         from benchflow.acp import runtime
         from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts
 
-        monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.01)
+        monkeypatch.setattr(runtime, "_acp_cancel_grace_timeout_sec", lambda: 0.01)
         session = ACPSession("noncooperative-wall-clock-session")
 
         class NoncooperativeClient:
@@ -1214,6 +1277,199 @@ class TestIdleTimeoutDiagnostics:
         assert client.cancel_calls == 1
         assert exc_info.value.terminal_trajectory_complete is False
         assert exc_info.value.diagnostic.pending_tool_call_ids == ["tc_stuck"]
+
+    @pytest.mark.asyncio
+    async def test_wall_timeout_drains_tool_terminal_after_prompt_response(
+        self, monkeypatch
+    ) -> None:
+        """Guards PR #1051: PromptResponse cannot outrun genuine tool terminal update."""
+        from types import SimpleNamespace
+
+        import benchflow.acp.runtime as runtime
+
+        monkeypatch.setattr(runtime, "_acp_cancel_grace_timeout_sec", lambda: 0.1)
+        session = ACPSession("response-before-tool-terminal")
+
+        class DelayedTerminalClient:
+            def __init__(self) -> None:
+                self.cancelled = asyncio.Event()
+                self.prompt_returned = asyncio.Event()
+
+            async def prompt(self, _prompt: str):
+                session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_delayed",
+                        "title": "long command",
+                        "kind": "bash",
+                    }
+                )
+                await self.cancelled.wait()
+                session.record_prompt_usage({"totalTokens": 11})
+                self.prompt_returned.set()
+                return SimpleNamespace(stop_reason="cancelled")
+
+            async def cancel(self) -> None:
+                self.cancelled.set()
+
+            async def drain_tool_call_updates(
+                self, tool_call_ids: set[str], timeout: float
+            ) -> bool:
+                assert self.prompt_returned.is_set()
+                assert tool_call_ids == {"tc_delayed"}
+                assert timeout > 0
+                await asyncio.sleep(0)
+                session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": "tc_delayed",
+                        "status": "cancelled",
+                    }
+                )
+                return True
+
+        with pytest.raises(runtime.AgentPromptTimeoutError) as exc_info:
+            await runtime.execute_prompts(
+                DelayedTerminalClient(),  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=0.01,  # type: ignore[arg-type]
+                idle_timeout=None,
+            )
+
+        assert session.tool_calls[0].status == ToolCallStatus.CANCELLED
+        assert exc_info.value.terminal_trajectory_complete is True
+        assert exc_info.value.diagnostic.cancel_prompt_completed is True
+        assert exc_info.value.diagnostic.cancel_tools_completed is True
+        assert session.latest_usage_totals() is not None
+        assert session.latest_usage_totals()["total_tokens"] == 11
+
+    @pytest.mark.asyncio
+    async def test_exceptional_prompt_is_not_a_completed_response(self) -> None:
+        """Guards PR #1051: failed prompt task cannot certify terminal timeout."""
+        import benchflow.acp.runtime as runtime
+
+        session = ACPSession("exceptional-prompt")
+
+        class ExceptionalClient:
+            def __init__(self) -> None:
+                self.cancelled = asyncio.Event()
+
+            async def prompt(self, _prompt: str):
+                await self.cancelled.wait()
+                raise RuntimeError("no PromptResponse")
+
+            async def cancel(self) -> None:
+                self.cancelled.set()
+
+        with pytest.raises(runtime.AgentPromptTimeoutError) as exc_info:
+            await runtime.execute_prompts(
+                ExceptionalClient(),  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=0.01,  # type: ignore[arg-type]
+                idle_timeout=None,
+            )
+
+        assert exc_info.value.terminal_trajectory_complete is False
+        assert exc_info.value.diagnostic.cancel_prompt_completed is False
+        assert exc_info.value.diagnostic.cancel_tools_completed is True
+
+    @pytest.mark.asyncio
+    async def test_cancel_send_is_independently_bounded(self, monkeypatch) -> None:
+        """Guards PR #1051: session/cancel send cannot consume drain grace."""
+        import benchflow.acp.runtime as runtime
+
+        monkeypatch.setattr(runtime, "_PROMPT_GRACEFUL_CANCEL_TIMEOUT_SEC", 0.01)
+        session = ACPSession("stuck-cancel-send")
+
+        class StuckCancelClient:
+            async def prompt(self, _prompt: str):
+                await asyncio.Future()
+
+            async def cancel(self) -> None:
+                await asyncio.Future()
+
+        with pytest.raises(runtime.AgentPromptTimeoutError) as exc_info:
+            await runtime.execute_prompts(
+                StuckCancelClient(),  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=0.01,  # type: ignore[arg-type]
+                idle_timeout=None,
+            )
+
+        assert exc_info.value.terminal_trajectory_complete is False
+        assert exc_info.value.diagnostic.cancel_grace_elapsed_sec == 0.0
+        assert exc_info.value.diagnostic.cancel_prompt_completed is False
+
+    @pytest.mark.parametrize(
+        "value",
+        ["bad", "0", "0.99", "301"],
+    )
+    def test_cancel_grace_timeout_rejects_invalid_env(
+        self, monkeypatch, value: str
+    ) -> None:
+        """Guards PR #1051: ACP cancel grace accepts only 1..300 seconds."""
+        import benchflow.acp.runtime as runtime
+
+        monkeypatch.setenv("BENCHFLOW_ACP_CANCEL_GRACE_TIMEOUT", value)
+        with pytest.raises(ValueError, match="must be"):
+            runtime._acp_cancel_grace_timeout_sec()
+
+    def test_cancel_grace_timeout_accepts_bounds(self, monkeypatch) -> None:
+        """Guards PR #1051: ACP cancel grace includes documented bounds."""
+        import benchflow.acp.runtime as runtime
+
+        monkeypatch.setenv("BENCHFLOW_ACP_CANCEL_GRACE_TIMEOUT", "1")
+        assert runtime._acp_cancel_grace_timeout_sec() == 1.0
+        monkeypatch.setenv("BENCHFLOW_ACP_CANCEL_GRACE_TIMEOUT", "300")
+        assert runtime._acp_cancel_grace_timeout_sec() == 300.0
+
+    @pytest.mark.asyncio
+    async def test_wall_clock_timeout_hard_cancels_unresponsive_acp_prompt(
+        self, monkeypatch
+    ) -> None:
+        """Guards PR #1051: unresponsive ACP cancellation stays bounded and partial."""
+        import benchflow.acp.runtime as runtime
+
+        monkeypatch.setattr(runtime, "_PROMPT_GRACEFUL_CANCEL_TIMEOUT_SEC", 0.01)
+        monkeypatch.setattr(runtime, "_acp_cancel_grace_timeout_sec", lambda: 0.01)
+
+        class UnresponsiveClient:
+            def __init__(self, session: ACPSession) -> None:
+                self._session = session
+                self.cancel_called = False
+
+            async def prompt(self, _prompt: str):
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_pending",
+                        "title": "stuck command",
+                        "kind": "bash",
+                    }
+                )
+                await asyncio.Future()
+
+            async def cancel(self) -> None:
+                self.cancel_called = True
+
+        session = ACPSession("unresponsive-wall-clock-session")
+        client = UnresponsiveClient(session)
+        with pytest.raises(runtime.AgentPromptTimeoutError) as exc_info:
+            await runtime.execute_prompts(
+                client,  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=0.01,  # type: ignore[arg-type]
+                idle_timeout=None,
+            )
+
+        assert client.cancel_called is True
+        assert exc_info.value.terminal_trajectory_complete is False
+        assert exc_info.value.diagnostic.pending_tool_call_ids == ["tc_pending"]
+        assert session.latest_usage_totals() is None
 
 
 class TestAcpHandshakeTimeout:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -863,7 +863,7 @@ class TestACPIdleWatchdog:
                 self.cancelled.set()
 
         client = GracefulClient()
-        with pytest.raises(IdleTimeoutError):
+        with pytest.raises(IdleTimeoutError) as exc_info:
             await execute_prompts(
                 client,  # type: ignore[arg-type]
                 session,
@@ -873,6 +873,15 @@ class TestACPIdleWatchdog:
             )
 
         assert client.cancel_calls == 1
+        assert exc_info.value.terminal_trajectory_complete is True
+        assert exc_info.value.executed_prompts == ["solve"]
+        assert exc_info.value.trajectory[-1] == {
+            "type": "agent_timeout",
+            "reason": "idle_timeout",
+            "timeout_sec": 1.0,
+            "pending_tool_call_ids": [],
+            "terminal_trajectory_complete": True,
+        }
         assert session.latest_usage_totals() == {
             "input_tokens": 11,
             "output_tokens": 3,

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -832,15 +832,67 @@ class TestACPInterleaving:
 
 class TestACPIdleWatchdog:
     @pytest.mark.asyncio
+    async def test_idle_timeout_requests_graceful_acp_cancel(self, monkeypatch) -> None:
+        """Guards PR #1050 follow-up: idle timeout drains ACP cancellation."""
+        from types import SimpleNamespace
+
+        from benchflow.acp import runtime
+        from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+
+        monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.1)
+        session = ACPSession("graceful-idle-session")
+
+        class GracefulClient:
+            def __init__(self) -> None:
+                self.cancelled = asyncio.Event()
+                self.cancel_calls = 0
+
+            async def prompt(self, _prompt: str):
+                await self.cancelled.wait()
+                session.record_prompt_usage(
+                    SimpleNamespace(
+                        input_tokens=11,
+                        output_tokens=3,
+                        total_tokens=14,
+                    )
+                )
+                return SimpleNamespace(stop_reason=StopReason.CANCELLED)
+
+            async def cancel(self) -> None:
+                self.cancel_calls += 1
+                self.cancelled.set()
+
+        client = GracefulClient()
+        with pytest.raises(IdleTimeoutError):
+            await execute_prompts(
+                client,  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=30,
+                idle_timeout=1,
+            )
+
+        assert client.cancel_calls == 1
+        assert session.latest_usage_totals() == {
+            "input_tokens": 11,
+            "output_tokens": 3,
+            "total_tokens": 14,
+            "cached_read_tokens": None,
+            "cached_write_tokens": None,
+            "thought_tokens": None,
+        }
+
+    @pytest.mark.asyncio
     async def test_idle_watchdog_returns_even_when_prompt_cancel_drain_stalls(
-        self,
+        self, monkeypatch
     ) -> None:
         """Guards the 2026-05-22 Daytona/Gemini blocker fix against stuck cancel drain.
 
-        When the idle watchdog fires it cancels the prompt task and drains it.
-        A non-cooperative agent — here one that swallows the cancellation and
-        blocks on an event that never arrives — must not be able to wedge the
-        watchdog: it bounds the drain and raises ``IdleTimeoutError`` anyway.
+        When the idle watchdog fires it requests ACP cancellation, then
+        hard-cancels and drains the prompt task if the agent does not respond.
+        A non-cooperative agent — here one that ignores the ACP request, swallows
+        local cancellation, and blocks on an event that never arrives — must not
+        wedge the watchdog: it bounds the drain and raises ``IdleTimeoutError``.
 
         Determinism: this asserts the *behaviour* (idle error raised; the stuck
         prompt task abandoned while still pending) rather than a wall-clock upper
@@ -850,7 +902,10 @@ class TestACPIdleWatchdog:
         load can never trip it, while a regression to an unbounded drain hangs
         past it and fails.
         """
+        from benchflow.acp import runtime
         from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+
+        monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.05)
 
         # release is never set while the watchdog runs, so the prompt task stays
         # wedged in its cancellation handler — exactly the stuck-drain scenario.
@@ -867,11 +922,14 @@ class TestACPIdleWatchdog:
                     await self.release.wait()
                     raise
 
+            async def cancel(self) -> None:
+                pass
+
         client = StubbornPromptClient()
         session = ACPSession("idle-session")
 
-        # Loose hang guard: ~4x the real runtime (1s idle detect + 0.25s bounded
-        # drain). Not a tight assertion — it only catches a true hang/regression.
+        # Loose hang guard: far above 1s idle detect + bounded graceful/hard
+        # drains. Not a tight assertion — it only catches a true hang/regression.
         hang_guard_sec = 5.0
 
         try:
@@ -1104,6 +1162,49 @@ class TestIdleTimeoutDiagnostics:
             "agent_timeout",
         ]
         assert exc_info.value.trajectory[1]["status"] == ToolCallStatus.PENDING.value
+
+    @pytest.mark.asyncio
+    async def test_noncooperative_acp_cancel_preserves_partial_timeout(
+        self, monkeypatch
+    ) -> None:
+        """Guards PR #1050 follow-up: hard-cancel fallback stays partial."""
+        from benchflow.acp import runtime
+        from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts
+
+        monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.01)
+        session = ACPSession("noncooperative-wall-clock-session")
+
+        class NoncooperativeClient:
+            def __init__(self) -> None:
+                self.cancel_calls = 0
+
+            async def prompt(self, _prompt: str):
+                session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_stuck",
+                        "title": "stuck command",
+                        "kind": "bash",
+                    }
+                )
+                await asyncio.Future()
+
+            async def cancel(self) -> None:
+                self.cancel_calls += 1
+
+        client = NoncooperativeClient()
+        with pytest.raises(AgentPromptTimeoutError) as exc_info:
+            await execute_prompts(
+                client,  # type: ignore[arg-type]
+                session,
+                ["solve"],
+                timeout=0.01,  # type: ignore[arg-type]
+                idle_timeout=None,
+            )
+
+        assert client.cancel_calls == 1
+        assert exc_info.value.terminal_trajectory_complete is False
+        assert exc_info.value.diagnostic.pending_tool_call_ids == ["tc_stuck"]
 
 
 class TestAcpHandshakeTimeout:

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -833,7 +833,7 @@ class TestACPInterleaving:
 class TestACPIdleWatchdog:
     @pytest.mark.asyncio
     async def test_idle_timeout_requests_graceful_acp_cancel(self, monkeypatch) -> None:
-        """Guards PR #1050 follow-up: idle timeout drains ACP cancellation."""
+        """Guards PR #1051: idle timeout drains ACP cancellation."""
         from types import SimpleNamespace
 
         from benchflow.acp import runtime
@@ -1167,7 +1167,7 @@ class TestIdleTimeoutDiagnostics:
     async def test_noncooperative_acp_cancel_preserves_partial_timeout(
         self, monkeypatch
     ) -> None:
-        """Guards PR #1050 follow-up: hard-cancel fallback stays partial."""
+        """Guards PR #1051: hard-cancel fallback stays partial."""
         from benchflow.acp import runtime
         from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts
 

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -95,14 +95,15 @@ def test_rollout_native_acp_usage_uses_cumulative_deltas():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("timeout_kind", ["wall", "idle"])
 async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, timeout_kind
 ):
-    """Guards PR #1051: cancelled prompt usage reaches result state."""
+    """Guards PR #1051: cancelled wall/idle usage reaches result state."""
     from benchflow.acp import runtime
     from benchflow.acp.session import ACPSession
     from benchflow.acp.types import StopReason
-    from benchflow.diagnostics import AgentPromptTimeoutError
+    from benchflow.diagnostics import AgentPromptTimeoutError, IdleTimeoutError
     from benchflow.rollout import Rollout, RolloutConfig, Scene
 
     monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.1)
@@ -113,22 +114,24 @@ async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
             self.cancelled = asyncio.Event()
 
         async def prompt(self, _prompt: str):
-            session.handle_update(
-                {
-                    "sessionUpdate": "tool_call",
-                    "toolCallId": "tc_cancelled",
-                    "title": "long command",
-                    "kind": "bash",
-                }
-            )
+            if timeout_kind == "wall":
+                session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_cancelled",
+                        "title": "long command",
+                        "kind": "bash",
+                    }
+                )
             await self.cancelled.wait()
-            session.handle_update(
-                {
-                    "sessionUpdate": "tool_call_update",
-                    "toolCallId": "tc_cancelled",
-                    "status": "cancelled",
-                }
-            )
+            if timeout_kind == "wall":
+                session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call_update",
+                        "toolCallId": "tc_cancelled",
+                        "status": "cancelled",
+                    }
+                )
             session.record_prompt_usage(
                 SimpleNamespace(
                     input_tokens=17,
@@ -145,19 +148,22 @@ async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
         RolloutConfig(
             task_path=tmp_path / "task",
             scenes=[Scene.single(agent="dummy")],
-            agent_idle_timeout=None,
+            agent_idle_timeout=1 if timeout_kind == "idle" else None,
         )
     )
     rollout._acp_client = GracefulClient()
     rollout._session = session
-    rollout._timeout = 0.01
+    rollout._timeout = 30 if timeout_kind == "idle" else 0.01
 
-    with pytest.raises(AgentPromptTimeoutError) as exc_info:
+    error_type = IdleTimeoutError if timeout_kind == "idle" else AgentPromptTimeoutError
+    with pytest.raises(error_type) as exc_info:
         await rollout.execute(["solve"])
 
     assert exc_info.value.terminal_trajectory_complete is True
     assert rollout._partial_trajectory is False
     assert rollout._trajectory_source == "acp"
+    expected_reason = "idle_timeout" if timeout_kind == "idle" else "wall_clock_timeout"
+    assert rollout._trajectory[-1]["reason"] == expected_reason
     assert rollout._native_usage_metrics["usage_source"] == "agent_native_acp"
     assert rollout._native_usage_metrics["total_tokens"] == 22
 

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from datetime import datetime
 from types import SimpleNamespace
@@ -91,6 +92,74 @@ def test_rollout_native_acp_usage_uses_cumulative_deltas():
         "price_source": None,
         "usage_details": {"thought_tokens": 3},
     }
+
+
+@pytest.mark.asyncio
+async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
+    tmp_path, monkeypatch
+):
+    """Guards PR #1050 follow-up: cancelled prompt usage reaches result state."""
+    from benchflow.acp import runtime
+    from benchflow.acp.session import ACPSession
+    from benchflow.acp.types import StopReason
+    from benchflow.diagnostics import AgentPromptTimeoutError
+    from benchflow.rollout import Rollout, RolloutConfig, Scene
+
+    monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.1)
+    session = ACPSession("rollout-timeout-session")
+
+    class GracefulClient:
+        def __init__(self) -> None:
+            self.cancelled = asyncio.Event()
+
+        async def prompt(self, _prompt: str):
+            session.handle_update(
+                {
+                    "sessionUpdate": "tool_call",
+                    "toolCallId": "tc_cancelled",
+                    "title": "long command",
+                    "kind": "bash",
+                }
+            )
+            await self.cancelled.wait()
+            session.handle_update(
+                {
+                    "sessionUpdate": "tool_call_update",
+                    "toolCallId": "tc_cancelled",
+                    "status": "cancelled",
+                }
+            )
+            session.record_prompt_usage(
+                SimpleNamespace(
+                    input_tokens=17,
+                    output_tokens=5,
+                    total_tokens=22,
+                )
+            )
+            return SimpleNamespace(stop_reason=StopReason.CANCELLED)
+
+        async def cancel(self) -> None:
+            self.cancelled.set()
+
+    rollout = Rollout(
+        RolloutConfig(
+            task_path=tmp_path / "task",
+            scenes=[Scene.single(agent="dummy")],
+            agent_idle_timeout=None,
+        )
+    )
+    rollout._acp_client = GracefulClient()
+    rollout._session = session
+    rollout._timeout = 0.01
+
+    with pytest.raises(AgentPromptTimeoutError) as exc_info:
+        await rollout.execute(["solve"])
+
+    assert exc_info.value.terminal_trajectory_complete is True
+    assert rollout._partial_trajectory is False
+    assert rollout._trajectory_source == "acp"
+    assert rollout._native_usage_metrics["usage_source"] == "agent_native_acp"
+    assert rollout._native_usage_metrics["total_tokens"] == 22
 
 
 def test_rollout_provider_usage_wins_over_native_acp_usage():

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -98,7 +98,7 @@ def test_rollout_native_acp_usage_uses_cumulative_deltas():
 async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
     tmp_path, monkeypatch
 ):
-    """Guards PR #1050 follow-up: cancelled prompt usage reaches result state."""
+    """Guards PR #1051: cancelled prompt usage reaches result state."""
     from benchflow.acp import runtime
     from benchflow.acp.session import ACPSession
     from benchflow.acp.types import StopReason

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -124,7 +124,16 @@ async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
                     }
                 )
             await self.cancelled.wait()
-            if timeout_kind == "wall":
+            if timeout_kind == "idle":
+                session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_cancelled",
+                        "title": "late cancellation cleanup",
+                        "kind": "bash",
+                    }
+                )
+            if timeout_kind in {"wall", "idle"}:
                 session.handle_update(
                     {
                         "sessionUpdate": "tool_call_update",
@@ -160,6 +169,9 @@ async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
         await rollout.execute(["solve"])
 
     assert exc_info.value.terminal_trajectory_complete is True
+    assert exc_info.value.n_tool_calls == 1
+    assert rollout._n_tool_calls == 1
+    assert exc_info.value.diagnostic.n_tool_calls == 1
     assert rollout._partial_trajectory is False
     assert rollout._trajectory_source == "acp"
     expected_reason = "idle_timeout" if timeout_kind == "idle" else "wall_clock_timeout"

--- a/tests/test_native_acp_usage.py
+++ b/tests/test_native_acp_usage.py
@@ -106,7 +106,7 @@ async def test_rollout_timeout_keeps_usage_from_graceful_acp_cancel(
     from benchflow.diagnostics import AgentPromptTimeoutError, IdleTimeoutError
     from benchflow.rollout import Rollout, RolloutConfig, Scene
 
-    monkeypatch.setattr(runtime, "_PROMPT_CANCEL_GRACE_TIMEOUT_SEC", 0.1)
+    monkeypatch.setattr(runtime, "_acp_cancel_grace_timeout_sec", lambda: 0.1)
     session = ACPSession("rollout-timeout-session")
 
     class GracefulClient:

--- a/tests/test_sandbox_hardening.py
+++ b/tests/test_sandbox_hardening.py
@@ -68,6 +68,27 @@ def _make_task(user=None):
     return task
 
 
+@pytest.mark.asyncio
+async def test_process_kill_requires_zero_survivors() -> None:
+    """Guards PR #1051: verifier cannot start without process-death proof."""
+    from benchflow.sandbox.lockdown import _kill_sandbox_user_procs
+
+    env = _make_env(
+        side_effect=[
+            MagicMock(stdout="", stderr="", exit_code=0),
+            MagicMock(stdout="", stderr="", exit_code=0),
+            MagicMock(stdout="", stderr="survivor", exit_code=1),
+        ]
+    )
+
+    with pytest.raises(RuntimeError, match="processes remain after kill"):
+        await _kill_sandbox_user_procs(env, "benchflow")
+
+    proof = env.exec.call_args_list[-1]
+    assert "! pgrep -u benchflow" in proof.args[0]
+    assert proof.kwargs["user"] == "root"
+
+
 def _snapshot_side_effect(present: frozenset = frozenset()) -> list:
     """Build side_effect list for _snapshot_build_config: mkdir -> per-file probes -> manifest write.
 

--- a/tests/test_trajectory_streaming.py
+++ b/tests/test_trajectory_streaming.py
@@ -106,7 +106,6 @@ class TestTrajectoryWriter:
         snap = _read_jsonl(traj_path)
         assert [e["type"] for e in snap] == ["user_message", "tool_call"]
         assert snap[1]["status"] == ToolCallStatus.PENDING.value
-
         session.handle_update(
             {
                 "sessionUpdate": "tool_call_update",
@@ -196,6 +195,34 @@ class TestTrajectoryWriter:
         )
         snapshot = _read_jsonl(traj_path)
         assert snapshot == [{"type": "oracle", "command": "solve.sh", "return_code": 0}]
+
+
+class TestTimeoutTerminalization:
+    def test_process_death_terminalizes_pending_tool_fail_closed(self) -> None:
+        """Guards PR #1051's framework-owned timeout terminalization."""
+        session = ACPSession("timeout")
+        session.handle_update(
+            {
+                "sessionUpdate": "tool_call",
+                "toolCallId": "tc_pending",
+                "title": "long command",
+                "kind": "bash",
+            }
+        )
+        session.record_agent_timeout(
+            timeout_sec=1800.0,
+            pending_tool_call_ids=["tc_pending"],
+            terminal_trajectory_complete=False,
+        )
+
+        assert session.terminalize_pending_tools_after_process_death() == ["tc_pending"]
+        trajectory = _capture_session_trajectory(session)
+        tool = trajectory[0]
+        assert tool["status"] == "cancelled"
+        assert tool["effects"] == "unknown"
+        assert tool["terminal_source"] == "benchflow"
+        assert trajectory[1]["terminal_trajectory_complete"] is True
+        assert session.pending_tool_call_ids() == []
 
 
 class TestMultiSceneCumulativeStreaming:

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -5,6 +5,7 @@ import contextlib
 import json
 import logging
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -23,6 +24,131 @@ from benchflow.trajectories.types import (
     LLMResponse,
     Trajectory,
 )
+
+
+@pytest.mark.asyncio
+async def test_timeout_terminalization_reaches_verifier_after_process_death(
+    tmp_path,
+) -> None:
+    """Guards PR #1051: verifier sees terminal evidence only after proof."""
+    from benchflow.acp.session import ACPSession
+    from benchflow.diagnostics import (
+        AgentPromptTimeoutDiagnostic,
+        RolloutDiagnostics,
+    )
+    from benchflow.rollout import Rollout
+    from benchflow.task import RolloutPaths
+    from benchflow.trajectories._capture import _capture_session_trajectory
+
+    session = ACPSession("timeout")
+    session.handle_update(
+        {
+            "sessionUpdate": "tool_call",
+            "toolCallId": "tc_pending",
+            "title": "long command",
+            "kind": "bash",
+        }
+    )
+    session.record_agent_timeout(
+        timeout_sec=1800.0,
+        pending_tool_call_ids=["tc_pending"],
+        terminal_trajectory_complete=False,
+    )
+    diagnostics = RolloutDiagnostics()
+    diagnostics.set(
+        AgentPromptTimeoutDiagnostic(
+            timeout_sec=1800.0,
+            pending_tool_call_ids=["tc_pending"],
+            terminal_event_recorded=True,
+        )
+    )
+    paths = RolloutPaths(tmp_path / "rollout")
+    order: list[str] = []
+
+    async def harden(*_args, **kwargs) -> None:
+        order.append("processes-dead")
+        await kwargs["after_agent_quiesced"]()
+
+    async def verify():
+        order.append("verifier")
+        rows = [
+            json.loads(line)
+            for line in (paths.agent_dir / "acp_trajectory.jsonl")
+            .read_text()
+            .splitlines()
+        ]
+        assert rows[0]["status"] == "cancelled"
+        assert rows[0]["effects"] == "unknown"
+        assert rows[0]["terminal_source"] == "benchflow"
+        return SimpleNamespace(rewards={"reward": 1.0})
+
+    planes = MagicMock()
+    planes.harden_before_verify = AsyncMock(side_effect=harden)
+    planes.verifier.return_value.verify = verify
+    env = MagicMock()
+    env.exec = AsyncMock(return_value=MagicMock(return_code=0, stdout=""))
+    env.upload_file = AsyncMock()
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = SimpleNamespace(
+        primary_agent="claude-agent-acp", sandbox_user="agent"
+    )
+    rollout._trajectory = _capture_session_trajectory(session)
+    rollout._trajectory_source = "partial_acp"
+    rollout._partial_trajectory = True
+    rollout._terminal_timeout = False
+    rollout._acp_client = SimpleNamespace(session=session)
+    rollout._session_traj_count = len(rollout._trajectory)
+    rollout._diagnostics = diagnostics
+    rollout._env = env
+    rollout._rollout_paths = paths
+    rollout._task = SimpleNamespace(
+        name="timeout-task",
+        config=SimpleNamespace(
+            verifier=SimpleNamespace(timeout_sec=10, reward_range=None)
+        ),
+    )
+    rollout._timing = {}
+    rollout._planes = planes
+    rollout._agent_cwd = "/app"
+
+    assert await rollout.verify() == {"reward": 1.0}
+    assert order == ["processes-dead", "verifier"]
+    assert rollout._partial_trajectory is False
+    assert rollout._terminal_timeout is True
+
+
+@pytest.mark.asyncio
+async def test_timeout_terminalization_requires_process_death_identity(
+    tmp_path,
+) -> None:
+    """Guards PR #1051: no sandbox user means no process-death claim."""
+    from benchflow.rollout import _verify_rollout
+
+    task = SimpleNamespace(
+        name="timeout-task",
+        config=SimpleNamespace(verifier=SimpleNamespace(timeout_sec=10)),
+    )
+    paths = SimpleNamespace(verifier_dir=tmp_path / "verifier")
+    planes = MagicMock()
+    callback = AsyncMock()
+
+    rewards, verifier_error, timeout = await _verify_rollout(
+        MagicMock(),
+        task,
+        paths,
+        {},
+        planes,
+        sandbox_user=None,
+        after_agent_quiesced=callback,
+    )
+
+    assert rewards is None
+    assert verifier_error is not None and "without a sandbox user" in verifier_error
+    assert timeout is None
+    callback.assert_not_awaited()
+    planes.verifier.assert_not_called()
+
 
 # classify_verifier_error
 

--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -97,8 +97,13 @@ async def test_timeout_terminalization_reaches_verifier_after_process_death(
     rollout._trajectory_source = "partial_acp"
     rollout._partial_trajectory = True
     rollout._terminal_timeout = False
-    rollout._acp_client = SimpleNamespace(session=session)
+    rollout._acp_client = SimpleNamespace(session=session, close=AsyncMock())
+    rollout._session = session
+    rollout._session_adapter = None
+    rollout._is_session_factory = False
     rollout._session_traj_count = len(rollout._trajectory)
+    rollout._session_tool_count = 1
+    rollout._n_tool_calls = 1
     rollout._diagnostics = diagnostics
     rollout._env = env
     rollout._rollout_paths = paths
@@ -111,7 +116,12 @@ async def test_timeout_terminalization_reaches_verifier_after_process_death(
     rollout._timing = {}
     rollout._planes = planes
     rollout._agent_cwd = "/app"
+    rollout._agent_launch = "claude-agent-acp"
+    rollout._active_role = "agent"
+    rollout._phase = "executed"
 
+    await rollout.disconnect()
+    assert rollout._acp_client is None
     assert await rollout.verify() == {"reward": 1.0}
     assert order == ["processes-dead", "verifier"]
     assert rollout._partial_trajectory is False


### PR DESCRIPTION
## Summary
- send ACP `session/cancel` before locally cancelling timed-out prompt tasks
- wait up to 5 seconds for terminal tool updates and final `PromptResponse.usage`
- keep hard-cancel fallback bounded and mark unresolved tool calls partial
- apply same cancellation sequence to wall-clock and idle timeouts

## Why
Native subscription usage arrives on final ACP prompt response. Immediate local task cancellation discarded that response, left tool calls pending, and made otherwise normal wall-clock timeouts artifact-incomplete.

## Verification
- `uv run pytest -q tests/test_acp.py tests/test_native_acp_usage.py tests/test_trajectory_streaming.py tests/test_session_factory_runtime.py` (136 passed)
- `uv run ruff check src/benchflow/acp/runtime.py tests/test_acp.py tests/test_native_acp_usage.py`
- `uv run ty check src/benchflow/acp/runtime.py`

No live experiment rerun performed.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1051" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->