### PR TITLE
fix(acp): cap how long a pending tool call defers the idle watchdog

### DIFF
--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -894,6 +894,15 @@ async def _prompt_with_idle_watchdog(
                 seen_update_count = session.tool_call_update_count
                 pending_since = now
                 last_tool_update_at = datetime.now(UTC)
+            # Observe the pending set every poll as well: a new tool call also
+            # grows the activity count, and tracking the snapshot only in the
+            # elif below would start its grace clock one poll late.
+            current_pending = tuple(sorted(session.pending_tool_call_ids()))
+            if current_pending != pending_snapshot:
+                pending_snapshot = current_pending
+                if current_pending:
+                    pending_since = now
+                    pending_set_changed_at = datetime.now(UTC)
             if cur_count > last_count:
                 last_progress = now
                 last_activity_at = datetime.now(UTC)
@@ -909,12 +918,7 @@ async def _prompt_with_idle_watchdog(
             # budget (#1061). A genuine model-side hang has no pending tool call
             # (the prior tool already completed via tool_call_update), so it
             # trips the idle path.
-            elif session.pending_tool_call_ids():
-                snapshot = tuple(sorted(session.pending_tool_call_ids()))
-                if snapshot != pending_snapshot:
-                    pending_snapshot = snapshot
-                    pending_since = now
-                    pending_set_changed_at = datetime.now(UTC)
+            elif current_pending:
                 if now - pending_since < pending_grace:
                     last_progress = now
                     last_activity_at = datetime.now(UTC)

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -841,6 +841,13 @@ async def _prompt_with_idle_watchdog(
     last_progress = asyncio.get_event_loop().time()
     last_activity_at = datetime.now(UTC)
     last_count = _activity_count()
+    # A pending tool call defers the idle watchdog only within this grace: a
+    # completion update lost in transit (e.g. a half-open PTY websocket frame
+    # drop) leaves the call pending forever and would otherwise disarm the
+    # watchdog for the rest of the wall-clock budget (#1061).
+    pending_grace = idle_timeout * 3
+    pending_snapshot: tuple[str, ...] = ()
+    pending_since = last_progress
     # poll_interval considers BOTH idle_timeout and wall-clock timeout so that
     # short overall budgets don't overshoot (e.g. timeout=30s with default
     # poll_interval=30s could overshoot 100%). Cap at 30s, floor at 1s.
@@ -870,13 +877,20 @@ async def _prompt_with_idle_watchdog(
             # (e.g. a long build/test/solver shell command), not hung. Those tools
             # emit no ACP updates until they return, so a >idle_timeout run would
             # otherwise false-fire the watchdog and discard real work. Treat a
-            # pending tool call as progress and defer to the wall-clock `timeout`
-            # backstop below for a tool that never returns. A genuine model-side
-            # hang has no pending tool call (the prior tool already completed via
-            # tool_call_update), so it still trips the idle path.
+            # pending tool call as progress, but only within pending_grace of the
+            # pending set last changing: a call whose completion update was lost
+            # in transit stays pending forever, and an unbounded deferral would
+            # disarm the watchdog for the rest of the wall-clock budget (#1061).
+            # A genuine model-side hang has no pending tool call (the prior tool
+            # already completed via tool_call_update), so it trips the idle path.
             elif session.pending_tool_call_ids():
-                last_progress = now
-                last_activity_at = datetime.now(UTC)
+                snapshot = tuple(sorted(session.pending_tool_call_ids()))
+                if snapshot != pending_snapshot:
+                    pending_snapshot = snapshot
+                    pending_since = now
+                if now - pending_since < pending_grace:
+                    last_progress = now
+                    last_activity_at = datetime.now(UTC)
             if now - last_progress >= idle_timeout:
                 diag = IdleTimeoutDiagnostic(
                     idle_timeout_sec=idle_timeout,

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -845,9 +845,19 @@ async def _prompt_with_idle_watchdog(
     # completion update lost in transit (e.g. a half-open PTY websocket frame
     # drop) leaves the call pending forever and would otherwise disarm the
     # watchdog for the rest of the wall-clock budget (#1061).
+    # The grace clock restarts whenever the pending set changes OR a
+    # tool_call_update is observed: in-progress updates mutate ToolCallRecord
+    # in place — invisible to both the pending-set snapshot and
+    # _activity_count — and a call still streaming progress is demonstrably
+    # alive. Only a call that stays pending AND silent for the full grace
+    # stops deferring the idle path.
     pending_grace = idle_timeout * 3
     pending_snapshot: tuple[str, ...] = ()
     pending_since = last_progress
+    seen_update_count = session.tool_call_update_count
+    # Poll-granular observation times, kept for truthful expiry diagnostics.
+    pending_set_changed_at: datetime | None = None
+    last_tool_update_at: datetime | None = None
     # poll_interval considers BOTH idle_timeout and wall-clock timeout so that
     # short overall budgets don't overshoot (e.g. timeout=30s with default
     # poll_interval=30s could overshoot 100%). Cap at 30s, floor at 1s.
@@ -869,6 +879,14 @@ async def _prompt_with_idle_watchdog(
                 break
             now = asyncio.get_event_loop().time()
             cur_count = _activity_count()
+            # Observe tool_call_update traffic every poll: an in-progress
+            # update proves the pending call's transport is alive, so it
+            # restarts the grace clock (but not the idle clock — with no
+            # pending call, updates alone are not progress).
+            if session.tool_call_update_count != seen_update_count:
+                seen_update_count = session.tool_call_update_count
+                pending_since = now
+                last_tool_update_at = datetime.now(UTC)
             if cur_count > last_count:
                 last_progress = now
                 last_activity_at = datetime.now(UTC)
@@ -878,20 +896,23 @@ async def _prompt_with_idle_watchdog(
             # emit no ACP updates until they return, so a >idle_timeout run would
             # otherwise false-fire the watchdog and discard real work. Treat a
             # pending tool call as progress, but only within pending_grace of the
-            # pending set last changing: a call whose completion update was lost
-            # in transit stays pending forever, and an unbounded deferral would
-            # disarm the watchdog for the rest of the wall-clock budget (#1061).
-            # A genuine model-side hang has no pending tool call (the prior tool
-            # already completed via tool_call_update), so it trips the idle path.
+            # last pending-set change or observed update: a call whose completion
+            # update was lost in transit stays pending forever, and an unbounded
+            # deferral would disarm the watchdog for the rest of the wall-clock
+            # budget (#1061). A genuine model-side hang has no pending tool call
+            # (the prior tool already completed via tool_call_update), so it
+            # trips the idle path.
             elif session.pending_tool_call_ids():
                 snapshot = tuple(sorted(session.pending_tool_call_ids()))
                 if snapshot != pending_snapshot:
                     pending_snapshot = snapshot
                     pending_since = now
+                    pending_set_changed_at = datetime.now(UTC)
                 if now - pending_since < pending_grace:
                     last_progress = now
                     last_activity_at = datetime.now(UTC)
             if now - last_progress >= idle_timeout:
+                pending_ids = session.pending_tool_call_ids()
                 diag = IdleTimeoutDiagnostic(
                     idle_timeout_sec=idle_timeout,
                     idle_duration_sec=int(now - last_progress),
@@ -900,7 +921,47 @@ async def _prompt_with_idle_watchdog(
                     n_message_chunks=len(session.message_chunks),
                     n_thought_chunks=len(session.thought_chunks),
                     last_activity_at=last_activity_at.isoformat(),
+                    pending_tool_call_ids=list(pending_ids),
+                    pending_grace_sec=pending_grace,
+                    pending_set_last_changed_at=(
+                        pending_set_changed_at.isoformat()
+                        if pending_set_changed_at is not None
+                        else None
+                    ),
+                    last_tool_update_at=(
+                        last_tool_update_at.isoformat()
+                        if last_tool_update_at is not None
+                        else None
+                    ),
+                    n_tool_call_updates=session.tool_call_update_count,
                 )
+                if pending_ids:
+                    # A non-empty pending set here means the grace expired
+                    # (an in-grace pending call would have deferred
+                    # last_progress this very poll). Report that — not the
+                    # generic "no new tool call, message, or thought" line,
+                    # which is untrue when updates were flowing earlier.
+                    fired_at = datetime.now(UTC)
+                    set_age = (
+                        f"{int((fired_at - pending_set_changed_at).total_seconds())}s ago"
+                        if pending_set_changed_at is not None
+                        else "unknown"
+                    )
+                    update_age = (
+                        f"{int((fired_at - last_tool_update_at).total_seconds())}s ago"
+                        if last_tool_update_at is not None
+                        else "never"
+                    )
+                    raise IdleTimeoutError(
+                        f"Agent idle for {idle_timeout}s: "
+                        f"{len(pending_ids)} pending tool call(s) exceeded the "
+                        f"{pending_grace}s pending grace "
+                        f"({', '.join(pending_ids)}; pending set last changed "
+                        f"{set_age}, last tool-call update {update_age}, "
+                        f"{session.tool_call_update_count} updates seen, "
+                        f"{len(session.tool_calls)} tool calls so far)",
+                        diag,
+                    )
                 raise IdleTimeoutError(
                     f"Agent idle for {idle_timeout}s with no new tool call, "
                     f"message, or thought "

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -21,13 +21,13 @@ Does not own:
 import asyncio
 import contextlib
 import logging
-from datetime import UTC, datetime
 from pathlib import Path
 
 from benchflow.acp.client import ACPClient
 from benchflow.acp.container_transport import ContainerTransport
 from benchflow.acp.selection import selected_acp_transport
 from benchflow.acp.types import McpServerSpec
+from benchflow.acp.watchdog import IdleWatchdog
 from benchflow.agents.protocol import ACPSessionAdapter
 from benchflow.agents.providers import (
     find_provider,
@@ -38,7 +38,6 @@ from benchflow.agents.registry import AGENTS, OPENCODE_PROXY_PROVIDER_ID
 from benchflow.diagnostics import (
     AgentPromptTimeoutDiagnostic,
     AgentPromptTimeoutError,
-    IdleTimeoutDiagnostic,
     IdleTimeoutError,
     TransportClosedDiagnostic,
     TransportClosedError,
@@ -813,13 +812,6 @@ async def _prompt_with_wall_clock_budget(
             await _cancel_and_drain_prompt_task(prompt_task)
 
 
-# A pending tool call defers the idle watchdog for at most this many idle
-# budgets while staying silent (no update traffic). Sized so legitimate silent
-# tools several times the idle budget survive, while a lost completion stops
-# disarming hang detection within the same order of magnitude (#1061).
-PENDING_GRACE_MULTIPLIER = 3
-
-
 async def _prompt_with_idle_watchdog(
     acp_client: ACPClient,
     session,
@@ -827,160 +819,29 @@ async def _prompt_with_idle_watchdog(
     timeout: int,
     idle_timeout: int,
 ):
-    """Run acp_client.prompt() with both a wall-clock and an idle watchdog.
-
-    The watchdog polls session.tool_calls every few seconds and aborts if no
-    progress was made in idle_timeout. This catches agents that hung silently
-    while the local process is still alive (no output to stdout, no tool calls
-    appended).
-    """
-
-    def _activity_count() -> int:
-        # Match the docstring contract: idle = no tool call AND no message
-        # AND no thought. Sum all three so streamed text resets the timer.
-        return (
-            len(session.tool_calls)
-            + len(session.message_chunks)
-            + len(session.thought_chunks)
-        )
-
+    """Run one ACP prompt with wall-clock and idle-watchdog budgets."""
     prompt_task = asyncio.create_task(acp_client.prompt(prompt))
-    last_progress = asyncio.get_event_loop().time()
-    last_activity_at = datetime.now(UTC)
-    last_count = _activity_count()
-    # A pending tool call defers the idle watchdog only within this grace: a
-    # completion update lost in transit (e.g. a half-open PTY websocket frame
-    # drop) leaves the call pending forever and would otherwise disarm the
-    # watchdog for the rest of the wall-clock budget (#1061).
-    # The grace clock restarts whenever the pending set changes OR a
-    # tool_call_update is observed: in-progress updates mutate ToolCallRecord
-    # in place — invisible to both the pending-set snapshot and
-    # _activity_count — and a call still streaming progress is demonstrably
-    # alive. Only a call that stays pending AND silent for the full grace
-    # stops deferring the idle path.
-    pending_grace = idle_timeout * PENDING_GRACE_MULTIPLIER
-    pending_snapshot: tuple[str, ...] = ()
-    pending_since = last_progress
-    seen_update_count = session.tool_call_update_count
-    # Poll-granular observation times, kept for truthful expiry diagnostics.
-    pending_set_changed_at: datetime | None = None
-    last_tool_update_at: datetime | None = None
-    # poll_interval considers BOTH idle_timeout and wall-clock timeout so that
-    # short overall budgets don't overshoot (e.g. timeout=30s with default
-    # poll_interval=30s could overshoot 100%). Cap at 30s, floor at 1s.
-    poll_interval = max(1, min(30, idle_timeout // 4, max(1, timeout // 4)))
-    # deadline is loop-INVARIANT (fixed at loop start), NOT re-derived from
-    # last_progress inside the loop. This is load-bearing: the idle branch below
-    # resets last_progress while a tool call is in-flight, so re-deriving the
-    # deadline from it would let an agent that emits a tool_call and then hangs
-    # forever push the wall-clock backstop out indefinitely. Keep this fixed.
-    deadline = last_progress + timeout
+    loop = asyncio.get_running_loop()
+    watchdog = IdleWatchdog.start(
+        session,
+        idle_timeout_sec=idle_timeout,
+        wall_timeout_sec=timeout,
+        now=loop.time(),
+    )
 
     try:
         while not prompt_task.done():
-            await asyncio.sleep(poll_interval)
+            await asyncio.sleep(watchdog.poll_interval_sec)
             # Re-check done() after the sleep — the prompt may have completed
             # during the poll interval. Without this, we'd cancel an already-
             # completed task and discard a successful result.
             if prompt_task.done():
                 break
-            now = asyncio.get_event_loop().time()
-            cur_count = _activity_count()
-            # Observe tool_call_update traffic every poll: an in-progress
-            # update proves the pending call's transport is alive, so it
-            # restarts the grace clock (but not the idle clock — with no
-            # pending call, updates alone are not progress).
-            if session.tool_call_update_count != seen_update_count:
-                seen_update_count = session.tool_call_update_count
-                pending_since = now
-                last_tool_update_at = datetime.now(UTC)
-            # Observe the pending set every poll as well: a new tool call also
-            # grows the activity count, and tracking the snapshot only in the
-            # elif below would start its grace clock one poll late.
-            current_pending = tuple(sorted(session.pending_tool_call_ids()))
-            if current_pending != pending_snapshot:
-                pending_snapshot = current_pending
-                if current_pending:
-                    pending_since = now
-                    pending_set_changed_at = datetime.now(UTC)
-            if cur_count > last_count:
-                last_progress = now
-                last_activity_at = datetime.now(UTC)
-                last_count = cur_count
-            # An in-flight tool call means the agent is actively executing a tool
-            # (e.g. a long build/test/solver shell command), not hung. Those tools
-            # emit no ACP updates until they return, so a >idle_timeout run would
-            # otherwise false-fire the watchdog and discard real work. Treat a
-            # pending tool call as progress, but only within pending_grace of the
-            # last pending-set change or observed update: a call whose completion
-            # update was lost in transit stays pending forever, and an unbounded
-            # deferral would disarm the watchdog for the rest of the wall-clock
-            # budget (#1061). A genuine model-side hang has no pending tool call
-            # (the prior tool already completed via tool_call_update), so it
-            # trips the idle path.
-            elif current_pending:
-                if now - pending_since < pending_grace:
-                    last_progress = now
-                    last_activity_at = datetime.now(UTC)
-            if now - last_progress >= idle_timeout:
-                pending_ids = session.pending_tool_call_ids()
-                diag = IdleTimeoutDiagnostic(
-                    idle_timeout_sec=idle_timeout,
-                    idle_duration_sec=int(now - last_progress),
-                    wall_clock_elapsed_sec=int(now - (deadline - timeout)),
-                    n_tool_calls=len(session.tool_calls),
-                    n_message_chunks=len(session.message_chunks),
-                    n_thought_chunks=len(session.thought_chunks),
-                    last_activity_at=last_activity_at.isoformat(),
-                    pending_tool_call_ids=list(pending_ids),
-                    pending_grace_sec=pending_grace,
-                    pending_set_last_changed_at=(
-                        pending_set_changed_at.isoformat()
-                        if pending_set_changed_at is not None
-                        else None
-                    ),
-                    last_tool_update_at=(
-                        last_tool_update_at.isoformat()
-                        if last_tool_update_at is not None
-                        else None
-                    ),
-                    n_tool_call_updates=session.tool_call_update_count,
-                )
-                if pending_ids:
-                    # A non-empty pending set here means the grace expired
-                    # (an in-grace pending call would have deferred
-                    # last_progress this very poll). Report that — not the
-                    # generic "no new tool call, message, or thought" line,
-                    # which is untrue when updates were flowing earlier.
-                    fired_at = datetime.now(UTC)
-                    set_age = (
-                        f"{int((fired_at - pending_set_changed_at).total_seconds())}s ago"
-                        if pending_set_changed_at is not None
-                        else "unknown"
-                    )
-                    update_age = (
-                        f"{int((fired_at - last_tool_update_at).total_seconds())}s ago"
-                        if last_tool_update_at is not None
-                        else "never"
-                    )
-                    raise IdleTimeoutError(
-                        f"Agent idle for {idle_timeout}s: "
-                        f"{len(pending_ids)} pending tool call(s) exceeded the "
-                        f"{pending_grace}s pending grace "
-                        f"({', '.join(pending_ids)}; pending set last changed "
-                        f"{set_age}, last tool-call update {update_age}, "
-                        f"{session.tool_call_update_count} updates seen, "
-                        f"{len(session.tool_calls)} tool calls so far)",
-                        diag,
-                    )
-                raise IdleTimeoutError(
-                    f"Agent idle for {idle_timeout}s with no new tool call, "
-                    f"message, or thought "
-                    f"(last activity {int(now - last_progress)}s ago, "
-                    f"{len(session.tool_calls)} tool calls so far)",
-                    diag,
-                )
-            if now > deadline:
+            now = loop.time()
+            watchdog.observe(session, now=now)
+            if watchdog.idle_expired(now):
+                raise watchdog.timeout_error(session, now=now)
+            if watchdog.wall_clock_expired(now):
                 if await _cancel_and_drain_prompt_task(prompt_task):
                     raise _agent_prompt_timeout_error(session, timeout)
                 raise TimeoutError(

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -813,14 +813,14 @@ async def _prompt_with_wall_clock_budget(
             await _cancel_and_drain_prompt_task(prompt_task)
 
 
-async # A pending tool call defers the idle watchdog for at most this many idle
+# A pending tool call defers the idle watchdog for at most this many idle
 # budgets while staying silent (no update traffic). Sized so legitimate silent
 # tools several times the idle budget survive, while a lost completion stops
 # disarming hang detection within the same order of magnitude (#1061).
 PENDING_GRACE_MULTIPLIER = 3
 
 
-def _prompt_with_idle_watchdog(
+async def _prompt_with_idle_watchdog(
     acp_client: ACPClient,
     session,
     prompt: str,

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -813,7 +813,14 @@ async def _prompt_with_wall_clock_budget(
             await _cancel_and_drain_prompt_task(prompt_task)
 
 
-async def _prompt_with_idle_watchdog(
+async # A pending tool call defers the idle watchdog for at most this many idle
+# budgets while staying silent (no update traffic). Sized so legitimate silent
+# tools several times the idle budget survive, while a lost completion stops
+# disarming hang detection within the same order of magnitude (#1061).
+PENDING_GRACE_MULTIPLIER = 3
+
+
+def _prompt_with_idle_watchdog(
     acp_client: ACPClient,
     session,
     prompt: str,
@@ -851,7 +858,7 @@ async def _prompt_with_idle_watchdog(
     # _activity_count — and a call still streaming progress is demonstrably
     # alive. Only a call that stays pending AND silent for the full grace
     # stops deferring the idle path.
-    pending_grace = idle_timeout * 3
+    pending_grace = idle_timeout * PENDING_GRACE_MULTIPLIER
     pending_snapshot: tuple[str, ...] = ()
     pending_since = last_progress
     seen_update_count = session.tool_call_update_count

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -202,12 +202,11 @@ class ACPSession:
         self.thought_chunks: list[str] = []
         self.tool_calls: list[ToolCallRecord] = []
         self._tool_call_map: dict[str, ToolCallRecord] = {}
-        # Monotonic count of tool_call_update notifications. In-progress
-        # updates mutate a ToolCallRecord in place — no list grows and the
-        # pending set is unchanged — so this counter is the only signal the
-        # idle watchdog has that a long-running call is still streaming
-        # progress (PR #1066 review).
+        # Total update count is diagnostic. Per-call pending versions let the
+        # idle watchdog distinguish relevant streaming progress from repeated
+        # terminal updates for another call (PR #1066).
         self.tool_call_update_count: int = 0
+        self._pending_tool_call_update_counts: dict[str, int] = {}
         # Distinct display titles across recorded tool calls, maintained
         # incrementally at record creation so the eval dashboard can detect
         # single-tool agents (prime-agent funnels everything through one
@@ -306,6 +305,20 @@ class ACPSession:
             for record in self.tool_calls
             if record.status in pending_statuses
         ]
+
+    def pending_tool_call_state(self) -> tuple[tuple[str, int], ...]:
+        """Return stable pending-call identities with progress versions."""
+        pending_statuses = {ToolCallStatus.PENDING, ToolCallStatus.IN_PROGRESS}
+        return tuple(
+            sorted(
+                (
+                    record.tool_call_id,
+                    self._pending_tool_call_update_counts.get(record.tool_call_id, 0),
+                )
+                for record in self.tool_calls
+                if record.status in pending_statuses
+            )
+        )
 
     def record_agent_timeout(
         self,
@@ -427,6 +440,10 @@ class ACPSession:
                 status = ToolCallStatus.IN_PROGRESS
             content = update.get("content")
             record.update_status(status, content)
+            if status in (ToolCallStatus.PENDING, ToolCallStatus.IN_PROGRESS):
+                self._pending_tool_call_update_counts[tc_id] = (
+                    self._pending_tool_call_update_counts.get(tc_id, 0) + 1
+                )
             # Canonicalize legacy OpenHands invoke_skill calls using the same
             # classifier the rescan path uses. Only upgrade to "skill"; never
             # downgrade, and never reclassify a tool that already has a real

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -202,6 +202,12 @@ class ACPSession:
         self.thought_chunks: list[str] = []
         self.tool_calls: list[ToolCallRecord] = []
         self._tool_call_map: dict[str, ToolCallRecord] = {}
+        # Monotonic count of tool_call_update notifications. In-progress
+        # updates mutate a ToolCallRecord in place — no list grows and the
+        # pending set is unchanged — so this counter is the only signal the
+        # idle watchdog has that a long-running call is still streaming
+        # progress (PR #1066 review).
+        self.tool_call_update_count: int = 0
         # Distinct display titles across recorded tool calls, maintained
         # incrementally at record creation so the eval dashboard can detect
         # single-tool agents (prime-agent funnels everything through one
@@ -401,6 +407,7 @@ class ACPSession:
             self._record_tool_call(record)
 
         elif update_type == "tool_call_update":
+            self.tool_call_update_count += 1
             tc_id = update.get("toolCallId", "")
             record = self._tool_call_map.get(tc_id)
             if not record:

--- a/src/benchflow/acp/watchdog.py
+++ b/src/benchflow/acp/watchdog.py
@@ -1,0 +1,249 @@
+"""Idle-watchdog state and pending-tool grace policy for ACP prompts."""
+
+from __future__ import annotations
+
+from collections.abc import Sized
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from benchflow.diagnostics import IdleTimeoutDiagnostic, IdleTimeoutError
+
+# A pending tool call defers the idle watchdog for at most this many idle
+# budgets while staying silent. Streaming updates restart the grace for their
+# own pending call; unrelated or terminal updates do not.
+PENDING_GRACE_MULTIPLIER = 3
+
+
+class WatchdogSession(Protocol):
+    """The small ACPSession surface consumed by the idle watchdog."""
+
+    tool_calls: Sized
+    message_chunks: Sized
+    thought_chunks: Sized
+    tool_call_update_count: int
+
+    def pending_tool_call_state(self) -> tuple[tuple[str, int], ...]: ...
+
+
+def _activity_count(session: WatchdogSession) -> int:
+    return (
+        len(session.tool_calls)
+        + len(session.message_chunks)
+        + len(session.thought_chunks)
+    )
+
+
+@dataclass
+class IdleWatchdog:
+    """Track prompt activity and enforce bounded pending-tool deferral."""
+
+    idle_timeout_sec: int
+    wall_timeout_sec: int
+    started_at: float
+    last_progress_at: float
+    last_activity_at: datetime
+    last_activity_count: int
+    pending_state: tuple[tuple[str, int], ...]
+    pending_last_progress_at: dict[str, float]
+    pending_last_update_at: dict[str, datetime]
+    pending_set_last_changed_at: datetime | None
+
+    @classmethod
+    def start(
+        cls,
+        session: WatchdogSession,
+        *,
+        idle_timeout_sec: int,
+        wall_timeout_sec: int,
+        now: float,
+        wall_now: datetime | None = None,
+    ) -> IdleWatchdog:
+        """Create a watchdog snapshot at prompt start."""
+        observed_at = wall_now or datetime.now(UTC)
+        pending_state = session.pending_tool_call_state()
+        return cls(
+            idle_timeout_sec=idle_timeout_sec,
+            wall_timeout_sec=wall_timeout_sec,
+            started_at=now,
+            last_progress_at=now,
+            last_activity_at=observed_at,
+            last_activity_count=_activity_count(session),
+            pending_state=pending_state,
+            pending_last_progress_at={call_id: now for call_id, _ in pending_state},
+            pending_last_update_at={},
+            pending_set_last_changed_at=observed_at if pending_state else None,
+        )
+
+    @property
+    def pending_grace_sec(self) -> int:
+        return self.idle_timeout_sec * PENDING_GRACE_MULTIPLIER
+
+    @property
+    def poll_interval_sec(self) -> int:
+        return max(
+            1,
+            min(
+                30,
+                self.idle_timeout_sec // 4,
+                max(1, self.wall_timeout_sec // 4),
+            ),
+        )
+
+    @property
+    def deadline(self) -> float:
+        return self.started_at + self.wall_timeout_sec
+
+    @property
+    def pending_ids(self) -> tuple[str, ...]:
+        return tuple(call_id for call_id, _version in self.pending_state)
+
+    @property
+    def n_pending_tool_updates(self) -> int:
+        return sum(version for _call_id, version in self.pending_state)
+
+    def observe(
+        self,
+        session: WatchdogSession,
+        *,
+        now: float,
+        wall_now: datetime | None = None,
+    ) -> None:
+        """Observe one poll and advance only the relevant grace clocks."""
+        observed_at = wall_now or datetime.now(UTC)
+        current_state = session.pending_tool_call_state()
+        previous_versions = dict(self.pending_state)
+        current_ids = tuple(call_id for call_id, _version in current_state)
+
+        if current_ids != self.pending_ids:
+            self.pending_set_last_changed_at = observed_at
+
+        for call_id, version in current_state:
+            if call_id not in previous_versions:
+                self.pending_last_progress_at[call_id] = now
+            if version > previous_versions.get(call_id, 0):
+                self.pending_last_progress_at[call_id] = now
+                self.pending_last_update_at[call_id] = observed_at
+
+        current_id_set = set(current_ids)
+        self.pending_last_progress_at = {
+            call_id: progress_at
+            for call_id, progress_at in self.pending_last_progress_at.items()
+            if call_id in current_id_set
+        }
+        self.pending_last_update_at = {
+            call_id: update_at
+            for call_id, update_at in self.pending_last_update_at.items()
+            if call_id in current_id_set
+        }
+
+        self.pending_state = current_state
+        current_activity_count = _activity_count(session)
+        if current_activity_count > self.last_activity_count:
+            self.last_progress_at = now
+            self.last_activity_at = observed_at
+            self.last_activity_count = current_activity_count
+        elif current_ids and not self.expired_pending_ids(now):
+            # Silent tools may legitimately run longer than idle_timeout. The
+            # grace, not unrelated session noise, owns this deferral.
+            self.last_progress_at = now
+            self.last_activity_at = observed_at
+
+    def expired_pending_ids(self, now: float) -> tuple[str, ...]:
+        """Pending calls whose own relevant progress grace has expired."""
+        return tuple(
+            call_id
+            for call_id in self.pending_ids
+            if now - self.pending_last_progress_at[call_id] >= self.pending_grace_sec
+        )
+
+    def idle_expired(self, now: float) -> bool:
+        return bool(self.expired_pending_ids(now)) or (
+            now - self.last_progress_at >= self.idle_timeout_sec
+        )
+
+    def wall_clock_expired(self, now: float) -> bool:
+        return now > self.deadline
+
+    def timeout_error(
+        self,
+        session: WatchdogSession,
+        *,
+        now: float,
+        wall_now: datetime | None = None,
+    ) -> IdleTimeoutError:
+        """Build a truthful idle error for generic or pending-grace expiry."""
+        fired_at = wall_now or datetime.now(UTC)
+        pending_ids = list(self.pending_ids)
+        expired_pending_ids = list(self.expired_pending_ids(now))
+        pending_versions = dict(self.pending_state)
+        n_expired_pending_updates = sum(
+            pending_versions[call_id] for call_id in expired_pending_ids
+        )
+        idle_duration = (
+            max(
+                now - self.pending_last_progress_at[call_id]
+                for call_id in expired_pending_ids
+            )
+            if expired_pending_ids
+            else now - self.last_progress_at
+        )
+        expired_update_times = [
+            self.pending_last_update_at[call_id]
+            for call_id in expired_pending_ids
+            if call_id in self.pending_last_update_at
+        ]
+        last_expired_update_at = (
+            max(expired_update_times) if expired_update_times else None
+        )
+        diagnostic = IdleTimeoutDiagnostic(
+            idle_timeout_sec=self.idle_timeout_sec,
+            idle_duration_sec=int(idle_duration),
+            wall_clock_elapsed_sec=int(now - self.started_at),
+            n_tool_calls=len(session.tool_calls),
+            n_message_chunks=len(session.message_chunks),
+            n_thought_chunks=len(session.thought_chunks),
+            last_activity_at=self.last_activity_at.isoformat(),
+            pending_tool_call_ids=pending_ids,
+            expired_pending_tool_call_ids=expired_pending_ids,
+            pending_grace_sec=self.pending_grace_sec,
+            pending_set_last_changed_at=(
+                self.pending_set_last_changed_at.isoformat()
+                if self.pending_set_last_changed_at is not None
+                else None
+            ),
+            last_tool_update_at=(
+                last_expired_update_at.isoformat()
+                if last_expired_update_at is not None
+                else None
+            ),
+            n_tool_call_updates=session.tool_call_update_count,
+            n_pending_tool_call_updates=self.n_pending_tool_updates,
+            n_expired_pending_tool_call_updates=n_expired_pending_updates,
+        )
+        if expired_pending_ids:
+            set_age = _age(fired_at, self.pending_set_last_changed_at)
+            update_age = _age(fired_at, last_expired_update_at)
+            return IdleTimeoutError(
+                f"Agent idle for {self.idle_timeout_sec}s: "
+                f"{len(expired_pending_ids)} pending tool call(s) exceeded the "
+                f"{self.pending_grace_sec}s pending grace "
+                f"({', '.join(expired_pending_ids)}; pending set last changed "
+                f"{set_age}, last pending-call update {update_age}, "
+                f"{n_expired_pending_updates} relevant updates seen, "
+                f"{len(session.tool_calls)} tool calls so far)",
+                diagnostic,
+            )
+        return IdleTimeoutError(
+            f"Agent idle for {self.idle_timeout_sec}s with no new tool call, "
+            f"message, or thought "
+            f"(last activity {int(now - self.last_progress_at)}s ago, "
+            f"{len(session.tool_calls)} tool calls so far)",
+            diagnostic,
+        )
+
+
+def _age(now: datetime, then: datetime | None) -> str:
+    if then is None:
+        return "never"
+    return f"{int((now - then).total_seconds())}s ago"

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -138,10 +138,13 @@ class IdleTimeoutDiagnostic(Diagnostic):
     # result.json dicts round-trip through format_issue_from_dict with the
     # defaults below.
     pending_tool_call_ids: list[str] = field(default_factory=list)
+    expired_pending_tool_call_ids: list[str] = field(default_factory=list)
     pending_grace_sec: int | None = None
     pending_set_last_changed_at: str | None = None
     last_tool_update_at: str | None = None
     n_tool_call_updates: int = 0
+    n_pending_tool_call_updates: int = 0
+    n_expired_pending_tool_call_updates: int = 0
 
     field: ClassVar[str] = "idle_timeout_info"
     category: ClassVar[str | None] = "idle_timeout"

--- a/src/benchflow/diagnostics.py
+++ b/src/benchflow/diagnostics.py
@@ -132,18 +132,34 @@ class IdleTimeoutDiagnostic(Diagnostic):
     n_message_chunks: int = 0
     n_thought_chunks: int = 0
     last_activity_at: str = ""
+    # Pending-grace truth (PR #1066): when the fire happened because a
+    # pending tool call exhausted the grace window, these say so instead of
+    # letting the fields above imply pure silence. Additive — older
+    # result.json dicts round-trip through format_issue_from_dict with the
+    # defaults below.
+    pending_tool_call_ids: list[str] = field(default_factory=list)
+    pending_grace_sec: int | None = None
+    pending_set_last_changed_at: str | None = None
+    last_tool_update_at: str | None = None
+    n_tool_call_updates: int = 0
 
     field: ClassVar[str] = "idle_timeout_info"
     category: ClassVar[str | None] = "idle_timeout"
     summary_description: ClassVar[str] = "hit idle timeout"
 
     def format_issue(self, task_name: str) -> str:
-        return (
+        line = (
             f"{task_name}: idle timeout after "
             f"{self.idle_duration_sec}s idle "
             f"({self.n_tool_calls} tool calls, "
             f"{self.wall_clock_elapsed_sec}s wall)"
         )
+        if self.pending_tool_call_ids:
+            line += (
+                f" — {len(self.pending_tool_call_ids)} pending tool call(s) "
+                f"exceeded the {self.pending_grace_sec}s pending grace"
+            )
+        return line
 
 
 @dataclass

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -901,13 +901,15 @@ class TestACPIdleWatchdog:
 class TestPendingToolCallGrace:
     @pytest.mark.asyncio
     async def test_lost_tool_call_completion_trips_idle_after_grace(self):
-        """Guards the #1061 fix: a tool call whose completion update never
-        arrives must stop deferring the idle watchdog once the pending grace
+        """Guards PR #1066's #1061 fix: a completion lost in transit.
+
+        A terminal update that never arrives must stop deferring the watchdog
+        once the pending grace
         (3x idle_timeout) elapses with no other session activity, instead of
         disarming it for the rest of the wall-clock budget.
 
-        Runtime: ~5s (3s grace + 1s idle + polls); the outer wait_for is a
-        loose hang guard, not a timing assertion.
+        Runtime: ~3s plus polling; the outer wait_for is a loose hang guard,
+        not a timing assertion.
         """
         from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
         from benchflow.acp.session import ToolCallRecord
@@ -934,7 +936,9 @@ class TestPendingToolCallGrace:
 
     @pytest.mark.asyncio
     async def test_streaming_tool_call_updates_defer_past_grace(self):
-        """A single long tool call that streams in-progress tool_call_update
+        """Guards PR #1066: relevant streaming updates restart the grace.
+
+        A single long tool call that streams in-progress tool_call_update
         notifications past the grace boundary is demonstrably alive and must
         NOT be idle-killed: updates mutate the ToolCallRecord in place, so
         they are invisible to both the pending-set snapshot and
@@ -986,13 +990,84 @@ class TestPendingToolCallGrace:
         assert session.pending_tool_call_ids() == ["tc_stream"]
 
     @pytest.mark.asyncio
+    async def test_unrelated_updates_do_not_extend_pending_grace(self):
+        """Guards PR #1066: other calls cannot hide a lost completion."""
+        from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+
+        class TerminalNoiseClient:
+            def __init__(self, session: ACPSession):
+                self._session = session
+
+            async def prompt(self, _prompt: str):
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "lost_completion",
+                        "title": "silent long call",
+                        "kind": "bash",
+                    }
+                )
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "already_done",
+                        "title": "finished call",
+                        "kind": "bash",
+                    }
+                )
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "still_streaming",
+                        "title": "healthy streaming call",
+                        "kind": "bash",
+                    }
+                )
+                while True:
+                    self._session.handle_update(
+                        {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "already_done",
+                            "status": "completed",
+                        }
+                    )
+                    self._session.handle_update(
+                        {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "still_streaming",
+                            "status": "in_progress",
+                        }
+                    )
+                    await asyncio.sleep(0.4)
+
+        session = ACPSession("unrelated-terminal-noise")
+        with pytest.raises(IdleTimeoutError, match="lost_completion"):
+            await asyncio.wait_for(
+                execute_prompts(
+                    TerminalNoiseClient(session),  # type: ignore[arg-type]
+                    session,
+                    ["solve"],
+                    timeout=7,
+                    idle_timeout=1,
+                ),
+                timeout=20.0,
+            )
+        assert session.pending_tool_call_ids() == [
+            "lost_completion",
+            "still_streaming",
+        ]
+        assert session.tool_call_update_count > 2
+
+    @pytest.mark.asyncio
     async def test_grace_expiry_reports_pending_truth(self):
-        """When the grace genuinely expires (call pending, updates stopped),
+        """Guards PR #1066: pending-grace expiry reports the real cause.
+
+        When the grace genuinely expires (call pending, updates stopped),
         the raised message and IdleTimeoutDiagnostic must say so — not claim
         'no new tool call, message, or thought' as if the session were
         silent all along.
 
-        Runtime: ~4s (2 quick updates, then silence through grace + idle).
+        Runtime: ~3s plus polling after the last relevant update.
         """
         from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
 
@@ -1037,8 +1112,11 @@ class TestPendingToolCallGrace:
         assert "tc_stall" in msg
         info = exc_info.value.diagnostic.to_dict()
         assert info["pending_tool_call_ids"] == ["tc_stall"]
+        assert info["expired_pending_tool_call_ids"] == ["tc_stall"]
         assert info["pending_grace_sec"] == 3  # 3x idle_timeout
         assert info["n_tool_call_updates"] == 2
+        assert info["n_pending_tool_call_updates"] == 2
+        assert info["n_expired_pending_tool_call_updates"] == 2
         assert info["pending_set_last_changed_at"] is not None
         assert info["last_tool_update_at"] is not None
         # Existing fields keep their meaning.

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -898,6 +898,41 @@ class TestACPIdleWatchdog:
                     await client.task
 
 
+class TestPendingToolCallGrace:
+    @pytest.mark.asyncio
+    async def test_lost_tool_call_completion_trips_idle_after_grace(self):
+        """Guards the #1061 fix: a tool call whose completion update never
+        arrives must stop deferring the idle watchdog once the pending grace
+        (3x idle_timeout) elapses with no other session activity, instead of
+        disarming it for the rest of the wall-clock budget.
+
+        Runtime: ~5s (3s grace + 1s idle + polls); the outer wait_for is a
+        loose hang guard, not a timing assertion.
+        """
+        from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+        from benchflow.acp.session import ToolCallRecord
+
+        class HangingPromptClient:
+            async def prompt(self, _prompt: str):
+                await asyncio.Future()
+
+        session = ACPSession("pending-grace-session")
+        # A tool call stuck in PENDING with no terminal update, ever.
+        session.tool_calls.append(ToolCallRecord("t1", "sleep 180", "execute"))
+
+        with pytest.raises(IdleTimeoutError, match="Agent idle for 1s"):
+            await asyncio.wait_for(
+                execute_prompts(
+                    HangingPromptClient(),  # type: ignore[arg-type]
+                    session,
+                    ["solve"],
+                    timeout=60,
+                    idle_timeout=1,
+                ),
+                timeout=20.0,
+            )
+
+
 class TestIdleTimeoutDiagnostics:
     """Guards ENG-149: idle timeouts must carry structured diagnostics."""
 

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -932,6 +932,119 @@ class TestPendingToolCallGrace:
                 timeout=20.0,
             )
 
+    @pytest.mark.asyncio
+    async def test_streaming_tool_call_updates_defer_past_grace(self):
+        """A single long tool call that streams in-progress tool_call_update
+        notifications past the grace boundary is demonstrably alive and must
+        NOT be idle-killed: updates mutate the ToolCallRecord in place, so
+        they are invisible to both the pending-set snapshot and
+        _activity_count — each observed update must reset the grace clock.
+        The wall-clock backstop (AgentPromptTimeoutError) still bounds it.
+
+        Runtime: ~7s (wall timeout 7 > grace 3 + idle 1, so an unpatched
+        grace clock false-fires the idle path first). The outer wait_for is
+        a loose hang guard, not a timing assertion.
+        """
+        from benchflow.acp.runtime import AgentPromptTimeoutError, execute_prompts
+
+        class StreamingToolClient:
+            def __init__(self, session: ACPSession):
+                self._session = session
+
+            async def prompt(self, _prompt: str):
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_stream",
+                        "title": "long training run",
+                        "kind": "bash",
+                    }
+                )
+                while True:  # stream progress until cancelled
+                    await asyncio.sleep(0.4)
+                    self._session.handle_update(
+                        {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "tc_stream",
+                            "status": "in_progress",
+                        }
+                    )
+
+        session = ACPSession("streaming-grace-session")
+        with pytest.raises(AgentPromptTimeoutError):
+            await asyncio.wait_for(
+                execute_prompts(
+                    StreamingToolClient(session),  # type: ignore[arg-type]
+                    session,
+                    ["solve"],
+                    timeout=7,
+                    idle_timeout=1,
+                ),
+                timeout=30.0,
+            )
+        # The call outlived the watchdog: still pending, never idle-killed.
+        assert session.pending_tool_call_ids() == ["tc_stream"]
+
+    @pytest.mark.asyncio
+    async def test_grace_expiry_reports_pending_truth(self):
+        """When the grace genuinely expires (call pending, updates stopped),
+        the raised message and IdleTimeoutDiagnostic must say so — not claim
+        'no new tool call, message, or thought' as if the session were
+        silent all along.
+
+        Runtime: ~4s (2 quick updates, then silence through grace + idle).
+        """
+        from benchflow.acp.runtime import IdleTimeoutError, execute_prompts
+
+        class StallAfterUpdatesClient:
+            def __init__(self, session: ACPSession):
+                self._session = session
+
+            async def prompt(self, _prompt: str):
+                self._session.handle_update(
+                    {
+                        "sessionUpdate": "tool_call",
+                        "toolCallId": "tc_stall",
+                        "title": "flaky build",
+                        "kind": "bash",
+                    }
+                )
+                for _ in range(2):
+                    await asyncio.sleep(0.2)
+                    self._session.handle_update(
+                        {
+                            "sessionUpdate": "tool_call_update",
+                            "toolCallId": "tc_stall",
+                            "status": "in_progress",
+                        }
+                    )
+                await asyncio.Future()  # completion update lost forever
+
+        session = ACPSession("grace-expiry-session")
+        with pytest.raises(IdleTimeoutError) as exc_info:
+            await asyncio.wait_for(
+                execute_prompts(
+                    StallAfterUpdatesClient(session),  # type: ignore[arg-type]
+                    session,
+                    ["solve"],
+                    timeout=60,
+                    idle_timeout=1,
+                ),
+                timeout=30.0,
+            )
+        msg = str(exc_info.value)
+        assert "pending grace" in msg
+        assert "tc_stall" in msg
+        info = exc_info.value.diagnostic.to_dict()
+        assert info["pending_tool_call_ids"] == ["tc_stall"]
+        assert info["pending_grace_sec"] == 3  # 3x idle_timeout
+        assert info["n_tool_call_updates"] == 2
+        assert info["pending_set_last_changed_at"] is not None
+        assert info["last_tool_update_at"] is not None
+        # Existing fields keep their meaning.
+        assert info["reason"] == "idle_timeout"
+        assert info["idle_duration_sec"] >= 1
+
 
 class TestIdleTimeoutDiagnostics:
     """Guards ENG-149: idle timeouts must carry structured diagnostics."""


### PR DESCRIPTION
## Description

Cap the silent deferral of each pending ACP tool call independently. A call gets `PENDING_GRACE_MULTIPLIER (3) x idle_timeout` since its own creation or last nonterminal update; streaming progress for that call restarts its grace, while duplicate terminal updates or progress from another call cannot conceal a lost completion.

The grace policy and diagnostics now live in a focused `acp/watchdog.py` state machine. The async runtime loop is 44 lines and `runtime.py` is back to 858 lines instead of crossing 1,000.

## Motivation and Context

The #1061 stall chain leaves a tool record pending forever when its terminal update is lost, while stderr traffic prevents the transport timeout. Main previously treated any pending call as progress until the multi-hour wall budget. This PR bounds that deferral without killing demonstrably streaming tools.

Expiry raises the existing retryable `IdleTimeoutError` with additive diagnostics naming all pending calls, the specifically expired calls, the grace, relevant update counts, and update ages.

Behavior change: a call that stays pending and fully silent beyond 3x the idle budget now fails instead of deferring to the wall clock. With the default 600-second idle timeout this is approximately a 30-minute silent cap (plus at most one watchdog poll); legitimate longer silent tools should raise `--agent-idle-timeout`.

Closes #1061.

- [x] I have raised an issue to propose this change (#1061)

## Types of changes

- [x] Bug fix
- [x] Breaking change: bounded silent pending-call behavior
- [ ] New feature
- [ ] Documentation

## Implemented Tasks

- [x] Track nonterminal progress versions per pending tool call
- [x] Enforce grace expiry per call, not per session-global update count
- [x] Ignore repeated terminal noise and updates from other calls
- [x] Preserve long-running calls that stream in-progress updates
- [x] Emit truthful, additive timeout diagnostics
- [x] Extract the watchdog state machine from the ACP runtime loop
- [x] Add PR-named regression coverage for lost, streaming, unrelated-noise, and diagnostic paths

## Validation

- [x] `tests/test_acp.py`: 100 passed
- [x] `tests/`: 5936 passed, 48 skipped, 7 deselected
- [x] Ruff format/lint and `ty check src/`
- [x] Direct adversarial ACP probe: repeated terminal updates and a different continuously streaming call do not hide the lost pending call
- [x] Real `gemini-3.1-pro-preview` Docker and Daytona E2E at the final working tree: reward 1.0 on both backends
- [x] Artifact validator: Docker 1/1 healthy and Daytona 1/1 healthy, with complete ACP + provider trajectories and training-ready rows
