### PR TITLE
feat(continue): typed continue-gate errors and batch skips instead of silent drops

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1113,6 +1113,15 @@ run folders (`config.json` + `trajectory/llm_trajectory.jsonl`) recursively,
 continues each, and prints a JSON batch summary (exits 1 if any continuation
 failed).
 
+Timeout runs that `continue` cannot resume — an agent with no replay ingress,
+or a run with no LLM recording at all — are reported under `skipped`/`skips`
+rather than aborting the batch or counting as failures, so the rest of the
+sweep still runs and the exit status stays 0. Each skip carries a `reason`
+(`unsupported_agent` or `no_llm_recording`) and `recoverable_in_principle`,
+which is `false` when nothing was recorded and no future ingress could help.
+Naming a single unsupported run explicitly (`bench eval continue <folder>`)
+still fails loudly with exit 1.
+
 ```bash
 bench eval continue-batch path/to/jobs-root --tasks-dir path/to/tasks
 ```

--- a/src/benchflow/cli/continue_cmd.py
+++ b/src/benchflow/cli/continue_cmd.py
@@ -212,10 +212,12 @@ def register_continue(
         import json
 
         from benchflow.continue_run.batch import (
+            BatchContinueResult,
             continue_batch,
             discover_timeout_run_folders,
             summarize_batch,
         )
+        from benchflow.continue_run.run_folder import ContinueUnsupportedError
 
         _apply_dotenv_to_process_env()
         # Fail fast on a bad ROOT instead of treating a typo'd/nonexistent path as
@@ -236,9 +238,26 @@ def register_continue(
                 err=True,
             )
             raise typer.Exit(1)
-        folders = discover_timeout_run_folders(root, limit=limit)
+        # Timeout runs `continue` cannot resume are skipped, not fatal — but they
+        # must still be reported, or a sweep silently leaves part of itself
+        # behind and the operator never learns why.
+        skips: list[BatchContinueResult] = []
+
+        def _record_skip(folder: Path, exc: ContinueUnsupportedError) -> None:
+            skips.append(BatchContinueResult.skip(folder, exc))
+
+        folders = discover_timeout_run_folders(root, limit=limit, on_skip=_record_skip)
+        if skips:
+            typer.secho(
+                f"Skipping {len(skips)} timeout run(s) benchflow continue cannot "
+                'resume; see "skips" below for the reason.',
+                fg=typer.colors.YELLOW,
+            )
         if not folders:
-            typer.secho("No timeout run folders found.", fg=typer.colors.YELLOW)
+            if not skips:
+                typer.secho("No timeout run folders found.", fg=typer.colors.YELLOW)
+                return
+            typer.echo(json.dumps(summarize_batch(skips), indent=2))
             return
 
         typer.echo(
@@ -257,8 +276,10 @@ def register_continue(
                 proxy_mode=proxy_mode,
             )
         )
-        summary = summarize_batch(results)
+        summary = summarize_batch([*results, *skips])
         typer.echo(json.dumps(summary, indent=2))
+        # Skips are deliberately not failures: exit status still reflects only
+        # continuations that were attempted and went wrong.
         if summary["failed"]:
             raise typer.Exit(1)
 

--- a/src/benchflow/continue_run/__init__.py
+++ b/src/benchflow/continue_run/__init__.py
@@ -23,13 +23,21 @@ on is wired for openhands via ``LLM_BASE_URL``).
 """
 
 from benchflow.continue_run.run_folder import (
+    CONTINUE_SUPPORTED_AGENTS,
+    ContinueUnsupportedError,
+    MissingRecordingError,
     RunFolder,
     RunFolderError,
+    UnsupportedAgentError,
     load_run_folder,
 )
 
 __all__ = [
+    "CONTINUE_SUPPORTED_AGENTS",
+    "ContinueUnsupportedError",
+    "MissingRecordingError",
     "RunFolder",
     "RunFolderError",
+    "UnsupportedAgentError",
     "load_run_folder",
 ]

--- a/src/benchflow/continue_run/batch.py
+++ b/src/benchflow/continue_run/batch.py
@@ -9,29 +9,65 @@ from pathlib import Path
 from typing import Any
 
 from benchflow.continue_run.orchestrator import ContinueResult, continue_run
-from benchflow.continue_run.run_folder import RunFolderError, load_run_folder
+from benchflow.continue_run.run_folder import (
+    ContinueUnsupportedError,
+    RunFolderError,
+    is_timeout_run,
+    load_run_folder,
+)
 
 ContinueRunner = Callable[..., Awaitable[ContinueResult]]
+#: Notified once per timeout candidate that `benchflow continue` cannot resume.
+SkipObserver = Callable[[Path, ContinueUnsupportedError], None]
 
 
 @dataclass(frozen=True)
 class BatchContinueResult:
-    """Result for one source folder in a batch continuation."""
+    """Result for one source folder in a batch continuation.
+
+    ``skipped`` separates *out of scope* from *failed*: a run whose agent has no
+    replay ingress, or that was never recorded, did not fail — the batch simply
+    could not act on it. Batch callers must not treat a skip as an error.
+    """
 
     folder: Path
     ok: bool
     continued: ContinueResult | None = None
     error: str | None = None
+    skipped: bool = False
+    reason_code: str | None = None
+    recoverable_in_principle: bool | None = None
+
+    @classmethod
+    def skip(cls, folder: Path, exc: ContinueUnsupportedError) -> BatchContinueResult:
+        """Record an out-of-scope run, carrying the gate's typed reason."""
+        return cls(
+            folder=folder,
+            ok=False,
+            error=str(exc),
+            skipped=True,
+            reason_code=exc.reason_code,
+            recoverable_in_principle=exc.recoverable_in_principle,
+        )
 
 
 def discover_timeout_run_folders(
-    root: str | Path, *, limit: int | None = None
+    root: str | Path,
+    *,
+    limit: int | None = None,
+    on_skip: SkipObserver | None = None,
 ) -> list[Path]:
     """Find OpenHands timeout run folders below ``root``.
 
     Discovery is intentionally artifact-based: a candidate must have a
     ``config.json`` and a usable ``trajectory/llm_trajectory.jsonl``. Non-timeout
     runs are skipped by ``load_run_folder(require_timeout=True)``.
+
+    ``on_skip`` is notified for each folder that *is* a timeout candidate but
+    that ``benchflow continue`` cannot resume (unsupported agent, or no LLM
+    recording). Without it those runs vanish silently, and the operator never
+    learns that part of the sweep was left behind. Finished runs from other
+    agents are not reported — they were never candidates.
     """
     root_path = Path(root).expanduser()
     candidates = [root_path] if (root_path / "config.json").is_file() else []
