### PR TITLE
fix(cli): reject --trials > 1 without --matrix

### DIFF
--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -266,8 +266,12 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--trials must be >= 1")
     if request.trials > 1 and request.matrix is None:
         # Only the matrix expansion consumes trials; a plain run would silently
-        # do one trial per task while the caller believes it ran N.
-        raise EvalPlanError("--trials > 1 requires --matrix")
+        # do one trial per task while the caller believes it ran N. Per-trial
+        # requests created by run_matrix_eval bypass this planner by design.
+        raise EvalPlanError(
+            "--trials > 1 requires --matrix; to repeat one model, use a "
+            'single-entry matrix such as "models: {default: <model>}"'
+        )
     if request.expected_tasks is not None and request.expected_tasks < 1:
         raise EvalPlanError("--expected-tasks must be >= 1")
     if request.canonicalize not in {"none", "one-healthy-per-task"}:

--- a/src/benchflow/eval_plan.py
+++ b/src/benchflow/eval_plan.py
@@ -264,6 +264,10 @@ def build_eval_plan(request: EvalCreateRequest) -> EvalPlan:
         raise EvalPlanError("--matrix currently requires --tasks-dir")
     if request.trials < 1:
         raise EvalPlanError("--trials must be >= 1")
+    if request.trials > 1 and request.matrix is None:
+        # Only the matrix expansion consumes trials; a plain run would silently
+        # do one trial per task while the caller believes it ran N.
+        raise EvalPlanError("--trials > 1 requires --matrix")
     if request.expected_tasks is not None and request.expected_tasks < 1:
         raise EvalPlanError("--expected-tasks must be >= 1")
     if request.canonicalize not in {"none", "one-healthy-per-task"}:

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -66,10 +66,11 @@ def test_build_concurrency_zero_rejected(tmp_path: Path):
 
 
 def test_trials_without_matrix_rejected(tmp_path: Path):
-    # Only --matrix consumes trials; a plain run silently does one trial/task.
+    """Guards PR #1064: plain runs must not silently ignore --trials."""
     result = _invoke(tmp_path, "--sandbox", "docker", "--trials", "3")
     assert result.exit_code == 1
     assert "--trials > 1 requires --matrix" in result.stderr
+    assert "single-entry matrix" in result.stderr
 
 
 def test_skill_mode_bogus_clean_error(tmp_path: Path):

--- a/tests/test_cli_arg_validation.py
+++ b/tests/test_cli_arg_validation.py
@@ -65,6 +65,13 @@ def test_build_concurrency_zero_rejected(tmp_path: Path):
     assert "--build-concurrency must be >= 1" in result.stderr
 
 
+def test_trials_without_matrix_rejected(tmp_path: Path):
+    # Only --matrix consumes trials; a plain run silently does one trial/task.
+    result = _invoke(tmp_path, "--sandbox", "docker", "--trials", "3")
+    assert result.exit_code == 1
+    assert "--trials > 1 requires --matrix" in result.stderr
+
+
 def test_skill_mode_bogus_clean_error(tmp_path: Path):
     result = _invoke(tmp_path, "--sandbox", "docker", "--skill-mode", "bogus")
     assert result.exit_code == 1


### PR DESCRIPTION
## Description

Reject `--trials > 1` without `--matrix` in `build_eval_plan` with a clean, actionable `EvalPlanError` that explains the supported single-entry-matrix path.

## Motivation and Context

Only the matrix expansion consumes trials; a plain run silently does one trial per task while the caller believes it ran N. The guard matches the neighboring flag-dependency validations (`--registry requires --dataset`, `--matrix currently requires --tasks-dir`). Matrix-generated per-trial requests bypass this planner by construction.

Closes #1060.

- [x] I have raised an issue to propose this change (#1060)

## Types of changes

- [x] Bug fix
- [ ] New feature
- [x] Breaking change: an invalid command that previously exited 0 now exits 1
- [ ] Documentation

## Implemented Tasks

- [x] Add the `--trials > 1 requires --matrix` guard to `build_eval_plan`
- [x] Explain the single-entry-matrix escape hatch
- [x] Add a PR-named CLI regression test

## Validation

- [x] `tests/`: 5932 passed, 48 skipped, 7 deselected
- [x] `ruff format --check`, `ruff check`, and `ty check src/`
- [x] Real `gemini-3.1-pro-preview` Docker matrix with one alias and two trials: both scored reward 1.0
- [x] Artifact validator: 2/2 healthy, both with ACP + provider LLM trajectories and training-ready result rows
