### PR TITLE
fix(rollout): clear stale LLM trajectory on rollout reuse

### DIFF
--- a/src/benchflow/rollout/_setup.py
+++ b/src/benchflow/rollout/_setup.py
@@ -273,6 +273,7 @@ def _init_rollout(
     rollout_dir.mkdir(parents=True, exist_ok=True)
     for subdir in ("agent", "verifier", "artifacts", "trajectory"):
         (rollout_dir / subdir).mkdir(exist_ok=True)
+    (rollout_dir / "trajectory" / "llm_trajectory.jsonl").unlink(missing_ok=True)
     return task, rollout_dir, rollout_paths, started_at, job_name, rollout_name
 
 

--- a/tests/test_sdk_internals.py
+++ b/tests/test_sdk_internals.py
@@ -382,6 +382,27 @@ class TestInitTrial:
         )
         assert rollout_name == "custom-trial"
 
+    def test_reused_rollout_drops_previous_llm_trajectory(self, task_dir, tmp_path):
+        """Drops a prior provider trajectory when a reused rollout has no new one."""
+        jobs_dir = tmp_path / "jobs"
+        _, rollout_dir, _, _, _, _ = self._init(
+            task_dir,
+            job_name="job",
+            rollout_name="rollout",
+            jobs_dir=jobs_dir,
+        )
+        trajectory = rollout_dir / "trajectory" / "llm_trajectory.jsonl"
+        trajectory.write_text('{"completion":"stale"}\n')
+
+        self._init(
+            task_dir,
+            job_name="job",
+            rollout_name="rollout",
+            jobs_dir=jobs_dir,
+        )
+
+        assert not trajectory.exists()
+
     def test_started_at_is_datetime(self, task_dir, tmp_path):
         _, _, _, started_at, _, _ = self._init(task_dir, jobs_dir=tmp_path / "jobs")
         assert isinstance(started_at, datetime)


### PR DESCRIPTION
## Problem

`_init_rollout()` can be called with explicit job and rollout names, so the target directory may already exist.
In that case, an old `trajectory/llm_trajectory.jsonl` is left in place.

Usually live capture replaces the file after the first completed model call.
If the new run fails before then, nothing overwrites it.
Training export and artifact inspection can then read the previous run's trajectory as if it came from the current attempt.

I reproduced this by initializing the same rollout path twice and placing a trajectory in between.
After the second initialization:

- `main`: `stale_exists=True`
- this patch: `stale_exists=False`

## Change

Remove this one attempt-owned file when the rollout directory is initialized.
The rest of the directory is left alone, and the separate continue-run flow is unchanged.

- `src/benchflow/rollout/_setup.py` removes the stale trajectory.
- `tests/test_sdk_internals.py` covers reuse of the same rollout path.

## Tests

`uv run pytest -q tests/test_sdk_internals.py`

Result: `51 passed`.