### PR TITLE
feat(review): integrate task rubrics into rollout scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 
 ### Added
+- **Task-local weighted rubrics now participate in normal rollout scoring.**
+  `bench eval run` and the SDK automatically launch an isolated
+  `codex-acp` / `openai/gpt-5.6-sol` (`xhigh`) reviewer when a task ships a
+  review-shaped `verifier/rubric.json` or `tests/rubric.json`. Final reward and
+  pass@1 require both a clean deterministic-verifier pass and every blocker;
+  non-blockers produce a gated weighted score. Solver workspace deltas and
+  reviewer evidence are retained, every score-bearing rollout/trainer/job
+  artifact is refreshed, reviewer telemetry is kept separate, and review
+  failures are retried then fail closed as unscored.
 - **ACP rollout directories render as an interactive reviewer page.**
   `bench eval view <rollout>` now assembles a JSON payload (normalized
   events + result/timing/verifier metadata) and renders it client-side in a

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -329,10 +329,13 @@ reason is a bare reward. Multi-failure CTRF reports roll up as
 `(details: …/verifier)` pointer names the artifact directory whenever one
 exists on disk.
 
-The final `Score: P/T (…%)` line is pass-threshold aggregation — a task counts
-as passed only at reward 1.0 — while `mean reward` beside it is the average raw
-verifier reward, so `0/1 (0.0%)` next to `mean reward 0.80` means partial
-credit below the pass threshold, not a flat zero.
+The final `Score: P/T (…%)` line is pass@1 aggregation — a task counts as
+passed only at final reward 1.0. Tasks with a weighted `verifier/rubric.json`
+or `tests/rubric.json` are reviewed automatically in a second sandbox, and
+must pass both the deterministic verifier and every blocker criterion. The
+line also reports mean rubric score and review coverage when reviewed tasks
+are present. For tasks without a review rubric, `mean reward` remains the
+average raw verifier reward.
 
 Set `BENCHFLOW_ACP_HANDSHAKE_TIMEOUT` to a number of seconds (default 60) to
 give slow-starting agents more time to answer the pre-prompt ACP handshake
@@ -375,15 +378,17 @@ bench review jobs/<job>/<rollout> -r my-rubric.json --agent gemini
 bench review jobs/<job> --passing --sandbox daytona -n 8 -m gemini/gemini-2.5-flash
 ```
 
-The default `opencode` reviewer has no registry default model, so `-m` is
-required with it (a run without one exits with an actionable error).
+This command is a read-only audit of existing results. Normal run and eval
+commands automatically integrate a shipped review rubric into final scoring;
+see [Rubric review](../rubric-review.md#automatic-scoring-during-normal-runs).
 
 | Flag | Default | Description |
 |---|---|---|
 | `--rubric`, `-r` | task / built-in | Rubric JSON file. Default: an admitted task copy's `verifier/rubric.json` (requires `--tasks-root` and a verified recorded digest), else the built-in default rubric |
 | `--prompt`, `-p` | built-in | Custom reviewer instruction template |
-| `--agent`, `-a` | `opencode` | Reviewer agent harness |
-| `--model`, `-m` | agent registry | Reviewer model (required for agents without a registry default; gateway ids such as `gemini/gemini-2.5-flash`) |
+| `--agent`, `-a` | `codex-acp` | Reviewer agent harness |
+| `--model`, `-m` | `openai/gpt-5.6-sol` | Reviewer model |
+| `--reasoning-effort` | `xhigh` | Reviewer reasoning effort |
 | `--sandbox` | `docker` | Sandbox backend for reviewer rollouts |
 | `--concurrency`, `-n` | `4` | Max concurrent reviews |
 | `--passing` | `false` | Only review passing rollouts (reward 1.0) |

--- a/docs/reference/python-api.md
+++ b/docs/reference/python-api.md
@@ -373,6 +373,7 @@ Batch orchestration with concurrency and retries.
 
 ```python
 from benchflow import Evaluation, EvaluationConfig, EvaluationResult, RetryConfig
+from benchflow.review import RubricReviewConfig
 
 # EvaluationConfig holds the per-job settings (agent/model/environment/...)
 # applied to every task discovered under tasks_dir.
@@ -381,6 +382,11 @@ config = EvaluationConfig(
     environment="daytona",
     concurrency=8,
     retry=RetryConfig(max_retries=2),
+    # This is already the default for tasks that ship a review rubric.
+    rubric_review=RubricReviewConfig(
+        model="openai/gpt-5.6-sol",
+        reasoning_effort="xhigh",
+    ),
 )
 evaluation = Evaluation(tasks_dir="tasks", jobs_dir="jobs/my-run", config=config)
 eval_result: EvaluationResult = await evaluation.run()

--- a/docs/rubric-review.md
+++ b/docs/rubric-review.md
@@ -1,17 +1,20 @@
 # Rubric review
 
-Rubric review is a detached, agentic quality review of finished rollouts. A
-reviewer agent reads a rollout's records — trajectory, result, verifier
-output, and the task definition — inside its own sandbox and grades the run
-against a rubric. Legacy rubrics produce one `pass` / `fail` /
-`not_applicable` verdict per criterion; weighted rubrics combine binary
-blocker verdicts with 0–2 scores.
+Rubric review is an isolated, agentic quality review of a finished rollout. A
+reviewer agent reads the solver's trajectory, deterministic verifier output,
+task definition, and created or modified workspace files inside a second
+sandbox. Legacy rubrics produce one `pass` / `fail` / `not_applicable` verdict
+per criterion; weighted rubrics combine binary blocker verdicts with 0–2
+scores.
 
-Review is **report-only**. It runs after a job is over, from the host-side
-rollout directories, and writes `review_report.json`. It never modifies a
-reviewed rollout's `rewards` or `result.json`, and there is no code path
-through which it could: the deterministic verifier is the only owner of
-`reward`.
+There are two entry points:
+
+- Normal `bench eval run`, SDK, and runtime rollouts automatically
+  review a task that ships `verifier/rubric.json` or `tests/rubric.json`. A
+  weighted review becomes part of that rollout's canonical reward and score.
+- `bench review` is the read-only audit command for already-finished rollouts.
+  It writes a separate `review_report.json` and never changes the source
+  rollout.
 
 This is distinct from the [`llm-judge` verifier strategy](./llm-judge.md):
 an llm-judge is part of a task's verifier and *produces* the reward, while
@@ -96,8 +99,15 @@ BenchFlow aggregates a structurally valid v0.2 review on the host:
 raw_quality = sum(score * weight) / (2 * sum(non-blocker weights))
 gates_pass = deterministic reward is 1.0 with no recorded error
              AND every blocker passes
-gated_quality = raw_quality if gates_pass, otherwise 0
+pass_at_1 = 1 if gates_pass, otherwise 0
+final_score = raw_quality if gates_pass, otherwise 0
 ```
+
+`weighted_points` and `max_weighted_points` retain the unnormalized weighted
+sum and denominator. `score` is the normalized, gated value in `[0, 1]` so it
+can be aggregated across tasks with different rubrics. A review or workspace
+capture error is unscored (`reward`, `pass_at_1`, and `score` are null), not a
+silent zero.
 
 The raw quality remains visible when a gate fails, making the rubric judgment
 auditable without mistaking it for a publishable result. A failed gate always
@@ -131,6 +141,62 @@ Rubric resolution order, per reviewed rollout:
 
 ## Running a review
 
+### Automatic scoring during normal runs
+
+No extra flag is required. When the selected task contains a review-shaped
+`verifier/rubric.json` or `tests/rubric.json`, BenchFlow captures the solver's
+workspace delta, finishes the deterministic verifier, and then launches the
+reviewer in a fresh sandbox of the same backend. The default reviewer is
+`codex-acp` with `openai/gpt-5.6-sol` at `xhigh` reasoning. It retries an
+invalid or failed review once without rerunning the solver.
+
+The reviewer sandbox receives read-only copies of the source trajectory,
+verifier output, task, workspace manifest, and every regular workspace file
+created or modified after task installation. Credential-like files, runtime
+configuration, VCS metadata, dependency trees, caches, and symlinks are
+excluded. The reviewer cannot modify the source sandbox or rollout.
+
+Override the policy in a YAML run config when necessary:
+
+```yaml
+tasks_dir: ./tasks
+agent: claude-agent-acp
+model: anthropic/claude-opus-4-6
+environment: daytona
+
+rubric_review:
+  enabled: true
+  agent: codex-acp
+  model: openai/gpt-5.6-sol
+  reasoning_effort: xhigh
+  environment: null       # inherit the solver's sandbox backend
+  timeout_sec: 1800
+  max_retries: 1
+  allow_open_network: false
+```
+
+Set `rubric_review.enabled: false` only for an explicitly unreviewed diagnostic
+run. Reviewer `agent_env` values can also be supplied through YAML or the SDK;
+only their key names are persisted in public config artifacts.
+
+For a valid weighted review, the integrated result obeys both gates:
+
+```text
+reward = pass_at_1 = 1 only when verifier reward == 1 with no verifier error
+                         and every blocker criterion passes
+score = weighted_points / max_weighted_points when reward == 1, else 0
+```
+
+The source rollout retains the complete audit under `review/` and refreshes
+all score-bearing representations: `result.json`, `timing.json`,
+`rewards.jsonl`, `results.jsonl`, and the files under `trainer/`. Job
+`summary.json`, CLI output, metrics, health summaries, and publish README files
+then derive pass@1 and score from those canonical per-rollout results. The
+reviewer's token, timing, and cost telemetry remains separate from the solver's
+telemetry.
+
+### Read-only review of existing rollouts
+
 ```bash
 # review one rollout
 bench review jobs/<job>/<rollout> --sandbox docker \
@@ -150,10 +216,9 @@ bench review jobs/<job> --failing -r spec-rubric.json \
 
 `--passing` selects rollouts with reward 1.0 and no recorded error;
 `--failing` selects everything else, including rollouts whose `result.json`
-is unreadable. The reviewer agent (`--agent`, default `opencode`) and model
-(`--model`; agents without a registry default require one — pass a gateway
-model id such as `gemini/gemini-2.5-flash`) are independent of whatever ran
-the original job.
+is unreadable. The reviewer agent (`--agent`, default `codex-acp`) and model
+(`--model`) are independent of whatever ran the original job. Its defaults
+match automatic scoring: `codex-acp`, `openai/gpt-5.6-sol`, and `xhigh`.
 
 ## How a review executes
 
