### PR TITLE
fix(rollout): skip process cleanup for Oracle

### DIFF
--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1380,8 +1380,16 @@ class Rollout:
         self._session = None
         self._session_adapter = None
         self._is_session_factory = False
-        # Kill any lingering agent processes to prevent context bleed between scenes
-        agent_pattern = _agent_process_kill_pattern(self._agent_launch)
+        # Kill any lingering agent processes to prevent context bleed between scenes.
+        # Oracle awaits solve.sh directly and starts no persistent agent. Its launch
+        # value is only a fallback label; on shared PID namespaces, a pkill pattern
+        # derived from it can match the host's ``--agent oracle`` command.
+        # Use the current launch label because connect_as() updates it for each role.
+        agent_pattern = (
+            None
+            if self._agent_launch.strip() == "oracle"
+            else _agent_process_kill_pattern(self._agent_launch)
+        )
         if self._env and agent_pattern:
             with contextlib.suppress(Exception):
                 await self._env.exec(

--- a/tests/test_oracle.py
+++ b/tests/test_oracle.py
@@ -1,6 +1,49 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("agent_launch", "cleanup_command"),
+    [
+        ("oracle", None),
+        ("opencode", "pkill -f '(^|[ /])opencode( |$)' || true"),
+        (
+            "oracle-agent-acp",
+            "pkill -f '(^|[ /])oracle\\-agent\\-acp( |$)' || true",
+        ),
+    ],
+)
+async def test_disconnect_skips_process_cleanup_only_for_oracle(
+    agent_launch: str, cleanup_command: str | None
+):
+    """Guards the Oracle fix against PR #274's unconditional label cleanup."""
+    from benchflow.rollout import Rollout
+
+    env = SimpleNamespace(exec=AsyncMock())
+    rollout = SimpleNamespace(
+        _phase="verified",
+        _is_session_factory=False,
+        _capture_partial_acp_trajectory=lambda: None,
+        _acp_client=None,
+        _session=None,
+        _session_adapter=None,
+        _agent_launch=agent_launch,
+        _env=env,
+        _active_role=None,
+        _session_tool_count=0,
+        _session_traj_count=0,
+    )
+
+    await Rollout.disconnect(rollout)
+
+    if cleanup_command:
+        env.exec.assert_awaited_once_with(cleanup_command, timeout_sec=10)
+    else:
+        env.exec.assert_not_awaited()
+    assert rollout._phase == "verified"
 
 
 def _oracle_env():


### PR DESCRIPTION
# fix(rollout): skip process cleanup for Oracle

## Summary

Oracle mode awaits `solve.sh` directly and does not start an ACP or session agent. `Rollout.disconnect()` nevertheless treated the fallback launch label `oracle` as a process name and derived this cleanup command:

```text
pkill -f '(^|[ /])oracle( |$)'
```

There is no persistent Oracle process for that pattern to clean up. On a runtime that shares the runner's PID namespace, it can instead match BenchFlow's own `--agent oracle` command and terminate the run after verification but before the final result is built.

This change skips pattern-based cleanup only when the current launch value is exactly `oracle`. Other agents, including similarly named launches such as `oracle-agent-acp`, keep the existing cleanup behavior. The check uses the current `_agent_launch`, so role changes through `connect_as()` remain aligned with the process that was actually launched.

## Testing

- Added regression coverage for `oracle`, `opencode`, and the `oracle-agent-acp` near-match; the regression fails on `main` and passes with this change.
- Ran the relevant rollout and lifecycle tests: `286 passed`. Ruff, changed-file formatting, and `ty check` also pass.
- Completed an end-to-end SkillsBench Oracle run on Daytona as a non-regression check: `1/1 passed, mean reward 1.00, errors=0`, with the final summary and artifacts written successfully.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1085" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->