@@ -46,6 +82,10 @@ def discover_timeout_run_folders(
         seen.add(resolved)
         try:
             load_run_folder(folder, require_timeout=True)
+        except ContinueUnsupportedError as exc:
+            if on_skip is not None and is_timeout_run(folder):
+                on_skip(folder, exc)
+            continue
         except RunFolderError:
             continue
         folders.append(folder)
@@ -85,6 +125,10 @@ async def continue_batch(
                     strict_divergence=strict_divergence,
                     proxy_mode=proxy_mode,
                 )
+            except ContinueUnsupportedError as exc:
+                # Out of scope, not broken: one unsupported run in a 200-run
+                # sweep must not cost the other 199 their continuation.
+                return BatchContinueResult.skip(folder, exc)
             except Exception as exc:
                 return BatchContinueResult(folder=folder, ok=False, error=str(exc))
             if result.error:
@@ -100,17 +144,34 @@ async def continue_batch(
 
 
 def summarize_batch(results: list[BatchContinueResult]) -> dict[str, Any]:
-    """Small JSON-serializable summary for CLI output and dashboards."""
+    """Small JSON-serializable summary for CLI output and dashboards.
+
+    ``skipped``/``skips`` are reported apart from ``failed``/``errors`` so a
+    sweep containing runs `continue` cannot resume is not scored as a batch of
+    failures — and so the operator still sees which runs were left behind, why,
+    and whether a future replay ingress could reach them.
+    """
     ok = [result for result in results if result.ok]
-    failed = [result for result in results if not result.ok]
+    skipped = [result for result in results if not result.ok and result.skipped]
+    failed = [result for result in results if not result.ok and not result.skipped]
     return {
         "total": len(results),
         "succeeded": len(ok),
         "failed": len(failed),
+        "skipped": len(skipped),
         "outputs": [
             str(result.continued.rollout_dir)
             for result in ok
             if result.continued is not None
+        ],
+        "skips": [
+            {
+                "folder": str(result.folder),
+                "reason": result.reason_code,
+                "recoverable_in_principle": result.recoverable_in_principle,
+                "detail": result.error,
+            }
+            for result in skipped
         ],
         "errors": [
             {

--- a/src/benchflow/continue_run/run_folder.py
+++ b/src/benchflow/continue_run/run_folder.py
@@ -32,9 +32,103 @@ logger = logging.getLogger(__name__)
 # continuing rather than a clean pass/fail.
 _TIMEOUT_CATEGORIES = frozenset({"timeout", "idle_timeout"})
 
+# ── which agents ``benchflow continue`` can resume ────────────────────────────
+#
+# Single source of truth: a future replay ingress adds its agent here and
+# nowhere else. The membership is *protocol*-derived, not a policy about open
+# vs closed model weights — see ``_WHY_PROTOCOL`` below for the mechanism.
+CONTINUE_SUPPORTED_AGENTS: frozenset[str] = frozenset({"openhands"})
+
+_TRAJECTORY_RELPATH = "trajectory/llm_trajectory.jsonl"
+
+_WHY_PROTOCOL = (
+    "That set is derived from the replay wire protocol, not from a policy about "
+    "which models are open: the replay proxy serves POST /v1/chat/completions "
+    "only, and the continuation hands the sandbox LLM_BASE_URL / LLM_API_KEY / "
+    "LLM_MODEL, which only the OpenHands agent template consumes. An agent that "
+    "speaks a different wire (Anthropic Messages, OpenAI Responses, Google "
+    "native) would 404 at the proxy and fall back to host credentials, burning a "
+    "full live run that the artifacts would then mislabel as a replay."
+)
+
+_NO_RECORDING_VERDICT = (
+    f"This run has no {_TRAJECTORY_RELPATH}, which is what a subscription-auth "
+    "run looks like: it bypasses the recording gateway, so nothing was captured "
+    "and it can never be continued — no replay ingress, present or future, can "
+    "reconstruct it."
+)
+
+# Offered as a possibility, not a promise: snapshot capture is opt-in and most
+# runs will not have one.
+_SNAPSHOT_HINT = (
+    "If a sandbox snapshot of the original container was captured, that is the "
+    "only remaining route to its state."
+)
+
+
+def _supported_agents_phrase() -> str:
+    names = sorted(CONTINUE_SUPPORTED_AGENTS)
+    return ", ".join(repr(name) for name in names)
+
 
 class RunFolderError(ValueError):
     """Raised when a run folder is missing required artifacts or malformed."""
+
+
+class ContinueUnsupportedError(RunFolderError):
+    """Triage verdict: ``benchflow continue`` cannot resume *this* run.
+
+    Distinct from a failure — nothing went wrong, the run is simply out of
+    scope. Batch mode records these as skips and keeps going (see
+    :mod:`benchflow.continue_run.batch`); the single-run CLI still exits 1.
+    """
+
+    #: stable, machine-readable reason for batch summaries
+    reason_code: str = "continue_unsupported"
+    #: whether a *future* replay ingress could ever rescue this run
+    recoverable_in_principle: bool = False
+
+
+class UnsupportedAgentError(ContinueUnsupportedError):
+    """The run's agent has no replay ingress (see ``CONTINUE_SUPPORTED_AGENTS``)."""
+
+    reason_code = "unsupported_agent"
+
+    def __init__(self, *, agent: str, has_recording: bool) -> None:
+        self.agent = agent
+        self.has_recording = has_recording
+        self.recoverable_in_principle = has_recording
+        self.supported_agents: tuple[str, ...] = tuple(
+            sorted(CONTINUE_SUPPORTED_AGENTS)
+        )
+        used = f"used agent {agent!r}" if agent else "recorded no agent"
+        if has_recording:
+            verdict = (
+                f"This run does have {_TRAJECTORY_RELPATH}, so it becomes "
+                f"continuable as soon as a replay ingress for {agent!r} ships — "
+                "the recording is not the blocker."
+            )
+        else:
+            verdict = _NO_RECORDING_VERDICT
+        super().__init__(
+            f"benchflow continue cannot resume this run: it {used}, and the only "
+            f"supported agent(s) are {_supported_agents_phrase()}. "
+            f"{_WHY_PROTOCOL} {verdict} {_SNAPSHOT_HINT}"
+        )
+
+
+class MissingRecordingError(ContinueUnsupportedError):
+    """No LLM recording exists, so no replay can reconstruct the run."""
+
+    reason_code = "no_llm_recording"
+    recoverable_in_principle = False
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        super().__init__(
+            f"missing required artifact: {path} — record-replay needs the LLM "
+            f"trajectory. {_NO_RECORDING_VERDICT} {_SNAPSHOT_HINT}"
+        )
 
 
 @dataclass(frozen=True)
@@ -149,10 +243,7 @@ def load_llm_exchanges(path: Path) -> list[LLMExchange]:
     resume (a single bad record should not strand a recoverable run).
     """
     if not path.is_file():
-        raise RunFolderError(
-            f"missing required artifact: {path} — record-replay needs the LLM "
-            "trajectory. Was this run captured with usage tracking enabled?"
-        )
+        raise MissingRecordingError(path)
     exchanges: list[LLMExchange] = []
     for lineno, raw in enumerate(path.read_text().splitlines(), start=1):
         if not raw.strip():
@@ -183,7 +274,19 @@ def load_run_folder(folder: str | Path, *, require_timeout: bool = False) -> Run
     config = _read_json(path / "config.json", required=True)
     result = _read_json(path / "result.json", required=False)
     prompts = _load_prompts(path / "prompts.json")
-    exchanges = load_llm_exchanges(path / "trajectory" / "llm_trajectory.jsonl")
+
+    # Triage before parsing. The agent gate runs first so an unsupported run is
+    # told whether it is blocked on a missing ingress (recoverable later) or on
+    # a missing recording (never recoverable) — the caller should learn that now,
+    # not after a protocol ingress ships.
+    trajectory_path = path / "trajectory" / "llm_trajectory.jsonl"
+    agent = str(config.get("agent") or result.get("agent") or "")
+    if agent not in CONTINUE_SUPPORTED_AGENTS:
+        raise UnsupportedAgentError(
+            agent=agent, has_recording=trajectory_path.is_file()
+        )
+
+    exchanges = load_llm_exchanges(trajectory_path)
 
     run = RunFolder(
         path=path,
@@ -192,12 +295,6 @@ def load_run_folder(folder: str | Path, *, require_timeout: bool = False) -> Run
         prompts=prompts,
         exchanges=exchanges,
     )
-
-    if run.agent != "openhands":
-        raise RunFolderError(
-            f"benchflow continue currently supports the 'openhands' agent only; "
-            f"this run used {run.agent!r}."
-        )
 
     if not run.is_timeout:
         msg = (

--- a/src/benchflow/continue_run/run_folder.py
+++ b/src/benchflow/continue_run/run_folder.py
@@ -220,6 +220,22 @@ def _read_json(path: Path, *, required: bool) -> dict[str, Any]:
     return data
 
 
+def is_timeout_run(folder: str | Path) -> bool:
+    """Cheap ``result.json``-only check for a timeout/idle-timeout run.
+
+    Triage helper for callers that must classify a folder *after*
+    :func:`load_run_folder` raised — the full load never got far enough to
+    compute :attr:`RunFolder.is_timeout`. Never raises: an unreadable or absent
+    ``result.json`` simply means "not a timeout candidate".
+    """
+    try:
+        result = _read_json(Path(folder).expanduser() / "result.json", required=False)
+    except RunFolderError:
+        return False
+    category = result.get("error_category")
+    return bool(category) and str(category) in _TIMEOUT_CATEGORIES
+
+
 def _load_prompts(path: Path) -> list[str]:
     """Read ``prompts.json`` — a JSON list of strings (or ``{"prompts": [...]}``)."""
     if not path.is_file():

--- a/tests/continue_run/test_batch.py
+++ b/tests/continue_run/test_batch.py
@@ -3,16 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from benchflow.cli.main import app
 from benchflow.continue_run.batch import (
     continue_batch,
     discover_timeout_run_folders,
     summarize_batch,
 )
 from benchflow.continue_run.orchestrator import ContinueResult
+from benchflow.continue_run.run_folder import load_run_folder
 
 from ._helpers import completion, exchange, write_run_folder
 
@@ -107,5 +111,192 @@ async def test_continue_batch_marks_agent_error_as_failed(tmp_path):
 
     summary = summarize_batch(results)
     assert results[0].ok is False
+    assert results[0].skipped is False
     assert summary["failed"] == 1
+    assert summary["skipped"] == 0
     assert summary["errors"][0]["output"].endswith("/continued")
+
+
+# ── #1083 step 1(c): one unsupported run must not sink the batch ──────────────
+
+
+@pytest.mark.asyncio
+async def test_mixed_batch_skips_unsupported_and_continues_the_rest(tmp_path):
+    """A batch of mostly-openhands runs continues; the odd ones out are skips."""
+    supported = [
+        write_run_folder(
+            tmp_path / f"oh-{idx}",
+            exchanges=[exchange(completion(content="a"))],
+            error_category="timeout",
+        )
+        for idx in range(3)
+    ]
+    unsupported = write_run_folder(
+        tmp_path / "acp",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+        error_category="timeout",
+    )
+    unrecorded = write_run_folder(
+        tmp_path / "subscription",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="timeout",
+    )
+    (unrecorded / "trajectory" / "llm_trajectory.jsonl").unlink()
+
+    folders = [*supported, unsupported, unrecorded]
+
+    async def runner(folder: Path, **kwargs):
+        # Real runners load the folder first; an unsupported one raises here.
+        load_run_folder(folder, require_timeout=kwargs.get("require_timeout", True))
+        return ContinueResult(
+            rollout_dir=folder / "continued",
+            rewards={"reward": 1.0},
+            error=None,
+            n_recorded=1,
+            n_live=1,
+            divergences=0,
+        )
+
+    results = await continue_batch(
+        folders,
+        concurrency=2,
+        tasks_dir=None,
+        model=None,
+        timeout=None,
+        output_dir=None,
+        runner=runner,
+    )
+
+    by_folder = {result.folder: result for result in results}
+    # the supported runs all completed — the batch was not aborted
+    assert [by_folder[folder].ok for folder in supported] == [True, True, True]
+
+    skipped = [result for result in results if result.skipped]
+    assert {result.folder for result in skipped} == {unsupported, unrecorded}
+    assert all(result.ok is False for result in skipped)
+    reasons = {result.folder: result.reason_code for result in skipped}
+    assert reasons[unsupported] == "unsupported_agent"
+    assert reasons[unrecorded] == "no_llm_recording"
+
+    summary = summarize_batch(results)
+    assert summary["total"] == 5
+    assert summary["succeeded"] == 3
+    # skips are reported separately — they are not run failures
+    assert summary["failed"] == 0
+    assert summary["skipped"] == 2
+    assert summary["errors"] == []
+    skip_rows = {row["folder"]: row for row in summary["skips"]}
+    assert skip_rows[str(unsupported)]["reason"] == "unsupported_agent"
+    assert skip_rows[str(unsupported)]["recoverable_in_principle"] is True
+    assert "claude-agent-acp" in skip_rows[str(unsupported)]["detail"]
+    assert skip_rows[str(unrecorded)]["reason"] == "no_llm_recording"
+    assert skip_rows[str(unrecorded)]["recoverable_in_principle"] is False
+
+
+@pytest.mark.asyncio
+async def test_batch_of_many_survives_a_minority_of_unsupported_runs(tmp_path):
+    """The #1083 shape: 190 of 200 supported must still be continued."""
+    total, unsupported_count = 20, 2
+    folders = [
+        write_run_folder(
+            tmp_path / f"run-{idx}",
+            exchanges=[exchange(completion(content="a"))],
+            agent="openhands" if idx >= unsupported_count else "claude-agent-acp",
+            error_category="timeout",
+        )
+        for idx in range(total)
+    ]
+
+    async def runner(folder: Path, **kwargs):
+        load_run_folder(folder)
+        return ContinueResult(
+            rollout_dir=folder / "continued",
+            rewards=None,
+            error=None,
+            n_recorded=1,
+            n_live=1,
+            divergences=0,
+        )
+
+    summary = summarize_batch(
+        await continue_batch(
+            folders,
+            concurrency=8,
+            tasks_dir=None,
+            model=None,
+            timeout=None,
+            output_dir=None,
+            runner=runner,
+        )
+    )
+    assert summary["succeeded"] == total - unsupported_count
+    assert summary["skipped"] == unsupported_count
+    assert summary["failed"] == 0
+
+
+def test_discovery_reports_unsupported_timeout_candidates(tmp_path):
+    """Discovery must not swallow the runs it drops for being unsupported."""
+    supported = write_run_folder(
+        tmp_path / "oh",
+        exchanges=[exchange(completion(content="a"))],
+        error_category="timeout",
+    )
+    unsupported = write_run_folder(
+        tmp_path / "acp",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+        error_category="timeout",
+    )
+    # A *finished* run from another agent was never a continue candidate and
+    # must stay quiet — otherwise a mixed jobs dir drowns the operator in noise.
+    write_run_folder(
+        tmp_path / "acp-done",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+        error_category=None,
+    )
+
+    seen: list[tuple[Path, str]] = []
+    folders = discover_timeout_run_folders(
+        tmp_path, on_skip=lambda folder, exc: seen.append((folder, exc.reason_code))
+    )
+
+    assert folders == [supported]
+    assert seen == [(unsupported, "unsupported_agent")]
+
+
+def test_batch_cli_reports_skips_and_exits_zero(tmp_path):
+    """`continue-batch` over an all-unsupported tree is not a batch failure."""
+    write_run_folder(
+        tmp_path / "acp",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+        error_category="timeout",
+    )
+
+    res = CliRunner().invoke(app, ["eval", "continue-batch", str(tmp_path)])
+
+    assert res.exit_code == 0, res.output
+    assert "Skipping 1 timeout run(s)" in res.output
+    payload = json.loads(res.output[res.output.index("{") :])
+    assert payload["skipped"] == 1
+    assert payload["failed"] == 0
+    assert payload["skips"][0]["reason"] == "unsupported_agent"
+    assert "claude-agent-acp" in payload["skips"][0]["detail"]
+
+
+def test_single_run_continue_still_fails_loudly(tmp_path):
+    """An explicitly named unsupported run must keep failing — not be skipped."""
+    folder = write_run_folder(
+        tmp_path / "acp",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+        error_category="timeout",
+    )
+
+    res = CliRunner().invoke(app, ["eval", "continue", str(folder)])
+
+    assert res.exit_code == 1
+    assert "claude-agent-acp" in res.output
+    assert "openhands" in res.output

--- a/tests/continue_run/test_run_folder.py
+++ b/tests/continue_run/test_run_folder.py
@@ -6,7 +6,14 @@ import json
 
 import pytest
 
-from benchflow.continue_run.run_folder import RunFolderError, load_run_folder
+from benchflow.continue_run.run_folder import (
+    CONTINUE_SUPPORTED_AGENTS,
+    ContinueUnsupportedError,
+    MissingRecordingError,
+    RunFolderError,
+    UnsupportedAgentError,
+    load_run_folder,
+)
 
 from ._helpers import completion, exchange, write_run_folder
 
@@ -64,6 +71,105 @@ def test_non_openhands_agent_rejected(tmp_path):
     )
     with pytest.raises(RunFolderError, match="openhands"):
         load_run_folder(folder)
+
+
+# ── #1083 step 1(b): the continue gate must explain itself ────────────────────
+
+
+def test_supported_agents_come_from_one_named_constant():
+    """A future replay ingress updates exactly one place."""
+    assert set(CONTINUE_SUPPORTED_AGENTS) == {"openhands"}
+
+
+def test_unsupported_agent_error_names_agent_and_reason(tmp_path):
+    """The gate says which agent this run used, what is supported, and WHY."""
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+    )
+    with pytest.raises(UnsupportedAgentError) as excinfo:
+        load_run_folder(folder)
+
+    exc = excinfo.value
+    message = str(exc)
+    # names *this* run's agent, not a generic complaint
+    assert "claude-agent-acp" in message
+    # names the supported set, and says the set is protocol-derived
+    assert "openhands" in message
+    assert "wire protocol" in message
+    # the actual reason: the replay proxy's ingress + the env the agent reads
+    assert "/v1/chat/completions" in message
+    assert "LLM_BASE_URL" in message
+    # typed, machine-readable triage verdict
+    assert isinstance(exc, ContinueUnsupportedError)
+    assert exc.reason_code == "unsupported_agent"
+    assert exc.agent == "claude-agent-acp"
+    assert exc.supported_agents == ("openhands",)
+
+
+def test_unsupported_agent_with_recording_is_recoverable_in_principle(tmp_path):
+    """A recorded run is blocked on an ingress, not on the recording."""
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+    )
+    with pytest.raises(UnsupportedAgentError) as excinfo:
+        load_run_folder(folder)
+
+    exc = excinfo.value
+    assert exc.has_recording is True
+    assert exc.recoverable_in_principle is True
+    message = str(exc)
+    assert "does have" in message
+    assert "never be continued" not in message
+    # the alternative route is offered conditionally, never promised
+    assert "if" in message.lower() and "snapshot" in message
+
+
+def test_unsupported_agent_without_recording_is_never_recoverable(tmp_path):
+    """A subscription-auth run must hear the permanent verdict, not the agent one."""
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        agent="claude-agent-acp",
+    )
+    (folder / "trajectory" / "llm_trajectory.jsonl").unlink()
+
+    with pytest.raises(UnsupportedAgentError) as excinfo:
+        load_run_folder(folder)
+
+    exc = excinfo.value
+    assert exc.has_recording is False
+    assert exc.recoverable_in_principle is False
+    message = str(exc)
+    assert "claude-agent-acp" in message
+    assert "never be continued" in message
+    assert "subscription-auth" in message
+
+
+def test_missing_recording_is_distinguished_from_wrong_agent(tmp_path):
+    """Supported agent + no recording is a *different*, permanent verdict."""
+    folder = write_run_folder(
+        tmp_path / "run",
+        exchanges=[exchange(completion(content="a"))],
+        agent="openhands",
+    )
+    (folder / "trajectory" / "llm_trajectory.jsonl").unlink()
+
+    with pytest.raises(MissingRecordingError) as excinfo:
+        load_run_folder(folder)
+
+    exc = excinfo.value
+    assert not isinstance(exc, UnsupportedAgentError)
+    assert exc.reason_code == "no_llm_recording"
+    assert exc.recoverable_in_principle is False
+    message = str(exc)
+    assert "subscription-auth" in message
+    assert "never be continued" in message
+    # does not blame the agent — this run's agent *is* supported
+    assert "only the OpenHands agent template" not in message
 
 
 def test_non_timeout_warns_but_loads_by_default(tmp_path):


### PR DESCRIPTION
### Continue triage: say why a run can't be resumed, and don't let one unsupported run tax the batch

Implements items 2 and 3 of step 1 in the proposed sequence from #1083. No replay-protocol code is touched.

#### Why

`bench eval continue` rejected every non-`openhands` run with `benchflow continue currently supports the 'openhands' agent only`. The statement is true but uninformative in three ways, which is why the limitation keeps getting read as "continue only supports open models":

- it gives no reason, so it reads as a policy about model openness rather than what it is — a wire-protocol constraint at the replay seam;
- it does not distinguish a *temporary* limit (this agent has no replay ingress yet) from a *permanent* one (the run was never recorded, so no ingress could ever help it);
- in batch mode the affected runs were dropped silently at discovery, so an operator sweeping 200 timed-out runs never learned that part of the sweep was left behind.

#### What's in scope here

**A typed, self-explaining gate.** `CONTINUE_SUPPORTED_AGENTS` is now the single source of truth — a future ingress adds its agent there and nowhere else. `ContinueUnsupportedError` carries a `reason_code` and `recoverable_in_principle` so callers can triage without parsing prose; `UnsupportedAgentError` and `MissingRecordingError` are its two cases. Both remain `RunFolderError` subclasses, so every existing catch site is unaffected.

The message now states the supported set, that the set is derived from the replay wire protocol (the proxy serves `POST /v1/chat/completions` only; the sandbox receives `LLM_BASE_URL`/`LLM_API_KEY`/`LLM_MODEL`, which only the OpenHands template consumes; another wire would 404 and fall back to host credentials, burning a live run the artifacts would then mislabel as a replay), and whether *this particular run* is recoverable at all.

That last point required moving the agent gate ahead of trajectory parsing. Previously a run that was both unsupported *and* unrecorded heard only the missing-artifact complaint. Now a subscription-auth run is told plainly that it can never be continued — before a protocol ingress ships and raises false hope.

**Batch continue reports skips instead of scoring them as failures.** One correction to the framing in #1083: `continue_batch._one` already wrapped each run, so a batch never aborted — the real defect was quieter. `discover_timeout_run_folders` swallowed unsupported runs at discovery with a bare `except RunFolderError: continue`, so a sweep of 200 with 10 unsupported printed `Continuing 190 timeout run(s)` and exited 0 with the operator never learning the 10 existed; and anything that did reach the runner was recorded as a plain failure, indistinguishable from a continuation that actually broke.

Now: `continue_batch` catches the typed error per run and records a skip; `summarize_batch` reports `skipped`/`skips` separately from `failed`/`errors`, each skip carrying its `reason` and `recoverable_in_principle`; skips do not set the batch's exit status. `discover_timeout_run_folders` gained an optional `on_skip` observer (default `None`; signature and return type unchanged) and `continue-batch` uses it to surface what discovery drops — only timeout *candidates*, so a finished run from another agent stays quiet in a mixed jobs dir.

The single-run path is deliberately unchanged: `bench eval continue <folder>` on an unsupported run still prints the error and exits 1. An explicit request should fail loudly; only a sweep should skip.

#### Deferred

- **`--snapshot-stages` on `bench eval run`** (item 1 of step 1 in #1083). The underlying machinery — `RolloutConfig.snapshot_stages`, the stage taxonomy, stage capture, and the `--keep-snapshots` export — is not on `main` yet (it is in #1046), so the flag has no destination to thread to. It follows once that lands, and the error message's snapshot clause gains the flag name at the same time. The clause is phrased conditionally and names no flag today, so it makes no promise the build cannot keep.
- **`claude-agent-acp` continue support** (step 2 of #1083): an Anthropic Messages ingress, or the gateway-in-front redesign. Adding the agent to `CONTINUE_SUPPORTED_AGENTS` is then a one-line change on this branch's foundation.
- **`codex-acp`** (step 3); `gemini` scoped out, per the issue.

#### Testing

10 new tests, each verified red before its change. Full suite 5895 passed / 94 skipped / 7 deselected against a pre-change baseline of 5885 / 94 / 7 — the delta is exactly the new tests. `ruff check`, `ruff format --check src tests tools`, and `ty check src/` all clean. `tests/test_cli_docs_drift.py` passes unmodified; no CLI flag was added, so the docs change is prose only.

Closes nothing on its own — #1083 stays open for the protocol work.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1084" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->