### PR TITLE
feat(sandbox): add Apptainer backend for HPC environments

### DIFF
--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1380,8 +1380,15 @@ class Rollout:
         self._session = None
         self._session_adapter = None
         self._is_session_factory = False
-        # Kill any lingering agent processes to prevent context bleed between scenes
-        agent_pattern = _agent_process_kill_pattern(self._agent_launch)
+        # Kill any lingering agent processes to prevent context bleed between scenes.
+        # Oracle solve.sh is awaited synchronously and has no live agent process;
+        # treating its registry label as a process pattern can match the host
+        # command line (``--agent oracle``) on runtimes without a PID namespace.
+        agent_pattern = (
+            None
+            if self._config.primary_agent == "oracle"
+            else _agent_process_kill_pattern(self._agent_launch)
+        )
         if self._env and agent_pattern:
             with contextlib.suppress(Exception):
                 await self._env.exec(

--- a/src/benchflow/sandbox/apptainer.py
+++ b/src/benchflow/sandbox/apptainer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
+import json
 import os
 import re
 import shlex
@@ -143,59 +143,59 @@ class ApptainerSandbox(BaseSandbox):
         runtime_dir = Path(tempfile.mkdtemp(prefix="benchflow-apptainer-"))
         staging_dir = runtime_dir / "staging"
         overlay_path = runtime_dir / "overlay.img"
-        staging_dir.mkdir()
-        self.rollout_paths.mkdir()
-        os.chmod(self.rollout_paths.rollout_dir, 0o777)
-        for directory in (
-            self.rollout_paths.agent_dir,
-            self.rollout_paths.verifier_dir,
-            self.rollout_paths.artifacts_dir,
-        ):
-            os.chmod(directory, 0o777)
-
+        # Register partial state before fallible setup so cleanup can reclaim it.
         self._runtime_dir = runtime_dir
         self._staging_dir = staging_dir
         self._overlay_path = overlay_path
-        self._instance_name = _safe_instance_name(
-            self.environment_name, self.session_id
-        )
-        self._default_cwd = self.task_env_config.workdir or image.workdir
-
-        overlay = await _run_apptainer(
-            "overlay",
-            "create",
-            "--fakeroot",
-            "--size",
-            str(self.task_env_config.storage_mb),
-            "--sparse",
-            str(overlay_path),
-            timeout_sec=self.task_env_config.build_timeout_sec,
-        )
-        if overlay.return_code != 0:
-            await self._force_cleanup()
-            raise RuntimeError(
-                f"Could not create Apptainer overlay: {_failure(overlay)}"
-            )
-
-        args = [
-            "instance",
-            "start",
-            "--fakeroot",
-            "--overlay",
-            str(overlay_path),
-            "--containall",
-            "--no-home",
-            "--cleanenv",
-            "--bind",
-            f"{staging_dir}:{_STAGING_DIR}",
-            "--bind",
-            f"{self.rollout_paths.rollout_dir}:{SandboxPaths().logs_dir}",
-        ]
-        if self.task_env_config.network_mode is NetworkMode.NO_NETWORK:
-            args.extend(["--net", "--network", "none"])
-        args.extend([str(image.path), self._instance_name])
-
         try:
+            staging_dir.mkdir()
+            self.rollout_paths.mkdir()
+            os.chmod(self.rollout_paths.rollout_dir, 0o777)
+            for directory in (
+                self.rollout_paths.agent_dir,
+                self.rollout_paths.verifier_dir,
+                self.rollout_paths.artifacts_dir,
+            ):
+                os.chmod(directory, 0o777)
+
+            instance_name = _safe_instance_name(self.environment_name, self.session_id)
+            self._default_cwd = self.task_env_config.workdir or image.workdir
+
+            overlay = await _run_apptainer(
+                "overlay",
+                "create",
+                "--fakeroot",
+                "--size",
+                str(self.task_env_config.storage_mb),
+                "--sparse",
+                str(overlay_path),
+                timeout_sec=self.task_env_config.build_timeout_sec,
+            )
+            if overlay.return_code != 0:
+                raise RuntimeError(
+                    f"Could not create Apptainer overlay: {_failure(overlay)}"
+                )
+
+            args = [
+                "instance",
+                "start",
+                "--fakeroot",
+                "--overlay",
+                str(overlay_path),
+                "--containall",
+                "--no-home",
+                "--cleanenv",
+                "--bind",
+                f"{staging_dir}:{_STAGING_DIR}",
+                "--bind",
+                f"{self.rollout_paths.rollout_dir}:{SandboxPaths().logs_dir}",
+            ]
+            if self.task_env_config.network_mode is NetworkMode.NO_NETWORK:
+                args.extend(["--net", "--network", "none"])
+            args.extend([str(image.path), instance_name])
+
+            # A timed-out start may still leave an instance under this name.
+            self._instance_name = instance_name
             started = await _run_apptainer(*args, timeout_sec=_STARTUP_TIMEOUT)
             if started.return_code != 0:
                 raise RuntimeError(
@@ -210,13 +210,46 @@ class ApptainerSandbox(BaseSandbox):
             await self._force_cleanup()
             raise
 
+    async def _forced_stop(self, name: str) -> str | None:
+        """Force-stop *name*, returning a failure detail if it remains live."""
+        try:
+            forced = await _run_apptainer(
+                "instance", "stop", "--force", name, timeout_sec=_STOP_TIMEOUT
+            )
+        except TimeoutError:
+            detail = f"forced stop timed out after {_STOP_TIMEOUT}s"
+        except Exception as error:
+            detail = str(error)[:200]
+        else:
+            if forced.return_code == 0:
+                return None
+            detail = _failure(forced)
+
+        try:
+            listed = await _run_apptainer(
+                "instance", "list", "--json", name, timeout_sec=_STOP_TIMEOUT
+            )
+            instances = json.loads(listed.stdout or "").get("instances")
+            if listed.return_code == 0 and instances == []:
+                return None
+        except (AttributeError, TypeError, ValueError, OSError, TimeoutError):
+            pass
+        return detail
+
     async def _force_cleanup(self) -> None:
+        """Tear down after a failed start or timed-out command."""
         name = self._instance_name
         if name:
-            with contextlib.suppress(Exception):
-                await _run_apptainer(
-                    "instance", "stop", "--force", name, timeout_sec=_STOP_TIMEOUT
+            detail = await self._forced_stop(name)
+            if detail is not None:
+                self.logger.warning(
+                    "Could not force-stop Apptainer instance %s (%s); keeping "
+                    "%s for retry during teardown.",
+                    name,
+                    detail,
+                    self._runtime_dir,
                 )
+                return
         if self._runtime_dir:
             shutil.rmtree(self._runtime_dir, ignore_errors=True)
         self._instance_name = None
@@ -227,16 +260,19 @@ class ApptainerSandbox(BaseSandbox):
     async def stop(self, delete: bool) -> None:
         name = self._instance_name
         if name:
-            result = await _run_apptainer(
-                "instance", "stop", name, timeout_sec=_STOP_TIMEOUT
-            )
-            if result.return_code != 0:
-                forced = await _run_apptainer(
-                    "instance", "stop", "--force", name, timeout_sec=_STOP_TIMEOUT
+            try:
+                result = await _run_apptainer(
+                    "instance", "stop", name, timeout_sec=_STOP_TIMEOUT
                 )
-                if forced.return_code != 0:
+                detail = None if result.return_code == 0 else _failure(result)
+            except TimeoutError:
+                detail = f"graceful stop timed out after {_STOP_TIMEOUT}s"
+            if detail is not None:
+                forced = await self._forced_stop(name)
+                if forced is not None:
                     raise RuntimeError(
-                        f"Could not stop Apptainer instance: {_failure(forced)}"
+                        f"Could not stop Apptainer instance {name}: {forced} "
+                        f"(graceful stop: {detail})"
                     )
         self._instance_name = None
         if delete and self._runtime_dir:

--- a/src/benchflow/sandbox/apptainer.py
+++ b/src/benchflow/sandbox/apptainer.py
@@ -1,0 +1,411 @@
+"""Local Apptainer sandbox backend."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path, PurePosixPath
+from typing import TYPE_CHECKING
+
+from benchflow.sandbox._base import BaseSandbox, ExecResult, wrap_command_with_env_file
+from benchflow.sandbox.apptainer_image import (
+    ApptainerImageBuilder,
+    require_apptainer,
+)
+from benchflow.task.config import NetworkMode
+from benchflow.task.paths import SandboxPaths
+
+if TYPE_CHECKING:
+    from benchflow.sandbox.process import LiveProcess
+
+_STARTUP_TIMEOUT = 60
+_STOP_TIMEOUT = 30
+_STAGING_DIR = PurePosixPath("/benchflow/staging")
+
+
+def _safe_instance_name(environment_name: str, session_id: str) -> str:
+    value = re.sub(r"[^a-zA-Z0-9_.-]+", "-", f"bf-{environment_name}-{session_id}")
+    return f"{value[:96].strip('-')}-{uuid.uuid4().hex[:8]}"
+
+
+async def _run_apptainer(*args: str, timeout_sec: float | None = None) -> ExecResult:
+    process = await asyncio.create_subprocess_exec(
+        "apptainer",
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(
+            process.communicate(), timeout=timeout_sec
+        )
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise
+    return ExecResult(
+        stdout=stdout.decode(errors="replace"),
+        stderr=stderr.decode(errors="replace"),
+        return_code=process.returncode or 0,
+    )
+
+
+def _failure(result: ExecResult) -> str:
+    return (result.stderr or result.stdout or "").strip()[-2000:]
+
+
+class ApptainerSandbox(BaseSandbox):
+    """A writable per-rollout Apptainer instance backed by a cached SIF."""
+
+    def __init__(
+        self, *args, image_builder: ApptainerImageBuilder | None = None, **kwargs
+    ):
+        self._instance_name: str | None = None
+        self._runtime_dir: Path | None = None
+        self._staging_dir: Path | None = None
+        self._overlay_path: Path | None = None
+        self._default_cwd: str | None = None
+        self._image_builder = image_builder
+        super().__init__(*args, **kwargs)
+
+    def _validate_definition(self) -> None:
+        image = self.task_env_config.docker_image
+        dockerfile = self.environment_dir / "Dockerfile"
+        if image:
+            path = Path(image).expanduser()
+            if path.suffix != ".sif":
+                raise ValueError(
+                    "Apptainer sandbox image must point to a local .sif file"
+                )
+        elif not dockerfile.is_file():
+            raise FileNotFoundError(
+                f"Apptainer requires {dockerfile} or sandbox.docker_image=<file.sif>"
+            )
+
+    @classmethod
+    def preflight(cls) -> None:
+        executable = require_apptainer()
+        result = subprocess.run(
+            [executable, "version"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Apptainer preflight failed: {result.stderr.strip()}")
+
+    @property
+    def sandbox_id(self) -> str | None:
+        return self._instance_name
+
+    @property
+    def is_mounted(self) -> bool:
+        return True
+
+    def _require_started(self) -> tuple[str, Path]:
+        if not self._instance_name or not self._staging_dir:
+            raise RuntimeError("Apptainer sandbox not started")
+        return self._instance_name, self._staging_dir
+
+    def _mounted_host_path(self, sandbox_path: str) -> Path | None:
+        if self.rollout_paths is None:
+            return None
+        path = PurePosixPath(sandbox_path)
+        try:
+            relative = path.relative_to(SandboxPaths().logs_dir)
+        except ValueError:
+            return None
+        if ".." in relative.parts:
+            return None
+        return self.rollout_paths.rollout_dir.joinpath(*relative.parts)
+
+    async def start(self, force_build: bool) -> None:
+        if self._instance_name:
+            return
+        if self.rollout_paths is None:
+            raise RuntimeError("Apptainer sandbox requires rollout paths")
+        builder = self._image_builder or ApptainerImageBuilder(
+            timeout_sec=self.task_env_config.build_timeout_sec
+        )
+        image = await builder.resolve(
+            dockerfile=self.environment_dir / "Dockerfile",
+            context_dir=self.environment_dir,
+            prebuilt=self.task_env_config.docker_image,
+            force_build=force_build,
+        )
+        runtime_dir = Path(tempfile.mkdtemp(prefix="benchflow-apptainer-"))
+        staging_dir = runtime_dir / "staging"
+        overlay_path = runtime_dir / "overlay.img"
+        staging_dir.mkdir()
+        self.rollout_paths.mkdir()
+        os.chmod(self.rollout_paths.rollout_dir, 0o777)
+        for directory in (
+            self.rollout_paths.agent_dir,
+            self.rollout_paths.verifier_dir,
+            self.rollout_paths.artifacts_dir,
+        ):
+            os.chmod(directory, 0o777)
+
+        self._runtime_dir = runtime_dir
+        self._staging_dir = staging_dir
+        self._overlay_path = overlay_path
+        self._instance_name = _safe_instance_name(
+            self.environment_name, self.session_id
+        )
+        self._default_cwd = self.task_env_config.workdir or image.workdir
+
+        overlay = await _run_apptainer(
+            "overlay",
+            "create",
+            "--fakeroot",
+            "--size",
+            str(self.task_env_config.storage_mb),
+            "--sparse",
+            str(overlay_path),
+            timeout_sec=self.task_env_config.build_timeout_sec,
+        )
+        if overlay.return_code != 0:
+            await self._force_cleanup()
+            raise RuntimeError(
+                f"Could not create Apptainer overlay: {_failure(overlay)}"
+            )
+
+        args = [
+            "instance",
+            "start",
+            "--fakeroot",
+            "--overlay",
+            str(overlay_path),
+            "--containall",
+            "--no-home",
+            "--cleanenv",
+            "--bind",
+            f"{staging_dir}:{_STAGING_DIR}",
+            "--bind",
+            f"{self.rollout_paths.rollout_dir}:{SandboxPaths().logs_dir}",
+        ]
+        if self.task_env_config.network_mode is NetworkMode.NO_NETWORK:
+            args.extend(["--net", "--network", "none"])
+        args.extend([str(image.path), self._instance_name])
+
+        try:
+            started = await _run_apptainer(*args, timeout_sec=_STARTUP_TIMEOUT)
+            if started.return_code != 0:
+                raise RuntimeError(
+                    f"Could not start Apptainer instance: {_failure(started)}"
+                )
+            probe = await self.exec("true", timeout_sec=30, user="root")
+            if probe.return_code != 0:
+                raise RuntimeError(
+                    f"Apptainer instance readiness check failed: {_failure(probe)}"
+                )
+        except BaseException:
+            await self._force_cleanup()
+            raise
+
+    async def _force_cleanup(self) -> None:
+        name = self._instance_name
+        if name:
+            with contextlib.suppress(Exception):
+                await _run_apptainer(
+                    "instance", "stop", "--force", name, timeout_sec=_STOP_TIMEOUT
+                )
+        if self._runtime_dir:
+            shutil.rmtree(self._runtime_dir, ignore_errors=True)
+        self._instance_name = None
+        self._runtime_dir = None
+        self._staging_dir = None
+        self._overlay_path = None
+
+    async def stop(self, delete: bool) -> None:
+        name = self._instance_name
+        if name:
+            result = await _run_apptainer(
+                "instance", "stop", name, timeout_sec=_STOP_TIMEOUT
+            )
+            if result.return_code != 0:
+                forced = await _run_apptainer(
+                    "instance", "stop", "--force", name, timeout_sec=_STOP_TIMEOUT
+                )
+                if forced.return_code != 0:
+                    raise RuntimeError(
+                        f"Could not stop Apptainer instance: {_failure(forced)}"
+                    )
+        self._instance_name = None
+        if delete and self._runtime_dir:
+            shutil.rmtree(self._runtime_dir)
+            self._runtime_dir = None
+            self._staging_dir = None
+            self._overlay_path = None
+
+    async def exec(
+        self,
+        command: str,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        timeout_sec: int | None = None,
+        user: str | int | None = None,
+        service: str = "main",
+    ) -> ExecResult:
+        if service != "main":
+            raise ValueError("apptainer is single-container; service must be 'main'")
+        name, _ = self._require_started()
+        merged = self._merge_env(env)
+        wrapped = (
+            wrap_command_with_env_file(
+                merged,
+                command,
+                env_path_prefix="/tmp/.benchflow_exec_env_",
+            )
+            if merged
+            else command
+        )
+        resolved_user = self._resolve_user(user)
+        if resolved_user not in {None, "root", 0, "0"}:
+            wrapped = (
+                f"exec su -s /bin/sh {shlex.quote(str(resolved_user))} "
+                f"-c {shlex.quote(wrapped)}"
+            )
+        args = ["exec", "--cleanenv"]
+        effective_cwd = cwd or self._default_cwd
+        if effective_cwd:
+            args.extend(["--cwd", effective_cwd])
+        args.extend([f"instance://{name}", "sh", "-c", wrapped])
+        try:
+            return await _run_apptainer(*args, timeout_sec=timeout_sec)
+        except TimeoutError:
+            await self._force_cleanup()
+            raise RuntimeError(
+                f"Command timed out after {timeout_sec}s: {command[:100]}"
+            ) from None
+
+    def _staging_path(self) -> tuple[Path, PurePosixPath]:
+        _, staging = self._require_started()
+        name = uuid.uuid4().hex
+        return staging / name, _STAGING_DIR / name
+
+    async def upload_file(
+        self,
+        source_path: Path | str,
+        target_path: str,
+        *,
+        mode: str | None = None,
+    ) -> None:
+        source = Path(source_path)
+        host_target = self._mounted_host_path(target_path)
+        if host_target is not None:
+            host_target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, host_target)
+            if mode is not None:
+                host_target.chmod(int(mode, 8))
+            return
+        host_stage, sandbox_stage = self._staging_path()
+        shutil.copy2(source, host_stage)
+        try:
+            target = PurePosixPath(target_path)
+            result = await self.exec(
+                f"mkdir -p {shlex.quote(str(target.parent))} && "
+                f"cp -p {shlex.quote(str(sandbox_stage))} {shlex.quote(str(target))}",
+                user="root",
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"upload_file failed: {_failure(result)}")
+            await self._apply_upload_mode(target_path, mode)
+        finally:
+            host_stage.unlink(missing_ok=True)
+
+    async def upload_dir(
+        self,
+        source_dir: Path | str,
+        target_dir: str,
+        service: str = "main",
+    ) -> None:
+        if service != "main":
+            raise ValueError("apptainer is single-container; service must be 'main'")
+        source = Path(source_dir)
+        if not source.is_dir():
+            raise FileNotFoundError(f"Source directory {source} does not exist")
+        host_target = self._mounted_host_path(target_dir)
+        if host_target is not None:
+            if host_target.exists():
+                shutil.rmtree(host_target)
+            shutil.copytree(source, host_target)
+            return
+        host_stage, sandbox_stage = self._staging_path()
+        shutil.copytree(source, host_stage)
+        try:
+            result = await self.exec(
+                f"mkdir -p {shlex.quote(target_dir)} && "
+                f"cp -a {shlex.quote(str(sandbox_stage))}/. {shlex.quote(target_dir)}/",
+                user="root",
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"upload_dir failed: {_failure(result)}")
+        finally:
+            shutil.rmtree(host_stage, ignore_errors=True)
+
+    async def download_file(self, source_path: str, target_path: Path | str) -> None:
+        target = Path(target_path)
+        host_source = self._mounted_host_path(source_path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if host_source is not None:
+            shutil.copy2(host_source, target)
+            return
+        host_stage, sandbox_stage = self._staging_path()
+        try:
+            result = await self.exec(
+                f"cp -p {shlex.quote(source_path)} {shlex.quote(str(sandbox_stage))}",
+                user="root",
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"download_file failed: {_failure(result)}")
+            shutil.copy2(host_stage, target)
+        finally:
+            host_stage.unlink(missing_ok=True)
+
+    async def download_dir(
+        self,
+        source_dir: str,
+        target_dir: Path | str,
+        service: str = "main",
+    ) -> None:
+        if service != "main":
+            raise ValueError("apptainer is single-container; service must be 'main'")
+        target = Path(target_dir)
+        host_source = self._mounted_host_path(source_dir)
+        if target.exists():
+            shutil.rmtree(target)
+        if host_source is not None:
+            shutil.copytree(host_source, target)
+            return
+        host_stage, sandbox_stage = self._staging_path()
+        host_stage.mkdir()
+        try:
+            result = await self.exec(
+                f"cp -a {shlex.quote(source_dir)}/. {shlex.quote(str(sandbox_stage))}/",
+                user="root",
+            )
+            if result.return_code != 0:
+                raise RuntimeError(f"download_dir failed: {_failure(result)}")
+            shutil.copytree(host_stage, target)
+        finally:
+            shutil.rmtree(host_stage, ignore_errors=True)
+
+    async def attach(self) -> None:
+        name, _ = self._require_started()
+        process = await asyncio.create_subprocess_exec(
+            "apptainer", "shell", f"instance://{name}"
+        )
+        await process.wait()
+
+    async def live_process(self, *, agent: str | None = None) -> LiveProcess:
+        from benchflow.sandbox.process import ApptainerProcess
+
+        return ApptainerProcess.from_sandbox_env(self)

--- a/src/benchflow/sandbox/apptainer_image.py
+++ b/src/benchflow/sandbox/apptainer_image.py
@@ -37,7 +37,10 @@ def _cache_root() -> Path:
 
 
 def _context_digest(config: ImageConfig) -> str:
-    """Hash the staged build context without following symlinks."""
+    """Hash the staged build context without following symlinks.
+
+    Symlinks contribute their link text, not the contents of their targets.
+    """
 
     digest = hashlib.sha256()
     dockerfile = config.dockerfile.resolve()
@@ -45,11 +48,11 @@ def _context_digest(config: ImageConfig) -> str:
     digest.update(dockerfile.relative_to(context).as_posix().encode())
     digest.update(json.dumps(config.build_args or {}, sort_keys=True).encode())
     for path in sorted(context.rglob("*")):
-        if path.is_symlink():
-            continue
         relative = path.relative_to(context).as_posix()
         mode = path.stat(follow_symlinks=False).st_mode
-        if stat.S_ISDIR(mode):
+        if stat.S_ISLNK(mode):
+            digest.update(f"l:{relative}:{os.readlink(path)}\0".encode())
+        elif stat.S_ISDIR(mode):
             digest.update(f"d:{relative}\0".encode())
         elif stat.S_ISREG(mode):
             digest.update(f"f:{relative}:{stat.S_IMODE(mode):o}\0".encode())
@@ -95,8 +98,10 @@ def dockerfile_workdir(
             )
             if expanded.startswith("/"):
                 workdir = expanded
-            elif workdir:
-                workdir = str(Path(workdir) / expanded)
+            else:
+                # SIF does not retain a base image's WORKDIR. Root is the only
+                # deterministic fallback for a leading relative instruction.
+                workdir = str(Path(workdir or "/") / expanded)
     return workdir
 
 
@@ -191,12 +196,7 @@ class ApptainerImageBuilder:
                 )
             metadata = path.stat()
             digest = f"{metadata.st_size:x}-{metadata.st_mtime_ns:x}"
-            workdir = (
-                dockerfile_workdir(dockerfile, build_args)
-                if dockerfile.is_file()
-                else None
-            )
-            return ApptainerImage(path, digest, workdir)
+            return ApptainerImage(path, digest)
 
         config = ImageConfig(
             dockerfile=dockerfile,

--- a/src/benchflow/sandbox/apptainer_image.py
+++ b/src/benchflow/sandbox/apptainer_image.py
@@ -1,0 +1,223 @@
+"""Content-addressed Apptainer images built from task Dockerfiles."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchflow.sandbox.protocol import ImageConfig, ImageRef
+
+_BUILD_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+@dataclass(frozen=True)
+class ApptainerImage:
+    """A local SIF and the image working directory used by ``exec``."""
+
+    path: Path
+    digest: str
+    workdir: str | None = None
+
+
+def _cache_root() -> Path:
+    configured = os.environ.get("BENCHFLOW_APPTAINER_CACHE_DIR")
+    return (
+        Path(configured).expanduser()
+        if configured
+        else Path.home() / ".cache" / "benchflow" / "apptainer"
+    )
+
+
+def _context_digest(config: ImageConfig) -> str:
+    """Hash the staged build context without following symlinks."""
+
+    digest = hashlib.sha256()
+    dockerfile = config.dockerfile.resolve()
+    context = config.context_dir.resolve()
+    digest.update(dockerfile.relative_to(context).as_posix().encode())
+    digest.update(json.dumps(config.build_args or {}, sort_keys=True).encode())
+    for path in sorted(context.rglob("*")):
+        if path.is_symlink():
+            continue
+        relative = path.relative_to(context).as_posix()
+        mode = path.stat(follow_symlinks=False).st_mode
+        if stat.S_ISDIR(mode):
+            digest.update(f"d:{relative}\0".encode())
+        elif stat.S_ISREG(mode):
+            digest.update(f"f:{relative}:{stat.S_IMODE(mode):o}\0".encode())
+            with path.open("rb") as handle:
+                while chunk := handle.read(1024 * 1024):
+                    digest.update(chunk)
+    return digest.hexdigest()
+
+
+_VARIABLE_RE = re.compile(
+    r"\$(?:\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)\}|(?P<plain>[A-Za-z_][A-Za-z0-9_]*))"
+)
+
+
+def dockerfile_workdir(
+    dockerfile: Path, build_args: dict[str, str] | None = None
+) -> str | None:
+    """Return the final stage's WORKDIR for ordinary Dockerfiles."""
+
+    values = dict(build_args or {})
+    workdir: str | None = None
+    for raw in dockerfile.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        instruction, _, value = line.partition(" ")
+        instruction = instruction.upper()
+        value = value.strip()
+        if instruction == "FROM":
+            workdir = None
+        elif instruction in {"ARG", "ENV"}:
+            assignments = value.split() if instruction == "ENV" else [value]
+            for assignment in assignments:
+                key, separator, item = assignment.partition("=")
+                if separator:
+                    values.setdefault(key, item)
+        elif instruction == "WORKDIR" and value:
+            expanded = _VARIABLE_RE.sub(
+                lambda match: values.get(
+                    match.group("braced") or match.group("plain"), match.group(0)
+                ),
+                value,
+            )
+            if expanded.startswith("/"):
+                workdir = expanded
+            elif workdir:
+                workdir = str(Path(workdir) / expanded)
+    return workdir
+
+
+async def _run(*args: str, timeout_sec: float) -> tuple[str, str]:
+    process = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout, stderr = await asyncio.wait_for(process.communicate(), timeout_sec)
+    except TimeoutError:
+        process.kill()
+        await process.wait()
+        raise RuntimeError(f"Apptainer command timed out: {args[1]}") from None
+    out = stdout.decode(errors="replace")
+    err = stderr.decode(errors="replace")
+    if process.returncode != 0:
+        detail = (err or out).strip()[-2000:]
+        raise RuntimeError(f"Apptainer command failed ({process.returncode}): {detail}")
+    return out, err
+
+
+class ApptainerImageBuilder:
+    """Build Dockerfile contexts into immutable, content-addressed SIFs."""
+
+    def __init__(self, cache_dir: Path | None = None, timeout_sec: float = 600) -> None:
+        self.cache_dir = (cache_dir or _cache_root()).resolve()
+        self.timeout_sec = timeout_sec
+
+    def _image_ref(self, config: ImageConfig) -> ImageRef:
+        digest = config.cache_key or _context_digest(config)
+        return ImageRef(str(self.cache_dir / f"{digest}.sif"), digest)
+
+    async def cached(self, config: ImageConfig) -> ImageRef | None:
+        image = self._image_ref(config)
+        return image if Path(image.tag).is_file() else None
+
+    async def build(self, config: ImageConfig) -> ImageRef:
+        if config.build_args:
+            raise ValueError(
+                "Apptainer BuildKit image builds do not accept Docker build arguments"
+            )
+        image = self._image_ref(config)
+        target = Path(image.tag)
+        if target.is_file():
+            return image
+        lock = _BUILD_LOCKS.setdefault(str(target), asyncio.Lock())
+        async with lock:
+            if target.is_file():
+                return image
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                dir=target.parent,
+                prefix=f".{target.stem}-",
+                suffix=".sif",
+                delete=False,
+            ) as handle:
+                temporary = Path(handle.name)
+            temporary.unlink()
+            args = ["apptainer", "build"]
+            buildkit_host = (
+                os.environ.get("BENCHFLOW_APPTAINER_BUILDKIT_HOST")
+                or os.environ.get("APPTAINER_BUILDKIT_HOST")
+                or os.environ.get("BUILDKIT_HOST")
+            )
+            if buildkit_host:
+                args.extend(["--buildkit-host", buildkit_host])
+            args.extend([str(temporary), f"buildkit:{config.context_dir.resolve()}"])
+            try:
+                await _run(*args, timeout_sec=self.timeout_sec)
+                await _run("apptainer", "inspect", str(temporary), timeout_sec=30)
+                os.replace(temporary, target)
+            finally:
+                temporary.unlink(missing_ok=True)
+        return image
+
+    async def resolve(
+        self,
+        *,
+        dockerfile: Path,
+        context_dir: Path,
+        prebuilt: str | None,
+        build_args: dict[str, str] | None = None,
+        force_build: bool = False,
+    ) -> ApptainerImage:
+        if prebuilt and not force_build:
+            path = Path(prebuilt).expanduser().resolve()
+            if path.suffix != ".sif" or not path.is_file():
+                raise ValueError(
+                    "Apptainer sandbox image must be an existing local .sif file"
+                )
+            metadata = path.stat()
+            digest = f"{metadata.st_size:x}-{metadata.st_mtime_ns:x}"
+            workdir = (
+                dockerfile_workdir(dockerfile, build_args)
+                if dockerfile.is_file()
+                else None
+            )
+            return ApptainerImage(path, digest, workdir)
+
+        config = ImageConfig(
+            dockerfile=dockerfile,
+            context_dir=context_dir,
+            build_args=build_args,
+        )
+        if force_build:
+            cached = self._image_ref(config)
+            Path(cached.tag).unlink(missing_ok=True)
+        image = await self.build(config)
+        return ApptainerImage(
+            Path(image.tag),
+            image.digest or "",
+            dockerfile_workdir(dockerfile, build_args),
+        )
+
+
+def require_apptainer() -> str:
+    """Return the Apptainer executable or raise an actionable error."""
+
+    executable = shutil.which("apptainer")
+    if not executable:
+        raise RuntimeError("Apptainer executable not found on PATH")
+    return executable

--- a/src/benchflow/sandbox/process/__init__.py
+++ b/src/benchflow/sandbox/process/__init__.py
@@ -4,6 +4,7 @@ Provides a bidirectional pipe (send lines in, read lines out) needed for
 ACP agents running inside containers. Implementations:
 
 - DockerProcess:         `docker compose exec -i` (local Docker)
+- ApptainerProcess:      `apptainer exec` (local Apptainer instance)
 - AppleContainerProcess: `container exec -i` (Apple Container)
 - DaytonaProcess:        SSH to a Daytona sandbox
 - DaytonaPtyProcess:     Daytona PTY WebSocket
@@ -24,11 +25,13 @@ from benchflow.sandbox.process._base import (
 )
 from benchflow.sandbox.process.agentcore import AgentCoreProcess
 from benchflow.sandbox.process.apple import AppleContainerProcess
+from benchflow.sandbox.process.apptainer import ApptainerProcess
 from benchflow.sandbox.process.daytona import DaytonaProcess, DaytonaPtyProcess
 from benchflow.sandbox.process.docker import DockerProcess
 
 __all__ = [
     "AgentCoreProcess",
+    "ApptainerProcess",
     "AppleContainerProcess",
     "DaytonaProcess",
     "DaytonaPtyProcess",

--- a/src/benchflow/sandbox/process/apptainer.py
+++ b/src/benchflow/sandbox/process/apptainer.py
@@ -1,0 +1,93 @@
+"""Live stdio through an Apptainer instance."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shlex
+import uuid
+from typing import Any
+
+from benchflow.sandbox.process._base import (
+    _BUFFER_LIMIT,
+    _ENV_KEY_RE,
+    SubprocessLiveProcess,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ApptainerProcess(SubprocessLiveProcess):
+    """Bidirectional process transport backed by ``apptainer exec``."""
+
+    def __init__(self, instance_name: str, default_cwd: str | None = None):
+        self._instance_name = instance_name
+        self._default_cwd = default_cwd
+        self._env_path = f"/tmp/.benchflow_agent_env_{uuid.uuid4().hex[:16]}"
+
+    @classmethod
+    def from_sandbox_env(cls, env: Any) -> ApptainerProcess:
+        name = getattr(env, "_instance_name", None)
+        if not isinstance(name, str) or not name:
+            raise RuntimeError("Apptainer sandbox not started")
+        return cls(name, getattr(env, "_default_cwd", None))
+
+    async def _write_env(self, env: dict[str, str]) -> None:
+        invalid = [key for key in env if not _ENV_KEY_RE.match(key)]
+        if invalid:
+            raise ValueError(
+                "Invalid environment variable name(s): " + ", ".join(sorted(invalid))
+            )
+        body = "".join(
+            f"export {key}={shlex.quote(value)}\n" for key, value in env.items()
+        )
+        process = await asyncio.create_subprocess_exec(
+            "apptainer",
+            "exec",
+            "--cleanenv",
+            f"instance://{self._instance_name}",
+            "sh",
+            "-c",
+            f"cat > {shlex.quote(self._env_path)} && "
+            f"chmod 600 {shlex.quote(self._env_path)}",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(
+            process.communicate(body.encode()), timeout=30
+        )
+        if process.returncode != 0:
+            raise RuntimeError(
+                "Failed to stage Apptainer process environment: "
+                + stderr.decode(errors="replace")[:500]
+            )
+
+    async def start(
+        self,
+        command: str,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        if env:
+            await self._write_env(env)
+            env_path = shlex.quote(self._env_path)
+            command = f". {env_path} && rm -f {env_path} && {command}"
+        args = ["apptainer", "exec", "--cleanenv"]
+        effective_cwd = cwd or self._default_cwd
+        if effective_cwd:
+            args.extend(["--cwd", effective_cwd])
+        args.extend([f"instance://{self._instance_name}", "sh", "-c", command])
+        process = await asyncio.create_subprocess_exec(
+            *args,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            limit=_BUFFER_LIMIT,
+        )
+        self._set_process(process)
+        logger.info(
+            "Apptainer process started (pid=%s, instance=%s)",
+            process.pid,
+            self._instance_name,
+        )

--- a/src/benchflow/sandbox/providers.py
+++ b/src/benchflow/sandbox/providers.py
@@ -61,6 +61,11 @@ _PROVIDERS: tuple[SandboxProvider, ...] = (
         supports_compose=True,
     ),
     SandboxProvider(
+        "apptainer",
+        extra=None,
+        model_proxy=ModelProxyLocation.HOST,
+    ),
+    SandboxProvider(
         "daytona",
         extra="sandbox-daytona",
         model_proxy=ModelProxyLocation.SANDBOX,

--- a/src/benchflow/sandbox/setup.py
+++ b/src/benchflow/sandbox/setup.py
@@ -659,7 +659,7 @@ def _create_sandbox_environment(
     preserve_agent_network: bool = False,
     environment_manifest: Any = None,
 ) -> Any:
-    """Create a sandbox environment (Docker, Daytona, or Modal).
+    """Create a sandbox environment for the selected provider.
 
     When ``environment_manifest`` is provided, its declared controls take
     effect at sandbox-construction time: the manifest's runnable ``image``
@@ -709,6 +709,18 @@ def _create_sandbox_environment(
         from benchflow.sandbox.docker import DockerSandbox
 
         return DockerSandbox(
+            environment_dir=environment_dir,
+            environment_name=task_path.name,
+            session_id=rollout_name,
+            rollout_paths=rollout_paths,
+            task_env_config=env_config,
+            persistent_env=manifest_env or None,
+        )
+    elif sandbox_type == "apptainer":
+        from benchflow.sandbox.apptainer import ApptainerSandbox
+
+        ApptainerSandbox.preflight()
+        return ApptainerSandbox(
             environment_dir=environment_dir,
             environment_name=task_path.name,
             session_id=rollout_name,

--- a/tests/test_apptainer_image.py
+++ b/tests/test_apptainer_image.py
@@ -1,6 +1,7 @@
 """Unit tests for Dockerfile-to-SIF image construction."""
 
 import asyncio
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -8,6 +9,7 @@ import pytest
 
 from benchflow.sandbox.apptainer_image import (
     ApptainerImageBuilder,
+    _context_digest,
     dockerfile_workdir,
 )
 from benchflow.sandbox.protocol import ImageConfig
@@ -110,8 +112,10 @@ async def test_builder_rejects_unsupported_docker_build_arguments(
 
 
 @pytest.mark.asyncio
-async def test_prebuilt_sif_keeps_task_dockerfile_workdir(tmp_path: Path) -> None:
-    """Use the task's Docker WORKDIR when executing a prebuilt SIF."""
+async def test_prebuilt_sif_does_not_inherit_task_dockerfile_workdir(
+    tmp_path: Path,
+) -> None:
+    """Guard PR #1073: a selected SIF is independent of the task Dockerfile."""
     config = _context(tmp_path, "FROM ubuntu:24.04\nWORKDIR /root\n")
     image = tmp_path / "task.sif"
     image.write_bytes(b"sif")
@@ -124,4 +128,30 @@ async def test_prebuilt_sif_keeps_task_dockerfile_workdir(tmp_path: Path) -> Non
     )
 
     assert resolved.path == image
-    assert resolved.workdir == "/root"
+    assert resolved.workdir is None
+
+
+def test_symlink_target_change_invalidates_the_cache_key(tmp_path: Path) -> None:
+    """Guard PR #1073: re-pointing a context symlink invalidates its SIF."""
+    config = _context(tmp_path)
+    before = _context_digest(config)
+
+    link = config.context_dir / "link"
+    os.symlink("first-target", link)
+    added = _context_digest(config)
+
+    link.unlink()
+    os.symlink("second-target", link)
+    repointed = _context_digest(config)
+
+    assert before != added
+    assert added != repointed
+
+
+def test_dockerfile_workdir_resolves_a_leading_relative_workdir(
+    tmp_path: Path,
+) -> None:
+    """Guard PR #1073: retain a leading relative WORKDIR deterministically."""
+    config = _context(tmp_path, "FROM ubuntu:24.04\nWORKDIR app\nWORKDIR src\n")
+
+    assert dockerfile_workdir(config.dockerfile) == "/app/src"

--- a/tests/test_apptainer_image.py
+++ b/tests/test_apptainer_image.py
@@ -1,0 +1,127 @@
+"""Unit tests for Dockerfile-to-SIF image construction."""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from benchflow.sandbox.apptainer_image import (
+    ApptainerImageBuilder,
+    dockerfile_workdir,
+)
+from benchflow.sandbox.protocol import ImageConfig
+
+
+def _context(tmp_path: Path, dockerfile: str = "FROM ubuntu:24.04\n") -> ImageConfig:
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    path = environment / "Dockerfile"
+    path.write_text(dockerfile)
+    return ImageConfig(dockerfile=path, context_dir=environment)
+
+
+def test_dockerfile_workdir_uses_final_stage_and_build_args(tmp_path: Path) -> None:
+    """Preserve the final Docker stage's WORKDIR for command execution."""
+    config = _context(
+        tmp_path,
+        "FROM ubuntu AS build\n"
+        "WORKDIR /build\n"
+        "FROM ubuntu\n"
+        "ARG ROOT=/workspace\n"
+        "WORKDIR $ROOT\n"
+        "WORKDIR task\n",
+    )
+
+    assert dockerfile_workdir(config.dockerfile) == "/workspace/task"
+
+
+@pytest.mark.asyncio
+async def test_builder_uses_content_addressed_cache(tmp_path: Path) -> None:
+    """Reuse the cached SIF when the build context is unchanged."""
+    config = _context(tmp_path)
+    builder = ApptainerImageBuilder(cache_dir=tmp_path / "cache")
+
+    async def fake_run(*args: str, timeout_sec: float):
+        if args[1] == "build":
+            Path(args[-2]).write_bytes(b"sif")
+        return "", ""
+
+    with patch(
+        "benchflow.sandbox.apptainer_image._run",
+        new=AsyncMock(side_effect=fake_run),
+    ) as run:
+        first = await builder.build(config)
+        second = await builder.build(config)
+
+    assert first == second
+    assert Path(first.tag).read_bytes() == b"sif"
+    assert run.await_count == 2
+    build_args = run.await_args_list[0].args
+    assert build_args[:2] == ("apptainer", "build")
+    assert build_args[-1] == f"buildkit:{config.context_dir.resolve()}"
+
+
+@pytest.mark.asyncio
+async def test_context_change_produces_a_new_cache_key(tmp_path: Path) -> None:
+    """Invalidate the cached image when the build context changes."""
+    config = _context(tmp_path)
+    builder = ApptainerImageBuilder(cache_dir=tmp_path / "cache")
+
+    before = builder._image_ref(config)
+    (config.context_dir / "input.txt").write_text("changed")
+    after = builder._image_ref(config)
+
+    assert before.digest != after.digest
+
+
+@pytest.mark.asyncio
+async def test_concurrent_builds_share_one_buildkit_invocation(tmp_path: Path) -> None:
+    """Share one image build across concurrent rollouts."""
+    config = _context(tmp_path)
+    builder = ApptainerImageBuilder(cache_dir=tmp_path / "cache")
+
+    async def fake_run(*args: str, timeout_sec: float):
+        if args[1] == "build":
+            Path(args[-2]).write_bytes(b"sif")
+        return "", ""
+
+    with patch(
+        "benchflow.sandbox.apptainer_image._run",
+        new=AsyncMock(side_effect=fake_run),
+    ) as run:
+        await asyncio.gather(builder.build(config), builder.build(config))
+
+    build_calls = [call for call in run.await_args_list if call.args[1] == "build"]
+    assert len(build_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_builder_rejects_unsupported_docker_build_arguments(
+    tmp_path: Path,
+) -> None:
+    """Reject unsupported build arguments instead of silently ignoring them."""
+    config = _context(tmp_path)
+    config.build_args = {"VERSION": "1"}
+    builder = ApptainerImageBuilder(cache_dir=tmp_path / "cache")
+
+    with pytest.raises(ValueError, match="build arguments"):
+        await builder.build(config)
+
+
+@pytest.mark.asyncio
+async def test_prebuilt_sif_keeps_task_dockerfile_workdir(tmp_path: Path) -> None:
+    """Use the task's Docker WORKDIR when executing a prebuilt SIF."""
+    config = _context(tmp_path, "FROM ubuntu:24.04\nWORKDIR /root\n")
+    image = tmp_path / "task.sif"
+    image.write_bytes(b"sif")
+    builder = ApptainerImageBuilder(cache_dir=tmp_path / "cache")
+
+    resolved = await builder.resolve(
+        dockerfile=config.dockerfile,
+        context_dir=config.context_dir,
+        prebuilt=str(image),
+    )
+
+    assert resolved.path == image
+    assert resolved.workdir == "/root"

--- a/tests/test_apptainer_sandbox.py
+++ b/tests/test_apptainer_sandbox.py
@@ -1,5 +1,7 @@
 """Contract tests for the local Apptainer sandbox provider."""
 
+import asyncio
+import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -169,3 +171,122 @@ async def test_live_process_stages_env_without_exposing_values_in_argv() -> None
     assert exec_args[5] == "instance://bf-task"
     assert ". /tmp/.benchflow_agent_env_" in exec_args[-1]
     assert "rm -f /tmp/.benchflow_agent_env_" in exec_args[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "error_type", [TimeoutError, asyncio.CancelledError], ids=["timeout", "cancelled"]
+)
+async def test_overlay_creation_interruption_removes_the_runtime_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[BaseException],
+) -> None:
+    """Guard PR #1073: reclaim storage when overlay creation is interrupted."""
+    sandbox, _, _ = _sandbox(tmp_path)
+    runtime_root = tmp_path / "runtime-root"
+    runtime_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(runtime_root))
+
+    with (
+        patch(
+            "benchflow.sandbox.apptainer._run_apptainer",
+            new=AsyncMock(side_effect=error_type()),
+        ),
+        pytest.raises(error_type),
+    ):
+        await sandbox.start(force_build=False)
+
+    assert sandbox._runtime_dir is None
+    assert sandbox._instance_name is None
+    assert list(runtime_root.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_failed_start_without_an_instance_removes_runtime_storage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guard PR #1073: a failed start without an instance is fully cleaned."""
+    sandbox, _, _ = _sandbox(tmp_path)
+    runtime_root = tmp_path / "runtime-root"
+    runtime_root.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(runtime_root))
+    success = ExecResult(stdout="", stderr="", return_code=0)
+    failure = ExecResult(stdout="", stderr="start failed", return_code=1)
+    absent = ExecResult(stdout='{"instances": []}', stderr="", return_code=0)
+
+    with (
+        patch(
+            "benchflow.sandbox.apptainer._run_apptainer",
+            new=AsyncMock(side_effect=[success, failure, failure, absent]),
+        ),
+        pytest.raises(RuntimeError, match="Could not start Apptainer instance"),
+    ):
+        await sandbox.start(force_build=False)
+
+    assert sandbox._instance_name is None
+    assert sandbox._runtime_dir is None
+    assert list(runtime_root.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_graceful_stop_timeout_still_forces_the_instance_down(
+    tmp_path: Path,
+) -> None:
+    """Guard PR #1073: force-stop an instance after graceful-stop timeout."""
+    sandbox, _, _ = _sandbox(tmp_path)
+    sandbox._instance_name = "bf-task"
+    sandbox._runtime_dir = tmp_path / "runtime"
+    sandbox._runtime_dir.mkdir()
+    success = ExecResult(stdout="", stderr="", return_code=0)
+
+    with patch(
+        "benchflow.sandbox.apptainer._run_apptainer",
+        new=AsyncMock(side_effect=[TimeoutError(), success]),
+    ) as run:
+        await sandbox.stop(delete=True)
+
+    assert run.await_args_list[-1].args == (
+        "instance",
+        "stop",
+        "--force",
+        "bf-task",
+    )
+    assert sandbox._instance_name is None
+    assert sandbox._runtime_dir is None
+
+
+@pytest.mark.asyncio
+async def test_unstoppable_instance_keeps_its_overlay_for_retry(
+    tmp_path: Path,
+) -> None:
+    """Guard PR #1073: retain storage while an instance remains live."""
+    sandbox, _, _ = _sandbox(tmp_path)
+    sandbox._instance_name = "bf-task"
+    sandbox._runtime_dir = tmp_path / "runtime"
+    sandbox._runtime_dir.mkdir()
+    failure = ExecResult(stdout="", stderr="still running", return_code=1)
+    running = ExecResult(
+        stdout='{"instances": [{"instance": "bf-task"}]}',
+        stderr="",
+        return_code=0,
+    )
+
+    with patch(
+        "benchflow.sandbox.apptainer._run_apptainer",
+        new=AsyncMock(side_effect=[failure, running]),
+    ):
+        await sandbox._force_cleanup()
+
+    assert sandbox._instance_name == "bf-task"
+    assert sandbox._runtime_dir is not None
+    assert sandbox._runtime_dir.is_dir()
+
+    with (
+        patch(
+            "benchflow.sandbox.apptainer._run_apptainer",
+            new=AsyncMock(side_effect=[failure, failure, running]),
+        ),
+        pytest.raises(RuntimeError, match="Could not stop Apptainer instance"),
+    ):
+        await sandbox.stop(delete=True)

--- a/tests/test_apptainer_sandbox.py
+++ b/tests/test_apptainer_sandbox.py
@@ -1,0 +1,171 @@
+"""Contract tests for the local Apptainer sandbox provider."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from benchflow.sandbox._base import ExecResult
+from benchflow.sandbox.apptainer import ApptainerSandbox
+from benchflow.sandbox.apptainer_image import ApptainerImage
+from benchflow.sandbox.process.apptainer import ApptainerProcess
+from benchflow.task import RolloutPaths
+from benchflow.task.config import NetworkMode, SandboxConfig
+
+
+def _sandbox(tmp_path: Path, *, network_mode: NetworkMode = NetworkMode.PUBLIC):
+    environment = tmp_path / "environment"
+    environment.mkdir()
+    (environment / "Dockerfile").write_text("FROM ubuntu:24.04\nWORKDIR /workspace\n")
+    rollout_paths = RolloutPaths(tmp_path / "rollout")
+    builder = AsyncMock()
+    builder.resolve.return_value = ApptainerImage(
+        tmp_path / "image.sif", "digest", "/workspace"
+    )
+    sandbox = ApptainerSandbox(
+        environment_dir=environment,
+        environment_name="task",
+        session_id="trial",
+        rollout_paths=rollout_paths,
+        task_env_config=SandboxConfig(
+            network_mode=network_mode,
+            storage_mb=64,
+        ),
+        image_builder=builder,
+    )
+    return sandbox, builder, rollout_paths
+
+
+@pytest.mark.asyncio
+async def test_start_creates_overlay_mounts_logs_and_enforces_no_network(
+    tmp_path: Path,
+) -> None:
+    """Express rollout isolation and network policy in Apptainer arguments."""
+    sandbox, builder, rollout_paths = _sandbox(
+        tmp_path, network_mode=NetworkMode.NO_NETWORK
+    )
+    success = ExecResult(stdout="", stderr="", return_code=0)
+
+    with patch(
+        "benchflow.sandbox.apptainer._run_apptainer",
+        new=AsyncMock(return_value=success),
+    ) as run:
+        await sandbox.start(force_build=False)
+        calls = [call.args for call in run.await_args_list]
+        start = next(args for args in calls if args[:2] == ("instance", "start"))
+
+        assert "--fakeroot" in start
+        assert "--overlay" in start
+        assert "--sparse" in calls[0]
+        assert "--containall" in start
+        assert "--no-home" in start
+        assert start[start.index("--net") : start.index("--net") + 3] == (
+            "--net",
+            "--network",
+            "none",
+        )
+        assert f"{rollout_paths.rollout_dir}:/logs" in start
+        assert sandbox.sandbox_id
+        assert sandbox.is_mounted
+        builder.resolve.assert_awaited_once()
+
+        await sandbox.stop(delete=True)
+
+
+@pytest.mark.asyncio
+async def test_exec_uses_image_workdir_and_merges_persistent_env(
+    tmp_path: Path,
+) -> None:
+    """Preserve working-directory and environment semantics during execution."""
+    sandbox, _, _ = _sandbox(tmp_path)
+    sandbox._instance_name = "bf-task"
+    sandbox._staging_dir = tmp_path / "staging"
+    sandbox._staging_dir.mkdir()
+    sandbox._default_cwd = "/workspace"
+    sandbox._persistent_env = {"TOKEN": "secret"}
+    success = ExecResult(stdout="ok", stderr="", return_code=0)
+
+    with patch(
+        "benchflow.sandbox.apptainer._run_apptainer",
+        new=AsyncMock(return_value=success),
+    ) as run:
+        result = await sandbox.exec("pwd", env={"MODE": "test"})
+
+    assert result.stdout == "ok"
+    args = run.await_args.args
+    assert args[:3] == ("exec", "--cleanenv", "--cwd")
+    assert args[3] == "/workspace"
+    wrapped = args[-1]
+    assert "TOKEN" not in wrapped
+    assert "secret" not in wrapped
+    assert "base64 -d" in wrapped
+
+
+@pytest.mark.asyncio
+async def test_logs_are_transferred_through_the_host_mount(tmp_path: Path) -> None:
+    """Transfer mounted rollout artifacts without an extra container copy."""
+    sandbox, _, rollout_paths = _sandbox(tmp_path)
+    sandbox._instance_name = "bf-task"
+    sandbox._staging_dir = tmp_path / "staging"
+    sandbox._staging_dir.mkdir()
+    rollout_paths.mkdir()
+    source = tmp_path / "reward.txt"
+    source.write_text("1")
+
+    await sandbox.upload_file(source, "/logs/verifier/reward.txt", mode="600")
+    target = tmp_path / "downloaded.txt"
+    await sandbox.download_file("/logs/verifier/reward.txt", target)
+
+    assert target.read_text() == "1"
+    assert (rollout_paths.verifier_dir / "reward.txt").stat().st_mode & 0o777 == 0o600
+
+
+def test_preflight_requires_apptainer_cli() -> None:
+    """Fail preflight before a rollout when the Apptainer CLI is unavailable."""
+    with (
+        patch(
+            "benchflow.sandbox.apptainer.require_apptainer",
+            side_effect=RuntimeError("missing"),
+        ),
+        pytest.raises(RuntimeError, match="missing"),
+    ):
+        ApptainerSandbox.preflight()
+
+
+@pytest.mark.asyncio
+async def test_live_process_inherits_instance_and_workdir(tmp_path: Path) -> None:
+    """Use the Apptainer live-process transport for ACP agents."""
+    sandbox, _, _ = _sandbox(tmp_path)
+    sandbox._instance_name = "bf-task"
+    sandbox._staging_dir = tmp_path / "staging"
+    sandbox._staging_dir.mkdir()
+    sandbox._default_cwd = "/workspace"
+
+    process = await sandbox.live_process()
+
+    assert process._instance_name == "bf-task"
+    assert process._default_cwd == "/workspace"
+
+
+@pytest.mark.asyncio
+async def test_live_process_stages_env_without_exposing_values_in_argv() -> None:
+    """Stage ACP environment values without exposing them in process arguments."""
+    staged = MagicMock(returncode=0)
+    staged.communicate = AsyncMock(return_value=(b"", b""))
+    running = MagicMock(pid=123, stderr=None)
+
+    with patch(
+        "benchflow.sandbox.process.apptainer.asyncio.create_subprocess_exec",
+        new=AsyncMock(side_effect=[staged, running]),
+    ) as spawn:
+        process = ApptainerProcess("bf-task", "/workspace")
+        await process.start("agent --stdio", env={"TOKEN": "top secret"})
+
+    stage_args = spawn.await_args_list[0].args
+    exec_args = spawn.await_args_list[1].args
+    assert "top secret" not in " ".join(str(arg) for arg in stage_args + exec_args)
+    assert exec_args[:3] == ("apptainer", "exec", "--cleanenv")
+    assert exec_args[3:5] == ("--cwd", "/workspace")
+    assert exec_args[5] == "instance://bf-task"
+    assert ". /tmp/.benchflow_agent_env_" in exec_args[-1]
+    assert "rm -f /tmp/.benchflow_agent_env_" in exec_args[-1]

--- a/tests/test_cli_live_progress.py
+++ b/tests/test_cli_live_progress.py
@@ -480,6 +480,7 @@ def test_rollout_disconnect_does_not_rewind_a_terminal_phase():
 
     def _rollout(phase: str) -> SimpleNamespace:
         return SimpleNamespace(
+            _config=SimpleNamespace(primary_agent="opencode"),
             _phase=phase,
             _is_session_factory=False,
             _capture_partial_acp_trajectory=lambda: None,
@@ -501,6 +502,40 @@ def test_rollout_disconnect_does_not_rewind_a_terminal_phase():
         done = _rollout(terminal)
         asyncio.run(Rollout.disconnect(done))
         assert done._phase == terminal
+
+
+def test_rollout_disconnect_does_not_pkill_oracle_label():
+    import asyncio
+
+    from benchflow.rollout import Rollout
+
+    class RecordingEnv:
+        def __init__(self) -> None:
+            self.commands: list[str] = []
+
+        async def exec(self, command: str, **_kwargs) -> None:
+            self.commands.append(command)
+
+    env = RecordingEnv()
+    rollout = SimpleNamespace(
+        _config=SimpleNamespace(primary_agent="oracle"),
+        _phase="verified",
+        _is_session_factory=False,
+        _capture_partial_acp_trajectory=lambda: None,
+        _acp_client=None,
+        _session=None,
+        _session_adapter=None,
+        _agent_launch="oracle",
+        _env=env,
+        _active_role=None,
+        _session_tool_count=0,
+        _session_traj_count=0,
+    )
+
+    asyncio.run(Rollout.disconnect(rollout))
+
+    assert env.commands == []
+    assert rollout._phase == "verified"
 
 
 def test_progress_enabled_respects_tty_and_optout(monkeypatch):

--- a/tests/test_env_setup.py
+++ b/tests/test_env_setup.py
@@ -243,6 +243,31 @@ class TestDepLocalName:
 
 
 class TestCreateEnvironment:
+    def test_apptainer_preflights_and_constructs_environment(self, tmp_path):
+        """Construct the Apptainer backend through the environment factory."""
+        env_config = MagicMock()
+        rollout_paths = MagicMock()
+        task = SimpleNamespace(
+            paths=SimpleNamespace(environment_dir=tmp_path / "environment"),
+            config=SimpleNamespace(sandbox=env_config),
+        )
+
+        with patch("benchflow.sandbox.apptainer.ApptainerSandbox") as apptainer_env:
+            result = _create_environment(
+                "apptainer", task, tmp_path, "trial", rollout_paths
+            )
+
+        apptainer_env.preflight.assert_called_once_with()
+        apptainer_env.assert_called_once_with(
+            environment_dir=tmp_path / "environment",
+            environment_name=tmp_path.name,
+            session_id="trial",
+            rollout_paths=rollout_paths,
+            task_env_config=env_config,
+            persistent_env=None,
+        )
+        assert result is apptainer_env.return_value
+
     def test_prefers_effective_task_path_environment_dir(self, tmp_path):
         original_env_dir = tmp_path / "original" / "environment"
         effective_task = tmp_path / "effective-task"

--- a/tests/test_runtime_capabilities.py
+++ b/tests/test_runtime_capabilities.py
@@ -159,8 +159,8 @@ def test_validator_reports_unknown_sandbox_backend() -> None:
     assert [(issue.path, issue.reason) for issue in issues] == [
         (
             "sandbox",
-            "unknown sandbox backend; use docker, daytona, modal, apple-container, "
-            "or agentcore",
+            "unknown sandbox backend; use docker, apptainer, daytona, modal, "
+            "apple-container, or agentcore",
         )
     ]
 

--- a/tests/test_sandbox_provider_registry_drift.py
+++ b/tests/test_sandbox_provider_registry_drift.py
@@ -33,6 +33,7 @@ def test_registry_is_the_single_source_of_truth() -> None:
     # deliberate edit here + a test update, never a silent scatter.
     assert SANDBOX_PROVIDERS == (
         "docker",
+        "apptainer",
         "daytona",
         "modal",
         "apple-container",
@@ -44,9 +45,11 @@ def test_registry_is_the_single_source_of_truth() -> None:
 def test_providers_phrase_is_byte_identical() -> None:
     # The refactor must be behavior-preserving for every help/error string that
     # used to hand-write this phrase.
-    assert providers_phrase() == "docker, daytona, modal, apple-container, or agentcore"
+    assert providers_phrase() == (
+        "docker, apptainer, daytona, modal, apple-container, or agentcore"
+    )
     assert providers_phrase(quote=True) == (
-        "'docker', 'daytona', 'modal', 'apple-container', or 'agentcore'"
+        "'docker', 'apptainer', 'daytona', 'modal', 'apple-container', or 'agentcore'"
     )
 
 
@@ -54,6 +57,8 @@ def test_model_proxy_placement_is_explicit_for_every_provider() -> None:
     """Guards PR #936 against routing host loopback into an Apple VM."""
 
     assert PROVIDERS_BY_NAME["docker"].model_proxy is ModelProxyLocation.HOST
+    assert PROVIDERS_BY_NAME["apptainer"].model_proxy is ModelProxyLocation.HOST
+    assert PROVIDERS_BY_NAME["apptainer"].enforces_no_network
     for provider in ("daytona", "modal", "apple-container", "agentcore"):
         assert PROVIDERS_BY_NAME[provider].model_proxy is ModelProxyLocation.SANDBOX
     assert (

--- a/tests/test_session_factory_runtime.py
+++ b/tests/test_session_factory_runtime.py
@@ -8,6 +8,7 @@ kernel path is exercised without omnigent/sandbox deps.
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -243,6 +244,7 @@ async def test_session_factory_partial_trajectory_captured_on_disconnect():
     ]
 
     r = Rollout.__new__(Rollout)
+    r._config = SimpleNamespace(primary_agent="session-factory")
     r._acp_client = None
     r._session = session
     r._session_adapter = None
@@ -317,6 +319,7 @@ async def test_disconnect_clears_session_factory_state():
     from benchflow.rollout import Rollout
 
     rollout = Rollout.__new__(Rollout)
+    rollout._config = SimpleNamespace(primary_agent="session-factory")
     rollout._acp_client = None
     rollout._session = _FakeSession()
     rollout._session_adapter = object()


### PR DESCRIPTION
# feat(sandbox): add Apptainer backend for HPC environments

## What this solves

BenchFlow tasks are usually packaged as Dockerfile build contexts, but Docker is often unavailable on HPC and other shared Linux systems. Those systems commonly provide Apptainer instead.

This PR adds `--sandbox apptainer` to the normal evaluation path:

```bash
bench eval run \
  --tasks-dir path/to/tasks \
  --agent oracle \
  --sandbox apptainer \
  --skill-mode no-skill
```

The provider accepts existing Dockerfile-based task environments and local SIF images. Dockerfile contexts are built into cached SIF images, while each rollout gets a separate writable overlay.

Scheduler allocations, environment modules, and site-specific setup stay outside BenchFlow, so the backend is not tied to Slurm or a particular cluster.

## Design

### Integration

`apptainer` uses the existing provider registry, capability checks, and sandbox factory. It is imported lazily, so other providers do not require an Apptainer installation.

### Image inputs and build

The image layer supports two inputs:

1. A task build context containing a Dockerfile.
2. An existing local `.sif` image.

For Dockerfile-based tasks, the backend uses Apptainer's native BuildKit bootstrap:

```text
Dockerfile + build context
          |
          v
Apptainer buildkit bootstrap
          |
          v
SIF image
```

Why not translate to a `.def` file: doing so reliably would require BenchFlow to reproduce multi-stage builds, build arguments, environment expansion, `COPY` ownership and permissions, shell forms, and `.dockerignore` behavior.

Instead, BuildKit evaluates the Dockerfile and build context, Apptainer creates the SIF, and BenchFlow owns caching and rollout lifecycle. Existing tasks do not need a second `.def` file, and no Docker daemon is involved.

Built images are stored in a content-addressed cache. Construction happens through a temporary output path; the completed image is inspected before an atomic rename makes it visible to other rollouts. An in-process lock prevents duplicate concurrent builds of the same context.

### Rollout isolation

Each sandbox receives its own runtime directory, instance name, and writable overlay:

```text
cached read-only SIF
        +
per-rollout writable overlay
        +
scoped bind mounts
        |
        v
Apptainer instance
```

The cached SIF is never modified by a rollout. Agent changes, generated files, package installations, and verifier state are written to the rollout overlay and disappear when that sandbox is deleted.

Instances are started with:

- `--fakeroot` for container-root semantics without host root privileges;
- `--containall` and `--no-home` to avoid inheriting the user's host environment;
- `--cleanenv` to prevent unintended environment leakage;
- an isolated writable overlay for rollout-local state;
- explicit bind mounts for staging and BenchFlow-owned logs;
- an isolated network namespace when the runtime policy disables networking.

`--fakeroot` does not grant host root privileges. It maps the calling user to root inside the container namespace, which preserves the task behavior expected from container images while keeping execution unprivileged on the host. The overlay is what makes this useful for agent workloads: the SIF remains immutable, while package installs and changes under paths such as `/root`, `/app`, and `/usr` are written to rollout-local storage.

A readiness probe completes before the sandbox is returned to the rollout. Partial startup failures use the same cleanup path as normal shutdown, preventing abandoned instances and temporary runtime directories.

### Execution and agent transport

Commands run through `apptainer exec` against the named instance. A rollout-scoped environment file avoids command-line quoting problems and keeps the host environment separate. Working directories, timeouts, output capture, exit status, sandbox users, and background processes continue to use BenchFlow's existing interfaces.

Uploads and downloads use a bound staging directory, while a dedicated log mount keeps artifacts available after teardown. `ApptainerProcess` handles the bidirectional stdin, stdout, and stderr required by long-lived ACP agents; keeping it separate makes process and lifecycle behavior independently testable.

Failed builds never replace cached images, and instance cleanup is scoped and idempotent.

## Runtime requirements

Dockerfile builds require Apptainer with BuildKit bootstrap support and a compatible rootless BuildKit service:

```bash
export BUILDKIT_HOST="unix:///path/to/buildkitd.sock"
```

An existing local SIF does not need BuildKit. Image caches may live on shared storage, while temporary BuildKit and Apptainer state can use node-local storage.

## Implementation details by file

| File | Change |
| --- | --- |
| `sandbox/apptainer_image.py` | Resolves Dockerfile contexts and local SIFs; implements deterministic caching, build locking, BuildKit construction, validation, and atomic publication. |
| `sandbox/apptainer.py` | Implements overlays, instance lifecycle, isolation, command execution, transfer, attachment, and cleanup. |
| `sandbox/process/apptainer.py` | Provides asynchronous bidirectional ACP process transport and termination. |
| `sandbox/process/__init__.py` | Exposes the Apptainer process implementation. |
| `sandbox/providers.py` | Registers the provider and its runtime capabilities. |
| `sandbox/setup.py` | Adds lazy construction and runtime preflight. |
| `rollout/__init__.py` | Skips process-pattern cleanup for synchronous Oracle runs. |

## Testing

The backend was tested end to end with a subset of SkillsBench tasks on a real HPC system. Oracle and ACP agent runs completed successfully, covering image construction, writable rollout state, verification, artifact collection, and cleanup.
