### PR TITLE
feat(agents): register Vercel fx agent

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,7 @@
 # OPENAI_API_KEY=             # codex-acp
 # GEMINI_API_KEY=             # gemini
 # ZAI_API_KEY=                # zai/ provider (openclaw, claude-agent-acp)
+# AI_GATEWAY_API_KEY=         # vercel/ provider (Vercel AI Gateway)
 
 # ── Provider options ────────────────────────────────────────
 # Optional OpenAI prompt cache retention policy. Allowed: in_memory, 24h.

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -216,6 +216,23 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_type="api_key",
         auth_env="OPENROUTER_API_KEY",
     ),
+    # Vercel AI Gateway exposes hosted models behind one AI_GATEWAY_API_KEY:
+    # OpenAI-compatible completions/responses under /v1, plus an Anthropic
+    # Messages surface at the root (clients append /v1/messages themselves).
+    # Model ids keep the gateway's creator/model form, so callers write
+    # vercel/<creator>/<model> (e.g. vercel/anthropic/claude-sonnet-4.5).
+    "vercel": ProviderConfig(
+        name="vercel",
+        base_url="https://ai-gateway.vercel.sh/v1",
+        api_protocol="openai-completions",
+        auth_type="api_key",
+        auth_env="AI_GATEWAY_API_KEY",
+        endpoints={
+            "openai-completions": "https://ai-gateway.vercel.sh/v1",
+            "openai-responses": "https://ai-gateway.vercel.sh/v1",
+            "anthropic-messages": "https://ai-gateway.vercel.sh",
+        },
+    ),
     # TODO: add eu-openai (https://eu.api.openai.com/v1) when needed.
     # ── OpenAI-compatible inference servers (user-supplied base_url) ──
     "vllm": ProviderConfig(

--- a/src/benchflow/agents/providers.py
+++ b/src/benchflow/agents/providers.py
@@ -216,11 +216,9 @@ PROVIDERS: dict[str, ProviderConfig] = {
         auth_type="api_key",
         auth_env="OPENROUTER_API_KEY",
     ),
-    # Vercel AI Gateway exposes hosted models behind one AI_GATEWAY_API_KEY:
-    # OpenAI-compatible completions/responses under /v1, plus an Anthropic
-    # Messages surface at the root (clients append /v1/messages themselves).
-    # Model ids keep the gateway's creator/model form, so callers write
-    # vercel/<creator>/<model> (e.g. vercel/anthropic/claude-sonnet-4.5).
+    # Vercel AI Gateway: OpenAI-compatible endpoints under /v1; the Anthropic
+    # Messages surface sits at the root (clients append /v1/messages). Model ids
+    # keep the gateway's creator/model form: vercel/anthropic/claude-sonnet-4.5.
     "vercel": ProviderConfig(
         name="vercel",
         base_url="https://ai-gateway.vercel.sh/v1",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -122,6 +122,8 @@ OPENCODE_PROXY_PROVIDER_ID = "benchflow"
 _OPENHANDS_CLI_GIT_REV = "2df8a2835d3f1bd2f2eadf5a7a2e1ad0dfb0d271"
 _OPENHANDS_SDK_VERSION = "1.28.1"
 _OPENHANDS_TOOLS_VERSION = "1.28.1"
+# fx release pin, passed to the fx.sh installer (`bash -s -- <version>`).
+_FX_VERSION = "v0.0.5"
 _JS_AGENT_PATH = (
     f"{_BENCHFLOW_BIN_PREFIX}:{_BENCHFLOW_JS_AGENT_PREFIX}/bin:"
     f"{_BENCHFLOW_NODE_PREFIX}/bin:$PATH"
@@ -985,6 +987,30 @@ AGENTS: dict[str, AgentConfig] = {
             '> "$BENCHFLOW_AGENT_HOME/.openhands/config.toml"'
         ),
         disallow_web_tools_owned_paths=["$HOME/.openhands"],
+    ),
+    "fx": AgentConfig(
+        name="fx",
+        description="Vercel fx agent via ACP (native binary; models served "
+        "through the Vercel AI Gateway)",
+        install_cmd=(
+            "export DEBIAN_FRONTEND=noninteractive && "
+            "( command -v curl >/dev/null 2>&1 || "
+            f"  {_apt_install('curl', 'ca-certificates')} ) && "
+            # Shared prefix so the sandbox user inherits the binary.
+            "export FX_INSTALL_DIR=/usr/local/bin && "
+            f"curl -fsSL https://fx.sh/setup.sh | bash -s -- {_FX_VERSION} && "
+            "command -v fx >/dev/null 2>&1"
+        ),
+        launch_cmd="fx acp",
+        protocol="acp",
+        requires_env=["AI_GATEWAY_API_KEY"],
+        # fx speaks the AI SDK gateway wire protocol, so the proxy is skipped
+        # via _NATIVE_PROTOCOL_AGENTS in providers/litellm_runtime.py.
+        env_mapping={
+            "BENCHFLOW_PROVIDER_API_KEY": "AI_GATEWAY_API_KEY",
+            "BENCHFLOW_PROVIDER_MODEL": "FX_MODEL",
+        },
+        supports_acp_set_model=False,
     ),
 }
 

--- a/src/benchflow/providers/litellm_runtime.py
+++ b/src/benchflow/providers/litellm_runtime.py
@@ -105,9 +105,11 @@ _LIVE_CAPTURE_INTERVAL_SEC = 1.0
 _LIVE_CAPTURE_STALL_WARN_TICKS = 30
 
 # Agents that cannot make model calls through LiteLLM. ``oracle`` has no model
-# at all. Gemini is routable through LiteLLM's native Google GenerateContent
+# at all. ``fx`` speaks the Vercel AI SDK gateway wire protocol
+# (/v3/ai/language-model), which the proxy does not expose.
+# Gemini is routable through LiteLLM's native Google GenerateContent
 # endpoints; keeping it behind the proxy is required for no-web reviewer runs.
-_NATIVE_PROTOCOL_AGENTS = frozenset({"oracle"})
+_NATIVE_PROTOCOL_AGENTS = frozenset({"oracle", "fx"})
 # Providers whose mandatory LiteLLM proxy runs inside the sandbox. Keeping this
 # placement policy in the canonical provider registry prevents a new backend from
 # accidentally handing an in-sandbox agent a host-loopback endpoint.

--- a/tests/test_agent_env_resolution.py
+++ b/tests/test_agent_env_resolution.py
@@ -128,5 +128,22 @@ class TestResolveAgentEnvGemini:
         assert result["GEMINI_API_KEY"] == "explicit"
 
 
+class TestResolveAgentEnvFx:
+    def test_vendor_named_gateway_model_uses_gateway_key(self, monkeypatch, tmp_path):
+        """Guards PR #1053: vercel/ models authenticate fx via AI_GATEWAY_API_KEY."""
+        _clear_keys(monkeypatch)
+        _patch_no_subscription(monkeypatch, tmp_path)
+        monkeypatch.setenv("BENCHFLOW_DOTENV_PATH", str(tmp_path / "no.env"))
+        monkeypatch.setenv("AI_GATEWAY_API_KEY", "vck-test")
+
+        result = resolve_agent_env(
+            agent="fx",
+            model="vercel/anthropic/claude-sonnet-4.5",
+            agent_env=None,
+        )
+        assert result["AI_GATEWAY_API_KEY"] == "vck-test"
+        assert result["FX_MODEL"] == "anthropic/claude-sonnet-4.5"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-xvs"])

--- a/tests/test_litellm_config.py
+++ b/tests/test_litellm_config.py
@@ -179,6 +179,18 @@ def test_openrouter_route_uses_openai_compatible_endpoint():
     assert route.required_env == ("OPENROUTER_API_KEY",)
 
 
+def test_vercel_route_uses_openai_compatible_endpoint():
+    route = resolve_litellm_route(
+        "vercel/anthropic/claude-sonnet-4.5",
+        {"AI_GATEWAY_API_KEY": "vck-test"},
+    )
+
+    assert route.upstream_model == "openai/anthropic/claude-sonnet-4.5"
+    assert route.litellm_params["api_base"] == "https://ai-gateway.vercel.sh/v1"
+    assert route.litellm_params["api_key"] == "os.environ/AI_GATEWAY_API_KEY"
+    assert route.required_env == ("AI_GATEWAY_API_KEY",)
+
+
 def test_proxy_config_registers_plain_and_openai_aliases():
     route = resolve_litellm_route(
         "aws-bedrock/us.anthropic.claude-opus-4-8",

--- a/tests/test_litellm_hardening.py
+++ b/tests/test_litellm_hardening.py
@@ -53,6 +53,7 @@ class _FakeHostServer:
     [
         ("gemini", "gemini-3.5-flash", True),
         ("oracle", "openai/gpt-4.1-mini", False),
+        ("fx", "vercel/anthropic/claude-sonnet-4.5", False),
         ("openhands", "gemini-3.5-flash", True),
         ("codex-acp", "openai/gpt-4.1-mini", True),
         ("openhands", None, False),

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -89,6 +89,23 @@ class TestFindProvider:
             == "qwen/qwen3.5-397b-a17b"
         )
 
+    def test_vercel_prefix(self):
+        name, cfg = find_provider("vercel/anthropic/claude-sonnet-4.5")
+
+        assert name == "vercel"
+        assert cfg.api_protocol == "openai-completions"
+        assert cfg.auth_env == "AI_GATEWAY_API_KEY"
+        assert cfg.base_url == "https://ai-gateway.vercel.sh/v1"
+        assert cfg.endpoints["anthropic-messages"] == "https://ai-gateway.vercel.sh"
+        assert (
+            resolve_auth_env("vercel/anthropic/claude-sonnet-4.5")
+            == "AI_GATEWAY_API_KEY"
+        )
+        assert (
+            strip_provider_prefix("vercel/anthropic/claude-sonnet-4.5")
+            == "anthropic/claude-sonnet-4.5"
+        )
+
     @pytest.mark.parametrize(
         ("model", "expected_protocol"),
         [

--- a/tests/test_registry_invariants.py
+++ b/tests/test_registry_invariants.py
@@ -485,6 +485,7 @@ def test_provider_model_prefixes_unique_and_resolvable():
         ("azure-foundry-anthropic/claude-opus-4-5", "azure-foundry-anthropic"),
         ("aws-bedrock/openai.gpt-oss-20b-1:0", "aws-bedrock"),
         ("github-models/openai/gpt-4.1-mini", "github-models"),
+        ("vercel/anthropic/claude-sonnet-4.5", "vercel"),
         ("zai/glm-5", "zai"),
         ("vllm/local-model", "vllm"),
         ("kimi/kimi-k2.6", "kimi"),


### PR DESCRIPTION
related to https://github.com/benchflow-ai/FrontierPhysics/issues/53

fx speaks ACP natively (fx acp) and only talks to the Vercel AI Gateway, so it joins _NATIVE_PROTOCOL_AGENTS and skips the LiteLLM proxy; usage comes from the agent protocol response.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1053" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->