### PR TITLE
feat: add explicit ACP lifecycle contracts

### DIFF
--- a/src/benchflow/acp/__init__.py
+++ b/src/benchflow/acp/__init__.py
@@ -7,12 +7,15 @@ transports. See acp/client.py for the main entry point.
 
 from .client import ACPClient, ACPError
 from .session import ACPSession
+from .termination import AcpSessionObservation, AgentTerminationReceipt
 from .transport import StdioTransport, Transport
 from .types import ContentBlock, StopReason, ToolKind
 
 __all__ = [
+    "AcpSessionObservation",
     "ACPClient",
     "ACPError",
+    "AgentTerminationReceipt",
     "ACPSession",
     "ContentBlock",
     "StdioTransport",

--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -4,6 +4,8 @@ import logging
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from pydantic import ValidationError
+
 from benchflow.agents.errors import AgentProtocolError
 
 from .session import ACPSession
@@ -66,6 +68,36 @@ class ACPClient:
         self._session: ACPSession | None = None
         self._initialize_result: InitializeResult | None = None
         self._ask_user_handler: AskUserHandler | None = None
+
+    def _redact_protocol_value(self, value: Any) -> Any:
+        redactor = getattr(type(self._transport), "redact_protocol_value", None)
+        if callable(redactor):
+            return redactor(self._transport, value)
+        return value
+
+    def _validate_protocol_result(self, model: Any, result: Any) -> Any:
+        try:
+            return model.model_validate(result)
+        except ValidationError as error:
+            details = self._redact_protocol_value(error.errors(include_url=False))
+            if not isinstance(details, list):
+                details = []
+            for detail in details:
+                if not isinstance(detail, dict):
+                    continue
+                context = detail.get("ctx")
+                if not isinstance(context, dict):
+                    continue
+                detail["ctx"] = {
+                    key: (
+                        ValueError(str(self._redact_protocol_value(str(value))))
+                        if isinstance(value, BaseException)
+                        else value
+                    )
+                    for key, value in context.items()
+                }
+            sanitized = ValidationError.from_exception_data(error.title, details)
+            raise sanitized.with_traceback(error.__traceback__) from None
 
     def on_ask_user(self, handler: AskUserHandler | None) -> None:
         """Register the agent-initiated ``session/request_permission`` handler.
@@ -135,46 +167,68 @@ class ACPClient:
         await self._transport.send(message)
 
     async def _read_until_response(self, request_id: int) -> dict[str, Any]:
-        """Read messages, handling notifications, until we get the response we want."""
+        """Dispatch raw wire messages while redacting every diagnostic boundary."""
         while True:
             msg = await self._transport.receive()
+            msg_id = self._redact_protocol_value(msg.get("id"))
+            method = self._redact_protocol_value(msg.get("method", ""))
             logger.debug(
-                f"ACPClient recv: id={msg.get('id')} method={msg.get('method', '')} "
-                f"has_result={'result' in msg} has_error={'error' in msg}"
+                "ACPClient recv: id=%s method=%s has_result=%s has_error=%s",
+                msg_id,
+                method,
+                "result" in msg,
+                "error" in msg,
             )
 
             # It's a response to our request (has id, no method — distinguishes
             # from echoed requests when running through a PTY)
             if "id" in msg and msg["id"] == request_id and "method" not in msg:
                 if msg.get("error"):
-                    raise ACPError(
-                        msg["error"].get("code", -1),
-                        msg["error"].get("message", "Unknown error"),
-                    )
+                    error = msg["error"]
+                    if isinstance(error, dict):
+                        raw_code = error.get("code", -1)
+                        raw_message = error.get("message", "Unknown error")
+                    else:
+                        raw_code = -1
+                        raw_message = error
+                    code = raw_code if type(raw_code) is int else -1
+                    message = self._redact_protocol_value(raw_message)
+                    raise ACPError(code, str(message))
                 return msg.get("result", {})
 
-            # It's a notification (no id)
+            # It's a notification (no id). Dispatch the untouched message.
             if "method" in msg and "id" not in msg:
                 try:
                     await self._handle_notification(msg)
                 except Exception as e:
+                    safe_method = self._redact_protocol_value(msg.get("method"))
+                    safe_error = self._redact_protocol_value(str(e))
                     logger.warning(
-                        f"Error handling notification {msg.get('method')}: {e}"
+                        "Error handling notification %s: %s",
+                        safe_method,
+                        safe_error,
                     )
                 continue
 
-            # It's a request from the agent (has id + method)
+            # It's a request from the agent (has id + method).
             if "method" in msg and "id" in msg:
-                logger.debug(f"ACPClient handling agent request: {msg.get('method')}")
+                safe_method = self._redact_protocol_value(msg.get("method"))
+                logger.debug("ACPClient handling agent request: %s", safe_method)
                 try:
                     await self._handle_agent_request(msg)
                 except Exception as e:
+                    safe_error = self._redact_protocol_value(str(e))
                     logger.warning(
-                        f"Error handling agent request {msg.get('method')}: {e}"
+                        "Error handling agent request %s: %s",
+                        safe_method,
+                        safe_error,
                     )
                 continue
 
-            logger.debug(f"ACPClient ignoring unknown message: {msg}")
+            logger.debug(
+                "ACPClient ignoring unknown message: %r",
+                self._redact_protocol_value(msg),
+            )
 
     async def _handle_notification(self, msg: dict[str, Any]) -> None:
         """Handle incoming notifications from the agent."""
@@ -183,9 +237,12 @@ class ACPClient:
 
         if method == "session/update" and self._session:
             update = params.get("update", {})
+            update_type = self._redact_protocol_value(update.get("sessionUpdate", "?"))
+            tool_call_id = self._redact_protocol_value(update.get("toolCallId", ""))
             logger.debug(
-                f"ACPClient session/update: {update.get('sessionUpdate', '?')}"
-                f" toolCallId={update.get('toolCallId', '')}"
+                "ACPClient session/update: %s toolCallId=%s",
+                update_type,
+                tool_call_id,
             )
             self._session.handle_update(update)
 
@@ -213,7 +270,7 @@ class ACPClient:
                     logger.warning(
                         "on_ask_user handler raised %s; falling back to "
                         "auto-approve for session/request_permission",
-                        e,
+                        self._redact_protocol_value(str(e)),
                     )
                     option_id = _auto_approve_option_id(options)
             else:
@@ -241,7 +298,7 @@ class ACPClient:
             # ran, corrupting trajectories.
             logger.warning(
                 "ACPClient received unsupported request %r — replying method-not-found",
-                method,
+                self._redact_protocol_value(method),
             )
             response = {
                 "jsonrpc": "2.0",
@@ -282,7 +339,9 @@ class ACPClient:
         result = await self._send_request(
             "initialize", params.model_dump(by_alias=True, exclude_none=True)
         )
-        self._initialize_result = InitializeResult.model_validate(result)
+        self._initialize_result = self._validate_protocol_result(
+            InitializeResult, result
+        )
         negotiated = self._initialize_result.protocol_version
         if negotiated != ACP_PROTOCOL_VERSION:
             logger.warning(
@@ -314,7 +373,9 @@ class ACPClient:
             "session/new", params.model_dump(by_alias=True, exclude_none=True)
         )
         session_id = result.get("sessionId", "default")
-        self._session = ACPSession(session_id)
+        self._session = ACPSession(
+            session_id, redact_protocol_value=self._redact_protocol_value
+        )
         self._session.model_state = result.get("models")
         self._session.mode_state = result.get("modes")
         self._session.config_options = result.get("configOptions") or []
@@ -340,7 +401,9 @@ class ACPClient:
         params = {"sessionId": session_id, "cwd": cwd, "mcpServers": server_params}
         result = await self._send_request("session/load", params)
         loaded_id = result.get("sessionId", session_id)
-        self._session = ACPSession(loaded_id)
+        self._session = ACPSession(
+            loaded_id, redact_protocol_value=self._redact_protocol_value
+        )
         self._session.model_state = result.get("models")
         self._session.mode_state = result.get("modes")
         self._session.config_options = result.get("configOptions") or []
@@ -434,7 +497,7 @@ class ACPClient:
         result = await self._send_request(
             "session/prompt", params.model_dump(by_alias=True, exclude_none=True)
         )
-        prompt_result = PromptResult.model_validate(result)
+        prompt_result = self._validate_protocol_result(PromptResult, result)
         # The SDK exposes ``stop_reason`` as a plain string; coerce it to the
         # vendored ``StopReason`` enum so consumers keep ``.value`` / member
         # comparisons working.

--- a/src/benchflow/acp/client.py
+++ b/src/benchflow/acp/client.py
@@ -316,6 +316,7 @@ class ACPClient:
         session_id = result.get("sessionId", "default")
         self._session = ACPSession(session_id)
         self._session.model_state = result.get("models")
+        self._session.mode_state = result.get("modes")
         self._session.config_options = result.get("configOptions") or []
         if self._initialize_result:
             self._session.agent_info = self._initialize_result.agent_info
@@ -341,6 +342,7 @@ class ACPClient:
         loaded_id = result.get("sessionId", session_id)
         self._session = ACPSession(loaded_id)
         self._session.model_state = result.get("models")
+        self._session.mode_state = result.get("modes")
         self._session.config_options = result.get("configOptions") or []
         if self._initialize_result:
             self._session.agent_info = self._initialize_result.agent_info
@@ -372,7 +374,31 @@ class ACPClient:
             "sessionId": self._session.session_id,
             "modelId": model_id,
         }
-        return await self._send_request("session/set_model", params)
+        result = await self._send_request("session/set_model", params)
+        if "models" in result:
+            self._session.model_state = result.get("models")
+        else:
+            model_state = dict(self._session.model_state or {})
+            model_state["currentModelId"] = model_id
+            self._session.model_state = model_state
+        acknowledged_model_id = model_id
+        if isinstance(self._session.model_state, dict):
+            current_model_id = self._session.model_state.get(
+                "currentModelId"
+            ) or self._session.model_state.get("current_model_id")
+            if isinstance(current_model_id, str) and current_model_id:
+                acknowledged_model_id = current_model_id
+        config_options = result.get("configOptions", self._session.config_options) or []
+        self._session.config_options = [
+            (
+                {**option, "currentValue": acknowledged_model_id}
+                if isinstance(option, dict)
+                and (option.get("id") == "model" or option.get("category") == "model")
+                else option
+            )
+            for option in config_options
+        ]
+        return result
 
     async def set_config_option(self, config_id: str, value: str) -> dict:
         """Set a session configuration option."""
@@ -386,6 +412,15 @@ class ACPClient:
         result = await self._send_request("session/set_config_option", params)
         if "configOptions" in result:
             self._session.config_options = result.get("configOptions") or []
+        else:
+            self._session.config_options = [
+                (
+                    {**option, "currentValue": value}
+                    if isinstance(option, dict) and option.get("id") == config_id
+                    else option
+                )
+                for option in self._session.config_options
+            ]
         return result
 
     async def prompt(self, text: str) -> PromptResult:
@@ -417,6 +452,13 @@ class ACPClient:
     @property
     def session(self) -> ACPSession | None:
         return self._session
+
+    async def close_session(self) -> bool:
+        """Close the ACP stream independently when the transport supports it."""
+        close_session = getattr(self._transport, "close_session", None)
+        if not callable(close_session):
+            return False
+        return await close_session()
 
     async def close(self) -> None:
         """Close the transport and clean up."""

--- a/src/benchflow/acp/container_transport.py
+++ b/src/benchflow/acp/container_transport.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any, TextIO
 
@@ -12,7 +13,10 @@ from benchflow.sandbox.process._base import (
     _UNKNOWN_PROCESS_TREE_TERMINATION,
     _ProcessTreeTermination,
 )
-from benchflow.trajectories.types import redact_trajectory_text
+from benchflow.trajectories.types import (
+    redact_trajectory_obj_with_exact_values,
+    redact_trajectory_text_with_exact_values,
+)
 
 from .transport import Transport, decode_json_rpc_message
 
@@ -81,6 +85,7 @@ class ContainerTransport(Transport):
         env: dict[str, str] | None = None,
         cwd: str | None = None,
         agent_log_path: Path | None = None,
+        runtime_credential_values: Collection[str] = (),
     ):
         self._cp = container_process
         self._command = command
@@ -88,6 +93,16 @@ class ContainerTransport(Transport):
         self._cwd = cwd
         self._agent_log_path = agent_log_path
         self._agent_log_file: TextIO | None = None
+        self._runtime_credential_values = tuple(
+            value for value in runtime_credential_values if value
+        )
+        configure_output_redaction = getattr(
+            type(container_process), "set_output_redaction_values", None
+        )
+        if callable(configure_output_redaction):
+            configure_output_redaction(
+                container_process, self._runtime_credential_values
+            )
         # First-message latch: the lenient PTY-noise decode applies only
         # until the first successfully decoded protocol message (prompt glue
         # is a startup phenomenon). Afterwards the strict whole-line decode
@@ -135,13 +150,22 @@ class ContainerTransport(Transport):
             if message is not None:
                 self._saw_protocol = True
                 return message
+            safe_text = redact_trajectory_text_with_exact_values(
+                text, self._runtime_credential_values
+            )
             # Capture non-protocol output (agent debug logs, errors, warnings).
             if self._agent_log_path:
                 if self._agent_log_file is None:
                     self._agent_log_file = self._agent_log_path.open("w")
-                self._agent_log_file.write(text + "\n")
+                self._agent_log_file.write(safe_text + "\n")
                 self._agent_log_file.flush()
-            logger.debug(f"Non-JSON-RPC from container agent: {text[:200]}")
+            logger.debug("Non-JSON-RPC from container agent: %s", safe_text[:200])
+
+    def redact_protocol_value(self, value: Any) -> Any:
+        """Exact-redact a protocol-derived value only at persistence boundaries."""
+        return redact_trajectory_obj_with_exact_values(
+            value, self._runtime_credential_values
+        )
 
     @property
     def termination_status(self) -> _ProcessTreeTermination:
@@ -186,7 +210,11 @@ class ContainerTransport(Transport):
                 and self._agent_log_path
             ):
                 with self._agent_log_path.open("a") as agent_log:
-                    agent_log.write(redact_trajectory_text(stderr))
+                    agent_log.write(
+                        redact_trajectory_text_with_exact_values(
+                            stderr, self._runtime_credential_values
+                        )
+                    )
                 self._stderr_appended = True
 
     async def close(self) -> None:

--- a/src/benchflow/acp/container_transport.py
+++ b/src/benchflow/acp/container_transport.py
@@ -6,12 +6,19 @@ from pathlib import Path
 from typing import Any, TextIO
 
 from benchflow.sandbox.process import LiveProcess
-from benchflow.sandbox.process._base import _ANSI_CSI_RE, _ANSI_OSC_RE
+from benchflow.sandbox.process._base import (
+    _ANSI_CSI_RE,
+    _ANSI_OSC_RE,
+    _UNKNOWN_PROCESS_TREE_TERMINATION,
+    _ProcessTreeTermination,
+)
 from benchflow.trajectories.types import redact_trajectory_text
 
 from .transport import Transport, decode_json_rpc_message
 
 logger = logging.getLogger(__name__)
+
+_ACP_SESSION_CLOSE_GRACE_SEC = 2.0
 
 
 def _decode_pty_json_rpc_message(text: str) -> dict[str, Any] | None:
@@ -87,6 +94,9 @@ class ContainerTransport(Transport):
         # rules, so an agent echoing valid protocol envelopes into its logs
         # mid-session can never impersonate protocol traffic.
         self._saw_protocol = False
+        self._termination_status = _UNKNOWN_PROCESS_TREE_TERMINATION
+        self._session_closed = False
+        self._stderr_appended = False
 
     async def start(self) -> None:
         """Start the agent process inside the sandbox."""
@@ -133,13 +143,53 @@ class ContainerTransport(Transport):
                 self._agent_log_file.flush()
             logger.debug(f"Non-JSON-RPC from container agent: {text[:200]}")
 
-    async def close(self) -> None:
-        """Terminate the agent process."""
+    @property
+    def termination_status(self) -> _ProcessTreeTermination:
+        """Last observed process-tree termination outcome."""
+        return self._termination_status
+
+    @property
+    def session_closed(self) -> bool:
+        """Whether the ACP input stream has been closed."""
+        return self._session_closed
+
+    async def process_tree_stopped(self) -> bool:
+        """Re-check descendant liveness through the owning live process."""
+        return await self._cp.process_tree_stopped()
+
+    async def close_session(self) -> bool:
+        """Close the ACP stream without signaling the owned process tree."""
         if self._agent_log_file:
             self._agent_log_file.close()
             self._agent_log_file = None
-        await self._cp.close()
-        stderr = getattr(self._cp, "stderr_tail", "")
-        if isinstance(stderr, str) and stderr and self._agent_log_path:
-            with self._agent_log_path.open("a") as agent_log:
-                agent_log.write(redact_trajectory_text(stderr))
+        if self._session_closed:
+            return True
+        self._session_closed = await self._cp.close_stdin()
+        if self._session_closed:
+            await self._cp.wait_for_session_closed(_ACP_SESSION_CLOSE_GRACE_SEC)
+        return self._session_closed
+
+    async def terminate_process_tree(self) -> _ProcessTreeTermination:
+        """Terminate descendants after the ACP stream-close stage."""
+        try:
+            status = await self._cp.terminate_process_tree()
+            if isinstance(status, _ProcessTreeTermination):
+                self._termination_status = status
+            self._session_closed = True
+            return self._termination_status
+        finally:
+            stderr = getattr(self._cp, "stderr_tail", "")
+            if (
+                not self._stderr_appended
+                and isinstance(stderr, str)
+                and stderr
+                and self._agent_log_path
+            ):
+                with self._agent_log_path.open("a") as agent_log:
+                    agent_log.write(redact_trajectory_text(stderr))
+                self._stderr_appended = True
+
+    async def close(self) -> None:
+        """Close the ACP stream, then terminate the owned process tree."""
+        await self.close_session()
+        await self.terminate_process_tree()

--- a/src/benchflow/acp/runtime.py
+++ b/src/benchflow/acp/runtime.py
@@ -21,6 +21,7 @@ Does not own:
 import asyncio
 import contextlib
 import logging
+from collections.abc import Collection
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -49,6 +50,7 @@ from benchflow.sandbox.lockdown import (
 )
 from benchflow.sandbox.process._base import _timeout_sec_from_env
 from benchflow.trajectories._capture import _capture_session_trajectory
+from benchflow.trajectories.types import redact_trajectory_obj_with_exact_values
 
 # Re-exported for backwards compatibility — tests and downstream code
 # import ``IdleTimeoutError`` from this module. The canonical definition
@@ -70,6 +72,16 @@ _PROMPT_CANCEL_DRAIN_TIMEOUT_SEC = 0.25
 _ACP_HANDSHAKE_TIMEOUT_ENV = "BENCHFLOW_ACP_HANDSHAKE_TIMEOUT"
 _ACP_HANDSHAKE_TIMEOUT_DEFAULT_SEC = 60.0
 _OPENHANDS_DISABLE_SUBAGENTS_ENV = "BENCHFLOW_OPENHANDS_DISABLE_SUBAGENTS"
+
+
+def _redact_transport_protocol_value(
+    transport: object, value: object, exact_values: Collection[str] = ()
+) -> object:
+    """Use a concrete transport redactor, including before transport creation."""
+    redactor = getattr(type(transport), "redact_protocol_value", None)
+    if callable(redactor):
+        return redactor(transport, value)
+    return redact_trajectory_obj_with_exact_values(value, exact_values)
 
 
 def _acp_handshake_timeout_sec() -> float:
@@ -574,6 +586,7 @@ async def connect_acp(
     agent_cwd: str,
     reasoning_effort: str | None = None,
     mcp_servers: list[McpServerSpec] | None = None,
+    runtime_credential_values: Collection[str] = (),
 ) -> tuple[ACPClient, object, ACPSessionAdapter, str]:
     """Create ACP transport, connect, init session, and configure model/effort.
 
@@ -625,6 +638,7 @@ async def connect_acp(
             )
             await asyncio.sleep(delay)
 
+        transport: ContainerTransport | None = None
         try:
             # The sandbox owns its transport: it knows how to reach into
             # itself, so there is no provider-name branch here. Backends with
@@ -641,6 +655,7 @@ async def connect_acp(
                 env=agent_env,
                 cwd=agent_cwd,
                 agent_log_path=agent_log,
+                runtime_credential_values=runtime_credential_values,
             )
             acp_client = ACPClient(transport)
             await acp_client.connect()
@@ -649,16 +664,26 @@ async def connect_acp(
                 acp_client.initialize(),
                 phase="initialize",
             )
-            agent_name = (
+            observed_agent_name = (
                 init_result.agent_info.name if init_result.agent_info else agent
             )
-            logger.info(f"ACP agent: {agent_name}")
+            agent_name = str(
+                _redact_transport_protocol_value(
+                    transport, observed_agent_name, runtime_credential_values
+                )
+            )
+            logger.info("ACP agent: %s", agent_name)
 
             session = await _wait_for_acp_handshake(
                 acp_client.session_new(cwd=agent_cwd, mcp_servers=mcp_servers),
                 phase="session_new",
             )
-            logger.info(f"Session: {session.session_id}")
+            logger.info(
+                "Session: %s",
+                _redact_transport_protocol_value(
+                    transport, session.session_id, runtime_credential_values
+                ),
+            )
             break
         except ConnectionError as e:
             # Close the failed client before retrying
@@ -668,7 +693,13 @@ async def connect_acp(
                 acp_client = None
             if attempt == _ACP_CONNECT_MAX_RETRIES:
                 raise
-            logger.warning(f"ACP connect failed (attempt {attempt + 1}): {e}")
+            logger.warning(
+                "ACP connect failed (attempt %s): %s",
+                attempt + 1,
+                _redact_transport_protocol_value(
+                    transport, str(e), runtime_credential_values
+                ),
+            )
             continue
         except Exception:
             # Non-retryable error — close client to prevent leak

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -192,7 +192,12 @@ class ACPSession:
     trajectory instead of a flat blob.
     """
 
-    def __init__(self, session_id: str):
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        redact_protocol_value: Callable[[Any], Any] | None = None,
+    ):
         self.session_id = session_id
         self.agent_info: AgentInfo | None = None
         self.agent_capabilities: AgentCapabilities | None = None
@@ -218,6 +223,7 @@ class ACPSession:
         # Optional sink invoked after every public state mutation so callers
         # can stream a trajectory snapshot to disk without polling.
         self.on_change: Callable[[ACPSession], None] | None = None
+        self._redact_protocol_value = redact_protocol_value
         # Console progress heartbeat. Without it a first-run user stares at
         # total silence between "Prompt 1/1: ..." and the verifier — observed
         # 18 minutes on a passing rollout (fresh-user dogfood 2026-08-09) with
@@ -226,6 +232,14 @@ class ACPSession:
         self._progress_enabled = _console_progress_enabled()
         self._prompt_started_at: float | None = None
         self._last_progress_at = 0.0
+
+    def redact_for_persistence(self, value: Any) -> Any:
+        """Return a redacted copy without mutating live ACP protocol state."""
+        if self._redact_protocol_value is not None:
+            return self._redact_protocol_value(value)
+        from benchflow.trajectories.types import redact_trajectory_obj
+
+        return redact_trajectory_obj(value)
 
     def _notify_change(self) -> None:
         self._maybe_log_progress()
@@ -237,7 +251,8 @@ class ACPSession:
             # error (not warning): a failing callback means trajectory
             # streaming is silently degraded for the rest of the run,
             # which is otherwise easy to miss in a 64-concurrency log.
-            logger.error(f"ACPSession on_change callback failed: {e}")
+            error = self.redact_for_persistence(str(e))
+            logger.error("ACPSession on_change callback failed: %s", error)
 
     def progress_snapshot(self) -> tuple[int, str]:
         """(tool-call count, last tool title) — the console heartbeat's
@@ -273,7 +288,8 @@ class ACPSession:
         calls, title = self.progress_snapshot()
         line = f"  … {elapsed_min:.1f}min, {calls} tool calls"
         if title:
-            line += f" (last: {title[:60]})"
+            safe_title = self.redact_for_persistence(title)
+            line += f" (last: {str(safe_title)[:60]})"
         logger.info(line)
 
     def record_user_prompt(self, text: str) -> None:
@@ -417,7 +433,8 @@ class ACPSession:
             try:
                 status = ToolCallStatus(update.get("status", "in_progress"))
             except ValueError:
-                logger.warning(f"Unknown tool call status: {update.get('status')}")
+                status_value = self.redact_for_persistence(update.get("status"))
+                logger.warning("Unknown tool call status: %s", status_value)
                 status = ToolCallStatus.IN_PROGRESS
             content = update.get("content")
             record.update_status(status, content)

--- a/src/benchflow/acp/session.py
+++ b/src/benchflow/acp/session.py
@@ -197,6 +197,7 @@ class ACPSession:
         self.agent_info: AgentInfo | None = None
         self.agent_capabilities: AgentCapabilities | None = None
         self.model_state: dict | None = None
+        self.mode_state: dict | None = None
         self.config_options: list[dict] = []
         self.message_chunks: list[str] = []
         self.thought_chunks: list[str] = []

--- a/src/benchflow/acp/termination.py
+++ b/src/benchflow/acp/termination.py
@@ -7,6 +7,8 @@ import logging
 from dataclasses import dataclass
 from pathlib import Path
 
+from benchflow.trajectories.types import redact_trajectory_obj
+
 logger = logging.getLogger(__name__)
 
 
@@ -99,6 +101,18 @@ def _trajectory_identity(path: Path | None) -> tuple[str | None, str | None]:
     return str(path), f"sha256:{digest.hexdigest()}"
 
 
+def _redact_observation_fields(
+    session: object, fields: dict[str, str | None]
+) -> dict[str, str | None]:
+    redactor = getattr(type(session), "redact_for_persistence", None)
+    redacted = (
+        redactor(session, fields)
+        if callable(redactor)
+        else redact_trajectory_obj(fields)
+    )
+    return redacted if isinstance(redacted, dict) else fields
+
+
 def _observe_acp_session(
     session: object | None,
     *,
@@ -126,12 +140,24 @@ def _observe_acp_session(
         stop_reason = getattr(stop_reason, "value", stop_reason)
     if not isinstance(stop_reason, str):
         stop_reason = None
+    fields = _redact_observation_fields(
+        session,
+        {
+            "agent_name": agent_name,
+            "model_id": model_id,
+            "mode_id": mode_id,
+            "stop_reason": stop_reason,
+        },
+    )
+    redacted_agent_name = fields.get("agent_name")
+    if not isinstance(redacted_agent_name, str) or not redacted_agent_name:
+        return None
     observed_path, observed_digest = _trajectory_identity(trajectory_path)
     return AcpSessionObservation(
-        agent_name=agent_name,
-        model_id=model_id,
-        mode_id=mode_id,
-        stop_reason=stop_reason,
+        agent_name=redacted_agent_name,
+        model_id=fields.get("model_id"),
+        mode_id=fields.get("mode_id"),
+        stop_reason=fields.get("stop_reason"),
         trajectory_path=observed_path,
         trajectory_digest=observed_digest,
     )

--- a/src/benchflow/acp/termination.py
+++ b/src/benchflow/acp/termination.py
@@ -1,0 +1,137 @@
+"""Public evidence contracts for stopping and observing an ACP session."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AgentTerminationReceipt:
+    """Observed outcomes from one idempotent ACP stop operation."""
+
+    cancel_requested: bool
+    cancel_acknowledged: bool
+    session_closed: bool
+    graceful_termination: bool
+    force_kill_required: bool
+    process_tree_stopped: bool
+
+    def __post_init__(self) -> None:
+        if self.cancel_acknowledged and not self.cancel_requested:
+            raise ValueError(
+                "cancellation cannot be acknowledged when it was not requested"
+            )
+        if self.graceful_termination and self.force_kill_required:
+            raise ValueError("graceful termination cannot require a force kill")
+        if self.graceful_termination and not self.process_tree_stopped:
+            raise ValueError("graceful termination requires a stopped process tree")
+
+    @property
+    def capture_safe(self) -> bool:
+        """Whether artifact capture may safely observe the final workspace."""
+        return self.session_closed and self.process_tree_stopped
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class AcpSessionObservation:
+    """Facts reported by a live ACP session and its retained trajectory."""
+
+    agent_name: str
+    model_id: str | None
+    mode_id: str | None
+    stop_reason: str | None
+    trajectory_path: str | None
+    trajectory_digest: str | None
+
+    def __post_init__(self) -> None:
+        if not self.agent_name:
+            raise ValueError("agent_name must come from a non-empty ACP observation")
+        if (self.trajectory_path is None) != (self.trajectory_digest is None):
+            raise ValueError(
+                "trajectory_path and trajectory_digest must be present together"
+            )
+
+
+def _state_string(state: object | None, wire_name: str, attr_name: str) -> str | None:
+    if isinstance(state, dict):
+        value = state.get(wire_name)
+    else:
+        value = getattr(state, attr_name, None)
+    return value if isinstance(value, str) and value else None
+
+
+def _observed_config_value(session: object, category: str) -> str | None:
+    options = getattr(session, "config_options", None)
+    if not isinstance(options, (list, tuple)):
+        return None
+    for option in options:
+        if isinstance(option, dict):
+            option_id = option.get("id")
+            option_category = option.get("category")
+            current_value = option.get("currentValue")
+        else:
+            option_id = getattr(option, "id", None)
+            option_category = getattr(option, "category", None)
+            current_value = getattr(option, "current_value", None)
+        if (option_id == category or option_category == category) and isinstance(
+            current_value, str
+        ):
+            return current_value
+    return None
+
+
+def _trajectory_identity(path: Path | None) -> tuple[str | None, str | None]:
+    if path is None or not path.is_file():
+        return None, None
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as trajectory:
+            for chunk in iter(lambda: trajectory.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        logger.warning("Could not digest ACP trajectory %s", path, exc_info=True)
+        return None, None
+    return str(path), f"sha256:{digest.hexdigest()}"
+
+
+def _observe_acp_session(
+    session: object | None,
+    *,
+    trajectory_path: Path | None,
+) -> AcpSessionObservation | None:
+    """Project only facts returned by the live ACP session."""
+    if session is None:
+        return None
+    agent_info = getattr(session, "agent_info", None)
+    if isinstance(agent_info, dict):
+        agent_name = agent_info.get("name")
+    else:
+        agent_name = getattr(agent_info, "name", None)
+    if not isinstance(agent_name, str) or not agent_name:
+        return None
+
+    model_id = _observed_config_value(session, "model") or _state_string(
+        getattr(session, "model_state", None), "currentModelId", "current_model_id"
+    )
+    mode_id = _observed_config_value(session, "mode") or _state_string(
+        getattr(session, "mode_state", None), "currentModeId", "current_mode_id"
+    )
+    stop_reason = getattr(session, "stop_reason", None)
+    if stop_reason is not None:
+        stop_reason = getattr(stop_reason, "value", stop_reason)
+    if not isinstance(stop_reason, str):
+        stop_reason = None
+    observed_path, observed_digest = _trajectory_identity(trajectory_path)
+    return AcpSessionObservation(
+        agent_name=agent_name,
+        model_id=model_id,
+        mode_id=mode_id,
+        stop_reason=stop_reason,
+        trajectory_path=observed_path,
+        trajectory_digest=observed_digest,
+    )

--- a/src/benchflow/acp/transport.py
+++ b/src/benchflow/acp/transport.py
@@ -7,6 +7,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from benchflow.sandbox.process import drain_oversized_line
+from benchflow.trajectories.types import redact_trajectory_obj
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +52,10 @@ class Transport(ABC):
     @abstractmethod
     async def receive(self) -> dict[str, Any]:
         """Receive a JSON-RPC message."""
+
+    def redact_protocol_value(self, value: Any) -> Any:
+        """Return a persistence-safe copy while leaving wire messages untouched."""
+        return redact_trajectory_obj(value)
 
     @abstractmethod
     async def close(self) -> None:

--- a/src/benchflow/agents/env.py
+++ b/src/benchflow/agents/env.py
@@ -24,7 +24,7 @@ from urllib.parse import urlparse
 
 from benchflow._dotenv import load_dotenv_env
 from benchflow.agents.codex_config import apply_codex_provider_config
-from benchflow.agents.registry import AGENTS
+from benchflow.agents.registry import AGENTS, _is_explicit_environment_control
 
 logger = logging.getLogger(__name__)
 
@@ -677,8 +677,29 @@ def resolve_agent_env(
     model: str | None,
     agent_env: dict[str, str] | None,
 ) -> dict[str, str]:
-    """Resolve agent environment from explicit overrides, then .env defaults."""
+    """Resolve the environment passed to an agent process."""
     agent_env = dict(agent_env or {})
+    agent_cfg = AGENTS.get(agent)
+    if agent_cfg and getattr(agent_cfg, "environment_policy", "inherit") == "explicit":
+        required = set(agent_cfg.requires_env)
+        agent_env = {
+            key: value
+            for key, value in agent_env.items()
+            if key in required or _is_explicit_environment_control(key)
+        }
+        missing = [key for key in agent_cfg.requires_env if not agent_env.get(key)]
+        if missing:
+            names = ", ".join(missing)
+            raise ValueError(
+                f"Explicit environment policy for agent {agent!r} requires "
+                f"runtime_credentials for: {names}"
+            )
+        # BenchFlow-owned, non-secret process controls. Explicit-policy agents
+        # bypass all ambient and provider inference below.
+        agent_env.setdefault("CLAUDE_CODE_MAX_OUTPUT_TOKENS", "128000")
+        agent_env.setdefault("CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "1")
+        return agent_env
+
     explicit_agent_env_keys = set(agent_env)
     # Inherit from .env file first, then from os.environ as fallback.
     # Both sources use setdefault so explicit agent_env keys take priority.
@@ -686,7 +707,6 @@ def resolve_agent_env(
     auto_inherit_env(agent_env)
     _normalize_codex_auth_env(agent, model, agent_env)
     pre_provider_env = dict(agent_env)
-    agent_cfg = AGENTS.get(agent)
     # Oracle runs solve.sh and never calls an LLM — model env vars and
     # API-key validation are skipped even if a caller forwards a model.
     if model and agent != "oracle":

--- a/src/benchflow/agents/manifest.py
+++ b/src/benchflow/agents/manifest.py
@@ -82,6 +82,9 @@ _SHIM_ONLY = frozenset(
         # Non-ACP "module:callable" seam, only meaningful when
         # protocol="session-factory"; the acp-only contract can never carry it.
         "session_factory",
+        # Runtime credential admission is enforced by the BenchFlow shim, not
+        # declared by agent-authored manifest data.
+        "environment_policy",
         "credential_files",
         "subscription_auth",
         "acp_model_config_id",

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -52,6 +52,7 @@ import base64
 import shlex
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Literal
 
 from benchflow._utils.text import describe_exception
 
@@ -439,6 +440,23 @@ class SubscriptionAuth:
     files: list[HostAuthFile] = field(default_factory=list)  # All files to copy
 
 
+AgentEnvironmentPolicy = Literal["inherit", "explicit"]
+_EXPLICIT_ENVIRONMENT_CONTROLS = frozenset(
+    {
+        "BENCHFLOW_DISALLOW_WEB_TOOLS",
+        "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+    }
+)
+
+
+def _is_explicit_environment_control(name: str) -> bool:
+    """Return whether a configured name is an approved non-secret control."""
+    return name in _EXPLICIT_ENVIRONMENT_CONTROLS
+
+
+
+
 @dataclass
 class AgentConfig:
     """Configuration for a supported agent."""
@@ -451,6 +469,7 @@ class AgentConfig:
     # Non-ACP only. When protocol == "session-factory", this is a
     # "module:callable" entrypoint that builds an Agent Protocol object.
     requires_env: list[str] = field(default_factory=list)
+    environment_policy: AgentEnvironmentPolicy = "inherit"
     description: str = ""
     skill_paths: list[str] = field(default_factory=list)
     install_timeout: int = 900  # seconds
@@ -1161,6 +1180,7 @@ def _acpx_wrap(config: AgentConfig) -> AgentConfig:
         protocol="acp",
         session_factory=config.session_factory,
         requires_env=config.requires_env,
+        environment_policy=config.environment_policy,
         description=f"{config.description} (via acpx)",
         skill_paths=config.skill_paths,
         install_timeout=config.install_timeout,
@@ -1355,6 +1375,7 @@ def register_agent(
     protocol: str = "acp",
     session_factory: str = "",
     requires_env: list[str] | None = None,
+    environment_policy: AgentEnvironmentPolicy = "inherit",
     description: str = "",
     skill_paths: list[str] | None = None,
     install_timeout: int = 900,
@@ -1394,6 +1415,7 @@ def register_agent(
         protocol=protocol,
         session_factory=session_factory,
         requires_env=requires_env or [],
+        environment_policy=environment_policy,
         description=description,
         skill_paths=skill_paths or [],
         install_timeout=install_timeout,

--- a/src/benchflow/agents/registry.py
+++ b/src/benchflow/agents/registry.py
@@ -455,8 +455,6 @@ def _is_explicit_environment_control(name: str) -> bool:
     return name in _EXPLICIT_ENVIRONMENT_CONTROLS
 
 
-
-
 @dataclass
 class AgentConfig:
     """Configuration for a supported agent."""

--- a/src/benchflow/contracts/user.py
+++ b/src/benchflow/contracts/user.py
@@ -62,7 +62,7 @@ class FunctionUser(BaseUser):
         self,
         fn: Callable[
             [int, str, RoundResult | None],
-            str | None | Awaitable[str | None],
+            str | Awaitable[str | None] | None,
         ],
     ) -> None:
         self._fn = fn

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -52,10 +52,11 @@ import shlex
 import shutil
 import tarfile
 import tempfile
+from collections.abc import Mapping
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 from benchflow._types import Role, Scene, Turn
 
@@ -75,9 +76,18 @@ from benchflow._types import Role, Scene, Turn
 from benchflow._utils.live_activity import ActivitySnapshot, SessionCounters
 from benchflow._utils.scoring import classify_error as classify_error
 from benchflow._utils.text import describe_exception
+from benchflow.acp.termination import (
+    AcpSessionObservation,
+    AgentTerminationReceipt,
+    _observe_acp_session,
+)
 from benchflow.acp.types import McpServerSpec
 from benchflow.agents.credentials import upload_credential
-from benchflow.agents.registry import AGENTS, _is_explicit_environment_control
+from benchflow.agents.registry import (
+    AGENTS,
+    AgentEnvironmentPolicy,
+    _is_explicit_environment_control,
+)
 from benchflow.contracts import (
     AgentProtocolError,
     AskUserRequest,
@@ -121,9 +131,6 @@ from benchflow.rollout._results import (
 )
 from benchflow.rollout._setup import (
     _agent_launch_with_web_policy as _agent_launch_with_web_policy,
-)
-from benchflow.rollout._setup import (
-    _agent_process_kill_pattern as _agent_process_kill_pattern,
 )
 from benchflow.rollout._setup import _apply_prompt_prefix as _apply_prompt_prefix
 from benchflow.rollout._setup import _apply_web_policy as _apply_web_policy
@@ -234,6 +241,10 @@ _SETUP_COMMAND_LOCK_SAFE_RE = re.compile(r"[^A-Za-z0-9._-]+")
 # them — the live dashboard renders the phase as a label and a backwards step
 # reads as the run having restarted (see disconnect()).
 _TERMINAL_PHASES = frozenset({"verifying", "verified", "cleaned"})
+_ACP_STOP_CANCEL_TIMEOUT_SEC = 5.0
+_ACP_STOP_CLOSE_TIMEOUT_SEC = 20.0
+_ACP_STOP_SESSION_CLOSE_TIMEOUT_SEC = 5.0
+_ACP_STOP_LIVENESS_TIMEOUT_SEC = 5.0
 
 
 _MCP_TRANSPORT_TO_ACP_TYPE = {
@@ -724,6 +735,9 @@ class Rollout:
         # install_agent().
         self._session_traj_count: int = 0
         self._session_tool_count: int = 0
+        self._termination_receipt: AgentTerminationReceipt | None = None
+        self._acp_session_observation: AcpSessionObservation | None = None
+        self._stop_agent_task: asyncio.Task[AgentTerminationReceipt] | None = None
 
         # Populated by execute()
         self._trajectory: list[dict] = []
@@ -787,6 +801,16 @@ class Rollout:
             )
         return cls(config, runtime_credentials=runtime_credentials)
 
+    def _plane_agent_config(self, agent: str) -> Any:
+        """Resolve typed plane metadata without trusting permissive mock attributes."""
+        resolver = getattr(self._planes, "agent_config", None)
+        if callable(resolver):
+            candidate = resolver(agent)
+            policy = getattr(candidate, "environment_policy", None)
+            if isinstance(policy, str) and policy in {"inherit", "explicit"}:
+                return candidate
+        return AGENTS.get(agent)
+
     def _resolve_agent_environment(
         self,
         agent: str,
@@ -794,16 +818,14 @@ class Rollout:
         configured_env: Mapping[str, str] | None,
     ) -> dict[str, str]:
         """Resolve one agent env without exposing the runtime credential bag."""
-        agent_cfg = self._planes.agent_config(agent)
-        if (
-            not agent_cfg
-            or getattr(agent_cfg, "environment_policy", "inherit") == "inherit"
-        ):
+        agent_cfg = self._plane_agent_config(agent)
+        if self._agent_environment_policy(agent) == "inherit":
             return self._planes.resolve_agent_env(
                 agent, model, dict(configured_env or {})
             )
 
-        required = set(agent_cfg.requires_env)
+        required_env = tuple(getattr(agent_cfg, "requires_env", ()) or ())
+        required = set(required_env)
         explicit_env = {
             key: value
             for key, value in (configured_env or {}).items()
@@ -812,11 +834,11 @@ class Rollout:
         explicit_env.update(
             {
                 key: self._runtime_credentials[key]
-                for key in agent_cfg.requires_env
+                for key in required_env
                 if key in self._runtime_credentials
             }
         )
-        missing = [key for key in agent_cfg.requires_env if not explicit_env.get(key)]
+        missing = [key for key in required_env if not explicit_env.get(key)]
         if missing:
             names = ", ".join(missing)
             raise ValueError(
@@ -834,9 +856,11 @@ class Rollout:
         )
         return {key: value for key, value in resolved.items() if key in admitted}
 
-    def _agent_environment_policy(self, agent: str) -> str:
-        agent_cfg = self._planes.agent_config(agent)
-        return getattr(agent_cfg, "environment_policy", "inherit")
+    def _agent_environment_policy(self, agent: str) -> AgentEnvironmentPolicy:
+        policy = getattr(
+            self._plane_agent_config(agent), "environment_policy", "inherit"
+        )
+        return "explicit" if policy == "explicit" else "inherit"
 
     def use_prebuilt_env(self, inner: Any) -> None:
         """Inject a caller-owned sandbox; skip creation and teardown.
@@ -911,6 +935,28 @@ class Rollout:
     @property
     def trajectory(self) -> list[dict]:
         return self._trajectory
+
+    @property
+    def acp_session_observation(self) -> AcpSessionObservation | None:
+        """Latest identity and artifact facts observed from the live ACP session."""
+        session = (
+            None
+            if getattr(self, "_is_session_factory", False)
+            else getattr(self, "_session", None)
+        )
+        rollout_dir = getattr(self, "_rollout_dir", None)
+        trajectory_path = (
+            rollout_dir / "trajectory" / "acp_trajectory.jsonl"
+            if isinstance(rollout_dir, Path)
+            else None
+        )
+        observed = _observe_acp_session(
+            session,
+            trajectory_path=trajectory_path,
+        )
+        if observed is not None:
+            self._acp_session_observation = observed
+        return getattr(self, "_acp_session_observation", None)
 
     def record_external_tool_call(
         self,
@@ -1343,6 +1389,9 @@ class Rollout:
 
     async def connect(self) -> None:
         """Open an ACP connection to the agent. Can be called multiple times."""
+        self._termination_receipt = None
+        self._stop_agent_task = None
+        self._acp_session_observation = None
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
         t0 = datetime.now()
@@ -1432,42 +1481,132 @@ class Rollout:
             TrajectoryWriter(traj_path), prior
         )
 
-    async def disconnect(self) -> None:
-        """Close the ACP client and clean up agent process, keeping the environment alive."""
+    async def stop_agent(self, *, cancel_requested: bool) -> AgentTerminationReceipt:
+        """Share one shielded stop operation across every concurrent caller."""
+        existing = getattr(self, "_termination_receipt", None)
+        if existing is not None:
+            return existing
+
+        stop_task: asyncio.Task[AgentTerminationReceipt] | None = getattr(
+            self, "_stop_agent_task", None
+        )
+        if stop_task is None:
+            stop_task = asyncio.create_task(
+                Rollout._stop_agent_once(self, cancel_requested=cancel_requested)
+            )
+            self._stop_agent_task = stop_task
+        try:
+            return await asyncio.shield(stop_task)
+        except asyncio.CancelledError:
+            await asyncio.shield(stop_task)
+            raise
+
+    async def _stop_agent_once(
+        self, *, cancel_requested: bool
+    ) -> AgentTerminationReceipt:
+        """Stop the live ACP process tree and publish immutable evidence once."""
+
         if getattr(self, "_is_session_factory", False):
             self._capture_partial_session_factory_trajectory()
         else:
             self._capture_partial_acp_trajectory()
-        if self._acp_client:
+
+        client = getattr(self, "_acp_client", None)
+        transport = getattr(client, "_transport", None) if client is not None else None
+        cancel_acknowledged = False
+        session_closed = client is None and getattr(self, "_session", None) is None
+
+        if cancel_requested and client is not None:
             try:
-                await self._acp_client.close()
-            except Exception as e:
-                logger.warning(f"ACP client close failed: {e}")
-            self._acp_client = None
+                await asyncio.wait_for(
+                    client.cancel(), timeout=_ACP_STOP_CANCEL_TIMEOUT_SEC
+                )
+                cancel_acknowledged = True
+            except Exception:
+                logger.warning("ACP session cancellation failed", exc_info=True)
+
+        close_session: Any = getattr(client, "close_session", None)
+        terminate_process_tree: Any = getattr(transport, "terminate_process_tree", None)
+        if (
+            client is not None
+            and callable(close_session)
+            and callable(terminate_process_tree)
+        ):
+            try:
+                session_closed = (
+                    await asyncio.wait_for(
+                        close_session(),
+                        timeout=_ACP_STOP_SESSION_CLOSE_TIMEOUT_SEC,
+                    )
+                    is True
+                )
+            except Exception:
+                logger.warning("ACP session close failed", exc_info=True)
+            try:
+                await terminate_process_tree()
+            except Exception:
+                logger.warning("ACP process-tree termination failed", exc_info=True)
+            session_closed = (
+                session_closed or getattr(transport, "session_closed", False) is True
+            )
+        elif client is not None:
+            try:
+                await asyncio.wait_for(
+                    client.close(), timeout=_ACP_STOP_CLOSE_TIMEOUT_SEC
+                )
+                session_closed = True
+            except Exception:
+                logger.warning("ACP client close failed", exc_info=True)
+
+        termination_status = getattr(transport, "termination_status", None)
+        graceful_termination = (
+            getattr(termination_status, "graceful_termination", False) is True
+        )
+        force_kill_required = (
+            getattr(termination_status, "force_kill_required", False) is True
+        )
+        process_tree_stopped = False
+        liveness_check = getattr(transport, "process_tree_stopped", None)
+        if callable(liveness_check):
+            try:
+                process_tree_stopped = (
+                    await asyncio.wait_for(
+                        liveness_check(), timeout=_ACP_STOP_LIVENESS_TIMEOUT_SEC
+                    )
+                    is True
+                )
+            except Exception:
+                logger.warning(
+                    "ACP process-tree liveness verification failed", exc_info=True
+                )
+        if not process_tree_stopped:
+            graceful_termination = False
+
+        _ = Rollout.acp_session_observation.__get__(self, Rollout)
+
+        receipt = AgentTerminationReceipt(
+            cancel_requested=cancel_requested,
+            cancel_acknowledged=cancel_acknowledged,
+            session_closed=session_closed,
+            graceful_termination=graceful_termination,
+            force_kill_required=force_kill_required,
+            process_tree_stopped=process_tree_stopped,
+        )
+        self._termination_receipt = receipt
+        self._acp_client = None
         self._session = None
         self._session_adapter = None
         self._is_session_factory = False
-        # Kill any lingering agent processes to prevent context bleed between scenes
-        agent_pattern = _agent_process_kill_pattern(self._agent_launch)
-        if self._env and agent_pattern:
-            with contextlib.suppress(Exception):
-                await self._env.exec(
-                    f"pkill -f {shlex.quote(agent_pattern)} || true",
-                    timeout_sec=10,
-                )
         self._active_role = None
         self._session_tool_count = 0
         self._session_traj_count = 0
-        # Rewinding the phase to "installed" is right for the between-scenes
-        # disconnect (another agent turn follows, and connect_as() will mark
-        # "connected"), but disconnect() is ALSO called from cleanup(), after
-        # verify() has already moved the rollout into its terminal phases. Left
-        # unguarded, that rewind made the live dashboard walk backwards —
-        # "verifying…" and then "running agent…" again for the whole teardown
-        # stretch — and briefly blanked ``Rollout.result``, which is gated on
-        # the same terminal phases.
         if getattr(self, "_phase", None) not in _TERMINAL_PHASES:
             self._phase = "installed"
+        return receipt
+
+    async def disconnect(self) -> None:
+        """Stop the current agent while keeping the environment alive."""
+        await Rollout.stop_agent(self, cancel_requested=False)
 
     def on_ask_user(self, handler: Any) -> None:
         """Register the agent-initiated ``session/request_permission`` handler.
@@ -2324,8 +2463,11 @@ class Rollout:
 
         Installs the role's agent binary and credentials if it differs
         from the primary agent (which was set up in install_agent()).
-        Updates _agent_launch so disconnect() kills the correct process.
+        Retains the role's launch command for the connection attempt.
         """
+        self._termination_receipt = None
+        self._stop_agent_task = None
+        self._acp_session_observation = None
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
         t0 = datetime.now()

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -80,6 +80,7 @@ from benchflow.acp.termination import (
     AcpSessionObservation,
     AgentTerminationReceipt,
     _observe_acp_session,
+    _trajectory_identity,
 )
 from benchflow.acp.types import McpServerSpec
 from benchflow.agents.credentials import upload_credential
@@ -245,6 +246,7 @@ _ACP_STOP_CANCEL_TIMEOUT_SEC = 5.0
 _ACP_STOP_CLOSE_TIMEOUT_SEC = 20.0
 _ACP_STOP_SESSION_CLOSE_TIMEOUT_SEC = 5.0
 _ACP_STOP_LIVENESS_TIMEOUT_SEC = 5.0
+_ACP_UNSAFE_OWNER_STOP_TIMEOUT_SEC = 30.0
 
 
 _MCP_TRANSPORT_TO_ACP_TYPE = {
@@ -1544,7 +1546,8 @@ class Rollout:
     async def _stop_agent_once(self) -> AgentTerminationReceipt:
         """Stop the live ACP process tree and publish immutable evidence once."""
 
-        if getattr(self, "_is_session_factory", False):
+        is_session_factory = getattr(self, "_is_session_factory", False)
+        if is_session_factory:
             self._capture_partial_session_factory_trajectory()
         else:
             self._capture_partial_acp_trajectory()
@@ -1555,7 +1558,9 @@ class Rollout:
         cancel_task = getattr(self, "_stop_agent_cancel_task", None)
         if cancel_task is not None:
             cancel_acknowledged = await asyncio.shield(cancel_task)
-        session_closed = client is None and getattr(self, "_session", None) is None
+        session = getattr(self, "_session", None)
+        no_owned_process = client is None and (session is None or is_session_factory)
+        session_closed = no_owned_process
 
         close_session: Any = getattr(client, "close_session", None)
         terminate_process_tree: Any = getattr(transport, "terminate_process_tree", None)
@@ -1597,7 +1602,7 @@ class Rollout:
         force_kill_required = (
             getattr(termination_status, "force_kill_required", False) is True
         )
-        process_tree_stopped = False
+        process_tree_stopped = no_owned_process
         liveness_check = getattr(transport, "process_tree_stopped", None)
         if callable(liveness_check):
             try:
@@ -1643,9 +1648,24 @@ class Rollout:
             self._phase = "installed"
         return receipt
 
+    @staticmethod
+    def _unsafe_capture_error(
+        receipt: AgentTerminationReceipt, *, action: str
+    ) -> RuntimeError:
+        return RuntimeError(
+            "Agent teardown was not capture-safe; "
+            f"{action} is blocked "
+            f"(session_closed={receipt.session_closed}, "
+            f"process_tree_stopped={receipt.process_tree_stopped})"
+        )
+
     async def disconnect(self) -> None:
-        """Stop the current agent while keeping the environment alive."""
-        await Rollout.stop_agent(self, cancel_requested=False)
+        """Stop the agent, failing closed when process-tree death is unproven."""
+        receipt = await Rollout.stop_agent(self, cancel_requested=False)
+        if not receipt.capture_safe:
+            raise Rollout._unsafe_capture_error(
+                receipt, action="downstream workspace access"
+            )
 
     def on_ask_user(self, handler: Any) -> None:
         """Register the agent-initiated ``session/request_permission`` handler.
@@ -2063,6 +2083,7 @@ class Rollout:
 
     async def verify(self) -> dict | None:
         """Run the verifier and return rewards."""
+        await self.disconnect()
         cfg = self._config
 
         # Mark the phase at entry (the other transitions mark completion):
@@ -2108,14 +2129,15 @@ class Rollout:
     async def soft_verify(self) -> tuple[dict | None, str | None, str | None]:
         """Run the verifier without full hardening — for intermediate feedback.
 
-        Skips process kill and workspace restore/chown (so the sandbox
-        stays usable for the next round), but DOES purge agent-injected
-        conftest.py / sitecustomize.py / .pth files to prevent the agent
-        from gaming intermediate test results.
+        Requires capture-safe agent teardown, then skips the verifier's broader
+        process sweep and workspace restore/chown so the sandbox stays usable
+        for the next round. It still purges agent-injected conftest.py,
+        sitecustomize.py, and .pth files before running the verifier.
 
         Returns (rewards, verifier_output, verifier_error). The final
         verify() still does full hardening.
         """
+        await self.disconnect()
         self._rollout_paths.verifier_dir.mkdir(parents=True, exist_ok=True)
         # Clean verifier output dir — chmod 777 so non-root verifier processes can write.
         # Keep /app present for task/verifier paths that still use the legacy
@@ -2189,12 +2211,43 @@ class Rollout:
 
     # Phase 5: CLEANUP
 
-    async def cleanup(self) -> None:
-        """Close ACP client and stop the environment."""
-        self._capture_partial_acp_trajectory()
-        await self.disconnect()
+    async def _stop_owned_sandbox_after_unsafe_receipt(self) -> None:
+        stop_task = asyncio.create_task(self._env.stop(delete=True))
+        try:
+            done, _ = await asyncio.wait(
+                {stop_task}, timeout=_ACP_UNSAFE_OWNER_STOP_TIMEOUT_SEC
+            )
+        except asyncio.CancelledError:
+            stop_task.cancel()
+            stop_task.add_done_callback(_deadline._swallow_abandoned_outcome)
+            raise
+        if stop_task not in done:
+            stop_task.cancel()
+            stop_task.add_done_callback(_deadline._swallow_abandoned_outcome)
+            logger.warning(
+                "Cleanup timed out stopping the rollout-owned sandbox after "
+                "unsafe agent termination"
+            )
+            return
+        try:
+            stop_task.result()
+        except Exception as e:
+            logger.warning(f"Cleanup failed: {e}")
 
-        if self._env and self._config.export_generated_skills_to:
+    async def cleanup(self) -> None:
+        """Stop the agent and environment without capturing a mutable workspace."""
+        self._capture_partial_acp_trajectory()
+        receipt = await Rollout.stop_agent(self, cancel_requested=False)
+        capture_safe = receipt.capture_safe
+        if not capture_safe:
+            safety_error = Rollout._unsafe_capture_error(
+                receipt, action="workspace verification, capture, and export"
+            )
+            if getattr(self, "_error", None) is None:
+                self._error = str(safety_error)
+            logger.error(str(safety_error))
+
+        if capture_safe and self._env and self._config.export_generated_skills_to:
             try:
                 await self._export_generated_skills()
             except Exception as e:
@@ -2267,10 +2320,13 @@ class Rollout:
             # caller — leave it running so they can reuse it or stop it
             # themselves. #388. getattr() keeps tests that bypass __init__
             # via Rollout.__new__() working.
-            try:
-                await self._env.stop(delete=True)
-            except Exception as e:
-                logger.warning(f"Cleanup failed: {e}")
+            if capture_safe:
+                try:
+                    await self._env.stop(delete=True)
+                except Exception as e:
+                    logger.warning(f"Cleanup failed: {e}")
+            else:
+                await self._stop_owned_sandbox_after_unsafe_receipt()
 
         if hasattr(self, "_task_tmp") and self._task_tmp:
             shutil.rmtree(self._task_tmp, ignore_errors=True)
@@ -2478,6 +2534,7 @@ class Rollout:
 
         Retries transient download failures up to 3 times (guards ENG-147).
         """
+        await self.disconnect()
         await _export_generated_skills_engine(self)
 
     async def _activate_step_skills(self, step: Step) -> None:
@@ -2747,6 +2804,19 @@ class Rollout:
             self._rollout_dir / "trajectory" / "llm_trajectory.jsonl"
         ).reconcile(trajectory)
 
+    def _refresh_acp_trajectory_observation(self) -> None:
+        observation = getattr(self, "_acp_session_observation", None)
+        if not isinstance(observation, AcpSessionObservation):
+            return
+        trajectory_path, trajectory_digest = _trajectory_identity(
+            self._rollout_dir / "trajectory" / "acp_trajectory.jsonl"
+        )
+        self._acp_session_observation = replace(
+            observation,
+            trajectory_path=trajectory_path,
+            trajectory_digest=trajectory_digest,
+        )
+
     def _reconcile_acp_tool_evidence(self, usage_runtime: Any) -> None:
         """Repair lossy ACP tool details from trusted provider capture."""
 
@@ -2765,6 +2835,7 @@ class Rollout:
         TrajectoryWriter(
             self._rollout_dir / "trajectory" / "acp_trajectory.jsonl"
         ).write_final(self._trajectory)
+        self._refresh_acp_trajectory_observation()
         # info, not warning: trajectory repair is evidence-mutation an auditor
         # should find at default (non-TTY/CI) verbosity, but as a warning it
         # survived the live dashboard's WARNING+ replay and printed between

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -55,7 +55,7 @@ import tempfile
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from benchflow._types import Role, Scene, Turn
 
@@ -77,7 +77,7 @@ from benchflow._utils.scoring import classify_error as classify_error
 from benchflow._utils.text import describe_exception
 from benchflow.acp.types import McpServerSpec
 from benchflow.agents.credentials import upload_credential
-from benchflow.agents.registry import AGENTS
+from benchflow.agents.registry import AGENTS, _is_explicit_environment_control
 from benchflow.contracts import (
     AgentProtocolError,
     AskUserRequest,
@@ -628,7 +628,12 @@ def _gateway_live_tokens(runtime: Any) -> int | None:
 class Rollout:
     """Decomposed trial lifecycle with independently-callable phases."""
 
-    def __init__(self, config: RolloutConfig) -> None:
+    def __init__(
+        self,
+        config: RolloutConfig,
+        *,
+        runtime_credentials: Mapping[str, str] | None = None,
+    ) -> None:
         self._planes = config.planes or default_rollout_planes()
         # Activate Docker DinD compatibility shim on first rollout
         # construction (idempotent). Keeps `import benchflow.rollout`
@@ -636,6 +641,7 @@ class Rollout:
         _install_docker_compat(self._planes)
 
         self._config = config
+        self._runtime_credentials = dict(runtime_credentials or {})
         self._phase = "created"
 
         # Populated by setup()
@@ -767,14 +773,70 @@ class Rollout:
         self._evolved_skills: dict[str, str] | None = None
 
     @classmethod
-    async def create(cls, config: RolloutConfig) -> Rollout:
+    async def create(
+        cls,
+        config: RolloutConfig,
+        *,
+        runtime_credentials: Mapping[str, str] | None = None,
+    ) -> Rollout:
         """Create a Rollout instance. Preferred over __init__ for consistency."""
         if config.skill_mode == SKILL_MODE_SELF_GEN:
             raise ValueError(
                 "self-gen requires the runtime orchestrator. Use bf.run(), "
                 "Evaluation.run(), or bf.run(RolloutConfig(...)) instead of Rollout.create()."
             )
-        return cls(config)
+        return cls(config, runtime_credentials=runtime_credentials)
+
+    def _resolve_agent_environment(
+        self,
+        agent: str,
+        model: str | None,
+        configured_env: Mapping[str, str] | None,
+    ) -> dict[str, str]:
+        """Resolve one agent env without exposing the runtime credential bag."""
+        agent_cfg = self._planes.agent_config(agent)
+        if (
+            not agent_cfg
+            or getattr(agent_cfg, "environment_policy", "inherit") == "inherit"
+        ):
+            return self._planes.resolve_agent_env(
+                agent, model, dict(configured_env or {})
+            )
+
+        required = set(agent_cfg.requires_env)
+        explicit_env = {
+            key: value
+            for key, value in (configured_env or {}).items()
+            if key not in required and _is_explicit_environment_control(key)
+        }
+        explicit_env.update(
+            {
+                key: self._runtime_credentials[key]
+                for key in agent_cfg.requires_env
+                if key in self._runtime_credentials
+            }
+        )
+        missing = [key for key in agent_cfg.requires_env if not explicit_env.get(key)]
+        if missing:
+            names = ", ".join(missing)
+            raise ValueError(
+                f"Explicit environment policy for agent {agent!r} requires "
+                f"runtime_credentials for: {names}"
+            )
+
+        resolved = self._planes.resolve_agent_env(agent, model, explicit_env)
+        admitted = set(explicit_env)
+        admitted.update(
+            {
+                "CLAUDE_CODE_MAX_OUTPUT_TOKENS",
+                "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+            }
+        )
+        return {key: value for key, value in resolved.items() if key in admitted}
+
+    def _agent_environment_policy(self, agent: str) -> str:
+        agent_cfg = self._planes.agent_config(agent)
+        return getattr(agent_cfg, "environment_policy", "inherit")
 
     def use_prebuilt_env(self, inner: Any) -> None:
         """Inject a caller-owned sandbox; skip creation and teardown.
@@ -953,8 +1015,10 @@ class Rollout:
             _task_disallows_internet(self._task) or cfg.self_gen_no_internet
         ) and cfg.primary_agent != "oracle"
         self._agent_env = _apply_web_policy(
-            self._planes.resolve_agent_env(
-                cfg.primary_agent, cfg.primary_model, cfg.agent_env
+            self._resolve_agent_environment(
+                cfg.primary_agent,
+                cfg.primary_model,
+                cfg.agent_env,
             ),
             disallow=self._disallow_web_tools,
         )
@@ -1066,6 +1130,7 @@ class Rollout:
             model=cfg.primary_model,
             reasoning_effort=cfg.primary_reasoning_effort,
             environment=cfg.environment,
+            environment_policy=self._agent_environment_policy(cfg.primary_agent),
             environment_manifest=cfg.environment_manifest,
             skill_policy=task_skill_policy,
             sandbox_user=cfg.sandbox_user,
@@ -1076,6 +1141,8 @@ class Rollout:
             timeout=self._timeout,
             started_at=self._started_at,
             agent_env=self._agent_env,
+            runtime_credential_names=self._runtime_credentials.keys(),
+            runtime_credential_values=self._runtime_credentials.values(),
             base_image_override=cfg.base_image_override,
             usage_tracking=cfg.usage_tracking.with_env_defaults(),
             concurrency=cfg.concurrency,
@@ -2263,8 +2330,8 @@ class Rollout:
         rollout_dir = self._require_rollout_dir()
         t0 = datetime.now()
 
-        # Merge cfg.agent_env (config-level) with role.env (role-specific) so
-        # provider creds from YAML reach the agent. role.env wins on overlap.
+        # Resolve the config-level and role-specific inputs through the same
+        # admission policy used for the primary agent.
         disallow_web_tools = getattr(self, "_disallow_web_tools", None)
         if disallow_web_tools is None:
             disallow_web_tools = _task_disallows_internet(getattr(self, "_task", None))
@@ -2274,7 +2341,7 @@ class Rollout:
             disallow_web_tools=disallow_web_tools,
         )
         agent_env = _apply_web_policy(
-            self._planes.resolve_agent_env(
+            self._resolve_agent_environment(
                 role.agent,
                 role.model,
                 {**(cfg.agent_env or {}), **(role.env or {})},

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -738,6 +738,8 @@ class Rollout:
         self._termination_receipt: AgentTerminationReceipt | None = None
         self._acp_session_observation: AcpSessionObservation | None = None
         self._stop_agent_task: asyncio.Task[AgentTerminationReceipt] | None = None
+        self._stop_agent_cancel_requested = False
+        self._stop_agent_cancel_task: asyncio.Task[bool] | None = None
 
         # Populated by execute()
         self._trajectory: list[dict] = []
@@ -807,7 +809,9 @@ class Rollout:
         if callable(resolver):
             candidate = resolver(agent)
             policy = getattr(candidate, "environment_policy", None)
-            if isinstance(policy, str) and policy in {"inherit", "explicit"}:
+            if candidate is not None and (
+                isinstance(policy, str) or type(candidate).__module__ != "unittest.mock"
+            ):
                 return candidate
         return AGENTS.get(agent)
 
@@ -860,7 +864,12 @@ class Rollout:
         policy = getattr(
             self._plane_agent_config(agent), "environment_policy", "inherit"
         )
-        return "explicit" if policy == "explicit" else "inherit"
+        if policy not in {"inherit", "explicit"}:
+            raise ValueError(
+                f"Unknown environment_policy {policy!r} for agent {agent!r}; "
+                "expected 'inherit' or 'explicit'"
+            )
+        return policy
 
     def use_prebuilt_env(self, inner: Any) -> None:
         """Inject a caller-owned sandbox; skip creation and teardown.
@@ -1391,6 +1400,8 @@ class Rollout:
         """Open an ACP connection to the agent. Can be called multiple times."""
         self._termination_receipt = None
         self._stop_agent_task = None
+        self._stop_agent_cancel_requested = False
+        self._stop_agent_cancel_task = None
         self._acp_session_observation = None
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
@@ -1454,6 +1465,9 @@ class Rollout:
                     getattr(self, "_task", None),
                     getattr(self, "_agent_cfg", None),
                 ),
+                runtime_credential_values=getattr(
+                    self, "_runtime_credentials", {}
+                ).values(),
             )
         self._native_usage_checkpoint = None
         self._reapply_ask_user_handler()
@@ -1482,18 +1496,22 @@ class Rollout:
         )
 
     async def stop_agent(self, *, cancel_requested: bool) -> AgentTerminationReceipt:
-        """Share one shielded stop operation across every concurrent caller."""
+        """Share one shielded stop operation and merge concurrent cancel intent."""
         existing = getattr(self, "_termination_receipt", None)
         if existing is not None:
             return existing
+
+        self._stop_agent_cancel_requested = bool(
+            getattr(self, "_stop_agent_cancel_requested", False) or cancel_requested
+        )
+        if self._stop_agent_cancel_requested:
+            Rollout._ensure_stop_agent_cancel_task(self)
 
         stop_task: asyncio.Task[AgentTerminationReceipt] | None = getattr(
             self, "_stop_agent_task", None
         )
         if stop_task is None:
-            stop_task = asyncio.create_task(
-                Rollout._stop_agent_once(self, cancel_requested=cancel_requested)
-            )
+            stop_task = asyncio.create_task(Rollout._stop_agent_once(self))
             self._stop_agent_task = stop_task
         try:
             return await asyncio.shield(stop_task)
@@ -1501,9 +1519,29 @@ class Rollout:
             await asyncio.shield(stop_task)
             raise
 
-    async def _stop_agent_once(
-        self, *, cancel_requested: bool
-    ) -> AgentTerminationReceipt:
+    def _ensure_stop_agent_cancel_task(self) -> asyncio.Task[bool] | None:
+        task: asyncio.Task[bool] | None = getattr(self, "_stop_agent_cancel_task", None)
+        if task is not None:
+            return task
+        client = getattr(self, "_acp_client", None)
+        cancel = getattr(client, "cancel", None)
+        if client is None or not callable(cancel):
+            return None
+        task = asyncio.create_task(Rollout._cancel_agent_once(self, client))
+        self._stop_agent_cancel_task = task
+        return task
+
+    async def _cancel_agent_once(self, client: Any) -> bool:
+        try:
+            await asyncio.wait_for(
+                client.cancel(), timeout=_ACP_STOP_CANCEL_TIMEOUT_SEC
+            )
+            return True
+        except (asyncio.CancelledError, Exception):
+            logger.warning("ACP session cancellation failed")
+            return False
+
+    async def _stop_agent_once(self) -> AgentTerminationReceipt:
         """Stop the live ACP process tree and publish immutable evidence once."""
 
         if getattr(self, "_is_session_factory", False):
@@ -1514,16 +1552,10 @@ class Rollout:
         client = getattr(self, "_acp_client", None)
         transport = getattr(client, "_transport", None) if client is not None else None
         cancel_acknowledged = False
+        cancel_task = getattr(self, "_stop_agent_cancel_task", None)
+        if cancel_task is not None:
+            cancel_acknowledged = await asyncio.shield(cancel_task)
         session_closed = client is None and getattr(self, "_session", None) is None
-
-        if cancel_requested and client is not None:
-            try:
-                await asyncio.wait_for(
-                    client.cancel(), timeout=_ACP_STOP_CANCEL_TIMEOUT_SEC
-                )
-                cancel_acknowledged = True
-            except Exception:
-                logger.warning("ACP session cancellation failed", exc_info=True)
 
         close_session: Any = getattr(client, "close_session", None)
         terminate_process_tree: Any = getattr(transport, "terminate_process_tree", None)
@@ -1581,6 +1613,13 @@ class Rollout:
                 )
         if not process_tree_stopped:
             graceful_termination = False
+
+        cancel_task = getattr(self, "_stop_agent_cancel_task", None)
+        if cancel_task is not None:
+            cancel_acknowledged = (
+                await asyncio.shield(cancel_task) or cancel_acknowledged
+            )
+        cancel_requested = bool(getattr(self, "_stop_agent_cancel_requested", False))
 
         _ = Rollout.acp_session_observation.__get__(self, Rollout)
 
@@ -2467,6 +2506,8 @@ class Rollout:
         """
         self._termination_receipt = None
         self._stop_agent_task = None
+        self._stop_agent_cancel_requested = False
+        self._stop_agent_cancel_task = None
         self._acp_session_observation = None
         cfg = self._config
         rollout_dir = self._require_rollout_dir()
@@ -2593,6 +2634,9 @@ class Rollout:
                 mcp_servers=_task_mcp_specs_for_agent(
                     role.agent, getattr(self, "_task", None), agent_cfg
                 ),
+                runtime_credential_values=getattr(
+                    self, "_runtime_credentials", {}
+                ).values(),
             )
         self._reapply_ask_user_handler()
         self._attach_trajectory_writer(rollout_dir)

--- a/src/benchflow/rollout/_results.py
+++ b/src/benchflow/rollout/_results.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections.abc import Collection
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,7 @@ from benchflow._utils.result_metadata import (
 from benchflow._utils.reward_events import build_rewards_jsonl_events
 from benchflow._utils.scoring import classify_error, classify_verifier_error
 from benchflow._utils.source_provenance import artifact_source_provenance
+from benchflow.agents.registry import AgentEnvironmentPolicy
 from benchflow.contracts import (
     BaseUser,
     DocumentNudgeUser,
@@ -140,6 +142,7 @@ def _write_config(
     agent: str,
     model: str | None,
     environment: str,
+    environment_policy: AgentEnvironmentPolicy = "inherit",
     skill_policy: TaskSkillPolicy,
     sandbox_user: str | None,
     context_root: str | Path | None,
@@ -148,6 +151,8 @@ def _write_config(
     skip_agent_install: bool = False,
     timeout: int,
     started_at: datetime,
+    runtime_credential_names: Collection[str] = (),
+    runtime_credential_values: Collection[str] = (),
     agent_env: dict[str, str],
     base_image_override: str | None = None,
     reasoning_effort: str | None = None,
@@ -172,8 +177,14 @@ def _write_config(
         if artifact_source and artifact_source.get("path")
         else task_path.name
     )
+    private_names = frozenset(runtime_credential_names)
+    private_values = frozenset(runtime_credential_values)
     recorded_env = {
-        k: v for k, v in agent_env.items() if _should_record_env_entry(k, v)
+        key: value
+        for key, value in agent_env.items()
+        if key not in private_names
+        and value not in private_values
+        and _should_record_env_entry(key, value)
     }
     config_data = {
         "task_path": recorded_task_path,
@@ -181,6 +192,7 @@ def _write_config(
         "model": model,
         "reasoning_effort": reasoning_effort,
         "environment": environment,
+        "environment_policy": environment_policy,
         "acp_transport": selected_acp_transport(
             agent=agent,
             environment=environment,

--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -25,7 +25,6 @@ import asyncio
 import contextlib
 import logging
 import os
-import re
 import shlex
 import tempfile
 from collections.abc import Callable
@@ -96,94 +95,6 @@ def _agent_launch_with_web_policy(
     return (planes or default_rollout_planes()).agent_launch(
         agent, disallow_web_tools=disallow
     )
-
-
-# Package runners whose *next* token is a subcommand (``uv run <agent>``,
-# ``npx <agent>``), not the agent binary — skip both.
-_PACKAGE_RUNNERS = frozenset({"uv", "uvx", "npx", "npm", "pnpm", "yarn", "pipx"})
-# Interpreters that launch an agent but never *identify* it: keying a
-# ``pkill -f`` pattern on one of these reaps every interpreter process in the
-# sandbox, not just the agent. (e.g. ``pythonX.Y`` is matched by the
-# ``python`` prefix in :func:`_is_generic_interpreter`.)
-_GENERIC_INTERPRETERS = (
-    frozenset(
-        {
-            "python",
-            "pypy",
-            "node",
-            "nodejs",
-            "deno",
-            "bun",
-            "ruby",
-            "perl",
-            "sh",
-            "bash",
-            "dash",
-            "env",
-        }
-    )
-    | _PACKAGE_RUNNERS
-)
-# Subcommands consumed by a package runner before the agent binary appears.
-_RUNNER_SUBCOMMANDS = frozenset({"run", "tool", "exec", "x"})
-# A leading ``FOO=bar`` environment-variable assignment (e.g. harvey-lab's
-# ``HARVEY_LABS_ROOT=/opt/harvey-labs ... python <shim>``).
-_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_]\w*=")
-# Shell operators that separate commands; the agent invocation is the final
-# command in a ``setup && … && <agent>`` launch (openhands).
-_SHELL_SEP_RE = re.compile(r"\s*(?:&&|\|\||;)\s*")
-
-
-def _is_generic_interpreter(basename: str) -> bool:
-    return basename in _GENERIC_INTERPRETERS or basename.startswith("python")
-
-
-def _agent_process_kill_pattern(agent_launch: str) -> str | None:
-    """Return a ``pkill -f`` pattern that targets the *agent* process only.
-
-    The pattern must identify the agent — never the interpreter that launches
-    it. Several agents launch as ``<venv>/bin/python <shim>`` (deepagents,
-    harvey-lab); naively keying on the first token then yields ``python``, and
-    ``pkill -f python`` reaps **every** Python process in the sandbox. That
-    includes Environment-plane services — mock APIs run as console scripts via
-    their ``#!/usr/bin/python`` shebang, so their argv is
-    ``/usr/bin/python /usr/local/bin/<svc> …`` — and Python verifiers. The
-    service is then dead when the verifier reads its live state, scoring 0.0
-    on an otherwise-correct rollout (BF-10).
-
-    Resolution:
-
-    1. Reduce to the **last shell-command segment** — for a
-       ``export … && mkdir … && <agent>`` launch (openhands) the agent is the
-       final command, not the leading ``export`` builtin.
-    2. Walk that segment and key on the agent's own binary/shim token, skipping
-       ``FOO=bar`` env assignments, generic interpreters, package-runner
-       subcommands (``uv run <agent>``), and flags.
-
-    Returns ``None`` when nothing specific enough is found — better to skip the
-    cleanup pkill than to fire a sandbox-wide one.
-    """
-    segments = [s for s in _SHELL_SEP_RE.split(agent_launch.strip()) if s.strip()]
-    if not segments:
-        return None
-
-    after_runner = False
-    for token in segments[-1].split():
-        if _ENV_ASSIGN_RE.match(token):  # FOO=bar prefix
-            continue
-        if token.startswith("-"):  # a flag (e.g. python -m, gemini --acp)
-            continue
-        basename = PurePosixPath(token).name
-        if not basename:
-            continue
-        if _is_generic_interpreter(basename):  # too broad to pkill on
-            after_runner = basename in _PACKAGE_RUNNERS
-            continue
-        if after_runner and basename in _RUNNER_SUBCOMMANDS:  # `uv run` etc.
-            after_runner = False
-            continue
-        return rf"(^|[ /]){re.escape(basename)}( |$)"
-    return None
 
 
 def _configured_task_workdir(task: Any) -> str | None:

--- a/src/benchflow/sandbox/process/_base.py
+++ b/src/benchflow/sandbox/process/_base.py
@@ -29,6 +29,7 @@ import shlex
 import signal
 import uuid
 from abc import ABC, abstractmethod
+from collections.abc import Collection
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
@@ -39,9 +40,17 @@ _STDERR_TAIL_LIMIT = 64 * 1024  # bounded stderr retained for rollout diagnostic
 _STDERR_DRAIN_TIMEOUT_SEC = 2
 _PROCESS_TREE_TERM_TIMEOUT_SEC = 5.0
 _PROCESS_TREE_KILL_TIMEOUT_SEC = 5.0
+_DEFAULT_PROCESS_CLOSE_TIMEOUT_SEC = 35.0
 _PROCESS_TREE_POLL_INTERVAL_SEC = 0.05
 _BOOTSTRAP_DONE = "__BENCHFLOW_BOOTSTRAP_DONE__"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _consume_task_result(task: asyncio.Task[None]) -> None:
+    """Retrieve a detached cleanup task result without surfacing it later."""
+    with contextlib.suppress(BaseException):
+        task.result()
+
 
 # Terminal control sequences a PTY-backed transport can interleave with
 # protocol output: ECMA-48 CSI (parameter bytes 0x30-0x3F, intermediate
@@ -143,6 +152,19 @@ class LiveProcess(ABC):
     async def close(self) -> None:
         """Terminate the process (idempotent — safe to call after death)."""
 
+    def set_output_redaction_values(self, values: Collection[str]) -> None:
+        """Privately retain exact values that must never cross output boundaries."""
+        self._output_redaction_values = tuple(value for value in values if value)
+
+    def _redact_output(self, text: str) -> str:
+        from benchflow.trajectories.types import (
+            redact_trajectory_text_with_exact_values,
+        )
+
+        return redact_trajectory_text_with_exact_values(
+            text, getattr(self, "_output_redaction_values", ())
+        )
+
     async def close_stdin(self) -> bool:
         """Close the ACP input stream when the backend exposes it independently."""
         return False
@@ -152,8 +174,27 @@ class LiveProcess(ABC):
         return False
 
     async def terminate_process_tree(self) -> _ProcessTreeTermination:
-        """Close the transport without claiming unobservable descendant liveness."""
-        await self.close()
+        """Bound unsupported close paths without claiming descendant liveness."""
+        close_task = asyncio.create_task(self.close())
+        try:
+            done, _ = await asyncio.wait(
+                {close_task}, timeout=_DEFAULT_PROCESS_CLOSE_TIMEOUT_SEC
+            )
+        except asyncio.CancelledError:
+            close_task.cancel()
+            close_task.add_done_callback(_consume_task_result)
+            raise
+        if close_task in done:
+            await close_task
+        else:
+            close_task.cancel()
+            close_task.add_done_callback(_consume_task_result)
+            await asyncio.sleep(0)
+            logger.warning(
+                "%s close exceeded %.0fs; descendant liveness remains unknown",
+                type(self).__name__,
+                _DEFAULT_PROCESS_CLOSE_TIMEOUT_SEC,
+            )
         return _UNKNOWN_PROCESS_TREE_TERMINATION
 
     async def process_tree_stopped(self) -> bool:
@@ -280,9 +321,7 @@ class SubprocessLiveProcess(LiveProcess):
             msg = f"Process closed stdout (rc={rc}): {hint}"
             stderr_snippet: str | None = None
             if stderr_text:
-                from benchflow.trajectories.types import redact_trajectory_text
-
-                stderr_snippet = redact_trajectory_text(stderr_text)[:_DIAG_TRUNCATE]
+                stderr_snippet = self._redact_output(stderr_text)[:_DIAG_TRUNCATE]
                 msg += f"\nstderr: {stderr_snippet}"
             # Raise a structured TransportClosedError at the source so
             # downstream code (rollout._build_rollout_result) doesn't have

--- a/src/benchflow/sandbox/process/_base.py
+++ b/src/benchflow/sandbox/process/_base.py
@@ -25,7 +25,11 @@ import contextlib
 import logging
 import os
 import re
+import shlex
+import signal
+import uuid
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +37,9 @@ _BUFFER_LIMIT = 10 * 1024 * 1024  # 10MB readline buffer
 _DIAG_TRUNCATE = 2000  # max chars for diagnostic stderr in error messages
 _STDERR_TAIL_LIMIT = 64 * 1024  # bounded stderr retained for rollout diagnostics
 _STDERR_DRAIN_TIMEOUT_SEC = 2
+_PROCESS_TREE_TERM_TIMEOUT_SEC = 5.0
+_PROCESS_TREE_KILL_TIMEOUT_SEC = 5.0
+_PROCESS_TREE_POLL_INTERVAL_SEC = 0.05
 _BOOTSTRAP_DONE = "__BENCHFLOW_BOOTSTRAP_DONE__"
 _ENV_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -91,6 +98,20 @@ async def drain_oversized_line(reader: asyncio.StreamReader) -> int:
     return skipped
 
 
+@dataclass(frozen=True, slots=True)
+class _ProcessTreeTermination:
+    graceful_termination: bool
+    force_kill_required: bool
+    process_tree_stopped: bool
+
+
+_UNKNOWN_PROCESS_TREE_TERMINATION = _ProcessTreeTermination(
+    graceful_termination=False,
+    force_kill_required=False,
+    process_tree_stopped=False,
+)
+
+
 class LiveProcess(ABC):
     """Abstract live stdin/stdout connection to a process inside a sandbox.
 
@@ -122,6 +143,28 @@ class LiveProcess(ABC):
     async def close(self) -> None:
         """Terminate the process (idempotent — safe to call after death)."""
 
+    async def close_stdin(self) -> bool:
+        """Close the ACP input stream when the backend exposes it independently."""
+        return False
+
+    async def wait_for_session_closed(self, timeout: float) -> bool:
+        """Wait for an independently requested stream close to end the adapter."""
+        return False
+
+    async def terminate_process_tree(self) -> _ProcessTreeTermination:
+        """Close the transport without claiming unobservable descendant liveness."""
+        await self.close()
+        return _UNKNOWN_PROCESS_TREE_TERMINATION
+
+    async def process_tree_stopped(self) -> bool:
+        """Whether all descendants are proven stopped.
+
+        Non-subprocess transports cannot infer this from a closed pipe or
+        WebSocket. They remain unsafe unless a backend overrides the method
+        with a real liveness check.
+        """
+        return False
+
     @property
     @abstractmethod
     def is_running(self) -> bool:
@@ -138,9 +181,17 @@ class SubprocessLiveProcess(LiveProcess):
 
     _process: asyncio.subprocess.Process | None = None
 
-    def _set_process(self, process: asyncio.subprocess.Process) -> None:
-        """Store a subprocess and drain stderr without blocking its stdout pipe."""
+    def _set_process(
+        self,
+        process: asyncio.subprocess.Process,
+        *,
+        owns_process_group: bool = False,
+    ) -> None:
+        """Store a subprocess and the process-group identity created at launch."""
         self._process = process
+        self._process_group_id = process.pid if owns_process_group else None
+        self._stdin_closed = False
+        self._termination_status: _ProcessTreeTermination | None = None
         self._stderr_tail = bytearray()
         self._stderr_task = (
             asyncio.create_task(self._drain_stderr(process.stderr))
@@ -261,22 +312,310 @@ class SubprocessLiveProcess(LiveProcess):
         self._process.stdin.write((data + "\n").encode())
         await self._process.stdin.drain()
 
-    async def close(self) -> None:
-        """Terminate the process (idempotent — safe to call after process death)."""
-        if self._process:
-            if self._process.stdin:
-                with contextlib.suppress(OSError):  # already closed
-                    self._process.stdin.close()
-            if self._process.returncode is None:
-                self._process.terminate()
-                try:
-                    await asyncio.wait_for(self._process.wait(), timeout=5)
-                except TimeoutError:
-                    self._process.kill()
-                    await self._process.wait()
+    async def close_stdin(self) -> bool:
+        """Close the ACP input stream without assuming test doubles are writers."""
+        process = self._process
+        if process is None:
+            return False
+        stdin = process.stdin
+        if stdin is None:
+            return process.returncode is not None
+        is_closing = getattr(type(stdin), "is_closing", None)
+        if getattr(self, "_stdin_closed", False) or (
+            callable(is_closing) and is_closing(stdin) is True
+        ):
+            self._stdin_closed = True
+            return True
+        try:
+            stdin.close()
+            wait_closed = getattr(type(stdin), "wait_closed", None)
+            if callable(wait_closed):
+                await wait_closed(stdin)
+        except OSError:
+            return process.returncode is not None
+        self._stdin_closed = True
+        return True
+
+    async def wait_for_session_closed(self, timeout: float) -> bool:
+        """Wait briefly for an ACP adapter to honor EOF before signaling it."""
+        process = self._process
+        if process is None:
+            return False
+        if process.returncode is not None:
+            return True
+        try:
+            await asyncio.wait_for(asyncio.shield(process.wait()), timeout=timeout)
+        except TimeoutError:
+            return False
+        return True
+
+    @property
+    def termination_status(self) -> _ProcessTreeTermination:
+        return (
+            getattr(self, "_termination_status", None)
+            or _UNKNOWN_PROCESS_TREE_TERMINATION
+        )
+
+    def _process_group_is_alive(self) -> bool:
+        process_group_id = getattr(self, "_process_group_id", None)
+        if process_group_id is None:
+            return False
+        try:
+            os.killpg(process_group_id, 0)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+        return True
+
+    async def process_tree_stopped(self) -> bool:
+        process_group_id = getattr(self, "_process_group_id", None)
+        if process_group_id is None:
+            return self.termination_status.process_tree_stopped
+        stopped = not self._process_group_is_alive()
+        if stopped:
+            self._process_group_id = None
+        return stopped
+
+    async def _wait_for_process_tree(self, timeout: float) -> bool:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while self._process_group_is_alive():
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(_PROCESS_TREE_POLL_INTERVAL_SEC, remaining))
+        self._process_group_id = None
+        return True
+
+    def _signal_process_group(self, sig: signal.Signals) -> bool:
+        process_group_id = getattr(self, "_process_group_id", None)
+        if process_group_id is None:
+            return False
+        if process_group_id == os.getpgrp():
+            logger.error("Refusing to signal BenchFlow's own process group")
+            return False
+        try:
+            os.killpg(process_group_id, sig)
+        except ProcessLookupError:
+            return False
+        except (OSError, PermissionError):
+            logger.warning(
+                "Could not signal owned process group %s with %s",
+                process_group_id,
+                sig.name,
+                exc_info=True,
+            )
+            return False
+        return True
+
+    async def _close_unowned_process(self) -> None:
+        """Preserve legacy leader cleanup without claiming descendant safety."""
+        if not self._process or self._process.returncode is not None:
+            return
+        self._process.terminate()
+        try:
+            await asyncio.wait_for(self._process.wait(), timeout=5)
+        except TimeoutError:
+            self._process.kill()
+            await self._process.wait()
+
+    async def terminate_process_tree(self) -> _ProcessTreeTermination:
+        """Stop the exact process group retained when this transport launched."""
+        existing = getattr(self, "_termination_status", None)
+        if existing is not None:
+            return existing
+        await self.close_stdin()
+
+        if getattr(self, "_process_group_id", None) is None:
+            await self._close_unowned_process()
             await self._finish_stderr_drain(cancel_on_timeout=True)
-            logger.info("Process terminated")
+            self._termination_status = _UNKNOWN_PROCESS_TREE_TERMINATION
+            return self._termination_status
+
+        graceful = False
+        force_required = False
+        stopped = await self.process_tree_stopped()
+        if not stopped:
+            term_sent = self._signal_process_group(signal.SIGTERM)
+            stopped = await self._wait_for_process_tree(_PROCESS_TREE_TERM_TIMEOUT_SEC)
+            graceful = term_sent and stopped
+        if not stopped:
+            force_required = True
+            self._signal_process_group(signal.SIGKILL)
+            stopped = await self._wait_for_process_tree(_PROCESS_TREE_KILL_TIMEOUT_SEC)
+        if self._process and self._process.returncode is None:
+            with contextlib.suppress(TimeoutError):
+                await asyncio.wait_for(self._process.wait(), timeout=0.5)
+        await self._finish_stderr_drain(cancel_on_timeout=True)
+        self._termination_status = _ProcessTreeTermination(
+            graceful_termination=graceful,
+            force_kill_required=force_required,
+            process_tree_stopped=stopped,
+        )
+        logger.info(
+            "Process tree termination: graceful=%s forced=%s stopped=%s",
+            graceful,
+            force_required,
+            stopped,
+        )
+        return self._termination_status
+
+    async def close(self) -> None:
+        """Terminate the owned process tree (idempotent after the first result)."""
+        await self.terminate_process_tree()
 
     @property
     def is_running(self) -> bool:
         return self._process is not None and self._process.returncode is None
+
+
+class _RemoteProcessGroupLiveProcess(SubprocessLiveProcess):
+    """Subprocess adapter that owns the exact process group inside its sandbox."""
+
+    _remote_process_group_path: str | None = None
+
+    def _build_remote_process_group_wrapper(self, command: str) -> tuple[str, str]:
+        """Build an isolated-group command without publishing identity yet."""
+        path = f"/tmp/.benchflow_agent_pgid_{uuid.uuid4().hex}"
+        inner = (
+            f"umask 077; printf '%s\\n' \"$$\" > {shlex.quote(path)}; "
+            f"exec bash -c {shlex.quote(command)}"
+        )
+        return f"exec setsid bash -c {shlex.quote(inner)}", path
+
+    def _wrap_remote_process_group(self, command: str) -> str:
+        """Create an isolated remote group and retain its launch identity."""
+        wrapped, path = self._build_remote_process_group_wrapper(command)
+        self._remote_process_group_path = path
+        self._termination_status = None
+        return wrapped
+
+    async def _exec_remote_process_group_command(self, command: str) -> int:
+        raise NotImplementedError
+
+    def _remote_process_group_command(self, operation: str) -> str | None:
+        path = self._remote_process_group_path
+        if path is None:
+            return None
+        prelude = (
+            f"pgid=$(cat {shlex.quote(path)} 2>/dev/null) || exit 2; "
+            "case \"$pgid\" in ''|*[!0-9]*) exit 2;; esac; "
+        )
+        if operation == "check":
+            return prelude + 'kill -0 -- "-$pgid" 2>/dev/null'
+        if operation in {"TERM", "KILL"}:
+            return prelude + f'kill -{operation} -- "-$pgid" 2>/dev/null'
+        raise ValueError(f"Unsupported process-group operation: {operation}")
+
+    async def _remote_process_group_alive(self) -> bool | None:
+        command = self._remote_process_group_command("check")
+        if command is None:
+            return None
+        try:
+            return_code = await self._exec_remote_process_group_command(command)
+        except Exception:
+            logger.warning(
+                "Remote process-group liveness command failed", exc_info=True
+            )
+            return None
+        if return_code == 0:
+            return True
+        if return_code == 1:
+            return False
+        return None
+
+    async def _signal_remote_process_group(self, operation: str) -> bool:
+        command = self._remote_process_group_command(operation)
+        if command is None:
+            return False
+        try:
+            return await self._exec_remote_process_group_command(command) == 0
+        except Exception:
+            logger.warning(
+                "Remote process-group %s command failed", operation, exc_info=True
+            )
+            return False
+
+    async def _wait_for_remote_process_tree(self, timeout: float) -> bool:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while True:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            try:
+                alive = await asyncio.wait_for(
+                    self._remote_process_group_alive(),
+                    timeout=remaining,
+                )
+            except TimeoutError:
+                return False
+            if alive is False:
+                return True
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return False
+            await asyncio.sleep(min(_PROCESS_TREE_POLL_INTERVAL_SEC, remaining))
+
+    async def process_tree_stopped(self) -> bool:
+        if self._remote_process_group_path is None:
+            return self.termination_status.process_tree_stopped
+        alive = await self._remote_process_group_alive()
+        return alive is False
+
+    async def _cleanup_remote_process_group_identity(self) -> None:
+        path = self._remote_process_group_path
+        if path is None:
+            return
+        try:
+            await self._exec_remote_process_group_command(f"rm -f {shlex.quote(path)}")
+        except Exception:
+            logger.warning(
+                "Could not remove remote process-group identity %s",
+                path,
+                exc_info=True,
+            )
+        self._remote_process_group_path = None
+
+    async def terminate_process_tree(self) -> _ProcessTreeTermination:
+        existing = getattr(self, "_termination_status", None)
+        if existing is not None:
+            return existing
+
+        await self.close_stdin()
+
+        graceful = False
+        force_required = False
+        identity_known = self._remote_process_group_path is not None
+        alive = await self._remote_process_group_alive()
+        stopped = alive is False
+        if identity_known and not stopped:
+            term_sent = await self._signal_remote_process_group("TERM")
+            stopped = await self._wait_for_remote_process_tree(
+                _PROCESS_TREE_TERM_TIMEOUT_SEC
+            )
+            graceful = term_sent and stopped
+        if identity_known and not stopped:
+            force_required = True
+            await self._signal_remote_process_group("KILL")
+            stopped = await self._wait_for_remote_process_tree(
+                _PROCESS_TREE_KILL_TIMEOUT_SEC
+            )
+
+        await self._close_unowned_process()
+        await self._finish_stderr_drain(cancel_on_timeout=True)
+        if stopped:
+            await self._cleanup_remote_process_group_identity()
+        self._termination_status = _ProcessTreeTermination(
+            graceful_termination=graceful,
+            force_kill_required=force_required,
+            process_tree_stopped=stopped,
+        )
+        logger.info(
+            "Remote process tree termination: graceful=%s forced=%s stopped=%s",
+            graceful,
+            force_required,
+            stopped,
+        )
+        return self._termination_status

--- a/src/benchflow/sandbox/process/agentcore.py
+++ b/src/benchflow/sandbox/process/agentcore.py
@@ -43,6 +43,30 @@ _READER_ENDED = object()
 _START_MARKER_TIMEOUT_SEC = 180
 _READLINE_TIMEOUT_ENV = "BENCHFLOW_AGENTCORE_READLINE_TIMEOUT"
 _READLINE_TIMEOUT_DEFAULT_SEC = 900.0
+_AGENTCORE_READER_CLOSE_TIMEOUT_SEC = 5.0
+_AGENTCORE_SHELL_CLOSE_TIMEOUT_SEC = 15.0
+
+
+def _consume_cleanup_result(future: asyncio.Future[Any]) -> None:
+    with contextlib.suppress(BaseException):
+        future.result()
+
+
+async def _await_cleanup_bounded(awaitable: Any, timeout: float) -> bool:
+    task = asyncio.ensure_future(awaitable)
+    try:
+        done, _ = await asyncio.wait({task}, timeout=timeout)
+    except asyncio.CancelledError:
+        task.cancel()
+        task.add_done_callback(_consume_cleanup_result)
+        raise
+    if task in done:
+        _consume_cleanup_result(task)
+        return True
+    task.cancel()
+    task.add_done_callback(_consume_cleanup_result)
+    await asyncio.sleep(0)
+    return False
 
 
 def _readline_timeout_sec() -> float:
@@ -120,7 +144,9 @@ class AgentCoreProcess(LiveProcess):
             raise
         except BaseException as exc:
             self._failure = exc
-            logger.warning("AgentCore shell reader stopped: %s", exc)
+            logger.warning(
+                "AgentCore shell reader stopped: %s", self._redact_output(str(exc))
+            )
         finally:
             # Wake any waiting readline() right now. Without this sentinel a
             # dead transport surfaces only when the read timeout expires, so an
@@ -162,7 +188,7 @@ class AgentCoreProcess(LiveProcess):
             logger.debug(
                 "AgentCore shell %s: %s",
                 getattr(frame.channel, "name", frame.channel),
-                payload.strip()[:500],
+                self._redact_output(payload.strip())[:500],
             )
 
     async def _write_env_file(self, env: dict[str, str]) -> str:
@@ -285,9 +311,14 @@ class AgentCoreProcess(LiveProcess):
                 # The shell died during startup. Without this the sentinel is
                 # consumed here (or cleared by the drain below) and the next
                 # readline waits out the full read timeout instead.
+                failure = (
+                    self._redact_output(str(self._failure))
+                    if self._failure is not None
+                    else "EOF"
+                )
                 msg = (
                     "AgentCore shell closed before the start marker "
-                    f"(session={self._session_id}): {self._failure or 'EOF'}"
+                    f"(session={self._session_id}): {failure}"
                 )
                 raise TransportClosedError(
                     msg,
@@ -351,8 +382,9 @@ class AgentCoreProcess(LiveProcess):
             # the transport is gone, and both must surface now rather than at
             # the read timeout.
             if self._failure is not None:
+                failure = self._redact_output(str(self._failure))
                 raise _closed(
-                    f"AgentCore shell transport failed: {self._failure}",
+                    f"AgentCore shell transport failed: {failure}",
                     "remote_session_killed",
                 ) from self._failure
             raise _closed(
@@ -392,15 +424,23 @@ class AgentCoreProcess(LiveProcess):
     async def close(self) -> None:
         self._closed = True
         if self._reader_task is not None:
-            self._reader_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await self._reader_task
+            reader_task = self._reader_task
             self._reader_task = None
+            reader_task.cancel()
+            if not await _await_cleanup_bounded(
+                reader_task, _AGENTCORE_READER_CLOSE_TIMEOUT_SEC
+            ):
+                logger.warning("AgentCore shell reader did not stop before deadline")
         if self._shell is not None:
-            with contextlib.suppress(Exception):
-                await self._shell.close()
+            shell = self._shell
             self._shell = None
-            logger.info("AgentCore shell terminated")
+            closed = await _await_cleanup_bounded(
+                shell.close(), _AGENTCORE_SHELL_CLOSE_TIMEOUT_SEC
+            )
+            if closed:
+                logger.info("AgentCore shell terminated")
+            else:
+                logger.warning("AgentCore shell close did not finish before deadline")
 
     @property
     def is_running(self) -> bool:

--- a/src/benchflow/sandbox/process/apple.py
+++ b/src/benchflow/sandbox/process/apple.py
@@ -11,13 +11,13 @@ from typing import Any
 from benchflow.sandbox.process._base import (
     _BUFFER_LIMIT,
     _ENV_KEY_RE,
-    SubprocessLiveProcess,
+    _RemoteProcessGroupLiveProcess,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class AppleContainerProcess(SubprocessLiveProcess):
+class AppleContainerProcess(_RemoteProcessGroupLiveProcess):
     """Live stdin/stdout through Apple Container's native exec transport."""
 
     def __init__(self, container_name: str):
@@ -94,6 +94,35 @@ class AppleContainerProcess(SubprocessLiveProcess):
                 f"(rc={proc.returncode}): {stderr.decode(errors='replace')[:500]}"
             )
 
+    async def _exec_remote_process_group_command(self, command: str) -> int:
+        process = await asyncio.create_subprocess_exec(
+            "container",
+            "exec",
+            self._container_name,
+            "bash",
+            "-c",
+            command,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            _, stderr = await asyncio.wait_for(process.communicate(), timeout=15)
+        except (TimeoutError, asyncio.CancelledError):
+            process.kill()
+            await process.wait()
+            raise
+        return_code = process.returncode
+        if return_code is None:
+            return 2
+        if return_code not in (0, 1, 2):
+            logger.warning(
+                "Apple process-group control failed (rc=%s): %s",
+                return_code,
+                stderr.decode(errors="replace")[:500],
+            )
+        return return_code
+
     async def start(
         self,
         command: str,
@@ -104,6 +133,7 @@ class AppleContainerProcess(SubprocessLiveProcess):
             await self._write_env_to_container(env)
             env_path = shlex.quote(self._env_path)
             command = f". {env_path} && rm -f {env_path} && {command}"
+        command = self._wrap_remote_process_group(command)
 
         args = ["container", "exec", "--interactive"]
         if cwd:
@@ -127,6 +157,7 @@ class AppleContainerProcess(SubprocessLiveProcess):
                         "Could not remove staged Apple container env after launch failure",
                         exc_info=True,
                     )
+            self._remote_process_group_path = None
             raise
         logger.info(
             "Apple Container process started (pid=%s, container=%s)",

--- a/src/benchflow/sandbox/process/daytona.py
+++ b/src/benchflow/sandbox/process/daytona.py
@@ -17,7 +17,7 @@ from benchflow.sandbox.process._base import (
     _DIAG_TRUNCATE,
     _ENV_KEY_RE,
     LiveProcess,
-    SubprocessLiveProcess,
+    _RemoteProcessGroupLiveProcess,
     _timeout_sec_from_env,
 )
 
@@ -112,7 +112,7 @@ async def _bootstrap_daytona_env_file(
         )
 
 
-class DaytonaProcess(SubprocessLiveProcess):
+class DaytonaProcess(_RemoteProcessGroupLiveProcess):
     """Live stdin/stdout via SSH to a Daytona sandbox.
 
     For DinD (compose) sandboxes, the SSH connects to the VM and then
@@ -273,6 +273,25 @@ class DaytonaProcess(SubprocessLiveProcess):
             error_label="Daytona agent env",
         )
 
+    async def _exec_remote_process_group_command(self, command: str) -> int:
+        if self._is_dind:
+            if self._compose_cmd_base:
+                parts = [*shlex.split(self._compose_cmd_base), "exec", "-T"]
+            else:
+                parts = ["docker", "compose", "exec", "-T"]
+            parts.extend(["main", "bash", "-c", command])
+            remote_command = shlex.join(parts)
+            if self._compose_cmd_prefix:
+                remote_command = f"{self._compose_cmd_prefix} {remote_command}"
+        else:
+            remote_command = command
+        response = await asyncio.wait_for(
+            self._sandbox.process.exec(remote_command, timeout=10),
+            timeout=30,
+        )
+        exit_code = getattr(response, "exit_code", None)
+        return exit_code if isinstance(exit_code, int) else 2
+
     async def start(
         self,
         command: str,
@@ -280,6 +299,7 @@ class DaytonaProcess(SubprocessLiveProcess):
         cwd: str | None = None,
     ) -> None:
         remote_env_path = None
+        self._remote_process_group_path = None
 
         if self._is_dind:
             # Build the docker compose exec command to run inside the DinD VM.
@@ -304,7 +324,10 @@ class DaytonaProcess(SubprocessLiveProcess):
                 )
                 for key in env:
                     inner_parts.extend(["--env", key])
-            inner_parts.extend(["main", "bash", "-c", command])
+            wrapped_command, process_group_path = (
+                self._build_remote_process_group_wrapper(command)
+            )
+            inner_parts.extend(["main", "bash", "-c", wrapped_command])
             inner_cmd = shlex.join(inner_parts)
 
             remote_cmd = (
@@ -339,14 +362,19 @@ class DaytonaProcess(SubprocessLiveProcess):
                 )
                 remote_env_path_q = shlex.quote(remote_env_path)
                 env_prefix = f". {remote_env_path_q} && rm -f {remote_env_path_q} && "
+            wrapped_command, process_group_path = (
+                self._build_remote_process_group_wrapper(command)
+            )
             if cwd:
-                remote_cmd = f"cd {shlex.quote(cwd)} && {env_prefix}{command}"
+                remote_cmd = f"cd {shlex.quote(cwd)} && {env_prefix}{wrapped_command}"
             else:
-                remote_cmd = f"{env_prefix}{command}"
+                remote_cmd = f"{env_prefix}{wrapped_command}"
             if remote_env_path:
                 remote_cmd = (
                     f"trap 'rm -f {shlex.quote(remote_env_path)}' EXIT; {remote_cmd}"
                 )
+        self._remote_process_group_path = process_group_path
+        self._termination_status = None
 
         try:
             ssh_access = await self._sandbox.create_ssh_access(
@@ -368,10 +396,16 @@ class DaytonaProcess(SubprocessLiveProcess):
                 limit=_BUFFER_LIMIT,
             )
             self._set_process(process)
-        except Exception:
+        except BaseException:
             if remote_env_path:
                 await self._cleanup_remote_env_file(remote_env_path)
-            await self.close()
+            if self._process is None:
+                # The remote wrapper never started, so its identity file cannot exist.
+                self._remote_process_group_path = None
+                if self._ssh_config_path:
+                    self._unlink_ssh_config(self._ssh_config_path)
+            else:
+                await self.close()
             raise
         self._ssh_config_cleanup_task = asyncio.create_task(
             self._cleanup_ssh_config_after_exit(process, ssh_config_path)
@@ -406,8 +440,8 @@ class DaytonaPtyProcess(LiveProcess):
         self._sandbox = sandbox
         self._compose_cmd_prefix = compose_cmd_prefix
         self._compose_cmd_base = compose_cmd_base
-        self._pty = None
-        self._line_buffer = asyncio.Queue()
+        self._pty: Any = None
+        self._line_buffer: asyncio.Queue[bytes] = asyncio.Queue()
         self._partial = b""
         self._closed = False
         self._remote_env_path: str | None = None

--- a/src/benchflow/sandbox/process/docker.py
+++ b/src/benchflow/sandbox/process/docker.py
@@ -8,12 +8,15 @@ import os
 import shlex
 from typing import Any
 
-from benchflow.sandbox.process._base import _BUFFER_LIMIT, SubprocessLiveProcess
+from benchflow.sandbox.process._base import (
+    _BUFFER_LIMIT,
+    _RemoteProcessGroupLiveProcess,
+)
 
 logger = logging.getLogger(__name__)
 
 
-class DockerProcess(SubprocessLiveProcess):
+class DockerProcess(_RemoteProcessGroupLiveProcess):
     """Live stdin/stdout via `docker compose exec -i`."""
 
     def __init__(
@@ -138,6 +141,33 @@ class DockerProcess(SubprocessLiveProcess):
                 f"(rc={proc.returncode}): {stderr.decode()[:500]}"
             )
 
+    async def _exec_remote_process_group_command(self, command: str) -> int:
+        cmd = self._compose_cmd()
+        cmd.extend(["exec", "-T", self._service, "bash", "-c", command])
+        process = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+            env=await asyncio.to_thread(self._host_env),
+        )
+        try:
+            _, stderr = await asyncio.wait_for(process.communicate(), timeout=15)
+        except (TimeoutError, asyncio.CancelledError):
+            process.kill()
+            await process.wait()
+            raise
+        return_code = process.returncode
+        if return_code is None:
+            return 2
+        if return_code not in (0, 1, 2):
+            logger.warning(
+                "Docker process-group control failed (rc=%s): %s",
+                return_code,
+                stderr.decode(errors="replace")[:500],
+            )
+        return return_code
+
     async def start(
         self,
         command: str,
@@ -152,6 +182,7 @@ class DockerProcess(SubprocessLiveProcess):
         if env:
             await self._write_env_to_container(env, proc_env)
             command = f"source {self._ENV_PATH} && rm -f {self._ENV_PATH} && {command}"
+        command = self._wrap_remote_process_group(command)
 
         cmd = self._compose_cmd()
         cmd.extend(["exec", "-i", "-T"])
@@ -179,6 +210,7 @@ class DockerProcess(SubprocessLiveProcess):
                         "Could not remove staged Docker env after launch failure",
                         exc_info=True,
                     )
+            self._remote_process_group_path = None
             raise
         logger.info(
             f"Docker process started (pid={process.pid}, project={self._project_name})"

--- a/src/benchflow/trajectories/_capture.py
+++ b/src/benchflow/trajectories/_capture.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Any
 
 from benchflow.acp.session import ACPSession
-from benchflow.trajectories.types import redact_acp_trajectory_jsonl
+from benchflow.trajectories.types import (
+    redact_acp_trajectory_jsonl,
+    redact_trajectory_obj,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -97,6 +100,15 @@ def _events_to_trajectory(events: list[dict]) -> list[dict]:
     return out
 
 
+def _redact_session_trajectory(session: object, trajectory: list[dict]) -> list[dict]:
+    """Use real session redactors without accepting permissive mock attributes."""
+    redactor = getattr(type(session), "redact_for_persistence", None)
+    if not callable(redactor):
+        return redact_trajectory_obj(trajectory)
+    redacted = redactor(session, trajectory)
+    return redacted if isinstance(redacted, list) else []
+
+
 def _snapshot_session_trajectory(session: ACPSession | None) -> list[dict]:
     """Non-destructive trajectory snapshot — safe to call mid-prompt.
 
@@ -119,9 +131,10 @@ def _snapshot_session_trajectory(session: ACPSession | None) -> list[dict]:
         # Legacy path — no event log, fall back to flat capture which has
         # no pending-text bookkeeping anyway.
         return _capture_session_trajectory(session)
-    return _events_to_trajectory(session.events) + _merge_pending_text(
+    trajectory = _events_to_trajectory(session.events) + _merge_pending_text(
         session._pending_text
     )
+    return _redact_session_trajectory(session, trajectory)
 
 
 class TrajectoryWriter:
@@ -198,8 +211,9 @@ def _capture_session_trajectory(session: ACPSession | None) -> list[dict]:
     if session._events_active:
         # Flush any trailing agent text that hasn't been recorded yet.
         session._flush_agent_text()
-        return _events_to_trajectory(session.events)
-
+        return _redact_session_trajectory(
+            session, _events_to_trajectory(session.events)
+        )
     # Legacy fallback: session has no event log (e.g. older agent shims
     # that manipulate session.tool_calls directly without going through
     # handle_update). Preserves the old flat behaviour.
@@ -219,7 +233,7 @@ def _capture_session_trajectory(session: ACPSession | None) -> list[dict]:
         trajectory.append({"type": "agent_message", "text": session.full_message})
     if session.full_thought:
         trajectory.append({"type": "agent_thought", "text": session.full_thought})
-    return trajectory
+    return _redact_session_trajectory(session, trajectory)
 
 
 async def _scrape_agent_trajectory(

--- a/src/benchflow/trajectories/types.py
+++ b/src/benchflow/trajectories/types.py
@@ -1,6 +1,7 @@
 """Trajectory types — raw LLM API request/response pairs captured from providers."""
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -478,6 +479,60 @@ def redact_trajectory_text(text: str) -> str:
     ``GITHUB_TOKEN=...`` env dump is scrubbed even without a known prefix.
     """
     return redact_trajectory_text_with_count(text)[0]
+
+
+def redact_trajectory_text_with_exact_values(
+    text: str, exact_values: Iterable[str]
+) -> str:
+    """Redact private values verbatim, then apply canonical secret patterns.
+
+    Longest-first replacement prevents an overlapping shorter credential from
+    exposing the unmatched suffix of a longer credential. Empty values are
+    ignored because every string contains an empty substring.
+    """
+    replacement = "***REDACTED***"
+    values = sorted(
+        {value for value in exact_values if value and value != replacement},
+        key=len,
+        reverse=True,
+    )
+    for value in values:
+        text = text.replace(value, replacement)
+    return redact_trajectory_text(text)
+
+
+def redact_trajectory_obj_with_exact_values(
+    obj: Any, exact_values: Iterable[str]
+) -> Any:
+    """Recursively exact-redact strings without mutating the source object."""
+    replacement = "***REDACTED***"
+    values = tuple(
+        sorted(
+            {value for value in exact_values if value and value != replacement},
+            key=len,
+            reverse=True,
+        )
+    )
+
+    def redact_text(value: str) -> str:
+        for exact in values:
+            value = value.replace(exact, replacement)
+        return redact_trajectory_text(value)
+
+    def redact(value: Any) -> Any:
+        if isinstance(value, dict):
+            redacted: dict[Any, Any] = {}
+            for key, item in value.items():
+                safe_key = redact_text(key) if isinstance(key, str) else key
+                redacted[safe_key] = _redact_field(safe_key, redact(item))
+            return redacted
+        if isinstance(value, list):
+            return [redact(item) for item in value]
+        if isinstance(value, str):
+            return redact_text(value)
+        return value
+
+    return redact(obj)
 
 
 def redact_trajectory_text_with_count(text: str) -> tuple[str, int]:

--- a/src/benchflow/trajectories/viewer/models.py
+++ b/src/benchflow/trajectories/viewer/models.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 type JsonValue = (
-    None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+    bool | int | float | str | list[JsonValue] | dict[str, JsonValue] | None
 )
 type JsonObject = dict[str, JsonValue]
 

--- a/tests/agents/test_manifest_dirscan.py
+++ b/tests/agents/test_manifest_dirscan.py
@@ -154,12 +154,14 @@ def test_merge_shim_only_keeps_core_shim_fields(tmp_path: Path):
         install_cmd="CORE-INSTALL",
         launch_cmd="CORE-LAUNCH",
         acp_model_config_id="model",  # a _SHIM_ONLY field core owns
+        environment_policy="explicit",
     )
     m["aliases"]["demo-code"] = "demo"
     register_manifest_agents(load_agents_from_dir(tmp_path), **m, merge_shim_only=True)
     merged = m["agents"]["demo"]
     assert merged.install_cmd == "echo install"  # DATA field comes from the manifest
     assert merged.acp_model_config_id == "model"  # _SHIM_ONLY preserved from core
+    assert merged.environment_policy == "explicit"
     assert m["installers"]["demo"] == "echo install"
     assert m["aliases"]["demo-code"] == "demo"
 

--- a/tests/fixtures/mock_acp_mutating_agent.py
+++ b/tests/fixtures/mock_acp_mutating_agent.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""ACP fixture whose TERM-resistant child continuously mutates a file."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _append_event(event: str) -> None:
+    with Path(os.environ["EVENT_PATH"]).open("a") as stream:
+        stream.write(event + "\n")
+        stream.flush()
+
+
+def _send(message: dict) -> None:
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def _start_mutating_child() -> None:
+    program = (
+        "import os, signal, time\n"
+        "from pathlib import Path\n"
+        "path = Path(os.environ['MUTATION_PATH'])\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "while True:\n"
+        "    with path.open('a') as stream:\n"
+        "        stream.write('x')\n"
+        "        stream.flush()\n"
+        "    time.sleep(0.01)\n"
+    )
+    subprocess.Popen(
+        [sys.executable, "-c", program],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        close_fds=True,
+    )
+
+
+def main() -> None:
+    _start_mutating_child()
+    try:
+        for line in sys.stdin:
+            message = json.loads(line)
+            method = message.get("method")
+            request_id = message.get("id")
+            if method == "initialize":
+                _send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {
+                            "protocolVersion": 1,
+                            "agentInfo": {
+                                "name": "mutating-agent",
+                                "version": "1.0.0",
+                            },
+                            "agentCapabilities": {},
+                            "authMethods": [],
+                        },
+                    }
+                )
+            elif method == "session/new":
+                _send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": {"sessionId": "mutating-session"},
+                    }
+                )
+            elif method == "session/cancel":
+                _append_event("cancel")
+            elif request_id is not None:
+                _send(
+                    {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {"code": -32601, "message": "unsupported"},
+                    }
+                )
+    finally:
+        _append_event("session_closed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -1,6 +1,7 @@
 """Tests for ACP client ↔ mock agent — Step 10."""
 
 import asyncio
+import json
 import sys
 from dataclasses import FrozenInstanceError, asdict
 from datetime import UTC, datetime
@@ -8,6 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
+from pydantic import ValidationError
 
 from benchflow.acp import AcpSessionObservation, AgentTerminationReceipt
 from benchflow.acp.client import ACPClient, ACPError
@@ -486,6 +488,160 @@ class TestTransportProtocolFiltering:
         log_text = agent_log.read_text()
         assert '"debug string from agent"' in log_text
         assert '["debug", "list"]' in log_text
+
+    @pytest.mark.asyncio
+    async def test_container_transport_exactly_redacts_runtime_credentials(
+        self, tmp_path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        shorter = "opaque-license-fragment"
+        longer = f"{shorter}-extended"
+        fake_process = AsyncMock()
+        fake_process.readline = AsyncMock(
+            side_effect=[
+                f"safe stdout {shorter} {longer}\n".encode(),
+                b'{"jsonrpc": "2.0", "id": 2, "result": {"ok": true}}\n',
+            ]
+        )
+        fake_process.close_stdin.return_value = True
+        fake_process.wait_for_session_closed.return_value = True
+        fake_process.stderr_tail = f"safe stderr {longer}\n"
+        agent_log = tmp_path / "agent.log"
+        transport = ContainerTransport(
+            container_process=fake_process,
+            command="agent acp",
+            agent_log_path=agent_log,
+            runtime_credential_values=[shorter, longer, ""],
+        )
+        caplog.set_level("DEBUG", logger="benchflow.acp.container_transport")
+
+        await transport.start()
+        assert await transport.receive() == {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "result": {"ok": True},
+        }
+        await transport.close()
+
+        persisted = agent_log.read_text()
+        observed = persisted + caplog.text
+        assert shorter not in observed
+        assert longer not in observed
+        assert "extended" not in observed
+        assert "safe stdout" in persisted
+        assert "safe stderr" in persisted
+        assert "***REDACTED***" in observed
+
+    @pytest.mark.asyncio
+    async def test_decoded_acp_update_and_error_redact_exact_runtime_credential(
+        self, tmp_path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from benchflow.trajectories._capture import TrajectoryWriter
+
+        credential = "opaque-license-value-123"
+        fake_process = AsyncMock()
+        fake_process.readline = AsyncMock(
+            side_effect=[
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 100001,
+                            "result": {"sessionId": "test-session"},
+                        }
+                    )
+                    + "\n"
+                ).encode(),
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/update",
+                            "params": {
+                                "update": {
+                                    "sessionUpdate": "agent_message_chunk",
+                                    "content": {
+                                        "type": "text",
+                                        "text": f"normal output {credential}",
+                                    },
+                                }
+                            },
+                        }
+                    )
+                    + "\n"
+                ).encode(),
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 999,
+                            "result": {"text": credential},
+                        }
+                    )
+                    + "\n"
+                ).encode(),
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 100002,
+                            "error": {
+                                "code": -32000,
+                                "message": f"agent failed with {credential}",
+                            },
+                        }
+                    )
+                    + "\n"
+                ).encode(),
+            ]
+        )
+        fake_process.close_stdin.return_value = True
+        fake_process.wait_for_session_closed.return_value = True
+        transport = ContainerTransport(
+            container_process=fake_process,
+            command="agent acp",
+            runtime_credential_values=[credential],
+        )
+        client = ACPClient(transport)
+        caplog.set_level("DEBUG", logger="benchflow.acp")
+
+        await client.connect()
+        session = await client.session_new()
+        trajectory_path = tmp_path / "acp_trajectory.jsonl"
+        session.on_change = TrajectoryWriter(trajectory_path)
+        try:
+            with pytest.raises(ACPError) as exc_info:
+                await client._send_request("test/decoded-output", {})
+        finally:
+            await client.close()
+
+        assert credential in session.full_message
+        persisted = trajectory_path.read_text()
+        assert credential not in persisted
+        assert credential not in str(exc_info.value)
+        assert credential not in caplog.text
+        assert "***REDACTED***" in persisted
+        assert "***REDACTED***" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_malformed_initialize_error_exactly_redacts_runtime_credential(
+        self,
+    ) -> None:
+        credential = "opaque-validation-license-123"
+        raw_result = {"protocolVersion": credential}
+        transport = ContainerTransport(
+            container_process=AsyncMock(),
+            command="agent acp",
+            runtime_credential_values=[credential],
+        )
+        client = ACPClient(transport)
+        client._send_request = AsyncMock(return_value=raw_result)  # type: ignore[method-assign]
+
+        with pytest.raises(ValidationError) as exc_info:
+            await client.initialize()
+
+        assert credential not in str(exc_info.value)
+        assert "***REDACTED***" in str(exc_info.value)
+        assert raw_result["protocolVersion"] == credential
 
     @pytest.mark.asyncio
     async def test_container_transport_does_not_create_empty_agent_log(

--- a/tests/test_acp.py
+++ b/tests/test_acp.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import sys
+from dataclasses import FrozenInstanceError, asdict
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
+from benchflow.acp import AcpSessionObservation, AgentTerminationReceipt
 from benchflow.acp.client import ACPClient, ACPError
 from benchflow.acp.container_transport import ContainerTransport
 from benchflow.acp.session import ACPSession
@@ -2230,3 +2232,145 @@ class TestVerifierTimeoutDiagnostics:
         rj = __import__("json").loads((tmp_path / "result.json").read_text())
         assert rj["verifier_error_category"] == "verifier_failure"
         assert rj["verifier_timeout_info"] is None
+
+
+class TestAgentTerminationContracts:
+    def test_receipt_is_an_immutable_exact_key_public_contract(self) -> None:
+        receipt = AgentTerminationReceipt(
+            cancel_requested=True,
+            cancel_acknowledged=True,
+            session_closed=True,
+            graceful_termination=False,
+            force_kill_required=True,
+            process_tree_stopped=True,
+        )
+
+        assert asdict(receipt) == {
+            "cancel_requested": True,
+            "cancel_acknowledged": True,
+            "session_closed": True,
+            "graceful_termination": False,
+            "force_kill_required": True,
+            "process_tree_stopped": True,
+        }
+        assert receipt.capture_safe is True
+        with pytest.raises(FrozenInstanceError):
+            receipt.session_closed = False  # type: ignore[misc]
+
+    @pytest.mark.parametrize(
+        "overrides",
+        [
+            {"cancel_requested": False, "cancel_acknowledged": True},
+            {"graceful_termination": True, "force_kill_required": True},
+        ],
+    )
+    def test_receipt_rejects_impossible_evidence(
+        self, overrides: dict[str, bool]
+    ) -> None:
+        values = {
+            "cancel_requested": True,
+            "cancel_acknowledged": False,
+            "session_closed": True,
+            "graceful_termination": False,
+            "force_kill_required": False,
+            "process_tree_stopped": True,
+            **overrides,
+        }
+
+        with pytest.raises(ValueError):
+            AgentTerminationReceipt(**values)
+
+    def test_unproven_process_tree_is_never_capture_safe(self) -> None:
+        receipt = AgentTerminationReceipt(
+            cancel_requested=False,
+            cancel_acknowledged=False,
+            session_closed=True,
+            graceful_termination=False,
+            force_kill_required=False,
+            process_tree_stopped=False,
+        )
+
+        assert receipt.capture_safe is False
+
+    def test_session_observation_is_an_immutable_exact_key_public_contract(
+        self,
+    ) -> None:
+        observation = AcpSessionObservation(
+            agent_name="observed-agent",
+            model_id="observed-model",
+            mode_id="observed-mode",
+            stop_reason="end_turn",
+            trajectory_path="/runs/1/trajectory/acp_trajectory.jsonl",
+            trajectory_digest="sha256:" + "a" * 64,
+        )
+
+        assert asdict(observation) == {
+            "agent_name": "observed-agent",
+            "model_id": "observed-model",
+            "mode_id": "observed-mode",
+            "stop_reason": "end_turn",
+            "trajectory_path": "/runs/1/trajectory/acp_trajectory.jsonl",
+            "trajectory_digest": "sha256:" + "a" * 64,
+        }
+        with pytest.raises(FrozenInstanceError):
+            observation.model_id = "configured-default"  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_session_new_retains_live_model_and_mode_results(self) -> None:
+        client = ACPClient(MagicMock())
+        client._send_request = AsyncMock(  # type: ignore[method-assign]
+            return_value={
+                "sessionId": "observed-session",
+                "models": {
+                    "availableModels": [
+                        {"modelId": "observed-model", "name": "Observed model"}
+                    ],
+                    "currentModelId": "observed-model",
+                },
+                "modes": {
+                    "availableModes": [
+                        {"id": "observed-mode", "name": "Observed mode"}
+                    ],
+                    "currentModeId": "observed-mode",
+                },
+                "configOptions": [],
+            }
+        )
+
+        session = await client.session_new()
+
+        assert session.model_state["currentModelId"] == "observed-model"
+        assert session.mode_state["currentModeId"] == "observed-mode"
+
+    @pytest.mark.asyncio
+    async def test_set_model_synchronizes_advertised_model_option_observation(
+        self,
+    ) -> None:
+        from benchflow.acp.termination import _observe_acp_session
+
+        client = ACPClient(MagicMock())
+        client._send_request = AsyncMock(  # type: ignore[method-assign]
+            side_effect=[
+                {
+                    "sessionId": "codex-session",
+                    "models": {"currentModelId": "session-new-model"},
+                    "configOptions": [
+                        {
+                            "id": "model",
+                            "category": "model",
+                            "currentValue": "session-new-model",
+                        }
+                    ],
+                },
+                {},
+            ]
+        )
+        session = await client.session_new()
+        session.agent_info = {"name": "codex-acp"}
+
+        await client.set_model("acknowledged-model")
+        observation = _observe_acp_session(session, trajectory_path=None)
+
+        assert session.config_options[0]["currentValue"] == "acknowledged-model"
+        assert observation is not None
+        assert observation.model_id == "acknowledged-model"

--- a/tests/test_acp_setup_failure_propagation.py
+++ b/tests/test_acp_setup_failure_propagation.py
@@ -12,12 +12,16 @@ caller aborts before prompting.
 
 from __future__ import annotations
 
+import hashlib
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from benchflow.acp.client import ACPClient
+from benchflow.acp.types import StopReason
 from benchflow.diagnostics import TransportClosedError
+from benchflow.rollout import Rollout
 
 
 def _stock_acp_mock() -> AsyncMock:
@@ -272,3 +276,76 @@ async def test_no_web_firewall_runs_after_session_new_before_return(tmp_path) ->
             "LLM_BASE_URL": "http://127.0.0.1:1234",
         },
     )
+
+
+def test_acp_observation_uses_only_live_session_identity(tmp_path) -> None:
+    rollout = Rollout.__new__(Rollout)
+    rollout._config = SimpleNamespace(primary_agent="configured-default")
+    rollout._session = SimpleNamespace(
+        agent_info=None,
+        model_state={"currentModelId": "wire-model"},
+        mode_state={"currentModeId": "wire-mode"},
+        stop_reason=StopReason.END_TURN,
+    )
+    rollout._rollout_dir = tmp_path
+    rollout._acp_session_observation = None
+
+    assert rollout.acp_session_observation is None
+
+
+def test_acp_observation_records_live_results_and_trajectory_digest(tmp_path) -> None:
+    trajectory = tmp_path / "trajectory" / "acp_trajectory.jsonl"
+    trajectory.parent.mkdir()
+    payload = b'{"type":"message"}\n'
+    trajectory.write_bytes(payload)
+    rollout = Rollout.__new__(Rollout)
+    rollout._session = SimpleNamespace(
+        agent_info=SimpleNamespace(name="wire-agent"),
+        model_state={"currentModelId": "wire-model"},
+        mode_state={"currentModeId": "wire-mode"},
+        stop_reason=StopReason.END_TURN,
+    )
+    rollout._rollout_dir = tmp_path
+    rollout._acp_session_observation = None
+
+    observation = rollout.acp_session_observation
+
+    assert observation is not None
+    assert observation.agent_name == "wire-agent"
+    assert observation.model_id == "wire-model"
+    assert observation.mode_id == "wire-mode"
+    assert observation.stop_reason == "end_turn"
+    assert observation.trajectory_path == str(trajectory)
+    assert observation.trajectory_digest == (
+        "sha256:" + hashlib.sha256(payload).hexdigest()
+    )
+
+
+def test_acp_observation_prefers_acknowledged_config_values(tmp_path) -> None:
+    rollout = Rollout.__new__(Rollout)
+    rollout._session = SimpleNamespace(
+        agent_info=SimpleNamespace(name="wire-agent"),
+        model_state={"currentModelId": "session-new-model"},
+        mode_state={"currentModeId": "session-new-mode"},
+        config_options=[
+            {
+                "id": "model",
+                "category": "model",
+                "currentValue": "acknowledged-model",
+            },
+            {
+                "id": "mode",
+                "category": "mode",
+                "currentValue": "acknowledged-mode",
+            },
+        ],
+        stop_reason=None,
+    )
+    rollout._rollout_dir = tmp_path
+    rollout._acp_session_observation = None
+
+    observation = rollout.acp_session_observation
+
+    assert observation is not None
+    assert observation.model_id == "acknowledged-model"
+    assert observation.mode_id == "acknowledged-mode"

--- a/tests/test_acp_setup_failure_propagation.py
+++ b/tests/test_acp_setup_failure_propagation.py
@@ -13,6 +13,7 @@ caller aborts before prompting.
 from __future__ import annotations
 
 import hashlib
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,7 +24,12 @@ from benchflow.acp.session import ACPSession
 from benchflow.acp.types import StopReason
 from benchflow.diagnostics import TransportClosedError
 from benchflow.rollout import Rollout
-from benchflow.trajectories.types import redact_trajectory_obj_with_exact_values
+from benchflow.trajectories.types import (
+    LLMExchange,
+    LLMRequest,
+    LLMResponse,
+    redact_trajectory_obj_with_exact_values,
+)
 
 
 def _stock_acp_mock() -> AsyncMock:
@@ -420,3 +426,86 @@ def test_acp_observation_exactly_redacts_protocol_metadata(tmp_path) -> None:
     assert credential in session.model_state["currentModelId"]
     assert credential in session.mode_state["currentModeId"]
     assert credential in session.stop_reason
+
+
+def test_reconciled_trajectory_refreshes_cached_observation_digest(tmp_path) -> None:
+    trajectory = tmp_path / "trajectory" / "acp_trajectory.jsonl"
+    trajectory.parent.mkdir()
+    acp_event = {
+        "type": "tool_call",
+        "tool_call_id": "call-1",
+        "title": "cat input.txt",
+        "status": "completed",
+        "content": [],
+    }
+    trajectory.write_text(json.dumps(acp_event) + "\n")
+    rollout = Rollout.__new__(Rollout)
+    rollout._session = SimpleNamespace(
+        agent_info=SimpleNamespace(name="wire-agent"),
+        model_state={"currentModelId": "wire-model"},
+        mode_state={"currentModeId": "wire-mode"},
+        stop_reason=StopReason.END_TURN,
+    )
+    rollout._rollout_dir = tmp_path
+    rollout._trajectory = [acp_event]
+    rollout._acp_session_observation = None
+    before = rollout.acp_session_observation
+    assert before is not None
+    rollout._session = None
+
+    provider_payload = json.dumps(
+        {
+            "contents": [
+                {
+                    "role": "model",
+                    "parts": [
+                        {
+                            "functionCall": {
+                                "id": "call-1",
+                                "name": "run_shell_command",
+                                "args": {"command": "cat input.txt"},
+                            }
+                        }
+                    ],
+                },
+                {
+                    "role": "user",
+                    "parts": [
+                        {
+                            "functionResponse": {
+                                "id": "call-1",
+                                "name": "run_shell_command",
+                                "response": {"output": "returned input"},
+                            }
+                        }
+                    ],
+                },
+            ]
+        }
+    )
+    exchange = LLMExchange(
+        request=LLMRequest(
+            body={"messages": [{"role": "user", "content": provider_payload}]}
+        ),
+        response=LLMResponse(body={}),
+    )
+    usage_runtime = SimpleNamespace(
+        server=SimpleNamespace(
+            trajectory=SimpleNamespace(exchanges=[exchange]),
+        )
+    )
+
+    rollout._reconcile_acp_tool_evidence(usage_runtime)
+
+    final_bytes = trajectory.read_bytes()
+    observation = rollout.acp_session_observation
+    assert observation is not None
+    assert observation.agent_name == before.agent_name
+    assert observation.model_id == before.model_id
+    assert observation.mode_id == before.mode_id
+    assert observation.stop_reason == before.stop_reason
+    assert observation.trajectory_path == str(trajectory)
+    assert observation.trajectory_digest == (
+        "sha256:" + hashlib.sha256(final_bytes).hexdigest()
+    )
+    assert observation.trajectory_digest != before.trajectory_digest

--- a/tests/test_acp_setup_failure_propagation.py
+++ b/tests/test_acp_setup_failure_propagation.py
@@ -19,9 +19,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from benchflow.acp.client import ACPClient
+from benchflow.acp.session import ACPSession
 from benchflow.acp.types import StopReason
 from benchflow.diagnostics import TransportClosedError
 from benchflow.rollout import Rollout
+from benchflow.trajectories.types import redact_trajectory_obj_with_exact_values
 
 
 def _stock_acp_mock() -> AsyncMock:
@@ -226,6 +228,40 @@ async def test_initialize_timeout_is_transport_failure_not_agent_timeout(
     mock_acp.close.assert_awaited()
 
 
+async def test_live_process_connection_error_retries_before_transport_exists(
+    tmp_path,
+) -> None:
+    from benchflow.acp.runtime import connect_acp
+
+    mock_acp = _stock_acp_mock()
+    mock_env = AsyncMock()
+    mock_env.live_process = AsyncMock(
+        side_effect=[ConnectionError("live process unavailable"), MagicMock()]
+    )
+
+    with (
+        patch("benchflow.acp.runtime.ContainerTransport", return_value=MagicMock()),
+        patch("benchflow.acp.runtime.ACPClient", return_value=mock_acp),
+        patch("benchflow.acp.runtime.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        client, session, _adapter, agent_name = await connect_acp(
+            env=mock_env,
+            agent="test-agent",
+            agent_launch="test-agent",
+            agent_env={},
+            sandbox_user=None,
+            model=None,
+            rollout_dir=tmp_path,
+            environment="docker",
+            agent_cwd="/app",
+        )
+
+    assert mock_env.live_process.await_count == 2
+    assert client is mock_acp
+    assert session.session_id == "s1"
+    assert agent_name == "test-agent"
+
+
 async def test_no_web_firewall_runs_after_session_new_before_return(tmp_path) -> None:
     """Guards PR #921: bootstrap first, then fail-closed egress isolation."""
     from benchflow.acp.runtime import connect_acp
@@ -349,3 +385,38 @@ def test_acp_observation_prefers_acknowledged_config_values(tmp_path) -> None:
     assert observation is not None
     assert observation.model_id == "acknowledged-model"
     assert observation.mode_id == "acknowledged-mode"
+
+
+def test_acp_observation_exactly_redacts_protocol_metadata(tmp_path) -> None:
+    credential = "opaque-observation-license-123"
+    session = ACPSession(
+        "session",
+        redact_protocol_value=lambda value: redact_trajectory_obj_with_exact_values(
+            value, [credential]
+        ),
+    )
+    session.agent_info = SimpleNamespace(name=f"agent-{credential}")
+    session.model_state = {"currentModelId": f"model-{credential}"}
+    session.mode_state = {"currentModeId": f"mode-{credential}"}
+    session.stop_reason = f"stop-{credential}"
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._session = session
+    rollout._rollout_dir = tmp_path
+    rollout._acp_session_observation = None
+
+    observation = rollout.acp_session_observation
+
+    assert observation is not None
+    persisted_values = (
+        observation.agent_name,
+        observation.model_id,
+        observation.mode_id,
+        observation.stop_reason,
+    )
+    assert credential not in " ".join(value for value in persisted_values if value)
+    assert all("***REDACTED***" in value for value in persisted_values if value)
+    assert credential in session.agent_info.name
+    assert credential in session.model_state["currentModelId"]
+    assert credential in session.mode_state["currentModeId"]
+    assert credential in session.stop_reason

--- a/tests/test_agent_env_resolution.py
+++ b/tests/test_agent_env_resolution.py
@@ -15,6 +15,12 @@ from pathlib import Path
 import pytest
 
 from benchflow.agents.env import auto_inherit_env, resolve_agent_env
+from benchflow.agents.registry import (
+    AGENT_INSTALLERS,
+    AGENT_LAUNCH,
+    AGENTS,
+    register_agent,
+)
 
 
 def _patch_no_subscription(monkeypatch, tmp_path):
@@ -126,6 +132,77 @@ class TestResolveAgentEnvGemini:
             agent_env={"GEMINI_API_KEY": "explicit"},
         )
         assert result["GEMINI_API_KEY"] == "explicit"
+
+
+@pytest.fixture
+def explicit_policy_agent():
+    name = "explicit-policy-env-test"
+    config = register_agent(
+        name,
+        install_cmd="true",
+        launch_cmd="true",
+        requires_env=["DEEPSEEK_API_KEY"],
+        environment_policy="explicit",
+    )
+    yield config
+    AGENTS.pop(name, None)
+    AGENT_INSTALLERS.pop(name, None)
+    AGENT_LAUNCH.pop(name, None)
+
+
+class TestExplicitAgentEnvironmentPolicy:
+    def test_ignores_dotenv_and_process_credentials(
+        self, monkeypatch, explicit_policy_agent
+    ):
+        monkeypatch.setattr(
+            "benchflow.agents.env.load_dotenv_env",
+            lambda: {
+                "DEEPSEEK_API_KEY": "dotenv-secret",
+                "OPENAI_API_KEY": "dotenv-openai",
+            },
+        )
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "process-secret")
+        monkeypatch.setenv("OPENAI_API_KEY", "process-openai")
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "process-aws")
+
+        resolved_env = resolve_agent_env(
+            explicit_policy_agent.name,
+            None,
+            {
+                "DEEPSEEK_API_KEY": "runtime-secret",
+                "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+                "OPENAI_API_KEY": "configured-openai",
+                "AWS_ACCESS_KEY_ID": "configured-aws",
+                "DATABASE_URL": "postgresql://ambient.example/db",
+                "PATH": "/unreviewed/bin",
+                "LD_PRELOAD": "/tmp/inject.so",
+            },
+        )
+
+        assert explicit_policy_agent.environment_policy == "explicit"
+        assert "OPENAI_API_KEY" not in resolved_env
+        assert "AWS_ACCESS_KEY_ID" not in resolved_env
+        assert "DATABASE_URL" not in resolved_env
+        assert "PATH" not in resolved_env
+        assert "LD_PRELOAD" not in resolved_env
+        assert resolved_env["DEEPSEEK_API_KEY"] == "runtime-secret"
+        assert resolved_env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "64000"
+
+    def test_requires_every_declared_runtime_credential(
+        self, monkeypatch, explicit_policy_agent
+    ):
+        monkeypatch.setattr(
+            "benchflow.agents.env.load_dotenv_env",
+            lambda: {"DEEPSEEK_API_KEY": "dotenv-secret"},
+        )
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "process-secret")
+
+        with pytest.raises(ValueError, match="DEEPSEEK_API_KEY") as exc_info:
+            resolve_agent_env(explicit_policy_agent.name, None, {})
+
+        message = str(exc_info.value)
+        assert "dotenv-secret" not in message
+        assert "process-secret" not in message
 
 
 if __name__ == "__main__":

--- a/tests/test_agent_registry.py
+++ b/tests/test_agent_registry.py
@@ -412,6 +412,7 @@ class TestRegisterAgent:
         assert cfg.session_factory == ""
         assert cfg.disallow_web_tools_setup_cmd == ""
         assert cfg.disallow_web_tools_launch_suffix == ""
+        assert cfg.environment_policy == "inherit"
 
     def test_passes_through_new_fields(self, cleanup_agent):
         cleanup_agent.append("rt-full-agent")
@@ -421,6 +422,8 @@ class TestRegisterAgent:
             launch_cmd="launch rt",
             protocol="session-factory",
             session_factory="my_agent.factory:create_agent",
+            requires_env=["DEEPSEEK_API_KEY"],
+            environment_policy="explicit",
             default_model="rt-model-1",
             api_protocol="openai-completions",
             disallow_web_tools_setup_cmd="printf 'no web' > /tmp/policy",
@@ -428,6 +431,8 @@ class TestRegisterAgent:
         )
         assert cfg.protocol == "session-factory"
         assert cfg.session_factory == "my_agent.factory:create_agent"
+        assert cfg.requires_env == ["DEEPSEEK_API_KEY"]
+        assert cfg.environment_policy == "explicit"
         assert cfg.default_model == "rt-model-1"
         assert cfg.api_protocol == "openai-completions"
         assert cfg.disallow_web_tools_setup_cmd == "printf 'no web' > /tmp/policy"
@@ -437,6 +442,8 @@ class TestRegisterAgent:
         registered = AGENTS["rt-full-agent"]
         assert registered.protocol == "session-factory"
         assert registered.session_factory == "my_agent.factory:create_agent"
+        assert registered.requires_env == ["DEEPSEEK_API_KEY"]
+        assert registered.environment_policy == "explicit"
         assert registered.default_model == "rt-model-1"
         assert registered.api_protocol == "openai-completions"
         assert registered.disallow_web_tools_launch_suffix == " --no-web"

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -1,6 +1,5 @@
 """Tests for agent install and skill deployment setup helpers."""
 
-import re
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,7 +10,6 @@ import pytest
 from benchflow.agents.install import apply_web_tool_policy, deploy_skills, install_agent
 from benchflow.agents.registry import AGENTS, AgentConfig
 from benchflow.models import AgentInstallError
-from benchflow.rollout._setup import _agent_process_kill_pattern
 
 
 class LocalShellEnv:
@@ -811,71 +809,3 @@ async def test_apply_web_tool_policy_is_gated_off_when_allowed():
     )
 
     env.exec.assert_not_called()
-
-
-# --- agent-process kill pattern (BF-10) -------------------------------------
-#
-# disconnect() runs `pkill -f <pattern>` to terminate the agent between scenes
-# while keeping the Environment alive. The pattern MUST identify the agent, not
-# the interpreter it runs under: an Environment-plane mock service is a console
-# script whose argv is `/usr/bin/python /usr/local/bin/<svc> …`, so a `python`
-# pattern would SIGTERM it too and the verifier would then find it dead.
-
-# A Python-based Environment-plane service (console script via its shebang),
-# exactly the argv shape the kill pattern must NOT match.
-_PY_SERVICE_ARGV = (
-    "/usr/local/bin/python /usr/local/bin/claw-gmail "
-    "--db /data/gmail.db serve --host 0.0.0.0 --port 9001 --no-mcp"
-)
-
-
-@pytest.mark.parametrize(
-    ("launch", "agent_argv"),
-    [
-        # python-launched shims: the regression — must key on the shim, not python
-        (
-            "/opt/benchflow/deepagents-venv/bin/python /opt/benchflow/bin/deepagents-acp-shim",
-            "/opt/benchflow/deepagents-venv/bin/python /opt/benchflow/bin/deepagents-acp-shim",
-        ),
-        # env-assignment prefix + python launcher (harvey-lab)
-        (
-            "HARVEY_LABS_ROOT=/opt/harvey-labs /opt/benchflow/harvey-lab-venv/bin/python "
-            "/opt/benchflow/bin/harvey-lab-acp-shim",
-            "/opt/benchflow/harvey-lab-venv/bin/python /opt/benchflow/bin/harvey-lab-acp-shim",
-        ),
-        # direct wrapper binaries (pi, claude, gemini-with-args)
-        ("/opt/benchflow/bin/pi-acp-launcher", "/opt/benchflow/bin/pi-acp-launcher"),
-        ("/opt/benchflow/bin/claude-agent-acp", "/opt/benchflow/bin/claude-agent-acp"),
-        (
-            "/opt/benchflow/bin/gemini --acp --yolo",
-            "/opt/benchflow/bin/gemini --acp --yolo",
-        ),
-        # compound `setup && … && <agent>` launch: key on the final command,
-        # not the leading `export` builtin (openhands).
-        (
-            'export PATH="$HOME/.local/bin:$PATH" && mkdir -p ~/.openhands && '
-            "{ printf '{}' > ~/.openhands/agent_settings.json; } && "
-            "openhands acp --always-approve --override-with-envs",
-            "/usr/bin/openhands acp --always-approve --override-with-envs",
-        ),
-        # package-runner subcommand: skip `uv` and `run`, key on the agent.
-        (
-            "uv run my-agent-acp --serve",
-            "/path/.venv/bin/python /path/my-agent-acp --serve",
-        ),
-    ],
-)
-def test_agent_kill_pattern_targets_agent_not_python_services(launch, agent_argv):
-    pattern = _agent_process_kill_pattern(launch)
-    assert pattern is not None
-    # never key on a bare interpreter — that is the BF-10 bug
-    assert pattern != r"(^|[ /])python( |$)"
-    # still kills the agent it was derived from
-    assert re.search(pattern, agent_argv), (pattern, agent_argv)
-    # but never reaps a co-resident Python Environment-plane service
-    assert not re.search(pattern, _PY_SERVICE_ARGV), (pattern, _PY_SERVICE_ARGV)
-
-
-def test_agent_kill_pattern_empty_launch_is_none():
-    assert _agent_process_kill_pattern("") is None
-    assert _agent_process_kill_pattern("   ") is None

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -128,9 +128,21 @@ def _make_daytona_sandbox(token="abc", exit_code=0, result=None):
     sandbox.create_ssh_access = AsyncMock(return_value=MagicMock(token=token))
     if result is None:
         result = "__BENCHFLOW_BOOTSTRAP_DONE__\n"
-    sandbox.process.exec = AsyncMock(
-        return_value=MagicMock(exit_code=exit_code, result=result)
-    )
+    process_group_alive = True
+
+    async def fake_exec(command, *args, **kwargs):
+        nonlocal process_group_alive
+        if 'kill -0 -- "-$pgid"' in command:
+            return MagicMock(exit_code=0 if process_group_alive else 1, result="")
+        if 'kill -TERM -- "-$pgid"' in command:
+            process_group_alive = False
+            return MagicMock(exit_code=0, result="")
+        if 'kill -KILL -- "-$pgid"' in command:
+            process_group_alive = False
+            return MagicMock(exit_code=0, result="")
+        return MagicMock(exit_code=exit_code, result=result)
+
+    sandbox.process.exec = AsyncMock(side_effect=fake_exec)
     return sandbox
 
 
@@ -316,7 +328,10 @@ class TestDockerProcessEnv:
             await proc.start(command="echo hello")
 
         assert len(calls) == 1
-        assert calls[0][-1] == "echo hello"
+        launch = calls[0][-1]
+        assert launch.startswith("exec setsid bash -c ")
+        assert "/tmp/.benchflow_agent_pgid_" in launch
+        assert "echo hello" in launch
 
     @pytest.mark.asyncio
     async def test_staged_env_is_removed_when_main_launch_fails(self):
@@ -458,7 +473,7 @@ class TestAppleContainerProcess:
             await proc.start("codex-acp", cwd="/root")
 
         assert len(calls) == 1
-        assert calls[0][0] == (
+        assert calls[0][0][:-1] == (
             "container",
             "exec",
             "--interactive",
@@ -467,8 +482,11 @@ class TestAppleContainerProcess:
             "bf_run",
             "bash",
             "-c",
-            "codex-acp",
         )
+        launch = calls[0][0][-1]
+        assert launch.startswith("exec setsid bash -c ")
+        assert "/tmp/.benchflow_agent_pgid_" in launch
+        assert "codex-acp" in launch
         assert calls[0][1]["stdin"] is asyncio.subprocess.PIPE
         assert calls[0][1]["stdout"] is asyncio.subprocess.PIPE
 
@@ -504,7 +522,9 @@ class TestAppleContainerProcess:
         main_command = calls[1][0][-1]
         assert ". /tmp/.benchflow_agent_env_" in main_command
         assert "rm -f /tmp/.benchflow_agent_env_" in main_command
-        assert main_command.endswith("&& codex-acp")
+        assert main_command.startswith("exec setsid bash -c ")
+        assert "/tmp/.benchflow_agent_pgid_" in main_command
+        assert "&& codex-acp" in main_command
 
     @pytest.mark.asyncio
     async def test_staged_env_is_removed_when_main_launch_fails(self):
@@ -566,10 +586,10 @@ class TestDaytonaProcessEnvFilePath:
         assert len(harness.calls) == 1
         bootstrap_cmd = sandbox.process.exec.await_args.args[0]
         live_cmd = harness.calls[0][-1]
-        assert "$$" not in live_cmd, (
-            "$$ in remote command — shlex.join() will quote it, mismatching "
-            f"the SDK bootstrap command. Got: {live_cmd[:200]!r}"
-        )
+        assert "/tmp/benchflow_env_$$" not in live_cmd
+        assert "exec setsid bash -c " in live_cmd
+        assert "/tmp/.benchflow_agent_pgid_" in live_cmd
+        assert '"$$"' in live_cmd
 
         # And: a real path was used in the SDK bootstrap (literal hex suffix,
         # no shell variable), while env values travel through Daytona's env map.
@@ -596,7 +616,10 @@ class TestDaytonaProcessEnvFilePath:
         assert len(harness.calls) == 1
         bootstrap_cmd = sandbox.process.exec.await_args.args[0]
         live_cmd = harness.calls[0][-1]
-        assert "$$" not in live_cmd
+        assert "/tmp/benchflow_env_$$" not in live_cmd
+        assert "exec setsid bash -c " in live_cmd
+        assert "/tmp/.benchflow_agent_pgid_" in live_cmd
+        assert '"$$"' in live_cmd
 
         assert "$$" not in bootstrap_cmd
         assert "/tmp/benchflow_env_" in bootstrap_cmd
@@ -819,6 +842,9 @@ class TestDaytonaProcessSecretArgv:
 
         write_config.assert_not_called()
         assert proc._ssh_config_path is None
+        assert proc._remote_process_group_path is None
+        await proc.close()
+        sandbox.process.exec.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_bootstrapped_env_file_is_removed_when_ssh_access_fails(self):

--- a/tests/test_provider_auth_detection.py
+++ b/tests/test_provider_auth_detection.py
@@ -20,7 +20,10 @@ from unittest.mock import AsyncMock
 import pytest
 
 from benchflow.providers.litellm_logging import trajectory_from_litellm_callback_log
+from benchflow.providers.runtime import ProviderRuntime
 from benchflow.rollout import (
+    Rollout,
+    RolloutConfig,
     _provider_auth_status_from_runtime,
     _provider_failure_from_runtime,
 )
@@ -410,3 +413,97 @@ def test_enforcement_still_fires_when_no_error_and_usage_missing(tmp_path):
     assert rollout._error == (
         "Token usage tracking is required, but no provider token usage was captured."
     )
+
+
+@pytest.mark.asyncio
+async def test_unsafe_owned_cleanup_imports_sandbox_provider_evidence_before_delete(
+    tmp_path,
+) -> None:
+    events: list[str] = []
+
+    class OwnedSandbox:
+        def __init__(self) -> None:
+            self.alive = True
+
+        async def stop(self, *, delete: bool) -> None:
+            events.append("sandbox_stop")
+            self.alive = False
+
+    class UnsafeTransport:
+        termination_status = SimpleNamespace(
+            graceful_termination=False,
+            force_kill_required=False,
+            process_tree_stopped=False,
+        )
+
+        async def process_tree_stopped(self) -> bool:
+            events.append("liveness")
+            return False
+
+    class UnsafeClient:
+        session = None
+
+        def __init__(self) -> None:
+            self._transport = UnsafeTransport()
+
+        async def close(self) -> None:
+            events.append("agent_close")
+
+    sandbox = OwnedSandbox()
+
+    class SandboxLocalServer:
+        def __init__(self) -> None:
+            self.trajectory = SimpleNamespace(exchanges=[])
+
+        async def stop(self) -> None:
+            events.append("provider_stop")
+            if not sandbox.alive:
+                raise RuntimeError("sandbox callback log was deleted")
+            self.trajectory.exchanges = [
+                SimpleNamespace(response=SimpleNamespace(status_code=503))
+            ]
+
+    server = SandboxLocalServer()
+    runtime = ProviderRuntime(
+        kind="usage-proxy",
+        agent_base_url="http://127.0.0.1:4000",
+        server=server,
+    )
+
+    async def stop_provider_runtime(provider_runtime) -> None:
+        await provider_runtime.server.stop()
+
+    def extract_usage(provider_runtime):
+        events.append(
+            "extract_runtime" if provider_runtime is runtime else "extract_none"
+        )
+        return {"usage_source": "unavailable"}
+
+    rollout = Rollout(RolloutConfig(task_path=tmp_path / "task"))
+    rollout._acp_client = UnsafeClient()
+    rollout._env = sandbox
+    rollout._usage_runtime = runtime
+    rollout._rollout_dir = tmp_path
+    rollout._error = "ACP error -32603: Internal error"
+    rollout._planes = SimpleNamespace(
+        stop_provider_runtime=stop_provider_runtime,
+        extract_usage=extract_usage,
+    )
+    rollout._write_llm_trajectory = lambda _runtime: None
+    rollout._reconcile_acp_tool_evidence = lambda _runtime: None
+
+    await rollout.cleanup()
+
+    assert events == [
+        "agent_close",
+        "liveness",
+        "provider_stop",
+        "extract_runtime",
+        "sandbox_stop",
+    ]
+    assert rollout._provider_failure_cached is not None
+    assert (
+        rollout._provider_failure_cached.error_suffix
+        == "provider unavailable (HTTP 503)"
+    )
+    assert rollout._error == "ACP error -32603: Internal error"

--- a/tests/test_rollout_architecture.py
+++ b/tests/test_rollout_architecture.py
@@ -3,7 +3,27 @@
 from __future__ import annotations
 
 import ast
+import asyncio
+import json
+from datetime import datetime
 from pathlib import Path
+
+import pytest
+
+from benchflow.agents.registry import (
+    AGENT_INSTALLERS,
+    AGENT_LAUNCH,
+    AGENTS,
+    AgentConfig,
+    register_agent,
+)
+from benchflow.rollout import (
+    Rollout,
+    RolloutConfig,
+    _build_rollout_result,
+    _write_config,
+)
+from benchflow.skill_policy import SKILL_MODE_NO_SKILL, resolve_task_skill_policy
 
 # ``rollout.py`` was split into the ``benchflow.rollout`` package; the kernel
 # invariant now spans every module in it.
@@ -56,3 +76,220 @@ def test_concrete_plane_bindings_live_at_composition_boundary() -> None:
     imported = _imported_modules(Path("src/benchflow/rollout_planes.py"))
 
     assert imported >= COMPOSITION_BOUNDARY_MODULES
+
+
+@pytest.fixture
+def explicit_policy_agent():
+    name = "explicit-policy-rollout-test"
+    config = register_agent(
+        name,
+        install_cmd="true",
+        launch_cmd="true",
+        requires_env=["DEEPSEEK_API_KEY"],
+        environment_policy="explicit",
+    )
+    yield config
+    AGENTS.pop(name, None)
+    AGENT_INSTALLERS.pop(name, None)
+    AGENT_LAUNCH.pop(name, None)
+
+
+@pytest.mark.asyncio
+async def test_runtime_credentials_are_keyword_only_and_isolated_per_rollout(
+    tmp_path: Path, explicit_policy_agent
+) -> None:
+    async def resolve(secret: str) -> dict[str, str]:
+        config = RolloutConfig(
+            task_path=tmp_path,
+            agent=explicit_policy_agent.name,
+            agent_env={
+                "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+                "OPENAI_API_KEY": "configured-openai",
+                "AWS_ACCESS_KEY_ID": "configured-aws",
+                "DATABASE_URL": "postgresql://ambient.example/db",
+                "PATH": "/unreviewed/bin",
+                "LD_PRELOAD": "/tmp/inject.so",
+            },
+        )
+        rollout = await Rollout.create(
+            config,
+            runtime_credentials={
+                "DEEPSEEK_API_KEY": secret,
+                "OPENAI_API_KEY": f"unrelated-{secret}",
+                "AWS_ACCESS_KEY_ID": f"unrelated-aws-{secret}",
+            },
+        )
+        return rollout._resolve_agent_environment(
+            config.primary_agent,
+            config.primary_model,
+            config.agent_env,
+        )
+
+    first, second = await asyncio.gather(
+        resolve("runtime-secret-1"),
+        resolve("runtime-secret-2"),
+    )
+
+    assert first["DEEPSEEK_API_KEY"] == "runtime-secret-1"
+    assert second["DEEPSEEK_API_KEY"] == "runtime-secret-2"
+    for resolved_env in (first, second):
+        assert "OPENAI_API_KEY" not in resolved_env
+        assert "AWS_ACCESS_KEY_ID" not in resolved_env
+        assert "DATABASE_URL" not in resolved_env
+        assert "PATH" not in resolved_env
+        assert "LD_PRELOAD" not in resolved_env
+        assert resolved_env["CLAUDE_CODE_MAX_OUTPUT_TOKENS"] == "64000"
+
+    config = RolloutConfig(task_path=tmp_path, agent=explicit_policy_agent.name)
+    with pytest.raises(TypeError):
+        await Rollout.create(config, {"DEEPSEEK_API_KEY": "positional-secret"})
+
+
+@pytest.mark.asyncio
+async def test_runtime_credentials_never_enter_serializable_surfaces(
+    tmp_path: Path, caplog, explicit_policy_agent
+) -> None:
+    secret = "runtime-secret-never-serialize"
+    deepseek_secret = "runtime-deepseek-secret"
+    explicit_policy_agent.requires_env.append("LICENSE")
+    supplied = {
+        "DEEPSEEK_API_KEY": deepseek_secret,
+        "LICENSE": secret,
+    }
+    config = RolloutConfig(
+        task_path=tmp_path,
+        agent=explicit_policy_agent.name,
+        agent_env={"CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000"},
+    )
+    rollout = await Rollout.create(config, runtime_credentials=supplied)
+    supplied["DEEPSEEK_API_KEY"] = "mutated-after-create"
+
+    resolved_env = rollout._resolve_agent_environment(
+        config.primary_agent,
+        config.primary_model,
+        config.agent_env,
+    )
+    assert resolved_env["DEEPSEEK_API_KEY"] == deepseek_secret
+    assert resolved_env["LICENSE"] == secret
+
+    skill_policy = resolve_task_skill_policy(
+        task_path=tmp_path,
+        skill_mode=SKILL_MODE_NO_SKILL,
+        runtime_skills_dir=None,
+        declared_sandbox_skills_dir=None,
+    )
+    _write_config(
+        tmp_path,
+        task_path=tmp_path,
+        agent=config.primary_agent,
+        model=config.primary_model,
+        environment=config.environment,
+        environment_policy=explicit_policy_agent.environment_policy,
+        skill_policy=skill_policy,
+        sandbox_user=config.sandbox_user,
+        context_root=None,
+        timeout=60,
+        started_at=datetime(2026, 1, 1),
+        agent_env=resolved_env,
+        runtime_credential_names=set(supplied),
+        runtime_credential_values={secret, deepseek_secret},
+    )
+    _build_rollout_result(
+        tmp_path,
+        task_name="explicit-policy-task",
+        rollout_name="rollout",
+        agent=config.primary_agent,
+        agent_name=config.primary_agent,
+        model=None,
+        n_tool_calls=0,
+        prompts=[],
+        error=None,
+        verifier_error=None,
+        trajectory=[],
+        partial_trajectory=False,
+        rewards=None,
+        started_at=datetime(2026, 1, 1),
+        timing={},
+        skill_policy=skill_policy,
+    )
+
+    recorded_config = json.loads((tmp_path / "config.json").read_text())
+    assert recorded_config["environment_policy"] == "explicit"
+    assert "DEEPSEEK_API_KEY" not in recorded_config["agent_env"]
+    assert "LICENSE" not in recorded_config["agent_env"]
+
+    serialized_surfaces = "\n".join(
+        [
+            (tmp_path / "config.json").read_text(),
+            (tmp_path / "result.json").read_text(),
+            repr(config),
+            repr(rollout),
+            caplog.text,
+        ]
+    )
+    assert secret not in serialized_surfaces
+    assert deepseek_secret not in serialized_surfaces
+
+    missing = await Rollout.create(
+        config,
+        runtime_credentials={"OPENAI_API_KEY": "unrelated-runtime-secret"},
+    )
+    with pytest.raises(ValueError) as exc_info:
+        missing._resolve_agent_environment(
+            config.primary_agent,
+            config.primary_model,
+            config.agent_env,
+        )
+    assert secret not in str(exc_info.value)
+    assert "unrelated-runtime-secret" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_plane_owned_explicit_policy_controls_resolution_and_metadata(
+    tmp_path: Path, monkeypatch
+) -> None:
+    agent = "plane-owned-explicit-agent"
+    plane_config = AgentConfig(
+        name=agent,
+        install_cmd="true",
+        launch_cmd="true",
+        requires_env=["LICENSE"],
+        environment_policy="explicit",
+    )
+    config = RolloutConfig(
+        task_path=tmp_path,
+        agent=agent,
+        agent_env={
+            "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+            "PATH": "/unreviewed/bin",
+        },
+    )
+    rollout = await Rollout.create(
+        config,
+        runtime_credentials={"LICENSE": "plane-runtime-secret"},
+    )
+    monkeypatch.setattr(
+        rollout._planes,
+        "agent_config",
+        lambda requested: plane_config if requested == agent else None,
+    )
+    monkeypatch.setattr(
+        rollout._planes,
+        "resolve_agent_env",
+        lambda _agent, _model, env: {
+            **dict(env or {}),
+            "DATABASE_URL": "postgresql://plane.example/db",
+        },
+    )
+
+    resolved = rollout._resolve_agent_environment(
+        config.primary_agent,
+        config.primary_model,
+        config.agent_env,
+    )
+
+    assert resolved == {
+        "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+        "LICENSE": "plane-runtime-secret",
+    }
+    assert rollout._agent_environment_policy(agent) == "explicit"

--- a/tests/test_rollout_architecture.py
+++ b/tests/test_rollout_architecture.py
@@ -293,3 +293,72 @@ async def test_plane_owned_explicit_policy_controls_resolution_and_metadata(
         "LICENSE": "plane-runtime-secret",
     }
     assert rollout._agent_environment_policy(agent) == "explicit"
+
+
+@pytest.mark.parametrize("policy", ["ambient", 7, None])
+@pytest.mark.asyncio
+async def test_unknown_environment_policy_fails_before_environment_resolution(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, policy: object
+) -> None:
+    agent = "invalid-policy-agent"
+    plane_config = AgentConfig(
+        name=agent,
+        install_cmd="true",
+        launch_cmd="true",
+        environment_policy="inherit",
+    )
+    plane_config.environment_policy = policy  # type: ignore[assignment]
+    config = RolloutConfig(task_path=tmp_path, agent=agent)
+    rollout = await Rollout.create(config)
+    resolve_calls: list[dict[str, str]] = []
+
+    monkeypatch.setattr(rollout._planes, "agent_config", lambda _agent: plane_config)
+    monkeypatch.setattr(
+        rollout._planes,
+        "resolve_agent_env",
+        lambda _agent, _model, env: resolve_calls.append(env) or env,
+    )
+
+    with pytest.raises(ValueError, match="environment_policy"):
+        rollout._resolve_agent_environment(agent, None, {})
+
+    assert resolve_calls == []
+
+
+@pytest.mark.asyncio
+async def test_runtime_credentials_reach_acp_output_redaction_boundary(
+    tmp_path: Path, explicit_policy_agent
+) -> None:
+    captured: dict[str, object] = {}
+
+    class _Planes:
+        async def ensure_litellm_runtime(self, **kwargs):
+            return kwargs["agent_env"], None
+
+        async def connect_acp(self, **kwargs):
+            captured.update(kwargs)
+            return object(), None, None, explicit_policy_agent.name
+
+    config = RolloutConfig(task_path=tmp_path, agent=explicit_policy_agent.name)
+    rollout = await Rollout.create(
+        config,
+        runtime_credentials={
+            "DEEPSEEK_API_KEY": "opaque-runtime-value",
+            "EMPTY_CREDENTIAL": "",
+        },
+    )
+    rollout._planes = _Planes()
+    rollout._env = object()
+    rollout._rollout_dir = tmp_path
+    rollout._agent_env = {"DEEPSEEK_API_KEY": "opaque-runtime-value"}
+    rollout._agent_launch = "true"
+    rollout._agent_cwd = "/app"
+    rollout._phase = "installed"
+    rollout._task = None
+
+    await rollout.connect()
+
+    assert set(captured["runtime_credential_values"]) == {
+        "",
+        "opaque-runtime-value",
+    }

--- a/tests/test_rollout_branch.py
+++ b/tests/test_rollout_branch.py
@@ -245,6 +245,7 @@ async def test_post_branch_execute_grows_off_the_parent_cursor(
     rollout._acp_client = object()
     await rollout.execute(["p1"])
     parent = rollout._cursor
+    rollout._acp_client = None
 
     async def run_child(child):
         return 1.0

--- a/tests/test_rollout_hard_deadline.py
+++ b/tests/test_rollout_hard_deadline.py
@@ -461,6 +461,31 @@ async def test_concurrent_stop_agent_callers_share_one_teardown_and_receipt() ->
 
 
 @pytest.mark.asyncio
+async def test_concurrent_stop_agent_merges_stronger_cancellation_intent() -> None:
+    events: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+    transport = _BlockingStopTransport(
+        events,
+        started=started,
+        release=release,
+    )
+    rollout = _rollout_at_stop_boundary(_StagedStopClient(transport, events))
+
+    first_call = asyncio.create_task(rollout.stop_agent(cancel_requested=False))
+    await started.wait()
+    second_call = asyncio.create_task(rollout.stop_agent(cancel_requested=True))
+    await asyncio.sleep(0)
+    release.set()
+    first, second = await asyncio.gather(first_call, second_call)
+
+    assert first is second
+    assert events.count("cancel") == 1
+    assert first.cancel_requested is True
+    assert first.cancel_acknowledged is True
+
+
+@pytest.mark.asyncio
 async def test_stop_agent_caller_cancellation_waits_for_shared_safe_teardown() -> None:
     events: list[str] = []
     started = asyncio.Event()

--- a/tests/test_rollout_hard_deadline.py
+++ b/tests/test_rollout_hard_deadline.py
@@ -198,3 +198,292 @@ async def test_evaluation_path_surfaces_infra_error(tmp_path, monkeypatch):
     assert result.error is not None
     assert "hard deadline" in result.error
     assert result.error_category == INFRA_ERROR
+
+
+class _StopTransport:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        graceful: bool,
+        forced: bool,
+        stopped: bool,
+        liveness_error: Exception | None = None,
+    ) -> None:
+        self.events = events
+        self.termination_status = SimpleNamespace(
+            graceful_termination=graceful,
+            force_kill_required=forced,
+            process_tree_stopped=stopped,
+        )
+        self._stopped = stopped
+        self._liveness_error = liveness_error
+
+    async def process_tree_stopped(self) -> bool:
+        self.events.append("liveness")
+        if self._liveness_error is not None:
+            raise self._liveness_error
+        return self._stopped
+
+
+class _StopClient:
+    session = None
+
+    def __init__(
+        self,
+        transport: _StopTransport,
+        events: list[str],
+        *,
+        cancel_error: Exception | None = None,
+        close_error: Exception | None = None,
+    ) -> None:
+        self._transport = transport
+        self._events = events
+        self._cancel_error = cancel_error
+        self._close_error = close_error
+
+    async def cancel(self) -> None:
+        self._events.append("cancel")
+        if self._cancel_error is not None:
+            raise self._cancel_error
+
+    async def close(self) -> None:
+        self._events.append("close")
+        if self._close_error is not None:
+            raise self._close_error
+
+
+def _rollout_at_stop_boundary(client: _StopClient) -> Rollout:
+    rollout = Rollout.__new__(Rollout)
+    rollout._acp_client = client
+    rollout._session = None
+    rollout._session_adapter = None
+    rollout._is_session_factory = False
+    rollout._active_role = None
+    rollout._session_tool_count = 0
+    rollout._session_traj_count = 0
+    rollout._phase = "executed"
+    rollout._termination_receipt = None
+    rollout._acp_session_observation = None
+    return rollout
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_orders_evidence_and_is_idempotent() -> None:
+    events: list[str] = []
+    transport = _StopTransport(
+        events,
+        graceful=False,
+        forced=True,
+        stopped=True,
+    )
+    rollout = _rollout_at_stop_boundary(_StopClient(transport, events))
+
+    first = await rollout.stop_agent(cancel_requested=True)
+    second = await rollout.stop_agent(cancel_requested=True)
+
+    assert events == ["cancel", "close", "liveness"]
+    assert second is first
+    assert first.cancel_requested is True
+    assert first.cancel_acknowledged is True
+    assert first.session_closed is True
+    assert first.graceful_termination is False
+    assert first.force_kill_required is True
+    assert first.process_tree_stopped is True
+    assert first.capture_safe is True
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_preserves_independent_failure_evidence() -> None:
+    events: list[str] = []
+    transport = _StopTransport(
+        events,
+        graceful=False,
+        forced=False,
+        stopped=True,
+        liveness_error=RuntimeError("cannot prove group death"),
+    )
+    rollout = _rollout_at_stop_boundary(
+        _StopClient(
+            transport,
+            events,
+            cancel_error=RuntimeError("cancel failed"),
+            close_error=RuntimeError("close failed"),
+        )
+    )
+
+    receipt = await rollout.stop_agent(cancel_requested=True)
+
+    assert events == ["cancel", "close", "liveness"]
+    assert receipt.cancel_acknowledged is False
+    assert receipt.session_closed is False
+    assert receipt.graceful_termination is False
+    assert receipt.force_kill_required is False
+    assert receipt.process_tree_stopped is False
+    assert receipt.capture_safe is False
+
+
+class _StagedStopTransport(_StopTransport):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__(
+            events,
+            graceful=False,
+            forced=False,
+            stopped=False,
+        )
+        self.session_closed = False
+
+    async def terminate_process_tree(self):
+        self.events.append("terminate")
+        await asyncio.sleep(0.02)
+        self.termination_status = SimpleNamespace(
+            graceful_termination=False,
+            force_kill_required=True,
+            process_tree_stopped=True,
+        )
+        self._stopped = True
+        return self.termination_status
+
+
+class _StagedStopClient(_StopClient):
+    async def close_session(self) -> bool:
+        self._events.append("close_session")
+        self._transport.session_closed = True
+        return True
+
+    async def close(self) -> None:
+        self._events.append("legacy_close")
+        raise AssertionError("stop_agent must use independently bounded stages")
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_does_not_preempt_transport_termination(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    transport = _StagedStopTransport(events)
+    client = _StagedStopClient(transport, events)
+    rollout = _rollout_at_stop_boundary(client)
+    monkeypatch.setattr(
+        "benchflow.rollout._ACP_STOP_CLOSE_TIMEOUT_SEC",
+        0.001,
+        raising=False,
+    )
+
+    receipt = await rollout.stop_agent(cancel_requested=True)
+
+    assert events == ["cancel", "close_session", "terminate", "liveness"]
+    assert receipt.session_closed is True
+    assert receipt.force_kill_required is True
+    assert receipt.process_tree_stopped is True
+    assert receipt.capture_safe is True
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_preserves_session_close_evidence_when_termination_fails() -> (
+    None
+):
+    events: list[str] = []
+    transport = _StagedStopTransport(events)
+
+    async def fail_termination():
+        events.append("terminate")
+        raise RuntimeError("termination control failed")
+
+    transport.terminate_process_tree = fail_termination
+    rollout = _rollout_at_stop_boundary(_StagedStopClient(transport, events))
+
+    receipt = await rollout.stop_agent(cancel_requested=True)
+
+    assert events == ["cancel", "close_session", "terminate", "liveness"]
+    assert receipt.session_closed is True
+    assert receipt.process_tree_stopped is False
+    assert receipt.capture_safe is False
+
+
+class _BlockingStopTransport(_StopTransport):
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        started: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        super().__init__(
+            events,
+            graceful=False,
+            forced=False,
+            stopped=False,
+        )
+        self.session_closed = False
+        self._started = started
+        self._release = release
+        self.termination_calls = 0
+
+    async def terminate_process_tree(self):
+        self.events.append("terminate")
+        self.termination_calls += 1
+        self._started.set()
+        await self._release.wait()
+        self.termination_status = SimpleNamespace(
+            graceful_termination=False,
+            force_kill_required=True,
+            process_tree_stopped=True,
+        )
+        self._stopped = True
+        return self.termination_status
+
+
+@pytest.mark.asyncio
+async def test_concurrent_stop_agent_callers_share_one_teardown_and_receipt() -> None:
+    events: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+    transport = _BlockingStopTransport(
+        events,
+        started=started,
+        release=release,
+    )
+    rollout = _rollout_at_stop_boundary(_StagedStopClient(transport, events))
+
+    first_call = asyncio.create_task(rollout.stop_agent(cancel_requested=True))
+    await started.wait()
+    second_call = asyncio.create_task(rollout.stop_agent(cancel_requested=True))
+    await asyncio.sleep(0)
+    release.set()
+    first, second = await asyncio.gather(first_call, second_call)
+
+    assert first is second
+    assert transport.termination_calls == 1
+    assert events.count("cancel") == 1
+    assert events.count("close_session") == 1
+    assert events.count("liveness") == 1
+
+
+@pytest.mark.asyncio
+async def test_stop_agent_caller_cancellation_waits_for_shared_safe_teardown() -> None:
+    events: list[str] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+    transport = _BlockingStopTransport(
+        events,
+        started=started,
+        release=release,
+    )
+    rollout = _rollout_at_stop_boundary(_StagedStopClient(transport, events))
+
+    caller = asyncio.create_task(rollout.stop_agent(cancel_requested=True))
+    await started.wait()
+    caller.cancel()
+    await asyncio.sleep(0)
+    cancellation_propagated_before_teardown = caller.done()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+
+    receipt = await rollout.stop_agent(cancel_requested=True)
+
+    assert cancellation_propagated_before_teardown is False
+    assert transport.termination_calls == 1
+    assert receipt.process_tree_stopped is True
+    assert receipt.capture_safe is True

--- a/tests/test_rollout_hard_deadline.py
+++ b/tests/test_rollout_hard_deadline.py
@@ -512,3 +512,196 @@ async def test_stop_agent_caller_cancellation_waits_for_shared_safe_teardown() -
     assert transport.termination_calls == 1
     assert receipt.process_tree_stopped is True
     assert receipt.capture_safe is True
+
+
+@pytest.mark.asyncio
+async def test_disconnect_is_idempotent_after_capture_safe_stop() -> None:
+    events: list[str] = []
+    transport = _StopTransport(
+        events,
+        graceful=True,
+        forced=False,
+        stopped=True,
+    )
+    rollout = _rollout_at_stop_boundary(_StopClient(transport, events))
+
+    await rollout.disconnect()
+    await rollout.disconnect()
+
+    assert events == ["close", "liveness"]
+
+
+@pytest.mark.asyncio
+async def test_unsafe_stop_blocks_final_verification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    events: list[str] = []
+    rollout = _rollout_at_stop_boundary(
+        _StopClient(
+            _StopTransport(
+                events,
+                graceful=False,
+                forced=False,
+                stopped=False,
+            ),
+            events,
+        )
+    )
+    rollout._config = SimpleNamespace(primary_agent="agent", sandbox_user=None)
+    rollout._trajectory = [{"type": "agent_message", "text": "done"}]
+    rollout._env = object()
+    rollout._task = object()
+    rollout._rollout_paths = SimpleNamespace(agent_dir=tmp_path / "agent")
+    rollout._timing = {}
+    rollout._planes = object()
+    rollout._agent_cwd = "/app"
+    publish = AsyncMock()
+    verify = AsyncMock(return_value=({"reward": 1.0}, None, None))
+    monkeypatch.setattr("benchflow.rollout._publish_trajectory_for_verifier", publish)
+    monkeypatch.setattr("benchflow.rollout._verify_rollout", verify)
+
+    with pytest.raises(RuntimeError, match="not capture-safe"):
+        await rollout.verify()
+
+    publish.assert_not_awaited()
+    verify.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unsafe_stop_blocks_soft_verification(tmp_path: Path) -> None:
+    events: list[str] = []
+    rollout = _rollout_at_stop_boundary(
+        _StopClient(
+            _StopTransport(
+                events,
+                graceful=False,
+                forced=False,
+                stopped=False,
+            ),
+            events,
+        )
+    )
+    rollout._rollout_paths = SimpleNamespace(verifier_dir=tmp_path / "verifier")
+    rollout._task = SimpleNamespace(
+        task_dir=tmp_path / "task",
+        config=SimpleNamespace(verifier=SimpleNamespace(timeout_sec=1)),
+    )
+    rollout._env = SimpleNamespace(exec=AsyncMock())
+    rollout._planes = SimpleNamespace(
+        clear_verifier_output_dir=AsyncMock(),
+        ensure_legacy_app_dir=AsyncMock(),
+        cleanup_verifier_python_hooks=AsyncMock(),
+        verifier=lambda **kwargs: SimpleNamespace(
+            verify=AsyncMock(return_value=SimpleNamespace(rewards={"reward": 1.0}))
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="not capture-safe"):
+        await rollout.soft_verify()
+
+    rollout._planes.clear_verifier_output_dir.assert_not_awaited()
+    rollout._planes.ensure_legacy_app_dir.assert_not_awaited()
+    rollout._planes.cleanup_verifier_python_hooks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unsafe_stop_blocks_branch_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    events: list[str] = []
+    rollout = _rollout_at_stop_boundary(
+        _StopClient(
+            _StopTransport(
+                events,
+                graceful=False,
+                forced=False,
+                stopped=False,
+            ),
+            events,
+        )
+    )
+    rollout._environment = object()
+    rollout._cursor = object()
+    checkpoint = AsyncMock(
+        side_effect=AssertionError("checkpointed an unsafe workspace")
+    )
+    monkeypatch.setattr("benchflow.rollout_branch._checkpoint_branch", checkpoint)
+
+    with pytest.raises(RuntimeError, match="not capture-safe"):
+        await rollout.branch(2)
+
+    checkpoint.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("externally_owned", [False, True])
+async def test_unsafe_stop_skips_export_and_respects_sandbox_ownership(
+    tmp_path: Path,
+    externally_owned: bool,
+) -> None:
+    config = RolloutConfig(
+        task_path=tmp_path / "task",
+        export_generated_skills_to=tmp_path / "export",
+    )
+    rollout = Rollout(config)
+    events: list[str] = []
+    rollout._acp_client = _StopClient(
+        _StopTransport(
+            events,
+            graceful=False,
+            forced=False,
+            stopped=False,
+        ),
+        events,
+    )
+    env_stop = AsyncMock()
+    rollout._env = SimpleNamespace(stop=env_stop)
+    rollout._env_externally_owned = externally_owned
+    rollout._rollout_dir = tmp_path
+    export = AsyncMock()
+    rollout._export_generated_skills = export
+
+    await rollout.cleanup()
+
+    export.assert_not_awaited()
+    assert env_stop.await_count == (0 if externally_owned else 1)
+    assert rollout._error is not None
+    assert "not capture-safe" in rollout._error
+
+
+@pytest.mark.asyncio
+async def test_unsafe_stop_bounds_rollout_owned_sandbox_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancelled = asyncio.Event()
+
+    class WedgedOwnedEnv:
+        async def stop(self, *, delete: bool) -> None:
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cancelled.set()
+
+    rollout = Rollout(RolloutConfig(task_path=tmp_path / "task"))
+    events: list[str] = []
+    rollout._acp_client = _StopClient(
+        _StopTransport(
+            events,
+            graceful=False,
+            forced=False,
+            stopped=False,
+        ),
+        events,
+    )
+    rollout._env = WedgedOwnedEnv()
+    monkeypatch.setattr(
+        "benchflow.rollout._ACP_UNSAFE_OWNER_STOP_TIMEOUT_SEC",
+        0.01,
+    )
+
+    await asyncio.wait_for(rollout.cleanup(), timeout=0.5)
+    await asyncio.wait_for(cancelled.wait(), timeout=0.5)
+
+    assert rollout._error is not None
+    assert "not capture-safe" in rollout._error

--- a/tests/test_sandbox_live_process.py
+++ b/tests/test_sandbox_live_process.py
@@ -10,13 +10,29 @@ each case guards is unchanged and named in its docstring.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import os
+import shlex
+import signal
+import sys
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from benchflow.acp.client import ACPClient
+from benchflow.acp.container_transport import ContainerTransport
+from benchflow.rollout import Rollout
 from benchflow.sandbox import process as process_pkg
 from benchflow.sandbox._base import BaseSandbox
+from benchflow.sandbox.process import _base as process_base
+from benchflow.sandbox.process._base import (
+    LiveProcess,
+    SubprocessLiveProcess,
+    _RemoteProcessGroupLiveProcess,
+)
 
 
 def _stub_sandbox(**attrs: object) -> SimpleNamespace:
@@ -222,3 +238,587 @@ class TestSingleTransportBackends:
             await _NoTransportSandbox().live_process()
 
         assert "does not provide a live agent transport" in str(excinfo.value)
+
+
+def _mutating_adapter_program(path: str) -> str:
+    child = (
+        "import signal, time\n"
+        "from pathlib import Path\n"
+        f"path = Path({path!r})\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "while True:\n"
+        "    with path.open('a') as stream:\n"
+        "        stream.write('x')\n"
+        "        stream.flush()\n"
+        "    time.sleep(0.01)\n"
+    )
+    return (
+        "import subprocess, sys, time\n"
+        f"subprocess.Popen([sys.executable, '-c', {child!r}], "
+        "stdin=subprocess.DEVNULL, stdout=subprocess.DEVNULL, "
+        "stderr=subprocess.DEVNULL, close_fds=True)\n"
+        "print('ready', flush=True)\n"
+        "time.sleep(3600)\n"
+    )
+
+
+async def _wait_for_mutation(path, *, previous_size: int = -1) -> int:
+    for _ in range(500):
+        if path.exists():
+            size = path.stat().st_size
+            if size > previous_size:
+                return size
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"child did not mutate {path}")
+
+
+class _LocalProcessGroup(SubprocessLiveProcess):
+    async def start(self, command, env=None, cwd=None) -> None:
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+        self._set_process(process, owns_process_group=True)
+
+
+class _LocalRemoteProcessGroup(_RemoteProcessGroupLiveProcess):
+    async def start(self, command, env=None, cwd=None) -> None:
+        wrapped = self._wrap_remote_process_group(
+            shlex.join([sys.executable, "-c", command])
+        )
+        process = await asyncio.create_subprocess_exec(
+            "bash",
+            "-c",
+            wrapped,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        self._set_process(process)
+
+    async def _exec_remote_process_group_command(self, command: str) -> int:
+        process = await asyncio.create_subprocess_exec(
+            "bash",
+            "-c",
+            command,
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        return await process.wait()
+
+
+class _AdapterOnlyProcess(LiveProcess):
+    def __init__(self) -> None:
+        self.process = None
+
+    async def start(self, command, env=None, cwd=None) -> None:
+        self.process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+        )
+
+    async def readline(self) -> bytes:
+        assert self.process is not None and self.process.stdout is not None
+        return await self.process.stdout.readline()
+
+    async def writeline(self, data: str) -> None:
+        assert self.process is not None and self.process.stdin is not None
+        self.process.stdin.write((data + "\n").encode())
+        await self.process.stdin.drain()
+
+    async def close(self) -> None:
+        if self.process is not None and self.process.returncode is None:
+            self.process.terminate()
+            await self.process.wait()
+
+    @property
+    def is_running(self) -> bool:
+        return self.process is not None and self.process.returncode is None
+
+
+@pytest.mark.asyncio
+async def test_owned_process_group_stops_adapter_and_mutating_child(
+    tmp_path, monkeypatch
+) -> None:
+    mutation_path = tmp_path / "mutations"
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_TERM_TIMEOUT_SEC", 0.1, raising=False
+    )
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_KILL_TIMEOUT_SEC", 1.0, raising=False
+    )
+    process = _LocalProcessGroup()
+    transport = ContainerTransport(
+        container_process=process,
+        command=_mutating_adapter_program(str(mutation_path)),
+    )
+    await transport.start()
+    assert await asyncio.wait_for(process.readline(), timeout=5) == b"ready\n"
+    await _wait_for_mutation(mutation_path)
+
+    await transport.close()
+
+    termination = transport.termination_status
+    assert termination.graceful_termination is False
+    assert termination.force_kill_required is True
+    assert termination.process_tree_stopped is True
+    stopped_size = mutation_path.stat().st_size
+    await asyncio.sleep(0.1)
+    assert mutation_path.stat().st_size == stopped_size
+
+
+@pytest.mark.asyncio
+async def test_remote_process_group_identity_stops_mutating_descendants(
+    tmp_path, monkeypatch
+) -> None:
+    mutation_path = tmp_path / "remote-mutations"
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_TERM_TIMEOUT_SEC", 0.1, raising=False
+    )
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_KILL_TIMEOUT_SEC", 1.0, raising=False
+    )
+    process = _LocalRemoteProcessGroup()
+    transport = ContainerTransport(
+        container_process=process,
+        command=_mutating_adapter_program(str(mutation_path)),
+    )
+    await transport.start()
+    assert await asyncio.wait_for(process.readline(), timeout=5) == b"ready\n"
+    await _wait_for_mutation(mutation_path)
+
+    await transport.close()
+
+    assert transport.termination_status.force_kill_required is True
+    assert transport.termination_status.process_tree_stopped is True
+    stopped_size = mutation_path.stat().st_size
+    await asyncio.sleep(0.1)
+    assert mutation_path.stat().st_size == stopped_size
+
+
+@pytest.mark.asyncio
+async def test_stopping_only_adapter_cannot_claim_capture_safe(tmp_path) -> None:
+    mutation_path = tmp_path / "mutations"
+    process = _AdapterOnlyProcess()
+    transport = ContainerTransport(
+        container_process=process,
+        command=_mutating_adapter_program(str(mutation_path)),
+    )
+    await transport.start()
+    assert await asyncio.wait_for(process.readline(), timeout=5) == b"ready\n"
+    first_size = await _wait_for_mutation(mutation_path)
+    assert process.process is not None
+    process_group_id = process.process.pid
+
+    try:
+        await transport.close()
+        await _wait_for_mutation(mutation_path, previous_size=first_size)
+        assert transport.termination_status.process_tree_stopped is False
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process_group_id, signal.SIGKILL)
+
+
+class _UnknownInitialLivenessProcess(_RemoteProcessGroupLiveProcess):
+    def __init__(self) -> None:
+        super().__init__()
+        self._remote_process_group_path = "/tmp/exact-agent-group"
+        self.events: list[str] = []
+        self._liveness = iter([None, True, False])
+
+    async def start(self, command, env=None, cwd=None) -> None:
+        raise AssertionError("this fake is never launched")
+
+    async def close_stdin(self) -> bool:
+        self.events.append("session_closed")
+        return True
+
+    async def _remote_process_group_alive(self) -> bool | None:
+        self.events.append("liveness")
+        return next(self._liveness)
+
+    async def _signal_remote_process_group(self, signal_name: str) -> bool:
+        self.events.append(signal_name)
+        return True
+
+    async def _cleanup_remote_process_group_identity(self) -> None:
+        self.events.append("cleanup")
+
+
+@pytest.mark.asyncio
+async def test_remote_group_still_signals_when_initial_liveness_is_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_TERM_TIMEOUT_SEC", 0.0, raising=False
+    )
+    process = _UnknownInitialLivenessProcess()
+
+    result = await process.terminate_process_tree()
+
+    assert process.events == [
+        "session_closed",
+        "liveness",
+        "TERM",
+        "KILL",
+        "liveness",
+        "liveness",
+        "cleanup",
+    ]
+    assert result.graceful_termination is False
+    assert result.force_kill_required is True
+    assert result.process_tree_stopped is True
+
+
+_MUTATING_ACP_AGENT = Path(__file__).parent / "fixtures" / "mock_acp_mutating_agent.py"
+
+
+class _FixtureProcessGroup(SubprocessLiveProcess):
+    def __init__(self) -> None:
+        self.events: list[str] = []
+        self.protocol_event_path: Path | None = None
+        self.signal_protocol_events: list[list[str]] = []
+
+    async def start(self, command, env=None, cwd=None) -> None:
+        process = await asyncio.create_subprocess_exec(
+            "bash",
+            "-c",
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+        )
+        self._set_process(process, owns_process_group=True)
+
+    async def close_stdin(self) -> bool:
+        if not getattr(self, "_stdin_closed", False):
+            self.events.append("session_close")
+        return await super().close_stdin()
+
+    async def process_tree_stopped(self) -> bool:
+        self.events.append("liveness")
+        return await super().process_tree_stopped()
+
+    async def _wait_for_process_tree(self, timeout: float) -> bool:
+        self.events.append("wait")
+        return await super()._wait_for_process_tree(timeout)
+
+    def _signal_process_group(self, sig: signal.Signals) -> bool:
+        self.events.append(sig.name)
+        if self.protocol_event_path is not None:
+            self.signal_protocol_events.append(
+                self.protocol_event_path.read_text().splitlines()
+            )
+        return super()._signal_process_group(sig)
+
+
+class _FixtureAdapterOnlyProcess(LiveProcess):
+    def __init__(self) -> None:
+        self.process = None
+
+    async def start(self, command, env=None, cwd=None) -> None:
+        self.process = await asyncio.create_subprocess_exec(
+            "bash",
+            "-c",
+            command,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            start_new_session=True,
+            cwd=cwd,
+            env={**os.environ, **(env or {})},
+        )
+
+    async def readline(self) -> bytes:
+        assert self.process is not None and self.process.stdout is not None
+        return await self.process.stdout.readline()
+
+    async def writeline(self, data: str) -> None:
+        assert self.process is not None and self.process.stdin is not None
+        self.process.stdin.write((data + "\n").encode())
+        await self.process.stdin.drain()
+
+    async def close_stdin(self) -> bool:
+        if self.process is None or self.process.stdin is None:
+            return False
+        self.process.stdin.close()
+        return True
+
+    async def close(self) -> None:
+        if self.process is None:
+            return
+        await self.close_stdin()
+        if self.process.returncode is None:
+            try:
+                await asyncio.wait_for(self.process.wait(), timeout=1)
+            except TimeoutError:
+                self.process.terminate()
+                await self.process.wait()
+
+    @property
+    def is_running(self) -> bool:
+        return self.process is not None and self.process.returncode is None
+
+
+async def _mutating_acp_rollout(tmp_path, process: LiveProcess):
+    mutation_path = tmp_path / "acp-mutations"
+    event_path = tmp_path / "acp-events"
+    transport = ContainerTransport(
+        container_process=process,
+        command=shlex.join([sys.executable, str(_MUTATING_ACP_AGENT)]),
+        env={
+            "MUTATION_PATH": str(mutation_path),
+            "EVENT_PATH": str(event_path),
+        },
+    )
+    client = ACPClient(transport)
+    await client.connect()
+    await client.initialize()
+    session = await client.session_new()
+    await _wait_for_mutation(mutation_path)
+
+    rollout = Rollout.__new__(Rollout)
+    rollout._acp_client = client
+    rollout._session = session
+    rollout._session_adapter = None
+    rollout._is_session_factory = False
+    rollout._active_role = None
+    rollout._session_tool_count = 0
+    rollout._session_traj_count = 0
+    rollout._n_tool_calls = 0
+    rollout._trajectory = []
+    rollout._rollout_dir = tmp_path
+    rollout._phase = "executed"
+    rollout._termination_receipt = None
+    rollout._acp_session_observation = None
+    return rollout, mutation_path, event_path
+
+
+@pytest.mark.asyncio
+async def test_rollout_stop_agent_kills_acp_adapter_and_mutating_child(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_TERM_TIMEOUT_SEC", 0.1, raising=False
+    )
+    process = _FixtureProcessGroup()
+    rollout, mutation_path, event_path = await _mutating_acp_rollout(tmp_path, process)
+    process.protocol_event_path = event_path
+
+    receipt = await rollout.stop_agent(cancel_requested=True)
+
+    assert event_path.read_text().splitlines() == ["cancel", "session_closed"]
+    assert receipt.cancel_acknowledged is True
+    assert receipt.session_closed is True
+    assert receipt.graceful_termination is False
+    assert receipt.force_kill_required is True
+    assert receipt.process_tree_stopped is True
+    assert receipt.capture_safe is True
+    stopped_size = mutation_path.stat().st_size
+    await asyncio.sleep(0.1)
+    assert mutation_path.stat().st_size == stopped_size
+
+    assert process.events == [
+        "session_close",
+        "liveness",
+        "SIGTERM",
+        "wait",
+        "SIGKILL",
+        "wait",
+        "liveness",
+    ]
+    assert process.signal_protocol_events == [
+        ["cancel", "session_closed"],
+        ["cancel", "session_closed"],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_rollout_stop_agent_marks_adapter_only_death_unsafe(tmp_path) -> None:
+    process = _FixtureAdapterOnlyProcess()
+    rollout, mutation_path, event_path = await _mutating_acp_rollout(tmp_path, process)
+    assert process.process is not None
+    process_group_id = process.process.pid
+
+    try:
+        receipt = await rollout.stop_agent(cancel_requested=True)
+
+        assert event_path.read_text().splitlines() == ["cancel", "session_closed"]
+        assert receipt.cancel_acknowledged is True
+        assert receipt.session_closed is True
+        assert receipt.process_tree_stopped is False
+        assert receipt.capture_safe is False
+        prior_size = mutation_path.stat().st_size
+        await _wait_for_mutation(mutation_path, previous_size=prior_size)
+    finally:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(process_group_id, signal.SIGKILL)
+
+
+class _PollingRemoteProcess(_RemoteProcessGroupLiveProcess):
+    def __init__(self, observations) -> None:
+        super().__init__()
+        self._observations = iter(observations)
+
+    async def start(self, command, env=None, cwd=None) -> None:
+        raise AssertionError("this fake is never launched")
+
+    async def _remote_process_group_alive(self) -> bool | None:
+        return next(self._observations)
+
+
+@pytest.mark.asyncio
+async def test_remote_liveness_retries_unknown_until_death_is_observed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process_base, "_PROCESS_TREE_POLL_INTERVAL_SEC", 0.001, raising=False
+    )
+    process = _PollingRemoteProcess([None, False])
+
+    stopped = await process._wait_for_remote_process_tree(0.1)
+
+    assert stopped is True
+
+
+class _SlowRemoteProbeProcess(_RemoteProcessGroupLiveProcess):
+    async def start(self, command, env=None, cwd=None) -> None:
+        raise AssertionError("this fake is never launched")
+
+    async def _remote_process_group_alive(self) -> bool | None:
+        await asyncio.sleep(1)
+        return True
+
+
+@pytest.mark.asyncio
+async def test_remote_liveness_probe_is_bounded_by_remaining_deadline() -> None:
+    process = _SlowRemoteProbeProcess()
+
+    stopped = await asyncio.wait_for(
+        process._wait_for_remote_process_tree(0.01),
+        timeout=0.2,
+    )
+
+    assert stopped is False
+
+
+class _TrackedControlProcess:
+    def __init__(self, process) -> None:
+        self._process = process
+        self.kill_called = False
+        self.wait_completed = False
+
+    @property
+    def returncode(self):
+        return self._process.returncode
+
+    async def communicate(self):
+        return await self._process.communicate()
+
+    def kill(self) -> None:
+        self.kill_called = True
+        self._process.kill()
+
+    async def wait(self):
+        return_code = await self._process.wait()
+        self.wait_completed = True
+        return return_code
+
+
+async def _assert_control_process_cleanup_on_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    backend_module,
+    execute_command,
+) -> None:
+    original_create_subprocess_exec = asyncio.create_subprocess_exec
+    started = asyncio.Event()
+    control_process = None
+
+    async def create_control_process(*args, **kwargs):
+        nonlocal control_process
+        child = await original_create_subprocess_exec(
+            sys.executable,
+            "-c",
+            "import time; time.sleep(60)",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.DEVNULL,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        control_process = _TrackedControlProcess(child)
+        started.set()
+        return control_process
+
+    monkeypatch.setattr(
+        backend_module.asyncio,
+        "create_subprocess_exec",
+        create_control_process,
+    )
+    task = asyncio.create_task(execute_command())
+    try:
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert control_process is not None
+        assert control_process.returncode is None
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert control_process.kill_called is True
+        assert control_process.wait_completed is True
+        assert control_process.returncode is not None
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        if control_process is not None and control_process.returncode is None:
+            control_process.kill()
+            await control_process.wait()
+
+
+@pytest.mark.asyncio
+async def test_apple_control_process_is_reaped_before_cancellation_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from benchflow.sandbox.process import apple as apple_module
+    from benchflow.sandbox.process.apple import AppleContainerProcess
+
+    process = AppleContainerProcess("benchflow-test")
+
+    await _assert_control_process_cleanup_on_cancellation(
+        monkeypatch,
+        apple_module,
+        lambda: process._exec_remote_process_group_command("true"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_docker_control_process_is_reaped_before_cancellation_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from benchflow.sandbox.process import docker as docker_module
+    from benchflow.sandbox.process.docker import DockerProcess
+
+    process = DockerProcess("benchflow-test", "/tmp", [])
+    monkeypatch.setattr(process, "_host_env", lambda: {})
+
+    await _assert_control_process_cleanup_on_cancellation(
+        monkeypatch,
+        docker_module,
+        lambda: process._exec_remote_process_group_command("true"),
+    )

--- a/tests/test_sandbox_live_process.py
+++ b/tests/test_sandbox_live_process.py
@@ -347,6 +347,85 @@ class _AdapterOnlyProcess(LiveProcess):
         return self.process is not None and self.process.returncode is None
 
 
+class _WedgedCloseProcess(LiveProcess):
+    def __init__(self) -> None:
+        self.close_started = asyncio.Event()
+        self.close_cancelled = asyncio.Event()
+
+    async def start(self, command, env=None, cwd=None) -> None:
+        raise AssertionError("this fake is never launched")
+
+    async def readline(self) -> bytes:
+        raise AssertionError("this fake is never read")
+
+    async def writeline(self, data: str) -> None:
+        raise AssertionError("this fake is never written")
+
+    async def close(self) -> None:
+        self.close_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            self.close_cancelled.set()
+
+    @property
+    def is_running(self) -> bool:
+        return True
+
+
+@pytest.mark.asyncio
+async def test_default_unprovable_process_termination_is_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        process_base, "_DEFAULT_PROCESS_CLOSE_TIMEOUT_SEC", 0.01, raising=False
+    )
+    process = _WedgedCloseProcess()
+
+    result = await asyncio.wait_for(process.terminate_process_tree(), timeout=0.2)
+
+    assert process.close_started.is_set()
+    assert process.close_cancelled.is_set()
+    assert result.process_tree_stopped is False
+
+
+@pytest.mark.asyncio
+async def test_agentcore_shell_close_is_backend_bounded(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from benchflow.sandbox.process import agentcore as agentcore_process
+
+    class _WedgedShell:
+        def __init__(self) -> None:
+            self.close_started = asyncio.Event()
+            self.close_cancelled = asyncio.Event()
+
+        async def close(self) -> None:
+            self.close_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                self.close_cancelled.set()
+
+    monkeypatch.setattr(
+        agentcore_process, "_AGENTCORE_SHELL_CLOSE_TIMEOUT_SEC", 0.01, raising=False
+    )
+    shell = _WedgedShell()
+    process = process_pkg.AgentCoreProcess(
+        sandbox=object(),
+        runtime_arn="arn:aws:bedrock-agentcore:us-west-2:1:runtime/test",
+        session_id="s" * 40,
+        region="us-west-2",
+    )
+    process._shell = shell
+
+    await asyncio.wait_for(process.close(), timeout=0.2)
+
+    assert shell.close_started.is_set()
+    assert shell.close_cancelled.is_set()
+    assert process._shell is None
+
+
 @pytest.mark.asyncio
 async def test_owned_process_group_stops_adapter_and_mutating_child(
     tmp_path, monkeypatch


### PR DESCRIPTION
## Summary

Implements the BenchFlow prerequisites from [RSI Bench's Sierra ACP migration plan](https://github.com/ARA-Labs/rsi-bench/blob/b301ba48a24cfdd6496a774d4b66332009b2d0b3/plans/sierra-acp-migration.md). Adds fail-closed explicit agent environment admission with a private runtime credential channel, live ACP session observations, and typed process-tree termination receipts that gate safe downstream capture.

## Plan Steps

- [x] Step 1: Add BenchFlow explicit environment policy (`24a98a45`)
- [x] Step 2: Add BenchFlow ACP stop and observation contracts (`018feba8`)
- [x] Integration hardening (`2c92519c`)

## Review Status

Engineering review: approved by the human developer. Per-task spec and quality reviews passed; whole-branch security/concurrency review passed after fixes.

## Test Plan

- [x] Task 1 focused suite: 49 passed
- [x] Task 2 focused suite: 156 passed
- [x] Full suite: 5926 passed, 58 skipped, 7 deselected; one pre-existing interactive trajectory-upload test remains environment-sensitive
- [x] `uv run ruff check src tests`
- [x] `uv run ruff format --check src tests`
- [ ] `uv run mypy src` — current main has 135 pre-existing diagnostics across 57 files, primarily optional dependency/stub and unrelated typing debt

## Release Dependency

RSI Bench requires these public contracts in the exact `benchflow==0.7.6` stable release before its downstream dependency lock and migration PR can be finalized.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1091" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->