@@ -234,7 +299,7 @@ no aggregate score:
 {
   "path": "…/jobs/2026-08-03__12-00-00",
   "rubric": {"path": "…", "criteria": ["…"], "contracts": ["v0.1"]},
-  "reviewer": {"agent": "opencode", "model": "gemini/gemini-2.5-flash", "environment": "docker", "network": "no-internet"},
+  "reviewer": {"agent": "codex-acp", "model": "openai/gpt-5.6-sol", "reasoning_effort": "xhigh", "environment": "docker", "network": "no-internet"},
   "job_summary": "Deterministic aggregation over VALID reviews only.",
   "trials": [
     {

--- a/docs/running-benchmarks.md
+++ b/docs/running-benchmarks.md
@@ -796,7 +796,10 @@ model: gemini/gemini-3.1-flash-lite-preview
 
 All fields from [CLI reference](./reference/cli.md#yaml-config-format) apply:
 `source`, `tasks_dir`, `agent`, `model`, `environment`, `concurrency`,
-`sandbox_setup_timeout`, `skills_dir`, `agent_env`, `max_retries`.
+`sandbox_setup_timeout`, `skills_dir`, `agent_env`, `max_retries`, and
+`rubric_review`. A task-local `verifier/rubric.json` or `tests/rubric.json`
+enables isolated automatic review by default; the reviewer policy and final
+score contract are documented in [Rubric review](./rubric-review.md).
 
 ---
 

--- a/src/benchflow/_utils/evaluation_results.py
+++ b/src/benchflow/_utils/evaluation_results.py
@@ -79,6 +79,8 @@ def rollout_result_payload(
         "error_category": result.error_category,
         "verifier_error": result.verifier_error,
         "verifier_error_category": result.verifier_error_category,
+        "final_score": result.final_score,
+        "rubric_review": result.rubric_review,
         "export_error": result.export_error,
         "n_tool_calls": result.n_tool_calls,
         "n_skill_invocations": n_skill_invocations,
@@ -132,6 +134,78 @@ def usage_summary(results: dict[str, dict]) -> dict[str, Any]:
             round(total_cost / len(covered), 10) if covered else None
         ),
         "telemetry_coverage": (len(covered) / len(completed) if completed else 0.0),
+    }
+
+
+def rubric_review_summary(results: dict[str, dict]) -> dict[str, Any]:
+    """Aggregate automatic rubric outcomes and reviewer-only telemetry."""
+
+    reviewed = [
+        result
+        for result in results.values()
+        if isinstance(result.get("rubric_review"), dict)
+    ]
+    if not reviewed:
+        return {}
+    final_scores = [
+        score
+        for result in reviewed
+        if isinstance((score := result.get("final_score")), dict)
+    ]
+    numeric_scores = [
+        float(score["score"])
+        for score in final_scores
+        if isinstance(score.get("score"), (int, float))
+        and not isinstance(score.get("score"), bool)
+    ]
+    passed = sum(score.get("pass") is True for score in final_scores)
+    failed = sum(score.get("pass") is False for score in final_scores)
+    errors = sum(
+        (result.get("rubric_review") or {}).get("status") == "error"
+        for result in reviewed
+    )
+    unweighted = sum(
+        (result.get("rubric_review") or {}).get("status") == "complete_unweighted"
+        for result in reviewed
+    )
+    reviewer_results = [
+        reviewer
+        for result in reviewed
+        if isinstance((review := result.get("rubric_review")), dict)
+        and isinstance((reviewer := review.get("reviewer")), dict)
+    ]
+    usage = [
+        agent_result
+        for reviewer in reviewer_results
+        if isinstance((agent_result := reviewer.get("agent_result")), dict)
+    ]
+
+    def usage_total(field: str) -> float:
+        return sum(
+            float(value)
+            for item in usage
+            if isinstance((value := item.get(field)), (int, float))
+            and not isinstance(value, bool)
+        )
+
+    required = len(reviewed)
+    completed = passed + failed
+    mean_score = sum(numeric_scores) / len(numeric_scores) if numeric_scores else None
+    return {
+        "rubric_review": {
+            "required": required,
+            "completed": completed,
+            "passed": passed,
+            "failed": failed,
+            "errored": errors,
+            "unweighted": unweighted,
+            "pass_at_1": passed / required if required else None,
+            "mean_score": mean_score,
+            "score_coverage": len(numeric_scores) / required if required else 0.0,
+            "reviewer_total_tokens": int(usage_total("total_tokens")),
+            "reviewer_total_cost_usd": round(usage_total("cost_usd"), 10),
+            "reviewer_usage_coverage": len(usage) / required if required else 0.0,
+        }
     }
 
 

--- a/src/benchflow/_utils/yaml_loader.py
+++ b/src/benchflow/_utils/yaml_loader.py
@@ -44,6 +44,7 @@ from typing import Any
 import yaml
 
 from benchflow._types import Role, Scene, Turn
+from benchflow.review.policy import RubricReviewConfig
 from benchflow.rollout import RolloutConfig
 from benchflow.skill_policy import SKILL_MODE_NO_SKILL
 from benchflow.usage_tracking import UsageTrackingConfig
@@ -132,6 +133,7 @@ def rollout_config_from_dict(
         skill_creator_dir=raw.get("skill_creator_dir"),
         self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
         usage_tracking=UsageTrackingConfig.from_mapping(raw),
+        rubric_review=RubricReviewConfig.coerce(raw.get("rubric_review")),
     )
 
 

--- a/src/benchflow/cli/_shared.py
+++ b/src/benchflow/cli/_shared.py
@@ -137,6 +137,10 @@ def _failure_reason(failure: TaskFailure, job_dir: Path | None = None) -> Failur
         return FailureLine(" ".join(failure.verifier_error.split()))
     rewards = failure.rewards or {}
     reward = rewards.get("reward")
+    failed_blockers = rewards.get("failed_blockers")
+    if isinstance(failed_blockers, list) and failed_blockers:
+        names = ", ".join(str(name) for name in failed_blockers)
+        return FailureLine(f"blocker rubric failed: {names}")
     shown = metric_breakdown(rewards)
     if shown is not None:
         return FailureLine(f"reward {reward} — {shown}")
@@ -189,9 +193,16 @@ def _report_eval_result(result: EvaluationResult, job_dir: Path | None = None) -
     # flat 0. getattr(): sharded aggregation and older callers don't carry it.
     mean_reward = getattr(result, "mean_reward", None)
     mean_part = f", mean reward {mean_reward:.2f}" if mean_reward is not None else ""
+    mean_final_score = getattr(result, "mean_final_score", None)
+    review_required = int(getattr(result, "rubric_reviews_required", 0) or 0)
+    rubric_part = (
+        f", rubric score {mean_final_score:.2f} ({review_required} reviewed)"
+        if mean_final_score is not None
+        else ""
+    )
     console.print(
         f"\n[{style}]{mark} Score: {result.passed}/{result.total} "
-        f"({result.score:.1%})[/{style}]{mean_part}{err_part}"
+        f"({result.score:.1%})[/{style}]{mean_part}{rubric_part}{err_part}"
     )
     # One dim reason line per FAILED task, so "0/1" doesn't force a dig into
     # summary.json to learn why. getattr(): sharded aggregation and older

--- a/src/benchflow/cli/eval_artifacts.py
+++ b/src/benchflow/cli/eval_artifacts.py
@@ -40,6 +40,7 @@ def _redacted_eval_config(eval_config: EvaluationConfig) -> dict:
         "source_provenance": eval_config.source_provenance,
         "dataset_name": eval_config.dataset_name,
         "dataset_version": eval_config.dataset_version,
+        "rubric_review": eval_config.rubric_review.to_config_artifact(),
     }
 
 

--- a/src/benchflow/cli/main.py
+++ b/src/benchflow/cli/main.py
@@ -1223,6 +1223,13 @@ def eval_metrics(
     table.add_row("Failed", f"[red]{summary['failed']}[/red]")
     table.add_row("Errored", f"[yellow]{summary['errored']}[/yellow]")
     table.add_row("Score", f"[bold]{summary['score']}[/bold]")
+    if summary.get("mean_final_score") is not None:
+        table.add_row(
+            "Rubric score",
+            f"{summary['mean_final_score']:.1%} "
+            f"({summary['rubric_reviews_completed']}/"
+            f"{summary['rubric_reviews_required']})",
+        )
     if summary.get("memory_score") is not None:
         scored = (summary.get("memory") or {}).get("scored", 0)
         table.add_row(

--- a/src/benchflow/cli/review.py
+++ b/src/benchflow/cli/review.py
@@ -17,6 +17,12 @@ from benchflow.cli._shared import (
     _parse_agent_env,
     console,
 )
+from benchflow.review.policy import (
+    DEFAULT_REVIEWER_AGENT,
+    DEFAULT_REVIEWER_MODEL,
+    DEFAULT_REVIEWER_REASONING_EFFORT,
+    DEFAULT_REVIEWER_TIMEOUT_SEC,
+)
 from benchflow.sandbox.providers import providers_phrase
 
 _REVIEW_OUTCOME_STYLES = {
@@ -147,11 +153,15 @@ def _review_command(
     agent: Annotated[
         str,
         typer.Option("--agent", "-a", help="Reviewer agent harness"),
-    ] = "opencode",
+    ] = DEFAULT_REVIEWER_AGENT,
     model: Annotated[
         str | None,
-        typer.Option("--model", "-m", help="Reviewer model (default: agent registry)"),
-    ] = None,
+        typer.Option("--model", "-m", help="Reviewer model"),
+    ] = DEFAULT_REVIEWER_MODEL,
+    reasoning_effort: Annotated[
+        str,
+        typer.Option("--reasoning-effort", help="Reviewer reasoning effort"),
+    ] = DEFAULT_REVIEWER_REASONING_EFFORT,
     environment: Annotated[
         str,
         typer.Option("--sandbox", help=f"Sandbox: {providers_phrase()}"),
@@ -171,7 +181,7 @@ def _review_command(
     timeout_sec: Annotated[
         int,
         typer.Option("--timeout-sec", help="Reviewer agent timeout per rollout"),
-    ] = 1800,
+    ] = DEFAULT_REVIEWER_TIMEOUT_SEC,
     agent_env: Annotated[
         list[str] | None,
         typer.Option("--agent-env", help="KEY=VALUE for the reviewer (repeatable)"),
@@ -241,6 +251,7 @@ def _review_command(
                 path,
                 agent=agent,
                 model=model,
+                reasoning_effort=reasoning_effort,
                 environment=environment,
                 rubric_path=rubric,
                 prompt_path=prompt,

--- a/src/benchflow/eval_artifacts.py
+++ b/src/benchflow/eval_artifacts.py
@@ -177,6 +177,19 @@ def _reward(result: dict[str, Any]) -> float | None:
     return None
 
 
+def _final_score(result: dict[str, Any]) -> tuple[bool | None, float | None]:
+    final = result.get("final_score")
+    if not isinstance(final, dict):
+        return None, None
+    passed = final.get("pass")
+    if type(passed) is not bool:
+        passed = None
+    score = final.get("score")
+    if not isinstance(score, (int, float)) or isinstance(score, bool):
+        score = None
+    return passed, float(score) if score is not None else None
+
+
 def _tool_call_count(result: dict[str, Any]) -> int:
     value = result.get("n_tool_calls")
     if isinstance(value, int) and value >= 0:
@@ -229,6 +242,7 @@ def build_health_summary(
             continue
         counts["total_rows"] += 1
         reward = _reward(result)
+        passed, final_score = _final_score(result)
         scored = reward is not None
         if scored:
             counts["scored_rows"] += 1
@@ -249,6 +263,13 @@ def build_health_summary(
                 "task_id": result.get("task_name") or rollout_dir.name,
                 "rollout_dir": str(rollout_dir),
                 "reward": reward,
+                "pass_at_1": int(passed) if passed is not None else None,
+                "final_score": final_score,
+                "rubric_review_status": (
+                    (result.get("rubric_review") or {}).get("status")
+                    if isinstance(result.get("rubric_review"), dict)
+                    else None
+                ),
                 "scored": scored,
                 "tool_calls": tool_calls,
                 "has_llm_trajectory": has_llm,
@@ -293,6 +314,10 @@ def render_run_summary_markdown(
     rows = canonical_task_rows(job_dir)
     rewards = [row["reward"] for row in rows if row["scored"]]
     mean_reward = sum(rewards) / len(rewards) if rewards else None
+    final_scores = [
+        row["final_score"] for row in rows if isinstance(row.get("final_score"), float)
+    ]
+    mean_final_score = sum(final_scores) / len(final_scores) if final_scores else None
     scored_count = sum(1 for row in rows if row["scored"])
     tool_call_count = sum(1 for row in rows if row["tool_calls"] > 0)
 
@@ -307,29 +332,43 @@ def render_run_summary_markdown(
         f"- Mean reward: {mean_reward:.3f}"
         if mean_reward is not None
         else "- Mean reward: n/a",
+        f"- Mean rubric score: {mean_final_score:.3f}"
+        if mean_final_score is not None
+        else "- Mean rubric score: n/a",
         f"- Tasks with tool calls: {tool_call_count}",
         "",
         "## Tasks",
         "",
-        "| Task | Reward | Tool calls | Issue |",
-        "| --- | --- | --- | --- |",
+        "| Task | Pass@1 | Score | Reward | Tool calls | Issue |",
+        "| --- | --- | --- | --- | --- | --- |",
     ]
     for row in rows:
         reward = f"{row['reward']:.3f}" if isinstance(row["reward"], float) else "—"
         issue = row.get("error") or row.get("verifier_error") or ""
         issue = truncate_end(_escape_md_cell(str(issue)), _ISSUE_CELL_LIMIT)
+        pass_at_1 = str(row["pass_at_1"]) if row.get("pass_at_1") is not None else "—"
+        final_score = (
+            f"{row['final_score']:.3f}"
+            if isinstance(row.get("final_score"), float)
+            else "—"
+        )
         lines.append(
-            f"| {_escape_md_cell(str(row['task_id']))} | {reward} | "
-            f"{row['tool_calls']} | {issue} |"
+            f"| {_escape_md_cell(str(row['task_id']))} | {pass_at_1} | "
+            f"{final_score} | {reward} | {row['tool_calls']} | {issue} |"
         )
     return "\n".join(lines) + "\n"
 
 
-def _canonical_score(row: dict[str, Any]) -> tuple[int, float, int]:
+def _canonical_score(row: dict[str, Any]) -> tuple[int, float, float, int]:
     scored = 1 if row["scored"] else 0
     reward = row["reward"] if isinstance(row["reward"], float) else float("-inf")
+    final_score = (
+        row["final_score"]
+        if isinstance(row.get("final_score"), float)
+        else float("-inf")
+    )
     tool_calls = int(row.get("tool_calls") or 0)
-    return scored, reward, tool_calls
+    return scored, reward, final_score, tool_calls
 
 
 def build_canonical_selection(

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -156,6 +156,7 @@ def _config_payload(
         "loop_strategy": (
             config.loop_strategy.to_mapping() if config.loop_strategy else None
         ),
+        "rubric_review": config.rubric_review.to_mapping(),
     }
     payload.update(config.usage_tracking.to_mapping())
     return payload
@@ -171,6 +172,16 @@ def _redacted_config_payload(config_payload: dict[str, Any]) -> dict[str, Any]:
             if _should_record_env_entry(str(key), str(value))
         }
         artifact_payload["agent_env_keys"] = sorted(str(key) for key in agent_env)
+    rubric_review = artifact_payload.get("rubric_review")
+    if isinstance(rubric_review, dict):
+        review_artifact = dict(rubric_review)
+        review_env = review_artifact.pop("agent_env", {})
+        review_artifact["agent_env_keys"] = (
+            sorted(str(key) for key in review_env)
+            if isinstance(review_env, dict)
+            else []
+        )
+        artifact_payload["rubric_review"] = review_artifact
     return artifact_payload
 
 
@@ -295,6 +306,75 @@ def _aggregate_result(
     shard_results: list[dict[str, Any]],
     elapsed_sec: float,
 ) -> EvaluationResult:
+    rubric_reviews_required = sum(
+        int(result.get("rubric_reviews_required", 0)) for result in shard_results
+    )
+    rubric_reviews_completed = sum(
+        int(result.get("rubric_reviews_completed", 0)) for result in shard_results
+    )
+    weighted_score_sum = sum(
+        float(mean_score) * int(result.get("rubric_reviews_completed", 0))
+        for result in shard_results
+        if isinstance((mean_score := result.get("mean_final_score")), (int, float))
+        and not isinstance(mean_score, bool)
+    )
+    review_parts = [
+        review
+        for shard in shard_results
+        if isinstance((review := shard.get("rubric_review")), dict)
+    ]
+
+    def review_sum(field: str) -> float:
+        return sum(
+            float(value)
+            for review in review_parts
+            if isinstance((value := review.get(field)), (int, float))
+            and not isinstance(value, bool)
+        )
+
+    reviewer_usage_count = sum(
+        round(
+            float(review.get("reviewer_usage_coverage", 0.0))
+            * int(review.get("required", 0))
+        )
+        for review in review_parts
+    )
+    rubric_review = (
+        {
+            "required": rubric_reviews_required,
+            "completed": rubric_reviews_completed,
+            "passed": int(review_sum("passed")),
+            "failed": int(review_sum("failed")),
+            "errored": int(review_sum("errored")),
+            "unweighted": int(review_sum("unweighted")),
+            "pass_at_1": (
+                review_sum("passed") / rubric_reviews_required
+                if rubric_reviews_required
+                else None
+            ),
+            "mean_score": (
+                weighted_score_sum / rubric_reviews_completed
+                if rubric_reviews_completed
+                else None
+            ),
+            "score_coverage": (
+                rubric_reviews_completed / rubric_reviews_required
+                if rubric_reviews_required
+                else 0.0
+            ),
+            "reviewer_total_tokens": int(review_sum("reviewer_total_tokens")),
+            "reviewer_total_cost_usd": round(
+                review_sum("reviewer_total_cost_usd"), 10
+            ),
+            "reviewer_usage_coverage": (
+                reviewer_usage_count / rubric_reviews_required
+                if rubric_reviews_required
+                else 0.0
+            ),
+        }
+        if rubric_reviews_required
+        else {}
+    )
     result = EvaluationResult(
         job_name="worker-sharded",
         config=config,
@@ -304,6 +384,14 @@ def _aggregate_result(
         errored=sum(int(r.get("errored", 0)) for r in shard_results),
         verifier_errored=sum(int(r.get("verifier_errored", 0)) for r in shard_results),
         elapsed_sec=elapsed_sec,
+        mean_final_score=(
+            weighted_score_sum / rubric_reviews_completed
+            if rubric_reviews_completed
+            else None
+        ),
+        rubric_reviews_required=rubric_reviews_required,
+        rubric_reviews_completed=rubric_reviews_completed,
+        rubric_review_details=rubric_review,
     )
     summary = {
         "job_name": result.job_name,
@@ -314,6 +402,12 @@ def _aggregate_result(
         "verifier_errored": result.verifier_errored,
         "score": result.score,
         "score_ratio": pass_rate(passed=result.passed, total=result.total),
+        "pass_at_1": f"{result.score:.1%}",
+        "pass_at_1_ratio": result.score,
+        "mean_final_score": result.mean_final_score,
+        "rubric_reviews_required": result.rubric_reviews_required,
+        "rubric_reviews_completed": result.rubric_reviews_completed,
+        **({"rubric_review": rubric_review} if rubric_review else {}),
         "score_excl_errors": result.score_excl_errors,
         "score_excl_errors_ratio": pass_rate_excl_errors(
             passed=result.passed,

--- a/src/benchflow/eval_sharding.py
+++ b/src/benchflow/eval_sharding.py
@@ -363,9 +363,7 @@ def _aggregate_result(
                 else 0.0
             ),
             "reviewer_total_tokens": int(review_sum("reviewer_total_tokens")),
-            "reviewer_total_cost_usd": round(
-                review_sum("reviewer_total_cost_usd"), 10
-            ),
+            "reviewer_total_cost_usd": round(review_sum("reviewer_total_cost_usd"), 10),
             "reviewer_usage_coverage": (
                 reviewer_usage_count / rubric_reviews_required
                 if rubric_reviews_required

--- a/src/benchflow/eval_worker.py
+++ b/src/benchflow/eval_worker.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from benchflow.evaluation import Evaluation, EvaluationConfig, RetryConfig
 from benchflow.loop_strategies import LoopStrategySpec
+from benchflow.review.policy import RubricReviewConfig
 from benchflow.skill_policy import SKILL_MODE_NO_SKILL
 from benchflow.usage_tracking import UsageTrackingConfig
 
@@ -82,6 +83,7 @@ def _evaluation_config(raw: dict[str, Any]) -> EvaluationConfig:
             if raw.get("loop_strategy")
             else None
         ),
+        rubric_review=RubricReviewConfig.coerce(raw.get("rubric_review")),
     )
 
 
@@ -96,6 +98,10 @@ def _result_payload(result) -> dict[str, Any]:
         "elapsed_sec": result.elapsed_sec,
         "score": result.score,
         "score_excl_errors": result.score_excl_errors,
+        "mean_final_score": result.mean_final_score,
+        "rubric_reviews_required": result.rubric_reviews_required,
+        "rubric_reviews_completed": result.rubric_reviews_completed,
+        "rubric_review": result.rubric_review_details,
     }
 
 

--- a/src/benchflow/evaluation.py
+++ b/src/benchflow/evaluation.py
@@ -30,6 +30,7 @@ from benchflow._utils.evaluation_results import (
     loop_summary,
     phase_timing_summary,
     rollout_result_payload,
+    rubric_review_summary,
     skill_invocation_summary,
     tool_call_summary,
     trajectory_step_summary,
@@ -79,6 +80,8 @@ from benchflow.loop_strategies import (
     parse_loop_strategy_spec,
 )
 from benchflow.models import RolloutResult
+from benchflow.review.policy import RubricReviewConfig
+from benchflow.review.resume import resume_incomplete_rubric_reviews
 from benchflow.skill_policy import (
     SKILL_MODE_NO_SKILL,
     SKILL_MODE_SELF_GEN,
@@ -395,12 +398,14 @@ def _check_resume_mismatch(job_dir: Path, config: EvaluationConfig) -> None:
     )
     prev_agent = ""
     prev_loop: dict | None = None
+    prev_review: dict | None = None
     if sample_dir:
         for cfg_file in sample_dir.rglob("config.json"):
             try:
                 cfg = json.loads(cfg_file.read_text())
                 prev_agent = cfg.get("agent", "")
                 prev_loop = cfg.get("loop") or loop_block(None)
+                prev_review = cfg.get("rubric_review")
                 break
             except (json.JSONDecodeError, OSError):
                 logger.debug("Could not read %s", cfg_file)
@@ -417,6 +422,13 @@ def _check_resume_mismatch(job_dir: Path, config: EvaluationConfig) -> None:
             f"Resuming with loop_strategy={current_loop} but "
             f"completed tasks used loop_strategy={prev_loop}. "
             f"Use a different jobs_dir to avoid mixing results."
+        )
+    current_review = config.rubric_review.to_config_artifact()
+    if prev_review is not None and prev_review != current_review:
+        raise ResumeMismatchError(
+            "refusing to resume: completed tasks used a different "
+            "rubric_review policy. Mixing reviewer models or reasoning levels "
+            "would publish incomparable final scores. Use a fresh --jobs-dir."
         )
 
 
@@ -513,6 +525,7 @@ class EvaluationConfig:
     dataset_version: str | None = None
     dataset_task_digests: dict[str, str] = field(default_factory=dict)
     usage_tracking: UsageTrackingConfig = field(default_factory=UsageTrackingConfig)
+    rubric_review: RubricReviewConfig = field(default_factory=RubricReviewConfig)
     # Environment-plane manifest applied to every rollout in the batch.
     # When set, each task's RolloutConfig.environment_manifest is populated
     # so the Environment plane (manifest-declared stateful environment,
@@ -541,6 +554,7 @@ class EvaluationConfig:
         self.sandbox_user = normalize_sandbox_user(self.sandbox_user)
         self.agent_idle_timeout = normalize_agent_idle_timeout(self.agent_idle_timeout)
         self.usage_tracking = UsageTrackingConfig.coerce(self.usage_tracking)
+        self.rubric_review = RubricReviewConfig.coerce(self.rubric_review)
         self.skill_mode = normalize_skill_mode(self.skill_mode)
         if isinstance(self.loop_strategy, str):
             self.loop_strategy = parse_loop_strategy_spec(self.loop_strategy)
@@ -614,6 +628,10 @@ class EvaluationResult:
     # pass/fail counts binarize at reward==1, which erases partial credit —
     # a 0.3 rubric score and a flat 0 both print as FAIL without this.
     mean_reward: float | None = None
+    mean_final_score: float | None = None
+    rubric_reviews_required: int = 0
+    rubric_reviews_completed: int = 0
+    rubric_review_details: dict[str, Any] = field(default_factory=dict)
 
     @property
     def score(self) -> float:
@@ -920,6 +938,7 @@ class Evaluation:
             environment_manifest=env_manifest,
             config_override=raw.get("config_override"),
             loop_strategy=raw.get("loop_strategy"),
+            rubric_review=RubricReviewConfig.coerce(raw.get("rubric_review")),
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -1011,6 +1030,7 @@ class Evaluation:
             ),
             self_gen_no_internet=bool(raw.get("self_gen_no_internet", False)),
             usage_tracking=UsageTrackingConfig.from_mapping(raw),
+            rubric_review=RubricReviewConfig.coerce(raw.get("rubric_review")),
         )
         return cls(tasks_dir=tasks_dir, jobs_dir=jobs_dir, config=config, **kwargs)
 
@@ -1298,6 +1318,7 @@ class Evaluation:
             dataset=dataset,
             task_digest=task_digest_value,
             usage_tracking=cfg.usage_tracking,
+            rubric_review=cfg.rubric_review,
             loop_strategy=cfg.loop_strategy,
         )
         if skill_mode == SKILL_MODE_SELF_GEN:
@@ -1355,6 +1376,7 @@ class Evaluation:
             self_gen_no_internet=cfg.self_gen_no_internet,
             source_provenance=task_source_provenance(cfg.source_provenance, task_dir),
             usage_tracking=cfg.usage_tracking,
+            rubric_review=cfg.rubric_review,
         )
 
     async def _run_task(self, task_dir: Path) -> RunResult:
@@ -1742,6 +1764,15 @@ class Evaluation:
                 "empty 0/0 summary."
             )
         completed = self._get_completed_tasks()
+        if completed:
+            _check_resume_mismatch(self._jobs_dir / self._job_name, self._config)
+            completed = await resume_incomplete_rubric_reviews(
+                completed,
+                tasks_dir=self._tasks_dir,
+                job_dir=self._jobs_dir / self._job_name,
+                source_environment=self._config.environment,
+                policy=self._config.rubric_review,
+            )
         remaining = [d for d in task_dirs if d.name not in completed]
 
         # A resumed sequential-shared job rebuilds the LearnerStore from the
@@ -1768,10 +1799,6 @@ class Evaluation:
                 f"({len(completed)} completed task(s), "
                 f"{len(remaining)} remaining)"
             )
-
-        # Warn if resuming with different config than completed tasks
-        if completed:
-            _check_resume_mismatch(self._jobs_dir / self._job_name, self._config)
 
         self._jobs_dir.mkdir(parents=True, exist_ok=True)
         self._prune_docker()
@@ -1840,6 +1867,7 @@ class Evaluation:
         score_counts = count_score_outcomes(all_results.values())
         audit_counts = count_audit_outcomes(all_results.values())
         memory, memory_scores = memory_summary(all_results)
+        review_summary = rubric_review_summary(all_results).get("rubric_review", {})
         # Per-task failure evidence for the CLI's final block — FAILED (scored,
         # reward != 1) tasks only, from data already in memory. Sorted by name
         # so the printed lines are deterministic across resume/concurrency.
@@ -1872,6 +1900,10 @@ class Evaluation:
             memory_scores=memory_scores,
             task_failures=task_failures,
             mean_reward=mean_scored_reward(all_results.values()),
+            mean_final_score=review_summary.get("mean_score"),
+            rubric_reviews_required=int(review_summary.get("required", 0)),
+            rubric_reviews_completed=int(review_summary.get("completed", 0)),
+            rubric_review_details=dict(review_summary),
         )
 
         assert (
@@ -1909,6 +1941,7 @@ class Evaluation:
             "concurrency": cfg.concurrency,
             "agent_idle_timeout_sec": cfg.agent_idle_timeout,
             "usage_tracking": cfg.usage_tracking.with_env_defaults().to_config_artifact(),
+            "rubric_review_policy": cfg.rubric_review.to_config_artifact(),
             "loop": loop_block(cfg.loop_strategy),
             "total": job_result.total,
             "passed": audit_counts["passed"],
@@ -1925,6 +1958,11 @@ class Evaluation:
             "score_ratio": pass_rate(
                 passed=audit_counts["passed"], total=job_result.total
             ),
+            "pass_at_1": f"{pass_rate(passed=audit_counts['passed'], total=job_result.total):.1%}",
+            "pass_at_1_ratio": pass_rate(
+                passed=audit_counts["passed"], total=job_result.total
+            ),
+            "mean_final_score": job_result.mean_final_score,
             "score_excl_errors": f"{pass_rate_excl_errors(passed=audit_counts['passed'], failed=audit_counts['failed']):.1%}",
             "score_excl_errors_ratio": pass_rate_excl_errors(
                 passed=audit_counts["passed"], failed=audit_counts["failed"]
@@ -1939,6 +1977,7 @@ class Evaluation:
             "memory_scores": memory_scores,
             **skill_invocation_summary(all_results),
             **usage_summary(all_results),
+            **rubric_review_summary(all_results),
             **loop_summary(all_results),
             **tool_call_summary(all_results),
             **trajectory_step_summary(all_results),

--- a/src/benchflow/metrics.py
+++ b/src/benchflow/metrics.py
@@ -46,6 +46,8 @@ class TaskMetrics:
     cost_usd: float | None = None
     usage_source: UsageSource = "unavailable"
     memory_score: float | None = None
+    rubric_score: float | None = None
+    rubric_review_status: str | None = None
 
     @property
     def outcome(self) -> str:
@@ -264,6 +266,26 @@ class BenchmarkMetrics:
         }
 
     @property
+    def rubric_review_tasks(self) -> list[TaskMetrics]:
+        return [task for task in self.tasks if task.rubric_review_status is not None]
+
+    @property
+    def rubric_scored_tasks(self) -> list[TaskMetrics]:
+        return [task for task in self.tasks if task.rubric_score is not None]
+
+    @property
+    def mean_final_score(self) -> float | None:
+        scored = self.rubric_scored_tasks
+        if not scored:
+            return None
+        return sum(task.rubric_score or 0.0 for task in scored) / len(scored)
+
+    @property
+    def rubric_score_coverage(self) -> float:
+        required = self.rubric_review_tasks
+        return len(self.rubric_scored_tasks) / len(required) if required else 0.0
+
+    @property
     def verifier_error_breakdown(self) -> dict[str, int]:
         """Categorize verifier errors."""
         breakdown: dict[str, int] = {}
@@ -288,6 +310,12 @@ class BenchmarkMetrics:
             "verifier_errored": self.verifier_errored,
             "score": f"{self.score:.1%}",
             "score_ratio": self.score,
+            "pass_at_1": f"{self.score:.1%}",
+            "pass_at_1_ratio": self.score,
+            "mean_final_score": self.mean_final_score,
+            "rubric_score_coverage": self.rubric_score_coverage,
+            "rubric_reviews_required": len(self.rubric_review_tasks),
+            "rubric_reviews_completed": len(self.rubric_scored_tasks),
             "score_excl_errors": f"{self.score_excl_errors:.1%}",
             "score_excl_errors_ratio": self.score_excl_errors,
             "avg_tool_calls": round(self.avg_tool_calls, 1),
@@ -328,6 +356,21 @@ def _safe_reward(rewards: dict) -> float:
     return val if isinstance(val, (int, float)) else 0.0
 
 
+def _result_rank(result: dict) -> tuple[int, float, float]:
+    """Rank attempts by availability, binary reward, then rubric quality."""
+    rewards = result.get("rewards")
+    has_rewards = int(isinstance(rewards, dict))
+    reward = _safe_reward(rewards) if isinstance(rewards, dict) else 0.0
+    final_score = result.get("final_score")
+    raw_score = final_score.get("score") if isinstance(final_score, dict) else None
+    rubric_score = (
+        float(raw_score)
+        if isinstance(raw_score, (int, float)) and not isinstance(raw_score, bool)
+        else float("-inf")
+    )
+    return has_rewards, reward, rubric_score
+
+
 def collect_metrics(
     results_dir: str | Path,
     benchmark: str = "",
@@ -337,7 +380,7 @@ def collect_metrics(
     """Collect metrics from a results directory.
 
     Reads all result.json files, picks the best result per task
-    (rewards > no rewards, higher reward preferred).
+    (rewards > no rewards, higher reward, then higher rubric score).
     """
     results_dir = Path(results_dir)
     best: dict[str, dict] = {}
@@ -346,15 +389,7 @@ def collect_metrics(
         try:
             r = json.loads(rfile.read_text())
             task = r["task_name"]
-            if (
-                task not in best
-                or (r.get("rewards") is not None and best[task].get("rewards") is None)
-                or (
-                    r.get("rewards")
-                    and best[task].get("rewards")
-                    and _safe_reward(r["rewards"]) > _safe_reward(best[task]["rewards"])
-                )
-            ):
+            if task not in best or _result_rank(r) > _result_rank(best[task]):
                 best[task] = r
         except Exception as e:
             logger.debug(f"Skipping corrupt result file {rfile}: {e}")
@@ -362,6 +397,23 @@ def collect_metrics(
     tasks = []
     for task_name, r in sorted(best.items()):
         reward = r.get("rewards", {}).get("reward") if r.get("rewards") else None
+        final_score = r.get("final_score")
+        raw_rubric_score = (
+            final_score.get("score") if isinstance(final_score, dict) else None
+        )
+        rubric_score = (
+            float(raw_rubric_score)
+            if isinstance(raw_rubric_score, (int, float))
+            and not isinstance(raw_rubric_score, bool)
+            else None
+        )
+        rubric_review = r.get("rubric_review")
+        raw_review_status = (
+            rubric_review.get("status") if isinstance(rubric_review, dict) else None
+        )
+        review_status = (
+            raw_review_status if isinstance(raw_review_status, str) else None
+        )
         # Calculate duration
         duration = 0.0
         try:
@@ -404,6 +456,8 @@ def collect_metrics(
                     "usage_source", r.get("usage_source", "unavailable")
                 ),
                 memory_score=memory_score_from_result(r),
+                rubric_score=rubric_score,
+                rubric_review_status=review_status,
             )
         )
 

--- a/src/benchflow/models.py
+++ b/src/benchflow/models.py
@@ -153,6 +153,8 @@ class RolloutResult:
         reward_events: list[RewardEvent] | None = None,
         evolved_skills: dict[str, str] | None = None,
         source_provenance: dict[str, Any] | None = None,
+        final_score: dict[str, Any] | None = None,
+        rubric_review: dict[str, Any] | None = None,
         started_at: datetime | None = None,
         finished_at: datetime | None = None,
     ):
@@ -185,6 +187,8 @@ class RolloutResult:
         self.reward_events = reward_events
         self.evolved_skills = evolved_skills
         self.source_provenance = source_provenance
+        self.final_score = final_score
+        self.rubric_review = rubric_review
         self.started_at = started_at
         self.finished_at = finished_at
 

--- a/src/benchflow/review/__init__.py
+++ b/src/benchflow/review/__init__.py
@@ -9,8 +9,9 @@ while non-blockers receive 0/1/2 scores that Benchflow aggregates host-side.
 Reviews run *after* rollouts, from their host-side directories, as ordinary
 rollouts of throwaway wrapper tasks (:mod:`benchflow.review.wrapper`), so
 every sandbox backend works unchanged.  Review results live in
-``review_report.json``; they are never merged into a reviewed rollout's
-rewards or ``result.json``.
+``review_report.json``. The detached ``bench review`` command remains
+read-only; the rollout lifecycle separately integrates weighted task rubrics
+into the source rollout's canonical final score.
 
 Public surface:
 
@@ -41,6 +42,14 @@ from benchflow.review.config import (
     find_task_rubric,
     load_rubric,
 )
+from benchflow.review.policy import (
+    DEFAULT_REVIEWER_AGENT,
+    DEFAULT_REVIEWER_MAX_RETRIES,
+    DEFAULT_REVIEWER_MODEL,
+    DEFAULT_REVIEWER_REASONING_EFFORT,
+    DEFAULT_REVIEWER_TIMEOUT_SEC,
+    RubricReviewConfig,
+)
 from benchflow.review.runner import (
     REVIEW_REPORT_FILENAME,
     ReviewReport,
@@ -60,6 +69,11 @@ from benchflow.review.wrapper import assemble_review_task
 
 __all__ = [
     "DEFAULT_RUBRIC_PATH",
+    "DEFAULT_REVIEWER_AGENT",
+    "DEFAULT_REVIEWER_MAX_RETRIES",
+    "DEFAULT_REVIEWER_MODEL",
+    "DEFAULT_REVIEWER_REASONING_EFFORT",
+    "DEFAULT_REVIEWER_TIMEOUT_SEC",
     "LEGACY_REVIEW_RUBRIC_CONTRACT",
     "PUBLISHABLE_QUALITY",
     "REVIEW_RUBRIC_CONTRACT",
@@ -79,6 +93,7 @@ __all__ = [
     "ReviewScoring",
     "Rubric",
     "RubricCriterion",
+    "RubricReviewConfig",
     "ScoredCriterionCheck",
     "TrialReview",
     "assemble_review_task",

--- a/src/benchflow/review/integration.py
+++ b/src/benchflow/review/integration.py
@@ -1,0 +1,563 @@
+"""Integrate a task's weighted rubric into one canonical rollout result.
+
+The reviewer itself remains an ordinary isolated rollout. This module owns
+the narrow bridge back to the source rollout: retrying the reviewer, retaining
+its audit artifacts under non-conflicting names, applying blocker gates, and
+refreshing every score-bearing source artifact exactly once.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from benchflow.models import RolloutResult
+from benchflow.review.config import ReviewRubricError, load_rubric
+from benchflow.review.policy import RubricReviewConfig
+from benchflow.review.runner import ReviewReport, TrialReview, run_reviews
+from benchflow.review.workspace import (
+    WORKSPACE_BASELINE_FILENAME,
+    read_workspace_manifest,
+)
+from benchflow.rollout._results import finalize_rubric_review_artifacts
+
+logger = logging.getLogger(__name__)
+
+REVIEW_ARTIFACT_DIRNAME = "review"
+
+
+def _discard_workspace_baseline(rollout_dir: Path) -> None:
+    """Keep the internal pre-agent inventory out of published artifacts."""
+
+    path = rollout_dir / "artifacts" / WORKSPACE_BASELINE_FILENAME
+    try:
+        path.unlink(missing_ok=True)
+    except OSError as exc:
+        logger.warning("Could not discard rubric workspace baseline %s: %s", path, exc)
+
+
+def _read_object(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None
+
+
+def _read_persisted_trajectory(rollout_dir: Path) -> list[dict[str, Any]]:
+    path = rollout_dir / "trajectory" / "acp_trajectory.jsonl"
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return []
+    events: list[dict[str, Any]] = []
+    for line in lines:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    return events
+
+
+def _persisted_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def load_persisted_rollout_result(rollout_dir: Path) -> RolloutResult:
+    """Rehydrate the result fields needed to finish an interrupted review."""
+
+    payload = _read_object(rollout_dir / "result.json")
+    if payload is None:
+        raise RuntimeError(f"missing or unreadable source result: {rollout_dir}")
+    task_name = payload.get("task_name")
+    if not isinstance(task_name, str) or not task_name:
+        raise RuntimeError("persisted source result has no task_name")
+    agent_result = payload.get("agent_result")
+    if not isinstance(agent_result, dict):
+        agent_result = {}
+    rewards = payload.get("rewards")
+    return RolloutResult(
+        task_name=task_name,
+        rollout_name=str(payload.get("rollout_name") or rollout_dir.name),
+        rewards=dict(rewards) if isinstance(rewards, dict) else None,
+        trajectory=_read_persisted_trajectory(rollout_dir),
+        agent=str(payload.get("agent") or ""),
+        agent_name=str(payload.get("agent_name") or ""),
+        model=(str(payload["model"]) if payload.get("model") is not None else None),
+        n_tool_calls=int(agent_result.get("n_tool_calls") or 0),
+        n_skill_invocations=int(agent_result.get("n_skill_invocations") or 0),
+        n_prompts=int(agent_result.get("n_prompts") or 0),
+        n_input_tokens=agent_result.get("n_input_tokens"),
+        n_output_tokens=agent_result.get("n_output_tokens"),
+        n_cache_read_tokens=agent_result.get("n_cache_read_tokens"),
+        n_cache_creation_tokens=agent_result.get("n_cache_creation_tokens"),
+        total_tokens=agent_result.get("total_tokens"),
+        cost_usd=agent_result.get("cost_usd"),
+        usage_source=agent_result.get("usage_source") or "unavailable",
+        price_source=agent_result.get("price_source"),
+        usage_details=agent_result.get("usage_details"),
+        error=payload.get("error"),
+        error_category=payload.get("error_category"),
+        verifier_error=payload.get("verifier_error"),
+        verifier_error_category=payload.get("verifier_error_category"),
+        export_error=payload.get("export_error"),
+        partial_trajectory=bool(payload.get("partial_trajectory", False)),
+        trajectory_source=payload.get("trajectory_source"),
+        source_provenance=(
+            dict(payload["source"])
+            if isinstance(payload.get("source"), dict)
+            else None
+        ),
+        final_score=(
+            dict(payload["final_score"])
+            if isinstance(payload.get("final_score"), dict)
+            else None
+        ),
+        rubric_review=(
+            dict(payload["rubric_review"])
+            if isinstance(payload.get("rubric_review"), dict)
+            else None
+        ),
+        started_at=_persisted_datetime(payload.get("started_at")),
+        finished_at=_persisted_datetime(payload.get("finished_at")),
+    )
+
+
+def _copy_tree_without_links(source: Path, destination: Path) -> None:
+    if not source.is_dir():
+        return
+    shutil.copytree(
+        source,
+        destination,
+        symlinks=True,
+        ignore=lambda directory, names: {
+            name for name in names if (Path(directory) / name).is_symlink()
+        },
+    )
+
+
+def _retain_reviewer_artifacts(
+    rollout_dir: Path,
+    report: ReviewReport,
+    trial: TrialReview,
+) -> tuple[str, dict[str, Any] | None]:
+    """Copy reviewer evidence under names that cannot pollute job discovery."""
+
+    destination = rollout_dir / REVIEW_ARTIFACT_DIRNAME
+    if destination.exists():
+        shutil.rmtree(destination)
+    destination.mkdir(parents=True)
+
+    report_data = report.to_dict()
+    report_data["path"] = "."
+    for trial_data in report_data.get("trials", []):
+        if isinstance(trial_data, dict):
+            trial_data["source_rollout"] = "."
+            trial_data["reviewer_rollout"] = "review/"
+    (destination / "review-report.json").write_text(
+        json.dumps(report_data, indent=2) + "\n", encoding="utf-8"
+    )
+
+    reviewer_result: dict[str, Any] | None = None
+    if trial.reviewer_rollout:
+        leaf = Path(trial.reviewer_rollout)
+        file_mapping = {
+            "config.json": "reviewer-config.json",
+            "result.json": "reviewer-result.json",
+            "timing.json": "reviewer-timing.json",
+            "prompts.json": "reviewer-prompts.json",
+            "rewards.jsonl": "reviewer-rewards.jsonl",
+            "results.jsonl": "reviewer-training-results.jsonl",
+        }
+        for source_name, destination_name in file_mapping.items():
+            source = leaf / source_name
+            if source.is_file() and not source.is_symlink():
+                shutil.copy2(source, destination / destination_name)
+        for dirname in ("agent", "verifier", "trajectory", "trainer", "artifacts"):
+            _copy_tree_without_links(leaf / dirname, destination / dirname)
+        reviewer_result = _read_object(leaf / "result.json")
+    return "review/review-report.json", reviewer_result
+
+
+def _reviewer_metadata(
+    policy: RubricReviewConfig,
+    *,
+    environment: str,
+    reviewer_result: dict[str, Any] | None,
+) -> dict[str, Any]:
+    metadata = {
+        **policy.to_config_artifact(),
+        "environment": environment,
+    }
+    if reviewer_result is not None:
+        metadata.update(
+            {
+                "rollout_name": reviewer_result.get("rollout_name"),
+                "agent_name": reviewer_result.get("agent_name"),
+                "agent_result": reviewer_result.get("agent_result"),
+                "timing": reviewer_result.get("timing"),
+                "error": reviewer_result.get("error"),
+                "verifier_error": reviewer_result.get("verifier_error"),
+            }
+        )
+    return metadata
+
+
+@dataclass(frozen=True)
+class _ReviewerOutcome:
+    """Reviewer retry result after durable evidence retention."""
+
+    trial: TrialReview | None
+    attempts: list[dict[str, Any]]
+    artifact_path: str | None = None
+    reviewer_result: dict[str, Any] | None = None
+    artifact_error: str | None = None
+
+
+async def _run_reviewer_with_retries(
+    *,
+    rollout_dir: Path,
+    task_path: Path,
+    rubric_path: Path,
+    environment: str,
+    policy: RubricReviewConfig,
+) -> _ReviewerOutcome:
+    """Run bounded attempts and retain the final attempt before temp cleanup."""
+
+    attempts: list[dict[str, Any]] = []
+    selected: tuple[ReviewReport, TrialReview] | None = None
+    with tempfile.TemporaryDirectory(prefix="benchflow-auto-review-") as temporary:
+        review_root = Path(temporary)
+        for attempt in range(1, policy.max_retries + 2):
+            attempt_dir = review_root / f"attempt-{attempt}"
+            try:
+                report, _ = await run_reviews(
+                    rollout_dir,
+                    agent=policy.agent,
+                    model=policy.model,
+                    reasoning_effort=policy.reasoning_effort,
+                    environment=environment,
+                    rubric_path=rubric_path,
+                    agent_env=policy.agent_env,
+                    concurrency=1,
+                    timeout_sec=policy.timeout_sec,
+                    open_network=policy.allow_open_network,
+                    tasks_root=task_path.parent,
+                    out_dir=attempt_dir,
+                )
+                trial = report.trials[0]
+                attempts.append(
+                    {
+                        "attempt": attempt,
+                        "valid": trial.review_valid,
+                        "error": trial.error,
+                    }
+                )
+                selected = report, trial
+                if trial.review_valid:
+                    break
+            except Exception as exc:
+                attempts.append(
+                    {"attempt": attempt, "valid": False, "error": str(exc)}
+                )
+
+        if selected is None:
+            return _ReviewerOutcome(trial=None, attempts=attempts)
+        report, trial = selected
+        try:
+            artifact_path, reviewer_result = _retain_reviewer_artifacts(
+                rollout_dir, report, trial
+            )
+        except OSError as exc:
+            return _ReviewerOutcome(
+                trial=trial,
+                attempts=attempts,
+                artifact_error=str(exc),
+            )
+        return _ReviewerOutcome(
+            trial=trial,
+            attempts=attempts,
+            artifact_path=artifact_path,
+            reviewer_result=reviewer_result,
+        )
+
+
+def _attach_reviewer_evidence(
+    payload: dict[str, Any],
+    outcome: _ReviewerOutcome,
+    *,
+    policy: RubricReviewConfig,
+    environment: str,
+) -> None:
+    """Project one retained reviewer attempt into the source result payload."""
+
+    payload["attempts"] = outcome.attempts
+    if outcome.artifact_error is not None:
+        payload["artifact_error"] = outcome.artifact_error
+    trial = outcome.trial
+    if trial is None:
+        return
+    payload.update(
+        {
+            "summary": trial.summary,
+            "checks": trial.checks,
+            "reviewer": _reviewer_metadata(
+                policy,
+                environment=environment,
+                reviewer_result=outcome.reviewer_result,
+            ),
+        }
+    )
+    if outcome.artifact_path is not None:
+        payload["artifact"] = outcome.artifact_path
+
+
+def _base_review_payload(
+    *,
+    policy: RubricReviewConfig,
+    rubric_path: Path,
+    original_rewards: dict[str, Any] | None,
+    workspace_manifest: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "status": "pending",
+        "rubric": {"path": str(rubric_path)},
+        "reviewer": policy.to_config_artifact(),
+        "workspace": workspace_manifest,
+        "deterministic_verifier_rewards": original_rewards,
+        "attempts": [],
+    }
+
+
+def _finish_review_error(
+    rollout_dir: Path,
+    result: RolloutResult,
+    *,
+    payload: dict[str, Any],
+    message: str,
+    started_at: datetime,
+) -> RolloutResult:
+    payload.update({"status": "error", "error": message})
+    prior_error = result.verifier_error
+    verifier_error = (
+        f"{prior_error}; rubric review failed: {message}"
+        if prior_error
+        else f"rubric review failed: {message}"
+    )
+    final_score = {
+        "status": "error",
+        "pass": None,
+        "pass_at_1": None,
+        "score": None,
+        "weighted_points": None,
+        "max_weighted_points": None,
+    }
+    return finalize_rubric_review_artifacts(
+        rollout_dir,
+        result,
+        rewards=None,
+        final_score=final_score,
+        rubric_review=payload,
+        verifier_error=verifier_error,
+        review_elapsed_sec=(datetime.now() - started_at).total_seconds(),
+    )
+
+
+def mark_task_rubric_review_error(
+    result: RolloutResult,
+    *,
+    rollout_dir: Path,
+    rubric_path: Path,
+    policy: RubricReviewConfig,
+    message: str,
+) -> RolloutResult:
+    """Fail closed when orchestration escapes the normal review error path."""
+
+    started_at = datetime.now()
+    _discard_workspace_baseline(rollout_dir)
+    payload = _base_review_payload(
+        policy=policy,
+        rubric_path=rubric_path,
+        original_rewards=(dict(result.rewards) if result.rewards is not None else None),
+        workspace_manifest=read_workspace_manifest(rollout_dir),
+    )
+    return _finish_review_error(
+        rollout_dir,
+        result,
+        payload=payload,
+        message=message,
+        started_at=started_at,
+    )
+
+
+def _finish_valid_review(
+    rollout_dir: Path,
+    result: RolloutResult,
+    *,
+    payload: dict[str, Any],
+    trial: TrialReview,
+    original_rewards: dict[str, Any] | None,
+    started_at: datetime,
+) -> RolloutResult:
+    """Integrate one structurally valid legacy or weighted reviewer result."""
+
+    payload["status"] = "complete"
+    if trial.scoring is None:
+        payload["status"] = "complete_unweighted"
+        payload["note"] = (
+            "Legacy rubric reviewed but not integrated into weighted final scoring"
+        )
+        final_score = {
+            "status": "not_weighted",
+            "pass": None,
+            "pass_at_1": None,
+            "score": None,
+            "weighted_points": None,
+            "max_weighted_points": None,
+        }
+        return finalize_rubric_review_artifacts(
+            rollout_dir,
+            result,
+            rewards=original_rewards,
+            final_score=final_score,
+            rubric_review=payload,
+            verifier_error=result.verifier_error,
+            review_elapsed_sec=(datetime.now() - started_at).total_seconds(),
+        )
+
+    scoring = trial.scoring
+    payload["scoring"] = scoring.to_dict()
+    rewards = dict(original_rewards or {})
+    verifier_reward = rewards.get("reward")
+    rewards.update(
+        {
+            "reward": scoring.reward,
+            "pass_at_1": float(scoring.passed),
+            "score": scoring.score,
+            "verifier_reward": verifier_reward,
+            "weighted_points": float(scoring.weighted_points),
+            "max_weighted_points": float(scoring.max_weighted_points),
+            "failed_blockers": list(scoring.failed_blockers),
+        }
+    )
+    final_score = {
+        "status": "complete",
+        "pass": scoring.passed,
+        "pass_at_1": int(scoring.passed),
+        "score": scoring.score,
+        "weighted_points": scoring.weighted_points,
+        "max_weighted_points": scoring.max_weighted_points,
+        "raw_quality": scoring.raw_quality,
+        "deterministic_pass": scoring.deterministic_pass,
+        "all_blockers_pass": scoring.all_blockers_pass,
+        "failed_blockers": list(scoring.failed_blockers),
+    }
+    return finalize_rubric_review_artifacts(
+        rollout_dir,
+        result,
+        rewards=rewards,
+        final_score=final_score,
+        rubric_review=payload,
+        verifier_error=result.verifier_error,
+        review_elapsed_sec=(datetime.now() - started_at).total_seconds(),
+    )
+
+
+async def integrate_task_rubric_review(
+    result: RolloutResult,
+    *,
+    rollout_dir: Path,
+    task_path: Path,
+    rubric_path: Path,
+    source_environment: str,
+    policy: RubricReviewConfig,
+    workspace_error: str | None,
+) -> RolloutResult:
+    """Run and integrate one automatic rubric review, failing closed on error."""
+
+    started_at = datetime.now()
+    _discard_workspace_baseline(rollout_dir)
+    original_rewards = dict(result.rewards) if result.rewards is not None else None
+    workspace_manifest = read_workspace_manifest(rollout_dir)
+    payload = _base_review_payload(
+        policy=policy,
+        rubric_path=rubric_path,
+        original_rewards=original_rewards,
+        workspace_manifest=workspace_manifest,
+    )
+    if workspace_error:
+        return _finish_review_error(
+            rollout_dir,
+            result,
+            payload=payload,
+            message=workspace_error,
+            started_at=started_at,
+        )
+    if workspace_manifest is None:
+        return _finish_review_error(
+            rollout_dir,
+            result,
+            payload=payload,
+            message="final workspace manifest is missing or unreadable",
+            started_at=started_at,
+        )
+    try:
+        rubric = load_rubric(rubric_path)
+    except ReviewRubricError as exc:
+        return _finish_review_error(
+            rollout_dir,
+            result,
+            payload=payload,
+            message=str(exc),
+            started_at=started_at,
+        )
+
+    payload["rubric"] = {
+        "path": str(rubric_path),
+        "contract": rubric.contract,
+        "criteria": [criterion.metadata() for criterion in rubric.criteria],
+    }
+    environment = policy.environment or source_environment
+    outcome = await _run_reviewer_with_retries(
+        rollout_dir=rollout_dir,
+        task_path=task_path,
+        rubric_path=rubric_path,
+        environment=environment,
+        policy=policy,
+    )
+    _attach_reviewer_evidence(
+        payload, outcome, policy=policy, environment=environment
+    )
+    trial = outcome.trial
+    if trial is None or not trial.review_valid or outcome.artifact_error is not None:
+        last_error = outcome.attempts[-1].get("error") if outcome.attempts else None
+        message = str(outcome.artifact_error or last_error or "invalid review")
+        return _finish_review_error(
+            rollout_dir,
+            result,
+            payload=payload,
+            message=message,
+            started_at=started_at,
+        )
+
+    return _finish_valid_review(
+        rollout_dir,
+        result,
+        payload=payload,
+        trial=trial,
+        original_rewards=original_rewards,
+        started_at=started_at,
+    )

--- a/src/benchflow/review/integration.py
+++ b/src/benchflow/review/integration.py
@@ -117,9 +117,7 @@ def load_persisted_rollout_result(rollout_dir: Path) -> RolloutResult:
         partial_trajectory=bool(payload.get("partial_trajectory", False)),
         trajectory_source=payload.get("trajectory_source"),
         source_provenance=(
-            dict(payload["source"])
-            if isinstance(payload.get("source"), dict)
-            else None
+            dict(payload["source"]) if isinstance(payload.get("source"), dict) else None
         ),
         final_score=(
             dict(payload["final_score"])
@@ -270,9 +268,7 @@ async def _run_reviewer_with_retries(
                 if trial.review_valid:
                     break
             except Exception as exc:
-                attempts.append(
-                    {"attempt": attempt, "valid": False, "error": str(exc)}
-                )
+                attempts.append({"attempt": attempt, "valid": False, "error": str(exc)})
 
         if selected is None:
             return _ReviewerOutcome(trial=None, attempts=attempts)
@@ -538,9 +534,7 @@ async def integrate_task_rubric_review(
         environment=environment,
         policy=policy,
     )
-    _attach_reviewer_evidence(
-        payload, outcome, policy=policy, environment=environment
-    )
+    _attach_reviewer_evidence(payload, outcome, policy=policy, environment=environment)
     trial = outcome.trial
     if trial is None or not trial.review_valid or outcome.artifact_error is not None:
         last_error = outcome.attempts[-1].get("error") if outcome.attempts else None

--- a/src/benchflow/review/lifecycle.py
+++ b/src/benchflow/review/lifecycle.py
@@ -1,0 +1,114 @@
+"""Automatic rubric-review state owned outside the general rollout engine."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from benchflow.models import RolloutResult
+from benchflow.review.config import find_task_rubric
+from benchflow.review.policy import RubricReviewConfig
+from benchflow.review.workspace import export_workspace_delta, record_workspace_baseline
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutomaticRubricReview:
+    """State machine for one source rollout's automatic review phase."""
+
+    task_path: Path
+    rubric_path: Path
+    policy: RubricReviewConfig
+    _baseline_ready: bool = False
+    _workspace_exported: bool = False
+    _workspace_error: str | None = None
+
+    @classmethod
+    def discover(
+        cls, task_path: Path, policy: RubricReviewConfig
+    ) -> AutomaticRubricReview | None:
+        """Create the lifecycle only when an enabled task ships a review rubric."""
+
+        if not policy.enabled:
+            return None
+        rubric_path = find_task_rubric(task_path)
+        return (
+            cls(task_path=task_path, rubric_path=rubric_path, policy=policy)
+            if rubric_path is not None
+            else None
+        )
+
+    async def record_baseline(self, sandbox: Any, workspace: str) -> float:
+        """Record the pre-solver workspace without failing the source rollout."""
+
+        started = datetime.now()
+        try:
+            await record_workspace_baseline(sandbox, workspace)
+            self._baseline_ready = True
+        except Exception as exc:
+            self._workspace_error = str(exc)
+            logger.error("Automatic rubric-review workspace setup failed: %s", exc)
+        return (datetime.now() - started).total_seconds()
+
+    async def export_workspace(
+        self,
+        sandbox: Any,
+        workspace: str,
+        *,
+        artifacts_dir: Path,
+    ) -> float | None:
+        """Capture solver outputs once, permitting a cleanup-phase retry."""
+
+        if not self._baseline_ready or self._workspace_exported:
+            return None
+        started = datetime.now()
+        try:
+            await export_workspace_delta(
+                sandbox,
+                workspace,
+                host_artifacts_dir=artifacts_dir,
+            )
+            self._workspace_exported = True
+            self._workspace_error = None
+        except Exception as exc:
+            self._workspace_error = str(exc)
+            logger.error("Automatic rubric-review workspace export failed: %s", exc)
+        return (datetime.now() - started).total_seconds()
+
+    async def integrate(
+        self,
+        result: RolloutResult,
+        *,
+        rollout_dir: Path,
+        source_environment: str,
+    ) -> RolloutResult:
+        """Run the isolated reviewer and fail closed on orchestration defects."""
+
+        from benchflow.review.integration import (
+            integrate_task_rubric_review,
+            mark_task_rubric_review_error,
+        )
+
+        try:
+            return await integrate_task_rubric_review(
+                result,
+                rollout_dir=rollout_dir,
+                task_path=self.task_path,
+                rubric_path=self.rubric_path,
+                source_environment=source_environment,
+                policy=self.policy,
+                workspace_error=self._workspace_error,
+            )
+        except Exception as exc:
+            logger.error("Automatic rubric review failed unexpectedly", exc_info=True)
+            return mark_task_rubric_review_error(
+                result,
+                rollout_dir=rollout_dir,
+                rubric_path=self.rubric_path,
+                policy=self.policy,
+                message=str(exc),
+            )

--- a/src/benchflow/review/policy.py
+++ b/src/benchflow/review/policy.py
@@ -1,0 +1,112 @@
+"""Configuration for automatic rubric review of completed rollouts.
+
+The policy lives outside :mod:`benchflow.rollout` so the detached review
+runner and every configuration surface share one set of defaults.  Secret
+environment values are deliberately omitted from serialized artifacts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from benchflow._utils.config import (
+    normalize_agent_name,
+    normalize_reasoning_effort,
+)
+
+DEFAULT_REVIEWER_AGENT = "codex-acp"
+DEFAULT_REVIEWER_MODEL = "openai/gpt-5.6-sol"
+DEFAULT_REVIEWER_REASONING_EFFORT = "xhigh"
+DEFAULT_REVIEWER_TIMEOUT_SEC = 1800
+DEFAULT_REVIEWER_MAX_RETRIES = 1
+
+
+@dataclass
+class RubricReviewConfig:
+    """Policy for the automatic reviewer that runs when a task has a rubric.
+
+    ``environment=None`` inherits the source rollout's sandbox backend.  This
+    keeps Docker, Daytona, and other providers on the same execution path.
+    ``agent_env`` is runtime-only and is never persisted with its values.
+    """
+
+    enabled: bool = True
+    agent: str = DEFAULT_REVIEWER_AGENT
+    model: str = DEFAULT_REVIEWER_MODEL
+    reasoning_effort: str = DEFAULT_REVIEWER_REASONING_EFFORT
+    environment: str | None = None
+    timeout_sec: int = DEFAULT_REVIEWER_TIMEOUT_SEC
+    max_retries: int = DEFAULT_REVIEWER_MAX_RETRIES
+    allow_open_network: bool = False
+    agent_env: dict[str, str] = field(default_factory=dict, repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self.enabled) is not bool:
+            raise ValueError("rubric_review.enabled must be a boolean")
+        self.agent = normalize_agent_name(self.agent)
+        if not isinstance(self.model, str) or not self.model.strip():
+            raise ValueError("rubric_review.model must be a non-empty string")
+        self.model = self.model.strip()
+        normalized_effort = normalize_reasoning_effort(self.reasoning_effort)
+        if normalized_effort is None:
+            raise ValueError("rubric_review.reasoning_effort cannot be empty")
+        self.reasoning_effort = normalized_effort
+        if self.environment is not None:
+            if not isinstance(self.environment, str) or not self.environment.strip():
+                raise ValueError(
+                    "rubric_review.environment must be null or a non-empty string"
+                )
+            self.environment = self.environment.strip()
+        if isinstance(self.timeout_sec, bool) or not isinstance(self.timeout_sec, int):
+            raise ValueError("rubric_review.timeout_sec must be an integer")
+        if self.timeout_sec <= 0:
+            raise ValueError("rubric_review.timeout_sec must be positive")
+        if isinstance(self.max_retries, bool) or not isinstance(self.max_retries, int):
+            raise ValueError("rubric_review.max_retries must be an integer")
+        if self.max_retries < 0:
+            raise ValueError("rubric_review.max_retries must be non-negative")
+        if type(self.allow_open_network) is not bool:
+            raise ValueError("rubric_review.allow_open_network must be a boolean")
+        if not isinstance(self.agent_env, dict) or any(
+            not isinstance(key, str) or not isinstance(value, str)
+            for key, value in self.agent_env.items()
+        ):
+            raise ValueError("rubric_review.agent_env must map strings to strings")
+
+    @classmethod
+    def coerce(
+        cls, value: RubricReviewConfig | dict[str, Any] | None
+    ) -> RubricReviewConfig:
+        """Normalize a dataclass, YAML/SDK mapping, or omitted policy."""
+
+        if value is None:
+            return cls()
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, dict):
+            return cls(**cast("dict[str, Any]", value))
+        raise ValueError("rubric_review must be a mapping or RubricReviewConfig")
+
+    def to_config_artifact(self) -> dict[str, Any]:
+        """Return the reproducibility-safe form written to run artifacts."""
+
+        artifact = self.to_mapping()
+        artifact.pop("agent_env")
+        artifact["agent_env_keys"] = sorted(self.agent_env)
+        return artifact
+
+    def to_mapping(self) -> dict[str, Any]:
+        """Return the complete runtime form used by private worker payloads."""
+
+        return {
+            "enabled": self.enabled,
+            "agent": self.agent,
+            "model": self.model,
+            "reasoning_effort": self.reasoning_effort,
+            "environment": self.environment,
+            "timeout_sec": self.timeout_sec,
+            "max_retries": self.max_retries,
+            "allow_open_network": self.allow_open_network,
+            "agent_env": dict(self.agent_env),
+        }

--- a/src/benchflow/review/prompts.py
+++ b/src/benchflow/review/prompts.py
@@ -36,6 +36,8 @@ Run records:
 - {trial_path}/result.json — outcome, rewards, and error details
 - {trial_path}/trajectory/ — the agent's recorded actions
 - {trial_path}/verifier/ — test output, when present
+- {trial_path}/artifacts/workspace/ — every workspace file created or modified by the agent
+- {trial_path}/artifacts/workspace-manifest.json — captured, deleted, and excluded workspace paths
 - {trial_path}/config.json — how the run was configured
 
 Work through the criteria one at a time. For each criterion, weigh the evidence before deciding, and cite the specific files or recorded steps that support your judgment in its explanation.

--- a/src/benchflow/review/resume.py
+++ b/src/benchflow/review/resume.py
@@ -45,9 +45,7 @@ def _rollout_directory(job_dir: Path, payload: dict[str, Any]) -> Path | None:
 
 def _read_result(rollout_dir: Path) -> dict[str, Any]:
     try:
-        payload = json.loads(
-            (rollout_dir / "result.json").read_text(encoding="utf-8")
-        )
+        payload = json.loads((rollout_dir / "result.json").read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise RuntimeError(
             f"rubric review resume did not produce a result in {rollout_dir}"
@@ -140,7 +138,9 @@ async def resume_incomplete_rubric_reviews(
                 workspace_error=None,
             )
         except Exception as exc:
-            logger.exception("Interrupted rubric review resume failed for %s", task_name)
+            logger.exception(
+                "Interrupted rubric review resume failed for %s", task_name
+            )
             mark_task_rubric_review_error(
                 result,
                 rollout_dir=rollout_dir,

--- a/src/benchflow/review/resume.py
+++ b/src/benchflow/review/resume.py
@@ -1,0 +1,152 @@
+"""Resume an interrupted automatic review without rerunning its source task."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from benchflow.review.config import find_task_rubric
+from benchflow.review.integration import (
+    integrate_task_rubric_review,
+    load_persisted_rollout_result,
+    mark_task_rubric_review_error,
+)
+from benchflow.review.policy import RubricReviewConfig
+from benchflow.review.runner import task_digest_issue
+from benchflow.review.workspace import read_workspace_manifest
+
+logger = logging.getLogger(__name__)
+
+
+def _task_directory(tasks_dir: Path, task_name: str) -> Path | None:
+    """Resolve an evaluation-owned task name without trusting result paths."""
+
+    root = tasks_dir.resolve()
+    if root.name == task_name:
+        return root
+    if Path(task_name).name != task_name:
+        return None
+    candidate = (root / task_name).resolve()
+    return candidate if root in candidate.parents and candidate.is_dir() else None
+
+
+def _rollout_directory(job_dir: Path, payload: dict[str, Any]) -> Path | None:
+    rollout_name = payload.get("rollout_name")
+    if not isinstance(rollout_name, str) or Path(rollout_name).name != rollout_name:
+        return None
+    root = job_dir.resolve()
+    candidate = (root / rollout_name).resolve()
+    if root not in candidate.parents or not (candidate / "result.json").is_file():
+        return None
+    return candidate
+
+
+def _read_result(rollout_dir: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(
+            (rollout_dir / "result.json").read_text(encoding="utf-8")
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            f"rubric review resume did not produce a result in {rollout_dir}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"rubric review resume did not produce an object in {rollout_dir}"
+        )
+    return payload
+
+
+def _pending_review_inputs(
+    *,
+    task_name: str,
+    payload: dict[str, Any],
+    tasks_dir: Path,
+    job_dir: Path,
+) -> tuple[Path, Path, Path] | None:
+    """Return exact, durable review inputs or signal a source rerun."""
+
+    task_dir = _task_directory(tasks_dir, task_name)
+    if task_dir is None:
+        return None
+    rubric_path = find_task_rubric(task_dir)
+    if rubric_path is None or isinstance(payload.get("final_score"), dict):
+        return None
+    rollout_dir = _rollout_directory(job_dir, payload)
+    if rollout_dir is None:
+        raise RuntimeError("source rollout directory cannot be resolved safely")
+    provenance_error = task_digest_issue(rollout_dir, task_dir)
+    if provenance_error is not None:
+        raise RuntimeError(provenance_error)
+    if read_workspace_manifest(rollout_dir) is None:
+        raise RuntimeError("final workspace evidence is missing or unreadable")
+    return task_dir, rubric_path, rollout_dir
+
+
+async def resume_incomplete_rubric_reviews(
+    completed: dict[str, dict[str, Any]],
+    *,
+    tasks_dir: Path,
+    job_dir: Path,
+    source_environment: str,
+    policy: RubricReviewConfig,
+) -> dict[str, dict[str, Any]]:
+    """Finish durable review phases and discard unsafe source reuse candidates."""
+
+    if not policy.enabled:
+        return completed
+    refreshed = dict(completed)
+    for task_name, payload in completed.items():
+        task_dir = _task_directory(tasks_dir, task_name)
+        if task_dir is None:
+            continue
+        rubric_path = find_task_rubric(task_dir)
+        if rubric_path is None or isinstance(payload.get("final_score"), dict):
+            continue
+        try:
+            inputs = _pending_review_inputs(
+                task_name=task_name,
+                payload=payload,
+                tasks_dir=tasks_dir,
+                job_dir=job_dir,
+            )
+        except (OSError, RuntimeError, ValueError) as exc:
+            logger.info(
+                "Re-running source task because its interrupted rubric review "
+                "cannot be resumed safely: %s (%s)",
+                task_name,
+                exc,
+            )
+            refreshed.pop(task_name, None)
+            continue
+        if inputs is None:  # defensive; pending status was established above
+            continue
+        task_dir, rubric_path, rollout_dir = inputs
+        logger.info(
+            "Resuming interrupted rubric review without re-running source task: %s",
+            task_name,
+        )
+        result = load_persisted_rollout_result(rollout_dir)
+        try:
+            await integrate_task_rubric_review(
+                result,
+                rollout_dir=rollout_dir,
+                task_path=task_dir,
+                rubric_path=rubric_path,
+                source_environment=source_environment,
+                policy=policy,
+                workspace_error=None,
+            )
+        except Exception as exc:
+            logger.exception("Interrupted rubric review resume failed for %s", task_name)
+            mark_task_rubric_review_error(
+                result,
+                rollout_dir=rollout_dir,
+                rubric_path=rubric_path,
+                policy=policy,
+                message=f"resume failed: {exc}",
+            )
+        refreshed[task_name] = _read_result(rollout_dir)
+    return refreshed

--- a/src/benchflow/review/runner.py
+++ b/src/benchflow/review/runner.py
@@ -36,6 +36,12 @@ from benchflow.review.config import (
     find_task_rubric,
     load_rubric,
 )
+from benchflow.review.policy import (
+    DEFAULT_REVIEWER_AGENT,
+    DEFAULT_REVIEWER_MODEL,
+    DEFAULT_REVIEWER_REASONING_EFFORT,
+    RubricReviewConfig,
+)
 from benchflow.review.scoring import ReviewScoring, score_weighted_review
 from benchflow.review.wrapper import (
     REVIEWER_AGENT_TIMEOUT_SEC,
@@ -94,6 +100,7 @@ class ReviewReport:
     agent: str
     model: str | None
     environment: str
+    reasoning_effort: str | None = None
     network: str = "no-internet"
     job_summary: str | None = None
     trials: list[TrialReview] = field(default_factory=list)
@@ -115,6 +122,7 @@ class ReviewReport:
             "reviewer": {
                 "agent": self.agent,
                 "model": self.model,
+                "reasoning_effort": self.reasoning_effort,
                 "environment": self.environment,
                 "network": self.network,
             },
@@ -172,6 +180,7 @@ def _is_passing(rollout_dir: Path) -> bool:
         and not isinstance(reward, bool)
         and reward == 1.0
         and result.get("error") is None
+        and result.get("verifier_error") is None
     )
 
 
@@ -251,7 +260,7 @@ def _source_task_dir(
     return candidate, None
 
 
-def _task_digest_issue(rollout_dir: Path, task_dir: Path) -> str | None:
+def task_digest_issue(rollout_dir: Path, task_dir: Path) -> str | None:
     """Compare the rollout's recorded task digest against the task on disk.
 
     Task evidence is admitted only when result/config provenance identifies
@@ -417,6 +426,7 @@ async def _review_one(
     template: str | None,
     agent: str,
     model: str | None,
+    reasoning_effort: str | None,
     environment: str,
     agent_env: dict[str, str],
     timeout_sec: int,
@@ -439,7 +449,7 @@ async def _review_one(
         logger.info("%s: %s", rollout_dir.name, skip_reason)
     if task_dir is not None:
         digest_issue = await asyncio.to_thread(
-            _task_digest_issue,
+            task_digest_issue,
             rollout_dir,
             task_dir,
         )
@@ -485,12 +495,14 @@ async def _review_one(
             task_path=wrapper_dir,
             agent=agent,
             model=model,
+            reasoning_effort=reasoning_effort,
             agent_env=dict(agent_env),
             environment=environment,
             jobs_dir=runtime_dir,
             timeout=timeout_sec,
             uploads=uploads,
             pre_agent_hooks=[_lock_review_evidence],
+            rubric_review=RubricReviewConfig(enabled=False),
         )
         result = await run_rollout(config)
         leaf = _reviewer_rollout_leaf(runtime_dir)
@@ -633,8 +645,9 @@ def _summarize_job(trials: list[TrialReview]) -> str | None:
 async def run_reviews(
     path: Path,
     *,
-    agent: str,
-    model: str | None = None,
+    agent: str = DEFAULT_REVIEWER_AGENT,
+    model: str | None = DEFAULT_REVIEWER_MODEL,
+    reasoning_effort: str | None = DEFAULT_REVIEWER_REASONING_EFFORT,
     environment: str = "docker",
     rubric_path: Path | None = None,
     prompt_path: Path | None = None,
@@ -688,6 +701,7 @@ async def run_reviews(
                 template=template,
                 agent=agent,
                 model=model,
+                reasoning_effort=reasoning_effort,
                 environment=environment,
                 agent_env=agent_env or {},
                 timeout_sec=timeout_sec,
@@ -720,6 +734,7 @@ async def run_reviews(
         criteria=criteria_names,
         agent=agent,
         model=model,
+        reasoning_effort=reasoning_effort,
         environment=environment,
         network="open (explicit --allow-open-network)"
         if open_network

--- a/src/benchflow/review/scoring.py
+++ b/src/benchflow/review/scoring.py
@@ -34,6 +34,24 @@ class ReviewScoring:
     gated_quality: float
     decision: PublicationDecision
 
+    @property
+    def passed(self) -> bool:
+        """Whether deterministic verification and every blocker passed."""
+
+        return self.deterministic_pass and self.all_blockers_pass
+
+    @property
+    def reward(self) -> float:
+        """Binary benchmark reward after deterministic and blocker gates."""
+
+        return 1.0 if self.passed else 0.0
+
+    @property
+    def score(self) -> float:
+        """Weighted non-blocker quality, zeroed whenever a gate fails."""
+
+        return self.gated_quality
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "deterministic_pass": self.deterministic_pass,

--- a/src/benchflow/review/workspace.py
+++ b/src/benchflow/review/workspace.py
@@ -1,0 +1,263 @@
+"""Capture final agent-created workspace files for isolated rubric review.
+
+Large benchmark workspaces often contain gigabytes of immutable task inputs.
+Copying the entire directory would both duplicate those inputs and risk
+including agent credentials. Instead, Benchflow records a metadata baseline
+after task upload and exports every regular file created or changed afterward.
+The reviewer receives that delta plus an auditable manifest.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import shlex
+from pathlib import PurePosixPath
+from typing import Any
+
+WORKSPACE_DIRNAME = "workspace"
+WORKSPACE_BASELINE_FILENAME = "workspace-baseline.json"
+WORKSPACE_MANIFEST_FILENAME = "workspace-manifest.json"
+
+_CAPTURE_SCRIPT = r"""
+import hashlib
+import json
+import os
+import shutil
+import stat
+import sys
+from pathlib import Path
+
+mode, root_arg, baseline_arg, destination_arg, manifest_arg = sys.argv[1:]
+root = Path(root_arg).resolve()
+baseline_path = Path(baseline_arg)
+destination = Path(destination_arg)
+manifest_path = Path(manifest_arg)
+
+EXCLUDED_ROOT_DIRS = {
+    ".aws", ".azure", ".cache", ".claude", ".codex", ".config", ".daytona",
+    ".gemini", ".gnupg", ".kube", ".local", ".npm", ".ssh",
+}
+EXCLUDED_DIR_NAMES = {
+    ".git", ".mypy_cache", ".pytest_cache", ".ruff_cache", ".venv",
+    "__pycache__", "node_modules",
+}
+EXCLUDED_FILE_NAMES = {
+    ".gitconfig", ".netrc", ".npmrc", ".pypirc", "auth.json", "credentials",
+    "credentials.json", "id_ed25519", "id_rsa",
+}
+
+
+def exclusion(relative):
+    parts = relative.parts
+    if not parts:
+        return None
+    if any(part in EXCLUDED_ROOT_DIRS for part in parts):
+        return "runtime credential/cache directory"
+    if any(part in EXCLUDED_DIR_NAMES for part in parts[:-1]):
+        return "generated dependency or VCS directory"
+    name = parts[-1]
+    lower = name.lower()
+    if lower == ".env" or lower.startswith(".env."):
+        return "environment secret file"
+    if lower in EXCLUDED_FILE_NAMES or lower.endswith((".pem", ".key", ".p12", ".pfx")):
+        return "credential-like file"
+    return None
+
+
+def inventory():
+    files = {}
+    excluded = {}
+    for directory, dirnames, filenames in os.walk(root, topdown=True, followlinks=False):
+        directory_path = Path(directory)
+        relative_dir = directory_path.relative_to(root)
+        kept_dirs = []
+        for name in sorted(dirnames):
+            relative = relative_dir / name
+            reason = exclusion(relative)
+            candidate = directory_path / name
+            if reason is not None:
+                excluded[relative.as_posix()] = reason
+            elif candidate.is_symlink():
+                excluded[relative.as_posix()] = "symbolic link"
+            else:
+                kept_dirs.append(name)
+        dirnames[:] = kept_dirs
+        for name in sorted(filenames):
+            candidate = directory_path / name
+            relative = candidate.relative_to(root)
+            reason = exclusion(relative)
+            if reason is not None:
+                excluded[relative.as_posix()] = reason
+                continue
+            try:
+                info = candidate.lstat()
+            except OSError:
+                excluded[relative.as_posix()] = "unreadable"
+                continue
+            if not stat.S_ISREG(info.st_mode):
+                excluded[relative.as_posix()] = "non-regular file"
+                continue
+            files[relative.as_posix()] = {
+                "size": info.st_size,
+                "mtime_ns": info.st_mtime_ns,
+                "ctime_ns": info.st_ctime_ns,
+            }
+    return files, excluded
+
+
+current, excluded = inventory()
+if mode == "baseline":
+    baseline_path.parent.mkdir(parents=True, exist_ok=True)
+    baseline_path.write_text(
+        json.dumps({"version": 1, "root": str(root), "files": current}, sort_keys=True),
+        encoding="utf-8",
+    )
+    raise SystemExit(0)
+
+baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+if baseline.get("version") != 1 or baseline.get("root") != str(root):
+    raise RuntimeError("workspace baseline does not match the final workspace")
+before = baseline.get("files")
+if not isinstance(before, dict):
+    raise RuntimeError("workspace baseline has no file inventory")
+
+if destination.exists():
+    shutil.rmtree(destination)
+destination.mkdir(parents=True)
+copied = []
+tree_hash = hashlib.sha256()
+for relative_text in sorted(current):
+    if before.get(relative_text) == current[relative_text]:
+        continue
+    source = root / Path(relative_text)
+    target = destination / Path(relative_text)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target, follow_symlinks=False)
+    digest = hashlib.sha256()
+    with source.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    item = {
+        "path": relative_text,
+        "size": current[relative_text]["size"],
+        "sha256": digest.hexdigest(),
+    }
+    copied.append(item)
+    tree_hash.update(
+        (relative_text + "\0" + item["sha256"] + "\n").encode("utf-8")
+    )
+
+manifest = {
+    "version": 1,
+    "source_workspace": str(root),
+    "capture": "files created or modified after task upload",
+    "copied_files": copied,
+    "copied_file_count": len(copied),
+    "copied_bytes": sum(item["size"] for item in copied),
+    "deleted_files": sorted(set(before) - set(current)),
+    "excluded_paths": [
+        {"path": path, "reason": excluded[path]} for path in sorted(excluded)
+    ],
+    "tree_sha256": tree_hash.hexdigest(),
+}
+manifest_path.parent.mkdir(parents=True, exist_ok=True)
+manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+baseline_path.unlink(missing_ok=True)
+"""
+
+
+def _capture_command(
+    mode: str,
+    *,
+    workspace: str,
+    baseline_path: str,
+    destination_path: str,
+    manifest_path: str,
+) -> str:
+    encoded = base64.b64encode(_CAPTURE_SCRIPT.encode("utf-8")).decode("ascii")
+    args = " ".join(
+        shlex.quote(value)
+        for value in (
+            mode,
+            workspace,
+            baseline_path,
+            destination_path,
+            manifest_path,
+        )
+    )
+    return f"printf %s {shlex.quote(encoded)} | base64 -d | python3 - {args}"
+
+
+def _artifact_paths() -> tuple[str, str, str]:
+    root = PurePosixPath("/logs/artifacts")
+    return (
+        str(root / WORKSPACE_BASELINE_FILENAME),
+        str(root / WORKSPACE_DIRNAME),
+        str(root / WORKSPACE_MANIFEST_FILENAME),
+    )
+
+
+async def record_workspace_baseline(sandbox: Any, workspace: str) -> None:
+    """Record the pre-agent workspace inventory inside the sandbox."""
+
+    baseline, destination, manifest = _artifact_paths()
+    result = await sandbox.exec(
+        _capture_command(
+            "baseline",
+            workspace=workspace,
+            baseline_path=baseline,
+            destination_path=destination,
+            manifest_path=manifest,
+        ),
+        user="root",
+        timeout_sec=300,
+    )
+    if result.return_code != 0:
+        detail = (result.stderr or result.stdout or "")[-500:]
+        raise RuntimeError(f"workspace baseline capture failed: {detail}")
+
+
+async def export_workspace_delta(
+    sandbox: Any,
+    workspace: str,
+    *,
+    host_artifacts_dir: Any,
+) -> None:
+    """Export created/modified workspace files into rollout artifacts."""
+
+    baseline, destination, manifest = _artifact_paths()
+    result = await sandbox.exec(
+        _capture_command(
+            "final",
+            workspace=workspace,
+            baseline_path=baseline,
+            destination_path=destination,
+            manifest_path=manifest,
+        ),
+        user="root",
+        timeout_sec=900,
+    )
+    if result.return_code != 0:
+        detail = (result.stderr or result.stdout or "")[-500:]
+        raise RuntimeError(f"workspace output capture failed: {detail}")
+    if not getattr(sandbox, "is_mounted", False):
+        host_artifacts_dir.mkdir(parents=True, exist_ok=True)
+        host_workspace = host_artifacts_dir / WORKSPACE_DIRNAME
+        host_workspace.mkdir(parents=True, exist_ok=True)
+        await sandbox.download_dir(destination, host_workspace)
+        await sandbox.download_file(
+            manifest,
+            host_artifacts_dir / WORKSPACE_MANIFEST_FILENAME,
+        )
+
+
+def read_workspace_manifest(rollout_dir: Any) -> dict[str, Any] | None:
+    """Read a captured workspace manifest from a host rollout directory."""
+
+    path = rollout_dir / "artifacts" / WORKSPACE_MANIFEST_FILENAME
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return value if isinstance(value, dict) else None

--- a/src/benchflow/review/wrapper.py
+++ b/src/benchflow/review/wrapper.py
@@ -36,6 +36,7 @@ from benchflow.review.config import (
     Rubric,
     build_review_response_model,
 )
+from benchflow.review.policy import DEFAULT_REVIEWER_TIMEOUT_SEC
 from benchflow.review.prompts import (
     TASK_MOUNT,
     TRIAL_MOUNT,
@@ -48,7 +49,7 @@ from benchflow.review.prompts import (
 REVIEWER_IMAGE = (
     "python@sha256:6771159cd4fa5d9bba1258caf0b82e6b73458c694d178ad97c5e925c2d0e1a91"
 )
-REVIEWER_AGENT_TIMEOUT_SEC = 1800
+REVIEWER_AGENT_TIMEOUT_SEC = DEFAULT_REVIEWER_TIMEOUT_SEC
 REVIEWER_VERIFIER_TIMEOUT_SEC = 120
 
 #: Rollout-side entries never copied into the evidence snapshot.  Excluding
@@ -59,6 +60,7 @@ _EVIDENCE_EXCLUDES = (
     "review",
     REVIEW_RESULT_FILENAME,
     "review_report.json",
+    "workspace-baseline.json",
 )
 
 #: Task-side material the reviewer must not see: skills would break no-skill

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -99,6 +99,7 @@ from benchflow.loop_strategies import (
     loop_block,
 )
 from benchflow.models import RolloutResult, TrajectorySource
+from benchflow.review.lifecycle import AutomaticRubricReview
 from benchflow.rollout import _deadline as _deadline
 from benchflow.rollout._config import GENERATED_SKILLS_ROOT as GENERATED_SKILLS_ROOT
 from benchflow.rollout._config import RolloutConfig as RolloutConfig
@@ -666,6 +667,7 @@ class Rollout:
         self._effective_task_path: Path = config.task_path
         self._task_tmp: Path | None = None
         self._task_skill_policy: TaskSkillPolicy | None = None
+        self._automatic_review: AutomaticRubricReview | None = None
         self._usage_runtime: Any = None
         self._usage_metrics: dict[str, Any] = self._planes.extract_usage(None)
         self._native_usage_metrics: dict[str, Any] = _zero_native_acp_usage_metrics()
@@ -1059,6 +1061,21 @@ class Rollout:
         if callable(configure_timeout):
             configure_timeout(self._env, self._timeout)
 
+        self._automatic_review = AutomaticRubricReview.discover(
+            cfg.task_path, cfg.rubric_review
+        )
+        if self._automatic_review is not None and cfg.task_digest is None:
+            try:
+                from benchflow._utils.task_authoring import task_digest
+
+                cfg.task_digest = task_digest(cfg.task_path)
+            except Exception as exc:
+                logger.warning(
+                    "Could not compute rubric-review task digest for %s: %s",
+                    cfg.task_path,
+                    exc,
+                )
+
         _write_config(
             self._rollout_dir,
             task_path=cfg.task_path,
@@ -1086,6 +1103,7 @@ class Rollout:
             task_digest=cfg.task_digest,
             config_override=cfg.config_override,
             loop_strategy=cfg.loop_strategy_spec,
+            rubric_review=cfg.rubric_review,
         )
 
         self._phase = "setup"
@@ -1185,6 +1203,7 @@ class Rollout:
                     self._env, cfg.generated_skills_root, cfg.sandbox_user
                 )
             await self._planes.lockdown_paths(self._env, self._effective_locked)
+            await self._record_review_workspace_baseline()
             self._phase = "installed"
             return
 
@@ -1251,8 +1270,19 @@ class Rollout:
                 self._env, cfg.generated_skills_root, cfg.sandbox_user
             )
         await self._planes.lockdown_paths(self._env, self._effective_locked)
+        await self._record_review_workspace_baseline()
 
         self._phase = "installed"
+
+    async def _record_review_workspace_baseline(self) -> None:
+        """Prepare output-only workspace evidence for automatic review."""
+
+        automatic_review = getattr(self, "_automatic_review", None)
+        if automatic_review is None:
+            return
+        self._timing["rubric_workspace_baseline"] = await automatic_review.record_baseline(
+            self._env, self._agent_cwd
+        )
 
     # Phase 3b: CONNECT (ACP session — re-entrant)
 
@@ -1843,6 +1873,11 @@ class Rollout:
         await _publish_trajectory_for_verifier(
             self._env, self._trajectory, self._rollout_paths.agent_dir
         )
+        # Snapshot solver outputs before verifier hardening recursively changes
+        # workspace ownership/mode metadata. The verifier still runs first from
+        # the scoring perspective; this only freezes the evidence that the
+        # subsequent isolated reviewer receives.
+        await self._export_review_workspace()
 
         (
             self._rewards,
@@ -1947,6 +1982,20 @@ class Rollout:
 
     # Phase 5: CLEANUP
 
+    async def _export_review_workspace(self) -> None:
+        """Capture final solver outputs once, retrying during cleanup on failure."""
+
+        automatic_review = getattr(self, "_automatic_review", None)
+        if not self._env or automatic_review is None:
+            return
+        elapsed = await automatic_review.export_workspace(
+            self._env,
+            self._agent_cwd,
+            artifacts_dir=self._rollout_paths.artifacts_dir,
+        )
+        if elapsed is not None:
+            self._timing["rubric_workspace_export"] = elapsed
+
     async def cleanup(self) -> None:
         """Close ACP client and stop the environment."""
         self._capture_partial_acp_trajectory()
@@ -1968,6 +2017,8 @@ class Rollout:
                 if self._export_error is None:
                     self._export_error = export_error
                 self._evolved_skills = None
+
+        await self._export_review_workspace()
 
         usage_runtime = getattr(self, "_usage_runtime", None)
         if usage_runtime is not None:
@@ -2096,8 +2147,16 @@ class Rollout:
         A trip becomes a normal infra-retryable error result and the
         abandoned attempt's cleanup is bounded too.
         """
-        return await _deadline.enforce_hard_deadline(
+        result = await _deadline.enforce_hard_deadline(
             self._run_lifecycle(), config=self._config
+        )
+        automatic_review = getattr(self, "_automatic_review", None)
+        if automatic_review is None or self._rollout_dir is None:
+            return result
+        return await automatic_review.integrate(
+            result,
+            rollout_dir=self._rollout_dir,
+            source_environment=self._config.environment,
         )
 
     async def _run_lifecycle(self) -> RolloutResult:

--- a/src/benchflow/rollout/__init__.py
+++ b/src/benchflow/rollout/__init__.py
@@ -1280,9 +1280,9 @@ class Rollout:
         automatic_review = getattr(self, "_automatic_review", None)
         if automatic_review is None:
             return
-        self._timing["rubric_workspace_baseline"] = await automatic_review.record_baseline(
-            self._env, self._agent_cwd
-        )
+        self._timing[
+            "rubric_workspace_baseline"
+        ] = await automatic_review.record_baseline(self._env, self._agent_cwd)
 
     # Phase 3b: CONNECT (ACP session — re-entrant)
 

--- a/src/benchflow/rollout/_config.py
+++ b/src/benchflow/rollout/_config.py
@@ -31,6 +31,7 @@ from benchflow.loop_strategies import (
     build_loop_user,
     parse_loop_strategy_spec,
 )
+from benchflow.review.policy import RubricReviewConfig
 from benchflow.skill_policy import (
     SKILL_MODE_NO_SKILL,
     SKILL_MODE_SELF_GEN,
@@ -128,6 +129,10 @@ class RolloutConfig:
     # budget without editing every task definition (#378).
     timeout: int | None = None
     usage_tracking: UsageTrackingConfig = field(default_factory=UsageTrackingConfig)
+    # When the trusted task contains a weighted rubric.json, run a second,
+    # isolated reviewer rollout and fold its blocker gates / weighted score
+    # into this rollout's final result. Tasks without a rubric are unchanged.
+    rubric_review: RubricReviewConfig = field(default_factory=RubricReviewConfig)
 
     # User-driven progressive-disclosure loop
     user: BaseUser | None = None
@@ -233,6 +238,7 @@ class RolloutConfig:
         self.reasoning_effort = normalize_reasoning_effort(self.reasoning_effort)
         self.agent_idle_timeout = normalize_agent_idle_timeout(self.agent_idle_timeout)
         self.usage_tracking = UsageTrackingConfig.coerce(self.usage_tracking)
+        self.rubric_review = RubricReviewConfig.coerce(self.rubric_review)
         for scene in self.scenes:
             for role in scene.roles:
                 role.agent = normalize_agent_name(role.agent)

--- a/src/benchflow/rollout/_results.py
+++ b/src/benchflow/rollout/_results.py
@@ -37,6 +37,7 @@ from benchflow.diagnostics import RolloutDiagnostics
 from benchflow.environment.manifest import EnvironmentManifest
 from benchflow.loop_strategies import LoopStrategySpec, loop_block
 from benchflow.models import RolloutResult, TrajectorySource
+from benchflow.review.policy import RubricReviewConfig
 from benchflow.skill_policy import (
     SKILL_MODE_NO_SKILL,
     TaskSkillPolicy,
@@ -67,9 +68,11 @@ def _write_rewards_jsonl(
     uses the same helper so the two paths can't drift.
     """
     events = build_rewards_jsonl_events(rewards, finished_at)
+    path = rollout_dir / "rewards.jsonl"
     if events:
-        path = rollout_dir / "rewards.jsonl"
         path.write_text("\n".join(json.dumps(e, default=str) for e in events) + "\n")
+    elif path.exists():
+        path.unlink()
 
 
 # Substrings that flag an env var name as secret-bearing for ``config.json``
@@ -161,6 +164,7 @@ def _write_config(
     environment_manifest: EnvironmentManifest | None = None,
     config_override: dict | None = None,
     loop_strategy: LoopStrategySpec | None = None,
+    rubric_review: RubricReviewConfig | None = None,
 ) -> None:
     """Write config.json to rollout_dir with secrets filtered out."""
     from benchflow.acp.selection import selected_acp_transport
@@ -203,6 +207,9 @@ def _write_config(
         "agent_env": recorded_env,
         "scenes": _scene_metadata(scenes or []),
         "loop": loop_block(loop_strategy),
+        "rubric_review": (
+            rubric_review.to_config_artifact() if rubric_review is not None else None
+        ),
     }
     if usage_tracking is not None:
         config_data["usage_tracking"] = usage_tracking.to_config_artifact()
@@ -558,6 +565,119 @@ def _write_trainer_artifact(
         )
     except Exception as e:  # pragma: no cover - defensive
         logger.warning("ADP artifact write failed: %s", e)
+
+
+def finalize_rubric_review_artifacts(
+    rollout_dir: Path,
+    result: RolloutResult,
+    *,
+    rewards: dict[str, Any] | None,
+    final_score: dict[str, Any],
+    rubric_review: dict[str, Any],
+    verifier_error: str | None = None,
+    review_elapsed_sec: float | None = None,
+) -> RolloutResult:
+    """Consistently refresh every score-bearing artifact after rubric review.
+
+    Job-level aggregators consume these per-rollout files later, so rewriting
+    the canonical rollout surfaces here prevents ``result.json``, reward
+    events, and trainer exports from reporting different verdicts.
+    """
+
+    result_path = rollout_dir / "result.json"
+    try:
+        result_data = json.loads(result_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"cannot refresh rubric-reviewed result: {exc}") from exc
+    if not isinstance(result_data, dict):
+        raise RuntimeError(
+            "cannot refresh rubric-reviewed result: root is not an object"
+        )
+
+    result.rewards = rewards
+    result.final_score = final_score
+    result.rubric_review = rubric_review
+    result.verifier_error = verifier_error
+    result.verifier_error_category = classify_verifier_error(verifier_error)
+    result.finished_at = datetime.now()
+
+    timing = result_data.get("timing")
+    if not isinstance(timing, dict):
+        timing = {}
+    if review_elapsed_sec is not None:
+        timing["rubric_review"] = round(review_elapsed_sec, 1)
+    if result.started_at is not None:
+        timing["total"] = round(
+            (result.finished_at - result.started_at).total_seconds(), 1
+        )
+
+    result_data.update(
+        {
+            "rewards": rewards,
+            "final_score": final_score,
+            "rubric_review": rubric_review,
+            "verifier_error": verifier_error,
+            "verifier_error_category": result.verifier_error_category,
+            "finished_at": str(result.finished_at),
+            "timing": timing,
+        }
+    )
+    # Refresh projections first and write result.json last. Its final_score is
+    # the durable commit marker used by evaluation resume; a process death
+    # before that last write safely retries review instead of accepting a
+    # half-refreshed rollout as complete.
+    (rollout_dir / "timing.json").write_text(
+        json.dumps(timing, indent=2), encoding="utf-8"
+    )
+    _write_rewards_jsonl(rollout_dir, rewards, result.finished_at)
+
+    prompts_path = rollout_dir / "prompts.json"
+    try:
+        prompts = json.loads(prompts_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        prompts = []
+    if not isinstance(prompts, list) or not all(
+        isinstance(prompt, str) for prompt in prompts
+    ):
+        prompts = []
+    agent_result = result_data.get("agent_result")
+    if not isinstance(agent_result, dict):
+        agent_result = {}
+    _write_trainer_artifact(
+        rollout_dir,
+        task_name=result.task_name,
+        rollout_name=result.rollout_name,
+        agent_name=result.agent_name or result.agent,
+        prompts=prompts,
+        trajectory=result.trajectory,
+        rewards=rewards,
+        model=result.model,
+        verifier_error=verifier_error,
+        total_prompt_tokens=result.n_input_tokens,
+        total_completion_tokens=result.n_output_tokens,
+        total_cached_tokens=result.n_cache_read_tokens,
+        total_cost_usd=result.cost_usd,
+    )
+    _write_results_jsonl(
+        rollout_dir,
+        task_name=result.task_name,
+        rollout_name=result.rollout_name,
+        agent=result.agent,
+        agent_name=result.agent_name,
+        model=result.model,
+        n_tool_calls=result.n_tool_calls,
+        prompts=prompts,
+        trajectory=result.trajectory,
+        partial_trajectory=result.partial_trajectory,
+        rewards=rewards,
+        error=result.error,
+        verifier_error=verifier_error,
+        export_error=result.export_error,
+        timing=timing,
+        agent_result=agent_result,
+    )
+    result_path.write_text(json.dumps(result_data, indent=2), encoding="utf-8")
+    return result
 
 
 def _is_document_user(user: BaseUser) -> bool:

--- a/src/benchflow/runtime.py
+++ b/src/benchflow/runtime.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from benchflow.agents.registry import AgentConfig, resolve_agent
+from benchflow.review.policy import RubricReviewConfig
 from benchflow.skill_policy import SKILL_MODE_NO_SKILL
 
 if TYPE_CHECKING:
@@ -220,6 +221,10 @@ class RuntimeConfig:
     pre_agent_hooks: list | None = None
     sandbox_locked_paths: list[str] | None = None
     usage_tracking: Any = None
+    rubric_review: RubricReviewConfig = field(default_factory=RubricReviewConfig)
+
+    def __post_init__(self) -> None:
+        self.rubric_review = RubricReviewConfig.coerce(self.rubric_review)
 
 
 @dataclass
@@ -348,6 +353,7 @@ class Runtime:
             skills_dir=config.skills_dir,
             skill_mode=config.skill_mode,
             usage_tracking=config.usage_tracking,
+            rubric_review=config.rubric_review,
         )
 
         rollout = await Rollout.create(trial_config)
@@ -447,6 +453,7 @@ async def run(
             agent=subject,
             model=model,
             usage_tracking=rc.usage_tracking,
+            rubric_review=rc.rubric_review,
         )
         rollout = await Rollout.create(rollout_config)
         return await rollout.run()

--- a/src/benchflow/sdk.py
+++ b/src/benchflow/sdk.py
@@ -175,6 +175,7 @@ class SDK:
         self_gen_no_internet: bool = False,
         source_provenance: dict[str, Any] | None = None,
         usage_tracking: Any = None,
+        rubric_review: Any = None,
     ) -> RolloutResult:
         """Run a task — delegates to :func:`benchflow.run`.
 
@@ -225,5 +226,6 @@ class SDK:
             self_gen_no_internet=self_gen_no_internet,
             source_provenance=source_provenance,
             usage_tracking=usage_tracking,
+            rubric_review=rubric_review,
         )
         return await run(config)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]

--- a/src/benchflow/trajectories/results.py
+++ b/src/benchflow/trajectories/results.py
@@ -53,6 +53,16 @@ def _reward_value(rewards: dict[str, Any] | None) -> float:
     return 0.0
 
 
+def _score_value(rewards: dict[str, Any] | None) -> float:
+    """Return rubric quality when present, otherwise the legacy reward."""
+
+    if isinstance(rewards, dict):
+        score = rewards.get("score")
+        if isinstance(score, (int, float)) and not isinstance(score, bool):
+            return float(score)
+    return _reward_value(rewards)
+
+
 def _metrics_from_rewards(
     rewards: dict[str, Any] | None,
     *,
@@ -562,7 +572,7 @@ def build_rollout_results_record(
         "metrics": metrics,
         "tool_defs": tool_defs,
         "token_usage": token_usage,
-        "score": reward,
+        "score": _score_value(rewards),
         "total_tool_calls": float(n_tool_calls),
         "trajectory": steps,
     }

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -10,7 +10,11 @@ from typing import Any
 from typer.testing import CliRunner
 
 from benchflow.cli.main import app
-from benchflow.eval_artifacts import build_canonical_selection, build_health_summary
+from benchflow.eval_artifacts import (
+    build_canonical_selection,
+    build_health_summary,
+    render_run_summary_markdown,
+)
 from benchflow.evaluation import Evaluation
 
 runner = CliRunner()
@@ -203,6 +207,37 @@ def test_eval_run_publish_bucket_writes_readme_summary(
     assert "task-a" in text
     assert "Mean reward: 1.000" in text
     assert "`oracle`" in text
+
+
+def test_health_and_publish_summary_include_integrated_rubric_score(
+    tmp_path: Path,
+) -> None:
+    """Guards the rubric final-score PR's health and publish projections."""
+
+    job_dir = tmp_path / "jobs" / "reviewed"
+    rollout_dir = job_dir / "task-a__abc"
+    _write_rollout(rollout_dir, "task-a")
+    (rollout_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 1.0, "pass_at_1": 1.0, "score": 0.75},
+                "final_score": {"pass": True, "pass_at_1": 1, "score": 0.75},
+                "rubric_review": {"status": "complete"},
+                "n_tool_calls": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    health = build_health_summary(job_dir)
+    assert health["rows"][0]["pass_at_1"] == 1
+    assert health["rows"][0]["final_score"] == 0.75
+    assert health["rows"][0]["rubric_review_status"] == "complete"
+
+    rendered = render_run_summary_markdown(job_dir)
+    assert "- Mean rubric score: 0.750" in rendered
+    assert "| task-a | 1 | 0.750 | 1.000 |" in rendered
 
 
 def test_eval_run_publish_bucket_readme_dedupes_retry_attempts(

--- a/tests/test_eval_artifact_cli.py
+++ b/tests/test_eval_artifact_cli.py
@@ -212,7 +212,7 @@ def test_eval_run_publish_bucket_writes_readme_summary(
 def test_health_and_publish_summary_include_integrated_rubric_score(
     tmp_path: Path,
 ) -> None:
-    """Guards the rubric final-score PR's health and publish projections."""
+    """Guards PR #1092's health and publish projections."""
 
     job_dir = tmp_path / "jobs" / "reviewed"
     rollout_dir = job_dir / "task-a__abc"

--- a/tests/test_eval_sharding.py
+++ b/tests/test_eval_sharding.py
@@ -74,7 +74,7 @@ def test_worker_payload_without_loop_strategy_stays_none() -> None:
 
 
 def test_worker_payload_round_trips_and_redacts_rubric_reviewer_policy() -> None:
-    """Guards the rubric final-score PR's private shard policy transport."""
+    """Guards PR #1092's private shard policy transport."""
 
     config = EvaluationConfig(
         rubric_review={
@@ -240,7 +240,7 @@ def test_worker_sharded_summary_includes_numeric_score_ratios(tmp_path) -> None:
 
 
 def test_worker_sharded_summary_aggregates_full_rubric_review(tmp_path) -> None:
-    """Guards the rubric final-score PR's cross-worker review summary."""
+    """Guards PR #1092's cross-worker review summary."""
 
     plan = EvalShardPlan(
         total_concurrency=2,

--- a/tests/test_eval_sharding.py
+++ b/tests/test_eval_sharding.py
@@ -73,6 +73,34 @@ def test_worker_payload_without_loop_strategy_stays_none() -> None:
     assert _evaluation_config(json.loads(json.dumps(payload))).loop_strategy is None
 
 
+def test_worker_payload_round_trips_and_redacts_rubric_reviewer_policy() -> None:
+    """Guards the rubric final-score PR's private shard policy transport."""
+
+    config = EvaluationConfig(
+        rubric_review={
+            "model": "azure-foundry-openai/gpt-5.6-sol",
+            "reasoning_effort": "xhigh",
+            "agent_env": {"AZURE_API_KEY": "review-secret"},
+        }
+    )
+    shard = EvalShard(index=0, task_names=("task-a",), concurrency=1)
+    raw = {
+        "tasks_dir": "/tasks",
+        "jobs_dir": "/jobs",
+        "result_path": "/result.json",
+        "config": _config_payload(config, shard=shard),
+    }
+
+    restored = _evaluation_config(json.loads(json.dumps(raw["config"])))
+    artifact = _worker_payload_artifact(raw)
+
+    assert restored.rubric_review.model == "azure-foundry-openai/gpt-5.6-sol"
+    assert restored.rubric_review.reasoning_effort == "xhigh"
+    assert restored.rubric_review.agent_env == {"AZURE_API_KEY": "review-secret"}
+    assert "review-secret" not in json.dumps(artifact)
+    assert artifact["config"]["rubric_review"]["agent_env_keys"] == ["AZURE_API_KEY"]
+
+
 def test_worker_payload_artifact_redacts_agent_env_secrets() -> None:
     config = EvaluationConfig(
         agent_env={
@@ -209,3 +237,74 @@ def test_worker_sharded_summary_includes_numeric_score_ratios(tmp_path) -> None:
     assert summary["score_ratio"] == pytest.approx(1 / 3)
     assert summary["score_excl_errors_ratio"] == pytest.approx(1 / 2)
     assert advertised_summary == summary
+
+
+def test_worker_sharded_summary_aggregates_full_rubric_review(tmp_path) -> None:
+    """Guards the rubric final-score PR's cross-worker review summary."""
+
+    plan = EvalShardPlan(
+        total_concurrency=2,
+        worker_concurrency=1,
+        shards=(
+            EvalShard(index=0, task_names=("task-a",), concurrency=1),
+            EvalShard(index=1, task_names=("task-b",), concurrency=1),
+        ),
+    )
+    shard_results = [
+        {
+            "total": 1,
+            "passed": 1,
+            "failed": 0,
+            "errored": 0,
+            "verifier_errored": 0,
+            "mean_final_score": 0.8,
+            "rubric_reviews_required": 1,
+            "rubric_reviews_completed": 1,
+            "rubric_review": {
+                "required": 1,
+                "completed": 1,
+                "passed": 1,
+                "failed": 0,
+                "errored": 0,
+                "unweighted": 0,
+                "reviewer_total_tokens": 100,
+                "reviewer_total_cost_usd": 0.02,
+                "reviewer_usage_coverage": 1.0,
+            },
+        },
+        {
+            "total": 1,
+            "passed": 0,
+            "failed": 1,
+            "errored": 0,
+            "verifier_errored": 0,
+            "mean_final_score": 0.4,
+            "rubric_reviews_required": 1,
+            "rubric_reviews_completed": 1,
+            "rubric_review": {
+                "required": 1,
+                "completed": 1,
+                "passed": 0,
+                "failed": 1,
+                "errored": 0,
+                "unweighted": 0,
+                "reviewer_total_tokens": 50,
+                "reviewer_total_cost_usd": 0.01,
+                "reviewer_usage_coverage": 1.0,
+            },
+        },
+    ]
+
+    result = _aggregate_result(
+        jobs_dir=tmp_path,
+        config=EvaluationConfig(),
+        plan=plan,
+        shard_results=shard_results,
+        elapsed_sec=1.0,
+    )
+    summary = json.loads((tmp_path / "summary.json").read_text())
+
+    assert result.mean_final_score == pytest.approx(0.6)
+    assert summary["rubric_review"]["pass_at_1"] == 0.5
+    assert summary["rubric_review"]["reviewer_total_tokens"] == 150
+    assert summary["rubric_review"]["reviewer_total_cost_usd"] == 0.03

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -116,6 +116,33 @@ def test_collect_metrics_basic(results_dir):
     assert "task-c" in s["errored_tasks"]
 
 
+def test_collect_metrics_surfaces_automatic_rubric_score(tmp_path):
+    """Guards the rubric final-score PR's metrics projection."""
+
+    rollout = tmp_path / "job" / "task-a__reviewed"
+    rollout.mkdir(parents=True)
+    (rollout / "result.json").write_text(
+        json.dumps(
+            {
+                "task_name": "task-a",
+                "rewards": {"reward": 1.0, "score": 0.75, "pass_at_1": 1.0},
+                "error": None,
+                "verifier_error": None,
+                "final_score": {"status": "complete", "pass": True, "score": 0.75},
+                "rubric_review": {"status": "complete"},
+            }
+        )
+    )
+
+    summary = collect_metrics(tmp_path).summary()
+
+    assert summary["pass_at_1_ratio"] == 1.0
+    assert summary["mean_final_score"] == 0.75
+    assert summary["rubric_reviews_required"] == 1
+    assert summary["rubric_reviews_completed"] == 1
+    assert summary["rubric_score_coverage"] == 1.0
+
+
 def test_collect_metrics_tool_calls(results_dir):
     """Test average tool call calculation (excludes errored tasks)."""
     metrics = collect_metrics(str(results_dir))
@@ -210,6 +237,31 @@ def test_collect_metrics_best_result_picking(results_dir_with_retries):
     assert s["error_breakdown"] == {"install_failure": 1}
     assert s["failed"] == 1
     assert "task-c" in s["failed_tasks"]
+
+
+def test_collect_metrics_breaks_pass_ties_with_rubric_score(tmp_path):
+    """Guards the rubric final-score PR's retry ranking across passed attempts."""
+    for attempt, score in (("attempt1", 0.25), ("attempt2", 0.75)):
+        trial = tmp_path / attempt / "task-a__trial"
+        trial.mkdir(parents=True)
+        (trial / "result.json").write_text(
+            json.dumps(
+                {
+                    "task_name": "task-a",
+                    "rewards": {"reward": 1.0, "score": score},
+                    "final_score": {"pass": True, "score": score},
+                    "error": None,
+                    "n_tool_calls": 0,
+                    "started_at": "2026-03-24 10:00:00.000000",
+                    "finished_at": "2026-03-24 10:01:00.000000",
+                }
+            )
+        )
+
+    summary = collect_metrics(tmp_path).summary()
+
+    assert summary["passed"] == 1
+    assert summary["mean_final_score"] == 0.75
 
 
 def test_collect_metrics_empty_dir(tmp_path):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -117,7 +117,7 @@ def test_collect_metrics_basic(results_dir):
 
 
 def test_collect_metrics_surfaces_automatic_rubric_score(tmp_path):
-    """Guards the rubric final-score PR's metrics projection."""
+    """Guards PR #1092's metrics projection."""
 
     rollout = tmp_path / "job" / "task-a__reviewed"
     rollout.mkdir(parents=True)
@@ -240,7 +240,7 @@ def test_collect_metrics_best_result_picking(results_dir_with_retries):
 
 
 def test_collect_metrics_breaks_pass_ties_with_rubric_score(tmp_path):
-    """Guards the rubric final-score PR's retry ranking across passed attempts."""
+    """Guards PR #1092's retry ranking across passed attempts."""
     for attempt, score in (("attempt1", 0.25), ("attempt2", 0.75)):
         trial = tmp_path / attempt / "task-a__trial"
         trial.mkdir(parents=True)

--- a/tests/test_review_integration.py
+++ b/tests/test_review_integration.py
@@ -55,7 +55,7 @@ def _rubric(task: Path) -> Path:
 
 
 def test_automatic_review_is_default_only_for_tasks_with_rubrics(tmp_path):
-    """Guards the rubric final-score PR's zero-configuration activation policy."""
+    """Guards PR #1092's zero-configuration activation policy."""
 
     plain_task = tmp_path / "plain"
     plain_task.mkdir()
@@ -174,7 +174,7 @@ def _fake_review(
 
 @pytest.mark.asyncio
 async def test_weighted_review_updates_every_score_artifact(tmp_path, monkeypatch):
-    """Guards the rubric final-score PR's canonical artifact synchronization."""
+    """Guards PR #1092's canonical artifact synchronization."""
 
     task = tmp_path / "tasks" / "task"
     rubric_path = _rubric(task)
@@ -227,7 +227,7 @@ async def test_weighted_review_updates_every_score_artifact(tmp_path, monkeypatc
 
 @pytest.mark.asyncio
 async def test_blocker_failure_zeros_reward_pass_and_score(tmp_path, monkeypatch):
-    """Guards the rubric final-score PR's blocker gate."""
+    """Guards PR #1092's blocker gate."""
 
     task = tmp_path / "tasks" / "task"
     rubric_path = _rubric(task)
@@ -263,7 +263,7 @@ async def test_blocker_failure_zeros_reward_pass_and_score(tmp_path, monkeypatch
 
 @pytest.mark.asyncio
 async def test_review_failure_removes_stale_reward_and_fails_closed(tmp_path):
-    """Guards the rubric final-score PR's unscored failure contract."""
+    """Guards PR #1092's unscored failure contract."""
 
     task = tmp_path / "tasks" / "task"
     rubric_path = _rubric(task)
@@ -301,7 +301,7 @@ async def test_review_failure_removes_stale_reward_and_fails_closed(tmp_path):
 async def test_invalid_review_retains_last_attempt_for_diagnostics(
     tmp_path, monkeypatch
 ):
-    """Guards the rubric final-score PR's invalid-review diagnostics."""
+    """Guards PR #1092's invalid-review diagnostics."""
 
     task = tmp_path / "tasks" / "task"
     rubric_path = _rubric(task)
@@ -335,7 +335,7 @@ async def test_invalid_review_retains_last_attempt_for_diagnostics(
 
 @pytest.mark.asyncio
 async def test_resume_finishes_review_without_rerunning_source(tmp_path, monkeypatch):
-    """Guards the rubric final-score PR's process-crash recovery path."""
+    """Guards PR #1092's process-crash recovery path."""
 
     task = tmp_path / "tasks" / "task"
     _rubric(task)
@@ -373,7 +373,7 @@ async def test_resume_finishes_review_without_rerunning_source(tmp_path, monkeyp
 
 @pytest.mark.asyncio
 async def test_resume_rejects_changed_task_bytes(tmp_path):
-    """Guards the rubric final-score PR's crash-resume provenance gate."""
+    """Guards PR #1092's crash-resume provenance gate."""
 
     task = tmp_path / "tasks" / "task"
     _rubric(task)
@@ -400,7 +400,7 @@ async def test_resume_rejects_changed_task_bytes(tmp_path):
 
 
 def test_workspace_capture_exports_delta_and_excludes_credentials(tmp_path):
-    """Guards the rubric final-score PR's output-only evidence boundary."""
+    """Guards PR #1092's output-only evidence boundary."""
 
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -459,7 +459,7 @@ def test_workspace_capture_exports_delta_and_excludes_credentials(tmp_path):
 
 
 def test_job_summary_separates_pass_at_one_quality_and_reviewer_usage():
-    """Guards the rubric final-score PR's job-level score and usage split."""
+    """Guards PR #1092's job-level score and usage split."""
 
     summary = rubric_review_summary(
         {

--- a/tests/test_review_integration.py
+++ b/tests/test_review_integration.py
@@ -1,0 +1,493 @@
+"""Automatic task-rubric integration and artifact consistency tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from benchflow._utils.evaluation_results import rubric_review_summary
+from benchflow._utils.task_authoring import task_digest
+from benchflow.evaluation import Evaluation, EvaluationConfig
+from benchflow.models import RolloutResult
+from benchflow.review.config import load_rubric
+from benchflow.review.integration import integrate_task_rubric_review
+from benchflow.review.lifecycle import AutomaticRubricReview
+from benchflow.review.policy import RubricReviewConfig
+from benchflow.review.resume import resume_incomplete_rubric_reviews
+from benchflow.review.runner import ReviewReport, TrialReview
+from benchflow.review.scoring import score_weighted_review
+from benchflow.review.workspace import _CAPTURE_SCRIPT
+
+
+def _rubric(task: Path) -> Path:
+    verifier = task / "verifier"
+    verifier.mkdir(parents=True)
+    path = verifier / "rubric.json"
+    path.write_text(
+        json.dumps(
+            {
+                "criteria": [
+                    {
+                        "name": "required_output",
+                        "blocker": 1,
+                        "weight": 10,
+                        "description": "Required output exists",
+                        "guidance": "Inspect the final workspace output.",
+                    },
+                    {
+                        "name": "quality",
+                        "blocker": 0,
+                        "weight": 3,
+                        "description": "Output quality",
+                        "guidance": "Judge the result quality.",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_automatic_review_is_default_only_for_tasks_with_rubrics(tmp_path):
+    """Guards the rubric final-score PR's zero-configuration activation policy."""
+
+    plain_task = tmp_path / "plain"
+    plain_task.mkdir()
+    reviewed_task = tmp_path / "reviewed"
+    _rubric(reviewed_task)
+    policy = RubricReviewConfig()
+
+    assert policy.enabled is True
+    assert policy.agent == "codex-acp"
+    assert policy.model == "openai/gpt-5.6-sol"
+    assert policy.reasoning_effort == "xhigh"
+    assert AutomaticRubricReview.discover(plain_task, policy) is None
+    assert AutomaticRubricReview.discover(reviewed_task, policy) is not None
+
+
+def _source_rollout(tmp_path: Path, *, reward: float = 1.0):
+    rollout = tmp_path / "jobs" / "task__abc123"
+    (rollout / "artifacts" / "workspace").mkdir(parents=True)
+    (rollout / "artifacts" / "workspace" / "answer.txt").write_text("42")
+    (rollout / "artifacts" / "workspace-manifest.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "copied_file_count": 1,
+                "copied_bytes": 2,
+                "copied_files": [{"path": "answer.txt", "size": 2}],
+            }
+        )
+    )
+    (rollout / "trajectory").mkdir()
+    (rollout / "trajectory" / "acp_trajectory.jsonl").write_text("")
+    (rollout / "prompts.json").write_text('["solve"]')
+    (rollout / "timing.json").write_text('{"total": 1.0}')
+    result_data = {
+        "task_name": "task",
+        "rollout_name": "task__abc123",
+        "rewards": {"reward": reward, "test_count": 3},
+        "agent": "gemini",
+        "agent_name": "gemini",
+        "model": "test-model",
+        "agent_result": {"usage_source": "unavailable"},
+        "error": None,
+        "verifier_error": None,
+        "timing": {"total": 1.0},
+    }
+    (rollout / "result.json").write_text(json.dumps(result_data))
+    (rollout / "rewards.jsonl").write_text('{"value": 1.0}\n')
+    result = RolloutResult(
+        task_name="task",
+        rollout_name="task__abc123",
+        rewards={"reward": reward, "test_count": 3},
+        trajectory=[],
+        agent="gemini",
+        agent_name="gemini",
+        model="test-model",
+        started_at=datetime.now(),
+    )
+    return rollout, result
+
+
+def _fake_review(
+    out_dir: Path,
+    *,
+    rubric_path: Path,
+    blocker: str = "pass",
+    deterministic_pass: bool = True,
+) -> tuple[ReviewReport, TrialReview]:
+    rubric = load_rubric(rubric_path)
+    checks = {
+        "required_output": {"outcome": blocker, "explanation": "inspected"},
+        "quality": {"score": 2, "explanation": "complete"},
+    }
+    leaf = out_dir / "runtime" / "reviewer__xyz"
+    (leaf / "trajectory").mkdir(parents=True)
+    (leaf / "config.json").write_text('{"agent":"codex-acp"}')
+    (leaf / "result.json").write_text(
+        json.dumps(
+            {
+                "rollout_name": "reviewer__xyz",
+                "agent_name": "codex",
+                "agent_result": {"total_tokens": 100, "cost_usd": 0.01},
+                "timing": {"total": 2.0},
+                "error": None,
+                "verifier_error": None,
+            }
+        )
+    )
+    (leaf / "timing.json").write_text('{"total":2.0}')
+    trial = TrialReview(
+        trial_name="task__abc123",
+        source_rollout="source",
+        review_valid=True,
+        summary="reviewed",
+        checks=checks,
+        reviewer_rollout=str(leaf),
+        rubric_path=str(rubric_path),
+        rubric_contract=rubric.contract,
+        criteria=[criterion.name for criterion in rubric.criteria],
+        criterion_metadata=[criterion.metadata() for criterion in rubric.criteria],
+        scoring=score_weighted_review(
+            rubric, checks, deterministic_pass=deterministic_pass
+        ),
+    )
+    report = ReviewReport(
+        path="source",
+        rubric_path=str(rubric_path),
+        criteria=trial.criteria,
+        agent="codex-acp",
+        model="openai/gpt-5.6-sol",
+        reasoning_effort="xhigh",
+        environment="docker",
+        trials=[trial],
+    )
+    return report, trial
+
+
+@pytest.mark.asyncio
+async def test_weighted_review_updates_every_score_artifact(tmp_path, monkeypatch):
+    """Guards the rubric final-score PR's canonical artifact synchronization."""
+
+    task = tmp_path / "tasks" / "task"
+    rubric_path = _rubric(task)
+    rollout, result = _source_rollout(tmp_path)
+    async def fake_run_reviews(_path, **kwargs):
+        report, _trial = _fake_review(
+            kwargs["out_dir"], rubric_path=kwargs["rubric_path"]
+        )
+        report_path = kwargs["out_dir"] / "review_report.json"
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(json.dumps(report.to_dict()))
+        return report, report_path
+
+    monkeypatch.setattr("benchflow.review.integration.run_reviews", fake_run_reviews)
+    policy = RubricReviewConfig()
+    updated = await integrate_task_rubric_review(
+        result,
+        rollout_dir=rollout,
+        task_path=task,
+        rubric_path=rubric_path,
+        source_environment="docker",
+        policy=policy,
+        workspace_error=None,
+    )
+
+    assert updated.rewards == {
+        "reward": 1.0,
+        "test_count": 3,
+        "pass_at_1": 1.0,
+        "score": 1.0,
+        "verifier_reward": 1.0,
+        "weighted_points": 6.0,
+        "max_weighted_points": 6.0,
+        "failed_blockers": [],
+    }
+    persisted = json.loads((rollout / "result.json").read_text())
+    assert persisted["final_score"]["pass"] is True
+    assert persisted["final_score"]["score"] == 1.0
+    assert persisted["rubric_review"]["reviewer"]["reasoning_effort"] == "xhigh"
+    reward_event = json.loads((rollout / "rewards.jsonl").read_text())
+    assert reward_event["value"] == 1.0
+    training = json.loads((rollout / "results.jsonl").read_text())
+    assert training["reward"] == 1.0
+    assert training["score"] == 1.0
+    assert training["metrics"]["pass_at_1"] == 1.0
+    assert (rollout / "trainer" / "verifiers.jsonl").is_file()
+    assert not list((rollout / "review").rglob("result.json"))
+    assert (rollout / "review" / "reviewer-result.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_blocker_failure_zeros_reward_pass_and_score(tmp_path, monkeypatch):
+    """Guards the rubric final-score PR's blocker gate."""
+
+    task = tmp_path / "tasks" / "task"
+    rubric_path = _rubric(task)
+    rollout, result = _source_rollout(tmp_path)
+
+    async def fake_run_reviews(_path, **kwargs):
+        report, _trial = _fake_review(
+            kwargs["out_dir"],
+            rubric_path=kwargs["rubric_path"],
+            blocker="fail",
+        )
+        return report, kwargs["out_dir"] / "review_report.json"
+
+    monkeypatch.setattr("benchflow.review.integration.run_reviews", fake_run_reviews)
+    updated = await integrate_task_rubric_review(
+        result,
+        rollout_dir=rollout,
+        task_path=task,
+        rubric_path=rubric_path,
+        source_environment="docker",
+        policy=RubricReviewConfig(max_retries=0),
+        workspace_error=None,
+    )
+
+    assert updated.rewards is not None
+    assert updated.final_score is not None
+    assert updated.rewards["reward"] == 0.0
+    assert updated.rewards["pass_at_1"] == 0.0
+    assert updated.rewards["score"] == 0.0
+    assert updated.final_score["weighted_points"] == 6
+    assert updated.final_score["failed_blockers"] == ["required_output"]
+
+
+@pytest.mark.asyncio
+async def test_review_failure_removes_stale_reward_and_fails_closed(tmp_path):
+    """Guards the rubric final-score PR's unscored failure contract."""
+
+    task = tmp_path / "tasks" / "task"
+    rubric_path = _rubric(task)
+    rollout, result = _source_rollout(tmp_path)
+    baseline = rollout / "artifacts" / "workspace-baseline.json"
+    baseline.write_text('{"private": "inventory"}')
+
+    updated = await integrate_task_rubric_review(
+        result,
+        rollout_dir=rollout,
+        task_path=task,
+        rubric_path=rubric_path,
+        source_environment="docker",
+        policy=RubricReviewConfig(max_retries=0),
+        workspace_error="workspace export unavailable",
+    )
+
+    assert updated.rewards is None
+    assert updated.final_score is not None
+    assert updated.final_score["status"] == "error"
+    assert updated.verifier_error == (
+        "rubric review failed: workspace export unavailable"
+    )
+    assert not (rollout / "rewards.jsonl").exists()
+    assert not baseline.exists()
+    persisted = json.loads((rollout / "result.json").read_text())
+    assert persisted["rewards"] is None
+    assert persisted["rubric_review"]["deterministic_verifier_rewards"] == {
+        "reward": 1.0,
+        "test_count": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_review_retains_last_attempt_for_diagnostics(
+    tmp_path, monkeypatch
+):
+    """Guards the rubric final-score PR's invalid-review diagnostics."""
+
+    task = tmp_path / "tasks" / "task"
+    rubric_path = _rubric(task)
+    rollout, result = _source_rollout(tmp_path)
+
+    async def fake_run_reviews(_path, **kwargs):
+        report, trial = _fake_review(
+            kwargs["out_dir"], rubric_path=kwargs["rubric_path"]
+        )
+        trial.review_valid = False
+        trial.error = "review result did not satisfy the rubric schema"
+        return report, kwargs["out_dir"] / "review_report.json"
+
+    monkeypatch.setattr("benchflow.review.integration.run_reviews", fake_run_reviews)
+    updated = await integrate_task_rubric_review(
+        result,
+        rollout_dir=rollout,
+        task_path=task,
+        rubric_path=rubric_path,
+        source_environment="docker",
+        policy=RubricReviewConfig(max_retries=0),
+        workspace_error=None,
+    )
+
+    assert updated.rewards is None
+    assert updated.rubric_review is not None
+    assert updated.rubric_review["status"] == "error"
+    assert updated.rubric_review["artifact"] == "review/review-report.json"
+    assert (rollout / "review" / "reviewer-result.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_resume_finishes_review_without_rerunning_source(tmp_path, monkeypatch):
+    """Guards the rubric final-score PR's process-crash recovery path."""
+
+    task = tmp_path / "tasks" / "task"
+    _rubric(task)
+    rollout, _result = _source_rollout(tmp_path)
+    persisted = json.loads((rollout / "result.json").read_text())
+    persisted["task_digest"] = task_digest(task)
+    (rollout / "result.json").write_text(json.dumps(persisted))
+
+    async def fake_run_reviews(_path, **kwargs):
+        return _fake_review(
+            kwargs["out_dir"], rubric_path=kwargs["rubric_path"]
+        )[0], kwargs["out_dir"] / "review_report.json"
+
+    monkeypatch.setattr("benchflow.review.integration.run_reviews", fake_run_reviews)
+    evaluation = Evaluation(
+        tasks_dir=task,
+        jobs_dir=tmp_path,
+        job_name="jobs",
+        config=EvaluationConfig(rubric_review=RubricReviewConfig(max_retries=0)),
+    )
+
+    completed = evaluation._get_completed_tasks()
+    refreshed = await resume_incomplete_rubric_reviews(
+        completed,
+        tasks_dir=task,
+        job_dir=tmp_path / "jobs",
+        source_environment="docker",
+        policy=evaluation._config.rubric_review,
+    )
+
+    assert refreshed["task"]["final_score"]["pass"] is True
+    assert refreshed["task"]["rewards"]["verifier_reward"] == 1.0
+    assert (rollout / "review" / "reviewer-result.json").is_file()
+
+
+@pytest.mark.asyncio
+async def test_resume_rejects_changed_task_bytes(tmp_path):
+    """Guards the rubric final-score PR's crash-resume provenance gate."""
+
+    task = tmp_path / "tasks" / "task"
+    _rubric(task)
+    rollout, _result = _source_rollout(tmp_path)
+    persisted = json.loads((rollout / "result.json").read_text())
+    persisted["task_digest"] = "sha256:" + "0" * 64
+    (rollout / "result.json").write_text(json.dumps(persisted))
+    evaluation = Evaluation(
+        tasks_dir=task,
+        jobs_dir=tmp_path,
+        job_name="jobs",
+        config=EvaluationConfig(rubric_review=RubricReviewConfig()),
+    )
+
+    completed = await resume_incomplete_rubric_reviews(
+        evaluation._get_completed_tasks(),
+        tasks_dir=task,
+        job_dir=tmp_path / "jobs",
+        source_environment="docker",
+        policy=evaluation._config.rubric_review,
+    )
+
+    assert completed == {}
+
+
+def test_workspace_capture_exports_delta_and_excludes_credentials(tmp_path):
+    """Guards the rubric final-score PR's output-only evidence boundary."""
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    (workspace / "input.bin").write_bytes(b"unchanged")
+    (workspace / ".codex").mkdir()
+    (workspace / ".codex" / "auth.json").write_text("secret")
+    (workspace / ".daytona" / "sessions").mkdir(parents=True)
+    (workspace / ".daytona" / "sessions" / "output.log").write_text("runtime")
+    (workspace / "project" / ".ssh").mkdir(parents=True)
+    (workspace / "project" / ".ssh" / "id_rsa").write_text("nested secret")
+    baseline = tmp_path / "artifacts" / "workspace-baseline.json"
+    destination = tmp_path / "artifacts" / "workspace"
+    manifest = tmp_path / "artifacts" / "workspace-manifest.json"
+
+    def capture(mode: str) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-",
+                mode,
+                str(workspace),
+                str(baseline),
+                str(destination),
+                str(manifest),
+            ],
+            input=_CAPTURE_SCRIPT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr
+
+    capture("baseline")
+    (workspace / "answer.txt").write_text("new output")
+    (workspace / "input.bin").write_bytes(b"changed")
+    (workspace / ".env").write_text("API_KEY=secret")
+    capture("final")
+
+    assert (destination / "answer.txt").read_text() == "new output"
+    assert (destination / "input.bin").read_bytes() == b"changed"
+    assert not (destination / ".env").exists()
+    assert not (destination / ".codex").exists()
+    assert not (destination / ".daytona").exists()
+    assert not (destination / "project" / ".ssh").exists()
+    captured = json.loads(manifest.read_text())
+    assert [item["path"] for item in captured["copied_files"]] == [
+        "answer.txt",
+        "input.bin",
+    ]
+    assert {item["path"] for item in captured["excluded_paths"]} >= {
+        ".codex",
+        ".daytona",
+        ".env",
+        "project/.ssh",
+    }
+
+
+def test_job_summary_separates_pass_at_one_quality_and_reviewer_usage():
+    """Guards the rubric final-score PR's job-level score and usage split."""
+
+    summary = rubric_review_summary(
+        {
+            "pass": {
+                "final_score": {"pass": True, "score": 0.8},
+                "rubric_review": {
+                    "status": "complete",
+                    "reviewer": {
+                        "agent_result": {"total_tokens": 100, "cost_usd": 0.02}
+                    },
+                },
+            },
+            "blocked": {
+                "final_score": {"pass": False, "score": 0.0},
+                "rubric_review": {
+                    "status": "complete",
+                    "reviewer": {
+                        "agent_result": {"total_tokens": 50, "cost_usd": 0.01}
+                    },
+                },
+            },
+            "plain": {"rewards": {"reward": 1.0}},
+        }
+    )["rubric_review"]
+
+    assert summary["required"] == 2
+    assert summary["completed"] == 2
+    assert summary["pass_at_1"] == 0.5
+    assert summary["mean_score"] == 0.4
+    assert summary["reviewer_total_tokens"] == 150
+    assert summary["reviewer_total_cost_usd"] == 0.03

--- a/tests/test_review_integration.py
+++ b/tests/test_review_integration.py
@@ -179,6 +179,7 @@ async def test_weighted_review_updates_every_score_artifact(tmp_path, monkeypatc
     task = tmp_path / "tasks" / "task"
     rubric_path = _rubric(task)
     rollout, result = _source_rollout(tmp_path)
+
     async def fake_run_reviews(_path, **kwargs):
         report, _trial = _fake_review(
             kwargs["out_dir"], rubric_path=kwargs["rubric_path"]
@@ -345,9 +346,9 @@ async def test_resume_finishes_review_without_rerunning_source(tmp_path, monkeyp
     (rollout / "result.json").write_text(json.dumps(persisted))
 
     async def fake_run_reviews(_path, **kwargs):
-        return _fake_review(
-            kwargs["out_dir"], rubric_path=kwargs["rubric_path"]
-        )[0], kwargs["out_dir"] / "review_report.json"
+        return _fake_review(kwargs["out_dir"], rubric_path=kwargs["rubric_path"])[
+            0
+        ], kwargs["out_dir"] / "review_report.json"
 
     monkeypatch.setattr("benchflow.review.integration.run_reviews", fake_run_reviews)
     evaluation = Evaluation(

--- a/tests/test_review_runtime.py
+++ b/tests/test_review_runtime.py
@@ -15,9 +15,9 @@ from benchflow.review.runner import (
     ReviewRunError,
     TrialReview,
     _lock_review_evidence,
-    _task_digest_issue,
     discover_rollouts,
     run_reviews,
+    task_digest_issue,
 )
 from benchflow.rollout import RolloutConfig
 
@@ -793,7 +793,7 @@ class TestTaskDigestAdmission:
         result = json.loads((rollout / "result.json").read_text(encoding="utf-8"))
         result.pop("task_digest")
         (rollout / "result.json").write_text(json.dumps(result), encoding="utf-8")
-        assert _task_digest_issue(rollout, task) is None
+        assert task_digest_issue(rollout, task) is None
 
     def test_missing_digest_excludes_task(self, tmp_path):
         """Guards PR #942: unverifiable task evidence fails closed."""
@@ -804,7 +804,7 @@ class TestTaskDigestAdmission:
             data = json.loads((rollout / filename).read_text(encoding="utf-8"))
             data.pop("task_digest", None)
             (rollout / filename).write_text(json.dumps(data), encoding="utf-8")
-        assert "missing" in (_task_digest_issue(rollout, task) or "")
+        assert "missing" in (task_digest_issue(rollout, task) or "")
 
     def test_conflicting_digests_exclude_task(self, tmp_path):
         """Guards PR #942: conflicting provenance cannot select task evidence."""
@@ -814,7 +814,7 @@ class TestTaskDigestAdmission:
         result = json.loads((rollout / "result.json").read_text(encoding="utf-8"))
         result["task_digest"] = "sha256:" + "0" * 64
         (rollout / "result.json").write_text(json.dumps(result), encoding="utf-8")
-        assert "conflicting" in (_task_digest_issue(rollout, task) or "")
+        assert "conflicting" in (task_digest_issue(rollout, task) or "")
 
     def test_digest_computation_failure_excludes_task(self, tmp_path, monkeypatch):
         """Guards PR #942: digest errors cannot admit unverified task files."""
@@ -826,7 +826,7 @@ class TestTaskDigestAdmission:
             raise OSError("cannot hash")
 
         monkeypatch.setattr("benchflow._utils.task_authoring.task_digest", fail)
-        assert "could not be verified" in (_task_digest_issue(rollout, task) or "")
+        assert "could not be verified" in (task_digest_issue(rollout, task) or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- automatically detect review-shaped task-local `rubric.json` files during normal CLI, batch, runtime, and SDK runs
- launch a fresh isolated reviewer sandbox using `codex-acp` + `openai/gpt-5.6-sol` at `xhigh` by default, with the source trajectory, verifier evidence, exact task, and filtered final workspace outputs
- make final reward/pass@1 binary on deterministic verification plus all blocker rubrics, then expose the gated weighted non-blocker score separately
- refresh rollout, reward-event, trainer, job-summary, metrics, health, publish, and sharded-worker projections from one canonical result
- retry reviewer-only failures once, fail closed when review evidence is incomplete, and safely resume an interrupted review without rerunning the source agent

## Design and safety

- dedicated `review.policy`, `review.workspace`, `review.lifecycle`, `review.integration`, and `review.resume` modules keep feature state and orchestration out of the already-large evaluation/rollout engines
- `result.json` is written last as the durable commit marker after dependent projections are refreshed
- workspace capture exports only new/modified regular files and excludes credentials, VCS/dependencies/caches, symlinks, and provider runtime directories such as `.daytona`
- reviewer secrets are runtime-only; public artifacts retain key names but never values
- legacy unweighted review rubrics remain audit-only and existing no-rubric tasks retain verifier scoring unchanged

## Verification

- `ruff check .` — pass
- `ty check src/` — pass
- impacted review/evaluation/metrics/runtime/SDK/YAML/rollout suite — 549 passed
- cross-provider Docker/Daytona/Modal abstraction/Apple Container/AgentCore suite — 596 passed, 11 platform skips
- final focused scoring/projection suite — 79 passed
- full Linux suite — 6035 passed, 19 skipped, 7 deselected; 10 unrelated environment failures from CRLF fixture hashes/scripts on the Windows checkout, Rich wrapping under the long WSL path, DrvFS symlink semantics, and a pre-existing `~/.claude` credential assumed absent by two tests

## Live E2E

- verified the exact live Azure key with a raw `gpt-5.6-sol` provider call before runs
- Docker: weighted pass and blocker-fail paths with a real xhigh reviewer; real source-agent failure gated to pass@1=0/score=0
- FrontierPhysics `diffuse-ib-rigid-body-fsi`: deterministic 18/18 plus isolated real reviewer produced pass@1=1 and weighted score `50/66 = 0.757575`; process interruption also exercised reviewer-only crash resume and task-digest refusal
- SkillsBench `3d-scan-calc`: real xhigh source model passed on Docker; oracle passed on Daytona with no rubric fields added
- Daytona weighted run: distinct source/reviewer VM IDs, pass@1=1, score=1.0, exactly `answer.txt` captured, `.daytona` excluded, and both VMs verified absent after teardown
- exact-value scan confirmed no Daytona or Azure credential was persisted in changed files or retained artifacts
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/benchflow-ai/benchflow/pull/1092" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->